### PR TITLE
chore: bmc-mock: redfish builder trait introduced

### DIFF
--- a/crates/bmc-mock/src/redfish/boot_option.rs
+++ b/crates/bmc-mock/src/redfish/boot_option.rs
@@ -12,10 +12,9 @@
 
 use std::borrow::Cow;
 
-use serde_json::json;
-
 use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
+use crate::redfish::Builder;
 
 pub fn collection(system_id: &str) -> redfish::Collection<'static> {
     let odata_id = format!(
@@ -62,6 +61,15 @@ pub struct BootOptionBuilder {
     value: serde_json::Value,
 }
 
+impl Builder for BootOptionBuilder {
+    fn apply_patch(self, patch: serde_json::Value) -> Self {
+        Self {
+            value: self.value.patch(patch),
+            id: self.id,
+        }
+    }
+}
+
 impl BootOptionBuilder {
     pub fn display_name(self, value: &str) -> Self {
         self.add_str_field("DisplayName", value)
@@ -79,17 +87,6 @@ impl BootOptionBuilder {
         BootOption {
             id: self.id,
             value: self.value,
-        }
-    }
-
-    fn add_str_field(self, name: &str, value: &str) -> Self {
-        self.apply_patch(json!({ name: value }))
-    }
-
-    fn apply_patch(self, patch: serde_json::Value) -> Self {
-        Self {
-            value: self.value.patch(patch),
-            id: self.id,
         }
     }
 }

--- a/crates/bmc-mock/src/redfish/ethernet_interface.rs
+++ b/crates/bmc-mock/src/redfish/ethernet_interface.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
  *
  * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
@@ -17,6 +17,7 @@ use serde_json::json;
 
 use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
+use crate::redfish::Builder;
 
 pub fn manager_collection(manager_id: &str) -> redfish::Collection<'static> {
     let odata_id = format!("/redfish/v1/Managers/{manager_id}/EthernetInterfaces");
@@ -80,6 +81,15 @@ pub struct EthernetInterfaceBuilder {
     value: serde_json::Value,
 }
 
+impl Builder for EthernetInterfaceBuilder {
+    fn apply_patch(self, patch: serde_json::Value) -> Self {
+        Self {
+            value: self.value.patch(patch),
+            id: self.id,
+        }
+    }
+}
+
 impl EthernetInterfaceBuilder {
     pub fn mac_address(self, addr: MacAddress) -> Self {
         self.add_str_field("MACAddress", &addr.to_string())
@@ -97,17 +107,6 @@ impl EthernetInterfaceBuilder {
         EthernetInterface {
             id: self.id,
             value: self.value,
-        }
-    }
-
-    fn add_str_field(self, name: &str, value: &str) -> Self {
-        self.apply_patch(json!({ name: value }))
-    }
-
-    fn apply_patch(self, patch: serde_json::Value) -> Self {
-        Self {
-            value: self.value.patch(patch),
-            id: self.id,
         }
     }
 }

--- a/crates/bmc-mock/src/redfish/manager_network_protocol.rs
+++ b/crates/bmc-mock/src/redfish/manager_network_protocol.rs
@@ -15,6 +15,7 @@ use serde_json::json;
 
 use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
+use crate::redfish::Builder;
 
 pub fn manager_resource<'a>(manager_id: &'a str) -> redfish::Resource<'a> {
     let odata_id = format!("/redfish/v1/Managers/{manager_id}/NetworkProtocol");
@@ -37,6 +38,14 @@ pub struct ManagerNetworkProtocolBuilder {
     value: serde_json::Value,
 }
 
+impl Builder for ManagerNetworkProtocolBuilder {
+    fn apply_patch(self, patch: serde_json::Value) -> Self {
+        Self {
+            value: self.value.patch(patch),
+        }
+    }
+}
+
 impl ManagerNetworkProtocolBuilder {
     pub fn ipmi_enabled(self, value: bool) -> Self {
         self.apply_patch(json!({"IPMI": { "ProtocolEnabled": value }}))
@@ -44,11 +53,5 @@ impl ManagerNetworkProtocolBuilder {
 
     pub fn build(self) -> serde_json::Value {
         self.value
-    }
-
-    fn apply_patch(self, patch: serde_json::Value) -> Self {
-        Self {
-            value: self.value.patch(patch),
-        }
     }
 }

--- a/crates/bmc-mock/src/redfish/mod.rs
+++ b/crates/bmc-mock/src/redfish/mod.rs
@@ -35,3 +35,27 @@ pub mod expander_router;
 
 pub use collection::Collection;
 pub use resource::Resource;
+
+trait Builder {
+    fn maybe_with<T, V>(self, f: fn(Self, &V) -> Self, v: &Option<T>) -> Self
+    where
+        T: AsRef<V>,
+        V: ?Sized,
+        Self: Sized,
+    {
+        if let Some(v) = v {
+            f(self, v.as_ref())
+        } else {
+            self
+        }
+    }
+
+    fn add_str_field(self, name: &str, value: &str) -> Self
+    where
+        Self: Sized,
+    {
+        self.apply_patch(serde_json::json!({ name: value }))
+    }
+
+    fn apply_patch(self, patch: serde_json::Value) -> Self;
+}

--- a/crates/bmc-mock/src/redfish/network_adapter.rs
+++ b/crates/bmc-mock/src/redfish/network_adapter.rs
@@ -16,6 +16,7 @@ use serde_json::json;
 
 use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
+use crate::redfish::Builder;
 
 const NETWORK_ADAPTER_TYPE: &str = "#NetworkAdapter.v1_7_0.NetworkAdapter";
 const NETWORK_ADAPTER_NAME: &str = "Network Adapter";
@@ -72,6 +73,16 @@ pub struct NetworkAdapterBuilder {
     functions: Vec<redfish::network_device_function::NetworkDeviceFunction>,
 }
 
+impl Builder for NetworkAdapterBuilder {
+    fn apply_patch(self, patch: serde_json::Value) -> Self {
+        Self {
+            value: self.value.patch(patch),
+            id: self.id,
+            functions: self.functions,
+        }
+    }
+}
+
 impl NetworkAdapterBuilder {
     pub fn manufacturer(self, value: &str) -> Self {
         self.add_str_field("Manufacturer", value)
@@ -113,18 +124,6 @@ impl NetworkAdapterBuilder {
         NetworkAdapter {
             id: self.id,
             value: self.value,
-            functions: self.functions,
-        }
-    }
-
-    fn add_str_field(self, name: &str, value: &str) -> Self {
-        self.apply_patch(json!({ name: value }))
-    }
-
-    fn apply_patch(self, patch: serde_json::Value) -> Self {
-        Self {
-            value: self.value.patch(patch),
-            id: self.id,
             functions: self.functions,
         }
     }

--- a/crates/bmc-mock/src/redfish/network_device_function.rs
+++ b/crates/bmc-mock/src/redfish/network_device_function.rs
@@ -16,6 +16,7 @@ use serde_json::json;
 
 use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
+use crate::redfish::Builder;
 
 pub fn chassis_collection(
     chassis_id: &str,
@@ -73,6 +74,15 @@ pub struct NetworkDeviceFunctionBuilder {
     value: serde_json::Value,
 }
 
+impl Builder for NetworkDeviceFunctionBuilder {
+    fn apply_patch(self, patch: serde_json::Value) -> Self {
+        Self {
+            value: self.value.patch(patch),
+            id: self.id,
+        }
+    }
+}
+
 impl NetworkDeviceFunctionBuilder {
     pub fn ethernet(self, v: serde_json::Value) -> Self {
         self.apply_patch(json!({ "Ethernet": v }))
@@ -86,13 +96,6 @@ impl NetworkDeviceFunctionBuilder {
         NetworkDeviceFunction {
             id: self.id,
             value: self.value,
-        }
-    }
-
-    fn apply_patch(self, patch: serde_json::Value) -> Self {
-        Self {
-            value: self.value.patch(patch),
-            id: self.id,
         }
     }
 }

--- a/crates/bmc-mock/src/redfish/pcie_device.rs
+++ b/crates/bmc-mock/src/redfish/pcie_device.rs
@@ -16,6 +16,7 @@ use serde_json::json;
 
 use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
+use crate::redfish::Builder;
 
 const PCIE_DEVICE_TYPE: &str = "#PCIeDevice.v1_5_0.PCIeDevice";
 
@@ -65,6 +66,16 @@ pub struct PcieDeviceBuilder {
     mat_dpu: bool,
 }
 
+impl Builder for PcieDeviceBuilder {
+    fn apply_patch(self, patch: serde_json::Value) -> Self {
+        Self {
+            value: self.value.patch(patch),
+            id: self.id,
+            mat_dpu: self.mat_dpu,
+        }
+    }
+}
+
 impl PcieDeviceBuilder {
     pub fn description(self, value: &str) -> Self {
         self.add_str_field("Description", value)
@@ -91,29 +102,17 @@ impl PcieDeviceBuilder {
         self
     }
 
-    pub fn build(self) -> PCIeDevice {
-        PCIeDevice {
-            id: self.id,
-            value: self.value,
-            is_mat_dpu: self.mat_dpu,
-        }
-    }
-
     pub fn status(self, status: redfish::resource::Status) -> Self {
         self.apply_patch(json!({
             "Status": status.into_json()
         }))
     }
 
-    fn add_str_field(self, name: &str, value: &str) -> Self {
-        self.apply_patch(json!({ name: value }))
-    }
-
-    fn apply_patch(self, patch: serde_json::Value) -> Self {
-        Self {
-            value: self.value.patch(patch),
+    pub fn build(self) -> PCIeDevice {
+        PCIeDevice {
             id: self.id,
-            mat_dpu: self.mat_dpu,
+            value: self.value,
+            is_mat_dpu: self.mat_dpu,
         }
     }
 }

--- a/crates/bmc-mock/src/redfish/secure_boot.rs
+++ b/crates/bmc-mock/src/redfish/secure_boot.rs
@@ -16,6 +16,7 @@ use serde_json::json;
 
 use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
+use crate::redfish::Builder;
 
 pub fn resource<'a>(system_id: &'a str) -> redfish::Resource<'a> {
     let odata_id = format!(
@@ -40,6 +41,14 @@ pub struct SecureBootBuilder {
     value: serde_json::Value,
 }
 
+impl Builder for SecureBootBuilder {
+    fn apply_patch(self, patch: serde_json::Value) -> Self {
+        Self {
+            value: self.value.patch(patch),
+        }
+    }
+}
+
 impl SecureBootBuilder {
     pub fn secure_boot_enable(self, v: bool) -> Self {
         self.apply_patch(json!({"SecureBootEnable": v}))
@@ -55,15 +64,5 @@ impl SecureBootBuilder {
 
     pub fn build(self) -> serde_json::Value {
         self.value
-    }
-
-    fn add_str_field(self, name: &str, value: &str) -> Self {
-        self.apply_patch(json!({ name: value }))
-    }
-
-    fn apply_patch(self, patch: serde_json::Value) -> Self {
-        Self {
-            value: self.value.patch(patch),
-        }
     }
 }

--- a/crates/bmc-mock/src/redfish/service_root.rs
+++ b/crates/bmc-mock/src/redfish/service_root.rs
@@ -16,11 +16,11 @@ use axum::Router;
 use axum::extract::State;
 use axum::response::Response;
 use axum::routing::get;
-use serde_json::json;
 
 use crate::bmc_state::BmcState;
 use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
+use crate::redfish::Builder;
 
 pub fn resource<'a>() -> redfish::Resource<'a> {
     redfish::Resource {
@@ -57,6 +57,14 @@ pub struct ServiceRootBuilder {
     value: serde_json::Value,
 }
 
+impl Builder for ServiceRootBuilder {
+    fn apply_patch(self, patch: serde_json::Value) -> Self {
+        Self {
+            value: self.value.patch(patch),
+        }
+    }
+}
+
 impl ServiceRootBuilder {
     pub fn build(self) -> serde_json::Value {
         self.value
@@ -84,15 +92,5 @@ impl ServiceRootBuilder {
 
     pub fn update_service(self, v: &redfish::Resource<'_>) -> Self {
         self.apply_patch(v.nav_property("UpdateService"))
-    }
-
-    fn add_str_field(self, name: &str, value: &str) -> Self {
-        self.apply_patch(json!({ name: value }))
-    }
-
-    fn apply_patch(self, patch: serde_json::Value) -> Self {
-        Self {
-            value: self.value.patch(patch),
-        }
     }
 }

--- a/crates/bmc-mock/src/redfish/software_inventory.rs
+++ b/crates/bmc-mock/src/redfish/software_inventory.rs
@@ -12,10 +12,9 @@
 
 use std::borrow::Cow;
 
-use serde_json::json;
-
 use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
+use crate::redfish::Builder;
 
 pub fn firmware_inventory_collection() -> redfish::Collection<'static> {
     let odata_id = format!(
@@ -63,6 +62,15 @@ pub struct SoftwareInventoryBuilder {
     value: serde_json::Value,
 }
 
+impl Builder for SoftwareInventoryBuilder {
+    fn apply_patch(self, patch: serde_json::Value) -> Self {
+        Self {
+            value: self.value.patch(patch),
+            id: self.id,
+        }
+    }
+}
+
 impl SoftwareInventoryBuilder {
     pub fn version(self, value: &str) -> Self {
         self.add_str_field("Version", value)
@@ -72,17 +80,6 @@ impl SoftwareInventoryBuilder {
         SoftwareInventory {
             id: self.id,
             value: self.value,
-        }
-    }
-
-    fn add_str_field(self, name: &str, value: &str) -> Self {
-        self.apply_patch(json!({ name: value }))
-    }
-
-    fn apply_patch(self, patch: serde_json::Value) -> Self {
-        Self {
-            value: self.value.patch(patch),
-            id: self.id,
         }
     }
 }

--- a/crates/bmc-mock/src/redfish/update_service.rs
+++ b/crates/bmc-mock/src/redfish/update_service.rs
@@ -19,6 +19,7 @@ use axum::routing::{get, post};
 
 use crate::bmc_state::BmcState;
 use crate::json::{JsonExt, JsonPatch};
+use crate::redfish::Builder;
 use crate::{http, redfish};
 
 pub fn resource<'a>() -> redfish::Resource<'a> {
@@ -115,17 +116,20 @@ pub struct UpdateServiceBuilder {
     value: serde_json::Value,
 }
 
-impl UpdateServiceBuilder {
-    pub fn build(self) -> serde_json::Value {
-        self.value
-    }
-    pub fn firmware_inventory(self, v: &redfish::Collection<'_>) -> Self {
-        self.apply_patch(v.nav_property("FirmwareInventory"))
-    }
-
+impl Builder for UpdateServiceBuilder {
     fn apply_patch(self, patch: serde_json::Value) -> Self {
         Self {
             value: self.value.patch(patch),
         }
+    }
+}
+
+impl UpdateServiceBuilder {
+    pub fn build(self) -> serde_json::Value {
+        self.value
+    }
+
+    pub fn firmware_inventory(self, v: &redfish::Collection<'_>) -> Self {
+        self.apply_patch(v.nav_property("FirmwareInventory"))
     }
 }


### PR DESCRIPTION
## Description
Redfish in bmc-mock has a builder per each resource. They follow the same pattern.
This change introduces Builder trait that consolidates this pattern and reduces copy-pasted code.  

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

