### PR TITLE
Fix get_dpf_state to accept only host ids including predicted hosts as well.

### DIFF
--- a/crates/api/src/handlers/dpf.rs
+++ b/crates/api/src/handlers/dpf.rs
@@ -47,7 +47,7 @@ pub(crate) async fn get_dpf_state(
     let request = request.get_ref();
 
     for machine_id in &request.machine_ids {
-        if machine_id.machine_type() != carbide_uuid::machine::MachineType::Host {
+        if machine_id.machine_type().is_dpu() {
             return Err(Status::invalid_argument("Only host id is expected!!"));
         }
     }


### PR DESCRIPTION
## Description
Fix get_dpf_state to accept only host ids including predicted hosts as well.
The current checks ignores the predicted hosts, which is wrong behaviour.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ x ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ x ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

