### PR TITLE
fix: do not try to delete machine from DPF if DPF is disabled for it

### DIFF
--- a/crates/api/src/handlers/machine.rs
+++ b/crates/api/src/handlers/machine.rs
@@ -486,10 +486,12 @@ pub(crate) async fn admin_force_delete_machine(
                 );
             }
 
-            api.kube_client_provider
-                .force_delete_machine(ip, &response.dpu_machine_ids)
-                .await
-                .map_err(CarbideError::DpfError)?;
+            if machine.dpf.used_for_ingestion {
+                api.kube_client_provider
+                    .force_delete_machine(ip, &response.dpu_machine_ids)
+                    .await
+                    .map_err(CarbideError::DpfError)?;
+            }
         } else {
             tracing::warn!(
                 "Failed to unlock this host because Forge could not retrieve the BMC IP address for machine {}",


### PR DESCRIPTION
## Description
Today on force delete BMM tries to create kubernetes client and delete resource. This
generates errors during integration testing and also add k8s API access as requirement
for deletion.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

