### PR TITLE
chore: add cli support for nvlink-info db backfill

### DIFF
--- a/crates/admin-cli/src/machine/args.rs
+++ b/crates/admin-cli/src/machine/args.rs
@@ -11,7 +11,7 @@
  */
 
 use carbide_uuid::machine::MachineId;
-use clap::{ArgGroup, Parser, ValueEnum};
+use clap::{ArgGroup, Parser, Subcommand, ValueEnum};
 
 #[derive(Parser, Debug)]
 pub enum Cmd {
@@ -49,6 +49,8 @@ pub enum Cmd {
             - Power shelf ID: Associated power shelf"
     )]
     Positions(Positions),
+    #[clap(subcommand, about = "Update/show NVLink info for an MNNVL machine")]
+    NvlinkInfo(NvlinkInfoCommand),
 }
 
 #[derive(Parser, Debug)]
@@ -382,4 +384,27 @@ pub struct Positions {
         help = "The machine(s) to query, leave empty for all (default)"
     )]
     pub machine: Vec<MachineId>,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum NvlinkInfoCommand {
+    #[clap(about = "Show existing NVLink info")]
+    Show(NvlinkInfoArgs),
+    #[clap(about = "Build NVLink info from Redfish + NMX-M and populate DB")]
+    Populate(NvlinkInfoPopulateArgs),
+}
+
+#[derive(Parser, Debug)]
+pub struct NvlinkInfoArgs {
+    #[clap(help = "Machine ID to query")]
+    pub machine_id: MachineId,
+}
+
+#[derive(Parser, Debug)]
+pub struct NvlinkInfoPopulateArgs {
+    #[clap(help = "Machine ID to populate")]
+    pub machine_id: MachineId,
+
+    #[clap(long, action, help = "Update the database with the nvlink_info")]
+    pub update_db: bool,
 }

--- a/crates/admin-cli/src/machine/cmds.rs
+++ b/crates/admin-cli/src/machine/cmds.rs
@@ -10,7 +10,7 @@
  * its affiliates is strictly prohibited.
  */
 
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt::Write;
 use std::fs;
 use std::pin::Pin;
@@ -35,7 +35,7 @@ use super::args::{
     MachineHardwareInfoGpus, MachineMetadataCommand, MachineMetadataCommandAddLabel,
     MachineMetadataCommandFromExpectedMachine, MachineMetadataCommandRemoveLabels,
     MachineMetadataCommandSet, MachineMetadataCommandShow, MachineQuery, NetworkCommand,
-    OverrideCommand, Positions, ShowMachine,
+    NvlinkInfoArgs, NvlinkInfoPopulateArgs, OverrideCommand, Positions, ShowMachine,
 };
 use crate::cfg::cli_options::SortField;
 use crate::rpc::ApiClient;
@@ -1147,6 +1147,276 @@ pub async fn positions(args: Positions, api_client: &ApiClient) -> CarbideCliRes
         ]);
     }
     table.printstd();
+
+    Ok(())
+}
+
+pub async fn handle_nvlink_info_show(
+    args: NvlinkInfoArgs,
+    api_client: &ApiClient,
+) -> CarbideCliResult<()> {
+    let machine = api_client.get_machine(args.machine_id).await?;
+
+    // Check if this is an MNNVL machine (GB200)
+    let is_mnnvl = machine
+        .discovery_info
+        .as_ref()
+        .and_then(|info| info.dmi_data.as_ref())
+        .map(|dmi| dmi.product_name.contains("GB200"))
+        .unwrap_or(false);
+
+    if !is_mnnvl {
+        return Err(CarbideCliError::GenericError(format!(
+            "Machine {} is not an MNNVL machine",
+            args.machine_id
+        )));
+    }
+
+    match machine.nvlink_info {
+        Some(nvlink_info) => {
+            println!("{}", serde_json::to_string_pretty(&nvlink_info)?);
+        }
+        None => {
+            return Err(CarbideCliError::GenericError(format!(
+                "Machine {} has no nvlink_info in database",
+                args.machine_id
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn handle_nvlink_info_populate(
+    args: NvlinkInfoPopulateArgs,
+    _output_format: OutputFormat,
+    api_client: &ApiClient,
+) -> CarbideCliResult<()> {
+    let machine = api_client.get_machine(args.machine_id).await?;
+    let update_db = args.update_db;
+
+    // Check if this is an MNNVL machine (GB200)
+    let is_mnnvl = machine
+        .discovery_info
+        .as_ref()
+        .and_then(|info| info.dmi_data.as_ref())
+        .map(|dmi| dmi.product_name.contains("GB200"))
+        .unwrap_or(false);
+
+    if !is_mnnvl {
+        return Err(CarbideCliError::GenericError(format!(
+            "Machine {} is not an MNNVL machine",
+            args.machine_id
+        )));
+    }
+
+    let bmc_ip = machine
+        .bmc_info
+        .as_ref()
+        .and_then(|b| b.ip.clone())
+        .ok_or_else(|| CarbideCliError::GenericError("No BMC IP available".to_string()))?;
+
+    // Fetch nmx-m compute nodes and build lookup map by (serial_number, tray_index)
+    let nmxm_compute_nodes: HashMap<(String, i32), serde_json::Value> = match api_client
+        .0
+        .nmxm_browse("nmx/v1/compute-nodes".to_string())
+        .await
+    {
+        Ok(response) => {
+            // Check for HTTP error codes
+            if response.code < 200 || response.code >= 300 {
+                return Err(CarbideCliError::GenericError(format!(
+                    "NMX-M compute-nodes request failed with HTTP {}: {}",
+                    response.code, response.body
+                )));
+            }
+            if let Ok(nodes) = serde_json::from_str::<Vec<serde_json::Value>>(&response.body) {
+                nodes
+                    .into_iter()
+                    .filter_map(|node| {
+                        let location_info = node.get("LocationInfo")?;
+                        let serial = location_info
+                            .get("ChassisSerialNumber")?
+                            .as_str()?
+                            .to_string();
+                        let tray_idx = location_info.get("TrayIndex")?.as_i64()? as i32;
+                        Some(((serial, tray_idx), node))
+                    })
+                    .collect()
+            } else {
+                HashMap::new()
+            }
+        }
+        Err(e) => {
+            return Err(CarbideCliError::GenericError(format!(
+                "Failed to fetch nmx-m compute nodes: {}",
+                e
+            )));
+        }
+    };
+
+    // Fetch Redfish data
+    let uri = format!("https://{}/redfish/v1/Chassis/CBC_0", bmc_ip);
+
+    let redfish_response = api_client
+        .0
+        .redfish_browse(uri.clone())
+        .await
+        .map_err(|e| CarbideCliError::GenericError(format!("Redfish call failed: {}", e)))?;
+
+    let json: serde_json::Value = serde_json::from_str(&redfish_response.text).map_err(|e| {
+        CarbideCliError::GenericError(format!("Failed to parse Redfish response: {}", e))
+    })?;
+
+    // Extract Oem.Nvidia.ComputeTrayIndex
+    let tray_index = json
+        .get("Oem")
+        .and_then(|oem| oem.get("Nvidia"))
+        .and_then(|nvidia| nvidia.get("ComputeTrayIndex"))
+        .and_then(|v| v.as_i64())
+        .map(|v| v as i32)
+        .ok_or_else(|| {
+            CarbideCliError::GenericError("No tray_index found in Redfish response".to_string())
+        })?;
+
+    // Extract SerialNumber
+    let serial_number = json
+        .get("SerialNumber")
+        .and_then(|s| s.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| {
+            CarbideCliError::GenericError("No SerialNumber found in Redfish response".to_string())
+        })?;
+
+    // Look up matching nmx-m compute node
+    let nmxm_node = nmxm_compute_nodes
+        .get(&(serial_number.clone(), tray_index))
+        .ok_or_else(|| {
+            CarbideCliError::GenericError(format!(
+                "No NMX-M compute node found for serial={}, tray_index={}",
+                serial_number, tray_index
+            ))
+        })?;
+
+    let domain_uuid = nmxm_node
+        .get("DomainUUID")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            CarbideCliError::GenericError("No DomainUUID found in NMX-M response".to_string())
+        })?;
+
+    let gpu_id_list: Vec<String> = nmxm_node
+        .get("GpuIDList")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if gpu_id_list.is_empty() {
+        return Err(CarbideCliError::GenericError(
+            "No GPUs found in NMX-M compute node".to_string(),
+        ));
+    }
+
+    // Fetch GPU details from nmx-m for each GPU in the list
+    let mut gpus: Vec<forgerpc::NvLinkGpu> = Vec::new();
+    for gpu_id in &gpu_id_list {
+        let gpu_path = format!("nmx/v1/gpus/{}", gpu_id);
+        let gpu_response = api_client
+            .0
+            .nmxm_browse(gpu_path.clone())
+            .await
+            .map_err(|e| {
+                CarbideCliError::GenericError(format!("Failed to fetch GPU {}: {}", gpu_id, e))
+            })?;
+
+        // Check for HTTP error codes
+        if gpu_response.code < 200 || gpu_response.code >= 300 {
+            return Err(CarbideCliError::GenericError(format!(
+                "NMX-M GPU {} request failed with HTTP {}: {}",
+                gpu_id, gpu_response.code, gpu_response.body
+            )));
+        }
+
+        let gpu_json: serde_json::Value =
+            serde_json::from_str(&gpu_response.body).map_err(|e| {
+                CarbideCliError::GenericError(format!(
+                    "Failed to parse GPU {} response: {}",
+                    gpu_id, e
+                ))
+            })?;
+
+        let gpu_nmx_m_id = gpu_json
+            .get("ID")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let gpu_device_id = gpu_json
+            .get("DeviceID")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as i32;
+        let gpu_device_uid = gpu_json
+            .get("DeviceUID")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let gpu_location = gpu_json.get("LocationInfo");
+        let gpu_tray_index = gpu_location
+            .and_then(|loc| loc.get("TrayIndex"))
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as i32;
+        let gpu_slot_id = gpu_location
+            .and_then(|loc| loc.get("SlotID"))
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as i32;
+
+        gpus.push(forgerpc::NvLinkGpu {
+            nmx_m_id: gpu_nmx_m_id,
+            device_id: gpu_device_id,
+            guid: gpu_device_uid,
+            tray_index: gpu_tray_index,
+            slot_id: gpu_slot_id,
+        });
+    }
+
+    // Parse domain_uuid as UUID
+    let domain_uuid_parsed = uuid::Uuid::parse_str(domain_uuid).map_err(|e| {
+        CarbideCliError::GenericError(format!("Failed to parse domain_uuid: {}", e))
+    })?;
+
+    // Build the nvlink_info structure for RPC
+    let nvlink_info_rpc = forgerpc::MachineNvLinkInfo {
+        domain_uuid: Some(carbide_uuid::nvlink::NvLinkDomainId::from(
+            domain_uuid_parsed,
+        )),
+        gpus: gpus.clone(),
+    };
+
+    // Build the nvlink_info structure as JSON for display
+    let nvlink_info = serde_json::json!({
+        "domain_uuid": domain_uuid,
+        "gpus": gpus.iter().map(|g| serde_json::json!({
+            "nmx_m_id": g.nmx_m_id,
+            "device_id": g.device_id,
+            "guid": g.guid,
+            "tray_index": g.tray_index,
+            "slot_id": g.slot_id,
+        })).collect::<Vec<_>>(),
+    });
+
+    if update_db {
+        api_client
+            .update_machine_nvlink_info(args.machine_id, nvlink_info_rpc)
+            .await?;
+        println!("Updated nvlink_info in db with the following nvlink-info:");
+    } else {
+        println!("\n\n Use --update-db option to apply the following nvlink-info:");
+    }
+
+    println!("{}", serde_json::to_string_pretty(&nvlink_info)?);
+
     Ok(())
 }
 

--- a/crates/admin-cli/src/machine/mod.rs
+++ b/crates/admin-cli/src/machine/mod.rs
@@ -90,6 +90,15 @@ impl Dispatch for Cmd {
                 },
             },
             Cmd::Positions(args) => cmds::positions(args, &ctx.api_client).await?,
+            Cmd::NvlinkInfo(cmd) => match cmd {
+                args::NvlinkInfoCommand::Show(args) => {
+                    cmds::handle_nvlink_info_show(args, &ctx.api_client).await?
+                }
+                args::NvlinkInfoCommand::Populate(args) => {
+                    cmds::handle_nvlink_info_populate(args, ctx.config.format, &ctx.api_client)
+                        .await?
+                }
+            },
         }
         Ok(())
     }

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -1690,6 +1690,20 @@ impl ApiClient {
             .await?)
     }
 
+    pub async fn update_machine_nvlink_info(
+        &self,
+        machine_id: MachineId,
+        nvlink_info: rpc::MachineNvLinkInfo,
+    ) -> CarbideCliResult<()> {
+        Ok(self
+            .0
+            .update_machine_nv_link_info(rpc::UpdateMachineNvLinkInfoRequest {
+                machine_id: Some(machine_id),
+                nvlink_info: Some(nvlink_info),
+            })
+            .await?)
+    }
+
     pub async fn get_all_instance_types(
         &self,
         page_size: usize,

--- a/crates/api-model/src/hardware_info.rs
+++ b/crates/api-model/src/hardware_info.rs
@@ -1060,6 +1060,31 @@ impl From<NvLinkGpu> for rpc::forge::NvLinkGpu {
     }
 }
 
+impl TryFrom<rpc::forge::MachineNvLinkInfo> for MachineNvLinkInfo {
+    type Error = rpc::errors::RpcDataConversionError;
+
+    fn try_from(value: rpc::forge::MachineNvLinkInfo) -> Result<Self, Self::Error> {
+        Ok(MachineNvLinkInfo {
+            domain_uuid: value.domain_uuid.ok_or(
+                rpc::errors::RpcDataConversionError::MissingArgument("domain_uuid"),
+            )?,
+            gpus: value.gpus.into_iter().map(NvLinkGpu::from).collect(),
+        })
+    }
+}
+
+impl From<rpc::forge::NvLinkGpu> for NvLinkGpu {
+    fn from(value: rpc::forge::NvLinkGpu) -> Self {
+        NvLinkGpu {
+            nmx_m_id: value.nmx_m_id,
+            tray_index: value.tray_index,
+            slot_id: value.slot_id,
+            device_id: value.device_id,
+            guid: value.guid,
+        }
+    }
+}
+
 #[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct NvLinkGpu {
     pub nmx_m_id: String,

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -980,6 +980,13 @@ impl Forge for Api {
         crate::handlers::machine::update_machine_metadata(self, request).await
     }
 
+    async fn update_machine_nv_link_info(
+        &self,
+        request: Request<rpc::UpdateMachineNvLinkInfoRequest>,
+    ) -> std::result::Result<Response<()>, Status> {
+        crate::handlers::machine::update_machine_nv_link_info(self, request).await
+    }
+
     async fn set_maintenance(
         &self,
         request: Request<rpc::MaintenanceRequest>,

--- a/crates/api/src/auth/internal_rbac_rules.rs
+++ b/crates/api/src/auth/internal_rbac_rules.rs
@@ -657,6 +657,7 @@ impl InternalRBACRules {
         );
         x.perm("ModifyDPFState", vec![ForgeAdminCLI]);
         x.perm("GetDPFState", vec![ForgeAdminCLI]);
+        x.perm("UpdateMachineNvLinkInfo", vec![ForgeAdminCLI]);
         x
     }
     fn perm(&mut self, msg: &str, principals: Vec<RulePrincipal>) {

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -266,6 +266,9 @@ service Forge {
   // Update the Metadata of a Machine
   rpc UpdateMachineMetadata(MachineMetadataUpdateRequest) returns (google.protobuf.Empty);
 
+  // Update the NVLink Info of a Machine
+  rpc UpdateMachineNvLinkInfo(UpdateMachineNvLinkInfoRequest) returns (google.protobuf.Empty);
+
   // Maintenance mode operations: enable, disable
   rpc SetMaintenance(MaintenanceRequest) returns (google.protobuf.Empty);
 
@@ -5640,6 +5643,11 @@ message RackManagerForgeResponse {
 message MachineNVLinkInfo {
   common.NVLinkDomainId domain_uuid = 1;
   repeated NVLinkGpu gpus = 2;
+}
+
+message UpdateMachineNvLinkInfoRequest {
+  common.MachineId machine_id = 1;
+  MachineNVLinkInfo nvlink_info = 2;
 }
 
 message NVLinkGpu {


### PR DESCRIPTION
## Description
carbide-api requires some information from scout and NMX-M to assign NMX-M IDs to the GPUs of a machine, which are needed to configure NVLink partitions. However, carbide can't get this information into its DB for instances that were created before nvlink support was rolled out. This PR adds an admin-cli command that gathers the required info from redfish and NMX-M, and optionally stores it in the DB.


## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

This commit was cherry-picked from release/v2025.12.19ytl, and the command has already been tested on existing instances in YTL.

