### PR TITLE
fix: beginning to add ipv6 support to carbide, a layer at a time

### DIFF
--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -1823,7 +1823,7 @@ pub async fn allocate_loopback_ip(
     common_pools: &CommonPools,
     txn: &mut PgConnection,
     owner_id: &str,
-) -> Result<Ipv4Addr, DatabaseError> {
+) -> Result<IpAddr, DatabaseError> {
     match crate::resource_pool::allocate(
         &common_pools.ethernet.pool_loopback_ip,
         txn,
@@ -1853,7 +1853,7 @@ pub async fn allocate_vpc_dpu_loopback(
     common_pools: &CommonPools,
     txn: &mut PgConnection,
     owner_id: &str,
-) -> Result<Ipv4Addr, DatabaseError> {
+) -> Result<IpAddr, DatabaseError> {
     match crate::resource_pool::allocate(
         &common_pools.ethernet.pool_vpc_dpu_loopback_ip,
         txn,
@@ -1887,7 +1887,7 @@ pub async fn allocate_secondary_vtep_ip(
     common_pools: &CommonPools,
     txn: &mut PgConnection,
     owner_id: &str,
-) -> Result<Ipv4Addr, DatabaseError> {
+) -> Result<IpAddr, DatabaseError> {
     match crate::resource_pool::allocate(
         &common_pools.ethernet.pool_secondary_vtep_ip,
         txn,

--- a/crates/api-db/src/resource_pool.rs
+++ b/crates/api-db/src/resource_pool.rs
@@ -428,7 +428,7 @@ pub async fn create_common_pools(
     let mut pool_names = Vec::new();
     let mut optional_pool_names = Vec::new();
 
-    let pool_loopback_ip: Arc<ResourcePool<Ipv4Addr>> =
+    let pool_loopback_ip: Arc<ResourcePool<IpAddr>> =
         Arc::new(ResourcePool::new(LOOPBACK_IP.to_string(), ValueType::Ipv4));
     pool_names.push(pool_loopback_ip.name().to_string());
     let pool_vlan_id: Arc<ResourcePool<i16>> =
@@ -444,14 +444,14 @@ pub async fn create_common_pools(
         Arc::new(ResourcePool::new(FNN_ASN.to_string(), ValueType::Integer));
     optional_pool_names.push(pool_fnn_asn.name().to_string());
 
-    let pool_vpc_dpu_loopback_ip: Arc<ResourcePool<Ipv4Addr>> = Arc::new(ResourcePool::new(
+    let pool_vpc_dpu_loopback_ip: Arc<ResourcePool<IpAddr>> = Arc::new(ResourcePool::new(
         VPC_DPU_LOOPBACK.to_string(),
         ValueType::Ipv4,
     ));
     //  TODO: This should be removed from optional once FNN become mandatory.
     optional_pool_names.push(pool_vpc_dpu_loopback_ip.name().to_string());
 
-    let pool_secondary_vtep_ip: Arc<ResourcePool<Ipv4Addr>> = Arc::new(ResourcePool::new(
+    let pool_secondary_vtep_ip: Arc<ResourcePool<IpAddr>> = Arc::new(ResourcePool::new(
         SECONDARY_VTEP_IP.to_string(),
         ValueType::Ipv4,
     ));

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -17,7 +17,7 @@
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, SocketAddr};
 use std::ops::Deref;
 
 use ::rpc::errors::RpcDataConversionError;
@@ -787,7 +787,7 @@ impl Machine {
         self.state.version
     }
 
-    pub fn loopback_ip(&self) -> Option<Ipv4Addr> {
+    pub fn loopback_ip(&self) -> Option<IpAddr> {
         self.network_config.loopback_ip
     }
 

--- a/crates/api-model/src/resource_pool/common.rs
+++ b/crates/api-model/src/resource_pool/common.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 use std::collections::HashMap;
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use std::sync::{Arc, Mutex};
 
 use tokio::sync::oneshot;
@@ -74,14 +74,14 @@ pub struct DpaPools {
 /// ResourcePools that are used for ethernet virtualization
 #[derive(Debug)]
 pub struct EthernetPools {
-    pub pool_loopback_ip: Arc<ResourcePool<Ipv4Addr>>,
+    pub pool_loopback_ip: Arc<ResourcePool<IpAddr>>,
     pub pool_vlan_id: Arc<ResourcePool<i16>>,
     pub pool_vni: Arc<ResourcePool<i32>>,
     pub pool_vpc_vni: Arc<ResourcePool<i32>>,
     pub pool_external_vpc_vni: Arc<ResourcePool<i32>>,
     pub pool_fnn_asn: Arc<ResourcePool<u32>>,
-    pub pool_vpc_dpu_loopback_ip: Arc<ResourcePool<Ipv4Addr>>,
-    pub pool_secondary_vtep_ip: Arc<ResourcePool<Ipv4Addr>>,
+    pub pool_vpc_dpu_loopback_ip: Arc<ResourcePool<IpAddr>>,
+    pub pool_secondary_vtep_ip: Arc<ResourcePool<IpAddr>>,
 }
 
 /// ResourcePools that are used for infiniband

--- a/crates/api/src/tests/common/api_fixtures/dpu.rs
+++ b/crates/api/src/tests/common/api_fixtures/dpu.rs
@@ -353,5 +353,5 @@ pub async fn loopback_ip(txn: &mut PgConnection, dpu_machine_id: &MachineId) -> 
         .await
         .unwrap()
         .unwrap();
-    IpAddr::V4(dpu.network_config.loopback_ip.unwrap())
+    dpu.network_config.loopback_ip.unwrap()
 }


### PR DESCRIPTION
## Description

This is going to be a bit of a lift, but I think we can do it in a few different phases/layers, with the RPC layer being last. DNS and DHCP should be a good time.

In this first PR, on a more foundational front, in which we switch several types from `Ipv4Addr` to `IpAddr` across `api-model`, `api-db`, and `resource_pool`. It's not all of them, but taking baby steps.

For the database, since the Postgres `inet` and `cidr` types already support IPv6, we're taken care of there, and everything else flows naturally, including in resource pools. All existing data remains IPv4 and continues to work just the same as it did. Tests were added to verify `network_config` in the database still works:
- `test_managed_host_network_config_ipv4_json_roundtrip`: Make sure IPv4-backed configs [still] serialize/deserialize correctly.
- `test_managed_host_network_config_ipv4_json_format_unchanged`: Make sure JSON output for IPv4 is identical to `Ipv4Addr`.
- `test_managed_host_network_config_deserialize_legacy_ipv4_json`: Make sure IPv4 JSON strings (as stored in Postgres) parse into `IpAddr` correctly.
- `test_managed_host_network_config_ipv6_json_roundtrip`: Make sure IPv6 addresses *also* roundtrip correctly through JSON.
- `test_managed_host_network_config_deserialize_ipv6_json`: Make sure IPv6 JSON strings parses correctly also.
- `test_managed_host_network_config_default`: aaand make sure the `Default` config is unchanged.

For resource pools, they store values as strings in the DB and parse them via `from_str`. A couple of new tests were introduced to ensure the `allocate()` and `release()` functions still work the same with IPv4, and now support IPv6. Tests are:
- `test_ip_addr_parse_from_pool_strings`: Make sure v4 and v6 work.
- `test_ip_addr_to_string_format`: Make sure v4 and v6 work.

Made sure that no callers were doing any IPv4 specific operations like working with `.octets()` or anything; they generally all just store the result as an `Option` (which `Option<IpAddr>` is compatible), or call `.to_string()`, which tests were added for to verify.

Regarding some IPv6 matching we had to return an error, there were two `match` in `vpc_dpu_loopback.rs` that returned errors on `IpAddr::V6`, and have been removed, now that the resource pool is typed as `IpAddr`. Again, IPv4 and IPv6 now both work in this case.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
https://github.com/NVIDIA/carbide-core/issues/84

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

