### PR TITLE
Fix unnecessary clones in carbide-admin-cli

### DIFF
--- a/crates/admin-cli/src/credential/cmds.rs
+++ b/crates/admin-cli/src/credential/cmds.rs
@@ -99,8 +99,8 @@ pub async fn delete_bmc(c: DeleteBMCredential, api_client: &ApiClient) -> Carbid
 }
 
 pub async fn add_uefi(c: AddUefiCredential, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let mut password = password_validator(c.password.clone())?;
-    if c.password.is_empty() {
+    let mut password = password_validator(c.password)?;
+    if password.is_empty() {
         password = Credentials::generate_password_no_special_char();
     }
 

--- a/crates/admin-cli/src/devenv/cmds.rs
+++ b/crates/admin-cli/src/devenv/cmds.rs
@@ -42,7 +42,7 @@ async fn get_or_create_vpc(api_client: &ApiClient) -> CarbideCliResult<Vpc> {
             vpc.id.unwrap(),
             vpc.metadata
                 .as_ref()
-                .map(|x| x.name.clone())
+                .map(|x| x.name.as_str())
                 .unwrap_or_default()
         );
         vpc
@@ -158,7 +158,7 @@ pub async fn apply_devenv_config(
     api_client: &ApiClient,
 ) -> Result<(), CarbideCliError> {
     // Read config file.
-    if !std::fs::exists(config.path.clone())? {
+    if !std::fs::exists(&config.path)? {
         return Err(CarbideCliError::GenericError(
             "Config file does not exists.".to_string(),
         ));

--- a/crates/admin-cli/src/dpu_remediation/args.rs
+++ b/crates/admin-cli/src/dpu_remediation/args.rs
@@ -64,7 +64,7 @@ pub struct CreateDpuRemediation {
 }
 
 impl CreateDpuRemediation {
-    pub fn metadata(&self) -> Option<::rpc::forge::Metadata> {
+    pub fn into_metadata(self) -> Option<::rpc::forge::Metadata> {
         if self.labels.is_none() && self.meta_name.is_none() && self.meta_description.is_none() {
             return None;
         }
@@ -87,8 +87,8 @@ impl CreateDpuRemediation {
         }
 
         Some(::rpc::forge::Metadata {
-            name: self.meta_name.clone().unwrap_or_default(),
-            description: self.meta_description.clone().unwrap_or_default(),
+            name: self.meta_name.unwrap_or_default(),
+            description: self.meta_description.unwrap_or_default(),
             labels,
         })
     }

--- a/crates/admin-cli/src/dpu_remediation/cmds.rs
+++ b/crates/admin-cli/src/dpu_remediation/cmds.rs
@@ -45,8 +45,8 @@ pub async fn create_dpu_remediation(
         .0
         .create_remediation(CreateRemediationRequest {
             script,
-            metadata: create_remediation.metadata(),
             retries: create_remediation.retries.unwrap_or_default() as i32,
+            metadata: create_remediation.into_metadata(),
         })
         .await?;
 

--- a/crates/admin-cli/src/expected_machines/cmds.rs
+++ b/crates/admin-cli/src/expected_machines/cmds.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 use std::pin::Pin;
 
 use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use mac_address::MacAddress;
 use prettytable::{Table, row};
 
 use super::args::ShowExpectedMachineQuery;
@@ -59,13 +60,14 @@ pub async fn show_expected_machines(
     let expected_macs = expected_machines
         .expected_machines
         .iter()
-        .map(|x| x.bmc_mac_address.clone().to_lowercase())
-        .collect::<Vec<String>>();
+        .filter_map(|x| x.bmc_mac_address.parse().ok())
+        .collect::<Vec<MacAddress>>();
 
-    let expected_mi: HashMap<String, ::rpc::forge::MachineInterface> =
-        HashMap::from_iter(all_mi.interfaces.iter().filter_map(|x| {
-            if expected_macs.contains(&x.mac_address.to_lowercase()) {
-                Some((x.mac_address.clone().to_lowercase(), x.clone()))
+    let expected_mi: HashMap<MacAddress, ::rpc::forge::MachineInterface> =
+        HashMap::from_iter(all_mi.interfaces.into_iter().filter_map(|x| {
+            let mac = x.mac_address.parse().ok()?;
+            if expected_macs.contains(&mac) {
+                Some((mac, x))
             } else {
                 None
             }
@@ -73,8 +75,8 @@ pub async fn show_expected_machines(
 
     let bmc_ips = expected_mi
         .iter()
-        .filter_map(|x| {
-            let ip = x.1.address.first()?;
+        .filter_map(|(_mac, interface)| {
+            let ip = interface.address.first()?;
             Some(ip.clone())
         })
         .collect::<Vec<_>>();
@@ -85,10 +87,10 @@ pub async fn show_expected_machines(
             .find_machine_ids_by_bmc_ips(bmc_ips)
             .await?
             .pairs
-            .iter()
+            .into_iter()
             .map(|x| {
                 (
-                    x.bmc_ip.clone(),
+                    x.bmc_ip,
                     x.machine_id
                         .map(|x| x.to_string())
                         .unwrap_or("Unlinked".to_string()),
@@ -111,7 +113,7 @@ async fn convert_and_print_into_nice_table(
     output: &mut Pin<Box<dyn tokio::io::AsyncWrite>>,
     expected_machines: &::rpc::forge::ExpectedMachineList,
     expected_discovered_machine_ids: &HashMap<String, String>,
-    expected_discovered_machine_interfaces: &HashMap<String, ::rpc::forge::MachineInterface>,
+    expected_discovered_machine_interfaces: &HashMap<MacAddress, ::rpc::forge::MachineInterface>,
 ) -> CarbideCliResult<()> {
     let mut table = Box::new(Table::new());
 
@@ -130,26 +132,36 @@ async fn convert_and_print_into_nice_table(
     ]);
 
     for expected_machine in &expected_machines.expected_machines {
-        let machine_interface = expected_discovered_machine_interfaces
-            .get(&expected_machine.bmc_mac_address.to_lowercase());
+        let default_pause_ingestion_and_poweron =
+            expected_machine.default_pause_ingestion_and_poweron();
+
+        let machine_interface = expected_machine
+            .bmc_mac_address
+            .parse::<MacAddress>()
+            .ok()
+            .and_then(|m| expected_discovered_machine_interfaces.get(&m));
         let machine_id = expected_discovered_machine_ids
             .get(
-                &machine_interface
-                    .and_then(|x| x.address.first().cloned())
-                    .unwrap_or("unknown".to_string()),
+                machine_interface
+                    .and_then(|x| x.address.first().map(String::as_str))
+                    .unwrap_or("unknown"),
             )
-            .cloned();
+            .map(String::as_str);
 
-        let metadata = expected_machine.metadata.clone().unwrap_or_default();
-        let labels = metadata
-            .labels
-            .iter()
-            .map(|label| {
-                let key = &label.key;
-                let value = label.value.clone().unwrap_or_default();
-                format!("\"{key}:{value}\"")
+        let labels = expected_machine
+            .metadata
+            .as_ref()
+            .map(|m| {
+                m.labels
+                    .iter()
+                    .map(|label| {
+                        let key = label.key.as_str();
+                        let value = label.value.as_deref().unwrap_or_default();
+                        format!("\"{key}:{value}\"")
+                    })
+                    .collect::<Vec<_>>()
             })
-            .collect::<Vec<_>>();
+            .unwrap_or_default();
 
         table.add_row(row![
             expected_machine.chassis_serial_number,
@@ -158,16 +170,20 @@ async fn convert_and_print_into_nice_table(
                 .map(|x| x.address.join("\n"))
                 .unwrap_or("Undiscovered".to_string()),
             expected_machine.fallback_dpu_serial_numbers.join("\n"),
-            machine_id.unwrap_or("Unlinked".to_string()),
-            metadata.name,
-            metadata.description,
-            labels.join(", "),
+            machine_id.unwrap_or("Unlinked"),
             expected_machine
-                .sku_id
+                .metadata
                 .as_ref()
-                .map(|x| x.to_string())
+                .map(|m| m.name.as_str())
                 .unwrap_or_default(),
-            expected_machine.default_pause_ingestion_and_poweron(),
+            expected_machine
+                .metadata
+                .as_ref()
+                .map(|m| m.description.as_str())
+                .unwrap_or_default(),
+            labels.join(", "),
+            expected_machine.sku_id.as_deref().unwrap_or_default(),
+            default_pause_ingestion_and_poweron,
             expected_machine.dpf_enabled.to_string(),
         ]);
     }

--- a/crates/admin-cli/src/expected_machines/mod.rs
+++ b/crates/admin-cli/src/expected_machines/mod.rs
@@ -20,7 +20,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Cmd;
 use serde::{Deserialize, Serialize};
 
@@ -45,25 +45,11 @@ impl Dispatch for Cmd {
                     eprintln!("Duplicate values not allowed for --fallback-dpu-serial-number");
                     return Ok(());
                 }
-                let metadata = expected_machine_data
-                    .metadata()
-                    .map_err(|e| CarbideCliError::GenericError(e.to_string()))?;
-                let host_nics = Vec::new();
+                let expected_machine: rpc::forge::ExpectedMachine =
+                    expected_machine_data.try_into()?;
                 ctx.api_client
-                    .add_expected_machine(
-                        expected_machine_data.bmc_mac_address,
-                        expected_machine_data.bmc_username.clone(),
-                        expected_machine_data.bmc_password.clone(),
-                        expected_machine_data.chassis_serial_number.clone(),
-                        expected_machine_data.fallback_dpu_serial_numbers.clone(),
-                        metadata,
-                        expected_machine_data.sku_id.clone(),
-                        expected_machine_data.id.clone(),
-                        host_nics,
-                        expected_machine_data.rack_id.clone(),
-                        expected_machine_data.default_pause_ingestion_and_poweron,
-                        expected_machine_data.dpf_enabled,
-                    )
+                    .0
+                    .add_expected_machine(expected_machine)
                     .await?;
                 Ok(())
             }
@@ -85,15 +71,15 @@ impl Dispatch for Cmd {
                 ctx.api_client
                     .patch_expected_machine(
                         expected_machine_data.bmc_mac_address,
-                        expected_machine_data.bmc_username.clone(),
-                        expected_machine_data.bmc_password.clone(),
-                        expected_machine_data.chassis_serial_number.clone(),
-                        expected_machine_data.fallback_dpu_serial_numbers.clone(),
-                        expected_machine_data.meta_name.clone(),
-                        expected_machine_data.meta_description.clone(),
-                        expected_machine_data.labels.clone(),
-                        expected_machine_data.sku_id.clone(),
-                        expected_machine_data.rack_id.clone(),
+                        expected_machine_data.bmc_username,
+                        expected_machine_data.bmc_password,
+                        expected_machine_data.chassis_serial_number,
+                        expected_machine_data.fallback_dpu_serial_numbers,
+                        expected_machine_data.meta_name,
+                        expected_machine_data.meta_description,
+                        expected_machine_data.labels,
+                        expected_machine_data.sku_id,
+                        expected_machine_data.rack_id,
                         expected_machine_data.default_pause_ingestion_and_poweron,
                         expected_machine_data.dpf_enabled,
                     )

--- a/crates/admin-cli/src/expected_power_shelf/args.rs
+++ b/crates/admin-cli/src/expected_power_shelf/args.rs
@@ -14,6 +14,8 @@ use clap::{ArgGroup, Parser};
 use mac_address::MacAddress;
 use serde::{Deserialize, Serialize};
 
+use crate::metadata::parse_rpc_labels;
+
 #[derive(Parser, Debug)]
 pub enum Cmd {
     #[clap(about = "Show expected power shelf")]
@@ -101,30 +103,23 @@ pub struct AddExpectedPowerShelf {
     pub ip_address: Option<String>,
 }
 
-impl AddExpectedPowerShelf {
-    pub fn metadata(&self) -> Result<::rpc::forge::Metadata, eyre::Report> {
-        let mut labels = Vec::new();
-        if let Some(list) = &self.labels {
-            for label in list {
-                let label = match label.split_once(':') {
-                    Some((k, v)) => rpc::forge::Label {
-                        key: k.trim().to_string(),
-                        value: Some(v.trim().to_string()),
-                    },
-                    None => rpc::forge::Label {
-                        key: label.trim().to_string(),
-                        value: None,
-                    },
-                };
-                labels.push(label);
-            }
-        }
-
-        Ok(::rpc::forge::Metadata {
-            name: self.meta_name.clone().unwrap_or_default(),
-            description: self.meta_description.clone().unwrap_or_default(),
+impl From<AddExpectedPowerShelf> for rpc::forge::ExpectedPowerShelf {
+    fn from(value: AddExpectedPowerShelf) -> Self {
+        let labels = parse_rpc_labels(value.labels.unwrap_or_default());
+        let metadata = rpc::forge::Metadata {
+            name: value.meta_name.unwrap_or_default(),
+            description: value.meta_description.unwrap_or_default(),
             labels,
-        })
+        };
+        rpc::forge::ExpectedPowerShelf {
+            bmc_mac_address: value.bmc_mac_address.to_string(),
+            bmc_username: value.bmc_username,
+            bmc_password: value.bmc_password,
+            shelf_serial_number: value.shelf_serial_number,
+            ip_address: value.ip_address.unwrap_or_default(),
+            rack_id: value.rack_id,
+            metadata: Some(metadata),
+        }
     }
 }
 
@@ -229,31 +224,6 @@ impl UpdateExpectedPowerShelf {
             return Err("One of the following options must be specified: bmc-user-name and bmc-password or shelf-serial-number".to_string());
         }
         Ok(())
-    }
-
-    pub fn metadata(&self) -> Result<::rpc::forge::Metadata, eyre::Report> {
-        let mut labels = Vec::new();
-        if let Some(list) = &self.labels {
-            for label in list {
-                let label = match label.split_once(':') {
-                    Some((k, v)) => rpc::forge::Label {
-                        key: k.trim().to_string(),
-                        value: Some(v.trim().to_string()),
-                    },
-                    None => rpc::forge::Label {
-                        key: label.trim().to_string(),
-                        value: None,
-                    },
-                };
-                labels.push(label);
-            }
-        }
-
-        Ok(::rpc::forge::Metadata {
-            name: self.meta_name.clone().unwrap_or_default(),
-            description: self.meta_description.clone().unwrap_or_default(),
-            labels,
-        })
     }
 }
 

--- a/crates/admin-cli/src/expected_power_shelf/mod.rs
+++ b/crates/admin-cli/src/expected_power_shelf/mod.rs
@@ -25,11 +25,11 @@ use crate::cfg::runtime::RuntimeContext;
 impl Dispatch for Cmd {
     async fn dispatch(self, ctx: RuntimeContext) -> CarbideCliResult<()> {
         match self {
-            Cmd::Show(query) => cmds::show(&query, &ctx.api_client, ctx.config.format).await?,
-            Cmd::Add(data) => cmds::add(&data, &ctx.api_client).await?,
-            Cmd::Delete(query) => cmds::delete(&query, &ctx.api_client).await?,
-            Cmd::Update(data) => cmds::update(&data, &ctx.api_client).await?,
-            Cmd::ReplaceAll(request) => cmds::replace_all(&request, &ctx.api_client).await?,
+            Cmd::Show(query) => cmds::show(query, &ctx.api_client, ctx.config.format).await?,
+            Cmd::Add(data) => cmds::add(data, &ctx.api_client).await?,
+            Cmd::Delete(query) => cmds::delete(query, &ctx.api_client).await?,
+            Cmd::Update(data) => cmds::update(data, &ctx.api_client).await?,
+            Cmd::ReplaceAll(request) => cmds::replace_all(request, &ctx.api_client).await?,
             Cmd::Erase => cmds::erase(&ctx.api_client).await?,
         }
         Ok(())

--- a/crates/admin-cli/src/expected_switch/args.rs
+++ b/crates/admin-cli/src/expected_switch/args.rs
@@ -14,6 +14,8 @@ use clap::{ArgGroup, Parser};
 use mac_address::MacAddress;
 use serde::{Deserialize, Serialize};
 
+use crate::metadata::parse_rpc_labels;
+
 #[derive(Parser, Debug)]
 pub enum Cmd {
     #[clap(about = "Show expected switch")]
@@ -90,30 +92,24 @@ pub struct AddExpectedSwitch {
     pub rack_id: Option<String>,
 }
 
-impl AddExpectedSwitch {
-    pub fn metadata(&self) -> Result<::rpc::forge::Metadata, eyre::Report> {
-        let mut labels = Vec::new();
-        if let Some(list) = &self.labels {
-            for label in list {
-                let label = match label.split_once(':') {
-                    Some((k, v)) => rpc::forge::Label {
-                        key: k.trim().to_string(),
-                        value: Some(v.trim().to_string()),
-                    },
-                    None => rpc::forge::Label {
-                        key: label.trim().to_string(),
-                        value: None,
-                    },
-                };
-                labels.push(label);
-            }
-        }
-
-        Ok(::rpc::forge::Metadata {
-            name: self.meta_name.clone().unwrap_or_default(),
-            description: self.meta_description.clone().unwrap_or_default(),
+impl From<AddExpectedSwitch> for rpc::forge::ExpectedSwitch {
+    fn from(value: AddExpectedSwitch) -> Self {
+        let labels = parse_rpc_labels(value.labels.unwrap_or_default());
+        let metadata = rpc::forge::Metadata {
+            name: value.meta_name.unwrap_or_default(),
+            description: value.meta_description.unwrap_or_default(),
             labels,
-        })
+        };
+        Self {
+            bmc_mac_address: value.bmc_mac_address.to_string(),
+            bmc_username: value.bmc_username,
+            bmc_password: value.bmc_password,
+            switch_serial_number: value.switch_serial_number,
+            metadata: Some(metadata),
+            rack_id: value.rack_id,
+            nvos_username: value.nvos_username,
+            nvos_password: value.nvos_password,
+        }
     }
 }
 
@@ -209,31 +205,6 @@ impl UpdateExpectedSwitch {
             return Err("One of the following options must be specified: bmc-user-name and bmc-password or switch-serial-number or nvos-username and nvos-password".to_string());
         }
         Ok(())
-    }
-
-    pub fn metadata(&self) -> Result<::rpc::forge::Metadata, eyre::Report> {
-        let mut labels = Vec::new();
-        if let Some(list) = &self.labels {
-            for label in list {
-                let label = match label.split_once(':') {
-                    Some((k, v)) => rpc::forge::Label {
-                        key: k.trim().to_string(),
-                        value: Some(v.trim().to_string()),
-                    },
-                    None => rpc::forge::Label {
-                        key: label.trim().to_string(),
-                        value: None,
-                    },
-                };
-                labels.push(label);
-            }
-        }
-
-        Ok(::rpc::forge::Metadata {
-            name: self.meta_name.clone().unwrap_or_default(),
-            description: self.meta_description.clone().unwrap_or_default(),
-            labels,
-        })
     }
 }
 

--- a/crates/admin-cli/src/expected_switch/mod.rs
+++ b/crates/admin-cli/src/expected_switch/mod.rs
@@ -26,9 +26,9 @@ impl Dispatch for Cmd {
     async fn dispatch(self, ctx: RuntimeContext) -> CarbideCliResult<()> {
         match self {
             Cmd::Show(query) => cmds::show(&query, &ctx.api_client, ctx.config.format).await?,
-            Cmd::Add(data) => cmds::add(&data, &ctx.api_client).await?,
+            Cmd::Add(data) => cmds::add(data, &ctx.api_client).await?,
             Cmd::Delete(query) => cmds::delete(&query, &ctx.api_client).await?,
-            Cmd::Update(data) => cmds::update(&data, &ctx.api_client).await?,
+            Cmd::Update(data) => cmds::update(data, &ctx.api_client).await?,
             Cmd::ReplaceAll(request) => cmds::replace_all(&request, &ctx.api_client).await?,
             Cmd::Erase => cmds::erase(&ctx.api_client).await?,
         }

--- a/crates/admin-cli/src/extension_service/cmds.rs
+++ b/crates/admin-cli/src/extension_service/cmds.rs
@@ -43,10 +43,10 @@ pub async fn handle_create(
             }
 
             Some(::rpc::forge::DpuExtensionServiceCredential {
-                registry_url: args.registry_url.clone().unwrap_or_default(),
+                registry_url: args.registry_url.unwrap_or_default(),
                 r#type: Some(Type::UsernamePassword(rpc::forge::UsernamePassword {
-                    username: args.username.clone().unwrap_or_default(),
-                    password: args.password.clone().unwrap_or_default(),
+                    username: args.username.unwrap_or_default(),
+                    password: args.password.unwrap_or_default(),
                 })),
             })
         } else {
@@ -98,10 +98,10 @@ pub async fn handle_update(
             }
 
             Some(::rpc::forge::DpuExtensionServiceCredential {
-                registry_url: args.registry_url.clone().unwrap(),
+                registry_url: args.registry_url.unwrap(),
                 r#type: Some(Type::UsernamePassword(rpc::forge::UsernamePassword {
-                    username: args.username.clone().unwrap(),
-                    password: args.password.clone().unwrap(),
+                    username: args.username.unwrap(),
+                    password: args.password.unwrap(),
                 })),
             })
         } else {
@@ -143,7 +143,7 @@ pub async fn handle_delete(
     api_client
         .0
         .delete_dpu_extension_service(DeleteDpuExtensionServiceRequest {
-            service_id: args.service_id.clone(),
+            service_id: args.service_id,
             versions: args.versions,
         })
         .await?;

--- a/crates/admin-cli/src/host/cmds.rs
+++ b/crates/admin-cli/src/host/cmds.rs
@@ -26,7 +26,7 @@ pub async fn trigger_reprovisioning(
     api_client: &ApiClient,
     update_message: Option<String>,
 ) -> CarbideCliResult<()> {
-    if let (Mode::Set, Some(update_message)) = (mode, &update_message) {
+    if let (Mode::Set, Some(update_message)) = (mode, update_message) {
         // Set a HostUpdateInProgress health override on the Host
 
         let host_machine = api_client
@@ -48,10 +48,7 @@ pub async fn trigger_reprovisioning(
             )));
         }
 
-        let report = get_health_report(
-            HealthOverrideTemplates::HostUpdate,
-            Some(update_message.clone()),
-        );
+        let report = get_health_report(HealthOverrideTemplates::HostUpdate, Some(update_message));
 
         api_client
             .machine_insert_health_report_override(host_id, report.into(), false)

--- a/crates/admin-cli/src/instance/cmds.rs
+++ b/crates/admin-cli/src/instance/cmds.rs
@@ -9,6 +9,7 @@
  * without an express license agreement from NVIDIA CORPORATION or
  * its affiliates is strictly prohibited.
  */
+use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::fmt::Write;
 use std::pin::Pin;
@@ -42,13 +43,16 @@ async fn convert_instance_to_nice_format(
     let mut data = vec![
         (
             "ID",
-            instance.id.map(|id| id.to_string()).unwrap_or_default(),
+            instance
+                .id
+                .map(|id| Cow::Owned(id.to_string()))
+                .unwrap_or_default(),
         ),
         (
             "MACHINE ID",
             instance
                 .machine_id
-                .map(|id| id.to_string())
+                .map(|id| Cow::Owned(id.to_string()))
                 .unwrap_or_default(),
         ),
         (
@@ -57,7 +61,7 @@ async fn convert_instance_to_nice_format(
                 .config
                 .as_ref()
                 .and_then(|config| config.tenant.as_ref())
-                .map(|tenant| tenant.tenant_organization_id.clone())
+                .map(|tenant| Cow::Borrowed(tenant.tenant_organization_id.as_str()))
                 .unwrap_or_default(),
         ),
         (
@@ -67,7 +71,7 @@ async fn convert_instance_to_nice_format(
                 .as_ref()
                 .and_then(|status| status.tenant.as_ref())
                 .and_then(|tenant| forgerpc::TenantState::try_from(tenant.state).ok())
-                .map(|state| format!("{state:?}"))
+                .map(|state| Cow::Owned(format!("{state:?}")))
                 .unwrap_or_default(),
         ),
         (
@@ -76,12 +80,16 @@ async fn convert_instance_to_nice_format(
                 .status
                 .as_ref()
                 .and_then(|status| status.tenant.as_ref())
-                .map(|tenant| tenant.state_details.clone())
+                .map(|tenant| Cow::Borrowed(tenant.state_details.as_str()))
                 .unwrap_or_default(),
         ),
         (
             "INSTANCE TYPE ID",
-            instance.instance_type_id.clone().unwrap_or_default(),
+            instance
+                .instance_type_id
+                .as_ref()
+                .map(|id| Cow::Borrowed(id.as_str()))
+                .unwrap_or_default(),
         ),
         (
             "CONFIGS SYNCED",
@@ -89,10 +97,10 @@ async fn convert_instance_to_nice_format(
                 .status
                 .as_ref()
                 .and_then(|status| forgerpc::SyncState::try_from(status.configs_synced).ok())
-                .map(|state| format!("{state:?}"))
+                .map(|state| Cow::Owned(format!("{state:?}")))
                 .unwrap_or_default(),
         ),
-        ("CONFIG VERSION", instance.config_version.clone()),
+        ("CONFIG VERSION", instance.config_version.as_str().into()),
         (
             "NETWORK CONFIG SYNCED",
             instance
@@ -100,12 +108,12 @@ async fn convert_instance_to_nice_format(
                 .as_ref()
                 .and_then(|status| status.network.as_ref())
                 .and_then(|status| forgerpc::SyncState::try_from(status.configs_synced).ok())
-                .map(|state| format!("{state:?}"))
+                .map(|state| Cow::Owned(format!("{state:?}")))
                 .unwrap_or_default(),
         ),
         (
             "NETWORK CONFIG VERSION",
-            instance.network_config_version.clone(),
+            instance.network_config_version.as_str().into(),
         ),
     ];
 
@@ -120,10 +128,10 @@ async fn convert_instance_to_nice_format(
             instance_os
                 .and_then(|os| match os.variant.as_ref() {
                     Some(::rpc::forge::operating_system::Variant::Ipxe(ipxe_os)) => {
-                        Some(ipxe_os.ipxe_script.clone())
+                        Some(Cow::Borrowed(ipxe_os.ipxe_script.as_str()))
                     }
                     Some(::rpc::forge::operating_system::Variant::OsImageId(image)) => {
-                        Some(format!("OS Image ID: {}", image.value))
+                        Some(Cow::Owned(format!("OS Image ID: {}", image.value)))
                     }
                     None => None,
                 })
@@ -132,7 +140,8 @@ async fn convert_instance_to_nice_format(
         (
             "USERDATA",
             instance_os
-                .and_then(|os| os.user_data.clone())
+                .and_then(|os| os.user_data.as_ref())
+                .map(|ud| ud.as_str().into())
                 .unwrap_or_default(),
         ),
         (
@@ -140,14 +149,16 @@ async fn convert_instance_to_nice_format(
             instance_os
                 .map(|os| os.run_provisioning_instructions_on_every_boot)
                 .unwrap_or_default()
-                .to_string(),
+                .to_string()
+                .into(),
         ),
         (
             "PHONE HOME ENABLED",
             instance_os
                 .map(|os| os.phone_home_enabled)
                 .unwrap_or_default()
-                .to_string(),
+                .to_string()
+                .into(),
         ),
     ];
 
@@ -188,50 +199,61 @@ async fn convert_instance_to_nice_format(
                 None
             };
 
-            let data = &[
+            let data: &[(&str, Cow<str>)] = &[
                 (
                     "FUNCTION_TYPE",
                     forgerpc::InterfaceFunctionType::try_from(interface.function_type)
                         .ok()
-                        .map(|ty| format!("{ty:?}"))
-                        .unwrap_or_else(|| "INVALID".to_string()),
+                        .map(|ty| format!("{ty:?}").into())
+                        .unwrap_or_else(|| "INVALID".into()),
                 ),
                 (
                     "VF ID",
                     status
                         .virtual_function_id
-                        .map(|id| id.to_string())
+                        .map(|id| id.to_string().into())
                         .unwrap_or_default(),
                 ),
                 (
                     "SEGMENT ID",
-                    interface.network_segment_id.unwrap_or_default().to_string(),
+                    interface
+                        .network_segment_id
+                        .unwrap_or_default()
+                        .to_string()
+                        .into(),
                 ),
                 (
                     "VPC PREFIX ID",
                     match &interface.network_details {
                         Some(forgerpc::instance_interface_config::NetworkDetails::SegmentId(_)) => {
-                            "Segment Based Allocation".to_string()
+                            "Segment Based Allocation".into()
                         }
                         Some(forgerpc::instance_interface_config::NetworkDetails::VpcPrefixId(
                             x,
-                        )) => x.to_string(),
-                        None => "NA".to_string(),
+                        )) => x.to_string().into(),
+                        None => "NA".into(),
                     },
                 ),
-                ("MAC ADDR", status.mac_address.clone().unwrap_or_default()),
-                ("ADDRESSES", status.addresses.clone().join(", ")),
+                (
+                    "MAC ADDR",
+                    status
+                        .mac_address
+                        .as_ref()
+                        .map(|s| s.as_str().into())
+                        .unwrap_or_default(),
+                ),
+                ("ADDRESSES", status.addresses.as_slice().join(", ").into()),
                 (
                     "VPC ID",
                     vpc.as_ref()
-                        .map(|v| v.id.unwrap_or_default().to_string())
-                        .unwrap_or("<not found>".to_string()),
+                        .map(|v| v.id.unwrap_or_default().to_string().into())
+                        .unwrap_or("<not found>".into()),
                 ),
                 (
                     "VPC NAME",
                     vpc.as_ref()
-                        .map(|v| v.name.clone())
-                        .unwrap_or("<not found>".to_string()),
+                        .map(|v| v.name.as_str().into())
+                        .unwrap_or("<not found>".into()),
                 ),
             ];
 
@@ -245,15 +267,14 @@ async fn convert_instance_to_nice_format(
         }
     }
 
-    if let Some(ib_config) = instance.config.clone().unwrap().infiniband
-        && let Some(ib_status) = instance.status.clone().unwrap().infiniband
+    if let Some(ib_config) = instance.config.as_ref().and_then(|c| c.infiniband.as_ref())
+        && let Some(ib_status) = instance.status.as_ref().and_then(|s| s.infiniband.as_ref())
     {
         writeln!(&mut lines, "IB INTERFACES:")?;
         writeln!(
             &mut lines,
             "\t{:<width$}: {}",
-            "IB CONFIG VERSION",
-            instance.ib_config_version.clone()
+            "IB CONFIG VERSION", instance.ib_config_version,
         )?;
         writeln!(
             &mut lines,
@@ -262,34 +283,58 @@ async fn convert_instance_to_nice_format(
         )?;
         for (i, interface) in ib_config.ib_interfaces.iter().enumerate() {
             let status = &ib_status.ib_interfaces[i];
-            let data = &[
+            let data: &[(&str, Cow<str>)] = &[
                 (
                     "FUNCTION_TYPE",
                     forgerpc::InterfaceFunctionType::try_from(interface.function_type)
                         .ok()
-                        .map(|ty| format!("{ty:?}"))
-                        .unwrap_or_else(|| "INVALID".to_string()),
+                        .map(|ty| format!("{ty:?}").into())
+                        .unwrap_or_else(|| "INVALID".into()),
                 ),
-                ("VENDOR", interface.vendor.clone().unwrap_or_default()),
-                ("DEVICE", interface.device.clone()),
-                ("DEVICE INSTANCE", interface.device_instance.to_string()),
+                (
+                    "VENDOR",
+                    interface
+                        .vendor
+                        .as_ref()
+                        .map(|v| v.as_str().into())
+                        .unwrap_or_default(),
+                ),
+                ("DEVICE", interface.device.as_str().into()),
+                (
+                    "DEVICE INSTANCE",
+                    interface.device_instance.to_string().into(),
+                ),
                 (
                     "VF ID",
                     interface
                         .virtual_function_id
-                        .map(|x| x.to_string())
+                        .map(|x| x.to_string().into())
                         .unwrap_or_default(),
                 ),
                 (
                     "PARTITION ID",
                     interface
                         .ib_partition_id
-                        .map(|x| x.to_string())
+                        .map(|x| x.to_string().into())
                         .unwrap_or_default(),
                 ),
-                ("PF GUID", status.pf_guid.clone().unwrap_or_default()),
-                ("GUID", status.guid.clone().unwrap_or_default()),
-                ("LID", status.lid.to_string()),
+                (
+                    "PF GUID",
+                    status
+                        .pf_guid
+                        .as_ref()
+                        .map(|g| g.as_str().into())
+                        .unwrap_or_default(),
+                ),
+                (
+                    "GUID",
+                    status
+                        .guid
+                        .as_ref()
+                        .map(|g| g.as_str().into())
+                        .unwrap_or_default(),
+                ),
+                ("LID", status.lid.to_string().into()),
             ];
 
             for (key, value) in data {
@@ -302,18 +347,22 @@ async fn convert_instance_to_nice_format(
         }
     }
 
-    if let Some(nsg_id) = instance.config.clone().unwrap().network_security_group_id {
+    if let Some(nsg_id) = instance
+        .config
+        .as_ref()
+        .and_then(|c| c.network_security_group_id.as_ref())
+    {
         writeln!(&mut lines, "NETWORK SECURITY GROUP ID: {nsg_id}")?;
     }
 
-    if let Some(metadata) = instance.metadata.clone() {
+    if let Some(metadata) = instance.metadata.as_ref() {
         writeln!(
             &mut lines,
             "LABELS: {}",
             metadata
                 .labels
                 .iter()
-                .map(|x| format!("{}: {}", x.key, x.value.clone().unwrap_or_default()))
+                .map(|x| format!("{}: {}", x.key, x.value.as_deref().unwrap_or_default()))
                 .collect::<Vec<String>>()
                 .join(", ")
         )?;
@@ -341,7 +390,7 @@ fn convert_instances_to_nice_table(instances: forgerpc::InstanceList) -> Box<Tab
             .config
             .as_ref()
             .and_then(|config| config.tenant.as_ref())
-            .map(|tenant| tenant.tenant_organization_id.clone())
+            .map(|tenant| tenant.tenant_organization_id.as_str())
             .unwrap_or_default();
 
         let labels = crate::metadata::get_nice_labels_from_rpc_metadata(instance.metadata.as_ref());
@@ -549,7 +598,7 @@ pub async fn handle_reboot(args: RebootInstance, api_client: &ApiClient) -> Carb
 pub async fn release(
     api_client: &ApiClient,
     release_request: ReleaseInstance,
-    opts: &GlobalOptions<'_>,
+    opts: GlobalOptions<'_>,
 ) -> CarbideCliResult<()> {
     if opts.cloud_unsafe_op.is_none() {
         return Err(CarbideCliError::GenericError(
@@ -619,7 +668,7 @@ pub async fn release(
 pub async fn allocate(
     api_client: &ApiClient,
     allocate_request: AllocateInstance,
-    opts: &GlobalOptions<'_>,
+    opts: GlobalOptions<'_>,
 ) -> CarbideCliResult<()> {
     if opts.cloud_unsafe_op.is_none() {
         return Err(CarbideCliError::GenericError(
@@ -638,7 +687,7 @@ pub async fn allocate(
     }
 
     let mut machine_ids: VecDeque<_> = if !allocate_request.machine_id.is_empty() {
-        allocate_request.machine_id.clone().into()
+        allocate_request.machine_id.iter().copied().collect()
     } else {
         api_client
             .0
@@ -731,7 +780,7 @@ pub async fn allocate(
 pub async fn update_os(
     api_client: &ApiClient,
     update_request: UpdateInstanceOS,
-    opts: &GlobalOptions<'_>,
+    opts: GlobalOptions<'_>,
 ) -> CarbideCliResult<()> {
     if opts.cloud_unsafe_op.is_none() {
         return Err(CarbideCliError::GenericError(
@@ -744,10 +793,10 @@ pub async fn update_os(
         .update_instance_config_with(
             update_request.instance,
             |config| {
-                config.os = Some(update_request.os.clone());
+                config.os = Some(update_request.os);
             },
             |_metadata| {},
-            opts.cloud_unsafe_op.clone(),
+            opts.cloud_unsafe_op,
         )
         .await
     {
@@ -764,7 +813,7 @@ pub async fn update_os(
 pub async fn update_ib_config(
     api_client: &ApiClient,
     update_request: UpdateIbConfig,
-    opts: &GlobalOptions<'_>,
+    opts: GlobalOptions<'_>,
 ) -> CarbideCliResult<()> {
     if opts.cloud_unsafe_op.is_none() {
         return Err(CarbideCliError::GenericError(
@@ -777,10 +826,10 @@ pub async fn update_ib_config(
         .update_instance_config_with(
             update_request.instance,
             |config| {
-                config.infiniband = Some(update_request.config.clone());
+                config.infiniband = Some(update_request.config);
             },
             |_metadata| {},
-            opts.cloud_unsafe_op.clone(),
+            opts.cloud_unsafe_op,
         )
         .await
     {

--- a/crates/admin-cli/src/instance/mod.rs
+++ b/crates/admin-cli/src/instance/mod.rs
@@ -26,7 +26,7 @@ impl Dispatch for Cmd {
     async fn dispatch(self, mut ctx: RuntimeContext) -> CarbideCliResult<()> {
         // Build the internal GlobalOptions from RuntimeContext for handlers that need it
         let opts = args::GlobalOptions {
-            format: ctx.config.format.clone(),
+            format: ctx.config.format,
             page_size: ctx.config.page_size,
             sort_by: &ctx.config.sort_by,
             cloud_unsafe_op: if ctx.config.cloud_unsafe_op_enabled {
@@ -49,11 +49,11 @@ impl Dispatch for Cmd {
                 .await?
             }
             Cmd::Reboot(args) => cmds::handle_reboot(args, &ctx.api_client).await?,
-            Cmd::Release(args) => cmds::release(&ctx.api_client, args, &opts).await?,
-            Cmd::Allocate(args) => cmds::allocate(&ctx.api_client, args, &opts).await?,
-            Cmd::UpdateOS(args) => cmds::update_os(&ctx.api_client, args, &opts).await?,
+            Cmd::Release(args) => cmds::release(&ctx.api_client, args, opts).await?,
+            Cmd::Allocate(args) => cmds::allocate(&ctx.api_client, args, opts).await?,
+            Cmd::UpdateOS(args) => cmds::update_os(&ctx.api_client, args, opts).await?,
             Cmd::UpdateIbConfig(args) => {
-                cmds::update_ib_config(&ctx.api_client, args, &opts).await?
+                cmds::update_ib_config(&ctx.api_client, args, opts).await?
             }
         }
         Ok(())

--- a/crates/admin-cli/src/instance_type/cmds.rs
+++ b/crates/admin-cli/src/instance_type/cmds.rs
@@ -67,7 +67,7 @@ fn convert_itypes_to_table(
             .iter()
             .map(|label| {
                 let key = &label.key;
-                let value = label.value.clone().unwrap_or_default();
+                let value = label.value.as_deref().unwrap_or_default();
                 format!("\"{key}:{value}\"")
             })
             .collect::<Vec<_>>();

--- a/crates/admin-cli/src/jump/cmds.rs
+++ b/crates/admin-cli/src/jump/cmds.rs
@@ -52,9 +52,7 @@ pub async fn jump(args: Cmd, ctx: &mut RuntimeContext) -> color_eyre::Result<()>
 
     // Is it an IP?
     if IpAddr::from_str(&args.id).is_ok() {
-        let req = forgerpc::FindIpAddressRequest {
-            ip: args.id.clone(),
-        };
+        let req = forgerpc::FindIpAddressRequest { ip: args.id };
 
         let resp = ctx.api_client.0.find_ip_address(req).await?;
 
@@ -71,7 +69,7 @@ pub async fn jump(args: Cmd, ctx: &mut RuntimeContext) -> color_eyre::Result<()>
                 }
             };
 
-            let config_format = ctx.config.format.clone();
+            let config_format = ctx.config.format;
 
             use forgerpc::IpType::*;
             match ip_type {
@@ -206,7 +204,7 @@ pub async fn jump(args: Cmd, ctx: &mut RuntimeContext) -> color_eyre::Result<()>
                             tenant_org_id: None,
                             name: None,
                         },
-                        ctx.config.format.clone(),
+                        ctx.config.format,
                         &ctx.api_client,
                         ctx.config.page_size,
                     )
@@ -215,7 +213,7 @@ pub async fn jump(args: Cmd, ctx: &mut RuntimeContext) -> color_eyre::Result<()>
                 forgerpc::UuidType::Instance => {
                     instance::cmds::handle_show(
                         instance::args::ShowInstance {
-                            id: args.id.clone(),
+                            id: args.id,
                             extrainfo: true,
                             tenant_org_id: None,
                             vpc_id: None,
@@ -238,7 +236,7 @@ pub async fn jump(args: Cmd, ctx: &mut RuntimeContext) -> color_eyre::Result<()>
                             all: false,
                             more: true,
                         },
-                        ctx.config.format.clone(),
+                        ctx.config.format,
                         &ctx.api_client,
                     )
                     .await?
@@ -252,7 +250,7 @@ pub async fn jump(args: Cmd, ctx: &mut RuntimeContext) -> color_eyre::Result<()>
                             label_key: None,
                             label_value: None,
                         },
-                        ctx.config.format.clone(),
+                        ctx.config.format,
                         &ctx.api_client,
                         1,
                     )
@@ -264,7 +262,7 @@ pub async fn jump(args: Cmd, ctx: &mut RuntimeContext) -> color_eyre::Result<()>
                             domain: Some(args.id.parse()?),
                             all: false,
                         },
-                        ctx.config.format.clone(),
+                        ctx.config.format,
                         &ctx.api_client,
                     )
                     .await?
@@ -274,7 +272,7 @@ pub async fn jump(args: Cmd, ctx: &mut RuntimeContext) -> color_eyre::Result<()>
                         &dpa::args::ShowDpa {
                             id: Some(args.id.parse()?),
                         },
-                        ctx.config.format.clone(),
+                        ctx.config.format,
                         &ctx.api_client,
                         1,
                     )
@@ -301,7 +299,7 @@ pub async fn jump(args: Cmd, ctx: &mut RuntimeContext) -> color_eyre::Result<()>
                             all: false,
                             more: true,
                         },
-                        ctx.config.format.clone(),
+                        ctx.config.format,
                         &ctx.api_client,
                     )
                     .await?
@@ -321,7 +319,7 @@ pub async fn jump(args: Cmd, ctx: &mut RuntimeContext) -> color_eyre::Result<()>
                         &dpa::args::ShowDpa {
                             id: Some(primary_key.parse()?),
                         },
-                        ctx.config.format.clone(),
+                        ctx.config.format,
                         &ctx.api_client,
                         1,
                     )

--- a/crates/admin-cli/src/machine/cmds.rs
+++ b/crates/admin-cli/src/machine/cmds.rs
@@ -26,6 +26,7 @@ use chrono::Utc;
 use health_report::{
     HealthAlertClassification, HealthProbeAlert, HealthProbeId, HealthProbeSuccess, HealthReport,
 };
+use mac_address::MacAddress;
 use prettytable::{Row, Table, row};
 use rpc::Machine;
 
@@ -53,30 +54,27 @@ fn convert_machine_to_nice_format(
             "ID",
             machine.id.map(|id| id.to_string()).unwrap_or_default(),
         ),
-        ("STATE", machine.state.clone().to_uppercase()),
-        ("STATE_VERSION", machine.state_version.clone()),
+        ("STATE", machine.state.to_uppercase()),
+        ("STATE_VERSION", machine.state_version),
         ("MACHINE TYPE", get_machine_type(machine.id)),
         (
             "FAILURE",
-            machine
-                .failure_details
-                .clone()
-                .unwrap_or("None".to_string()),
+            machine.failure_details.unwrap_or("None".to_string()),
         ),
         ("VERSION", machine.version),
         ("SKU", sku),
         ("SKU DEVICE TYPE", sku_device_type),
     ];
-    if let Some(di) = machine.discovery_info.as_ref()
-        && let Some(dmi) = di.dmi_data.as_ref()
+    if let Some(di) = machine.discovery_info
+        && let Some(dmi) = di.dmi_data
     {
-        data.push(("VENDOR", dmi.sys_vendor.clone()));
-        data.push(("PRODUCT NAME", dmi.product_name.clone()));
-        data.push(("PRODUCT SERIAL", dmi.product_serial.clone()));
-        data.push(("BOARD SERIAL", dmi.board_serial.clone()));
-        data.push(("CHASSIS SERIAL", dmi.chassis_serial.clone()));
-        data.push(("BIOS VERSION", dmi.bios_version.clone()));
-        data.push(("BOARD VERSION", dmi.board_version.clone()));
+        data.push(("VENDOR", dmi.sys_vendor));
+        data.push(("PRODUCT NAME", dmi.product_name));
+        data.push(("PRODUCT SERIAL", dmi.product_serial));
+        data.push(("BOARD SERIAL", dmi.board_serial));
+        data.push(("CHASSIS SERIAL", dmi.chassis_serial));
+        data.push(("BIOS VERSION", dmi.bios_version));
+        data.push(("BOARD VERSION", dmi.board_version));
     }
     let autoupdate = if let Some(autoupdate) = machine.firmware_autoupdate {
         autoupdate.to_string()
@@ -182,9 +180,9 @@ fn convert_machine_to_nice_format(
                     "Domain ID",
                     interface.domain_id.unwrap_or_default().to_string(),
                 ),
-                ("Hostname", interface.hostname.clone()),
+                ("Hostname", interface.hostname),
                 ("Primary", interface.primary_interface.to_string()),
-                ("MAC Address", interface.mac_address.clone()),
+                ("MAC Address", interface.mac_address),
                 ("Addresses", interface.address.join(",")),
             ];
 
@@ -277,10 +275,10 @@ fn convert_machines_to_nice_table(machines: forgerpc::MachineList) -> Box<Table>
             )
         };
         let mut vendor = String::new();
-        if let Some(di) = machine.discovery_info.as_ref()
-            && let Some(dmi) = di.dmi_data.as_ref()
+        if let Some(di) = machine.discovery_info
+            && let Some(dmi) = di.dmi_data
         {
-            vendor = dmi.sys_vendor.clone();
+            vendor = dmi.sys_vendor;
         }
 
         let labels = crate::metadata::get_nice_labels_from_rpc_metadata(machine.metadata.as_ref());
@@ -294,7 +292,7 @@ fn convert_machines_to_nice_table(machines: forgerpc::MachineList) -> Box<Table>
             String::from(if is_unhealthy { "U" } else { "H" }),
             machine_id_string,
             machine.state.to_uppercase(),
-            machine.state_version.clone(),
+            machine.state_version,
             dpu_id,
             id,
             address,
@@ -661,7 +659,7 @@ pub async fn force_delete(
         );
 
         if dpu_machine_id.is_empty() && !response.dpu_machine_id.is_empty() {
-            dpu_machine_id = response.dpu_machine_id.clone();
+            dpu_machine_id = response.dpu_machine_id;
         }
 
         if response.all_done {
@@ -1012,17 +1010,26 @@ pub async fn metadata_from_expected_machine(
         )));
     }
     let machine = machines.remove(0);
-    let bmc_mac = machine
+    let bmc_mac: MacAddress = machine
         .bmc_info
-        .as_ref()
-        .and_then(|bmc_info| bmc_info.mac.clone())
+        .and_then(|bmc_info| bmc_info.mac)
+        .map(|mac| mac.parse())
+        .transpose()
+        .map_or_else(
+            |e| {
+                Err(CarbideCliError::GenericError(format!(
+                    "Invalid BMC MAC address found for Machine with ID {}: {}",
+                    cmd.machine, e
+                )))
+            },
+            Ok,
+        )?
         .ok_or_else(|| {
             CarbideCliError::GenericError(format!(
                 "No BMC MAC address found for Machine with ID {}",
                 cmd.machine
             ))
-        })?
-        .to_ascii_lowercase();
+        })?;
 
     let mut metadata = machine.metadata.ok_or_else(|| {
         CarbideCliError::GenericError("Machine does not carry Metadata that can be patched".into())
@@ -1034,15 +1041,20 @@ pub async fn metadata_from_expected_machine(
         .await?
         .expected_machines;
     let expected_machine = expected_machines
-        .iter()
-        .find(|em| em.bmc_mac_address.to_ascii_lowercase() == bmc_mac)
+        .into_iter()
+        .find(|em| {
+            em.bmc_mac_address
+                .parse::<MacAddress>()
+                .is_ok_and(|m| m == bmc_mac)
+        })
         .ok_or_else(|| {
             CarbideCliError::GenericError(format!(
                 "No expected Machine found for Machine with ID {} and BMC Mac address {}",
                 cmd.machine, bmc_mac
             ))
         })?;
-    let expected_machine_metadata = expected_machine.metadata.clone().ok_or_else(|| {
+
+    let expected_machine_metadata = expected_machine.metadata.ok_or_else(|| {
         CarbideCliError::GenericError(format!(
             "No expected Machine Metadata found for Machine with ID {} and BMC Mac address {}",
             cmd.machine, bmc_mac
@@ -1052,7 +1064,7 @@ pub async fn metadata_from_expected_machine(
     if cmd.replace_all {
         // Configure the Machines metadata in the same way as if the Machine was freshly ingested
         metadata.name = if expected_machine_metadata.name.is_empty() {
-            machine.id.unwrap().to_string()
+            machine.id.map(|id| id.to_string()).unwrap_or_default()
         } else {
             expected_machine_metadata.name
         };

--- a/crates/admin-cli/src/machine_interfaces/cmds.rs
+++ b/crates/admin-cli/src/machine_interfaces/cmds.rs
@@ -197,14 +197,11 @@ fn convert_machine_to_nice_format(
             machine_interface.domain_id.unwrap_or_default().to_string(),
         ),
         ("Domain Name", domain_name.unwrap().to_string()),
-        ("Hostname", machine_interface.hostname.clone()),
+        ("Hostname", machine_interface.hostname),
         ("Primary", machine_interface.primary_interface.to_string()),
-        ("MAC Address", machine_interface.mac_address.clone()),
+        ("MAC Address", machine_interface.mac_address),
         ("Addresses", machine_interface.address.join(",")),
-        (
-            "Vendor",
-            machine_interface.vendor.clone().unwrap_or_default(),
-        ),
+        ("Vendor", machine_interface.vendor.unwrap_or_default()),
     ];
     let mut lines = String::new();
 

--- a/crates/admin-cli/src/measurement/mod.rs
+++ b/crates/admin-cli/src/measurement/mod.rs
@@ -46,22 +46,22 @@ impl Dispatch for Cmd {
 
         match self {
             // Handle everything with the `bundle` subcommand.
-            Cmd::Bundle(subcmd) => bundle::cmds::dispatch(&subcmd, &mut cli_data).await?,
+            Cmd::Bundle(subcmd) => bundle::cmds::dispatch(subcmd, &mut cli_data).await?,
 
             // Handle everything with the `journal` subcommand.
-            Cmd::Journal(subcmd) => journal::cmds::dispatch(&subcmd, &mut cli_data).await?,
+            Cmd::Journal(subcmd) => journal::cmds::dispatch(subcmd, &mut cli_data).await?,
 
             // Handle everything with the `profile` subcommand.
-            Cmd::Profile(subcmd) => profile::cmds::dispatch(&subcmd, &mut cli_data).await?,
+            Cmd::Profile(subcmd) => profile::cmds::dispatch(subcmd, &mut cli_data).await?,
 
             // Handle everything with the `report` subcommand.
-            Cmd::Report(subcmd) => report::cmds::dispatch(&subcmd, &mut cli_data).await?,
+            Cmd::Report(subcmd) => report::cmds::dispatch(subcmd, &mut cli_data).await?,
 
             // Handle everything with the `machine` subcommand.
-            Cmd::Machine(subcmd) => machine::cmds::dispatch(&subcmd, &mut cli_data).await?,
+            Cmd::Machine(subcmd) => machine::cmds::dispatch(subcmd, &mut cli_data).await?,
 
             // Handle everything with the `site` subcommand.
-            Cmd::Site(subcmd) => site::cmds::dispatch(&subcmd, &mut cli_data).await?,
+            Cmd::Site(subcmd) => site::cmds::dispatch(subcmd, &mut cli_data).await?,
         }
 
         Ok(())
@@ -72,7 +72,7 @@ impl Dispatch for Cmd {
 pub struct MachineIdList(Vec<MachineId>);
 
 impl ToTable for MachineIdList {
-    fn to_table(&self) -> eyre::Result<String> {
+    fn into_table(self) -> eyre::Result<String> {
         let mut table = prettytable::Table::new();
         table.add_row(prettytable::row!["machine_id"]);
         for machine_id in self.0.iter() {

--- a/crates/admin-cli/src/metadata.rs
+++ b/crates/admin-cli/src/metadata.rs
@@ -25,3 +25,24 @@ pub(crate) fn get_nice_labels_from_rpc_metadata(metadata: Option<&Metadata>) -> 
         })
         .unwrap_or_default()
 }
+
+pub(crate) fn parse_rpc_labels(labels: Vec<String>) -> Vec<rpc::forge::Label> {
+    labels
+        .into_iter()
+        .map(|label| match label.split_once(':') {
+            Some((k, v)) => rpc::forge::Label {
+                key: k.trim().to_string(),
+                value: Some(v.trim().to_string()),
+            },
+            None => rpc::forge::Label {
+                key: if label.contains(char::is_whitespace) {
+                    label.trim().to_string()
+                } else {
+                    // avoid allocations on the happy path
+                    label
+                },
+                value: None,
+            },
+        })
+        .collect()
+}

--- a/crates/admin-cli/src/mlx/connections/cmds.rs
+++ b/crates/admin-cli/src/mlx/connections/cmds.rs
@@ -13,6 +13,8 @@
 // connections/cmds.rs
 // Command handlers for connection operations.
 
+use std::borrow::Cow;
+
 use chrono::{DateTime, Utc};
 use prettytable::{Cell, Row, Table};
 use rpc::admin_cli::{CarbideCliResult, OutputFormat};
@@ -124,9 +126,9 @@ fn print_connections_table(connections: &[rpc::forge::ScoutStreamConnectionInfo]
             None => "null".to_string(),
         };
         let connect_time = if let Ok(dt) = conn.connected_at.parse::<DateTime<Utc>>() {
-            dt.format("%Y-%m-%d %H:%M:%S").to_string()
+            Cow::Owned(dt.format("%Y-%m-%d %H:%M:%S").to_string())
         } else {
-            conn.connected_at.clone()
+            Cow::Borrowed(&conn.connected_at)
         };
 
         table.add_row(Row::new(vec![

--- a/crates/admin-cli/src/network_devices/cmds.rs
+++ b/crates/admin-cli/src/network_devices/cmds.rs
@@ -35,7 +35,7 @@ pub async fn handle_show(
 
     match output_format {
         OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&devices)?),
-        OutputFormat::AsciiTable => show_network_devices_info(&devices)?,
+        OutputFormat::AsciiTable => show_network_devices_info(devices)?,
         OutputFormat::Csv => println!("CSV not yet supported."),
         OutputFormat::Yaml => println!("YAML not yet supported."),
     }
@@ -43,11 +43,11 @@ pub async fn handle_show(
     Ok(())
 }
 
-fn show_network_devices_info(data: &rpc::forge::NetworkTopologyData) -> CarbideCliResult<()> {
+fn show_network_devices_info(data: rpc::forge::NetworkTopologyData) -> CarbideCliResult<()> {
     let mut lines = String::new();
 
     writeln!(&mut lines, "{}", "-".repeat(95))?;
-    for network_device in &data.network_devices {
+    for network_device in data.network_devices {
         writeln!(
             &mut lines,
             "Network Device: {}/{}",
@@ -56,7 +56,7 @@ fn show_network_devices_info(data: &rpc::forge::NetworkTopologyData) -> CarbideC
         writeln!(
             &mut lines,
             "Description:    {}",
-            network_device.description.clone().unwrap_or_default()
+            network_device.description.unwrap_or_default()
         )?;
         writeln!(
             &mut lines,

--- a/crates/admin-cli/src/network_security_group/cmds.rs
+++ b/crates/admin-cli/src/network_security_group/cmds.rs
@@ -71,7 +71,7 @@ fn convert_nsgs_to_table(
             .iter()
             .map(|label| {
                 let key = &label.key;
-                let value = label.value.clone().unwrap_or_default();
+                let value = label.value.as_deref().unwrap_or_default();
                 format!("\"{key}:{value}\"")
             })
             .collect::<Vec<_>>();

--- a/crates/admin-cli/src/nvl_logical_partition/cmds.rs
+++ b/crates/admin-cli/src/nvl_logical_partition/cmds.rs
@@ -69,7 +69,7 @@ async fn show_logical_partition_details(
     } else {
         println!(
             "{}",
-            convert_partition_to_nice_format(&logical_partition).unwrap_or_else(|x| x.to_string())
+            convert_partition_to_nice_format(logical_partition).unwrap_or_else(|x| x.to_string())
         );
     }
     Ok(())
@@ -96,7 +96,7 @@ fn convert_partitions_to_nice_table(
 }
 
 fn convert_partition_to_nice_format(
-    partition: &forgerpc::NvLinkLogicalPartition,
+    partition: forgerpc::NvLinkLogicalPartition,
 ) -> CarbideCliResult<String> {
     let width = 25;
     let mut lines = String::new();
@@ -115,11 +115,9 @@ fn convert_partition_to_nice_format(
             "NAME",
             partition
                 .config
-                .clone()
-                .unwrap_or_default()
-                .metadata
-                .unwrap_or_default()
-                .name,
+                .and_then(|c| c.metadata)
+                .map(|m| m.name)
+                .unwrap_or_default(),
         ),
         (
             "STATUS",

--- a/crates/admin-cli/src/nvl_partition/cmds.rs
+++ b/crates/admin-cli/src/nvl_partition/cmds.rs
@@ -50,7 +50,7 @@ async fn show_nvl_partitions(
     name: Option<String>,
 ) -> CarbideCliResult<()> {
     let all_nvl_partitions = api_client
-        .get_all_nv_link_partitions(tenant_org_id.clone(), name.clone(), page_size)
+        .get_all_nv_link_partitions(tenant_org_id, name, page_size)
         .await?;
     if json {
         println!("{}", serde_json::to_string_pretty(&all_nvl_partitions)?);
@@ -77,7 +77,7 @@ async fn show_nvl_partition_details(
     } else {
         println!(
             "{}",
-            convert_nvl_partition_to_nice_format(&nvl_partition).unwrap_or_else(|x| x.to_string())
+            convert_nvl_partition_to_nice_format(nvl_partition).unwrap_or_else(|x| x.to_string())
         );
     }
     Ok(())
@@ -93,7 +93,7 @@ fn convert_nvl_partitions_to_nice_table(
     for nvl_partition in nvl_partitions.partitions {
         table.add_row(row![
             nvl_partition.id.unwrap_or_default(),
-            nvl_partition.name.clone(),
+            nvl_partition.name,
         ]);
     }
 
@@ -101,14 +101,14 @@ fn convert_nvl_partitions_to_nice_table(
 }
 
 fn convert_nvl_partition_to_nice_format(
-    nvl_partition: &forgerpc::NvLinkPartition,
+    nvl_partition: forgerpc::NvLinkPartition,
 ) -> CarbideCliResult<String> {
     let width = 25;
     let mut lines = String::new();
 
     let data = vec![
         ("ID", nvl_partition.id.unwrap_or_default().0.to_string()),
-        ("NAME", nvl_partition.name.clone()),
+        ("NAME", nvl_partition.name),
         (
             "LOGICAL PARTITION ID",
             nvl_partition
@@ -116,7 +116,7 @@ fn convert_nvl_partition_to_nice_format(
                 .map(|logical_partition_id| logical_partition_id.to_string())
                 .unwrap_or_default(),
         ),
-        ("NMX-M-ID", nvl_partition.nmx_m_id.clone()),
+        ("NMX-M-ID", nvl_partition.nmx_m_id),
         (
             "NVLINK DOMAIN UUID",
             nvl_partition.domain_uuid.unwrap_or_default().0.to_string(),

--- a/crates/admin-cli/src/power_shelf/cmds.rs
+++ b/crates/admin-cli/src/power_shelf/cmds.rs
@@ -40,7 +40,7 @@ pub fn show_power_shelves(
             );
             println!("{:-<120}", "");
 
-            for shelf in &power_shelves {
+            for shelf in power_shelves {
                 let id = shelf
                     .id
                     .as_ref()
@@ -50,8 +50,8 @@ pub fn show_power_shelves(
                 let name = shelf
                     .config
                     .as_ref()
-                    .map(|config| config.name.clone())
-                    .unwrap_or_else(|| "N/A".to_string());
+                    .map(|config| config.name.as_str())
+                    .unwrap_or_else(|| "N/A");
 
                 let capacity = shelf
                     .config
@@ -70,22 +70,22 @@ pub fn show_power_shelves(
                 let location = shelf
                     .config
                     .as_ref()
-                    .and_then(|config| config.location.clone())
-                    .unwrap_or_else(|| "N/A".to_string());
+                    .and_then(|config| config.location.as_deref())
+                    .unwrap_or("N/A");
 
                 let power_state = shelf
                     .status
                     .as_ref()
-                    .and_then(|status| status.power_state.clone())
-                    .unwrap_or_else(|| "N/A".to_string());
+                    .and_then(|status| status.power_state.as_deref())
+                    .unwrap_or("N/A");
 
                 let health = shelf
                     .status
                     .as_ref()
-                    .and_then(|status| status.health_status.clone())
-                    .unwrap_or_else(|| "N/A".to_string());
+                    .and_then(|status| status.health_status.as_deref())
+                    .unwrap_or("N/A");
 
-                let controller_state = shelf.controller_state.clone();
+                let controller_state = shelf.controller_state.as_str();
 
                 println!(
                     "{:<36} {:<20} {:<10} {:<10} {:<15} {:<10} {:<10} {:<25}",
@@ -113,8 +113,8 @@ pub fn show_power_shelves(
                 let name = shelf
                     .config
                     .as_ref()
-                    .map(|config| config.name.clone())
-                    .unwrap_or_else(|| "N/A".to_string());
+                    .map(|config| config.name.as_str())
+                    .unwrap_or_else(|| "N/A");
 
                 let capacity = shelf
                     .config
@@ -133,22 +133,22 @@ pub fn show_power_shelves(
                 let location = shelf
                     .config
                     .as_ref()
-                    .and_then(|config| config.location.clone())
-                    .unwrap_or_else(|| "N/A".to_string());
+                    .and_then(|config| config.location.as_deref())
+                    .unwrap_or("N/A");
 
                 let power_state = shelf
                     .status
                     .as_ref()
-                    .and_then(|status| status.power_state.clone())
-                    .unwrap_or_else(|| "N/A".to_string());
+                    .and_then(|status| status.power_state.as_deref())
+                    .unwrap_or("N/A");
 
                 let health = shelf
                     .status
                     .as_ref()
-                    .and_then(|status| status.health_status.clone())
-                    .unwrap_or_else(|| "N/A".to_string());
+                    .and_then(|status| status.health_status.as_deref())
+                    .unwrap_or("N/A");
 
-                let controller_state = shelf.controller_state.clone();
+                let controller_state = shelf.controller_state.as_str();
 
                 println!(
                     "{},{},{},{},{},{},{},{}",
@@ -182,8 +182,8 @@ pub async fn list_power_shelves(api_client: &ApiClient) -> Result<()> {
         let name = shelf
             .config
             .as_ref()
-            .map(|config| config.name.clone())
-            .unwrap_or_else(|| "Unnamed".to_string());
+            .map(|config| config.name.as_str())
+            .unwrap_or_else(|| "Unnamed");
 
         let id = shelf
             .id
@@ -194,16 +194,16 @@ pub async fn list_power_shelves(api_client: &ApiClient) -> Result<()> {
         let power_state = shelf
             .status
             .as_ref()
-            .and_then(|status| status.power_state.clone())
-            .unwrap_or_else(|| "Unknown".to_string());
+            .and_then(|status| status.power_state.as_deref())
+            .unwrap_or("Unknown");
 
         let health = shelf
             .status
             .as_ref()
-            .and_then(|status| status.health_status.clone())
-            .unwrap_or_else(|| "Unknown".to_string());
+            .and_then(|status| status.health_status.as_deref())
+            .unwrap_or("Unknown");
 
-        let controller_state = shelf.controller_state.clone();
+        let controller_state = shelf.controller_state.as_str();
 
         println!(
             "{}. {} (ID: {}) - Power: {}, Health: {}, State: {}",
@@ -220,20 +220,20 @@ pub async fn list_power_shelves(api_client: &ApiClient) -> Result<()> {
 }
 
 pub async fn handle_show(
-    args: &ShowPowerShelf,
+    args: ShowPowerShelf,
     output_format: OutputFormat,
     api_client: &ApiClient,
 ) -> CarbideCliResult<()> {
     let query = match args.identifier {
-        Some(ref id) if !id.is_empty() => {
+        Some(id) if !id.is_empty() => {
             // Try to parse as PowerShelfId, otherwise treat as name.
-            match PowerShelfId::from_str(id) {
+            match PowerShelfId::from_str(&id) {
                 Ok(power_shelf_id) => rpc::forge::PowerShelfQuery {
                     name: None,
                     power_shelf_id: Some(power_shelf_id),
                 },
                 Err(_) => rpc::forge::PowerShelfQuery {
-                    name: Some(id.clone()),
+                    name: Some(id),
                     power_shelf_id: None,
                 },
             }

--- a/crates/admin-cli/src/power_shelf/mod.rs
+++ b/crates/admin-cli/src/power_shelf/mod.rs
@@ -26,7 +26,7 @@ impl Dispatch for Cmd {
     async fn dispatch(self, ctx: RuntimeContext) -> CarbideCliResult<()> {
         match self {
             Cmd::Show(show_opts) => {
-                cmds::handle_show(&show_opts, ctx.config.format, &ctx.api_client).await?
+                cmds::handle_show(show_opts, ctx.config.format, &ctx.api_client).await?
             }
             Cmd::List => cmds::list_power_shelves(&ctx.api_client).await?,
         }

--- a/crates/admin-cli/src/rack/cmds.rs
+++ b/crates/admin-cli/src/rack/cmds.rs
@@ -19,9 +19,9 @@ use crate::cfg::cli_options::AddNode;
 use crate::rms::args::{AvailableFwImages, FirmwareInventory, PowerState, RemoveNode};
 use crate::rpc::{ApiClient, RmsApiClient};
 
-pub async fn show_rack(api_client: &ApiClient, show_opts: &ShowRack) -> Result<()> {
+pub async fn show_rack(api_client: &ApiClient, show_opts: ShowRack) -> Result<()> {
     let query = rpc::forge::GetRackRequest {
-        id: show_opts.identifier.clone(),
+        id: show_opts.identifier,
     };
     let response = api_client.0.get_rack(query).await?;
     let racks = response.rack;
@@ -101,8 +101,8 @@ pub async fn list_racks(api_client: &ApiClient) -> Result<()> {
                     .join("\n");
                 let expected_nvlink_switches = r.expected_nvlink_switches.join("\n");
                 table.add_row(prettytable::row![
-                    r.id.clone(),
-                    r.rack_state.clone(),
+                    r.id.as_str(),
+                    r.rack_state.as_str(),
                     expected_compute_trays,
                     current_compute_trays,
                     expected_power_shelves,
@@ -123,9 +123,9 @@ pub async fn list_racks(api_client: &ApiClient) -> Result<()> {
     Ok(())
 }
 
-pub async fn delete_rack(api_client: &ApiClient, delete_opts: &DeleteRack) -> Result<()> {
+pub async fn delete_rack(api_client: &ApiClient, delete_opts: DeleteRack) -> Result<()> {
     let query = rpc::forge::DeleteRackRequest {
-        id: delete_opts.identifier.clone(),
+        id: delete_opts.identifier,
     };
     api_client.0.delete_rack(query).await?;
     Ok(())
@@ -138,11 +138,11 @@ pub async fn get_inventory(rms_client: &RmsApiClient) -> Result<()> {
 }
 
 #[allow(dead_code)]
-pub async fn add_node(rms_client: &RmsApiClient, add_node_opts: &AddNode) -> Result<()> {
+pub async fn add_node(rms_client: &RmsApiClient, add_node_opts: AddNode) -> Result<()> {
     let new_node = ::rpc::protos::rack_manager::NewNodeInfo {
-        node_id: add_node_opts.node_id.clone(),
-        mac_address: add_node_opts.mac_address.clone(),
-        ip_address: add_node_opts.ip_address.clone(),
+        node_id: add_node_opts.node_id,
+        mac_address: add_node_opts.mac_address,
+        ip_address: add_node_opts.ip_address,
         port: add_node_opts.port,
         username: None,
         password: None,
@@ -154,10 +154,8 @@ pub async fn add_node(rms_client: &RmsApiClient, add_node_opts: &AddNode) -> Res
     Ok(())
 }
 
-pub async fn remove_node(rms_client: &RmsApiClient, remove_node_opts: &RemoveNode) -> Result<()> {
-    let response = rms_client
-        .remove_node(remove_node_opts.node_id.clone())
-        .await?;
+pub async fn remove_node(rms_client: &RmsApiClient, remove_node_opts: RemoveNode) -> Result<()> {
+    let response = rms_client.remove_node(remove_node_opts.node_id).await?;
     println!("{:#?}", response);
     Ok(())
 }
@@ -170,21 +168,19 @@ pub async fn get_poweron_order(rms_client: &RmsApiClient) -> Result<()> {
 
 pub async fn get_power_state(
     rms_client: &RmsApiClient,
-    power_state_opts: &PowerState,
+    power_state_opts: PowerState,
 ) -> Result<()> {
-    let response = rms_client
-        .get_power_state(power_state_opts.node_id.clone())
-        .await?;
+    let response = rms_client.get_power_state(power_state_opts.node_id).await?;
     println!("{:#?}", response);
     Ok(())
 }
 
 pub async fn get_firmware_inventory(
     rms_client: &RmsApiClient,
-    firmware_inventory_opts: &FirmwareInventory,
+    firmware_inventory_opts: FirmwareInventory,
 ) -> Result<()> {
     let response = rms_client
-        .get_firmware_inventory(firmware_inventory_opts.node_id.clone())
+        .get_firmware_inventory(firmware_inventory_opts.node_id)
         .await?;
     println!("{:#?}", response);
     Ok(())
@@ -192,10 +188,10 @@ pub async fn get_firmware_inventory(
 
 pub async fn get_available_fw_images(
     rms_client: &RmsApiClient,
-    available_fw_images_opts: &AvailableFwImages,
+    available_fw_images_opts: AvailableFwImages,
 ) -> Result<()> {
     let response = rms_client
-        .get_available_fw_images(available_fw_images_opts.node_id.clone())
+        .get_available_fw_images(available_fw_images_opts.node_id)
         .await?;
     println!("{:#?}", response);
     Ok(())

--- a/crates/admin-cli/src/rack/mod.rs
+++ b/crates/admin-cli/src/rack/mod.rs
@@ -25,9 +25,9 @@ use crate::cfg::runtime::RuntimeContext;
 impl Dispatch for Cmd {
     async fn dispatch(self, ctx: RuntimeContext) -> CarbideCliResult<()> {
         match self {
-            Cmd::Show(show_opts) => cmds::show_rack(&ctx.api_client, &show_opts).await?,
+            Cmd::Show(show_opts) => cmds::show_rack(&ctx.api_client, show_opts).await?,
             Cmd::List => cmds::list_racks(&ctx.api_client).await?,
-            Cmd::Delete(delete_opts) => cmds::delete_rack(&ctx.api_client, &delete_opts).await?,
+            Cmd::Delete(delete_opts) => cmds::delete_rack(&ctx.api_client, delete_opts).await?,
         }
         Ok(())
     }

--- a/crates/admin-cli/src/rack_firmware.rs
+++ b/crates/admin-cli/src/rack_firmware.rs
@@ -99,7 +99,7 @@ pub async fn handle_rack_firmware(
                             ]));
 
                             // Collect components with their subcomponents for display
-                            let mut component_subcomps: Vec<(String, Vec<serde_json::Value>)> =
+                            let mut component_subcomps: Vec<(String, &[serde_json::Value])> =
                                 Vec::new();
 
                             if let Some(comp_map) = components.as_object() {
@@ -129,8 +129,7 @@ pub async fn handle_rack_firmware(
                                         entry.get("subcomponents").and_then(|s| s.as_array())
                                         && !subcomps.is_empty()
                                     {
-                                        component_subcomps
-                                            .push((component.to_string(), subcomps.clone()));
+                                        component_subcomps.push((component.to_string(), subcomps));
                                     }
                                 }
                             }
@@ -236,7 +235,7 @@ pub async fn handle_rack_firmware(
         }
 
         RackFirmwareActions::Apply(opts) => {
-            apply_firmware(&opts, format, api_client).await?;
+            apply_firmware(opts, format, api_client).await?;
         }
     }
 
@@ -244,7 +243,7 @@ pub async fn handle_rack_firmware(
 }
 
 async fn apply_firmware(
-    opts: &RackFirmwareApply,
+    opts: RackFirmwareApply,
     format: OutputFormat,
     api_client: &ApiClient,
 ) -> Result<(), CarbideCliError> {
@@ -254,9 +253,9 @@ async fn apply_firmware(
     );
 
     let request = rpc::forge::RackFirmwareApplyRequest {
-        rack_id: opts.rack_id.clone(),
-        firmware_id: opts.firmware_id.clone(),
-        firmware_type: opts.firmware_type.clone(),
+        rack_id: opts.rack_id,
+        firmware_id: opts.firmware_id,
+        firmware_type: opts.firmware_type,
     };
 
     let response = api_client

--- a/crates/admin-cli/src/rms/cmds.rs
+++ b/crates/admin-cli/src/rms/cmds.rs
@@ -22,7 +22,7 @@ pub async fn inventory(api_client: &RmsApiClient) -> CarbideCliResult<()> {
         .map_err(|e| CarbideCliError::GenericError(e.to_string()))
 }
 
-pub async fn remove_node(args: &RemoveNode, api_client: &RmsApiClient) -> CarbideCliResult<()> {
+pub async fn remove_node(args: RemoveNode, api_client: &RmsApiClient) -> CarbideCliResult<()> {
     rack::cmds::remove_node(api_client, args)
         .await
         .map_err(|e| CarbideCliError::GenericError(e.to_string()))
@@ -34,14 +34,14 @@ pub async fn poweron_order(api_client: &RmsApiClient) -> CarbideCliResult<()> {
         .map_err(|e| CarbideCliError::GenericError(e.to_string()))
 }
 
-pub async fn power_state(args: &PowerState, api_client: &RmsApiClient) -> CarbideCliResult<()> {
+pub async fn power_state(args: PowerState, api_client: &RmsApiClient) -> CarbideCliResult<()> {
     rack::cmds::get_power_state(api_client, args)
         .await
         .map_err(|e| CarbideCliError::GenericError(e.to_string()))
 }
 
 pub async fn firmware_inventory(
-    args: &FirmwareInventory,
+    args: FirmwareInventory,
     api_client: &RmsApiClient,
 ) -> CarbideCliResult<()> {
     rack::cmds::get_firmware_inventory(api_client, args)
@@ -50,7 +50,7 @@ pub async fn firmware_inventory(
 }
 
 pub async fn available_fw_images(
-    args: &AvailableFwImages,
+    args: AvailableFwImages,
     api_client: &RmsApiClient,
 ) -> CarbideCliResult<()> {
     rack::cmds::get_available_fw_images(api_client, args)

--- a/crates/admin-cli/src/rms/mod.rs
+++ b/crates/admin-cli/src/rms/mod.rs
@@ -26,15 +26,11 @@ impl Dispatch for Cmd {
     async fn dispatch(self, ctx: RuntimeContext) -> CarbideCliResult<()> {
         match self {
             Cmd::Inventory => cmds::inventory(&ctx.rms_client).await,
-            Cmd::RemoveNode(ref args) => cmds::remove_node(args, &ctx.rms_client).await,
+            Cmd::RemoveNode(args) => cmds::remove_node(args, &ctx.rms_client).await,
             Cmd::PoweronOrder => cmds::poweron_order(&ctx.rms_client).await,
-            Cmd::PowerState(ref args) => cmds::power_state(args, &ctx.rms_client).await,
-            Cmd::FirmwareInventory(ref args) => {
-                cmds::firmware_inventory(args, &ctx.rms_client).await
-            }
-            Cmd::AvailableFwImages(ref args) => {
-                cmds::available_fw_images(args, &ctx.rms_client).await
-            }
+            Cmd::PowerState(args) => cmds::power_state(args, &ctx.rms_client).await,
+            Cmd::FirmwareInventory(args) => cmds::firmware_inventory(args, &ctx.rms_client).await,
+            Cmd::AvailableFwImages(args) => cmds::available_fw_images(args, &ctx.rms_client).await,
             Cmd::BkcFiles => cmds::bkc_files(&ctx.rms_client).await,
             Cmd::CheckBkcCompliance => cmds::check_bkc_compliance(&ctx.rms_client).await,
         }

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -37,6 +37,7 @@ use carbide_uuid::nvlink::{NvLinkLogicalPartitionId, NvLinkPartitionId};
 use carbide_uuid::vpc::VpcId;
 use mac_address::MacAddress;
 
+use crate::IntoOnlyOne;
 use crate::expected_machines::args::ExpectedMachineJson;
 use crate::instance::args::AllocateInstance;
 use crate::machine::MachineAutoupdate;
@@ -88,7 +89,7 @@ impl ApiClient {
         request: rpc::MachineSearchConfig,
         page_size: usize,
     ) -> CarbideCliResult<rpc::MachineList> {
-        let all_machine_ids = self.0.find_machine_ids(request.clone()).await?;
+        let all_machine_ids = self.0.find_machine_ids(request).await?;
         let mut all_machines = rpc::MachineList {
             machines: Vec::with_capacity(all_machine_ids.machine_ids.len()),
         };
@@ -203,10 +204,10 @@ impl ApiClient {
     ) -> CarbideCliResult<rpc::InstanceList> {
         let all_ids = self
             .get_instance_ids(
-                tenant_org_id.clone(),
-                vpc_id.clone(),
-                label_key.clone(),
-                label_value.clone(),
+                tenant_org_id,
+                vpc_id,
+                label_key,
+                label_value,
                 instance_type_id,
             )
             .await?;
@@ -261,9 +262,7 @@ impl ApiClient {
         name: Option<String>,
         page_size: usize,
     ) -> CarbideCliResult<rpc::NetworkSegmentList> {
-        let all_ids = self
-            .get_segment_ids(tenant_org_id.clone(), name.clone())
-            .await?;
+        let all_ids = self.get_segment_ids(tenant_org_id, name).await?;
         let mut all_list = rpc::NetworkSegmentList {
             network_segments: Vec::with_capacity(all_ids.network_segments_ids.len()),
         };
@@ -410,7 +409,7 @@ impl ApiClient {
         endpoint_ids: &[String],
     ) -> CarbideCliResult<::rpc::site_explorer::ExploredEndpointList> {
         let request = ::rpc::site_explorer::ExploredEndpointsByIdsRequest {
-            endpoint_ids: Vec::from(endpoint_ids),
+            endpoint_ids: endpoint_ids.to_vec(),
         };
         Ok(self.0.find_explored_endpoints_by_ids(request).await?)
     }
@@ -460,40 +459,6 @@ impl ApiClient {
             expiry,
         };
         Ok(self.0.set_dynamic_config(request).await?)
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub async fn add_expected_machine(
-        &self,
-        bmc_mac_address: MacAddress,
-        bmc_username: String,
-        bmc_password: String,
-        chassis_serial_number: String,
-        fallback_dpu_serial_numbers: Option<Vec<String>>,
-        metadata: ::rpc::forge::Metadata,
-        sku_id: Option<String>,
-        id: Option<String>,
-        host_nics: Vec<::rpc::forge::ExpectedHostNic>,
-        rack_id: Option<String>,
-        default_pause_ingestion_and_poweron: Option<bool>,
-        dpf_enabled: bool,
-    ) -> Result<(), CarbideCliError> {
-        let request = rpc::ExpectedMachine {
-            bmc_mac_address: bmc_mac_address.to_string(),
-            bmc_username,
-            bmc_password,
-            chassis_serial_number,
-            fallback_dpu_serial_numbers: fallback_dpu_serial_numbers.unwrap_or_default(),
-            metadata: Some(metadata),
-            sku_id,
-            id: id.map(|s| ::rpc::common::Uuid { value: s }),
-            host_nics,
-            rack_id,
-            default_pause_ingestion_and_poweron,
-            dpf_enabled,
-        };
-
-        Ok(self.0.add_expected_machine(request).await?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -577,69 +542,15 @@ impl ApiClient {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub async fn add_expected_power_shelf(
-        &self,
-        bmc_mac_address: MacAddress,
-        bmc_username: String,
-        bmc_password: String,
-        shelf_serial_number: String,
-        metadata: ::rpc::forge::Metadata,
-        rack_id: Option<String>,
-        ip_address: Option<String>,
-    ) -> Result<(), CarbideCliError> {
-        let request = rpc::ExpectedPowerShelf {
-            bmc_mac_address: bmc_mac_address.to_string(),
-            bmc_username,
-            bmc_password,
-            shelf_serial_number,
-            ip_address: ip_address.unwrap_or_default(),
-            metadata: Some(metadata),
-            rack_id,
-        };
-        self.0
-            .add_expected_power_shelf(request)
-            .await
-            .map_err(CarbideCliError::ApiInvocationError)
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub async fn add_expected_switch(
-        &self,
-        bmc_mac_address: MacAddress,
-        bmc_username: String,
-        bmc_password: String,
-        switch_serial_number: String,
-        metadata: ::rpc::forge::Metadata,
-        rack_id: Option<String>,
-        nvos_username: Option<String>,
-        nvos_password: Option<String>,
-    ) -> Result<(), CarbideCliError> {
-        let request = rpc::ExpectedSwitch {
-            bmc_mac_address: bmc_mac_address.to_string(),
-            bmc_username,
-            bmc_password,
-            switch_serial_number,
-            metadata: Some(metadata),
-            rack_id,
-            nvos_username,
-            nvos_password,
-        };
-        self.0
-            .add_expected_switch(request)
-            .await
-            .map_err(CarbideCliError::ApiInvocationError)
-    }
-
-    #[allow(clippy::too_many_arguments)]
     pub async fn update_expected_power_shelf(
         &self,
         bmc_mac_address: MacAddress,
         bmc_username: Option<String>,
         bmc_password: Option<String>,
         shelf_serial_number: Option<String>,
-        metadata: ::rpc::forge::Metadata,
         rack_id: Option<String>,
         ip_address: Option<String>,
+        metadata: ::rpc::forge::Metadata,
     ) -> Result<(), CarbideCliError> {
         let expected_power_shelf = self
             .0
@@ -669,10 +580,10 @@ impl ApiClient {
         bmc_username: Option<String>,
         bmc_password: Option<String>,
         switch_serial_number: Option<String>,
-        metadata: ::rpc::forge::Metadata,
         rack_id: Option<String>,
         nvos_username: Option<String>,
         nvos_password: Option<String>,
+        metadata: ::rpc::forge::Metadata,
     ) -> Result<(), CarbideCliError> {
         let expected_switch = self
             .0
@@ -784,7 +695,7 @@ impl ApiClient {
         label_value: Option<String>,
     ) -> CarbideCliResult<rpc::VpcList> {
         let all_ids = self
-            .get_vpc_ids(tenant_org_id.clone(), name.clone(), label_key, label_value)
+            .get_vpc_ids(tenant_org_id, name, label_key, label_value)
             .await?;
         let mut all_list = rpc::VpcList {
             vpcs: Vec::with_capacity(all_ids.vpc_ids.len()),
@@ -963,9 +874,7 @@ impl ApiClient {
         name: Option<String>,
         page_size: usize,
     ) -> CarbideCliResult<rpc::IbPartitionList> {
-        let all_ids = self
-            .get_ib_partition_ids(tenant_org_id.clone(), name.clone())
-            .await?;
+        let all_ids = self.get_ib_partition_ids(tenant_org_id, name).await?;
         let mut all_list = rpc::IbPartitionList {
             ib_partitions: Vec::with_capacity(all_ids.ib_partition_ids.len()),
         };
@@ -1015,7 +924,7 @@ impl ApiClient {
         tenant_org_id: Option<String>,
         page_size: usize,
     ) -> CarbideCliResult<rpc::TenantKeySetList> {
-        let all_ids = self.get_keyset_ids(tenant_org_id.clone()).await?;
+        let all_ids = self.get_keyset_ids(tenant_org_id).await?;
         let mut all_list = rpc::TenantKeySetList {
             keyset: Vec::with_capacity(all_ids.keyset_ids.len()),
         };
@@ -1164,15 +1073,14 @@ impl ApiClient {
                     ))?
                     .pci_properties
                     .as_ref()
-                    .map(|pci| pci.device.clone())
-                    .clone();
+                    .map(|pci| pci.device.as_str());
 
-                if device.is_none() {
+                let Some(device) = device else {
                     continue;
-                }
+                };
 
                 let device_instance = *next_device_instance
-                    .entry(device.clone())
+                    .entry(device)
                     .and_modify(|i| *i += 1)
                     .or_insert(0) as u32;
 
@@ -1180,7 +1088,7 @@ impl ApiClient {
                     function_type: rpc::InterfaceFunctionType::Physical as i32,
                     network_segment_id: Some(network_segment_id), // to support legacy.
                     network_details: Some(NetworkDetails::SegmentId(network_segment_id)),
-                    device: device.clone(),
+                    device: Some(device.to_string()),
                     device_instance,
                     virtual_function_id: None,
                 });
@@ -1193,7 +1101,7 @@ impl ApiClient {
                             network_details: Some(NetworkDetails::SegmentId(
                                 *vf_network_segment_id,
                             )),
-                            device: device.clone(),
+                            device: Some(device.to_string()),
                             device_instance,
                             virtual_function_id: Some(vf_function_id),
                         });
@@ -1206,8 +1114,8 @@ impl ApiClient {
                 interface_config,
                 allocate_instance
                     .tenant_org
-                    .clone()
-                    .unwrap_or("Forge-simulation-tenant".to_string()),
+                    .as_deref()
+                    .unwrap_or("Forge-simulation-tenant"),
             )
         } else if !allocate_instance.vpc_prefix_id.is_empty() {
             let Some(discovery_info) = &machine.discovery_info else {
@@ -1246,7 +1154,7 @@ impl ApiClient {
                     };
 
                     let device_instance = *interface_index_map
-                        .entry(pci_properties.device.clone())
+                        .entry(pci_properties.device.as_str())
                         .and_modify(|c| *c += 1)
                         .or_insert(0u32);
 
@@ -1286,7 +1194,7 @@ impl ApiClient {
 
             (
                 interface_configs,
-                allocate_instance.tenant_org.clone().ok_or_else(|| {
+                allocate_instance.tenant_org.as_deref().ok_or_else(|| {
                     CarbideCliError::GenericError(
                         "Tenant org is mandatory in case of vpc_prefix.".to_string(),
                     )
@@ -1310,7 +1218,7 @@ impl ApiClient {
             ));
         }
         let tenant_config = rpc::TenantConfig {
-            tenant_organization_id: tenant_org,
+            tenant_organization_id: tenant_org.to_string(),
             tenant_keyset_ids: vec![],
             hostname: None,
         };
@@ -1410,17 +1318,18 @@ impl ApiClient {
 
         let instance = find_response
             .instances
-            .first()
+            .into_iter()
+            .next()
             .ok_or_else(|| CarbideCliError::InstanceNotFound(instance_id))?;
 
-        let config = instance.config.clone().map(|mut c| {
+        let config = instance.config.map(|mut c| {
             modify_config(&mut c);
             c
         });
 
         tracing::info!("{}", serde_json::to_string(&config).unwrap_or_default());
 
-        let metadata = instance.metadata.clone().map(|mut m| {
+        let metadata = instance.metadata.map(|mut m| {
             modify_metadata(&mut m);
 
             let mut labels: Vec<rpc::Label> = m
@@ -1443,7 +1352,7 @@ impl ApiClient {
 
         let update_instance_request = rpc::InstanceConfigUpdateRequest {
             instance_id: Some(instance_id),
-            if_version_match: Some(instance.config_version.clone()),
+            if_version_match: Some(instance.config_version),
             config,
             metadata,
         };
@@ -1539,10 +1448,9 @@ impl ApiClient {
         description: Option<String>,
     ) -> CarbideCliResult<rpc::OsImage> {
         let os_image = self.0.get_os_image(id).await?;
-        if os_image.attributes.is_none() {
+        let Some(mut new_attrs) = os_image.attributes else {
             return Err(CarbideCliError::Empty);
-        }
-        let mut new_attrs = os_image.attributes.clone().unwrap();
+        };
         if auth_type.is_some() {
             new_attrs.auth_type = auth_type;
         }
@@ -1824,9 +1732,7 @@ impl ApiClient {
         name: Option<String>,
         page_size: usize,
     ) -> CarbideCliResult<rpc::NvLinkPartitionList> {
-        let all_ids = self
-            .get_nv_link_partition_ids(tenant_org_id.clone(), name.clone())
-            .await?;
+        let all_ids = self.get_nv_link_partition_ids(tenant_org_id, name).await?;
         let mut all_list = rpc::NvLinkPartitionList {
             partitions: Vec::with_capacity(all_ids.partition_ids.len()),
         };
@@ -1847,12 +1753,9 @@ impl ApiClient {
             .get_nv_link_partitions_by_ids(std::slice::from_ref(&nvl_partition_id))
             .await?;
 
-        if partitions.partitions.len() != 1 {
-            return Err(CarbideCliError::GenericError(
-                "Unknown NvLink Partition ID".to_string(),
-            ));
-        }
-        Ok(partitions.partitions[0].clone())
+        partitions.partitions.into_only_one_or_else(|_| {
+            CarbideCliError::GenericError("Unknown NvLink Partition ID".to_string())
+        })
     }
 
     async fn get_nv_link_partition_ids(
@@ -1889,7 +1792,7 @@ impl ApiClient {
         name: Option<String>,
         page_size: usize,
     ) -> CarbideCliResult<rpc::NvLinkLogicalPartitionList> {
-        let all_ids = self.get_logical_partition_ids(name.clone()).await?;
+        let all_ids = self.get_logical_partition_ids(name).await?;
         let mut all_list = rpc::NvLinkLogicalPartitionList {
             partitions: Vec::with_capacity(all_ids.partition_ids.len()),
         };
@@ -1910,12 +1813,11 @@ impl ApiClient {
             .get_logical_partitions_by_ids(std::slice::from_ref(&partition_id))
             .await?;
 
-        if partitions.partitions.len() != 1 {
-            return Err(CarbideCliError::GenericError(format!(
-                "Multiple logical partitions found for ID: {partition_id}",
-            )));
-        }
-        Ok(partitions.partitions[0].clone())
+        partitions.partitions.into_only_one_or_else(|len| {
+            CarbideCliError::GenericError(format!(
+                "Expected a single logical partition found for ID: {partition_id}, found {len}",
+            ))
+        })
     }
 
     async fn get_logical_partition_ids(
@@ -2174,20 +2076,17 @@ impl ApiClient {
             service_ids: vec![service_id],
         };
 
-        let service_response = self.0.find_dpu_extension_services_by_ids(request).await;
+        let service_response = self.0.find_dpu_extension_services_by_ids(request).await?;
 
-        match service_response {
-            Ok(service_response) => match service_response.services.len() {
-                0 => Err(CarbideCliError::GenericError(
-                    "Extension service not found".to_string(),
-                )),
-                1 => Ok(service_response.services.first().unwrap().clone()),
-                _ => Err(CarbideCliError::GenericError(
+        service_response.services.into_only_one_or_else(|len| {
+            if len == 0 {
+                CarbideCliError::GenericError("Extension service not found".to_string())
+            } else {
+                CarbideCliError::GenericError(
                     "Multiple extension services found for the same ID".to_string(),
-                )),
-            },
-            Err(e) => Err(CarbideCliError::ApiInvocationError(e)),
-        }
+                )
+            }
+        })
     }
 
     pub async fn modify_dpf_state(

--- a/crates/admin-cli/src/scout_stream/mod.rs
+++ b/crates/admin-cli/src/scout_stream/mod.rs
@@ -175,7 +175,7 @@ fn print_connections_table(connections: &[rpc::forge::ScoutStreamConnectionInfo]
         let connect_time = if let Ok(dt) = conn.connected_at.parse::<DateTime<Utc>>() {
             Cow::Owned(dt.format("%Y-%m-%d %H:%M:%S").to_string())
         } else {
-            Cow::Borrowed(&conn.connected_at.clone())
+            Cow::Borrowed(&conn.connected_at)
         };
 
         table.add_row(Row::new(vec![

--- a/crates/admin-cli/src/sku/cmds.rs
+++ b/crates/admin-cli/src/sku/cmds.rs
@@ -236,11 +236,11 @@ async fn show_sku_details(
             let model = sku
                 .components
                 .as_ref()
-                .and_then(|c| c.chassis.as_ref().map(|c| c.model.clone()));
+                .and_then(|c| c.chassis.as_ref().map(|c| c.model.as_str()));
             let architecture = sku
                 .components
                 .as_ref()
-                .and_then(|c| c.chassis.as_ref().map(|c| c.architecture.clone()));
+                .and_then(|c| c.chassis.as_ref().map(|c| c.architecture.as_str()));
 
             writeln!(output, "{:<width$}: {}", "Model", model.unwrap_or_default(),)?;
             writeln!(

--- a/crates/admin-cli/src/switch/cmds.rs
+++ b/crates/admin-cli/src/switch/cmds.rs
@@ -9,7 +9,7 @@
  * without an express license agreement from NVIDIA CORPORATION or
  * its affiliates is strictly prohibited.
  */
-
+use std::borrow::Cow;
 use std::str::FromStr;
 
 use carbide_uuid::switch::SwitchId;
@@ -34,34 +34,34 @@ pub fn show_switches(switches: Vec<Switch>, output_format: OutputFormat) -> Resu
                 let id = switch
                     .id
                     .as_ref()
-                    .map(|id| id.to_string())
-                    .unwrap_or_else(|| "N/A".to_string());
+                    .map(|id| Cow::Owned(id.to_string()))
+                    .unwrap_or_else(|| Cow::Borrowed("N/A"));
 
                 let name = switch
                     .config
                     .as_ref()
-                    .map(|config| config.name.clone())
-                    .unwrap_or_else(|| "N/A".to_string());
+                    .map(|config| config.name.as_str())
+                    .unwrap_or_else(|| "N/A");
 
                 let location = switch
                     .config
                     .as_ref()
-                    .and_then(|config| config.location.clone())
-                    .unwrap_or_else(|| "N/A".to_string());
+                    .and_then(|config| config.location.as_deref())
+                    .unwrap_or("N/A");
 
                 let power_state = switch
                     .status
                     .as_ref()
-                    .and_then(|status| status.power_state.clone())
-                    .unwrap_or_else(|| "N/A".to_string());
+                    .and_then(|status| status.power_state.as_deref())
+                    .unwrap_or("N/A");
 
                 let health = switch
                     .status
                     .as_ref()
-                    .and_then(|status| status.health_status.clone())
-                    .unwrap_or_else(|| "N/A".to_string());
+                    .and_then(|status| status.health_status.as_deref())
+                    .unwrap_or("N/A");
 
-                let controller_state = switch.controller_state.clone();
+                let controller_state = &switch.controller_state;
 
                 println!(
                     "{:<36} {:<20} {:<10} {:<10} {:<15} {:<10}",
@@ -83,34 +83,34 @@ pub fn show_switches(switches: Vec<Switch>, output_format: OutputFormat) -> Resu
                 let id = switch
                     .id
                     .as_ref()
-                    .map(|id| id.to_string())
-                    .unwrap_or_else(|| "N/A".to_string());
+                    .map(|id| Cow::Owned(id.to_string()))
+                    .unwrap_or_else(|| Cow::Borrowed("N/A"));
 
                 let name = switch
                     .config
                     .as_ref()
-                    .map(|config| config.name.clone())
-                    .unwrap_or_else(|| "N/A".to_string());
+                    .map(|config| config.name.as_str())
+                    .unwrap_or_else(|| "N/A");
 
                 let location = switch
                     .config
                     .as_ref()
-                    .and_then(|config| config.location.clone())
-                    .unwrap_or_else(|| "N/A".to_string());
+                    .and_then(|config| config.location.as_deref())
+                    .unwrap_or("N/A");
 
                 let power_state = switch
                     .status
                     .as_ref()
-                    .and_then(|status| status.power_state.clone())
-                    .unwrap_or_else(|| "N/A".to_string());
+                    .and_then(|status| status.power_state.as_deref())
+                    .unwrap_or("N/A");
 
                 let health = switch
                     .status
                     .as_ref()
-                    .and_then(|status| status.health_status.clone())
-                    .unwrap_or_else(|| "N/A".to_string());
+                    .and_then(|status| status.health_status.as_deref())
+                    .unwrap_or("N/A");
 
-                let controller_state = switch.controller_state.clone();
+                let controller_state = switch.controller_state.as_str();
 
                 println!(
                     "{},{},{},{},{},{}",
@@ -144,28 +144,28 @@ pub async fn list_switches(api_client: &ApiClient) -> Result<()> {
         let name = switch
             .config
             .as_ref()
-            .map(|config| config.name.clone())
-            .unwrap_or_else(|| "Unnamed".to_string());
+            .map(|config| config.name.as_str())
+            .unwrap_or_else(|| "Unnamed");
 
         let id = switch
             .id
             .as_ref()
-            .map(|id| id.to_string())
-            .unwrap_or_else(|| "N/A".to_string());
+            .map(|id| Cow::Owned(id.to_string()))
+            .unwrap_or_else(|| Cow::Borrowed("N/A"));
 
         let power_state = switch
             .status
             .as_ref()
-            .and_then(|status| status.power_state.clone())
-            .unwrap_or_else(|| "Unknown".to_string());
+            .and_then(|status| status.power_state.as_deref())
+            .unwrap_or("Unknown");
 
         let health = switch
             .status
             .as_ref()
-            .and_then(|status| status.health_status.clone())
-            .unwrap_or_else(|| "Unknown".to_string());
+            .and_then(|status| status.health_status.as_deref())
+            .unwrap_or("Unknown");
 
-        let controller_state = switch.controller_state.clone();
+        let controller_state = switch.controller_state.as_str();
 
         println!(
             "{}. {} (ID: {}) - Power: {}, Health: {}, State: {}",
@@ -182,20 +182,20 @@ pub async fn list_switches(api_client: &ApiClient) -> Result<()> {
 }
 
 pub async fn handle_show(
-    args: &ShowSwitch,
+    args: ShowSwitch,
     output_format: OutputFormat,
     api_client: &ApiClient,
 ) -> CarbideCliResult<()> {
     let query = match args.identifier {
-        Some(ref id) if !id.is_empty() => {
+        Some(id) if !id.is_empty() => {
             // Try to parse as SwitchId, otherwise treat as name
-            match SwitchId::from_str(id) {
+            match SwitchId::from_str(&id) {
                 Ok(switch_id) => rpc::forge::SwitchQuery {
                     name: None,
                     switch_id: Some(switch_id),
                 },
                 Err(_) => rpc::forge::SwitchQuery {
-                    name: Some(id.clone()),
+                    name: Some(id),
                     switch_id: None,
                 },
             }

--- a/crates/admin-cli/src/switch/mod.rs
+++ b/crates/admin-cli/src/switch/mod.rs
@@ -26,7 +26,7 @@ impl Dispatch for Cmd {
     async fn dispatch(self, ctx: RuntimeContext) -> CarbideCliResult<()> {
         match self {
             Cmd::Show(show_opts) => {
-                cmds::handle_show(&show_opts, ctx.config.format, &ctx.api_client).await?
+                cmds::handle_show(show_opts, ctx.config.format, &ctx.api_client).await?
             }
             Cmd::List => cmds::list_switches(&ctx.api_client).await?,
         }

--- a/crates/admin-cli/src/tenant/cmds.rs
+++ b/crates/admin-cli/src/tenant/cmds.rs
@@ -43,7 +43,7 @@ fn convert_tenants_to_table(tenants: &[forgerpc::Tenant]) -> CarbideCliResult<Bo
             .iter()
             .map(|label| {
                 let key = &label.key;
-                let value = label.value.clone().unwrap_or_default();
+                let value = label.value.as_deref().unwrap_or_default();
                 format!("\"{key}:{value}\"")
             })
             .collect::<Vec<_>>();
@@ -138,7 +138,7 @@ pub async fn update(
     output_format: OutputFormat,
     api_client: &ApiClient,
 ) -> CarbideCliResult<()> {
-    let id = args.tenant_org.clone();
+    let id = args.tenant_org;
 
     let tenant = api_client
         .0

--- a/crates/admin-cli/src/vpc_prefix/cmds.rs
+++ b/crates/admin-cli/src/vpc_prefix/cmds.rs
@@ -28,7 +28,7 @@ use super::args::{VpcPrefixCreate, VpcPrefixDelete, VpcPrefixShow};
 use crate::rpc::ApiClient;
 
 pub async fn show(
-    args: &VpcPrefixShow,
+    args: VpcPrefixShow,
     output_format: OutputFormat,
     api_client: &ApiClient,
     batch_size: usize,
@@ -42,7 +42,7 @@ pub async fn show(
 }
 
 pub async fn create(
-    args: &VpcPrefixCreate,
+    args: VpcPrefixCreate,
     output_format: OutputFormat,
     api_client: &ApiClient,
 ) -> CarbideCliResult<()> {
@@ -53,7 +53,7 @@ pub async fn create(
         .map_err(CarbideCliError::from)
 }
 
-pub async fn delete(args: &VpcPrefixDelete, api_client: &ApiClient) -> CarbideCliResult<()> {
+pub async fn delete(args: VpcPrefixDelete, api_client: &ApiClient) -> CarbideCliResult<()> {
     do_delete(api_client, args).await
 }
 
@@ -78,10 +78,10 @@ impl ShowOutput {
     }
 }
 
-impl From<&VpcPrefixShow> for ShowMethod {
-    fn from(show_args: &VpcPrefixShow) -> Self {
-        match &show_args.prefix_selector {
-            Some(selector) => ShowMethod::Get(selector.clone()),
+impl From<VpcPrefixShow> for ShowMethod {
+    fn from(show_args: VpcPrefixShow) -> Self {
+        match show_args.prefix_selector {
+            Some(selector) => ShowMethod::Get(selector),
             None => {
                 let mut search = match_all();
                 search.vpc_id = show_args.vpc_id;
@@ -101,12 +101,12 @@ impl From<&VpcPrefixShow> for ShowMethod {
 
 async fn do_create(
     api_client: &ApiClient,
-    create_args: &VpcPrefixCreate,
+    create_args: VpcPrefixCreate,
 ) -> Result<ShowOutput, CarbideCliError> {
     let new_prefix = VpcPrefixCreationRequest {
         id: create_args.vpc_prefix_id,
         prefix: create_args.prefix.to_string(),
-        name: create_args.name.clone(),
+        name: create_args.name,
         vpc_id: Some(create_args.vpc_id),
     };
     Ok(api_client
@@ -118,7 +118,7 @@ async fn do_create(
 
 async fn do_delete(
     api_client: &ApiClient,
-    delete_args: &VpcPrefixDelete,
+    delete_args: VpcPrefixDelete,
 ) -> Result<(), CarbideCliError> {
     let delete_prefix = VpcPrefixDeletionRequest {
         id: Some(delete_args.vpc_prefix_id),

--- a/crates/admin-cli/src/vpc_prefix/mod.rs
+++ b/crates/admin-cli/src/vpc_prefix/mod.rs
@@ -25,17 +25,17 @@ use crate::cfg::runtime::RuntimeContext;
 impl Dispatch for Cmd {
     async fn dispatch(self, ctx: RuntimeContext) -> CarbideCliResult<()> {
         match self {
-            Cmd::Create(args) => cmds::create(&args, ctx.config.format, &ctx.api_client).await,
+            Cmd::Create(args) => cmds::create(args, ctx.config.format, &ctx.api_client).await,
             Cmd::Show(args) => {
                 cmds::show(
-                    &args,
+                    args,
                     ctx.config.format,
                     &ctx.api_client,
                     ctx.config.page_size,
                 )
                 .await
             }
-            Cmd::Delete(args) => cmds::delete(&args, &ctx.api_client).await,
+            Cmd::Delete(args) => cmds::delete(args, &ctx.api_client).await,
         }
     }
 }

--- a/crates/measured-boot/src/bundle.rs
+++ b/crates/measured-boot/src/bundle.rs
@@ -139,7 +139,7 @@ impl TryFrom<MeasurementBundlePb> for MeasurementBundle {
 // the default table view, this gets used to print a pretty table.
 #[cfg(feature = "cli")]
 impl ToTable for MeasurementBundle {
-    fn to_table(&self) -> eyre::Result<String> {
+    fn into_table(self) -> eyre::Result<String> {
         let mut table = prettytable::Table::new();
         let mut values_table = prettytable::Table::new();
         values_table.add_row(prettytable::row!["pcr_register", "value"]);

--- a/crates/measured-boot/src/journal.rs
+++ b/crates/measured-boot/src/journal.rs
@@ -144,7 +144,7 @@ impl TryFrom<MeasurementJournalPb> for MeasurementJournal {
 // the default table view, this gets used to print a pretty table.
 #[cfg(feature = "cli")]
 impl ToTable for MeasurementJournal {
-    fn to_table(&self) -> eyre::Result<String> {
+    fn into_table(self) -> eyre::Result<String> {
         let profile_id: String = match self.profile_id {
             Some(profile_id) => profile_id.to_string(),
             None => "<none>".to_string(),

--- a/crates/measured-boot/src/machine.rs
+++ b/crates/measured-boot/src/machine.rs
@@ -99,7 +99,7 @@ impl TryFrom<CandidateMachinePb> for CandidateMachine {
 
 #[cfg(feature = "cli")]
 impl ToTable for CandidateMachine {
-    fn to_table(&self) -> eyre::Result<String> {
+    fn into_table(self) -> eyre::Result<String> {
         let mut table = prettytable::Table::new();
         let journal_table = match &self.journal {
             Some(journal) => journal.to_nested_prettytable(),

--- a/crates/measured-boot/src/profile.rs
+++ b/crates/measured-boot/src/profile.rs
@@ -104,7 +104,7 @@ impl TryFrom<MeasurementSystemProfilePb> for MeasurementSystemProfile {
 // the default table view, this gets used to print a pretty table.
 #[cfg(feature = "cli")]
 impl ToTable for MeasurementSystemProfile {
-    fn to_table(&self) -> eyre::Result<String> {
+    fn into_table(self) -> eyre::Result<String> {
         let mut table = prettytable::Table::new();
         let mut attrs_table = prettytable::Table::new();
         attrs_table.add_row(prettytable::row!["name", "value"]);

--- a/crates/measured-boot/src/records.rs
+++ b/crates/measured-boot/src/records.rs
@@ -914,7 +914,7 @@ impl TryFrom<CandidateMachineSummaryPb> for CandidateMachineSummary {
 
 #[cfg(feature = "cli")]
 impl ToTable for CandidateMachineSummary {
-    fn to_table(&self) -> eyre::Result<String> {
+    fn into_table(self) -> eyre::Result<String> {
         let mut table = prettytable::Table::new();
         table.add_row(prettytable::row!["machine_id", self.machine_id]);
         table.add_row(prettytable::row!["created_ts", self.ts]);
@@ -1088,7 +1088,7 @@ impl TryFrom<MeasurementApprovedMachineRecordPb> for MeasurementApprovedMachineR
 
 #[cfg(feature = "cli")]
 impl ToTable for MeasurementApprovedMachineRecord {
-    fn to_table(&self) -> eyre::Result<String> {
+    fn into_table(self) -> eyre::Result<String> {
         let pcr_registers: String = match self.pcr_registers.clone() {
             Some(pcr_registers) => pcr_registers,
             None => "".to_string(),
@@ -1201,7 +1201,7 @@ impl TryFrom<MeasurementApprovedProfileRecordPb> for MeasurementApprovedProfileR
 
 #[cfg(feature = "cli")]
 impl ToTable for MeasurementApprovedProfileRecord {
-    fn to_table(&self) -> eyre::Result<String> {
+    fn into_table(self) -> eyre::Result<String> {
         let pcr_registers: String = match self.pcr_registers.clone() {
             Some(pcr_registers) => pcr_registers,
             None => "".to_string(),

--- a/crates/measured-boot/src/report.rs
+++ b/crates/measured-boot/src/report.rs
@@ -116,7 +116,7 @@ impl TryFrom<MeasurementReportPb> for MeasurementReport {
 // the default table view, this gets used to print a pretty table.
 #[cfg(feature = "cli")]
 impl ToTable for MeasurementReport {
-    fn to_table(&self) -> eyre::Result<String> {
+    fn into_table(self) -> eyre::Result<String> {
         let mut table = prettytable::Table::new();
         let mut values_table = prettytable::Table::new();
         values_table.add_row(prettytable::row!["pcr_register", "value"]);

--- a/crates/measured-boot/src/site.rs
+++ b/crates/measured-boot/src/site.rs
@@ -54,7 +54,7 @@ impl From<&ImportSiteMeasurementsResponse> for ImportResult {
 
 #[cfg(feature = "cli")]
 impl ToTable for ImportResult {
-    fn to_table(&self) -> eyre::Result<String> {
+    fn into_table(self) -> eyre::Result<String> {
         let mut table = prettytable::Table::new();
         table.add_row(prettytable::row!["status", self.status]);
         Ok(table.to_string())
@@ -73,7 +73,7 @@ pub struct SiteModel {
 
 #[cfg(feature = "cli")]
 impl ToTable for SiteModel {
-    fn to_table(&self) -> eyre::Result<String> {
+    fn into_table(self) -> eyre::Result<String> {
         Ok("lol, not implemented for SiteModel. try -o json or -o yaml.".to_string())
     }
 }

--- a/crates/uuid/src/infiniband/mod.rs
+++ b/crates/uuid/src/infiniband/mod.rs
@@ -66,6 +66,12 @@ impl fmt::Display for IBPartitionId {
     }
 }
 
+impl From<IBPartitionId> for String {
+    fn from(id: IBPartitionId) -> Self {
+        id.to_string()
+    }
+}
+
 #[cfg(feature = "sqlx")]
 impl PgHasArrayType for IBPartitionId {
     fn array_type_info() -> PgTypeInfo {


### PR DESCRIPTION
## Description

I sometimes idly fix up code to not use `.clone()` when I'm reading it, and I've
built up a pretty large branch of changes to admin-cli over time. It finally got
to the point where I think it's worth a PR for, since even though the perf
impact is pretty negligible, I think it's good for the codebase to reflect best
practices since there are a lot of people still learning rust on the team.

Also, fix the debug-bundle timestamps, since using Strings causes clones
everywhere, and carrying DateTime<Utc> around makes it copyable and a lot
simpler. In the process, fix cases where we're parsing the logs multiple times
just to get timestamps, and fix broken pagination due to getting the oldest
timestamp instead of the newest one. (I've tested and it now pagination actually
works properly.)

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Other than the debug-bundle stuff, this should be a bug-for-bug compatible
change, no actual functionality should be affected. I'll leave comments inline
in the PR for any places worth mentioning.