### PR TITLE
Store the flag if a machine is ingested using DPF.

### DIFF
--- a/crates/admin-cli/src/dpf/cmds.rs
+++ b/crates/admin-cli/src/dpf/cmds.rs
@@ -77,18 +77,20 @@ pub async fn show(
 
     if response.len() == 1 {
         println!(
-            "DPF state for machine {}: {}",
+            "DPF status for machine {}:",
             response[0].machine_id.unwrap_or_default(),
-            response[0].dpf_enabled
         );
+        println!("\tEnabled            : {}", response[0].enabled);
+        println!("\tUsed For Ingestion : {}", response[0].used_for_ingestion);
     } else {
         let mut table = prettytable::Table::new();
-        table.set_titles(row!["Id", "State",]);
+        table.set_titles(row!["Id", "Enabled", "Used For Ingestion"]);
 
         for dpf_state in response {
             table.add_row(row![
                 dpf_state.machine_id.unwrap_or_default().to_string(),
-                dpf_state.dpf_enabled.to_string(),
+                dpf_state.enabled.to_string(),
+                dpf_state.used_for_ingestion.to_string(),
             ]);
         }
         table.printstd();

--- a/crates/api-db/migrations/20260205120158_dpf_jsonb_migration.sql
+++ b/crates/api-db/migrations/20260205120158_dpf_jsonb_migration.sql
@@ -1,0 +1,18 @@
+-- Add migration script here
+-- Convert dpf_enabled (boolean) to dpf (jsonb) with structure {enabled: bool, used_for_ingestion: bool}
+
+-- Step 1: Add the new dpf column as JSONB (nullable initially)
+ALTER TABLE machines ADD COLUMN dpf JSONB;
+
+-- Step 2: Migrate data from dpf_enabled to dpf.enabled, initialize used_for_ingestion to false and last_monitor_cycle_executed_at to current UTC time
+UPDATE machines
+SET dpf = jsonb_build_object(
+    'enabled', dpf_enabled,
+    'used_for_ingestion', false
+);
+
+-- Step 3: Make dpf NOT NULL now that all rows have values
+ALTER TABLE machines ALTER COLUMN dpf SET NOT NULL;
+
+-- Step 4: Drop the old dpf_enabled column
+ALTER TABLE machines DROP COLUMN dpf_enabled;

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -42,7 +42,7 @@ use model::machine::network::{
 use model::machine::nvlink::MachineNvLinkStatusObservation;
 use model::machine::upgrade_policy::AgentUpgradePolicy;
 use model::machine::{
-    FailureDetails, Machine, MachineInterfaceSnapshot, MachineLastRebootRequested,
+    Dpf, FailureDetails, Machine, MachineInterfaceSnapshot, MachineLastRebootRequested,
     MachineLastRebootRequestedMode, ManagedHostState, ReprovisionRequest, UpgradeDecision,
 };
 use model::machine_interface_address::MachineInterfaceAssociation;
@@ -1276,7 +1276,7 @@ pub async fn create(
     };
 
     let query = r#"INSERT INTO machines(
-                            id, controller_state_version, controller_state, network_config_version, network_config, machine_state_model_version, asn, version, name, description, labels, hw_sku, dpf_enabled)
+                            id, controller_state_version, controller_state, network_config_version, network_config, machine_state_model_version, asn, version, name, description, labels, hw_sku, dpf)
                             VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::json, $12, $13) RETURNING id"#;
     let machine_id: MachineId = sqlx::query_as(query)
         .bind(&stable_machine_id_string)
@@ -1291,7 +1291,10 @@ pub async fn create(
         .bind(&metadata.description)
         .bind(sqlx::types::Json(&metadata.labels))
         .bind(sku_id)
-        .bind(dpf_enabled)
+        .bind(sqlx::types::Json(Dpf {
+            enabled: dpf_enabled,
+            used_for_ingestion: false,
+        }))
         .fetch_one(&mut *txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -2199,11 +2202,25 @@ pub async fn clear_quarantine_state(
 pub async fn modify_dpf_state(
     txn: &mut PgConnection,
     machine_id: &MachineId,
-    state: bool,
+    status: bool,
 ) -> Result<(), DatabaseError> {
-    let query = "UPDATE machines set dpf_enabled=$1 WHERE id=$2";
+    let query = "UPDATE machines set dpf = jsonb_set(dpf, '{enabled}', to_jsonb($1)) WHERE id=$2";
     sqlx::query(query)
-        .bind(state)
+        .bind(status)
+        .bind(machine_id)
+        .execute(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    Ok(())
+}
+
+pub async fn mark_machine_ingestion_done_with_dpf(
+    txn: &mut PgConnection,
+    machine_id: &MachineId,
+) -> Result<(), DatabaseError> {
+    let query = "UPDATE machines set dpf = jsonb_set(dpf, '{used_for_ingestion}', to_jsonb(true)) WHERE id=$1";
+    sqlx::query(query)
         .bind(machine_id)
         .execute(txn)
         .await

--- a/crates/api-model/src/machine/json.rs
+++ b/crates/api-model/src/machine/json.rs
@@ -33,7 +33,7 @@ use crate::machine::network::{MachineNetworkStatusObservation, ManagedHostNetwor
 use crate::machine::nvlink::MachineNvLinkStatusObservation;
 use crate::machine::topology::MachineTopology;
 use crate::machine::{
-    FailureDetails, HostReprovisionRequest, Machine, MachineInterfaceSnapshot,
+    Dpf, FailureDetails, HostReprovisionRequest, Machine, MachineInterfaceSnapshot,
     MachineLastRebootRequested, MachineStateHistory, ManagedHostState, ReprovisionRequest,
     UpgradeDecision,
 };
@@ -103,7 +103,7 @@ pub struct MachineSnapshotPgJson {
     pub hw_sku_device_type: Option<String>,
     pub update_complete: bool,
     pub nvlink_info: Option<MachineNvLinkInfo>,
-    pub dpf_enabled: bool,
+    pub dpf: Dpf,
 }
 
 impl TryFrom<MachineSnapshotPgJson> for Machine {
@@ -216,7 +216,7 @@ impl TryFrom<MachineSnapshotPgJson> for Machine {
             hw_sku_device_type: value.hw_sku_device_type,
             update_complete: value.update_complete,
             nvlink_info: value.nvlink_info,
-            dpf_enabled: value.dpf_enabled,
+            dpf: value.dpf,
         })
     }
 }

--- a/crates/api/src/handlers/dpf.rs
+++ b/crates/api/src/handlers/dpf.rs
@@ -85,10 +85,7 @@ pub(crate) async fn get_dpf_state(
     Ok(Response::new(rpc::DpfStateResponse {
         dpf_states: dpf_states
             .into_iter()
-            .map(|machine| rpc::dpf_state_response::DpfState {
-                machine_id: machine.id.into(),
-                dpf_enabled: machine.dpf_enabled,
-            })
+            .map(|machine| machine.into())
             .collect(),
     }))
 }

--- a/crates/api/src/tests/dpf.rs
+++ b/crates/api/src/tests/dpf.rs
@@ -753,9 +753,13 @@ async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
     }
 
     let mut txn = env.db_txn().await;
-    let dpu = mh.dpu().db_machine(&mut txn).await;
 
-    assert!(matches!(dpu.current_state(), ManagedHostState::Ready));
+    assert!(mh.host().db_machine(&mut txn).await.dpf.used_for_ingestion);
+    for i in 0..mh.dpu_ids.len() {
+        let dpu = mh.dpu_n(i).db_machine(&mut txn).await;
+        assert!(dpu.dpf.used_for_ingestion);
+        assert!(matches!(dpu.current_state(), ManagedHostState::Ready));
+    }
 
     let carbide_machines_per_state = env.test_meter.parsed_metrics("carbide_machines_per_state");
 

--- a/crates/api/src/tests/machine_creator.rs
+++ b/crates/api/src/tests/machine_creator.rs
@@ -1211,7 +1211,7 @@ async fn test_site_explorer_creates_managed_host_with_dpf_disable(
 
     assert_eq!(machines.len(), 2);
     for machine in machines {
-        assert!(!machine.dpf_enabled);
+        assert!(!machine.dpf.enabled);
     }
 
     Ok(())
@@ -1349,7 +1349,7 @@ async fn test_site_explorer_creates_managed_host_with_dpf_enabled(
 
     assert_eq!(machines.len(), 2);
     for machine in machines {
-        assert!(machine.dpf_enabled);
+        assert!(machine.dpf.enabled);
     }
 
     Ok(())

--- a/crates/api/src/tests/machine_states.rs
+++ b/crates/api/src/tests/machine_states.rs
@@ -62,6 +62,12 @@ async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
     let mut txn = env.db_txn().await;
     let dpu = mh.dpu().db_machine(&mut txn).await;
 
+    assert!(!mh.host().db_machine(&mut txn).await.dpf.used_for_ingestion);
+    for i in 0..mh.dpu_ids.len() {
+        let dpu = mh.dpu_n(i).db_machine(&mut txn).await;
+        assert!(!dpu.dpf.used_for_ingestion);
+    }
+
     assert!(matches!(dpu.current_state(), ManagedHostState::Ready));
 
     let carbide_machines_per_state = env.test_meter.parsed_metrics("carbide_machines_per_state");

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -2434,7 +2434,7 @@ async fn test_machine_creation_with_sku(
             assert_eq!(m.hw_sku, None);
         } else {
             assert_eq!(m.hw_sku, Some("Sku1".to_string()));
-            assert!(m.dpf_enabled);
+            assert!(m.dpf.enabled);
         }
     }
 

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -6449,7 +6449,8 @@ message ModifyDPFStateRequest {
 message DPFStateResponse {
   message DPFState {
     common.MachineId machine_id = 1;
-    bool dpf_enabled = 2;
+    bool enabled = 2;
+    bool used_for_ingestion = 3;
   }
   repeated DPFState dpf_states = 1;
 }


### PR DESCRIPTION
## Description
There is no way to find if a node is ingested using DPF. This flag is needed to decide if DPU re-provisioing should be done using DPF or iPxe workflow.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

