### PR TITLE
chore: Support instance reboots by instance_id and machine_id

### DIFF
--- a/crates/admin-cli/src/instance/cmds.rs
+++ b/crates/admin-cli/src/instance/cmds.rs
@@ -531,6 +531,7 @@ pub async fn handle_reboot(args: RebootInstance, api_client: &ApiClient) -> Carb
     api_client
         .0
         .invoke_instance_power(InstancePowerRequest {
+            instance_id: Some(args.instance),
             machine_id: Some(machine_id),
             operation: forgerpc::instance_power_request::Operation::PowerReset as i32,
             boot_with_custom_ipxe: args.custom_pxe,

--- a/crates/api/src/tests/dpu_reprovisioning.rs
+++ b/crates/api/src/tests/dpu_reprovisioning.rs
@@ -382,7 +382,8 @@ async fn test_instance_reprov_with_firmware_upgrade(pool: sqlx::PgPool) {
     mh.dpu().trigger_dpu_reprovisioning(Mode::Set, true).await;
     env.api
         .invoke_instance_power(tonic::Request::new(::rpc::forge::InstancePowerRequest {
-            machine_id: mh.id.into(),
+            instance_id: tinstance.id.into(),
+            machine_id: None,
             apply_updates_on_reboot: true,
             boot_with_custom_ipxe: false,
             operation: 0,
@@ -680,7 +681,8 @@ async fn test_instance_reprov_without_firmware_upgrade(pool: sqlx::PgPool) {
     mh.dpu().trigger_dpu_reprovisioning(Mode::Set, false).await;
     env.api
         .invoke_instance_power(tonic::Request::new(::rpc::forge::InstancePowerRequest {
-            machine_id: mh.id.into(),
+            instance_id: tinstance.id.into(),
+            machine_id: None,
             apply_updates_on_reboot: true,
             boot_with_custom_ipxe: false,
             operation: 0,
@@ -724,7 +726,8 @@ async fn test_instance_reprov_without_firmware_upgrade(pool: sqlx::PgPool) {
     assert!(
         env.api
             .invoke_instance_power(tonic::Request::new(::rpc::forge::InstancePowerRequest {
-                machine_id: mh.id.into(),
+                instance_id: tinstance.id.into(),
+                machine_id: None,
                 apply_updates_on_reboot: true,
                 boot_with_custom_ipxe: false,
                 operation: 0,
@@ -1572,7 +1575,8 @@ async fn test_instance_reprov_restart_failed(pool: sqlx::PgPool) {
     mh.dpu().trigger_dpu_reprovisioning(Mode::Set, false).await;
     env.api
         .invoke_instance_power(tonic::Request::new(::rpc::forge::InstancePowerRequest {
-            machine_id: mh.id.into(),
+            instance_id: tinstance.id.into(),
+            machine_id: None,
             apply_updates_on_reboot: true,
             boot_with_custom_ipxe: false,
             operation: 0,
@@ -1620,7 +1624,8 @@ async fn test_instance_reprov_restart_failed(pool: sqlx::PgPool) {
     assert!(
         env.api
             .invoke_instance_power(tonic::Request::new(::rpc::forge::InstancePowerRequest {
-                machine_id: mh.id.into(),
+                instance_id: tinstance.id.into(),
+                machine_id: None,
                 apply_updates_on_reboot: true,
                 boot_with_custom_ipxe: false,
                 operation: 0,

--- a/crates/api/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api/src/tests/host_bmc_firmware_test.rs
@@ -1187,7 +1187,8 @@ async fn test_instance_upgrading_actual(
 
         // Simulate a tenant OKing the request
         let request = rpc::forge::InstancePowerRequest {
-            machine_id: mh.id.into(),
+            instance_id: tinstance.id.into(),
+            machine_id: None,
             operation: rpc::forge::instance_power_request::Operation::PowerReset.into(),
             boot_with_custom_ipxe: false,
             apply_updates_on_reboot: true,

--- a/crates/api/src/tests/instance_ipxe_behaviors.rs
+++ b/crates/api/src/tests/instance_ipxe_behaviors.rs
@@ -10,7 +10,7 @@
  * its affiliates is strictly prohibited.
  */
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::instance::InstanceId;
 use carbide_uuid::network::NetworkSegmentId;
 use common::api_fixtures::{TestEnv, TestManagedHost, create_test_env};
 use rpc::forge::forge_server::Forge;
@@ -58,7 +58,7 @@ async fn test_instance_uses_custom_ipxe_only_once(pool: sqlx::PgPool) {
     ));
 
     // A regular reboot attempt should still lead to returning "exit"
-    invoke_instance_power(&env, mh.id, false).await;
+    invoke_instance_power(&env, tinstance.id, false).await;
     let pxe = host_interface.get_pxe_instructions(host_arch).await;
     assert!(
         pxe.pxe_script.contains("Current state: Assigned/Ready"),
@@ -70,12 +70,12 @@ async fn test_instance_uses_custom_ipxe_only_once(pool: sqlx::PgPool) {
     ));
 
     // A reboot with flag `boot_with_custom_ipxe` should provide the custom iPXE
-    invoke_instance_power(&env, mh.id, true).await;
+    invoke_instance_power(&env, tinstance.id, true).await;
     let pxe = host_interface.get_pxe_instructions(host_arch).await;
     assert_eq!(pxe.pxe_script, "SomeRandomiPxe");
 
     // The next reboot should again lead to returning "exit"
-    invoke_instance_power(&env, mh.id, false).await;
+    invoke_instance_power(&env, tinstance.id, false).await;
     let pxe = host_interface.get_pxe_instructions(host_arch).await;
     assert!(
         pxe.pxe_script.contains("Current state: Assigned/Ready"),
@@ -85,6 +85,33 @@ async fn test_instance_uses_custom_ipxe_only_once(pool: sqlx::PgPool) {
     assert!(pxe.pxe_script.contains(
         "This state assumes an OS is provisioned and will exit into the OS in 5 seconds."
     ));
+
+    // A reboot should also be possible with just MachineId
+    // TODO: Remove these assertions after the `machine_id` based reboots are removed.
+    env.api
+        .invoke_instance_power(tonic::Request::new(rpc::forge::InstancePowerRequest {
+            instance_id: None,
+            machine_id: Some(mh.id),
+            operation: rpc::forge::instance_power_request::Operation::PowerReset as _,
+            boot_with_custom_ipxe: false,
+            apply_updates_on_reboot: false,
+        }))
+        .await
+        .unwrap();
+
+    // A request with mismatching Machine and InstanceId should fail
+    let err = env
+        .api
+        .invoke_instance_power(tonic::Request::new(rpc::forge::InstancePowerRequest {
+            instance_id: Some(tinstance.id),
+            machine_id: Some(mh.dpu_ids[0]),
+            operation: rpc::forge::instance_power_request::Operation::PowerReset as _,
+            boot_with_custom_ipxe: false,
+            apply_updates_on_reboot: false,
+        }))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
 }
 
 #[crate::sqlx_test]
@@ -117,24 +144,25 @@ async fn test_instance_always_boot_with_custom_ipxe(pool: sqlx::PgPool) {
     assert_eq!(pxe.pxe_script, "SomeRandomiPxe");
 
     // A regular reboot attempt should also return custom iPXE instructions
-    invoke_instance_power(&env, mh.id, false).await;
+    invoke_instance_power(&env, tinstance.id, false).await;
     let pxe = host_interface.get_pxe_instructions(host_arch).await;
     assert_eq!(pxe.pxe_script, "SomeRandomiPxe");
 
     // A reboot with flag `boot_with_custom_ipxe` should also return custom iPXE instructions
-    invoke_instance_power(&env, mh.id, true).await;
+    invoke_instance_power(&env, tinstance.id, true).await;
     let pxe = host_interface.get_pxe_instructions(host_arch).await;
     assert_eq!(pxe.pxe_script, "SomeRandomiPxe");
 }
 
 async fn invoke_instance_power(
     env: &TestEnv,
-    host_machine_id: MachineId,
+    instance_id: InstanceId,
     boot_with_custom_ipxe: bool,
 ) {
     env.api
         .invoke_instance_power(tonic::Request::new(rpc::forge::InstancePowerRequest {
-            machine_id: Some(host_machine_id),
+            instance_id: Some(instance_id),
+            machine_id: None,
             operation: rpc::forge::instance_power_request::Operation::PowerReset as _,
             boot_with_custom_ipxe,
             apply_updates_on_reboot: false,

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1806,6 +1806,8 @@ message MachineState {
 }
 
 message InstancePowerRequest {
+  // The Machine to perform power operation on.
+  // Deprecated: User `instance_id` field instead.
   common.MachineId machine_id = 1;
 
   enum Operation {
@@ -1829,6 +1831,9 @@ message InstancePowerRequest {
   // In case update is needed, and user wants to approve, they can inform via this flag.
   // If this flag is true, first update will be performed and then host will be rebooted.
   bool apply_updates_on_reboot = 4;
+
+  // The instance to perform power operation on.
+  common.InstanceId instance_id = 5;
 }
 
 message InstancePowerResult {


### PR DESCRIPTION
## Description

The `InvokeInstancePower` method was a bit special: It was supposed to be invoked by tenants. And yet it carried a MachineId as argument, not an InstanceId.

This change allows the method to be invoked by either as InstanceId or MachineId. After the callers of the API are transitioned, we can change the API to only accept Instance IDs.

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

