### PR TITLE
chore: bmc-mock: no tar routers for host / DPU machines mock

### DIFF
--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -584,14 +584,6 @@ where
         )]),
         carbide_api_url: format!("https://{}:{}", api_addr.ip(), api_addr.port()),
         log_file: None,
-        bmc_mock_host_tar: PathBuf::from(format!(
-            "{}/crates/bmc-mock/dell_poweredge_r750.tar.gz",
-            test_env.root_dir.to_string_lossy()
-        )),
-        bmc_mock_dpu_tar: PathBuf::from(format!(
-            "{}/crates/bmc-mock/nvidia_dpu.tar.gz",
-            test_env.root_dir.to_string_lossy()
-        )),
         use_pxe_api: true,
         pxe_server_host: None,
         pxe_server_port: None,

--- a/crates/api-test-helper/src/machine_a_tron.rs
+++ b/crates/api-test-helper/src/machine_a_tron.rs
@@ -13,7 +13,6 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-use bmc_mock::TarGzOption;
 use forge_tls::client_config::get_forge_root_ca_path;
 use futures::future::try_join_all;
 use machine_a_tron::{
@@ -40,11 +39,6 @@ pub async fn run_local(
 ) -> eyre::Result<(Vec<HostMachineHandle>, MachineATronHandle)> {
     let forge_root_ca_path = get_forge_root_ca_path(None, None); // Will get it from the local repo
     let forge_client_config = ForgeClientConfig::new(forge_root_ca_path.clone(), None);
-
-    let dpu_tar_router =
-        bmc_mock::tar_router(TarGzOption::Disk(&app_config.bmc_mock_dpu_tar), None)?;
-    let host_tar_router =
-        bmc_mock::tar_router(TarGzOption::Disk(&app_config.bmc_mock_host_tar), None)?;
 
     let api_config = ApiConfig::new_with_multiple_urls(
         &app_config.carbide_api_url,
@@ -85,8 +79,6 @@ pub async fn run_local(
         app_config,
         forge_client_config,
         bmc_mock_certs_dir: Some(repo_root.join("crates/bmc-mock")),
-        host_tar_router,
-        dpu_tar_router,
         api_throttler,
         desired_firmware_versions: desired_firmware,
         forge_api_client,

--- a/crates/bmc-mock/src/bmc_state.rs
+++ b/crates/bmc-mock/src/bmc_state.rs
@@ -57,7 +57,6 @@ pub struct BmcState {
     pub system_state: Arc<SystemState>,
     pub chassis_state: Arc<ChassisState>,
     pub update_service_state: Arc<UpdateServiceState>,
-    pub bios: Arc<Mutex<serde_json::Value>>,
     pub dell_attrs: Arc<Mutex<serde_json::Value>>,
     pub injected_bugs: Arc<InjectedBugs>,
 }
@@ -107,17 +106,6 @@ impl BmcState {
             job.end_time = Some(chrono::offset::Utc::now());
             jobs.insert(job.job_id.clone(), job);
         }
-    }
-
-    pub fn update_bios(&mut self, v: serde_json::Value) {
-        let mut bios = self.bios.lock().unwrap();
-        json_patch(&mut bios, v);
-    }
-
-    pub fn get_bios(&self, mut base: serde_json::Value) -> serde_json::Value {
-        let bios = self.bios.lock().unwrap();
-        json_patch(&mut base, bios.clone());
-        base
     }
 
     pub fn update_dell_attrs(&mut self, v: serde_json::Value) {

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -75,8 +75,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         info!("Using archive {} as default", tar_path.to_string_lossy());
         bmc_mock::tar_router(TarGzOption::Disk(&tar_path), Some(&mut tar_router_entries)).unwrap()
     } else {
-        info!("Using default targz handler");
-        bmc_mock::default_host_tar_router(Some(&mut tar_router_entries))
+        info!("Using default BMC mock");
+        bmc_mock::default_host_mock()
     };
 
     routers_by_ip.insert("".to_owned(), router);

--- a/crates/bmc-mock/src/redfish/bios.rs
+++ b/crates/bmc-mock/src/redfish/bios.rs
@@ -9,101 +9,52 @@
  * without an express license agreement from NVIDIA CORPORATION or
  * its affiliates is strictly prohibited.
  */
+use std::borrow::Cow;
 
-use axum::Router;
-use axum::body::Body;
-use axum::extract::{Json, Path, Request, State};
-use axum::response::{IntoResponse, Response};
-use axum::routing::{get, patch, post};
 use serde_json::json;
 
-use crate::json::JsonExt;
-use crate::mock_machine_router::MockWrapperState;
-use crate::{MachineInfo, redfish};
+use crate::json::{JsonExt, JsonPatch};
+use crate::redfish;
 
-pub fn add_routes(r: Router<MockWrapperState>) -> Router<MockWrapperState> {
-    r.route(
-        "/redfish/v1/Systems/{system_id}/Bios/Actions/Bios.ChangePassword",
-        post(change_password_action),
-    )
-    .route("/redfish/v1/Systems/Bluefield/Bios", get(get_dpu_bios))
-    .route("/redfish/v1/Systems/{system_id}/Bios", get(get_bios))
-    .route(
-        "/redfish/v1/Systems/Bluefield/Bios/Settings",
-        patch(patch_dpu_bios),
-    )
-    .route(
-        "/redfish/v1/Systems/{system_id}/Bios/Settings",
-        patch(patch_bios_settings),
-    )
+pub fn resource<'a>(system_id: &str) -> redfish::Resource<'a> {
+    let odata_id = format!(
+        "{}/Bios",
+        redfish::computer_system::resource(system_id).odata_id
+    );
+    redfish::Resource {
+        odata_id: Cow::Owned(odata_id),
+        odata_type: Cow::Borrowed("#Bios.v1_2_0.Bios"),
+        name: Cow::Borrowed("BIOS Configuration"),
+        id: Cow::Borrowed("BIOS"),
+    }
 }
 
-async fn change_password_action(Path(_system_id): Path<String>) -> Response {
-    json!({}).into_ok_response()
+pub fn change_password_target(resource: &redfish::Resource<'_>) -> String {
+    format!("{}/Actions/Bios.ChangePassword", resource.odata_id)
 }
 
-async fn get_dpu_bios(
-    State(mut state): State<MockWrapperState>,
-    request: Request<Body>,
-) -> Response {
-    state
-        .call_inner_router(request)
-        .await
-        .map(|inner_bios| {
-            // We only rewrite this line if it's a DPU we're mocking
-            let MachineInfo::Dpu(dpu) = state.machine_info else {
-                return inner_bios.into_ok_response();
-            };
-            let patched_bios = state.bmc_state.get_bios(inner_bios);
-            // For DPUs in NicMode, rewrite the BIOS attributes to reflect as such
-            let mode = if dpu.nic_mode { "NicMode" } else { "DpuMode" };
-            patched_bios
-                .patch(json!({"Attributes": {"NicMode": mode}}))
-                .into_ok_response()
-        })
-        .unwrap_or_else(|err| err.into_response())
+pub fn builder(resource: &redfish::Resource) -> BiosBuilder {
+    BiosBuilder {
+        value: resource.json_patch(),
+    }
 }
 
-async fn get_bios(State(mut state): State<MockWrapperState>, request: Request<Body>) -> Response {
-    state
-        .call_inner_router(request)
-        .await
-        .map(|inner_bios| state.bmc_state.get_bios(inner_bios).into_ok_response())
-        .unwrap_or_else(|err| err.into_response())
+pub struct BiosBuilder {
+    value: serde_json::Value,
 }
 
-async fn patch_bios_settings(
-    State(mut state): State<MockWrapperState>,
-    Json(patch_bios_request): Json<serde_json::Value>,
-) -> Response {
-    // TODO: this is Dell-specific implementation. Need to be
-    // refactoried to be generic.
-    // Clear is transformed to Enabled state after reboot. Check if we
-    // need to apply this logic here.
-    const TPM2_HIERARCHY: &str = "Tpm2Hierarchy";
-    const ATTRIBUTES: &str = "Attributes";
-    let tpm2_clear_to_enabled = patch_bios_request
-        .as_object()
-        .and_then(|obj| obj.get(ATTRIBUTES))
-        .and_then(|v| v.as_object())
-        .and_then(|obj| obj.get(TPM2_HIERARCHY))
-        .and_then(|v| v.as_str())
-        .is_some_and(|v| v == "Clear");
-    let patch_bios_request = if tpm2_clear_to_enabled {
-        patch_bios_request.patch(json!({ATTRIBUTES: {
-            TPM2_HIERARCHY: "Enabled"
-        }}))
-    } else {
-        patch_bios_request
-    };
-    state.bmc_state.update_bios(patch_bios_request);
-    redfish::oem::dell::idrac::create_job_with_location(state)
-}
+impl BiosBuilder {
+    pub fn attributes(self, value: serde_json::Value) -> Self {
+        self.apply_patch(json!({"Attributes": value}))
+    }
 
-async fn patch_dpu_bios(
-    State(mut state): State<MockWrapperState>,
-    Json(patch_bios_request): Json<serde_json::Value>,
-) -> Response {
-    state.bmc_state.update_bios(patch_bios_request);
-    json!({}).into_ok_response()
+    pub fn build(self) -> serde_json::Value {
+        self.value
+    }
+
+    fn apply_patch(self, patch: serde_json::Value) -> Self {
+        Self {
+            value: self.value.patch(patch),
+        }
+    }
 }

--- a/crates/bmc-mock/src/redfish_expander.rs
+++ b/crates/bmc-mock/src/redfish_expander.rs
@@ -236,11 +236,11 @@ mod tests {
     use serde_json::Value;
     use tower::Service;
 
-    use crate::{default_host_tar_router, wrap_router_with_redfish_expander};
+    use crate::{default_host_mock, wrap_router_with_redfish_expander};
 
     #[tokio::test]
     async fn test_expand() {
-        let tar_router = default_host_tar_router(None);
+        let tar_router = default_host_mock();
         let mut subject = wrap_router_with_redfish_expander(tar_router.clone());
 
         let response_body = subject

--- a/crates/machine-a-tron/config/mac.toml
+++ b/crates/machine-a-tron/config/mac.toml
@@ -45,18 +45,6 @@ use_pxe_api = true
 pxe_server_host = "192.168.1.77"
 pxe_server_port = "8080"
 
-# bmc_mock_host_tar configures default mocked data for BMC-mock to use for host
-# machines in machine-a-tron. Path is relative to REPO_ROOT.  Defaults to data
-# captured from a dell server (check `default_bmc_mock_host_tar` in config.rs).
-#
-# bmc_mock_host_tar = "dev/bmc-mock/dell_poweredge_r750.tar.gz"
-
-# bmc_mock_dpu_tar configures default mocked data for BMC-mock to use for dpu
-# machines in machine-a-tron. Path is relative to REPO_ROOT.  Defaults to data
-# captured from a real DPU.
-#
-# bmc_mock_dpu_tar = "dev/bmc-mock/nvidia_dpu.tar.gz"
-
 # Port to listen on for running bmc-mock instances for each host/DPU. We use a
 # nonstandard port to avoid needing to run as root. Note: This must correspond
 # with the value of the site_explorer.override_target_port option in carbide's

--- a/crates/machine-a-tron/config/mat.toml
+++ b/crates/machine-a-tron/config/mat.toml
@@ -38,18 +38,6 @@ use_pxe_api = false
 pxe_server_host = "192.168.1.77"
 pxe_server_port = "8080"
 
-# bmc_mock_host_tar configures default mocked data for BMC-mock to use for host
-# machines in machine-a-tron. Path is relative to REPO_ROOT.  Defaults to data
-# captured from a dell server (check `default_bmc_mock_host_tar` in config.rs).
-#
-# bmc_mock_host_tar = "dev/bmc-mock/dell_poweredge_r750.tar.gz"
-
-# bmc_mock_dpu_tar configures default mocked data for BMC-mock to use for dpu
-# machines in machine-a-tron. Path is relative to REPO_ROOT.  Defaults to data
-# captured from a real DPU.
-#
-# bmc_mock_dpu_tar = "dev/bmc-mock/nvidia_dpu.tar.gz"
-
 # Port to listen on for running bmc-mock instances for each host/DPU. We use a
 # nonstandard port to avoid needing to run as root. Note: This must correspond
 # with the value of the site_explorer.override_target_port option in carbide's

--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -47,17 +47,8 @@ impl BmcMockWrapper {
         hostname: Arc<dyn HostnameQuerying>,
         host_id: Uuid,
     ) -> Self {
-        let tar_router = match machine_info {
-            MachineInfo::Dpu(_) => app_context.dpu_tar_router.clone(),
-            MachineInfo::Host(_) => app_context.host_tar_router.clone(),
-        };
-
-        let bmc_mock_router = bmc_mock::wrap_router_with_mock_machine(
-            tar_router,
-            machine_info.clone(),
-            power_control,
-            host_id.to_string(),
-        );
+        let bmc_mock_router =
+            bmc_mock::machine_router(machine_info.clone(), power_control, host_id.to_string());
 
         BmcMockWrapper {
             machine_info,

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -15,7 +15,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::Router;
 use bmc_mock::{DpuMachineInfo, HostMachineInfo};
 use carbide_uuid::machine::MachineId;
 use clap::Parser;
@@ -199,10 +198,6 @@ pub struct MachineATronConfig {
     #[serde(default = "default_false")]
     pub use_single_bmc_mock: bool,
 
-    #[serde(default = "default_bmc_mock_host_tar")]
-    pub bmc_mock_host_tar: PathBuf,
-    #[serde(default = "default_bmc_mock_dpu_tar")]
-    pub bmc_mock_dpu_tar: PathBuf,
     #[serde(default = "default_false")]
     pub use_pxe_api: bool,
     pub pxe_server_host: Option<String>,
@@ -356,13 +351,6 @@ fn default_bmc_mock_port() -> u16 {
     2000
 }
 
-fn default_bmc_mock_host_tar() -> PathBuf {
-    PathBuf::from("dev/bmc-mock/dell_poweredge_r750.tar.gz")
-}
-fn default_bmc_mock_dpu_tar() -> PathBuf {
-    PathBuf::from("dev/bmc-mock/nvidia_dpu.tar.gz")
-}
-
 fn default_template_dir() -> String {
     String::from("dev/machine-a-tron/templates")
 }
@@ -402,8 +390,6 @@ pub struct MachineATronContext {
     pub app_config: MachineATronConfig,
     pub forge_client_config: ForgeClientConfig,
     pub bmc_mock_certs_dir: Option<PathBuf>,
-    pub host_tar_router: Router,
-    pub dpu_tar_router: Router,
     pub bmc_registration_mode: BmcRegistrationMode,
     pub api_throttler: ApiThrottler,
     /// These are the firmware versions the server wants us to be on. If not configured for other

--- a/dev/deployment/localdev/Dockerfile.machine-a-tron.localdev
+++ b/dev/deployment/localdev/Dockerfile.machine-a-tron.localdev
@@ -13,8 +13,6 @@ FROM runtime-container-localdev:latest as carbide
 
 WORKDIR ./carbide
 COPY .skaffold/target/carbide-machine-a-tron/debug/machine-a-tron /opt/machine-a-tron/bin/
-COPY crates/bmc-mock/dell_poweredge_r750.tar.gz /opt/machine-a-tron/
-COPY crates/bmc-mock/nvidia_dpu.tar.gz /opt/machine-a-tron/
 COPY crates/machine-a-tron/templates /opt/machine-a-tron/templates
 
 # bmc-mock expects certs here

--- a/dev/docker-env/mat.toml
+++ b/dev/docker-env/mat.toml
@@ -38,18 +38,6 @@ interface = "carbide0"
 pxe_server_host = "172.20.0.1"
 pxe_server_port = "1083"
 
-# bmc_mock_host_tar configures default mocked data for BMC-mock to use for host
-# machines in machine-a-tron. Path is relative to REPO_ROOT.  Defaults to data
-# captured from a dell server (check `default_bmc_mock_host_tar` in config.rs).
-#
-bmc_mock_host_tar = "../bmc-mock/dell_poweredge_r750.tar.gz"
-
-# bmc_mock_dpu_tar configures default mocked data for BMC-mock to use for dpu
-# machines in machine-a-tron. Path is relative to REPO_ROOT.  Defaults to data
-# captured from a real DPU.
-#
-bmc_mock_dpu_tar = "../bmc-mock/nvidia_dpu.tar.gz"
-
 # Port to listen on for running bmc-mock instances for each host/DPU. We use a
 # nonstandard port to avoid needing to run as root. Note: This must correspond
 # with the value of the site_explorer.override_target_port option in carbide's


### PR DESCRIPTION
## Description
Finally all BMC responses are generated by BMC mock, no routes from tar files are used.

In this change:
- Bios resource response is geneated for Dell / DPU machines
- Dependency from tar routers is removed from machine-a-tron
- Corresponding tar files are removed from machine-a-tron containers

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

After this change machin-a-tron's overrides stop working at all because all repsonses is generated and overrides modified  data from routes.
