### PR TITLE
Fix build without linux-build feature and resolve mkosi network issues

### DIFF
--- a/crates/api/src/handlers/measured_boot.rs
+++ b/crates/api/src/handlers/measured_boot.rs
@@ -16,16 +16,21 @@
  */
 
 use ::rpc::protos::measured_boot as pb;
+#[cfg(feature = "linux-build")]
 pub use ::rpc::{forge as rpc_forge, machine_discovery as rpc_md};
-use carbide_uuid::machine::MachineId;
-use db::attestation::secret_ak_pub;
-use sqlx::PgConnection;
 use tonic::{Request, Response, Status};
+#[cfg(feature = "linux-build")]
+use {
+    crate::{CarbideError, attestation as attest},
+    carbide_uuid::machine::MachineId,
+    db::attestation::secret_ak_pub,
+    sqlx::PgConnection,
+};
 
 use crate::api::Api;
 use crate::measured_boot::rpc::{bundle, journal, machine, profile, report, site};
-use crate::{CarbideError, attestation as attest};
 
+#[cfg(feature = "linux-build")]
 pub(crate) async fn create_attest_key_bind_challenge(
     txn: &mut PgConnection,
     attest_key_info: &rpc_md::AttestKeyInfo,

--- a/crates/api/src/handlers/mod.rs
+++ b/crates/api/src/handlers/mod.rs
@@ -49,7 +49,6 @@ pub mod machine_quarantine;
 pub mod machine_scout;
 pub mod machine_validation;
 pub mod managed_host;
-#[cfg(feature = "linux-build")]
 pub mod measured_boot;
 pub mod mlx_admin;
 pub mod network_devices;

--- a/pxe/Makefile.toml
+++ b/pxe/Makefile.toml
@@ -443,7 +443,7 @@ category = "Ephemeral Image"
 script = '''
   PROFILE="scout-oss-x86_64"
   export PATH=${PATH}:/sbin
-  ${REPO_ROOT}/pxe/mkosi/bin/mkosi --profile ${PROFILE} --output-dir=${MKOSI_BUILD_TMP} build
+  ${REPO_ROOT}/pxe/mkosi/bin/mkosi --profile ${PROFILE} --output-dir=${MKOSI_BUILD_TMP} --with-network build
 '''
 
 [tasks.mkosi-build-scout-loader-x86_64]


### PR DESCRIPTION
## Description
Fix container build failures (`boot-artifacts-x86_64`, `bmm-core`).

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
[[BUG] Building fails on ssh-console-mock-api when linux-build is disabled](https://github.com/NVIDIA/bare-metal-manager-core/issues/244)

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

