### PR TITLE
fix(pxe): update mkosi profiles to use nvidia 580 drivers

### DIFF
--- a/pxe/mkosi.profiles/scout-oss-aarch64/mkosi.postinst.chroot
+++ b/pxe/mkosi.profiles/scout-oss-aarch64/mkosi.postinst.chroot
@@ -10,7 +10,7 @@ set -Eeux
 # NVIDIA DRIVERS & DCGM
 # ============================================================================
 # We install these in postinst to avoid double-triggering the DKMS build
-NV_PACKAGES="cuda-drivers-575=575.57.08-0ubuntu1 datacenter-gpu-manager-4-cuda12=1:4.2.3-2 datacenter-gpu-manager-4-core=1:4.2.3-2 datacenter-gpu-manager-4-proprietary-cuda12=1:4.2.3-2 libnvidia-cfg1-575=575.57.08-0ubuntu1 libnvidia-common-575=575.57.08-0ubuntu1 libnvidia-compute-575=575.57.08-0ubuntu1 libnvidia-decode-575=575.57.08-0ubuntu1 libnvidia-encode-575=575.57.08-0ubuntu1 libnvidia-extra-575=575.57.08-0ubuntu1 libnvidia-fbc1-575=575.57.08-0ubuntu1 libnvidia-gl-575=575.57.08-0ubuntu1 libnvidia-gpucomp-575=575.57.08-0ubuntu1 nvidia-compute-utils-575=575.57.08-0ubuntu1 nvidia-dkms-575-open=575.57.08-0ubuntu1 nvidia-driver-575-open=575.57.08-0ubuntu1 nvidia-fabricmanager-575=575.57.08-1 nvidia-firmware-575=575.57.08-0ubuntu1 nvidia-kernel-common-575=575.57.08-0ubuntu1 nvidia-kernel-source-575-open=575.57.08-0ubuntu1 nvidia-modprobe=575.57.08-0ubuntu1 nvidia-persistenced=575.57.08-1ubuntu1 nvidia-utils-575=575.57.08-0ubuntu1 xserver-xorg-video-nvidia-575=575.57.08-0ubuntu1 libxnvctrl0=575.57.08-0ubuntu1 nvidia-settings=575.57.08-0ubuntu1 nvidia-imex-575=575.57.08-1 mft"
+NV_PACKAGES="cuda-drivers-580=580.126.16-1ubuntu1 datacenter-gpu-manager-4-cuda12=1:4.2.3-2 datacenter-gpu-manager-4-core=1:4.2.3-2 datacenter-gpu-manager-4-proprietary-cuda12=1:4.2.3-2 libnvidia-cfg1-580=580.126.16-1ubuntu1 libnvidia-common-580=580.126.16-1ubuntu1 libnvidia-compute-580=580.126.16-1ubuntu1 libnvidia-decode-580=580.126.16-1ubuntu1 libnvidia-encode-580=580.126.16-1ubuntu1 libnvidia-extra-580=580.126.16-1ubuntu1 libnvidia-fbc1-580=580.126.16-1ubuntu1 libnvidia-gl-580=580.126.16-1ubuntu1 libnvidia-gpucomp-580=580.126.16-1ubuntu1 nvidia-compute-utils-580=580.126.16-1ubuntu1 nvidia-dkms-580-open=580.126.16-1ubuntu1 nvidia-driver-580-open=580.126.16-1ubuntu1 nvidia-fabricmanager=580.126.16-1 nvidia-firmware-580=580.126.16-1ubuntu1 nvidia-kernel-common-580=580.126.16-1ubuntu1 nvidia-kernel-source-580-open=580.126.16-1ubuntu1 nvidia-modprobe=580.126.16-1ubuntu1 nvidia-persistenced=580.126.16-1ubuntu1 nvidia-utils-580=580.126.16-1ubuntu1 xserver-xorg-video-nvidia-580=580.126.16-1ubuntu1 libxnvctrl0=580.126.16-1ubuntu1 nvidia-settings=580.126.16-1ubuntu1 nvidia-imex=580.126.16-1 mft"
 APT_SANDBOX_OPTS="-o APT::Sandbox::User=root"
 export DEBIAN_FRONTEND=noninteractive
 
@@ -18,7 +18,7 @@ apt-get ${APT_SANDBOX_OPTS} update
 
 # Debug: Check what NVIDIA driver packages are actually available
 echo "=== Checking NVIDIA repository status ==="
-apt-cache policy cuda-drivers-575 || echo "cuda-drivers-575 not found"
+apt-cache policy cuda-drivers-580 || echo "cuda-drivers-580 not found"
 echo "=== Available cuda-drivers versions ==="
 apt-cache search cuda-drivers | head -20
 echo "=== Available nvidia-driver versions ==="
@@ -62,9 +62,9 @@ do
 done
 
 # Check the nvidia driver versions are consistent
-NV_PKGS="cuda-drivers-575 libnvidia-common-575 libnvidia-compute-575 nvidia-compute-utils-575
-         nvidia-dkms-575-open nvidia-driver-575-open nvidia-fabricmanager-575 nvidia-firmware-575
-         nvidia-kernel-common-575 nvidia-kernel-source-575-open nvidia-persistenced"
+NV_PKGS="cuda-drivers-580 libnvidia-common-580 libnvidia-compute-580 nvidia-compute-utils-580
+         nvidia-dkms-580-open nvidia-driver-580-open nvidia-fabricmanager nvidia-firmware-580
+         nvidia-kernel-common-580 nvidia-kernel-source-580-open nvidia-persistenced"
 if [ $(dpkg -l ${NV_PKGS} | grep '^ii' | awk '{print $3}' | cut -d. -f1-2 | sort -u | wc -l) -ne 1 ]
 then
   echo "ERROR: Mismatched nvidia package versions, dcgmi may not run"

--- a/pxe/mkosi.profiles/scout-oss-x86_64/mkosi.postinst.chroot
+++ b/pxe/mkosi.profiles/scout-oss-x86_64/mkosi.postinst.chroot
@@ -10,7 +10,7 @@ set -Eeux
 # NVIDIA DRIVERS & DCGM
 # ============================================================================
 # We install these in postinst to avoid double-triggering the DKMS build
-NV_PACKAGES="cuda-drivers-575=575.57.08-0ubuntu1 datacenter-gpu-manager-4-cuda12=1:4.2.3-2 datacenter-gpu-manager-4-core=1:4.2.3-2 datacenter-gpu-manager-4-proprietary-cuda12=1:4.2.3-2 libnvidia-cfg1-575=575.57.08-0ubuntu1 libnvidia-common-575=575.57.08-0ubuntu1 libnvidia-compute-575=575.57.08-0ubuntu1 libnvidia-decode-575=575.57.08-0ubuntu1 libnvidia-encode-575=575.57.08-0ubuntu1 libnvidia-extra-575=575.57.08-0ubuntu1 libnvidia-fbc1-575=575.57.08-0ubuntu1 libnvidia-gl-575=575.57.08-0ubuntu1 libnvidia-gpucomp-575=575.57.08-0ubuntu1 nvidia-compute-utils-575=575.57.08-0ubuntu1 nvidia-dkms-575-open=575.57.08-0ubuntu1 nvidia-driver-575-open=575.57.08-0ubuntu1 nvidia-fabricmanager-575=575.57.08-1 nvidia-firmware-575=575.57.08-0ubuntu1 nvidia-kernel-common-575=575.57.08-0ubuntu1 nvidia-kernel-source-575-open=575.57.08-0ubuntu1 nvidia-modprobe=575.57.08-0ubuntu1 nvidia-persistenced=575.57.08-1ubuntu1 nvidia-utils-575=575.57.08-0ubuntu1 xserver-xorg-video-nvidia-575=575.57.08-0ubuntu1 libxnvctrl0=575.57.08-0ubuntu1 nvidia-settings=575.57.08-0ubuntu1 nvidia-imex-575=575.57.08-1 mft"
+NV_PACKAGES="cuda-drivers-580=580.126.16-1ubuntu1 datacenter-gpu-manager-4-cuda12=1:4.2.3-2 datacenter-gpu-manager-4-core=1:4.2.3-2 datacenter-gpu-manager-4-proprietary-cuda12=1:4.2.3-2 libnvidia-cfg1-580=580.126.16-1ubuntu1 libnvidia-common-580=580.126.16-1ubuntu1 libnvidia-compute-580=580.126.16-1ubuntu1 libnvidia-decode-580=580.126.16-1ubuntu1 libnvidia-encode-580=580.126.16-1ubuntu1 libnvidia-extra-580=580.126.16-1ubuntu1 libnvidia-fbc1-580=580.126.16-1ubuntu1 libnvidia-gl-580=580.126.16-1ubuntu1 libnvidia-gpucomp-580=580.126.16-1ubuntu1 nvidia-compute-utils-580=580.126.16-1ubuntu1 nvidia-dkms-580-open=580.126.16-1ubuntu1 nvidia-driver-580-open=580.126.16-1ubuntu1 nvidia-fabricmanager=580.126.16-1 nvidia-firmware-580=580.126.16-1ubuntu1 nvidia-kernel-common-580=580.126.16-1ubuntu1 nvidia-kernel-source-580-open=580.126.16-1ubuntu1 nvidia-modprobe=580.126.16-1ubuntu1 nvidia-persistenced=580.126.16-1ubuntu1 nvidia-utils-580=580.126.16-1ubuntu1 xserver-xorg-video-nvidia-580=580.126.16-1ubuntu1 libxnvctrl0=580.126.16-1ubuntu1 nvidia-settings=580.126.16-1ubuntu1 nvidia-imex=580.126.16-1 mft"
 APT_SANDBOX_OPTS="-o APT::Sandbox::User=root"
 export DEBIAN_FRONTEND=noninteractive
 
@@ -18,7 +18,7 @@ apt-get ${APT_SANDBOX_OPTS} update
 
 # Debug: Check what NVIDIA driver packages are actually available
 echo "=== Checking NVIDIA repository status ==="
-apt-cache policy cuda-drivers-575 || echo "cuda-drivers-575 not found"
+apt-cache policy cuda-drivers-580 || echo "cuda-drivers-580 not found"
 echo "=== Available cuda-drivers versions ==="
 apt-cache search cuda-drivers | head -20
 echo "=== Available nvidia-driver versions ==="
@@ -62,9 +62,9 @@ do
 done
 
 # Check the nvidia driver versions are consistent
-NV_PKGS="cuda-drivers-575 libnvidia-common-575 libnvidia-compute-575 nvidia-compute-utils-575
-         nvidia-dkms-575-open nvidia-driver-575-open nvidia-fabricmanager-575 nvidia-firmware-575
-         nvidia-kernel-common-575 nvidia-kernel-source-575-open nvidia-persistenced"
+NV_PKGS="cuda-drivers-580 libnvidia-common-580 libnvidia-compute-580 nvidia-compute-utils-580
+         nvidia-dkms-580-open nvidia-driver-580-open nvidia-fabricmanager nvidia-firmware-580
+         nvidia-kernel-common-580 nvidia-kernel-source-580-open nvidia-persistenced"
 if [ $(dpkg -l ${NV_PKGS} | grep '^ii' | awk '{print $3}' | cut -d. -f1-2 | sort -u | wc -l) -ne 1 ]
 then
   echo "ERROR: Mismatched nvidia package versions, dcgmi may not run"


### PR DESCRIPTION
## Description

This takes care of https://github.com/NVIDIA/bare-metal-manager-core/issues/292.

There's a bug in the nvidia 575 drivers that don't play nice with the kernel starting in v6.15. Our ARM64 runners just switched from `6.14.0-1015-nvidia-64k` (which was before the bug) to `6.17.0-1008-nvidia-64k`, and now `build-boot-artifacts-ephemeral-image-arm-host` is failing to build.

Recommendation is to move to the 580 drivers -- they are considered LTS and will be receiving updates through 2028. Target version is, which just got released, and I checked the `apt` repos and `580.126.16` is indeed available.

FYI, **there's a whole bunch of package renaming** that has happened from 580 -> 590, so we'll run into that at some point: https://docs.nvidia.com/datacenter/tesla/driver-installation-guide/recent-updates.html

For this one, main changes were:
- Packages with branch designation names went from `575` -> `580`.
- Versions switched from `575.57.08-0ubuntu1` to to `580.126.16-1ubuntu1`.
- `nvidia-fabricmanager` and `nvidia-imex` dropped the branch designation and no longer have `-580` in their name.
 
Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

