### PR TITLE
fix: introduce first-class RackId for RMS instead of using a string

### DIFF
--- a/crates/admin-cli/src/cfg/cli_options.rs
+++ b/crates/admin-cli/src/cfg/cli_options.rs
@@ -11,6 +11,7 @@
  */
 use std::path::PathBuf;
 
+use carbide_uuid::rack::RackId;
 use clap::{Parser, ValueEnum, ValueHint};
 use rpc::admin_cli::OutputFormat;
 
@@ -383,7 +384,7 @@ pub struct RackFirmwareDelete {
 #[derive(Parser, Debug)]
 pub struct RackFirmwareApply {
     #[clap(help = "Rack ID to apply firmware to")]
-    pub rack_id: String,
+    pub rack_id: RackId,
 
     #[clap(help = "Firmware configuration ID to apply")]
     pub firmware_id: String,

--- a/crates/admin-cli/src/expected_machines/args.rs
+++ b/crates/admin-cli/src/expected_machines/args.rs
@@ -11,6 +11,7 @@
  */
 use std::collections::HashMap;
 
+use carbide_uuid::rack::RackId;
 use clap::{ArgGroup, Parser};
 use mac_address::MacAddress;
 use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
@@ -167,7 +168,7 @@ pub struct ExpectedMachine {
         help = "Rack ID for this machine",
         action = clap::ArgAction::Append
     )]
-    pub rack_id: Option<String>,
+    pub rack_id: Option<RackId>,
 
     #[clap(
         long = "default_pause_ingestion_and_poweron",
@@ -249,7 +250,7 @@ pub struct ExpectedMachineJson {
     pub sku_id: Option<String>,
     #[serde(default)]
     pub host_nics: Vec<rpc::forge::ExpectedHostNic>,
-    pub rack_id: Option<String>,
+    pub rack_id: Option<RackId>,
     pub default_pause_ingestion_and_poweron: Option<bool>,
     pub dpf_enabled: bool,
 }
@@ -346,7 +347,7 @@ pub struct PatchExpectedMachine {
         group = "group",
         help = "A RACK ID that will be added for the newly created Machine."
     )]
-    pub rack_id: Option<String>,
+    pub rack_id: Option<RackId>,
 
     #[clap(
         long = "default_pause_ingestion_and_poweron",

--- a/crates/admin-cli/src/expected_power_shelf/args.rs
+++ b/crates/admin-cli/src/expected_power_shelf/args.rs
@@ -10,6 +10,7 @@
  * its affiliates is strictly prohibited.
  */
 
+use carbide_uuid::rack::RackId;
 use clap::{ArgGroup, Parser};
 use mac_address::MacAddress;
 use serde::{Deserialize, Serialize};
@@ -92,7 +93,7 @@ pub struct AddExpectedPowerShelf {
         help = "Rack ID for this machine",
         action = clap::ArgAction::Append
     )]
-    pub rack_id: Option<String>,
+    pub rack_id: Option<RackId>,
 
     #[clap(
         long = "ip_address",
@@ -203,7 +204,7 @@ pub struct UpdateExpectedPowerShelf {
         help = "Rack ID for this power shelf",
         action = clap::ArgAction::Append
     )]
-    pub rack_id: Option<String>,
+    pub rack_id: Option<RackId>,
 
     #[clap(
         long = "ip_address",
@@ -242,6 +243,6 @@ pub struct ExpectedPowerShelfJson {
     #[serde(default)]
     pub metadata: Option<rpc::forge::Metadata>,
     pub host_name: Option<String>,
-    pub rack_id: Option<String>,
+    pub rack_id: Option<RackId>,
     pub ip_address: Option<String>,
 }

--- a/crates/admin-cli/src/expected_switch/args.rs
+++ b/crates/admin-cli/src/expected_switch/args.rs
@@ -10,6 +10,7 @@
  * its affiliates is strictly prohibited.
  */
 
+use carbide_uuid::rack::RackId;
 use clap::{ArgGroup, Parser};
 use mac_address::MacAddress;
 use serde::{Deserialize, Serialize};
@@ -89,7 +90,7 @@ pub struct AddExpectedSwitch {
         help = "Rack ID for this machine",
         action = clap::ArgAction::Append
     )]
-    pub rack_id: Option<String>,
+    pub rack_id: Option<RackId>,
 }
 
 impl From<AddExpectedSwitch> for rpc::forge::ExpectedSwitch {
@@ -190,7 +191,7 @@ pub struct UpdateExpectedSwitch {
         help = "Rack ID for this switch",
         action = clap::ArgAction::Append
     )]
-    pub rack_id: Option<String>,
+    pub rack_id: Option<RackId>,
 }
 
 impl UpdateExpectedSwitch {
@@ -224,5 +225,5 @@ pub struct ExpectedSwitchJson {
     pub nvos_password: Option<String>,
     #[serde(default)]
     pub metadata: Option<rpc::forge::Metadata>,
-    pub rack_id: Option<String>,
+    pub rack_id: Option<RackId>,
 }

--- a/crates/admin-cli/src/rack/cmds.rs
+++ b/crates/admin-cli/src/rack/cmds.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -30,7 +30,7 @@ pub async fn show_rack(api_client: &ApiClient, show_opts: ShowRack) -> Result<()
     }
 
     for r in racks {
-        println!("ID: {}", r.id);
+        println!("ID: {}", r.id.map(|id| id.to_string()).unwrap_or_default());
         println!("State: {}", r.rack_state);
         println!("Expected Compute Tray BMCs:");
         for mac_address in r.expected_compute_trays {
@@ -100,7 +100,7 @@ pub async fn list_racks(api_client: &ApiClient) -> Result<()> {
                     .join("\n");
                 let expected_nvlink_switches = r.expected_nvlink_switches.join("\n");
                 table.add_row(prettytable::row![
-                    r.id.as_str(),
+                    r.id.map(|id| id.to_string()).unwrap_or_default(),
                     r.rack_state.as_str(),
                     expected_compute_trays,
                     current_compute_trays,

--- a/crates/admin-cli/src/rack_firmware.rs
+++ b/crates/admin-cli/src/rack_firmware.rs
@@ -253,7 +253,7 @@ async fn apply_firmware(
     );
 
     let request = rpc::forge::RackFirmwareApplyRequest {
-        rack_id: opts.rack_id,
+        rack_id: Some(opts.rack_id),
         firmware_id: opts.firmware_id,
         firmware_type: opts.firmware_type,
     };

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -34,6 +34,7 @@ use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use carbide_uuid::network::NetworkSegmentId;
 use carbide_uuid::nvlink::{NvLinkLogicalPartitionId, NvLinkPartitionId};
+use carbide_uuid::rack::RackId;
 use carbide_uuid::vpc::VpcId;
 use mac_address::MacAddress;
 
@@ -473,7 +474,7 @@ impl ApiClient {
         meta_description: Option<String>,
         labels: Option<Vec<String>>,
         sku_id: Option<String>,
-        rack_id: Option<String>,
+        rack_id: Option<RackId>,
         default_pause_ingestion_and_poweron: Option<bool>,
         dpf_enabled: bool,
     ) -> Result<(), CarbideCliError> {
@@ -548,7 +549,7 @@ impl ApiClient {
         bmc_username: Option<String>,
         bmc_password: Option<String>,
         shelf_serial_number: Option<String>,
-        rack_id: Option<String>,
+        rack_id: Option<RackId>,
         ip_address: Option<String>,
         metadata: ::rpc::forge::Metadata,
     ) -> Result<(), CarbideCliError> {
@@ -580,7 +581,7 @@ impl ApiClient {
         bmc_username: Option<String>,
         bmc_password: Option<String>,
         switch_serial_number: Option<String>,
-        rack_id: Option<String>,
+        rack_id: Option<RackId>,
         nvos_username: Option<String>,
         nvos_password: Option<String>,
         metadata: ::rpc::forge::Metadata,

--- a/crates/api-db/src/expected_machine.rs
+++ b/crates/api-db/src/expected_machine.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -306,7 +306,7 @@ pub async fn update<'a>(
         .bind(sqlx::types::Json(&data.metadata.labels))
         .bind(&data.sku_id)
         .bind(sqlx::types::Json(&data.host_nics))
-        .bind(&data.rack_id)
+        .bind(data.rack_id)
         .bind(data.default_pause_ingestion_and_poweron)
         .bind(data.dpf_enabled)
         .bind(value.bmc_mac_address)
@@ -341,7 +341,7 @@ pub async fn update_by_id(
         .bind(sqlx::types::Json(&data.metadata.labels))
         .bind(&data.sku_id)
         .bind(sqlx::types::Json(&data.host_nics))
-        .bind(&data.rack_id)
+        .bind(data.rack_id)
         .bind(data.default_pause_ingestion_and_poweron)
         .bind(data.dpf_enabled)
         .bind(id)

--- a/crates/api-db/src/expected_power_shelf.rs
+++ b/crates/api-db/src/expected_power_shelf.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -13,6 +13,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::net::IpAddr;
 
+use carbide_uuid::rack::RackId;
 use itertools::Itertools;
 use mac_address::MacAddress;
 use model::expected_power_shelf::{ExpectedPowerShelf, LinkedExpectedPowerShelf};
@@ -101,7 +102,7 @@ pub async fn create(
     serial_number: String,
     ip_address: Option<IpAddr>,
     metadata: Metadata,
-    rack_id: Option<String>,
+    rack_id: Option<RackId>,
 ) -> DatabaseResult<ExpectedPowerShelf> {
     let query = "INSERT INTO expected_power_shelves
             (bmc_mac_address, bmc_username, bmc_password, serial_number, ip_address, metadata_name, metadata_description, metadata_labels, rack_id)
@@ -166,7 +167,7 @@ pub async fn update<'a>(
     serial_number: String,
     ip_address: Option<IpAddr>,
     metadata: Metadata,
-    rack_id: Option<String>,
+    rack_id: Option<RackId>,
 ) -> DatabaseResult<&'a mut ExpectedPowerShelf> {
     let query = "UPDATE expected_power_shelves SET bmc_username=$1, bmc_password=$2, serial_number=$3, ip_address=$4, metadata_name=$5, metadata_description=$6, metadata_labels=$7, rack_id=$8 WHERE bmc_mac_address=$9 RETURNING bmc_mac_address";
 
@@ -178,7 +179,7 @@ pub async fn update<'a>(
         .bind(&metadata.name)
         .bind(&metadata.description)
         .bind(sqlx::types::Json(&metadata.labels))
-        .bind(rack_id.clone())
+        .bind(rack_id)
         .bind(expected_power_shelf.bmc_mac_address)
         .fetch_one(txn)
         .await

--- a/crates/api-db/src/expected_switch.rs
+++ b/crates/api-db/src/expected_switch.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -12,6 +12,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 
+use carbide_uuid::rack::RackId;
 use itertools::Itertools;
 use mac_address::MacAddress;
 use model::expected_switch::{ExpectedSwitch, LinkedExpectedSwitch};
@@ -127,7 +128,7 @@ pub async fn create(
     bmc_password: String,
     serial_number: String,
     metadata: Metadata,
-    rack_id: Option<String>,
+    rack_id: Option<RackId>,
     nvos_username: Option<String>,
     nvos_password: Option<String>,
 ) -> DatabaseResult<ExpectedSwitch> {
@@ -194,7 +195,7 @@ pub async fn update<'a>(
     bmc_password: String,
     serial_number: String,
     metadata: Metadata,
-    rack_id: Option<String>,
+    rack_id: Option<RackId>,
     nvos_username: Option<String>,
     nvos_password: Option<String>,
 ) -> DatabaseResult<&'a mut ExpectedSwitch> {
@@ -207,7 +208,7 @@ pub async fn update<'a>(
         .bind(&metadata.name)
         .bind(&metadata.description)
         .bind(sqlx::types::Json(&metadata.labels))
-        .bind(&rack_id)
+        .bind(rack_id)
         .bind(&nvos_username)
         .bind(&nvos_password)
         .bind(expected_switch.bmc_mac_address)

--- a/crates/api-db/src/rack_state_history.rs
+++ b/crates/api-db/src/rack_state_history.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -9,6 +9,7 @@
  * without an express license agreement from NVIDIA CORPORATION or
  * its affiliates is strictly prohibited.
  */
+use carbide_uuid::rack::RackId;
 use config_version::ConfigVersion;
 use model::rack::{RackState, RackStateHistory};
 use model::rack_state_history::DbRackStateHistory;
@@ -28,8 +29,8 @@ use crate::{DatabaseError, DatabaseResult};
 #[allow(dead_code)]
 pub async fn find_by_rack_ids(
     txn: &mut PgConnection,
-    ids: &[String],
-) -> DatabaseResult<std::collections::HashMap<String, Vec<RackStateHistory>>> {
+    ids: &[RackId],
+) -> DatabaseResult<std::collections::HashMap<RackId, Vec<RackStateHistory>>> {
     let query = "SELECT rack_id, state::TEXT, state_version, timestamp
         FROM rack_state_history
         WHERE rack_id=ANY($1)
@@ -54,7 +55,7 @@ pub async fn find_by_rack_ids(
 /// Store each state for debugging purpose.
 pub async fn persist(
     txn: &mut PgConnection,
-    rack_id: &str,
+    rack_id: RackId,
     state: &RackState,
     state_version: ConfigVersion,
 ) -> DatabaseResult<RackStateHistory> {

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -12,6 +12,7 @@
 use std::collections::HashMap;
 
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
+use carbide_uuid::rack::RackId;
 use mac_address::MacAddress;
 use rpc::errors::RpcDataConversionError;
 use serde::{Deserialize, Serialize};
@@ -58,7 +59,7 @@ pub struct ExpectedMachineData {
     pub override_id: Option<Uuid>,
     #[serde(default)]
     pub host_nics: Vec<ExpectedHostNic>,
-    pub rack_id: Option<String>,
+    pub rack_id: Option<RackId>,
     pub default_pause_ingestion_and_poweron: Option<bool>,
     #[serde(default)]
     pub dpf_enabled: bool,

--- a/crates/api-model/src/expected_power_shelf.rs
+++ b/crates/api-model/src/expected_power_shelf.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 
 use carbide_uuid::power_shelf::PowerShelfId;
+use carbide_uuid::rack::RackId;
 use mac_address::MacAddress;
 use serde::Deserialize;
 use sqlx::postgres::PgRow;
@@ -38,7 +39,7 @@ pub struct ExpectedPowerShelf {
     pub ip_address: Option<IpAddr>,
     #[serde(default = "default_metadata_for_deserializer")]
     pub metadata: Metadata,
-    pub rack_id: Option<String>,
+    pub rack_id: Option<RackId>,
 }
 
 impl<'r> FromRow<'r, PgRow> for ExpectedPowerShelf {

--- a/crates/api-model/src/expected_switch.rs
+++ b/crates/api-model/src/expected_switch.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -12,6 +12,7 @@
 
 use std::collections::HashMap;
 
+use carbide_uuid::rack::RackId;
 use carbide_uuid::switch::SwitchId;
 use mac_address::MacAddress;
 use serde::Deserialize;
@@ -38,7 +39,7 @@ pub struct ExpectedSwitch {
     pub nvos_password: Option<String>,
     #[serde(default = "default_metadata_for_deserializer")]
     pub metadata: Metadata,
-    pub rack_id: Option<String>,
+    pub rack_id: Option<RackId>,
 }
 
 impl<'r> FromRow<'r, PgRow> for ExpectedSwitch {

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -13,6 +13,7 @@ use std::fmt::Display;
 
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::power_shelf::PowerShelfId;
+use carbide_uuid::rack::RackId;
 use chrono::{DateTime, Utc};
 use config_version::{ConfigVersion, Versioned};
 use mac_address::MacAddress;
@@ -26,7 +27,7 @@ use crate::controller_outcome::PersistentStateHandlerOutcome;
 
 #[derive(Debug, Clone)]
 pub struct Rack {
-    pub id: String,
+    pub id: RackId,
     pub config: RackConfig,
     pub controller_state: Versioned<RackState>,
     pub controller_state_outcome: Option<PersistentStateHandlerOutcome>,
@@ -38,7 +39,7 @@ pub struct Rack {
 impl From<Rack> for rpc::forge::Rack {
     fn from(value: Rack) -> Self {
         rpc::forge::Rack {
-            id: value.id,
+            id: Some(value.id),
             rack_state: value.controller_state.value.to_string(),
             expected_compute_trays: value
                 .config

--- a/crates/api-model/src/rack_state_history.rs
+++ b/crates/api-model/src/rack_state_history.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -9,6 +9,7 @@
  * without an express license agreement from NVIDIA CORPORATION or
  * its affiliates is strictly prohibited.
  */
+use carbide_uuid::rack::RackId;
 use config_version::ConfigVersion;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
@@ -17,8 +18,7 @@ use sqlx::FromRow;
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
 pub struct DbRackStateHistory {
     /// The ID of the rack that experienced the state change
-    // TODO(chet): Change this to RackId.
-    pub rack_id: String,
+    pub rack_id: RackId,
 
     /// The state that was entered
     pub state: String,

--- a/crates/api/src/dhcp/discover.rs
+++ b/crates/api/src/dhcp/discover.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -14,6 +14,7 @@ use std::str::FromStr;
 
 use ::rpc::forge as rpc;
 use carbide_uuid::machine::MachineId;
+use carbide_uuid::rack::RackId;
 use db::dhcp_entry::DhcpEntry;
 use db::{self, expected_machine, machine_interface};
 use mac_address::MacAddress;
@@ -313,8 +314,9 @@ async fn update_rack_config_predicted_id_with_actual(
         false => racks[0].clone(),
         true => {
             let expected_compute_trays = vec![*parsed_mac];
-            let rack_id: String = Default::default();
-            let rack = db::rack::create(txn, &rack_id, expected_compute_trays, vec![], vec![])
+            #[allow(deprecated)]
+            let rack_id: RackId = RackId::default();
+            let rack = db::rack::create(txn, rack_id, expected_compute_trays, vec![], vec![])
                 .await
                 .map_err(CarbideError::from)?;
             tracing::warn!(
@@ -331,7 +333,7 @@ async fn update_rack_config_predicted_id_with_actual(
         .find(|item| *item == predicted)
     {
         *item = *actual;
-        db::rack::update(txn, &rack.id, &config)
+        db::rack::update(txn, rack.id, &config)
             .await
             .map_err(CarbideError::from)?;
     }

--- a/crates/api/src/handlers/expected_switch.rs
+++ b/crates/api/src/handlers/expected_switch.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -31,8 +31,6 @@ pub async fn add_expected_switch(
     let metadata = model::metadata::Metadata::try_from(metadata)
         .map_err(|e| Status::invalid_argument(format!("Invalid metadata: {}", e)))?;
 
-    let rack_id = expected_switch.rack_id.filter(|s| !s.is_empty());
-
     let mut txn = api
         .database_connection
         .begin()
@@ -46,7 +44,7 @@ pub async fn add_expected_switch(
         expected_switch.bmc_password,
         expected_switch.switch_serial_number,
         metadata,
-        rack_id,
+        expected_switch.rack_id,
         expected_switch.nvos_username,
         expected_switch.nvos_password,
     )
@@ -99,8 +97,6 @@ pub async fn update_expected_switch(
     let metadata = model::metadata::Metadata::try_from(metadata)
         .map_err(|e| Status::invalid_argument(format!("Invalid metadata: {}", e)))?;
 
-    let rack_id = expected_switch.rack_id.filter(|s| !s.is_empty());
-
     let mut txn = api
         .database_connection
         .begin()
@@ -124,7 +120,7 @@ pub async fn update_expected_switch(
         expected_switch.bmc_password,
         expected_switch.switch_serial_number,
         metadata,
-        rack_id,
+        expected_switch.rack_id,
         expected_switch.nvos_username,
         expected_switch.nvos_password,
     )
@@ -223,8 +219,6 @@ pub async fn replace_all_expected_switches(
         let metadata = model::metadata::Metadata::try_from(metadata)
             .map_err(|e| Status::invalid_argument(format!("Invalid metadata: {}", e)))?;
 
-        let rack_id = expected_switch.rack_id.filter(|s| !s.is_empty());
-
         db_expected_switch::create(
             &mut txn,
             bmc_mac_address,
@@ -232,7 +226,7 @@ pub async fn replace_all_expected_switches(
             expected_switch.bmc_password,
             expected_switch.switch_serial_number,
             metadata,
-            rack_id,
+            expected_switch.rack_id,
             expected_switch.nvos_username,
             expected_switch.nvos_password,
         )

--- a/crates/api/src/handlers/rack.rs
+++ b/crates/api/src/handlers/rack.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -9,7 +9,10 @@
  * without an express license agreement from NVIDIA CORPORATION or
  * its affiliates is strictly prohibited.
  */
+use std::str::FromStr;
+
 use ::rpc::forge as rpc;
+use carbide_uuid::rack::RackId;
 use db::{WithTransaction, rack as db_rack};
 use futures_util::FutureExt;
 use tonic::{Request, Response, Status};
@@ -25,7 +28,9 @@ pub async fn get_rack(
         .with_txn(|txn| {
             async move {
                 if let Some(id) = req.id {
-                    let r = db_rack::get(txn, id.as_str())
+                    let rack_id = RackId::from_str(&id)
+                        .map_err(|e| Status::invalid_argument(format!("Invalid rack ID: {}", e)))?;
+                    let r = db_rack::get(txn, rack_id)
                         .await
                         .map_err(|e| Status::internal(format!("Getting rack {}", e)))?;
                     Ok::<_, Status>(vec![r.into()])
@@ -52,7 +57,9 @@ pub async fn delete_rack(
     let req = request.into_inner();
     api.with_txn(|txn| {
         async move {
-            let rack = db_rack::get(txn, req.id.as_str())
+            let rack_id = RackId::from_str(&req.id)
+                .map_err(|e| Status::invalid_argument(format!("Invalid rack ID: {}", e)))?;
+            let rack = db_rack::get(txn, rack_id)
                 .await
                 .map_err(|e| Status::internal(format!("Getting rack {}", e)))?;
             db_rack::mark_as_deleted(&rack, txn)

--- a/crates/api/src/handlers/rack_firmware.rs
+++ b/crates/api/src/handlers/rack_firmware.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -914,9 +914,12 @@ pub async fn apply(
     request: Request<RackFirmwareApplyRequest>,
 ) -> Result<Response<RackFirmwareApplyResponse>, Status> {
     let req = request.into_inner();
+    let rack_id = req
+        .rack_id
+        .ok_or_else(|| Status::invalid_argument("rack_id is required"))?;
 
     tracing::info!(
-        rack_id = %req.rack_id,
+        rack_id = %rack_id,
         firmware_id = %req.firmware_id,
         firmware_type = %req.firmware_type,
         "Starting firmware apply operation"
@@ -949,7 +952,7 @@ pub async fn apply(
             serde_json::json!({})
         });
 
-    let rack = db::rack::get(&mut txn, &req.rack_id)
+    let rack = db::rack::get(&mut txn, rack_id)
         .await
         .map_err(|e| Status::internal(format!("Failed to get rack: {}", e)))?;
 
@@ -978,12 +981,12 @@ pub async fn apply(
     if all_devices.is_empty() {
         return Err(Status::failed_precondition(format!(
             "Rack '{}' contains no devices",
-            req.rack_id
+            rack_id
         )));
     }
 
     tracing::info!(
-        rack_id = %req.rack_id,
+        rack_id = %rack_id,
         device_count = all_devices.len(),
         "Found devices in rack"
     );
@@ -1053,7 +1056,7 @@ pub async fn apply(
 
             match rms_client
                 .update_firmware(
-                    req.rack_id.clone(),
+                    rack_id,
                     device_id.clone(),
                     full_firmware_path.clone(),
                     target.clone(),
@@ -1111,7 +1114,7 @@ pub async fn apply(
     }
 
     tracing::info!(
-        rack_id = %req.rack_id,
+        rack_id = %rack_id,
         firmware_id = %req.firmware_id,
         successful = successful_updates,
         failed = failed_updates,

--- a/crates/api/src/rack/rms_client.rs
+++ b/crates/api/src/rack/rms_client.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -10,6 +10,7 @@
  * its affiliates is strictly prohibited.
  */
 
+use carbide_uuid::rack::RackId;
 use forge_tls::rms_client_config::{rms_client_cert_info, rms_root_ca_path};
 use rpc::forge_tls_client::{ApiConfig, ForgeClientConfig};
 use rpc::protos::rack_manager::{
@@ -125,42 +126,42 @@ pub trait RmsApi: Send + Sync + 'static {
     ) -> Result<rpc::protos::rack_manager::InventoryResponse, RackManagerError>;
     async fn remove_node(
         &self,
-        rack_id: String,
+        rack_id: RackId,
         node_id: String,
     ) -> Result<rpc::protos::rack_manager::InventoryResponse, RackManagerError>;
     async fn get_poweron_order(
         &self,
-        rack_id: String,
+        rack_id: RackId,
     ) -> Result<rpc::protos::rack_manager::InventoryResponse, RackManagerError>;
     async fn set_poweron_order(
         &self,
-        rack_id: String,
+        rack_id: RackId,
         poweron_order: Vec<PowerOnOrderItem>,
     ) -> Result<rpc::protos::rack_manager::InventoryResponse, RackManagerError>;
     async fn get_power_state(
         &self,
-        rack_id: String,
+        rack_id: RackId,
         node_id: String,
     ) -> Result<rpc::protos::rack_manager::PowerControlResponse, RackManagerError>;
     async fn set_power_state(
         &self,
-        rack_id: String,
+        rack_id: RackId,
         node_id: String,
         operation: PowerOperation,
     ) -> Result<rpc::protos::rack_manager::PowerControlResponse, RackManagerError>;
     async fn rack_power(
         &self,
-        rack_id: String,
+        rack_id: RackId,
         operation: RackPowerOperation,
     ) -> Result<rpc::protos::rack_manager::PowerControlResponse, RackManagerError>;
     async fn get_firmware_inventory(
         &self,
-        rack_id: String,
+        rack_id: RackId,
         node_id: String,
     ) -> Result<rpc::protos::rack_manager::FirmwareResponse, RackManagerError>;
     async fn update_firmware(
         &self,
-        rack_id: String,
+        rack_id: RackId,
         node_id: String,
         filename: String,
         target: String,
@@ -168,14 +169,14 @@ pub trait RmsApi: Send + Sync + 'static {
     ) -> Result<rpc::protos::rack_manager::FirmwareResponse, RackManagerError>;
     async fn update_firmware_by_node_type(
         &self,
-        rack_id: String,
+        rack_id: RackId,
         node_type: i32,
         filename: String,
         target: String,
     ) -> Result<rpc::protos::rack_manager::FirmwareResponse, RackManagerError>;
     async fn get_available_fw_images(
         &self,
-        rack_id: String,
+        rack_id: RackId,
         node_id: String,
     ) -> Result<rpc::protos::rack_manager::FirmwareResponse, RackManagerError>;
     async fn get_bkc_files(
@@ -263,10 +264,13 @@ impl RmsApi for RackManagerApi {
 
     async fn remove_node(
         &self,
-        rack_id: String,
+        rack_id: RackId,
         node_id: String,
     ) -> Result<rpc::protos::rack_manager::InventoryResponse, RackManagerError> {
-        let remove_node_command = rpc::protos::rack_manager::RemoveNodeCommand { rack_id, node_id };
+        let remove_node_command = rpc::protos::rack_manager::RemoveNodeCommand {
+            rack_id: rack_id.to_string(),
+            node_id,
+        };
         let cmd =
             rpc::protos::rack_manager::inventory_request::Command::RemoveNode(remove_node_command);
         let message = rpc::protos::rack_manager::InventoryRequest {
@@ -283,10 +287,11 @@ impl RmsApi for RackManagerApi {
 
     async fn get_poweron_order(
         &self,
-        rack_id: String,
+        rack_id: RackId,
     ) -> Result<rpc::protos::rack_manager::InventoryResponse, RackManagerError> {
-        let get_poweron_order_command =
-            rpc::protos::rack_manager::GetPowerOnOrderCommand { rack_id };
+        let get_poweron_order_command = rpc::protos::rack_manager::GetPowerOnOrderCommand {
+            rack_id: rack_id.to_string(),
+        };
         let cmd = rpc::protos::rack_manager::inventory_request::Command::GetPowerOnOrder(
             get_poweron_order_command,
         );
@@ -303,11 +308,11 @@ impl RmsApi for RackManagerApi {
     #[allow(dead_code)]
     async fn set_poweron_order(
         &self,
-        rack_id: String,
+        rack_id: RackId,
         poweron_order: Vec<PowerOnOrderItem>,
     ) -> Result<rpc::protos::rack_manager::InventoryResponse, RackManagerError> {
         let set_poweron_order_command = rpc::protos::rack_manager::SetPowerOnOrderCommand {
-            rack_id,
+            rack_id: rack_id.to_string(),
             power_on_order: poweron_order,
         };
         let cmd = rpc::protos::rack_manager::inventory_request::Command::SetPowerOnOrder(
@@ -325,11 +330,13 @@ impl RmsApi for RackManagerApi {
 
     async fn get_power_state(
         &self,
-        rack_id: String,
+        rack_id: RackId,
         node_id: String,
     ) -> Result<rpc::protos::rack_manager::PowerControlResponse, RackManagerError> {
-        let get_power_state_command =
-            rpc::protos::rack_manager::GetPowerStateCommand { rack_id, node_id };
+        let get_power_state_command = rpc::protos::rack_manager::GetPowerStateCommand {
+            rack_id: rack_id.to_string(),
+            node_id,
+        };
         let cmd = rpc::protos::rack_manager::power_control_request::Command::GetPowerState(
             get_power_state_command,
         );
@@ -346,12 +353,12 @@ impl RmsApi for RackManagerApi {
     #[allow(dead_code)]
     async fn set_power_state(
         &self,
-        rack_id: String,
+        rack_id: RackId,
         node_id: String,
         operation: PowerOperation,
     ) -> Result<rpc::protos::rack_manager::PowerControlResponse, RackManagerError> {
         let set_power_state_command = rpc::protos::rack_manager::SetPowerStateCommand {
-            rack_id,
+            rack_id: rack_id.to_string(),
             node_id,
             operation: operation.into(),
         };
@@ -371,11 +378,11 @@ impl RmsApi for RackManagerApi {
     #[allow(dead_code)]
     async fn rack_power(
         &self,
-        rack_id: String,
+        rack_id: RackId,
         operation: RackPowerOperation,
     ) -> Result<rpc::protos::rack_manager::PowerControlResponse, RackManagerError> {
         let rack_power_command = rpc::protos::rack_manager::RackPowerCommand {
-            rack_id,
+            rack_id: rack_id.to_string(),
             operation: operation.into(),
         };
         let cmd = rpc::protos::rack_manager::power_control_request::Command::RackPower(
@@ -395,11 +402,14 @@ impl RmsApi for RackManagerApi {
 
     async fn get_firmware_inventory(
         &self,
-        rack_id: String,
+        rack_id: RackId,
         node_id: String,
     ) -> Result<rpc::protos::rack_manager::FirmwareResponse, RackManagerError> {
         let get_firmware_inventory_command =
-            rpc::protos::rack_manager::GetFirmwareInventoryCommand { rack_id, node_id };
+            rpc::protos::rack_manager::GetFirmwareInventoryCommand {
+                rack_id: rack_id.to_string(),
+                node_id,
+            };
         let cmd = rpc::protos::rack_manager::firmware_request::Command::GetFirmwareInventory(
             get_firmware_inventory_command,
         );
@@ -416,14 +426,14 @@ impl RmsApi for RackManagerApi {
     #[allow(dead_code)]
     async fn update_firmware(
         &self,
-        rack_id: String,
+        rack_id: RackId,
         node_id: String,
         filename: String,
         target: String,
         activate: bool,
     ) -> Result<rpc::protos::rack_manager::FirmwareResponse, RackManagerError> {
         let update_firmware_command = rpc::protos::rack_manager::UpdateFirmwareCommand {
-            rack_id,
+            rack_id: rack_id.to_string(),
             node_id,
             filename,
             target,
@@ -445,14 +455,14 @@ impl RmsApi for RackManagerApi {
     #[allow(dead_code)]
     async fn update_firmware_by_node_type(
         &self,
-        rack_id: String,
+        rack_id: RackId,
         node_type: i32,
         filename: String,
         target: String,
     ) -> Result<rpc::protos::rack_manager::FirmwareResponse, RackManagerError> {
         let update_firmware_by_node_type_command =
             rpc::protos::rack_manager::UpdateFirmwareByNodeTypeCommand {
-                rack_id,
+                rack_id: rack_id.to_string(),
                 node_type,
                 filename,
                 target,
@@ -472,12 +482,12 @@ impl RmsApi for RackManagerApi {
 
     async fn get_available_fw_images(
         &self,
-        rack_id: String,
+        rack_id: RackId,
         node_id: String,
     ) -> Result<rpc::protos::rack_manager::FirmwareResponse, RackManagerError> {
         let get_available_fw_images_command =
             rpc::protos::rack_manager::GetAvailableFwImagesCommand {
-                rack_id: Some(rack_id),
+                rack_id: Some(rack_id.to_string()),
                 node_id: Some(node_id),
             };
         let cmd = rpc::protos::rack_manager::firmware_request::Command::GetAvailableFwImages(
@@ -692,7 +702,7 @@ pub mod test_support {
 
         async fn remove_node(
             &self,
-            _rack_id: String,
+            _rack_id: RackId,
             _node_id: String,
         ) -> Result<rpc::protos::rack_manager::InventoryResponse, RackManagerError> {
             Ok(rpc::protos::rack_manager::InventoryResponse::default())
@@ -700,14 +710,14 @@ pub mod test_support {
 
         async fn get_poweron_order(
             &self,
-            _rack_id: String,
+            _rack_id: RackId,
         ) -> Result<rpc::protos::rack_manager::InventoryResponse, RackManagerError> {
             Ok(rpc::protos::rack_manager::InventoryResponse::default())
         }
 
         async fn set_poweron_order(
             &self,
-            _rack_id: String,
+            _rack_id: RackId,
             _poweron_order: Vec<PowerOnOrderItem>,
         ) -> Result<rpc::protos::rack_manager::InventoryResponse, RackManagerError> {
             Ok(rpc::protos::rack_manager::InventoryResponse::default())
@@ -715,7 +725,7 @@ pub mod test_support {
 
         async fn get_power_state(
             &self,
-            _rack_id: String,
+            _rack_id: RackId,
             _node_id: String,
         ) -> Result<rpc::protos::rack_manager::PowerControlResponse, RackManagerError> {
             Ok(rpc::protos::rack_manager::PowerControlResponse::default())
@@ -723,7 +733,7 @@ pub mod test_support {
 
         async fn set_power_state(
             &self,
-            _rack_id: String,
+            _rack_id: RackId,
             _node_id: String,
             _operation: PowerOperation,
         ) -> Result<rpc::protos::rack_manager::PowerControlResponse, RackManagerError> {
@@ -732,7 +742,7 @@ pub mod test_support {
 
         async fn rack_power(
             &self,
-            _rack_id: String,
+            _rack_id: RackId,
             _operation: RackPowerOperation,
         ) -> Result<rpc::protos::rack_manager::PowerControlResponse, RackManagerError> {
             Ok(rpc::protos::rack_manager::PowerControlResponse::default())
@@ -740,7 +750,7 @@ pub mod test_support {
 
         async fn get_firmware_inventory(
             &self,
-            _rack_id: String,
+            _rack_id: RackId,
             _node_id: String,
         ) -> Result<rpc::protos::rack_manager::FirmwareResponse, RackManagerError> {
             Ok(rpc::protos::rack_manager::FirmwareResponse::default())
@@ -748,7 +758,7 @@ pub mod test_support {
 
         async fn update_firmware(
             &self,
-            _rack_id: String,
+            _rack_id: RackId,
             _node_id: String,
             _filename: String,
             _target: String,
@@ -759,7 +769,7 @@ pub mod test_support {
 
         async fn update_firmware_by_node_type(
             &self,
-            _rack_id: String,
+            _rack_id: RackId,
             _node_type: i32,
             _filename: String,
             _target: String,
@@ -769,7 +779,7 @@ pub mod test_support {
 
         async fn get_available_fw_images(
             &self,
-            _rack_id: String,
+            _rack_id: RackId,
             _node_id: String,
         ) -> Result<rpc::protos::rack_manager::FirmwareResponse, RackManagerError> {
             Ok(rpc::protos::rack_manager::FirmwareResponse::default())

--- a/crates/api/src/site_explorer/mod.rs
+++ b/crates/api/src/site_explorer/mod.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -794,7 +794,7 @@ impl SiteExplorer {
             }
         }
 
-        if let Some(rack_id) = &e_ps.rack_id {
+        if let Some(rack_id) = e_ps.rack_id {
             let rack = match db::rack::get(&mut txn, rack_id).await {
                 Ok(rack) => rack,
                 Err(_) => db::rack::create(
@@ -829,7 +829,7 @@ impl SiteExplorer {
             let bmc_mac_address = expected_power_shelf
                 .map(|m| m.bmc_mac_address.to_string())
                 .unwrap_or_default();
-            let rack_id = expected_power_shelf.and_then(|ps| ps.rack_id.clone());
+            let rack_id = expected_power_shelf.and_then(|ps| ps.rack_id);
 
             match rack_id {
                 Some(rack_id) => {
@@ -966,7 +966,7 @@ impl SiteExplorer {
             let bmc_mac_address = expected_switch
                 .map(|m| m.bmc_mac_address.to_string())
                 .unwrap_or_default();
-            let rack_id = expected_switch.and_then(|s| s.rack_id.clone());
+            let rack_id = expected_switch.and_then(|s| s.rack_id);
 
             match rack_id {
                 Some(rack_id) => {

--- a/crates/api/src/site_explorer/rms.rs
+++ b/crates/api/src/site_explorer/rms.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -12,6 +12,7 @@
 
 use std::sync::Arc;
 
+use carbide_uuid::rack::RackId;
 use rpc::protos::rack_manager::NewNodeInfo;
 
 use crate::CarbideError;
@@ -20,7 +21,7 @@ use crate::rack::rms_client::{RmsApi, RmsNodeType};
 // Helper function to add a node to the Rack Manager
 pub async fn add_node_to_rms(
     rms_client: Arc<Box<dyn RmsApi>>,
-    rack_id: String,
+    rack_id: RackId,
     node_id: String,
     ip_address: String,
     port: i32,
@@ -28,7 +29,7 @@ pub async fn add_node_to_rms(
     node_type: RmsNodeType,
 ) -> Result<(), CarbideError> {
     let new_node_info = NewNodeInfo {
-        rack_id,
+        rack_id: rack_id.to_string(),
         node_id,
         mac_address,
         ip_address,

--- a/crates/api/src/state_controller/rack/handler.rs
+++ b/crates/api/src/state_controller/rack/handler.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -12,6 +12,7 @@
 
 use std::cmp::Ordering;
 
+use carbide_uuid::rack::RackId;
 use db::{expected_machine as db_expected_machine, rack as db_rack};
 use model::machine::{LoadSnapshotOptions, ManagedHostState};
 use model::rack::{
@@ -31,7 +32,7 @@ pub struct RackStateHandler {}
 
 #[async_trait::async_trait]
 impl StateHandler for RackStateHandler {
-    type ObjectId = String;
+    type ObjectId = RackId;
     type State = Rack;
     type ControllerState = RackState;
     type ContextObjects = RackStateHandlerContextObjects;
@@ -64,7 +65,7 @@ impl StateHandler for RackStateHandler {
                                         && !config.compute_trays.contains(&machine_id)
                                     {
                                         config.compute_trays.push(machine_id);
-                                        db_rack::update(&mut txn, id, &config).await?;
+                                        db_rack::update(&mut txn, *id, &config).await?;
                                     }
                                 }
                                 Err(_) => {

--- a/crates/api/src/state_controller/rack/io.rs
+++ b/crates/api/src/state_controller/rack/io.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -10,8 +10,9 @@
  * its affiliates is strictly prohibited.
  */
 
-//! State Controller IO implementation for PowerShelves
+//! State Controller IO implementation for Racks
 
+use carbide_uuid::rack::RackId;
 use config_version::{ConfigVersion, Versioned};
 use db::rack::IdColumn;
 use db::{DatabaseError, ObjectColumnFilter, rack as db_rack};
@@ -24,13 +25,13 @@ use crate::state_controller::io::StateControllerIO;
 use crate::state_controller::metrics::NoopMetricsEmitter;
 use crate::state_controller::rack::context::RackStateHandlerContextObjects;
 
-/// State Controller IO implementation for PowerShelves
+/// State Controller IO implementation for Racks
 #[derive(Default, Debug)]
 pub struct RackStateControllerIO {}
 
 #[async_trait::async_trait]
 impl StateControllerIO for RackStateControllerIO {
-    type ObjectId = String;
+    type ObjectId = RackId;
     type State = Rack;
     type ControllerState = RackState;
     type MetricsEmitter = NoopMetricsEmitter;
@@ -74,7 +75,7 @@ impl StateControllerIO for RackStateControllerIO {
     async fn load_controller_state(
         &self,
         _txn: &mut PgConnection,
-        _object_id: &Self::ObjectId,
+        _rack_id: &Self::ObjectId,
         state: &Self::State,
     ) -> Result<Versioned<Self::ControllerState>, DatabaseError> {
         Ok(state.controller_state.clone())
@@ -83,18 +84,16 @@ impl StateControllerIO for RackStateControllerIO {
     async fn persist_controller_state(
         &self,
         txn: &mut PgConnection,
-        object_id: &Self::ObjectId,
+        rack_id: &Self::ObjectId,
         old_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<(), DatabaseError> {
         let _updated =
-            db_rack::try_update_controller_state(txn, object_id.as_str(), old_version, new_state)
-                .await?;
+            db_rack::try_update_controller_state(txn, *rack_id, old_version, new_state).await?;
 
         // Persist state history for debugging purposes
         let _history =
-            db::rack_state_history::persist(txn, object_id.as_str(), new_state, old_version)
-                .await?;
+            db::rack_state_history::persist(txn, *rack_id, new_state, old_version).await?;
 
         Ok(())
     }
@@ -102,10 +101,10 @@ impl StateControllerIO for RackStateControllerIO {
     async fn persist_outcome(
         &self,
         txn: &mut PgConnection,
-        object_id: &Self::ObjectId,
+        rack_id: &Self::ObjectId,
         outcome: PersistentStateHandlerOutcome,
     ) -> Result<(), DatabaseError> {
-        db_rack::update_controller_state_outcome(txn, object_id.as_str(), outcome).await
+        db_rack::update_controller_state_outcome(txn, *rack_id, outcome).await
     }
 
     fn metric_state_names(state: &RackState) -> (&'static str, &'static str) {

--- a/crates/api/src/tests/expected_power_shelf.rs
+++ b/crates/api/src/tests/expected_power_shelf.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -11,6 +11,7 @@
  */
 use std::default::Default;
 
+use carbide_uuid::rack::RackId;
 use common::api_fixtures::create_test_env;
 use db::DatabaseError;
 use mac_address::MacAddress;
@@ -197,7 +198,7 @@ async fn test_add_expected_power_shelf(pool: sqlx::PgPool) {
                     },
                 ],
             }),
-            rack_id: Some("rack-1".to_string()),
+            rack_id: Some(RackId::from(uuid::Uuid::new_v4())),
         },
     ] {
         env.api
@@ -333,7 +334,7 @@ async fn test_update_expected_power_shelf(pool: sqlx::PgPool) {
                     },
                 ],
             }),
-            rack_id: Some("rack-2".to_string()),
+            rack_id: Some(RackId::from(uuid::Uuid::new_v4())),
         },
     ] {
         env.api
@@ -450,7 +451,7 @@ async fn test_replace_all_expected_power_shelves(pool: sqlx::PgPool) {
         shelf_serial_number: "PS-NEW-001".into(),
         ip_address: "192.168.100.1".into(),
         metadata: Some(rpc::Metadata::default()),
-        rack_id: Some("rack-new-1".to_string()),
+        rack_id: Some(RackId::from(uuid::Uuid::new_v4())),
     };
 
     let expected_power_shelf_2 = rpc::forge::ExpectedPowerShelf {
@@ -460,7 +461,7 @@ async fn test_replace_all_expected_power_shelves(pool: sqlx::PgPool) {
         shelf_serial_number: "PS-NEW-002".into(),
         ip_address: "192.168.100.2".into(),
         metadata: Some(rpc::Metadata::default()),
-        rack_id: Some("rack-new-2".to_string()),
+        rack_id: Some(RackId::from(uuid::Uuid::new_v4())),
     };
 
     expected_power_shelf_list
@@ -542,7 +543,7 @@ async fn test_add_expected_power_shelf_with_ip(pool: sqlx::PgPool) {
         shelf_serial_number: "PS-IP-001".into(),
         ip_address: "10.0.0.100".into(),
         metadata: Some(rpc::Metadata::default()),
-        rack_id: Some("rack-1".to_string()),
+        rack_id: Some(RackId::from(uuid::Uuid::new_v4())),
     };
 
     env.api

--- a/crates/api/src/tests/rack_state_controller/fixtures/rack.rs
+++ b/crates/api/src/tests/rack_state_controller/fixtures/rack.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -10,13 +10,14 @@
  * its affiliates is strictly prohibited.
  */
 
+use carbide_uuid::rack::RackId;
 use model::rack::RackState;
 use sqlx::PgConnection;
 
 /// Helper function to set rack controller state directly in database
 pub async fn set_rack_controller_state(
     txn: &mut PgConnection,
-    rack_id: &str,
+    rack_id: RackId,
     state: RackState,
 ) -> Result<(), sqlx::Error> {
     sqlx::query("UPDATE racks SET controller_state = $1 WHERE id = $2")
@@ -31,7 +32,7 @@ pub async fn set_rack_controller_state(
 /// Helper function to mark rack as deleted
 pub async fn mark_rack_as_deleted(
     txn: &mut PgConnection,
-    rack_id: &str,
+    rack_id: RackId,
 ) -> Result<(), sqlx::Error> {
     sqlx::query("UPDATE racks SET deleted = NOW() WHERE id = $1")
         .bind(rack_id)

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -2772,7 +2772,7 @@ async fn test_site_explorer_power_shelf_discovery(
         expected_power_shelf.serial_number.clone(),
         expected_power_shelf.ip_address,
         expected_power_shelf.metadata.clone(),
-        expected_power_shelf.rack_id.clone(),
+        expected_power_shelf.rack_id,
     )
     .await?;
     txn.commit().await?;
@@ -2931,7 +2931,7 @@ async fn test_site_explorer_power_shelf_with_expected_config(
         expected_power_shelf.serial_number.clone(),
         expected_power_shelf.ip_address,
         expected_power_shelf.metadata.clone(),
-        expected_power_shelf.rack_id.clone(),
+        expected_power_shelf.rack_id,
     )
     .await?;
     txn.commit().await?;
@@ -3093,7 +3093,7 @@ async fn test_site_explorer_power_shelf_creation_limit(
             expected_power_shelf.serial_number.clone(),
             expected_power_shelf.ip_address,
             expected_power_shelf.metadata.clone(),
-            expected_power_shelf.rack_id.clone(),
+            expected_power_shelf.rack_id,
         )
         .await?;
     }
@@ -3244,7 +3244,7 @@ async fn test_site_explorer_power_shelf_disabled(
         expected_power_shelf.serial_number.clone(),
         expected_power_shelf.ip_address,
         expected_power_shelf.metadata.clone(),
-        expected_power_shelf.rack_id.clone(),
+        expected_power_shelf.rack_id,
     )
     .await?;
     txn.commit().await?;
@@ -3381,7 +3381,7 @@ async fn test_site_explorer_power_shelf_error_handling(
         expected_power_shelf.serial_number.clone(),
         expected_power_shelf.ip_address,
         expected_power_shelf.metadata.clone(),
-        expected_power_shelf.rack_id.clone(),
+        expected_power_shelf.rack_id,
     )
     .await?;
     txn.commit().await?;
@@ -3530,7 +3530,7 @@ async fn test_site_explorer_creates_power_shelf(
         expected_power_shelf.serial_number.clone(),
         expected_power_shelf.ip_address,
         expected_power_shelf.metadata.clone(),
-        expected_power_shelf.rack_id.clone(),
+        expected_power_shelf.rack_id,
     )
     .await?;
     txn.commit().await?;
@@ -3745,7 +3745,7 @@ async fn test_power_shelf_state_history(
         expected_power_shelf.serial_number.clone(),
         expected_power_shelf.ip_address,
         expected_power_shelf.metadata.clone(),
-        expected_power_shelf.rack_id.clone(),
+        expected_power_shelf.rack_id,
     )
     .await?;
     txn.commit().await?;
@@ -3969,7 +3969,7 @@ async fn test_power_shelf_state_history_multiple(
         expected_power_shelf1.serial_number.clone(),
         expected_power_shelf1.ip_address,
         expected_power_shelf1.metadata.clone(),
-        expected_power_shelf1.rack_id.clone(),
+        expected_power_shelf1.rack_id,
     )
     .await?;
 
@@ -3981,7 +3981,7 @@ async fn test_power_shelf_state_history_multiple(
         expected_power_shelf2.serial_number.clone(),
         expected_power_shelf2.ip_address,
         expected_power_shelf2.metadata.clone(),
-        expected_power_shelf2.rack_id.clone(),
+        expected_power_shelf2.rack_id,
     )
     .await?;
     txn.commit().await?;
@@ -4260,7 +4260,7 @@ async fn test_power_shelf_state_history_error_handling(
         expected_power_shelf.serial_number.clone(),
         expected_power_shelf.ip_address,
         expected_power_shelf.metadata.clone(),
-        expected_power_shelf.rack_id.clone(),
+        expected_power_shelf.rack_id,
     )
     .await?;
     txn.commit().await?;
@@ -4456,7 +4456,7 @@ async fn test_site_explorer_power_shelf_discovery_with_static_ip(
         expected_power_shelf.serial_number.clone(),
         expected_power_shelf.ip_address,
         expected_power_shelf.metadata.clone(),
-        expected_power_shelf.rack_id.clone(),
+        expected_power_shelf.rack_id,
     )
     .await?;
     txn.commit().await?;

--- a/crates/api/src/web/rack.rs
+++ b/crates/api/src/web/rack.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -92,7 +92,7 @@ async fn fetch_racks(api: &Api) -> Result<Vec<RackRecord>, (http::StatusCode, St
                 .join(", ");
 
             RackRecord {
-                id: rack.id,
+                id: rack.id.map(|id| id.to_string()).unwrap_or_default(),
                 rack_state: rack.rack_state,
                 expected_compute_trays: if expected_compute_trays.is_empty() {
                     "N/A".to_string()

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -37,6 +37,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .extern_path(".common.NetworkPrefixId", "::carbide_uuid::network::NetworkPrefixId")
         .extern_path(".common.NetworkSegmentId", "::carbide_uuid::network::NetworkSegmentId")
         .extern_path(".common.PowerShelfId", "::carbide_uuid::power_shelf::PowerShelfId")
+        .extern_path(".common.RackId", "::carbide_uuid::rack::RackId")
         .extern_path(".common.NVLinkPartitionId", "::carbide_uuid::nvlink::NvLinkPartitionId")
         .extern_path(".common.NVLinkLogicalPartitionId", "::carbide_uuid::nvlink::NvLinkLogicalPartitionId")
         .extern_path(".common.NVLinkDomainId", "::carbide_uuid::nvlink::NvLinkDomainId")
@@ -796,6 +797,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 ".common.PowerShelfId",
                 "::carbide_uuid::power_shelf::PowerShelfId",
             ),
+            (".common.RackId", "::carbide_uuid::rack::RackId"),
             (
                 ".common.NVLinkPartitionId",
                 "::carbide_uuid::nvlink::NvLinkPartitionId",

--- a/crates/rpc/proto/common.proto
+++ b/crates/rpc/proto/common.proto
@@ -25,6 +25,10 @@ message PowerShelfId {
   string id = 1;
 }
 
+message RackId {
+  string id = 1;
+}
+
 message SwitchId {
   string id = 1;
 }

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1564,7 +1564,7 @@ message ExpectedPowerShelf {
   string ip_address = 5;
   // Metadata that will automatically get associated with a newly created PowerShelf
   Metadata metadata = 6;
-  optional string rack_id = 7;
+  optional common.RackId rack_id = 7;
 }
 
 message ExpectedPowerShelfRequest {
@@ -1680,7 +1680,7 @@ message ExpectedSwitch {
   string switch_serial_number = 4;
   // Metadata that will automatically get associated with a newly created Switch
   Metadata metadata = 5;
-  optional string rack_id = 6;
+  optional common.RackId rack_id = 6;
   optional string nvos_username = 7;
   optional string nvos_password = 8;
 }
@@ -4510,7 +4510,7 @@ message ExpectedMachine {
   // Unique identifier for the expected machine. When omitted, server generates one.
   optional common.UUID id = 8;
   repeated ExpectedHostNic host_nics = 9;
-  optional string rack_id = 10;
+  optional common.RackId rack_id = 10;
   optional bool default_pause_ingestion_and_poweron = 11;
   bool dpf_enabled = 12;
 }
@@ -5635,7 +5635,7 @@ message GetRackResponse {
 }
 
 message Rack {
-  string id = 1;
+  common.RackId id = 1;
   string rack_state = 2;
   repeated string expected_compute_trays = 3;
   repeated string expected_power_shelves = 4;
@@ -6419,7 +6419,7 @@ message RackFirmwareDeleteRequest {
 }
 
 message RackFirmwareApplyRequest {
-  string rack_id = 1;
+  common.RackId rack_id = 1;
   string firmware_id = 2;
   string firmware_type = 3; // "dev" or "prod"
 }

--- a/crates/ssh-console-mock-api-server/build.rs
+++ b/crates/ssh-console-mock-api-server/build.rs
@@ -37,6 +37,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build_server(true)
         .build_client(false) // we're using ForgeApiClient from rpc crate
         .extern_path(".common.MachineId", "::carbide_uuid::machine::MachineId")
+        .extern_path(".common.RackId", "::carbide_uuid::rack::RackId")
         .protoc_arg("--experimental_allow_proto3_optional")
         .out_dir("src/generated")
         .compile_protos(

--- a/crates/uuid/src/lib.rs
+++ b/crates/uuid/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -25,6 +25,7 @@ pub mod network;
 pub mod network_security_group;
 pub mod nvlink;
 pub mod power_shelf;
+pub mod rack;
 pub mod switch;
 pub mod typed_uuids;
 pub mod vpc;

--- a/crates/uuid/src/rack/mod.rs
+++ b/crates/uuid/src/rack/mod.rs
@@ -1,0 +1,523 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+ */
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::fmt::{Debug, Display, Formatter, Write};
+use std::str::FromStr;
+
+use data_encoding::BASE32_DNSSEC;
+use prost::DecodeError;
+use prost::bytes::{Buf, BufMut};
+use prost::encoding::{DecodeContext, WireType};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+#[cfg(feature = "sqlx")]
+use sqlx::{
+    encode::IsNull,
+    error::BoxDynError,
+    postgres::{PgHasArrayType, PgTypeInfo},
+    {Database, Postgres, Row},
+};
+
+use crate::DbPrimaryUuid;
+
+/// This is a fixed-size hash of the rack hardware.
+pub type HardwareHash = [u8; 32];
+/// This is the base32-encoded representation of the hardware hash. It is a fixed size instead of a
+/// String so that we can implement the Copy trait.
+pub type HardwareIdBase32 = [u8; RACK_ID_HARDWARE_ID_BASE32_LENGTH];
+
+/// The `RackId` uniquely identifies a rack that is managed by the Forge system
+///
+/// `RackId`s are derived from a hardware fingerprint, and are thereby
+/// globally unique.
+///
+/// RackIds are using an encoding which makes them valid DNS names.
+/// This requires the use of lowercase characters only.
+///
+/// Examples for RackIds can be:
+/// - ps100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0
+/// - ps100rtjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0
+/// - ps100hsasb5dsh6e6ogogslpovne4rj82rp9jlf00qd7mcvmaadv85phk3g
+/// - ps100rsasb5dsh6e6ogogslpovne4rj82rp9jlf00qd7mcvmaadv85phk3g
+/// - ps100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct RackId {
+    /// The hardware source from which the Rack ID was derived
+    source: RackIdSource,
+    /// The rack hash which was derived via hashing from the hardware piece
+    /// that is indicated in `source`, encoded via base32. Must be valid utf-8.
+    hardware_id: HardwareIdBase32,
+    /// The Type of the Rack
+    ty: RackType,
+}
+
+impl Ord for RackId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.to_string().cmp(&other.to_string())
+    }
+}
+
+impl PartialOrd for RackId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Default for RackId {
+    #[allow(deprecated)]
+    fn default() -> Self {
+        Self::default()
+    }
+}
+
+impl Debug for RackId {
+    // The derived Debug implementation is messy, just output the string
+    // representation even when debugging.
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+// Make RackId bindable directly into a sqlx query.
+#[cfg(feature = "sqlx")]
+impl sqlx::Encode<'_, sqlx::Postgres> for RackId {
+    fn encode_by_ref(
+        &self,
+        buf: &mut <Postgres as Database>::ArgumentBuffer<'_>,
+    ) -> Result<IsNull, BoxDynError> {
+        buf.extend(self.to_string().as_bytes());
+        Ok(sqlx::encode::IsNull::No)
+    }
+}
+
+#[cfg(feature = "sqlx")]
+impl<'r, DB> sqlx::Decode<'r, DB> for RackId
+where
+    DB: sqlx::database::Database,
+    String: sqlx::Decode<'r, DB>,
+{
+    fn decode(
+        value: <DB as sqlx::database::Database>::ValueRef<'r>,
+    ) -> Result<Self, sqlx::error::BoxDynError> {
+        let str_id: String = String::decode(value)?;
+        Ok(RackId::from_str(&str_id).map_err(|e| sqlx::Error::Decode(Box::new(e)))?)
+    }
+}
+
+#[cfg(feature = "sqlx")]
+impl<'r> sqlx::FromRow<'r, sqlx::postgres::PgRow> for RackId {
+    fn from_row(row: &'r sqlx::postgres::PgRow) -> Result<Self, sqlx::Error> {
+        let id: RackId = row.try_get::<RackId, _>(0)?;
+        Ok(id)
+    }
+}
+
+#[cfg(feature = "sqlx")]
+impl<DB> sqlx::Type<DB> for RackId
+where
+    DB: sqlx::Database,
+    String: sqlx::Type<DB>,
+{
+    fn type_info() -> <DB as sqlx::Database>::TypeInfo {
+        String::type_info()
+    }
+
+    fn compatible(ty: &DB::TypeInfo) -> bool {
+        String::compatible(ty)
+    }
+}
+
+#[cfg(feature = "sqlx")]
+impl PgHasArrayType for RackId {
+    fn array_type_info() -> PgTypeInfo {
+        <&str as PgHasArrayType>::array_type_info()
+    }
+
+    fn array_compatible(ty: &PgTypeInfo) -> bool {
+        <&str as PgHasArrayType>::array_compatible(ty)
+    }
+}
+
+impl RackId {
+    pub fn new(source: RackIdSource, hardware_hash: HardwareHash, ty: RackType) -> RackId {
+        // BASE32_DNSSEC is chosen to just generate lowercase characters and
+        // numbers - which will result in valid DNS names for RackIds.
+        let encoded = BASE32_DNSSEC.encode(&hardware_hash);
+        assert_eq!(encoded.len(), RACK_ID_HARDWARE_ID_BASE32_LENGTH);
+
+        Self {
+            source,
+            hardware_id: encoded.as_bytes().try_into().unwrap(),
+            ty,
+        }
+    }
+
+    /// The hardware source from which the Rack ID was derived
+    pub fn source(&self) -> RackIdSource {
+        self.source
+    }
+
+    /// The type of the Rack
+    pub fn rack_type(&self) -> RackType {
+        self.ty
+    }
+
+    /// Generate Remote ID based on Rack ID.
+    /// Remote Id is inserted by dhcrelay on DPU in each DHCP request sent by host.
+    /// This field is used only for DPU.
+    pub fn remote_id(&self) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(self.to_string().as_bytes());
+        let hash: [u8; 32] = hasher.finalize().into();
+        BASE32_DNSSEC.encode(&hash)
+    }
+
+    /// NOTE: NEVER USE THIS!
+    /// Tonic's codegen requires all types to implement Default, but there is
+    /// no logical reason to construct a "default" RackId in real code, so
+    /// we simply construct a bogus one here.
+    #[allow(clippy::should_implement_trait)]
+    #[deprecated(
+        note = "Do not use `RackId::default()` directly; only implemented for prost interop"
+    )]
+    pub fn default() -> Self {
+        Self::new(
+            RackIdSource::ProductBoardChassisSerial,
+            [0; 32],
+            RackType::Rack,
+        )
+    }
+}
+
+impl DbPrimaryUuid for RackId {
+    fn db_primary_uuid_name() -> &'static str {
+        "rack_id"
+    }
+}
+
+/// The hardware source from which the Rack ID is derived.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum RackIdSource {
+    /// The Rack ID was generated by hashing the TPM EkCertificate data.
+    Tpm,
+    /// The Rack ID was generated by the concatenation of product, board and chassis serial
+    /// and hashing the resulting value.
+    /// If any of those values is not available in DMI data, an empty
+    /// string will be used instead. At least one serial number must have been
+    /// available to generate this ID.
+    ProductBoardChassisSerial,
+}
+
+impl RackIdSource {
+    /// Returns the character that identifies the source type
+    pub const fn id_char(self) -> char {
+        match self {
+            RackIdSource::Tpm => 't',
+            RackIdSource::ProductBoardChassisSerial => 's',
+        }
+    }
+
+    /// Parses the `RackIdSource` from a character
+    pub fn from_id_char(c: char) -> Option<Self> {
+        match c {
+            c if c == Self::Tpm.id_char() => Some(Self::Tpm),
+            c if c == Self::ProductBoardChassisSerial.id_char() => {
+                Some(Self::ProductBoardChassisSerial)
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Extra flags that are associated with the rack ID
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum RackType {
+    /// The Rack is a Rack
+    Rack,
+    /// The Rack is a Host
+    Host,
+}
+
+impl RackType {
+    /// Returns `true` if the Rack is a Rack
+    pub fn is_rack(self) -> bool {
+        self == RackType::Rack
+    }
+
+    /// Returns `true` if the Rack is a Host
+    pub fn is_host(self) -> bool {
+        self == RackType::Host
+    }
+}
+
+impl std::fmt::Display for RackType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RackType::Rack => f.write_str("Rack"),
+            RackType::Host => f.write_str("Host"),
+        }
+    }
+}
+
+impl RackType {
+    /// Returns the character that identifies the flag
+    pub const fn id_char(self) -> char {
+        match self {
+            RackType::Rack => 'r',
+            RackType::Host => 'h',
+        }
+    }
+
+    /// Parses the `RackType` from a character
+    pub fn from_id_char(c: char) -> Option<Self> {
+        match c {
+            c if c == Self::Rack.id_char() => Some(Self::Rack),
+            c if c == Self::Host.id_char() => Some(Self::Host),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for RackId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `ps` is for power-shelf
+        // `1` is a version identifier
+        // The next 2 bytes `00` are reserved
+        f.write_str("ps100")?;
+        // Write the rack type
+        f.write_char(self.ty.id_char())?;
+        // The next character determines how the RackId is derived (`RackIdSource`)
+        f.write_char(self.source.id_char())?;
+        // Then follows the actual source data. self.hardware_id is guaranteed to have been written
+        // from a valid string, so we can use from_utf8_unchecked.
+        unsafe { f.write_str(std::str::from_utf8_unchecked(self.hardware_id.as_slice())) }
+    }
+}
+
+impl From<uuid::Uuid> for RackId {
+    fn from(value: uuid::Uuid) -> Self {
+        // This is a fallback implementation - in practice, RackId should be created
+        // from hardware hashes, not random UUIDs
+        let mut hasher = Sha256::new();
+        hasher.update(value.as_bytes());
+        let hash: [u8; 32] = hasher.finalize().into();
+
+        Self::new(
+            RackIdSource::Tpm, // Default source
+            hash,
+            RackType::Rack, // Default type
+        )
+    }
+}
+
+/// The length that is used for the prefix in Rack IDs
+pub const RACK_ID_PREFIX_LENGTH: usize = 7;
+
+/// The length of the hardware ID substring embedded in the Rack ID
+///
+/// Since it's a base32 encoded SHA256 (32byte), this makes 52 bytes
+pub const RACK_ID_HARDWARE_ID_BASE32_LENGTH: usize = 52;
+
+/// The length of a valid RackID
+///
+/// It is made up of the prefix length (5 bytes) plus the encoded hardware ID length
+pub const RACK_ID_LENGTH: usize = RACK_ID_PREFIX_LENGTH + RACK_ID_HARDWARE_ID_BASE32_LENGTH;
+
+#[derive(thiserror::Error, Debug, Clone)]
+pub enum RackIdParseError {
+    #[error("The Rack ID has an invalid length of {0}")]
+    Length(usize),
+    #[error("The Rack ID {0} has an invalid prefix")]
+    Prefix(String),
+    #[error("The Rack ID {0} has an invalid encoding")]
+    Encoding(String),
+}
+
+impl FromStr for RackId {
+    type Err = RackIdParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() != RACK_ID_LENGTH {
+            return Err(RackIdParseError::Length(s.len()));
+        }
+        // Check for version 1 and 2 reserved bytes
+        if !s.starts_with("ps100") {
+            return Err(RackIdParseError::Prefix(s.to_string()));
+        }
+
+        // Everything after the prefix needs to be valid base32
+        let hardware_id = &s.as_bytes()[RACK_ID_PREFIX_LENGTH..];
+
+        let mut hardware_hash: HardwareHash = [0u8; 32];
+        match BASE32_DNSSEC.decode_mut(hardware_id, &mut hardware_hash) {
+            Err(_) => return Err(RackIdParseError::Encoding(s.to_string())),
+            Ok(size) if size != 32 => return Err(RackIdParseError::Encoding(s.to_string())),
+            _ => {}
+        }
+
+        let ty = RackType::from_id_char(s.as_bytes()[5] as char)
+            .ok_or_else(|| RackIdParseError::Prefix(s.to_string()))?;
+        let source = RackIdSource::from_id_char(s.as_bytes()[6] as char)
+            .ok_or_else(|| RackIdParseError::Prefix(s.to_string()))?;
+
+        Ok(RackId::new(source, hardware_hash, ty))
+    }
+}
+
+impl Serialize for RackId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for RackId {
+    fn deserialize<D>(deserializer: D) -> Result<RackId, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        let str_value = String::deserialize(deserializer)?;
+        let id = RackId::from_str(&str_value).map_err(|err| Error::custom(err.to_string()))?;
+        Ok(id)
+    }
+}
+
+// Implement [`prost::Message`] manually so that we can be wire-compatible with the
+// `.common.RackId` protobuf message, which is what we actually serialize. Do this by
+// constructing a `legacy_rpc::RackId` and delegate all  [`prost::Message`] methods to it.
+impl prost::Message for RackId {
+    fn encode_raw(&self, buf: &mut impl BufMut)
+    where
+        Self: Sized,
+    {
+        legacy_rpc::RackId::from(*self).encode_raw(buf);
+    }
+
+    fn merge_field(
+        &mut self,
+        tag: u32,
+        wire_type: WireType,
+        buf: &mut impl Buf,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        Self: Sized,
+    {
+        let mut legacy_message = legacy_rpc::RackId::from(*self);
+        legacy_message.merge_field(tag, wire_type, buf, ctx)?;
+        *self = RackId::from_str(&legacy_message.id)
+            .map_err(|_| DecodeError::new(format!("Invalid rack id: {}", legacy_message.id)))?;
+        Ok(())
+    }
+
+    fn encoded_len(&self) -> usize {
+        legacy_rpc::RackId::from(*self).encoded_len()
+    }
+
+    #[allow(deprecated)]
+    fn clear(&mut self) {
+        *self = RackId::default();
+    }
+}
+
+mod legacy_rpc {
+    /// Backwards compatibility shim for [`super::RackId`] to be sent as a protobuf message
+    /// in a way that is compatible with the `.common.RackId` message, which is defined as:
+    ///
+    /// ```ignore
+    /// message RackId {
+    ///     string id = 1;
+    /// }
+    /// ```
+    ///
+    /// This allows us to use [`super::RackId`] directly instead of having to convert it
+    /// manually every time, while still interacting with peers that expect a `.common.RackId`
+    /// to be serialized.
+    #[derive(prost::Message)]
+    pub struct RackId {
+        #[prost(string, tag = "1")]
+        pub id: String,
+    }
+
+    impl From<super::RackId> for RackId {
+        fn from(value: crate::rack::RackId) -> Self {
+            Self {
+                id: value.to_string(),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rack_id_round_trip() {
+        let rack_id_str = "ps100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg";
+        let rack_id = RackId::from_str(rack_id_str)
+            .expect("Should have successfully converted from a valid string");
+        let round_tripped = rack_id.to_string();
+        assert_eq!(rack_id_str, round_tripped);
+    }
+
+    #[test]
+    fn test_invalid_rack_ids() {
+        match RackId::from_str("ps100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hc") {
+            // one character short
+            Err(RackIdParseError::Length(_)) => {} // Expect an error
+            Ok(_) => panic!("Converting from a too-short rack ID should have failed"),
+            Err(e) => panic!(
+                "Converting from a too-short string should have failed with a length error, got {e}"
+            ),
+        }
+
+        match RackId::from_str("PS100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg") {
+            Err(RackIdParseError::Prefix(_)) => {} // Expect an error
+            Ok(_) => {
+                panic!("Converting from a rack ID with an invalid prefix should have failed")
+            }
+            Err(e) => panic!(
+                "Converting from a rack ID with an invalid prefix should have failed with a Prefix error, got {e}"
+            ),
+        }
+
+        match RackId::from_str("ps100xt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg") {
+            Err(RackIdParseError::Prefix(_)) => {} // Expect an error
+            Ok(_) => panic!("Converting from a rack ID with type `x` should have failed"),
+            Err(e) => panic!(
+                "Converting from a rack ID with type `x` should have failed with a Prefix error, got {e}"
+            ),
+        }
+
+        match RackId::from_str("ps100dx038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg") {
+            Err(RackIdParseError::Prefix(_)) => {} // Expect an error
+            Ok(_) => panic!("Converting from a rack ID with source `x` should have failed"),
+            Err(e) => panic!(
+                "Converting from a rack ID with source `x` should have failed with a Prefix error, got {e}"
+            ),
+        }
+
+        match RackId::from_str("ps100ht038bg3qsho433vkg684heguv28!qaggmrsh2ugn1qk096n2c6hcg") {
+            Err(RackIdParseError::Encoding(_)) => {} // Expect an error
+            Ok(_) => panic!("Converting from a rack ID with a `!` should have failed"),
+            Err(e) => panic!(
+                "Converting from a rack ID with a `!` should have failed with an Encoding error, got {e}"
+            ),
+        }
+    }
+}


### PR DESCRIPTION
## Description

All of the other RMS components (including `PowerShelf` and `Switch`) have their own uniquely-typed UUIDs. Make sure we're doing the same for `RackId`.

Includes:
- The introduction of a `uuid::rack::RackId` in the `uuid` crate.
- The introduction of a `common.RackId` in `common.proto`.
- Updating various proto messages to use `common.RackId`.
- Updating API calls throughout.
- Updating the `carbide-admin-cli` to use it.
- Updating object filtering.
- Updating tests.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

