### PR TITLE
chore: bmc-mock: computer systems objects are generated now

### DIFF
--- a/crates/bmc-mock/src/bug.rs
+++ b/crates/bmc-mock/src/bug.rs
@@ -18,6 +18,8 @@ use arc_swap::ArcSwap;
 use duration_str::deserialize_option_duration;
 use serde::{Deserialize, Serialize};
 
+use crate::redfish;
+
 #[derive(Clone, Default)]
 pub struct InjectedBugs {
     all_dpu_lost_on_host: Arc<AtomicBool>,
@@ -80,25 +82,18 @@ pub struct AllDpuLostOnHost {}
 impl AllDpuLostOnHost {
     // This is Network adapter as it was reproduced in FORGE-7578.
     pub fn network_adapter(&self, chassis_id: &str, network_adapter_id: &str) -> serde_json::Value {
-        serde_json::json!({
-            "Id": network_adapter_id,
-            "Name": "Network Adpapter",
-            "Status": {
-                "State": "Enabled",
-                "Health": "OK"
-            },
-            "@odata.id": format!("/redfish/v1/Chassis/{chassis_id}/NetworkAdapters/{network_adapter_id}"),
-            "@odata.context": "/redfish/v1/$metadata#NetworkAdapter.NetworkAdapter",
-            "SKU": "",
-            "Model": "",
-            "Description": "A NetworkAdapter represents the physical network adapter capable of connecting to a computer network.",
-            "@odata.type": "#NetworkAdapter.v1_9_0.NetworkAdapter",
-            "SerialNumber": "",
-            "PartNumber": "",
-            "Manufacturer": "",
-            "NetworkDeviceFunctions": {
-                "@odata.id": format!("/redfish/v1/Chassis/{chassis_id}/NetworkAdapters/{network_adapter_id}/NetworkDeviceFunctions")
-            },
-        })
+        let resource = redfish::network_adapter::chassis_resource(chassis_id, network_adapter_id);
+        redfish::network_adapter::builder(&resource)
+            .status(redfish::resource::Status::Ok)
+            .model("")
+            .serial_number("")
+            .manufacturer("")
+            .part_number("")
+            .sku("")
+            .network_device_functions(&redfish::network_device_function::chassis_collection(
+                chassis_id,
+                network_adapter_id,
+            ))
+            .build()
     }
 }

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -158,6 +158,7 @@ impl MachineInfo {
                     })
                     .collect();
                 redfish::computer_system::SystemConfig {
+                    bmc_vendor: redfish::oem::BmcVendor::Dell,
                     systems: vec![redfish::computer_system::SingleSystemConfig {
                         id: Cow::Borrowed("System.Embedded.1"),
                         eth_interfaces,
@@ -169,6 +170,7 @@ impl MachineInfo {
                 }
             }
             MachineInfo::Dpu(dpu) => redfish::computer_system::SystemConfig {
+                bmc_vendor: redfish::oem::BmcVendor::Nvidia,
                 systems: vec![redfish::computer_system::SingleSystemConfig {
                     id: Cow::Borrowed("Bluefield"),
                     eth_interfaces: vec![

--- a/crates/bmc-mock/src/redfish/boot_options.rs
+++ b/crates/bmc-mock/src/redfish/boot_options.rs
@@ -10,6 +10,8 @@
  * its affiliates is strictly prohibited.
  */
 
+use std::borrow::Cow;
+
 use axum::Router;
 use axum::body::Body;
 use axum::extract::{Request, State};
@@ -19,9 +21,18 @@ use lazy_static::lazy_static;
 use regex::{Captures, Regex};
 use serde_json::json;
 
-use crate::MachineInfo;
 use crate::json::JsonExt;
 use crate::mock_machine_router::MockWrapperState;
+use crate::{MachineInfo, redfish};
+
+pub fn system_collection(system_id: &str) -> redfish::Collection<'static> {
+    let odata_id = format!("/redfish/v1/Systems/{system_id}/BootOptions");
+    redfish::Collection {
+        odata_id: Cow::Owned(odata_id),
+        odata_type: Cow::Borrowed("#BootOptionCollection.BootOptionCollection"),
+        name: Cow::Borrowed("Boot Options Collection"),
+    }
+}
 
 pub fn add_routes(r: Router<MockWrapperState>) -> Router<MockWrapperState> {
     r.route(

--- a/crates/bmc-mock/src/redfish/computer_system.rs
+++ b/crates/bmc-mock/src/redfish/computer_system.rs
@@ -14,15 +14,14 @@ use std::borrow::Cow;
 use std::sync::{Arc, Mutex};
 
 use axum::Router;
-use axum::body::Body;
-use axum::extract::{Json, Path, Request, State};
-use axum::http::{Method, StatusCode};
+use axum::extract::{Json, Path, State};
+use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, patch, post};
 use serde_json::json;
 
-use crate::json::JsonExt;
-use crate::mock_machine_router::{MockWrapperError, MockWrapperState, fallback_to_inner_router};
+use crate::json::{JsonExt, JsonPatch};
+use crate::mock_machine_router::{MockWrapperError, MockWrapperState};
 use crate::{MockPowerState, POWER_CYCLE_DELAY, PowerControl, redfish};
 
 pub fn collection() -> redfish::Collection<'static> {
@@ -43,7 +42,17 @@ pub fn resource<'a>(system_id: &'a str) -> redfish::Resource<'a> {
     }
 }
 
-pub fn add_routes(r: Router<MockWrapperState>) -> Router<MockWrapperState> {
+pub fn reset_target(system_id: &str) -> String {
+    format!(
+        "{}/Actions/ComputerSystem.Reset",
+        resource(system_id).odata_id
+    )
+}
+
+pub fn add_routes(
+    r: Router<MockWrapperState>,
+    bmc_vendor: redfish::oem::BmcVendor,
+) -> Router<MockWrapperState> {
     const SYSTEM_ID: &str = "{system_id}";
     const ETH_ID: &str = "{eth_id}";
     r.route(&collection().odata_id, get(get_system_collection))
@@ -51,13 +60,10 @@ pub fn add_routes(r: Router<MockWrapperState>) -> Router<MockWrapperState> {
             &resource(SYSTEM_ID).odata_id,
             get(get_system).patch(patch_system),
         )
+        .route(&reset_target(SYSTEM_ID), post(post_reset_system))
         .route(
-            "/redfish/v1/Systems/{system_id}/Actions/ComputerSystem.Reset",
-            post(post_reset_system),
-        )
-        .route(
-            "/redfish/v1/Systems/Bluefield/Settings",
-            patch(patch_dpu_settings).get(fallback_to_inner_router),
+            &bmc_vendor.make_settings_odata_id(&resource(SYSTEM_ID).odata_id),
+            patch(patch_dpu_settings),
         )
         .route(
             &redfish::ethernet_interface::system_resource(SYSTEM_ID, ETH_ID).odata_id,
@@ -79,6 +85,7 @@ pub struct SingleSystemConfig {
 }
 
 pub struct SystemConfig {
+    pub bmc_vendor: redfish::oem::BmcVendor,
     pub systems: Vec<SingleSystemConfig>,
 }
 
@@ -152,107 +159,43 @@ async fn get_system_collection(State(state): State<MockWrapperState>) -> Respons
 }
 
 async fn get_system(
-    State(mut state): State<MockWrapperState>,
+    State(state): State<MockWrapperState>,
     Path(system_id): Path<String>,
-    request: Request<Body>,
 ) -> Response {
-    let json = match state.call_inner_router(request).await {
-        Ok(json) => json,
-        Err(err) => return err.into_response(),
-    };
     let Some(system_state) = state.bmc_state.system_state.find(&system_id) else {
         return not_found();
     };
 
-    let json = if let Some(state) = system_state
+    let mut b = builder(&resource(&system_id))
+        .ethernet_interfaces(redfish::ethernet_interface::system_collection(&system_id))
+        .serial_number(&system_state.config.serial_number)
+        .boot_options(&redfish::boot_options::system_collection(&system_id));
+
+    if let Some(state) = system_state
         .config
         .power_control
         .as_ref()
         .map(|control| control.get_power_state())
     {
-        let power_state = match state {
-            MockPowerState::On => "On",
-            MockPowerState::Off => "Off",
-            MockPowerState::PowerCycling { since } => {
-                if since.elapsed() < POWER_CYCLE_DELAY {
-                    "Off"
-                } else {
-                    "On"
-                }
-            }
-        };
-        json.patch(json!({ "PowerState": power_state }))
-    } else {
-        json
-    };
-    let json = json
-        .patch(
-            redfish::ethernet_interface::system_collection(&system_id)
-                .nav_property("EthernetInterfaces"),
-        )
-        .patch(json!({ "SerialNumber": &system_state.config.serial_number }));
+        b = b.power_state(state)
+    }
 
-    let mut json = if let Some(boot_order) = system_state.boot_order_override() {
-        json.patch(json!({"Boot": {"BootOrder": boot_order}}))
-    } else {
-        json
-    };
-
-    if system_id != "System.Embedded.1" {
-        return json.into_ok_response();
+    if let Some(boot_order) = system_state.boot_order_override() {
+        b = b.boot_order(&boot_order)
     }
 
     let dpu_count = system_state.config.pcie_dpu_count;
     if dpu_count == 0 {
-        return json.into_ok_response();
+        return b.build().into_ok_response();
     }
 
-    // Modify the Pcie Device List
-    // 1) Include a new entry for every mocked DPU in the host
-    // 2) Remove all unmocked DPU entries from the list
-    // (1): Create a new pcie device for the mocked DPUs in this host
     let mut pcie_devices = Vec::new();
     for index in 1..=dpu_count {
-        pcie_devices
-            .push(redfish::chassis::gen_dpu_pcie_device_resource(&system_id, index).entity_ref());
+        pcie_devices.push(redfish::chassis::gen_dpu_pcie_device_resource(
+            &system_id, index,
+        ));
     }
-
-    // (2) Remove any Pcie devices from the host's original list that refer to unmocked DPUs
-    let Some(devices) = json
-        .as_object_mut()
-        .and_then(|v| v.remove("PCIeDevices"))
-        .and_then(|mut v| v.as_array_mut().map(std::mem::take))
-    else {
-        return json.into_ok_response();
-    };
-    for device in devices {
-        let Some(odata_id) = device.get("@odata.id").and_then(|v| v.as_str()) else {
-            continue;
-        };
-        let Ok(upstream_json) = state
-            .call_inner_router(
-                Request::builder()
-                    .method(Method::GET)
-                    .uri(odata_id)
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-        else {
-            continue;
-        };
-        // Keep all default PCIE devices. Just remove any of the DPU entries
-        if upstream_json
-            .get("Manufacturer")
-            .and_then(|v| v.as_str())
-            .is_some_and(|v| v != "Mellanox Technologies")
-        {
-            pcie_devices.push(device);
-        }
-    }
-
-    json.patch(json!({"PCIeDevices": pcie_devices}))
-        .into_ok_response()
+    b.pcie_devices(&pcie_devices).build().into_ok_response()
 }
 
 async fn get_ethernet_interface(
@@ -359,4 +302,66 @@ async fn post_reset_system(
 
 fn not_found() -> Response {
     json!("").into_response(StatusCode::NOT_FOUND)
+}
+
+pub fn builder(resource: &redfish::Resource) -> SystemBuilder {
+    SystemBuilder {
+        value: resource.json_patch(),
+    }
+}
+
+pub struct SystemBuilder {
+    value: serde_json::Value,
+}
+
+impl SystemBuilder {
+    pub fn serial_number(self, v: &str) -> Self {
+        self.add_str_field("SerialNumber", v)
+    }
+
+    pub fn ethernet_interfaces(self, v: redfish::Collection<'_>) -> Self {
+        self.apply_patch(v.nav_property("EthernetInterfaces"))
+    }
+
+    pub fn boot_order(self, boot_order: &[String]) -> Self {
+        self.apply_patch(json!({"Boot": {"BootOrder": boot_order}}))
+    }
+
+    pub fn boot_options(self, boot_options: &redfish::Collection<'_>) -> Self {
+        self.apply_patch(json!({"Boot": boot_options.nav_property("BootOptions")}))
+    }
+
+    pub fn pcie_devices(self, devices: &[redfish::Resource<'_>]) -> Self {
+        let devices = devices.iter().map(|r| r.entity_ref()).collect::<Vec<_>>();
+        self.apply_patch(json!({"PCIeDevices": devices}))
+    }
+
+    pub fn power_state(self, state: MockPowerState) -> Self {
+        let power_state = match state {
+            MockPowerState::On => "On",
+            MockPowerState::Off => "Off",
+            MockPowerState::PowerCycling { since } => {
+                if since.elapsed() < POWER_CYCLE_DELAY {
+                    "Off"
+                } else {
+                    "On"
+                }
+            }
+        };
+        self.add_str_field("PowerState", power_state)
+    }
+
+    pub fn build(self) -> serde_json::Value {
+        self.value
+    }
+
+    fn add_str_field(self, name: &str, value: &str) -> Self {
+        self.apply_patch(json!({ name: value }))
+    }
+
+    fn apply_patch(self, patch: serde_json::Value) -> Self {
+        Self {
+            value: self.value.patch(patch),
+        }
+    }
 }

--- a/crates/bmc-mock/src/redfish/manager.rs
+++ b/crates/bmc-mock/src/redfish/manager.rs
@@ -44,7 +44,7 @@ pub fn resource<'a>(manager_id: &'a str) -> redfish::Resource<'a> {
 }
 
 pub fn reset_target(manager_id: &str) -> String {
-    format!("/redfish/v1/Managers/{manager_id}/Actions/Manager.Reset")
+    format!("{}/Actions/Manager.Reset", resource(manager_id).odata_id)
 }
 
 pub fn builder(resource: &redfish::Resource<'_>) -> ManagerBuilder {

--- a/crates/bmc-mock/src/redfish/network_adapter.rs
+++ b/crates/bmc-mock/src/redfish/network_adapter.rs
@@ -67,6 +67,10 @@ impl NetworkAdapterBuilder {
         self.add_str_field("SerialNumber", value)
     }
 
+    pub fn sku(self, value: &str) -> Self {
+        self.add_str_field("SKU", value)
+    }
+
     pub fn network_device_functions(self, collection: &redfish::Collection<'_>) -> Self {
         Self {
             value: self

--- a/crates/bmc-mock/src/redfish/oem/mod.rs
+++ b/crates/bmc-mock/src/redfish/oem/mod.rs
@@ -12,3 +12,19 @@
 
 pub mod dell;
 pub mod nvidia;
+
+#[derive(Clone, Copy, Debug)]
+pub enum BmcVendor {
+    Dell,
+    Nvidia,
+}
+
+impl BmcVendor {
+    // This function creates settings of the resource from the resource
+    // id. Real identifier is different for different BMC vendors.
+    pub fn make_settings_odata_id(&self, resource_odata_id: &str) -> String {
+        match self {
+            BmcVendor::Nvidia | BmcVendor::Dell => format!("{resource_odata_id}/Settings"),
+        }
+    }
+}


### PR DESCRIPTION
## Description

BMC mock generates all /v1/Systems/{} responses without using tar router.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
