### PR TITLE
feat(api): register managed host with RMS if part of an RMS-managed rack

### DIFF
--- a/crates/api/src/site_explorer/mod.rs
+++ b/crates/api/src/site_explorer/mod.rs
@@ -68,7 +68,7 @@ mod metrics;
 pub use metrics::SiteExplorationMetrics;
 mod bmc_endpoint_explorer;
 mod redfish;
-mod rms;
+pub mod rms;
 pub use bmc_endpoint_explorer::BmcEndpointExplorer;
 mod boot_order_tracker;
 use boot_order_tracker::BootOrderTracker;
@@ -162,6 +162,7 @@ impl SiteExplorer {
                 database_connection.clone(),
                 explorer_config.clone(),
                 common_pools,
+                rms_client.clone(),
             ),
             database_connection,
             enabled: explorer_config.enabled,

--- a/crates/api/src/state_controller/common_services.rs
+++ b/crates/api/src/state_controller/common_services.rs
@@ -55,7 +55,5 @@ pub struct CommonStateHandlerServices {
     pub dpa_info: Option<Arc<DpaInfo>>,
 
     /// Rack Manager Service client
-    /// Optional for now, but will be required in the future.
-    #[allow(dead_code)]
     pub rms_client: Option<Arc<dyn RmsApi>>,
 }

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -62,8 +62,8 @@ use model::machine::infiniband::{IbConfigNotSyncedReason, ib_config_synced};
 use model::machine::nvlink::nvlink_config_synced;
 use model::machine::{
     BomValidating, BomValidatingContext, CleanupState, CreateBossVolumeContext,
-    CreateBossVolumeState, DpuDiscoveringState, DpuInitNextStateResolver, DpuInitState,
-    FailureCause, FailureDetails, FailureSource, HostPlatformConfigurationState,
+    CreateBossVolumeState, DpuDiscoveringState, DpuDiscoveringStates, DpuInitNextStateResolver,
+    DpuInitState, FailureCause, FailureDetails, FailureSource, HostPlatformConfigurationState,
     HostReprovisionState, InitialResetPhase, InstallDpuOsState, InstanceNextStateResolver,
     InstanceState, LockdownInfo, LockdownState, Machine, MachineLastRebootRequested,
     MachineLastRebootRequestedMode, MachineNextStateResolver, MachineState, ManagedHostState,
@@ -89,9 +89,11 @@ use crate::cfg::file::{
     PowerManagerOptions, TimePeriod,
 };
 use crate::firmware_downloader::FirmwareDownloader;
+use crate::rack::rms_client::{RackManagerError, RmsNodeType};
 use crate::redfish::{
     self, host_power_control, host_power_control_with_location, set_host_uefi_password,
 };
+use crate::site_explorer::rms;
 use crate::state_controller::common_services::CommonStateHandlerServices;
 use crate::state_controller::machine::context::MachineStateHandlerContextObjects;
 use crate::state_controller::machine::{
@@ -693,6 +695,186 @@ impl MachineStateHandler {
         }
 
         match &mh_state {
+            ManagedHostState::VerifyRmsMembership => {
+                let dpu_ids = mh_snapshot.host_snapshot.associated_dpu_machine_ids();
+                let next_state = ManagedHostState::DpuDiscoveringState {
+                    dpu_states: DpuDiscoveringStates {
+                        states: dpu_ids
+                            .into_iter()
+                            .map(|id| (id, DpuDiscoveringState::Initializing))
+                            .collect(),
+                    },
+                };
+
+                let Some(rms_client) = &ctx.services.rms_client else {
+                    tracing::debug!(
+                        machine_id = %host_machine_id,
+                        "No RMS client configured, skipping RMS verification"
+                    );
+                    return Ok(StateHandlerOutcome::transition(next_state));
+                };
+
+                // If there's no rack_id, this machine isn't rack-managed,
+                // so skip RMS verification entirely.
+                let expected_machine =
+                    if let Some(bmc_mac) = mh_snapshot.host_snapshot.bmc_info.mac {
+                        db::expected_machine::find_by_bmc_mac_address(txn, bmc_mac).await?
+                    } else {
+                        None
+                    };
+
+                let rack_id = expected_machine.as_ref().and_then(|em| em.data.rack_id);
+                if rack_id.is_none() {
+                    tracing::debug!(
+                        machine_id = %host_machine_id,
+                        "No rack_id configured for machine, skipping RMS verification"
+                    );
+                    return Ok(StateHandlerOutcome::transition(next_state));
+                }
+
+                let node_id_str = host_machine_id.to_string();
+
+                match rms_client.inventory_get().await {
+                    Ok(response) => {
+                        let node_found = response
+                            .response
+                            .as_ref()
+                            .is_some_and(|r| {
+                                if let rpc::protos::rack_manager::inventory_response::Response::GetInventory(inv) = r {
+                                    inv.nodes.iter().any(|n| n.node_id == node_id_str)
+                                } else {
+                                    false
+                                }
+                            });
+
+                        if node_found {
+                            tracing::info!(
+                                machine_id = %host_machine_id,
+                                "Verified machine is registered with RMS, skipping registration"
+                            );
+                            Ok(StateHandlerOutcome::transition(next_state))
+                        } else {
+                            tracing::info!(
+                                machine_id = %host_machine_id,
+                                "Machine not found in RMS inventory, registering"
+                            );
+                            Ok(StateHandlerOutcome::transition(
+                                ManagedHostState::RegisterRmsMembership,
+                            ))
+                        }
+                    }
+                    Err(e) => {
+                        // NotFound means the node definitely isn't registered —
+                        // move on to registration. Any other error (connectivity,
+                        // internal, etc.) means we should retry verification.
+                        let is_not_found = matches!(
+                            &e,
+                            RackManagerError::ApiInvocationError(status)
+                                if status.code() == tonic::Code::NotFound
+                        );
+
+                        if is_not_found {
+                            tracing::warn!(
+                                machine_id = %host_machine_id,
+                                "RMS returned NotFound during verification, registering"
+                            );
+                            Ok(StateHandlerOutcome::transition(
+                                ManagedHostState::RegisterRmsMembership,
+                            ))
+                        } else {
+                            tracing::warn!(
+                                machine_id = %host_machine_id,
+                                "Failed to verify RMS membership: {e}, will retry"
+                            );
+                            Ok(StateHandlerOutcome::wait(
+                                "Waiting to retry RMS verification".to_string(),
+                            ))
+                        }
+                    }
+                }
+            }
+
+            ManagedHostState::RegisterRmsMembership => {
+                let dpu_ids = mh_snapshot.host_snapshot.associated_dpu_machine_ids();
+                let next_state = ManagedHostState::DpuDiscoveringState {
+                    dpu_states: DpuDiscoveringStates {
+                        states: dpu_ids
+                            .into_iter()
+                            .map(|id| (id, DpuDiscoveringState::Initializing))
+                            .collect(),
+                    },
+                };
+
+                // We only reach RegisterRmsMembership via VerifyRmsMembership,
+                // which already confirmed rms_client and rack_id exist. But
+                // guard defensively in case this state is entered directly
+                // (e.g. after a restart with persisted state).
+                let Some(rms_client) = &ctx.services.rms_client else {
+                    tracing::debug!(
+                        machine_id = %host_machine_id,
+                        "No RMS client configured, skipping RMS registration"
+                    );
+                    return Ok(StateHandlerOutcome::transition(next_state));
+                };
+
+                let bmc_mac = mh_snapshot.host_snapshot.bmc_info.mac;
+
+                let expected_machine = if let Some(mac) = bmc_mac {
+                    db::expected_machine::find_by_bmc_mac_address(txn, mac).await?
+                } else {
+                    None
+                };
+
+                let rack_id = expected_machine.as_ref().and_then(|em| em.data.rack_id);
+                let Some(rack_id) = rack_id else {
+                    tracing::debug!(
+                        machine_id = %host_machine_id,
+                        "No rack_id configured for machine, skipping RMS registration"
+                    );
+                    return Ok(StateHandlerOutcome::transition(next_state));
+                };
+
+                let bmc_ip = mh_snapshot
+                    .host_snapshot
+                    .bmc_info
+                    .ip
+                    .clone()
+                    .unwrap_or_default();
+
+                match rms::add_node_to_rms(
+                    rms_client.as_ref(),
+                    rack_id,
+                    host_machine_id.to_string(),
+                    bmc_ip,
+                    443,
+                    bmc_mac.unwrap_or_default(),
+                    RmsNodeType::Compute,
+                )
+                .await
+                {
+                    Ok(()) => {
+                        tracing::info!(
+                            machine_id = %host_machine_id,
+                            "Successfully registered machine with RMS"
+                        );
+                        // NOTE: We could also transition back to VerifyRmsMembership
+                        // here to confirm the registration took effect. For now, we
+                        // trust that a successful add_node means we're registered
+                        // and move forward.
+                        Ok(StateHandlerOutcome::transition(next_state))
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            machine_id = %host_machine_id,
+                            "Failed to register machine with RMS: {e}, will retry"
+                        );
+                        Ok(StateHandlerOutcome::wait(
+                            "Waiting to retry RMS registration".to_string(),
+                        ))
+                    }
+                }
+            }
+
             ManagedHostState::DpuDiscoveringState { .. } => {
                 if mh_snapshot
                     .host_snapshot

--- a/crates/api/src/state_controller/machine/io.rs
+++ b/crates/api/src/state_controller/machine/io.rs
@@ -233,6 +233,8 @@ impl StateControllerIO for MachineStateControllerIO {
             }
         }
         match state {
+            ManagedHostState::RegisterRmsMembership => ("registerrmsmembership", ""),
+            ManagedHostState::VerifyRmsMembership => ("verifyrmsmembership", ""),
             ManagedHostState::DpuDiscoveringState { dpu_states } => {
                 // Min state indicates the least processed DPU. The state machine is blocked
                 // becasue of this.

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -355,6 +355,8 @@ impl TestEnv {
     ) -> ManagedHostState {
         //This block is to fill data that is populated within statemachine
         match state.clone() {
+            ManagedHostState::RegisterRmsMembership => state.clone(),
+            ManagedHostState::VerifyRmsMembership => state.clone(),
             ManagedHostState::DpuDiscoveringState { .. } => state.clone(),
             ManagedHostState::DPUInit { .. } => state.clone(),
             ManagedHostState::HostInit { machine_state } => {
@@ -1367,7 +1369,7 @@ pub async fn create_test_env_with_overrides(
         scout_reporting_timeout: config.machine_state_controller.scout_reporting_timeout,
     };
 
-    let rms_sim = Arc::new(RmsSim);
+    let rms_sim = Arc::new(RmsSim::default());
 
     let api = Arc::new(Api {
         kube_client_provider: Arc::new(TestDpfKubeClient {}),
@@ -1442,7 +1444,7 @@ pub async fn create_test_env_with_overrides(
         ipmi_tool: ipmi_tool.clone(),
         site_config: config.clone(),
         dpa_info: None,
-        rms_client: None,
+        rms_client: rms_sim.as_rms_client(),
     });
 
     let state_controller_id = uuid::Uuid::new_v4().to_string();

--- a/crates/api/src/tests/machine_history.rs
+++ b/crates/api/src/tests/machine_history.rs
@@ -31,6 +31,7 @@ async fn test_machine_state_history(pool: sqlx::PgPool) -> Result<(), Box<dyn st
 
     let expected_initial_states_json = serde_json::json!([
         {"state": "created"},
+        {"state": "verifyrmsmembership"},
         {"state": "dpudiscoveringstate", "dpu_states": {"states": {&dpu_machine_id_string: {"dpudiscoverystate": "initializing"}}}},
         {"state": "dpudiscoveringstate", "dpu_states": {"states": {&dpu_machine_id_string: {"dpudiscoverystate": "configuring"}}}},
         {"state": "dpudiscoveringstate", "dpu_states": {"states": {&dpu_machine_id_string: {"dpudiscoverystate": "enablershim"}}}},


### PR DESCRIPTION
## Description

This was a flow that got lost amidst the bidirectional merging of repos, managed host refactoring (with the new `machine_creator.rs`), and preparing for the Carbide OSS release.

The original code was going to be "put back" in PR [#211](https://github.com/NVIDIA/bare-metal-manager-core/pull/211), but there was some discussion around now being the time to, instead of doing it how it was done originally, make it a part of the host state machine -- the idea is if the host node is in an RMS-managed rack, we should ensure the compute node gets registered with RMS as the first thing before moving along (even before the `Dpu` states).

So, this does that, where we now have a:
- `RegisterRmsMembership` state -- this will, if configured to, register the machine with RMS. If it fails, it will stay in this state and retry on each iteration.
- `VerifyRmsMembership` state -- this will, if configured to, verify the machine is successfully registered within RMS. If it finds no matching node, it will go back to `RegisterRmsMembership` to keep trying again. If it fails to retrieve info, it will keep re-verifying until it gets info. If it finds a node, it will continue forward.

For verifying membership, we pull in the `GetInventoryResponse` message. If the node is not found, we will return to `RegisterRmsMembership`. If there is an ERROR during verification, we'll continue to re-verify in `VerifyRmsMembership` until we either get a positive or negative confirmation.

These states are skipped entirely (and transitions directly to the `Dpu*` states) if:
- There is no `RmsClient` configured, and/or,
- There is no `rack_id` configured for the node.

Tests updated, as well as new integration tests added to make sure state handling works as expected.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

