### PR TITLE
feat: Emit metrics with `carbide_` and additional prefix

### DIFF
--- a/book/src/manuals/metrics/carbide_core_metrics.md
+++ b/book/src/manuals/metrics/carbide_core_metrics.md
@@ -4,6 +4,7 @@ This file contains a list of metrics exported by Carbide. The list is auto-gener
 
 <table>
 <tr><td>Name</td><td>Type</td><td>Description</td></tr>
+<tr><td>carbide_active_host_firmware_update_count</td><td>gauge</td><td>The number of host machines in the system currently working on updating their firmware.</td></tr>
 <tr><td>carbide_api_db_queries_total</td><td>counter</td><td>The amount of database queries that occured inside a span</td></tr>
 <tr><td>carbide_api_db_span_query_time_milliseconds</td><td>histogram</td><td>Total time the request spent inside a span on database transactions</td></tr>
 <tr><td>carbide_api_grpc_server_duration_milliseconds</td><td>histogram</td><td>Processing time for a request on the carbide API server</td></tr>
@@ -17,12 +18,83 @@ This file contains a list of metrics exported by Carbide. The list is auto-gener
 <tr><td>carbide_api_vault_requests_succeeded_total</td><td>counter</td><td>The amount of tls connections that were successful</td></tr>
 <tr><td>carbide_api_vault_token_time_until_refresh_seconds</td><td>gauge</td><td>The amount of time, in seconds, until the vault token is required to be refreshed</td></tr>
 <tr><td>carbide_api_version</td><td>gauge</td><td>Version (git sha, build date, etc) of this service</td></tr>
+<tr><td>carbide_available_ips_count</td><td>gauge</td><td>The total number of available ips in the site</td></tr>
+<tr><td>carbide_concurrent_machine_updates_available</td><td>gauge</td><td>The number of machines in the system that we will update concurrently.</td></tr>
 <tr><td>carbide_db_pool_idle_conns</td><td>gauge</td><td>The amount of idle connections in the carbide database pool</td></tr>
 <tr><td>carbide_db_pool_total_conns</td><td>gauge</td><td>The amount of total (active + idle) connections in the carbide database pool</td></tr>
+<tr><td>carbide_dpu_agent_version_count</td><td>gauge</td><td>The amount of Forge DPU agents which have reported a certain version.</td></tr>
+<tr><td>carbide_dpu_firmware_version_count</td><td>gauge</td><td>The amount of DPUs which have reported a certain firmware version.</td></tr>
+<tr><td>carbide_dpus_healthy_count</td><td>gauge</td><td>The total number of DPUs in the system that have reported healthy in the last report. Healthy does not imply up - the report from the DPU might be outdated.</td></tr>
+<tr><td>carbide_dpus_up_count</td><td>gauge</td><td>The total number of DPUs in the system that are up. Up means we have received a health report less than 5 minutes ago.</td></tr>
+<tr><td>carbide_endpoint_exploration_duration_milliseconds</td><td>histogram</td><td>The time it took to explore an endpoint</td></tr>
+<tr><td>carbide_endpoint_exploration_expected_machines_missing_overall_count</td><td>gauge</td><td>The total number of machines that were expected but not identified</td></tr>
+<tr><td>carbide_endpoint_exploration_expected_power_shelves_missing_overall_count</td><td>gauge</td><td>The total number of power shelves that were expected but not identified</td></tr>
+<tr><td>carbide_endpoint_exploration_identified_managed_hosts_overall_count</td><td>gauge</td><td>The total number of managed hosts identified by expectation</td></tr>
+<tr><td>carbide_endpoint_exploration_machines_explored_overall_count</td><td>gauge</td><td>The total number of machines explored by machine type</td></tr>
+<tr><td>carbide_endpoint_exploration_success_count</td><td>gauge</td><td>The amount of endpoint explorations that have been successful</td></tr>
+<tr><td>carbide_endpoint_explorations_count</td><td>gauge</td><td>The amount of endpoint explorations that have been attempted</td></tr>
+<tr><td>carbide_gpus_in_use_count</td><td>gauge</td><td>The total number of GPUs that are actively used by tenants in instances in the Forge site</td></tr>
+<tr><td>carbide_gpus_total_count</td><td>gauge</td><td>The total number of GPUs available in the Forge site</td></tr>
+<tr><td>carbide_gpus_usable_count</td><td>gauge</td><td>The remaining number of GPUs in the Forge site which are available for immediate instance creation</td></tr>
+<tr><td>carbide_hosts_by_sku_count</td><td>gauge</td><td>The amount of hosts by SKU and device type (&#x27;unknown&#x27; for hosts without SKU)</td></tr>
+<tr><td>carbide_hosts_health_overrides_count</td><td>gauge</td><td>The amount of health overrides that are configured in the site</td></tr>
+<tr><td>carbide_hosts_health_status_count</td><td>gauge</td><td>The total number of Managed Hosts in the system that have reported any a healthy nor not healthy status - based on the presence of health probe alerts</td></tr>
+<tr><td>carbide_hosts_in_use_count</td><td>gauge</td><td>The total number of hosts that are actively used by tenants as instances in the Forge site</td></tr>
+<tr><td>carbide_hosts_usable_count</td><td>gauge</td><td>The remaining number of hosts in the Forge site which are available for immediate instance creation</td></tr>
+<tr><td>carbide_hosts_with_bios_password_set</td><td>gauge</td><td>The total number of Hosts in the system that have their BIOS password set.</td></tr>
+<tr><td>carbide_ib_partitions_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_ib_partitions in the system</td></tr>
+<tr><td>carbide_ib_partitions_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to handle state for all carbide_ib_partitions in the system</td></tr>
+<tr><td>carbide_ib_partitions_object_tasks_enqueued_total</td><td>counter</td><td>The amount of types that object handling tasks that have been freshly enqueued for objects of type carbide_ib_partitions</td></tr>
+<tr><td>carbide_ib_partitions_total</td><td>gauge</td><td>The total number of carbide_ib_partitions in the system</td></tr>
+<tr><td>carbide_machine_updates_started_count</td><td>gauge</td><td>The number of machines in the system that in the process of updating.</td></tr>
+<tr><td>carbide_machine_validation_completed</td><td>gauge</td><td>Count of machine validation that have completed successfully</td></tr>
+<tr><td>carbide_machine_validation_failed</td><td>gauge</td><td>Count of machine validation that have failed</td></tr>
+<tr><td>carbide_machine_validation_in_progress</td><td>gauge</td><td>Count of machine validation that are in progress</td></tr>
+<tr><td>carbide_machine_validation_tests</td><td>gauge</td><td>The details of machine validation tests</td></tr>
+<tr><td>carbide_machines_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_machines in the system</td></tr>
+<tr><td>carbide_machines_handler_latency_in_state_milliseconds</td><td>histogram</td><td>The amount of time it took to invoke the state handler for objects of type carbide_machines in a certain state</td></tr>
+<tr><td>carbide_machines_in_maintenance_count</td><td>gauge</td><td>The total number of machines in the system that are in maintenance.</td></tr>
+<tr><td>carbide_machines_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to handle state for all carbide_machines in the system</td></tr>
+<tr><td>carbide_machines_object_tasks_completed_total</td><td>counter</td><td>The amount of object handling tasks that have been completed for objects of type carbide_machines</td></tr>
+<tr><td>carbide_machines_object_tasks_dispatched_total</td><td>counter</td><td>The amount of types that object handling tasks that have been dequeued and dispatched for processing for objects of type carbide_machines</td></tr>
+<tr><td>carbide_machines_object_tasks_enqueued_total</td><td>counter</td><td>The amount of types that object handling tasks that have been freshly enqueued for objects of type carbide_machines</td></tr>
+<tr><td>carbide_machines_object_tasks_requeued_total</td><td>counter</td><td>The amount of object handling tasks that have been requeued for objects of type carbide_machines</td></tr>
+<tr><td>carbide_machines_per_state</td><td>gauge</td><td>The number of carbide_machines in the system with a given state</td></tr>
+<tr><td>carbide_machines_per_state_above_sla</td><td>gauge</td><td>The number of carbide_machines in the system which had been longer in a state than allowed per SLA</td></tr>
+<tr><td>carbide_machines_state_entered_total</td><td>counter</td><td>The amount of types that objects of type carbide_machines have entered a certain state</td></tr>
+<tr><td>carbide_machines_state_exited_total</td><td>counter</td><td>The amount of types that objects of type carbide_machines have exited a certain state</td></tr>
+<tr><td>carbide_machines_time_in_state_seconds</td><td>histogram</td><td>The amount of time objects of type carbide_machines have spent in a certain state</td></tr>
+<tr><td>carbide_machines_total</td><td>gauge</td><td>The total number of carbide_machines in the system</td></tr>
+<tr><td>carbide_machines_with_state_handling_errors_per_state</td><td>gauge</td><td>The number of carbide_machines in the system with a given state that failed state handling</td></tr>
+<tr><td>carbide_measured_boot_bundles_total</td><td>gauge</td><td>The total number of measured boot bundles.</td></tr>
+<tr><td>carbide_measured_boot_machines_per_bundle_state_total</td><td>gauge</td><td>The total number of machines per a given measured boot bundle state.</td></tr>
+<tr><td>carbide_measured_boot_machines_per_machine_state_total</td><td>gauge</td><td>The total number of machines per a given measured boot machine state.</td></tr>
+<tr><td>carbide_measured_boot_machines_total</td><td>gauge</td><td>The total number of machines reporting measurements.</td></tr>
+<tr><td>carbide_measured_boot_profiles_total</td><td>gauge</td><td>The total number of measured boot profiles.</td></tr>
+<tr><td>carbide_network_segments_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_network_segments in the system</td></tr>
+<tr><td>carbide_network_segments_handler_latency_in_state_milliseconds</td><td>histogram</td><td>The amount of time it took to invoke the state handler for objects of type carbide_network_segments in a certain state</td></tr>
+<tr><td>carbide_network_segments_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to handle state for all carbide_network_segments in the system</td></tr>
+<tr><td>carbide_network_segments_object_tasks_completed_total</td><td>counter</td><td>The amount of object handling tasks that have been completed for objects of type carbide_network_segments</td></tr>
+<tr><td>carbide_network_segments_object_tasks_dispatched_total</td><td>counter</td><td>The amount of types that object handling tasks that have been dequeued and dispatched for processing for objects of type carbide_network_segments</td></tr>
+<tr><td>carbide_network_segments_object_tasks_enqueued_total</td><td>counter</td><td>The amount of types that object handling tasks that have been freshly enqueued for objects of type carbide_network_segments</td></tr>
+<tr><td>carbide_network_segments_object_tasks_requeued_total</td><td>counter</td><td>The amount of object handling tasks that have been requeued for objects of type carbide_network_segments</td></tr>
+<tr><td>carbide_network_segments_per_state</td><td>gauge</td><td>The number of carbide_network_segments in the system with a given state</td></tr>
+<tr><td>carbide_network_segments_per_state_above_sla</td><td>gauge</td><td>The number of carbide_network_segments in the system which had been longer in a state than allowed per SLA</td></tr>
+<tr><td>carbide_network_segments_state_entered_total</td><td>counter</td><td>The amount of types that objects of type carbide_network_segments have entered a certain state</td></tr>
+<tr><td>carbide_network_segments_state_exited_total</td><td>counter</td><td>The amount of types that objects of type carbide_network_segments have exited a certain state</td></tr>
+<tr><td>carbide_network_segments_time_in_state_seconds</td><td>histogram</td><td>The amount of time objects of type carbide_network_segments have spent in a certain state</td></tr>
+<tr><td>carbide_network_segments_total</td><td>gauge</td><td>The total number of carbide_network_segments in the system</td></tr>
+<tr><td>carbide_network_segments_with_state_handling_errors_per_state</td><td>gauge</td><td>The number of carbide_network_segments in the system with a given state that failed state handling</td></tr>
 <tr><td>carbide_nvlink_partition_monitor_nmxm_changes_applied_total</td><td>counter</td><td>Number of changes requested to Nmx-M</td></tr>
+<tr><td>carbide_pending_dpu_nic_firmware_update_count</td><td>gauge</td><td>The number of machines in the system that need a firmware update.</td></tr>
+<tr><td>carbide_pending_host_firmware_update_count</td><td>gauge</td><td>The number of host machines in the system that need a firmware update.</td></tr>
 <tr><td>carbide_power_shelves_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_power_shelves in the system</td></tr>
+<tr><td>carbide_power_shelves_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to handle state for all carbide_power_shelves in the system</td></tr>
 <tr><td>carbide_power_shelves_object_tasks_enqueued_total</td><td>counter</td><td>The amount of types that object handling tasks that have been freshly enqueued for objects of type carbide_power_shelves</td></tr>
 <tr><td>carbide_power_shelves_total</td><td>gauge</td><td>The total number of carbide_power_shelves in the system</td></tr>
+<tr><td>carbide_preingestion_total</td><td>gauge</td><td>The amount of known machines currently being evaluated prior to ingestion</td></tr>
+<tr><td>carbide_preingestion_waiting_download</td><td>gauge</td><td>The amount of machines that are waiting for firmware downloads on other machines to complete before doing thier own</td></tr>
+<tr><td>carbide_preingestion_waiting_installation</td><td>gauge</td><td>The amount of machines which have had firmware uploaded to them and are currently in the process of installing that firmware</td></tr>
 <tr><td>carbide_racks_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_racks in the system</td></tr>
 <tr><td>carbide_racks_handler_latency_in_state_milliseconds</td><td>histogram</td><td>The amount of time it took to invoke the state handler for objects of type carbide_racks in a certain state</td></tr>
 <tr><td>carbide_racks_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to handle state for all carbide_racks in the system</td></tr>
@@ -33,89 +105,22 @@ This file contains a list of metrics exported by Carbide. The list is auto-gener
 <tr><td>carbide_racks_per_state_above_sla</td><td>gauge</td><td>The number of carbide_racks in the system which had been longer in a state than allowed per SLA</td></tr>
 <tr><td>carbide_racks_total</td><td>gauge</td><td>The total number of carbide_racks in the system</td></tr>
 <tr><td>carbide_racks_with_state_handling_errors_per_state</td><td>gauge</td><td>The number of carbide_racks in the system with a given state that failed state handling</td></tr>
+<tr><td>carbide_reboot_attempts_in_booting_with_discovery_image</td><td>histogram</td><td>The amount of machines rebooted again in BootingWithDiscoveryImage since there is no response after a certain time from host.</td></tr>
+<tr><td>carbide_reserved_ips_count</td><td>gauge</td><td>The total number of reserved ips in the site</td></tr>
 <tr><td>carbide_resourcepool_free_count</td><td>gauge</td><td>Count of values in the pool currently available for allocation</td></tr>
 <tr><td>carbide_resourcepool_used_count</td><td>gauge</td><td>Count of values in the pool currently allocated</td></tr>
+<tr><td>carbide_running_dpu_updates_count</td><td>gauge</td><td>The number of machines in the system that running a firmware update.</td></tr>
+<tr><td>carbide_site_exploration_expected_machines_sku_count</td><td>gauge</td><td>The total count of expected machines by SKU ID and device type</td></tr>
+<tr><td>carbide_site_exploration_identified_managed_hosts_count</td><td>gauge</td><td>The amount of Host+DPU pairs that has been identified in the last SiteExplorer run</td></tr>
+<tr><td>carbide_site_explorer_bmc_reset_count</td><td>gauge</td><td>The amount of BMC resets initiated in the last SiteExplorer run</td></tr>
+<tr><td>carbide_site_explorer_create_machines_latency_milliseconds</td><td>histogram</td><td>The time it to perform create_machines inside site-explorer</td></tr>
+<tr><td>carbide_site_explorer_created_machines_count</td><td>gauge</td><td>The amount of Machine pairs that had been created by Site Explorer after being identified</td></tr>
+<tr><td>carbide_site_explorer_created_power_shelves_count</td><td>gauge</td><td>The amount of Power Shelves that had been created by Site Explorer after being identified</td></tr>
+<tr><td>carbide_site_explorer_iteration_latency_milliseconds</td><td>histogram</td><td>The time it took to perform one site explorer iteration</td></tr>
 <tr><td>carbide_switches_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_switches in the system</td></tr>
+<tr><td>carbide_switches_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to handle state for all carbide_switches in the system</td></tr>
 <tr><td>carbide_switches_object_tasks_enqueued_total</td><td>counter</td><td>The amount of types that object handling tasks that have been freshly enqueued for objects of type carbide_switches</td></tr>
 <tr><td>carbide_switches_total</td><td>gauge</td><td>The total number of carbide_switches in the system</td></tr>
-<tr><td>forge_active_host_firmware_update_count</td><td>gauge</td><td>The number of host machines in the system currently working on updating their firmware.</td></tr>
-<tr><td>forge_available_ips_count</td><td>gauge</td><td>The total number of available ips in the Forge site</td></tr>
-<tr><td>forge_concurrent_machine_updates_available</td><td>gauge</td><td>The number of machines in the system that we will update concurrently.</td></tr>
-<tr><td>forge_dpu_agent_version_count</td><td>gauge</td><td>The amount of Forge DPU agents which have reported a certain version.</td></tr>
-<tr><td>forge_dpu_firmware_version_count</td><td>gauge</td><td>The amount of DPUs which have reported a certain firmware version.</td></tr>
-<tr><td>forge_dpus_healthy_count</td><td>gauge</td><td>The total number of DPUs in the system that have reported healthy in the last report. Healthy does not imply up - the report from the DPU might be outdated.</td></tr>
-<tr><td>forge_dpus_up_count</td><td>gauge</td><td>The total number of DPUs in the system that are up. Up means we have received a health report less than 5 minutes ago.</td></tr>
-<tr><td>forge_endpoint_exploration_duration_milliseconds</td><td>histogram</td><td>The time it took to explore an endpoint</td></tr>
-<tr><td>forge_endpoint_exploration_expected_machines_missing_overall_count</td><td>gauge</td><td>The total number of machines that were expected but not identified</td></tr>
-<tr><td>forge_endpoint_exploration_expected_power_shelves_missing_overall_count</td><td>gauge</td><td>The total number of power shelves that were expected but not identified</td></tr>
-<tr><td>forge_endpoint_exploration_identified_managed_hosts_overall_count</td><td>gauge</td><td>The total number of managed hosts identified by expectation</td></tr>
-<tr><td>forge_endpoint_exploration_machines_explored_overall_count</td><td>gauge</td><td>The total number of machines explored by machine type</td></tr>
-<tr><td>forge_endpoint_exploration_success_count</td><td>gauge</td><td>The amount of endpoint explorations that have been successful</td></tr>
-<tr><td>forge_endpoint_explorations_count</td><td>gauge</td><td>The amount of endpoint explorations that have been attempted</td></tr>
-<tr><td>forge_gpus_in_use_count</td><td>gauge</td><td>The total number of GPUs that are actively used by tenants in instances in the Forge site</td></tr>
-<tr><td>forge_gpus_total_count</td><td>gauge</td><td>The total number of GPUs available in the Forge site</td></tr>
-<tr><td>forge_gpus_usable_count</td><td>gauge</td><td>The remaining number of GPUs in the Forge site which are available for immediate instance creation</td></tr>
-<tr><td>forge_hosts_by_sku_count</td><td>gauge</td><td>The amount of hosts by SKU and device type (&#x27;unknown&#x27; for hosts without SKU)</td></tr>
-<tr><td>forge_hosts_health_overrides_count</td><td>gauge</td><td>The amount of health overrides that are configured in the site</td></tr>
-<tr><td>forge_hosts_health_status_count</td><td>gauge</td><td>The total number of Managed Hosts in the system that have reported any a healthy nor not healthy status - based on the presence of health probe alerts</td></tr>
-<tr><td>forge_hosts_in_use_count</td><td>gauge</td><td>The total number of hosts that are actively used by tenants as instances in the Forge site</td></tr>
-<tr><td>forge_hosts_usable_count</td><td>gauge</td><td>The remaining number of hosts in the Forge site which are available for immediate instance creation</td></tr>
-<tr><td>forge_hosts_with_bios_password_set</td><td>gauge</td><td>The total number of Hosts in the system that have their BIOS password set.</td></tr>
-<tr><td>forge_ib_partitions_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all forge_ib_partitions in the system</td></tr>
-<tr><td>forge_ib_partitions_object_tasks_enqueued_total</td><td>counter</td><td>The amount of types that object handling tasks that have been freshly enqueued for objects of type forge_ib_partitions</td></tr>
-<tr><td>forge_ib_partitions_total</td><td>gauge</td><td>The total number of forge_ib_partitions in the system</td></tr>
-<tr><td>forge_machine_updates_started_count</td><td>gauge</td><td>The number of machines in the system that in the process of updating.</td></tr>
-<tr><td>forge_machine_validation_completed</td><td>gauge</td><td>Count of machine validation that have completed successfully</td></tr>
-<tr><td>forge_machine_validation_failed</td><td>gauge</td><td>Count of machine validation that have failed</td></tr>
-<tr><td>forge_machine_validation_in_progress</td><td>gauge</td><td>Count of machine validation that are in progress</td></tr>
-<tr><td>forge_machine_validation_tests</td><td>gauge</td><td>The details of machine validation tests</td></tr>
-<tr><td>forge_machines_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all forge_machines in the system</td></tr>
-<tr><td>forge_machines_handler_latency_in_state_milliseconds</td><td>histogram</td><td>The amount of time it took to invoke the state handler for objects of type forge_machines in a certain state</td></tr>
-<tr><td>forge_machines_in_maintenance_count</td><td>gauge</td><td>The total number of machines in the system that are in maintenance.</td></tr>
-<tr><td>forge_machines_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to handle state for all forge_machines in the system</td></tr>
-<tr><td>forge_machines_object_tasks_completed_total</td><td>counter</td><td>The amount of object handling tasks that have been completed for objects of type forge_machines</td></tr>
-<tr><td>forge_machines_object_tasks_dispatched_total</td><td>counter</td><td>The amount of types that object handling tasks that have been dequeued and dispatched for processing for objects of type forge_machines</td></tr>
-<tr><td>forge_machines_object_tasks_enqueued_total</td><td>counter</td><td>The amount of types that object handling tasks that have been freshly enqueued for objects of type forge_machines</td></tr>
-<tr><td>forge_machines_per_state</td><td>gauge</td><td>The number of forge_machines in the system with a given state</td></tr>
-<tr><td>forge_machines_per_state_above_sla</td><td>gauge</td><td>The number of forge_machines in the system which had been longer in a state than allowed per SLA</td></tr>
-<tr><td>forge_machines_state_entered_total</td><td>counter</td><td>The amount of types that objects of type forge_machines have entered a certain state</td></tr>
-<tr><td>forge_machines_state_exited_total</td><td>counter</td><td>The amount of types that objects of type forge_machines have exited a certain state</td></tr>
-<tr><td>forge_machines_time_in_state_seconds</td><td>histogram</td><td>The amount of time objects of type forge_machines have spent in a certain state</td></tr>
-<tr><td>forge_machines_total</td><td>gauge</td><td>The total number of forge_machines in the system</td></tr>
-<tr><td>forge_machines_with_state_handling_errors_per_state</td><td>gauge</td><td>The number of forge_machines in the system with a given state that failed state handling</td></tr>
-<tr><td>forge_measured_boot_bundles_total</td><td>gauge</td><td>The total number of measured boot bundles.</td></tr>
-<tr><td>forge_measured_boot_machines_per_bundle_state_total</td><td>gauge</td><td>The total number of machines per a given measured boot bundle state.</td></tr>
-<tr><td>forge_measured_boot_machines_per_machine_state_total</td><td>gauge</td><td>The total number of machines per a given measured boot machine state.</td></tr>
-<tr><td>forge_measured_boot_machines_total</td><td>gauge</td><td>The total number of machines reporting measurements.</td></tr>
-<tr><td>forge_measured_boot_profiles_total</td><td>gauge</td><td>The total number of measured boot profiles.</td></tr>
-<tr><td>forge_network_segments_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all forge_network_segments in the system</td></tr>
-<tr><td>forge_network_segments_handler_latency_in_state_milliseconds</td><td>histogram</td><td>The amount of time it took to invoke the state handler for objects of type forge_network_segments in a certain state</td></tr>
-<tr><td>forge_network_segments_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to handle state for all forge_network_segments in the system</td></tr>
-<tr><td>forge_network_segments_object_tasks_completed_total</td><td>counter</td><td>The amount of object handling tasks that have been completed for objects of type forge_network_segments</td></tr>
-<tr><td>forge_network_segments_object_tasks_dispatched_total</td><td>counter</td><td>The amount of types that object handling tasks that have been dequeued and dispatched for processing for objects of type forge_network_segments</td></tr>
-<tr><td>forge_network_segments_object_tasks_enqueued_total</td><td>counter</td><td>The amount of types that object handling tasks that have been freshly enqueued for objects of type forge_network_segments</td></tr>
-<tr><td>forge_network_segments_per_state</td><td>gauge</td><td>The number of forge_network_segments in the system with a given state</td></tr>
-<tr><td>forge_network_segments_per_state_above_sla</td><td>gauge</td><td>The number of forge_network_segments in the system which had been longer in a state than allowed per SLA</td></tr>
-<tr><td>forge_network_segments_state_entered_total</td><td>counter</td><td>The amount of types that objects of type forge_network_segments have entered a certain state</td></tr>
-<tr><td>forge_network_segments_state_exited_total</td><td>counter</td><td>The amount of types that objects of type forge_network_segments have exited a certain state</td></tr>
-<tr><td>forge_network_segments_time_in_state_seconds</td><td>histogram</td><td>The amount of time objects of type forge_network_segments have spent in a certain state</td></tr>
-<tr><td>forge_network_segments_total</td><td>gauge</td><td>The total number of forge_network_segments in the system</td></tr>
-<tr><td>forge_network_segments_with_state_handling_errors_per_state</td><td>gauge</td><td>The number of forge_network_segments in the system with a given state that failed state handling</td></tr>
-<tr><td>forge_pending_dpu_nic_firmware_update_count</td><td>gauge</td><td>The number of machines in the system that need a firmware update.</td></tr>
-<tr><td>forge_pending_host_firmware_update_count</td><td>gauge</td><td>The number of host machines in the system that need a firmware update.</td></tr>
-<tr><td>forge_preingestion_total</td><td>gauge</td><td>The amount of known machines currently being evaluated prior to ingestion</td></tr>
-<tr><td>forge_preingestion_waiting_download</td><td>gauge</td><td>The amount of machines that are waiting for firmware downloads on other machines to complete before doing thier own</td></tr>
-<tr><td>forge_preingestion_waiting_installation</td><td>gauge</td><td>The amount of machines which have had firmware uploaded to them and are currently in the process of installing that firmware</td></tr>
-<tr><td>forge_reboot_attempts_in_booting_with_discovery_image</td><td>histogram</td><td>The amount of machines rebooted again in BootingWithDiscoveryImage since there is no response after a certain time from host.</td></tr>
-<tr><td>forge_reserved_ips_count</td><td>gauge</td><td>The total number of reserved ips in the Forge site</td></tr>
-<tr><td>forge_running_dpu_updates_count</td><td>gauge</td><td>The number of machines in the system that running a firmware update.</td></tr>
-<tr><td>forge_site_exploration_expected_machines_sku_count</td><td>gauge</td><td>The total count of expected machines by SKU ID and device type</td></tr>
-<tr><td>forge_site_exploration_identified_managed_hosts_count</td><td>gauge</td><td>The amount of Host+DPU pairs that has been identified in the last SiteExplorer run</td></tr>
-<tr><td>forge_site_explorer_bmc_reset_count</td><td>gauge</td><td>The amount of BMC resets initiated in the last SiteExplorer run</td></tr>
-<tr><td>forge_site_explorer_create_machines_latency_milliseconds</td><td>histogram</td><td>The time it to perform create_machines inside site-explorer</td></tr>
-<tr><td>forge_site_explorer_created_machines_count</td><td>gauge</td><td>The amount of Machine pairs that had been created by Site Explorer after being identified</td></tr>
-<tr><td>forge_site_explorer_created_power_shelves_count</td><td>gauge</td><td>The amount of Power Shelves that had been created by Site Explorer after being identified</td></tr>
-<tr><td>forge_site_explorer_iteration_latency_milliseconds</td><td>histogram</td><td>The time it took to perform one site explorer iteration</td></tr>
-<tr><td>forge_total_ips_count</td><td>gauge</td><td>The total number of ips in the Forge site</td></tr>
-<tr><td>forge_unavailable_dpu_nic_firmware_update_count</td><td>gauge</td><td>The number of machines in the system that need a firmware update but are unavailble for update.</td></tr>
+<tr><td>carbide_total_ips_count</td><td>gauge</td><td>The total number of ips in the site</td></tr>
+<tr><td>carbide_unavailable_dpu_nic_firmware_update_count</td><td>gauge</td><td>The number of machines in the system that need a firmware update but are unavailble for update.</td></tr>
 <table>

--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -142,6 +142,11 @@ async fn test_integration() -> eyre::Result<()> {
 
 fn generate_core_metric_docs(metrics_endpoints: &[SocketAddr]) {
     let infos = metrics::collect_metric_infos(metrics_endpoints).unwrap();
+    // Delete everything with "alt_metric_" prefix
+    let infos: Vec<_> = infos
+        .into_iter()
+        .filter(|metric| !metric.name.starts_with("alt_metric"))
+        .collect();
     let mut docs = "# Carbide core metrics\n\n".to_string();
     use std::fmt::Write;
 
@@ -275,10 +280,12 @@ async fn test_metrics_integration() -> eyre::Result<()> {
                 // Therefore wait for the updated metrics to show up.
                 let metrics = metrics::wait_for_metric_line(
                     &carbide_metrics_addrs,
-                    r#"forge_machines_per_state{fresh="true",state="ready",substate=""} 1"#,
+                    r#"carbide_machines_per_state{fresh="true",state="ready",substate=""} 1"#,
                 )
                     .await?;
-                metrics::assert_metric_line(&metrics, r#"forge_machines_total{fresh="true"} 1"#);
+                metrics::assert_metric_line(&metrics, r#"carbide_machines_total{fresh="true"} 1"#);
+                // Also check that metrics are emitted under the configured `alt_metric_prefix`
+                metrics::assert_metric_line(&metrics, r#"alt_metric_machines_total{fresh="true"} 1"#);
                 metrics::assert_not_metric_line(
                     &metrics,
                     "machine_reboot_attempts_in_booting_with_discovery_image",
@@ -302,13 +309,13 @@ async fn test_metrics_integration() -> eyre::Result<()> {
 
                 let metrics = metrics::wait_for_metric_line(
                     &carbide_metrics_addrs,
-                    r#"forge_machines_per_state{fresh="true",state="assigned",substate="ready"} 1"#,
+                    r#"carbide_machines_per_state{fresh="true",state="assigned",substate="ready"} 1"#,
                 )
                     .await?;
-                metrics::assert_metric_line(&metrics, r#"forge_machines_total{fresh="true"} 1"#);
+                metrics::assert_metric_line(&metrics, r#"carbide_machines_total{fresh="true"} 1"#);
                 metrics::assert_not_metric_line(
                     &metrics,
-                    r#"forge_machines_per_state{fresh="true",state="ready",substate=""}"#,
+                    r#"carbide_machines_per_state{fresh="true",state="ready",substate=""}"#,
                 );
                 metrics::assert_not_metric_line(
                     &metrics,
@@ -317,8 +324,8 @@ async fn test_metrics_integration() -> eyre::Result<()> {
 
                 instance::release(&carbide_api_addrs, &host_machine_id, &instance_id, true).await?;
 
-                let metrics = metrics::wait_for_metric_line(&carbide_metrics_addrs, r#"forge_machines_per_state{fresh="true",state="waitingforcleanup",substate="hostcleanup"} 1"#).await?;
-                metrics::assert_metric_line(&metrics, r#"forge_machines_total{fresh="true"} 1"#);
+                let metrics = metrics::wait_for_metric_line(&carbide_metrics_addrs, r#"carbide_machines_per_state{fresh="true",state="waitingforcleanup",substate="hostcleanup"} 1"#).await?;
+                metrics::assert_metric_line(&metrics, r#"carbide_machines_total{fresh="true"} 1"#);
 
                 machine::wait_for_state(
                     &carbide_api_addrs,
@@ -331,43 +338,43 @@ async fn test_metrics_integration() -> eyre::Result<()> {
                 // It stays in Discovered until we notify that reboot happened, which this test doesn't
                 let metrics = metrics::wait_for_metric_line(
                     &carbide_metrics_addrs,
-                    r#"forge_machines_per_state{fresh="true",state="hostnotready",substate="discovered"} 1"#,
+                    r#"carbide_machines_per_state{fresh="true",state="hostnotready",substate="discovered"} 1"#,
                 )
                     .await?;
                 metrics::assert_not_metric_line(
                     &metrics,
-                    r#"forge_machines_per_state{fresh="true",state="assigned""#,
+                    r#"carbide_machines_per_state{fresh="true",state="assigned""#,
                 );
 
-                // Explicitly test that the histogram for `forge_reboot_attempts_in_booting_with_discovery_image_bucket`
+                // Explicitly test that the histogram for `carbide_reboot_attempts_in_booting_with_discovery_image_bucket`
                 // uses the custom buckets we defined for retries/attempts
                 for &(bucket, count) in &[(0, 0), (1, 1), (2, 1), (3, 1), (5, 1), (10, 1)] {
                     metrics::assert_metric_line(
                         &metrics,
                         &format!(
-                            r#"forge_reboot_attempts_in_booting_with_discovery_image_bucket{{le="{bucket}"}} {count}"#
+                            r#"carbide_reboot_attempts_in_booting_with_discovery_image_bucket{{le="{bucket}"}} {count}"#
                         ),
                     );
                 }
                 metrics::assert_not_metric_line(
                     &metrics,
-                    r#"forge_reboot_attempts_in_booting_with_discovery_image_bucket{le="4"}"#,
+                    r#"carbide_reboot_attempts_in_booting_with_discovery_image_bucket{le="4"}"#,
                 );
                 metrics::assert_not_metric_line(
                     &metrics,
-                    r#"forge_reboot_attempts_in_booting_with_discovery_image_bucket{le="6"}"#,
+                    r#"carbide_reboot_attempts_in_booting_with_discovery_image_bucket{le="6"}"#,
                 );
                 metrics::assert_metric_line(
                     &metrics,
-                    r#"forge_reboot_attempts_in_booting_with_discovery_image_bucket{le="+Inf"} 1"#,
+                    r#"carbide_reboot_attempts_in_booting_with_discovery_image_bucket{le="+Inf"} 1"#,
                 );
                 metrics::assert_metric_line(
                     &metrics,
-                    "forge_reboot_attempts_in_booting_with_discovery_image_sum 1",
+                    "carbide_reboot_attempts_in_booting_with_discovery_image_sum 1",
                 );
                 metrics::assert_metric_line(
                     &metrics,
-                    "forge_reboot_attempts_in_booting_with_discovery_image_count 1",
+                    "carbide_reboot_attempts_in_booting_with_discovery_image_count 1",
                 );
 
                 Ok(())

--- a/crates/api-test-helper/src/api_server.rs
+++ b/crates/api-test-helper/src/api_server.rs
@@ -68,6 +68,7 @@ pub async fn start(
             r#"
         listen = "{addr}"
         metrics_endpoint = "{metrics_addr}"
+        alt_metric_prefix = "alt_metric_"
         database_url = "{db_url}"
         max_database_connections = 1000
         asn = 65535

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -76,6 +76,11 @@ pub struct CarbideConfig {
     /// prometheus metrics under /metrics
     pub metrics_endpoint: Option<SocketAddr>,
 
+    /// An alternative prefix under which metrics will be emitted besides `carbide_`.
+    /// Setting this flag will allow to dual emit metrics to migrate dashboards and alerts.
+    /// Note that seting the flag will load to increased load on the observability system.
+    pub alt_metric_prefix: Option<String>,
+
     /// A connection string for the utilized postgres database
     pub database_url: String,
 

--- a/crates/api/src/ib_fabric_monitor/metrics.rs
+++ b/crates/api/src/ib_fabric_monitor/metrics.rs
@@ -119,7 +119,7 @@ pub struct IbFabricMonitorInstruments {
 impl IbFabricMonitorInstruments {
     pub fn new(meter: Meter, shared_metrics: SharedMetricsHolder<IbFabricMonitorMetrics>) -> Self {
         let iteration_latency = meter
-            .f64_histogram("forge_ib_monitor_iteration_latency")
+            .f64_histogram("carbide_ib_monitor_iteration_latency")
             .with_description("The time it took to perform one IB fabric monitor iteration")
             .with_unit("ms")
             .build();
@@ -127,7 +127,7 @@ impl IbFabricMonitorInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_ib_monitor_fabrics_count")
+                .u64_observable_gauge("carbide_ib_monitor_fabrics_count")
                 .with_description("The amount of InfiniBand fabrics that are monitored")
                 .with_callback(move |o| {
                     metrics.if_available(|metrics, attrs| {
@@ -140,7 +140,7 @@ impl IbFabricMonitorInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_ib_monitor_machine_ib_status_updates_count")
+                .u64_observable_gauge("carbide_ib_monitor_machine_ib_status_updates_count")
                 .with_description(
                     "The amount of Machines where the infiniband_status_observation got updated",
                 )
@@ -153,14 +153,14 @@ impl IbFabricMonitorInstruments {
         }
 
         let ufm_changes_applied = meter
-            .u64_counter("forge_ib_monitor_ufm_changes_applied")
+            .u64_counter("carbide_ib_monitor_ufm_changes_applied")
             .with_description("The amount of changes that have been performed at UFM")
             .build();
 
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_ib_monitor_machines_by_port_state_count")
+                .u64_observable_gauge("carbide_ib_monitor_machines_by_port_state_count")
                 .with_description(
                     "The amount of Machines where the amount of total and active ports matches the values in attributes",
                 )
@@ -187,7 +187,7 @@ impl IbFabricMonitorInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_ib_monitor_machines_by_ports_with_partitions_count")
+                .u64_observable_gauge("carbide_ib_monitor_machines_by_ports_with_partitions_count")
                 .with_description(
                     "The amount of Machines where a certain amount of ports is associated with at least one partition",
                 )
@@ -213,7 +213,7 @@ impl IbFabricMonitorInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_ib_monitor_machines_with_missing_pkeys_count")
+                .u64_observable_gauge("carbide_ib_monitor_machines_with_missing_pkeys_count")
                 .with_description(
                     "The amount of machines where at least one port is not assigned to the expected pkey on UFM",
                 )
@@ -228,7 +228,7 @@ impl IbFabricMonitorInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_ib_monitor_machines_with_unexpected_pkeys_count")
+                .u64_observable_gauge("carbide_ib_monitor_machines_with_unexpected_pkeys_count")
                 .with_description(
                     "The amount of machines where at least one port is assigned to an unexpected pkey on UFM",
                 )
@@ -243,7 +243,7 @@ impl IbFabricMonitorInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_ib_monitor_machines_with_unknown_pkeys_count")
+                .u64_observable_gauge("carbide_ib_monitor_machines_with_unknown_pkeys_count")
                 .with_description(
                     "The amount of machines where at least one port is assigned to a pkey value that is not associated with any partition ID",
                 )
@@ -258,7 +258,7 @@ impl IbFabricMonitorInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_ib_monitor_ufm_version_count")
+                .u64_observable_gauge("carbide_ib_monitor_ufm_version_count")
                 .with_description("The amount of UFM deployments per version")
                 .with_callback(move |o| {
                     metrics.if_available(|metrics, attrs| {
@@ -287,7 +287,7 @@ impl IbFabricMonitorInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_ib_monitor_fabric_error_count")
+                .u64_observable_gauge("carbide_ib_monitor_fabric_error_count")
                 .with_description("The errors encountered while checking fabric states")
                 .with_callback(move |o| {
                     metrics.if_available(|metrics, attrs| {
@@ -319,7 +319,7 @@ impl IbFabricMonitorInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_ib_monitor_insecure_fabric_configuration_count")
+                .u64_observable_gauge("carbide_ib_monitor_insecure_fabric_configuration_count")
                 .with_description(
                     "The amount of InfiniBand fabrics that are not configured securely",
                 )
@@ -343,7 +343,9 @@ impl IbFabricMonitorInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_ib_monitor_allow_insecure_fabric_configuration_count")
+                .u64_observable_gauge(
+                    "carbide_ib_monitor_allow_insecure_fabric_configuration_count",
+                )
                 .with_description(
                     "The amount of InfiniBand fabrics that are not configured securely",
                 )
@@ -367,7 +369,7 @@ impl IbFabricMonitorInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_ib_monitor_ufm_partitions_count")
+                .u64_observable_gauge("carbide_ib_monitor_ufm_partitions_count")
                 .with_description(
                     "The amount partitions registered at UFM in total (incl non Forge partitions)",
                 )
@@ -390,7 +392,7 @@ impl IbFabricMonitorInstruments {
         {
             let metrics = shared_metrics;
             meter
-                .u64_observable_gauge("forge_ib_monitor_ufm_ports_by_state_count")
+                .u64_observable_gauge("carbide_ib_monitor_ufm_ports_by_state_count")
                 .with_description(
                     "Total number of ports reported by UFM (incl non Forge managed ports)",
                 )

--- a/crates/api/src/machine_update_manager/dpu_nic_firmware_metrics.rs
+++ b/crates/api/src/machine_update_manager/dpu_nic_firmware_metrics.rs
@@ -41,7 +41,7 @@ impl DpuNicFirmwareUpdateMetrics {
         let unavailable_dpu_updates = self.unavailable_dpu_updates.clone();
         let running_dpu_updates = self.running_dpu_updates.clone();
         meter
-            .u64_observable_gauge("forge_pending_dpu_nic_firmware_update_count")
+            .u64_observable_gauge("carbide_pending_dpu_nic_firmware_update_count")
             .with_description("The number of machines in the system that need a firmware update.")
             .with_callback(move |observer| {
                 observer.observe(pending_firmware_updates.load(Relaxed), &[]);
@@ -49,7 +49,7 @@ impl DpuNicFirmwareUpdateMetrics {
             .build();
 
         meter
-            .u64_observable_gauge("forge_unavailable_dpu_nic_firmware_update_count")
+            .u64_observable_gauge("carbide_unavailable_dpu_nic_firmware_update_count")
             .with_description(
                 "The number of machines in the system that need a firmware update but are unavailble for update.",
             )
@@ -59,7 +59,7 @@ impl DpuNicFirmwareUpdateMetrics {
             .build();
 
         meter
-            .u64_observable_gauge("forge_running_dpu_updates_count")
+            .u64_observable_gauge("carbide_running_dpu_updates_count")
             .with_description(
                 "The number of machines in the system that running a firmware update.",
             )

--- a/crates/api/src/machine_update_manager/host_firmware.rs
+++ b/crates/api/src/machine_update_manager/host_firmware.rs
@@ -225,7 +225,7 @@ impl HostFirmwareUpdateMetrics {
         let pending_firmware_updates = self.pending_firmware_updates.clone();
         let active_firmware_updates = self.active_firmware_updates.clone();
         meter
-            .u64_observable_gauge("forge_pending_host_firmware_update_count")
+            .u64_observable_gauge("carbide_pending_host_firmware_update_count")
             .with_description(
                 "The number of host machines in the system that need a firmware update.",
             )
@@ -234,7 +234,7 @@ impl HostFirmwareUpdateMetrics {
             })
             .build();
         meter
-            .u64_observable_gauge("forge_active_host_firmware_update_count")
+            .u64_observable_gauge("carbide_active_host_firmware_update_count")
             .with_description(
                 "The number of host machines in the system currently working on updating their firmware.",
             )

--- a/crates/api/src/machine_update_manager/metrics.rs
+++ b/crates/api/src/machine_update_manager/metrics.rs
@@ -35,14 +35,14 @@ impl MachineUpdateManagerMetrics {
         let concurrent_machine_updates_available =
             self.concurrent_machine_updates_available.clone();
         meter
-            .u64_observable_gauge("forge_machines_in_maintenance_count")
+            .u64_observable_gauge("carbide_machines_in_maintenance_count")
             .with_description("The total number of machines in the system that are in maintenance.")
             .with_callback(move |observer| {
                 observer.observe(machines_in_maintenance.load(Ordering::Relaxed), &[])
             })
             .build();
         meter
-            .u64_observable_gauge("forge_machine_updates_started_count")
+            .u64_observable_gauge("carbide_machine_updates_started_count")
             .with_description(
                 "The number of machines in the system that in the process of updating.",
             )
@@ -51,7 +51,7 @@ impl MachineUpdateManagerMetrics {
             })
             .build();
         meter
-            .u64_observable_gauge("forge_concurrent_machine_updates_available")
+            .u64_observable_gauge("carbide_concurrent_machine_updates_available")
             .with_description(
                 "The number of machines in the system that we will update concurrently.",
             )

--- a/crates/api/src/machine_validation/fixtures/test_metrics_collector.txt
+++ b/crates/api/src/machine_validation/fixtures/test_metrics_collector.txt
@@ -1,12 +1,12 @@
-# HELP forge_machine_validation_completed Count of machine validation that have completed successfully
-# TYPE forge_machine_validation_completed gauge
-forge_machine_validation_completed 10
-# HELP forge_machine_validation_failed Count of machine validation that have failed
-# TYPE forge_machine_validation_failed gauge
-forge_machine_validation_failed 15
-# HELP forge_machine_validation_in_progress Count of machine validation that are in progress
-# TYPE forge_machine_validation_in_progress gauge
-forge_machine_validation_in_progress 20
-# HELP forge_machine_validation_tests The details of machine validation tests
-# TYPE forge_machine_validation_tests gauge
-forge_machine_validation_tests{TestId="forge_Test1",isVerified="true"} 1
+# HELP carbide_machine_validation_completed Count of machine validation that have completed successfully
+# TYPE carbide_machine_validation_completed gauge
+carbide_machine_validation_completed 10
+# HELP carbide_machine_validation_failed Count of machine validation that have failed
+# TYPE carbide_machine_validation_failed gauge
+carbide_machine_validation_failed 15
+# HELP carbide_machine_validation_in_progress Count of machine validation that are in progress
+# TYPE carbide_machine_validation_in_progress gauge
+carbide_machine_validation_in_progress 20
+# HELP carbide_machine_validation_tests The details of machine validation tests
+# TYPE carbide_machine_validation_tests gauge
+carbide_machine_validation_tests{TestId="forge_Test1",isVerified="true"} 1

--- a/crates/api/src/machine_validation/metrics.rs
+++ b/crates/api/src/machine_validation/metrics.rs
@@ -38,7 +38,7 @@ fn hydrate_meter(meter: Meter, shared_metrics: SharedMetricsHolder<MachineValida
     {
         let metrics = shared_metrics.clone();
         meter
-            .u64_observable_gauge("forge_machine_validation_completed")
+            .u64_observable_gauge("carbide_machine_validation_completed")
             .with_description("Count of machine validation that have completed successfully")
             .with_callback(move |observer| {
                 metrics.if_available(|metrics, attrs| {
@@ -51,7 +51,7 @@ fn hydrate_meter(meter: Meter, shared_metrics: SharedMetricsHolder<MachineValida
     {
         let metrics = shared_metrics.clone();
         meter
-            .u64_observable_gauge("forge_machine_validation_failed")
+            .u64_observable_gauge("carbide_machine_validation_failed")
             .with_description("Count of machine validation that have failed")
             .with_callback(move |observer| {
                 metrics.if_available(|metrics, attrs| {
@@ -64,7 +64,7 @@ fn hydrate_meter(meter: Meter, shared_metrics: SharedMetricsHolder<MachineValida
     {
         let metrics = shared_metrics.clone();
         meter
-            .u64_observable_gauge("forge_machine_validation_in_progress")
+            .u64_observable_gauge("carbide_machine_validation_in_progress")
             .with_description("Count of machine validation that are in progress")
             .with_callback(move |observer| {
                 metrics.if_available(|metrics, attrs| {
@@ -76,7 +76,7 @@ fn hydrate_meter(meter: Meter, shared_metrics: SharedMetricsHolder<MachineValida
     {
         let metrics = shared_metrics;
         meter
-            .u64_observable_gauge("forge_machine_validation_tests")
+            .u64_observable_gauge("carbide_machine_validation_tests")
             .with_description("The details of machine validation tests")
             .with_callback(move |observer| {
                 metrics.if_available(|metrics, attrs| {

--- a/crates/api/src/measured_boot/metrics_collector/metrics.rs
+++ b/crates/api/src/measured_boot/metrics_collector/metrics.rs
@@ -77,7 +77,7 @@ fn hydrate_meter(
     {
         let metrics = shared_metrics.clone();
         meter
-            .u64_observable_gauge("forge_measured_boot_profiles_total")
+            .u64_observable_gauge("carbide_measured_boot_profiles_total")
             .with_description("The total number of measured boot profiles.")
             .with_callback(move |observer| {
                 metrics.if_available(|metrics, attrs| {
@@ -90,7 +90,7 @@ fn hydrate_meter(
     {
         let metrics = shared_metrics.clone();
         meter
-            .u64_observable_gauge("forge_measured_boot_bundles_total")
+            .u64_observable_gauge("carbide_measured_boot_bundles_total")
             .with_description("The total number of measured boot bundles.")
             .with_callback(move |observer| {
                 metrics.if_available(|metrics, attrs| {
@@ -103,7 +103,7 @@ fn hydrate_meter(
     {
         let metrics = shared_metrics.clone();
         meter
-            .u64_observable_gauge("forge_measured_boot_machines_total")
+            .u64_observable_gauge("carbide_measured_boot_machines_total")
             .with_description("The total number of machines reporting measurements.")
             .with_callback(move |observer| {
                 metrics.if_available(|metrics, attrs| {
@@ -116,7 +116,7 @@ fn hydrate_meter(
     {
         let metrics = shared_metrics.clone();
         meter
-            .u64_observable_gauge("forge_measured_boot_machines_per_profile_total")
+            .u64_observable_gauge("carbide_measured_boot_machines_per_profile_total")
             .with_description("The total number of machines per measured boot system profile.")
             .with_callback(move |observer| {
                 metrics.if_available(|metrics, attrs| {
@@ -138,7 +138,7 @@ fn hydrate_meter(
     {
         let metrics = shared_metrics.clone();
         meter
-            .u64_observable_gauge("forge_measured_boot_machines_per_bundle_total")
+            .u64_observable_gauge("carbide_measured_boot_machines_per_bundle_total")
             .with_description("The total number of machines per measured boot bundle.")
             .with_callback(move |observer| {
                 metrics.if_available(|metrics, attrs| {
@@ -156,7 +156,7 @@ fn hydrate_meter(
     {
         let metrics = shared_metrics.clone();
         meter
-            .u64_observable_gauge("forge_measured_boot_machines_per_bundle_state_total")
+            .u64_observable_gauge("carbide_measured_boot_machines_per_bundle_state_total")
             .with_description(
                 "The total number of machines per a given measured boot bundle state.",
             )
@@ -180,7 +180,7 @@ fn hydrate_meter(
     {
         let metrics = shared_metrics.clone();
         meter
-            .u64_observable_gauge("forge_measured_boot_machines_per_machine_state_total")
+            .u64_observable_gauge("carbide_measured_boot_machines_per_machine_state_total")
             .with_description(
                 "The total number of machines per a given measured boot machine state.",
             )
@@ -204,7 +204,7 @@ fn hydrate_meter(
     {
         let metrics = shared_metrics;
         meter
-            .u64_observable_gauge("forge_measured_boot_machines_per_pcr_value_total")
+            .u64_observable_gauge("carbide_measured_boot_machines_per_pcr_value_total")
             .with_description(
                 "The total number of machines with a given PCR value at a given PCR index.",
             )

--- a/crates/api/src/measured_boot/tests/test_data/test_metrics_collector.txt
+++ b/crates/api/src/measured_boot/tests/test_data/test_metrics_collector.txt
@@ -1,38 +1,38 @@
-# HELP forge_measured_boot_bundles_total The total number of measured boot bundles.
-# TYPE forge_measured_boot_bundles_total gauge
-forge_measured_boot_bundles_total 4
-# HELP forge_measured_boot_machines_per_bundle_state_total The total number of machines per a given measured boot bundle state.
-# TYPE forge_measured_boot_machines_per_bundle_state_total gauge
-forge_measured_boot_machines_per_bundle_state_total{bundle_state="Active"} 1
-forge_measured_boot_machines_per_bundle_state_total{bundle_state="Obsolete"} 1
-forge_measured_boot_machines_per_bundle_state_total{bundle_state="Pending"} 1
-forge_measured_boot_machines_per_bundle_state_total{bundle_state="Retired"} 3
-forge_measured_boot_machines_per_bundle_state_total{bundle_state="Revoked"} 4
-# HELP forge_measured_boot_machines_per_bundle_total The total number of machines per measured boot bundle.
-# TYPE forge_measured_boot_machines_per_bundle_total gauge
-forge_measured_boot_machines_per_bundle_total{bundle_id="33be881e-5871-4519-b7dd-84946f3b758a"} 4
-forge_measured_boot_machines_per_bundle_total{bundle_id="3e4ec902-f834-448c-9c0d-aca7da84d5d7"} 3
-forge_measured_boot_machines_per_bundle_total{bundle_id="53008cc3-988e-459c-a4c1-acb0ea44a884"} 2
-forge_measured_boot_machines_per_bundle_total{bundle_id="f567ae32-690c-4108-8ee8-5116c64ff3f0"} 1
-# HELP forge_measured_boot_machines_per_machine_state_total The total number of machines per a given measured boot machine state.
-# TYPE forge_measured_boot_machines_per_machine_state_total gauge
-forge_measured_boot_machines_per_machine_state_total{machine_state="Discovered"} 1
-forge_measured_boot_machines_per_machine_state_total{machine_state="Measured"} 3
-forge_measured_boot_machines_per_machine_state_total{machine_state="MeasuringFailed"} 4
-forge_measured_boot_machines_per_machine_state_total{machine_state="PendingBundle"} 2
-# HELP forge_measured_boot_machines_per_pcr_value_total The total number of machines with a given PCR value at a given PCR index.
-# TYPE forge_measured_boot_machines_per_pcr_value_total gauge
-forge_measured_boot_machines_per_pcr_value_total{pcr_index="0",pcr_value="aa"} 5
-forge_measured_boot_machines_per_pcr_value_total{pcr_index="1",pcr_value="bb"} 5
-# HELP forge_measured_boot_machines_per_profile_total The total number of machines per measured boot system profile.
-# TYPE forge_measured_boot_machines_per_profile_total gauge
-forge_measured_boot_machines_per_profile_total{profile_id="254542a1-0fb2-4250-91df-b5ecfa52645e"} 2
-forge_measured_boot_machines_per_profile_total{profile_id="4ed2dea5-c325-4317-aeb3-e9766956d9fc"} 3
-forge_measured_boot_machines_per_profile_total{profile_id="bf13aaeb-c9e6-4e42-9b2f-5aa525c56124"} 1
-forge_measured_boot_machines_per_profile_total{profile_id="c5c926f3-a454-497c-95ff-d21647590631"} 4
-# HELP forge_measured_boot_machines_total The total number of machines reporting measurements.
-# TYPE forge_measured_boot_machines_total gauge
-forge_measured_boot_machines_total 10
-# HELP forge_measured_boot_profiles_total The total number of measured boot profiles.
-# TYPE forge_measured_boot_profiles_total gauge
-forge_measured_boot_profiles_total 10
+# HELP carbide_measured_boot_bundles_total The total number of measured boot bundles.
+# TYPE carbide_measured_boot_bundles_total gauge
+carbide_measured_boot_bundles_total 4
+# HELP carbide_measured_boot_machines_per_bundle_state_total The total number of machines per a given measured boot bundle state.
+# TYPE carbide_measured_boot_machines_per_bundle_state_total gauge
+carbide_measured_boot_machines_per_bundle_state_total{bundle_state="Active"} 1
+carbide_measured_boot_machines_per_bundle_state_total{bundle_state="Obsolete"} 1
+carbide_measured_boot_machines_per_bundle_state_total{bundle_state="Pending"} 1
+carbide_measured_boot_machines_per_bundle_state_total{bundle_state="Retired"} 3
+carbide_measured_boot_machines_per_bundle_state_total{bundle_state="Revoked"} 4
+# HELP carbide_measured_boot_machines_per_bundle_total The total number of machines per measured boot bundle.
+# TYPE carbide_measured_boot_machines_per_bundle_total gauge
+carbide_measured_boot_machines_per_bundle_total{bundle_id="33be881e-5871-4519-b7dd-84946f3b758a"} 4
+carbide_measured_boot_machines_per_bundle_total{bundle_id="3e4ec902-f834-448c-9c0d-aca7da84d5d7"} 3
+carbide_measured_boot_machines_per_bundle_total{bundle_id="53008cc3-988e-459c-a4c1-acb0ea44a884"} 2
+carbide_measured_boot_machines_per_bundle_total{bundle_id="f567ae32-690c-4108-8ee8-5116c64ff3f0"} 1
+# HELP carbide_measured_boot_machines_per_machine_state_total The total number of machines per a given measured boot machine state.
+# TYPE carbide_measured_boot_machines_per_machine_state_total gauge
+carbide_measured_boot_machines_per_machine_state_total{machine_state="Discovered"} 1
+carbide_measured_boot_machines_per_machine_state_total{machine_state="Measured"} 3
+carbide_measured_boot_machines_per_machine_state_total{machine_state="MeasuringFailed"} 4
+carbide_measured_boot_machines_per_machine_state_total{machine_state="PendingBundle"} 2
+# HELP carbide_measured_boot_machines_per_pcr_value_total The total number of machines with a given PCR value at a given PCR index.
+# TYPE carbide_measured_boot_machines_per_pcr_value_total gauge
+carbide_measured_boot_machines_per_pcr_value_total{pcr_index="0",pcr_value="aa"} 5
+carbide_measured_boot_machines_per_pcr_value_total{pcr_index="1",pcr_value="bb"} 5
+# HELP carbide_measured_boot_machines_per_profile_total The total number of machines per measured boot system profile.
+# TYPE carbide_measured_boot_machines_per_profile_total gauge
+carbide_measured_boot_machines_per_profile_total{profile_id="254542a1-0fb2-4250-91df-b5ecfa52645e"} 2
+carbide_measured_boot_machines_per_profile_total{profile_id="4ed2dea5-c325-4317-aeb3-e9766956d9fc"} 3
+carbide_measured_boot_machines_per_profile_total{profile_id="bf13aaeb-c9e6-4e42-9b2f-5aa525c56124"} 1
+carbide_measured_boot_machines_per_profile_total{profile_id="c5c926f3-a454-497c-95ff-d21647590631"} 4
+# HELP carbide_measured_boot_machines_total The total number of machines reporting measurements.
+# TYPE carbide_measured_boot_machines_total gauge
+carbide_measured_boot_machines_total 10
+# HELP carbide_measured_boot_profiles_total The total number of measured boot profiles.
+# TYPE carbide_measured_boot_profiles_total gauge
+carbide_measured_boot_profiles_total 10

--- a/crates/api/src/preingestion_manager/fixtures/test_metrics_collector.txt
+++ b/crates/api/src/preingestion_manager/fixtures/test_metrics_collector.txt
@@ -1,9 +1,9 @@
-# HELP forge_preingestion_total The amount of known machines currently being evaluated prior to ingestion
-# TYPE forge_preingestion_total gauge
-forge_preingestion_total 20
-# HELP forge_preingestion_waiting_download The amount of machines that are waiting for firmware downloads on other machines to complete before doing thier own
-# TYPE forge_preingestion_waiting_download gauge
-forge_preingestion_waiting_download 10
-# HELP forge_preingestion_waiting_installation The amount of machines which have had firmware uploaded to them and are currently in the process of installing that firmware
-# TYPE forge_preingestion_waiting_installation gauge
-forge_preingestion_waiting_installation 15
+# HELP carbide_preingestion_total The amount of known machines currently being evaluated prior to ingestion
+# TYPE carbide_preingestion_total gauge
+carbide_preingestion_total 20
+# HELP carbide_preingestion_waiting_download The amount of machines that are waiting for firmware downloads on other machines to complete before doing thier own
+# TYPE carbide_preingestion_waiting_download gauge
+carbide_preingestion_waiting_download 10
+# HELP carbide_preingestion_waiting_installation The amount of machines which have had firmware uploaded to them and are currently in the process of installing that firmware
+# TYPE carbide_preingestion_waiting_installation gauge
+carbide_preingestion_waiting_installation 15

--- a/crates/api/src/preingestion_manager/metrics.rs
+++ b/crates/api/src/preingestion_manager/metrics.rs
@@ -34,7 +34,7 @@ fn hydrate_meter(meter: Meter, shared_metrics: SharedMetricsHolder<PreingestionM
     {
         let metrics = shared_metrics.clone();
         meter
-            .u64_observable_gauge("forge_preingestion_total")
+            .u64_observable_gauge("carbide_preingestion_total")
             .with_description(
                 "The amount of known machines currently being evaluated prior to ingestion",
             )
@@ -49,7 +49,7 @@ fn hydrate_meter(meter: Meter, shared_metrics: SharedMetricsHolder<PreingestionM
     {
         let metrics = shared_metrics.clone();
         meter
-                .u64_observable_gauge("forge_preingestion_waiting_installation")
+                .u64_observable_gauge("carbide_preingestion_waiting_installation")
                 .with_description(
                     "The amount of machines which have had firmware uploaded to them and are currently in the process of installing that firmware"
                 ).with_callback(move |observer| {
@@ -62,7 +62,7 @@ fn hydrate_meter(meter: Meter, shared_metrics: SharedMetricsHolder<PreingestionM
     {
         let metrics = shared_metrics;
         meter
-            .u64_observable_gauge("forge_preingestion_waiting_download")
+            .u64_observable_gauge("carbide_preingestion_waiting_download")
             .with_description("The amount of machines that are waiting for firmware downloads on other machines to complete before doing thier own")
             .with_callback(move |observer| {
                 metrics.if_available(|metrics, attrs| {

--- a/crates/api/src/run.rs
+++ b/crates/api/src/run.rs
@@ -79,6 +79,11 @@ pub async fn run(
     // Spin up the webserver which servers `/metrics` requests
     let (metrics_stop_tx, metrics_stop_rx) = oneshot::channel();
     if let Some(metrics_address) = carbide_config.metrics_endpoint {
+        // If a replacement prefix for "carbide_" is configured, also emit metrics under that
+        let additional_prefix = carbide_config
+            .alt_metric_prefix
+            .clone()
+            .map(|alt_prefix| ("carbide_".to_string(), alt_prefix));
         tokio::task::Builder::new()
             .name("metrics_endpoint")
             .spawn(async move {
@@ -86,6 +91,7 @@ pub async fn run(
                     &MetricsEndpointConfig {
                         address: metrics_address,
                         registry: metrics.registry,
+                        additional_prefix,
                     },
                     metrics_stop_rx,
                 )

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -652,7 +652,7 @@ pub async fn initialize_and_start_controllers(
     // If they are assigned to _ then the destructor will be immediately called
     let _machine_state_controller_handle = StateController::<MachineStateControllerIO>::builder()
         .database(db_pool.clone(), work_lock_manager_handle.clone())
-        .meter("forge_machines", meter.clone())
+        .meter("carbide_machines", meter.clone())
         .processor_id(state_controller_id.clone())
         .services(handler_services.clone())
         .iteration_config((&carbide_config.machine_state_controller.controller).into())
@@ -715,7 +715,7 @@ pub async fn initialize_and_start_controllers(
 
     let ns_builder = StateController::<NetworkSegmentStateControllerIO>::builder()
         .database(db_pool.clone(), work_lock_manager_handle.clone())
-        .meter("forge_network_segments", meter.clone())
+        .meter("carbide_network_segments", meter.clone())
         .processor_id(state_controller_id.clone())
         .services(handler_services.clone());
     let _network_segment_controller_handle = ns_builder
@@ -741,7 +741,7 @@ pub async fn initialize_and_start_controllers(
         _dpa_interface_state_controller_handle = Some(
             StateController::<DpaInterfaceStateControllerIO>::builder()
                 .database(db_pool.clone(), work_lock_manager_handle.clone())
-                .meter("forge_dpa_interfaces", meter.clone())
+                .meter("carbide_dpa_interfaces", meter.clone())
                 .processor_id(state_controller_id.clone())
                 .services(handler_services.clone())
                 .iteration_config(
@@ -764,7 +764,7 @@ pub async fn initialize_and_start_controllers(
 
         let _spdm_state_controller_handle = StateController::<SpdmStateControllerIO>::builder()
             .database(db_pool.clone(), work_lock_manager_handle.clone())
-            .meter("spdm_attestation", meter.clone())
+            .meter("carbide_spdm_attestation", meter.clone())
             .processor_id(state_controller_id.clone())
             .services(handler_services.clone())
             .iteration_config((&carbide_config.spdm_state_controller.controller).into())
@@ -779,7 +779,7 @@ pub async fn initialize_and_start_controllers(
     let _ib_partition_controller_handle =
         StateController::<IBPartitionStateControllerIO>::builder()
             .database(db_pool.clone(), work_lock_manager_handle.clone())
-            .meter("forge_ib_partitions", meter.clone())
+            .meter("carbide_ib_partitions", meter.clone())
             .processor_id(state_controller_id.clone())
             .services(handler_services.clone())
             .iteration_config((&carbide_config.ib_partition_state_controller.controller).into())

--- a/crates/api/src/site_explorer/metrics.rs
+++ b/crates/api/src/site_explorer/metrics.rs
@@ -254,7 +254,7 @@ impl SiteExplorerInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_endpoint_explorations_count")
+                .u64_observable_gauge("carbide_endpoint_explorations_count")
                 .with_description("The amount of endpoint explorations that have been attempted")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
@@ -267,7 +267,7 @@ impl SiteExplorerInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_endpoint_exploration_success_count")
+                .u64_observable_gauge("carbide_endpoint_exploration_success_count")
                 .with_description("The amount of endpoint explorations that have been successful")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
@@ -280,7 +280,7 @@ impl SiteExplorerInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_endpoint_exploration_failures_count")
+                .u64_observable_gauge("carbide_endpoint_exploration_failures_count")
                 .with_description("The amount of endpoint explorations that have failed by error")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
@@ -299,7 +299,7 @@ impl SiteExplorerInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_endpoint_exploration_failures_overall_count")
+                .u64_observable_gauge("carbide_endpoint_exploration_failures_overall_count")
                 .with_description(
                     "The total number of endpoint explorations that have failed by error",
                 )
@@ -321,7 +321,7 @@ impl SiteExplorerInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_endpoint_exploration_preingestions_incomplete_overall_count")
+                .u64_observable_gauge("carbide_endpoint_exploration_preingestions_incomplete_overall_count")
                 .with_description("The total number of machines in a preingestion state by expectation and machine type")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
@@ -349,7 +349,7 @@ impl SiteExplorerInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_endpoint_exploration_expected_serial_number_mismatches_overall_count")
+                .u64_observable_gauge("carbide_endpoint_exploration_expected_serial_number_mismatches_overall_count")
                 .with_description("The total number of found expected machines by machine type where the observed and expected serial numbers do not match")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
@@ -373,7 +373,9 @@ impl SiteExplorerInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_endpoint_exploration_machines_explored_overall_count")
+                .u64_observable_gauge(
+                    "carbide_endpoint_exploration_machines_explored_overall_count",
+                )
                 .with_description("The total number of machines explored by machine type")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
@@ -402,7 +404,7 @@ impl SiteExplorerInstruments {
             let metrics = shared_metrics.clone();
             meter
                 .u64_observable_gauge(
-                    "forge_endpoint_exploration_identified_managed_hosts_overall_count",
+                    "carbide_endpoint_exploration_identified_managed_hosts_overall_count",
                 )
                 .with_description("The total number of managed hosts identified by expectation")
                 .with_callback(move |observer| {
@@ -426,7 +428,7 @@ impl SiteExplorerInstruments {
             let metrics = shared_metrics.clone();
             meter
                 .u64_observable_gauge(
-                    "forge_endpoint_exploration_expected_machines_missing_overall_count",
+                    "carbide_endpoint_exploration_expected_machines_missing_overall_count",
                 )
                 .with_description(
                     "The total number of machines that were expected but not identified",
@@ -444,19 +446,19 @@ impl SiteExplorerInstruments {
         }
 
         let endpoint_exploration_duration = meter
-            .f64_histogram("forge_endpoint_exploration_duration")
+            .f64_histogram("carbide_endpoint_exploration_duration")
             .with_description("The time it took to explore an endpoint")
             .with_unit("ms")
             .build();
 
         let site_explorer_iteration_latency = meter
-            .f64_histogram("forge_site_explorer_iteration_latency")
+            .f64_histogram("carbide_site_explorer_iteration_latency")
             .with_description("The time it took to perform one site explorer iteration")
             .with_unit("ms")
             .build();
 
         let site_explorer_create_machines_latency = meter
-            .f64_histogram("forge_site_explorer_create_machines_latency")
+            .f64_histogram("carbide_site_explorer_create_machines_latency")
             .with_description("The time it to perform create_machines inside site-explorer")
             .with_unit("ms")
             .build();
@@ -464,7 +466,7 @@ impl SiteExplorerInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_site_exploration_identified_managed_hosts_count")
+                .u64_observable_gauge("carbide_site_exploration_identified_managed_hosts_count")
                 .with_description("The amount of Host+DPU pairs that has been identified in the last SiteExplorer run")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
@@ -480,7 +482,7 @@ impl SiteExplorerInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_site_explorer_created_machines_count")
+                .u64_observable_gauge("carbide_site_explorer_created_machines_count")
                 .with_description("The amount of Machine pairs that had been created by Site Explorer after being identified")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
@@ -496,7 +498,7 @@ impl SiteExplorerInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_site_explorer_bmc_reset_count")
+                .u64_observable_gauge("carbide_site_explorer_bmc_reset_count")
                 .with_description("The amount of BMC resets initiated in the last SiteExplorer run")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
@@ -510,7 +512,7 @@ impl SiteExplorerInstruments {
             let metrics = shared_metrics.clone();
             meter
                 .u64_observable_gauge(
-                    "forge_endpoint_exploration_expected_power_shelves_missing_overall_count",
+                    "carbide_endpoint_exploration_expected_power_shelves_missing_overall_count",
                 )
                 .with_description(
                     "The total number of power shelves that were expected but not identified",
@@ -531,7 +533,7 @@ impl SiteExplorerInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_site_exploration_expected_machines_sku_count")
+                .u64_observable_gauge("carbide_site_exploration_expected_machines_sku_count")
                 .with_description("The total count of expected machines by SKU ID and device type")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
@@ -558,7 +560,7 @@ impl SiteExplorerInstruments {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_host_dpu_pairing_blockers_count")
+                .u64_observable_gauge("carbide_host_dpu_pairing_blockers_count")
                 .with_description(
                     "Count of host+dpu pairing blockers by reason. These are issues that prevent \
                      a host from being paired with its dpu(s) and require manual intervention.",
@@ -580,7 +582,7 @@ impl SiteExplorerInstruments {
             let metrics = shared_metrics.clone();
             meter
                 .u64_observable_gauge(
-                    "forge_endpoint_exploration_expected_power_shelves_missing_overall_count",
+                    "carbide_endpoint_exploration_expected_power_shelves_missing_overall_count",
                 )
                 .with_description(
                     "The total number of power shelves that were expected but not identified",
@@ -601,7 +603,7 @@ impl SiteExplorerInstruments {
         {
             let metrics = shared_metrics;
             meter
-                .u64_observable_gauge("forge_site_explorer_created_power_shelves_count")
+                .u64_observable_gauge("carbide_site_explorer_created_power_shelves_count")
                 .with_description("The amount of Power Shelves that had been created by Site Explorer after being identified")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {

--- a/crates/api/src/state_controller/machine/metrics.rs
+++ b/crates/api/src/state_controller/machine/metrics.rs
@@ -119,7 +119,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_gpus_total_count")
+                .u64_observable_gauge("carbide_gpus_total_count")
                 .with_description("The total number of GPUs available in the Forge site")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
@@ -131,7 +131,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_hosts_usable_count")
+                .u64_observable_gauge("carbide_hosts_usable_count")
                 .with_description("The remaining number of hosts in the Forge site which are available for immediate instance creation")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
@@ -146,7 +146,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_gpus_usable_count")
+                .u64_observable_gauge("carbide_gpus_usable_count")
                 .with_description("The remaining number of GPUs in the Forge site which are available for immediate instance creation")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
@@ -161,7 +161,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_gpus_in_use_count")
+                .u64_observable_gauge("carbide_gpus_in_use_count")
                 .with_description("The total number of GPUs that are actively used by tenants in instances in the Forge site")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
@@ -177,7 +177,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_hosts_in_use_count")
+                .u64_observable_gauge("carbide_hosts_in_use_count")
                 .with_description("The total number of hosts that are actively used by tenants as instances in the Forge site")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
@@ -193,7 +193,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_gpus_in_use_by_tenant_count")
+                .u64_observable_gauge("carbide_gpus_in_use_by_tenant_count")
                 .with_description(
                     "The number of GPUs that are actively used by tenants as instances - by tenant",
                 )
@@ -213,7 +213,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_hosts_in_use_by_tenant_count")
+                .u64_observable_gauge("carbide_hosts_in_use_by_tenant_count")
                 .with_description(
                     "The number of hosts that are actively used by tenants as instances - by tenant",
                 )
@@ -232,7 +232,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_dpus_up_count")
+                .u64_observable_gauge("carbide_dpus_up_count")
                 .with_description("The total number of DPUs in the system that are up. Up means we have received a health report less than 5 minutes ago.")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
@@ -247,7 +247,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_dpus_healthy_count")
+                .u64_observable_gauge("carbide_dpus_healthy_count")
                 .with_description("The total number of DPUs in the system that have reported healthy in the last report. Healthy does not imply up - the report from the DPU might be outdated.")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
@@ -262,7 +262,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_hosts_health_status_count")
+                .u64_observable_gauge("carbide_hosts_health_status_count")
                 .with_description("The total number of Managed Hosts in the system that have reported any a healthy nor not healthy status - based on the presence of health probe alerts")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
@@ -289,7 +289,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_hosts_health_overrides_count")
+                .u64_observable_gauge("carbide_hosts_health_overrides_count")
                 .with_description("The amount of health overrides that are configured in the site")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
@@ -327,7 +327,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_dpu_health_check_failed_count")
+                .u64_observable_gauge("carbide_dpu_health_check_failed_count")
                 .with_description(
                     "The total number of DPUs in the system that have failed a health-check.",
                 )
@@ -362,7 +362,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_hosts_unhealthy_by_probe_id_count")
+                .u64_observable_gauge("carbide_hosts_unhealthy_by_probe_id_count")
                 .with_description(
                     "The amount of ManagedHosts which reported a certain Health Probe Alert",
                 )
@@ -394,7 +394,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_hosts_unhealthy_by_classification_count")
+                .u64_observable_gauge("carbide_hosts_unhealthy_by_classification_count")
                 .with_description(
                     "The amount of ManagedHosts which are marked with a certain classification due to being unhealthy",
                 )
@@ -419,7 +419,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_alerts_suppressed_count")
+                .u64_observable_gauge("carbide_alerts_suppressed_count")
                 .with_description(
                     "Whether external metrics based alerting is suppressed for a specific host",
                 )
@@ -440,7 +440,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_hosts_by_sku_count")
+                .u64_observable_gauge("carbide_hosts_by_sku_count")
                 .with_description(
                     "The amount of hosts by SKU and device type ('unknown' for hosts without SKU)",
                 )
@@ -465,7 +465,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_dpu_agent_version_count")
+                .u64_observable_gauge("carbide_dpu_agent_version_count")
                 .with_description(
                     "The amount of Forge DPU agents which have reported a certain version.",
                 )
@@ -488,7 +488,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_dpu_firmware_version_count")
+                .u64_observable_gauge("carbide_dpu_firmware_version_count")
                 .with_description(
                     "The amount of DPUs which have reported a certain firmware version.",
                 )
@@ -509,7 +509,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_machine_inventory_component_version_count")
+                .u64_observable_gauge("carbide_machine_inventory_component_version_count")
                 .with_description(
                     "The amount of machines report software components with a certain version.",
                 )
@@ -537,7 +537,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .i64_observable_gauge("forge_dpu_client_certificate_expiration_time")
+                .i64_observable_gauge("carbide_dpu_client_certificate_expiration_time")
                 .with_description("The expiration time (epoch seconds) for the client certificate associated with a given DPU.")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
@@ -556,19 +556,19 @@ impl MetricsEmitter for MachineMetricsEmitter {
         };
 
         let machine_reboot_attempts_in_booting_with_discovery_image = meter
-            .u64_histogram("forge_reboot_attempts_in_booting_with_discovery_image")
+            .u64_histogram("carbide_reboot_attempts_in_booting_with_discovery_image")
             .with_description("The amount of machines rebooted again in BootingWithDiscoveryImage since there is no response after a certain time from host.")
             .build();
 
         let machine_reboot_attempts_in_failed_during_discovery = meter
-            .u64_histogram("forge_reboot_attempts_in_failed_during_discovery")
+            .u64_histogram("carbide_reboot_attempts_in_failed_during_discovery")
             .with_description("The amount of machines rebooted again in Failed state due to discovery failure since there is no response after a certain time from host.")
             .build();
 
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_hosts_with_bios_password_set")
+                .u64_observable_gauge("carbide_hosts_with_bios_password_set")
                 .with_description(
                     "The total number of Hosts in the system that have their BIOS password set.",
                 )
@@ -582,7 +582,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_hosts_with_scout_heartbeat_timeout")
+                .u64_observable_gauge("carbide_hosts_with_scout_heartbeat_timeout")
                 .with_description("Scout heartbeat timeout status for hosts")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
@@ -603,7 +603,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
         {
             let metrics = shared_metrics;
             meter
-                .u64_observable_gauge("forge_machine_validation_tests_on_machines")
+                .u64_observable_gauge("carbide_machine_validation_tests_on_machines")
                 .with_description(
                     "For a given context the count of machine validation tests failed.",
                 )

--- a/crates/api/src/state_controller/network_segment/metrics.rs
+++ b/crates/api/src/state_controller/network_segment/metrics.rs
@@ -56,8 +56,8 @@ impl MetricsEmitter for NetworkSegmentMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_available_ips_count")
-                .with_description("The total number of available ips in the Forge site")
+                .u64_observable_gauge("carbide_available_ips_count")
+                .with_description("The total number of available ips in the site")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
                         for (_seg_id, seg_stats) in metrics.seg_stats.clone() {
@@ -82,8 +82,8 @@ impl MetricsEmitter for NetworkSegmentMetricsEmitter {
         {
             let metrics = shared_metrics.clone();
             meter
-                .u64_observable_gauge("forge_reserved_ips_count")
-                .with_description("The total number of reserved ips in the Forge site")
+                .u64_observable_gauge("carbide_reserved_ips_count")
+                .with_description("The total number of reserved ips in the site")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
                         for (_seg_id, seg_stats) in metrics.seg_stats.clone() {
@@ -108,8 +108,8 @@ impl MetricsEmitter for NetworkSegmentMetricsEmitter {
         {
             let metrics = shared_metrics;
             meter
-                .u64_observable_gauge("forge_total_ips_count")
-                .with_description("The total number of ips in the Forge site")
+                .u64_observable_gauge("carbide_total_ips_count")
+                .with_description("The total number of ips in the site")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
                         for (_seg_id, seg_stats) in metrics.seg_stats.clone() {

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -959,6 +959,7 @@ pub fn get_config() -> CarbideConfig {
         site_global_vpc_vni: None,
         listen: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 1079),
         metrics_endpoint: None,
+        alt_metric_prefix: None,
         database_url: "pgsql:://localhost".to_string(),
         max_database_connections: 1000,
         asn: 0,
@@ -1421,7 +1422,7 @@ pub async fn create_test_env_with_overrides(
 
     let machine_controller = StateController::<MachineStateControllerIO>::builder()
         .database(db_pool.clone(), work_lock_manager_handle.clone())
-        .meter("forge_machines", test_meter.meter())
+        .meter("carbide_machines", test_meter.meter())
         .processor_id(state_controller_id.clone())
         .services(handler_services.clone())
         .state_handler(Arc::new(machine_swap.clone()))
@@ -1447,7 +1448,7 @@ pub async fn create_test_env_with_overrides(
 
     let ib_controller = StateController::builder()
         .database(db_pool.clone(), work_lock_manager_handle.clone())
-        .meter("forge_machines", test_meter.meter())
+        .meter("carbide_machines", test_meter.meter())
         .processor_id(state_controller_id.clone())
         .services(handler_services.clone())
         .state_handler(Arc::new(ib_swap.clone()))
@@ -1466,7 +1467,7 @@ pub async fn create_test_env_with_overrides(
 
     let mut network_controller = StateController::builder()
         .database(db_pool.clone(), work_lock_manager_handle.clone())
-        .meter("forge_machines", test_meter.meter())
+        .meter("carbide_machines", test_meter.meter())
         .processor_id(state_controller_id.clone())
         .services(handler_services.clone())
         .state_handler(Arc::new(network_swap.clone()))

--- a/crates/api/src/tests/dpf.rs
+++ b/crates/api/src/tests/dpf.rs
@@ -752,9 +752,9 @@ async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
 
     assert!(matches!(dpu.current_state(), ManagedHostState::Ready));
 
-    let forge_machines_per_state = env.test_meter.parsed_metrics("forge_machines_per_state");
+    let carbide_machines_per_state = env.test_meter.parsed_metrics("carbide_machines_per_state");
 
-    assert!(forge_machines_per_state.contains(&(
+    assert!(carbide_machines_per_state.contains(&(
         "{fresh=\"true\",state=\"ready\",substate=\"\"}".to_string(),
         "2".to_string()
     )));
@@ -784,7 +784,7 @@ async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
 
     let states_entered = env
         .test_meter
-        .parsed_metrics("forge_machines_state_entered_total");
+        .parsed_metrics("carbide_machines_state_entered_total");
 
     for expected in expected_states_entered.iter() {
         let actual = states_entered
@@ -828,7 +828,7 @@ async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
 
     let states_exited = env
         .test_meter
-        .parsed_metrics("forge_machines_state_exited_total");
+        .parsed_metrics("carbide_machines_state_exited_total");
 
     for expected in expected_states_exited.iter() {
         let actual = states_exited

--- a/crates/api/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api/src/tests/host_bmc_firmware_test.rs
@@ -703,13 +703,13 @@ async fn test_postingestion_bmc_upgrade(pool: sqlx::PgPool) -> CarbideResult<()>
 
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_pending_host_firmware_update_count")
+            .formatted_metric("carbide_pending_host_firmware_update_count")
             .unwrap(),
         "0"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_active_host_firmware_update_count")
+            .formatted_metric("carbide_active_host_firmware_update_count")
             .unwrap(),
         "0"
     );

--- a/crates/api/src/tests/ib_fabric_monitor.rs
+++ b/crates/api/src/tests/ib_fabric_monitor.rs
@@ -31,37 +31,37 @@ async fn test_ib_fabric_monitor(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
     env.run_ib_fabric_monitor_iteration().await;
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_fabrics_count")
+            .formatted_metric("carbide_ib_monitor_fabrics_count")
             .unwrap(),
         "1"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machine_ib_status_updates_count")
+            .formatted_metric("carbide_ib_monitor_machine_ib_status_updates_count")
             .unwrap(),
         "0"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_ufm_version_count")
+            .formatted_metric("carbide_ib_monitor_ufm_version_count")
             .unwrap(),
         r#"{fabric="default",version="mock_ufm_1.0"} 1"#
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_fabric_error_count"),
+            .formatted_metric("carbide_ib_monitor_fabric_error_count"),
         None
     );
     // The default partition is found
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_ufm_partitions_count")
+            .formatted_metric("carbide_ib_monitor_ufm_partitions_count")
             .unwrap(),
         r#"{fabric="default"} 1"#
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_iteration_latency_milliseconds_count")
+            .formatted_metric("carbide_ib_monitor_iteration_latency_milliseconds_count")
             .unwrap(),
         r#"1"#
     );
@@ -69,13 +69,13 @@ async fn test_ib_fabric_monitor(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
     // The fabric is configured securely
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_insecure_fabric_configuration_count")
+            .formatted_metric("carbide_ib_monitor_insecure_fabric_configuration_count")
             .unwrap(),
         r#"{fabric="default"} 0"#
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_allow_insecure_fabric_configuration_count")
+            .formatted_metric("carbide_ib_monitor_allow_insecure_fabric_configuration_count")
             .unwrap(),
         r#"{fabric="default"} 0"#
     );
@@ -88,13 +88,13 @@ async fn test_ib_fabric_monitor(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
     env.run_ib_fabric_monitor_iteration().await;
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_insecure_fabric_configuration_count")
+            .formatted_metric("carbide_ib_monitor_insecure_fabric_configuration_count")
             .unwrap(),
         r#"{fabric="default"} 1"#
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_allow_insecure_fabric_configuration_count")
+            .formatted_metric("carbide_ib_monitor_allow_insecure_fabric_configuration_count")
             .unwrap(),
         r#"{fabric="default"} 0"#
     );

--- a/crates/api/src/tests/ib_instance.rs
+++ b/crates/api/src/tests/ib_instance.rs
@@ -136,25 +136,25 @@ async fn test_create_instance_with_ib_config(pool: sqlx::PgPool) {
     assert_eq!(&machine.state, "Assigned/Ready");
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machines_with_missing_pkeys_count")
+            .formatted_metric("carbide_ib_monitor_machines_with_missing_pkeys_count")
             .unwrap(),
         "0"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machines_with_unexpected_pkeys_count")
+            .formatted_metric("carbide_ib_monitor_machines_with_unexpected_pkeys_count")
             .unwrap(),
         "0"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machines_with_unknown_pkeys_count")
+            .formatted_metric("carbide_ib_monitor_machines_with_unknown_pkeys_count")
             .unwrap(),
         "0"
     );
     assert_eq!(
         env.test_meter
-            .parsed_metrics("forge_ib_monitor_ufm_changes_applied_total"),
+            .parsed_metrics("carbide_ib_monitor_ufm_changes_applied_total"),
         vec![
             (
                 "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"error\"}".to_string(),
@@ -235,7 +235,7 @@ async fn test_create_instance_with_ib_config(pool: sqlx::PgPool) {
     verify_pkey_guids(ib_conn.clone(), &[(pkey_u16, vec![])]).await;
     assert_eq!(
         env.test_meter
-            .parsed_metrics("forge_ib_monitor_ufm_changes_applied_total"),
+            .parsed_metrics("carbide_ib_monitor_ufm_changes_applied_total"),
         vec![
             (
                 "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"error\"}".to_string(),
@@ -690,25 +690,25 @@ async fn test_update_instance_ib_config(pool: sqlx::PgPool) {
     assert_eq!(&machine.state, "Assigned/Ready");
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machines_with_missing_pkeys_count")
+            .formatted_metric("carbide_ib_monitor_machines_with_missing_pkeys_count")
             .unwrap(),
         "0"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machines_with_unexpected_pkeys_count")
+            .formatted_metric("carbide_ib_monitor_machines_with_unexpected_pkeys_count")
             .unwrap(),
         "0"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machines_with_unknown_pkeys_count")
+            .formatted_metric("carbide_ib_monitor_machines_with_unknown_pkeys_count")
             .unwrap(),
         "0"
     );
     assert_eq!(
         env.test_meter
-            .parsed_metrics("forge_ib_monitor_ufm_changes_applied_total"),
+            .parsed_metrics("carbide_ib_monitor_ufm_changes_applied_total"),
         vec![
             (
                 "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"error\"}".to_string(),
@@ -854,25 +854,25 @@ async fn test_update_instance_ib_config(pool: sqlx::PgPool) {
     env.run_ib_fabric_monitor_iteration().await;
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machine_ib_status_updates_count")
+            .formatted_metric("carbide_ib_monitor_machine_ib_status_updates_count")
             .unwrap(),
         "0"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machines_with_missing_pkeys_count")
+            .formatted_metric("carbide_ib_monitor_machines_with_missing_pkeys_count")
             .unwrap(),
         "1"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machines_with_unexpected_pkeys_count")
+            .formatted_metric("carbide_ib_monitor_machines_with_unexpected_pkeys_count")
             .unwrap(),
         "1"
     );
     assert_eq!(
         env.test_meter
-            .parsed_metrics("forge_ib_monitor_ufm_changes_applied_total"),
+            .parsed_metrics("carbide_ib_monitor_ufm_changes_applied_total"),
         vec![
             (
                 "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"error\"}".to_string(),
@@ -907,25 +907,25 @@ async fn test_update_instance_ib_config(pool: sqlx::PgPool) {
     env.run_ib_fabric_monitor_iteration().await;
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machine_ib_status_updates_count")
+            .formatted_metric("carbide_ib_monitor_machine_ib_status_updates_count")
             .unwrap(),
         "1"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machines_with_missing_pkeys_count")
+            .formatted_metric("carbide_ib_monitor_machines_with_missing_pkeys_count")
             .unwrap(),
         "0"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machines_with_unexpected_pkeys_count")
+            .formatted_metric("carbide_ib_monitor_machines_with_unexpected_pkeys_count")
             .unwrap(),
         "0"
     );
     assert_eq!(
         env.test_meter
-            .parsed_metrics("forge_ib_monitor_ufm_changes_applied_total"),
+            .parsed_metrics("carbide_ib_monitor_ufm_changes_applied_total"),
         vec![
             (
                 "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"error\"}".to_string(),
@@ -1000,7 +1000,7 @@ async fn test_update_instance_ib_config(pool: sqlx::PgPool) {
     .await;
     assert_eq!(
         env.test_meter
-            .parsed_metrics("forge_ib_monitor_ufm_changes_applied_total"),
+            .parsed_metrics("carbide_ib_monitor_ufm_changes_applied_total"),
         vec![
             (
                 "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"error\"}".to_string(),

--- a/crates/api/src/tests/ib_machine.rs
+++ b/crates/api/src/tests/ib_machine.rs
@@ -86,7 +86,7 @@ async fn monitor_ib_status_and_fix_incorrect_pkey_associations(pool: sqlx::PgPoo
     }
     assert_eq!(
         env.test_meter
-            .parsed_metrics("forge_ib_monitor_machines_by_port_state_count"),
+            .parsed_metrics("carbide_ib_monitor_machines_by_port_state_count"),
         vec![(
             "{active_ports=\"6\",total_ports=\"6\"}".to_string(),
             "2".to_string()
@@ -94,19 +94,19 @@ async fn monitor_ib_status_and_fix_incorrect_pkey_associations(pool: sqlx::PgPoo
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machines_with_missing_pkeys_count")
+            .formatted_metric("carbide_ib_monitor_machines_with_missing_pkeys_count")
             .unwrap(),
         "0"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machines_with_unexpected_pkeys_count")
+            .formatted_metric("carbide_ib_monitor_machines_with_unexpected_pkeys_count")
             .unwrap(),
         "0"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machines_with_unknown_pkeys_count")
+            .formatted_metric("carbide_ib_monitor_machines_with_unknown_pkeys_count")
             .unwrap(),
         "0"
     );
@@ -199,13 +199,13 @@ async fn monitor_ib_status_and_fix_incorrect_pkey_associations(pool: sqlx::PgPoo
     env.ib_fabric_monitor.run_single_iteration().await.unwrap();
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machine_ib_status_updates_count")
+            .formatted_metric("carbide_ib_monitor_machine_ib_status_updates_count")
             .unwrap(),
         "1"
     );
     assert_eq!(
         env.test_meter
-            .parsed_metrics("forge_ib_monitor_machines_by_port_state_count"),
+            .parsed_metrics("carbide_ib_monitor_machines_by_port_state_count"),
         vec![
             (
                 "{active_ports=\"4\",total_ports=\"6\"}".to_string(),
@@ -219,7 +219,7 @@ async fn monitor_ib_status_and_fix_incorrect_pkey_associations(pool: sqlx::PgPoo
     );
     assert_eq!(
         env.test_meter
-            .parsed_metrics("forge_ib_monitor_machines_by_ports_with_partitions_count"),
+            .parsed_metrics("carbide_ib_monitor_machines_by_ports_with_partitions_count"),
         vec![
             ("{ports_with_partitions=\"0\"}".to_string(), "1".to_string()),
             ("{ports_with_partitions=\"2\"}".to_string(), "1".to_string())
@@ -227,26 +227,26 @@ async fn monitor_ib_status_and_fix_incorrect_pkey_associations(pool: sqlx::PgPoo
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machines_with_missing_pkeys_count")
+            .formatted_metric("carbide_ib_monitor_machines_with_missing_pkeys_count")
             .unwrap(),
         "0"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machines_with_unexpected_pkeys_count")
+            .formatted_metric("carbide_ib_monitor_machines_with_unexpected_pkeys_count")
             .unwrap(),
         "1"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machines_with_unknown_pkeys_count")
+            .formatted_metric("carbide_ib_monitor_machines_with_unknown_pkeys_count")
             .unwrap(),
         "1"
     );
     // Automatic reconcilation unassigns the unexpected pkey
     assert_eq!(
         env.test_meter
-            .parsed_metrics("forge_ib_monitor_ufm_changes_applied_total"),
+            .parsed_metrics("carbide_ib_monitor_ufm_changes_applied_total"),
         vec![
             (
                 "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"error\"}".to_string(),
@@ -370,13 +370,13 @@ async fn monitor_ib_status_and_fix_incorrect_pkey_associations(pool: sqlx::PgPoo
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machine_ib_status_updates_count")
+            .formatted_metric("carbide_ib_monitor_machine_ib_status_updates_count")
             .unwrap(),
         "1"
     );
     assert_eq!(
         env.test_meter
-            .parsed_metrics("forge_ib_monitor_machines_by_port_state_count"),
+            .parsed_metrics("carbide_ib_monitor_machines_by_port_state_count"),
         vec![
             (
                 "{active_ports=\"4\",total_ports=\"6\"}".to_string(),
@@ -390,31 +390,31 @@ async fn monitor_ib_status_and_fix_incorrect_pkey_associations(pool: sqlx::PgPoo
     );
     assert_eq!(
         env.test_meter
-            .parsed_metrics("forge_ib_monitor_machines_by_ports_with_partitions_count"),
+            .parsed_metrics("carbide_ib_monitor_machines_by_ports_with_partitions_count"),
         vec![("{ports_with_partitions=\"0\"}".to_string(), "2".to_string())]
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machines_with_missing_pkeys_count")
+            .formatted_metric("carbide_ib_monitor_machines_with_missing_pkeys_count")
             .unwrap(),
         "0"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machines_with_unexpected_pkeys_count")
+            .formatted_metric("carbide_ib_monitor_machines_with_unexpected_pkeys_count")
             .unwrap(),
         "0"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_ib_monitor_machines_with_unknown_pkeys_count")
+            .formatted_metric("carbide_ib_monitor_machines_with_unknown_pkeys_count")
             .unwrap(),
         "0"
     );
     // No additional changes means the counter metric has the same values
     assert_eq!(
         env.test_meter
-            .parsed_metrics("forge_ib_monitor_ufm_changes_applied_total"),
+            .parsed_metrics("carbide_ib_monitor_ufm_changes_applied_total"),
         vec![
             (
                 "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"error\"}".to_string(),

--- a/crates/api/src/tests/instance.rs
+++ b/crates/api/src/tests/instance.rs
@@ -2011,7 +2011,7 @@ async fn test_bootingwithdiscoveryimage_delay(_: PgPoolOptions, options: PgConne
 
     assert!(
         env.test_meter
-            .formatted_metric("forge_reboot_attempts_in_booting_with_discovery_image_count")
+            .formatted_metric("carbide_reboot_attempts_in_booting_with_discovery_image_count")
             .is_none(),
         "State is not changed. The reboot counter should only increased once state changed"
     );
@@ -2035,7 +2035,7 @@ async fn test_bootingwithdiscoveryimage_delay(_: PgPoolOptions, options: PgConne
 
     assert!(
         env.test_meter
-            .formatted_metric("forge_reboot_attempts_in_booting_with_discovery_image_count")
+            .formatted_metric("carbide_reboot_attempts_in_booting_with_discovery_image_count")
             .is_none(),
         "State is not changed. The reboot counter should only increased once state changed"
     );
@@ -2044,13 +2044,13 @@ async fn test_bootingwithdiscoveryimage_delay(_: PgPoolOptions, options: PgConne
 
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_reboot_attempts_in_booting_with_discovery_image_sum")
+            .formatted_metric("carbide_reboot_attempts_in_booting_with_discovery_image_sum")
             .unwrap(),
         "2"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_reboot_attempts_in_booting_with_discovery_image_count")
+            .formatted_metric("carbide_reboot_attempts_in_booting_with_discovery_image_count")
             .unwrap(),
         "1"
     );

--- a/crates/api/src/tests/machine_health.rs
+++ b/crates/api/src/tests/machine_health.rs
@@ -219,7 +219,7 @@ async fn test_machine_health_aggregation(
     // we start off with no overrides
     let mut override_metrics = env
         .test_meter
-        .formatted_metrics("forge_hosts_health_overrides_count");
+        .formatted_metrics("carbide_hosts_health_overrides_count");
     override_metrics.sort();
     assert_eq!(
         override_metrics,
@@ -285,7 +285,7 @@ async fn test_machine_health_aggregation(
     env.run_machine_state_controller_iteration().await;
     let mut override_metrics = env
         .test_meter
-        .formatted_metrics("forge_hosts_health_overrides_count");
+        .formatted_metrics("carbide_hosts_health_overrides_count");
     override_metrics.sort();
     assert_eq!(
         override_metrics,
@@ -335,7 +335,7 @@ async fn test_machine_health_aggregation(
     env.run_machine_state_controller_iteration().await;
     let mut override_metrics = env
         .test_meter
-        .formatted_metrics("forge_hosts_health_overrides_count");
+        .formatted_metrics("carbide_hosts_health_overrides_count");
     override_metrics.sort();
     assert_eq!(
         override_metrics,

--- a/crates/api/src/tests/machine_states.rs
+++ b/crates/api/src/tests/machine_states.rs
@@ -59,9 +59,9 @@ async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
 
     assert!(matches!(dpu.current_state(), ManagedHostState::Ready));
 
-    let forge_machines_per_state = env.test_meter.parsed_metrics("forge_machines_per_state");
+    let carbide_machines_per_state = env.test_meter.parsed_metrics("carbide_machines_per_state");
 
-    assert!(forge_machines_per_state.contains(&(
+    assert!(carbide_machines_per_state.contains(&(
         "{fresh=\"true\",state=\"ready\",substate=\"\"}".to_string(),
         "2".to_string()
     )));
@@ -91,7 +91,7 @@ async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
 
     let states_entered = env
         .test_meter
-        .parsed_metrics("forge_machines_state_entered_total");
+        .parsed_metrics("carbide_machines_state_entered_total");
 
     for expected in expected_states_entered.iter() {
         let actual = states_entered
@@ -135,7 +135,7 @@ async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
 
     let states_exited = env
         .test_meter
-        .parsed_metrics("forge_machines_state_exited_total");
+        .parsed_metrics("carbide_machines_state_exited_total");
 
     for expected in expected_states_exited.iter() {
         let actual = states_exited
@@ -326,29 +326,29 @@ async fn test_dpu_heartbeat(pool: sqlx::PgPool) -> sqlx::Result<()> {
 
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_dpus_up_count{fresh=\"true\"}")
+            .formatted_metric("carbide_dpus_up_count{fresh=\"true\"}")
             .unwrap(),
         "1"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_dpus_healthy_count{fresh=\"true\"}")
+            .formatted_metric("carbide_dpus_healthy_count{fresh=\"true\"}")
             .unwrap(),
         r#"1"#
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_dpu_health_check_failed_count"),
+            .formatted_metric("carbide_dpu_health_check_failed_count"),
         None
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_hosts_unhealthy_by_probe_id_count{fresh=\"true\",probe_id=\"HeartbeatTimeout\",probe_target=\"forge-dpu-agent\"}"),
+            .formatted_metric("carbide_hosts_unhealthy_by_probe_id_count{fresh=\"true\",probe_id=\"HeartbeatTimeout\",probe_target=\"forge-dpu-agent\"}"),
         None,
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_hosts_unhealthy_by_probe_id_count{fresh=\"true\",probe_id=\"HeartbeatTimeout\",probe_target=\"hardware-health\"}"),
+            .formatted_metric("carbide_hosts_unhealthy_by_probe_id_count{fresh=\"true\",probe_id=\"HeartbeatTimeout\",probe_target=\"hardware-health\"}"),
         None,
     );
 
@@ -392,38 +392,38 @@ async fn test_dpu_heartbeat(pool: sqlx::PgPool) -> sqlx::Result<()> {
     // The up count reflects the heartbeat timeout.
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_dpus_up_count{fresh=\"true\"}")
+            .formatted_metric("carbide_dpus_up_count{fresh=\"true\"}")
             .unwrap(),
         "0"
     );
     // The report now says heartbeat timeout, which is unhealthy.
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_dpus_healthy_count{fresh=\"true\"}")
+            .formatted_metric("carbide_dpus_healthy_count{fresh=\"true\"}")
             .unwrap(),
         "0"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_dpu_health_check_failed_count{failure=\"HeartbeatTimeout [Target: forge-dpu-agent]\",fresh=\"true\",probe_id=\"HeartbeatTimeout\",probe_target=\"forge-dpu-agent\"}")
+            .formatted_metric("carbide_dpu_health_check_failed_count{failure=\"HeartbeatTimeout [Target: forge-dpu-agent]\",fresh=\"true\",probe_id=\"HeartbeatTimeout\",probe_target=\"forge-dpu-agent\"}")
             .unwrap(),
         "1"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_hosts_unhealthy_by_probe_id_count{fresh=\"true\",in_use=\"false\",probe_id=\"HeartbeatTimeout\",probe_target=\"forge-dpu-agent\"}")
+            .formatted_metric("carbide_hosts_unhealthy_by_probe_id_count{fresh=\"true\",in_use=\"false\",probe_id=\"HeartbeatTimeout\",probe_target=\"forge-dpu-agent\"}")
             .unwrap(),
         "1",
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_hosts_unhealthy_by_probe_id_count{fresh=\"true\",in_use=\"false\",probe_id=\"HeartbeatTimeout\",probe_target=\"hardware-health\"}"),
+            .formatted_metric("carbide_hosts_unhealthy_by_probe_id_count{fresh=\"true\",in_use=\"false\",probe_id=\"HeartbeatTimeout\",probe_target=\"hardware-health\"}"),
         None,
     );
     assert_eq!(
         env.test_meter
             .formatted_metric(
-                "forge_hosts_health_status_count{fresh=\"true\",healthy=\"false\",in_use=\"false\"}"
+                "carbide_hosts_health_status_count{fresh=\"true\",healthy=\"false\",in_use=\"false\"}"
             )
             .unwrap(),
         "1"
@@ -500,13 +500,13 @@ async fn test_failed_state_host_discovery_recovery(pool: sqlx::PgPool) {
     env.run_machine_state_controller_iteration().await;
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_reboot_attempts_in_failed_during_discovery_sum")
+            .formatted_metric("carbide_reboot_attempts_in_failed_during_discovery_sum")
             .unwrap(),
         "1"
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_reboot_attempts_in_failed_during_discovery_count")
+            .formatted_metric("carbide_reboot_attempts_in_failed_during_discovery_count")
             .unwrap(),
         "1"
     );
@@ -541,7 +541,7 @@ async fn test_failed_state_host_discovery_recovery(pool: sqlx::PgPool) {
     )
     .await;
 
-    // We use forge_dpu_agent's health reporting as a signal that
+    // We use dpu_agent's health reporting as a signal that
     // DPU has rebooted.
     mh.network_configured(&env).await;
 
@@ -604,13 +604,13 @@ async fn test_managed_host_version_metrics(pool: sqlx::PgPool) {
 
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_gpus_in_use_count")
+            .formatted_metric("carbide_gpus_in_use_count")
             .unwrap(),
         r#"{fresh="true"} 0"#
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_hosts_in_use_count")
+            .formatted_metric("carbide_hosts_in_use_count")
             .unwrap(),
         r#"{fresh="true"} 0"#
     );
@@ -618,26 +618,26 @@ async fn test_managed_host_version_metrics(pool: sqlx::PgPool) {
     // and never becomes ready. Once it does, the test should be updated.
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_hosts_usable_count")
+            .formatted_metric("carbide_hosts_usable_count")
             .unwrap(),
         r#"{fresh="true"} 1"#
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_gpus_usable_count")
+            .formatted_metric("carbide_gpus_usable_count")
             .unwrap(),
         r#"{fresh="true"} 1"#
     );
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_gpus_total_count")
+            .formatted_metric("carbide_gpus_total_count")
             .unwrap(),
         r#"{fresh="true"} 2"#
     );
 
     let mut health_status_metrics = env
         .test_meter
-        .formatted_metrics("forge_hosts_health_status_count");
+        .formatted_metrics("carbide_hosts_health_status_count");
     health_status_metrics.sort();
     assert_eq!(health_status_metrics.len(), 4);
 
@@ -655,21 +655,21 @@ async fn test_managed_host_version_metrics(pool: sqlx::PgPool) {
 
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_dpu_firmware_version_count")
+            .formatted_metric("carbide_dpu_firmware_version_count")
             .unwrap(),
         r#"{firmware_version="24.42.1000",fresh="true"} 2"#,
     );
 
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_dpu_agent_version_count")
+            .formatted_metric("carbide_dpu_agent_version_count")
             .unwrap(),
         format!(r#"{{fresh="true",version="{TEST_DPU_AGENT_VERSION}"}} 2"#)
     );
 
     let mut inventory_metrics = env
         .test_meter
-        .formatted_metrics("forge_machine_inventory_component_version_count");
+        .formatted_metrics("carbide_machine_inventory_component_version_count");
     inventory_metrics.sort();
 
     for expected in &[
@@ -688,7 +688,9 @@ async fn test_managed_host_version_metrics(pool: sqlx::PgPool) {
 
     // Now that we track all hosts (including those without SKU as "unknown"),
     // we should have SKU metrics for the created hosts
-    let sku_metrics = env.test_meter.formatted_metric("forge_hosts_by_sku_count");
+    let sku_metrics = env
+        .test_meter
+        .formatted_metric("carbide_hosts_by_sku_count");
     assert_eq!(
         sku_metrics.unwrap(),
         r#"{device_type="unknown",fresh="true",sku="unknown"} 2"#

--- a/crates/api/src/tests/metrics_fixtures/test_dpu_nic_firmware_metrics.txt
+++ b/crates/api/src/tests/metrics_fixtures/test_dpu_nic_firmware_metrics.txt
@@ -1,9 +1,9 @@
-# HELP forge_pending_dpu_nic_firmware_update_count The number of machines in the system that need a firmware update.
-# TYPE forge_pending_dpu_nic_firmware_update_count gauge
-forge_pending_dpu_nic_firmware_update_count 5
-# HELP forge_running_dpu_updates_count The number of machines in the system that running a firmware update.
-# TYPE forge_running_dpu_updates_count gauge
-forge_running_dpu_updates_count 10
-# HELP forge_unavailable_dpu_nic_firmware_update_count The number of machines in the system that need a firmware update but are unavailble for update.
-# TYPE forge_unavailable_dpu_nic_firmware_update_count gauge
-forge_unavailable_dpu_nic_firmware_update_count 15
+# HELP carbide_pending_dpu_nic_firmware_update_count The number of machines in the system that need a firmware update.
+# TYPE carbide_pending_dpu_nic_firmware_update_count gauge
+carbide_pending_dpu_nic_firmware_update_count 5
+# HELP carbide_running_dpu_updates_count The number of machines in the system that running a firmware update.
+# TYPE carbide_running_dpu_updates_count gauge
+carbide_running_dpu_updates_count 10
+# HELP carbide_unavailable_dpu_nic_firmware_update_count The number of machines in the system that need a firmware update but are unavailble for update.
+# TYPE carbide_unavailable_dpu_nic_firmware_update_count gauge
+carbide_unavailable_dpu_nic_firmware_update_count 15

--- a/crates/api/src/tests/metrics_fixtures/test_host_firmware_metrics.txt
+++ b/crates/api/src/tests/metrics_fixtures/test_host_firmware_metrics.txt
@@ -1,6 +1,6 @@
-# HELP forge_active_host_firmware_update_count The number of host machines in the system currently working on updating their firmware.
-# TYPE forge_active_host_firmware_update_count gauge
-forge_active_host_firmware_update_count 10
-# HELP forge_pending_host_firmware_update_count The number of host machines in the system that need a firmware update.
-# TYPE forge_pending_host_firmware_update_count gauge
-forge_pending_host_firmware_update_count 5
+# HELP carbide_active_host_firmware_update_count The number of host machines in the system currently working on updating their firmware.
+# TYPE carbide_active_host_firmware_update_count gauge
+carbide_active_host_firmware_update_count 10
+# HELP carbide_pending_host_firmware_update_count The number of host machines in the system that need a firmware update.
+# TYPE carbide_pending_host_firmware_update_count gauge
+carbide_pending_host_firmware_update_count 5

--- a/crates/api/src/tests/metrics_fixtures/test_machine_update_manager_metrics.txt
+++ b/crates/api/src/tests/metrics_fixtures/test_machine_update_manager_metrics.txt
@@ -1,6 +1,6 @@
-# HELP forge_machine_updates_started_count The number of machines in the system that in the process of updating.
-# TYPE forge_machine_updates_started_count gauge
-forge_machine_updates_started_count 100
-# HELP forge_machines_in_maintenance_count The total number of machines in the system that are in maintenance.
-# TYPE forge_machines_in_maintenance_count gauge
-forge_machines_in_maintenance_count 100
+# HELP carbide_machine_updates_started_count The number of machines in the system that in the process of updating.
+# TYPE carbide_machine_updates_started_count gauge
+carbide_machine_updates_started_count 100
+# HELP carbide_machines_in_maintenance_count The total number of machines in the system that are in maintenance.
+# TYPE carbide_machines_in_maintenance_count gauge
+carbide_machines_in_maintenance_count 100

--- a/crates/api/src/tests/metrics_fixtures/test_network_segment_metrics_admin.txt
+++ b/crates/api/src/tests/metrics_fixtures/test_network_segment_metrics_admin.txt
@@ -8,146 +8,146 @@ carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="remove",s
 carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="remove",status="true"} 0
 carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="update",status="false"} 0
 carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="update",status="true"} 0
-# HELP forge_available_ips_count The total number of available ips in the Forge site
-# TYPE forge_available_ips_count gauge
-forge_available_ips_count{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="admin"} 253
-# HELP forge_ib_monitor_ufm_changes_applied_total The amount of changes that have been performed at UFM
-# TYPE forge_ib_monitor_ufm_changes_applied_total counter
-forge_ib_monitor_ufm_changes_applied_total{fabric="default",operation="bind_guid_to_pkey",status="error"} 0
-forge_ib_monitor_ufm_changes_applied_total{fabric="default",operation="bind_guid_to_pkey",status="ok"} 0
-forge_ib_monitor_ufm_changes_applied_total{fabric="default",operation="unbind_guid_from_pkey",status="error"} 0
-forge_ib_monitor_ufm_changes_applied_total{fabric="default",operation="unbind_guid_from_pkey",status="ok"} 0
-# HELP forge_machines_enqueuer_iteration_latency_milliseconds The overall time it took to enqueue state handling tasks for all forge_machines in the system
-# TYPE forge_machines_enqueuer_iteration_latency_milliseconds histogram
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="0"} 0
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="5"} 1
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="10"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="25"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="50"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="75"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="100"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="250"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="500"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="750"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="1000"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="2500"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="5000"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="7500"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="10000"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="+Inf"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_sum 10.406267
-forge_machines_enqueuer_iteration_latency_milliseconds_count 2
-# HELP forge_machines_handler_latency_in_state_milliseconds The amount of time it took to invoke the state handler for objects of type forge_machines in a certain state
-# TYPE forge_machines_handler_latency_in_state_milliseconds histogram
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="0"} 0
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="5"} 0
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="10"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="25"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="50"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="75"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="100"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="250"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="500"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="750"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="1000"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="2500"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="5000"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="7500"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="10000"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="+Inf"} 1
-forge_machines_handler_latency_in_state_milliseconds_sum{state="deleting",substate="drainallocatedips"} 5.474484
-forge_machines_handler_latency_in_state_milliseconds_count{state="deleting",substate="drainallocatedips"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="0"} 0
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="5"} 0
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="10"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="25"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="50"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="75"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="100"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="250"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="500"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="750"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="1000"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="2500"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="5000"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="7500"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="10000"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="+Inf"} 1
-forge_machines_handler_latency_in_state_milliseconds_sum{state="ready",substate=""} 5.1987250000000005
-forge_machines_handler_latency_in_state_milliseconds_count{state="ready",substate=""} 1
-# HELP forge_machines_iteration_latency_milliseconds The overall time it took to handle state for all forge_machines in the system
-# TYPE forge_machines_iteration_latency_milliseconds histogram
-forge_machines_iteration_latency_milliseconds_bucket{le="0"} 0
-forge_machines_iteration_latency_milliseconds_bucket{le="5"} 1
-forge_machines_iteration_latency_milliseconds_bucket{le="10"} 1
-forge_machines_iteration_latency_milliseconds_bucket{le="25"} 2
-forge_machines_iteration_latency_milliseconds_bucket{le="50"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="75"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="100"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="250"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="500"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="750"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="1000"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="2500"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="5000"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="7500"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="10000"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="+Inf"} 3
-forge_machines_iteration_latency_milliseconds_sum 44.459362
-forge_machines_iteration_latency_milliseconds_count 3
-# HELP forge_machines_object_tasks_completed_total The amount of object handling tasks that have been completed for objects of type forge_machines
-# TYPE forge_machines_object_tasks_completed_total counter
-forge_machines_object_tasks_completed_total 2
-# HELP forge_machines_object_tasks_dispatched_total The amount of types that object handling tasks that have been dequeued and dispatched for processing for objects of type forge_machines
-# TYPE forge_machines_object_tasks_dispatched_total counter
-forge_machines_object_tasks_dispatched_total 2
-# HELP forge_machines_object_tasks_enqueued_total The amount of types that object handling tasks that have been freshly enqueued for objects of type forge_machines
-# TYPE forge_machines_object_tasks_enqueued_total counter
-forge_machines_object_tasks_enqueued_total 1
-# HELP forge_machines_object_tasks_requeued_total The amount of object handling tasks that have been requeued for objects of type forge_machines
-# TYPE forge_machines_object_tasks_requeued_total counter
-forge_machines_object_tasks_requeued_total 1
-# HELP forge_machines_per_state The number of forge_machines in the system with a given state
-# TYPE forge_machines_per_state gauge
-forge_machines_per_state{fresh="true",state="deleting",substate="drainallocatedips"} 1
-# HELP forge_machines_per_state_above_sla The number of forge_machines in the system which had been longer in a state than allowed per SLA
-# TYPE forge_machines_per_state_above_sla gauge
-forge_machines_per_state_above_sla{fresh="true",state="deleting",substate="drainallocatedips"} 0
-# HELP forge_machines_state_entered_total The amount of types that objects of type forge_machines have entered a certain state
-# TYPE forge_machines_state_entered_total counter
-forge_machines_state_entered_total{state="deleting",substate="drainallocatedips"} 1
-# HELP forge_machines_state_exited_total The amount of types that objects of type forge_machines have exited a certain state
-# TYPE forge_machines_state_exited_total counter
-forge_machines_state_exited_total{state="ready",substate=""} 1
-# HELP forge_machines_time_in_state_seconds The amount of time objects of type forge_machines have spent in a certain state
-# TYPE forge_machines_time_in_state_seconds histogram
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="0"} 0
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="5"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="10"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="25"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="50"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="75"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="100"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="250"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="500"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="750"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="1000"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="2500"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="5000"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="7500"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="10000"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="+Inf"} 1
-forge_machines_time_in_state_seconds_sum{next_state="deleting",next_substate="drainallocatedips",state="ready",substate=""} 0.091039928
-forge_machines_time_in_state_seconds_count{next_state="deleting",next_substate="drainallocatedips",state="ready",substate=""} 1
-# HELP forge_machines_total The total number of forge_machines in the system
-# TYPE forge_machines_total gauge
-forge_machines_total{fresh="true"} 1
-# HELP forge_machines_with_state_handling_errors_per_state The number of forge_machines in the system with a given state that failed state handling
-# TYPE forge_machines_with_state_handling_errors_per_state gauge
-forge_machines_with_state_handling_errors_per_state{error="any",fresh="true",state="deleting",substate="drainallocatedips"} 0
-# HELP forge_reserved_ips_count The total number of reserved ips in the Forge site
-# TYPE forge_reserved_ips_count gauge
-forge_reserved_ips_count{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="admin"} 1
-# HELP forge_total_ips_count The total number of ips in the Forge site
-# TYPE forge_total_ips_count gauge
-forge_total_ips_count{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="admin"} 256
+# HELP carbide_available_ips_count The total number of available ips in the site
+# TYPE carbide_available_ips_count gauge
+carbide_available_ips_count{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="admin"} 253
+# HELP carbide_ib_monitor_ufm_changes_applied_total The amount of changes that have been performed at UFM
+# TYPE carbide_ib_monitor_ufm_changes_applied_total counter
+carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="bind_guid_to_pkey",status="error"} 0
+carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="bind_guid_to_pkey",status="ok"} 0
+carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="unbind_guid_from_pkey",status="error"} 0
+carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="unbind_guid_from_pkey",status="ok"} 0
+# HELP carbide_machines_enqueuer_iteration_latency_milliseconds The overall time it took to enqueue state handling tasks for all carbide_machines in the system
+# TYPE carbide_machines_enqueuer_iteration_latency_milliseconds histogram
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="0"} 0
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="5"} 1
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="10"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="25"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="50"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="75"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="100"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="250"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="500"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="750"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="1000"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="2500"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="5000"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="7500"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="10000"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="+Inf"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_sum 10.406267
+carbide_machines_enqueuer_iteration_latency_milliseconds_count 2
+# HELP carbide_machines_handler_latency_in_state_milliseconds The amount of time it took to invoke the state handler for objects of type carbide_machines in a certain state
+# TYPE carbide_machines_handler_latency_in_state_milliseconds histogram
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="0"} 0
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="5"} 0
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="10"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="25"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="50"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="75"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="100"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="250"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="500"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="750"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="1000"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="2500"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="5000"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="7500"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="10000"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="+Inf"} 1
+carbide_machines_handler_latency_in_state_milliseconds_sum{state="deleting",substate="drainallocatedips"} 5.474484
+carbide_machines_handler_latency_in_state_milliseconds_count{state="deleting",substate="drainallocatedips"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="0"} 0
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="5"} 0
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="10"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="25"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="50"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="75"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="100"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="250"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="500"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="750"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="1000"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="2500"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="5000"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="7500"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="10000"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="+Inf"} 1
+carbide_machines_handler_latency_in_state_milliseconds_sum{state="ready",substate=""} 5.1987250000000005
+carbide_machines_handler_latency_in_state_milliseconds_count{state="ready",substate=""} 1
+# HELP carbide_machines_iteration_latency_milliseconds The overall time it took to handle state for all carbide_machines in the system
+# TYPE carbide_machines_iteration_latency_milliseconds histogram
+carbide_machines_iteration_latency_milliseconds_bucket{le="0"} 0
+carbide_machines_iteration_latency_milliseconds_bucket{le="5"} 1
+carbide_machines_iteration_latency_milliseconds_bucket{le="10"} 1
+carbide_machines_iteration_latency_milliseconds_bucket{le="25"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="50"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="75"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="100"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="250"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="500"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="750"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="1000"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="2500"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="5000"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="7500"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="10000"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="+Inf"} 3
+carbide_machines_iteration_latency_milliseconds_sum 44.459362
+carbide_machines_iteration_latency_milliseconds_count 3
+# HELP carbide_machines_object_tasks_completed_total The amount of object handling tasks that have been completed for objects of type carbide_machines
+# TYPE carbide_machines_object_tasks_completed_total counter
+carbide_machines_object_tasks_completed_total 2
+# HELP carbide_machines_object_tasks_dispatched_total The amount of types that object handling tasks that have been dequeued and dispatched for processing for objects of type carbide_machines
+# TYPE carbide_machines_object_tasks_dispatched_total counter
+carbide_machines_object_tasks_dispatched_total 2
+# HELP carbide_machines_object_tasks_enqueued_total The amount of types that object handling tasks that have been freshly enqueued for objects of type carbide_machines
+# TYPE carbide_machines_object_tasks_enqueued_total counter
+carbide_machines_object_tasks_enqueued_total 1
+# HELP carbide_machines_object_tasks_requeued_total The amount of object handling tasks that have been requeued for objects of type carbide_machines
+# TYPE carbide_machines_object_tasks_requeued_total counter
+carbide_machines_object_tasks_requeued_total 1
+# HELP carbide_machines_per_state The number of carbide_machines in the system with a given state
+# TYPE carbide_machines_per_state gauge
+carbide_machines_per_state{fresh="true",state="deleting",substate="drainallocatedips"} 1
+# HELP carbide_machines_per_state_above_sla The number of carbide_machines in the system which had been longer in a state than allowed per SLA
+# TYPE carbide_machines_per_state_above_sla gauge
+carbide_machines_per_state_above_sla{fresh="true",state="deleting",substate="drainallocatedips"} 0
+# HELP carbide_machines_state_entered_total The amount of types that objects of type carbide_machines have entered a certain state
+# TYPE carbide_machines_state_entered_total counter
+carbide_machines_state_entered_total{state="deleting",substate="drainallocatedips"} 1
+# HELP carbide_machines_state_exited_total The amount of types that objects of type carbide_machines have exited a certain state
+# TYPE carbide_machines_state_exited_total counter
+carbide_machines_state_exited_total{state="ready",substate=""} 1
+# HELP carbide_machines_time_in_state_seconds The amount of time objects of type carbide_machines have spent in a certain state
+# TYPE carbide_machines_time_in_state_seconds histogram
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="0"} 0
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="5"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="10"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="25"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="50"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="75"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="100"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="250"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="500"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="750"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="1000"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="2500"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="5000"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="7500"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="10000"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="+Inf"} 1
+carbide_machines_time_in_state_seconds_sum{next_state="deleting",next_substate="drainallocatedips",state="ready",substate=""} 0.091039928
+carbide_machines_time_in_state_seconds_count{next_state="deleting",next_substate="drainallocatedips",state="ready",substate=""} 1
+# HELP carbide_machines_total The total number of carbide_machines in the system
+# TYPE carbide_machines_total gauge
+carbide_machines_total{fresh="true"} 1
+# HELP carbide_machines_with_state_handling_errors_per_state The number of carbide_machines in the system with a given state that failed state handling
+# TYPE carbide_machines_with_state_handling_errors_per_state gauge
+carbide_machines_with_state_handling_errors_per_state{error="any",fresh="true",state="deleting",substate="drainallocatedips"} 0
+# HELP carbide_reserved_ips_count The total number of reserved ips in the site
+# TYPE carbide_reserved_ips_count gauge
+carbide_reserved_ips_count{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="admin"} 1
+# HELP carbide_total_ips_count The total number of ips in the site
+# TYPE carbide_total_ips_count gauge
+carbide_total_ips_count{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="admin"} 256

--- a/crates/api/src/tests/metrics_fixtures/test_network_segment_metrics_tenant.txt
+++ b/crates/api/src/tests/metrics_fixtures/test_network_segment_metrics_tenant.txt
@@ -8,137 +8,137 @@ carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="remove",s
 carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="remove",status="true"} 0
 carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="update",status="false"} 0
 carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="update",status="true"} 0
-# HELP forge_ib_monitor_ufm_changes_applied_total The amount of changes that have been performed at UFM
-# TYPE forge_ib_monitor_ufm_changes_applied_total counter
-forge_ib_monitor_ufm_changes_applied_total{fabric="default",operation="bind_guid_to_pkey",status="error"} 0
-forge_ib_monitor_ufm_changes_applied_total{fabric="default",operation="bind_guid_to_pkey",status="ok"} 0
-forge_ib_monitor_ufm_changes_applied_total{fabric="default",operation="unbind_guid_from_pkey",status="error"} 0
-forge_ib_monitor_ufm_changes_applied_total{fabric="default",operation="unbind_guid_from_pkey",status="ok"} 0
-# HELP forge_machines_enqueuer_iteration_latency_milliseconds The overall time it took to enqueue state handling tasks for all forge_machines in the system
-# TYPE forge_machines_enqueuer_iteration_latency_milliseconds histogram
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="0"} 0
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="5"} 1
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="10"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="25"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="50"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="75"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="100"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="250"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="500"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="750"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="1000"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="2500"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="5000"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="7500"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="10000"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="+Inf"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_sum 10.540408
-forge_machines_enqueuer_iteration_latency_milliseconds_count 2
-# HELP forge_machines_handler_latency_in_state_milliseconds The amount of time it took to invoke the state handler for objects of type forge_machines in a certain state
-# TYPE forge_machines_handler_latency_in_state_milliseconds histogram
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="0"} 0
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="5"} 0
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="10"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="25"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="50"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="75"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="100"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="250"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="500"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="750"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="1000"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="2500"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="5000"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="7500"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="10000"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="+Inf"} 1
-forge_machines_handler_latency_in_state_milliseconds_sum{state="deleting",substate="drainallocatedips"} 5.12397
-forge_machines_handler_latency_in_state_milliseconds_count{state="deleting",substate="drainallocatedips"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="0"} 0
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="5"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="10"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="25"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="50"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="75"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="100"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="250"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="500"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="750"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="1000"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="2500"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="5000"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="7500"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="10000"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="+Inf"} 1
-forge_machines_handler_latency_in_state_milliseconds_sum{state="ready",substate=""} 3.9689590000000003
-forge_machines_handler_latency_in_state_milliseconds_count{state="ready",substate=""} 1
-# HELP forge_machines_iteration_latency_milliseconds The overall time it took to handle state for all forge_machines in the system
-# TYPE forge_machines_iteration_latency_milliseconds histogram
-forge_machines_iteration_latency_milliseconds_bucket{le="0"} 0
-forge_machines_iteration_latency_milliseconds_bucket{le="5"} 1
-forge_machines_iteration_latency_milliseconds_bucket{le="10"} 1
-forge_machines_iteration_latency_milliseconds_bucket{le="25"} 2
-forge_machines_iteration_latency_milliseconds_bucket{le="50"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="75"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="100"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="250"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="500"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="750"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="1000"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="2500"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="5000"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="7500"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="10000"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="+Inf"} 3
-forge_machines_iteration_latency_milliseconds_sum 46.85431
-forge_machines_iteration_latency_milliseconds_count 3
-# HELP forge_machines_object_tasks_completed_total The amount of object handling tasks that have been completed for objects of type forge_machines
-# TYPE forge_machines_object_tasks_completed_total counter
-forge_machines_object_tasks_completed_total 2
-# HELP forge_machines_object_tasks_dispatched_total The amount of types that object handling tasks that have been dequeued and dispatched for processing for objects of type forge_machines
-# TYPE forge_machines_object_tasks_dispatched_total counter
-forge_machines_object_tasks_dispatched_total 2
-# HELP forge_machines_object_tasks_enqueued_total The amount of types that object handling tasks that have been freshly enqueued for objects of type forge_machines
-# TYPE forge_machines_object_tasks_enqueued_total counter
-forge_machines_object_tasks_enqueued_total 1
-# HELP forge_machines_object_tasks_requeued_total The amount of object handling tasks that have been requeued for objects of type forge_machines
-# TYPE forge_machines_object_tasks_requeued_total counter
-forge_machines_object_tasks_requeued_total 1
-# HELP forge_machines_per_state The number of forge_machines in the system with a given state
-# TYPE forge_machines_per_state gauge
-forge_machines_per_state{fresh="true",state="deleting",substate="drainallocatedips"} 1
-# HELP forge_machines_per_state_above_sla The number of forge_machines in the system which had been longer in a state than allowed per SLA
-# TYPE forge_machines_per_state_above_sla gauge
-forge_machines_per_state_above_sla{fresh="true",state="deleting",substate="drainallocatedips"} 0
-# HELP forge_machines_state_entered_total The amount of types that objects of type forge_machines have entered a certain state
-# TYPE forge_machines_state_entered_total counter
-forge_machines_state_entered_total{state="deleting",substate="drainallocatedips"} 1
-# HELP forge_machines_state_exited_total The amount of types that objects of type forge_machines have exited a certain state
-# TYPE forge_machines_state_exited_total counter
-forge_machines_state_exited_total{state="ready",substate=""} 1
-# HELP forge_machines_time_in_state_seconds The amount of time objects of type forge_machines have spent in a certain state
-# TYPE forge_machines_time_in_state_seconds histogram
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="0"} 0
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="5"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="10"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="25"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="50"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="75"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="100"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="250"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="500"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="750"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="1000"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="2500"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="5000"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="7500"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="10000"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="+Inf"} 1
-forge_machines_time_in_state_seconds_sum{next_state="deleting",next_substate="drainallocatedips",state="ready",substate=""} 0.085621773
-forge_machines_time_in_state_seconds_count{next_state="deleting",next_substate="drainallocatedips",state="ready",substate=""} 1
-# HELP forge_machines_total The total number of forge_machines in the system
-# TYPE forge_machines_total gauge
-forge_machines_total{fresh="true"} 1
-# HELP forge_machines_with_state_handling_errors_per_state The number of forge_machines in the system with a given state that failed state handling
-# TYPE forge_machines_with_state_handling_errors_per_state gauge
-forge_machines_with_state_handling_errors_per_state{error="any",fresh="true",state="deleting",substate="drainallocatedips"} 0
+# HELP carbide_ib_monitor_ufm_changes_applied_total The amount of changes that have been performed at UFM
+# TYPE carbide_ib_monitor_ufm_changes_applied_total counter
+carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="bind_guid_to_pkey",status="error"} 0
+carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="bind_guid_to_pkey",status="ok"} 0
+carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="unbind_guid_from_pkey",status="error"} 0
+carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="unbind_guid_from_pkey",status="ok"} 0
+# HELP carbide_machines_enqueuer_iteration_latency_milliseconds The overall time it took to enqueue state handling tasks for all carbide_machines in the system
+# TYPE carbide_machines_enqueuer_iteration_latency_milliseconds histogram
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="0"} 0
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="5"} 1
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="10"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="25"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="50"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="75"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="100"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="250"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="500"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="750"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="1000"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="2500"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="5000"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="7500"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="10000"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="+Inf"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_sum 10.540408
+carbide_machines_enqueuer_iteration_latency_milliseconds_count 2
+# HELP carbide_machines_handler_latency_in_state_milliseconds The amount of time it took to invoke the state handler for objects of type carbide_machines in a certain state
+# TYPE carbide_machines_handler_latency_in_state_milliseconds histogram
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="0"} 0
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="5"} 0
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="10"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="25"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="50"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="75"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="100"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="250"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="500"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="750"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="1000"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="2500"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="5000"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="7500"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="10000"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="+Inf"} 1
+carbide_machines_handler_latency_in_state_milliseconds_sum{state="deleting",substate="drainallocatedips"} 5.12397
+carbide_machines_handler_latency_in_state_milliseconds_count{state="deleting",substate="drainallocatedips"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="0"} 0
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="5"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="10"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="25"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="50"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="75"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="100"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="250"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="500"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="750"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="1000"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="2500"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="5000"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="7500"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="10000"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="+Inf"} 1
+carbide_machines_handler_latency_in_state_milliseconds_sum{state="ready",substate=""} 3.9689590000000003
+carbide_machines_handler_latency_in_state_milliseconds_count{state="ready",substate=""} 1
+# HELP carbide_machines_iteration_latency_milliseconds The overall time it took to handle state for all carbide_machines in the system
+# TYPE carbide_machines_iteration_latency_milliseconds histogram
+carbide_machines_iteration_latency_milliseconds_bucket{le="0"} 0
+carbide_machines_iteration_latency_milliseconds_bucket{le="5"} 1
+carbide_machines_iteration_latency_milliseconds_bucket{le="10"} 1
+carbide_machines_iteration_latency_milliseconds_bucket{le="25"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="50"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="75"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="100"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="250"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="500"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="750"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="1000"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="2500"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="5000"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="7500"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="10000"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="+Inf"} 3
+carbide_machines_iteration_latency_milliseconds_sum 46.85431
+carbide_machines_iteration_latency_milliseconds_count 3
+# HELP carbide_machines_object_tasks_completed_total The amount of object handling tasks that have been completed for objects of type carbide_machines
+# TYPE carbide_machines_object_tasks_completed_total counter
+carbide_machines_object_tasks_completed_total 2
+# HELP carbide_machines_object_tasks_dispatched_total The amount of types that object handling tasks that have been dequeued and dispatched for processing for objects of type carbide_machines
+# TYPE carbide_machines_object_tasks_dispatched_total counter
+carbide_machines_object_tasks_dispatched_total 2
+# HELP carbide_machines_object_tasks_enqueued_total The amount of types that object handling tasks that have been freshly enqueued for objects of type carbide_machines
+# TYPE carbide_machines_object_tasks_enqueued_total counter
+carbide_machines_object_tasks_enqueued_total 1
+# HELP carbide_machines_object_tasks_requeued_total The amount of object handling tasks that have been requeued for objects of type carbide_machines
+# TYPE carbide_machines_object_tasks_requeued_total counter
+carbide_machines_object_tasks_requeued_total 1
+# HELP carbide_machines_per_state The number of carbide_machines in the system with a given state
+# TYPE carbide_machines_per_state gauge
+carbide_machines_per_state{fresh="true",state="deleting",substate="drainallocatedips"} 1
+# HELP carbide_machines_per_state_above_sla The number of carbide_machines in the system which had been longer in a state than allowed per SLA
+# TYPE carbide_machines_per_state_above_sla gauge
+carbide_machines_per_state_above_sla{fresh="true",state="deleting",substate="drainallocatedips"} 0
+# HELP carbide_machines_state_entered_total The amount of types that objects of type carbide_machines have entered a certain state
+# TYPE carbide_machines_state_entered_total counter
+carbide_machines_state_entered_total{state="deleting",substate="drainallocatedips"} 1
+# HELP carbide_machines_state_exited_total The amount of types that objects of type carbide_machines have exited a certain state
+# TYPE carbide_machines_state_exited_total counter
+carbide_machines_state_exited_total{state="ready",substate=""} 1
+# HELP carbide_machines_time_in_state_seconds The amount of time objects of type carbide_machines have spent in a certain state
+# TYPE carbide_machines_time_in_state_seconds histogram
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="0"} 0
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="5"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="10"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="25"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="50"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="75"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="100"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="250"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="500"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="750"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="1000"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="2500"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="5000"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="7500"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="10000"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="+Inf"} 1
+carbide_machines_time_in_state_seconds_sum{next_state="deleting",next_substate="drainallocatedips",state="ready",substate=""} 0.085621773
+carbide_machines_time_in_state_seconds_count{next_state="deleting",next_substate="drainallocatedips",state="ready",substate=""} 1
+# HELP carbide_machines_total The total number of carbide_machines in the system
+# TYPE carbide_machines_total gauge
+carbide_machines_total{fresh="true"} 1
+# HELP carbide_machines_with_state_handling_errors_per_state The number of carbide_machines in the system with a given state that failed state handling
+# TYPE carbide_machines_with_state_handling_errors_per_state gauge
+carbide_machines_with_state_handling_errors_per_state{error="any",fresh="true",state="deleting",substate="drainallocatedips"} 0

--- a/crates/api/src/tests/metrics_fixtures/test_network_segment_metrics_tor.txt
+++ b/crates/api/src/tests/metrics_fixtures/test_network_segment_metrics_tor.txt
@@ -8,146 +8,146 @@ carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="remove",s
 carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="remove",status="true"} 0
 carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="update",status="false"} 0
 carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="update",status="true"} 0
-# HELP forge_available_ips_count The total number of available ips in the Forge site
-# TYPE forge_available_ips_count gauge
-forge_available_ips_count{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="tor"} 253
-# HELP forge_ib_monitor_ufm_changes_applied_total The amount of changes that have been performed at UFM
-# TYPE forge_ib_monitor_ufm_changes_applied_total counter
-forge_ib_monitor_ufm_changes_applied_total{fabric="default",operation="bind_guid_to_pkey",status="error"} 0
-forge_ib_monitor_ufm_changes_applied_total{fabric="default",operation="bind_guid_to_pkey",status="ok"} 0
-forge_ib_monitor_ufm_changes_applied_total{fabric="default",operation="unbind_guid_from_pkey",status="error"} 0
-forge_ib_monitor_ufm_changes_applied_total{fabric="default",operation="unbind_guid_from_pkey",status="ok"} 0
-# HELP forge_machines_enqueuer_iteration_latency_milliseconds The overall time it took to enqueue state handling tasks for all forge_machines in the system
-# TYPE forge_machines_enqueuer_iteration_latency_milliseconds histogram
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="0"} 0
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="5"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="10"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="25"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="50"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="75"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="100"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="250"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="500"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="750"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="1000"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="2500"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="5000"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="7500"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="10000"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_bucket{le="+Inf"} 2
-forge_machines_enqueuer_iteration_latency_milliseconds_sum 8.576246999999999
-forge_machines_enqueuer_iteration_latency_milliseconds_count 2
-# HELP forge_machines_handler_latency_in_state_milliseconds The amount of time it took to invoke the state handler for objects of type forge_machines in a certain state
-# TYPE forge_machines_handler_latency_in_state_milliseconds histogram
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="0"} 0
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="5"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="10"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="25"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="50"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="75"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="100"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="250"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="500"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="750"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="1000"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="2500"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="5000"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="7500"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="10000"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="+Inf"} 1
-forge_machines_handler_latency_in_state_milliseconds_sum{state="deleting",substate="drainallocatedips"} 3.9417130000000005
-forge_machines_handler_latency_in_state_milliseconds_count{state="deleting",substate="drainallocatedips"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="0"} 0
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="5"} 0
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="10"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="25"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="50"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="75"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="100"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="250"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="500"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="750"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="1000"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="2500"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="5000"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="7500"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="10000"} 1
-forge_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="+Inf"} 1
-forge_machines_handler_latency_in_state_milliseconds_sum{state="ready",substate=""} 5.230594
-forge_machines_handler_latency_in_state_milliseconds_count{state="ready",substate=""} 1
-# HELP forge_machines_iteration_latency_milliseconds The overall time it took to handle state for all forge_machines in the system
-# TYPE forge_machines_iteration_latency_milliseconds histogram
-forge_machines_iteration_latency_milliseconds_bucket{le="0"} 0
-forge_machines_iteration_latency_milliseconds_bucket{le="5"} 1
-forge_machines_iteration_latency_milliseconds_bucket{le="10"} 1
-forge_machines_iteration_latency_milliseconds_bucket{le="25"} 2
-forge_machines_iteration_latency_milliseconds_bucket{le="50"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="75"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="100"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="250"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="500"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="750"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="1000"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="2500"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="5000"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="7500"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="10000"} 3
-forge_machines_iteration_latency_milliseconds_bucket{le="+Inf"} 3
-forge_machines_iteration_latency_milliseconds_sum 42.644988999999995
-forge_machines_iteration_latency_milliseconds_count 3
-# HELP forge_machines_object_tasks_completed_total The amount of object handling tasks that have been completed for objects of type forge_machines
-# TYPE forge_machines_object_tasks_completed_total counter
-forge_machines_object_tasks_completed_total 2
-# HELP forge_machines_object_tasks_dispatched_total The amount of types that object handling tasks that have been dequeued and dispatched for processing for objects of type forge_machines
-# TYPE forge_machines_object_tasks_dispatched_total counter
-forge_machines_object_tasks_dispatched_total 2
-# HELP forge_machines_object_tasks_enqueued_total The amount of types that object handling tasks that have been freshly enqueued for objects of type forge_machines
-# TYPE forge_machines_object_tasks_enqueued_total counter
-forge_machines_object_tasks_enqueued_total 1
-# HELP forge_machines_object_tasks_requeued_total The amount of object handling tasks that have been requeued for objects of type forge_machines
-# TYPE forge_machines_object_tasks_requeued_total counter
-forge_machines_object_tasks_requeued_total 1
-# HELP forge_machines_per_state The number of forge_machines in the system with a given state
-# TYPE forge_machines_per_state gauge
-forge_machines_per_state{fresh="true",state="deleting",substate="drainallocatedips"} 1
-# HELP forge_machines_per_state_above_sla The number of forge_machines in the system which had been longer in a state than allowed per SLA
-# TYPE forge_machines_per_state_above_sla gauge
-forge_machines_per_state_above_sla{fresh="true",state="deleting",substate="drainallocatedips"} 0
-# HELP forge_machines_state_entered_total The amount of types that objects of type forge_machines have entered a certain state
-# TYPE forge_machines_state_entered_total counter
-forge_machines_state_entered_total{state="deleting",substate="drainallocatedips"} 1
-# HELP forge_machines_state_exited_total The amount of types that objects of type forge_machines have exited a certain state
-# TYPE forge_machines_state_exited_total counter
-forge_machines_state_exited_total{state="ready",substate=""} 1
-# HELP forge_machines_time_in_state_seconds The amount of time objects of type forge_machines have spent in a certain state
-# TYPE forge_machines_time_in_state_seconds histogram
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="0"} 0
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="5"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="10"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="25"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="50"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="75"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="100"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="250"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="500"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="750"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="1000"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="2500"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="5000"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="7500"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="10000"} 1
-forge_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="+Inf"} 1
-forge_machines_time_in_state_seconds_sum{next_state="deleting",next_substate="drainallocatedips",state="ready",substate=""} 0.089736764
-forge_machines_time_in_state_seconds_count{next_state="deleting",next_substate="drainallocatedips",state="ready",substate=""} 1
-# HELP forge_machines_total The total number of forge_machines in the system
-# TYPE forge_machines_total gauge
-forge_machines_total{fresh="true"} 1
-# HELP forge_machines_with_state_handling_errors_per_state The number of forge_machines in the system with a given state that failed state handling
-# TYPE forge_machines_with_state_handling_errors_per_state gauge
-forge_machines_with_state_handling_errors_per_state{error="any",fresh="true",state="deleting",substate="drainallocatedips"} 0
-# HELP forge_reserved_ips_count The total number of reserved ips in the Forge site
-# TYPE forge_reserved_ips_count gauge
-forge_reserved_ips_count{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="tor"} 1
-# HELP forge_total_ips_count The total number of ips in the Forge site
-# TYPE forge_total_ips_count gauge
-forge_total_ips_count{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="tor"} 256
+# HELP carbide_available_ips_count The total number of available ips in the site
+# TYPE carbide_available_ips_count gauge
+carbide_available_ips_count{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="tor"} 253
+# HELP carbide_ib_monitor_ufm_changes_applied_total The amount of changes that have been performed at UFM
+# TYPE carbide_ib_monitor_ufm_changes_applied_total counter
+carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="bind_guid_to_pkey",status="error"} 0
+carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="bind_guid_to_pkey",status="ok"} 0
+carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="unbind_guid_from_pkey",status="error"} 0
+carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="unbind_guid_from_pkey",status="ok"} 0
+# HELP carbide_machines_enqueuer_iteration_latency_milliseconds The overall time it took to enqueue state handling tasks for all carbide_machines in the system
+# TYPE carbide_machines_enqueuer_iteration_latency_milliseconds histogram
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="0"} 0
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="5"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="10"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="25"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="50"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="75"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="100"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="250"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="500"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="750"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="1000"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="2500"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="5000"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="7500"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="10000"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="+Inf"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_sum 8.576246999999999
+carbide_machines_enqueuer_iteration_latency_milliseconds_count 2
+# HELP carbide_machines_handler_latency_in_state_milliseconds The amount of time it took to invoke the state handler for objects of type carbide_machines in a certain state
+# TYPE carbide_machines_handler_latency_in_state_milliseconds histogram
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="0"} 0
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="5"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="10"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="25"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="50"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="75"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="100"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="250"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="500"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="750"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="1000"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="2500"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="5000"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="7500"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="10000"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="+Inf"} 1
+carbide_machines_handler_latency_in_state_milliseconds_sum{state="deleting",substate="drainallocatedips"} 3.9417130000000005
+carbide_machines_handler_latency_in_state_milliseconds_count{state="deleting",substate="drainallocatedips"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="0"} 0
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="5"} 0
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="10"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="25"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="50"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="75"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="100"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="250"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="500"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="750"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="1000"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="2500"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="5000"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="7500"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="10000"} 1
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="+Inf"} 1
+carbide_machines_handler_latency_in_state_milliseconds_sum{state="ready",substate=""} 5.230594
+carbide_machines_handler_latency_in_state_milliseconds_count{state="ready",substate=""} 1
+# HELP carbide_machines_iteration_latency_milliseconds The overall time it took to handle state for all carbide_machines in the system
+# TYPE carbide_machines_iteration_latency_milliseconds histogram
+carbide_machines_iteration_latency_milliseconds_bucket{le="0"} 0
+carbide_machines_iteration_latency_milliseconds_bucket{le="5"} 1
+carbide_machines_iteration_latency_milliseconds_bucket{le="10"} 1
+carbide_machines_iteration_latency_milliseconds_bucket{le="25"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="50"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="75"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="100"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="250"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="500"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="750"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="1000"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="2500"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="5000"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="7500"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="10000"} 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="+Inf"} 3
+carbide_machines_iteration_latency_milliseconds_sum 42.644988999999995
+carbide_machines_iteration_latency_milliseconds_count 3
+# HELP carbide_machines_object_tasks_completed_total The amount of object handling tasks that have been completed for objects of type carbide_machines
+# TYPE carbide_machines_object_tasks_completed_total counter
+carbide_machines_object_tasks_completed_total 2
+# HELP carbide_machines_object_tasks_dispatched_total The amount of types that object handling tasks that have been dequeued and dispatched for processing for objects of type carbide_machines
+# TYPE carbide_machines_object_tasks_dispatched_total counter
+carbide_machines_object_tasks_dispatched_total 2
+# HELP carbide_machines_object_tasks_enqueued_total The amount of types that object handling tasks that have been freshly enqueued for objects of type carbide_machines
+# TYPE carbide_machines_object_tasks_enqueued_total counter
+carbide_machines_object_tasks_enqueued_total 1
+# HELP carbide_machines_object_tasks_requeued_total The amount of object handling tasks that have been requeued for objects of type carbide_machines
+# TYPE carbide_machines_object_tasks_requeued_total counter
+carbide_machines_object_tasks_requeued_total 1
+# HELP carbide_machines_per_state The number of carbide_machines in the system with a given state
+# TYPE carbide_machines_per_state gauge
+carbide_machines_per_state{fresh="true",state="deleting",substate="drainallocatedips"} 1
+# HELP carbide_machines_per_state_above_sla The number of carbide_machines in the system which had been longer in a state than allowed per SLA
+# TYPE carbide_machines_per_state_above_sla gauge
+carbide_machines_per_state_above_sla{fresh="true",state="deleting",substate="drainallocatedips"} 0
+# HELP carbide_machines_state_entered_total The amount of types that objects of type carbide_machines have entered a certain state
+# TYPE carbide_machines_state_entered_total counter
+carbide_machines_state_entered_total{state="deleting",substate="drainallocatedips"} 1
+# HELP carbide_machines_state_exited_total The amount of types that objects of type carbide_machines have exited a certain state
+# TYPE carbide_machines_state_exited_total counter
+carbide_machines_state_exited_total{state="ready",substate=""} 1
+# HELP carbide_machines_time_in_state_seconds The amount of time objects of type carbide_machines have spent in a certain state
+# TYPE carbide_machines_time_in_state_seconds histogram
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="0"} 0
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="5"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="10"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="25"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="50"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="75"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="100"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="250"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="500"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="750"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="1000"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="2500"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="5000"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="7500"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="10000"} 1
+carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="+Inf"} 1
+carbide_machines_time_in_state_seconds_sum{next_state="deleting",next_substate="drainallocatedips",state="ready",substate=""} 0.089736764
+carbide_machines_time_in_state_seconds_count{next_state="deleting",next_substate="drainallocatedips",state="ready",substate=""} 1
+# HELP carbide_machines_total The total number of carbide_machines in the system
+# TYPE carbide_machines_total gauge
+carbide_machines_total{fresh="true"} 1
+# HELP carbide_machines_with_state_handling_errors_per_state The number of carbide_machines in the system with a given state that failed state handling
+# TYPE carbide_machines_with_state_handling_errors_per_state gauge
+carbide_machines_with_state_handling_errors_per_state{error="any",fresh="true",state="deleting",substate="drainallocatedips"} 0
+# HELP carbide_reserved_ips_count The total number of reserved ips in the site
+# TYPE carbide_reserved_ips_count gauge
+carbide_reserved_ips_count{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="tor"} 1
+# HELP carbide_total_ips_count The total number of ips in the site
+# TYPE carbide_total_ips_count gauge
+carbide_total_ips_count{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="tor"} 256

--- a/crates/api/src/tests/network_segment.rs
+++ b/crates/api/src/tests/network_segment.rs
@@ -243,21 +243,21 @@ async fn test_network_segment_max_history_length(
 
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_available_ips_count")
+            .formatted_metric("carbide_available_ips_count")
             .unwrap(),
         r#"{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="admin"} 253"#
     );
 
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_total_ips_count")
+            .formatted_metric("carbide_total_ips_count")
             .unwrap(),
         r#"{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="admin"} 256"#
     );
 
     assert_eq!(
         env.test_meter
-            .formatted_metric("forge_reserved_ips_count")
+            .formatted_metric("carbide_reserved_ips_count")
             .unwrap(),
         r#"{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="admin"} 1"#
     );
@@ -676,13 +676,13 @@ async fn test_network_segment_metrics(
     if matches!(test_type, MetricsTestType::Tenant) {
         assert!(
             env.test_meter
-                .formatted_metric("forge_available_ips_count")
+                .formatted_metric("carbide_available_ips_count")
                 .is_none()
         );
     } else {
         assert_eq!(
             env.test_meter
-                .formatted_metric("forge_available_ips_count")
+                .formatted_metric("carbide_available_ips_count")
                 .unwrap(),
             avail_str
         );
@@ -695,13 +695,13 @@ async fn test_network_segment_metrics(
     if matches!(test_type, MetricsTestType::Tenant) {
         assert!(
             env.test_meter
-                .formatted_metric("forge_total_ips_count")
+                .formatted_metric("carbide_total_ips_count")
                 .is_none()
         );
     } else {
         assert_eq!(
             env.test_meter
-                .formatted_metric("forge_total_ips_count")
+                .formatted_metric("carbide_total_ips_count")
                 .unwrap(),
             total_str
         );
@@ -714,13 +714,13 @@ async fn test_network_segment_metrics(
     if matches!(test_type, MetricsTestType::Tenant) {
         assert!(
             env.test_meter
-                .formatted_metric("forge_reserved_ips_count")
+                .formatted_metric("carbide_reserved_ips_count")
                 .is_none()
         );
     } else {
         assert_eq!(
             env.test_meter
-                .formatted_metric("forge_reserved_ips_count")
+                .formatted_metric("carbide_reserved_ips_count")
                 .unwrap(),
             reserved_str
         );
@@ -752,13 +752,13 @@ async fn test_network_segment_metrics(
     if matches!(test_type, MetricsTestType::Tenant) {
         assert!(
             env.test_meter
-                .formatted_metric("forge_available_ips_count")
+                .formatted_metric("carbide_available_ips_count")
                 .is_none()
         );
     } else {
         assert_eq!(
             env.test_meter
-                .formatted_metric("forge_available_ips_count")
+                .formatted_metric("carbide_available_ips_count")
                 .unwrap(),
             avail_str
         );
@@ -771,13 +771,13 @@ async fn test_network_segment_metrics(
     if matches!(test_type, MetricsTestType::Tenant) {
         assert!(
             env.test_meter
-                .formatted_metric("forge_total_ips_count")
+                .formatted_metric("carbide_total_ips_count")
                 .is_none()
         );
     } else {
         assert_eq!(
             env.test_meter
-                .formatted_metric("forge_total_ips_count")
+                .formatted_metric("carbide_total_ips_count")
                 .unwrap(),
             total_str
         );
@@ -790,13 +790,13 @@ async fn test_network_segment_metrics(
     if matches!(test_type, MetricsTestType::Tenant) {
         assert!(
             env.test_meter
-                .formatted_metric("forge_reserved_ips_count")
+                .formatted_metric("carbide_reserved_ips_count")
                 .is_none()
         );
     } else {
         assert_eq!(
             env.test_meter
-                .formatted_metric("forge_reserved_ips_count")
+                .formatted_metric("carbide_reserved_ips_count")
                 .unwrap(),
             reserved_str
         );

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -477,31 +477,31 @@ async fn test_site_explorer_main(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
     // We should also have metric entries
     assert_eq!(
         test_meter
-            .formatted_metric("forge_endpoint_explorations_count")
+            .formatted_metric("carbide_endpoint_explorations_count")
             .unwrap(),
         "2"
     );
     assert!(
         test_meter
-            .formatted_metric("forge_endpoint_exploration_success_count")
+            .formatted_metric("carbide_endpoint_exploration_success_count")
             .is_some()
     );
     // The failure metric is not emitted if no failure happened
     assert_eq!(
         test_meter
-            .formatted_metric("forge_endpoint_exploration_duration_milliseconds_count")
+            .formatted_metric("carbide_endpoint_exploration_duration_milliseconds_count")
             .unwrap_or("2".to_string()),
         "2"
     );
     assert_eq!(
         test_meter
-            .formatted_metric("forge_site_exploration_identified_managed_hosts_count")
+            .formatted_metric("carbide_site_exploration_identified_managed_hosts_count")
             .unwrap(),
         "0"
     );
     assert_eq!(
         test_meter
-            .formatted_metric("forge_site_explorer_created_machines_count")
+            .formatted_metric("carbide_site_explorer_created_machines_count")
             .unwrap(),
         "0"
     );
@@ -541,30 +541,30 @@ async fn test_site_explorer_main(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
 
     assert_eq!(
         test_meter
-            .formatted_metric("forge_endpoint_explorations_count")
+            .formatted_metric("carbide_endpoint_explorations_count")
             .unwrap(),
         "2"
     );
     assert!(
         test_meter
-            .formatted_metric("forge_endpoint_exploration_success_count")
+            .formatted_metric("carbide_endpoint_exploration_success_count")
             .is_some()
     );
     assert_eq!(
         test_meter
-            .formatted_metric("forge_endpoint_exploration_duration_milliseconds_count")
+            .formatted_metric("carbide_endpoint_exploration_duration_milliseconds_count")
             .unwrap_or("4".to_string()),
         "4"
     );
     assert_eq!(
         test_meter
-            .formatted_metric("forge_site_exploration_identified_managed_hosts_count")
+            .formatted_metric("carbide_site_exploration_identified_managed_hosts_count")
             .unwrap(),
         "0"
     );
     assert_eq!(
         test_meter
-            .formatted_metric("forge_site_explorer_created_machines_count")
+            .formatted_metric("carbide_site_explorer_created_machines_count")
             .unwrap(),
         "0"
     );
@@ -689,7 +689,7 @@ async fn test_site_explorer_main(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
 
     assert_eq!(
         test_meter
-            .formatted_metric("forge_site_exploration_identified_managed_hosts_count")
+            .formatted_metric("carbide_site_exploration_identified_managed_hosts_count")
             .unwrap(),
         "2"
     );
@@ -903,9 +903,9 @@ async fn test_site_explorer_audit_exploration_results(
     );
 
     explorer.run_single_iteration().await.unwrap();
-    // forge_endpoint_exploration_preingestions_incomplete_overall_count
+    // carbide_endpoint_exploration_preingestions_incomplete_overall_count
     let m: HashMap<String, String> = test_meter
-        .parsed_metrics("forge_endpoint_exploration_preingestions_incomplete_overall_count")
+        .parsed_metrics("carbide_endpoint_exploration_preingestions_incomplete_overall_count")
         .into_iter()
         .collect();
 
@@ -969,9 +969,9 @@ async fn test_site_explorer_audit_exploration_results(
 
     // Check for the expected metrics
 
-    // forge_endpoint_exploration_failures_overall_count
+    // carbide_endpoint_exploration_failures_overall_count
     let m: HashMap<String, String> = test_meter
-        .parsed_metrics("forge_endpoint_exploration_failures_overall_count")
+        .parsed_metrics("carbide_endpoint_exploration_failures_overall_count")
         .into_iter()
         .collect();
 
@@ -979,18 +979,18 @@ async fn test_site_explorer_audit_exploration_results(
     assert!(m.get("{failure=\"unauthorized\"}").unwrap() == "1");
     assert!(m.get("{failure=\"missing_credentials\"}").unwrap() == "1");
 
-    // forge_endpoint_exploration_preingestions_incomplete_overall_count
+    // carbide_endpoint_exploration_preingestions_incomplete_overall_count
     let m: HashMap<String, String> = test_meter
-        .parsed_metrics("forge_endpoint_exploration_preingestions_incomplete_overall_count")
+        .parsed_metrics("carbide_endpoint_exploration_preingestions_incomplete_overall_count")
         .into_iter()
         .collect();
     // Everything should be done with preingestion now.
     assert!(m.is_empty());
 
-    // forge_endpoint_exploration_expected_serial_number_mismatches_overall_count
+    // carbide_endpoint_exploration_expected_serial_number_mismatches_overall_count
     let m: HashMap<String, String> = test_meter
         .parsed_metrics(
-            "forge_endpoint_exploration_expected_serial_number_mismatches_overall_count",
+            "carbide_endpoint_exploration_expected_serial_number_mismatches_overall_count",
         )
         .into_iter()
         .collect();
@@ -998,9 +998,9 @@ async fn test_site_explorer_audit_exploration_results(
     assert!(!m.is_empty());
     assert_eq!(m.get("{machine_type=\"host\"}").unwrap(), "3");
 
-    // forge_endpoint_exploration_machines_explored_overall_count
+    // carbide_endpoint_exploration_machines_explored_overall_count
     let m: HashMap<String, String> = test_meter
-        .parsed_metrics("forge_endpoint_exploration_machines_explored_overall_count")
+        .parsed_metrics("carbide_endpoint_exploration_machines_explored_overall_count")
         .into_iter()
         .collect();
 
@@ -1020,17 +1020,19 @@ async fn test_site_explorer_audit_exploration_results(
         "1"
     );
 
-    // forge_endpoint_exploration_expected_machines_missing_overall_count
+    // carbide_endpoint_exploration_expected_machines_missing_overall_count
     assert_eq!(
         test_meter
-            .formatted_metric("forge_endpoint_exploration_expected_machines_missing_overall_count")
+            .formatted_metric(
+                "carbide_endpoint_exploration_expected_machines_missing_overall_count"
+            )
             .unwrap(),
         "1"
     );
 
-    // forge_endpoint_exploration_identified_managed_hosts_overall_count
+    // carbide_endpoint_exploration_identified_managed_hosts_overall_count
     let m: HashMap<String, String> = test_meter
-        .parsed_metrics("forge_endpoint_exploration_identified_managed_hosts_overall_count")
+        .parsed_metrics("carbide_endpoint_exploration_identified_managed_hosts_overall_count")
         .into_iter()
         .collect();
 
@@ -2433,7 +2435,7 @@ async fn test_machine_creation_with_sku(
 
     // Verify expected machine SKU metrics
     let expected_metrics: HashMap<String, String> = test_meter
-        .parsed_metrics("forge_site_exploration_expected_machines_sku_count")
+        .parsed_metrics("carbide_site_exploration_expected_machines_sku_count")
         .into_iter()
         .collect();
 
@@ -2687,7 +2689,7 @@ async fn test_expected_machine_device_type_metrics(
 
     // Verify expected machines SKU count metrics
     let device_type_metrics: HashMap<String, String> = test_meter
-        .parsed_metrics("forge_site_exploration_expected_machines_sku_count")
+        .parsed_metrics("carbide_site_exploration_expected_machines_sku_count")
         .into_iter()
         .collect();
 
@@ -2868,13 +2870,13 @@ async fn test_site_explorer_power_shelf_discovery(
     // Check metrics
     assert_eq!(
         test_meter
-            .formatted_metric("forge_endpoint_explorations_count")
+            .formatted_metric("carbide_endpoint_explorations_count")
             .unwrap(),
         "1"
     );
     assert_eq!(
         test_meter
-            .formatted_metric("forge_site_explorer_created_power_shelves_count")
+            .formatted_metric("carbide_site_explorer_created_power_shelves_count")
             .unwrap(),
         "1"
     );
@@ -3177,7 +3179,7 @@ async fn test_site_explorer_power_shelf_creation_limit(
     // Check that only 2 power shelves were created due to limit
     assert_eq!(
         test_meter
-            .formatted_metric("forge_site_explorer_created_power_shelves_count")
+            .formatted_metric("carbide_site_explorer_created_power_shelves_count")
             .unwrap(),
         "2"
     );
@@ -3188,7 +3190,7 @@ async fn test_site_explorer_power_shelf_creation_limit(
     // Check that all 3 power shelves were created
     assert_eq!(
         test_meter
-            .formatted_metric("forge_site_explorer_created_power_shelves_count")
+            .formatted_metric("carbide_site_explorer_created_power_shelves_count")
             .unwrap(),
         "1"
     );
@@ -3313,7 +3315,7 @@ async fn test_site_explorer_power_shelf_disabled(
     // Check that no power shelves were created
     assert_eq!(
         test_meter
-            .formatted_metric("forge_site_explorer_created_power_shelves_count")
+            .formatted_metric("carbide_site_explorer_created_power_shelves_count")
             .unwrap(),
         "0"
     );
@@ -3443,7 +3445,7 @@ async fn test_site_explorer_power_shelf_error_handling(
     // Check metrics for error
     assert_eq!(
         test_meter
-            .formatted_metric("forge_endpoint_exploration_failures_count")
+            .formatted_metric("carbide_endpoint_exploration_failures_count")
             .unwrap(),
         "{failure=\"unauthorized\"} 1"
     );
@@ -4548,13 +4550,13 @@ async fn test_site_explorer_power_shelf_discovery_with_static_ip(
     // Check metrics
     assert_eq!(
         test_meter
-            .formatted_metric("forge_endpoint_explorations_count")
+            .formatted_metric("carbide_endpoint_explorations_count")
             .unwrap(),
         "1"
     );
     assert_eq!(
         test_meter
-            .formatted_metric("forge_site_explorer_created_power_shelves_count")
+            .formatted_metric("carbide_site_explorer_created_power_shelves_count")
             .unwrap(),
         "1"
     );


### PR DESCRIPTION
## Description

This change allows to configure carbide to emit metrics under an additional prefix that is configurable via setting `alt_metric_prefix`. The default prefix changes to `carbide_`.

This seting allows to migrate dashboards and alerts that used the past prefix to `carbide_`.

## Type of Change
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

FORGE-7344

## Breaking Changes
- [x] This PR contains breaking changes

Operators should set an `alt_metric_prefix` in config files to retain legacy metrics

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes


