### PR TITLE
feat: Add mark-manual-upgrade-complete admin-cli command

### DIFF
--- a/crates/admin-cli/src/host/args.rs
+++ b/crates/admin-cli/src/host/args.rs
@@ -37,6 +37,9 @@ pub enum HostReprovision {
     Clear(HostReprovisionClear),
     #[clap(about = "List all hosts pending reprovisioning.")]
     List,
+    // TODO: Remove when manual upgrade feature is removed
+    #[clap(about = "Mark manual firmware upgrade as complete for a host.")]
+    MarkManualUpgradeComplete(ManualFirmwareUpgradeComplete),
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -66,4 +69,14 @@ pub struct HostReprovisionClear {
 
     #[clap(short, long, action)]
     pub update_firmware: bool,
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct ManualFirmwareUpgradeComplete {
+    #[clap(
+        short,
+        long,
+        help = "Machine ID for which manual firmware upgrade should be set."
+    )]
+    pub id: MachineId,
 }

--- a/crates/admin-cli/src/host/cmds.rs
+++ b/crates/admin-cli/src/host/cmds.rs
@@ -113,6 +113,20 @@ pub fn generate_uefi_password() -> CarbideCliResult<()> {
     Ok(())
 }
 
+pub async fn mark_manual_firmware_upgrade_complete(
+    machine_id: MachineId,
+    api_client: &ApiClient,
+) -> CarbideCliResult<()> {
+    api_client
+        .0
+        .mark_manual_firmware_upgrade_complete(machine_id)
+        .await?;
+
+    println!("Marked manual firmware upgrade as complete for machine {machine_id}",);
+
+    Ok(())
+}
+
 fn print_pending_hosts(hosts: ::rpc::forge::HostReprovisioningListResponse) {
     let mut table = Table::new();
 

--- a/crates/admin-cli/src/host/mod.rs
+++ b/crates/admin-cli/src/host/mod.rs
@@ -50,6 +50,9 @@ impl Dispatch for Cmd {
                     .await
                 }
                 args::HostReprovision::List => cmds::list_hosts_pending(&ctx.api_client).await,
+                args::HostReprovision::MarkManualUpgradeComplete(data) => {
+                    cmds::mark_manual_firmware_upgrade_complete(data.id, &ctx.api_client).await
+                }
             },
         }
     }

--- a/crates/admin-cli/src/host/tests.rs
+++ b/crates/admin-cli/src/host/tests.rs
@@ -150,3 +150,32 @@ fn parse_reprovision_set_missing_id_fails() {
     let result = Cmd::try_parse_from(["host", "reprovision", "set"]);
     assert!(result.is_err(), "should fail without --id");
 }
+
+// parse_reprovision_mark_manual_upgrade_complete ensures
+// mark-manual-upgrade-complete parses with required --id.
+#[test]
+fn parse_reprovision_mark_manual_upgrade_complete() {
+    let cmd = Cmd::try_parse_from([
+        "host",
+        "reprovision",
+        "mark-manual-upgrade-complete",
+        "--id",
+        TEST_MACHINE_ID,
+    ])
+    .expect("should parse mark-manual-upgrade-complete");
+
+    match cmd {
+        Cmd::Reprovision(HostReprovision::MarkManualUpgradeComplete(args)) => {
+            assert_eq!(args.id.to_string(), TEST_MACHINE_ID);
+        }
+        _ => panic!("expected Reprovision MarkManualUpgradeComplete variant"),
+    }
+}
+
+// parse_reprovision_mark_manual_upgrade_complete_missing_id_fails
+// ensures mark-manual-upgrade-complete requires --id.
+#[test]
+fn parse_reprovision_mark_manual_upgrade_complete_missing_id_fails() {
+    let result = Cmd::try_parse_from(["host", "reprovision", "mark-manual-upgrade-complete"]);
+    assert!(result.is_err(), "should fail without --id");
+}

--- a/crates/api-db/src/host_machine_update.rs
+++ b/crates/api-db/src/host_machine_update.rs
@@ -145,10 +145,11 @@ pub async fn set_manual_firmware_upgrade_completed(
     txn: &mut PgConnection,
     machine_id: &MachineId,
 ) -> Result<(), DatabaseError> {
-    let query = "UPDATE machines SET manual_firmware_upgrade_completed = NOW() WHERE id = $1";
-    sqlx::query(query)
+    let query =
+        "UPDATE machines SET manual_firmware_upgrade_completed = NOW() WHERE id = $1 RETURNING id";
+    let _id = sqlx::query_as::<_, MachineId>(query)
         .bind(machine_id)
-        .execute(txn)
+        .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
 

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -1065,6 +1065,14 @@ impl Forge for Api {
         crate::handlers::host_reprovisioning::trigger_host_reprovisioning(self, request).await
     }
 
+    async fn mark_manual_firmware_upgrade_complete(
+        &self,
+        request: Request<MachineId>,
+    ) -> Result<Response<()>, Status> {
+        crate::handlers::host_reprovisioning::mark_manual_firmware_upgrade_complete(self, request)
+            .await
+    }
+
     async fn list_hosts_waiting_for_reprovisioning(
         &self,
         request: Request<rpc::HostReprovisioningListRequest>,

--- a/crates/api/src/auth/internal_rbac_rules.rs
+++ b/crates/api/src/auth/internal_rbac_rules.rs
@@ -213,6 +213,7 @@ impl InternalRBACRules {
         x.perm("TriggerDpuReprovisioning", vec![ForgeAdminCLI]);
         x.perm("TriggerHostReprovisioning", vec![ForgeAdminCLI, Rla]);
         x.perm("ListDpuWaitingForReprovisioning", vec![ForgeAdminCLI]);
+        x.perm("MarkManualFirmwareUpgradeComplete", vec![ForgeAdminCLI]);
         x.perm(
             "ListHostsWaitingForReprovisioning",
             vec![ForgeAdminCLI, Rla],

--- a/crates/api/src/handlers/host_reprovisioning.rs
+++ b/crates/api/src/handlers/host_reprovisioning.rs
@@ -125,3 +125,19 @@ pub(crate) async fn list_hosts_waiting_for_reprovisioning(
 
     Ok(Response::new(rpc::HostReprovisioningListResponse { hosts }))
 }
+
+pub async fn mark_manual_firmware_upgrade_complete(
+    api: &Api,
+    request: Request<MachineId>,
+) -> Result<Response<()>, Status> {
+    log_request_data(&request);
+    let machine_id = convert_and_log_machine_id(Some(&request.into_inner()))?;
+
+    let mut txn = api.txn_begin().await?;
+
+    db::host_machine_update::set_manual_firmware_upgrade_completed(&mut txn, &machine_id).await?;
+
+    txn.commit().await?;
+
+    Ok(Response::new(()))
+}

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -281,6 +281,9 @@ service Forge {
   rpc TriggerHostReprovisioning(HostReprovisioningRequest) returns (google.protobuf.Empty);
   // List hosts waiting for reprovisioning
   rpc ListHostsWaitingForReprovisioning(HostReprovisioningListRequest) returns (HostReprovisioningListResponse);
+  // TODO: Remove when manual upgrade feature is removed
+  // Mark host as having completed manual firmware upgrade
+  rpc MarkManualFirmwareUpgradeComplete(common.MachineId) returns (google.protobuf.Empty);
 
   rpc GetDpuInfoList(GetDpuInfoListRequest) returns (GetDpuInfoListResponse);
 


### PR DESCRIPTION
## Description

Follow up to https://github.com/NVIDIA/carbide-core/pull/159. Adding a new cli command to mark a machine as manual-upgrade-complete.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

