### PR TITLE
fix: flake: Assigned/WaitingForNetworkConfig may be missed by poll

### DIFF
--- a/crates/api-test-helper/src/instance.rs
+++ b/crates/api-test-helper/src/instance.rs
@@ -83,7 +83,7 @@ pub async fn create(
         return Ok(instance_id);
     }
 
-    wait_for_state(addrs, host_machine_id, "Assigned/WaitingForNetworkConfig").await?;
+    wait_for_state(addrs, host_machine_id, "Assigned/Ready").await?;
 
     if phone_home_enable {
         wait_for_instance_state(addrs, &instance_id, "PROVISIONING").await?;


### PR DESCRIPTION
## Description
In some cases integration test can miss `Assigned/WaitingForNetworkConfig` state if state machine advanced fast to `Assigned/Ready`. This PR fixes this behavior by relaxing state requirements to  wait to `Assigned/Ready`

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

I was able to reproduce issue by adding sleep before WaitForNetworkConfig state wait. 
