### PR TITLE
fix: limit physical nvlink partition names

### DIFF
--- a/crates/api/src/nvl_partition_monitor/mod.rs
+++ b/crates/api/src/nvl_partition_monitor/mod.rs
@@ -1338,13 +1338,13 @@ impl NvlPartitionMonitor {
                 match operation.operation_type {
                     NmxmPartitionOperationType::Create => {
                         // Create the nvl partition.
+                        let name =
+                            format!("{}{}", logical_partition_id, operation.gpu_ids.join(","));
+                        // NMX-M has a limit of 244 characters for the partition name
+                        let name: String = name.chars().take(240).collect();
                         let request = libnmxm::nmxm_model::CreatePartitionRequest {
                             // For integration test to pass, till we can fix SimClient to cache partition info dynamically
-                            name: format!(
-                                "{}{}",
-                                logical_partition_id,
-                                operation.gpu_ids.join(",")
-                            ),
+                            name,
                             members: Box::new(libnmxm::nmxm_model::PartitionMembers::Ids(
                                 operation.gpu_ids.clone(),
                             )),


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
Limit partition names to 240 characters so that we are under NMX-M API's limit of 244.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

