### PR TITLE
chore(api-db): clean up clones + remove .to_string() where Encode works

### DIFF
--- a/crates/api-db/src/bmc_metadata.rs
+++ b/crates/api-db/src/bmc_metadata.rs
@@ -34,7 +34,7 @@ pub async fn update_bmc_network_into_topologies(
     let query = "UPDATE machine_topologies SET topology = jsonb_set(topology, '{bmc_info}', $1, true) WHERE machine_id=$2 RETURNING machine_id";
     sqlx::query_as::<_, MachineId>(query)
         .bind(json!(bmc_info))
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_optional(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?

--- a/crates/api-db/src/desired_firmware.rs
+++ b/crates/api-db/src/desired_firmware.rs
@@ -57,7 +57,7 @@ async fn snapshot_desired_firmware_for_model(
 
     sqlx::query(query)
         .bind(model.vendor.to_pascalcase())
-        .bind(model.model.clone())
+        .bind(&model.model)
         .bind(sqlx::types::Json(DesiredFirmwareVersions::from(
             model.clone(),
         )))

--- a/crates/api-db/src/dpa_interface.rs
+++ b/crates/api-db/src/dpa_interface.rs
@@ -444,7 +444,7 @@ pub async fn try_update_network_config(
     let query_result: Result<DpaInterfaceId, _> = sqlx::query_as(query)
         .bind(next_version)
         .bind(sqlx::types::Json(new_state))
-        .bind(interface_id.to_string())
+        .bind(interface_id)
         .bind(expected_version)
         .fetch_one(txn)
         .await;

--- a/crates/api-db/src/dpu_machine_update.rs
+++ b/crates/api-db/src/dpu_machine_update.rs
@@ -58,7 +58,7 @@ pub async fn trigger_reprovisioning_for_managed_host(
         let query = r#"UPDATE machines SET reprovisioning_requested=$1 WHERE controller_state = '{"state": "ready"}' AND id=$2 RETURNING id"#;
         sqlx::query(query)
             .bind(sqlx::types::Json(req))
-            .bind(machine_update.dpu_machine_id.to_string())
+            .bind(machine_update.dpu_machine_id)
             .fetch_one(inner_txn.as_pgconn())
             .await
             .map_err(|err: sqlx::Error| match err {

--- a/crates/api-db/src/dpu_remediation.rs
+++ b/crates/api-db/src/dpu_remediation.rs
@@ -269,7 +269,7 @@ pub async fn find_remediations_by_remediation_id_and_machine(
     let query = "SELECT * FROM applied_dpu_remediations WHERE id=$1 AND dpu_machine_id=$2 ORDER BY attempt DESC";
     sqlx::query_as(query)
         .bind(remediation_id)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_all(txn.deref_mut())
         .await
         .map_err(|e| DatabaseError::new(query, e))

--- a/crates/api-db/src/host_machine_update.rs
+++ b/crates/api-db/src/host_machine_update.rs
@@ -102,7 +102,7 @@ pub async fn trigger_host_reprovisioning_request(
     // The WHERE on controller state means that we'll update it in the case where we were in ready, but not when assigned.
     let query = r#"UPDATE machines SET host_reprovisioning_requested=$2, update_complete = false WHERE id=$1 RETURNING id"#;
     let _id = sqlx::query_as::<_, MachineId>(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .bind(sqlx::types::Json(req))
         .fetch_one(&mut *txn)
         .await
@@ -117,7 +117,7 @@ pub async fn clear_host_reprovisioning_request(
 ) -> Result<(), DatabaseError> {
     let query = "UPDATE machines SET host_reprovisioning_requested = NULL WHERE id=$1 RETURNING id";
     let _id = sqlx::query_as::<_, MachineId>(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -133,7 +133,7 @@ pub async fn reset_host_reprovisioning_request(
     // The WHERE on controller state means that we'll update it in the case where we were in ready, but not when assigned.
     let query = r#"UPDATE machines SET host_reprovisioning_requested = jsonb_set(host_reprovisioning_requested, '{request_reset}', $2::jsonb) WHERE id=$1 RETURNING id"#;
     let _id = sqlx::query_as::<_, MachineId>(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .bind(sqlx::types::Json(!clear_reset))
         .fetch_one(&mut *txn)
         .await

--- a/crates/api-db/src/instance.rs
+++ b/crates/api-db/src/instance.rs
@@ -149,7 +149,7 @@ pub async fn find_id_by_machine_id(
 ) -> Result<Option<InstanceId>, DatabaseError> {
     let query = "SELECT id from instances WHERE machine_id = $1";
     sqlx::query_as(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_optional(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))
@@ -161,7 +161,7 @@ pub async fn find_by_machine_id(
 ) -> Result<Option<InstanceSnapshot>, DatabaseError> {
     let query = "SELECT row_to_json(i.*) from instances i WHERE machine_id = $1";
     sqlx::query_as(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_optional(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))
@@ -216,7 +216,7 @@ pub async fn use_custom_ipxe_on_next_boot(
     // Fetch one to make sure atleast one row is updated.
     let _: (MachineId,) = sqlx::query_as(query)
         .bind(boot_with_custom_ipxe)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -236,7 +236,7 @@ pub async fn set_custom_pxe_reboot_requested(
     let query = "UPDATE instances SET custom_pxe_reboot_requested=$1::bool WHERE machine_id=$2 RETURNING machine_id";
     let _: (MachineId,) = sqlx::query_as(query)
         .bind(requested)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -554,7 +554,7 @@ pub async fn update_reboot_requested_time(
     let query = "UPDATE machines SET last_reboot_requested=$1 WHERE id=$2 RETURNING id";
     let _id = sqlx::query_as::<_, MachineId>(query)
         .bind(sqlx::types::Json(&data))
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -574,7 +574,7 @@ pub async fn update_restart_verification_status(
     let query = "UPDATE machines SET last_reboot_requested=$1 WHERE id=$2 RETURNING id";
     let _id = sqlx::query_as::<_, MachineId>(query)
         .bind(sqlx::types::Json(&current_reboot))
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -601,7 +601,7 @@ pub async fn update_bios_password_set_time(
 ) -> Result<(), DatabaseError> {
     let query = "UPDATE machines SET bios_password_set_time=NOW() WHERE id=$1 RETURNING id";
     let _id = sqlx::query_as::<_, MachineId>(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -615,7 +615,7 @@ pub async fn update_discovery_time(
 ) -> Result<(), DatabaseError> {
     let query = "UPDATE machines SET last_discovery_time=NOW() WHERE id=$1 RETURNING id";
     let _id = sqlx::query_as::<_, MachineId>(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -629,7 +629,7 @@ pub async fn update_scout_contact_time(
 ) -> Result<(), DatabaseError> {
     let query = "UPDATE machines SET last_scout_contact_time=NOW() WHERE id=$1 RETURNING id";
     let _id = sqlx::query_as::<_, MachineId>(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -649,7 +649,7 @@ pub async fn find_host_by_dpu_machine_id(
         );
     }
     let machine = sqlx::query_as(&query)
-        .bind(dpu_machine_id.to_string())
+        .bind(dpu_machine_id)
         .fetch_optional(txn)
         .await
         .map_err(|e| DatabaseError::query(&query, e))?;
@@ -692,7 +692,7 @@ pub async fn find_dpus_by_host_machine_id(
         );
     }
     let machines = sqlx::query_as(&query)
-        .bind(host_machine_id.to_string())
+        .bind(host_machine_id)
         .fetch_all(txn)
         .await
         .map_err(|e| DatabaseError::query(&query, e))?;
@@ -718,7 +718,7 @@ pub async fn update_metadata(
         .bind(&metadata.name)
         .bind(&metadata.description)
         .bind(sqlx::types::Json(&metadata.labels))
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .bind(expected_version)
         .fetch_one(txn)
         .await;
@@ -747,7 +747,7 @@ pub async fn update_network_status_observation(
                 ) RETURNING id";
     let _id: (MachineId,) = match sqlx::query_as(query)
         .bind(sqlx::types::Json(&observation))
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .bind(observation.observed_at)
         .fetch_one(&mut *txn)
         .await
@@ -786,7 +786,7 @@ pub async fn update_infiniband_status_observation(
             ) RETURNING id";
     let _id: (MachineId,) = sqlx::query_as(query)
         .bind(sqlx::types::Json(&observation))
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .bind(observation.observed_at.to_rfc3339())
         .fetch_one(txn)
         .await
@@ -804,7 +804,7 @@ pub async fn update_nvlink_status_observation(
                 (nvlink_status_observation->>'observed_at' IS NULL OR nvlink_status_observation->>'observed_at' <= $3) RETURNING id";
     let _id: (MachineId,) = sqlx::query_as(query)
         .bind(sqlx::types::Json(&observation))
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .bind(observation.observed_at.to_rfc3339())
         .fetch_one(txn)
         .await
@@ -829,7 +829,7 @@ async fn update_health_report(
     let observed_at = health_report.observed_at.unwrap_or_else(chrono::Utc::now);
     let _id: (MachineId,) = match sqlx::query_as(&query)
         .bind(sqlx::types::Json(&health_report))
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .bind(observed_at)
         .fetch_one(&mut *txn)
         .await
@@ -862,7 +862,7 @@ async fn debug_failed_machine_status_update(
     // Dump the raw Machine state for debugging purposes
     let query = "SELECT * from machines WHERE id = $1";
     match sqlx::query(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_optional(txn)
         .await
     {
@@ -915,7 +915,7 @@ pub async fn update_log_parser_health_report(
     );
     let _id: (MachineId,) = sqlx::query_as(&query)
         .bind(sqlx::types::Json(&health_report))
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::new("update health report", e))?;
@@ -1002,7 +1002,7 @@ pub async fn insert_health_report_override(
 
     let _id: (MachineId,) = sqlx::query_as(&query)
         .bind(sqlx::types::Json(&health_report))
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::new("insert health report override", e))?;
@@ -1027,7 +1027,7 @@ pub async fn remove_health_report_override(
     );
 
     let _id: (MachineId,) = sqlx::query_as(&query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::new("remove health report override", e))?;
@@ -1045,7 +1045,7 @@ pub async fn update_agent_reported_inventory(
     tracing::debug!(machine_id = %machine_id, "Updating machine inventory");
     let _id: (MachineId,) = sqlx::query_as(query)
         .bind(sqlx::types::Json(&inventory))
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -1089,7 +1089,7 @@ pub async fn force_cleanup(
     // it stays up to date.
     let query = r#"call cleanup_machine_by_id($1)"#;
     let _query_result = sqlx::query(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .execute(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -1115,7 +1115,7 @@ pub async fn try_update_network_config(
     let query_result: Result<MachineId, _> = sqlx::query_as(query)
         .bind(next_version)
         .bind(sqlx::types::Json(new_state))
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .bind(expected_version)
         .fetch_one(txn)
         .await;
@@ -1165,8 +1165,8 @@ pub async fn try_sync_stable_id_with_current_machine_id_for_host(
     // also change.
     let query = "UPDATE machines SET id=$1 WHERE id=$2 RETURNING id";
     let machine_id = sqlx::query_as(query)
-        .bind(stable_machine_id.to_string())
-        .bind(current_machine_id.to_string())
+        .bind(stable_machine_id)
+        .bind(current_machine_id)
         .fetch_one(&mut *txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -1176,9 +1176,9 @@ pub async fn try_sync_stable_id_with_current_machine_id_for_host(
     // If someone changed the name manually then don't bother
     let query = "UPDATE machines SET name=$1 WHERE id=$2 AND name=$3";
     sqlx::query(query)
-        .bind(stable_machine_id.to_string())
-        .bind(stable_machine_id.to_string())
-        .bind(current_machine_id.to_string())
+        .bind(stable_machine_id)
+        .bind(stable_machine_id)
+        .bind(current_machine_id)
         .execute(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -1207,7 +1207,7 @@ pub async fn clear_failure_details(
     let query = "UPDATE machines SET failure_details = $1::json WHERE id = $2 RETURNING id";
     let _id: (MachineId,) = sqlx::query_as(query)
         .bind(sqlx::types::Json(failure_details))
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -1331,7 +1331,7 @@ pub async fn trigger_dpu_reprovisioning_request(
 
     let query = "UPDATE machines SET reprovisioning_requested=$2 WHERE id=$1 RETURNING id";
     let _id = sqlx::query_as::<_, MachineId>(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .bind(sqlx::types::Json(req))
         .fetch_one(txn)
         .await
@@ -1352,7 +1352,7 @@ pub async fn update_dpu_reprovision_start_time(
                                                 '{started_at}', $2, true)
                        WHERE id=$1 RETURNING id"#;
     let _id = sqlx::query_as::<_, MachineId>(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .bind(sqlx::types::Json(current_time))
         .fetch_one(txn)
         .await
@@ -1372,7 +1372,7 @@ pub async fn update_host_reprovision_start_time(
                                                 '{started_at}', $2, true)
                        WHERE id=$1 RETURNING id"#;
     let _id = sqlx::query_as::<_, MachineId>(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .bind(sqlx::types::Json(current_time))
         .fetch_one(txn)
         .await
@@ -1426,7 +1426,7 @@ pub async fn update_update_complete(
                         SET update_complete = $2
                        WHERE id=$1 RETURNING id"#;
     let _id = sqlx::query_as::<_, MachineId>(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .bind(complete)
         .fetch_one(txn)
         .await
@@ -1443,7 +1443,7 @@ pub async fn update_controller_state_outcome(
     let query = "UPDATE machines SET controller_state_outcome=$1 WHERE id=$2";
     sqlx::query(query)
         .bind(sqlx::types::Json(outcome))
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .execute(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -1461,7 +1461,7 @@ pub async fn approve_dpu_reprovision_request(
                                                 '{user_approval_received}', $2, true)
                        WHERE id=$1 RETURNING id"#;
     let _id = sqlx::query_as::<_, MachineId>(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .bind(sqlx::types::Json(true))
         .fetch_one(txn)
         .await
@@ -1480,7 +1480,7 @@ pub async fn approve_host_reprovision_request(
                                                 '{user_approval_received}', $2, true)
                        WHERE id=$1 RETURNING id"#;
     let _id = sqlx::query_as::<_, MachineId>(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .bind(sqlx::types::Json(true))
         .fetch_one(txn)
         .await
@@ -1535,7 +1535,7 @@ pub async fn clear_dpu_reprovisioning_request(
     };
 
     let _id = sqlx::query_as::<_, MachineId>(&query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::new("clear reprovisioning_requested", e))?;
@@ -1627,7 +1627,7 @@ pub async fn set_dpu_agent_upgrade_requested(
     let query = "UPDATE machines SET dpu_agent_upgrade_requested = $1::json WHERE id = $2";
     sqlx::query(query)
         .bind(sqlx::types::Json(decision))
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .execute(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -1745,7 +1745,7 @@ pub async fn update_machine_validation_time(
 ) -> Result<(), DatabaseError> {
     let query = "UPDATE machines SET last_machine_validation_time=NOW() WHERE id=$1 RETURNING id";
     let _id = sqlx::query_as::<_, MachineId>(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -1761,7 +1761,7 @@ pub async fn update_machine_validation_id(
     let base_query = "UPDATE machines SET {column}=$1 WHERE id=$2 RETURNING id".to_owned();
     sqlx::query_as(&base_query.replace("{column}", context_column_name.as_str()))
         .bind(validation_id)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::query(&base_query, e))
@@ -1775,7 +1775,7 @@ pub async fn update_failure_details_by_machine_id(
     let query = "UPDATE machines SET failure_details = $1::json WHERE id = $2 RETURNING id";
     let _id: (MachineId,) = sqlx::query_as(query)
         .bind(sqlx::types::Json(failure))
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -1957,7 +1957,7 @@ pub async fn set_machine_validation_request(
     let query =
         "UPDATE machines SET on_demand_machine_validation_request=$2 WHERE id=$1 RETURNING id";
     let _id = sqlx::query_as::<_, MachineId>(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .bind(machine_validation_request)
         .fetch_one(txn)
         .await

--- a/crates/api-db/src/machine_health_history.rs
+++ b/crates/api-db/src/machine_health_history.rs
@@ -146,7 +146,7 @@ pub async fn persist(
         SELECT * FROM new_history_record
         WHERE NOT EXISTS (SELECT health_hash FROM last_history_record WHERE last_history_record.health_hash = new_history_record.health_hash);";
     let _query_result = sqlx::query(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .bind(sqlx::types::Json(health))
         .bind(health_hash)
         .bind(chrono::Utc::now())
@@ -165,8 +165,8 @@ pub async fn update_machine_ids(
 ) -> Result<(), DatabaseError> {
     let query = "UPDATE machine_health_history SET machine_id=$1 WHERE machine_id=$2";
     sqlx::query(query)
-        .bind(new_machine_id.to_string())
-        .bind(old_machine_id.to_string())
+        .bind(new_machine_id)
+        .bind(old_machine_id)
         .execute(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -148,7 +148,7 @@ pub async fn associate_interface_with_dpu_machine(
     let query =
         "UPDATE machine_interfaces SET attached_dpu_machine_id=$1 where id=$2::uuid RETURNING id";
     sqlx::query_as(query)
-        .bind(dpu_machine_id.to_string())
+        .bind(dpu_machine_id)
         .bind(*interface_id)
         .fetch_one(txn)
         .await
@@ -774,7 +774,7 @@ pub async fn find_by_machine_and_segment(
         );
     }
     sqlx::query_as::<_, MachineInterfaceSnapshot>(&query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .bind(segment_id)
         .fetch_all(txn)
         .await

--- a/crates/api-db/src/machine_state_history.rs
+++ b/crates/api-db/src/machine_state_history.rs
@@ -103,7 +103,7 @@ pub async fn persist(
         VALUES ($1, $2, $3)
         RETURNING machine_id, state::TEXT, state_version, timestamp";
     sqlx::query_as::<_, DbMachineStateHistory>(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .bind(sqlx::types::Json(state))
         .bind(state_version)
         .fetch_one(txn)
@@ -120,8 +120,8 @@ pub async fn update_machine_ids(
 ) -> Result<(), DatabaseError> {
     let query = "UPDATE machine_state_history SET machine_id=$1 WHERE machine_id=$2";
     sqlx::query(query)
-        .bind(new_machine_id.to_string())
-        .bind(old_machine_id.to_string())
+        .bind(new_machine_id)
+        .bind(old_machine_id)
         .execute(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;

--- a/crates/api-db/src/machine_topology.rs
+++ b/crates/api-db/src/machine_topology.rs
@@ -39,7 +39,7 @@ async fn update(
     );
     let query = "UPDATE machine_topologies SET topology=jsonb_set(topology, '{discovery_data}', $2::jsonb), topology_update_needed=false, updated=NOW() WHERE machine_id=$1 RETURNING *";
     let res = sqlx::query_as(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .bind(sqlx::types::Json(&discovery_data))
         .fetch_one(txn)
         .await
@@ -83,7 +83,7 @@ pub async fn create_or_update(
 
     let query = "INSERT INTO machine_topologies VALUES ($1, $2::json) RETURNING *";
     let res = sqlx::query_as(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .bind(sqlx::types::Json(&topology_data))
         .fetch_one(txn)
         .await
@@ -301,7 +301,7 @@ pub async fn set_topology_update_needed(
 ) -> Result<(), DatabaseError> {
     let query = "UPDATE machine_topologies SET topology_update_needed=$2 WHERE machine_id=$1 RETURNING machine_id";
     let _id = sqlx::query_as::<_, MachineId>(query)
-        .bind(machine_id.to_string())
+        .bind(machine_id)
         .bind(value)
         .fetch_one(txn)
         .await
@@ -386,7 +386,7 @@ pub mod test_helpers {
         );
         let query = "UPDATE machine_topologies SET topology=jsonb_set(topology, '{discovery_data}', $2::jsonb), topology_update_needed=false, updated=NOW() WHERE machine_id=$1 RETURNING *";
         let res = sqlx::query_as(query)
-            .bind(machine_id.to_string())
+            .bind(machine_id)
             .bind(sqlx::types::Json(&discovery_data))
             .fetch_one(txn)
             .await
@@ -430,7 +430,7 @@ pub mod test_helpers {
 
         let query = "INSERT INTO machine_topologies VALUES ($1, $2::json) RETURNING *";
         let res = sqlx::query_as(query)
-            .bind(machine_id.to_string())
+            .bind(machine_id)
             .bind(sqlx::types::Json(&topology_data))
             .fetch_one(txn)
             .await

--- a/crates/api-db/src/machine_validation.rs
+++ b/crates/api-db/src/machine_validation.rs
@@ -147,7 +147,7 @@ pub async fn create_new_run(
         .bind(format!("Test_{machine_id}"))
         .bind(machine_id)
         .bind(sqlx::types::Json(filter))
-        .bind(context.clone())
+        .bind(&context)
         .bind(format!("Running validation on {machine_id}"))
         .bind(status.state.to_string())
         .execute(&mut *txn)

--- a/crates/api-db/src/measured_boot/interface/bundle.rs
+++ b/crates/api-db/src/measured_boot/interface/bundle.rs
@@ -42,7 +42,7 @@ pub async fn insert_measurement_bundle_record(
             let query = "insert into measurement_bundles(profile_id, name, state) values($1, $2, $3) returning *";
             sqlx::query_as(query)
                 .bind(profile_id)
-                .bind(name.clone())
+                .bind(&name)
                 .bind(set_state)
                 .fetch_one(txn)
                 .await
@@ -52,7 +52,7 @@ pub async fn insert_measurement_bundle_record(
                 "insert into measurement_bundles(profile_id, name) values($1, $2) returning *";
             sqlx::query_as(query)
                 .bind(profile_id)
-                .bind(name.clone())
+                .bind(&name)
                 .fetch_one(txn)
                 .await
         }
@@ -343,7 +343,7 @@ pub async fn import_measurement_bundle(
     sqlx::query_as(&query)
         .bind(bundle.bundle_id)
         .bind(bundle.profile_id)
-        .bind(bundle.name.clone())
+        .bind(&bundle.name)
         .bind(bundle.ts)
         .bind(bundle.state)
         .fetch_one(txn)
@@ -383,7 +383,7 @@ pub async fn import_measurement_bundles_value(
         .bind(bundle.value_id)
         .bind(bundle.bundle_id)
         .bind(bundle.pcr_register)
-        .bind(bundle.sha_any.clone())
+        .bind(&bundle.sha_any)
         .bind(bundle.ts)
         .fetch_one(txn)
         .await

--- a/crates/api-db/src/measured_boot/interface/profile.rs
+++ b/crates/api-db/src/measured_boot/interface/profile.rs
@@ -38,10 +38,7 @@ pub async fn insert_measurement_profile_record(
     name: String,
 ) -> Result<MeasurementSystemProfileRecord, sqlx::Error> {
     let query = "insert into measurement_system_profiles(name) values($1) returning *";
-    sqlx::query_as(query)
-        .bind(name.clone())
-        .fetch_one(txn)
-        .await
+    sqlx::query_as(query).bind(&name).fetch_one(txn).await
 }
 
 /// insert_measurement_profile_attr_records takes a hashmap of
@@ -385,7 +382,7 @@ pub async fn import_measurement_profile(
 
     sqlx::query_as(&query)
         .bind(profile.profile_id)
-        .bind(profile.name.clone())
+        .bind(&profile.name)
         .bind(profile.ts)
         .fetch_one(txn)
         .await
@@ -426,8 +423,8 @@ pub async fn import_measurement_system_profiles_attr(
     sqlx::query_as(&query)
         .bind(bundle.attribute_id)
         .bind(bundle.profile_id)
-        .bind(bundle.key.clone())
-        .bind(bundle.value.clone())
+        .bind(&bundle.key)
+        .bind(&bundle.value)
         .bind(bundle.ts)
         .fetch_one(txn)
         .await

--- a/crates/api-db/src/network_devices.rs
+++ b/crates/api-db/src/network_devices.rs
@@ -182,7 +182,7 @@ pub mod dpu_to_network_device_map {
                        RETURNING *"#;
 
         sqlx::query_as(query)
-            .bind(dpu_id.to_string())
+            .bind(dpu_id)
             .bind(local_port)
             .bind(remote_port)
             .bind(network_device_id)
@@ -201,7 +201,7 @@ pub mod dpu_to_network_device_map {
         let query = r#"DELETE from port_to_network_device_map WHERE dpu_id=$1 RETURNING dpu_id"#;
 
         let _ids = sqlx::query_as::<_, MachineId>(query)
-            .bind(dpu_id.to_string())
+            .bind(dpu_id)
             .fetch_all(txn.deref_mut())
             .await
             .map_err(|e| DatabaseError::query(query, e))?;

--- a/crates/api-db/src/nvl_logical_partition.rs
+++ b/crates/api-db/src/nvl_logical_partition.rs
@@ -236,8 +236,8 @@ impl NewLogicalPartition {
 
         let partition: LogicalPartitionSnapshotPgJson = sqlx::query_as(query)
             .bind(self.id)
-            .bind(config.metadata.name.clone())
-            .bind(config.metadata.description.clone())
+            .bind(&config.metadata.name)
+            .bind(&config.metadata.description)
             .bind(config.tenant_organization_id.to_string())
             .bind(config_version)
             .bind(sqlx::types::Json(&state))
@@ -371,7 +371,7 @@ pub async fn update(
 
     let partition: NvLinkLogicalPartitionId = sqlx::query_as(query)
         .bind(name)
-        .bind(partition.description.clone())
+        .bind(&partition.description)
         .bind(partition.id)
         .fetch_one(txn)
         .await

--- a/crates/api-db/src/nvl_partition.rs
+++ b/crates/api-db/src/nvl_partition.rs
@@ -148,7 +148,7 @@ impl NewNvlPartition {
         let partition: NvlPartitionSnapshotPgJson = sqlx::query_as(query)
             .bind(self.id)
             .bind(&self.nmx_m_id)
-            .bind(self.name.0.clone())
+            .bind(&self.name.0)
             .bind(self.domain_uuid)
             .bind(self.logical_partition_id)
             .fetch_one(txn)

--- a/crates/api-db/src/power_shelf.rs
+++ b/crates/api-db/src/power_shelf.rs
@@ -60,8 +60,8 @@ pub async fn create(
         "INSERT INTO power_shelves (id, name, config, controller_state, controller_state_version) VALUES ($1, $2, $3, $4, $5) RETURNING id",
     );
     let _: PowerShelfId = query
-        .bind(new_power_shelf.id.to_string())
-        .bind(new_power_shelf.config.name.clone())
+        .bind(new_power_shelf.id)
+        .bind(&new_power_shelf.config.name)
         .bind(sqlx::types::Json(&new_power_shelf.config))
         .bind(sqlx::types::Json(&state))
         .bind(version)

--- a/crates/api-db/src/switch.rs
+++ b/crates/api-db/src/switch.rs
@@ -55,8 +55,8 @@ pub async fn create(txn: &mut PgConnection, new_switch: &NewSwitch) -> DatabaseR
         "INSERT INTO switches (id, name, config, controller_state, controller_state_version) VALUES ($1, $2, $3, $4, $5) RETURNING id",
     );
     let id = query
-        .bind(new_switch.id.to_string())
-        .bind(new_switch.config.name.clone())
+        .bind(new_switch.id)
+        .bind(&new_switch.config.name)
         .bind(sqlx::types::Json(&new_switch.config))
         .bind(sqlx::types::Json(&state))
         .bind(version)

--- a/crates/api-db/src/tenant_keyset.rs
+++ b/crates/api-db/src/tenant_keyset.rs
@@ -61,8 +61,7 @@ pub async fn find_by_ids(
         "SELECT * FROM tenant_keysets WHERE (organization_id, keyset_id) IN ",
     );
     builder.push_tuples(ids.iter(), |mut b, id| {
-        b.push_bind(id.organization_id.clone())
-            .push_bind(id.keyset_id.clone());
+        b.push_bind(&id.organization_id).push_bind(&id.keyset_id);
     });
     // execute
     let query = builder.build_query_as();


### PR DESCRIPTION
## Description

Just doing a little housekeeping. Remove `.clone()` where we don't need it, and drop `.to_string()` in places where the underlying type implements `Encode` and can `.bind()` naturally.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

