### PR TITLE
feat: handle failures in configuring the boot order on hosts

### DIFF
--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1740,6 +1740,10 @@ pub enum SetBootOrderState {
     WaitForSetBootOrderJobScheduled,
     RebootHost,
     WaitForSetBootOrderJobCompletion,
+    HandleJobFailure {
+        failure: String,
+        power_state: PowerState,
+    },
     CheckBootOrder,
 }
 


### PR DESCRIPTION
## Description

feat: handle failures in configuring the boot order. If Carbide cannot query the job scheduled to make the boot order changes OR the job fails for some reason, power cycle the host and reboot the BMC before restarting the boot order flow. Added a new HandleJobFailure state that facilitates the power cycle & bmc reboot. We transition back to the CheckBootOrder state from HandleJobFailure, which checks the boot order and the retry count to determine if Carbide should continue trying to configure the boot order on the host.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

