### PR TITLE
chore: bmc-mock: Dell PowerEdge R750 support

### DIFF
--- a/crates/bmc-mock/src/bmc_state.rs
+++ b/crates/bmc-mock/src/bmc_state.rs
@@ -34,12 +34,6 @@ pub struct BmcState {
     pub injected_bugs: Arc<InjectedBugs>,
 }
 
-#[derive(Debug, Clone)]
-pub enum JobState {
-    Scheduled,
-    Completed,
-}
-
 impl BmcState {
     pub fn complete_all_bios_jobs(&self) {
         if let redfish::oem::State::DellIdrac(v) = &self.oem_state {

--- a/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
+++ b/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
@@ -1,0 +1,220 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use mac_address::MacAddress;
+use serde_json::json;
+
+use crate::{PowerControl, hw, redfish};
+
+pub type SlotNumber = usize;
+
+pub struct DellPowerEdgeR750<'a> {
+    pub bmc_mac_address: MacAddress,
+    pub product_serial_number: Cow<'a, str>,
+    pub nics: Vec<(SlotNumber, hw::nic::Nic)>,
+    pub embedded_nic: EmbeddedNic,
+}
+
+pub struct EmbeddedNic {
+    pub port_1: MacAddress,
+    pub port_2: MacAddress,
+}
+
+impl DellPowerEdgeR750<'_> {
+    pub fn manager_config(&self) -> redfish::manager::Config {
+        redfish::manager::Config {
+            id: "iDRAC.Embedded.1",
+            eth_interfaces: vec![
+                redfish::ethernet_interface::builder(
+                    &redfish::ethernet_interface::manager_resource("iDRAC.Embedded.1", "NIC.1"),
+                )
+                .mac_address(self.bmc_mac_address)
+                .interface_enabled(true)
+                .build(),
+            ],
+            firmware_version: "6.00.30.00",
+        }
+    }
+
+    pub fn system_config(
+        &self,
+        pc: Arc<dyn PowerControl>,
+    ) -> redfish::computer_system::SystemConfig {
+        let power_control = Some(pc);
+        let serial_number = self.product_serial_number.to_string().into();
+        let system_id = "System.Embedded.1";
+
+        let eth_interfaces = [
+            (1, &self.embedded_nic.port_1),
+            (2, &self.embedded_nic.port_2),
+        ]
+        .into_iter()
+        .map(|(port, mac)| {
+            let eth_id = format!("NIC.Embedded.{port}-1-1");
+            let resource = redfish::ethernet_interface::system_resource(system_id, &eth_id);
+            redfish::ethernet_interface::builder(&resource)
+                .description(&format!("Embedded NIC 1 Port {port} Partition 1"))
+                .mac_address(*mac)
+                .interface_enabled(true)
+                .build()
+        })
+        .chain(self.nics.iter().map(|(slot_number, nic)| {
+            let eth_id = format!("NIC.Slot.{slot_number}-1");
+            let resource = redfish::ethernet_interface::system_resource(system_id, &eth_id);
+            redfish::ethernet_interface::builder(&resource)
+                .description(&format!("NIC in Slot {slot_number} Port 1"))
+                .mac_address(nic.mac_address)
+                .interface_enabled(true)
+                .build()
+        }))
+        .collect();
+
+        let boot_opt_builder = |id: &str| {
+            redfish::boot_option::builder(&redfish::boot_option::resource(system_id, id))
+                .boot_option_reference(id)
+        };
+        let boot_options = self
+            .nics
+            .iter()
+            .map(|(slot_number, _)| format!("HTTP Device 1: NIC in Slot {slot_number} Port 1"))
+            .chain(std::iter::once(
+                "PCIe SSD in Slot 2 in Bay 1: EFI Fixed Disk Boot Device 1".to_string(),
+            ))
+            .enumerate()
+            .map(|(index, display_name)| {
+                boot_opt_builder(&format!("Boot{index:04X}"))
+                    .display_name(&display_name)
+                    .build()
+            })
+            .collect();
+
+        redfish::computer_system::SystemConfig {
+            systems: vec![redfish::computer_system::SingleSystemConfig {
+                id: Cow::Borrowed(system_id),
+                manufacturer: Some("Dell Inc.".into()),
+                model: Some("PowerEdge R750".into()),
+                eth_interfaces,
+                serial_number,
+                boot_order_mode: redfish::computer_system::BootOrderMode::DellOem,
+                power_control,
+                chassis: vec!["System.Embedded.1".into()],
+                boot_options,
+                bios_mode: redfish::computer_system::BiosMode::DellOem,
+                base_bios: redfish::bios::builder(&redfish::bios::resource(system_id))
+                    .attributes(json!({
+                        "BootSeqRetry": "Disabled",
+                        "SetBootOrderEn": "NIC.HttpDevice.1-1,Disk.Bay.2:Enclosure.Internal.0-1",
+                        "InBandManageabilityInterface": "Enabled",
+                        "UefiVariableAccess": "Standard",
+                        "SerialComm": "OnConRedir",
+                        "SerialPortAddress": "Com1",
+                        "FailSafeBaud": "115200",
+                        "ConTermType": "Vt100Vt220",
+                        "RedirAfterBoot": "Enabled",
+                        "SriovGlobalEnable": "Enabled",
+                        "TpmSecurity": "On",
+                        "Tpm2Algorithm": "SHA256",
+                        "Tpm2Hierarchy": "Enabled",
+                        "HttpDev1EnDis": "Enabled",
+                        "PxeDev1EnDis": "Disabled",
+                        "HttpDev1Interface": "NIC.Slot.5-1",
+                    }))
+                    .build(),
+            }],
+        }
+    }
+
+    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+        let chassis_id = "System.Embedded.1";
+        let net_adapter_builder = |id: &str| {
+            redfish::network_adapter::builder(&redfish::network_adapter::chassis_resource(
+                chassis_id, id,
+            ))
+        };
+        let network_adapters = std::iter::once(
+            net_adapter_builder("NIC.Embedded.1")
+                .manufacturer("Broadcom Inc. and subsidiaries")
+                .build(),
+        )
+        .chain(self.nics.iter().map(|(slot, nic)| {
+            let network_adapter_id = format!("NIC.Slot.{slot}");
+            let function_id = format!("NIC.Slot.{slot}-1");
+            let func_resource = &redfish::network_device_function::chassis_resource(
+                chassis_id,
+                &network_adapter_id,
+                &function_id,
+            );
+            let function = redfish::network_device_function::builder(func_resource)
+                .ethernet(json!({"MACAddress": &nic.mac_address}))
+                .oem(redfish::oem::dell::network_device_function::dell_nic_info(
+                    &function_id,
+                    *slot,
+                    &nic.serial_number,
+                ))
+                .build();
+            redfish::network_adapter::builder_from_nic(
+                &redfish::network_adapter::chassis_resource(chassis_id, &network_adapter_id),
+                nic,
+            )
+            .network_device_functions(
+                &redfish::network_device_function::chassis_collection(
+                    chassis_id,
+                    &network_adapter_id,
+                ),
+                vec![function],
+            )
+            .status(redfish::resource::Status::Ok)
+            .build()
+        }))
+        .collect();
+
+        let pcie_devices = self
+            .nics
+            .iter()
+            .map(|(slot, nic)| {
+                let pcie_device_id = format!("mat_{}", slot);
+                redfish::pcie_device::builder_from_nic(
+                    &redfish::pcie_device::chassis_resource(chassis_id, &pcie_device_id),
+                    nic,
+                )
+                .status(redfish::resource::Status::Ok)
+                .build()
+            })
+            .collect();
+
+        redfish::chassis::ChassisConfig {
+            chassis: vec![redfish::chassis::SingleChassisConfig {
+                id: Cow::Borrowed(chassis_id),
+                manufacturer: Some("Dell Inc.".into()),
+                part_number: Some("01J4WFA05".into()),
+                model: Some("PowerEdge R750".into()),
+                serial_number: Some(self.product_serial_number.to_string().into()),
+                network_adapters: Some(network_adapters),
+                pcie_devices: Some(pcie_devices),
+            }],
+        }
+    }
+
+    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+        redfish::update_service::UpdateServiceConfig {
+            firmware_inventory: vec![],
+        }
+    }
+}

--- a/crates/bmc-mock/src/hw/mod.rs
+++ b/crates/bmc-mock/src/hw/mod.rs
@@ -1,17 +1,28 @@
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+ * SPDX-License-Identifier: Apache-2.0
  *
- * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
- * property and proprietary rights in and to this material, related
- * documentation and any modifications thereto. Any use, reproduction,
- * disclosure or distribution of this material and related documentation
- * without an express license agreement from NVIDIA CORPORATION or
- * its affiliates is strictly prohibited.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 //! Submodules of this module defines support of specific hardware
 //! (i.e. how this hardware is represented via Redfish).
 
+/// Description of NIC card.
+pub mod nic;
+
 /// Support of the Bluefield3 DPU.
 pub mod bluefield3;
+
+/// Support of the Dell PowerEdge R750 servers.
+pub mod dell_poweredge_r750;

--- a/crates/bmc-mock/src/hw/nic.rs
+++ b/crates/bmc-mock/src/hw/nic.rs
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+
+use mac_address::MacAddress;
+
+pub struct Nic {
+    pub mac_address: MacAddress,
+    pub serial_number: String,
+    pub manufacturer: Option<Cow<'static, str>>,
+    pub model: Option<Cow<'static, str>>,
+    pub description: Option<Cow<'static, str>>,
+    pub part_number: Option<Cow<'static, str>>,
+    pub firmware_version: Option<Cow<'static, str>>,
+    pub is_mat_dpu: bool,
+}
+
+impl Nic {
+    pub fn rooftop(mac: MacAddress) -> Self {
+        let serial_number = format!("RT{}", mac.to_string().replace(':', ""));
+        Nic {
+            manufacturer: Some("Rooftop Technologies".into()),
+            model: Some("Rooftop 10 Kilobit Ethernet Adapter".into()),
+            serial_number,
+            part_number: Some("31337".into()),
+            description: None,
+            firmware_version: None,
+            mac_address: mac,
+            is_mat_dpu: false,
+        }
+    }
+}

--- a/crates/bmc-mock/src/redfish/network_adapter.rs
+++ b/crates/bmc-mock/src/redfish/network_adapter.rs
@@ -20,8 +20,8 @@ use std::borrow::Cow;
 use serde_json::json;
 
 use crate::json::{JsonExt, JsonPatch};
-use crate::redfish;
 use crate::redfish::Builder;
+use crate::{hw, redfish};
 
 const NETWORK_ADAPTER_TYPE: &str = "#NetworkAdapter.v1_7_0.NetworkAdapter";
 const NETWORK_ADAPTER_NAME: &str = "Network Adapter";
@@ -72,6 +72,14 @@ pub fn builder(resource: &redfish::Resource) -> NetworkAdapterBuilder {
     }
 }
 
+pub fn builder_from_nic(resource: &redfish::Resource, nic: &hw::nic::Nic) -> NetworkAdapterBuilder {
+    let b = builder(resource).serial_number(&nic.serial_number);
+    b.maybe_with(NetworkAdapterBuilder::description, &nic.description)
+        .maybe_with(NetworkAdapterBuilder::manufacturer, &nic.manufacturer)
+        .maybe_with(NetworkAdapterBuilder::model, &nic.model)
+        .maybe_with(NetworkAdapterBuilder::part_number, &nic.part_number)
+}
+
 pub struct NetworkAdapterBuilder {
     id: Cow<'static, str>,
     value: serde_json::Value,
@@ -107,6 +115,10 @@ impl NetworkAdapterBuilder {
 
     pub fn sku(self, value: &str) -> Self {
         self.add_str_field("SKU", value)
+    }
+
+    pub fn description(self, value: &str) -> Self {
+        self.add_str_field("Description", value)
     }
 
     pub fn network_device_functions(

--- a/crates/bmc-mock/src/redfish/oem/dell/idrac.rs
+++ b/crates/bmc-mock/src/redfish/oem/dell/idrac.rs
@@ -28,7 +28,7 @@ use rand::Rng;
 use rand::distr::StandardUniform;
 use serde_json::json;
 
-use crate::bmc_state::{BmcState, JobState};
+use crate::bmc_state::BmcState;
 use crate::json::{JsonExt, JsonPatch, json_patch};
 use crate::{http, redfish};
 
@@ -104,6 +104,12 @@ async fn patch_managers_oem_dell_attributes(
     };
     state.update_attrs(attrs);
     json!({}).into_ok_response()
+}
+
+#[derive(Debug, Clone)]
+pub enum JobState {
+    Scheduled,
+    Completed,
 }
 
 async fn get_dell_job(State(state): State<BmcState>, Path(job_id): Path<String>) -> Response {

--- a/crates/bmc-mock/src/redfish/oem/dell/network_device_function.rs
+++ b/crates/bmc-mock/src/redfish/oem/dell/network_device_function.rs
@@ -17,19 +17,14 @@
 
 use serde_json::json;
 
-use crate::DpuMachineInfo;
-
-pub fn dpu_dell_nic_info(function_id: &str, machine_info: &DpuMachineInfo) -> serde_json::Value {
+pub fn dell_nic_info(function_id: &str, slot: usize, serial_number: &str) -> serde_json::Value {
     json!({
         "Dell": {
             "@odata.type": "#DellOem.v1_3_0.DellOemResources",
             "DellNIC": {
                 "Id": function_id,
-                "SerialNumber": machine_info.serial,
-                // TODO: We need more precise model of the
-                // hardware. Slot / port must be part of machine_info
-                // in future.
-                "DeviceDescription": "NIC in Slot 5 Port 1"
+                "SerialNumber": serial_number,
+                "DeviceDescription": format!("NIC in Slot {} Port 1", slot)
             }
         }
     })

--- a/crates/bmc-mock/src/redfish/pcie_device.rs
+++ b/crates/bmc-mock/src/redfish/pcie_device.rs
@@ -20,8 +20,8 @@ use std::borrow::Cow;
 use serde_json::json;
 
 use crate::json::{JsonExt, JsonPatch};
-use crate::redfish;
 use crate::redfish::Builder;
+use crate::{hw, redfish};
 
 const PCIE_DEVICE_TYPE: &str = "#PCIeDevice.v1_5_0.PCIeDevice";
 
@@ -51,6 +51,16 @@ pub fn builder(resource: &redfish::Resource) -> PcieDeviceBuilder {
         value: resource.json_patch(),
         mat_dpu: false,
     }
+}
+
+pub fn builder_from_nic(resource: &redfish::Resource, nic: &hw::nic::Nic) -> PcieDeviceBuilder {
+    let b = builder(resource).serial_number(&nic.serial_number);
+    let b = if nic.is_mat_dpu { b.mat_dpu() } else { b };
+    b.maybe_with(PcieDeviceBuilder::description, &nic.description)
+        .maybe_with(PcieDeviceBuilder::manufacturer, &nic.manufacturer)
+        .maybe_with(PcieDeviceBuilder::model, &nic.model)
+        .maybe_with(PcieDeviceBuilder::part_number, &nic.part_number)
+        .maybe_with(PcieDeviceBuilder::firmware_version, &nic.firmware_version)
 }
 
 pub struct PCIeDevice {
@@ -86,12 +96,12 @@ impl PcieDeviceBuilder {
         self.add_str_field("Description", value)
     }
 
-    pub fn firmware_version(self, value: &str) -> Self {
-        self.add_str_field("FirmwareVersion", value)
-    }
-
     pub fn manufacturer(self, value: &str) -> Self {
         self.add_str_field("Manufacturer", value)
+    }
+
+    pub fn model(self, value: &str) -> Self {
+        self.add_str_field("Model", value)
     }
 
     pub fn part_number(self, value: &str) -> Self {
@@ -100,6 +110,10 @@ impl PcieDeviceBuilder {
 
     pub fn serial_number(self, value: &str) -> Self {
         self.add_str_field("SerialNumber", value)
+    }
+
+    pub fn firmware_version(self, value: &str) -> Self {
+        self.add_str_field("FirmwareVersion", value)
     }
 
     pub fn mat_dpu(mut self) -> Self {


### PR DESCRIPTION
## Description
Move out all BMC simulation configuration generation from MachineInfo to specific hardware implementation.
The next step will be adding support simulation of GB200 machine that will be parameterized in HostMachineInfo.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
