### PR TITLE
fix: continuing ipv6 work -- accept v6 site prefixes & network segments

### DIFF
--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -321,8 +321,8 @@ pub async fn start_api(
 
     let ib_fabric_manager: Arc<dyn IBFabricManager> = Arc::new(ib_fabric_manager_impl);
 
-    let site_fabric_prefixes = ethernet_virtualization::SiteFabricPrefixList::from_ipv4_slice(
-        carbide_config.site_fabric_prefixes.as_slice(),
+    let site_fabric_prefixes = ethernet_virtualization::SiteFabricPrefixList::from_ipnetwork_vec(
+        carbide_config.site_fabric_prefixes.clone(),
     );
 
     let eth_data = ethernet_virtualization::EthVirtData {


### PR DESCRIPTION
## Description

In our latest episode of enabling IPv6 support in Carbide, we are making additional backend changes to support IPv6 site prefixes and network segments.

The two core changes to enable this were:
1. Removed the explicit IPv6 guard on network segment creation, now allowing users to create segments with IPv6 (or dual-stack) prefixes.
2. Updates `site_fabric_prefixes` from `Vec<Ipv4Network>` to `Vec<IpNetwork>`, so that IPv6 site fabric prefixes can now be configured, while maintaining existing compatibility + configuration with IPv4. Site prefixes are now family-aware.

Both changes are in `crates/api-model/src/network_segment/mod.rs`.

The database layer has ALWAYS supported IPv6 natively. This change simply updates the API layer so it no longer rejects it, and now site operators can configure both IPv4 and IPv6 site fabric prefixes in their site config. Existing IPv4-only configs continue to work as they did — `IpNetwork` deserializes `"192.0.2.0/24"` the same way `Ipv4Network` does.

There's still obviously a lot more to do in here, but making progress with the backend. Some TODOs for the next round include:
- SVI IP allocation.
- Deny prefixes (this ends up being more involved wrt plumbing v6 rules through to nvue).
- Also dropped some comments inline in the code.

Lots of tests added, including test for tenant prefixes:
- `test_ipv6_prefix_accepted`: Make sure an IPv6 prefix is now accepted for admin segments.
- `test_dual_stack_prefixes_accepted`: Ensures IPv4 + IPv6 prefixes together are accepted.
- `test_ipv6_tenant_prefix_size_validation`: /64 is allowed, /127 and /128 are rejected for tenant segments.
- `test_ipv4_tenant_prefix_size_validation_unchanged`: /24 still allowed, /31 and /32 still rejected.

...and tests for site prefixes:
- `test_site_prefix_list`: IPv4 containment in a mixed address-family list.
- `test_site_prefix_list_ipv6_containment`: Ensure IPv6 subnet (/64) is contained in IPv6 supernet (/48); non-matching IPv6 is rejected.
- `test_site_prefix_list_cross_family_never_matches`: Ensure IPv4 prefix never matches IPv6 site fabric prefix + vice versa.
- `test_site_prefix_list_dual_stack`: Tests dual-stack site fabric w/ both v4 and v6 prefixes match both families correctly.

...and some segment tests:
- `test_create_network_segment_with_ipv6_prefix`: Creates an admin segment with a v6 prefix through the full API handler path, verifying it persists and round-trips correctly.
- `test_create_dual_stack_tenant_segment`: Creates a tenant segment with both v4 AND v6 prefixes (with a v6 site prefix configured), verifies both prefixes persist.
- `test_ipv6_tenant_prefix_rejected_when_not_in_site_fabric`: Verifies an IPv6 prefix NOT contained in the configured site fabric prefix(es) is rejected, just like an uncontained IPv4 prefix would be.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
https://github.com/NVIDIA/carbide-core/issues/84

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

