### PR TITLE
Keep context about firmware_number for multi-file upgrades

### DIFF
--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1395,8 +1395,18 @@ pub enum NetworkConfigUpdateState {
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum HostReprovisionState {
+    // deprecated, kept for backwards compatibility with existing database entries: FORGE-7975
     CheckingFirmware,
+    // deprecated, kept for backwards compatibility with existing database entries: FORGE-7975
     CheckingFirmwareRepeat,
+    CheckingFirmwareV2 {
+        firmware_type: Option<FirmwareComponentType>,
+        firmware_number: Option<u32>,
+    },
+    CheckingFirmwareRepeatV2 {
+        firmware_type: Option<FirmwareComponentType>,
+        firmware_number: Option<u32>,
+    },
     InitialReset {
         phase: InitialResetPhase,
         last_time: DateTime<Utc>,
@@ -1422,6 +1432,7 @@ pub enum HostReprovisionState {
     ResetForNewFirmware {
         final_version: String,
         firmware_type: FirmwareComponentType,
+        firmware_number: Option<u32>,
         power_drains_needed: Option<u32>,
         delay_until: Option<i64>,
         last_power_drain_operation: Option<PowerDrainState>,
@@ -1429,6 +1440,7 @@ pub enum HostReprovisionState {
     NewFirmwareReportedWait {
         final_version: String,
         firmware_type: FirmwareComponentType,
+        firmware_number: Option<u32>,
         previous_reset_time: Option<i64>,
     },
     FailedFirmwareUpgrade {

--- a/crates/api/src/state_controller/machine/handler/helpers.rs
+++ b/crates/api/src/state_controller/machine/handler/helpers.rs
@@ -394,7 +394,10 @@ impl NextState for InstanceNextStateResolver {
                 if host_snapshot.host_reprovision_requested.is_some() {
                     Ok(ManagedHostState::Assigned {
                         instance_state: InstanceState::HostReprovision {
-                            reprovision_state: HostReprovisionState::CheckingFirmware,
+                            reprovision_state: HostReprovisionState::CheckingFirmwareV2 {
+                                firmware_type: None,
+                                firmware_number: None,
+                            },
                         },
                     })
                 } else {

--- a/crates/api/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api/src/tests/host_bmc_firmware_test.rs
@@ -546,7 +546,7 @@ async fn test_postingestion_bmc_upgrade(pool: sqlx::PgPool) -> CarbideResult<()>
     else {
         panic!("Not in HostReprovision");
     };
-    let HostReprovisionState::CheckingFirmwareRepeat = reprovision_state else {
+    let HostReprovisionState::CheckingFirmwareRepeatV2 { .. } = reprovision_state else {
         panic!("Not in reset {reprovision_state:?}");
     };
     txn.commit().await.unwrap();
@@ -571,17 +571,30 @@ async fn test_postingestion_bmc_upgrade(pool: sqlx::PgPool) -> CarbideResult<()>
     else {
         panic!("Not in HostReprovision");
     };
-    let HostReprovisionState::WaitingForFirmwareUpgrade { firmware_type, .. } = reprovision_state
+    let HostReprovisionState::WaitingForFirmwareUpgrade {
+        firmware_type,
+        firmware_number,
+        ..
+    } = reprovision_state
     else {
         panic!("Not in WaitingForFirmwareUpgrade");
     };
     assert_eq!(firmware_type, &FirmwareComponentType::Bmc);
+    assert_eq!(firmware_number, &Some(0));
     txn.commit().await.unwrap();
 
     // Another state machine pass
+    // WaitingForFirmwareUpgrade -> CheckingFirmware (firmware_number: 1)
     env.run_machine_state_controller_iteration().await;
+
+    // Another state machine pass
+    // CheckingFirmware -> WaitingForUpload (firmware_number: 1)
+    env.run_machine_state_controller_iteration().await;
+
     // Wait a bit for upload to complete
     sleep(Duration::from_millis(6000)).await;
+
+    // WaitingForUpload -> WaitingForFirmwareUpgrade
     env.run_machine_state_controller_iteration().await;
 
     let mut txn = env.pool.begin().await.unwrap();
@@ -674,9 +687,9 @@ async fn test_postingestion_bmc_upgrade(pool: sqlx::PgPool) -> CarbideResult<()>
     else {
         panic!("Not in HostReprovision");
     };
-    if reprovision_state != &HostReprovisionState::CheckingFirmwareRepeat {
+    let HostReprovisionState::CheckingFirmwareRepeatV2 { .. } = reprovision_state else {
         panic!("Not in checking");
-    }
+    };
     txn.commit().await.unwrap();
 
     // Another state machine pass
@@ -1285,7 +1298,7 @@ async fn test_instance_upgrading_actual_part_2(
     let InstanceState::HostReprovision { reprovision_state } = instance_state else {
         panic!("Unexpected state {:?}", host.state)
     };
-    let HostReprovisionState::CheckingFirmware = reprovision_state else {
+    let HostReprovisionState::CheckingFirmwareV2 { .. } = reprovision_state else {
         panic!("Unexpected state {:?}", host.state)
     };
     assert!(host.host_reprovision_requested.is_some());
@@ -1437,7 +1450,7 @@ async fn test_instance_upgrading_actual_part_2(
     let InstanceState::HostReprovision { reprovision_state } = instance_state else {
         panic!("Unexpected state {:?}", host.state)
     };
-    let HostReprovisionState::CheckingFirmwareRepeat = reprovision_state else {
+    let HostReprovisionState::CheckingFirmwareRepeatV2 { .. } = reprovision_state else {
         panic!("Not in reset {reprovision_state:?}");
     };
 
@@ -1461,7 +1474,7 @@ async fn test_instance_upgrading_actual_part_2(
     sleep(Duration::from_millis(6000)).await;
     env.run_machine_state_controller_iteration().await;
 
-    // It should have "started" a BMC upgrade now
+    // It should have "started" a BMC upgrade now (first file out of 2)
     let mut txn = env.pool.begin().await.unwrap();
     let host = mh.host().db_machine(&mut txn).await;
 
@@ -1472,11 +1485,16 @@ async fn test_instance_upgrading_actual_part_2(
     let InstanceState::HostReprovision { reprovision_state } = instance_state else {
         panic!("Unexpected state {:?}", host.state)
     };
-    let HostReprovisionState::WaitingForFirmwareUpgrade { firmware_type, .. } = reprovision_state
+    let HostReprovisionState::WaitingForFirmwareUpgrade {
+        firmware_type,
+        firmware_number,
+        ..
+    } = reprovision_state
     else {
         panic!("Not in WaitingForFirmwareUpgrade");
     };
     assert_eq!(firmware_type, FirmwareComponentType::Bmc);
+    assert_eq!(firmware_number, Some(0));
     // Check that the TenantState is what we expect based on the instance/machine state.
     let instance = tinstance.db_instance(&mut txn).await;
 
@@ -1494,11 +1512,7 @@ async fn test_instance_upgrading_actual_part_2(
     txn.commit().await.unwrap();
 
     // Another state machine pass
-    env.run_machine_state_controller_iteration().await;
-    sleep(Duration::from_millis(6000)).await;
-    // Another state machine pass
-    env.run_machine_state_controller_iteration().await;
-    // Another state machine pass
+    // WaitingForFirmwareUpgrade -> CheckingFirmware (firmware_number: 1)
     env.run_machine_state_controller_iteration().await;
     let mut txn = env.pool.begin().await.unwrap();
     let host = mh.host().db_machine(&mut txn).await;
@@ -1508,9 +1522,40 @@ async fn test_instance_upgrading_actual_part_2(
     let InstanceState::HostReprovision { reprovision_state } = instance_state else {
         panic!("Unexpected state {:?}", host.state)
     };
-    let HostReprovisionState::ResetForNewFirmware { .. } = reprovision_state else {
+    let HostReprovisionState::CheckingFirmwareV2 {
+        firmware_number, ..
+    } = reprovision_state
+    else {
+        panic!("Not in CheckingFirmware: {reprovision_state:?}");
+    };
+    assert_eq!(firmware_number, Some(1));
+
+    // Another state machine pass
+    // CheckingFirmware -> WaitingForUpload (firmware_number: 1)
+    env.run_machine_state_controller_iteration().await;
+    sleep(Duration::from_millis(6000)).await;
+    // Another state machine pass
+    // WaitingForUpload -> WaitingForFirmwareUpgrade
+    env.run_machine_state_controller_iteration().await;
+    // Another state machine pass
+    // WaitingForFirmwareUpgrade -> ResetForNewFirmware
+    env.run_machine_state_controller_iteration().await;
+    let mut txn = env.pool.begin().await.unwrap();
+    let host = mh.host().db_machine(&mut txn).await;
+    let ManagedHostState::Assigned { instance_state } = host.state.clone().value else {
+        panic!("Unexpected state {:?}", host.state);
+    };
+    let InstanceState::HostReprovision { reprovision_state } = instance_state else {
+        panic!("Unexpected state {:?}", host.state)
+    };
+    let HostReprovisionState::ResetForNewFirmware {
+        firmware_number, ..
+    } = reprovision_state
+    else {
         panic!("Not in reset {reprovision_state:?}");
     };
+
+    assert_eq!(firmware_number, Some(1));
 
     // Check that the TenantState is what we expect based on the instance/machine state.
     let instance = tinstance.db_instance(&mut txn).await;
@@ -1596,9 +1641,9 @@ async fn test_instance_upgrading_actual_part_2(
     let InstanceState::HostReprovision { reprovision_state } = instance_state else {
         panic!("Unexpected state {:?}", host.state)
     };
-    if reprovision_state != HostReprovisionState::CheckingFirmwareRepeat {
+    let HostReprovisionState::CheckingFirmwareRepeatV2 { .. } = reprovision_state else {
         panic!("Not in checking");
-    }
+    };
 
     // Check that the TenantState is what we expect based on the instance/machine state.
     let instance = tinstance.db_instance(&mut txn).await;
@@ -1811,7 +1856,7 @@ async fn test_script_upgrade(pool: sqlx::PgPool) -> CarbideResult<()> {
     else {
         panic!("Not in HostReprovision");
     };
-    let HostReprovisionState::CheckingFirmwareRepeat = reprovision_state else {
+    let HostReprovisionState::CheckingFirmwareRepeatV2 { .. } = reprovision_state else {
         panic!("Not in CheckingFirmwareRepeat");
     };
     txn.commit().await.unwrap();
@@ -1915,7 +1960,7 @@ async fn test_script_upgrade_failure(pool: sqlx::PgPool) -> CarbideResult<()> {
             panic!("Not in HostReprovision");
         };
         assert_eq!(*retry_count, retry_i);
-        let HostReprovisionState::CheckingFirmware = reprovision_state else {
+        let HostReprovisionState::CheckingFirmwareV2 { .. } = reprovision_state else {
             panic!("Not in CheckingFirmware");
         };
         txn.commit().await.unwrap();
@@ -2492,7 +2537,7 @@ async fn test_manual_firmware_upgrade_workflow(pool: sqlx::PgPool) -> CarbideRes
         matches!(
             host.current_state(),
             ManagedHostState::HostReprovision {
-                reprovision_state: HostReprovisionState::CheckingFirmwareRepeat,
+                reprovision_state: HostReprovisionState::CheckingFirmwareRepeatV2 { .. },
                 ..
             }
         ),


### PR DESCRIPTION
## Description

Currently, if something goes wrong while doing a multi-file upgrade the context is lost. Adding firmware_number to some sub-states to keep the context.

Update:

Had to add V2 variants of `CheckingFirmware` and `CheckingFirmwareRepeat` to keep it backwards compatible. Otherwise deserializing would fail for machines that are in these states currently.

Once the machines cycle through the states, I will do a migration. Here is the ticket for it with a plan: https://jirasw.nvidia.com/browse/FORGE-7975 

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
In the future we can think about creating a separate struct for the context that each `HostReprovision` sub-state will carry. Otherwise it is getting confusing.

