### PR TITLE
chore: bmc-mock, integration test: Wiwynn GB200 initial support

### DIFF
--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -116,6 +116,15 @@ async fn test_integration() -> eyre::Result<()> {
             Ipv4Addr::new(172, 20, 0, 2),
         )
         .boxed(),
+        test_machine_a_tron_multidpu(
+            HostHardwareType::WiwynnGB200Nvl,
+            &test_env,
+            &bmc_address_registry,
+            &managed_segment_id,
+            // Relay IP in admin net
+            Ipv4Addr::new(172, 20, 0, 2),
+        )
+        .boxed(),
         test_machine_a_tron_zerodpu(
             HostHardwareType::DellPowerEdgeR750,
             &test_env,

--- a/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
+++ b/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
@@ -40,22 +40,24 @@ pub struct EmbeddedNic {
 impl DellPowerEdgeR750<'_> {
     pub fn manager_config(&self) -> redfish::manager::Config {
         redfish::manager::Config {
-            id: "iDRAC.Embedded.1",
-            eth_interfaces: vec![
-                redfish::ethernet_interface::builder(
-                    &redfish::ethernet_interface::manager_resource("iDRAC.Embedded.1", "NIC.1"),
-                )
-                .mac_address(self.bmc_mac_address)
-                .interface_enabled(true)
-                .build(),
-            ],
-            firmware_version: "6.00.30.00",
+            managers: vec![redfish::manager::SingleConfig {
+                id: "iDRAC.Embedded.1",
+                eth_interfaces: vec![
+                    redfish::ethernet_interface::builder(
+                        &redfish::ethernet_interface::manager_resource("iDRAC.Embedded.1", "NIC.1"),
+                    )
+                    .mac_address(self.bmc_mac_address)
+                    .interface_enabled(true)
+                    .build(),
+                ],
+                firmware_version: "6.00.30.00",
+            }],
         }
     }
 
     pub fn system_config(&self, pc: Arc<dyn PowerControl>) -> redfish::computer_system::Config {
         let power_control = Some(pc);
-        let serial_number = self.product_serial_number.to_string().into();
+        let serial_number = Some(self.product_serial_number.to_string().into());
         let system_id = "System.Embedded.1";
 
         let eth_interfaces = [
@@ -107,14 +109,14 @@ impl DellPowerEdgeR750<'_> {
                 id: Cow::Borrowed(system_id),
                 manufacturer: Some("Dell Inc.".into()),
                 model: Some("PowerEdge R750".into()),
-                eth_interfaces,
+                eth_interfaces: Some(eth_interfaces),
                 serial_number,
                 boot_order_mode: redfish::computer_system::BootOrderMode::DellOem,
                 power_control,
                 chassis: vec!["System.Embedded.1".into()],
-                boot_options,
+                boot_options: Some(boot_options),
                 bios_mode: redfish::computer_system::BiosMode::DellOem,
-                base_bios: redfish::bios::builder(&redfish::bios::resource(system_id))
+                base_bios: Some(redfish::bios::builder(&redfish::bios::resource(system_id))
                     .attributes(json!({
                         "BootSeqRetry": "Disabled",
                         "SetBootOrderEn": "NIC.HttpDevice.1-1,Disk.Bay.2:Enclosure.Internal.0-1",
@@ -133,7 +135,7 @@ impl DellPowerEdgeR750<'_> {
                         "PxeDev1EnDis": "Disabled",
                         "HttpDev1Interface": "NIC.Slot.5-1",
                     }))
-                    .build(),
+                    .build()),
             }],
         }
     }

--- a/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
+++ b/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
@@ -14,3 +14,140 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use serde_json::json;
+
+use crate::{PowerControl, hw, redfish};
+
+pub struct WiwynnGB200Nvl<'a> {
+    pub product_serial_number: Cow<'a, str>,
+    pub dpu1: hw::bluefield3::Bluefield3<'a>,
+    pub dpu2: hw::bluefield3::Bluefield3<'a>,
+}
+
+impl WiwynnGB200Nvl<'_> {
+    pub fn manager_config(&self) -> redfish::manager::Config {
+        redfish::manager::Config {
+            managers: vec![
+                redfish::manager::SingleConfig {
+                    id: "BMC_0",
+                    eth_interfaces: vec![], // TODO: eth0 / eth1 / hmcusb0 / hostusb0
+                    firmware_version: "25.06-2_NV_WW_02",
+                },
+                redfish::manager::SingleConfig {
+                    id: "HGX_BMC_0",
+                    eth_interfaces: vec![], // TODO: usb0
+                    firmware_version: "GB200Nvl-25.06-A",
+                },
+            ],
+        }
+    }
+
+    pub fn system_config(&self, pc: Arc<dyn PowerControl>) -> redfish::computer_system::Config {
+        let system_id = "System_0";
+        let power_control = Some(pc);
+        let serial_number = Some(self.product_serial_number.to_string().into());
+        let boot_opt_builder = |id: &str| {
+            redfish::boot_option::builder(&redfish::boot_option::resource(system_id, id))
+                .boot_option_reference(id)
+        };
+        let boot_options = [
+            boot_opt_builder("Boot0020")
+                .display_name("Ubuntu")
+                .uefi_device_path("HD(1,GPT,C07AA982-7D30-4663-9538-776771BBED85,0x800,0x219800)/\\EFI\\ubuntu\\shimaa64.efi")
+                .build()
+        ].into_iter().chain([&self.dpu1, &self.dpu2].into_iter().enumerate().map(|(index, dpu)| {
+            let mac = dpu.host_mac_address.to_string().replace(":", "").to_uppercase();
+            let display_name = format!("UEFI HTTPv4 (MAC:{mac})");
+            boot_opt_builder(&format!("Boot{index:04X}"))
+                .display_name(&display_name)
+                .uefi_device_path(&format!("MAC({mac},0x1)/IPv4(0.0.0.0,0x0,DHCP,0.0.0.0,0.0.0.0,0.0.0.0)/Uri()"))
+                .build()
+        })).collect();
+
+        redfish::computer_system::Config {
+            systems: vec![
+                redfish::computer_system::SingleSystemConfig {
+                    id: system_id.into(),
+                    manufacturer: Some("WIWYNN".into()),
+                    model: Some("GB200 NVL".into()),
+                    eth_interfaces: None,
+                    serial_number,
+                    boot_order_mode: redfish::computer_system::BootOrderMode::ViaSettings,
+                    power_control,
+                    chassis: vec!["BMC_0".into()],
+                    boot_options: Some(boot_options),
+                    bios_mode: redfish::computer_system::BiosMode::Generic,
+                    base_bios: Some(
+                        redfish::bios::builder(&redfish::bios::resource(system_id))
+                            .attributes(json!({
+                                "EmbeddedUefiShell": "Enabled",
+                            }))
+                            .build(),
+                    ),
+                },
+                redfish::computer_system::SingleSystemConfig {
+                    id: "HGX_Baseboard_0".into(),
+                    manufacturer: Some("NVIDIA".into()),
+                    model: Some("GB200 NVL".into()),
+                    chassis: vec!["HGX_Chassis_0".into()],
+                    eth_interfaces: None,
+                    power_control: None,
+                    boot_options: None,
+                    serial_number: None,
+                    boot_order_mode: redfish::computer_system::BootOrderMode::Generic,
+                    bios_mode: redfish::computer_system::BiosMode::Generic,
+                    base_bios: None,
+                },
+            ],
+        }
+    }
+
+    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+        let dpu_chassis = |chassis_id: &'static str, bf3: &hw::bluefield3::Bluefield3<'_>| {
+            let nic = bf3.host_nic();
+            let network_adapters = Some(vec![
+                redfish::network_adapter::builder_from_nic(
+                    &redfish::network_adapter::chassis_resource(chassis_id, chassis_id),
+                    &nic,
+                )
+                .status(redfish::resource::Status::Ok)
+                .build(),
+            ]);
+
+            redfish::chassis::SingleChassisConfig {
+                id: chassis_id.into(),
+                manufacturer: nic.manufacturer,
+                part_number: nic.part_number,
+                model: Some("GB200 NVL".into()),
+                serial_number: None,
+                network_adapters,
+                pcie_devices: Some(vec![]),
+            }
+        };
+        redfish::chassis::ChassisConfig {
+            chassis: vec![
+                redfish::chassis::SingleChassisConfig {
+                    id: "Chassis_0".into(),
+                    manufacturer: Some("NVIDIA".into()),
+                    part_number: Some("B81.11810.000D".into()),
+                    model: Some("GB200 NVL".into()),
+                    serial_number: None,
+                    network_adapters: None,
+                    pcie_devices: None,
+                },
+                dpu_chassis("Riser_Slot1_BlueField_3_Card", &self.dpu1),
+                dpu_chassis("Riser_Slot2_BlueField_3_Card", &self.dpu2),
+            ],
+        }
+    }
+
+    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+        redfish::update_service::UpdateServiceConfig {
+            firmware_inventory: vec![],
+        }
+    }
+}

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -39,12 +39,13 @@ pub use mock_machine_router::{
     BmcCommand, SetSystemPowerError, SetSystemPowerResult, machine_router,
 };
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq)]
 pub enum HostHardwareType {
     #[serde(rename = "dell_poweredge_r750")]
+    #[default]
     DellPowerEdgeR750,
-    // #[serde(rename = "wiwynn_gb200_nvl")]
-    // WiwynnGB200Nvl,
+    #[serde(rename = "wiwynn_gb200_nvl")]
+    WiwynnGB200Nvl,
 }
 
 #[derive(Debug, Copy, Clone, Default)]

--- a/crates/bmc-mock/src/redfish/account_service.rs
+++ b/crates/bmc-mock/src/redfish/account_service.rs
@@ -38,8 +38,11 @@ pub fn resource() -> redfish::Resource<'static> {
 }
 
 pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
-    r.route(&resource().odata_id, get(get_root))
-        .route(&ACCOUNTS_COLLECTION_RESOURCE.odata_id, get(get_accounts))
+    r.route(&resource().odata_id, get(get_root).patch(patch_root))
+        .route(
+            &ACCOUNTS_COLLECTION_RESOURCE.odata_id,
+            get(get_accounts).post(create_account),
+        )
         .route(
             format!("{}/{{account_id}}", ACCOUNTS_COLLECTION_RESOURCE.odata_id).as_str(),
             get(get_account).patch(patch_account),
@@ -68,6 +71,10 @@ pub async fn get_root() -> Response {
         .into_ok_response()
 }
 
+pub async fn patch_root() -> Response {
+    json!({}).into_ok_response()
+}
+
 pub fn account_resource(id: impl Display) -> redfish::Resource<'static> {
     redfish::Resource {
         odata_id: Cow::Owned(format!("{}/{id}", ACCOUNTS_COLLECTION_RESOURCE.odata_id)),
@@ -85,6 +92,10 @@ pub async fn get_accounts() -> Response {
     ACCOUNTS_COLLECTION_RESOURCE
         .with_members(&members)
         .into_ok_response()
+}
+
+pub async fn create_account(Path(_account_id): Path<String>) -> Response {
+    json!({}).into_ok_response()
 }
 
 pub async fn patch_account(Path(_account_id): Path<String>) -> Response {

--- a/crates/bmc-mock/src/redfish/oem/mod.rs
+++ b/crates/bmc-mock/src/redfish/oem/mod.rs
@@ -24,6 +24,7 @@ use crate::redfish::Resource;
 pub enum BmcVendor {
     Dell,
     Nvidia,
+    Wiwynn,
 }
 
 impl BmcVendor {
@@ -31,13 +32,16 @@ impl BmcVendor {
         match self {
             BmcVendor::Nvidia => "Nvidia",
             BmcVendor::Dell => "Dell",
+            BmcVendor::Wiwynn => "WIWYNN",
         }
     }
     // This function creates settings of the resource from the resource
     // id. Real identifier is different for different BMC vendors.
     pub fn make_settings_odata_id(&self, resource: &Resource<'_>) -> String {
         match self {
-            BmcVendor::Nvidia | BmcVendor::Dell => format!("{}/Settings", resource.odata_id),
+            BmcVendor::Nvidia | BmcVendor::Dell | BmcVendor::Wiwynn => {
+                format!("{}/Settings", resource.odata_id)
+            }
         }
     }
 }

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -319,7 +319,7 @@ pub struct PersistedHostMachine {
 impl From<PersistedHostMachine> for HostMachineInfo {
     fn from(value: PersistedHostMachine) -> Self {
         Self {
-            hw_type: value.hw_type.unwrap_or(HostHardwareType::DellPowerEdgeR750),
+            hw_type: value.hw_type.unwrap_or_default(),
             bmc_mac_address: value.bmc_mac_address,
             serial: value.serial,
             dpus: value.dpus.into_iter().map(Into::into).collect(),
@@ -331,6 +331,7 @@ impl From<PersistedHostMachine> for HostMachineInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PersistedDpuMachine {
     pub mat_id: Uuid,
+    pub hw_type: Option<HostHardwareType>,
     pub bmc_mac_address: MacAddress,
     pub host_mac_address: MacAddress,
     pub oob_mac_address: MacAddress,
@@ -346,6 +347,7 @@ pub struct PersistedDpuMachine {
 impl From<PersistedDpuMachine> for DpuMachineInfo {
     fn from(value: PersistedDpuMachine) -> Self {
         Self {
+            hw_type: value.hw_type.unwrap_or_default(),
             bmc_mac_address: value.bmc_mac_address,
             host_mac_address: value.host_mac_address,
             oob_mac_address: value.oob_mac_address,
@@ -381,7 +383,7 @@ fn default_network_status_run_interval() -> Duration {
 }
 
 fn default_host_hardware_type() -> HostHardwareType {
-    HostHardwareType::DellPowerEdgeR750
+    HostHardwareType::default()
 }
 
 fn default_scout_run_interval() -> Duration {

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -20,8 +20,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 use bmc_mock::{
-    BmcCommand, HostHardwareType, HostMachineInfo, MachineInfo, SetSystemPowerResult,
-    SystemPowerControl,
+    BmcCommand, HostMachineInfo, MachineInfo, SetSystemPowerResult, SystemPowerControl,
 };
 use carbide_uuid::machine::MachineId;
 use eyre::Context;
@@ -94,9 +93,7 @@ impl HostMachine {
             })
             .collect::<Vec<_>>();
         let host_info = HostMachineInfo {
-            hw_type: persisted_host_machine
-                .hw_type
-                .unwrap_or(HostHardwareType::DellPowerEdgeR750),
+            hw_type: persisted_host_machine.hw_type.unwrap_or_default(),
             bmc_mac_address: persisted_host_machine.bmc_mac_address,
             serial: persisted_host_machine.serial.clone(),
             dpus: persisted_host_machine
@@ -161,6 +158,7 @@ impl HostMachine {
         let dpu_machines = (1..=config.dpu_per_host_count as u8)
             .map(|index| {
                 DpuMachine::new(
+                    config.hw_type,
                     mat_id,
                     index,
                     app_context.clone(),

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -21,8 +21,8 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use bmc_mock::{
-    BmcCommand, HostHardwareType, HostMachineInfo, HostnameQuerying, MachineInfo, MockPowerState,
-    POWER_CYCLE_DELAY, PowerControl, SetSystemPowerError, SetSystemPowerResult, SystemPowerControl,
+    BmcCommand, HostMachineInfo, HostnameQuerying, MachineInfo, MockPowerState, POWER_CYCLE_DELAY,
+    PowerControl, SetSystemPowerError, SetSystemPowerResult, SystemPowerControl,
 };
 use carbide_uuid::machine::MachineId;
 use mac_address::MacAddress;
@@ -209,7 +209,7 @@ impl MachineStateMachine {
                     h.bmc_dhcp_id,
                     h.machine_dhcp_id,
                     MachineInfo::Host(HostMachineInfo {
-                        hw_type: h.hw_type.unwrap_or(HostHardwareType::DellPowerEdgeR750),
+                        hw_type: h.hw_type.unwrap_or_default(),
                         bmc_mac_address: h.bmc_mac_address,
                         serial: h.serial,
                         dpus: h.dpus.into_iter().map(Into::into).collect(),


### PR DESCRIPTION
## Description
Integration test for Wiwynn GB200 is initially supported and passed.
Machine-a-tron also can create GB200 machines by using hw_type set to "wiwynn_gb200_nvl".
However, support is not complete (machine-a-tron sends Dell's discovery reoprts to carbide).

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

