### PR TITLE
fix(api): Allow per VPC routing profiles

### DIFF
--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -775,11 +775,12 @@ impl ApiClient {
             .0
             .create_vpc(VpcCreationRequest {
                 name: name.to_string(),
+                vni: None,
+                routing_profile_type: None,
                 tenant_organization_id: "devenv_test_org".to_string(),
                 tenant_keyset_id: None,
-                vni: None,
                 network_virtualization_type: Some(
-                    VpcVirtualizationType::EthernetVirtualizerWithNvue as i32,
+                    VpcVirtualizationType::EthernetVirtualizerWithNvue.into(),
                 ),
                 id: Some(vpc_id),
                 metadata: Some(rpc::Metadata {
@@ -866,7 +867,7 @@ impl ApiClient {
         let request = rpc::VpcUpdateVirtualizationRequest {
             id: vpc.id,
             if_version_match: None,
-            network_virtualization_type: Some(virtualizer as i32),
+            network_virtualization_type: Some(virtualizer.into()),
         };
         self.0.update_vpc_virtualization(request).await?;
 

--- a/crates/api-model/src/tenant/mod.rs
+++ b/crates/api-model/src/tenant/mod.rs
@@ -568,14 +568,14 @@ impl<'r> sqlx::FromRow<'r, PgRow> for TenantKeyset {
 /*                                    */
 /* ********************************** */
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd)]
 pub enum RoutingProfileType {
-    Admin,
-    Internal,
-    PrivilegedInternal,
-    Maintenance,
     #[default]
     External,
+    Internal,
+    Maintenance,
+    PrivilegedInternal,
+    Admin,
 }
 
 /// A string is not a valid profile type

--- a/crates/api/src/tests/common/rpc_builder.rs
+++ b/crates/api/src/tests/common/rpc_builder.rs
@@ -44,6 +44,7 @@ pub struct VpcCreationRequest {
     pub metadata: ::core::option::Option<rpc::forge::Metadata>,
     pub network_security_group_id: ::core::option::Option<::prost::alloc::string::String>,
     pub vni: ::core::option::Option<u32>,
+    pub routing_profile_type: ::core::option::Option<i32>,
     pub default_nvlink_logical_partition_id:
         ::core::option::Option<::carbide_uuid::nvlink::NvLinkLogicalPartitionId>,
 }

--- a/crates/api/src/tests/resource_pool.rs
+++ b/crates/api/src/tests/resource_pool.rs
@@ -165,7 +165,6 @@ async fn test_simple(db_pool: sqlx::PgPool) -> Result<(), eyre::Report> {
     db::resource_pool::release(&pool, &mut txn, auto_allocated).await?;
     db::resource_pool::release(&pool, &mut txn, non_auto_allocated).await?;
 
-    // and then there was one
     assert_eq!(
         db::resource_pool::stats(&mut *txn, pool.name()).await?,
         St {

--- a/crates/api/src/tests/tenants.rs
+++ b/crates/api/src/tests/tenants.rs
@@ -20,11 +20,11 @@ use rpc::forge::{CreateTenantKeysetResponse, TenantKeysetIdentifier};
 use tonic::Code;
 
 use crate::tests::common;
-use crate::tests::common::api_fixtures::create_managed_host;
+use crate::tests::common::api_fixtures::{create_managed_host, create_test_env_with_fnn};
 
 #[crate::sqlx_test]
 async fn test_tenant(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
+    let env = create_test_env_with_fnn(pool).await;
 
     // Reject generally invalid metadata with just a name that is too short
     let tenant_create = env
@@ -305,6 +305,31 @@ async fn test_tenant(pool: sqlx::PgPool) {
         }))
         .await
         .unwrap();
+
+    // Now perform one more good create just to confirm that we can set
+    // the routing profile to something other than default
+    let tenant_create = env
+        .api
+        .create_tenant(tonic::Request::new(rpc::forge::CreateTenantRequest {
+            organization_id: "Org2".to_string(),
+            routing_profile_type: Some(rpc::forge::RoutingProfileType::Internal.into()),
+            metadata: Some(rpc::forge::Metadata {
+                name: "Name".to_string(),
+                description: "".to_string(),
+                labels: vec![],
+            }),
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let tenant = tenant_create.tenant.unwrap();
+
+    assert_eq!(
+        tenant.routing_profile_type,
+        Some(rpc::forge::RoutingProfileType::Internal.into())
+    );
+    assert_eq!(tenant.organization_id, "Org2");
 }
 
 #[crate::sqlx_test]

--- a/crates/api/src/tests/vpc.rs
+++ b/crates/api/src/tests/vpc.rs
@@ -28,12 +28,79 @@ use model::vpc::{UpdateVpc, UpdateVpcVirtualization};
 use rpc::forge::forge_server::Forge;
 
 use crate::tests::common;
+use crate::tests::common::api_fixtures::create_test_env_with_fnn;
 use crate::tests::common::rpc_builder::{VpcCreationRequest, VpcUpdateRequest};
 use crate::{DatabaseError, db_init};
 
 #[crate::sqlx_test]
-async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
+async fn create_vpc_for_tenant_without_profile(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env(pool).await;
+
+    // Create a tenant.
+    let tenant = env
+        .api
+        .create_tenant(tonic::Request::new(rpc::forge::CreateTenantRequest {
+            organization_id: "sizzle".to_string(),
+            routing_profile_type: None,
+            metadata: Some(rpc::forge::Metadata {
+                name: "sizzle".to_string(),
+                description: "".to_string(),
+                labels: vec![],
+            }),
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .tenant
+        .unwrap();
+
+    // Try to request a VPC without sending a valid tenant org.
+    // This should fail.
+    assert!(
+        env.api
+            .create_vpc(
+                VpcCreationRequest::builder("", "")
+                    .metadata(rpc::forge::Metadata {
+                        name: "Forge".to_string(),
+                        description: "".to_string(),
+                        labels: Vec::new(),
+                    })
+                    .routing_profile_type(rpc::forge::RoutingProfileType::PrivilegedInternal)
+                    .tonic_request(),
+            )
+            .await
+            .unwrap_err()
+            .message()
+            .contains("no tenant found")
+    );
+
+    // Try to request a VPC with a routing profile when the tenant has no routing profile type
+    assert!(
+        env.api
+            .create_vpc(
+                VpcCreationRequest::builder("", tenant.organization_id)
+                    .metadata(rpc::forge::Metadata {
+                        name: "Forge".to_string(),
+                        description: "".to_string(),
+                        labels: Vec::new(),
+                    })
+                    .routing_profile_type(rpc::forge::RoutingProfileType::PrivilegedInternal)
+                    .tonic_request(),
+            )
+            .await
+            .unwrap_err()
+            .message()
+            .contains("with no routing-profile type")
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_fnn(pool).await;
 
     // Create a tenant.
     let tenant = env
@@ -110,6 +177,26 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
         .into_inner()
         .tenant
         .unwrap();
+
+    // Try to request an elevated routing profile type for the VPC.
+    // This should fail.
+    assert!(
+        env.api
+            .create_vpc(
+                VpcCreationRequest::builder("", &tenant.organization_id)
+                    .metadata(rpc::forge::Metadata {
+                        name: "Forge".to_string(),
+                        description: "".to_string(),
+                        labels: Vec::new(),
+                    })
+                    .routing_profile_type(rpc::forge::RoutingProfileType::PrivilegedInternal)
+                    .tonic_request(),
+            )
+            .await
+            .unwrap_err()
+            .message()
+            .contains("greater than associated tenant")
+    );
 
     // No network_virtualization_type, should default
     let forge_vpc = env

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -452,6 +452,7 @@ impl ApiClient {
                 network_security_group_id: None,
                 network_virtualization_type: None,
                 vni: None,
+                routing_profile_type: None,
                 metadata: Some(rpc::forge::Metadata {
                     name: format!("vpc_{vpc_count}"),
                     description: "".to_string(),

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1177,6 +1177,13 @@ message VpcCreationRequest {
   // The requested VNI must be available in a resource-pool range that is not
   // marked for auto-assignment; otherwise, the request will be rejected.
   optional uint32 vni = 15;
+
+  // Desired routing profile type for this VPC.
+  // The requested type must be equal to or less than
+  // type of the tenant.
+  // For example, an internal tenant can request internal or external VPCs,
+  // but an external tenant can only request external VPCs.
+  optional RoutingProfileType routing_profile_type = 16;  
 }
 
 enum VpcVirtualizationType {


### PR DESCRIPTION
## Description

- Adds an option for VPC creation requests to allow the creation of VPCs with routing-profiles different than the profile of the tenant that owns them.
- Restricts VPC routing profiles to equal-to or less "routing privileges" than those of the tenant that owns the VPC.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

