### PR TITLE
Add DbReader trait to make read-only db calls simpler

### DIFF
--- a/crates/api-db/src/attestation/ek_cert_verification_status.rs
+++ b/crates/api-db/src/attestation/ek_cert_verification_status.rs
@@ -14,6 +14,7 @@ use carbide_uuid::machine::MachineId;
 use model::attestation::EkCertVerificationStatus;
 use sqlx::PgConnection;
 
+use crate::db_read::DbReader;
 use crate::{DatabaseError, DatabaseResult};
 
 pub async fn get_by_ek_sha256(
@@ -54,7 +55,7 @@ pub async fn get_by_issuer(
 }
 
 pub async fn get_by_machine_id(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     machine_id: MachineId,
 ) -> DatabaseResult<Option<EkCertVerificationStatus>> {
     let query = "SELECT * FROM ek_cert_verification_status WHERE machine_id = ($1)";

--- a/crates/api-db/src/db_read.rs
+++ b/crates/api-db/src/db_read.rs
@@ -1,0 +1,329 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material and related documentation
+ * without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+ */
+
+use futures_util::future::BoxFuture;
+use futures_util::stream::BoxStream;
+use sqlx::{Database, Describe, Either, Execute, PgConnection, PgExecutor, PgPool, Postgres};
+
+/// A trait describing a database handle intended for use in read-only database operations.
+///
+/// A DbReader can be implemented by:
+/// - `&mut PgConnection`
+/// - `&mut PgTransaction`
+/// - `&mut PgPoolReader`
+/// - `&PgPool`
+///
+/// To make a database function accept a DbReader, you have a few options:
+///
+/// # Short-cut: "Leaf" functions that run a single query
+///
+/// For database functions that directly execute exactly one SQL query, or which delegate to exactly
+/// one function that does the same, your function can accept a simple `impl DbReader<'_>`:
+///
+/// ```
+/// use db::db_read::DbReader;
+/// async fn simple_db_func(db: impl DbReader<'_>) -> sqlx::Result<String> {
+///     sqlx::query_scalar("SELECT 'test'").fetch_one(db).await
+/// }
+/// ```
+///
+/// Note, that if you accept an `impl DbReader`, then callers need to re-borrow in order to avoid
+/// moves (`&mut *txn` or `txn.as_mut()`)
+///
+/// # More complex: Functions that run multiple queries or delegate to other functions
+///
+/// An issue with using `impl DbReader<'_>` is that passing it anywhere will move it out, and you
+/// cannot use it again. If you need to pass a DbReader to more than one query, you'll need to use a
+/// `&mut` reference, and make your function generic, with
+/// [HRTB](https://doc.rust-lang.org/nomicon/hrtb.html), and use `&mut *db` to avoid moving the
+/// value:
+///
+/// ```
+/// use db::db_read::DbReader;
+/// async fn two_db_calls<DB>(db: &mut DB) -> sqlx::Result<()>
+/// where
+///     for<'db> &'db mut DB: DbReader<'db>
+/// {
+///     // Use `&mut *db` to avoid moving
+///     sqlx::query_scalar::<_, String>("SELECT 'test'").fetch_one(&mut *db).await?;
+///     sqlx::query_scalar::<_, String>("SELECT 'test'").fetch_one(db).await?;
+///     Ok(())
+/// }
+/// ```
+///
+/// The `for<'db> &'db mut DB: DbReader<'db>` tells rust "I'm taking a `&mut` reference to
+/// something, and the type of that something needs to be such that any `&mut` reference to it
+/// implements the `DbReader` trait." This is because it's reference itself that implements
+/// `DbReader`, not the thing it points to.
+///
+/// # Calling DbReader functions from writer functions
+///
+/// One important use case is calling "read-only" database functions when you're holding a
+/// PgTransaction or PgConnection.
+///
+/// - [`&mut PgTransaction`] A PgTransaction can be passed via `.as_mut()` to turn it into a
+///   `&mut PgConnection` first, which implements DbReader.
+/// - [`&mut PgConnection`] This can be passed unaltered to a function expecting a DbReader, as
+///   PgConnection implements the trait directly.
+///
+/// # Calling DbReader functions with PgPoolReader or a PgPool
+///
+/// Due to sqlx's trait limitations, a `&mut PgPool` cannot implement DbReader, only a
+/// `&PgPool` can. So we have to choose if you want our db functions to take a generic `&mut DB` or a
+/// generic `&DB`. But the former is usable by PgTransaction, PgConnection, and PgPoolReader, but a
+/// `&DB` is only usable by PgPool.
+///
+/// So the guidance is to always accept a `&mut DB`, and if you want to call it from a PgPool, wrap
+/// the PgPool in a PgPoolReader first.
+///
+/// # Complete example
+///
+/// ```
+/// use db::db_read::PgPoolReader;
+///
+/// mod db_funcs {
+///     use db::db_read::DbReader;
+///
+///     // This is callable from any of our db types: PgConnection, PgTransaction, PgPool, and
+///     // PgPoolReader, and is simple to write. But the limitation is that you can only use it
+///     // once, since it is "moved out" the first time it is used.
+///     pub async fn callable_from_everything(db: impl DbReader<'_>) -> sqlx::Result<String> {
+///         sqlx::query_scalar("SELECT 'test'").fetch_one(db).await
+///     }
+///
+///     // This is callable from any `&mut` type: PgConnection, PgTransaction, and PgPoolReader. But
+///     // the downside is that you have to type out the generics and HRTB lines:
+///     pub async fn callable_from_all_but_pgpool<DB>(db: &mut DB) -> sqlx::Result<String>
+///     where
+///         for<'db> &'db mut DB: DbReader<'db>
+///     {
+///         sqlx::query_scalar("SELECT 'test'").fetch_one(db).await
+///     }
+///
+///     /// This is a not-recommended example: It's callable by PgPool, but not PgTransaction,
+///     /// PgConnection, nor PgPoolReader.
+///     pub async fn callable_from_pgpool_only<DB>(db: &DB) -> sqlx::Result<String>
+///     where
+///         for<'db> &'db DB: DbReader<'db>
+///     {
+///         sqlx::query_scalar("SELECT 'test'").fetch_one(db).await
+///     }
+/// }
+///
+/// async fn has_a_transaction(txn: &mut sqlx::PgTransaction<'_>) -> sqlx::Result<()> {
+///     // Transactions always must be passed with `.as_mut()` to convert them to a PgConnection
+///     db_funcs::callable_from_everything(txn.as_mut()).await?;
+///     db_funcs::callable_from_all_but_pgpool(txn.as_mut()).await?;
+///     db_funcs::callable_from_all_but_pgpool(txn.as_mut()).await?;
+///     Ok(())
+/// }
+///
+/// async fn has_a_pg_connection(conn: &mut sqlx::PgConnection) -> sqlx::Result<()> {
+///     // Passing to `impl DbReader<'_>` functions means doing `&mut *` to avoid moving
+///     db_funcs::callable_from_everything(&mut *conn).await?;
+///
+///     // When passing to functions taking `&mut DB` with HRTB, you can just pass the reference
+///     // as-is, and don't need to re-borrow.
+///     db_funcs::callable_from_all_but_pgpool(conn).await?;
+///     db_funcs::callable_from_all_but_pgpool(conn).await?;
+///     Ok(())
+/// }
+///
+/// async fn has_a_pg_pool_reader(pool: &mut PgPoolReader) -> sqlx::Result<()> {
+///     // Passing to `impl DbReader<'_>` functions means doing `&mut *` to avoid moving
+///     db_funcs::callable_from_everything(&mut *pool).await?;
+///
+///     // When passing to functions taking `&mut DB` with HRTB, you can just pass the reference
+///     // as-is, and don't need to re-borrow.
+///     db_funcs::callable_from_all_but_pgpool(pool).await?;
+///     db_funcs::callable_from_all_but_pgpool(pool).await?;
+///     Ok(())
+/// }
+///
+/// async fn has_a_pg_pool(pool: &sqlx::PgPool) -> sqlx::Result<()> {
+///     // Passing to `impl DbReader<'_>` functions means doing `&*` to avoid moving
+///     db_funcs::callable_from_everything(&*pool).await?;
+///
+///     // When passing to functions taking `&DB` with HRTB, you can just pass the reference as-is,
+///     // and don't need to re-borrow.
+///     db_funcs::callable_from_pgpool_only(pool).await?;
+///     db_funcs::callable_from_pgpool_only(pool).await?;
+///     Ok(())
+/// }
+/// ```
+///
+/// # Why go through the effort?
+///
+/// For cases where you're only reading data, in order to avoid long-running work while holding open
+/// a PgConnection or PgTransaction, it is beneficial to pass a reference to the *database pool*
+/// around, rather than a connection or transaction. This avoids consuming database resources until
+/// you actually need to execute a query. Passing a PgConnection or PgTransaction around should be
+/// reserved for cases where we know we need to *write* to the database, where we need to ensure
+/// that it is rolled back on failure, and that multiple writes are committed atomically.
+///
+/// But there's an ergonomics issue with passing a PgPool around: You still need to actually acquire
+/// a connection to call database functions, or create a transaction and immediately commit it. This
+/// gets confusing, because it's not clear from reading the code whether the transaction is being
+/// created because we're actually writing to the database, or if we're just making a transaction so
+/// that we can pass a live PgConnection to a db function.
+///
+/// # Why not have db functions accept PgPool?
+///
+/// If a function accepts a PgPool, then it can *not* be called from a context where we really *do*
+/// want to hold a transaction. If we want to write to data, then in the same transaction read back
+/// the data we just wrote to, the PgPool would check out a new connection to perform the read, and
+/// not see the data that was just written. This means we'd have to have two of every relevant
+/// function: One which takes a PgPool, and one which takes a PgConnection/PgTransaction.
+///
+/// # Why not accept a sqlx::Executor trait instead?
+///
+/// The reason is complicated and comes down to the choices sqlx made for their trait.
+/// [`sqlx::Executor`] is sqlx's way of having functions be agnostic to whether you call it from a
+/// Connection/Transaction or via a Pool. But it has all the same drawbacks as above: If you want
+/// to use it more than once, you need to take a `&mut` reference and use generics and HRTB's. But
+/// it's worse, because if you do take a `&mut` reference, then you *don't* support PgPool, since
+/// PgPool only implements Executor if it's an *immutable* reference.
+///
+/// In addition, the DbReader trait gives us the control to separate read-only functions from
+/// writable ones. This allows cases where we intentionally don't want to be able to write to the
+/// database, by only putting a PgPoolReader in scope instead of a PgPool, preventing any code paths
+/// from writing to the database at all.
+pub trait DbReader<'txn>: PgExecutor<'txn> {}
+
+/// A database handle that can only be sent to database functions accepting a `DbReader` trait. It
+/// cannot be passed to functions expecting a PgConnection or PgTransaction.
+#[derive(Debug, Clone)]
+pub struct PgPoolReader {
+    inner: PgPool,
+}
+
+impl From<PgPool> for PgPoolReader {
+    fn from(pool: PgPool) -> Self {
+        Self { inner: pool }
+    }
+}
+
+impl<'a> DbReader<'a> for &'a mut PgPoolReader {}
+impl<'c> DbReader<'c> for &'c mut PgConnection {}
+impl<'c, 'txn> DbReader<'c> for &'c mut crate::Transaction<'txn> {}
+impl<'c> DbReader<'c> for &'c PgPool {}
+impl AsMut<PgPoolReader> for PgPoolReader {
+    fn as_mut(&mut self) -> &mut PgPoolReader {
+        self
+    }
+}
+
+impl<'c> sqlx::Executor<'c> for &'c mut PgPoolReader {
+    type Database = Postgres;
+
+    fn fetch_many<'e, 'q: 'e, E>(
+        self,
+        query: E,
+    ) -> BoxStream<
+        'e,
+        Result<
+            Either<<Self::Database as Database>::QueryResult, <Self::Database as Database>::Row>,
+            sqlx::Error,
+        >,
+    >
+    where
+        'c: 'e,
+        E: 'q + Execute<'q, Self::Database>,
+    {
+        self.inner.fetch_many(query)
+    }
+
+    fn fetch_optional<'e, 'q: 'e, E>(
+        self,
+        query: E,
+    ) -> BoxFuture<'e, Result<Option<<Self::Database as Database>::Row>, sqlx::Error>>
+    where
+        'c: 'e,
+        E: 'q + Execute<'q, Self::Database>,
+    {
+        self.inner.fetch_optional(query)
+    }
+
+    fn prepare_with<'e, 'q: 'e>(
+        self,
+        sql: &'q str,
+        parameters: &'e [<Self::Database as Database>::TypeInfo],
+    ) -> BoxFuture<'e, Result<<Self::Database as Database>::Statement<'q>, sqlx::Error>>
+    where
+        'c: 'e,
+    {
+        self.inner.prepare_with(sql, parameters)
+    }
+
+    fn describe<'e, 'q: 'e>(
+        self,
+        sql: &'q str,
+    ) -> BoxFuture<'e, Result<Describe<Self::Database>, sqlx::Error>>
+    where
+        'c: 'e,
+    {
+        self.inner.describe(sql)
+    }
+}
+
+impl<'c, 'txn> sqlx::Executor<'c> for &'c mut crate::Transaction<'txn> {
+    type Database = Postgres;
+
+    fn fetch_many<'e, 'q: 'e, E>(
+        self,
+        query: E,
+    ) -> BoxStream<
+        'e,
+        Result<
+            Either<<Self::Database as Database>::QueryResult, <Self::Database as Database>::Row>,
+            sqlx::Error,
+        >,
+    >
+    where
+        'c: 'e,
+        E: 'q + Execute<'q, Self::Database>,
+    {
+        self.inner.fetch_many(query)
+    }
+
+    fn fetch_optional<'e, 'q: 'e, E>(
+        self,
+        query: E,
+    ) -> BoxFuture<'e, Result<Option<<Self::Database as Database>::Row>, sqlx::Error>>
+    where
+        'c: 'e,
+        E: 'q + Execute<'q, Self::Database>,
+    {
+        self.inner.fetch_optional(query)
+    }
+
+    fn prepare_with<'e, 'q: 'e>(
+        self,
+        sql: &'q str,
+        parameters: &'e [<Self::Database as Database>::TypeInfo],
+    ) -> BoxFuture<'e, Result<<Self::Database as Database>::Statement<'q>, sqlx::Error>>
+    where
+        'c: 'e,
+    {
+        self.inner.prepare_with(sql, parameters)
+    }
+
+    fn describe<'e, 'q: 'e>(
+        self,
+        sql: &'q str,
+    ) -> BoxFuture<'e, Result<Describe<Self::Database>, sqlx::Error>>
+    where
+        'c: 'e,
+    {
+        self.inner.describe(sql)
+    }
+}

--- a/crates/api-db/src/dpu_machine_update.rs
+++ b/crates/api-db/src/dpu_machine_update.rs
@@ -100,7 +100,7 @@ pub async fn get_updated_machines(
     host_health_config: HostHealthConfig,
 ) -> Result<Vec<DpuMachineUpdate>, DatabaseError> {
     let machine_ids = crate::machine::find_machine_ids(
-        txn,
+        &mut *txn,
         MachineSearchConfig {
             include_predicted_host: true,
             ..Default::default()

--- a/crates/api-db/src/instance_address.rs
+++ b/crates/api-db/src/instance_address.rs
@@ -32,6 +32,7 @@ use model::network_segment::{
 use sqlx::{FromRow, PgConnection, PgTransaction, query_as};
 
 use super::{ObjectColumnFilter, network_segment};
+use crate::db_read::DbReader;
 use crate::ip_allocator::{IpAllocator, UsedIpResolver};
 use crate::{DatabaseError, DatabaseResult, Transaction};
 
@@ -292,7 +293,7 @@ pub async fn allocate(
                 .copied()
                 .collect::<Vec<IpAddr>>();
 
-            let dhcp_handler: Box<dyn UsedIpResolver + Send> =
+            let dhcp_handler: Box<dyn UsedIpResolver<PgConnection> + Send> =
                 Box::new(UsedOverlayNetworkIpResolver {
                     segment_id: segment.id,
                     busy_ips,
@@ -303,7 +304,7 @@ pub async fn allocate(
             // a /32). For now, hard-code 32 as the length -- the plan is to
             // update the InstanceInterfaceConfig to request the prefix_length.
             let ip_allocator = IpAllocator::new(
-                &mut inner_txn,
+                inner_txn.as_pgconn(),
                 segment,
                 dhcp_handler,
                 AddressSelectionStrategy::Automatic,
@@ -343,7 +344,10 @@ pub struct UsedOverlayNetworkIpResolver {
 }
 
 #[async_trait::async_trait]
-impl UsedIpResolver for UsedOverlayNetworkIpResolver {
+impl<DB> UsedIpResolver<DB> for UsedOverlayNetworkIpResolver
+where
+    for<'db> &'db mut DB: DbReader<'db>,
+{
     // DEPRECATED
     // With the introduction of `used_prefixes()` this is no
     // longer an accurate approach for finding all allocated
@@ -357,7 +361,7 @@ impl UsedIpResolver for UsedOverlayNetworkIpResolver {
     // target the `address` column of the `instance_addresses`
     // table, in which a single /32 is stored (although, as an
     // `inet`, it could techincally also have a prefix length).
-    async fn used_ips(&self, txn: &mut PgConnection) -> Result<Vec<IpAddr>, DatabaseError> {
+    async fn used_ips(&self, txn: &mut DB) -> Result<Vec<IpAddr>, DatabaseError> {
         // IpAddrContainer is a small private struct used
         // for binding the result of the subsequent SQL
         // query, so we can implement FromRow and return
@@ -394,7 +398,7 @@ WHERE network_segments.id = $1::uuid";
     // or a /30 (for FNN prefix allocations), where the `address`
     // column would contain the host IP allocated from the
     // /30 prefix.
-    async fn used_prefixes(&self, txn: &mut PgConnection) -> Result<Vec<IpNetwork>, DatabaseError> {
+    async fn used_prefixes(&self, txn: &mut DB) -> Result<Vec<IpNetwork>, DatabaseError> {
         // IpNetworkContainer is a small private struct used
         // for binding the result of the subsequent SQL
         // query, so we can implement FromRow and return
@@ -543,10 +547,11 @@ pub async fn allocate_svi_ip(
     txn: &mut PgTransaction<'_>,
     segment: &NetworkSegment,
 ) -> DatabaseResult<(NetworkPrefixId, IpAddr)> {
-    let dhcp_handler: Box<dyn UsedIpResolver + Send> = Box::new(UsedOverlayNetworkIpResolver {
-        segment_id: segment.id,
-        busy_ips: vec![],
-    });
+    let dhcp_handler: Box<dyn UsedIpResolver<PgConnection> + Send> =
+        Box::new(UsedOverlayNetworkIpResolver {
+            segment_id: segment.id,
+            busy_ips: vec![],
+        });
 
     // If either requested addresses are auto-generated, we lock the entire table
     let query = "LOCK TABLE instance_addresses IN ACCESS EXCLUSIVE MODE";
@@ -556,7 +561,7 @@ pub async fn allocate_svi_ip(
         .map_err(|e| DatabaseError::query(query, e))?;
 
     let mut addresses_allocator = IpAllocator::new(
-        txn,
+        txn.as_mut(),
         segment,
         dhcp_handler,
         AddressSelectionStrategy::Automatic,

--- a/crates/api-db/src/lib.rs
+++ b/crates/api-db/src/lib.rs
@@ -12,10 +12,12 @@
 
 // Allow txn_without_commit in tests
 #![cfg_attr(test, allow(txn_without_commit))]
+#![allow(unknown_lints)]
 
 pub mod attestation;
 pub mod bmc_metadata;
 pub mod carbide_version;
+pub mod db_read;
 pub mod desired_firmware;
 pub mod dhcp_entry;
 pub mod dhcp_record;
@@ -565,6 +567,7 @@ impl From<::measured_boot::Error> for DatabaseError {
     }
 }
 
+#[derive(Debug)]
 pub struct Transaction<'a> {
     inner: sqlx::PgTransaction<'a>,
 }

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -52,6 +52,7 @@ use uuid::Uuid;
 
 use super::{DatabaseError, ObjectFilter, Transaction, queries};
 use crate::DatabaseResult;
+use crate::db_read::DbReader;
 
 #[derive(Serialize)]
 struct ReprovisionRequestRestart {
@@ -1635,7 +1636,7 @@ pub async fn set_dpu_agent_upgrade_requested(
 }
 
 pub async fn find_machine_ids(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     search_config: MachineSearchConfig,
 ) -> Result<Vec<MachineId>, DatabaseError> {
     let mut qb = sqlx::QueryBuilder::new("SELECT id FROM machines");

--- a/crates/api-db/src/measured_boot/bundle.rs
+++ b/crates/api-db/src/measured_boot/bundle.rs
@@ -118,7 +118,7 @@ pub async fn from_id(
     txn: &mut PgConnection,
     bundle_id: MeasurementBundleId,
 ) -> DatabaseResult<MeasurementBundle> {
-    match get_measurement_bundle_by_id(txn, bundle_id).await? {
+    match get_measurement_bundle_by_id(&mut *txn, bundle_id).await? {
         Some(info) => {
             let values = get_measurement_bundle_values_for_bundle_id(txn, info.bundle_id).await?;
             Ok(from_info_and_values(info, values)?)

--- a/crates/api-db/src/measured_boot/interface/bundle.rs
+++ b/crates/api-db/src/measured_boot/interface/bundle.rs
@@ -25,6 +25,7 @@ use measured_boot::records::{
 use sqlx::PgConnection;
 
 use crate::DatabaseError;
+use crate::db_read::DbReader;
 use crate::measured_boot::interface::common;
 
 /// insert_measurement_bundle_record is a very basic insert of a
@@ -184,7 +185,7 @@ pub async fn update_state_for_bundle_id(
 /// for the given `bundle_id`, if it exists. This leverages the generic
 /// get_object_for_id function since its a simple/common pattern.
 pub async fn get_measurement_bundle_by_id(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     bundle_id: MeasurementBundleId,
 ) -> Result<Option<MeasurementBundleRecord>, DatabaseError> {
     common::get_object_for_id(txn, bundle_id)

--- a/crates/api-db/src/measured_boot/interface/common.rs
+++ b/crates/api-db/src/measured_boot/interface/common.rs
@@ -26,6 +26,7 @@ use measured_boot::pcr::PcrRegisterValue;
 use sqlx::postgres::PgRow;
 use sqlx::{Encode, PgConnection, PgTransaction, Postgres};
 
+use crate::db_read::DbReader;
 use crate::{DatabaseError, DatabaseResult};
 
 // DISCOVERY_PROFILE_ATTRS are the attributes we pull
@@ -79,7 +80,7 @@ pub fn generate_name() -> DatabaseResult<String> {
 /// the DbPrimaryUuid and DbTable traits (which are traits defined in this
 /// crate) to build the query.
 pub async fn get_object_for_id<T, R>(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     id: T,
 ) -> Result<Option<R>, DatabaseError>
 where
@@ -99,7 +100,7 @@ where
 /// the DbPrimaryUuid and DbTable traits (which are traits defined in this
 /// crate) to build the query.
 pub async fn get_object_for_unique_column<T, R>(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     col_name: &str,
     value: T,
 ) -> Result<Option<R>, DatabaseError>

--- a/crates/api-db/src/measured_boot/interface/machine.rs
+++ b/crates/api-db/src/measured_boot/interface/machine.rs
@@ -20,6 +20,7 @@ use measured_boot::records::{MeasurementJournalRecord, MeasurementMachineState};
 use sqlx::PgConnection;
 
 use crate::DatabaseError;
+use crate::db_read::DbReader;
 use crate::measured_boot::interface::common;
 use crate::measured_boot::machine::CandidateMachineRecord;
 
@@ -27,21 +28,19 @@ use crate::measured_boot::machine::CandidateMachineRecord;
 /// machine ID by checking its most recent bundle (or lack thereof), and
 /// using that result to give it a corresponding MeasurementMachineState.
 pub async fn get_candidate_machine_state(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     machine_id: MachineId,
 ) -> Result<MeasurementMachineState, DatabaseError> {
-    Ok(
-        match get_latest_journal_for_id(&mut *txn, machine_id).await? {
-            Some(record) => record.state,
-            None => MeasurementMachineState::Discovered,
-        },
-    )
+    Ok(match get_latest_journal_for_id(txn, machine_id).await? {
+        Some(record) => record.state,
+        None => MeasurementMachineState::Discovered,
+    })
 }
 
 /// get_latest_journal_for_id returns the latest journal record for the
 /// provided machine ID.
 pub async fn get_latest_journal_for_id(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     machine_id: MachineId,
 ) -> Result<Option<MeasurementJournalRecord>, DatabaseError> {
     let query = "select distinct on (machine_id) * from measurement_journal where machine_id = $1 order by machine_id,ts desc";

--- a/crates/api-db/src/measured_boot/journal.rs
+++ b/crates/api-db/src/measured_boot/journal.rs
@@ -23,6 +23,7 @@ use measured_boot::journal::MeasurementJournal;
 use measured_boot::records::{MeasurementJournalRecord, MeasurementMachineState};
 use sqlx::PgConnection;
 
+use crate::db_read::DbReader;
 use crate::measured_boot::interface::common;
 use crate::measured_boot::interface::journal::{
     delete_journal_where_id, get_measurement_journal_record_by_id,
@@ -190,7 +191,7 @@ async fn get_measurement_journals(
 /// get_latest_journal_for_id returns the latest journal record for the
 /// provided machine ID.
 pub async fn get_latest_journal_for_id(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     machine_id: MachineId,
 ) -> DatabaseResult<Option<MeasurementJournal>> {
     let query = "select distinct on (machine_id) * from measurement_journal where machine_id = $1 order by machine_id,ts desc";

--- a/crates/api-db/src/measured_boot/machine.rs
+++ b/crates/api-db/src/measured_boot/machine.rs
@@ -28,6 +28,7 @@ use rpc::protos::measured_boot::CandidateMachineSummaryPb;
 use serde::Serialize;
 use sqlx::{FromRow, PgConnection};
 
+use crate::db_read::DbReader;
 use crate::measured_boot::interface::bundle::get_measurement_bundle_by_id;
 use crate::measured_boot::interface::common;
 use crate::measured_boot::interface::machine::{
@@ -138,22 +139,25 @@ pub fn bundle_state_to_machine_state(
 /// machine ID by checking its most recent bundle (or lack thereof), and
 /// using that result to give it a corresponding MeasurementMachineState.
 pub async fn get_measurement_machine_state(
-    txn: &mut PgConnection,
+    db_reader: impl DbReader<'_>,
     machine_id: MachineId,
 ) -> Result<MeasurementMachineState, DatabaseError> {
-    get_candidate_machine_state(txn, machine_id).await
+    get_candidate_machine_state(db_reader, machine_id).await
 }
 
 /// get_measurement_bundle_state returns the state of the current bundle
 /// associated with the machine, if one exists.
-pub async fn get_measurement_bundle_state(
-    txn: &mut PgConnection,
+pub async fn get_measurement_bundle_state<DB>(
+    db_reader: &mut DB,
     machine_id: &MachineId,
-) -> eyre::Result<Option<MeasurementBundleState>> {
-    let result = get_latest_journal_for_id(&mut *txn, *machine_id).await?;
+) -> eyre::Result<Option<MeasurementBundleState>>
+where
+    for<'db> &'db mut DB: DbReader<'db>,
+{
+    let result = get_latest_journal_for_id(&mut *db_reader, *machine_id).await?;
     if let Some(journal_record) = result
         && let Some(bundle_id) = journal_record.bundle_id
-        && let Some(bundle) = get_measurement_bundle_by_id(txn, bundle_id).await?
+        && let Some(bundle) = get_measurement_bundle_by_id(db_reader, bundle_id).await?
     {
         return Ok(Some(bundle.state));
     }
@@ -181,7 +185,7 @@ async fn get_candidate_machines(txn: &mut PgConnection) -> DatabaseResult<Vec<Ca
             ))),
         }?;
 
-        let journal = get_latest_journal_for_id(txn, record.machine_id).await?;
+        let journal = get_latest_journal_for_id(&mut *txn, record.machine_id).await?;
         let state = machine_state_from_journal(&journal);
 
         res.push(CandidateMachine {

--- a/crates/api-db/src/measured_boot/report.rs
+++ b/crates/api-db/src/measured_boot/report.rs
@@ -460,7 +460,9 @@ async fn same_as_previous_one(
     values: &[PcrRegisterValue],
 ) -> DatabaseResult<SameOrNot> {
     let latest_journal =
-        match crate::measured_boot::journal::get_latest_journal_for_id(txn, machine_id).await? {
+        match crate::measured_boot::journal::get_latest_journal_for_id(&mut *txn, machine_id)
+            .await?
+        {
             Some(journal) => journal,
             None => return Ok(SameOrNot::Different),
         };

--- a/crates/api-db/src/vpc.rs
+++ b/crates/api-db/src/vpc.rs
@@ -362,7 +362,7 @@ pub async fn update_virtualization(
 
     // Update SVI IP for stretchable segments.
     let network_segments = crate::network_segment::find_by(
-        txn,
+        txn.as_mut(),
         ObjectColumnFilter::One(network_segment::VpcColumn, &vpc.id),
         model::network_segment::NetworkSegmentSearchConfig::default(),
     )

--- a/crates/api/src/handlers/machine.rs
+++ b/crates/api/src/handlers/machine.rs
@@ -41,7 +41,7 @@ pub(crate) async fn find_machine_ids(
     let search_config = request.into_inner().try_into()?;
 
     let machine_ids = api
-        .with_txn(|txn| db::machine::find_machine_ids(txn, search_config).boxed())
+        .with_txn(|txn| db::machine::find_machine_ids(txn.as_mut(), search_config).boxed())
         .await??;
 
     Ok(Response::new(::rpc::common::MachineIdList {

--- a/crates/api/src/handlers/network_segment.rs
+++ b/crates/api/src/handlers/network_segment.rs
@@ -68,7 +68,7 @@ pub(crate) async fn find_by_ids(
     let segments = api
         .with_txn(|txn| {
             db::network_segment::find_by(
-                txn,
+                txn.as_mut(),
                 ObjectColumnFilter::List(network_segment::IdColumn, &network_segments_ids),
                 NetworkSegmentSearchConfig {
                     include_history,
@@ -255,7 +255,7 @@ pub(crate) async fn save(
     if allocate_svi_ip {
         db::network_segment::allocate_svi_ip(&network_segment, txn).await?;
         let network_segments = db::network_segment::find_by(
-            txn,
+            txn.as_mut(),
             ObjectColumnFilter::One(network_segment::IdColumn, &network_segment.id),
             NetworkSegmentSearchConfig::default(),
         )

--- a/crates/api/src/handlers/site_explorer.rs
+++ b/crates/api/src/handlers/site_explorer.rs
@@ -69,7 +69,7 @@ pub(crate) async fn find_explored_endpoints_by_ids(
     }
 
     let result = api
-        .with_txn(|txn| db::explored_endpoints::find_by_ips(txn, ips).boxed())
+        .with_txn(|txn| db::explored_endpoints::find_by_ips(txn.as_mut(), ips).boxed())
         .await?
         .map(|ep| ::rpc::site_explorer::ExploredEndpointList {
             endpoints: ep

--- a/crates/api/src/ib_fabric_monitor/mod.rs
+++ b/crates/api/src/ib_fabric_monitor/mod.rs
@@ -411,7 +411,7 @@ impl IbFabricMonitor {
         txn: &mut PgConnection,
     ) -> CarbideResult<HashMap<MachineId, ManagedHostStateSnapshot>> {
         let machine_ids = db::machine::find_machine_ids(
-            txn,
+            &mut *txn,
             MachineSearchConfig {
                 include_predicted_host: true,
                 ..Default::default()

--- a/crates/api/src/machine_update_manager/mod.rs
+++ b/crates/api/src/machine_update_manager/mod.rs
@@ -147,7 +147,7 @@ impl MachineUpdateManager {
         txn: &mut PgConnection,
     ) -> CarbideResult<HashMap<MachineId, ManagedHostStateSnapshot>> {
         let machine_ids = db::machine::find_machine_ids(
-            txn,
+            &mut *txn,
             MachineSearchConfig {
                 include_predicted_host: true,
                 ..Default::default()

--- a/crates/api/src/nvl_partition_monitor/mod.rs
+++ b/crates/api/src/nvl_partition_monitor/mod.rs
@@ -1496,7 +1496,7 @@ impl NvlPartitionMonitor {
         txn: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     ) -> CarbideResult<HashMap<MachineId, ManagedHostStateSnapshot>> {
         let mnvvl_machine_ids = find_machine_ids(
-            txn,
+            txn.as_mut(),
             MachineSearchConfig {
                 mnnvl_only: true,
                 include_predicted_host: true,

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -8653,7 +8653,7 @@ pub async fn find_explored_refreshed_endpoint(
         .ip_addr()
         .map_err(StateHandlerError::GenericError)?;
 
-    let endpoint = db::explored_endpoints::find_by_ips(txn, vec![addr]).await?;
+    let endpoint = db::explored_endpoints::find_by_ips(&mut *txn, vec![addr]).await?;
     let endpoint = endpoint
         .into_iter()
         .next()

--- a/crates/api/src/state_controller/machine/mod.rs
+++ b/crates/api/src/state_controller/machine/mod.rs
@@ -14,6 +14,7 @@
 
 use carbide_uuid::machine::MachineId;
 use db::attestation::ek_cert_verification_status;
+use db::db_read::DbReader;
 use db::measured_boot::machine::{get_measurement_bundle_state, get_measurement_machine_state};
 use eyre::eyre;
 use measured_boot::records::{MeasurementBundleState, MeasurementMachineState};
@@ -98,16 +99,19 @@ pub enum MeasuringOutcome {
     Unsuccessful((FailureDetails, MachineId)),
 }
 
-async fn get_measuring_prerequisites(
+async fn get_measuring_prerequisites<DB>(
     machine_id: &MachineId,
-    txn: &mut PgConnection,
-) -> Result<(MeasurementMachineState, EkCertVerificationStatus), StateHandlerError> {
-    let machine_state = get_measurement_machine_state(txn, *machine_id)
+    db_reader: &mut DB,
+) -> Result<(MeasurementMachineState, EkCertVerificationStatus), StateHandlerError>
+where
+    for<'db> &'db mut DB: DbReader<'db>,
+{
+    let machine_state = get_measurement_machine_state(&mut *db_reader, *machine_id)
         .await
         .map_err(StateHandlerError::DBError)?;
 
     let ek_cert_verification_status =
-        ek_cert_verification_status::get_by_machine_id(txn, *machine_id)
+        ek_cert_verification_status::get_by_machine_id(&mut *db_reader, *machine_id)
             .await
             .map_err(|e| {
                 StateHandlerError::GenericError(eyre!(

--- a/crates/api/src/tests/dpu_machine_update.rs
+++ b/crates/api/src/tests/dpu_machine_update.rs
@@ -80,7 +80,7 @@ async fn create_machines(
 pub async fn get_all_snapshots(test_env: &TestEnv) -> HashMap<MachineId, ManagedHostStateSnapshot> {
     let mut txn = test_env.pool.begin().await.unwrap();
     let machine_ids = db::machine::find_machine_ids(
-        &mut txn,
+        txn.as_mut(),
         MachineSearchConfig {
             include_predicted_host: true,
             ..Default::default()

--- a/crates/api/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api/src/tests/host_bmc_firmware_test.rs
@@ -515,7 +515,7 @@ async fn test_postingestion_bmc_upgrade(pool: sqlx::PgPool) -> CarbideResult<()>
 
     // "Site explorer" pass
     let endpoints =
-        db::explored_endpoints::find_by_ips(&mut txn, vec![host.bmc_info.ip_addr().unwrap()])
+        db::explored_endpoints::find_by_ips(txn.as_mut(), vec![host.bmc_info.ip_addr().unwrap()])
             .await
             .unwrap();
     let mut endpoint = endpoints.into_iter().next().unwrap();
@@ -636,7 +636,7 @@ async fn test_postingestion_bmc_upgrade(pool: sqlx::PgPool) -> CarbideResult<()>
 
     // "Site explorer" pass to indicate that we're at the desired version
     let endpoints =
-        db::explored_endpoints::find_by_ips(&mut txn, vec![host.bmc_info.ip_addr().unwrap()])
+        db::explored_endpoints::find_by_ips(txn.as_mut(), vec![host.bmc_info.ip_addr().unwrap()])
             .await?;
     let mut endpoint = endpoints.into_iter().next().unwrap();
     endpoint.report.service[0].inventories[0].version = Some("6.00.30.00".to_string());
@@ -1404,7 +1404,7 @@ async fn test_instance_upgrading_actual_part_2(
 
     // "Site explorer" pass
     let endpoints =
-        db::explored_endpoints::find_by_ips(&mut txn, vec![host.bmc_info.ip_addr().unwrap()])
+        db::explored_endpoints::find_by_ips(txn.as_mut(), vec![host.bmc_info.ip_addr().unwrap()])
             .await
             .unwrap();
     let mut endpoint = endpoints.into_iter().next().unwrap();
@@ -1573,7 +1573,7 @@ async fn test_instance_upgrading_actual_part_2(
 
     // "Site explorer" pass to indicate that we're at the desired version
     let endpoints =
-        db::explored_endpoints::find_by_ips(&mut txn, vec![host.bmc_info.ip_addr().unwrap()])
+        db::explored_endpoints::find_by_ips(txn.as_mut(), vec![host.bmc_info.ip_addr().unwrap()])
             .await
             .unwrap();
     let mut endpoint = endpoints.into_iter().next().unwrap();
@@ -2561,7 +2561,7 @@ async fn test_manual_firmware_upgrade_workflow(pool: sqlx::PgPool) -> CarbideRes
 
     // "Site explorer" pass
     let endpoints =
-        db::explored_endpoints::find_by_ips(&mut txn, vec![host.bmc_info.ip_addr().unwrap()])
+        db::explored_endpoints::find_by_ips(txn.as_mut(), vec![host.bmc_info.ip_addr().unwrap()])
             .await
             .unwrap();
     let mut endpoint = endpoints.into_iter().next().unwrap();

--- a/crates/api/src/tests/instance.rs
+++ b/crates/api/src/tests/instance.rs
@@ -1720,8 +1720,11 @@ async fn test_instance_address_creation(_: PgPoolOptions, options: PgConnectOpti
         segment_id: segment_id_1,
         busy_ips: vec![],
     };
-    let used_ips = allocated_ip_resolver.used_ips(&mut txn).await.unwrap();
-    let used_prefixes = allocated_ip_resolver.used_prefixes(&mut txn).await.unwrap();
+    let used_ips = allocated_ip_resolver.used_ips(txn.as_mut()).await.unwrap();
+    let used_prefixes = allocated_ip_resolver
+        .used_prefixes(txn.as_mut())
+        .await
+        .unwrap();
     assert_eq!(1, used_ips.len());
     assert_eq!(1, used_prefixes.len());
     assert_eq!("192.0.4.3", used_ips[0].to_string());
@@ -1732,8 +1735,11 @@ async fn test_instance_address_creation(_: PgPoolOptions, options: PgConnectOpti
         segment_id: segment_id_2,
         busy_ips: vec![],
     };
-    let used_ips = allocated_ip_resolver.used_ips(&mut txn).await.unwrap();
-    let used_prefixes = allocated_ip_resolver.used_prefixes(&mut txn).await.unwrap();
+    let used_ips = allocated_ip_resolver.used_ips(txn.as_mut()).await.unwrap();
+    let used_prefixes = allocated_ip_resolver
+        .used_prefixes(txn.as_mut())
+        .await
+        .unwrap();
     assert_eq!(1, used_ips.len());
     assert_eq!(1, used_prefixes.len());
     assert_eq!("192.1.4.3", used_ips[0].to_string());
@@ -2296,7 +2302,7 @@ async fn test_allocate_network_vpc_prefix_id(_: PgPoolOptions, options: PgConnec
 
     let mut txn = env.db_txn().await;
     let network_segment = db::network_segment::find_by(
-        &mut txn,
+        txn.as_mut(),
         ObjectColumnFilter::One(
             IdColumn,
             &config.network.interfaces[0].network_segment_id.unwrap(),
@@ -2421,7 +2427,7 @@ async fn test_allocate_and_release_instance_vpc_prefix_id(
         .unwrap();
 
     let ns = db::network_segment::find_by(
-        &mut txn,
+        txn.as_mut(),
         ObjectColumnFilter::One(db::network_segment::IdColumn, &ns_id),
         NetworkSegmentSearchConfig::default(),
     )
@@ -2462,7 +2468,7 @@ async fn test_allocate_and_release_instance_vpc_prefix_id(
 
     let mut txn = env.db_txn().await;
     let mut ns = db::network_segment::find_by(
-        &mut txn,
+        txn.as_mut(),
         ObjectColumnFilter::One(
             IdColumn,
             &fetched_instance.config.network.interfaces[0]
@@ -2533,7 +2539,7 @@ async fn test_allocate_and_release_instance_vpc_prefix_id(
     // Address is freed during delete
     let mut txn = env.db_txn().await;
     let network_segments = db::network_segment::find_by(
-        &mut txn,
+        txn.as_mut(),
         ObjectColumnFilter::List(IdColumn, &segment_ids),
         NetworkSegmentSearchConfig::default(),
     )
@@ -2613,7 +2619,7 @@ async fn test_vpc_prefix_handling(pool: PgPool) {
         .unwrap();
 
     let ns1 = db::network_segment::find_by(
-        &mut txn,
+        txn.as_mut(),
         ObjectColumnFilter::One(IdColumn, &ns_id),
         NetworkSegmentSearchConfig::default(),
     )
@@ -2642,7 +2648,7 @@ async fn test_vpc_prefix_handling(pool: PgPool) {
         .unwrap();
 
     let ns2 = db::network_segment::find_by(
-        &mut txn,
+        txn.as_mut(),
         ObjectColumnFilter::One(IdColumn, &ns_id),
         NetworkSegmentSearchConfig::default(),
     )
@@ -2670,7 +2676,7 @@ async fn test_vpc_prefix_handling(pool: PgPool) {
         .unwrap();
 
     let ns3 = db::network_segment::find_by(
-        &mut txn,
+        txn.as_mut(),
         ObjectColumnFilter::One(IdColumn, &ns_id),
         NetworkSegmentSearchConfig::default(),
     )
@@ -2705,7 +2711,7 @@ async fn test_vpc_prefix_handling(pool: PgPool) {
         .unwrap();
 
     let ns4 = db::network_segment::find_by(
-        &mut txn,
+        txn.as_mut(),
         ObjectColumnFilter::One(IdColumn, &ns_id),
         NetworkSegmentSearchConfig::default(),
     )
@@ -4311,7 +4317,7 @@ async fn test_allocate_network_multi_dpu_vpc_prefix_id(
 
     for iface in config.network.interfaces {
         let network_segment = db::network_segment::find_by(
-            &mut txn,
+            txn.as_mut(),
             ObjectColumnFilter::One(IdColumn, &iface.network_segment_id.unwrap()),
             NetworkSegmentSearchConfig::default(),
         )

--- a/crates/api/src/tests/machine_find.rs
+++ b/crates/api/src/tests/machine_find.rs
@@ -286,7 +286,7 @@ async fn test_find_machine_ids(pool: sqlx::PgPool) {
     .unwrap();
     let mut txn = env.pool.begin().await.unwrap();
 
-    let machine_ids = db::machine::find_machine_ids(&mut txn, config)
+    let machine_ids = db::machine::find_machine_ids(txn.as_mut(), config)
         .await
         .unwrap();
 
@@ -328,7 +328,7 @@ async fn test_find_machine_ids(pool: sqlx::PgPool) {
     };
 
     // Try to find machines for the instance type.
-    let machine_ids = db::machine::find_machine_ids(&mut txn, config)
+    let machine_ids = db::machine::find_machine_ids(txn.as_mut(), config)
         .await
         .unwrap();
 
@@ -353,7 +353,7 @@ async fn test_find_dpu_machine_ids(pool: sqlx::PgPool) {
     .unwrap();
     let mut txn = env.pool.begin().await.unwrap();
 
-    let machine_ids = db::machine::find_machine_ids(&mut txn, config)
+    let machine_ids = db::machine::find_machine_ids(txn.as_mut(), config)
         .await
         .unwrap();
 
@@ -378,7 +378,7 @@ async fn test_find_predicted_host_machine_ids(pool: sqlx::PgPool) {
     .unwrap();
     let mut txn = env.pool.begin().await.unwrap();
 
-    let machine_ids = db::machine::find_machine_ids(&mut txn, config)
+    let machine_ids = db::machine::find_machine_ids(txn.as_mut(), config)
         .await
         .unwrap();
 
@@ -396,7 +396,7 @@ async fn test_find_host_machine_ids_when_predicted(pool: sqlx::PgPool) {
     let _dpu_machine_id = create_dpu_machine(&env, &host_config).await;
     let mut txn = env.pool.begin().await.unwrap();
 
-    let machine_ids = db::machine::find_machine_ids(&mut txn, config)
+    let machine_ids = db::machine::find_machine_ids(txn.as_mut(), config)
         .await
         .unwrap();
 
@@ -413,7 +413,7 @@ async fn test_find_host_machine_ids(pool: sqlx::PgPool) {
     let mut txn = env.pool.begin().await.unwrap();
 
     tracing::info!("finding machine ids");
-    let machine_ids = db::machine::find_machine_ids(&mut txn, config)
+    let machine_ids = db::machine::find_machine_ids(txn.as_mut(), config)
         .await
         .unwrap();
     assert_eq!(machine_ids.len(), 1);
@@ -440,7 +440,7 @@ async fn test_find_mixed_host_machine_ids(pool: sqlx::PgPool) {
     let mut txn = env.pool.begin().await.unwrap();
 
     tracing::info!("finding machine ids");
-    let machine_ids = db::machine::find_machine_ids(&mut txn, config)
+    let machine_ids = db::machine::find_machine_ids(txn.as_mut(), config)
         .await
         .unwrap();
     assert_eq!(machine_ids.len(), 2);

--- a/crates/api/src/tests/machine_health.rs
+++ b/crates/api/src/tests/machine_health.rs
@@ -581,7 +581,7 @@ async fn test_count_unhealthy_nonupgrading_host_machines(
 
     let mut txn = env.pool.begin().await?;
     let machine_ids = db::machine::find_machine_ids(
-        &mut txn,
+        txn.as_mut(),
         model::machine::machine_search_config::MachineSearchConfig::default(),
     )
     .await?;
@@ -626,7 +626,7 @@ async fn test_count_unhealthy_nonupgrading_host_machines(
 
     let mut txn = env.pool.begin().await?;
     let machine_ids = db::machine::find_machine_ids(
-        &mut txn,
+        txn.as_mut(),
         model::machine::machine_search_config::MachineSearchConfig::default(),
     )
     .await?;

--- a/crates/api/src/tests/machine_topology.rs
+++ b/crates/api/src/tests/machine_topology.rs
@@ -58,7 +58,7 @@ async fn test_crud_machine_topology(pool: sqlx::PgPool) -> Result<(), Box<dyn st
 
     let mut txn = env.pool.begin().await?;
     let segment = db::network_segment::find_by(
-        &mut txn,
+        txn.as_mut(),
         ObjectColumnFilter::One(network_segment::IdColumn, &env.admin_segment.unwrap()),
         model::network_segment::NetworkSegmentSearchConfig::default(),
     )
@@ -210,7 +210,7 @@ async fn test_v1_cpu_topology(pool: sqlx::PgPool) -> Result<(), Box<dyn std::err
 
     let mut txn = env.pool.begin().await?;
     let segment = db::network_segment::find_by(
-        &mut txn,
+        txn.as_mut(),
         ObjectColumnFilter::One(network_segment::IdColumn, &env.admin_segment.unwrap()),
         model::network_segment::NetworkSegmentSearchConfig::default(),
     )

--- a/crates/api/src/tests/network_segment.rs
+++ b/crates/api/src/tests/network_segment.rs
@@ -134,7 +134,7 @@ async fn test_network_segment_delete_fails_with_associated_machine_interface(
 
     let mut txn = env.pool.begin().await?;
     let db_segment = db::network_segment::find_by(
-        &mut txn,
+        txn.as_mut(),
         ObjectColumnFilter::One(db::network_segment::IdColumn, &segment.id.unwrap()),
         network_segment::NetworkSegmentSearchConfig::default(),
     )
@@ -298,7 +298,7 @@ async fn test_network_segment_max_history_length(
 
     let mut txn = env.pool.begin().await.unwrap();
     let mut version = db::network_segment::find_by(
-        &mut txn,
+        txn.as_mut(),
         ObjectColumnFilter::One(db::network_segment::IdColumn, &segment_id),
         network_segment::NetworkSegmentSearchConfig::default(),
     )
@@ -323,7 +323,7 @@ async fn test_network_segment_max_history_length(
             .unwrap()
         );
         version = db::network_segment::find_by(
-            &mut txn,
+            txn.as_mut(),
             ObjectColumnFilter::One(db::network_segment::IdColumn, &segment_id),
             network_segment::NetworkSegmentSearchConfig::default(),
         )
@@ -484,7 +484,7 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
     let search_cfg = NetworkSegmentSearchConfig::default();
     let mut txn = db_pool.begin().await?;
     let num_before = db::network_segment::find_by(
-        &mut txn,
+        txn.as_mut(),
         ObjectColumnFilter::<db::network_segment::IdColumn>::All,
         search_cfg,
     )
@@ -494,7 +494,7 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
     crate::db_init::create_initial_networks(&env.api, &env.pool, &networks).await?;
     let mut txn = db_pool.begin().await?;
     let num_after = db::network_segment::find_by(
-        &mut txn,
+        txn.as_mut(),
         ObjectColumnFilter::<db::network_segment::IdColumn>::All,
         search_cfg,
     )
@@ -885,7 +885,7 @@ async fn test_update_svi_ip(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error
 
     let mut txn = env.pool.begin().await?;
     let segments = db::network_segment::find_by(
-        &mut txn,
+        txn.as_mut(),
         ObjectColumnFilter::One(VpcColumn, &vpc_id),
         network_segment::NetworkSegmentSearchConfig::default(),
     )
@@ -910,7 +910,7 @@ async fn test_update_svi_ip(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error
     // Already created segments must have SVI allocated.
     let mut txn = env.pool.begin().await?;
     let segments = db::network_segment::find_by(
-        &mut txn,
+        txn.as_mut(),
         ObjectColumnFilter::One(VpcColumn, &vpc_id),
         network_segment::NetworkSegmentSearchConfig::default(),
     )
@@ -938,7 +938,7 @@ async fn test_update_svi_ip(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error
 
     let mut txn = env.pool.begin().await?;
     let segments = db::network_segment::find_by(
-        &mut txn,
+        txn.as_mut(),
         ObjectColumnFilter::One(VpcColumn, &vpc_id),
         network_segment::NetworkSegmentSearchConfig::default(),
     )
@@ -993,7 +993,7 @@ async fn test_update_svi_ip_post_instance_allocation(
 
     let mut txn = env.pool.begin().await?;
     let segments = db::network_segment::find_by(
-        &mut txn,
+        txn.as_mut(),
         ObjectColumnFilter::One(db::network_segment::IdColumn, &segment_id),
         network_segment::NetworkSegmentSearchConfig::default(),
     )
@@ -1032,7 +1032,7 @@ async fn test_update_svi_ip_post_instance_allocation(
     // At this moment, the third IP is taken from the tenant subnet for the instance.
     let mut txn = env.pool.begin().await?;
     let mut segment = db::network_segment::find_by(
-        &mut txn,
+        txn.as_mut(),
         ObjectColumnFilter::One(db::network_segment::IdColumn, &segment_id),
         network_segment::NetworkSegmentSearchConfig::default(),
     )
@@ -1048,7 +1048,7 @@ async fn test_update_svi_ip_post_instance_allocation(
 
     let mut txn = env.pool.begin().await?;
     let mut segment = db::network_segment::find_by(
-        &mut txn,
+        txn.as_mut(),
         ObjectColumnFilter::One(db::network_segment::IdColumn, &segment_id),
         network_segment::NetworkSegmentSearchConfig::default(),
     )

--- a/crates/api/src/tests/prevent_duplicate_mac_addresses.rs
+++ b/crates/api/src/tests/prevent_duplicate_mac_addresses.rs
@@ -27,7 +27,7 @@ async fn prevent_duplicate_mac_addresses(
     let mut txn = env.pool.begin().await?;
 
     let network_segment = db::network_segment::find_by(
-        &mut txn,
+        txn.as_mut(),
         ObjectColumnFilter::One(network_segment::IdColumn, &env.admin_segment.unwrap()),
         model::network_segment::NetworkSegmentSearchConfig::default(),
     )

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -4580,7 +4580,7 @@ async fn test_get_machine_position_info(
 
     // Get the existing explored endpoint (created by create_managed_host) and update it with position info
     let mut txn = env.pool.begin().await?;
-    let existing = db::explored_endpoints::find_by_ips(&mut txn, vec![bmc_ip])
+    let existing = db::explored_endpoints::find_by_ips(txn.as_mut(), vec![bmc_ip])
         .await?
         .pop()
         .unwrap();

--- a/crates/api/src/tests/tpm_ca.rs
+++ b/crates/api/src/tests/tpm_ca.rs
@@ -63,7 +63,7 @@ pub mod tests {
         let mut txn = env.pool.begin().await?;
 
         let segment = db::network_segment::find_by(
-            &mut txn,
+            txn.as_mut(),
             ObjectColumnFilter::One(db::network_segment::IdColumn, &env.admin_segment.unwrap()),
             network_segment::NetworkSegmentSearchConfig::default(),
         )
@@ -114,7 +114,7 @@ pub mod tests {
         let mut txn = env.pool.begin().await?;
 
         let segment = db::network_segment::find_by(
-            &mut txn,
+            txn.as_mut(),
             ObjectColumnFilter::One(db::network_segment::IdColumn, &env.admin_segment.unwrap()),
             network_segment::NetworkSegmentSearchConfig::default(),
         )
@@ -257,7 +257,7 @@ pub mod tests {
 
         let mut txn: sqlx::Transaction<'_, sqlx::Postgres> = env.pool.begin().await?;
 
-        let ek_cert_status = ek_cert_verification_status::get_by_machine_id(&mut txn, host_id)
+        let ek_cert_status = ek_cert_verification_status::get_by_machine_id(txn.as_mut(), host_id)
             .await
             .expect("Failed: could not make a look up for EkCertVerificationStatus in DB")
             .expect("Failed: could not find EkCertVerificationStatus for given machine in DB");
@@ -291,7 +291,7 @@ pub mod tests {
 
         let mut txn: sqlx::Transaction<'_, sqlx::Postgres> = env.pool.begin().await?;
 
-        let ek_cert_status = ek_cert_verification_status::get_by_machine_id(&mut txn, host_id)
+        let ek_cert_status = ek_cert_verification_status::get_by_machine_id(txn.as_mut(), host_id)
             .await
             .expect("Failed: could not make a look up for EkCertVerificationStatus in DB")
             .expect("Failed: could not find EkCertVerificationStatus for given machine in DB");
@@ -1177,7 +1177,7 @@ pub mod tests {
         let mut txn = env.pool.begin().await?;
 
         let segment = db::network_segment::find_by(
-            &mut txn,
+            txn.as_mut(),
             ObjectColumnFilter::One(db::network_segment::IdColumn, &env.admin_segment.unwrap()),
             network_segment::NetworkSegmentSearchConfig::default(),
         )

--- a/lints/carbide-lints/src/txn_held_across_await.rs
+++ b/lints/carbide-lints/src/txn_held_across_await.rs
@@ -122,9 +122,9 @@ impl Default for TxnHeldAcrossAwait {
                 .collect::<Vec<_>>()
         })
         .collect();
-        let txn_self_methods = vec!["deref_mut".to_string(), "as_pgconn".to_string()]
+        let txn_self_methods = vec!["deref_mut", "as_pgconn", "as_mut"]
             .into_iter()
-            .map(|s| Symbol::intern(&s))
+            .map(|s| Symbol::intern(s))
             .collect();
 
         Self {


### PR DESCRIPTION
## Description
See doc-comments on the DbReader trait: The purpose here is to make it so it's easier to write code that doesn't hold open a PgConnection, by making it so you can carry a PgPoolReader around instead, which can be passed directly to the same database methods that currently require a PgConnection or PgTransaction.

This eliminates a lot of the awkwardness using `pool.with_txn(|txn| ...)` just to read from the database.

At first this just migrates the subset of carbide-api-db that MachineStateHandler needs, which is going to simplify a followup PR that will eliminate the last instances of the txn_held_across_await lint. Mainly, the measured_boot and IP allocation db wrappers.

## Type of Change
- [X] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

See #190 for work that builds on this.