### PR TITLE
chore: add logging of DPU restarts from machine FSM

### DIFF
--- a/crates/api/src/site_explorer/mod.rs
+++ b/crates/api/src/site_explorer/mod.rs
@@ -1677,7 +1677,6 @@ impl SiteExplorer {
                     // Try to generate a MachineId and parsed version info based on the retrieved data
                     if let Ok(report) = &mut result {
                         if !report.is_power_shelf() {
-                            tracing::info!("Generating MachineId for machine");
                             if let Err(error) = report.generate_machine_id(false) {
                                 tracing::error!(%error, "Can not generate MachineId for explored endpoint");
                             }


### PR DESCRIPTION
## Description
This is an additional logging improvement to improve transparency into hardware actions.

In addition, this commit drops logging of "generating machine id" on each exploration report.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

