### PR TITLE
feat(api): add managed host node to RMS if part of a rack managed node

### DIFF
--- a/crates/api/src/site_explorer/mod.rs
+++ b/crates/api/src/site_explorer/mod.rs
@@ -68,7 +68,7 @@ mod metrics;
 pub use metrics::SiteExplorationMetrics;
 mod bmc_endpoint_explorer;
 mod redfish;
-mod rms;
+pub mod rms;
 pub use bmc_endpoint_explorer::BmcEndpointExplorer;
 mod boot_order_tracker;
 use boot_order_tracker::BootOrderTracker;
@@ -162,6 +162,7 @@ impl SiteExplorer {
                 database_connection.clone(),
                 explorer_config.clone(),
                 common_pools,
+                rms_client.clone(),
             ),
             database_connection,
             enabled: explorer_config.enabled,

--- a/crates/api/src/state_controller/common_services.rs
+++ b/crates/api/src/state_controller/common_services.rs
@@ -55,7 +55,5 @@ pub struct CommonStateHandlerServices {
     pub dpa_info: Option<Arc<DpaInfo>>,
 
     /// Rack Manager Service client
-    /// Optional for now, but will be required in the future.
-    #[allow(dead_code)]
     pub rms_client: Option<Arc<dyn RmsApi>>,
 }

--- a/crates/api/src/state_controller/machine/io.rs
+++ b/crates/api/src/state_controller/machine/io.rs
@@ -233,6 +233,8 @@ impl StateControllerIO for MachineStateControllerIO {
             }
         }
         match state {
+            ManagedHostState::RegisterRmsMembership => ("registerrmsmembership", ""),
+            ManagedHostState::VerifyRmsMembership => ("verifyrmsmembership", ""),
             ManagedHostState::DpuDiscoveringState { dpu_states } => {
                 // Min state indicates the least processed DPU. The state machine is blocked
                 // becasue of this.

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -355,6 +355,8 @@ impl TestEnv {
     ) -> ManagedHostState {
         //This block is to fill data that is populated within statemachine
         match state.clone() {
+            ManagedHostState::RegisterRmsMembership => state.clone(),
+            ManagedHostState::VerifyRmsMembership => state.clone(),
             ManagedHostState::DpuDiscoveringState { .. } => state.clone(),
             ManagedHostState::DPUInit { .. } => state.clone(),
             ManagedHostState::HostInit { machine_state } => {
@@ -1367,7 +1369,7 @@ pub async fn create_test_env_with_overrides(
         scout_reporting_timeout: config.machine_state_controller.scout_reporting_timeout,
     };
 
-    let rms_sim = Arc::new(RmsSim);
+    let rms_sim = Arc::new(RmsSim::default());
 
     let api = Arc::new(Api {
         kube_client_provider: Arc::new(TestDpfKubeClient {}),
@@ -1442,7 +1444,7 @@ pub async fn create_test_env_with_overrides(
         ipmi_tool: ipmi_tool.clone(),
         site_config: config.clone(),
         dpa_info: None,
-        rms_client: None,
+        rms_client: rms_sim.as_rms_client(),
     });
 
     let state_controller_id = uuid::Uuid::new_v4().to_string();

--- a/crates/api/src/tests/machine_history.rs
+++ b/crates/api/src/tests/machine_history.rs
@@ -31,6 +31,7 @@ async fn test_machine_state_history(pool: sqlx::PgPool) -> Result<(), Box<dyn st
 
     let expected_initial_states_json = serde_json::json!([
         {"state": "created"},
+        {"state": "verifyrmsmembership"},
         {"state": "dpudiscoveringstate", "dpu_states": {"states": {&dpu_machine_id_string: {"dpudiscoverystate": "initializing"}}}},
         {"state": "dpudiscoveringstate", "dpu_states": {"states": {&dpu_machine_id_string: {"dpudiscoverystate": "configuring"}}}},
         {"state": "dpudiscoveringstate", "dpu_states": {"states": {&dpu_machine_id_string: {"dpudiscoverystate": "enablershim"}}}},


### PR DESCRIPTION
_Note that this is https://github.com/NVIDIA/bare-metal-manager-core/pull/226, but something happened with whatever the earlier Github outage/issues were with runners, and things got super wonky, so I had to make an entirely new branch and re-open this. It actually seemed to not even know about my fork anymore, so I also just re-forked. Maybe it was a mix of Github issues + this repo being renamed and going public? Nooo clue._

_See the previous PR for discussion. @Matthias247 had approved it after discussion, but then it was stuck._

## Description

This was a flow that got lost amidst the bidirectional merging of repos, managed host refactoring (with the new `machine_creator.rs`), and preparing for the Carbide OSS release.

The original code was going to be "put back" in PR [#211](https://github.com/NVIDIA/bare-metal-manager-core/pull/211), but there was some discussion around now being the time to, instead of doing it how it was done originally, make it a part of the host state machine -- the idea is if the host node is in an RMS-managed rack, we should ensure the compute node gets registered with RMS as the first thing before moving along (even before the `Dpu` states).

So, this does that, where we now have a:
- `RegisterRmsMembership` state -- this will, if configured to, register the machine with RMS. If it fails, it will stay in this state and retry on each iteration.
- `VerifyRmsMembership` state -- this will, if configured to, verify the machine is successfully registered within RMS. If it finds no matching node, it will go back to `RegisterRmsMembership` to keep trying again. If it fails to retrieve info, it will keep re-verifying until it gets info. If it finds a node, it will continue forward.

For verifying membership, we pull in the `GetInventoryResponse` message. If the node is not found, we will return to `RegisterRmsMembership`. If there is an ERROR during verification, we'll continue to re-verify in `VerifyRmsMembership` until we either get a positive or negative confirmation.

These states are skipped entirely (and transitions directly to the `Dpu*` states) if:
- There is no `RmsClient` configured, and/or,
- There is no `rack_id` configured for the node.

Tests updated, as well as new integration tests added to make sure state handling works as expected.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->