### PR TITLE
fix: Fix state controller enqueuing and metric reliability

### DIFF
--- a/crates/api/src/state_controller/controller/builder.rs
+++ b/crates/api/src/state_controller/controller/builder.rs
@@ -214,6 +214,7 @@ impl<IO: StateControllerIO> Builder<IO> {
             task_sender,
             task_receiver,
             data_since_iteration_start: Default::default(),
+            object_metrics: Default::default(),
             last_log_time: std::time::Instant::now(),
             stats_since_last_log: Default::default(),
             processor_span,

--- a/crates/api/src/state_controller/controller/periodic_enqueuer.rs
+++ b/crates/api/src/state_controller/controller/periodic_enqueuer.rs
@@ -213,6 +213,11 @@ impl<IO: StateControllerIO> PeriodicEnqueuer<IO> {
             .iter()
             .map(|object_id| object_id.to_string())
             .collect();
+        txn.commit().await?;
+
+        // The transactions for listing and enqueuing are decoupled to avoid
+        // any locking side-effects
+        let mut txn = self.pool.begin().await?;
         iteration_metrics.num_enqueued_objects =
             db::queue_objects(&mut txn, IO::DB_QUEUED_OBJECTS_TABLE_NAME, &queued_objects).await?;
 


### PR DESCRIPTION
## Description

With the decoupling of state handler enqueuing and processing, we observed an issue in actual deployment where the emitted metrics where no longer stable. E.g. the `carbide_machines_total` metric might have fluctuated randomly between 90 and 100 for an environment with 100 machines.

This symptom could have been triggered by a race condition where the state handlers enqueued for iteration N+1 would have finished executing before metrics for iteration N are emitted. In this case, the metrics are emitted for iteration N, but would be missing for iteration N+1.

This change prevents that by always carrying forward metrics for an additional iteration: If the state handler executes for "Object A" within iteration 1, the metrics for the object will be emitted both when iteration 1 finished, and when iteration 2 finished. This will provide smoothened metrics.

The unit-test that had been added to validate the problem (`test_state_handler_metrics_are_stable`) also detect a secondary problem: If multiple locations enqueued objects for processing, a database deadlock could occur if these code path passed object IDs in different orders. In particular this happened when the periodic enqueuer tried to enqueue objects, while the state processor also enqueued objects that just transitioned states. Sorting the enqueued objects by ID consistently solves this problem.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

Issue 5866582

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

