### PR TITLE
fix(api): add ipv6 support to the prefix allocator

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -16,7 +16,9 @@
 #
 [book]
 title = "NVIDIA Bare Metal Manager Documentation"
-authors = ["NVIDIA Bare Metal Manager Development Team <carbide-dev@exchange.nvidia.com>"]
+authors = [
+  "NVIDIA Bare Metal Manager Development Team <carbide-dev@exchange.nvidia.com>",
+]
 
 [rust]
 edition = "2021"

--- a/crates/admin-cli/src/vpc_prefix/cmds.rs
+++ b/crates/admin-cli/src/vpc_prefix/cmds.rs
@@ -333,8 +333,8 @@ impl IntoTable for ShowOutput {
             "VpcId",
             "Prefix",
             "Name",
-            "Total 31 Segments",
-            "Available 31 Segments",
+            "Total Linknets",
+            "Available Linknets",
         ]
     }
 
@@ -353,11 +353,10 @@ impl IntoTable for ShowOutput {
         let name = row.name.as_str();
         let mut r = vec![vpc_prefix_id, vpc_id, prefix.into(), name.into()];
 
-        if row.total_31_segments != 0 {
-            r.push(row.total_31_segments.to_string().into());
-            r.push(row.available_31_segments.to_string().into());
+        if let Some(status) = &row.status {
+            r.push(status.total_linknet_segments.to_string().into());
+            r.push(status.available_linknet_segments.to_string().into());
         } else {
-            // Total 31 segments can not be 0. This means logic is not yet implemented on server.
             r.push("NA".into());
             r.push("NA".into());
         }

--- a/crates/api-model/src/vpc_prefix.rs
+++ b/crates/api-model/src/vpc_prefix.rs
@@ -43,6 +43,8 @@ pub struct VpcPrefixStatus {
     pub last_used_prefix: Option<IpNetwork>,
     pub total_31_segments: u32,
     pub available_31_segments: u32,
+    pub total_linknet_segments: u64,
+    pub available_linknet_segments: u64,
 }
 
 impl<'r> sqlx::FromRow<'r, PgRow> for VpcPrefix {
@@ -68,6 +70,8 @@ impl<'r> sqlx::FromRow<'r, PgRow> for VpcPrefix {
                 last_used_prefix,
                 total_31_segments: 0,
                 available_31_segments: 0,
+                total_linknet_segments: 0,
+                available_linknet_segments: 0,
             },
         })
     }
@@ -217,12 +221,16 @@ impl From<VpcPrefixStatus> for rpc::forge::VpcPrefixStatus {
         let VpcPrefixStatus {
             total_31_segments,
             available_31_segments,
+            total_linknet_segments,
+            available_linknet_segments,
             ..
         } = db_status;
 
         Self {
             total_31_segments,
             available_31_segments,
+            total_linknet_segments,
+            available_linknet_segments,
         }
     }
 }

--- a/crates/dsx-exchange-consumer/Cargo.toml
+++ b/crates/dsx-exchange-consumer/Cargo.toml
@@ -38,7 +38,10 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { features = ["env-filter", "local-time"], workspace = true }
+tracing-subscriber = { features = [
+  "env-filter",
+  "local-time",
+], workspace = true }
 url = { workspace = true }
 
 # [local-dependencies]

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1287,6 +1287,8 @@ message VpcPrefixConfig {
 message VpcPrefixStatus {
   uint32 total_31_segments = 1;
   uint32 available_31_segments = 2;
+  uint64 total_linknet_segments = 3;
+  uint64 available_linknet_segments = 4;
 }
 
 message VpcPrefixCreationRequest {


### PR DESCRIPTION
## Description

This PR generalizes the VPC prefix allocator from `IPv4PrefixAllocator` to `PrefixAllocator`, enabling it to work with both IPv4 and IPv6; it removes the explicit IPv6 rejection guards that we had in place in the instance allocation path. It is the next PR in a series focused on enabling IPv6 support to Carbide (tracked in [#84](https://github.com/NVIDIA/metal-manager-core/issues/84))

For context, The VPC prefix allocator carves small subnets (FNN "linknets") out of a larger VPC prefix and assigns them to network segments during instance provisioning. Previously, it was entirely hardcoded to IPv4 types (`Ipv4Addr`, `Ipv4Network`, and `u32` arithmetic). With this PR, it has been generalized to `IpAddr` and `IpNetwork`, with new `u128` arithmetic added to support both IPv4 and IPv6.

This is a very similar approach taken for the `IpAllocator` work that was done in [#217](https://github.com/NVIDIA/bare-metal-manager-core/pull/217), where we made the `IpAllocator` family-aware as well.

Primary changes to turn this into a `PrefixAllocator` include:
- The aforementioned `IpNetwork` and `IpAddr` changes (e.g. `Ip4Network::new(addr, prefix)` simply becomes `IpNetwork::new(addr, prefix)`).
- The aforementioned `u128` arithmetic changes, which is now the uniform mechanism for doing math for addressing.
- Introducing a simple `max_prefix_bits()` to be the family-aware replacement for `MAX_PREFIX_LEN`.
- Introducing a simple `networks_overlap()` to be the family-aware replacement for `.overlaps()`.
- `total_network_possible` becomes `u128` instead of `u32`.

Additional changes include:
- `PrefixIterator` now operates against a `u128` instead of an `Ipv4Addr`.
- `get_next_usable_address` now uses `IpAddr` and `IpNetwork` with `u128` arithmetic.
- Gateway assignment is now family aware. Since IPv6 uses RAs, we won't set one.
- `allocate_network()` now naturally extracts an `IpNetwork` of whatever the family is.
- FNN "linknet" prefix length is family aware:
  - IPv4 (/31) -- RFC 3021 ("Using 31-Bit Prefixes on IPv4 Point-to-Point Links")
  - IPv6 (/127) -- RFC 6164 ("Using 127-Bit IPv6 Prefixes on Inter-Router Links")
- Added `total_linknet_segments` and `available_linknet_segments` stats (which can also be displayed in the admin CLI) -- this is to work on deprecating the `total_31_segments` and `available_31_segments`, but I don't remove them yet.

**Considerations**

1. There's probably something we could do to make `PrefixAllocator` generic over an address type/family trait, but it seemed better to do `u128` arithmetic, since we can use the same arithmetic for both families without needing a trait, e.g.
- IPv6 addresses are of course native `u128`.
- IPv4 addresses upcast to `u128`.
- All bit-shifting, comparison, and wrapping logic works identically.
- We're already doing similar work in `ip_allocator.rs`.

2. Introducing `networks_overlap()` could have also been turned into a family-aware match on `Ipv4Network.overlaps()` or `Ipv6Network.overlaps()` (since there's not one that exists for `IpNetwork.overlaps()`, but I ended up doing this instead. If we want we could do the other way.

The following tests were added:

| Test | Address Family | Description |
|------|----------------|-------------|
| `test_next_iter` | IPv4 | `/31` subnets step through `/29` VPC prefix correctly. |
| `test_next_iter_overflow` | IPv4 | `/31` in `/30` wraps after 2 subnets. |
| `test_next_iter_ipv6` | IPv6 | `/127` subnets step through `/120` VPC prefix (`fd00::100/120`). |
| `test_next_iter_ipv6_wrap_around` | IPv6 | `/127` in `/126` wraps after 2 subnets. |
| `test_next_iter_ipv6_with_last_used` | IPv6 | Iterator resumes after `last_used_prefix`, skipping already-allocated subnet. |

...and the existing `PrefixAllocator` tests were also updated to confirm IPv4 behavior is unchanged.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
https://github.com/NVIDIA/bare-metal-manager-core/issues/84

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->