### PR TITLE
chore: Rename IpxeOperatingSystem to InlineIpxe

### DIFF
--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -776,7 +776,7 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
                 phone_home_enabled: false,
                 run_provisioning_instructions_on_every_boot: false,
                 user_data: Some("".to_string()),
-                variant: Some(rpc::forge::operating_system::Variant::Ipxe(rpc::forge::IpxeOperatingSystem {
+                variant: Some(rpc::forge::operating_system::Variant::Ipxe(rpc::forge::InlineIpxe {
                     ipxe_script: " chain http://10.217.126.4/public/blobs/internal/x86_64/qcow-imager.efi loglevel=7 console=ttyS0,115200 console=tty0 pci=realloc=off image_url=https://pbss.s8k.io/v1/AUTH_team-forge/images.qcow2/carbide-dev-environment/carbide-dev-environment-latest.qcow2".to_string(),
                     user_data: Some("".to_string()),
                 })),

--- a/crates/api-model/src/instance/snapshot.rs
+++ b/crates/api-model/src/instance/snapshot.rs
@@ -34,7 +34,7 @@ use crate::machine::infiniband::MachineInfinibandStatusObservation;
 use crate::machine::nvlink::MachineNvLinkStatusObservation;
 use crate::machine::{ManagedHostState, ReprovisionRequest};
 use crate::metadata::Metadata;
-use crate::os::{IpxeOperatingSystem, OperatingSystem, OperatingSystemVariant};
+use crate::os::{InlineIpxe, OperatingSystem, OperatingSystemVariant};
 use crate::tenant::TenantOrganizationId;
 
 /// Represents a snapshot view of an `Instance`
@@ -204,7 +204,7 @@ impl TryFrom<InstanceSnapshotPgJson> for InstanceSnapshot {
         let os = OperatingSystem {
             variant: match value.os_image_id {
                 Some(x) => OperatingSystemVariant::OsImage(x),
-                None => OperatingSystemVariant::Ipxe(IpxeOperatingSystem {
+                None => OperatingSystemVariant::Ipxe(InlineIpxe {
                     ipxe_script: value.os_ipxe_script,
                 }),
             },

--- a/crates/api-model/src/os.rs
+++ b/crates/api-model/src/os.rs
@@ -17,27 +17,25 @@ use uuid::Uuid;
 use crate::ConfigValidationError;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct IpxeOperatingSystem {
+pub struct InlineIpxe {
     /// The iPXE script which is booted into
     pub ipxe_script: String,
 }
 
-impl TryFrom<rpc::forge::IpxeOperatingSystem> for IpxeOperatingSystem {
+impl TryFrom<rpc::forge::InlineIpxe> for InlineIpxe {
     type Error = RpcDataConversionError;
 
-    fn try_from(config: rpc::forge::IpxeOperatingSystem) -> Result<Self, Self::Error> {
+    fn try_from(config: rpc::forge::InlineIpxe) -> Result<Self, Self::Error> {
         Ok(Self {
             ipxe_script: config.ipxe_script,
         })
     }
 }
 
-impl TryFrom<IpxeOperatingSystem> for rpc::forge::IpxeOperatingSystem {
+impl TryFrom<InlineIpxe> for rpc::forge::InlineIpxe {
     type Error = RpcDataConversionError;
 
-    fn try_from(
-        config: IpxeOperatingSystem,
-    ) -> Result<rpc::forge::IpxeOperatingSystem, Self::Error> {
+    fn try_from(config: InlineIpxe) -> Result<rpc::forge::InlineIpxe, Self::Error> {
         Ok(Self {
             ipxe_script: config.ipxe_script,
             user_data: None,
@@ -45,12 +43,12 @@ impl TryFrom<IpxeOperatingSystem> for rpc::forge::IpxeOperatingSystem {
     }
 }
 
-impl IpxeOperatingSystem {
+impl InlineIpxe {
     /// Validates the operating system
     pub fn validate(&self) -> Result<(), ConfigValidationError> {
         if self.ipxe_script.trim().is_empty() {
             return Err(ConfigValidationError::invalid_value(
-                "IpxeOperatingSystem::ipxe_script is empty",
+                "InlineIpxe::ipxe_script is empty",
             ));
         }
 
@@ -61,7 +59,7 @@ impl IpxeOperatingSystem {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OperatingSystemVariant {
     /// An operating system that is booted into via iPXE
-    Ipxe(IpxeOperatingSystem),
+    Ipxe(InlineIpxe),
     OsImage(Uuid),
 }
 
@@ -139,7 +137,7 @@ impl TryFrom<OperatingSystem> for rpc::forge::OperatingSystem {
     fn try_from(config: OperatingSystem) -> Result<rpc::forge::OperatingSystem, Self::Error> {
         let variant = match config.variant {
             OperatingSystemVariant::Ipxe(ipxe) => {
-                let mut ipxe: rpc::forge::IpxeOperatingSystem = ipxe.try_into()?;
+                let mut ipxe: rpc::forge::InlineIpxe = ipxe.try_into()?;
                 ipxe.user_data = config.user_data.clone();
                 rpc::forge::operating_system::Variant::Ipxe(ipxe)
             }

--- a/crates/api/src/tests/common/api_fixtures/instance.rs
+++ b/crates/api/src/tests/common/api_fixtures/instance.rs
@@ -266,7 +266,7 @@ pub fn default_os_config() -> rpc::forge::OperatingSystem {
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData".to_string()),
         variant: Some(rpc::forge::operating_system::Variant::Ipxe(
-            rpc::forge::IpxeOperatingSystem {
+            rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe".to_string(),
                 user_data: Some("SomeRandomData".to_string()),
             },

--- a/crates/api/src/tests/instance.rs
+++ b/crates/api/src/tests/instance.rs
@@ -3609,7 +3609,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_delete_vf(
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
         variant: Some(rpc::forge::operating_system::Variant::Ipxe(
-            rpc::forge::IpxeOperatingSystem {
+            rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
             },
@@ -3985,7 +3985,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_state_machine(
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
         variant: Some(rpc::forge::operating_system::Variant::Ipxe(
-            rpc::forge::IpxeOperatingSystem {
+            rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
             },
@@ -4927,7 +4927,7 @@ async fn test_can_not_update_instance_config_after_deletion(
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
         variant: Some(rpc::forge::operating_system::Variant::Ipxe(
-            rpc::forge::IpxeOperatingSystem {
+            rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
             },

--- a/crates/api/src/tests/instance_allocate.rs
+++ b/crates/api/src/tests/instance_allocate.rs
@@ -195,12 +195,10 @@ async fn test_zero_dpu_instance_allocation_explicit_network_config(
                     phone_home_enabled: false,
                     run_provisioning_instructions_on_every_boot: false,
                     user_data: None,
-                    variant: Some(forge::operating_system::Variant::Ipxe(
-                        forge::IpxeOperatingSystem {
-                            ipxe_script: "exit".to_string(),
-                            user_data: None,
-                        },
-                    )),
+                    variant: Some(forge::operating_system::Variant::Ipxe(forge::InlineIpxe {
+                        ipxe_script: "exit".to_string(),
+                        user_data: None,
+                    })),
                 }),
                 network: Some(forge::InstanceNetworkConfig {
                     interfaces: vec![forge::InstanceInterfaceConfig {
@@ -290,12 +288,10 @@ async fn test_zero_dpu_instance_allocation_no_network_config(
                     phone_home_enabled: false,
                     run_provisioning_instructions_on_every_boot: false,
                     user_data: None,
-                    variant: Some(forge::operating_system::Variant::Ipxe(
-                        forge::IpxeOperatingSystem {
-                            ipxe_script: "exit".to_string(),
-                            user_data: None,
-                        },
-                    )),
+                    variant: Some(forge::operating_system::Variant::Ipxe(forge::InlineIpxe {
+                        ipxe_script: "exit".to_string(),
+                        user_data: None,
+                    })),
                 }),
                 network: None, // code under test: Network config is None
                 infiniband: None,
@@ -386,12 +382,10 @@ async fn test_zero_dpu_instance_allocation_multi_segment_no_network_config(
                     phone_home_enabled: false,
                     run_provisioning_instructions_on_every_boot: false,
                     user_data: None,
-                    variant: Some(forge::operating_system::Variant::Ipxe(
-                        forge::IpxeOperatingSystem {
-                            ipxe_script: "exit".to_string(),
-                            user_data: None,
-                        },
-                    )),
+                    variant: Some(forge::operating_system::Variant::Ipxe(forge::InlineIpxe {
+                        ipxe_script: "exit".to_string(),
+                        user_data: None,
+                    })),
                 }),
                 network: None, // code under test: Network config is None
                 infiniband: None,
@@ -513,12 +507,10 @@ async fn test_reject_single_dpu_instance_allocation_no_network_config(
                     phone_home_enabled: false,
                     run_provisioning_instructions_on_every_boot: false,
                     user_data: None,
-                    variant: Some(forge::operating_system::Variant::Ipxe(
-                        forge::IpxeOperatingSystem {
-                            ipxe_script: "exit".to_string(),
-                            user_data: None,
-                        },
-                    )),
+                    variant: Some(forge::operating_system::Variant::Ipxe(forge::InlineIpxe {
+                        ipxe_script: "exit".to_string(),
+                        user_data: None,
+                    })),
                 }),
                 network: None,
                 infiniband: None,
@@ -573,12 +565,10 @@ async fn test_reject_single_dpu_instance_allocation_host_inband_network_config(
                     phone_home_enabled: false,
                     run_provisioning_instructions_on_every_boot: false,
                     user_data: None,
-                    variant: Some(forge::operating_system::Variant::Ipxe(
-                        forge::IpxeOperatingSystem {
-                            ipxe_script: "exit".to_string(),
-                            user_data: None,
-                        },
-                    )),
+                    variant: Some(forge::operating_system::Variant::Ipxe(forge::InlineIpxe {
+                        ipxe_script: "exit".to_string(),
+                        user_data: None,
+                    })),
                 }),
                 network: Some(forge::InstanceNetworkConfig {
                     interfaces: vec![forge::InstanceInterfaceConfig {
@@ -718,12 +708,10 @@ async fn test_reject_zero_dpu_instance_allocation_multiple_vpcs(
                     phone_home_enabled: false,
                     run_provisioning_instructions_on_every_boot: false,
                     user_data: None,
-                    variant: Some(forge::operating_system::Variant::Ipxe(
-                        forge::IpxeOperatingSystem {
-                            ipxe_script: "exit".to_string(),
-                            user_data: None,
-                        },
-                    )),
+                    variant: Some(forge::operating_system::Variant::Ipxe(forge::InlineIpxe {
+                        ipxe_script: "exit".to_string(),
+                        user_data: None,
+                    })),
                 }),
                 network: None,
                 infiniband: None,
@@ -778,12 +766,10 @@ async fn test_single_dpu_instance_allocation(
                     phone_home_enabled: false,
                     run_provisioning_instructions_on_every_boot: false,
                     user_data: None,
-                    variant: Some(forge::operating_system::Variant::Ipxe(
-                        forge::IpxeOperatingSystem {
-                            ipxe_script: "exit".to_string(),
-                            user_data: None,
-                        },
-                    )),
+                    variant: Some(forge::operating_system::Variant::Ipxe(forge::InlineIpxe {
+                        ipxe_script: "exit".to_string(),
+                        user_data: None,
+                    })),
                 }),
                 network: Some(forge::InstanceNetworkConfig {
                     interfaces: vec![forge::InstanceInterfaceConfig {

--- a/crates/api/src/tests/instance_config_update.rs
+++ b/crates/api/src/tests/instance_config_update.rs
@@ -73,7 +73,7 @@ async fn test_update_instance_config(_: PgPoolOptions, options: PgConnectOptions
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
         variant: Some(rpc::forge::operating_system::Variant::Ipxe(
-            rpc::forge::IpxeOperatingSystem {
+            rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
             },
@@ -122,7 +122,7 @@ async fn test_update_instance_config(_: PgPoolOptions, options: PgConnectOptions
         run_provisioning_instructions_on_every_boot: true,
         user_data: Some("SomeRandomData2".to_string()),
         variant: Some(rpc::forge::operating_system::Variant::Ipxe(
-            rpc::forge::IpxeOperatingSystem {
+            rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe2".to_string(),
                 user_data: Some("SomeRandomData2".to_string()),
             },
@@ -224,7 +224,7 @@ async fn test_update_instance_config(_: PgPoolOptions, options: PgConnectOptions
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData3".to_string()),
         variant: Some(rpc::forge::operating_system::Variant::Ipxe(
-            rpc::forge::IpxeOperatingSystem {
+            rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe3".to_string(),
                 user_data: Some("SomeRandomData3".to_string()),
             },
@@ -328,7 +328,7 @@ async fn test_reject_invalid_instance_config_updates(_: PgPoolOptions, options: 
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
         variant: Some(rpc::forge::operating_system::Variant::Ipxe(
-            rpc::forge::IpxeOperatingSystem {
+            rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
             },
@@ -364,7 +364,7 @@ async fn test_reject_invalid_instance_config_updates(_: PgPoolOptions, options: 
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData2".to_string()),
         variant: Some(rpc::forge::operating_system::Variant::Ipxe(
-            rpc::forge::IpxeOperatingSystem {
+            rpc::forge::InlineIpxe {
                 ipxe_script: "".to_string(),
                 user_data: Some("SomeRandomData2".to_string()),
             },
@@ -387,7 +387,7 @@ async fn test_reject_invalid_instance_config_updates(_: PgPoolOptions, options: 
     assert_eq!(err.code(), tonic::Code::InvalidArgument);
     assert_eq!(
         err.message(),
-        "Invalid value: IpxeOperatingSystem::ipxe_script is empty"
+        "Invalid value: InlineIpxe::ipxe_script is empty"
     );
 
     // The tenant of an instance can not be updated
@@ -557,7 +557,7 @@ async fn test_update_instance_config_vpc_prefix_no_network_update(
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
         variant: Some(rpc::forge::operating_system::Variant::Ipxe(
-            rpc::forge::IpxeOperatingSystem {
+            rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
             },
@@ -680,7 +680,7 @@ async fn test_update_instance_config_vpc_prefix_network_update(
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
         variant: Some(rpc::forge::operating_system::Variant::Ipxe(
-            rpc::forge::IpxeOperatingSystem {
+            rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
             },
@@ -863,7 +863,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_post_instance_del
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
         variant: Some(rpc::forge::operating_system::Variant::Ipxe(
-            rpc::forge::IpxeOperatingSystem {
+            rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
             },
@@ -999,7 +999,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_multidpu(
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
         variant: Some(rpc::forge::operating_system::Variant::Ipxe(
-            rpc::forge::IpxeOperatingSystem {
+            rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
             },
@@ -1147,7 +1147,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_multidpu_differen
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
         variant: Some(rpc::forge::operating_system::Variant::Ipxe(
-            rpc::forge::IpxeOperatingSystem {
+            rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
             },

--- a/crates/api/src/tests/instance_os.rs
+++ b/crates/api/src/tests/instance_os.rs
@@ -30,7 +30,7 @@ async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConn
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
         variant: Some(rpc::forge::operating_system::Variant::Ipxe(
-            rpc::forge::IpxeOperatingSystem {
+            rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
             },
@@ -63,7 +63,7 @@ async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConn
         run_provisioning_instructions_on_every_boot: true,
         user_data: Some("SomeRandomData2".to_string()),
         variant: Some(rpc::forge::operating_system::Variant::Ipxe(
-            rpc::forge::IpxeOperatingSystem {
+            rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe2".to_string(),
                 user_data: Some("SomeRandomData2".to_string()),
             },
@@ -92,7 +92,7 @@ async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConn
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData3".to_string()),
         variant: Some(rpc::forge::operating_system::Variant::Ipxe(
-            rpc::forge::IpxeOperatingSystem {
+            rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe3".to_string(),
                 user_data: Some("SomeRandomData3".to_string()),
             },
@@ -169,7 +169,7 @@ async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConn
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData2".to_string()),
         variant: Some(rpc::forge::operating_system::Variant::Ipxe(
-            rpc::forge::IpxeOperatingSystem {
+            rpc::forge::InlineIpxe {
                 ipxe_script: "".to_string(),
                 user_data: None,
             },
@@ -190,6 +190,6 @@ async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConn
     assert_eq!(err.code(), tonic::Code::InvalidArgument);
     assert_eq!(
         err.message(),
-        "Invalid value: IpxeOperatingSystem::ipxe_script is empty"
+        "Invalid value: InlineIpxe::ipxe_script is empty"
     );
 }

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -18,8 +18,8 @@ use mac_address::MacAddress;
 use rpc::forge::machine_cleanup_info::CleanupStepResult;
 use rpc::forge::operating_system::Variant;
 use rpc::forge::{
-    ConfigSetting, ExpectedMachine, IpxeOperatingSystem, MachineType, MachinesByIdsRequest,
-    OperatingSystem, PxeInstructions, SetDynamicConfigRequest,
+    ConfigSetting, ExpectedMachine, InlineIpxe, MachineType, MachinesByIdsRequest, OperatingSystem,
+    PxeInstructions, SetDynamicConfigRequest,
 };
 use rpc::protos::forge_api_client::ForgeApiClient;
 
@@ -330,7 +330,7 @@ impl ApiClient {
         let instance_config = rpc::InstanceConfig {
             tenant: Some(tenant_config),
             os: Some(OperatingSystem {
-                variant: Some(Variant::Ipxe(IpxeOperatingSystem {
+                variant: Some(Variant::Ipxe(InlineIpxe {
                     ipxe_script: "Non-existing-ipxe".to_string(),
                     user_data: None,
                 })),

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -253,7 +253,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .type_attribute("forge.PowerOptions",
                         "#[derive(serde::Deserialize, serde::Serialize)]")
         .type_attribute(
-            "forge.IpxeOperatingSystem",
+            "forge.InlineIpxe",
             "#[derive(serde::Deserialize, serde::Serialize)]",
         )
         .type_attribute("forge.NetworkSegmentList", "#[derive(serde::Serialize)]")

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1935,7 +1935,7 @@ message TenantConfig {
 message OperatingSystem {
   // Contains the operating system definition based on the variant of operating system
   oneof variant {
-    IpxeOperatingSystem ipxe = 1;
+    InlineIpxe ipxe = 1;
     common.UUID os_image_id = 2;
   }
 
@@ -1966,7 +1966,7 @@ message OperatingSystem {
   optional string user_data = 13;
 }
 
-message IpxeOperatingSystem {
+message InlineIpxe {
   // The iPXE script which is booted into
   string ipxe_script = 1;
   // Optional user-data that is associated with the iPXE script

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -811,7 +811,7 @@ mod tests {
     use carbide_uuid::machine::MachineId;
 
     use self::forge::operating_system::Variant;
-    use self::forge::{IpxeOperatingSystem, OperatingSystem};
+    use self::forge::{InlineIpxe, OperatingSystem};
     use super::*;
     use crate::protos::dns::{Domain, Metadata};
 
@@ -853,7 +853,7 @@ mod tests {
             phone_home_enabled: true,
             run_provisioning_instructions_on_every_boot: true,
             user_data: Some("def".to_string()),
-            variant: Some(Variant::Ipxe(IpxeOperatingSystem {
+            variant: Some(Variant::Ipxe(InlineIpxe {
                 ipxe_script: "abc".to_string(),
                 user_data: Some("def".to_string()),
             })),


### PR DESCRIPTION
## Description
Preparation to move Operating Systems from carbide-rest to carbide-core as source-of-truth.
Current name is really misleading since the struct is just raw iPXE script.
NOTE: replacement PR for [#95](https://github.com/NVIDIA/carbide-core/pull/95)

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes: NO

## Related to [FORGE-2852](https://jirasw.nvidia.com/browse/FORGE-2852)
