### PR TITLE
chore: add created timestamp to logical partition

### DIFF
--- a/crates/api-db/src/nvl_logical_partition.rs
+++ b/crates/api-db/src/nvl_logical_partition.rs
@@ -204,6 +204,7 @@ impl TryFrom<LogicalPartition> for rpc::NvLinkLogicalPartition {
             config_version: src.config_version.version_string(),
             status,
             config: Some(config),
+            created: Some(src.created.into()),
         })
     }
 }

--- a/crates/api/src/web/nvlink.rs
+++ b/crates/api/src/web/nvlink.rs
@@ -89,6 +89,7 @@ struct LogicalPartitionDetail {
     id: String,
     name: String,
     state: String,
+    created: String,
     physical_partitions: Vec<ShowPhysicalPartitionDetail>,
 }
 
@@ -104,6 +105,11 @@ impl From<ShowLogicalPartition> for LogicalPartitionDetail {
             };
             physical_partitions.push(pp);
         }
+        let created = show
+            .partition
+            .created
+            .map(|c| c.to_string())
+            .unwrap_or_default();
         Self {
             id: show.partition.id.map(|i| i.to_string()).unwrap_or_default(),
             name: show
@@ -117,6 +123,7 @@ impl From<ShowLogicalPartition> for LogicalPartitionDetail {
                 .unwrap_or_default()
                 .as_str_name()
                 .to_string(),
+            created,
             physical_partitions,
         }
     }

--- a/crates/api/templates/logical_partition_detail.html
+++ b/crates/api/templates/logical_partition_detail.html
@@ -10,6 +10,7 @@
         <tr><th>ID</th><td>{{ id }}</td></tr>
         <tr><th>Name</th><td>{{ name }}</td></tr>
         <tr><th>State</th><td>{{ state }}</td></tr>
+        <tr><th>Created</th><td>{{ created }}</td></tr>
 </table>
 
 <h2>Physical Partitions</h2>

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -5736,6 +5736,8 @@ message NVLinkLogicalPartition {
   string config_version = 3;
 
   NVLinkLogicalPartitionStatus status = 4;
+
+  google.protobuf.Timestamp created = 5;
 }
 
 message NVLinkLogicalPartitionList {


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
Add a created timestamp to the logical partition page in the admin UI.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

