### PR TITLE
feat: Export DPU metrics to Augtera collector

### DIFF
--- a/bluefield/otel/otel_config.yaml
+++ b/bluefield/otel/otel_config.yaml
@@ -365,6 +365,17 @@ exporters:
       initial_interval: 5s
       max_interval: 30s
       max_elapsed_time: 1h
+  otlp/site/augtera:
+    # LoadBalancer service augtera/otel-collector-relay
+    endpoint: 10.91.192.144:4317
+    tls:
+      insecure: true
+      # TODO: Add cert and key files
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 1h
   prometheus:
     endpoint: "127.0.0.1:9999"
     resource_to_telemetry_conversion:
@@ -431,7 +442,7 @@ service:
         - resource/metrics-node-exporter
         - telemetry_stats
         - batch/metrics
-      exporters: [otlp/site, prometheus]
+      exporters: [otlp/site, otlp/site/augtera, prometheus]
     metrics/dts:
       receivers: [prometheus/dts]
       processors:
@@ -441,7 +452,7 @@ service:
         - transform/metrics-dts
         - telemetry_stats
         - batch/metrics
-      exporters: [otlp/site, prometheus]
+      exporters: [otlp/site, otlp/site/augtera, prometheus]
     metrics/transceiver-exporter:
       receivers: [prometheus/transceiver]
       processors:
@@ -450,7 +461,7 @@ service:
         - resource/metrics-transceiver
         - telemetry_stats
         - batch/metrics
-      exporters: [otlp/site, prometheus]
+      exporters: [otlp/site, otlp/site/augtera, prometheus]
     metrics/hostmetrics:
       receivers: [hostmetrics]
       processors:

--- a/crates/agent/templates/dpu_extension_service_observability.tmpl
+++ b/crates/agent/templates/dpu_extension_service_observability.tmpl
@@ -47,7 +47,7 @@ service:
                     - resource/metrics-{{ .Id }}
                     - telemetry_stats
                     - batch/metrics
-                exporters: [otlp/site, prometheus]
+                exporters: [otlp/site, otlp/site/augtera, prometheus]
             {{- end }}
             {{- range $obsvConfig.Logging}}
             logs/{{ .Id }}:


### PR DESCRIPTION
## Description

Export DPU metrics to Augtera collector by extending the otelcol config with an OTLP exporter pointing to the Augtera service LoadBalancer IP.

- TLS support to be done
- limit to metrics from DPU extension services, node-exporter, DTS and transceiver

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

