### PR TITLE
chore: bump libredfish to v0.39.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5409,7 +5409,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.39.2#687c07e88a233407f5cd096f60878bea088c84c3"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.39.3#df4bc4a589e3c9f5f6f655e13b06ab13ffd032d9"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.39.2" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.39.3" }
 ansi-to-html = "0.2.2"
 
 tokio = { version = "1", features = ["full", "tracing"] }


### PR DESCRIPTION
## Description
This PR brings in the following changes from libredfish `v0.39.3`:
- fix: don't disable secure boot in machine_setup for DPUs by @krish-nvidia in https://github.com/NVIDIA/libredfish/pull/35

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

