### PR TITLE
chore(admin-cli,api,rpc): hit the "unmut" button, continued

### DIFF
--- a/crates/admin-cli/src/redfish/cmds.rs
+++ b/crates/admin-cli/src/redfish/cmds.rs
@@ -223,14 +223,11 @@ pub async fn action(action: RedfishAction) -> color_eyre::Result<()> {
                 "Status",
             ]);
             for dev in redfish.get_drives_metrics().await? {
-                let mut status = ResourceStatus {
+                let status = dev.status.unwrap_or(ResourceStatus {
                     health: Some(libredfish::model::ResourceHealth::Ok),
                     health_rollup: Some(libredfish::model::ResourceHealth::Ok),
                     state: Some(libredfish::model::ResourceState::Unknown),
-                };
-                if let Some(x) = dev.status {
-                    status = x;
-                }
+                });
                 let mut predictlife = 100;
                 if let Some(ref _pred_fail) = dev.failure_predicted
                     && *_pred_fail

--- a/crates/api/src/web/instance.rs
+++ b/crates/api/src/web/instance.rs
@@ -141,10 +141,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
         }
     };
 
-    let mut instances: Vec<InstanceDisplay> = Vec::new();
-    for rp in out.instances.into_iter() {
-        instances.push(rp.into());
-    }
+    let instances: Vec<InstanceDisplay> = out.instances.into_iter().map(Into::into).collect();
     let tmpl = InstanceShow { instances };
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -428,10 +428,11 @@ impl From<health_report::HealthProbeAlert> for health::HealthProbeAlert {
 impl TryFrom<health::HealthProbeAlert> for health_report::HealthProbeAlert {
     type Error = health_report::HealthReportConversionError;
     fn try_from(alert: health::HealthProbeAlert) -> Result<Self, Self::Error> {
-        let mut classifications = Vec::new();
-        for c in alert.classifications {
-            classifications.push(c.parse()?);
-        }
+        let classifications = alert
+            .classifications
+            .into_iter()
+            .map(|c| c.parse())
+            .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self {
             id: alert.id.parse()?,
@@ -453,20 +454,11 @@ impl TryFrom<health::HealthProbeAlert> for health_report::HealthProbeAlert {
 
 impl From<health_report::HealthReport> for health::HealthReport {
     fn from(report: health_report::HealthReport) -> Self {
-        let mut successes = Vec::new();
-        let mut alerts = Vec::new();
-        for success in report.successes {
-            successes.push(success.into());
-        }
-        for alert in report.alerts {
-            alerts.push(alert.into());
-        }
-
         Self {
             source: report.source,
             observed_at: report.observed_at.map(Timestamp::from),
-            successes,
-            alerts,
+            successes: report.successes.into_iter().map(Into::into).collect(),
+            alerts: report.alerts.into_iter().map(Into::into).collect(),
         }
     }
 }


### PR DESCRIPTION
## Description

Continung to go through the codebase finding some more low hanging examples of using "`mut`" when we can instead just accumulate with an iterator chain. Here are the latest findings!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

