### PR TITLE
ib_partition - moved metadata out of ib_partition_config

### DIFF
--- a/crates/admin-cli/src/ib_partition/cmds.rs
+++ b/crates/admin-cli/src/ib_partition/cmds.rs
@@ -107,10 +107,7 @@ fn convert_ib_partitions_to_nice_table(ib_partitions: forgerpc::IbPartitionList)
     ]);
 
     for ib_partition in ib_partitions.ib_partitions {
-        let metadata = ib_partition
-            .config
-            .as_ref()
-            .and_then(|c| c.metadata.as_ref());
+        let metadata = ib_partition.metadata.as_ref();
         let labels = crate::metadata::get_nice_labels_from_rpc_metadata(metadata);
 
         table.add_row(row![
@@ -157,7 +154,7 @@ fn convert_ib_partition_to_nice_format(
 
     let default_config = forgerpc::IbPartitionConfig::default();
     let config = ib_partition.config.as_ref().unwrap_or(&default_config);
-    let metadata = config.metadata.as_ref();
+    let metadata = ib_partition.metadata.as_ref();
     let labels = crate::metadata::get_nice_labels_from_rpc_metadata(metadata);
 
     let default_status = forgerpc::IbPartitionStatus::default();

--- a/crates/api/src/handlers/ib_partition.rs
+++ b/crates/api/src/handlers/ib_partition.rs
@@ -39,7 +39,7 @@ pub(crate) async fn create(
     resp.config.rate_limit = Some(fabric_config.rate_limit.clone());
     resp.config.service_level = Some(fabric_config.service_level.clone());
 
-    resp.config.pkey = allocate_pkey(api, &mut txn, &resp.config.metadata.name).await?;
+    resp.config.pkey = allocate_pkey(api, &mut txn, &resp.metadata.name).await?;
     let resp = db::ib_partition::create(resp, &mut txn, fabric_config.max_partition_per_tenant)
         .await
         .map_err(|e| {

--- a/crates/api/src/tests/common/api_fixtures/ib_partition.rs
+++ b/crates/api/src/tests/common/api_fixtures/ib_partition.rs
@@ -31,11 +31,11 @@ pub async fn create_ib_partition(
             config: Some(IbPartitionConfig {
                 name: name.clone(),
                 tenant_organization_id: tenant,
-                metadata: Some(rpc::Metadata {
-                    name,
-                    labels: Default::default(),
-                    description: "".to_string(),
-                }),
+            }),
+            metadata: Some(rpc::Metadata {
+                name,
+                labels: Default::default(),
+                description: "".to_string(),
             }),
         }))
         .await

--- a/crates/api/src/tests/ib_partition_find.rs
+++ b/crates/api/src/tests/ib_partition_find.rs
@@ -143,10 +143,11 @@ async fn test_find_ib_partitions_by_ids(pool: sqlx::PgPool) {
     assert_eq!(partition_list.ib_partitions.len(), 1);
 
     let partition3config = partition3.config.unwrap();
-    let clone3config = partition_list.ib_partitions[0].clone().config.unwrap();
+    let part3_list = partition_list.ib_partitions[0].clone();
+    let clone3config = part3_list.config.unwrap();
     assert_eq!(
-        partition3config.metadata.unwrap().name,
-        clone3config.metadata.unwrap().name
+        partition3.metadata.unwrap().name,
+        part3_list.metadata.unwrap().name
     );
     assert_eq!(
         partition3config.tenant_organization_id,

--- a/crates/api/src/tests/ib_partition_lifecycle.rs
+++ b/crates/api/src/tests/ib_partition_lifecycle.rs
@@ -39,14 +39,14 @@ async fn create_ib_partition_with_api(
         config: Some(IbPartitionConfig {
             name: name.clone(),
             tenant_organization_id: FIXTURE_TENANT_ORG_ID.to_string(),
-            metadata: Some(rpc::Metadata {
-                name,
-                labels: vec![Label {
-                    key: "example_key".into(),
-                    value: Some("example_value".into()),
-                }],
-                description: "example description".into(),
-            }),
+        }),
+        metadata: Some(rpc::Metadata {
+            name,
+            labels: vec![Label {
+                key: "example_key".into(),
+                value: Some("example_value".into()),
+            }],
+            description: "example description".into(),
         }),
     };
 
@@ -273,14 +273,14 @@ async fn test_reject_create_with_invalid_metadata(
         config: Some(IbPartitionConfig {
             name: "partition1".into(),
             tenant_organization_id: FIXTURE_TENANT_ORG_ID.to_string(),
-            metadata: Some(rpc::Metadata {
-                name: "".into(), // Invalid name
-                labels: vec![Label {
-                    key: "example_key".into(),
-                    value: Some("example_value".into()),
-                }],
-                description: "example description".into(),
-            }),
+        }),
+        metadata: Some(rpc::Metadata {
+            name: "".into(), // Invalid name
+            labels: vec![Label {
+                key: "example_key".into(),
+                value: Some("example_value".into()),
+            }],
+            description: "example description".into(),
         }),
     };
 
@@ -319,14 +319,14 @@ async fn create_ib_partition_with_api_with_id(
         config: Some(IbPartitionConfig {
             name: "partition1".into(),
             tenant_organization_id: FIXTURE_TENANT_ORG_ID.to_string(),
-            metadata: Some(rpc::Metadata {
-                name: "partition1".into(),
-                labels: vec![Label {
-                    key: "example_label".into(),
-                    value: Some("example_value".into()),
-                }],
-                description: "description".into(),
-            }),
+        }),
+        metadata: Some(rpc::Metadata {
+            name: "partition1".into(),
+            labels: vec![Label {
+                key: "example_label".into(),
+                value: Some("example_value".into()),
+            }],
+            description: "description".into(),
         }),
     };
 
@@ -347,16 +347,17 @@ async fn test_update_ib_partition(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
     let new_partition = NewIBPartition {
         id,
         config: IBPartitionConfig {
+            name: "partition1".to_string(),
             pkey: Some(42.try_into().unwrap()),
             tenant_organization_id: FIXTURE_TENANT_ORG_ID.to_string().try_into().unwrap(),
             mtu: Some(IBMtu::default()),
             rate_limit: Some(IBRateLimit::default()),
             service_level: Some(IBServiceLevel::default()),
-            metadata: Metadata {
-                name: "partition1".to_string(),
-                labels: HashMap::from([("example_label".into(), "example_value".into())]),
-                description: "new description".to_string(),
-            },
+        },
+        metadata: Metadata {
+            name: "partition1".to_string(),
+            labels: HashMap::from([("example_label".into(), "example_value".into())]),
+            description: "new description".to_string(),
         },
     };
     let mut txn = pool.begin().await?;
@@ -417,23 +418,24 @@ async fn test_reject_update_with_invalid_metadata(
     let new_partition = NewIBPartition {
         id,
         config: IBPartitionConfig {
+            name: "partition1".to_string(),
             pkey: Some(42.try_into().unwrap()),
             tenant_organization_id: FIXTURE_TENANT_ORG_ID.to_string().try_into().unwrap(),
             mtu: Some(IBMtu::default()),
             rate_limit: Some(IBRateLimit::default()),
             service_level: Some(IBServiceLevel::default()),
-            metadata: Metadata {
-                name: "partition1".to_string(),
-                labels: HashMap::from([("example_label".into(), "example_value".into())]),
-                description: "new description".to_string(),
-            },
+        },
+        metadata: Metadata {
+            name: "partition1".to_string(),
+            labels: HashMap::from([("example_label".into(), "example_value".into())]),
+            description: "new description".to_string(),
         },
     };
     let mut txn = pool.begin().await?;
     let mut partition: IBPartition = db::ib_partition::create(new_partition, &mut txn, 10).await?;
     txn.commit().await?;
 
-    partition.config.metadata.name = "".to_string(); // Invalid name
+    partition.metadata.name = "".to_string(); // Invalid name
 
     let mut txn = pool.begin().await?;
     let result = db::ib_partition::update(&partition, &mut txn).await;

--- a/crates/api/src/web/ib_partition.rs
+++ b/crates/api/src/web/ib_partition.rs
@@ -40,11 +40,10 @@ struct IbPartitionRowDisplay {
 
 impl From<forgerpc::IbPartition> for IbPartitionRowDisplay {
     fn from(partition: forgerpc::IbPartition) -> Self {
-        let config = partition.config.unwrap_or_default();
         Self {
             id: partition.id.map(|id| id.to_string()).unwrap_or_default(),
-            tenant_organization_id: config.tenant_organization_id,
-            metadata: config.metadata.unwrap_or_default(),
+            tenant_organization_id: partition.config.unwrap_or_default().tenant_organization_id,
+            metadata: partition.metadata.unwrap_or_default(),
             state: partition
                 .status
                 .as_ref()
@@ -133,8 +132,8 @@ async fn fetch_ib_partitions(api: Arc<Api>) -> Result<Vec<forgerpc::IbPartition>
     partitions.sort_unstable_by(|p1, p2: &rpc::IbPartition| {
         // Sort by tenant_org and name
         // Otherwise fall back to ID
-        if let (Some(p1), Some(p2)) = (p1.config.as_ref(), p2.config.as_ref()) {
-            let ord = p1.tenant_organization_id.cmp(&p2.tenant_organization_id);
+        if let (Some(pc1), Some(pc2)) = (p1.config.as_ref(), p2.config.as_ref()) {
+            let ord = pc1.tenant_organization_id.cmp(&pc2.tenant_organization_id);
             if ord.is_ne() {
                 return ord;
             }
@@ -176,12 +175,11 @@ struct IbPartitionDetail {
 
 impl From<forgerpc::IbPartition> for IbPartitionDetail {
     fn from(partition: forgerpc::IbPartition) -> Self {
-        let config = partition.config.unwrap_or_default();
         Self {
             id: partition.id.map(|id| id.to_string()).unwrap_or_default(),
             config_version: partition.config_version,
-            tenant_organization_id: config.tenant_organization_id,
-            metadata: config.metadata.unwrap_or_default(),
+            tenant_organization_id: partition.config.unwrap_or_default().tenant_organization_id,
+            metadata: partition.metadata.unwrap_or_default(),
             state: partition
                 .status
                 .as_ref()

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1382,8 +1382,7 @@ message IBPartitionConfig {
   string name = 1;
   // The ID of tenant that IBPartition belong to
   string tenantOrganizationId = 2; // protolint:disable:this FIELD_NAMES_LOWER_SNAKE_CASE
-  // Metadata associated with this IB Partition
-  Metadata metadata = 3;
+
 }
 
 // Describe the status and applied configuration of an IBPartition
@@ -1417,6 +1416,8 @@ message IBPartition {
   string config_version = 3;
 
   IBPartitionStatus status = 4;
+
+  Metadata metadata = 5;
 }
 
 message IBPartitionList {
@@ -1429,6 +1430,8 @@ message IBPartitionCreationRequest {
   // a random ID.
   // The Partition ID must be unique within the Forge site.
   optional common.IBPartitionId id = 2;
+
+  Metadata metadata = 3;
 }
 
 message IBPartitionDeletionRequest {


### PR DESCRIPTION
## Description
https://github.com/NVIDIA/carbide-core/pull/64 incorrectly added metadata to `IBParitionConfig`, which breaks status/config/metadata pattern in the API. This PR fixes this

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

