### PR TITLE
feat: Allow to explicitlty request state handling for objects

### DIFF
--- a/crates/api-db/migrations/20260129120000_queued_objects_without_iteration_ids.sql
+++ b/crates/api-db/migrations/20260129120000_queued_objects_without_iteration_ids.sql
@@ -1,0 +1,25 @@
+-- Removes iteration_id column from all queued_objects tables
+
+ALTER TABLE machine_state_controller_queued_objects
+    DROP COLUMN iteration_id;
+
+ALTER TABLE network_segments_controller_queued_objects
+    DROP COLUMN iteration_id;
+
+ALTER TABLE ib_partition_controller_queued_objects
+    DROP COLUMN iteration_id;
+
+ALTER TABLE dpa_interfaces_controller_queued_objects
+    DROP COLUMN iteration_id;
+
+ALTER TABLE power_shelf_controller_queued_objects
+    DROP COLUMN iteration_id;
+
+ALTER TABLE switch_controller_queued_objects
+    DROP COLUMN iteration_id;
+
+ALTER TABLE rack_controller_queued_objects
+    DROP COLUMN iteration_id;
+
+ALTER TABLE attestation_controller_queued_objects
+    DROP COLUMN iteration_id;

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -47,6 +47,8 @@ use crate::rack::rms_client::RmsApi;
 use crate::redfish::RedfishClientPool;
 use crate::scout_stream::ConnectionRegistry;
 use crate::site_explorer::EndpointExplorer;
+use crate::state_controller::controller::Enqueuer;
+use crate::state_controller::machine::io::MachineStateControllerIO;
 use crate::{CarbideError, CarbideResult, measured_boot};
 
 pub struct Api {
@@ -66,6 +68,7 @@ pub struct Api {
     pub(crate) rms_client: Option<Arc<Box<dyn RmsApi>>>,
     pub(crate) nmxm_pool: Arc<dyn NmxmClientPool>,
     pub(crate) work_lock_manager_handle: WorkLockManagerHandle,
+    pub(crate) machine_state_handler_enqueuer: Enqueuer<MachineStateControllerIO>,
 }
 
 pub(crate) type ScoutStreamType =

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -64,7 +64,7 @@ use crate::redfish::RedfishClientPool;
 use crate::scout_stream::ConnectionRegistry;
 use crate::site_explorer::{BmcEndpointExplorer, SiteExplorer};
 use crate::state_controller::common_services::CommonStateHandlerServices;
-use crate::state_controller::controller::StateController;
+use crate::state_controller::controller::{Enqueuer, StateController};
 use crate::state_controller::dpa_interface::handler::DpaInterfaceStateHandler;
 use crate::state_controller::dpa_interface::io::DpaInterfaceStateControllerIO;
 use crate::state_controller::ib_partition::handler::IBPartitionStateHandler;
@@ -366,7 +366,7 @@ pub async fn start_api(
         certificate_provider: vault_client.clone(),
         common_pools,
         credential_provider: vault_client,
-        database_connection: db_pool,
+        database_connection: db_pool.clone(),
         dpu_health_log_limiter: LogLimiter::default(),
         dynamic_settings,
         endpoint_explorer: bmc_explorer,
@@ -378,6 +378,7 @@ pub async fn start_api(
         rms_client: rms_client.clone(),
         nmxm_pool: shared_nmxm_pool,
         work_lock_manager_handle,
+        machine_state_handler_enqueuer: Enqueuer::new(db_pool),
     });
 
     let (controllers_stop_tx, controllers_stop_rx) = oneshot::channel();

--- a/crates/api/src/state_controller/controller.rs
+++ b/crates/api/src/state_controller/controller.rs
@@ -23,6 +23,8 @@ use crate::state_controller::state_handler::StateHandlerError;
 
 mod builder;
 pub mod db;
+mod enqueuer;
+pub use enqueuer::Enqueuer;
 pub mod periodic_enqueuer;
 pub mod processor;
 
@@ -61,8 +63,6 @@ impl<'r> FromRow<'r, PgRow> for ControllerIteration {
 pub struct QueuedObject {
     /// The ID of the object which should get scheduled
     pub object_id: String,
-    /// The ID of the run for which the object was scheduled
-    pub iteration_id: ControllerIterationId,
     /// Identifies the processor which is executing the state handler
     /// The value of this field will be NULL in case the object is not yet processed
     pub processed_by: Option<String>,
@@ -71,11 +71,9 @@ pub struct QueuedObject {
 impl<'r> FromRow<'r, PgRow> for QueuedObject {
     fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
         let object_id = row.try_get("object_id")?;
-        let iteration_id: i64 = row.try_get("iteration_id")?;
         let processed_by: Option<String> = row.try_get("processed_by")?;
         Ok(QueuedObject {
             object_id,
-            iteration_id: ControllerIterationId(iteration_id),
             processed_by,
         })
     }

--- a/crates/api/src/state_controller/controller/db.rs
+++ b/crates/api/src/state_controller/controller/db.rs
@@ -109,10 +109,10 @@ pub enum LockIterationTableError {
 pub async fn queue_objects(
     txn: &mut PgConnection,
     table_id: &str,
-    queued_objects: &[(String, ControllerIterationId)],
+    queued_objects: &[String],
 ) -> Result<usize, DatabaseError> {
     // Make sure we are not running into the BIND_LIMIT
-    // The theoretical limit would be BIND_LIMIT/2 (for 2 parameters)
+    // The theoretical limit would be BIND_LIMIT
     // However shorter transactions are ok here - we still queue 1k objects
     // per chunk
     const OBJECTS_PER_QUERY: usize = BIND_LIMIT / 32;
@@ -122,10 +122,10 @@ pub async fn queue_objects(
     for queued_objects in queued_objects.chunks(OBJECTS_PER_QUERY) {
         let mut builder = sqlx::QueryBuilder::new("INSERT INTO ");
         builder.push(table_id);
-        builder.push("(object_id, iteration_id)");
+        builder.push("(object_id)");
 
-        builder.push_values(queued_objects, |mut b, (object_id, iteration_id)| {
-            b.push_bind(object_id).push_bind(iteration_id.0);
+        builder.push_values(queued_objects, |mut b, object_id| {
+            b.push_bind(object_id);
         });
 
         builder.push("ON CONFLICT (object_id) DO NOTHING");
@@ -147,7 +147,7 @@ pub async fn fetch_queued_objects(
     txn: &mut PgConnection,
     table_id: &str,
 ) -> Result<Vec<QueuedObject>, DatabaseError> {
-    let query = format!("SELECT * from {table_id} ORDER BY iteration_id ASC");
+    let query = format!("SELECT * from {table_id}");
 
     let result = sqlx::query_as(&query)
         .fetch_all(txn)
@@ -170,7 +170,7 @@ pub async fn acquire_queued_objects(
 ) -> Result<Vec<QueuedObject>, DatabaseError> {
     let query = format!(
         "WITH dequeued_ids AS (
-            SELECT object_id FROM {table_id} WHERE (processed_by IS NULL OR processing_started_at + $1::interval < now()) ORDER BY iteration_id ASC FOR UPDATE SKIP LOCKED LIMIT {count}
+            SELECT object_id FROM {table_id} WHERE (processed_by IS NULL OR processing_started_at + $1::interval < now()) FOR UPDATE SKIP LOCKED LIMIT {count}
         )
         UPDATE {table_id} SET processed_by=$2, processing_started_at=now() WHERE object_id in (SELECT object_id FROM dequeued_ids) RETURNING *"
     );

--- a/crates/api/src/state_controller/controller/enqueuer.rs
+++ b/crates/api/src/state_controller/controller/enqueuer.rs
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material and related documentation
+ * without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+ */
+
+use ::db::DatabaseError;
+
+use super::db;
+use crate::state_controller::io::StateControllerIO;
+
+/// Allows to request state handling for objects of a certain type
+#[derive(Debug, Clone)]
+pub struct Enqueuer<IO: StateControllerIO> {
+    pool: sqlx::PgPool,
+    _phantom_object: std::marker::PhantomData<IO::ObjectId>,
+}
+
+impl<IO: StateControllerIO> Enqueuer<IO> {
+    pub fn new(pool: sqlx::PgPool) -> Self {
+        Self {
+            pool,
+            _phantom_object: std::marker::PhantomData,
+        }
+    }
+
+    /// Requests state handling for the given object
+    pub async fn enqueue_object(&self, object_id: &IO::ObjectId) -> Result<bool, DatabaseError> {
+        let mut conn = self.pool.acquire().await.map_err(DatabaseError::acquire)?;
+
+        let num_enqueued = db::queue_objects(
+            &mut conn,
+            IO::DB_QUEUED_OBJECTS_TABLE_NAME,
+            &[object_id.to_string()],
+        )
+        .await?;
+
+        Ok(num_enqueued == 1)
+    }
+}

--- a/crates/api/src/state_controller/controller/periodic_enqueuer.rs
+++ b/crates/api/src/state_controller/controller/periodic_enqueuer.rs
@@ -185,11 +185,7 @@ impl<IO: StateControllerIO> PeriodicEnqueuer<IO> {
         tracing::trace!(iteration_data = ?locked_controller_iteration.iteration_data, "Starting iteration with ID ");
         iteration_metrics.iteration_id = Some(locked_controller_iteration.iteration_data.id);
 
-        self.enqueue_objects(
-            iteration_metrics,
-            locked_controller_iteration.iteration_data.id,
-        )
-        .await?;
+        self.enqueue_objects(iteration_metrics).await?;
 
         Ok(locked_controller_iteration.iteration_data)
     }
@@ -199,7 +195,6 @@ impl<IO: StateControllerIO> PeriodicEnqueuer<IO> {
     async fn enqueue_objects(
         &mut self,
         iteration_metrics: &mut PeriodicEnqueuerMetrics,
-        iteration_id: ControllerIterationId,
     ) -> Result<(), IterationError> {
         // We start by grabbing a list of objects that should be active
         // The list might change until we fetch more data. However that should be ok:
@@ -211,7 +206,7 @@ impl<IO: StateControllerIO> PeriodicEnqueuer<IO> {
 
         let queued_objects: Vec<_> = object_ids
             .iter()
-            .map(|object_id| (object_id.to_string(), iteration_id))
+            .map(|object_id| object_id.to_string())
             .collect();
         iteration_metrics.num_enqueued_objects =
             db::queue_objects(&mut txn, IO::DB_QUEUED_OBJECTS_TABLE_NAME, &queued_objects).await?;

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -95,7 +95,7 @@ use crate::redfish::test_support::RedfishSim;
 use crate::scout_stream;
 use crate::site_explorer::{BmcEndpointExplorer, SiteExplorer};
 use crate::state_controller::common_services::CommonStateHandlerServices;
-use crate::state_controller::controller::StateController;
+use crate::state_controller::controller::{Enqueuer, StateController};
 use crate::state_controller::ib_partition::handler::IBPartitionStateHandler;
 use crate::state_controller::ib_partition::io::IBPartitionStateControllerIO;
 use crate::state_controller::machine::handler::{
@@ -1333,6 +1333,7 @@ pub async fn create_test_env_with_overrides(
         rms_client: rms_sim.as_rms_client(),
         nmxm_pool: nmxm_sim.clone(),
         work_lock_manager_handle: work_lock_manager_handle.clone(),
+        machine_state_handler_enqueuer: Enqueuer::new(db_pool.clone()),
     });
 
     let attestation_enabled = config.attestation_enabled;


### PR DESCRIPTION
## Description

With this change, state handling for objects can be requested explicitly via a new `Enqueuer::enqueue_object` API.

Using the API means certain workflows don't have to wait anymore for the next periodic iteration in order to make progress.

E.g. with the changes in this MR, the state handler of hosts will be executed again immediately after scout reports that cleanup finished or a reboot completed.

The change also removes `iteration_id` from the queued objects tables. There was no good use-case for it anymore.

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

