### PR TITLE
Support for dpf_enabled flag in expected_machines.

### DIFF
--- a/crates/admin-cli/src/cfg/cli_options.rs
+++ b/crates/admin-cli/src/cfg/cli_options.rs
@@ -298,7 +298,12 @@ pub enum CliCommand {
     )]
     LogicalPartition(nvl_logical_partition::Cmd),
 
-    #[clap(about = "DPF management", subcommand)]
+    #[clap(subcommand)]
+    #[clap(verbatim_doc_comment)]
+    /// DPF-related commands.
+    /// Note: These commands update the DPF state of the machine, which determines DPF-based DPU re-provisioning.
+    /// The state is saved in the machine's metadata and will be deleted if the machine is force-deleted.
+    /// To make the state persistent, add the DPF state for a machine (host) to the expected machines table.
     Dpf(crate::dpf::args::Cmd),
 
     #[clap(about = "Tenant management", subcommand, visible_alias = "tm")]

--- a/crates/admin-cli/src/expected_machines/args.rs
+++ b/crates/admin-cli/src/expected_machines/args.rs
@@ -167,12 +167,22 @@ pub struct ExpectedMachine {
         action = clap::ArgAction::Append
     )]
     pub rack_id: Option<String>,
+
     #[clap(
         long = "default_pause_ingestion_and_poweron",
         value_name = "DEFAULT_PAUSE_INGESTION_AND_POWERON",
         help = "Optional flag to pause machine's ingestion and power on. False - don't pause, true - will pause it. The actual mutable state is stored in explored_endpoints."
     )]
     pub default_pause_ingestion_and_poweron: Option<bool>,
+
+    #[clap(
+        long,
+        action = clap::ArgAction::Set,
+        value_name = "DPF_ENABLED",
+        help = "DPF enable/disable for this machine. Default is updated as true.",
+        default_value_t = true
+    )]
+    pub dpf_enabled: bool,
 }
 
 impl ExpectedMachine {
@@ -225,6 +235,7 @@ pub struct ExpectedMachineJson {
     pub host_nics: Vec<rpc::forge::ExpectedHostNic>,
     pub rack_id: Option<String>,
     pub default_pause_ingestion_and_poweron: Option<bool>,
+    pub dpf_enabled: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -320,12 +331,22 @@ pub struct PatchExpectedMachine {
         help = "A RACK ID that will be added for the newly created Machine."
     )]
     pub rack_id: Option<String>,
+
     #[clap(
         long = "default_pause_ingestion_and_poweron",
         value_name = "DEFAULT_PAUSE_INGESTION_AND_POWERON",
         help = "Optional flag to pause machine's ingestion and power on. False - don't pause, true - will pause it. The actual mutable state is stored in explored_endpoints."
     )]
     pub default_pause_ingestion_and_poweron: Option<bool>,
+
+    #[clap(
+        long,
+        action = clap::ArgAction::Set,
+        value_name = "DPF_ENABLED",
+        help = "DPF enable/disable for this machine. Default is updated as true.",
+        default_value_t = true
+    )]
+    pub dpf_enabled: bool,
 }
 
 impl PatchExpectedMachine {

--- a/crates/admin-cli/src/expected_machines/cmds.rs
+++ b/crates/admin-cli/src/expected_machines/cmds.rs
@@ -125,7 +125,8 @@ async fn convert_and_print_into_nice_table(
         "Description",
         "Labels",
         "SKU ID",
-        "Pause On Ingestion"
+        "Pause On Ingestion",
+        "DPF State",
     ]);
 
     for expected_machine in &expected_machines.expected_machines {
@@ -167,6 +168,7 @@ async fn convert_and_print_into_nice_table(
                 .map(|x| x.to_string())
                 .unwrap_or_default(),
             expected_machine.default_pause_ingestion_and_poweron(),
+            expected_machine.dpf_enabled.to_string(),
         ]);
     }
 

--- a/crates/admin-cli/src/expected_machines/mod.rs
+++ b/crates/admin-cli/src/expected_machines/mod.rs
@@ -62,6 +62,7 @@ impl Dispatch for Cmd {
                         host_nics,
                         expected_machine_data.rack_id.clone(),
                         expected_machine_data.default_pause_ingestion_and_poweron,
+                        expected_machine_data.dpf_enabled,
                     )
                     .await?;
                 Ok(())
@@ -94,6 +95,7 @@ impl Dispatch for Cmd {
                         expected_machine_data.sku_id.clone(),
                         expected_machine_data.rack_id.clone(),
                         expected_machine_data.default_pause_ingestion_and_poweron,
+                        expected_machine_data.dpf_enabled,
                     )
                     .await?;
                 Ok(())
@@ -132,6 +134,7 @@ impl Dispatch for Cmd {
                         expected_machine.sku_id,
                         expected_machine.rack_id,
                         expected_machine.default_pause_ingestion_and_poweron,
+                        expected_machine.dpf_enabled,
                     )
                     .await?;
                 Ok(())

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -476,6 +476,7 @@ impl ApiClient {
         host_nics: Vec<::rpc::forge::ExpectedHostNic>,
         rack_id: Option<String>,
         default_pause_ingestion_and_poweron: Option<bool>,
+        dpf_enabled: bool,
     ) -> Result<(), CarbideCliError> {
         let request = rpc::ExpectedMachine {
             bmc_mac_address: bmc_mac_address.to_string(),
@@ -489,6 +490,7 @@ impl ApiClient {
             host_nics,
             rack_id,
             default_pause_ingestion_and_poweron,
+            dpf_enabled,
         };
 
         Ok(self.0.add_expected_machine(request).await?)
@@ -508,6 +510,7 @@ impl ApiClient {
         sku_id: Option<String>,
         rack_id: Option<String>,
         default_pause_ingestion_and_poweron: Option<bool>,
+        dpf_enabled: bool,
     ) -> Result<(), CarbideCliError> {
         let expected_machine = self
             .0
@@ -567,6 +570,7 @@ impl ApiClient {
             host_nics: expected_machine.host_nics,
             rack_id: rack_id.or(expected_machine.rack_id),
             default_pause_ingestion_and_poweron,
+            dpf_enabled,
         };
 
         Ok(self.0.update_expected_machine(request).await?)
@@ -714,6 +718,7 @@ impl ApiClient {
                     rack_id: machine.rack_id,
                     default_pause_ingestion_and_poweron: machine
                         .default_pause_ingestion_and_poweron,
+                    dpf_enabled: machine.dpf_enabled,
                 })
                 .collect(),
         };

--- a/crates/api-db/migrations/20260122093707_dpf_state_expected_machine.sql
+++ b/crates/api-db/migrations/20260122093707_dpf_state_expected_machine.sql
@@ -1,0 +1,2 @@
+-- Add migration script here
+ALTER TABLE expected_machines ADD COLUMN dpf_enabled BOOLEAN NOT NULL DEFAULT TRUE;

--- a/crates/api-db/src/dpa_interface.rs
+++ b/crates/api-db/src/dpa_interface.rs
@@ -482,6 +482,7 @@ mod test {
             ManagedHostState::Ready,
             &Metadata::default(),
             None,
+            true,
             2,
         )
         .await?;

--- a/crates/api-db/src/expected_machine.rs
+++ b/crates/api-db/src/expected_machine.rs
@@ -183,13 +183,13 @@ pub async fn create(
 ) -> DatabaseResult<ExpectedMachine> {
     // If an id was provided in the RPC, we want to use it
     let query_with_id = "INSERT INTO expected_machines
-            (id, bmc_mac_address, bmc_username, bmc_password, serial_number, fallback_dpu_serial_numbers, metadata_name, metadata_description, metadata_labels, sku_id, host_nics, rack_id, default_pause_ingestion_and_poweron)
+            (id, bmc_mac_address, bmc_username, bmc_password, serial_number, fallback_dpu_serial_numbers, metadata_name, metadata_description, metadata_labels, sku_id, host_nics, rack_id, default_pause_ingestion_and_poweron, dpf_enabled)
             VALUES
-            ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::text[], $7, $8, $9::jsonb, $10::varchar, $11::jsonb, $12, $13) RETURNING *";
+            ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::text[], $7, $8, $9::jsonb, $10::varchar, $11::jsonb, $12, $13, $14) RETURNING *";
     let query_without_id = "INSERT INTO expected_machines
-            (bmc_mac_address, bmc_username, bmc_password, serial_number, fallback_dpu_serial_numbers, metadata_name, metadata_description, metadata_labels, sku_id, host_nics, rack_id, default_pause_ingestion_and_poweron)
+            (bmc_mac_address, bmc_username, bmc_password, serial_number, fallback_dpu_serial_numbers, metadata_name, metadata_description, metadata_labels, sku_id, host_nics, rack_id, default_pause_ingestion_and_poweron, dpf_enabled)
             VALUES
-            ($1::macaddr, $2::varchar, $3::varchar, $4::varchar, $5::text[], $6, $7, $8::jsonb, $9::varchar, $10::jsonb, $11, $12) RETURNING *";
+            ($1::macaddr, $2::varchar, $3::varchar, $4::varchar, $5::text[], $6, $7, $8::jsonb, $9::varchar, $10::jsonb, $11, $12, $13) RETURNING *";
 
     if let Some(id) = data.override_id {
         sqlx::query_as(query_with_id)
@@ -206,6 +206,7 @@ pub async fn create(
             .bind(sqlx::types::Json(data.host_nics))
             .bind(data.rack_id)
             .bind(data.default_pause_ingestion_and_poweron.unwrap_or(false))
+            .bind(data.dpf_enabled)
             .fetch_one(txn)
             .await
             .map_err(|err: sqlx::Error| match err {
@@ -228,6 +229,7 @@ pub async fn create(
             .bind(sqlx::types::Json(data.host_nics))
             .bind(data.rack_id)
             .bind(data.default_pause_ingestion_and_poweron.unwrap_or(false))
+            .bind(data.dpf_enabled)
             .fetch_one(txn)
             .await
             .map_err(|err: sqlx::Error| match err {
@@ -292,7 +294,7 @@ pub async fn update<'a>(
     txn: &mut PgConnection,
     data: ExpectedMachineData,
 ) -> DatabaseResult<&'a mut ExpectedMachine> {
-    let query = "UPDATE expected_machines SET bmc_username=$1, bmc_password=$2, serial_number=$3, fallback_dpu_serial_numbers=$4, metadata_name=$5, metadata_description=$6, metadata_labels=$7, sku_id=$8, host_nics=$9::jsonb, rack_id=$10, default_pause_ingestion_and_poweron=COALESCE($11, default_pause_ingestion_and_poweron) WHERE bmc_mac_address=$12 RETURNING bmc_mac_address";
+    let query = "UPDATE expected_machines SET bmc_username=$1, bmc_password=$2, serial_number=$3, fallback_dpu_serial_numbers=$4, metadata_name=$5, metadata_description=$6, metadata_labels=$7, sku_id=$8, host_nics=$9::jsonb, rack_id=$10, default_pause_ingestion_and_poweron=COALESCE($11, default_pause_ingestion_and_poweron), dpf_enabled=$12 WHERE bmc_mac_address=$13 RETURNING bmc_mac_address";
 
     let _: () = sqlx::query_as(query)
         .bind(&data.bmc_username)
@@ -306,6 +308,7 @@ pub async fn update<'a>(
         .bind(sqlx::types::Json(&data.host_nics))
         .bind(&data.rack_id)
         .bind(data.default_pause_ingestion_and_poweron)
+        .bind(data.dpf_enabled)
         .bind(value.bmc_mac_address)
         .fetch_one(txn)
         .await
@@ -326,7 +329,7 @@ pub async fn update_by_id(
     id: Uuid,
     data: ExpectedMachineData,
 ) -> DatabaseResult<()> {
-    let query = "UPDATE expected_machines SET bmc_username=$1, bmc_password=$2, serial_number=$3, fallback_dpu_serial_numbers=$4, metadata_name=$5, metadata_description=$6, metadata_labels=$7, sku_id=$8, host_nics=$9::jsonb, rack_id=$10, default_pause_ingestion_and_poweron=COALESCE($11, default_pause_ingestion_and_poweron) WHERE id=$12 RETURNING id";
+    let query = "UPDATE expected_machines SET bmc_username=$1, bmc_password=$2, serial_number=$3, fallback_dpu_serial_numbers=$4, metadata_name=$5, metadata_description=$6, metadata_labels=$7, sku_id=$8, host_nics=$9::jsonb, rack_id=$10, default_pause_ingestion_and_poweron=COALESCE($11, default_pause_ingestion_and_poweron), dpf_enabled=$12 WHERE id=$13 RETURNING id";
 
     let _: () = sqlx::query_as(query)
         .bind(&data.bmc_username)
@@ -340,6 +343,7 @@ pub async fn update_by_id(
         .bind(sqlx::types::Json(&data.host_nics))
         .bind(&data.rack_id)
         .bind(data.default_pause_ingestion_and_poweron)
+        .bind(data.dpf_enabled)
         .bind(id)
         .fetch_one(txn)
         .await

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -60,6 +60,8 @@ pub struct ExpectedMachineData {
     pub host_nics: Vec<ExpectedHostNic>,
     pub rack_id: Option<String>,
     pub default_pause_ingestion_and_poweron: Option<bool>,
+    #[serde(default)]
+    pub dpf_enabled: bool,
 }
 // Important : new fields for expected machine (and data) should be optional _and_ serde(default),
 // unless you want to go update all the files in each production deployment that autoload
@@ -92,6 +94,7 @@ impl<'r> FromRow<'r, PgRow> for ExpectedMachine {
                 host_nics,
                 default_pause_ingestion_and_poweron: row
                     .try_get("default_pause_ingestion_and_poweron")?,
+                dpf_enabled: row.try_get("dpf_enabled")?,
             },
         })
     }
@@ -145,6 +148,7 @@ impl From<ExpectedMachine> for rpc::forge::ExpectedMachine {
             default_pause_ingestion_and_poweron: expected_machine
                 .data
                 .default_pause_ingestion_and_poweron,
+            dpf_enabled: expected_machine.data.dpf_enabled,
         }
     }
 }
@@ -189,6 +193,7 @@ impl TryFrom<rpc::forge::ExpectedMachine> for ExpectedMachineData {
             host_nics: em.host_nics.into_iter().map(|nic| nic.into()).collect(),
             rack_id: em.rack_id,
             default_pause_ingestion_and_poweron: em.default_pause_ingestion_and_poweron,
+            dpf_enabled: em.dpf_enabled,
         })
     }
 }

--- a/crates/api/src/measured_boot/tests/common.rs
+++ b/crates/api/src/measured_boot/tests/common.rs
@@ -49,6 +49,7 @@ pub async fn create_test_machine(
         ManagedHostState::Ready,
         &Metadata::default(),
         None,
+        true,
         CURRENT_STATE_MODEL_VERSION,
     )
     .await?;

--- a/crates/api/src/measured_boot/tests/rpc.rs
+++ b/crates/api/src/measured_boot/tests/rpc.rs
@@ -2036,6 +2036,7 @@ mod tests {
             ManagedHostState::Ready,
             &Metadata::default(),
             None,
+            true,
             CURRENT_STATE_MODEL_VERSION,
         )
         .await

--- a/crates/api/src/tests/machine_creator.rs
+++ b/crates/api/src/tests/machine_creator.rs
@@ -1073,3 +1073,283 @@ async fn test_mi_attach_dpu_if_mi_created_after_machine_creation(
 
     Ok(())
 }
+
+#[crate::sqlx_test]
+async fn test_site_explorer_creates_managed_host_with_dpf_disable(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Prevent Firmware update here, since we test it in other method
+    let mut config = common::api_fixtures::get_config();
+    config.dpu_config.dpu_models = HashMap::new();
+    let env = common::api_fixtures::create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides::with_config(config),
+    )
+    .await;
+
+    let explorer_config = SiteExplorerConfig {
+        enabled: true,
+        explorations_per_run: 2,
+        concurrent_explorations: 1,
+        run_interval: std::time::Duration::from_secs(1),
+        create_machines: Arc::new(true.into()),
+        create_power_shelves: Arc::new(true.into()),
+        explore_power_shelves_from_static_ip: Arc::new(true.into()),
+        power_shelves_created_per_run: 1,
+        create_switches: Arc::new(true.into()),
+        switches_created_per_run: 1,
+        ..Default::default()
+    };
+
+    let machine_creator =
+        MachineCreator::new(env.pool.clone(), explorer_config, env.common_pools.clone());
+
+    let oob_mac = MacAddress::from_str("a0:88:c2:08:80:95")?;
+    let response = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder(oob_mac, "192.0.1.1")
+                .vendor_string("NVIDIA/OOB")
+                .tonic_request(),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(!response.address.is_empty());
+
+    // Use a known DPU serial so we can assert on the generated MachineId
+    let dpu_serial = "MT2328XZ185R".to_string();
+    let expected_machine_id =
+        "fm100ds3gfip02lfgleidqoitqgh8d8mdc4a3j2tdncbjrfjtvrrhn2kleg".to_string();
+
+    let mock_dpu = DpuConfig::with_serial(dpu_serial.clone());
+    let mock_host = ManagedHostConfig::with_dpus(vec![mock_dpu.clone()]);
+    let mut dpu_report: EndpointExplorationReport = mock_dpu.clone().into();
+    dpu_report.generate_machine_id(false)?;
+
+    assert!(dpu_report.machine_id.as_ref().is_some());
+    assert_eq!(
+        dpu_report.machine_id.as_ref().unwrap().to_string(),
+        expected_machine_id,
+    );
+
+    let response = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder(mock_host.bmc_mac_address, "192.0.1.1")
+                .vendor_string("NVIDIA/OOB")
+                .tonic_request(),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(!response.address.is_empty());
+
+    let interface_id = response.machine_interface_id;
+    let mut ifaces = env
+        .api
+        .find_interfaces(tonic::Request::new(rpc::forge::InterfaceSearchQuery {
+            id: Some(interface_id.unwrap()),
+            ip: None,
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(ifaces.interfaces.len(), 1);
+    let iface = ifaces.interfaces.remove(0);
+    let mut addresses = iface.address;
+    let host_bmc_ip = addresses.remove(0);
+
+    let dpu_report = Arc::new(dpu_report);
+    let exploration_report = ExploredManagedHost {
+        host_bmc_ip: IpAddr::from_str(&host_bmc_ip)?,
+        dpus: vec![ExploredDpu {
+            bmc_ip: IpAddr::from_str(response.address.as_str())?,
+            host_pf_mac_address: Some(mock_dpu.host_mac_address),
+            report: dpu_report.clone(),
+        }],
+    };
+
+    let expected_machine = model::expected_machine::ExpectedMachine {
+        id: Some(uuid::Uuid::new_v4()),
+        bmc_mac_address: mock_host.bmc_mac_address,
+        data: model::expected_machine::ExpectedMachineData {
+            dpf_enabled: false,
+            ..Default::default()
+        },
+    };
+
+    assert!(
+        machine_creator
+            .create_managed_host(
+                &exploration_report,
+                &mut EndpointExplorationReport::default(),
+                Some(&expected_machine),
+                &env.pool,
+            )
+            .await?
+    );
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let machines = db::machine::find(
+        &mut txn,
+        db::ObjectFilter::All,
+        MachineSearchConfig {
+            include_predicted_host: true,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(machines.len(), 2);
+    for machine in machines {
+        if machine.is_dpu() {
+            assert!(machine.dpf_enabled);
+        } else {
+            assert!(!machine.dpf_enabled);
+        }
+    }
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_site_explorer_creates_managed_host_with_dpf_enabled(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Prevent Firmware update here, since we test it in other method
+    let mut config = common::api_fixtures::get_config();
+    config.dpu_config.dpu_models = HashMap::new();
+    let env = common::api_fixtures::create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides::with_config(config),
+    )
+    .await;
+
+    let explorer_config = SiteExplorerConfig {
+        enabled: true,
+        explorations_per_run: 2,
+        concurrent_explorations: 1,
+        run_interval: std::time::Duration::from_secs(1),
+        create_machines: Arc::new(true.into()),
+        create_power_shelves: Arc::new(true.into()),
+        explore_power_shelves_from_static_ip: Arc::new(true.into()),
+        power_shelves_created_per_run: 1,
+        create_switches: Arc::new(true.into()),
+        switches_created_per_run: 1,
+        ..Default::default()
+    };
+
+    let machine_creator =
+        MachineCreator::new(env.pool.clone(), explorer_config, env.common_pools.clone());
+
+    let oob_mac = MacAddress::from_str("a0:88:c2:08:80:95")?;
+    let response = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder(oob_mac, "192.0.1.1")
+                .vendor_string("NVIDIA/OOB")
+                .tonic_request(),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(!response.address.is_empty());
+
+    // Use a known DPU serial so we can assert on the generated MachineId
+    let dpu_serial = "MT2328XZ185R".to_string();
+    let expected_machine_id =
+        "fm100ds3gfip02lfgleidqoitqgh8d8mdc4a3j2tdncbjrfjtvrrhn2kleg".to_string();
+
+    let mock_dpu = DpuConfig::with_serial(dpu_serial.clone());
+    let mock_host = ManagedHostConfig::with_dpus(vec![mock_dpu.clone()]);
+    let mut dpu_report: EndpointExplorationReport = mock_dpu.clone().into();
+    dpu_report.generate_machine_id(false)?;
+
+    assert!(dpu_report.machine_id.as_ref().is_some());
+    assert_eq!(
+        dpu_report.machine_id.as_ref().unwrap().to_string(),
+        expected_machine_id,
+    );
+
+    let response = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder(mock_host.bmc_mac_address, "192.0.1.1")
+                .vendor_string("NVIDIA/OOB")
+                .tonic_request(),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(!response.address.is_empty());
+
+    let interface_id = response.machine_interface_id;
+    let mut ifaces = env
+        .api
+        .find_interfaces(tonic::Request::new(rpc::forge::InterfaceSearchQuery {
+            id: Some(interface_id.unwrap()),
+            ip: None,
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(ifaces.interfaces.len(), 1);
+    let iface = ifaces.interfaces.remove(0);
+    let mut addresses = iface.address;
+    let host_bmc_ip = addresses.remove(0);
+
+    let dpu_report = Arc::new(dpu_report);
+    let exploration_report = ExploredManagedHost {
+        host_bmc_ip: IpAddr::from_str(&host_bmc_ip)?,
+        dpus: vec![ExploredDpu {
+            bmc_ip: IpAddr::from_str(response.address.as_str())?,
+            host_pf_mac_address: Some(mock_dpu.host_mac_address),
+            report: dpu_report.clone(),
+        }],
+    };
+
+    let expected_machine = model::expected_machine::ExpectedMachine {
+        id: Some(uuid::Uuid::new_v4()),
+        bmc_mac_address: mock_host.bmc_mac_address,
+        data: model::expected_machine::ExpectedMachineData {
+            dpf_enabled: true,
+            ..Default::default()
+        },
+    };
+
+    assert!(
+        machine_creator
+            .create_managed_host(
+                &exploration_report,
+                &mut EndpointExplorationReport::default(),
+                Some(&expected_machine),
+                &env.pool,
+            )
+            .await?
+    );
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let machines = db::machine::find(
+        &mut txn,
+        db::ObjectFilter::All,
+        MachineSearchConfig {
+            include_predicted_host: true,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(machines.len(), 2);
+    for machine in machines {
+        assert!(machine.dpf_enabled);
+    }
+
+    Ok(())
+}

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -1399,6 +1399,7 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
             default_pause_ingestion_and_poweron: None,
             host_nics: vec![],
             rack_id: None,
+            dpf_enabled: true,
         },
     )
     .await?;
@@ -1450,6 +1451,7 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
             default_pause_ingestion_and_poweron: None,
             host_nics: vec![],
             rack_id: None,
+            dpf_enabled: true,
         },
     )
     .await?;
@@ -2394,6 +2396,7 @@ async fn test_machine_creation_with_sku(
             default_pause_ingestion_and_poweron: None,
             host_nics: vec![],
             rack_id: None,
+            dpf_enabled: true,
         },
     )
     .await?;
@@ -2424,6 +2427,7 @@ async fn test_machine_creation_with_sku(
             assert_eq!(m.hw_sku, None);
         } else {
             assert_eq!(m.hw_sku, Some("Sku1".to_string()));
+            assert!(m.dpf_enabled);
         }
     }
 
@@ -2524,6 +2528,7 @@ async fn test_expected_machine_device_type_metrics(
             default_pause_ingestion_and_poweron: None,
             host_nics: vec![],
             rack_id: None,
+            dpf_enabled: true,
         },
     )
     .await?;
@@ -2542,6 +2547,7 @@ async fn test_expected_machine_device_type_metrics(
             default_pause_ingestion_and_poweron: None,
             host_nics: vec![],
             rack_id: None,
+            dpf_enabled: true,
         },
     )
     .await?;
@@ -2560,6 +2566,7 @@ async fn test_expected_machine_device_type_metrics(
             default_pause_ingestion_and_poweron: None,
             host_nics: vec![],
             rack_id: None,
+            dpf_enabled: true,
         },
     )
     .await?;

--- a/crates/api/src/tests/sku.rs
+++ b/crates/api/src/tests/sku.rs
@@ -790,6 +790,7 @@ pub mod tests {
                 default_pause_ingestion_and_poweron: None,
                 host_nics: vec![],
                 rack_id: None,
+                dpf_enabled: true,
             },
         )
         .await?;
@@ -878,6 +879,7 @@ pub mod tests {
                 default_pause_ingestion_and_poweron: None,
                 host_nics: vec![],
                 rack_id: None,
+                dpf_enabled: true,
             },
         )
         .await?;
@@ -941,6 +943,7 @@ pub mod tests {
                 default_pause_ingestion_and_poweron: None,
                 host_nics: vec![],
                 rack_id: None,
+                dpf_enabled: true,
             },
         )
         .await?;
@@ -1021,6 +1024,7 @@ pub mod tests {
                 default_pause_ingestion_and_poweron: None,
                 host_nics: vec![],
                 rack_id: None,
+                dpf_enabled: true,
             },
         )
         .await?;
@@ -1452,6 +1456,7 @@ pub mod tests {
                 default_pause_ingestion_and_poweron: None,
                 host_nics: vec![],
                 rack_id: None,
+                dpf_enabled: true,
             },
         )
         .await?;

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -547,6 +547,7 @@ impl ApiClient {
                 host_nics: vec![],
                 rack_id: None,
                 default_pause_ingestion_and_poweron: None,
+                dpf_enabled: true,
             })
             .await
             .map_err(ClientApiError::InvocationError)

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -4499,6 +4499,7 @@ message ExpectedMachine {
   repeated ExpectedHostNic host_nics = 9;
   optional string rack_id = 10;
   optional bool default_pause_ingestion_and_poweron = 11;
+  bool dpf_enabled = 12;
 }
 
 message ExpectedMachineRequest {


### PR DESCRIPTION
Support for dpf_enabled flag in expected_machines. The dpf_enabled flag is used to update dpf field while creating Machine object.

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ x ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

