### PR TITLE
chore: bmc-mock: added additional endpoints for Dell jobs

### DIFF
--- a/crates/bmc-mock/src/redfish/oem/dell/idrac.rs
+++ b/crates/bmc-mock/src/redfish/oem/dell/idrac.rs
@@ -36,7 +36,15 @@ pub fn add_routes(r: Router<MockWrapperState>) -> Router<MockWrapperState> {
             post(post_dell_create_bios_job),
         )
         .route(
+            "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/Jobs",
+            post(post_dell_create_bios_job),
+        )
+        .route(
             "/redfish/v1/Managers/iDRAC.Embedded.1/Jobs/{job_id}",
+            get(get_dell_job),
+        )
+        .route(
+            "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/Jobs/{job_id}",
             get(get_dell_job),
         )
         .route("/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellJobService/Actions/DellJobService.DeleteJobQueue",


### PR DESCRIPTION
## Description
Dell supports two endpoints for Jobs interface:
/redfish/v1/Managers/iDRAC.Embedded.1/Jobs/{job_id}
and
/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/Jobs/{job_id}

This change adds second endpoint to bmc-mock.

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

