### PR TITLE
Support for DPF enable/disable for expected machines

### DIFF
--- a/crates/admin-cli/src/cfg/cli_options.rs
+++ b/crates/admin-cli/src/cfg/cli_options.rs
@@ -289,7 +289,12 @@ pub enum CliCommand {
     )]
     LogicalPartition(nvl_logical_partition::Cmd),
 
-    #[clap(about = "DPF management", subcommand)]
+    #[clap(subcommand)]
+    #[clap(verbatim_doc_comment)]
+    /// DPF-related commands.
+    /// Note: These commands update the DPF state of the machine, which determines DPF-based DPU re-provisioning.
+    /// The state is saved in the machine's metadata and will be deleted if the machine is force-deleted.
+    /// To make the state persistent, add the DPF state for a machine (host) to the expected machines table.
     Dpf(crate::dpf::args::Cmd),
 
     #[clap(about = "Tenant management", subcommand, visible_alias = "tm")]

--- a/crates/admin-cli/src/expected_machines/args.rs
+++ b/crates/admin-cli/src/expected_machines/args.rs
@@ -167,6 +167,15 @@ pub struct ExpectedMachine {
         action = clap::ArgAction::Append
     )]
     pub rack_id: Option<String>,
+
+    #[clap(
+        long,
+        action = clap::ArgAction::Set,
+        value_name = "DPF_ENABLED",
+        help = "DPF enable/disable for this machine. Default is updated as true.",
+        default_value_t = true
+    )]
+    pub dpf_enabled: bool,
 }
 
 impl ExpectedMachine {
@@ -218,6 +227,7 @@ pub struct ExpectedMachineJson {
     #[serde(default)]
     pub host_nics: Vec<rpc::forge::ExpectedHostNic>,
     pub rack_id: Option<String>,
+    pub dpf_enabled: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -313,6 +323,15 @@ pub struct PatchExpectedMachine {
         help = "A RACK ID that will be added for the newly created Machine."
     )]
     pub rack_id: Option<String>,
+
+    #[clap(
+        long,
+        action = clap::ArgAction::Set,
+        value_name = "DPF_ENABLED",
+        help = "DPF enable/disable for this machine. Default is updated as true.",
+        default_value_t = true
+    )]
+    pub dpf_enabled: bool,
 }
 
 impl PatchExpectedMachine {

--- a/crates/admin-cli/src/expected_machines/cmds.rs
+++ b/crates/admin-cli/src/expected_machines/cmds.rs
@@ -125,6 +125,7 @@ async fn convert_and_print_into_nice_table(
         "Description",
         "Labels",
         "SKU ID",
+        "DPF State",
     ]);
 
     for expected_machine in &expected_machines.expected_machines {
@@ -165,6 +166,7 @@ async fn convert_and_print_into_nice_table(
                 .as_ref()
                 .map(|x| x.to_string())
                 .unwrap_or_default(),
+            expected_machine.dpf_enabled.to_string(),
         ]);
     }
 

--- a/crates/admin-cli/src/expected_machines/mod.rs
+++ b/crates/admin-cli/src/expected_machines/mod.rs
@@ -61,6 +61,7 @@ impl Dispatch for Cmd {
                         expected_machine_data.id.clone(),
                         host_nics,
                         expected_machine_data.rack_id.clone(),
+                        expected_machine_data.dpf_enabled,
                     )
                     .await?;
                 Ok(())
@@ -92,6 +93,7 @@ impl Dispatch for Cmd {
                         expected_machine_data.labels.clone(),
                         expected_machine_data.sku_id.clone(),
                         expected_machine_data.rack_id.clone(),
+                        expected_machine_data.dpf_enabled,
                     )
                     .await?;
                 Ok(())
@@ -129,6 +131,7 @@ impl Dispatch for Cmd {
                         ),
                         expected_machine.sku_id,
                         expected_machine.rack_id,
+                        expected_machine.dpf_enabled,
                     )
                     .await?;
                 Ok(())

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -474,6 +474,7 @@ impl ApiClient {
         id: Option<String>,
         host_nics: Vec<::rpc::forge::ExpectedHostNic>,
         rack_id: Option<String>,
+        dpf_enabled: bool,
     ) -> Result<(), CarbideCliError> {
         let request = rpc::ExpectedMachine {
             bmc_mac_address: bmc_mac_address.to_string(),
@@ -486,6 +487,7 @@ impl ApiClient {
             id: id.map(|s| ::rpc::common::Uuid { value: s }),
             host_nics,
             rack_id,
+            dpf_enabled,
         };
 
         Ok(self.0.add_expected_machine(request).await?)
@@ -504,6 +506,7 @@ impl ApiClient {
         labels: Option<Vec<String>>,
         sku_id: Option<String>,
         rack_id: Option<String>,
+        dpf_enabled: bool,
     ) -> Result<(), CarbideCliError> {
         let expected_machine = self
             .0
@@ -562,6 +565,7 @@ impl ApiClient {
             // TODO(chet): Add support for patching host_nics at some point.
             host_nics: expected_machine.host_nics,
             rack_id: rack_id.or(expected_machine.rack_id),
+            dpf_enabled,
         };
 
         Ok(self.0.update_expected_machine(request).await?)
@@ -699,6 +703,7 @@ impl ApiClient {
                     sku_id: machine.sku_id,
                     host_nics: machine.host_nics,
                     rack_id: machine.rack_id,
+                    dpf_enabled: machine.dpf_enabled,
                 })
                 .collect(),
         };

--- a/crates/api-db/migrations/20260122093707_dpf_state_expected_machine.sql
+++ b/crates/api-db/migrations/20260122093707_dpf_state_expected_machine.sql
@@ -1,0 +1,2 @@
+-- Add migration script here
+ALTER TABLE expected_machines ADD COLUMN dpf_enabled BOOLEAN NOT NULL DEFAULT TRUE;

--- a/crates/api-db/src/dpa_interface.rs
+++ b/crates/api-db/src/dpa_interface.rs
@@ -432,6 +432,7 @@ mod test {
             ManagedHostState::Ready,
             &Metadata::default(),
             None,
+            true,
             2,
         )
         .await?;

--- a/crates/api-db/src/expected_machine.rs
+++ b/crates/api-db/src/expected_machine.rs
@@ -183,13 +183,13 @@ pub async fn create(
 ) -> DatabaseResult<ExpectedMachine> {
     // If an id was provided in the RPC, we want to use it
     let query_with_id = "INSERT INTO expected_machines
-            (id, bmc_mac_address, bmc_username, bmc_password, serial_number, fallback_dpu_serial_numbers, metadata_name, metadata_description, metadata_labels, sku_id, host_nics, rack_id)
+            (id, bmc_mac_address, bmc_username, bmc_password, serial_number, fallback_dpu_serial_numbers, metadata_name, metadata_description, metadata_labels, sku_id, host_nics, rack_id, dpf_enabled)
             VALUES
-            ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::text[], $7, $8, $9::jsonb, $10::varchar, $11::jsonb, $12) RETURNING *";
+            ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::text[], $7, $8, $9::jsonb, $10::varchar, $11::jsonb, $12, $13) RETURNING *";
     let query_without_id = "INSERT INTO expected_machines
-            (bmc_mac_address, bmc_username, bmc_password, serial_number, fallback_dpu_serial_numbers, metadata_name, metadata_description, metadata_labels, sku_id, host_nics, rack_id)
+            (bmc_mac_address, bmc_username, bmc_password, serial_number, fallback_dpu_serial_numbers, metadata_name, metadata_description, metadata_labels, sku_id, host_nics, rack_id, dpf_enabled)
             VALUES
-            ($1::macaddr, $2::varchar, $3::varchar, $4::varchar, $5::text[], $6, $7, $8::jsonb, $9::varchar, $10::jsonb, $11) RETURNING *";
+            ($1::macaddr, $2::varchar, $3::varchar, $4::varchar, $5::text[], $6, $7, $8::jsonb, $9::varchar, $10::jsonb, $11, $12) RETURNING *";
 
     if let Some(id) = data.override_id {
         sqlx::query_as(query_with_id)
@@ -205,6 +205,7 @@ pub async fn create(
             .bind(data.sku_id)
             .bind(sqlx::types::Json(data.host_nics))
             .bind(data.rack_id)
+            .bind(data.dpf_enabled)
             .fetch_one(txn)
             .await
             .map_err(|err: sqlx::Error| match err {
@@ -226,6 +227,7 @@ pub async fn create(
             .bind(data.sku_id)
             .bind(sqlx::types::Json(data.host_nics))
             .bind(data.rack_id)
+            .bind(data.dpf_enabled)
             .fetch_one(txn)
             .await
             .map_err(|err: sqlx::Error| match err {
@@ -290,7 +292,7 @@ pub async fn update<'a>(
     txn: &mut PgConnection,
     data: ExpectedMachineData,
 ) -> DatabaseResult<&'a mut ExpectedMachine> {
-    let query = "UPDATE expected_machines SET bmc_username=$1, bmc_password=$2, serial_number=$3, fallback_dpu_serial_numbers=$4, metadata_name=$5, metadata_description=$6, metadata_labels=$7, sku_id=$8, host_nics=$9::jsonb, rack_id=$10 WHERE bmc_mac_address=$11 RETURNING bmc_mac_address";
+    let query = "UPDATE expected_machines SET bmc_username=$1, bmc_password=$2, serial_number=$3, fallback_dpu_serial_numbers=$4, metadata_name=$5, metadata_description=$6, metadata_labels=$7, sku_id=$8, host_nics=$9::jsonb, rack_id=$10, dpf_enabled=$11 WHERE bmc_mac_address=$12 RETURNING bmc_mac_address";
 
     let _: () = sqlx::query_as(query)
         .bind(&data.bmc_username)
@@ -303,6 +305,7 @@ pub async fn update<'a>(
         .bind(&data.sku_id)
         .bind(sqlx::types::Json(&data.host_nics))
         .bind(&data.rack_id)
+        .bind(data.dpf_enabled)
         .bind(value.bmc_mac_address)
         .fetch_one(txn)
         .await
@@ -323,7 +326,7 @@ pub async fn update_by_id(
     id: Uuid,
     data: ExpectedMachineData,
 ) -> DatabaseResult<()> {
-    let query = "UPDATE expected_machines SET bmc_username=$1, bmc_password=$2, serial_number=$3, fallback_dpu_serial_numbers=$4, metadata_name=$5, metadata_description=$6, metadata_labels=$7, sku_id=$8, host_nics=$9::jsonb, rack_id=$10 WHERE id=$11 RETURNING id";
+    let query = "UPDATE expected_machines SET bmc_username=$1, bmc_password=$2, serial_number=$3, fallback_dpu_serial_numbers=$4, metadata_name=$5, metadata_description=$6, metadata_labels=$7, sku_id=$8, host_nics=$9::jsonb, rack_id=$10, dpf_enabled=$11 WHERE id=$12 RETURNING id";
 
     let _: () = sqlx::query_as(query)
         .bind(&data.bmc_username)
@@ -336,6 +339,7 @@ pub async fn update_by_id(
         .bind(&data.sku_id)
         .bind(sqlx::types::Json(&data.host_nics))
         .bind(&data.rack_id)
+        .bind(data.dpf_enabled)
         .bind(id)
         .fetch_one(txn)
         .await

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -125,6 +125,7 @@ pub async fn get_or_create(
             state,
             &Metadata::default(),
             None,
+            true,
             2,
         )
         .await?;
@@ -1212,6 +1213,7 @@ pub async fn clear_failure_details(
 ///
 /// If metadata.name is empty then it is initialized in
 /// stable_machine_id.to_string().
+#[allow(clippy::too_many_arguments)]
 pub async fn create(
     txn: &mut PgConnection,
     common_pools: Option<&CommonPools>,
@@ -1219,6 +1221,7 @@ pub async fn create(
     state: ManagedHostState,
     metadata: &Metadata,
     sku_id: Option<&String>,
+    dpf_enabled: bool,
     state_model_version: i16,
 ) -> DatabaseResult<Machine> {
     let stable_machine_id_string = stable_machine_id.to_string();
@@ -1258,8 +1261,8 @@ pub async fn create(
     };
 
     let query = r#"INSERT INTO machines(
-                            id, controller_state_version, controller_state, network_config_version, network_config, machine_state_model_version, asn, version, name, description, labels, hw_sku)
-                            VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::json, $12) RETURNING id"#;
+                            id, controller_state_version, controller_state, network_config_version, network_config, machine_state_model_version, asn, version, name, description, labels, hw_sku, dpf_enabled)
+                            VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::json, $12, $13) RETURNING id"#;
     let machine_id: MachineId = sqlx::query_as(query)
         .bind(&stable_machine_id_string)
         .bind(state_version)
@@ -1273,6 +1276,7 @@ pub async fn create(
         .bind(&metadata.description)
         .bind(sqlx::types::Json(&metadata.labels))
         .bind(sku_id)
+        .bind(dpf_enabled)
         .fetch_one(&mut *txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -2265,6 +2269,7 @@ mod test {
             ManagedHostState::Ready,
             &Metadata::default(),
             None,
+            true,
             2,
         )
         .await?;

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -59,6 +59,8 @@ pub struct ExpectedMachineData {
     #[serde(default)]
     pub host_nics: Vec<ExpectedHostNic>,
     pub rack_id: Option<String>,
+    #[serde(default)]
+    pub dpf_enabled: bool,
 }
 // Important : new fields for expected machine (and data) should be optional _and_ serde(default),
 // unless you want to go update all the files in each production deployment that autoload
@@ -89,6 +91,7 @@ impl<'r> FromRow<'r, PgRow> for ExpectedMachine {
                 override_id: None,
                 rack_id: row.try_get("rack_id")?,
                 host_nics,
+                dpf_enabled: row.try_get("dpf_enabled")?,
             },
         })
     }
@@ -139,6 +142,7 @@ impl From<ExpectedMachine> for rpc::forge::ExpectedMachine {
             sku_id: expected_machine.data.sku_id,
             rack_id: expected_machine.data.rack_id,
             host_nics,
+            dpf_enabled: expected_machine.data.dpf_enabled,
         }
     }
 }
@@ -182,6 +186,7 @@ impl TryFrom<rpc::forge::ExpectedMachine> for ExpectedMachineData {
             override_id: em.id.and_then(|u| Uuid::parse_str(&u.value).ok()),
             host_nics: em.host_nics.into_iter().map(|nic| nic.into()).collect(),
             rack_id: em.rack_id,
+            dpf_enabled: em.dpf_enabled,
         })
     }
 }

--- a/crates/api/src/measured_boot/tests/common.rs
+++ b/crates/api/src/measured_boot/tests/common.rs
@@ -49,6 +49,7 @@ pub async fn create_test_machine(
         ManagedHostState::Ready,
         &Metadata::default(),
         None,
+        true,
         CURRENT_STATE_MODEL_VERSION,
     )
     .await?;

--- a/crates/api/src/measured_boot/tests/rpc.rs
+++ b/crates/api/src/measured_boot/tests/rpc.rs
@@ -2036,6 +2036,7 @@ mod tests {
             ManagedHostState::Ready,
             &Metadata::default(),
             None,
+            true,
             CURRENT_STATE_MODEL_VERSION,
         )
         .await

--- a/crates/api/src/tests/machine_creator.rs
+++ b/crates/api/src/tests/machine_creator.rs
@@ -1078,3 +1078,285 @@ async fn test_mi_attach_dpu_if_mi_created_after_machine_creation(
 
     Ok(())
 }
+
+#[crate::sqlx_test]
+async fn test_site_explorer_creates_managed_host_with_dpf_disable(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Prevent Firmware update here, since we test it in other method
+    let mut config = common::api_fixtures::get_config();
+    config.dpu_config.dpu_models = HashMap::new();
+    let env = common::api_fixtures::create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides::with_config(config),
+    )
+    .await;
+
+    let explorer_config = SiteExplorerConfig {
+        enabled: true,
+        explorations_per_run: 2,
+        concurrent_explorations: 1,
+        run_interval: std::time::Duration::from_secs(1),
+        create_machines: Arc::new(true.into()),
+        create_power_shelves: Arc::new(true.into()),
+        explore_power_shelves_from_static_ip: Arc::new(true.into()),
+        power_shelves_created_per_run: 1,
+        create_switches: Arc::new(true.into()),
+        explore_switches_from_static_ip: Arc::new(true.into()),
+        switches_created_per_run: 1,
+        ..Default::default()
+    };
+
+    let machine_creator =
+        MachineCreator::new(env.pool.clone(), explorer_config, env.common_pools.clone());
+
+    let oob_mac = MacAddress::from_str("a0:88:c2:08:80:95")?;
+    let response = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder(oob_mac, "192.0.1.1")
+                .vendor_string("NVIDIA/OOB")
+                .tonic_request(),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(!response.address.is_empty());
+
+    // Use a known DPU serial so we can assert on the generated MachineId
+    let dpu_serial = "MT2328XZ185R".to_string();
+    let expected_machine_id =
+        "fm100ds3gfip02lfgleidqoitqgh8d8mdc4a3j2tdncbjrfjtvrrhn2kleg".to_string();
+
+    let mock_dpu = DpuConfig::with_serial(dpu_serial.clone());
+    let mock_host = ManagedHostConfig::with_dpus(vec![mock_dpu.clone()]);
+    let mut dpu_report: EndpointExplorationReport = mock_dpu.clone().into();
+    dpu_report.generate_machine_id(false)?;
+
+    assert!(dpu_report.machine_id.as_ref().is_some());
+    assert_eq!(
+        dpu_report.machine_id.as_ref().unwrap().to_string(),
+        expected_machine_id,
+    );
+
+    let response = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder(mock_host.bmc_mac_address, "192.0.1.1")
+                .vendor_string("NVIDIA/OOB")
+                .tonic_request(),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(!response.address.is_empty());
+
+    let interface_id = response.machine_interface_id;
+    let mut ifaces = env
+        .api
+        .find_interfaces(tonic::Request::new(rpc::forge::InterfaceSearchQuery {
+            id: Some(interface_id.unwrap()),
+            ip: None,
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(ifaces.interfaces.len(), 1);
+    let iface = ifaces.interfaces.remove(0);
+    let mut addresses = iface.address;
+    let host_bmc_ip = addresses.remove(0);
+
+    let dpu_report = Arc::new(dpu_report);
+    let exploration_report = ExploredManagedHost {
+        host_bmc_ip: IpAddr::from_str(&host_bmc_ip)?,
+        dpus: vec![ExploredDpu {
+            bmc_ip: IpAddr::from_str(response.address.as_str())?,
+            host_pf_mac_address: Some(mock_dpu.host_mac_address),
+            report: dpu_report.clone(),
+        }],
+    };
+
+    let expected_machine = model::expected_machine::ExpectedMachine {
+        id: Some(uuid::Uuid::new_v4()),
+        bmc_mac_address: mock_host.bmc_mac_address,
+        data: model::expected_machine::ExpectedMachineData {
+            dpf_enabled: false,
+            ..Default::default()
+        },
+    };
+
+    assert!(
+        machine_creator
+            .create_managed_host(
+                &exploration_report,
+                EndpointExplorationReport::default(),
+                Some(&expected_machine),
+                &env.pool,
+            )
+            .await?
+    );
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let machines = db::machine::find(
+        &mut txn,
+        db::ObjectFilter::All,
+        MachineSearchConfig {
+            include_predicted_host: true,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(machines.len(), 2);
+    for machine in machines {
+        if machine.is_dpu() {
+            assert!(machine.dpf_enabled);
+        } else {
+            assert!(!machine.dpf_enabled);
+        }
+    }
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_site_explorer_creates_managed_host_with_dpf_enabled(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Prevent Firmware update here, since we test it in other method
+    let mut config = common::api_fixtures::get_config();
+    config.dpu_config.dpu_models = HashMap::new();
+    let env = common::api_fixtures::create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides::with_config(config),
+    )
+    .await;
+
+    let explorer_config = SiteExplorerConfig {
+        enabled: true,
+        explorations_per_run: 2,
+        concurrent_explorations: 1,
+        run_interval: std::time::Duration::from_secs(1),
+        create_machines: Arc::new(true.into()),
+        create_power_shelves: Arc::new(true.into()),
+        explore_power_shelves_from_static_ip: Arc::new(true.into()),
+        power_shelves_created_per_run: 1,
+        create_switches: Arc::new(true.into()),
+        explore_switches_from_static_ip: Arc::new(true.into()),
+        switches_created_per_run: 1,
+        ..Default::default()
+    };
+
+    let machine_creator =
+        MachineCreator::new(env.pool.clone(), explorer_config, env.common_pools.clone());
+
+    let oob_mac = MacAddress::from_str("a0:88:c2:08:80:95")?;
+    let response = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder(oob_mac, "192.0.1.1")
+                .vendor_string("NVIDIA/OOB")
+                .tonic_request(),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(!response.address.is_empty());
+
+    // Use a known DPU serial so we can assert on the generated MachineId
+    let dpu_serial = "MT2328XZ185R".to_string();
+    let expected_machine_id =
+        "fm100ds3gfip02lfgleidqoitqgh8d8mdc4a3j2tdncbjrfjtvrrhn2kleg".to_string();
+
+    let mock_dpu = DpuConfig::with_serial(dpu_serial.clone());
+    let mock_host = ManagedHostConfig::with_dpus(vec![mock_dpu.clone()]);
+    let mut dpu_report: EndpointExplorationReport = mock_dpu.clone().into();
+    dpu_report.generate_machine_id(false)?;
+
+    assert!(dpu_report.machine_id.as_ref().is_some());
+    assert_eq!(
+        dpu_report.machine_id.as_ref().unwrap().to_string(),
+        expected_machine_id,
+    );
+
+    let response = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder(mock_host.bmc_mac_address, "192.0.1.1")
+                .vendor_string("NVIDIA/OOB")
+                .tonic_request(),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(!response.address.is_empty());
+
+    let interface_id = response.machine_interface_id;
+    let mut ifaces = env
+        .api
+        .find_interfaces(tonic::Request::new(rpc::forge::InterfaceSearchQuery {
+            id: Some(interface_id.unwrap()),
+            ip: None,
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(ifaces.interfaces.len(), 1);
+    let iface = ifaces.interfaces.remove(0);
+    let mut addresses = iface.address;
+    let host_bmc_ip = addresses.remove(0);
+
+    let dpu_report = Arc::new(dpu_report);
+    let exploration_report = ExploredManagedHost {
+        host_bmc_ip: IpAddr::from_str(&host_bmc_ip)?,
+        dpus: vec![ExploredDpu {
+            bmc_ip: IpAddr::from_str(response.address.as_str())?,
+            host_pf_mac_address: Some(mock_dpu.host_mac_address),
+            report: dpu_report.clone(),
+        }],
+    };
+
+    let expected_machine = model::expected_machine::ExpectedMachine {
+        id: Some(uuid::Uuid::new_v4()),
+        bmc_mac_address: mock_host.bmc_mac_address,
+        data: model::expected_machine::ExpectedMachineData {
+            dpf_enabled: true,
+            ..Default::default()
+        },
+    };
+
+    assert!(
+        machine_creator
+            .create_managed_host(
+                &exploration_report,
+                EndpointExplorationReport::default(),
+                Some(&expected_machine),
+                &env.pool,
+            )
+            .await?
+    );
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let machines = db::machine::find(
+        &mut txn,
+        db::ObjectFilter::All,
+        MachineSearchConfig {
+            include_predicted_host: true,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(machines.len(), 2);
+    for machine in machines {
+        assert!(machine.dpf_enabled);
+    }
+
+    Ok(())
+}

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -1242,6 +1242,7 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
             override_id: None,
             host_nics: vec![],
             rack_id: None,
+            dpf_enabled: true,
         },
     )
     .await?;
@@ -1292,6 +1293,7 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
             override_id: None,
             host_nics: vec![],
             rack_id: None,
+            dpf_enabled: true,
         },
     )
     .await?;
@@ -2234,6 +2236,7 @@ async fn test_machine_creation_with_sku(
             override_id: None,
             host_nics: vec![],
             rack_id: None,
+            dpf_enabled: true,
         },
     )
     .await?;
@@ -2264,6 +2267,7 @@ async fn test_machine_creation_with_sku(
             assert_eq!(m.hw_sku, None);
         } else {
             assert_eq!(m.hw_sku, Some("Sku1".to_string()));
+            assert!(m.dpf_enabled);
         }
     }
 
@@ -2363,6 +2367,7 @@ async fn test_expected_machine_device_type_metrics(
             override_id: None,
             host_nics: vec![],
             rack_id: None,
+            dpf_enabled: true,
         },
     )
     .await?;
@@ -2380,6 +2385,7 @@ async fn test_expected_machine_device_type_metrics(
             override_id: None,
             host_nics: vec![],
             rack_id: None,
+            dpf_enabled: true,
         },
     )
     .await?;
@@ -2397,6 +2403,7 @@ async fn test_expected_machine_device_type_metrics(
             override_id: None,
             host_nics: vec![],
             rack_id: None,
+            dpf_enabled: true,
         },
     )
     .await?;

--- a/crates/api/src/tests/sku.rs
+++ b/crates/api/src/tests/sku.rs
@@ -789,6 +789,7 @@ pub mod tests {
                 override_id: None,
                 host_nics: vec![],
                 rack_id: None,
+                dpf_enabled: true,
             },
         )
         .await?;
@@ -876,6 +877,7 @@ pub mod tests {
                 override_id: None,
                 host_nics: vec![],
                 rack_id: None,
+                dpf_enabled: true,
             },
         )
         .await?;
@@ -938,6 +940,7 @@ pub mod tests {
                 override_id: None,
                 host_nics: vec![],
                 rack_id: None,
+                dpf_enabled: true,
             },
         )
         .await?;
@@ -1017,6 +1020,7 @@ pub mod tests {
                 override_id: None,
                 host_nics: vec![],
                 rack_id: None,
+                dpf_enabled: true,
             },
         )
         .await?;
@@ -1447,6 +1451,7 @@ pub mod tests {
                 override_id: None,
                 host_nics: vec![],
                 rack_id: None,
+                dpf_enabled: true,
             },
         )
         .await?;

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -546,6 +546,7 @@ impl ApiClient {
                 id: None,
                 host_nics: vec![],
                 rack_id: None,
+                dpf_enabled: true,
             })
             .await
             .map_err(ClientApiError::InvocationError)

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -4412,6 +4412,7 @@ message ExpectedMachine {
   optional common.UUID id = 8;
   repeated ExpectedHostNic host_nics = 9;
   optional string rack_id = 10;
+  bool dpf_enabled = 11;
 }
 
 message ExpectedMachineRequest {


### PR DESCRIPTION
This flag is passed to the site explorer to create machines with DPF enabled or disabled.

## Description
Support for dpf_enabled flag in expected_machines. The dpf_enabled flag is used to update dpf field while creating Machine object.

## Type of Change
<!-- Check one that best describes this PR -->
- [ x ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
[issue-42](https://github.com/NVIDIA/carbide-core/issues/42)

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ x ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

