### PR TITLE
fix(agent): one forge_client_config to rule them all, ref!

### DIFF
--- a/crates/agent/src/instance_metadata_endpoint.rs
+++ b/crates/agent/src/instance_metadata_endpoint.rs
@@ -64,7 +64,7 @@ pub struct InstanceMetadataRouterStateImpl {
     latest_network_config: ArcSwapOption<ManagedHostNetworkConfigResponse>,
     machine_id: MachineId,
     forge_api: String,
-    forge_client_config: ForgeClientConfig,
+    forge_client_config: Arc<ForgeClientConfig>,
     outbound_governor:
         Arc<RateLimiter<NotKeyed, InMemoryState, clock::DefaultClock, NoOpMiddleware>>,
 }
@@ -110,7 +110,7 @@ impl InstanceMetadataRouterStateImpl {
     pub fn new(
         machine_id: MachineId,
         forge_api: String,
-        forge_client_config: ForgeClientConfig,
+        forge_client_config: Arc<ForgeClientConfig>,
     ) -> Self {
         Self {
             latest_instance_data: ArcSwapOption::new(None),

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -99,14 +99,16 @@ pub async fn start(cmdline: command_line::Options) -> eyre::Result<()> {
         tracing::warn!("Pretending local host is a DPU. Dev only.");
     }
 
-    let forge_client_config = ForgeClientConfig::new(
-        agent.forge_system.root_ca.clone(),
-        Some(ClientCert {
-            cert_path: agent.forge_system.client_cert.clone(),
-            key_path: agent.forge_system.client_key.clone(),
-        }),
-    )
-    .use_mgmt_vrf()?;
+    let forge_client_config = Arc::new(
+        ForgeClientConfig::new(
+            agent.forge_system.root_ca.clone(),
+            Some(ClientCert {
+                cert_path: agent.forge_system.client_cert.clone(),
+                key_path: agent.forge_system.client_key.clone(),
+            }),
+        )
+        .use_mgmt_vrf()?,
+    );
 
     match cmdline.cmd {
         None => {
@@ -223,7 +225,7 @@ pub async fn start(cmdline: command_line::Options) -> eyre::Result<()> {
                     ),
                     machine_id,
                     forge_api: forge_api_server.clone(),
-                    forge_client_config: forge_client_config.clone(),
+                    forge_client_config: Arc::clone(&forge_client_config),
                 },
             )
             .await;

--- a/crates/agent/src/machine_inventory_updater.rs
+++ b/crates/agent/src/machine_inventory_updater.rs
@@ -9,6 +9,7 @@
  * without an express license agreement from NVIDIA CORPORATION or
  * its affiliates is strictly prohibited.
  */
+use std::sync::Arc;
 use std::time::Duration;
 
 use ::rpc::forge as rpc;
@@ -25,7 +26,7 @@ pub struct MachineInventoryUpdaterConfig {
     pub update_inventory_interval: Duration,
     pub machine_id: MachineId,
     pub forge_api: String,
-    pub forge_client_config: ForgeClientConfig,
+    pub forge_client_config: Arc<ForgeClientConfig>,
 }
 
 pub async fn single_run(config: &MachineInventoryUpdaterConfig) -> eyre::Result<()> {

--- a/crates/agent/src/network_monitor.rs
+++ b/crates/agent/src/network_monitor.rs
@@ -110,7 +110,7 @@ impl NetworkMonitor {
     pub async fn run(
         &mut self,
         forge_api: &str,
-        client_config: ForgeClientConfig,
+        client_config: Arc<ForgeClientConfig>,
         close_receiver: &mut watch::Receiver<bool>,
     ) {
         // Initial fetch peer dpu list from API

--- a/crates/agent/src/periodic_config_fetcher.rs
+++ b/crates/agent/src/periodic_config_fetcher.rs
@@ -100,7 +100,7 @@ impl Drop for PeriodicConfigFetcher {
 
 impl PeriodicConfigFetcher {
     pub async fn new(config: PeriodicConfigFetcherConfig) -> Self {
-        let forge_client_config = config.forge_client_config.clone();
+        let forge_client_config = Arc::clone(&config.forge_client_config);
         // Fetch the sitename from Carbide at the start and keep it in State
         // so that it can be made available as instance metadata.
         let sitename = match fetch_sitename(&forge_client_config, &config.forge_api).await {
@@ -157,7 +157,7 @@ pub struct PeriodicConfigFetcherConfig {
     pub config_fetch_interval: Duration,
     pub machine_id: MachineId,
     pub forge_api: String,
-    pub forge_client_config: ForgeClientConfig,
+    pub forge_client_config: Arc<ForgeClientConfig>,
 }
 
 // Use the version grpc call to carbide to get

--- a/crates/certs/src/cert_renewal.rs
+++ b/crates/certs/src/cert_renewal.rs
@@ -11,10 +11,11 @@
  */
 
 use std::ops::Add;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use ::rpc::forge as rpc;
-use ::rpc::forge_tls_client::{self, ApiConfig};
+use ::rpc::forge_tls_client::{self, ApiConfig, ForgeClientConfig};
 use carbide_host_support::registration;
 use eyre::Context;
 use forge_tls::client_config::ClientCert;
@@ -30,14 +31,11 @@ const MAX_CERT_RENEWAL_FAILURE_TIME_SECS: u64 = 5 * 60; // 5min
 pub struct ClientCertRenewer {
     cert_renewal_time: std::time::Instant,
     forge_api_server: String,
-    client_config: forge_tls_client::ForgeClientConfig,
+    client_config: Arc<ForgeClientConfig>,
 }
 
 impl ClientCertRenewer {
-    pub fn new(
-        forge_api_server: String,
-        client_config: forge_tls_client::ForgeClientConfig,
-    ) -> Self {
+    pub fn new(forge_api_server: String, client_config: Arc<ForgeClientConfig>) -> Self {
         let cert_renewal_period =
             rand::rng().random_range(MIN_CERT_RENEWAL_TIME_SECS..MAX_CERT_RENEWAL_TIME_SECS);
         let cert_renewal_time = Instant::now().add(Duration::from_secs(cert_renewal_period));

--- a/crates/dpu-otel-agent/src/lib.rs
+++ b/crates/dpu-otel-agent/src/lib.rs
@@ -10,6 +10,8 @@
  * its affiliates is strictly prohibited.
  */
 
+use std::sync::Arc;
+
 use ::rpc::forge_tls_client::ForgeClientConfig;
 use carbide_host_support::agent_config::AgentConfig;
 pub use command_line::{AgentCommand, Options, RunOptions};
@@ -35,14 +37,16 @@ pub async fn start(cmdline: command_line::Options) -> eyre::Result<()> {
     };
     tracing::info!("Using configuration from {path}: {agent:?}");
 
-    let forge_client_config = ForgeClientConfig::new(
-        agent.forge_system.root_ca.clone(),
-        Some(ClientCert {
-            cert_path: agent.forge_system.client_cert.clone(),
-            key_path: agent.forge_system.client_key.clone(),
-        }),
-    )
-    .use_mgmt_vrf()?;
+    let forge_client_config = Arc::new(
+        ForgeClientConfig::new(
+            agent.forge_system.root_ca.clone(),
+            Some(ClientCert {
+                cert_path: agent.forge_system.client_cert.clone(),
+                key_path: agent.forge_system.client_key.clone(),
+            }),
+        )
+        .use_mgmt_vrf()?,
+    );
 
     match cmdline.cmd {
         None => {

--- a/crates/dpu-otel-agent/src/main_loop.rs
+++ b/crates/dpu-otel-agent/src/main_loop.rs
@@ -12,9 +12,10 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 
-use ::rpc::forge_tls_client;
+use ::rpc::forge_tls_client::ForgeClientConfig;
 use carbide_host_support::agent_config::AgentConfig;
 use carbide_systemd::systemd;
 use forge_certs::cert_renewal::ClientCertRenewer;
@@ -35,7 +36,7 @@ pub enum ProcessingError {
 }
 
 pub async fn setup_and_run(
-    forge_client_config: forge_tls_client::ForgeClientConfig,
+    forge_client_config: Arc<ForgeClientConfig>,
     agent_config: AgentConfig,
     options: command_line::RunOptions,
 ) -> eyre::Result<()> {
@@ -52,7 +53,7 @@ pub async fn setup_and_run(
     // Setup client certificate renewal
     let forge_api_server = agent_config.forge_system.api_server.clone();
     let mut client_cert_renewer =
-        ClientCertRenewer::new(forge_api_server.clone(), forge_client_config.clone());
+        ClientCertRenewer::new(forge_api_server.clone(), Arc::clone(&forge_client_config));
 
     // If the configured certs do not exist, copy them to the configured path from existing certs
     // specified in the run args. If they do exist, also check that they are not more than a day

--- a/crates/dpu-remediation/src/remediation.rs
+++ b/crates/dpu-remediation/src/remediation.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::path::Path;
 use std::process::Stdio;
+use std::sync::Arc;
 use std::time::Duration;
 
 use carbide_uuid::dpu_remediations::RemediationId;
@@ -53,14 +54,14 @@ impl MachineInfo {
 
 pub struct RemediationExecutor {
     forge_api_server: String,
-    forge_client_config: ForgeClientConfig,
+    forge_client_config: Arc<ForgeClientConfig>,
     machine_info: MachineInfo,
 }
 
 impl RemediationExecutor {
     pub fn new(
         forge_api_server: String,
-        forge_client_config: ForgeClientConfig,
+        forge_client_config: Arc<ForgeClientConfig>,
         machine_info: MachineInfo,
     ) -> Self {
         Self {


### PR DESCRIPTION
## Description

...aka get rid of `.clone()` of the client config. We should be creating one `ForgeClientConfig` at `start()` for the lifetime of the `carbide-dpu-agent` process, and then pass around references to it, not cloning it out of convenience.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

