### PR TITLE
fix: Issue all queued nmx-m operations even if the monitor encounters an error

### DIFF
--- a/crates/api/src/nvl_partition_monitor/mod.rs
+++ b/crates/api/src/nvl_partition_monitor/mod.rs
@@ -1349,81 +1349,94 @@ impl NvlPartitionMonitor {
                                 operation.gpu_ids.clone(),
                             )),
                         };
-                        let result =
-                            nmxm_client
-                                .create_partition(Some(request))
-                                .await
-                                .map_err(|e| {
-                                    CarbideError::internal(format!(
-                                        "Failed to create partition: {e}"
-                                    ))
-                                })?;
-                        pending_operations
-                            .entry(logical_partition_id)
-                            .and_modify(|ops| {
-                                ops.push(NmxmPartitionOperation {
-                                    domain_uuid: operation.domain_uuid,
-                                    operation_type: NmxmPartitionOperationType::Pending(
-                                        result.operation_id.clone(),
-                                    ),
-                                    original_operation_type: Some(
-                                        NmxmPartitionOperationType::Create,
-                                    ),
-                                    gpu_ids: operation.gpu_ids.clone(),
-                                    name: operation.name.clone(),
-                                    db_partition_id: operation.db_partition_id,
-                                });
-                            })
-                            .or_insert(vec![NmxmPartitionOperation {
-                                domain_uuid: operation.domain_uuid,
-                                operation_type: NmxmPartitionOperationType::Pending(
-                                    result.operation_id.clone(),
-                                ),
-                                original_operation_type: Some(NmxmPartitionOperationType::Create),
-                                gpu_ids: operation.gpu_ids.clone(),
-                                name: operation.name.clone(),
-                                db_partition_id: operation.db_partition_id,
-                            }]);
+                        match nmxm_client.create_partition(Some(request)).await {
+                            Ok(result) => {
+                                pending_operations
+                                    .entry(logical_partition_id)
+                                    .and_modify(|ops| {
+                                        ops.push(NmxmPartitionOperation {
+                                            domain_uuid: operation.domain_uuid,
+                                            operation_type: NmxmPartitionOperationType::Pending(
+                                                result.operation_id.clone(),
+                                            ),
+                                            original_operation_type: Some(
+                                                NmxmPartitionOperationType::Create,
+                                            ),
+                                            gpu_ids: operation.gpu_ids.clone(),
+                                            name: operation.name.clone(),
+                                            db_partition_id: operation.db_partition_id,
+                                        });
+                                    })
+                                    .or_insert(vec![NmxmPartitionOperation {
+                                        domain_uuid: operation.domain_uuid,
+                                        operation_type: NmxmPartitionOperationType::Pending(
+                                            result.operation_id.clone(),
+                                        ),
+                                        original_operation_type: Some(
+                                            NmxmPartitionOperationType::Create,
+                                        ),
+                                        gpu_ids: operation.gpu_ids.clone(),
+                                        name: operation.name.clone(),
+                                        db_partition_id: operation.db_partition_id,
+                                    }]);
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    %logical_partition_id,
+                                    "Failed to issue create partition to NMX-M, continuing with other operations: {e}"
+                                );
+                            }
+                        }
                     }
                     NmxmPartitionOperationType::Remove(nmx_m_partition_id) => {
                         // Remove from the partition.
 
-                        let result = nmxm_client
+                        match nmxm_client
                             .delete_partition(nmx_m_partition_id.clone())
                             .await
-                            .map_err(|e| {
-                                CarbideError::internal(format!("Failed to create partition: {e}"))
-                            })?;
-                        pending_operations
-                            .entry(logical_partition_id)
-                            .and_modify(|ops| {
-                                ops.push(NmxmPartitionOperation {
-                                    domain_uuid: operation.domain_uuid,
-                                    operation_type: NmxmPartitionOperationType::Pending(
-                                        result.operation_id.clone(),
-                                    ),
-                                    original_operation_type: Some(
-                                        NmxmPartitionOperationType::Remove(
-                                            nmx_m_partition_id.clone(),
+                        {
+                            Ok(result) => {
+                                pending_operations
+                                    .entry(logical_partition_id)
+                                    .and_modify(|ops| {
+                                        ops.push(NmxmPartitionOperation {
+                                            domain_uuid: operation.domain_uuid,
+                                            operation_type: NmxmPartitionOperationType::Pending(
+                                                result.operation_id.clone(),
+                                            ),
+                                            original_operation_type: Some(
+                                                NmxmPartitionOperationType::Remove(
+                                                    nmx_m_partition_id.clone(),
+                                                ),
+                                            ),
+                                            gpu_ids: operation.gpu_ids.clone(),
+                                            name: operation.name.clone(),
+                                            db_partition_id: operation.db_partition_id,
+                                        });
+                                    })
+                                    .or_insert(vec![NmxmPartitionOperation {
+                                        domain_uuid: operation.domain_uuid,
+                                        operation_type: NmxmPartitionOperationType::Pending(
+                                            result.operation_id.clone(),
                                         ),
-                                    ),
-                                    gpu_ids: operation.gpu_ids.clone(),
-                                    name: operation.name.clone(),
-                                    db_partition_id: operation.db_partition_id,
-                                });
-                            })
-                            .or_insert(vec![NmxmPartitionOperation {
-                                domain_uuid: operation.domain_uuid,
-                                operation_type: NmxmPartitionOperationType::Pending(
-                                    result.operation_id.clone(),
-                                ),
-                                original_operation_type: Some(NmxmPartitionOperationType::Remove(
-                                    nmx_m_partition_id.clone(),
-                                )),
-                                gpu_ids: operation.gpu_ids.clone(),
-                                name: operation.name.clone(),
-                                db_partition_id: operation.db_partition_id,
-                            }]);
+                                        original_operation_type: Some(
+                                            NmxmPartitionOperationType::Remove(
+                                                nmx_m_partition_id.clone(),
+                                            ),
+                                        ),
+                                        gpu_ids: operation.gpu_ids.clone(),
+                                        name: operation.name.clone(),
+                                        db_partition_id: operation.db_partition_id,
+                                    }]);
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    %logical_partition_id,
+                                    %nmx_m_partition_id,
+                                    "Failed to issue delete partition to NMX-M, continuing with other operations: {e}"
+                                );
+                            }
+                        }
                     }
                     NmxmPartitionOperationType::RemoveDefaultPartition(nmx_m_partition_id) => {
                         tracing::info!("NOT Removing default partition {nmx_m_partition_id}");
@@ -1476,42 +1489,52 @@ impl NvlPartitionMonitor {
                                 operation.gpu_ids.clone(),
                             )),
                         };
-                        let result = nmxm_client
+                        match nmxm_client
                             .update_partition(nmx_m_partition_id.clone(), request)
                             .await
-                            .map_err(|e| {
-                                CarbideError::internal(format!("Failed to update partition: {e}"))
-                            })?;
-                        pending_operations
-                            .entry(logical_partition_id)
-                            .and_modify(|ops| {
-                                ops.push(NmxmPartitionOperation {
-                                    domain_uuid: operation.domain_uuid,
-                                    operation_type: NmxmPartitionOperationType::Pending(
-                                        result.operation_id.clone(),
-                                    ),
-                                    original_operation_type: Some(
-                                        NmxmPartitionOperationType::Update(
-                                            nmx_m_partition_id.clone(),
+                        {
+                            Ok(result) => {
+                                pending_operations
+                                    .entry(logical_partition_id)
+                                    .and_modify(|ops| {
+                                        ops.push(NmxmPartitionOperation {
+                                            domain_uuid: operation.domain_uuid,
+                                            operation_type: NmxmPartitionOperationType::Pending(
+                                                result.operation_id.clone(),
+                                            ),
+                                            original_operation_type: Some(
+                                                NmxmPartitionOperationType::Update(
+                                                    nmx_m_partition_id.clone(),
+                                                ),
+                                            ),
+                                            gpu_ids: operation.gpu_ids.clone(),
+                                            name: operation.name.clone(),
+                                            db_partition_id: operation.db_partition_id,
+                                        });
+                                    })
+                                    .or_insert(vec![NmxmPartitionOperation {
+                                        domain_uuid: operation.domain_uuid,
+                                        operation_type: NmxmPartitionOperationType::Pending(
+                                            result.operation_id.clone(),
                                         ),
-                                    ),
-                                    gpu_ids: operation.gpu_ids.clone(),
-                                    name: operation.name.clone(),
-                                    db_partition_id: operation.db_partition_id,
-                                });
-                            })
-                            .or_insert(vec![NmxmPartitionOperation {
-                                domain_uuid: operation.domain_uuid,
-                                operation_type: NmxmPartitionOperationType::Pending(
-                                    result.operation_id.clone(),
-                                ),
-                                original_operation_type: Some(NmxmPartitionOperationType::Update(
-                                    nmx_m_partition_id.clone(),
-                                )),
-                                gpu_ids: operation.gpu_ids.clone(),
-                                name: operation.name.clone(),
-                                db_partition_id: operation.db_partition_id,
-                            }]);
+                                        original_operation_type: Some(
+                                            NmxmPartitionOperationType::Update(
+                                                nmx_m_partition_id.clone(),
+                                            ),
+                                        ),
+                                        gpu_ids: operation.gpu_ids.clone(),
+                                        name: operation.name.clone(),
+                                        db_partition_id: operation.db_partition_id,
+                                    }]);
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    %logical_partition_id,
+                                    %nmx_m_partition_id,
+                                    "Failed to issue update partition to NMX-M, continuing with other operations: {e}"
+                                );
+                            }
+                        }
                     }
                     NmxmPartitionOperationType::Pending(_operation_id) => {
                         // This will be handled by the poll_nmx_m_operations_with_timeout function, there should not be any Pending operations in this step.

--- a/crates/api/src/nvlink.rs
+++ b/crates/api/src/nvlink.rs
@@ -117,6 +117,7 @@ pub mod test_support {
         _state: Arc<Mutex<u32>>,
         _partitions: Arc<Mutex<Vec<libnmxm::nmxm_model::Partition>>>,
         _gpus: Arc<Mutex<Vec<libnmxm::nmxm_model::Gpu>>>,
+        _fail_after_n_creates: Option<Arc<Mutex<usize>>>,
     }
 
     impl Default for NmxmSimClient {
@@ -125,13 +126,22 @@ pub mod test_support {
                 _state: Arc::new(Mutex::new(0)),
                 _partitions: Arc::new(Mutex::new(Vec::new())),
                 _gpus: Arc::new(Mutex::new(Self::default_gpus())),
+                _fail_after_n_creates: None,
             }
         }
     }
 
     impl NmxmSimClient {
+        // After n create_requests succeed, they will start failing.
+        pub fn with_fail_after_n_creates(n: usize) -> Self {
+            NmxmSimClient {
+                _fail_after_n_creates: Some(Arc::new(Mutex::new(n))),
+                ..Self::default()
+            }
+        }
+
         pub fn with_default_partition() -> Self {
-            let client = NmxmSimClient::default();
+            let client = Self::default();
             client.create_default_partition(
                 client
                     ._gpus
@@ -533,6 +543,15 @@ pub mod test_support {
             &self,
             _req: Option<libnmxm::nmxm_model::CreatePartitionRequest>,
         ) -> Result<libnmxm::nmxm_model::AsyncResponse, NmxmApiError> {
+            {
+                if let Some(fail_counter) = &self._fail_after_n_creates {
+                    let mut fail_counter = fail_counter.lock().unwrap();
+                    if *fail_counter == 0 {
+                        return Err(NmxmApiError::InvalidArguments);
+                    }
+                    *fail_counter -= 1;
+                }
+            }
             let r = _req.unwrap();
             let mut _p = self._partitions.lock().unwrap();
             let partition = libnmxm::nmxm_model::Partition {
@@ -627,6 +646,7 @@ pub mod test_support {
                 _state: self._state.clone(),
                 _partitions: self._partitions.clone(),
                 _gpus: self._gpus.clone(),
+                _fail_after_n_creates: self._fail_after_n_creates.clone(),
             }))
         }
     }

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -258,6 +258,8 @@ pub struct TestEnvOverrides {
     pub dpf_config: Option<DpfConfig>,
     pub fnn_config: Option<FnnConfig>,
     pub nmxm_default_partition: Option<bool>,
+    // After n create_requests succeed, they will start failing.
+    pub nmxm_fail_after_n_creates: Option<usize>,
 }
 
 impl TestEnvOverrides {
@@ -1236,7 +1238,9 @@ pub async fn create_test_env_with_overrides(
     let certificate_provider = Arc::new(TestCertificateProvider::new());
     let redfish_sim = Arc::new(RedfishSim::default());
     let nmxm_sim: Arc<dyn NmxmClientPool> =
-        Arc::new(if overrides.nmxm_default_partition == Some(true) {
+        Arc::new(if let Some(n) = overrides.nmxm_fail_after_n_creates {
+            NmxmSimClient::with_fail_after_n_creates(n)
+        } else if overrides.nmxm_default_partition == Some(true) {
             NmxmSimClient::with_default_partition()
         } else {
             NmxmSimClient::default()

--- a/crates/api/src/tests/nvl_instance.rs
+++ b/crates/api/src/tests/nvl_instance.rs
@@ -301,6 +301,109 @@ async fn test_with_multiple_nv_link_logical_partitions(pool: sqlx::PgPool) {
 }
 
 #[crate::sqlx_test]
+async fn test_nvl_partition_monitor_adds_successful_partitions_when_some_creates_fail(
+    pool: sqlx::PgPool,
+) {
+    let mut config = common::api_fixtures::get_config();
+    if let Some(nvlink_config) = config.nvlink_config.as_mut() {
+        nvlink_config.enabled = true;
+    }
+
+    // Fail after one create succeeds.
+    let mut overrides = TestEnvOverrides::with_config(config);
+    overrides.nmxm_fail_after_n_creates = Some(1);
+
+    let env = common::api_fixtures::create_test_env_with_overrides(pool.clone(), overrides).await;
+
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+
+    let NvlLogicalPartitionFixture {
+        id: logical_partition_id1,
+        logical_partition: _logical_partition1,
+    } = create_nvl_logical_partition(&env, "test_partition1".to_string()).await;
+    let NvlLogicalPartitionFixture {
+        id: logical_partition_id2,
+        logical_partition: _logical_partition2,
+    } = create_nvl_logical_partition(&env, "test_partition2".to_string()).await;
+
+    let mh = create_managed_host_with_hardware_info_template(
+        &env,
+        HardwareInfoTemplate::Custom(
+            crate::tests::common::api_fixtures::host::GB200_COMPUTE_TRAY_1_INFO_JSON,
+        ),
+    )
+    .await;
+
+    let discovery_info = mh.host().rpc_machine().await.discovery_info.unwrap();
+    let gpus: Vec<Gpu> = discovery_info.gpus.to_vec();
+
+    let nvl_config = rpc::forge::InstanceNvLinkConfig {
+        gpu_configs: gpus
+            .iter()
+            .filter_map(|gpu| {
+                gpu.platform_info.as_ref().map(|platform_info| {
+                    rpc::forge::InstanceNvLinkGpuConfig {
+                        device_instance: platform_info.module_id,
+                        logical_partition_id: None,
+                    }
+                })
+            })
+            .collect(),
+    };
+
+    let (_tinstance, instance) =
+        create_instance_with_nvlink_config(&env, &mh, nvl_config.clone(), segment_id).await;
+
+    let nvl_config = rpc::forge::InstanceNvLinkConfig {
+        gpu_configs: gpus
+            .iter()
+            .filter_map(|gpu| {
+                gpu.platform_info.as_ref().map(|platform_info| {
+                    let nvl_logical_partition_id = if platform_info.module_id > 2 {
+                        Some(logical_partition_id2)
+                    } else {
+                        Some(logical_partition_id1)
+                    };
+                    rpc::forge::InstanceNvLinkGpuConfig {
+                        device_instance: platform_info.module_id,
+                        logical_partition_id: nvl_logical_partition_id,
+                    }
+                })
+            })
+            .collect(),
+    };
+    let mut txn = pool.begin().await.unwrap();
+    update_instance_nvlink_config(
+        &mut txn,
+        &instance.id(),
+        &InstanceNvLinkConfig::try_from(nvl_config).unwrap(),
+    )
+    .await;
+    txn.commit().await.unwrap();
+
+    // The monitor should successfully create one partition, but the second creation should fail.
+    env.run_nvl_partition_monitor_iteration().await;
+    env.run_nvl_partition_monitor_iteration().await;
+
+    let request_all = tonic::Request::new(rpc::forge::NvLinkPartitionSearchFilter {
+        name: None,
+        tenant_organization_id: None,
+    });
+    let ids_all = env
+        .api
+        .find_nv_link_partition_ids(request_all)
+        .await
+        .map(|response| response.into_inner())
+        .unwrap();
+
+    assert_eq!(
+        ids_all.partition_ids.len(),
+        1,
+        "expected exactly one partition in DB when one NMX-M create fails"
+    );
+}
+
+#[crate::sqlx_test]
 async fn test_create_instances_with_nvl_configs_same_logical_partition_different_domains(
     pool: sqlx::PgPool,
 ) {


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
Do not exit early from execute_nmx_m_operations() if we cannot issue an operation to NMX-M. Instead add only successfully enqueued operations to pending list and ignore any that errored out. Exiting execute_nmx_m_operations() early with an error was resulting in skipped db updates even for those operations that were successfully enqueued and completed by NMX-M.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

