### PR TITLE
nvbugs 5834644 dell r760 psu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5447,7 +5447,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.39.3#df4bc4a589e3c9f5f6f655e13b06ab13ffd032d9"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.41.0#d5ec83e59ec05cd873fe0e2f2119b5cefdb7bb2b"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.39.3" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.41.0" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.3" }
 ansi-to-html = "0.2.2"
 

--- a/crates/api/src/redfish.rs
+++ b/crates/api/src/redfish.rs
@@ -820,6 +820,7 @@ pub mod test_support {
         Power(libredfish::SystemPowerControl),
         BmcReset,
         SetUtcTimezone,
+        DisablePsuHotSpare,
     }
 
     pub struct RedfishSimActions {
@@ -2009,6 +2010,18 @@ pub mod test_support {
                 .unwrap()
                 .actions
                 .push(RedfishSimAction::SetUtcTimezone);
+            Ok(())
+        }
+
+        async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
+            self.state
+                .lock()
+                .unwrap()
+                .hosts
+                .get_mut(&self._host)
+                .unwrap()
+                .actions
+                .push(RedfishSimAction::DisablePsuHotSpare);
             Ok(())
         }
     }

--- a/crates/bmc-mock/src/redfish/oem/dell/idrac.rs
+++ b/crates/bmc-mock/src/redfish/oem/dell/idrac.rs
@@ -88,6 +88,7 @@ async fn get_managers_oem_dell_attributes(State(state): State<BmcState>) -> Resp
                 "Racadm.1.Enable": "Enabled",
                 "SSH.1.Enable": "Enabled",
                 "SerialRedirection.1.Enable": "Enabled",
+                "ServerPwr.1.PSRapidOn": "Enabled",
                 "WebServer.1.HostHeaderCheck": "Disabled",
             }
         }));


### PR DESCRIPTION
## Description
Configure Dell PowerEdge R760 servers to disable PSU Hot Spare mode during pre-ingestion. Ensures even power distribution across all 4 PSUs instead of keeping one in standby. Uses libredfish v0.41.0 with new disable_psu_hot_spare() method.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
https://nvbugspro.nvidia.com/bug/5834644

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [] Unit tests added/updated
- [] Integration tests added/updated  
- [] Manual testing performed
- [] No testing required (docs, internal refactor, etc.)

Mock infrastructure added (RedfishSim support)
Manual verification plan: Test on Dell R760 hardware in dev/staging environment post-merge to verify:
    - PSU Hot Spare is successfully disabled during pre-ingestion
    - All 4 PSUs show active (not standby) status
    - No regression on other Dell models

## Additional Notes
- Non-blocking error handling: PSU configuration failures log warnings but don't stop pre-ingestion
- Configuration runs in Initial state, after time sync, before firmware checks
- Updated libredfish dependency from v0.39.3 to v0.41.0

