### PR TITLE
feat: Make OTEL exporter lists configurable via environment variables

### DIFF
--- a/bluefield/otel/config-fragments/exporters.yaml
+++ b/bluefield/otel/config-fragments/exporters.yaml
@@ -1,0 +1,18 @@
+exporters:
+  otlp/site:
+    endpoint: otel-receiver.forge:443
+    tls:
+      ca_file: /opt/forge/forge_root.pem
+      cert_file: /etc/ssl/certs/forge-dpu-otel-agent.pem
+      key_file: /etc/ssl/private/forge-dpu-otel-agent.key
+      reload_interval: 1h
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 1h
+  prometheus:
+    endpoint: "127.0.0.1:9999"
+    resource_to_telemetry_conversion:
+      enabled: true
+

--- a/bluefield/otel/otel_config.yaml
+++ b/bluefield/otel/otel_config.yaml
@@ -352,24 +352,6 @@ processors:
             where metric.name == "hw_port_state"
             or metric.name == "ib_port_state"
 
-exporters:
-  otlp/site:
-    endpoint: otel-receiver.forge:443
-    tls:
-      ca_file: /opt/forge/forge_root.pem
-      cert_file: /etc/ssl/certs/forge-dpu-otel-agent.pem
-      key_file: /etc/ssl/private/forge-dpu-otel-agent.key
-      reload_interval: 1h
-    retry_on_failure:
-      enabled: true
-      initial_interval: 5s
-      max_interval: 30s
-      max_elapsed_time: 1h
-  prometheus:
-    endpoint: "127.0.0.1:9999"
-    resource_to_telemetry_conversion:
-      enabled: true
-
 service:
   pipelines:
     logs/journald:
@@ -382,7 +364,7 @@ service:
         - transform/journald
         - telemetry_stats
         - batch/logs
-      exporters: [otlp/site]
+      exporters: ${env:OTELCOL_LOGS_EXPORTERS_LIST}
     logs/journald-kernel:
       receivers: [journald/kernel]
       processors:
@@ -393,7 +375,7 @@ service:
         - transform/journald-kernel
         - telemetry_stats
         - batch/logs
-      exporters: [otlp/site]
+      exporters: ${env:OTELCOL_LOGS_EXPORTERS_LIST}
     logs/hbn:
       receivers: [filelog/doca]
       processors:
@@ -403,7 +385,7 @@ service:
         - resource/logs-hbn
         - telemetry_stats
         - batch/logs
-      exporters: [otlp/site]
+      exporters: ${env:OTELCOL_LOGS_EXPORTERS_LIST}
     logs/auth:
       receivers: [filelog/auth]
       processors:
@@ -413,7 +395,7 @@ service:
         - resource/logs-auth
         - telemetry_stats
         - batch/logs
-      exporters: [otlp/site]
+      exporters: ${env:OTELCOL_LOGS_EXPORTERS_LIST}
     metrics/fmds:
       receivers: [prometheus/fmds]
       processors:
@@ -422,7 +404,7 @@ service:
         - resource/metrics-fmds
         - telemetry_stats
         - batch/metrics
-      exporters: [otlp/site, prometheus]
+      exporters: ${env:OTELCOL_METRICS_EXPORTERS_LIST}
     metrics/node-exporter:
       receivers: [prometheus/node]
       processors:
@@ -431,7 +413,7 @@ service:
         - resource/metrics-node-exporter
         - telemetry_stats
         - batch/metrics
-      exporters: [otlp/site, prometheus]
+      exporters: ${env:OTELCOL_METRICS_EXPORTERS_LIST}
     metrics/dts:
       receivers: [prometheus/dts]
       processors:
@@ -441,7 +423,7 @@ service:
         - transform/metrics-dts
         - telemetry_stats
         - batch/metrics
-      exporters: [otlp/site, prometheus]
+      exporters: ${env:OTELCOL_METRICS_EXPORTERS_LIST}
     metrics/transceiver-exporter:
       receivers: [prometheus/transceiver]
       processors:
@@ -450,7 +432,7 @@ service:
         - resource/metrics-transceiver
         - telemetry_stats
         - batch/metrics
-      exporters: [otlp/site, prometheus]
+      exporters: ${env:OTELCOL_METRICS_EXPORTERS_LIST}
     metrics/hostmetrics:
       receivers: [hostmetrics]
       processors:
@@ -459,7 +441,7 @@ service:
         - resource/hostmetrics
         - telemetry_stats
         - batch/metrics
-      exporters: [otlp/site, prometheus]
+      exporters: ${env:OTELCOL_METRICS_EXPORTERS_LIST}
     metrics/hostmetrics-disk:
       receivers: [hostmetrics/disk]
       processors:
@@ -468,7 +450,7 @@ service:
         - resource/hostmetrics-disk
         - telemetry_stats
         - batch/metrics-disk
-      exporters: [otlp/site, prometheus]
+      exporters: ${env:OTELCOL_METRICS_EXPORTERS_LIST}
     metrics/log-stats:
       receivers: [prometheus/log-stats]
       processors:
@@ -476,7 +458,7 @@ service:
         - resourcedetection
         - resource/log-stats
         - batch/metrics
-      exporters: [otlp/site, prometheus]
+      exporters: ${env:OTELCOL_METRICS_EXPORTERS_LIST}
   extensions: [file_storage/cursors]
   # Internal otel collector metrics by default are exposed on port 8888,
   # already in use by Forge, causing otelcol-contrib to terminate with an

--- a/bluefield/otel/otelcol-wrapper
+++ b/bluefield/otel/otelcol-wrapper
@@ -1,5 +1,8 @@
 #!/bin/bash -p
 
+# Set default exporter lists if not already set
+export OTELCOL_LOGS_EXPORTERS_LIST="${OTELCOL_LOGS_EXPORTERS_LIST:-[otlp/site]}"
+export OTELCOL_METRICS_EXPORTERS_LIST="${OTELCOL_METRICS_EXPORTERS_LIST:-[otlp/site, prometheus]}"
 
 $HOSTNAME=$(hostname)
 

--- a/bluefield/otel/otelcol-wrapper-validate
+++ b/bluefield/otel/otelcol-wrapper-validate
@@ -1,5 +1,9 @@
 #!/bin/bash -p
 
+# Set default exporter lists if not already set
+export OTELCOL_LOGS_EXPORTERS_LIST="${OTELCOL_LOGS_EXPORTERS_LIST:-[otlp/site]}"
+export OTELCOL_METRICS_EXPORTERS_LIST="${OTELCOL_METRICS_EXPORTERS_LIST:-[otlp/site, prometheus]}"
+
 source /etc/otelcol-contrib/otelcol-wrapper-imports
 
 /usr/bin/otelcol-contrib validate --config=/etc/otelcol-contrib/config.yaml ${ADDITIONAL_CONFIGS}

--- a/crates/agent/templates/dpu_extension_service_observability.tmpl
+++ b/crates/agent/templates/dpu_extension_service_observability.tmpl
@@ -47,7 +47,7 @@ service:
                     - resource/metrics-{{ .Id }}
                     - telemetry_stats
                     - batch/metrics
-                exporters: [otlp/site, prometheus]
+                exporters: ${env:OTELCOL_METRICS_EXPORTERS_LIST}
             {{- end }}
             {{- range $obsvConfig.Logging}}
             logs/{{ .Id }}:
@@ -59,5 +59,5 @@ service:
                     - resource/logs-{{ .Id }}
                     - telemetry_stats
                     - batch/logs
-                exporters: [otlp/site]
+                exporters: ${env:OTELCOL_LOGS_EXPORTERS_LIST}
             {{- end }}


### PR DESCRIPTION
## Description

Make exporter lists configurable via environment variables to allow per-deployment customization without config file 
changes:
- OTELCOL_LOGS_EXPORTERS_LIST (default: [otlp/site])
- OTELCOL_METRICS_EXPORTERS_LIST (default: [otlp/site, prometheus])

Also add exporters config fragment for dynamic exporter definitions.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

