### PR TITLE
chore(measured-boot): clean up some old constructor cruft

### DIFF
--- a/crates/api-db/src/measured_boot/interface/bundle.rs
+++ b/crates/api-db/src/measured_boot/interface/bundle.rs
@@ -215,14 +215,6 @@ pub async fn get_measurement_bundle_records(
         .map_err(|e| e.with_op_name("get_measurement_bundle_records"))
 }
 
-pub async fn get_measurement_bundle_records_with_txn(
-    txn: &mut PgConnection,
-) -> Result<Vec<MeasurementBundleRecord>, DatabaseError> {
-    common::get_all_objects(txn)
-        .await
-        .map_err(|e| e.with_op_name("get_measurement_bundle_records_with_txn"))
-}
-
 /// get_measurement_bundle_records_for_profile_id returns all
 /// MeasurementBundleRecord instances in the database with the given profile
 /// ID.

--- a/crates/api-db/src/measured_boot/interface/common.rs
+++ b/crates/api-db/src/measured_boot/interface/common.rs
@@ -266,8 +266,6 @@ where
 /// you're done. If you want more control, you can
 /// use acquire_advisory_lock + release_advisory_lock.
 pub async fn acquire_advisory_txn_lock(
-    // Note: This is a PgTransaction, not a PgConnection, because we will be doing table locking,
-    // which must happen in a transaction.
     txn: &mut PgTransaction<'_>,
     key: &str,
 ) -> Result<(), DatabaseError> {

--- a/crates/api-db/src/measured_boot/journal.rs
+++ b/crates/api-db/src/measured_boot/journal.rs
@@ -31,7 +31,7 @@ use crate::measured_boot::interface::journal::{
 };
 use crate::{DatabaseError, DatabaseResult};
 
-pub async fn new_with_txn(
+pub async fn new(
     txn: &mut PgConnection,
     machine_id: MachineId,
     report_id: MeasurementReportId,

--- a/crates/api-db/src/measured_boot/machine.rs
+++ b/crates/api-db/src/measured_boot/machine.rs
@@ -74,7 +74,7 @@ impl DbTable for CandidateMachineRecord {
     }
 }
 
-pub async fn from_id_with_txn(
+pub async fn from_id(
     txn: &mut PgConnection,
     machine_id: MachineId,
 ) -> DatabaseResult<CandidateMachine> {

--- a/crates/api/src/handlers/attestation.rs
+++ b/crates/api/src/handlers/attestation.rs
@@ -180,18 +180,15 @@ pub(crate) async fn attest_quote(
     // In this case, we're not doing anything with
     // the resulting report (at least not yet), so just
     // throw it away.
-    let report = db::measured_boot::report::new_with_txn(
-        &mut txn,
-        machine_id,
-        pcr_values.into_inner().as_slice(),
-    )
-    .await
-    .map_err(|e| {
-        Status::internal(format!(
-            "Failed storing measurement report: (machine_id: {}, err: {})",
-            &machine_id, e
-        ))
-    })?;
+    let report =
+        db::measured_boot::report::new(&mut txn, machine_id, pcr_values.into_inner().as_slice())
+            .await
+            .map_err(|e| {
+                Status::internal(format!(
+                    "Failed storing measurement report: (machine_id: {}, err: {})",
+                    &machine_id, e
+                ))
+            })?;
 
     txn.commit().await?;
 

--- a/crates/api/src/measured_boot/rpc/machine.rs
+++ b/crates/api/src/measured_boot/rpc/machine.rs
@@ -38,7 +38,7 @@ pub async fn handle_attest_candidate_machine(
     req: AttestCandidateMachineRequest,
 ) -> Result<AttestCandidateMachineResponse, Status> {
     let mut txn = api.txn_begin().await?;
-    let report = db::measured_boot::report::new_with_txn(
+    let report = db::measured_boot::report::new(
         &mut txn,
         MachineId::from_str(&req.machine_id).map_err(|_| {
             CarbideError::from(RpcDataConversionError::InvalidMachineId(req.machine_id))
@@ -63,7 +63,7 @@ pub async fn handle_show_candidate_machine(
     let machine = match req.selector {
         // Show a machine with the given ID.
         Some(show_candidate_machine_request::Selector::MachineId(machine_uuid)) => {
-            db::measured_boot::machine::from_id_with_txn(
+            db::measured_boot::machine::from_id(
                 &mut txn,
                 MachineId::from_str(&machine_uuid).map_err(|_| {
                     CarbideError::from(RpcDataConversionError::InvalidMachineId(machine_uuid))

--- a/crates/api/src/measured_boot/rpc/profile.rs
+++ b/crates/api/src/measured_boot/rpc/profile.rs
@@ -61,7 +61,7 @@ pub async fn handle_create_system_measurement_profile(
         vals.insert(kv_pair.key, kv_pair.value);
     }
 
-    let system_profile = db::measured_boot::profile::new_with_txn(&mut txn, req.name, &vals)
+    let system_profile = db::measured_boot::profile::new(&mut txn, req.name, &vals)
         .await
         .map_err(|e| Status::invalid_argument(e.to_string()))?;
 
@@ -153,7 +153,7 @@ pub async fn handle_show_measurement_system_profile(
     let system_profile = match req.selector {
         // Show a system profile with the given profile ID.
         Some(show_measurement_system_profile_request::Selector::ProfileId(profile_uuid)) => {
-            db::measured_boot::profile::load_from_id_with_txn(&mut txn, profile_uuid)
+            db::measured_boot::profile::load_from_id(&mut txn, profile_uuid)
                 .await
                 .map_err(|e| Status::internal(format!("{e}")))?
         }

--- a/crates/api/src/measured_boot/tests/common.rs
+++ b/crates/api/src/measured_boot/tests/common.rs
@@ -54,7 +54,7 @@ pub async fn create_test_machine(
     )
     .await?;
     db::machine_topology::create_or_update(txn, &machine_id, topology).await?;
-    let machine = db::measured_boot::machine::from_id_with_txn(txn, machine_id).await?;
+    let machine = db::measured_boot::machine::from_id(txn, machine_id).await?;
     assert_eq!(machine_id, machine.machine_id);
     Ok(machine)
 }

--- a/crates/api/src/measured_boot/tests/integration.rs
+++ b/crates/api/src/measured_boot/tests/integration.rs
@@ -227,14 +227,11 @@ mod tests {
         // deal with princess-network and beer-louisiana
 
         let dell_r750_profile =
-            db::measured_boot::profile::new_with_txn(&mut txn, None, &dell_r750_attrs).await?;
+            db::measured_boot::profile::new(&mut txn, None, &dell_r750_attrs).await?;
 
-        let princess_report = db::measured_boot::report::new_with_txn(
-            &mut txn,
-            princess_network.machine_id,
-            &princess_values,
-        )
-        .await?;
+        let princess_report =
+            db::measured_boot::report::new(&mut txn, princess_network.machine_id, &princess_values)
+                .await?;
         assert_eq!(princess_report.machine_id, princess_network.machine_id);
 
         let princess_journal =
@@ -251,12 +248,9 @@ mod tests {
         );
         assert_eq!(princess_journal.bundle_id, None);
 
-        let report = db::measured_boot::report::new_with_txn(
-            &mut txn,
-            beer_louisiana.machine_id,
-            &beer_values,
-        )
-        .await?;
+        let report =
+            db::measured_boot::report::new(&mut txn, beer_louisiana.machine_id, &beer_values)
+                .await?;
         assert_eq!(report.machine_id, beer_louisiana.machine_id);
 
         let beer_journal = db::measured_boot::journal::get_latest_for_machine_id(
@@ -269,12 +263,9 @@ mod tests {
         assert_eq!(beer_journal.state, MeasurementMachineState::PendingBundle);
         assert_eq!(beer_journal.bundle_id, None);
 
-        let lime_report = db::measured_boot::report::new_with_txn(
-            &mut txn,
-            lime_coconut.machine_id,
-            &bad_dell_values,
-        )
-        .await?;
+        let lime_report =
+            db::measured_boot::report::new(&mut txn, lime_coconut.machine_id, &bad_dell_values)
+                .await?;
         assert_eq!(lime_report.machine_id, lime_coconut.machine_id);
 
         let lime_journal = db::measured_boot::journal::get_latest_for_machine_id(
@@ -287,12 +278,9 @@ mod tests {
         assert_eq!(lime_journal.state, MeasurementMachineState::PendingBundle);
 
         // and now deal with slippery-lilac
-        let report = db::measured_boot::report::new_with_txn(
-            &mut txn,
-            slippery_lilac.machine_id,
-            &dgx_h100_values,
-        )
-        .await?;
+        let report =
+            db::measured_boot::report::new(&mut txn, slippery_lilac.machine_id, &dgx_h100_values)
+                .await?;
         assert_eq!(report.machine_id, slippery_lilac.machine_id);
 
         let slippery_profile =
@@ -318,7 +306,7 @@ mod tests {
         assert_eq!(slippery_journal.bundle_id, None);
 
         // and now kick off silly-salander and cat-videos
-        let report = db::measured_boot::report::new_with_txn(
+        let report = db::measured_boot::report::new(
             &mut txn,
             silly_salamander.machine_id,
             &dgx_h100_v1_values,
@@ -326,12 +314,9 @@ mod tests {
         .await?;
         assert_eq!(report.machine_id, silly_salamander.machine_id);
 
-        let cat_report = db::measured_boot::report::new_with_txn(
-            &mut txn,
-            cat_videos.machine_id,
-            &dgx_h100_v1_values,
-        )
-        .await?;
+        let cat_report =
+            db::measured_boot::report::new(&mut txn, cat_videos.machine_id, &dgx_h100_v1_values)
+                .await?;
         assert_eq!(cat_report.machine_id, cat_videos.machine_id);
 
         let silly_journal = db::measured_boot::journal::get_latest_for_machine_id(
@@ -351,7 +336,7 @@ mod tests {
         assert_eq!(silly_journal.state, cat_journal.state);
 
         let pcr_set = parse_pcr_index_input("0-2,4")?;
-        let bundle = db::measured_boot::report::create_active_bundle_with_txn(
+        let bundle = db::measured_boot::report::create_active_bundle(
             &mut txn,
             &princess_report,
             &Some(pcr_set),
@@ -424,7 +409,7 @@ mod tests {
         );
 
         let pcr_set = parse_pcr_index_input("1")?;
-        let bundle = db::measured_boot::report::create_revoked_bundle_with_txn(
+        let bundle = db::measured_boot::report::create_revoked_bundle(
             &mut txn,
             &lime_report,
             &Some(pcr_set),
@@ -497,8 +482,7 @@ mod tests {
         );
 
         let bundle =
-            db::measured_boot::report::create_active_bundle_with_txn(&mut txn, &cat_report, &None)
-                .await?;
+            db::measured_boot::report::create_active_bundle(&mut txn, &cat_report, &None).await?;
         assert_eq!(bundle.pcr_values().len(), 5);
         assert_eq!(bundle.state, MeasurementBundleState::Active);
 

--- a/crates/api/src/measured_boot/tests/journal.rs
+++ b/crates/api/src/measured_boot/tests/journal.rs
@@ -32,7 +32,7 @@ mod tests {
             MachineId::from_str("fm100hseddco33hvlofuqvg543p6p9aj60g76q5cq491g9m9tgtf2dk0530")?;
         let report_id = MeasurementReportId::new();
         let profile_id = MeasurementSystemProfileId::new();
-        let journal = db::measured_boot::journal::new_with_txn(
+        let journal = db::measured_boot::journal::new(
             &mut txn,
             machine_id,
             report_id,

--- a/crates/api/src/measured_boot/tests/rpc.rs
+++ b/crates/api/src/measured_boot/tests/rpc.rs
@@ -194,12 +194,9 @@ mod tests {
             },
         ];
 
-        let princess_report = db::measured_boot::report::new_with_txn(
-            &mut txn,
-            princess_network.machine_id,
-            &princess_values,
-        )
-        .await?;
+        let princess_report =
+            db::measured_boot::report::new(&mut txn, princess_network.machine_id, &princess_values)
+                .await?;
         assert_eq!(princess_report.machine_id, princess_network.machine_id);
         txn.commit().await?;
 


### PR DESCRIPTION
## Description

Back when I was originally working on `measured-boot`, I had a bunch of functions that took a `&Pool`, and then once I integrated it into Carbide, I started just passing it a `&txn`, so I ended up making a bunch of `new_with_txn` functions, and then having `new` just wrap that by making a `&txn`. None of that is necessary anymore and just adds to bloat -- it always takes a `&txn`, so lets not make people think otherwise (and clean up any old code that takes a `&Pool`).

Fwiw, we can't get rid of `new` in general here (and just build structs), because `new` does a bunch of RAII-ish stuff behind the scenes to actually get you a new DB-backed instance of something.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

