### PR TITLE
feat: add promotion and release workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -322,7 +322,7 @@ jobs:
       image_name: nvcr.io/0837451325059433/carbide-dev/nvmetal-carbide
       image_tag: ${{ needs.prepare.outputs.version }}
       platforms: linux/amd64
-      runner: linux-amd64-cpu8
+      runner: linux-amd64-cpu16
       push: true
       load: true
       tag_latest: false
@@ -371,7 +371,7 @@ jobs:
       - prepare
       - build-forge-cli-x86_64
       - build-forge-cli-aarch64
-    if: github.event_name != 'schedule' && !contains(github.ref, 'pull-request/')
+    if: ${{ !cancelled() && github.event_name != 'schedule' && !contains(github.ref, 'pull-request/') && needs.build-forge-cli-x86_64.result == 'success' && needs.build-forge-cli-aarch64.result == 'success' }}
     runs-on: linux-amd64-cpu4
     steps:
       - name: Checkout code
@@ -802,3 +802,27 @@ jobs:
       notify-on-failure: true
     secrets:
       slack-bot-token: ${{ secrets.CDS_SLACK_BOT_OAUTH_TOKEN }}
+
+  # ============================================================================
+  # PUSH MAIN TAG
+  # ============================================================================
+  push-main-tag:
+    runs-on: linux-amd64-cpu4
+    needs:
+      - prepare
+      - build-release-container-x86_64
+      - build-release-artifacts-x86-host
+      - build-release-artifacts-arm-host
+      - merge-manifests-forge-cli
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-release-container-x86_64.result == 'success' && needs.build-release-artifacts-x86-host.result == 'success' && needs.build-release-artifacts-arm-host.result == 'success' && needs.merge-manifests-forge-cli.result == 'success' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.TAG_PAT_TOKEN }}
+      - name: Push tag
+        uses: NVIDIA/dsx-github-actions/.github/actions/git-tag@95e609360851cfc141918c2c21e57762d77394ac
+        with:
+          tag: main-${{ needs.prepare.outputs.short_sha }}
+          github_token: ${{ secrets.TAG_PAT_TOKEN }}

--- a/.github/workflows/promotion-rc.yaml
+++ b/.github/workflows/promotion-rc.yaml
@@ -1,0 +1,147 @@
+name: Carbide Promotion to Release Candidate
+
+on:
+  push:
+    tags:
+      - 'main-[0-9a-f]*'
+
+jobs:
+  # ============================================================================
+  # PROMOTE TO RELEASE CANDIDATE
+  # ============================================================================
+  qa-promote-to-release-candidate:
+    runs-on: linux-amd64-cpu4
+    environment: 
+      name: promote-release-candidate
+    steps:
+      - name: QA promote to release candidate
+        run: echo "QA promoting to release candidate registry ngcr.io/0837451325059433/carbide"  
+  # ============================================================================
+  # Calculate release candidate version
+  # ============================================================================
+  calculate-release-candidate-version:
+    runs-on: linux-amd64-cpu4
+    needs:
+      - qa-promote-to-release-candidate
+    outputs:
+      rc_version: ${{ steps.calc.outputs.rc_version }}
+      short_sha: ${{ steps.calc.outputs.short_sha }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Calculate release candidate version
+        id: calc
+        run: |
+          set -euo pipefail
+          
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+          # 1. Find the latest stable tag (e.g. v0.1.0 or 0.1.0)
+          # Sort by version, filtering for standard semver patterns
+          LATEST_TAG=$(git tag -l | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1 || echo "0.1.0")
+          
+          # Normalize tag (remove 'v' prefix if present for calculation)
+          VERSION_NUM=${LATEST_TAG#v}
+          
+          echo "Latest stable tag: $LATEST_TAG (normalized: $VERSION_NUM)"
+          
+          # Split into Major.Minor.Patch
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION_NUM"
+          
+          # 2. Determine Bump Type
+          # Scan commit messages since the last stable tag for "minor" keyword
+          if [ "$LATEST_TAG" == "0.0.0" ]; then
+            # If no previous tag, we are starting from scratch.
+            # "0.1.0 -> 0.1.1 (patch) unless 'minor' in commit msg -> 0.2.0 or major: in commit msg -> 1.0.0"
+            # For initial 0.0.0, let's check log from beginning.
+            LOG_RANGE="HEAD"
+          else
+            LOG_RANGE="$LATEST_TAG..HEAD"
+          fi
+          
+          # Check for "^minor:" (case insensitive) in commit messages
+          if git log "$LOG_RANGE" --pretty=format:%B | grep -i -q "^minor:"; then
+            BUMP_TYPE="minor"
+            NEW_MINOR=$((MINOR + 1))
+            NEW_PATCH=0
+            NEW_VERSION="$MAJOR.$NEW_MINOR.$NEW_PATCH"
+          elif git log "$LOG_RANGE" --pretty=format:%B | grep -i -q "^major:"; then
+            BUMP_TYPE="major"
+            NEW_MAJOR=$((MAJOR + 1))
+            NEW_MINOR=0
+            NEW_PATCH=0
+            NEW_VERSION="$NEW_MAJOR.$NEW_MINOR.$NEW_PATCH"
+          else
+            BUMP_TYPE="patch"
+            NEW_PATCH=$((PATCH + 1))
+            NEW_VERSION="$MAJOR.$MINOR.$NEW_PATCH"
+          fi
+          
+          echo "Bump type: $BUMP_TYPE"
+          echo "Target new version: $NEW_VERSION"
+          
+          # 3. Calculate RC Number
+          # Search for existing RC tags for this target version: X.Y.Z-rc.*
+          # Example: if NEW_VERSION is 0.1.1, look for 0.1.1-rc.1, 0.1.1-rc.2, etc.
+          
+          # Find highest existing rc for this version
+          # We grep for exact version match followed by -rc.N
+          EXISTING_RCS=$(git tag -l | grep -E "^v?${NEW_VERSION}-rc\.[0-9]+$" | sort -V | tail -n 1 || echo "")
+          echo "Existing RCs: $EXISTING_RCS"
+          if [ -z "$EXISTING_RCS" ]; then
+            # No RC exists yet, start at 1
+            NEXT_RC=1
+          else
+            # Extract the RC number
+            # Remove everything up to the last dot
+            LAST_RC_NUM=${EXISTING_RCS##*.}
+            NEXT_RC=$((LAST_RC_NUM + 1))
+          fi
+          
+          FINAL_RC_VERSION="${NEW_VERSION}-rc.${NEXT_RC}"
+          
+          echo "Final RC Version: $FINAL_RC_VERSION"
+          echo "rc_version=${FINAL_RC_VERSION}" >> "$GITHUB_OUTPUT"
+
+
+  # ============================================================================
+  # ReTag To Release Candidate
+  # ============================================================================
+  promote-carbide-core-release-candidate:
+    needs:
+      - calculate-release-candidate-version
+    uses: NVIDIA/dsx-github-actions/.github/workflows/promote-image.yml@95e609360851cfc141918c2c21e57762d77394ac
+    with:
+      source: nvcr.io/0837451325059433/carbide-dev/nvmetal-carbide
+      source_tag: main-${{ needs.calculate-release-candidate-version.outputs.short_sha }}
+      destination: nvcr.io/0837451325059433/carbide/nvmetal-carbide
+      destination_tag: ${{ needs.calculate-release-candidate-version.outputs.rc_version }}
+    secrets:
+      SOURCE_USERNAME: ${{ secrets.NVCR_USERNAME }}
+      SOURCE_PASSWORD: ${{ secrets.NVCR_TOKEN }}
+      DEST_USERNAME: ${{ secrets.NVCR_PROD_USERNAME }}
+      DEST_PASSWORD: ${{ secrets.NVCR_PROD_TOKEN }}
+
+  # ============================================================================
+  # Push Git Tag
+  # ============================================================================
+  push-git-tag:
+    runs-on: linux-amd64-cpu4
+    needs:
+      - promote-carbide-core-release-candidate
+      - calculate-release-candidate-version
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.TAG_PAT_TOKEN }}
+
+      - name: Push Git Tag
+        uses: NVIDIA/dsx-github-actions/.github/actions/git-tag@95e609360851cfc141918c2c21e57762d77394ac
+        with:
+          tag: v${{ needs.calculate-release-candidate-version.outputs.rc_version }}
+          github_token: ${{ secrets.TAG_PAT_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,85 @@
+name: Carbide Release new version
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+'
+
+jobs:
+  # ============================================================================
+  # Release new version
+  # ============================================================================
+  release-new-version-approve:
+    runs-on: linux-amd64-cpu4
+    environment:
+      name: release-new-version-approve
+    steps:
+      - name: Release new version
+        run: echo "Releasing new version to NVIDIA Catalog"
+
+  # ============================================================================
+  # Fetch new version
+  # ============================================================================
+  fetch-new-version:
+    runs-on: linux-amd64-cpu4
+    needs:
+      - release-new-version-approve
+    outputs:
+      version: ${{ steps.fetch.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch version
+        id: fetch
+        run: |
+          set -euo pipefail
+          
+          # Extract full tag (e.g. v0.0.1-rc.1)
+          FULL_TAG=${GITHUB_REF#refs/tags/}
+          
+          # Extract base version (e.g. v0.0.1) by removing everything after the last -rc pattern
+          # Or more simply, just regex match the vX.Y.Z part
+          VERSION=$(echo "$FULL_TAG" | grep -oE '^v[0-9]+\.[0-9]+\.[0-9]+')
+          
+          echo "Full Tag: $FULL_TAG"
+          echo "Release Version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+
+  # ============================================================================
+  # Release new version
+  # ============================================================================
+  release-new-version:
+    runs-on: linux-amd64-cpu4
+    needs:
+      - fetch-new-version
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Push Git Tag
+        uses: NVIDIA/dsx-github-actions/.github/actions/git-tag@95e609360851cfc141918c2c21e57762d77394ac
+        with:
+          tag: ${{ needs.fetch-new-version.outputs.version }}
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: false
+        with:
+          name: ${{ needs.fetch-new-version.outputs.version }}
+          tag_name: ${{ needs.fetch-new-version.outputs.version }}
+      - name: Release new version
+        if: false
+        run: |
+          VERSION="${{ needs.fetch-new-version.outputs.version }}"
+          REPO="${{ github.repository }}"
+          RELEASE_URL="https://github.com/$REPO/releases/tag/$VERSION"
+          
+          echo "Releasing new version $VERSION to NVIDIA Catalog"
+          echo "## 🚀 Release Created" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Release carbide version: **$VERSION**" >> "$GITHUB_STEP_SUMMARY"
+          echo "🔗 [View Release Notes]($RELEASE_URL)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
1. Full pipeline post-merge to main: https://github.com/NVIDIA/carbide-core/actions/runs/19926895719 
push tag main-<sha> automatically

2. promote to RC flow: https://github.com/NVIDIA/carbide-core/actions/runs/19931748694
waiting manually approval
promote artifacts to NGC carbide team
push tag vX.Y.Z-rc.N

3. official release flow: https://github.com/NVIDIA/carbide-core/actions/runs/19931861621
waiting manually approval
push tag vX.Y.Z
publish release 

manually approval snapshot:   
<img width="3093" height="495" alt="image" src="https://github.com/user-attachments/assets/d6a2deee-37ed-4fd4-b476-5cab7b9a6523" />

<img width="732" height="438" alt="image" src="https://github.com/user-attachments/assets/50ce870d-2196-4cd6-891c-1a5d35295d2c" />
