### PR TITLE
CI: Add pre-commit for secrets scanning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# Pre-commit hooks configuration
+# See https://pre-commit.com for more information
+# Install: pip install pre-commit && pre-commit install
+# Run manually: pre-commit run --all-files
+
+repos:
+  # TruffleHog - Secret scanning
+  - repo: https://github.com/trufflesecurity/trufflehog
+    rev: v3.63.2
+    hooks:
+      - id: trufflehog
+        name: TruffleHog Secret Scan
+        description: Detect secrets in your codebase
+        entry: bash -c 'trufflehog git file://. --since-commit HEAD --only-verified --fail'
+        language: system
+        stages: [pre-commit]

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -103,3 +103,34 @@ instructions.
 ### Metrics and Logs
 
 Carbide collects metrics and logs from the managed hosts and the site controller. This information is in Prometheus format and can be scraped by a Prometheus server.
+
+## Development and Security
+
+### Code Quality and Security Scanning
+
+Carbide uses pre-commit hooks to enforce code quality and security standards. The following checks are automatically run before each commit:
+
+- **TruffleHog**: Scans for secrets and credentials accidentally committed to the repository. This helps prevent sensitive information from being exposed in version control.
+
+#### Setting Up Pre-commit Hooks
+
+To enable pre-commit hooks locally:
+
+```bash
+# Install pre-commit
+pip install pre-commit
+
+# Install the git hooks
+pre-commit install
+
+# (Optional) Run against all files
+pre-commit run --all-files
+```
+
+#### Manual Secret Scanning
+
+To scan the entire repository for secrets:
+
+```bash
+trufflehog git file://. --only-verified
+```


### PR DESCRIPTION
## Description
Adds pre-commit hooks with TruffleHog secret scanning to prevent accidental commits of sensitive credentials and secrets to the repository.

 Changes

  - Added .pre-commit-config.yaml: Configures TruffleHog (v3.63.2) to scan for secrets before each commit, only failing on verified secrets
  - Updated docs/overview.md: Added "Development and Security" section with:
    - Instructions for installing and setting up pre-commit hooks
    - Manual secret scanning commands using TruffleHog
    - Explanation of security tooling

  Why This Matters

  This change improves repository security by automatically detecting secrets (API keys, passwords, tokens, etc.) before they're committed. The hook runs locally during git commit and fails if verified secrets are detected, preventing
  sensitive information from entering version control history.

  Setup Instructions

  Developers will need to run:
  pip install pre-commit
  pre-commit install

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

