### PR TITLE
perf: Wakeup state machine if DPU acknowledges config changes

### DIFF
--- a/crates/api-model/src/instance/status/extension_service.rs
+++ b/crates/api-model/src/instance/status/extension_service.rs
@@ -535,6 +535,30 @@ impl InstanceExtensionServiceStatusObservation {
             })
             .collect()
     }
+
+    pub fn any_observed_version_changed(&self, other: &Self) -> bool {
+        if (self.config_version != other.config_version)
+            || (self.instance_config_version != other.instance_config_version)
+        {
+            return true;
+        }
+
+        let self_extension_service_versions: HashMap<ExtensionServiceId, ConfigVersion> =
+            HashMap::from_iter(
+                self.extension_service_statuses
+                    .iter()
+                    .map(|svc| (svc.service_id, svc.version)),
+            );
+        let other_extension_service_versions: HashMap<ExtensionServiceId, ConfigVersion> =
+            HashMap::from_iter(
+                other
+                    .extension_service_statuses
+                    .iter()
+                    .map(|svc| (svc.service_id, svc.version)),
+            );
+
+        self_extension_service_versions != other_extension_service_versions
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/api-model/src/instance/status/network.rs
+++ b/crates/api-model/src/instance/status/network.rs
@@ -472,6 +472,11 @@ pub struct InstanceNetworkStatusObservation {
 }
 
 impl InstanceNetworkStatusObservation {
+    pub fn any_observed_version_changed(&self, other: &Self) -> bool {
+        self.config_version != other.config_version
+            || self.instance_config_version != other.instance_config_version
+    }
+
     pub fn aggregate_instance_observation(
         dpu_snapshots: &[Machine],
     ) -> HashMap<MachineId, InstanceNetworkStatusObservation> {

--- a/crates/api-model/src/machine/network.rs
+++ b/crates/api-model/src/machine/network.rs
@@ -42,6 +42,38 @@ pub struct MachineNetworkStatusObservation {
 }
 
 impl MachineNetworkStatusObservation {
+    pub fn any_observed_version_changed(&self, other: &Self) -> bool {
+        if self.network_config_version != other.network_config_version {
+            return true;
+        }
+
+        if match (
+            &self.instance_network_observation,
+            &other.instance_network_observation,
+        ) {
+            (None, Some(_)) => true,
+            (Some(_), None) => true,
+            (None, None) => false,
+            (Some(a), Some(b)) => a.any_observed_version_changed(b),
+        } {
+            return true;
+        }
+
+        if match (
+            &self.extension_service_observation,
+            &other.extension_service_observation,
+        ) {
+            (None, Some(_)) => true,
+            (Some(_), None) => true,
+            (None, None) => false,
+            (Some(a), Some(b)) => a.any_observed_version_changed(b),
+        } {
+            return true;
+        }
+
+        false
+    }
+
     pub fn expired_version_health_report(
         &self,
         staleness_threshold: Duration,

--- a/crates/api/src/handlers/dpu.rs
+++ b/crates/api/src/handlers/dpu.rs
@@ -18,8 +18,8 @@ use ::rpc::errors::RpcDataConversionError;
 use ::rpc::{common as rpc_common, forge as rpc};
 use carbide_uuid::machine::MachineId;
 use db::{
-    ObjectColumnFilter, WithTransaction, dpu_agent_upgrade_policy, network_security_group,
-    network_segment,
+    DatabaseError, ObjectColumnFilter, WithTransaction, dpu_agent_upgrade_policy,
+    network_security_group, network_segment,
 };
 use forge_network::virtualization::VpcVirtualizationType;
 use futures_util::FutureExt;
@@ -824,6 +824,11 @@ pub(crate) async fn record_dpu_network_status(
         obs
     };
 
+    let any_observed_version_changed = match dpu_machine.network_status_observation {
+        None => true,
+        Some(old_observation) => old_observation.any_observed_version_changed(&machine_obs),
+    };
+
     // Instance network observation is the part of network observation now.
     db::machine::update_network_status_observation(&mut txn, &dpu_machine_id, &machine_obs).await?;
     tracing::trace!(
@@ -906,7 +911,35 @@ pub(crate) async fn record_dpu_network_status(
         tracing::Span::current().record("logfmt.suppress", true);
     }
 
+    // After everything else is done and the transaction is actually committed - wakeup
+    // the host state handler to speed up reaction on the state change.
+    // We only do this wakeup in case anything interesting changed to avoid the
+    // state handler running unnecessarily.
+    if any_observed_version_changed
+        && let Err(err) = wakeup_host_state_handler_by_dpu_id(api, &dpu_machine_id).await
+    {
+        tracing::warn!(%err, %dpu_machine_id, "Failed to wakeup state handler for host machine");
+    }
+
     Ok(Response::new(()))
+}
+
+async fn wakeup_host_state_handler_by_dpu_id(
+    api: &Api,
+    dpu_machine_id: &MachineId,
+) -> Result<(), DatabaseError> {
+    let mut txn = api.txn_begin().await?;
+    let host_machine =
+        db::machine::lookup_host_machine_ids_by_dpu_ids(&mut txn, &[*dpu_machine_id]).await?;
+    txn.rollback().await?;
+
+    if let Some(host_machine_id) = host_machine.first() {
+        api.machine_state_handler_enqueuer
+            .enqueue_object(host_machine_id)
+            .await?;
+    }
+
+    Ok(())
 }
 
 /// Network status of each managed host, as reported by forge-dpu-agent.


### PR DESCRIPTION
## Description

If the DPU reports a different version number than previously, it is likely that the desired configurations have been applied and that therefore the state handler can make progress. Therefore we re-schedule the state handler for immediate execution.

This should make wait states like WaitingForNetworkConfig shorer by half of the state handler iteration time (15s).

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

