### PR TITLE
chore: Use a stable message in StaleAgentVersion alert

### DIFF
--- a/crates/api-model/src/machine/network.rs
+++ b/crates/api-model/src/machine/network.rs
@@ -106,9 +106,9 @@ impl MachineNetworkStatusObservation {
                         "forge-dpu-agent".to_string(),
                         self.machine_id.to_string(),
                         format!(
-                            "Agent version is {}, which is out of date for {}",
+                            "Agent version is {}, which is out of date since {}",
                             agent_version,
-                            config_version::format_duration(staleness),
+                            superseded_at.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
                         ),
                         prevent_allocations,
                     ))


### PR DESCRIPTION
## Description

The previously used message changed on every state handler iteration, which lead the system to insert a new health history record.

With this change, the message will be stable, so that history is only written once when the agent version gets outdated.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

bug 5881435

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes


