### PR TITLE
FORGE-5259: change default boot url to use golan driver for hosts wit…

### DIFF
--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -412,6 +412,14 @@ pub struct CarbideConfig {
     // DPF Config
     #[serde(default)]
     pub dpf: DpfConfig,
+
+    /// The URL to use for overriding the PXE boot url on X86 machines.
+    #[serde(default)]
+    pub x86_pxe_boot_url_override: Option<String>,
+
+    /// The URL to use for overriding the PXE boot url on ARM machines.
+    #[serde(default)]
+    pub arm_pxe_boot_url_override: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]

--- a/crates/api/src/ethernet_virtualization.rs
+++ b/crates/api/src/ethernet_virtualization.rs
@@ -89,6 +89,7 @@ pub async fn admin_network(
     dpu_machine_id: &MachineId,
     fnn_enabled_on_admin: bool,
     common_pools: &CommonPools,
+    booturl: &Option<String>,
 ) -> Result<(rpc::FlatInterfaceConfig, MachineInterfaceId), tonic::Status> {
     let admin_segment = db::network_segment::admin(txn).await?;
 
@@ -227,7 +228,7 @@ pub async fn admin_network(
         },
         prefix: prefix.prefix.to_string(),
         fqdn: format!("{}.{}", interface.hostname, domain),
-        booturl: None,
+        booturl: booturl.clone(),
         svi_ip,
         tenant_vrf_loopback_ip,
         is_l2_segment: true,
@@ -253,6 +254,7 @@ pub async fn tenant_network(
     network_security_group_details: Option<(i32, NetworkSecurityGroup)>,
     segment: &NetworkSegment,
     vpc_peering_policy_on_existing: Option<VpcPeeringPolicy>,
+    booturl: &Option<String>,
 ) -> Result<rpc::FlatInterfaceConfig, tonic::Status> {
     // Any stretchable segment is treated as L2 segment by FNN.
     let is_l2_segment = segment.can_stretch.unwrap_or(true);
@@ -453,7 +455,7 @@ pub async fn tenant_network(
         // FIXME: Right now we are sending instance IP as hostname. This should be replaced by
         // user's provided fqdn later.
         fqdn,
-        booturl: None,
+        booturl: booturl.clone(),
         svi_ip,
         tenant_vrf_loopback_ip: loopback_ip,
         is_l2_segment,

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -1092,6 +1092,8 @@ pub fn get_config() -> CarbideConfig {
         dsx_exchange_event_bus: None,
         use_onboard_nic: Arc::new(false.into()),
         dpf: crate::cfg::file::DpfConfig::default(),
+        x86_pxe_boot_url_override: None,
+        arm_pxe_boot_url_override: None,
     }
 }
 

--- a/crates/dhcp-server/src/util.rs
+++ b/crates/dhcp-server/src/util.rs
@@ -56,10 +56,10 @@ pub fn machine_get_filename(
         let base_url = config.dhcp_config.carbide_provisioning_server_ipv4;
         match arch {
             MachineArchitecture::EfiX64 => {
-                format!("http://{base_url}:8080/public/blobs/internal/x86_64/ipxe.efi")
+                format!("http://{base_url}:8080/public/blobs/internal/x86_64/golan.efi")
             }
             MachineArchitecture::Arm64 => {
-                format!("http://{base_url}:8080/public/blobs/internal/aarch64/ipxe.efi")
+                format!("http://{base_url}:8080/public/blobs/internal/aarch64/golan.efi")
             }
             MachineArchitecture::BiosX86 => {
                 tracing::warn!(

--- a/pxe/Makefile.toml
+++ b/pxe/Makefile.toml
@@ -619,11 +619,10 @@ script = '''
 [tasks.ipxe-install-efi-x86_64]
 category = "iPXE Kernel"
 description = "Copy the x86_64 EFI iPXE kernel to the boot controller static files directory"
-command = "mv"
-args = [
-  "ipxe/upstream/src/bin-x86_64-efi/snponly.efi",
-  "static/blobs/internal/x86_64/ipxe.efi",
-]
+script = '''
+  mv "ipxe/upstream/src/bin-x86_64-efi/snponly.efi" "static/blobs/internal/x86_64/ipxe.efi"
+  mv "ipxe/upstream/src/bin-x86_64-efi/golan.efi" "static/blobs/internal/x86_64/golan.efi"
+'''
 dependencies = ["ipxe-build-efi-x86_64"]
 
 [tasks.ipxe-aarch64]
@@ -651,11 +650,10 @@ dependencies = [
 [tasks.ipxe-install-efi-aarch64]
 category = "iPXE Kernel"
 description = "Copy the aarch64 EFI iPXE kernel to the boot controller static files directory"
-command = "mv"
-args = [
-  "ipxe/upstream/src/bin-arm64-efi/ipxe.efi",
-  "static/blobs/internal/aarch64/ipxe.efi",
-]
+script = '''
+  mv "ipxe/upstream/src/bin-arm64-efi/ipxe.efi" "static/blobs/internal/aarch64/ipxe.efi"
+  mv "ipxe/upstream/src/bin-arm64-efi/golan.efi" "static/blobs/internal/aarch64/golan.efi"
+'''
 dependencies = ["ipxe-build-efi-aarch64"]
 
 [tasks.ipxe-install-efi-aarch64-ci]
@@ -682,6 +680,11 @@ script = '''
     VERSION=${IPXE_BANNER_VERSION} \
     EMBED=${REPO_ROOT}/pxe/ipxe/local/embed.ipxe \
     DEBUG=tls
+  make -j ${LD_ARG} \
+    bin-x86_64-efi/golan.efi \
+    VERSION=${IPXE_BANNER_VERSION} \
+    EMBED=${REPO_ROOT}/pxe/ipxe/local/embed.ipxe \
+    DEBUG=tls
 '''
 cwd = "ipxe/upstream/src"
 
@@ -702,10 +705,23 @@ script = '''
       EMBED=/src/pxe/ipxe/local/embed.ipxe \
       DEBUG=snp,tls \
       EXTRA_CFLAGS="-Wno-unused-parameter -Wno-unused-variable"
+    make -j \
+      CROSS_COMPILE=aarch64-linux-gnu- \
+      bin-arm64-efi/golan.efi \
+      VERSION=${IPXE_BANNER_VERSION} \
+      EMBED=/src/pxe/ipxe/local/embed.ipxe \
+      DEBUG=snp,tls \
+      EXTRA_CFLAGS="-Wno-unused-parameter -Wno-unused-variable"
   else
     make -j \
       CROSS_COMPILE=aarch64-linux-gnu- \
       bin-arm64-efi/ipxe.efi \
+      VERSION=${IPXE_BANNER_VERSION} \
+      EMBED=${REPO_ROOT}/pxe/ipxe/local/embed.ipxe \
+      DEBUG=snp,tls
+    make -j \
+      CROSS_COMPILE=aarch64-linux-gnu- \
+      bin-arm64-efi/golan.efi \
       VERSION=${IPXE_BANNER_VERSION} \
       EMBED=${REPO_ROOT}/pxe/ipxe/local/embed.ipxe \
       DEBUG=snp,tls


### PR DESCRIPTION
Updates the DPUs DHCP server to serve the golan pxe binary instead of the snponly binary.  This allows PXE to use the bluefield driver and avoid internal errors within the pxe client.

Note that carbide renames the snponly binary to be ipxe.efi when building the x86 build artifacts.

x86 host changes: snponly -> golan
arm host changes: ipxe -> golan

This also adds the ability to set the booturl for both x86 and arm hosts.  Because this updates the DPU DHCP server config, this has no effect on non-dpu hosts

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [X] **Add** - New feature or capability
- [X] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
FORGE-5259: 

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

