### PR TITLE
switch from golan to snponly

### DIFF
--- a/crates/dhcp-server/src/util.rs
+++ b/crates/dhcp-server/src/util.rs
@@ -56,10 +56,10 @@ pub fn machine_get_filename(
         let base_url = config.dhcp_config.carbide_provisioning_server_ipv4;
         match arch {
             MachineArchitecture::EfiX64 => {
-                format!("http://{base_url}:8080/public/blobs/internal/x86_64/golan.efi")
+                format!("http://{base_url}:8080/public/blobs/internal/x86_64/ipxe.efi")
             }
             MachineArchitecture::Arm64 => {
-                format!("http://{base_url}:8080/public/blobs/internal/aarch64/golan.efi")
+                format!("http://{base_url}:8080/public/blobs/internal/aarch64/ipxe.efi")
             }
             MachineArchitecture::BiosX86 => {
                 tracing::warn!(


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
This Changes the ipxe bootloader from the golan to the snp.  Some machines are failing to get an IP from DHCP using the golan

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->
https://nvbugspro.nvidia.com/bug/5866258

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

