### PR TITLE
txn_held_across_await: Lint on holding a DbReader across await too

### DIFF
--- a/lints/carbide-lints/tests/fixtures/app/src/main.rs
+++ b/lints/carbide-lints/tests/fixtures/app/src/main.rs
@@ -1,19 +1,3 @@
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 use std::ops::DerefMut;
 
 use sqlx::pool::PoolConnection;
@@ -311,6 +295,20 @@ async fn good_move_out() -> PgTransaction<'static> {
     make_transaction()
 }
 
+// TDD NOTE: When trait detection works, this should emit the lint.
+async fn bad_takes_db_reader() {
+    let mut txn = make_transaction();
+    bad_takes_db_reader_inner(&mut txn).await;
+    txn.commit().await.unwrap();
+}
+
+async fn bad_takes_db_reader_inner<DB>(_db: &mut DB)
+where
+    for<'db> &'db mut DB: db_read::DbReader<'db>,
+{
+    unrelated_async_work("bad").await;
+}
+
 #[tokio::main]
 async fn main() {
     // Actually call the functions to dead code warnings. But we're not actually running this code,
@@ -335,4 +333,11 @@ async fn main() {
     bad_missing_commit_param(make_transaction());
     let owned_txn = good_move_out().await;
     owned_txn.commit().await.unwrap();
+    bad_takes_db_reader().await;
+}
+
+pub mod db_read {
+    pub trait DbReader<'c>: sqlx::PgExecutor<'c> {}
+
+    impl<'c> DbReader<'c> for &'c mut sqlx::PgConnection {}
 }

--- a/lints/carbide-lints/tests/fixtures/app/src/main.stderr
+++ b/lints/carbide-lints/tests/fixtures/app/src/main.stderr
@@ -153,10 +153,22 @@ error: sqlx::Transaction is dropped by this function without commit()/rollback()
     = note: `-D txn-without-commit` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(txn_without_commit)]`
 
+error: A sqlx::Transaction is being held across this 'await' point
+   --> src/main.rs:309:33
+    |
+309 |     unrelated_async_work("bad").await;
+    |                                 ^^^^^
+    |
+note: Transaction declared here
+   --> src/main.rs:305:40
+    |
+305 | async fn bad_takes_db_reader_inner<DB>(_db: &mut DB)
+    |                                        ^^^
+
 error: sqlx::Transaction is dropped by this function without commit()/rollback(), or being moved out
    --> src/main.rs:290:29
     |
 290 | fn bad_missing_commit_param(_txn: PgTransaction<'_>) {
     |                             ^^^^
 
-error: could not compile `sqlx_app` (bin "sqlx_app") due to 14 previous errors
+error: could not compile `sqlx_app` (bin "sqlx_app") due to 15 previous errors


### PR DESCRIPTION
## Description
A DbReader is used to make db functions agnostic to whether they accept a PgConnection or a PgPool, but it can also be used to bypass the txn_held_across_await lint by "laundering" a PgConnection as a DbReader.

So teach the lint to recognize DbReader too... This involves making the lint detect traits instead of just concrete types.

(Also, take the license header out of the test fixture, since it broke all the assertions.)

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [X] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

