### PR TITLE
chore: bmc-mock: get rid of two BMC states and explicit POST/PATCH

### DIFF
--- a/crates/bmc-mock/src/json.rs
+++ b/crates/bmc-mock/src/json.rs
@@ -10,6 +10,42 @@
  * its affiliates is strictly prohibited.
  */
 
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+
+pub trait JsonExt {
+    fn patch(self, patch: impl JsonPatch) -> serde_json::Value
+    where
+        Self: Sized;
+
+    fn into_ok_response(self) -> impl IntoResponse
+    where
+        Self: Sized;
+}
+
+impl JsonExt for serde_json::Value {
+    fn patch(mut self, patch: impl JsonPatch) -> serde_json::Value {
+        json_patch(&mut self, patch.json_patch());
+        self
+    }
+    fn into_ok_response(self) -> impl IntoResponse
+    where
+        Self: Sized + ToString,
+    {
+        (StatusCode::OK, self.to_string())
+    }
+}
+
+pub trait JsonPatch {
+    fn json_patch(&self) -> serde_json::Value;
+}
+
+impl JsonPatch for serde_json::Value {
+    fn json_patch(&self) -> serde_json::Value {
+        self.clone()
+    }
+}
+
 pub fn json_patch(target: &mut serde_json::Value, patch: serde_json::Value) {
     match (target, patch) {
         (serde_json::Value::Object(target_obj), serde_json::Value::Object(patch_obj)) => {

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -43,6 +43,7 @@ mod bug;
 mod json;
 mod machine_info;
 mod mock_machine_router;
+mod redfish;
 mod redfish_expander;
 mod tar_router;
 

--- a/crates/bmc-mock/src/redfish/account_service.rs
+++ b/crates/bmc-mock/src/redfish/account_service.rs
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material and related documentation
+ * without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+ */
+
+use std::borrow::Cow;
+use std::fmt::Display;
+
+use axum::Router;
+use axum::extract::Path;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use serde_json::json;
+
+use crate::json::JsonExt;
+use crate::mock_machine_router::MockWrapperState;
+use crate::redfish;
+
+const SERVICE_RESOURCE: redfish::Resource<'static> = redfish::Resource {
+    odata_id: Cow::Borrowed("/redfish/v1/AccountService"),
+    odata_type: Cow::Borrowed("#AccountService.v1_9_0.AccountService"),
+    id: Cow::Borrowed("AccountService"),
+    name: Cow::Borrowed("Account Service"),
+};
+
+const ACCOUNTS_COLLECTION_RESOURCE: redfish::Collection<'static> = redfish::Collection {
+    odata_id: Cow::Borrowed("/redfish/v1/AccountService/Accounts"),
+    odata_type: Cow::Borrowed("#ManagerAccountCollection.ManagerAccountCollection"),
+    name: Cow::Borrowed("Accounts Collection"),
+};
+
+pub fn add_routes(r: Router<MockWrapperState>) -> Router<MockWrapperState> {
+    r.route(&SERVICE_RESOURCE.odata_id, get(get_root))
+        .route(&ACCOUNTS_COLLECTION_RESOURCE.odata_id, get(get_accounts))
+        .route(
+            format!("{}/{{account_id}}", ACCOUNTS_COLLECTION_RESOURCE.odata_id).as_str(),
+            get(get_account).patch(patch_account),
+        )
+}
+
+pub async fn get_root() -> impl IntoResponse {
+    let service_attrs = json!({
+        "AccountLockoutCounterResetAfter": 0,
+        "AccountLockoutDuration": 0,
+        "AccountLockoutThreshold": 0,
+        "AuthFailureLoggingThreshold": 2,
+        "LocalAccountAuth": "Fallback",
+        "MaxPasswordLength": 40,
+        "MinPasswordLength": 0,
+    });
+    service_attrs
+        .patch(SERVICE_RESOURCE)
+        .patch(ACCOUNTS_COLLECTION_RESOURCE.nav_property("Accounts"))
+        .into_ok_response()
+}
+
+pub fn account_resource(id: impl Display) -> redfish::Resource<'static> {
+    redfish::Resource {
+        odata_id: Cow::Owned(format!("{}/{id}", ACCOUNTS_COLLECTION_RESOURCE.odata_id)),
+        odata_type: Cow::Borrowed("#ManagerAccount.v1_8_0.ManagerAccount"),
+        name: Cow::Borrowed("User Account"),
+        id: Cow::Owned(id.to_string()),
+    }
+}
+
+pub async fn get_accounts() -> impl IntoResponse {
+    // This is Dell-specific behavior of Account handling. Fixed slots...
+    let members = (1..16)
+        .map(|v| json!({"@odata.id": format!("{}/{v}", ACCOUNTS_COLLECTION_RESOURCE.odata_id)}))
+        .collect::<Vec<_>>();
+    ACCOUNTS_COLLECTION_RESOURCE
+        .with_members(&members)
+        .into_ok_response()
+}
+
+pub async fn patch_account(Path(_account_id): Path<String>) -> impl IntoResponse {
+    json!({}).into_ok_response()
+}
+
+pub async fn get_account(Path(account_id): Path<String>) -> impl IntoResponse {
+    // This is Dell behavior must be fixed for other platform.
+    let (username, role_id) = if account_id == "2" {
+        ("root", "Administrator")
+    } else {
+        ("", "")
+    };
+    json!({
+        "UserName": username,
+        "RoleId": role_id,
+        "AccountTypes": ["Redfish"]
+    })
+    .patch(account_resource(account_id))
+    .into_ok_response()
+}

--- a/crates/bmc-mock/src/redfish/bios.rs
+++ b/crates/bmc-mock/src/redfish/bios.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material and related documentation
+ * without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+ */
+
+use axum::Router;
+use axum::extract::Path;
+use axum::response::IntoResponse;
+use axum::routing::post;
+use serde_json::json;
+
+use crate::json::JsonExt;
+use crate::mock_machine_router::MockWrapperState;
+
+pub fn add_routes(r: Router<MockWrapperState>) -> Router<MockWrapperState> {
+    r.route(
+        "/redfish/v1/Systems/{system_id}/Bios/Actions/Bios.ChangePassword",
+        post(change_password_action),
+    )
+}
+
+async fn change_password_action(Path(_system_id): Path<String>) -> impl IntoResponse {
+    json!({}).into_ok_response()
+}

--- a/crates/bmc-mock/src/redfish/collection.rs
+++ b/crates/bmc-mock/src/redfish/collection.rs
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material and related documentation
+ * without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+ */
+
+use std::borrow::Cow;
+
+use serde_json::json;
+
+use crate::json::{JsonExt, JsonPatch};
+
+/// Defines minimal set of Redfish resource attributes.
+pub struct Collection<'a> {
+    pub odata_id: Cow<'a, str>,
+    pub odata_type: Cow<'a, str>,
+    pub name: Cow<'a, str>,
+}
+
+impl Collection<'_> {
+    pub fn nav_property(&self, name: &str) -> serde_json::Value {
+        json!({
+            name: {
+                "@odata.id": self.odata_id
+            }
+        })
+    }
+
+    pub fn with_members(&self, members: &[impl serde::Serialize]) -> serde_json::Value {
+        self.json_patch().patch(json!({
+            "Members": members,
+        }))
+    }
+}
+
+impl JsonPatch for Collection<'_> {
+    fn json_patch(&self) -> serde_json::Value {
+        json!({
+            "@odata.id": self.odata_id,
+            "@odata.type": self.odata_type,
+            "Name": self.name,
+        })
+    }
+}

--- a/crates/bmc-mock/src/redfish/mod.rs
+++ b/crates/bmc-mock/src/redfish/mod.rs
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material and related documentation
+ * without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+ */
+
+pub mod account_service;
+pub mod bios;
+pub mod collection;
+pub mod oem;
+pub mod resource;
+
+pub use collection::Collection;
+pub use resource::Resource;

--- a/crates/bmc-mock/src/redfish/oem/dell/idrac.rs
+++ b/crates/bmc-mock/src/redfish/oem/dell/idrac.rs
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material and related documentation
+ * without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+ */
+
+use axum::Router;
+use axum::response::IntoResponse;
+use axum::routing::patch;
+use serde_json::json;
+
+use crate::json::JsonExt;
+use crate::mock_machine_router::MockWrapperState;
+
+pub fn add_routes(r: Router<MockWrapperState>) -> Router<MockWrapperState> {
+    r.route(
+        "/redfish/v1/Managers/iDRAC.Embedded.1/Attributes",
+        patch(set_idrac_attributes),
+    )
+}
+
+async fn set_idrac_attributes() -> impl IntoResponse {
+    json!({}).into_ok_response()
+}

--- a/crates/bmc-mock/src/redfish/oem/dell/mod.rs
+++ b/crates/bmc-mock/src/redfish/oem/dell/mod.rs
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material and related documentation
+ * without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+ */
+
+pub mod idrac;

--- a/crates/bmc-mock/src/redfish/oem/mod.rs
+++ b/crates/bmc-mock/src/redfish/oem/mod.rs
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material and related documentation
+ * without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+ */
+
+pub mod dell;
+pub mod nvidia;

--- a/crates/bmc-mock/src/redfish/oem/nvidia/bluefield.rs
+++ b/crates/bmc-mock/src/redfish/oem/nvidia/bluefield.rs
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material and related documentation
+ * without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+ */
+
+use axum::Router;
+use axum::response::IntoResponse;
+use axum::routing::post;
+use serde_json::json;
+
+use crate::json::JsonExt;
+use crate::mock_machine_router::MockWrapperState;
+
+pub fn add_routes(r: Router<MockWrapperState>) -> Router<MockWrapperState> {
+    r.route(
+        "/redfish/v1/Systems/Bluefield/Oem/Nvidia/Actions/HostRshim.Set",
+        post(hostrshim_set),
+    )
+}
+
+async fn hostrshim_set() -> impl IntoResponse {
+    json!({}).into_ok_response()
+}

--- a/crates/bmc-mock/src/redfish/oem/nvidia/mod.rs
+++ b/crates/bmc-mock/src/redfish/oem/nvidia/mod.rs
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material and related documentation
+ * without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+ */
+
+pub mod bluefield;

--- a/crates/bmc-mock/src/redfish/resource.rs
+++ b/crates/bmc-mock/src/redfish/resource.rs
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material and related documentation
+ * without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+ */
+
+use std::borrow::Cow;
+
+use serde_json::json;
+
+use crate::json::JsonPatch;
+
+/// Defines minimal set of Redfish resource attributes.
+pub struct Resource<'a> {
+    pub odata_id: Cow<'a, str>,
+    pub odata_type: Cow<'a, str>,
+    pub id: Cow<'a, str>,
+    pub name: Cow<'a, str>,
+}
+
+impl JsonPatch for Resource<'_> {
+    fn json_patch(&self) -> serde_json::Value {
+        json!({
+            "@odata.id": self.odata_id,
+            "@odata.type": self.odata_type,
+            "Id": self.id,
+            "Name": self.name,
+        })
+    }
+}

--- a/crates/bmc-mock/src/tar_router.rs
+++ b/crates/bmc-mock/src/tar_router.rs
@@ -15,39 +15,26 @@
 /// https://gitlab-master.nvidia.com/nvmetal/libredfish/-/tree/forge/tests/mockups?ref_type=heads
 ///
 /// There is one for each vendor we support in the libredfish repo.
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::io::Read;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time;
 
+use axum::Router;
 use axum::body::Body;
 use axum::extract::{Path as AxumPath, State as AxumState};
-use axum::http::{HeaderMap, Request, StatusCode};
+use axum::http::{Request, StatusCode};
 use axum::response::IntoResponse;
 use axum::routing::get;
-use axum::{Json, Router};
 use bytes::Buf;
 use eyre::Context;
 use flate2::read::GzDecoder;
-use regex::Regex;
-use serde::Deserialize;
 
-use crate::SetSystemPowerReq;
-
-const MAX_HISTORY_ENTRIES: usize = 1000;
 pub type EntryMap = Arc<Mutex<HashMap<String, String>>>;
-type HistoryMap = Arc<Mutex<HashMap<String, VecDeque<String>>>>;
-
-const POWER_CYLE_TIME_SECS: u64 = 5;
 
 #[derive(Clone, Default)]
 struct BmcState {
-    is_on: Arc<AtomicBool>,
-    off_until: Arc<Mutex<Option<time::SystemTime>>>,
     entries: EntryMap,
-    history: HistoryMap,
 }
 
 /// Allows callers to specify an in-memory tar (like via include_bytes!()) or a path to one on the
@@ -125,90 +112,22 @@ pub fn tar_router(
         }
     };
 
-    let bmc_state = BmcState {
-        is_on: Arc::new(AtomicBool::new(true)),
-        entries,
-        ..Default::default()
-    };
+    let bmc_state = BmcState { entries };
 
     Ok(Router::new()
-        .route("/history", get(get_history_macs))
-        .route("/history/{mac}", get(get_history))
-        .route("/{*path}", get(get_from_tar).patch(set_any).post(set_any))
+        .route("/{*path}", get(get_from_tar))
         .fallback(not_found_handler)
         .with_state(bmc_state))
-}
-
-async fn get_history_macs(AxumState(shared_state): AxumState<BmcState>) -> impl IntoResponse {
-    let history_map = shared_state.history.lock().unwrap();
-    (
-        StatusCode::OK,
-        serde_json::to_string_pretty(&history_map.keys().collect::<Vec<&String>>()).unwrap(),
-    )
-}
-
-async fn get_history(
-    AxumState(shared_state): AxumState<BmcState>,
-    AxumPath(mac_address): AxumPath<String>,
-) -> impl IntoResponse {
-    let mut history_map = shared_state.history.lock().unwrap();
-    match history_map.get_mut(&mac_address) {
-        None => {
-            tracing::trace!("No history for mac address: {mac_address}");
-            (
-                StatusCode::NOT_FOUND,
-                serde_json::to_string("no history for mac address").unwrap(),
-            )
-        }
-        Some(history) => (
-            StatusCode::OK,
-            serde_json::to_string_pretty(history).unwrap(),
-        ),
-    }
-}
-
-fn append_history(
-    history: Arc<Mutex<HashMap<String, VecDeque<String>>>>,
-    mac_address: &str,
-    path: &String,
-) {
-    let mut history_map = history.lock().unwrap();
-    let history = match history_map.get_mut(mac_address) {
-        None => {
-            tracing::trace!("New history for mac address: {mac_address}");
-            history_map.insert(mac_address.to_owned(), VecDeque::default());
-            history_map.get_mut(mac_address).unwrap()
-        }
-        Some(history) => history,
-    };
-    history.push_back(path.to_owned());
-    while history.len() > MAX_HISTORY_ENTRIES {
-        history.pop_front();
-    }
-}
-
-lazy_static::lazy_static! {
-    static ref GET_SYSTEM_RE: Regex = Regex::new(r#"Systems/[A-Za-z0-9\-_.~]+$"#).unwrap();
-    static ref GET_MANAGER_RE: Regex = Regex::new(r#"Managers/[A-Za-z0-9\-_.~]+$"#).unwrap();
 }
 
 /// Read redfish data from the tar
 async fn get_from_tar(
     AxumState(shared_state): AxumState<BmcState>,
     AxumPath(mut path): AxumPath<String>,
-    request: Request<Body>,
 ) -> impl IntoResponse {
     if path.ends_with('/') {
         path.pop();
     };
-
-    maybe_power_back_on(&shared_state);
-
-    let really_to_mac = request
-        .headers()
-        .get("x-really-to-mac")
-        .map_or("", |v| v.to_str().unwrap());
-    append_history(shared_state.history.clone(), really_to_mac, &path);
 
     match shared_state.entries.lock().unwrap().get(&path) {
         None => {
@@ -216,98 +135,8 @@ async fn get_from_tar(
             tracing::trace!("Not found: {path}");
             (StatusCode::NOT_FOUND, path)
         }
-        Some(s) => {
-            if really_to_mac.is_empty() {
-                tracing::trace!("Get: {path}");
-            } else {
-                tracing::trace!("Get: {path} for {really_to_mac}");
-            }
-            if GET_SYSTEM_RE.is_match(&path) || GET_MANAGER_RE.is_match(&path) {
-                // TODO Parse it as JSON. This works for now
-                if !shared_state.is_on.load(Ordering::Relaxed) {
-                    tracing::debug!("Reporting powered off");
-                    let on = r#""PowerState": "On","#;
-                    let off = r#""PowerState": "Off","#;
-                    return (StatusCode::OK, s.replace(on, off));
-                }
-            }
-            (StatusCode::OK, s.clone())
-        }
+        Some(s) => (StatusCode::OK, s.clone()),
     }
-}
-
-fn maybe_power_back_on(state: &BmcState) {
-    let mut off_until = state.off_until.lock().unwrap();
-    if let Some(off_timeout) = *off_until
-        && off_timeout < time::SystemTime::now()
-    {
-        *off_until = None;
-        state.is_on.store(true, Ordering::Relaxed);
-        tracing::debug!("Powered back on");
-    }
-}
-
-fn set_system_power(shared_state: BmcState, req: SetSystemPowerReq) {
-    tracing::debug!("Power action: {:?}", req.reset_type);
-    use super::SystemPowerControl::*;
-    match req.reset_type {
-        On | ForceOn => {
-            // Permanently on
-            shared_state.is_on.store(true, Ordering::Relaxed);
-            *shared_state.off_until.lock().unwrap() = None;
-        }
-        GracefulShutdown | ForceOff | Nmi | Suspend => {
-            // Permanently off
-            shared_state.is_on.store(false, Ordering::Relaxed);
-            *shared_state.off_until.lock().unwrap() = None;
-        }
-        GracefulRestart | ForceRestart => {
-            // Reboot. These don't affect power state, On or Off.
-        }
-        Pause | Resume => {
-            // Unhandled
-        }
-        PowerCycle => {
-            // Reboot but also cut the power
-            //
-            // Off for POWER_CYLE_TIME_SECS (might need to adjust)
-            // Switched back on in get_from_tar's maybe_power_back_on
-            shared_state.is_on.store(false, Ordering::Relaxed);
-            let t = time::SystemTime::now() + time::Duration::from_secs(POWER_CYLE_TIME_SECS);
-            *shared_state.off_until.lock().unwrap() = Some(t);
-        }
-        PushPowerButton => {
-            // Presumably toggle power
-            let current = shared_state.is_on.load(Ordering::SeqCst);
-            shared_state.is_on.store(!current, Ordering::SeqCst);
-            *shared_state.off_until.lock().unwrap() = None;
-        }
-    }
-}
-
-/// Accept any POST or PATCH
-async fn set_any(
-    AxumState(shared_state): AxumState<BmcState>,
-    AxumPath(mut path): AxumPath<String>,
-    headers: HeaderMap,
-    Json(body): Json<serde_json::Value>,
-) -> impl IntoResponse {
-    if path.ends_with('/') {
-        path.pop();
-    };
-    tracing::debug!("Set: {path}");
-    let really_to_mac = headers
-        .get("x-really-to-mac")
-        .map_or("", |v| v.to_str().unwrap());
-    append_history(shared_state.history.clone(), really_to_mac, &path);
-
-    // This can't be its own route because of https://github.com/tokio-rs/axum/issues/1986
-    if path.ends_with("Actions/ComputerSystem.Reset") {
-        let power_req = SetSystemPowerReq::deserialize(body).unwrap();
-        set_system_power(shared_state, power_req);
-    }
-
-    StatusCode::OK
 }
 
 // We should never get here, but axum's matchit bug means we sometimes do: https://github.com/tokio-rs/axum/issues/1986


### PR DESCRIPTION
## Description
This is first PR of series of PRs for refactoring of the machine-a-tron to support multiple simulated hosts.

What is in here:

- Remove double power state handling in tar router and in bmc mock wrapper.
- Removes handlers for set_any to make all POST/PATCH requests explicitly handled
- Added account_service that simulates Dell behavior (for now)

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

