### PR TITLE
chore: Remove double locking in PeriodicEnqueuer

### DIFF
--- a/crates/api/src/state_controller/controller/builder.rs
+++ b/crates/api/src/state_controller/controller/builder.rs
@@ -173,7 +173,6 @@ impl<IO: StateControllerIO> Builder<IO> {
         let enqueuer = PeriodicEnqueuer::<IO> {
             pool: database.clone(),
             work_lock_manager_handle,
-            work_key: IO::DB_WORK_KEY,
             stop_token: stop_token.clone(),
             metric_emitter: period_enqueuer_metric_emitter,
             iteration_config: self.iteration_config,

--- a/crates/api/src/state_controller/controller/periodic_enqueuer.rs
+++ b/crates/api/src/state_controller/controller/periodic_enqueuer.rs
@@ -31,7 +31,6 @@ pub(super) struct PeriodicEnqueuer<IO: StateControllerIO> {
     /// A database connection pool that can be used for additional queries
     pub(super) pool: sqlx::PgPool,
     pub(super) work_lock_manager_handle: WorkLockManagerHandle,
-    pub(super) work_key: &'static str,
     pub(super) io: Arc<IO>,
     pub(super) metric_emitter: Option<EnqueuerMetricsEmitter>,
     pub(super) stop_token: CancellationToken,
@@ -165,26 +164,6 @@ impl<IO: StateControllerIO> PeriodicEnqueuer<IO> {
         &mut self,
         iteration_metrics: &mut PeriodicEnqueuerMetrics,
     ) -> Result<ControllerIteration, IterationError> {
-        let _lock = match self
-            .work_lock_manager_handle
-            .try_acquire_lock(self.work_key.into())
-            .await
-        {
-            Ok(lock) => {
-                tracing::Span::current().record("skipped_iteration", false);
-                tracing::trace!(lock = IO::DB_WORK_KEY, "PeriodicEnqueuer acquired the lock");
-                lock
-            }
-            Err(e) => {
-                tracing::Span::current().record("skipped_iteration", true);
-                tracing::info!(
-                    lock = IO::DB_WORK_KEY,
-                    "PeriodicEnqueuer was not able to obtain the lock: {e}",
-                );
-                return Err(IterationError::LockError);
-            }
-        };
-
         let locked_controller_iteration = match db::lock_and_start_iteration(
             &self.pool,
             &self.work_lock_manager_handle,
@@ -194,6 +173,7 @@ impl<IO: StateControllerIO> PeriodicEnqueuer<IO> {
         {
             Ok(locked_controller_iteration) => locked_controller_iteration,
             Err(e) => {
+                tracing::Span::current().record("skipped_iteration", true);
                 tracing::error!(
                     iteration_table_id = IO::DB_ITERATION_ID_TABLE_NAME,
                     error = %e,

--- a/crates/api/src/state_controller/dpa_interface/io.rs
+++ b/crates/api/src/state_controller/dpa_interface/io.rs
@@ -36,7 +36,6 @@ impl StateControllerIO for DpaInterfaceStateControllerIO {
     type MetricsEmitter = DpaInterfaceMetricsEmitter;
     type ContextObjects = DpaInterfaceStateHandlerContextObjects;
 
-    const DB_WORK_KEY: &'static str = "dpa_interfaces_controller_lock";
     const DB_ITERATION_ID_TABLE_NAME: &'static str = "dpa_interfaces_controller_iteration_ids";
     const DB_QUEUED_OBJECTS_TABLE_NAME: &'static str = "dpa_interfaces_controller_queued_objects";
 

--- a/crates/api/src/state_controller/ib_partition/io.rs
+++ b/crates/api/src/state_controller/ib_partition/io.rs
@@ -37,7 +37,6 @@ impl StateControllerIO for IBPartitionStateControllerIO {
     type MetricsEmitter = NoopMetricsEmitter;
     type ContextObjects = IBPartitionStateHandlerContextObjects;
 
-    const DB_WORK_KEY: &'static str = "ib_partition_controller_lock";
     const DB_ITERATION_ID_TABLE_NAME: &'static str = "ib_partition_controller_iteration_ids";
     const DB_QUEUED_OBJECTS_TABLE_NAME: &'static str = "ib_partition_controller_queued_objects";
 

--- a/crates/api/src/state_controller/io.rs
+++ b/crates/api/src/state_controller/io.rs
@@ -50,12 +50,6 @@ pub trait StateControllerIO: Send + Sync + std::fmt::Debug + 'static + Default {
         ObjectMetrics = <Self::MetricsEmitter as MetricsEmitter>::ObjectMetrics,
     >;
 
-    /// The name of the work item that will be locked via db::work_lock_manager.
-    ///
-    /// This lock will prevent multiple instances of controller running on multiple nodes
-    /// from making changes to objects at the same time
-    const DB_WORK_KEY: &'static str;
-
     /// The name of the table in the database that will be used to generate run IDs
     /// The table will be locked whenever a new iteration is started
     const DB_ITERATION_ID_TABLE_NAME: &'static str;

--- a/crates/api/src/state_controller/machine/io.rs
+++ b/crates/api/src/state_controller/machine/io.rs
@@ -45,7 +45,6 @@ impl StateControllerIO for MachineStateControllerIO {
     type MetricsEmitter = MachineMetricsEmitter;
     type ContextObjects = MachineStateHandlerContextObjects;
 
-    const DB_WORK_KEY: &'static str = "machine_state_controller_lock";
     const DB_ITERATION_ID_TABLE_NAME: &'static str = "machine_state_controller_iteration_ids";
     const DB_QUEUED_OBJECTS_TABLE_NAME: &'static str = "machine_state_controller_queued_objects";
 

--- a/crates/api/src/state_controller/network_segment/io.rs
+++ b/crates/api/src/state_controller/network_segment/io.rs
@@ -36,7 +36,6 @@ impl StateControllerIO for NetworkSegmentStateControllerIO {
     type MetricsEmitter = NetworkSegmentMetricsEmitter;
     type ContextObjects = NetworkSegmentStateHandlerContextObjects;
 
-    const DB_WORK_KEY: &'static str = "network_segments_controller_lock";
     const DB_ITERATION_ID_TABLE_NAME: &'static str = "network_segments_controller_iteration_ids";
     const DB_QUEUED_OBJECTS_TABLE_NAME: &'static str = "network_segments_controller_queued_objects";
 

--- a/crates/api/src/state_controller/power_shelf/io.rs
+++ b/crates/api/src/state_controller/power_shelf/io.rs
@@ -37,7 +37,6 @@ impl StateControllerIO for PowerShelfStateControllerIO {
     type MetricsEmitter = NoopMetricsEmitter;
     type ContextObjects = PowerShelfStateHandlerContextObjects;
 
-    const DB_WORK_KEY: &'static str = "power_shelf_controller_lock";
     const DB_ITERATION_ID_TABLE_NAME: &'static str = "power_shelf_controller_iteration_ids";
     const DB_QUEUED_OBJECTS_TABLE_NAME: &'static str = "power_shelf_controller_queued_objects";
 

--- a/crates/api/src/state_controller/rack/io.rs
+++ b/crates/api/src/state_controller/rack/io.rs
@@ -36,7 +36,6 @@ impl StateControllerIO for RackStateControllerIO {
     type MetricsEmitter = NoopMetricsEmitter;
     type ContextObjects = RackStateHandlerContextObjects;
 
-    const DB_WORK_KEY: &'static str = "rack_controller_lock";
     const DB_ITERATION_ID_TABLE_NAME: &'static str = "rack_controller_iteration_ids";
     const DB_QUEUED_OBJECTS_TABLE_NAME: &'static str = "rack_controller_queued_objects";
 

--- a/crates/api/src/state_controller/spdm/io.rs
+++ b/crates/api/src/state_controller/spdm/io.rs
@@ -40,7 +40,6 @@ impl StateControllerIO for SpdmStateControllerIO {
     type MetricsEmitter = SpdmMetricsEmitter;
     type ContextObjects = SpdmStateHandlerContextObjects;
 
-    const DB_WORK_KEY: &str = "attestation_state_controller_lock";
     const DB_ITERATION_ID_TABLE_NAME: &'static str = "attestation_controller_iteration_ids";
     const DB_QUEUED_OBJECTS_TABLE_NAME: &'static str = "attestation_controller_queued_objects";
 

--- a/crates/api/src/state_controller/switch/io.rs
+++ b/crates/api/src/state_controller/switch/io.rs
@@ -37,7 +37,6 @@ impl StateControllerIO for SwitchStateControllerIO {
     type MetricsEmitter = NoopMetricsEmitter;
     type ContextObjects = SwitchStateHandlerContextObjects;
 
-    const DB_WORK_KEY: &'static str = "switch_controller_lock";
     const DB_ITERATION_ID_TABLE_NAME: &'static str = "switch_controller_iteration_ids";
     const DB_QUEUED_OBJECTS_TABLE_NAME: &'static str = "switch_controller_queued_objects";
 

--- a/crates/api/src/tests/state_controller.rs
+++ b/crates/api/src/tests/state_controller.rs
@@ -543,7 +543,6 @@ impl StateControllerIO for TestStateControllerIO {
     type MetricsEmitter = NoopMetricsEmitter;
     type ContextObjects = TestStateControllerContextObjects;
 
-    const DB_WORK_KEY: &'static str = "test_state_controller_lock";
     const DB_ITERATION_ID_TABLE_NAME: &'static str = "test_state_controller_iteration_ids";
     const DB_QUEUED_OBJECTS_TABLE_NAME: &'static str = "test_state_controller_queued_objects";
 


### PR DESCRIPTION
## Description

The PeriodicEnqueuer component temporarily used 2 locks to assure that only a single instance was running during updates to the latest carbide version.

Since that version got rolled out already, this change can remove one of the locks.

Note: There might be related entries left behind in the work_locks table. This change won't clean them up, since it can't be reliably done (migration might run before the previous carbide-api instance is torn down).

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)


## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

