### PR TITLE
chore(uuid): migrate remaining typed UUID-based IDs to be a TypedUuid

### DIFF
--- a/crates/admin-cli/src/nvl_partition/cmds.rs
+++ b/crates/admin-cli/src/nvl_partition/cmds.rs
@@ -107,7 +107,7 @@ fn convert_nvl_partition_to_nice_format(
     let mut lines = String::new();
 
     let data = vec![
-        ("ID", nvl_partition.id.unwrap_or_default().0.to_string()),
+        ("ID", nvl_partition.id.unwrap_or_default().to_string()),
         ("NAME", nvl_partition.name),
         (
             "LOGICAL PARTITION ID",
@@ -119,7 +119,7 @@ fn convert_nvl_partition_to_nice_format(
         ("NMX-M-ID", nvl_partition.nmx_m_id),
         (
             "NVLINK DOMAIN UUID",
-            nvl_partition.domain_uuid.unwrap_or_default().0.to_string(),
+            nvl_partition.domain_uuid.unwrap_or_default().to_string(),
         ),
     ];
 

--- a/crates/api-db/src/instance_address.rs
+++ b/crates/api-db/src/instance_address.rs
@@ -451,7 +451,9 @@ impl AssignIpsFrom<(&Machine, &NetworkPrefix)> for InstanceInterfaceConfig {
                 "Managed host has multiple interfaces in the desired network segment. Cannot know which to assign to the instance config."
             );
             return Err(DatabaseError::FindOneReturnedManyResultsError(
-                self.network_segment_id.map(|a| a.0).unwrap_or_default(),
+                self.network_segment_id
+                    .map(uuid::Uuid::from)
+                    .unwrap_or_default(),
             ));
         }
 

--- a/crates/api-db/src/machine_boot_override.rs
+++ b/crates/api-db/src/machine_boot_override.rs
@@ -114,7 +114,7 @@ pub async fn find_optional(
         0 => Ok(None),
         1 => Ok(Some(interfaces.remove(0))),
         _ => Err(DatabaseError::FindOneReturnedManyResultsError(
-            machine_interface_id.0,
+            machine_interface_id.into(),
         )),
     }
 }

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -257,10 +257,12 @@ pub async fn find_one(
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
     let mut interfaces = find_by(txn, ObjectColumnFilter::One(IdColumn, &interface_id)).await?;
     match interfaces.len() {
-        0 => Err(DatabaseError::FindOneReturnedNoResultsError(interface_id.0)),
+        0 => Err(DatabaseError::FindOneReturnedNoResultsError(
+            interface_id.into(),
+        )),
         1 => Ok(interfaces.remove(0)),
         _ => Err(DatabaseError::FindOneReturnedManyResultsError(
-            interface_id.0,
+            interface_id.into(),
         )),
     }
 }

--- a/crates/api-db/src/measured_boot/bundle.rs
+++ b/crates/api-db/src/measured_boot/bundle.rs
@@ -827,8 +827,8 @@ mod tests {
         values: Vec<MeasurementBundleValueRecord>,
     ) -> MeasurementBundle {
         MeasurementBundle {
-            bundle_id: MeasurementBundleId(bundle_uuid),
-            profile_id: MeasurementSystemProfileId(profile_uuid),
+            bundle_id: MeasurementBundleId::from(bundle_uuid),
+            profile_id: MeasurementSystemProfileId::from(profile_uuid),
             name: "funny-rabbit".to_string(),
             state: MeasurementBundleState::Active,
             values,
@@ -843,8 +843,8 @@ mod tests {
         sha_any: &str,
     ) -> MeasurementBundleValueRecord {
         MeasurementBundleValueRecord {
-            value_id: MeasurementBundleValueId(record_uuid),
-            bundle_id: MeasurementBundleId(bundle_uuid),
+            value_id: MeasurementBundleValueId::from(record_uuid),
+            bundle_id: MeasurementBundleId::from(bundle_uuid),
             pcr_register,
             sha_any: sha_any.to_string(),
             ts: chrono::DateTime::from_timestamp(1431648000, 0).unwrap(),
@@ -1038,7 +1038,8 @@ mod tests {
             .flatten()
         {
             assert_eq!(
-                MEASUREMENT_BUNDLE_UUID_3, bundle_id.0,
+                MEASUREMENT_BUNDLE_UUID_3,
+                uuid::Uuid::from(bundle_id),
                 "Incorrect bundle was selected"
             );
         } else {
@@ -1086,7 +1087,8 @@ mod tests {
             .flatten()
         {
             assert_eq!(
-                MEASUREMENT_BUNDLE_UUID_2, bundle_id.0,
+                MEASUREMENT_BUNDLE_UUID_2,
+                uuid::Uuid::from(bundle_id),
                 "Incorrect bundle was selected"
             );
         } else {
@@ -1120,7 +1122,8 @@ mod tests {
         {
             // the correct bundle just happens to be the first one added
             assert_eq!(
-                MEASUREMENT_BUNDLE_UUID_2, bundle_id.0,
+                MEASUREMENT_BUNDLE_UUID_2,
+                uuid::Uuid::from(bundle_id),
                 "Incorrect bundle was selected"
             );
         } else {

--- a/crates/api-db/src/network_segment.rs
+++ b/crates/api-db/src/network_segment.rs
@@ -495,7 +495,7 @@ pub async fn set_vpc_id_and_can_stretch(
 ) -> Result<(), DatabaseError> {
     let query = "UPDATE network_segments SET vpc_id=$1, can_stretch=true WHERE id=$2";
     sqlx::query(query)
-        .bind(vpc_id.0)
+        .bind(vpc_id)
         .bind(value.id)
         .execute(txn)
         .await

--- a/crates/api-model/src/extension_service/mod.rs
+++ b/crates/api-model/src/extension_service/mod.rs
@@ -244,7 +244,7 @@ impl<'r> FromRow<'r, PgRow> for ExtensionServiceSnapshot {
 impl From<ExtensionServiceSnapshot> for rpc::DpuExtensionService {
     fn from(snapshot: ExtensionServiceSnapshot) -> Self {
         Self {
-            service_id: snapshot.service_id.to_string(),
+            service_id: snapshot.service_id.into(),
             service_type: snapshot.service_type as i32,
             service_name: snapshot.service_name,
             tenant_organization_id: snapshot.tenant_organization_id.to_string(),

--- a/crates/api-model/src/instance/config/extension_services.rs
+++ b/crates/api-model/src/instance/config/extension_services.rs
@@ -58,7 +58,7 @@ impl TryFrom<rpc::InstanceDpuExtensionServiceConfig> for InstanceExtensionServic
 impl From<InstanceExtensionServiceConfig> for rpc::InstanceDpuExtensionServiceConfig {
     fn from(config: InstanceExtensionServiceConfig) -> Self {
         rpc::InstanceDpuExtensionServiceConfig {
-            service_id: config.service_id.to_string(),
+            service_id: config.service_id.into(),
             version: config.version.to_string(),
         }
     }

--- a/crates/api-model/src/instance/config/network.rs
+++ b/crates/api-model/src/instance/config/network.rs
@@ -664,9 +664,7 @@ impl From<NetworkDetails> for rpc::forge::instance_interface_config::NetworkDeta
     fn from(value: NetworkDetails) -> Self {
         match value {
             NetworkDetails::NetworkSegment(network_segment_id) => {
-                rpc::forge::instance_interface_config::NetworkDetails::SegmentId(
-                    network_segment_id.0.into(),
-                )
+                rpc::forge::instance_interface_config::NetworkDetails::SegmentId(network_segment_id)
             }
             NetworkDetails::VpcPrefixId(uuid) => {
                 rpc::forge::instance_interface_config::NetworkDetails::VpcPrefixId(uuid)
@@ -829,7 +827,7 @@ where
 {
     let mut out_map = s.serialize_map(Some(map.len()))?;
     for (k, v) in map {
-        let uuid: uuid::Uuid = k.into();
+        let uuid: uuid::Uuid = (*k).into();
         out_map.serialize_entry(&uuid, v)?
     }
     out_map.end()

--- a/crates/api-model/src/instance/status/extension_service.rs
+++ b/crates/api-model/src/instance/status/extension_service.rs
@@ -397,7 +397,7 @@ impl TryFrom<InstanceExtensionServiceStatus> for rpc::InstanceDpuExtensionServic
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self {
-            service_id: status.service_id.to_string(),
+            service_id: status.service_id.into(),
             version: status.version.to_string(),
             deployment_status: rpc::DpuExtensionServiceDeploymentStatus::from(
                 status.overall_status,
@@ -482,7 +482,7 @@ impl TryFrom<rpc::DpuExtensionServiceStatusObservation> for ExtensionServiceStat
 impl From<ExtensionServiceStatusObservation> for rpc::DpuExtensionServiceStatusObservation {
     fn from(observation: ExtensionServiceStatusObservation) -> Self {
         Self {
-            service_id: observation.service_id.to_string(),
+            service_id: observation.service_id.into(),
             service_type: rpc::DpuExtensionServiceType::from(observation.service_type).into(),
             service_name: observation.service_name,
             version: observation.version.to_string(),

--- a/crates/api-model/src/instance/status/network.rs
+++ b/crates/api-model/src/instance/status/network.rs
@@ -756,19 +756,17 @@ mod tests {
                 },
                 InstanceInterfaceConfig {
                     function_id: InterfaceFunctionId::Virtual { id: 1 },
-                    network_segment_id: Some(
-                        uuid::Uuid::from_u128(base_uuid.0.as_u128() + 1).into(),
-                    ),
+                    network_segment_id: Some(base_uuid.offset(1)),
                     ip_addrs: HashMap::from([(
-                        uuid::Uuid::from_u128(prefix_uuid.0.as_u128() + 1).into(),
+                        prefix_uuid.offset(1),
                         "127.0.0.2".parse().unwrap(),
                     )]),
                     interface_prefixes: HashMap::from([(
-                        uuid::Uuid::from_u128(prefix_uuid.0.as_u128() + 1).into(),
+                        prefix_uuid.offset(1),
                         "127.0.0.2/32".parse().unwrap(),
                     )]),
                     network_segment_gateways: HashMap::from([(
-                        uuid::Uuid::from_u128(prefix_uuid.0.as_u128() + 1).into(),
+                        prefix_uuid.offset(1),
                         "127.0.0.2/32".parse().unwrap(),
                     )]),
                     host_inband_mac_address: None,
@@ -778,19 +776,17 @@ mod tests {
                 },
                 InstanceInterfaceConfig {
                     function_id: InterfaceFunctionId::Virtual { id: 2 },
-                    network_segment_id: Some(
-                        uuid::Uuid::from_u128(base_uuid.0.as_u128() + 2).into(),
-                    ),
+                    network_segment_id: Some(base_uuid.offset(2)),
                     ip_addrs: HashMap::from([(
-                        uuid::Uuid::from_u128(prefix_uuid.0.as_u128() + 2).into(),
+                        prefix_uuid.offset(2),
                         "127.0.0.3".parse().unwrap(),
                     )]),
                     interface_prefixes: HashMap::from([(
-                        uuid::Uuid::from_u128(prefix_uuid.0.as_u128() + 2).into(),
+                        prefix_uuid.offset(2),
                         "127.0.0.3/32".parse().unwrap(),
                     )]),
                     network_segment_gateways: HashMap::from([(
-                        uuid::Uuid::from_u128(prefix_uuid.0.as_u128() + 2).into(),
+                        prefix_uuid.offset(2),
                         "127.0.0.3/32".parse().unwrap(),
                     )]),
                     host_inband_mac_address: None,
@@ -832,19 +828,17 @@ mod tests {
                 },
                 InstanceInterfaceConfig {
                     function_id: InterfaceFunctionId::Virtual { id: 1 },
-                    network_segment_id: Some(
-                        uuid::Uuid::from_u128(base_uuid.0.as_u128() + 1).into(),
-                    ),
+                    network_segment_id: Some(base_uuid.offset(1)),
                     ip_addrs: HashMap::from([(
-                        uuid::Uuid::from_u128(prefix_uuid.0.as_u128() + 1).into(),
+                        prefix_uuid.offset(1),
                         "127.0.2.2".parse().unwrap(),
                     )]),
                     interface_prefixes: HashMap::from([(
-                        uuid::Uuid::from_u128(prefix_uuid.0.as_u128() + 1).into(),
+                        prefix_uuid.offset(1),
                         "127.0.2.0/24".parse().unwrap(),
                     )]),
                     network_segment_gateways: HashMap::from([(
-                        uuid::Uuid::from_u128(prefix_uuid.0.as_u128() + 1).into(),
+                        prefix_uuid.offset(1),
                         "127.0.2.1/24".parse().unwrap(),
                     )]),
                     host_inband_mac_address: Some(MacAddress::new([1, 2, 3, 4, 5, 16])),
@@ -854,19 +848,17 @@ mod tests {
                 },
                 InstanceInterfaceConfig {
                     function_id: InterfaceFunctionId::Virtual { id: 2 },
-                    network_segment_id: Some(
-                        uuid::Uuid::from_u128(base_uuid.0.as_u128() + 2).into(),
-                    ),
+                    network_segment_id: Some(base_uuid.offset(2)),
                     ip_addrs: HashMap::from([(
-                        uuid::Uuid::from_u128(prefix_uuid.0.as_u128() + 2).into(),
+                        prefix_uuid.offset(2),
                         "127.0.3.2".parse().unwrap(),
                     )]),
                     interface_prefixes: HashMap::from([(
-                        uuid::Uuid::from_u128(prefix_uuid.0.as_u128() + 2).into(),
+                        prefix_uuid.offset(2),
                         "127.0.3.0/24".parse().unwrap(),
                     )]),
                     network_segment_gateways: HashMap::from([(
-                        uuid::Uuid::from_u128(prefix_uuid.0.as_u128() + 2).into(),
+                        prefix_uuid.offset(2),
                         "127.0.3.1/24".parse().unwrap(),
                     )]),
                     host_inband_mac_address: Some(MacAddress::new([1, 2, 3, 4, 5, 26])),

--- a/crates/api-model/src/instance/status/nvlink.rs
+++ b/crates/api-model/src/instance/status/nvlink.rs
@@ -95,7 +95,7 @@ impl InstanceNvLinkStatus {
                     configs_synced = SyncState::Pending;
                     InstanceNvLinkGpuStatus {
                         logical_partition_id: None,
-                        domain_id: NvLinkDomainId(uuid::Uuid::nil()),
+                        domain_id: NvLinkDomainId::default(),
                         gpu_guid: "".to_string(), // just an empty string as status is not ready yet
                     }
                 }
@@ -115,7 +115,7 @@ impl InstanceNvLinkStatus {
                 .iter()
                 .map(|cfg| InstanceNvLinkGpuStatus {
                     logical_partition_id: None,
-                    domain_id: NvLinkDomainId(uuid::Uuid::nil()),
+                    domain_id: NvLinkDomainId::default(),
                     gpu_guid: cfg.device_instance.to_string(), // just fill it with the index as status is not ready.
                 })
                 .collect(),
@@ -148,9 +148,7 @@ impl TryFrom<rpc::InstanceNvLinkGpuStatus> for InstanceNvLinkGpuStatus {
         Ok(Self {
             logical_partition_id: status.logical_partition_id,
             gpu_guid: status.gpu_guid.unwrap_or_default(),
-            domain_id: status
-                .domain_id
-                .unwrap_or(NvLinkDomainId(uuid::Uuid::nil())),
+            domain_id: status.domain_id.unwrap_or_default(),
         })
     }
 }

--- a/crates/api-model/src/machine/infiniband.rs
+++ b/crates/api-model/src/machine/infiniband.rs
@@ -89,7 +89,7 @@ impl From<MachineIbInterfaceStatusObservation> for rpc::forge::MachineIbInterfac
             }),
             associated_partition_ids: machine_ib_interface.associated_partition_ids.map(|ids| {
                 rpc::common::StringList {
-                    items: ids.into_iter().map(|id| id.0.into()).collect(),
+                    items: ids.into_iter().map(|id| id.into()).collect(),
                 }
             }),
         }

--- a/crates/api-model/src/machine/nvlink.rs
+++ b/crates/api-model/src/machine/nvlink.rs
@@ -75,7 +75,7 @@ impl Default for MachineNvLinkGpuStatusObservation {
             partition_id: None,
             logical_partition_id: None,
             device_instance: 0,
-            domain_id: NvLinkDomainId(uuid::Uuid::nil()),
+            domain_id: NvLinkDomainId::default(),
             guid: 0,
         }
     }

--- a/crates/api-model/src/vpc_prefix.rs
+++ b/crates/api-model/src/vpc_prefix.rs
@@ -109,9 +109,9 @@ impl TryFrom<rpc::forge::VpcPrefixCreationRequest> for NewVpcPrefix {
             metadata,
         } = value;
 
-        let id = id.unwrap_or_else(|| VpcPrefixId::from(uuid::Uuid::new_v4()));
+        let id = id.unwrap_or_else(VpcPrefixId::new);
         let vpc_id = vpc_id.ok_or(RpcDataConversionError::MissingArgument("vpc_id"))?;
-        // let id = VpcPrefixId::from(uuid::Uuid::new_v4());
+        // let id = VpcPrefixId::new();
 
         Ok(Self {
             id,

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -180,7 +180,7 @@ carbide-prost-builder = { path = "../prost-builder" }
 prometheus-text-parser = { path = "../prometheus-text-parser" }
 prost = { workspace = true }
 tower-test = { workspace = true }
-hyper = { features = ["client", "http1"] , workspace = true }
+hyper = { features = ["client", "http1"], workspace = true }
 http = { workspace = true }
 once_cell = { workspace = true }
 kube = { default-features = false, features = [
@@ -188,7 +188,7 @@ kube = { default-features = false, features = [
   "derive",
   "client",
   "rustls-tls",
-] , workspace = true }
+], workspace = true }
 
 [lints]
 workspace = true

--- a/crates/api/src/measured_boot/tests/journal.rs
+++ b/crates/api/src/measured_boot/tests/journal.rs
@@ -30,8 +30,8 @@ mod tests {
         let mut txn = pool.begin().await?;
         let machine_id =
             MachineId::from_str("fm100hseddco33hvlofuqvg543p6p9aj60g76q5cq491g9m9tgtf2dk0530")?;
-        let report_id = MeasurementReportId(uuid::Uuid::new_v4());
-        let profile_id = MeasurementSystemProfileId(uuid::Uuid::new_v4());
+        let report_id = MeasurementReportId::new();
+        let profile_id = MeasurementSystemProfileId::new();
         let journal = db::measured_boot::journal::new_with_txn(
             &mut txn,
             machine_id,

--- a/crates/api/src/network_segment/allocate.rs
+++ b/crates/api/src/network_segment/allocate.rs
@@ -102,7 +102,7 @@ impl Ipv4PrefixAllocator {
         let prefix = self.next_free_prefix(txn).await?;
 
         let name = format!("vpc_prefix_{}", prefix.network());
-        let segment_id = NetworkSegmentId(uuid::Uuid::new_v4());
+        let segment_id = NetworkSegmentId::new();
 
         let ns = NewNetworkSegment {
             id: segment_id,

--- a/crates/api/src/nvl_partition_monitor/mod.rs
+++ b/crates/api/src/nvl_partition_monitor/mod.rs
@@ -697,7 +697,11 @@ impl NvlPartitionMonitor {
                 let mut updated_gpu = db_gpu.clone();
 
                 // Match GPU by domain_uuid, guid (device_uid), and device_id
-                let key = (nvlink_info.domain_uuid.0, db_gpu.guid, db_gpu.device_id);
+                let key = (
+                    nvlink_info.domain_uuid.into(),
+                    db_gpu.guid,
+                    db_gpu.device_id,
+                );
                 match nmx_m_gpu_map.get(&key) {
                     Some(nmx_m_gpu) => {
                         let nmx_m_id = nmx_m_gpu.id.as_deref().unwrap_or_default();
@@ -1433,7 +1437,7 @@ impl NvlPartitionMonitor {
                     NmxmPartitionOperationType::Create => {
                         // Create the nvl partition in the database
                         let new_partition = db::nvl_partition::NewNvlPartition {
-                            id: NvLinkPartitionId::from(uuid::Uuid::new_v4()),
+                            id: NvLinkPartitionId::new(),
                             logical_partition_id,
                             name: NvlPartitionName::try_from(operation.name.clone())?,
                             domain_uuid: operation.domain_uuid,

--- a/crates/api/src/tests/common/api_fixtures/vpc.rs
+++ b/crates/api/src/tests/common/api_fixtures/vpc.rs
@@ -26,7 +26,7 @@ pub async fn create_vpc(
 ) -> (VpcId, rpc::Vpc) {
     let tenant_config = default_tenant_config();
 
-    let vpc_id = VpcId::from(uuid::Uuid::new_v4());
+    let vpc_id = VpcId::new();
     let request = VpcCreationRequest::builder(
         "",
         tenant_org_id.unwrap_or(tenant_config.tenant_organization_id),

--- a/crates/api/src/tests/finder.rs
+++ b/crates/api/src/tests/finder.rs
@@ -148,7 +148,7 @@ async fn test_identify_uuid(db_pool: sqlx::PgPool) -> Result<(), eyre::Report> {
 
     // Network segment
     let req = rpc::forge::IdentifyUuidRequest {
-        uuid: Some(segment_id.0.into()),
+        uuid: Some(segment_id.into()),
     };
     let res = env
         .api
@@ -160,7 +160,7 @@ async fn test_identify_uuid(db_pool: sqlx::PgPool) -> Result<(), eyre::Report> {
 
     // Instance
     let req = rpc::forge::IdentifyUuidRequest {
-        uuid: Some(tinstance.id.0.into()),
+        uuid: Some(tinstance.id.into()),
     };
     let res = env
         .api
@@ -172,7 +172,7 @@ async fn test_identify_uuid(db_pool: sqlx::PgPool) -> Result<(), eyre::Report> {
 
     // Machine interface
     let req = rpc::forge::IdentifyUuidRequest {
-        uuid: interface_id.map(|id| id.0.into()),
+        uuid: interface_id.map(|id| id.into()),
     };
     let res = env
         .api
@@ -195,7 +195,7 @@ async fn test_identify_uuid(db_pool: sqlx::PgPool) -> Result<(), eyre::Report> {
         .await
         .unwrap();
     let req = rpc::forge::IdentifyUuidRequest {
-        uuid: Some(segment.vpc_id.unwrap().0.into()),
+        uuid: Some(segment.vpc_id.unwrap().into()),
     };
     let res = env
         .api

--- a/crates/api/src/tests/ib_instance.rs
+++ b/crates/api/src/tests/ib_instance.rs
@@ -1051,7 +1051,7 @@ pub async fn try_allocate_instance(
         .await?;
 
     let instance = instance.into_inner();
-    let instance_id = uuid::Uuid::from(instance.id.expect("Missing instance ID"));
+    let instance_id: uuid::Uuid = instance.id.expect("Missing instance ID").into();
     Ok((instance_id, instance))
 }
 

--- a/crates/api/src/tests/ib_partition_lifecycle.rs
+++ b/crates/api/src/tests/ib_partition_lifecycle.rs
@@ -313,7 +313,7 @@ async fn create_ib_partition_with_api_with_id(
     )
     .await;
 
-    let id = IBPartitionId::from(uuid::Uuid::new_v4());
+    let id = IBPartitionId::new();
     let request = rpc::forge::IbPartitionCreationRequest {
         id: Some(id),
         config: Some(IbPartitionConfig {
@@ -343,7 +343,7 @@ async fn create_ib_partition_with_api_with_id(
 
 #[crate::sqlx_test]
 async fn test_update_ib_partition(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
-    let id = IBPartitionId::from(uuid::Uuid::new_v4());
+    let id = IBPartitionId::new();
     let new_partition = NewIBPartition {
         id,
         config: IBPartitionConfig {
@@ -414,7 +414,7 @@ async fn test_update_ib_partition(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
 async fn test_reject_update_with_invalid_metadata(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let id = IBPartitionId::from(uuid::Uuid::new_v4());
+    let id = IBPartitionId::new();
     let new_partition = NewIBPartition {
         id,
         config: IBPartitionConfig {

--- a/crates/api/src/tests/instance.rs
+++ b/crates/api/src/tests/instance.rs
@@ -1622,7 +1622,7 @@ async fn test_can_not_create_instance_for_dpu(_: PgPoolOptions, options: PgConne
     let host_config = env.managed_host_config();
     let dpu_machine_id = dpu::create_dpu_machine(&env, &host_config).await;
     let request = crate::instance::InstanceAllocationRequest {
-        instance_id: InstanceId::from(uuid::Uuid::new_v4()),
+        instance_id: InstanceId::new(),
         machine_id: dpu_machine_id,
         instance_type_id: None,
         config: model::instance::config::InstanceConfig {
@@ -5907,7 +5907,7 @@ async fn test_allocate_instance_with_invalid_ib_partition(
     let mh = create_managed_host(&env).await;
 
     // Use a non-existent IB partition ID
-    let invalid_partition_id = carbide_uuid::infiniband::IBPartitionId::from(uuid::Uuid::new_v4());
+    let invalid_partition_id = carbide_uuid::infiniband::IBPartitionId::new();
 
     let ib_config = rpc::forge::InstanceInfinibandConfig {
         ib_interfaces: vec![rpc::forge::InstanceIbInterfaceConfig {

--- a/crates/api/src/tests/instance_allocate.rs
+++ b/crates/api/src/tests/instance_allocate.rs
@@ -203,7 +203,7 @@ async fn test_zero_dpu_instance_allocation_explicit_network_config(
                 network: Some(forge::InstanceNetworkConfig {
                     interfaces: vec![forge::InstanceInterfaceConfig {
                         function_type: forge::InterfaceFunctionType::Physical as i32,
-                        network_segment_id: Some(host_inband_segment.id.0.into()),
+                        network_segment_id: Some(host_inband_segment.id),
                         network_details: None,
                         device: None,
                         device_instance: 0u32,
@@ -239,7 +239,7 @@ async fn test_zero_dpu_instance_allocation_explicit_network_config(
     );
     assert_eq!(
         instance_network_restrictions.network_segment_ids,
-        vec![host_inband_segment.id.0.into()],
+        vec![host_inband_segment.id],
         "Machine that was just ingested should have instance network restrictions listing its network segment ID's",
     );
 
@@ -680,7 +680,7 @@ async fn test_reject_zero_dpu_instance_allocation_multiple_vpcs(
             .iter()
             .contains(&host_inband_segment.id),
         "Machine that was just ingested should have instance network restrictions showing host_inband_segment {}",
-        host_inband_segment.id.0,
+        host_inband_segment.id,
     );
     assert!(
         instance_network_restrictions
@@ -688,7 +688,7 @@ async fn test_reject_zero_dpu_instance_allocation_multiple_vpcs(
             .iter()
             .contains(&host_inband_2_segment.id),
         "Machine that was just ingested should have instance network restrictions showing host_inband_2_segment {}",
-        host_inband_2_segment.id.0,
+        host_inband_2_segment.id,
     );
 
     // Allocate an instance without specifying a network config

--- a/crates/api/src/tests/instance_config_update.rs
+++ b/crates/api/src/tests/instance_config_update.rs
@@ -432,7 +432,7 @@ async fn test_reject_invalid_instance_config_updates(_: PgPoolOptions, options: 
         .interfaces
         .push(rpc::forge::InstanceInterfaceConfig {
             function_type: rpc::forge::InterfaceFunctionType::Virtual as _,
-            network_segment_id: Some(NetworkSegmentId::from(uuid::Uuid::new_v4())),
+            network_segment_id: Some(NetworkSegmentId::new()),
             network_details: None,
             device: None,
             device_instance: 0u32,

--- a/crates/api/src/tests/vpc.rs
+++ b/crates/api/src/tests/vpc.rs
@@ -524,7 +524,7 @@ async fn prevent_duplicate_vni(pool: sqlx::PgPool) -> Result<(), Box<dyn std::er
 #[crate::sqlx_test]
 async fn find_vpc_by_id(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
     let mut txn = pool.begin().await?;
-    let vpc_id = VpcId::from(uuid::Uuid::new_v4());
+    let vpc_id = VpcId::new();
 
     sqlx::query(r#"
         INSERT INTO vpcs (id, name, organization_id, version) VALUES ($1, 'test vpc 1', '2829bbe3-c169-4cd9-8b2a-19a8b1618a93', 'V1-T1666644937952267');
@@ -543,7 +543,7 @@ async fn find_vpc_by_id(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Er
 #[crate::sqlx_test]
 async fn test_vpc_with_id(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env(pool).await;
-    let id = VpcId::from(uuid::Uuid::new_v4());
+    let id = VpcId::new();
 
     // No network_virtualization_type, should default
     let forge_vpc = env

--- a/crates/api/src/tests/vpc_find.rs
+++ b/crates/api/src/tests/vpc_find.rs
@@ -177,7 +177,7 @@ async fn test_find_vpcs_by_ids_none(pool: sqlx::PgPool) {
 #[crate::sqlx_test]
 async fn find_vpc_by_name(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
     let mut txn = pool.begin().await?;
-    let vpc_id = VpcId::from(uuid::Uuid::new_v4());
+    let vpc_id = VpcId::new();
 
     sqlx::query(r#"
         INSERT INTO vpcs (id, name, organization_id, version) VALUES ($1, 'test vpc 1', '2829bbe3-c169-4cd9-8b2a-19a8b1618a93', 'V1-T1666644937952267');

--- a/crates/api/src/web/attestation.rs
+++ b/crates/api/src/web/attestation.rs
@@ -258,7 +258,7 @@ pub async fn show_attestation_results(
 
     let attestation_results = AttestationResults {
         journal_time: latest_journal.ts.to_string(),
-        journal_id: latest_journal.journal_id.0.to_string(),
+        journal_id: latest_journal.journal_id.to_string(),
         attestation_status: if latest_journal.bundle_id.is_some() {
             ATTESTED.to_string()
         } else {

--- a/crates/host-support/src/registration.rs
+++ b/crates/host-support/src/registration.rs
@@ -260,7 +260,7 @@ pub async fn register_machine(
     Ok((
         RegistrationData { machine_id },
         response.attest_key_challenge,
-        response.machine_interface_id.map(|x| x.0),
+        response.machine_interface_id.map(uuid::Uuid::from),
     ))
 }
 

--- a/crates/pxe/src/extractors/machine_interface.rs
+++ b/crates/pxe/src/extractors/machine_interface.rs
@@ -48,7 +48,12 @@ impl TryFrom<MaybeMachineInterface> for MachineInterface {
 
         let uuid = match (value.uuid, value.uuid_as_param) {
             (Some(uuid), _) => Ok(uuid),
-            (None, Some(uuid)) => uuid.parse().map_err(PxeRequestError::UuidConversion),
+            (None, Some(uuid)) => {
+                uuid.parse()
+                    .map_err(|e: carbide_uuid::typed_uuids::UuidError| {
+                        PxeRequestError::UuidConversion(e.into())
+                    })
+            }
             _ => Err(PxeRequestError::MissingMachineId),
         }?;
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -868,8 +868,9 @@ mod tests {
     /// Test to check that serializing a type with a custom Timestamp implementation works
     #[test]
     fn test_serialize_domain() {
-        let uuid =
-            carbide_uuid::domain::DomainId(::uuid::uuid!("91609f10-c91d-470d-a260-1234560c0000"));
+        let uuid = carbide_uuid::domain::DomainId::from(::uuid::uuid!(
+            "91609f10-c91d-470d-a260-1234560c0000"
+        ));
         let ts = std::time::SystemTime::now();
         let ts2 = ts.checked_add(Duration::from_millis(1500)).unwrap();
 

--- a/crates/utils/src/models/dhcp.rs
+++ b/crates/utils/src/models/dhcp.rs
@@ -49,6 +49,8 @@ pub enum DhcpDataError {
     RpcConversion(#[from] RpcDataConversionError),
     #[error("DhcpDataError: UuidConversionError: {0}")]
     UuidConversion(#[from] UuidConversionError),
+    #[error("DhcpDataError: UuidParseError: {0}")]
+    UuidParseError(#[from] carbide_uuid::typed_uuids::UuidError),
 }
 
 impl Default for DhcpConfig {

--- a/crates/uuid/src/dpa_interface/mod.rs
+++ b/crates/uuid/src/dpa_interface/mod.rs
@@ -10,65 +10,94 @@
  * its affiliates is strictly prohibited.
  */
 
-use std::fmt;
-use std::str::FromStr;
+use crate::typed_uuids::{TypedUuid, UuidSubtype};
 
-use serde::{Deserialize, Serialize};
-#[cfg(feature = "sqlx")]
-use sqlx::postgres::{PgHasArrayType, PgTypeInfo};
-#[cfg(feature = "sqlx")]
-use sqlx::{FromRow, Type};
+/// Marker type for DpaInterfaceId
+pub struct DpaInterfaceIdMarker;
 
-use crate::{UuidConversionError, grpc_uuid_message};
-
-#[derive(
-    Debug, Clone, Copy, Serialize, Deserialize, Eq, Hash, PartialEq, Default, Ord, PartialOrd,
-)]
-#[cfg_attr(feature = "sqlx", derive(FromRow, Type))]
-#[cfg_attr(feature = "sqlx", sqlx(type_name = "UUID"))]
-pub struct DpaInterfaceId(pub uuid::Uuid);
-
-grpc_uuid_message!(DpaInterfaceId);
-
-pub const NULL_DPA_INTERFACE_ID: DpaInterfaceId = DpaInterfaceId(uuid::Uuid::nil());
-
-impl From<DpaInterfaceId> for uuid::Uuid {
-    fn from(id: DpaInterfaceId) -> Self {
-        id.0
-    }
+impl UuidSubtype for DpaInterfaceIdMarker {
+    const TYPE_NAME: &'static str = "DpaInterfaceId";
 }
 
-impl From<uuid::Uuid> for DpaInterfaceId {
-    fn from(uuid: uuid::Uuid) -> Self {
-        Self(uuid)
-    }
-}
+/// DpaInterfaceId is a strongly typed UUID for DPA interfaces.
+pub type DpaInterfaceId = TypedUuid<DpaInterfaceIdMarker>;
 
-impl FromStr for DpaInterfaceId {
-    type Err = UuidConversionError;
-    fn from_str(input: &str) -> Result<Self, UuidConversionError> {
-        Ok(Self(uuid::Uuid::parse_str(input).map_err(|_| {
-            UuidConversionError::InvalidUuid {
-                ty: "DpaInterfaceId",
-                value: input.to_string(),
-            }
-        })?))
-    }
-}
+/// A constant representing a null/empty DPA interface ID.
+pub const NULL_DPA_INTERFACE_ID: DpaInterfaceId = TypedUuid::nil();
 
-impl fmt::Display for DpaInterfaceId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::str::FromStr;
 
-#[cfg(feature = "sqlx")]
-impl PgHasArrayType for DpaInterfaceId {
-    fn array_type_info() -> PgTypeInfo {
-        <sqlx::types::Uuid as PgHasArrayType>::array_type_info()
+    use super::*;
+
+    #[test]
+    fn test_uuid_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = DpaInterfaceId::from(orig);
+        let back = uuid::Uuid::from(id);
+        assert_eq!(orig, back);
     }
 
-    fn array_compatible(ty: &PgTypeInfo) -> bool {
-        <sqlx::types::Uuid as PgHasArrayType>::array_compatible(ty)
+    #[test]
+    fn test_string_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = DpaInterfaceId::from(orig);
+        let as_string = id.to_string();
+        let parsed = DpaInterfaceId::from_str(&as_string).expect("failed to parse");
+        assert_eq!(id, parsed);
+    }
+
+    #[test]
+    fn test_json_round_trip() {
+        let id = DpaInterfaceId::new();
+        let json = serde_json::to_string(&id).expect("failed to serialize");
+        let parsed: DpaInterfaceId = serde_json::from_str(&json).expect("failed to deserialize");
+        assert_eq!(id, parsed);
+        assert!(json.starts_with('"') && json.ends_with('"'));
+    }
+
+    #[test]
+    fn test_ordering() {
+        let id1 = DpaInterfaceId::from(uuid::Uuid::nil());
+        let id2 = DpaInterfaceId::from(uuid::Uuid::max());
+        assert!(id1 < id2);
+    }
+
+    #[test]
+    fn test_default() {
+        let id = DpaInterfaceId::default();
+        assert_eq!(uuid::Uuid::from(id), uuid::Uuid::nil());
+    }
+
+    #[test]
+    fn test_copy() {
+        let id1 = DpaInterfaceId::new();
+        let id2 = id1;
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn test_hash_consistency() {
+        let uuid = uuid::Uuid::new_v4();
+        let id1 = DpaInterfaceId::from(uuid);
+        let id2 = DpaInterfaceId::from(uuid);
+        let mut set = HashSet::new();
+        set.insert(id1);
+        assert!(set.contains(&id2));
+    }
+
+    #[test]
+    fn test_debug_includes_type_name() {
+        let id = DpaInterfaceId::from(uuid::Uuid::nil());
+        let debug = format!("{:?}", id);
+        assert!(debug.contains("DpaInterfaceId"));
+    }
+
+    #[test]
+    fn test_null_constant() {
+        assert_eq!(NULL_DPA_INTERFACE_ID, DpaInterfaceId::default());
+        assert_eq!(uuid::Uuid::from(NULL_DPA_INTERFACE_ID), uuid::Uuid::nil());
     }
 }

--- a/crates/uuid/src/extension_service/mod.rs
+++ b/crates/uuid/src/extension_service/mod.rs
@@ -10,62 +10,86 @@
  * its affiliates is strictly prohibited.
  */
 
-use std::fmt;
-use std::str::FromStr;
+use crate::typed_uuids::{TypedUuid, UuidSubtype};
 
-use serde::{Deserialize, Serialize};
-#[cfg(feature = "sqlx")]
-use sqlx::{
-    FromRow, Type,
-    postgres::{PgHasArrayType, PgTypeInfo},
-};
+/// Marker type for ExtensionServiceId
+pub struct ExtensionServiceIdMarker;
 
-use crate::{UuidConversionError, grpc_uuid_message};
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, Hash, PartialEq, Default)]
-#[cfg_attr(feature = "sqlx", derive(FromRow, Type))]
-#[cfg_attr(feature = "sqlx", sqlx(type_name = "UUID"))]
-pub struct ExtensionServiceId(pub uuid::Uuid);
-
-grpc_uuid_message!(ExtensionServiceId);
-
-impl From<ExtensionServiceId> for uuid::Uuid {
-    fn from(id: ExtensionServiceId) -> Self {
-        id.0
-    }
+impl UuidSubtype for ExtensionServiceIdMarker {
+    const TYPE_NAME: &'static str = "ExtensionServiceId";
 }
 
-impl From<uuid::Uuid> for ExtensionServiceId {
-    fn from(uuid: uuid::Uuid) -> Self {
-        Self(uuid)
-    }
-}
+/// ExtensionServiceId is a strongly typed UUID specific to an extension service.
+pub type ExtensionServiceId = TypedUuid<ExtensionServiceIdMarker>;
 
-impl FromStr for ExtensionServiceId {
-    type Err = UuidConversionError;
-    fn from_str(input: &str) -> Result<Self, UuidConversionError> {
-        Ok(Self(uuid::Uuid::parse_str(input).map_err(|_| {
-            UuidConversionError::InvalidUuid {
-                ty: "ExtensionServiceId",
-                value: input.to_string(),
-            }
-        })?))
-    }
-}
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::str::FromStr;
 
-impl fmt::Display for ExtensionServiceId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
+    use super::*;
 
-#[cfg(feature = "sqlx")]
-impl PgHasArrayType for ExtensionServiceId {
-    fn array_type_info() -> PgTypeInfo {
-        <sqlx::types::Uuid as PgHasArrayType>::array_type_info()
+    #[test]
+    fn test_uuid_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = ExtensionServiceId::from(orig);
+        let back = uuid::Uuid::from(id);
+        assert_eq!(orig, back);
     }
 
-    fn array_compatible(ty: &PgTypeInfo) -> bool {
-        <sqlx::types::Uuid as PgHasArrayType>::array_compatible(ty)
+    #[test]
+    fn test_string_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = ExtensionServiceId::from(orig);
+        let as_string = id.to_string();
+        let parsed = ExtensionServiceId::from_str(&as_string).expect("failed to parse");
+        assert_eq!(id, parsed);
+    }
+
+    #[test]
+    fn test_json_round_trip() {
+        let id = ExtensionServiceId::new();
+        let json = serde_json::to_string(&id).expect("failed to serialize");
+        let parsed: ExtensionServiceId =
+            serde_json::from_str(&json).expect("failed to deserialize");
+        assert_eq!(id, parsed);
+        assert!(json.starts_with('"') && json.ends_with('"'));
+    }
+
+    #[test]
+    fn test_ordering() {
+        let id1 = ExtensionServiceId::from(uuid::Uuid::nil());
+        let id2 = ExtensionServiceId::from(uuid::Uuid::max());
+        assert!(id1 < id2);
+    }
+
+    #[test]
+    fn test_default() {
+        let id = ExtensionServiceId::default();
+        assert_eq!(uuid::Uuid::from(id), uuid::Uuid::nil());
+    }
+
+    #[test]
+    fn test_copy() {
+        let id1 = ExtensionServiceId::new();
+        let id2 = id1;
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn test_hash_consistency() {
+        let uuid = uuid::Uuid::new_v4();
+        let id1 = ExtensionServiceId::from(uuid);
+        let id2 = ExtensionServiceId::from(uuid);
+        let mut set = HashSet::new();
+        set.insert(id1);
+        assert!(set.contains(&id2));
+    }
+
+    #[test]
+    fn test_debug_includes_type_name() {
+        let id = ExtensionServiceId::from(uuid::Uuid::nil());
+        let debug = format!("{:?}", id);
+        assert!(debug.contains("ExtensionServiceId"));
     }
 }

--- a/crates/uuid/src/infiniband/mod.rs
+++ b/crates/uuid/src/infiniband/mod.rs
@@ -10,75 +10,95 @@
  * its affiliates is strictly prohibited.
  */
 
-use std::fmt;
-use std::str::FromStr;
+use crate::typed_uuids::{TypedUuid, UuidSubtype};
 
-use serde::{Deserialize, Serialize};
-#[cfg(feature = "sqlx")]
-use sqlx::{
-    postgres::{PgHasArrayType, PgTypeInfo},
-    {FromRow, Type},
-};
+/// Marker type for IBPartitionId
+pub struct IBPartitionIdMarker;
 
-use crate::{UuidConversionError, grpc_uuid_message};
+impl UuidSubtype for IBPartitionIdMarker {
+    const TYPE_NAME: &'static str = "IBPartitionId";
+}
 
 /// IBPartitionId is a strongly typed UUID specific to an Infiniband
 /// segment ID, with trait implementations allowing it to be passed
-/// around as a UUID, an RPC UUID, bound to sqlx queries, etc. This
-/// is similar to what we do for MachineId, VpcId, InstanceId,
-/// NetworkSegmentId, and basically all of the IDs in measured boot.
-#[derive(
-    Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, Default, Ord, PartialOrd,
-)]
-#[cfg_attr(feature = "sqlx", derive(FromRow, Type))]
-#[cfg_attr(feature = "sqlx", sqlx(type_name = "UUID"))]
-pub struct IBPartitionId(pub uuid::Uuid);
+/// around as a UUID, an RPC UUID, bound to sqlx queries, etc.
+pub type IBPartitionId = TypedUuid<IBPartitionIdMarker>;
 
-grpc_uuid_message!(IBPartitionId);
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::str::FromStr;
 
-impl From<IBPartitionId> for uuid::Uuid {
-    fn from(id: IBPartitionId) -> Self {
-        id.0
-    }
-}
+    use super::*;
 
-impl From<uuid::Uuid> for IBPartitionId {
-    fn from(uuid: uuid::Uuid) -> Self {
-        Self(uuid)
-    }
-}
-
-impl FromStr for IBPartitionId {
-    type Err = UuidConversionError;
-    fn from_str(input: &str) -> Result<Self, UuidConversionError> {
-        Ok(Self(uuid::Uuid::parse_str(input).map_err(|_| {
-            UuidConversionError::InvalidUuid {
-                ty: "IBPartitionId",
-                value: input.to_string(),
-            }
-        })?))
-    }
-}
-
-impl fmt::Display for IBPartitionId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<IBPartitionId> for String {
-    fn from(id: IBPartitionId) -> Self {
-        id.to_string()
-    }
-}
-
-#[cfg(feature = "sqlx")]
-impl PgHasArrayType for IBPartitionId {
-    fn array_type_info() -> PgTypeInfo {
-        <sqlx::types::Uuid as PgHasArrayType>::array_type_info()
+    #[test]
+    fn test_uuid_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = IBPartitionId::from(orig);
+        let back = uuid::Uuid::from(id);
+        assert_eq!(orig, back);
     }
 
-    fn array_compatible(ty: &PgTypeInfo) -> bool {
-        <sqlx::types::Uuid as PgHasArrayType>::array_compatible(ty)
+    #[test]
+    fn test_string_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = IBPartitionId::from(orig);
+        let as_string = id.to_string();
+        let parsed = IBPartitionId::from_str(&as_string).expect("failed to parse");
+        assert_eq!(id, parsed);
+    }
+
+    #[test]
+    fn test_json_round_trip() {
+        let id = IBPartitionId::new();
+        let json = serde_json::to_string(&id).expect("failed to serialize");
+        let parsed: IBPartitionId = serde_json::from_str(&json).expect("failed to deserialize");
+        assert_eq!(id, parsed);
+        assert!(json.starts_with('"') && json.ends_with('"'));
+    }
+
+    #[test]
+    fn test_ordering() {
+        let id1 = IBPartitionId::from(uuid::Uuid::nil());
+        let id2 = IBPartitionId::from(uuid::Uuid::max());
+        assert!(id1 < id2);
+    }
+
+    #[test]
+    fn test_default() {
+        let id = IBPartitionId::default();
+        assert_eq!(uuid::Uuid::from(id), uuid::Uuid::nil());
+    }
+
+    #[test]
+    fn test_copy() {
+        let id1 = IBPartitionId::new();
+        let id2 = id1;
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn test_hash_consistency() {
+        let uuid = uuid::Uuid::new_v4();
+        let id1 = IBPartitionId::from(uuid);
+        let id2 = IBPartitionId::from(uuid);
+        let mut set = HashSet::new();
+        set.insert(id1);
+        assert!(set.contains(&id2));
+    }
+
+    #[test]
+    fn test_debug_includes_type_name() {
+        let id = IBPartitionId::from(uuid::Uuid::nil());
+        let debug = format!("{:?}", id);
+        assert!(debug.contains("IBPartitionId"));
+    }
+
+    #[test]
+    fn test_into_string() {
+        let uuid = uuid::Uuid::new_v4();
+        let id = IBPartitionId::from(uuid);
+        let s: String = id.into();
+        assert_eq!(s, uuid.to_string());
     }
 }

--- a/crates/uuid/src/lib.rs
+++ b/crates/uuid/src/lib.rs
@@ -71,6 +71,8 @@ pub enum UuidConversionError {
     MissingId(&'static str),
     #[error("Invalid MachineId: {0}")]
     InvalidMachineId(String),
+    #[error("UUID parse error: {0}")]
+    UuidError(#[from] uuid::Error),
 }
 
 #[derive(
@@ -87,52 +89,4 @@ pub enum UuidConversionError {
 pub(crate) struct CommonUuidPlaceholder {
     #[prost(string, tag = "1")]
     pub value: ::prost::alloc::string::String,
-}
-
-/// Implements `prost::Message` for a Uuid wrapper that is wire-compatible
-/// with common.UUID (`{ string value = 1; }`).
-///
-/// Usage:
-///     grpc_uuid_message!(uuid::machine::DomainId);
-#[macro_export]
-macro_rules! grpc_uuid_message {
-    ($ty:ty) => {
-        impl ::prost::Message for $ty {
-            fn encode_raw(&self, buf: &mut impl ::prost::bytes::BufMut) {
-                let tmp = $crate::CommonUuidPlaceholder {
-                    value: self.0.to_string(),
-                };
-                // Delegate to prost for the actual encoding of the shim.
-                ::prost::Message::encode_raw(&tmp, buf);
-            }
-
-            fn merge_field(
-                &mut self,
-                tag: u32,
-                wire_type: ::prost::encoding::WireType,
-                buf: &mut impl ::prost::bytes::Buf,
-                ctx: ::prost::encoding::DecodeContext,
-            ) -> Result<(), ::prost::DecodeError> {
-                // Decode through the shim type, which has the identical wire layout.
-                let mut tmp = <$crate::CommonUuidPlaceholder>::default();
-                ::prost::Message::merge_field(&mut tmp, tag, wire_type, buf, ctx)?;
-                let parsed = ::uuid::Uuid::parse_str(&tmp.value).map_err(|_| {
-                    ::prost::DecodeError::new(format!("invalid UUID: {}", tmp.value))
-                })?;
-                *self = Self(parsed);
-                Ok(())
-            }
-
-            fn encoded_len(&self) -> usize {
-                let tmp = $crate::CommonUuidPlaceholder {
-                    value: self.0.to_string(),
-                };
-                ::prost::Message::encoded_len(&tmp)
-            }
-
-            fn clear(&mut self) {
-                *self = Self::default();
-            }
-        }
-    };
 }

--- a/crates/uuid/src/measured_boot/mod.rs
+++ b/crates/uuid/src/measured_boot/mod.rs
@@ -18,11 +18,7 @@
  *  worked with, since it would be otherwise easy to pass the wrong UUID
  *  to the wrong part of a query. Being able to type the specific ID ends
  *  up catching a lot of potential bugs.
- *
- *  To make this work, the keys must derive {FromRow,Type}, and explicitly
- *  set #[sqlx(type_name = "UUID")]. Without that trifecta, sqlx gets all
- *  mad because it cant bind it as a UUID.
-*/
+ */
 
 use std::fmt;
 use std::str::FromStr;
@@ -33,12 +29,16 @@ use sqlx::{
     encode::IsNull,
     error::BoxDynError,
     postgres::PgTypeInfo,
-    {Database, FromRow, Postgres, Type},
+    {Database, Postgres},
 };
 
-use super::DbPrimaryUuid;
+use crate::UuidConversionError;
 use crate::machine::MachineId;
-use crate::{UuidConversionError, grpc_uuid_message};
+use crate::typed_uuids::{TypedUuid, UuidSubtype};
+
+// ============================================================================
+// TrustedMachineId - Special enum type (not migrated to TypedUuid)
+// ============================================================================
 
 /// TrustedMachineId is a special adaptation of a
 /// Carbide MachineId, which has support for being
@@ -106,391 +106,324 @@ impl sqlx::Type<sqlx::Postgres> for TrustedMachineId {
     }
 }
 
-impl DbPrimaryUuid for TrustedMachineId {
+impl crate::DbPrimaryUuid for TrustedMachineId {
     fn db_primary_uuid_name() -> &'static str {
         "machine_id"
     }
 }
 
-/// MeasurementSystemProfileId
-///
+// ============================================================================
+// MeasurementSystemProfileId
+// ============================================================================
+
+/// Marker type for MeasurementSystemProfileId
+pub struct MeasurementSystemProfileIdMarker;
+
+impl UuidSubtype for MeasurementSystemProfileIdMarker {
+    const TYPE_NAME: &'static str = "MeasurementSystemProfileId";
+    const DB_COLUMN_NAME: &'static str = "profile_id";
+}
+
 /// Primary key for a measurement_system_profiles table entry, which is the table
 /// containing general metadata about a machine profile.
-///
-/// Impls the DbPrimaryUuid trait, which is used for doing generic selects
-/// defined in db/interface/common.rs, as well as other various trait impls
-/// as required by serde, sqlx, etc.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, Hash, PartialEq, Default)]
-#[cfg_attr(feature = "sqlx", derive(FromRow, Type))]
-#[cfg_attr(feature = "sqlx", sqlx(type_name = "UUID"))]
-pub struct MeasurementSystemProfileId(pub uuid::Uuid);
-grpc_uuid_message!(MeasurementSystemProfileId);
+pub type MeasurementSystemProfileId = TypedUuid<MeasurementSystemProfileIdMarker>;
 
-impl From<MeasurementSystemProfileId> for uuid::Uuid {
-    fn from(id: MeasurementSystemProfileId) -> Self {
-        id.0
-    }
+// ============================================================================
+// MeasurementSystemProfileAttrId
+// ============================================================================
+
+/// Marker type for MeasurementSystemProfileAttrId
+pub struct MeasurementSystemProfileAttrIdMarker;
+
+impl UuidSubtype for MeasurementSystemProfileAttrIdMarker {
+    const TYPE_NAME: &'static str = "MeasurementSystemProfileAttrId";
 }
 
-impl FromStr for MeasurementSystemProfileId {
-    type Err = UuidConversionError;
-
-    fn from_str(input: &str) -> Result<Self, UuidConversionError> {
-        Ok(Self(uuid::Uuid::parse_str(input).map_err(|_| {
-            UuidConversionError::InvalidUuid {
-                ty: "MeasurementSystemProfileId",
-                value: input.to_string(),
-            }
-        })?))
-    }
-}
-
-impl fmt::Display for MeasurementSystemProfileId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl DbPrimaryUuid for MeasurementSystemProfileId {
-    fn db_primary_uuid_name() -> &'static str {
-        "profile_id"
-    }
-}
-
-/// MeasurementSystemProfileAttrId
-///
 /// Primary key for a measurement_system_profiles_attrs table entry, which is
 /// the table containing the attributes used to map machines to profiles.
-///
-/// Includes code for various implementations.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Default, Eq, Hash)]
-#[cfg_attr(feature = "sqlx", derive(FromRow, Type))]
-#[cfg_attr(feature = "sqlx", sqlx(type_name = "UUID"))]
-pub struct MeasurementSystemProfileAttrId(pub uuid::Uuid);
-grpc_uuid_message!(MeasurementSystemProfileAttrId);
+pub type MeasurementSystemProfileAttrId = TypedUuid<MeasurementSystemProfileAttrIdMarker>;
 
-impl From<MeasurementSystemProfileAttrId> for uuid::Uuid {
-    fn from(id: MeasurementSystemProfileAttrId) -> Self {
-        id.0
-    }
+// ============================================================================
+// MeasurementBundleId
+// ============================================================================
+
+/// Marker type for MeasurementBundleId
+pub struct MeasurementBundleIdMarker;
+
+impl UuidSubtype for MeasurementBundleIdMarker {
+    const TYPE_NAME: &'static str = "MeasurementBundleId";
+    const DB_COLUMN_NAME: &'static str = "bundle_id";
 }
 
-impl FromStr for MeasurementSystemProfileAttrId {
-    type Err = UuidConversionError;
-
-    fn from_str(input: &str) -> Result<Self, UuidConversionError> {
-        Ok(Self(uuid::Uuid::parse_str(input).map_err(|_| {
-            UuidConversionError::InvalidUuid {
-                ty: "MeasurementSystemProfileAttrId",
-                value: input.to_string(),
-            }
-        })?))
-    }
-}
-
-impl fmt::Display for MeasurementSystemProfileAttrId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-/// MeasurementBundleId
-///
 /// Primary key for a measurement_bundles table entry, where a bundle is
 /// a collection of measurements that come from the measurement_bundles table.
-///
-/// Impls the DbPrimaryUuid trait, which is used for doing generic selects
-/// defined in db/interface/common.rs, ToTable for printing via prettytable,
-/// as well as other various trait impls as required by serde, sqlx, etc.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, Hash, PartialEq, Default)]
-#[cfg_attr(feature = "sqlx", derive(FromRow, Type))]
-#[cfg_attr(feature = "sqlx", sqlx(type_name = "UUID"))]
-pub struct MeasurementBundleId(pub uuid::Uuid);
-grpc_uuid_message!(MeasurementBundleId);
+pub type MeasurementBundleId = TypedUuid<MeasurementBundleIdMarker>;
 
-impl From<MeasurementBundleId> for uuid::Uuid {
-    fn from(id: MeasurementBundleId) -> Self {
-        id.0
-    }
+// ============================================================================
+// MeasurementBundleValueId
+// ============================================================================
+
+/// Marker type for MeasurementBundleValueId
+pub struct MeasurementBundleValueIdMarker;
+
+impl UuidSubtype for MeasurementBundleValueIdMarker {
+    const TYPE_NAME: &'static str = "MeasurementBundleValueId";
 }
 
-impl FromStr for MeasurementBundleId {
-    type Err = UuidConversionError;
-
-    fn from_str(input: &str) -> Result<Self, UuidConversionError> {
-        Ok(Self(uuid::Uuid::parse_str(input).map_err(|_| {
-            UuidConversionError::InvalidUuid {
-                ty: "MeasurementBundleId",
-                value: input.to_string(),
-            }
-        })?))
-    }
-}
-
-impl fmt::Display for MeasurementBundleId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl DbPrimaryUuid for MeasurementBundleId {
-    fn db_primary_uuid_name() -> &'static str {
-        "bundle_id"
-    }
-}
-
-/// MeasurementBundleValueId
-///
 /// Primary key for a measurement_bundles_values table entry, where a value is
 /// a single measurement that is part of a measurement bundle.
-///
-/// Includes code for various implementations.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Default, Eq, Hash)]
-#[cfg_attr(feature = "sqlx", derive(FromRow, Type))]
-#[cfg_attr(feature = "sqlx", sqlx(type_name = "UUID"))]
-pub struct MeasurementBundleValueId(pub uuid::Uuid);
-grpc_uuid_message!(MeasurementBundleValueId);
+pub type MeasurementBundleValueId = TypedUuid<MeasurementBundleValueIdMarker>;
 
-impl From<MeasurementBundleValueId> for uuid::Uuid {
-    fn from(id: MeasurementBundleValueId) -> Self {
-        id.0
-    }
+// ============================================================================
+// MeasurementReportId
+// ============================================================================
+
+/// Marker type for MeasurementReportId
+pub struct MeasurementReportIdMarker;
+
+impl UuidSubtype for MeasurementReportIdMarker {
+    const TYPE_NAME: &'static str = "MeasurementReportId";
+    const DB_COLUMN_NAME: &'static str = "report_id";
 }
 
-impl FromStr for MeasurementBundleValueId {
-    type Err = UuidConversionError;
-
-    fn from_str(input: &str) -> Result<Self, UuidConversionError> {
-        Ok(Self(uuid::Uuid::parse_str(input).map_err(|_| {
-            UuidConversionError::InvalidUuid {
-                ty: "MeasurementBundleValueId",
-                value: input.to_string(),
-            }
-        })?))
-    }
-}
-
-impl fmt::Display for MeasurementBundleValueId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-/// MeasurementReportId
-///
 /// Primary key for a measurement_reports table entry, which contains reports
 /// of all reported measurement bundles for a given machine.
-///
-/// Impls the DbPrimaryUuid trait, which is used for doing generic selects
-/// defined in db/interface/common.rs, as well as other various trait impls
-/// as required by serde, sqlx, etc.
-#[derive(Debug, Clone, Copy, Eq, Hash, Serialize, Deserialize, PartialEq, Default)]
-#[cfg_attr(feature = "sqlx", derive(FromRow, Type))]
-#[cfg_attr(feature = "sqlx", sqlx(type_name = "UUID"))]
-pub struct MeasurementReportId(pub uuid::Uuid);
-grpc_uuid_message!(MeasurementReportId);
+pub type MeasurementReportId = TypedUuid<MeasurementReportIdMarker>;
 
-impl From<MeasurementReportId> for uuid::Uuid {
-    fn from(id: MeasurementReportId) -> Self {
-        id.0
-    }
+// ============================================================================
+// MeasurementReportValueId
+// ============================================================================
+
+/// Marker type for MeasurementReportValueId
+pub struct MeasurementReportValueIdMarker;
+
+impl UuidSubtype for MeasurementReportValueIdMarker {
+    const TYPE_NAME: &'static str = "MeasurementReportValueId";
 }
 
-impl FromStr for MeasurementReportId {
-    type Err = UuidConversionError;
-
-    fn from_str(input: &str) -> Result<Self, UuidConversionError> {
-        Ok(Self(uuid::Uuid::parse_str(input).map_err(|_| {
-            UuidConversionError::InvalidUuid {
-                ty: "MeasurementReportId",
-                value: input.to_string(),
-            }
-        })?))
-    }
-}
-
-impl fmt::Display for MeasurementReportId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl DbPrimaryUuid for MeasurementReportId {
-    fn db_primary_uuid_name() -> &'static str {
-        "report_id"
-    }
-}
-
-/// MeasurementReportValueId
-///
 /// Primary key for a measurement_reports_values table entry, which is the
 /// backing values reported for each report into measurement_reports.
-///
-/// Includes code for various implementations.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Default, Eq, Hash)]
-#[cfg_attr(feature = "sqlx", derive(FromRow, Type))]
-#[cfg_attr(feature = "sqlx", sqlx(type_name = "UUID"))]
-pub struct MeasurementReportValueId(pub uuid::Uuid);
-grpc_uuid_message!(MeasurementReportValueId);
+pub type MeasurementReportValueId = TypedUuid<MeasurementReportValueIdMarker>;
 
-impl From<MeasurementReportValueId> for uuid::Uuid {
-    fn from(id: MeasurementReportValueId) -> Self {
-        id.0
-    }
+// ============================================================================
+// MeasurementJournalId
+// ============================================================================
+
+/// Marker type for MeasurementJournalId
+pub struct MeasurementJournalIdMarker;
+
+impl UuidSubtype for MeasurementJournalIdMarker {
+    const TYPE_NAME: &'static str = "MeasurementJournalId";
+    const DB_COLUMN_NAME: &'static str = "journal_id";
 }
 
-impl FromStr for MeasurementReportValueId {
-    type Err = UuidConversionError;
-
-    fn from_str(input: &str) -> Result<Self, UuidConversionError> {
-        Ok(Self(uuid::Uuid::parse_str(input).map_err(|_| {
-            UuidConversionError::InvalidUuid {
-                ty: "MeasurementReportValueId",
-                value: input.to_string(),
-            }
-        })?))
-    }
-}
-
-impl fmt::Display for MeasurementReportValueId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-/// MeasurementJournalId
-///
 /// Primary key for a measurement_journal table entry, which is the journal
 /// of all reported measurement bundles for a given machine.
-///
-/// Impls the DbPrimaryUuid trait, which is used for doing generic selects
-/// defined in db/interface/common.rs, as well as other various trait impls
-/// as required by serde, sqlx, etc.
-#[derive(Debug, Clone, Copy, Eq, Hash, Serialize, Deserialize, PartialEq, Default)]
-#[cfg_attr(feature = "sqlx", derive(FromRow, Type))]
-#[cfg_attr(feature = "sqlx", sqlx(type_name = "UUID"))]
-pub struct MeasurementJournalId(pub uuid::Uuid);
-grpc_uuid_message!(MeasurementJournalId);
+pub type MeasurementJournalId = TypedUuid<MeasurementJournalIdMarker>;
 
-impl From<MeasurementJournalId> for uuid::Uuid {
-    fn from(id: MeasurementJournalId) -> Self {
-        id.0
-    }
+// ============================================================================
+// MeasurementApprovedMachineId
+// ============================================================================
+
+/// Marker type for MeasurementApprovedMachineId
+pub struct MeasurementApprovedMachineIdMarker;
+
+impl UuidSubtype for MeasurementApprovedMachineIdMarker {
+    const TYPE_NAME: &'static str = "MeasurementApprovedMachineId";
+    const DB_COLUMN_NAME: &'static str = "approval_id";
 }
 
-impl FromStr for MeasurementJournalId {
-    type Err = UuidConversionError;
-
-    fn from_str(input: &str) -> Result<Self, UuidConversionError> {
-        Ok(Self(uuid::Uuid::parse_str(input).map_err(|_| {
-            UuidConversionError::InvalidUuid {
-                ty: "MeasurementJournalId",
-                value: input.to_string(),
-            }
-        })?))
-    }
-}
-
-impl fmt::Display for MeasurementJournalId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl DbPrimaryUuid for MeasurementJournalId {
-    fn db_primary_uuid_name() -> &'static str {
-        "journal_id"
-    }
-}
-
-/// MeasurementApprovedMachineId
-///
 /// Primary key for a measurement_approved_machines table entry, which is how
 /// control is enabled at the site-level for auto-approving machine reports
 /// into golden measurement bundles.
-///
-/// Impls the DbPrimaryUuid trait, which is used for doing generic selects
-/// defined in db/interface/common.rs, as well as other various trait impls
-/// as required by serde, sqlx, etc.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Default, Eq, Hash)]
-#[cfg_attr(feature = "sqlx", derive(FromRow, Type))]
-#[cfg_attr(feature = "sqlx", sqlx(type_name = "UUID"))]
-pub struct MeasurementApprovedMachineId(pub uuid::Uuid);
-grpc_uuid_message!(MeasurementApprovedMachineId);
+pub type MeasurementApprovedMachineId = TypedUuid<MeasurementApprovedMachineIdMarker>;
 
-impl From<MeasurementApprovedMachineId> for uuid::Uuid {
-    fn from(id: MeasurementApprovedMachineId) -> Self {
-        id.0
-    }
+// ============================================================================
+// MeasurementApprovedProfileId
+// ============================================================================
+
+/// Marker type for MeasurementApprovedProfileId
+pub struct MeasurementApprovedProfileIdMarker;
+
+impl UuidSubtype for MeasurementApprovedProfileIdMarker {
+    const TYPE_NAME: &'static str = "MeasurementApprovedProfileId";
+    const DB_COLUMN_NAME: &'static str = "approval_id";
 }
 
-impl FromStr for MeasurementApprovedMachineId {
-    type Err = UuidConversionError;
-
-    fn from_str(input: &str) -> Result<Self, UuidConversionError> {
-        Ok(Self(uuid::Uuid::parse_str(input).map_err(|_| {
-            UuidConversionError::InvalidUuid {
-                ty: "MeasurementApprovedMachineId",
-                value: input.to_string(),
-            }
-        })?))
-    }
-}
-
-impl fmt::Display for MeasurementApprovedMachineId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl DbPrimaryUuid for MeasurementApprovedMachineId {
-    fn db_primary_uuid_name() -> &'static str {
-        "approval_id"
-    }
-}
-
-/// MeasurementApprovedProfileId
-///
 /// Primary key for a measurement_approved_profiles table entry, which is how
 /// control is enabled at the site-level for auto-approving machine reports
 /// for a specific profile into golden measurement bundles.
-///
-/// Impls the DbPrimaryUuid trait, which is used for doing generic selects
-/// defined in db/interface/common.rs, as well as other various trait impls
-/// as required by serde, sqlx, etc.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Default, Eq, Hash)]
-#[cfg_attr(feature = "sqlx", derive(FromRow, Type))]
-#[cfg_attr(feature = "sqlx", sqlx(type_name = "UUID"))]
-pub struct MeasurementApprovedProfileId(pub uuid::Uuid);
-grpc_uuid_message!(MeasurementApprovedProfileId);
+pub type MeasurementApprovedProfileId = TypedUuid<MeasurementApprovedProfileIdMarker>;
 
-impl From<MeasurementApprovedProfileId> for uuid::Uuid {
-    fn from(id: MeasurementApprovedProfileId) -> Self {
-        id.0
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+    use crate::DbPrimaryUuid;
+
+    // MeasurementSystemProfileId tests
+    #[test]
+    fn test_system_profile_id_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = MeasurementSystemProfileId::from(orig);
+        assert_eq!(uuid::Uuid::from(id), orig);
     }
-}
 
-impl FromStr for MeasurementApprovedProfileId {
-    type Err = UuidConversionError;
-
-    fn from_str(input: &str) -> Result<Self, UuidConversionError> {
-        Ok(Self(uuid::Uuid::parse_str(input).map_err(|_| {
-            UuidConversionError::InvalidUuid {
-                ty: "MeasurementApprovedProfileId",
-                value: input.to_string(),
-            }
-        })?))
+    #[test]
+    fn test_system_profile_id_db_column() {
+        assert_eq!(
+            MeasurementSystemProfileId::db_primary_uuid_name(),
+            "profile_id"
+        );
     }
-}
 
-impl fmt::Display for MeasurementApprovedProfileId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
+    #[test]
+    fn test_system_profile_id_debug() {
+        let id = MeasurementSystemProfileId::from(uuid::Uuid::nil());
+        assert!(format!("{:?}", id).contains("MeasurementSystemProfileId"));
     }
-}
 
-impl DbPrimaryUuid for MeasurementApprovedProfileId {
-    fn db_primary_uuid_name() -> &'static str {
-        "approval_id"
+    // MeasurementSystemProfileAttrId tests
+    #[test]
+    fn test_system_profile_attr_id_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = MeasurementSystemProfileAttrId::from(orig);
+        assert_eq!(uuid::Uuid::from(id), orig);
+    }
+
+    #[test]
+    fn test_system_profile_attr_id_db_column() {
+        assert_eq!(MeasurementSystemProfileAttrId::db_primary_uuid_name(), "id");
+    }
+
+    // MeasurementBundleId tests
+    #[test]
+    fn test_bundle_id_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = MeasurementBundleId::from(orig);
+        assert_eq!(uuid::Uuid::from(id), orig);
+    }
+
+    #[test]
+    fn test_bundle_id_db_column() {
+        assert_eq!(MeasurementBundleId::db_primary_uuid_name(), "bundle_id");
+    }
+
+    #[test]
+    fn test_bundle_id_string_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = MeasurementBundleId::from(orig);
+        let parsed = MeasurementBundleId::from_str(&id.to_string()).unwrap();
+        assert_eq!(id, parsed);
+    }
+
+    // MeasurementBundleValueId tests
+    #[test]
+    fn test_bundle_value_id_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = MeasurementBundleValueId::from(orig);
+        assert_eq!(uuid::Uuid::from(id), orig);
+    }
+
+    #[test]
+    fn test_bundle_value_id_db_column() {
+        assert_eq!(MeasurementBundleValueId::db_primary_uuid_name(), "id");
+    }
+
+    // MeasurementReportId tests
+    #[test]
+    fn test_report_id_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = MeasurementReportId::from(orig);
+        assert_eq!(uuid::Uuid::from(id), orig);
+    }
+
+    #[test]
+    fn test_report_id_db_column() {
+        assert_eq!(MeasurementReportId::db_primary_uuid_name(), "report_id");
+    }
+
+    #[test]
+    fn test_report_id_json_round_trip() {
+        let id = MeasurementReportId::new();
+        let json = serde_json::to_string(&id).unwrap();
+        let parsed: MeasurementReportId = serde_json::from_str(&json).unwrap();
+        assert_eq!(id, parsed);
+    }
+
+    // MeasurementReportValueId tests
+    #[test]
+    fn test_report_value_id_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = MeasurementReportValueId::from(orig);
+        assert_eq!(uuid::Uuid::from(id), orig);
+    }
+
+    #[test]
+    fn test_report_value_id_db_column() {
+        assert_eq!(MeasurementReportValueId::db_primary_uuid_name(), "id");
+    }
+
+    // MeasurementJournalId tests
+    #[test]
+    fn test_journal_id_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = MeasurementJournalId::from(orig);
+        assert_eq!(uuid::Uuid::from(id), orig);
+    }
+
+    #[test]
+    fn test_journal_id_db_column() {
+        assert_eq!(MeasurementJournalId::db_primary_uuid_name(), "journal_id");
+    }
+
+    // MeasurementApprovedMachineId tests
+    #[test]
+    fn test_approved_machine_id_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = MeasurementApprovedMachineId::from(orig);
+        assert_eq!(uuid::Uuid::from(id), orig);
+    }
+
+    #[test]
+    fn test_approved_machine_id_db_column() {
+        assert_eq!(
+            MeasurementApprovedMachineId::db_primary_uuid_name(),
+            "approval_id"
+        );
+    }
+
+    // MeasurementApprovedProfileId tests
+    #[test]
+    fn test_approved_profile_id_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = MeasurementApprovedProfileId::from(orig);
+        assert_eq!(uuid::Uuid::from(id), orig);
+    }
+
+    #[test]
+    fn test_approved_profile_id_db_column() {
+        assert_eq!(
+            MeasurementApprovedProfileId::db_primary_uuid_name(),
+            "approval_id"
+        );
+    }
+
+    // TrustedMachineId tests (special enum type)
+    #[test]
+    fn test_trusted_machine_id_any() {
+        let id = TrustedMachineId::from_str("*").expect("failed to parse");
+        assert_eq!(id, TrustedMachineId::Any);
+        assert_eq!(id.to_string(), "*");
+    }
+
+    #[test]
+    fn test_trusted_machine_id_db_column_name() {
+        assert_eq!(TrustedMachineId::db_primary_uuid_name(), "machine_id");
     }
 }

--- a/crates/uuid/src/nvlink/mod.rs
+++ b/crates/uuid/src/nvlink/mod.rs
@@ -10,162 +10,138 @@
  * its affiliates is strictly prohibited.
  */
 
-use std::fmt;
-use std::str::FromStr;
+use crate::typed_uuids::{TypedUuid, UuidSubtype};
 
-use serde::{Deserialize, Serialize};
-#[cfg(feature = "sqlx")]
-use sqlx::{
-    postgres::{PgHasArrayType, PgTypeInfo},
-    {FromRow, Type},
-};
+/// Marker type for NvLinkPartitionId
+pub struct NvLinkPartitionIdMarker;
 
-use crate::{UuidConversionError, grpc_uuid_message};
-
-/// NvlinkPartitionId is a strongly typed UUID specific to an Infiniband
-/// segment ID, with trait implementations allowing it to be passed
-/// around as a UUID, an RPC UUID, bound to sqlx queries, etc. This
-/// is similar to what we do for MachineId, VpcId, InstanceId,
-/// NetworkSegmentId, and basically all of the IDs in measured boot.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, Default)]
-#[cfg_attr(feature = "sqlx", derive(FromRow, Type))]
-#[cfg_attr(feature = "sqlx", sqlx(type_name = "UUID"))]
-pub struct NvLinkPartitionId(pub uuid::Uuid);
-
-grpc_uuid_message!(NvLinkPartitionId);
-
-impl From<NvLinkPartitionId> for uuid::Uuid {
-    fn from(id: NvLinkPartitionId) -> Self {
-        id.0
-    }
+impl UuidSubtype for NvLinkPartitionIdMarker {
+    const TYPE_NAME: &'static str = "NvLinkPartitionId";
 }
 
-impl From<uuid::Uuid> for NvLinkPartitionId {
-    fn from(uuid: uuid::Uuid) -> Self {
-        Self(uuid)
-    }
+/// NvLinkPartitionId is a strongly typed UUID specific to an NvLink partition.
+pub type NvLinkPartitionId = TypedUuid<NvLinkPartitionIdMarker>;
+
+/// Marker type for NvLinkLogicalPartitionId
+pub struct NvLinkLogicalPartitionIdMarker;
+
+impl UuidSubtype for NvLinkLogicalPartitionIdMarker {
+    const TYPE_NAME: &'static str = "NvLinkLogicalPartitionId";
 }
 
-impl FromStr for NvLinkPartitionId {
-    type Err = UuidConversionError;
-    fn from_str(input: &str) -> Result<Self, UuidConversionError> {
-        Ok(Self(uuid::Uuid::parse_str(input).map_err(|_| {
-            UuidConversionError::InvalidUuid {
-                ty: "NvlinkPartitionId",
-                value: input.to_string(),
-            }
-        })?))
-    }
+/// NvLinkLogicalPartitionId is a strongly typed UUID for NvLink logical partitions.
+pub type NvLinkLogicalPartitionId = TypedUuid<NvLinkLogicalPartitionIdMarker>;
+
+/// Marker type for NvLinkDomainId
+pub struct NvLinkDomainIdMarker;
+
+impl UuidSubtype for NvLinkDomainIdMarker {
+    const TYPE_NAME: &'static str = "NvLinkDomainId";
 }
 
-impl fmt::Display for NvLinkPartitionId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
+/// NvLinkDomainId is a strongly typed UUID for NvLink domains.
+pub type NvLinkDomainId = TypedUuid<NvLinkDomainIdMarker>;
 
-#[cfg(feature = "sqlx")]
-impl PgHasArrayType for NvLinkPartitionId {
-    fn array_type_info() -> PgTypeInfo {
-        <sqlx::types::Uuid as PgHasArrayType>::array_type_info()
-    }
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::str::FromStr;
 
-    fn array_compatible(ty: &PgTypeInfo) -> bool {
-        <sqlx::types::Uuid as PgHasArrayType>::array_compatible(ty)
-    }
-}
+    use super::*;
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, Default)]
-#[cfg_attr(feature = "sqlx", derive(FromRow, Type))]
-#[cfg_attr(feature = "sqlx", sqlx(type_name = "UUID"))]
-pub struct NvLinkLogicalPartitionId(pub uuid::Uuid);
-
-grpc_uuid_message!(NvLinkLogicalPartitionId);
-
-impl From<NvLinkLogicalPartitionId> for uuid::Uuid {
-    fn from(id: NvLinkLogicalPartitionId) -> Self {
-        id.0
-    }
-}
-
-impl From<uuid::Uuid> for NvLinkLogicalPartitionId {
-    fn from(uuid: uuid::Uuid) -> Self {
-        Self(uuid)
-    }
-}
-
-impl FromStr for NvLinkLogicalPartitionId {
-    type Err = UuidConversionError;
-    fn from_str(input: &str) -> Result<Self, UuidConversionError> {
-        Ok(Self(uuid::Uuid::parse_str(input).map_err(|_| {
-            UuidConversionError::InvalidUuid {
-                ty: "NvlinkLogicalPartitionId",
-                value: input.to_string(),
-            }
-        })?))
-    }
-}
-
-impl fmt::Display for NvLinkLogicalPartitionId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-#[cfg(feature = "sqlx")]
-impl PgHasArrayType for NvLinkLogicalPartitionId {
-    fn array_type_info() -> PgTypeInfo {
-        <sqlx::types::Uuid as PgHasArrayType>::array_type_info()
+    // NvLinkPartitionId tests
+    #[test]
+    fn test_partition_id_uuid_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = NvLinkPartitionId::from(orig);
+        let back = uuid::Uuid::from(id);
+        assert_eq!(orig, back);
     }
 
-    fn array_compatible(ty: &PgTypeInfo) -> bool {
-        <sqlx::types::Uuid as PgHasArrayType>::array_compatible(ty)
-    }
-}
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, Default)]
-#[cfg_attr(feature = "sqlx", derive(FromRow, Type))]
-#[cfg_attr(feature = "sqlx", sqlx(type_name = "UUID"))]
-pub struct NvLinkDomainId(pub uuid::Uuid);
-
-grpc_uuid_message!(NvLinkDomainId);
-
-impl From<NvLinkDomainId> for uuid::Uuid {
-    fn from(id: NvLinkDomainId) -> Self {
-        id.0
-    }
-}
-
-impl From<uuid::Uuid> for NvLinkDomainId {
-    fn from(uuid: uuid::Uuid) -> Self {
-        Self(uuid)
-    }
-}
-
-impl FromStr for NvLinkDomainId {
-    type Err = UuidConversionError;
-    fn from_str(input: &str) -> Result<Self, UuidConversionError> {
-        Ok(Self(uuid::Uuid::parse_str(input).map_err(|_| {
-            UuidConversionError::InvalidUuid {
-                ty: "NvlinkinkDomainId",
-                value: input.to_string(),
-            }
-        })?))
-    }
-}
-
-impl fmt::Display for NvLinkDomainId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-#[cfg(feature = "sqlx")]
-impl PgHasArrayType for NvLinkDomainId {
-    fn array_type_info() -> PgTypeInfo {
-        <sqlx::types::Uuid as PgHasArrayType>::array_type_info()
+    #[test]
+    fn test_partition_id_string_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = NvLinkPartitionId::from(orig);
+        let as_string = id.to_string();
+        let parsed = NvLinkPartitionId::from_str(&as_string).expect("failed to parse");
+        assert_eq!(id, parsed);
     }
 
-    fn array_compatible(ty: &PgTypeInfo) -> bool {
-        <sqlx::types::Uuid as PgHasArrayType>::array_compatible(ty)
+    #[test]
+    fn test_partition_id_json_round_trip() {
+        let id = NvLinkPartitionId::new();
+        let json = serde_json::to_string(&id).expect("failed to serialize");
+        let parsed: NvLinkPartitionId = serde_json::from_str(&json).expect("failed to deserialize");
+        assert_eq!(id, parsed);
+        assert!(json.starts_with('"') && json.ends_with('"'));
+    }
+
+    #[test]
+    fn test_partition_id_ordering() {
+        let id1 = NvLinkPartitionId::from(uuid::Uuid::nil());
+        let id2 = NvLinkPartitionId::from(uuid::Uuid::max());
+        assert!(id1 < id2);
+    }
+
+    #[test]
+    fn test_partition_id_default() {
+        let id = NvLinkPartitionId::default();
+        assert_eq!(uuid::Uuid::from(id), uuid::Uuid::nil());
+    }
+
+    #[test]
+    fn test_partition_id_copy() {
+        let id1 = NvLinkPartitionId::new();
+        let id2 = id1;
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn test_partition_id_hash_consistency() {
+        let uuid = uuid::Uuid::new_v4();
+        let id1 = NvLinkPartitionId::from(uuid);
+        let id2 = NvLinkPartitionId::from(uuid);
+        let mut set = HashSet::new();
+        set.insert(id1);
+        assert!(set.contains(&id2));
+    }
+
+    #[test]
+    fn test_partition_id_debug_includes_type_name() {
+        let id = NvLinkPartitionId::from(uuid::Uuid::nil());
+        let debug = format!("{:?}", id);
+        assert!(debug.contains("NvLinkPartitionId"));
+    }
+
+    // NvLinkLogicalPartitionId tests
+    #[test]
+    fn test_logical_partition_id_uuid_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = NvLinkLogicalPartitionId::from(orig);
+        let back = uuid::Uuid::from(id);
+        assert_eq!(orig, back);
+    }
+
+    #[test]
+    fn test_logical_partition_id_debug_includes_type_name() {
+        let id = NvLinkLogicalPartitionId::from(uuid::Uuid::nil());
+        let debug = format!("{:?}", id);
+        assert!(debug.contains("NvLinkLogicalPartitionId"));
+    }
+
+    // NvLinkDomainId tests
+    #[test]
+    fn test_domain_id_uuid_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = NvLinkDomainId::from(orig);
+        let back = uuid::Uuid::from(id);
+        assert_eq!(orig, back);
+    }
+
+    #[test]
+    fn test_domain_id_debug_includes_type_name() {
+        let id = NvLinkDomainId::from(uuid::Uuid::nil());
+        let debug = format!("{:?}", id);
+        assert!(debug.contains("NvLinkDomainId"));
     }
 }

--- a/crates/uuid/src/vpc/mod.rs
+++ b/crates/uuid/src/vpc/mod.rs
@@ -10,74 +10,96 @@
  * its affiliates is strictly prohibited.
  */
 
-use std::fmt;
-use std::str::FromStr;
+use crate::typed_uuids::{TypedUuid, UuidSubtype};
 
-use serde::{Deserialize, Serialize};
-#[cfg(feature = "sqlx")]
-use sqlx::{
-    postgres::{PgHasArrayType, PgTypeInfo},
-    {FromRow, Type},
-};
+/// Marker type for VpcId
+pub struct VpcIdMarker;
 
-use super::typed_uuids::{TypedUuid, UuidSubtype};
-use crate::{UuidConversionError, grpc_uuid_message};
+impl UuidSubtype for VpcIdMarker {
+    const TYPE_NAME: &'static str = "VpcId";
+}
 
 /// VpcId is a strongly typed UUID specific to a VPC ID, with
 /// trait implementations allowing it to be passed around as
 /// a UUID, an RPC UUID, bound to sqlx queries, etc.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, Hash, PartialEq, Default)]
-#[cfg_attr(feature = "sqlx", derive(FromRow, Type))]
-#[cfg_attr(feature = "sqlx", sqlx(type_name = "UUID"))]
-pub struct VpcId(pub uuid::Uuid);
+pub type VpcId = TypedUuid<VpcIdMarker>;
 
-grpc_uuid_message!(VpcId);
-
-impl From<VpcId> for uuid::Uuid {
-    fn from(id: VpcId) -> Self {
-        id.0
-    }
-}
-
-impl From<uuid::Uuid> for VpcId {
-    fn from(uuid: uuid::Uuid) -> Self {
-        Self(uuid)
-    }
-}
-
-impl FromStr for VpcId {
-    type Err = UuidConversionError;
-    fn from_str(input: &str) -> Result<Self, UuidConversionError> {
-        Ok(Self(uuid::Uuid::parse_str(input).map_err(|_| {
-            UuidConversionError::InvalidUuid {
-                ty: "VpcId",
-                value: input.to_string(),
-            }
-        })?))
-    }
-}
-
-impl fmt::Display for VpcId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-#[cfg(feature = "sqlx")]
-impl PgHasArrayType for VpcId {
-    fn array_type_info() -> PgTypeInfo {
-        <sqlx::types::Uuid as PgHasArrayType>::array_type_info()
-    }
-
-    fn array_compatible(ty: &PgTypeInfo) -> bool {
-        <sqlx::types::Uuid as PgHasArrayType>::array_compatible(ty)
-    }
-}
-
-pub struct VpcPrefixMarker {}
+/// Marker type for VpcPrefixId
+pub struct VpcPrefixMarker;
 
 impl UuidSubtype for VpcPrefixMarker {
     const TYPE_NAME: &'static str = "VpcPrefixId";
 }
 
 pub type VpcPrefixId = TypedUuid<VpcPrefixMarker>;
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn test_vpc_id_uuid_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = VpcId::from(orig);
+        let back = uuid::Uuid::from(id);
+        assert_eq!(orig, back);
+    }
+
+    #[test]
+    fn test_vpc_id_string_round_trip() {
+        let orig = uuid::Uuid::new_v4();
+        let id = VpcId::from(orig);
+        let as_string = id.to_string();
+        let parsed = VpcId::from_str(&as_string).expect("failed to parse");
+        assert_eq!(id, parsed);
+    }
+
+    #[test]
+    fn test_vpc_id_json_round_trip() {
+        let id = VpcId::new();
+        let json = serde_json::to_string(&id).expect("failed to serialize");
+        let parsed: VpcId = serde_json::from_str(&json).expect("failed to deserialize");
+        assert_eq!(id, parsed);
+        assert!(json.starts_with('"') && json.ends_with('"'));
+    }
+
+    #[test]
+    fn test_vpc_id_ordering() {
+        let id1 = VpcId::from(uuid::Uuid::nil());
+        let id2 = VpcId::from(uuid::Uuid::max());
+        assert!(id1 < id2);
+    }
+
+    #[test]
+    fn test_vpc_id_default() {
+        let id = VpcId::default();
+        assert_eq!(uuid::Uuid::from(id), uuid::Uuid::nil());
+    }
+
+    #[test]
+    fn test_vpc_id_copy() {
+        let id1 = VpcId::new();
+        let id2 = id1;
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn test_vpc_id_hash_consistency() {
+        let uuid = uuid::Uuid::new_v4();
+        let id1 = VpcId::from(uuid);
+        let id2 = VpcId::from(uuid);
+        let mut set = HashSet::new();
+        set.insert(id1);
+        assert!(set.contains(&id2));
+    }
+
+    #[test]
+    fn test_vpc_id_debug_includes_type_name() {
+        let id = VpcId::from(uuid::Uuid::nil());
+        let debug = format!("{:?}", id);
+        assert!(debug.contains("VpcId"));
+    }
+}


### PR DESCRIPTION
## Description

This migrates the remaining typed UUID-based IDs that we had within the `uuid` crate to all be a `TypedUuid`. This does NOT include hardware-backed IDs like `MachineId`.

For those who don't know, `TypedUuid` provides strongly typed IDs for all of the things we use IDs for throughout Carbide which are UUID-derived. This includes benefits like:
- Ensuring type safety for database identifiers.
- Ensuring we're passing around the correct ID -- it's easy to make mistakes when everything is just a `uuid::Uuid` and variable names aren't well named.
- A layer of abstraction that makes UUID an implementation detail of how the ID is computed.
- Lots of little conveniences for free that make working with IDs a lot more simple (formatting, equality, hashing, `.into()` common use cases, etc).

To make one, it's as simple as:
```
use carbide_uuid::typed_uuids::{TypedUuid, UuidSubtype};

pub struct SomeIdMarker;

impl UuidSubtype for SomeIdMarker {
    // Used in Debug output.
    const TYPE_NAME: &'static str = "SomeId";

    // The database column name when using FromRow.
    // Defaults to "id" if not specified.
    // Override as needed.
    const DB_COLUMN_NAME: &'static str = "some_id";
}

pub type SomeId = TypedUuid<SomeIdMarker>;
```

In any case, while I was in here, I also added a few things:

### 1. `new()` Constructor
```
// Before:
let id = SomeId::from(uuid::Uuid::new_v4());

// After:
let id = SomeId::new();
```

### 2. `offset()` Method
```
// Before:
let id1 = base_id;
let id2 = uuid::Uuid::from_u128(uuid::Uuid::from(base_id).as_u128() + 1).into();
let id3 = uuid::Uuid::from_u128(uuid::Uuid::from(base_id).as_u128() + 2).into();

// After:
let id1 = base_id;
let id2 = base_id.offset(1);
let id3 = base_id.offset(2);
```

### 3. `From<TypedUuid<T>> for String` Implementation
```
// Before:
let rpc_uuid: common::Uuid = uuid::Uuid::from(some_id).into();
let rpc_uuid: common::Uuid = some_id.to_string().into();

// After:
let rpc_uuid: common::Uuid = some_id.into();
```

...which also simplifies struct field assignments:

```
// Before:
rpc::SomeMessage {
    id: some_id.to_string(),
}

// After:
rpc::SomeMessage {
    id: some_id.into(),
}
```

### 4. Simplified Display in Format Strings
```
// Before:
assert!(thing, "error with id {}", uuid::Uuid::from(some_id));

// After:
assert!(thing, "error for id {}", some_id);
```

As a result, the resulting cleanup included:
- Replacing `SomeId::from(uuid::Uuid::new_v4())` with `SomeId::new()`.
- Replacing `uuid::Uuid::from(id).into()` with `id.into()`.
- Replacing `.to_string()` with `.into()` where target the type was String.
- Removed a bunch of unnecessary `uuid::Uuid::from()` in format strings.

A bunch of super boilerplate tests were added to each ID as well. Maybe that could be a macro?

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

