### PR TITLE
chore: nv-redfish 0.1.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,13 +42,13 @@ tracing-appender = "0.2.4"
 tracing-opentelemetry = "0.29.0"
 
 # NV-Redfish
-nv-redfish = { version = "0.1.3", features = [
+nv-redfish = { version = "0.1.4", features = [
   "std-redfish",
   "update-service",
   "resource-status",
 ] }
-nv-redfish-core = { version = "0.1.3" }
-nv-redfish-bmc-http = { version = "0.1.3", features = ["reqwest"] }
+nv-redfish-core = { version = "0.1.4" }
+nv-redfish-bmc-http = { version = "0.1.4", features = ["reqwest"] }
 
 ########
 # MARK: - Pinned packages that we can't upgrade due to conflicts or just bugs


### PR DESCRIPTION
## Description
Bumped nv-redfish to 0.1.4, version 0.1.3 had missing License info in Cargo.toml

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

