### PR TITLE
Fix rust-analyzer E0308 issue

### DIFF
--- a/crates/admin-cli/src/main.rs
+++ b/crates/admin-cli/src/main.rs
@@ -278,16 +278,17 @@ async fn main() -> color_eyre::Result<()> {
 pub async fn get_output_file_or_stdout(
     output_filename: Option<&str>,
 ) -> Result<Pin<Box<dyn tokio::io::AsyncWrite>>, CarbideCliError> {
-    if let Some(filename) = output_filename {
+    let output: Pin<Box<dyn tokio::io::AsyncWrite>> = if let Some(filename) = output_filename {
         let file = tokio::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
             .open(filename)
             .await?;
-        Ok(Box::pin(file))
+        Box::pin(file)
     } else {
-        Ok(Box::pin(tokio::io::stdout()))
-    }
+        Box::pin(tokio::io::stdout())
+    };
+    Ok(output)
 }
 
 pub(crate) trait IntoOnlyOne<T> {


### PR DESCRIPTION
## Description

rust-analyzer is complaining: `expected Result<Pin<Box<File, Global>>, {unknown}>, found Result<Pin<Box<Stdout, Global>>, {unknown}> (rust-analyzer E0308)`.

It feels like a rust-analyzer bug because rustc is compiling the project just fine. But it is still annoying to see an error in the editor.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)


