### PR TITLE
chore(health): don't clone Endpoints, just reference them

### DIFF
--- a/crates/health/src/discovery.rs
+++ b/crates/health/src/discovery.rs
@@ -145,7 +145,7 @@ pub async fn run_discovery_iteration(
     for endpoint in &sharded_endpoints {
         let key = endpoint.addr.hash_key().to_string();
         if !ctx.endpoint_monitors.contains_key(&key) {
-            let endpoint_arc = Arc::new((*endpoint).clone());
+            let endpoint_arc = (*endpoint).clone();
             let collector_registry = Arc::new(ctx.metrics_manager.create_collector_registry(
                 format!("health_monitor_collector_{}", endpoint.addr.hash_key()),
                 metrics_prefix,


### PR DESCRIPTION
## Description

I'm systematically going through the codebase as time permits, looking for uses of `.clone()` and seeing what can be done to reduce how much we're doing it.

In this case, what you'll see is that the use of `.clone()` itself isn't changing, but instead, the underlying thing we are cloning is (and the benefits that come from it).

Previously, the `EndpointSource` trait returned an owned `Vec<BmcEndpoint>`:
```
pub trait EndpointSource: Send + Sync {
    fn fetch_bmc_hosts<'a>(&'a self) -> BoxFuture<'a, Result<Vec<BmcEndpoint>, HealthError>>;
}
```

What this ended up causing was an entire clone of `Vec<BmcEndpoint>` on every fetch:
```
impl EndpointSource for StaticEndpointSource {
    fn fetch_bmc_hosts<'a>(&'a self) -> BoxFuture<'a, Result<Vec<BmcEndpoint>, HealthError>> {
        Box::pin(async move { Ok(self.endpoints.clone()) })  <-- entire clone here
    }
}
```

And in `discovery.rs`, it would redef an `Endpoint`, clone it, and then wrap it in an `Arc`:
```
for endpoint in &sharded_endpoints {
    let endpoint_arc = Arc::new((*endpoint).clone());
}
```

So you'd end up with this thing where you'd:
1. Fetch + clone the full `Vec<BmcEndpoint>`.
2. Iterate over references to the underlying `&BmcEndpoint`.
3. Dereference + `.clone()` + wrap it in an `Arc`.

So instead, lets just make it a `Vec<Arc<BmdEndpoint>>`, which allows us to define the `BmcEndpoint` once, and then pass around `Arcs`. We're still doing `.clone()`, but a lot less exepensive (and one real source of truth). Before, a `.clone()` was expensive in the sense that:
- `BmcAddr` -> `String`
- `BmcCredentials` -> (`String`, `String`)
- `Option<MachineData>` -> More `String`.

Now we just `.clone()` the `Arc` to the `BmcEndpoint`.

Also added tests to ensure what this is designed to do works as intended.


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

