### PR TITLE
chore(api): move measured_boot api logic into handlers/

### DIFF
--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -50,7 +50,7 @@ use crate::scout_stream::ConnectionRegistry;
 use crate::site_explorer::EndpointExplorer;
 use crate::state_controller::controller::Enqueuer;
 use crate::state_controller::machine::io::MachineStateControllerIO;
-use crate::{CarbideError, CarbideResult, measured_boot};
+use crate::{CarbideError, CarbideResult};
 
 pub struct Api {
     pub(crate) database_connection: sqlx::PgPool,
@@ -1520,78 +1520,42 @@ impl Forge for Api {
         &self,
         request: Request<measured_boot_pb::CreateMeasurementSystemProfileRequest>,
     ) -> Result<Response<measured_boot_pb::CreateMeasurementSystemProfileResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::profile::handle_create_system_measurement_profile(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::create_system_profile(self, request).await
     }
 
     async fn delete_measurement_system_profile(
         &self,
         request: Request<measured_boot_pb::DeleteMeasurementSystemProfileRequest>,
     ) -> Result<Response<measured_boot_pb::DeleteMeasurementSystemProfileResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::profile::handle_delete_measurement_system_profile(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::delete_system_profile(self, request).await
     }
 
     async fn rename_measurement_system_profile(
         &self,
         request: Request<measured_boot_pb::RenameMeasurementSystemProfileRequest>,
     ) -> Result<Response<measured_boot_pb::RenameMeasurementSystemProfileResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::profile::handle_rename_measurement_system_profile(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::rename_system_profile(self, request).await
     }
 
     async fn show_measurement_system_profile(
         &self,
         request: Request<measured_boot_pb::ShowMeasurementSystemProfileRequest>,
     ) -> Result<Response<measured_boot_pb::ShowMeasurementSystemProfileResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::profile::handle_show_measurement_system_profile(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::show_system_profile(self, request).await
     }
 
     async fn show_measurement_system_profiles(
         &self,
         request: Request<measured_boot_pb::ShowMeasurementSystemProfilesRequest>,
     ) -> Result<Response<measured_boot_pb::ShowMeasurementSystemProfilesResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::profile::handle_show_measurement_system_profiles(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::show_system_profiles(self, request).await
     }
 
     async fn list_measurement_system_profiles(
         &self,
         request: Request<measured_boot_pb::ListMeasurementSystemProfilesRequest>,
     ) -> Result<Response<measured_boot_pb::ListMeasurementSystemProfilesResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::profile::handle_list_measurement_system_profiles(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::list_system_profiles(self, request).await
     }
 
     async fn list_measurement_system_profile_bundles(
@@ -1599,13 +1563,7 @@ impl Forge for Api {
         request: Request<measured_boot_pb::ListMeasurementSystemProfileBundlesRequest>,
     ) -> Result<Response<measured_boot_pb::ListMeasurementSystemProfileBundlesResponse>, Status>
     {
-        Ok(Response::new(
-            measured_boot::rpc::profile::handle_list_measurement_system_profile_bundles(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::list_system_profile_bundles(self, request).await
     }
 
     async fn list_measurement_system_profile_machines(
@@ -1613,429 +1571,252 @@ impl Forge for Api {
         request: Request<measured_boot_pb::ListMeasurementSystemProfileMachinesRequest>,
     ) -> Result<Response<measured_boot_pb::ListMeasurementSystemProfileMachinesResponse>, Status>
     {
-        Ok(Response::new(
-            measured_boot::rpc::profile::handle_list_measurement_system_profile_machines(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::list_system_profile_machines(self, request).await
     }
 
     async fn create_measurement_report(
         &self,
         request: Request<measured_boot_pb::CreateMeasurementReportRequest>,
     ) -> Result<Response<measured_boot_pb::CreateMeasurementReportResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::report::handle_create_measurement_report(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::create_report(self, request).await
     }
 
     async fn delete_measurement_report(
         &self,
         request: Request<measured_boot_pb::DeleteMeasurementReportRequest>,
     ) -> Result<Response<measured_boot_pb::DeleteMeasurementReportResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::report::handle_delete_measurement_report(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::delete_report(self, request).await
     }
 
     async fn promote_measurement_report(
         &self,
         request: Request<measured_boot_pb::PromoteMeasurementReportRequest>,
     ) -> Result<Response<measured_boot_pb::PromoteMeasurementReportResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::report::handle_promote_measurement_report(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::promote_report(self, request).await
     }
 
     async fn revoke_measurement_report(
         &self,
         request: Request<measured_boot_pb::RevokeMeasurementReportRequest>,
     ) -> Result<Response<measured_boot_pb::RevokeMeasurementReportResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::report::handle_revoke_measurement_report(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::revoke_report(self, request).await
     }
 
     async fn show_measurement_report_for_id(
         &self,
         request: Request<measured_boot_pb::ShowMeasurementReportForIdRequest>,
     ) -> Result<Response<measured_boot_pb::ShowMeasurementReportForIdResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::report::handle_show_measurement_report_for_id(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::show_report_for_id(self, request).await
     }
 
     async fn show_measurement_reports_for_machine(
         &self,
         request: Request<measured_boot_pb::ShowMeasurementReportsForMachineRequest>,
     ) -> Result<Response<measured_boot_pb::ShowMeasurementReportsForMachineResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::report::handle_show_measurement_reports_for_machine(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::show_reports_for_machine(self, request).await
     }
 
     async fn show_measurement_reports(
         &self,
         request: Request<measured_boot_pb::ShowMeasurementReportsRequest>,
     ) -> Result<Response<measured_boot_pb::ShowMeasurementReportsResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::report::handle_show_measurement_reports(self, request.into_inner())
-                .await?,
-        ))
+        crate::handlers::measured_boot::show_reports(self, request).await
     }
 
     async fn list_measurement_report(
         &self,
         request: Request<measured_boot_pb::ListMeasurementReportRequest>,
     ) -> Result<Response<measured_boot_pb::ListMeasurementReportResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::report::handle_list_measurement_report(self, request.into_inner())
-                .await?,
-        ))
+        crate::handlers::measured_boot::list_report(self, request).await
     }
 
     async fn match_measurement_report(
         &self,
         request: Request<measured_boot_pb::MatchMeasurementReportRequest>,
     ) -> Result<Response<measured_boot_pb::MatchMeasurementReportResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::report::handle_match_measurement_report(self, request.into_inner())
-                .await?,
-        ))
+        crate::handlers::measured_boot::match_report(self, request).await
     }
 
     async fn create_measurement_bundle(
         &self,
         request: Request<measured_boot_pb::CreateMeasurementBundleRequest>,
     ) -> Result<Response<measured_boot_pb::CreateMeasurementBundleResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::bundle::handle_create_measurement_bundle(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::create_bundle(self, request).await
     }
 
     async fn delete_measurement_bundle(
         &self,
         request: Request<measured_boot_pb::DeleteMeasurementBundleRequest>,
     ) -> Result<Response<measured_boot_pb::DeleteMeasurementBundleResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::bundle::handle_delete_measurement_bundle(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::delete_bundle(self, request).await
     }
 
     async fn rename_measurement_bundle(
         &self,
         request: Request<measured_boot_pb::RenameMeasurementBundleRequest>,
     ) -> Result<Response<measured_boot_pb::RenameMeasurementBundleResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::bundle::handle_rename_measurement_bundle(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::rename_bundle(self, request).await
     }
 
     async fn update_measurement_bundle(
         &self,
         request: Request<measured_boot_pb::UpdateMeasurementBundleRequest>,
     ) -> Result<Response<measured_boot_pb::UpdateMeasurementBundleResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::bundle::handle_update_measurement_bundle(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::update_bundle(self, request).await
     }
 
     async fn show_measurement_bundle(
         &self,
         request: Request<measured_boot_pb::ShowMeasurementBundleRequest>,
     ) -> Result<Response<measured_boot_pb::ShowMeasurementBundleResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::bundle::handle_show_measurement_bundle(self, request.into_inner())
-                .await?,
-        ))
+        crate::handlers::measured_boot::show_bundle(self, request).await
     }
 
     async fn show_measurement_bundles(
         &self,
         request: Request<measured_boot_pb::ShowMeasurementBundlesRequest>,
     ) -> Result<Response<measured_boot_pb::ShowMeasurementBundlesResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::bundle::handle_show_measurement_bundles(self, request.into_inner())
-                .await?,
-        ))
+        crate::handlers::measured_boot::show_bundles(self, request).await
     }
 
     async fn list_measurement_bundles(
         &self,
         request: Request<measured_boot_pb::ListMeasurementBundlesRequest>,
     ) -> Result<Response<measured_boot_pb::ListMeasurementBundlesResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::bundle::handle_list_measurement_bundles(self, request.into_inner())
-                .await?,
-        ))
+        crate::handlers::measured_boot::list_bundles(self, request).await
     }
 
     async fn list_measurement_bundle_machines(
         &self,
         request: Request<measured_boot_pb::ListMeasurementBundleMachinesRequest>,
     ) -> Result<Response<measured_boot_pb::ListMeasurementBundleMachinesResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::bundle::handle_list_measurement_bundle_machines(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::list_bundle_machines(self, request).await
     }
 
     async fn find_closest_bundle_match(
         &self,
         request: Request<measured_boot_pb::FindClosestBundleMatchRequest>,
     ) -> Result<Response<measured_boot_pb::ShowMeasurementBundleResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::bundle::handle_find_closest_match(self, request.into_inner())
-                .await?,
-        ))
+        crate::handlers::measured_boot::find_closest_bundle_match(self, request).await
     }
 
     async fn delete_measurement_journal(
         &self,
         request: Request<measured_boot_pb::DeleteMeasurementJournalRequest>,
     ) -> Result<Response<measured_boot_pb::DeleteMeasurementJournalResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::journal::handle_delete_measurement_journal(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::delete_journal(self, request).await
     }
 
     async fn show_measurement_journal(
         &self,
         request: Request<measured_boot_pb::ShowMeasurementJournalRequest>,
     ) -> Result<Response<measured_boot_pb::ShowMeasurementJournalResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::journal::handle_show_measurement_journal(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::show_journal(self, request).await
     }
 
     async fn show_measurement_journals(
         &self,
         request: Request<measured_boot_pb::ShowMeasurementJournalsRequest>,
     ) -> Result<Response<measured_boot_pb::ShowMeasurementJournalsResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::journal::handle_show_measurement_journals(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::show_journals(self, request).await
     }
 
     async fn list_measurement_journal(
         &self,
         request: Request<measured_boot_pb::ListMeasurementJournalRequest>,
     ) -> Result<Response<measured_boot_pb::ListMeasurementJournalResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::journal::handle_list_measurement_journal(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::list_journal(self, request).await
     }
 
     async fn attest_candidate_machine(
         &self,
         request: Request<measured_boot_pb::AttestCandidateMachineRequest>,
     ) -> Result<Response<measured_boot_pb::AttestCandidateMachineResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::machine::handle_attest_candidate_machine(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::attest_candidate_machine(self, request).await
     }
 
     async fn show_candidate_machine(
         &self,
         request: Request<measured_boot_pb::ShowCandidateMachineRequest>,
     ) -> Result<Response<measured_boot_pb::ShowCandidateMachineResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::machine::handle_show_candidate_machine(self, request.into_inner())
-                .await?,
-        ))
+        crate::handlers::measured_boot::show_candidate_machine(self, request).await
     }
 
     async fn show_candidate_machines(
         &self,
         request: Request<measured_boot_pb::ShowCandidateMachinesRequest>,
     ) -> Result<Response<measured_boot_pb::ShowCandidateMachinesResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::machine::handle_show_candidate_machines(self, request.into_inner())
-                .await?,
-        ))
+        crate::handlers::measured_boot::show_candidate_machines(self, request).await
     }
 
     async fn list_candidate_machines(
         &self,
         request: Request<measured_boot_pb::ListCandidateMachinesRequest>,
     ) -> Result<Response<measured_boot_pb::ListCandidateMachinesResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::machine::handle_list_candidate_machines(self, request.into_inner())
-                .await?,
-        ))
+        crate::handlers::measured_boot::list_candidate_machines(self, request).await
     }
 
     async fn import_site_measurements(
         &self,
         request: Request<measured_boot_pb::ImportSiteMeasurementsRequest>,
     ) -> Result<Response<measured_boot_pb::ImportSiteMeasurementsResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::site::handle_import_site_measurements(self, request.into_inner())
-                .await?,
-        ))
+        crate::handlers::measured_boot::import_site_measurements(self, request).await
     }
 
     async fn export_site_measurements(
         &self,
         request: Request<measured_boot_pb::ExportSiteMeasurementsRequest>,
     ) -> Result<Response<measured_boot_pb::ExportSiteMeasurementsResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::site::handle_export_site_measurements(self, request.into_inner())
-                .await?,
-        ))
+        crate::handlers::measured_boot::export_site_measurements(self, request).await
     }
 
     async fn add_measurement_trusted_machine(
         &self,
         request: Request<measured_boot_pb::AddMeasurementTrustedMachineRequest>,
     ) -> Result<Response<measured_boot_pb::AddMeasurementTrustedMachineResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::site::handle_add_measurement_trusted_machine(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::add_trusted_machine(self, request).await
     }
 
     async fn remove_measurement_trusted_machine(
         &self,
         request: Request<measured_boot_pb::RemoveMeasurementTrustedMachineRequest>,
     ) -> Result<Response<measured_boot_pb::RemoveMeasurementTrustedMachineResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::site::handle_remove_measurement_trusted_machine(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::remove_trusted_machine(self, request).await
     }
 
     async fn list_measurement_trusted_machines(
         &self,
         request: Request<measured_boot_pb::ListMeasurementTrustedMachinesRequest>,
     ) -> Result<Response<measured_boot_pb::ListMeasurementTrustedMachinesResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::site::handle_list_measurement_trusted_machines(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::list_trusted_machines(self, request).await
     }
 
     async fn add_measurement_trusted_profile(
         &self,
         request: Request<measured_boot_pb::AddMeasurementTrustedProfileRequest>,
     ) -> Result<Response<measured_boot_pb::AddMeasurementTrustedProfileResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::site::handle_add_measurement_trusted_profile(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::add_trusted_profile(self, request).await
     }
 
     async fn remove_measurement_trusted_profile(
         &self,
         request: Request<measured_boot_pb::RemoveMeasurementTrustedProfileRequest>,
     ) -> Result<Response<measured_boot_pb::RemoveMeasurementTrustedProfileResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::site::handle_remove_measurement_trusted_profile(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::remove_trusted_profile(self, request).await
     }
 
     async fn list_measurement_trusted_profiles(
         &self,
         request: Request<measured_boot_pb::ListMeasurementTrustedProfilesRequest>,
     ) -> Result<Response<measured_boot_pb::ListMeasurementTrustedProfilesResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::site::handle_list_measurement_trusted_profiles(
-                self,
-                request.into_inner(),
-            )
-            .await?,
-        ))
+        crate::handlers::measured_boot::list_trusted_profiles(self, request).await
     }
 
     async fn list_attestation_summary(
         &self,
         request: Request<measured_boot_pb::ListAttestationSummaryRequest>,
     ) -> Result<Response<measured_boot_pb::ListAttestationSummaryResponse>, Status> {
-        Ok(Response::new(
-            measured_boot::rpc::site::handle_list_attestation_summary(self, request.into_inner())
-                .await?,
-        ))
+        crate::handlers::measured_boot::list_attestation_summary(self, request).await
     }
 
     // Host has rebooted

--- a/crates/api/src/handlers/measured_boot.rs
+++ b/crates/api/src/handlers/measured_boot.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -10,12 +10,15 @@
  * its affiliates is strictly prohibited.
  */
 
+use ::rpc::protos::measured_boot as pb;
 pub use ::rpc::{forge as rpc_forge, machine_discovery as rpc_md};
 use carbide_uuid::machine::MachineId;
 use db::attestation::secret_ak_pub;
 use sqlx::PgConnection;
-use tonic::Status;
+use tonic::{Request, Response, Status};
 
+use crate::api::Api;
+use crate::measured_boot::rpc::{bundle, journal, machine, profile, report, site};
 use crate::{CarbideError, attestation as attest};
 
 pub(crate) async fn create_attest_key_bind_challenge(
@@ -44,4 +47,391 @@ pub(crate) async fn create_attest_key_bind_challenge(
         cred_blob: cli_cred_blob,
         encrypted_secret: cli_secret,
     })
+}
+
+pub async fn create_system_profile(
+    api: &Api,
+    request: Request<pb::CreateMeasurementSystemProfileRequest>,
+) -> Result<Response<pb::CreateMeasurementSystemProfileResponse>, Status> {
+    profile::handle_create_system_measurement_profile(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn delete_system_profile(
+    api: &Api,
+    request: Request<pb::DeleteMeasurementSystemProfileRequest>,
+) -> Result<Response<pb::DeleteMeasurementSystemProfileResponse>, Status> {
+    profile::handle_delete_measurement_system_profile(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn rename_system_profile(
+    api: &Api,
+    request: Request<pb::RenameMeasurementSystemProfileRequest>,
+) -> Result<Response<pb::RenameMeasurementSystemProfileResponse>, Status> {
+    profile::handle_rename_measurement_system_profile(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn show_system_profile(
+    api: &Api,
+    request: Request<pb::ShowMeasurementSystemProfileRequest>,
+) -> Result<Response<pb::ShowMeasurementSystemProfileResponse>, Status> {
+    profile::handle_show_measurement_system_profile(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn show_system_profiles(
+    api: &Api,
+    request: Request<pb::ShowMeasurementSystemProfilesRequest>,
+) -> Result<Response<pb::ShowMeasurementSystemProfilesResponse>, Status> {
+    profile::handle_show_measurement_system_profiles(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn list_system_profiles(
+    api: &Api,
+    request: Request<pb::ListMeasurementSystemProfilesRequest>,
+) -> Result<Response<pb::ListMeasurementSystemProfilesResponse>, Status> {
+    profile::handle_list_measurement_system_profiles(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn list_system_profile_bundles(
+    api: &Api,
+    request: Request<pb::ListMeasurementSystemProfileBundlesRequest>,
+) -> Result<Response<pb::ListMeasurementSystemProfileBundlesResponse>, Status> {
+    profile::handle_list_measurement_system_profile_bundles(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn list_system_profile_machines(
+    api: &Api,
+    request: Request<pb::ListMeasurementSystemProfileMachinesRequest>,
+) -> Result<Response<pb::ListMeasurementSystemProfileMachinesResponse>, Status> {
+    profile::handle_list_measurement_system_profile_machines(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn create_report(
+    api: &Api,
+    request: Request<pb::CreateMeasurementReportRequest>,
+) -> Result<Response<pb::CreateMeasurementReportResponse>, Status> {
+    report::handle_create_measurement_report(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn delete_report(
+    api: &Api,
+    request: Request<pb::DeleteMeasurementReportRequest>,
+) -> Result<Response<pb::DeleteMeasurementReportResponse>, Status> {
+    report::handle_delete_measurement_report(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn promote_report(
+    api: &Api,
+    request: Request<pb::PromoteMeasurementReportRequest>,
+) -> Result<Response<pb::PromoteMeasurementReportResponse>, Status> {
+    report::handle_promote_measurement_report(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn revoke_report(
+    api: &Api,
+    request: Request<pb::RevokeMeasurementReportRequest>,
+) -> Result<Response<pb::RevokeMeasurementReportResponse>, Status> {
+    report::handle_revoke_measurement_report(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn show_report_for_id(
+    api: &Api,
+    request: Request<pb::ShowMeasurementReportForIdRequest>,
+) -> Result<Response<pb::ShowMeasurementReportForIdResponse>, Status> {
+    report::handle_show_measurement_report_for_id(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn show_reports_for_machine(
+    api: &Api,
+    request: Request<pb::ShowMeasurementReportsForMachineRequest>,
+) -> Result<Response<pb::ShowMeasurementReportsForMachineResponse>, Status> {
+    report::handle_show_measurement_reports_for_machine(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn show_reports(
+    api: &Api,
+    request: Request<pb::ShowMeasurementReportsRequest>,
+) -> Result<Response<pb::ShowMeasurementReportsResponse>, Status> {
+    report::handle_show_measurement_reports(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn list_report(
+    api: &Api,
+    request: Request<pb::ListMeasurementReportRequest>,
+) -> Result<Response<pb::ListMeasurementReportResponse>, Status> {
+    report::handle_list_measurement_report(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn match_report(
+    api: &Api,
+    request: Request<pb::MatchMeasurementReportRequest>,
+) -> Result<Response<pb::MatchMeasurementReportResponse>, Status> {
+    report::handle_match_measurement_report(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn create_bundle(
+    api: &Api,
+    request: Request<pb::CreateMeasurementBundleRequest>,
+) -> Result<Response<pb::CreateMeasurementBundleResponse>, Status> {
+    bundle::handle_create_measurement_bundle(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn delete_bundle(
+    api: &Api,
+    request: Request<pb::DeleteMeasurementBundleRequest>,
+) -> Result<Response<pb::DeleteMeasurementBundleResponse>, Status> {
+    bundle::handle_delete_measurement_bundle(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn rename_bundle(
+    api: &Api,
+    request: Request<pb::RenameMeasurementBundleRequest>,
+) -> Result<Response<pb::RenameMeasurementBundleResponse>, Status> {
+    bundle::handle_rename_measurement_bundle(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn update_bundle(
+    api: &Api,
+    request: Request<pb::UpdateMeasurementBundleRequest>,
+) -> Result<Response<pb::UpdateMeasurementBundleResponse>, Status> {
+    bundle::handle_update_measurement_bundle(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn show_bundle(
+    api: &Api,
+    request: Request<pb::ShowMeasurementBundleRequest>,
+) -> Result<Response<pb::ShowMeasurementBundleResponse>, Status> {
+    bundle::handle_show_measurement_bundle(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn show_bundles(
+    api: &Api,
+    request: Request<pb::ShowMeasurementBundlesRequest>,
+) -> Result<Response<pb::ShowMeasurementBundlesResponse>, Status> {
+    bundle::handle_show_measurement_bundles(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn list_bundles(
+    api: &Api,
+    request: Request<pb::ListMeasurementBundlesRequest>,
+) -> Result<Response<pb::ListMeasurementBundlesResponse>, Status> {
+    bundle::handle_list_measurement_bundles(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn list_bundle_machines(
+    api: &Api,
+    request: Request<pb::ListMeasurementBundleMachinesRequest>,
+) -> Result<Response<pb::ListMeasurementBundleMachinesResponse>, Status> {
+    bundle::handle_list_measurement_bundle_machines(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn find_closest_bundle_match(
+    api: &Api,
+    request: Request<pb::FindClosestBundleMatchRequest>,
+) -> Result<Response<pb::ShowMeasurementBundleResponse>, Status> {
+    bundle::handle_find_closest_match(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn delete_journal(
+    api: &Api,
+    request: Request<pb::DeleteMeasurementJournalRequest>,
+) -> Result<Response<pb::DeleteMeasurementJournalResponse>, Status> {
+    journal::handle_delete_measurement_journal(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn show_journal(
+    api: &Api,
+    request: Request<pb::ShowMeasurementJournalRequest>,
+) -> Result<Response<pb::ShowMeasurementJournalResponse>, Status> {
+    journal::handle_show_measurement_journal(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn show_journals(
+    api: &Api,
+    request: Request<pb::ShowMeasurementJournalsRequest>,
+) -> Result<Response<pb::ShowMeasurementJournalsResponse>, Status> {
+    journal::handle_show_measurement_journals(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn list_journal(
+    api: &Api,
+    request: Request<pb::ListMeasurementJournalRequest>,
+) -> Result<Response<pb::ListMeasurementJournalResponse>, Status> {
+    journal::handle_list_measurement_journal(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn attest_candidate_machine(
+    api: &Api,
+    request: Request<pb::AttestCandidateMachineRequest>,
+) -> Result<Response<pb::AttestCandidateMachineResponse>, Status> {
+    machine::handle_attest_candidate_machine(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn show_candidate_machine(
+    api: &Api,
+    request: Request<pb::ShowCandidateMachineRequest>,
+) -> Result<Response<pb::ShowCandidateMachineResponse>, Status> {
+    machine::handle_show_candidate_machine(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn show_candidate_machines(
+    api: &Api,
+    request: Request<pb::ShowCandidateMachinesRequest>,
+) -> Result<Response<pb::ShowCandidateMachinesResponse>, Status> {
+    machine::handle_show_candidate_machines(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn list_candidate_machines(
+    api: &Api,
+    request: Request<pb::ListCandidateMachinesRequest>,
+) -> Result<Response<pb::ListCandidateMachinesResponse>, Status> {
+    machine::handle_list_candidate_machines(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn import_site_measurements(
+    api: &Api,
+    request: Request<pb::ImportSiteMeasurementsRequest>,
+) -> Result<Response<pb::ImportSiteMeasurementsResponse>, Status> {
+    site::handle_import_site_measurements(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn export_site_measurements(
+    api: &Api,
+    request: Request<pb::ExportSiteMeasurementsRequest>,
+) -> Result<Response<pb::ExportSiteMeasurementsResponse>, Status> {
+    site::handle_export_site_measurements(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn add_trusted_machine(
+    api: &Api,
+    request: Request<pb::AddMeasurementTrustedMachineRequest>,
+) -> Result<Response<pb::AddMeasurementTrustedMachineResponse>, Status> {
+    site::handle_add_measurement_trusted_machine(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn remove_trusted_machine(
+    api: &Api,
+    request: Request<pb::RemoveMeasurementTrustedMachineRequest>,
+) -> Result<Response<pb::RemoveMeasurementTrustedMachineResponse>, Status> {
+    site::handle_remove_measurement_trusted_machine(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn list_trusted_machines(
+    api: &Api,
+    request: Request<pb::ListMeasurementTrustedMachinesRequest>,
+) -> Result<Response<pb::ListMeasurementTrustedMachinesResponse>, Status> {
+    site::handle_list_measurement_trusted_machines(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn add_trusted_profile(
+    api: &Api,
+    request: Request<pb::AddMeasurementTrustedProfileRequest>,
+) -> Result<Response<pb::AddMeasurementTrustedProfileResponse>, Status> {
+    site::handle_add_measurement_trusted_profile(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn remove_trusted_profile(
+    api: &Api,
+    request: Request<pb::RemoveMeasurementTrustedProfileRequest>,
+) -> Result<Response<pb::RemoveMeasurementTrustedProfileResponse>, Status> {
+    site::handle_remove_measurement_trusted_profile(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn list_trusted_profiles(
+    api: &Api,
+    request: Request<pb::ListMeasurementTrustedProfilesRequest>,
+) -> Result<Response<pb::ListMeasurementTrustedProfilesResponse>, Status> {
+    site::handle_list_measurement_trusted_profiles(api, request.into_inner())
+        .await
+        .map(Response::new)
+}
+
+pub async fn list_attestation_summary(
+    api: &Api,
+    request: Request<pb::ListAttestationSummaryRequest>,
+) -> Result<Response<pb::ListAttestationSummaryResponse>, Status> {
+    site::handle_list_attestation_summary(api, request.into_inner())
+        .await
+        .map(Response::new)
 }


### PR DESCRIPTION
## Description

The measured boot logic in `api.rs` is already pretty slim/boilerplate as it is, but since we have a `handlers/` pattern with everything, take advantage of the existing `handlers::measured_boot` (which is only used for a couple of calls), and move everything else in there.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

