### PR TITLE
fix(agent): Added multipath aspath ignore to tenant VRF configs

### DIFF
--- a/crates/agent/templates/nvue_startup_fnn.conf
+++ b/crates/agent/templates/nvue_startup_fnn.conf
@@ -434,6 +434,9 @@
             {{- end }}
         {{- end }}
           bgp:
+            path-selection:
+              multipath:
+                aspath-ignore: on
             address-family:
               ipv4-unicast:
               {{- if $nvueConfig.UseAdminNetwork }}

--- a/crates/agent/templates/tests/full_nvue_startup_fnn_l3.yaml.expected
+++ b/crates/agent/templates/tests/full_nvue_startup_fnn_l3.yaml.expected
@@ -317,6 +317,9 @@
                 vlan10:
                   type: interface
           bgp:
+            path-selection:
+              multipath:
+                aspath-ignore: on
             address-family:
               ipv4-unicast:
                 network:

--- a/crates/agent/templates/tests/nvue_startup_fnn_classic.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_classic.yaml.expected
@@ -341,6 +341,9 @@
               10.217.5.125/32: {} 
         router:
           bgp:
+            path-selection:
+              multipath:
+                aspath-ignore: on
             address-family:
               ipv4-unicast:
                 enable: on
@@ -419,6 +422,9 @@
               10.217.5.124/32: {} 
         router:
           bgp:
+            path-selection:
+              multipath:
+                aspath-ignore: on
             address-family:
               ipv4-unicast:
                 enable: on

--- a/crates/agent/templates/tests/nvue_startup_fnn_classic_with_empty_nsg_default_deny.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_classic_with_empty_nsg_default_deny.yaml.expected
@@ -352,6 +352,9 @@
               10.217.5.125/32: {} 
         router:
           bgp:
+            path-selection:
+              multipath:
+                aspath-ignore: on
             address-family:
               ipv4-unicast:
                 enable: on
@@ -430,6 +433,9 @@
               10.217.5.124/32: {} 
         router:
           bgp:
+            path-selection:
+              multipath:
+                aspath-ignore: on
             address-family:
               ipv4-unicast:
                 enable: on

--- a/crates/agent/templates/tests/nvue_startup_quarantined_fnn.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_quarantined_fnn.yaml.expected
@@ -364,6 +364,9 @@
               10.217.5.125/32: {} 
         router:
           bgp:
+            path-selection:
+              multipath:
+                aspath-ignore: on
             address-family:
               ipv4-unicast:
                 enable: on
@@ -442,6 +445,9 @@
               10.217.5.124/32: {} 
         router:
           bgp:
+            path-selection:
+              multipath:
+                aspath-ignore: on
             address-family:
               ipv4-unicast:
                 enable: on


### PR DESCRIPTION
## Description
This adds aspath-ignore to tenant VRF configs on managed host DPUs so that multiple paths from the same ASN are allowed into an ECMP group.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

