### PR TITLE
chore: hw health expose livez probe

### DIFF
--- a/crates/health/src/metrics.rs
+++ b/crates/health/src/metrics.rs
@@ -365,14 +365,11 @@ fn serve_request(
             .header(CONTENT_TYPE, "text/plain; charset=utf-8")
             .body("ok".to_string())
             .expect("BUG: Response::builder error")),
-        _ => serve_metrics(req, metrics_manager),
+        _ => serve_metrics(metrics_manager),
     }
 }
 
-fn serve_metrics(
-    _req: Request<Incoming>,
-    metrics_manager: Arc<MetricsManager>,
-) -> Result<Response<String>, hyper::Error> {
+fn serve_metrics(metrics_manager: Arc<MetricsManager>) -> Result<Response<String>, hyper::Error> {
     let encoder = TextEncoder::new();
     let body = match metrics_manager.export_all() {
         Ok(body) => body,


### PR DESCRIPTION
## Description
Right now HW health does not have livez probe, which creates problem when metrics payload is too large, this adds separate /livez to be used for this purpose

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

