### PR TITLE
chore: Remove OS configuration within TenantConfig

### DIFF
--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -1310,10 +1310,6 @@ impl ApiClient {
             ));
         }
         let tenant_config = rpc::TenantConfig {
-            user_data: None,
-            custom_ipxe: "Non-existing-ipxe".to_string(),
-            phone_home_enabled: false,
-            always_boot_with_custom_ipxe: false,
             tenant_organization_id: tenant_org,
             tenant_keyset_ids: vec![],
             hostname: None,

--- a/crates/agent/src/periodic_config_fetcher.rs
+++ b/crates/agent/src/periodic_config_fetcher.rs
@@ -277,8 +277,8 @@ pub fn instance_metadata_from_instance(
     let user_data = instance
         .config
         .as_ref()
-        .and_then(|config| config.tenant.as_ref())
-        .and_then(|tenant_config| tenant_config.user_data.clone())
+        .and_then(|config| config.os.as_ref())
+        .and_then(|os_config| os_config.user_data.clone())
         .unwrap_or_default();
 
     let devices = match extract_instance_ib_config(&instance) {

--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -769,10 +769,6 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
         config: Some(rpc::InstanceConfig {
             tenant: Some(rpc::TenantConfig {
                 tenant_organization_id: "Forge-simulation-tenant".to_string(),
-                user_data: Some("".to_string()),
-                custom_ipxe: " chain http://10.217.126.4/public/blobs/internal/x86_64/qcow-imager.efi loglevel=7 console=ttyS0,115200 console=tty0 pci=realloc=off image_url=https://pbss.s8k.io/v1/AUTH_team-forge/images.qcow2/carbide-dev-environment/carbide-dev-environment-latest.qcow2".to_string(),
-                always_boot_with_custom_ipxe: false,
-                phone_home_enabled: false,
                 hostname: None,
                 tenant_keyset_ids: vec![],
             }),

--- a/crates/api-model/src/instance/config/tenant_config.rs
+++ b/crates/api-model/src/instance/config/tenant_config.rs
@@ -64,11 +64,7 @@ impl TryFrom<TenantConfig> for rpc::forge::TenantConfig {
     fn try_from(config: TenantConfig) -> Result<rpc::forge::TenantConfig, Self::Error> {
         Ok(Self {
             tenant_organization_id: config.tenant_organization_id.to_string(),
-            custom_ipxe: String::new(),
-            user_data: None,
             tenant_keyset_ids: config.tenant_keyset_ids,
-            always_boot_with_custom_ipxe: false,
-            phone_home_enabled: false,
             hostname: config.hostname,
         })
     }

--- a/crates/api-test-helper/src/instance.rs
+++ b/crates/api-test-helper/src/instance.rs
@@ -31,23 +31,25 @@ pub async fn create(
         segment_id.unwrap_or("<none>")
     );
 
-    let tenant = match hostname {
-        Some(hostname) => serde_json::json!({
-                "tenant_organization_id": "MyOrg",
-                "user_data": "hello",
-                "custom_ipxe": "chain --autofree https://boot.netboot.xyz",
-                "phone_home_enabled": phone_home_enable,
-                "hostname": hostname,
-                "tenantKeysetIds": keyset_ids,
-        }),
-        None => serde_json::json!({
-                 "tenant_organization_id": "MyOrg",
-                 "user_data": "hello",
-                 "custom_ipxe": "chain --autofree https://boot.netboot.xyz",
-                 "phone_home_enabled": phone_home_enable,
-                "tenantKeysetIds": keyset_ids,
-        }),
-    };
+    let mut tenant = serde_json::json!({
+        "tenant_organization_id": "MyOrg",
+        "tenantKeysetIds": keyset_ids,
+    });
+
+    if let Some(hostname) = hostname {
+        tenant
+            .as_object_mut()
+            .unwrap()
+            .insert("hostname".to_string(), serde_json::json!(hostname));
+    }
+
+    let os = serde_json::json!({
+        "ipxe": {
+            "ipxe_script": "chain --autofree https://boot.netboot.xyz"
+        },
+        "phone_home_enabled": phone_home_enable,
+        "user_data": "hello",
+    });
 
     let instance_config = match segment_id {
         Some(segment_id) => serde_json::json!({
@@ -57,7 +59,8 @@ pub async fn create(
                     "function_type": "PHYSICAL",
                     "network_segment_id": {"value": segment_id}
                 }]
-            }
+            },
+            "os": os,
         }),
         // omit network from config if we're not specifying a segment
         None => serde_json::json!({

--- a/crates/api/src/tests/common/api_fixtures/instance.rs
+++ b/crates/api/src/tests/common/api_fixtures/instance.rs
@@ -276,10 +276,6 @@ pub fn default_os_config() -> rpc::forge::OperatingSystem {
 
 pub fn default_tenant_config() -> rpc::TenantConfig {
     rpc::TenantConfig {
-        user_data: None,
-        custom_ipxe: "".to_string(),
-        phone_home_enabled: false,
-        always_boot_with_custom_ipxe: false,
         tenant_organization_id: "Tenant1".to_string(),
         tenant_keyset_ids: vec![],
         hostname: None,

--- a/crates/api/src/tests/instance_allocate.rs
+++ b/crates/api/src/tests/instance_allocate.rs
@@ -187,15 +187,21 @@ async fn test_zero_dpu_instance_allocation_explicit_network_config(
             config: Some(forge::InstanceConfig {
                 tenant: Some(forge::TenantConfig {
                     tenant_organization_id: "2829bbe3-c169-4cd9-8b2a-19a8b1618a93".to_string(), // from sql fixture
-                    user_data: None,
-                    custom_ipxe: "exit".to_string(),
-                    always_boot_with_custom_ipxe: false,
-                    phone_home_enabled: false,
                     hostname: None,
                     tenant_keyset_ids: vec![],
                 }),
                 network_security_group_id: None,
-                os: None,
+                os: Some(forge::OperatingSystem {
+                    phone_home_enabled: false,
+                    run_provisioning_instructions_on_every_boot: false,
+                    user_data: None,
+                    variant: Some(forge::operating_system::Variant::Ipxe(
+                        forge::IpxeOperatingSystem {
+                            ipxe_script: "exit".to_string(),
+                            user_data: None,
+                        },
+                    )),
+                }),
                 network: Some(forge::InstanceNetworkConfig {
                     interfaces: vec![forge::InstanceInterfaceConfig {
                         function_type: forge::InterfaceFunctionType::Physical as i32,
@@ -277,14 +283,20 @@ async fn test_zero_dpu_instance_allocation_no_network_config(
             config: Some(forge::InstanceConfig {
                 tenant: Some(forge::TenantConfig {
                     tenant_organization_id: "2829bbe3-c169-4cd9-8b2a-19a8b1618a93".to_string(), // from sql fixture
-                    user_data: None,
-                    custom_ipxe: "exit".to_string(),
-                    always_boot_with_custom_ipxe: false,
-                    phone_home_enabled: false,
                     hostname: None,
                     tenant_keyset_ids: vec![],
                 }),
-                os: None,
+                os: Some(forge::OperatingSystem {
+                    phone_home_enabled: false,
+                    run_provisioning_instructions_on_every_boot: false,
+                    user_data: None,
+                    variant: Some(forge::operating_system::Variant::Ipxe(
+                        forge::IpxeOperatingSystem {
+                            ipxe_script: "exit".to_string(),
+                            user_data: None,
+                        },
+                    )),
+                }),
                 network: None, // code under test: Network config is None
                 infiniband: None,
                 nvlink: None,
@@ -367,14 +379,20 @@ async fn test_zero_dpu_instance_allocation_multi_segment_no_network_config(
             config: Some(forge::InstanceConfig {
                 tenant: Some(forge::TenantConfig {
                     tenant_organization_id: "2829bbe3-c169-4cd9-8b2a-19a8b1618a93".to_string(), // from sql fixture
-                    user_data: None,
-                    custom_ipxe: "exit".to_string(),
-                    always_boot_with_custom_ipxe: false,
-                    phone_home_enabled: false,
                     hostname: None,
                     tenant_keyset_ids: vec![],
                 }),
-                os: None,
+                os: Some(forge::OperatingSystem {
+                    phone_home_enabled: false,
+                    run_provisioning_instructions_on_every_boot: false,
+                    user_data: None,
+                    variant: Some(forge::operating_system::Variant::Ipxe(
+                        forge::IpxeOperatingSystem {
+                            ipxe_script: "exit".to_string(),
+                            user_data: None,
+                        },
+                    )),
+                }),
                 network: None, // code under test: Network config is None
                 infiniband: None,
                 nvlink: None,
@@ -488,14 +506,20 @@ async fn test_reject_single_dpu_instance_allocation_no_network_config(
             config: Some(forge::InstanceConfig {
                 tenant: Some(forge::TenantConfig {
                     tenant_organization_id: "2829bbe3-c169-4cd9-8b2a-19a8b1618a93".to_string(), // from sql fixture
-                    user_data: None,
-                    custom_ipxe: "exit".to_string(),
-                    always_boot_with_custom_ipxe: false,
-                    phone_home_enabled: false,
                     hostname: None,
                     tenant_keyset_ids: vec![],
                 }),
-                os: None,
+                os: Some(forge::OperatingSystem {
+                    phone_home_enabled: false,
+                    run_provisioning_instructions_on_every_boot: false,
+                    user_data: None,
+                    variant: Some(forge::operating_system::Variant::Ipxe(
+                        forge::IpxeOperatingSystem {
+                            ipxe_script: "exit".to_string(),
+                            user_data: None,
+                        },
+                    )),
+                }),
                 network: None,
                 infiniband: None,
                 nvlink: None,
@@ -542,14 +566,20 @@ async fn test_reject_single_dpu_instance_allocation_host_inband_network_config(
             config: Some(forge::InstanceConfig {
                 tenant: Some(forge::TenantConfig {
                     tenant_organization_id: "2829bbe3-c169-4cd9-8b2a-19a8b1618a93".to_string(), // from sql fixture
-                    user_data: None,
-                    custom_ipxe: "exit".to_string(),
-                    always_boot_with_custom_ipxe: false,
-                    phone_home_enabled: false,
                     hostname: None,
                     tenant_keyset_ids: vec![],
                 }),
-                os: None,
+                os: Some(forge::OperatingSystem {
+                    phone_home_enabled: false,
+                    run_provisioning_instructions_on_every_boot: false,
+                    user_data: None,
+                    variant: Some(forge::operating_system::Variant::Ipxe(
+                        forge::IpxeOperatingSystem {
+                            ipxe_script: "exit".to_string(),
+                            user_data: None,
+                        },
+                    )),
+                }),
                 network: Some(forge::InstanceNetworkConfig {
                     interfaces: vec![forge::InstanceInterfaceConfig {
                         function_type: forge::InterfaceFunctionType::Physical as i32,
@@ -681,14 +711,20 @@ async fn test_reject_zero_dpu_instance_allocation_multiple_vpcs(
                 network_security_group_id: None,
                 tenant: Some(forge::TenantConfig {
                     tenant_organization_id: "2829bbe3-c169-4cd9-8b2a-19a8b1618a93".to_string(), // from sql fixture
-                    user_data: None,
-                    custom_ipxe: "exit".to_string(),
-                    always_boot_with_custom_ipxe: false,
-                    phone_home_enabled: false,
                     hostname: None,
                     tenant_keyset_ids: vec![],
                 }),
-                os: None,
+                os: Some(forge::OperatingSystem {
+                    phone_home_enabled: false,
+                    run_provisioning_instructions_on_every_boot: false,
+                    user_data: None,
+                    variant: Some(forge::operating_system::Variant::Ipxe(
+                        forge::IpxeOperatingSystem {
+                            ipxe_script: "exit".to_string(),
+                            user_data: None,
+                        },
+                    )),
+                }),
                 network: None,
                 infiniband: None,
                 dpu_extension_services: None,
@@ -735,14 +771,20 @@ async fn test_single_dpu_instance_allocation(
             config: Some(forge::InstanceConfig {
                 tenant: Some(forge::TenantConfig {
                     tenant_organization_id: "2829bbe3-c169-4cd9-8b2a-19a8b1618a93".to_string(), // from sql fixture
-                    user_data: None,
-                    custom_ipxe: "exit".to_string(),
-                    always_boot_with_custom_ipxe: false,
-                    phone_home_enabled: false,
                     hostname: None,
                     tenant_keyset_ids: vec![],
                 }),
-                os: None,
+                os: Some(forge::OperatingSystem {
+                    phone_home_enabled: false,
+                    run_provisioning_instructions_on_every_boot: false,
+                    user_data: None,
+                    variant: Some(forge::operating_system::Variant::Ipxe(
+                        forge::IpxeOperatingSystem {
+                            ipxe_script: "exit".to_string(),
+                            user_data: None,
+                        },
+                    )),
+                }),
                 network: Some(forge::InstanceNetworkConfig {
                     interfaces: vec![forge::InstanceInterfaceConfig {
                         function_type: forge::InterfaceFunctionType::Physical as i32,

--- a/crates/api/src/tests/instance_config_update.rs
+++ b/crates/api/src/tests/instance_config_update.rs
@@ -24,28 +24,14 @@ use crate::tests::common::{self};
 
 /// Compares an expected instance configuration with the actual instance configuration
 ///
-/// We can't directly call `assert_eq` since carbide will fill in the OS details into
-/// the TenantConfig fields if they are not directly specified.
+/// We can't directly call `assert_eq` since carbide will fill in details into various fields
+/// that are not expected
 fn assert_config_equals(
     actual: &rpc::forge::InstanceConfig,
     expected: &rpc::forge::InstanceConfig,
 ) {
     let mut expected = expected.clone();
     let mut actual = actual.clone();
-    match &expected.os.as_ref().unwrap().variant {
-        Some(rpc::forge::operating_system::Variant::Ipxe(ipxe)) => {
-            let tenant = expected.tenant.as_mut().unwrap();
-            tenant.custom_ipxe = ipxe.ipxe_script.clone();
-            tenant.user_data = expected.os.as_ref().unwrap().user_data.clone();
-            tenant.always_boot_with_custom_ipxe = expected
-                .os
-                .as_ref()
-                .unwrap()
-                .run_provisioning_instructions_on_every_boot;
-            tenant.phone_home_enabled = expected.os.as_ref().unwrap().phone_home_enabled;
-        }
-        _ => panic!("Unexpected OS type"),
-    }
     if let Some(network) = &mut expected.network {
         network.interfaces.iter_mut().for_each(|x| {
             if let Some(NetworkDetails::VpcPrefixId(_)) = x.network_details {

--- a/crates/api/src/tests/instance_ipxe_behaviors.rs
+++ b/crates/api/src/tests/instance_ipxe_behaviors.rs
@@ -38,8 +38,8 @@ async fn test_instance_uses_custom_ipxe_only_once(pool: sqlx::PgPool) {
             .rpc_instance()
             .await
             .config()
-            .tenant()
-            .always_boot_with_custom_ipxe
+            .os()
+            .run_provisioning_instructions_on_every_boot
     );
 
     // First boot should return custom iPXE instructions
@@ -104,8 +104,8 @@ async fn test_instance_always_boot_with_custom_ipxe(pool: sqlx::PgPool) {
             .rpc_instance()
             .await
             .config()
-            .tenant()
-            .always_boot_with_custom_ipxe
+            .os()
+            .run_provisioning_instructions_on_every_boot
     );
 
     // First boot should return custom iPXE instructions

--- a/crates/api/src/tests/instance_os.rs
+++ b/crates/api/src/tests/instance_os.rs
@@ -10,33 +10,13 @@
  * its affiliates is strictly prohibited.
  */
 
-use common::api_fixtures::instance::{
-    default_os_config, default_tenant_config, single_interface_network_config,
-};
+use common::api_fixtures::instance::{default_tenant_config, single_interface_network_config};
 use common::api_fixtures::{create_managed_host, create_test_env};
 use config_version::ConfigVersion;
 use rpc::forge::forge_server::Forge;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 
 use crate::tests::common;
-
-fn verify_os_in_tenant_config(
-    tenant_config: &rpc::forge::TenantConfig,
-    expected_os: &rpc::forge::OperatingSystem,
-) {
-    let mut expected_tenant_config = tenant_config.clone();
-    match &expected_os.variant {
-        Some(rpc::forge::operating_system::Variant::Ipxe(ipxe)) => {
-            expected_tenant_config.custom_ipxe = ipxe.ipxe_script.clone();
-            expected_tenant_config.user_data = expected_os.user_data.clone();
-        }
-        _ => panic!("Unexpected OS type"),
-    }
-    expected_tenant_config.always_boot_with_custom_ipxe =
-        expected_os.run_provisioning_instructions_on_every_boot;
-    expected_tenant_config.phone_home_enabled = expected_os.phone_home_enabled;
-    assert_eq!(tenant_config, &expected_tenant_config);
-}
 
 #[crate::sqlx_test]
 async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConnectOptions) {
@@ -73,10 +53,8 @@ async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConn
 
     assert_eq!(instance.status().tenant(), rpc::forge::TenantState::Ready);
 
-    let tenant_config = instance.config().tenant();
     let os = instance.config().os();
     assert_eq!(os, &initial_os);
-    verify_os_in_tenant_config(tenant_config, &initial_os);
     let initial_config_version = instance.config_version();
     assert_eq!(initial_config_version.version_nr(), 1);
 
@@ -104,10 +82,8 @@ async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConn
         .await
         .unwrap()
         .into_inner();
-    let tenant_config = instance.config.as_ref().unwrap().tenant.as_ref().unwrap();
     let os = instance.config.as_ref().unwrap().os.as_ref().unwrap();
     assert_eq!(os, &updated_os_1);
-    verify_os_in_tenant_config(tenant_config, &updated_os_1);
     let updated_config_version = instance.config_version.parse::<ConfigVersion>().unwrap();
     assert_eq!(updated_config_version.version_nr(), 2);
 
@@ -161,10 +137,8 @@ async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConn
         .unwrap()
         .into_inner();
 
-    let tenant_config = instance.config.as_ref().unwrap().tenant.as_ref().unwrap();
     let os = instance.config.as_ref().unwrap().os.as_ref().unwrap();
     assert_eq!(os, &updated_os_2);
-    verify_os_in_tenant_config(tenant_config, &updated_os_2);
     let updated_config_version = instance.config_version.parse::<ConfigVersion>().unwrap();
     assert_eq!(updated_config_version.version_nr(), 3);
 
@@ -218,53 +192,4 @@ async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConn
         err.message(),
         "Invalid value: IpxeOperatingSystem::ipxe_script is empty"
     );
-}
-
-/// Instance creation using legacy method to pass OS
-/// This should be removed once the mechanism is removed
-#[crate::sqlx_test]
-async fn test_instance_creation_with_os_in_tenantconfig(
-    _: PgPoolOptions,
-    options: PgConnectOptions,
-) {
-    let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
-    let env = create_test_env(pool).await;
-    let segment_id = env.create_vpc_and_tenant_segment().await;
-    let mh = create_managed_host(&env).await;
-
-    let mut tenant_config = default_tenant_config();
-    // We don't use this OS object, but just copy parameters over
-    // carbide is supposed to build an equivalent Os object from it
-    let os_config = default_os_config();
-    match &os_config.variant {
-        Some(rpc::forge::operating_system::Variant::Ipxe(ipxe)) => {
-            tenant_config.custom_ipxe = ipxe.ipxe_script.clone();
-            tenant_config.user_data = os_config.user_data.clone();
-            tenant_config.always_boot_with_custom_ipxe =
-                os_config.run_provisioning_instructions_on_every_boot;
-            tenant_config.phone_home_enabled = os_config.phone_home_enabled;
-        }
-        _ => panic!("Unsupported OS"),
-    }
-
-    let config = rpc::InstanceConfig {
-        tenant: Some(tenant_config.clone()),
-        os: None,
-        network: Some(single_interface_network_config(segment_id)),
-        infiniband: None,
-        network_security_group_id: None,
-        dpu_extension_services: None,
-        nvlink: None,
-    };
-
-    let tinstance = mh.instance_builer(&env).config(config).build().await;
-
-    let instance = tinstance.rpc_instance().await;
-
-    assert_eq!(instance.status().tenant(), rpc::forge::TenantState::Ready);
-
-    let actual_tenant_config = instance.config().tenant();
-    let actual_os = instance.config().os();
-    assert_eq!(actual_os, &os_config);
-    assert_eq!(actual_tenant_config, &tenant_config);
 }

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -16,9 +16,10 @@ use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use mac_address::MacAddress;
 use rpc::forge::machine_cleanup_info::CleanupStepResult;
+use rpc::forge::operating_system::Variant;
 use rpc::forge::{
-    ConfigSetting, ExpectedMachine, MachineType, MachinesByIdsRequest, PxeInstructions,
-    SetDynamicConfigRequest,
+    ConfigSetting, ExpectedMachine, IpxeOperatingSystem, MachineType, MachinesByIdsRequest,
+    OperatingSystem, PxeInstructions, SetDynamicConfigRequest,
 };
 use rpc::protos::forge_api_client::ForgeApiClient;
 
@@ -321,10 +322,6 @@ impl ApiClient {
         };
 
         let tenant_config = rpc::TenantConfig {
-            user_data: None,
-            custom_ipxe: "Non-existing-ipxe".to_string(),
-            phone_home_enabled: false,
-            always_boot_with_custom_ipxe: false,
             tenant_organization_id: "Forge-simulation-tenant".to_string(),
             tenant_keyset_ids: vec![],
             hostname: None,
@@ -332,7 +329,15 @@ impl ApiClient {
 
         let instance_config = rpc::InstanceConfig {
             tenant: Some(tenant_config),
-            os: None,
+            os: Some(OperatingSystem {
+                variant: Some(Variant::Ipxe(IpxeOperatingSystem {
+                    ipxe_script: "Non-existing-ipxe".to_string(),
+                    user_data: None,
+                })),
+                user_data: None,
+                phone_home_enabled: false,
+                run_provisioning_instructions_on_every_boot: false,
+            }),
             network: Some(rpc::InstanceNetworkConfig {
                 interfaces: vec![interface_config],
             }),

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -993,7 +993,7 @@ message RuntimeConfig {
 
   // BOM Validation Configuration
   bool bom_validation_enabled = 35;
-  bool bom_validation_ignore_unassigned_machines = 36;  // TODO: Remove after all consumers updated
+  bool bom_validation_ignore_unassigned_machines = 36; // TODO: Remove after all consumers updated
 
   repeated string dpu_nic_firmware_update_versions=37;
 
@@ -1911,30 +1911,9 @@ message TenantConfig {
   // Identifies the tenant that uses this instance
   string tenant_organization_id = 1;
 
-  // These fields are deprecated. If no `os` or `os_reference` object is defined
-  // in `InstanceConfig`, the fields would still be utilized. Otherwise
-  // the `os` configurations would take precedence.
-  optional string user_data = 11;
-  string custom_ipxe = 12;
-
-  // If this flag is set to `true`, the instance will receive the `custom_ipxe` instructions
-  // on every reboot attempts. Depending on the type of iPXE instructions, this might
-  // lead the instance to reinstall itself on every reboot.
-  //
-  // If the flag is set to `false` or not specified, Forge will only provide the
-  // `custom_ipxe` script on the first boot attempt. For every subsequent boot,
-  // the instance will use the default boot action - which is usually to boot from
-  // the hard drive.
-  //
-  // If the `custom_ipxe` instructions should only be used for specific reboots
-  // in order to trigger reinstallation, tenants can use the `InvokeInstancePower`
-  // API to reboot instances with the `boot_with_custom_ipxe` parameter set to
-  // `true`.
-  bool always_boot_with_custom_ipxe = 13;
-
-  // If this flag is set to `true` the instance will not transition to a Ready state until
-  // InstancePhoneHomeLastContact is updated
-  bool phone_home_enabled = 14;
+  // These fields have been used for OS configuration in the past.
+  // They are now replaced with the OperatingSystem message.
+  reserved 11, 12, 13, 14;
 
   optional string hostname = 15;
 
@@ -2445,9 +2424,9 @@ enum IssueCategory {
 
 // Message containing details about an issue reported during instance release
 message Issue {
-  IssueCategory category = 1;    // Category of issue
-  string summary = 2;    // User-friendly summary of the issue
-  string details = 3;    // Additional context about the issue
+  IssueCategory category = 1; // Category of issue
+  string summary = 2; // User-friendly summary of the issue
+  string details = 3; // Additional context about the issue
 }
 
 message InstanceReleaseRequest {
@@ -2922,7 +2901,7 @@ message SSHKeyValidationResponse {
 }
 
 message CredentialRequest {
-  string host_id = 1;  // UUID, IP address, host name or MAC address
+  string host_id = 1; // UUID, IP address, host name or MAC address
 }
 
 message CredentialResponse {
@@ -3593,14 +3572,14 @@ message ForgeAgentControlRequest {
 
 message ForgeAgentControlResponse {
   enum Action {
-    NOOP = 0;       // No operation. Do nothing
-    RESET = 1;      // Wipe the machine, prepare for next tenant
-    DISCOVERY = 2;  // Run full discovery
-    REBUILD = 3;    // Future thingy
-    RETRY = 4;      // Machine needs more time to come in proper state. Retry again.
-    MEASURE = 5;    // Machine needs to send measurements for attestation.
-    LOGERROR = 6;   // Log error.
-    MACHINE_VALIDATION = 7;   // Machine validation.
+    NOOP = 0; // No operation. Do nothing
+    RESET = 1; // Wipe the machine, prepare for next tenant
+    DISCOVERY = 2; // Run full discovery
+    REBUILD = 3; // Future thingy
+    RETRY = 4; // Machine needs more time to come in proper state. Retry again.
+    MEASURE = 5; // Machine needs to send measurements for attestation.
+    LOGERROR = 6; // Log error.
+    MACHINE_VALIDATION = 7; // Machine validation.
     MLX_ACTION = 8; // MlxAction for DPA NICs
   }
   Action action = 1;
@@ -4213,13 +4192,13 @@ message DpuReprovisioningListRequest {
 
 message DpuReprovisioningListResponse {
   message DpuReprovisioningListItem {
-    common.MachineId id = 1;  // Dpu Machine ID
-    string state = 2;  // ManagedHost state
-    string initiator = 3;  // Who requested this reprovisioning.
-    google.protobuf.Timestamp requested_at = 4;  // When reprovisioning was requested.
+    common.MachineId id = 1; // Dpu Machine ID
+    string state = 2; // ManagedHost state
+    string initiator = 3; // Who requested this reprovisioning.
+    google.protobuf.Timestamp requested_at = 4; // When reprovisioning was requested.
     bool update_firmware = 5;
     optional google.protobuf.Timestamp initiated_at = 6;  // When reprovisioning is started.
-    bool user_approval_received = 7;  // User approval received or not if needed
+    bool user_approval_received = 7; // User approval received or not if needed
   }
   repeated DpuReprovisioningListItem dpus = 1;
 }
@@ -4240,11 +4219,11 @@ message HostReprovisioningListRequest {
 message HostReprovisioningListResponse {
   message HostReprovisioningListItem {
     common.MachineId id = 1; // Machine ID
-    string state = 2;  // ManagedHost state
-    string initiator = 3;  // Who requested this reprovisioning.
-    google.protobuf.Timestamp requested_at = 4;  // When reprovisioning was requested.
+    string state = 2; // ManagedHost state
+    string initiator = 3; // Who requested this reprovisioning.
+    google.protobuf.Timestamp requested_at = 4; // When reprovisioning was requested.
     optional google.protobuf.Timestamp initiated_at = 5;  // When reprovisioning is started.
-    bool user_approval_received = 6;  // User approval received or not if needed
+    bool user_approval_received = 6; // User approval received or not if needed
   }
   repeated HostReprovisioningListItem hosts = 1;
 }


### PR DESCRIPTION
## Description

The OS configuration had been migrated to an OperatingSystem message some time ago. The fields in TenantConfig just maintained for backward compatibility. They are no longer required and thereby removed.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [x] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [x] This PR contains breaking changes

Breaking changes for users which still rely on these fields. However there are no known users.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes


