### PR TITLE
fix: nvlink partitioning metrics

### DIFF
--- a/crates/api/src/nvl_partition_monitor/mod.rs
+++ b/crates/api/src/nvl_partition_monitor/mod.rs
@@ -33,6 +33,7 @@ use model::machine::nvlink::{MachineNvLinkGpuStatusObservation, MachineNvLinkSta
 use model::machine::{HostHealthConfig, LoadSnapshotOptions, ManagedHostStateSnapshot};
 use sqlx::PgPool;
 use tokio::sync::oneshot;
+use tracing::Instrument;
 
 use crate::api::TransactionVending;
 use crate::cfg::file::NvLinkConfig;
@@ -652,8 +653,10 @@ impl NvlPartitionMonitor {
             otel.status_message = tracing::field::Empty,
             metrics = tracing::field::Empty,
         );
-        let _enter = check_nvl_partition_span.enter();
-        let result = self.run_single_iteration_inner(&mut metrics).await;
+        let result = self
+            .run_single_iteration_inner(&mut metrics)
+            .instrument(check_nvl_partition_span.clone())
+            .await;
         check_nvl_partition_span.record(
             "otel.status_code",
             if result.is_ok() { "ok" } else { "error" },
@@ -755,7 +758,7 @@ impl NvlPartitionMonitor {
             metrics,
         )?;
 
-        self.record_nvlink_status_observation(observations?).await?;
+        self.record_nvlink_status_observation(observations).await?;
 
         let nmx_m_operations = partition_processing_context.nmx_m_operations;
 


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
This PR fixes two issues with nvlink partitioning metrics:
- Always record metrics, even if the partition monitor encounters an error.
- populate the operation name correctly in metrics' applied changes tracker.


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

