### PR TITLE
chore: allow optional ID when creating VPC peering

### DIFF
--- a/crates/admin-cli/src/vpc_peering/args.rs
+++ b/crates/admin-cli/src/vpc_peering/args.rs
@@ -36,6 +36,9 @@ pub struct CreateVpcPeering {
 
     #[clap(help = "The ID of other VPC ID to peer")]
     pub vpc2_id: VpcId,
+
+    #[clap(long, help = "Optional desired ID for the VPC peering")]
+    pub id: Option<VpcPeeringId>,
 }
 
 #[derive(Parser, Debug)]

--- a/crates/admin-cli/src/vpc_peering/cmds.rs
+++ b/crates/admin-cli/src/vpc_peering/cmds.rs
@@ -38,6 +38,7 @@ pub async fn create(
         .create_vpc_peering(VpcPeeringCreationRequest {
             vpc_id: Some(args.vpc1_id),
             peer_vpc_id: Some(args.vpc2_id),
+            id: args.id,
         })
         .await?;
 

--- a/crates/api-db/src/vpc_peering.rs
+++ b/crates/api-db/src/vpc_peering.rs
@@ -30,6 +30,7 @@ pub async fn create(
     txn: &mut PgConnection,
     vpc_id_1: VpcId,
     vpc_id_2: VpcId,
+    id: VpcPeeringId,
 ) -> Result<VpcPeering, DatabaseError> {
     let uuid1: Uuid = vpc_id_1.into();
     let uuid2: Uuid = vpc_id_2.into();
@@ -49,15 +50,16 @@ pub async fn create(
     }
 
     let query = r#"
-            INSERT INTO vpc_peerings (vpc1_id, vpc2_id)
-            SELECT $1, $2
+            INSERT INTO vpc_peerings (id, vpc1_id, vpc2_id)
+            SELECT $1, $2, $3
             WHERE NOT EXISTS (
-                SELECT 1 FROM vpc_peerings WHERE vpc1_id = $1 AND vpc2_id = $2
+                SELECT 1 FROM vpc_peerings WHERE id = $1 OR (vpc1_id = $2 AND vpc2_id = $3)
             )
             RETURNING *
         "#;
 
     match sqlx::query_as::<_, VpcPeering>(query)
+        .bind(id)
         .bind(vpc1_id)
         .bind(vpc2_id)
         .fetch_one(txn)
@@ -66,7 +68,7 @@ pub async fn create(
         Ok(vpc_peering) => Ok(vpc_peering),
         Err(sqlx::Error::RowNotFound) => Err(DatabaseError::AlreadyFoundError {
             kind: "VpcPeering",
-            id: format!("{vpc_id_1} and {vpc_id_2}"),
+            id: format!("id={id} between vpc1_id={vpc_id_1} and vpc2_id={vpc_id_2}"),
         }),
 
         Err(e) => Err(DatabaseError::query(query, e)),

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1369,6 +1369,9 @@ message VpcPeeringList {
 message VpcPeeringCreationRequest {
   common.VpcId vpc_id = 1;
   common.VpcId peer_vpc_id = 2;
+
+  // The desired ID for this VPC peering. If the ID is not provided, a random one will be generated.
+  optional common.VpcPeeringId id = 3; 
 }
 
 message VpcPeeringSearchFilter {


### PR DESCRIPTION
## Description
Adds support for an optional desired ID when creating a VPC peering. This is needed so the cloud side can use a chosen ID and match VPC peerings between the cloud and carbide sides. If the client provides an ID in the create request, that ID is used as the VPC peering’s ID instead of a randomly generated one. If omitted, behavior is unchanged (server-generated ID). 

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)



