### PR TITLE
chore: bmc-mock: computer systems objects are generated now

### DIFF
--- a/crates/bmc-mock/src/bug.rs
+++ b/crates/bmc-mock/src/bug.rs
@@ -18,6 +18,8 @@ use arc_swap::ArcSwap;
 use duration_str::deserialize_option_duration;
 use serde::{Deserialize, Serialize};
 
+use crate::redfish;
+
 #[derive(Clone, Default)]
 pub struct InjectedBugs {
     all_dpu_lost_on_host: Arc<AtomicBool>,
@@ -80,25 +82,18 @@ pub struct AllDpuLostOnHost {}
 impl AllDpuLostOnHost {
     // This is Network adapter as it was reproduced in FORGE-7578.
     pub fn network_adapter(&self, chassis_id: &str, network_adapter_id: &str) -> serde_json::Value {
-        serde_json::json!({
-            "Id": network_adapter_id,
-            "Name": "Network Adpapter",
-            "Status": {
-                "State": "Enabled",
-                "Health": "OK"
-            },
-            "@odata.id": format!("/redfish/v1/Chassis/{chassis_id}/NetworkAdapters/{network_adapter_id}"),
-            "@odata.context": "/redfish/v1/$metadata#NetworkAdapter.NetworkAdapter",
-            "SKU": "",
-            "Model": "",
-            "Description": "A NetworkAdapter represents the physical network adapter capable of connecting to a computer network.",
-            "@odata.type": "#NetworkAdapter.v1_9_0.NetworkAdapter",
-            "SerialNumber": "",
-            "PartNumber": "",
-            "Manufacturer": "",
-            "NetworkDeviceFunctions": {
-                "@odata.id": format!("/redfish/v1/Chassis/{chassis_id}/NetworkAdapters/{network_adapter_id}/NetworkDeviceFunctions")
-            },
-        })
+        let resource = redfish::network_adapter::chassis_resource(chassis_id, network_adapter_id);
+        redfish::network_adapter::builder(&resource)
+            .status(redfish::resource::Status::Ok)
+            .model("")
+            .serial_number("")
+            .manufacturer("")
+            .part_number("")
+            .sku("")
+            .network_device_functions(&redfish::network_device_function::chassis_collection(
+                chassis_id,
+                network_adapter_id,
+            ))
+            .build()
     }
 }

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -158,6 +158,7 @@ impl MachineInfo {
                     })
                     .collect();
                 redfish::computer_system::SystemConfig {
+                    bmc_vendor: redfish::oem::BmcVendor::Dell,
                     systems: vec![redfish::computer_system::SingleSystemConfig {
                         id: Cow::Borrowed("System.Embedded.1"),
                         eth_interfaces,
@@ -169,6 +170,7 @@ impl MachineInfo {
                 }
             }
             MachineInfo::Dpu(dpu) => redfish::computer_system::SystemConfig {
+                bmc_vendor: redfish::oem::BmcVendor::Nvidia,
                 systems: vec![redfish::computer_system::SingleSystemConfig {
                     id: Cow::Borrowed("Bluefield"),
                     eth_interfaces: vec![

--- a/crates/bmc-mock/src/redfish/boot_options.rs
+++ b/crates/bmc-mock/src/redfish/boot_options.rs
@@ -10,6 +10,8 @@
  * its affiliates is strictly prohibited.
  */
 
+use std::borrow::Cow;
+
 use axum::Router;
 use axum::body::Body;
 use axum::extract::{Request, State};
@@ -19,9 +21,18 @@ use lazy_static::lazy_static;
 use regex::{Captures, Regex};
 use serde_json::json;
 
-use crate::MachineInfo;
 use crate::json::JsonExt;
 use crate::mock_machine_router::MockWrapperState;
+use crate::{MachineInfo, redfish};
+
+pub fn system_collection(system_id: &str) -> redfish::Collection<'static> {
+    let odata_id = format!("/redfish/v1/Systems/{system_id}/BootOptions");
+    redfish::Collection {
+        odata_id: Cow::Owned(odata_id),
+        odata_type: Cow::Borrowed("#BootOptionCollection.BootOptionCollection"),
+        name: Cow::Borrowed("Boot Options Collection"),
+    }
+}
 
 pub fn add_routes(r: Router<MockWrapperState>) -> Router<MockWrapperState> {
     r.route(

--- a/crates/bmc-mock/src/redfish/manager.rs
+++ b/crates/bmc-mock/src/redfish/manager.rs
@@ -44,7 +44,7 @@ pub fn resource<'a>(manager_id: &'a str) -> redfish::Resource<'a> {
 }
 
 pub fn reset_target(manager_id: &str) -> String {
-    format!("/redfish/v1/Managers/{manager_id}/Actions/Manager.Reset")
+    format!("{}/Actions/Manager.Reset", resource(manager_id).odata_id)
 }
 
 pub fn builder(resource: &redfish::Resource<'_>) -> ManagerBuilder {

--- a/crates/bmc-mock/src/redfish/network_adapter.rs
+++ b/crates/bmc-mock/src/redfish/network_adapter.rs
@@ -67,6 +67,10 @@ impl NetworkAdapterBuilder {
         self.add_str_field("SerialNumber", value)
     }
 
+    pub fn sku(self, value: &str) -> Self {
+        self.add_str_field("SKU", value)
+    }
+
     pub fn network_device_functions(self, collection: &redfish::Collection<'_>) -> Self {
         Self {
             value: self

--- a/crates/bmc-mock/src/redfish/oem/mod.rs
+++ b/crates/bmc-mock/src/redfish/oem/mod.rs
@@ -12,3 +12,21 @@
 
 pub mod dell;
 pub mod nvidia;
+
+use crate::redfish::Resource;
+
+#[derive(Clone, Copy, Debug)]
+pub enum BmcVendor {
+    Dell,
+    Nvidia,
+}
+
+impl BmcVendor {
+    // This function creates settings of the resource from the resource
+    // id. Real identifier is different for different BMC vendors.
+    pub fn make_settings_odata_id(&self, resource: &Resource<'_>) -> String {
+        match self {
+            BmcVendor::Nvidia | BmcVendor::Dell => format!("{}/Settings", resource.odata_id),
+        }
+    }
+}


### PR DESCRIPTION
## Description

BMC mock generates all /v1/Systems/{} responses without using tar router.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
