### PR TITLE
chore: Drop dead code

### DIFF
--- a/crates/api-db/src/power_shelf_state_history.rs
+++ b/crates/api-db/src/power_shelf_state_history.rs
@@ -80,7 +80,6 @@ pub async fn find_by_power_shelf_ids(
     Ok(histories)
 }
 
-#[allow(dead_code)]
 pub async fn for_power_shelf(
     txn: &mut PgConnection,
     id: &PowerShelfId,
@@ -118,7 +117,6 @@ pub async fn persist(
 }
 
 /// Renames all history entries using one Power Shelf ID into using another Power Shelf ID
-#[allow(dead_code)]
 pub async fn update_power_shelf_ids(
     txn: &mut PgConnection,
     old_power_shelf_id: &PowerShelfId,

--- a/crates/api-db/src/rack.rs
+++ b/crates/api-db/src/rack.rs
@@ -166,7 +166,6 @@ pub async fn mark_as_deleted(rack: &Rack, txn: &mut PgConnection) -> DatabaseRes
     Ok(updated_rack)
 }
 
-#[allow(dead_code)]
 pub async fn final_delete(txn: &mut PgConnection, rack_id: RackId) -> DatabaseResult<()> {
     let query = "DELETE from racks WHERE id=$1";
     sqlx::query(query)

--- a/crates/api-db/src/rack_firmware.rs
+++ b/crates/api-db/src/rack_firmware.rs
@@ -116,7 +116,6 @@ impl RackFirmware {
     }
 
     /// Update the configuration
-    #[allow(dead_code)]
     pub async fn update_config(
         txn: &mut PgConnection,
         id: &str,
@@ -133,7 +132,6 @@ impl RackFirmware {
     }
 
     /// Update the available flag
-    #[allow(dead_code)]
     pub async fn set_available(
         txn: &mut PgConnection,
         id: &str,

--- a/crates/api-db/src/rack_state_history.rs
+++ b/crates/api-db/src/rack_state_history.rs
@@ -31,7 +31,6 @@ use crate::{DatabaseError, DatabaseResult};
 ///
 /// * `txn` - A reference to an open Transaction
 ///
-#[allow(dead_code)]
 pub async fn find_by_rack_ids(
     txn: &mut PgConnection,
     ids: &[RackId],

--- a/crates/api-db/src/switch_state_history.rs
+++ b/crates/api-db/src/switch_state_history.rs
@@ -81,7 +81,6 @@ pub async fn find_by_switch_ids(
 }
 
 #[cfg(test)] // only used in tests today
-#[allow(dead_code)]
 pub async fn for_switch(
     txn: &mut PgConnection,
     id: &SwitchId,
@@ -119,7 +118,6 @@ pub async fn persist(
 }
 
 /// Renames all history entries using one Switch ID into using another Switch ID
-#[allow(dead_code)]
 pub async fn update_switch_ids(
     txn: &mut PgConnection,
     old_switch_id: &SwitchId,

--- a/crates/api-model/src/power_shelf/mod.rs
+++ b/crates/api-model/src/power_shelf/mod.rs
@@ -165,7 +165,6 @@ impl TryFrom<PowerShelf> for rpc::PowerShelf {
 }
 
 impl PowerShelf {
-    #[allow(dead_code)]
     pub fn is_marked_as_deleted(&self) -> bool {
         self.deleted.is_some()
     }

--- a/crates/api-model/src/power_shelf/power_shelf_id.rs
+++ b/crates/api-model/src/power_shelf/power_shelf_id.rs
@@ -51,7 +51,6 @@ pub fn from_hardware_info(
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, thiserror::Error)]
-#[allow(dead_code)]
 pub enum MissingHardwareInfo {
     #[error("The TPM certificate has no bytes")]
     TPMCertEmpty,

--- a/crates/api-model/src/switch/mod.rs
+++ b/crates/api-model/src/switch/mod.rs
@@ -260,7 +260,6 @@ impl From<SwitchStateHistoryRecord> for rpc::SwitchStateHistoryRecord {
 }
 
 impl Switch {
-    #[allow(dead_code)]
     pub fn is_marked_as_deleted(&self) -> bool {
         self.deleted.is_some()
     }

--- a/crates/api-model/src/switch/switch_id.rs
+++ b/crates/api-model/src/switch/switch_id.rs
@@ -47,7 +47,6 @@ pub fn from_hardware_info(
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, thiserror::Error)]
-#[allow(dead_code)]
 pub enum MissingHardwareInfo {
     #[error("The TPM certificate has no bytes")]
     TPMCertEmpty,

--- a/crates/api/src/dpa/lockdown.rs
+++ b/crates/api/src/dpa/lockdown.rs
@@ -93,8 +93,8 @@ pub fn build_lockdown_key(
 // version.
 //
 // TODO(chet): Once I update the unlock flow to support
-// multiple unlock keys, I'll remove this.
-#[allow(dead_code)]
+// multiple unlock keys, I'll remove the #[cfg(test)].
+#[cfg(test)]
 pub fn derive_candidate_keys(
     site_wide_root: &[u8],
     ctx: &KdfContext,
@@ -153,25 +153,6 @@ pub async fn build_supernic_lockdown_key(
     let ctx = build_kdf_context(txn, dpa_interface_id).await?;
     let secret = fetch_kdf_secret(credential_provider).await?;
     build_lockdown_key(secret.as_bytes(), &ctx, KdfContextVersion::V1)
-}
-
-// build_supernic_lockdown_keys builds all candidate lockdown keys
-// for the given SuperNIC, covering all KdfContextVersions. Use
-// this for unlocking a card, where we may need to try multiple
-// key versions.
-//
-// TODO(chet): Once I update the unlock flow to support
-// multiple unlock keys, I'll remove this.
-#[allow(dead_code)]
-#[allow(txn_held_across_await)]
-pub async fn build_supernic_lockdown_keys(
-    txn: &mut PgConnection,
-    dpa_interface_id: DpaInterfaceId,
-    credential_provider: &dyn CredentialProvider,
-) -> Result<Vec<String>, eyre::Report> {
-    let ctx = build_kdf_context(txn, dpa_interface_id).await?;
-    let secret = fetch_kdf_secret(credential_provider).await?;
-    derive_candidate_keys(secret.as_bytes(), &ctx)
 }
 
 #[cfg(test)]

--- a/crates/api/src/handlers/expected_power_shelf.rs
+++ b/crates/api/src/handlers/expected_power_shelf.rs
@@ -340,7 +340,6 @@ pub async fn get_all_expected_power_shelves_linked(
 
 // Utility method called by `explore`. Not a grpc handler.
 // TODO(chet): Remove dead_code once the exploration is wired up.
-#[allow(dead_code)]
 pub(crate) async fn query(
     api: &Api,
     mac: MacAddress,

--- a/crates/api/src/handlers/expected_switch.rs
+++ b/crates/api/src/handlers/expected_switch.rs
@@ -297,7 +297,6 @@ pub async fn get_all_expected_switches_linked(
 
 // Utility method called by `explore`. Not a grpc handler.
 // TODO(chet): Remove dead_code once wired up with the explorer.
-#[allow(dead_code)]
 pub(crate) async fn query(
     api: &Api,
     mac: MacAddress,

--- a/crates/api/src/nvlink.rs
+++ b/crates/api/src/nvlink.rs
@@ -52,7 +52,6 @@ pub trait NmxmClientPool: Send + Sync + 'static {
     ) -> Result<Box<dyn Nmxm>, NvLinkPartitionError>;
 }
 
-#[allow(dead_code)]
 #[derive(Debug)]
 pub struct NmxmClientPoolImpl<C> {
     pool: libnmxm::NmxmClientPool,

--- a/crates/api/src/state_controller/controller/processor.rs
+++ b/crates/api/src/state_controller/controller/processor.rs
@@ -111,10 +111,10 @@ impl std::default::Default for DataSinceStartOfIteration {
 }
 
 #[derive(Debug, Copy, Clone)]
-#[allow(dead_code)]
 pub(super) struct SingleIterationResult {
     /// The amount of object handling tasks that have been dequeued from the database
     /// and dispatched for handling
+    #[allow(dead_code)]
     pub(super) num_dispatched_tasks: usize,
     /// The amount of object handling tasks which completed
     pub(super) num_completed_tasks: usize,
@@ -138,9 +138,9 @@ pub(super) struct StatsSinceLastLog {
 }
 
 #[derive(Debug, Default, Clone)]
-#[allow(dead_code)]
 struct QueueStats {
     /// The ID of the latest iteration that had been started
+    #[allow(dead_code)]
     latest_iteration: Option<ControllerIterationId>,
     /// The ID of the last iteration (before the most recent one)
     previous_iteration: Option<ControllerIterationId>,
@@ -768,6 +768,7 @@ async fn process_object<IO: StateControllerIO>(
     if let Some(next_state) = &metrics.common.next_state {
         state_change_emitter.emit(StateChangeEvent {
             object_id: &object_id,
+            #[cfg(test)]
             previous_state: metrics.common.initial_state.as_ref(),
             new_state: next_state,
             timestamp: chrono::Utc::now(),

--- a/crates/api/src/state_controller/state_change_emitter.rs
+++ b/crates/api/src/state_controller/state_change_emitter.rs
@@ -28,7 +28,7 @@ pub struct StateChangeEvent<'a, Id, S> {
     /// The ID of the object that changed state.
     pub object_id: &'a Id,
     /// The state before the transition (if known).
-    #[allow(dead_code)] // not used by any hooks yet
+    #[cfg(test)] // not used by any hooks yet, only used in tests
     pub previous_state: Option<&'a S>,
     /// The new state after the transition.
     pub new_state: &'a S,

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -332,9 +332,7 @@ pub struct TestEnv {
     pub machine_state_handler: SwapHandler<MachineStateHandler>,
     network_segment_controller: Arc<Mutex<StateController<NetworkSegmentStateControllerIO>>>,
     ib_partition_controller: Arc<Mutex<StateController<IBPartitionStateControllerIO>>>,
-    #[allow(dead_code)]
     power_shelf_controller: Arc<Mutex<StateController<PowerShelfStateControllerIO>>>,
-    #[allow(dead_code)]
     switch_controller: Arc<Mutex<StateController<SwitchStateControllerIO>>>,
     pub reachability_params: ReachabilityParams,
     pub test_meter: TestMeter,
@@ -589,7 +587,6 @@ impl TestEnv {
     /// Runs one iteration of the power shelf state controller handler with the services
     /// in this test environment
     #[allow(clippy::await_holding_refcell_ref)]
-    #[allow(dead_code)]
     pub async fn run_power_shelf_controller_iteration(&self) {
         self.power_shelf_controller
             .lock()
@@ -601,7 +598,6 @@ impl TestEnv {
     /// Runs one iteration of the switch state controller handler with the services
     /// in this test environment
     #[allow(clippy::await_holding_refcell_ref)]
-    #[allow(dead_code)]
     pub async fn run_switch_controller_iteration(&self) {
         self.switch_controller
             .lock()
@@ -611,7 +607,6 @@ impl TestEnv {
     }
 
     /// Runs power shelf controller iterations until a condition is met
-    #[allow(dead_code)]
     pub async fn run_power_shelf_controller_iteration_until_condition(
         &self,
         max_iterations: u32,
@@ -630,7 +625,6 @@ impl TestEnv {
     }
 
     /// Runs switch controller iterations until a condition is met
-    #[allow(dead_code)]
     pub async fn run_switch_controller_iteration_until_condition(
         &self,
         max_iterations: u32,
@@ -1666,10 +1660,8 @@ pub async fn create_test_env_with_overrides(
         machine_state_handler: machine_swap,
         ib_fabric_monitor: Arc::new(ib_fabric_monitor),
         ib_partition_controller: Arc::new(Mutex::new(ib_controller)),
-        #[allow(dead_code)]
         switch_controller: Arc::new(Mutex::new(switch_controller)),
         network_segment_controller: Arc::new(Mutex::new(network_controller)),
-        #[allow(dead_code)]
         power_shelf_controller: Arc::new(Mutex::new(power_shelf_controller)),
         reachability_params,
         attestation_enabled,

--- a/crates/api/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/site_explorer.rs
@@ -1514,26 +1514,8 @@ pub async fn new_power_shelf(
     Ok(power_shelf_id)
 }
 
-#[allow(dead_code)]
-pub async fn new_power_shelfs(env: &TestEnv, count: u32) -> eyre::Result<Vec<PowerShelfId>> {
-    let mut power_shelf_ids = Vec::new();
-    for i in 0..count {
-        power_shelf_ids.push(
-            new_power_shelf(
-                env,
-                Some(format!("Test Power Shelf {}", i)),
-                None,
-                None,
-                None,
-            )
-            .await?,
-        );
-    }
-    Ok(power_shelf_ids)
-}
-
 /// Creates a new switch for testing purposes
-#[allow(dead_code)]
+#[cfg(test)]
 pub async fn new_switch(
     env: &TestEnv,
     name: Option<String>,

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -144,9 +144,7 @@ struct FakePowerShelf {
     pub bmc_password: String,
     #[allow(dead_code)]
     pub dhcp_vendor: String,
-    #[allow(dead_code)]
     pub segment: NetworkSegmentId,
-    #[allow(dead_code)]
     pub ip: String, // DHCP assigned IP (may be different from ip_address)
 }
 

--- a/crates/api/src/tests/state_controller.rs
+++ b/crates/api/src/tests/state_controller.rs
@@ -393,10 +393,10 @@ async fn test_queue_objects(pool: sqlx::PgPool) -> sqlx::Result<()> {
 struct TestStateControllerIO {}
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct TestObject {
     pub id: String,
     pub controller_state: Versioned<TestObjectControllerState>,
+    #[allow(dead_code)]
     pub controller_state_outcome: Option<PersistentStateHandlerOutcome>,
 }
 

--- a/crates/api/src/tests/switch_state_controller/fixtures/switch.rs
+++ b/crates/api/src/tests/switch_state_controller/fixtures/switch.rs
@@ -16,60 +16,8 @@
  */
 
 use carbide_uuid::switch::SwitchId;
-use model::switch::{SwitchConfig, SwitchControllerState, SwitchStatus};
+use model::switch::SwitchControllerState;
 use sqlx::PgConnection;
-
-/// Creates a basic switch configuration for testing
-#[allow(dead_code)]
-pub fn create_basic_switch_config() -> SwitchConfig {
-    SwitchConfig {
-        name: "Basic Test Switch".to_string(),
-        enable_nmxc: false,
-        fabric_manager_config: None,
-        location: Some("Data Center A, Rack 1".to_string()),
-    }
-}
-
-/// Creates an NMXC switch configuration for testing
-#[allow(dead_code)]
-pub fn create_nmxc_switch_config() -> SwitchConfig {
-    SwitchConfig {
-        name: "High Capacity Switch".to_string(),
-        enable_nmxc: true,
-        fabric_manager_config: None,
-        location: Some("Data Center B, Rack 2".to_string()),
-    }
-}
-
-/// Creates a switch status for testing
-#[allow(dead_code)]
-pub fn create_test_switch_status() -> SwitchStatus {
-    SwitchStatus {
-        switch_name: "Test Switch".to_string(),
-        power_state: "on".to_string(),
-        health_status: "ok".to_string(),
-    }
-}
-
-/// Creates a switch status with warning health
-#[allow(dead_code)]
-pub fn create_warning_switch_status() -> SwitchStatus {
-    SwitchStatus {
-        switch_name: "Warning Switch".to_string(),
-        power_state: "on".to_string(),
-        health_status: "warning".to_string(),
-    }
-}
-
-/// Creates a switch status with critical health
-#[allow(dead_code)]
-pub fn create_critical_switch_status() -> SwitchStatus {
-    SwitchStatus {
-        switch_name: "Critical Switch".to_string(),
-        power_state: "off".to_string(),
-        health_status: "critical".to_string(),
-    }
-}
 
 /// Helper function to set switch controller state directly in database
 pub async fn set_switch_controller_state(
@@ -92,22 +40,6 @@ pub async fn mark_switch_as_deleted(
     switch_id: &SwitchId,
 ) -> Result<(), sqlx::Error> {
     sqlx::query("UPDATE switches SET deleted = NOW() WHERE id = $1")
-        .bind(switch_id)
-        .execute(txn)
-        .await?;
-
-    Ok(())
-}
-
-/// Helper function to update switch status
-#[allow(dead_code)]
-pub async fn update_switch_status(
-    txn: &mut PgConnection,
-    switch_id: &SwitchId,
-    status: &SwitchStatus,
-) -> Result<(), sqlx::Error> {
-    sqlx::query("UPDATE switches SET status = $1 WHERE id = $2")
-        .bind(serde_json::to_value(status).unwrap())
         .bind(switch_id)
         .execute(txn)
         .await?;

--- a/crates/libmlx/src/device/discovery.rs
+++ b/crates/libmlx/src/device/discovery.rs
@@ -79,8 +79,7 @@ struct VersionXml {
     #[serde(rename = "@current")]
     current: String,
     #[serde(rename = "@available")]
-    #[allow(dead_code)]
-    available: String,
+    _available: String,
 }
 
 // MacsXml represents MAC address information from

--- a/crates/libmlx/tests/runner/common/mod.rs
+++ b/crates/libmlx/tests/runner/common/mod.rs
@@ -25,7 +25,6 @@ use libmlx::variables::variable::MlxConfigVariable;
 use serde_json::json;
 
 /// Creates a test registry with common variable types for testing
-#[allow(dead_code)]
 pub fn create_test_registry() -> MlxVariableRegistry {
     let variables = vec![
         // Boolean variable
@@ -131,7 +130,6 @@ pub fn create_test_registry() -> MlxVariableRegistry {
 }
 
 /// Creates a simple registry with minimal variables for focused testing
-#[allow(dead_code)]
 pub fn create_minimal_test_registry() -> MlxVariableRegistry {
     let variables = vec![
         MlxConfigVariable::builder()
@@ -152,7 +150,6 @@ pub fn create_minimal_test_registry() -> MlxVariableRegistry {
 }
 
 /// Creates sample mlxconfig JSON response for testing
-#[allow(dead_code)]
 pub fn create_sample_json_response(device: &str) -> serde_json::Value {
     json!({
         "Device #1": {
@@ -202,7 +199,6 @@ pub fn create_sample_json_response(device: &str) -> serde_json::Value {
 }
 
 /// Creates sample JSON response with array variables
-#[allow(dead_code)]
 pub fn create_array_json_response(device: &str) -> serde_json::Value {
     json!({
         "Device #1": {
@@ -343,7 +339,6 @@ pub fn create_array_json_response(device: &str) -> serde_json::Value {
 }
 
 /// Creates test device info
-#[allow(dead_code)]
 pub fn create_test_device_info() -> QueriedDeviceInfo {
     QueriedDeviceInfo::new()
         .with_device_id("01:00.0")

--- a/crates/mqttea/tests/client.rs
+++ b/crates/mqttea/tests/client.rs
@@ -100,19 +100,6 @@ impl<T> TestHandler<T> {
             count: Arc::new(AtomicUsize::new(0)),
         }
     }
-
-    #[allow(dead_code)]
-    async fn get_messages(&self) -> Vec<(T, String)>
-    where
-        T: Clone,
-    {
-        self.messages.lock().await.clone()
-    }
-
-    #[allow(dead_code)]
-    fn message_count(&self) -> usize {
-        self.count.load(Ordering::Relaxed)
-    }
 }
 
 // Verify rumqttc client is async.

--- a/crates/nras/src/keystore.rs
+++ b/crates/nras/src/keystore.rs
@@ -21,10 +21,10 @@ use jsonwebtoken as jst;
 
 use crate::NrasError;
 
-#[allow(dead_code)]
 #[derive(Debug, serde::Deserialize)]
 struct Jwk {
     kty: String,
+    #[allow(dead_code)]
     crv: Option<String>,
     kid: String,
     x: Option<String>,

--- a/crates/scout/src/mlx_device.rs
+++ b/crates/scout/src/mlx_device.rs
@@ -24,7 +24,7 @@ use carbide_uuid::machine::MachineId;
 use libmlx::device::discovery;
 use libmlx::device::report::MlxDeviceReport;
 use libmlx::lockdown::error::MlxResult;
-use libmlx::lockdown::lockdown::{LockStatus, LockdownManager, StatusReport};
+use libmlx::lockdown::lockdown::{LockdownManager, StatusReport};
 use libmlx::profile::error::MlxProfileError;
 use libmlx::profile::serialization::SerializableProfile;
 use libmlx::registry::registries;
@@ -106,16 +106,6 @@ pub fn unlock_device(device_address: &str, key: &str) -> MlxResult<()> {
     let manager = LockdownManager::new()?;
     manager.unlock_device(device_address, key)?;
     Ok(())
-}
-
-// device_lockdown_status returns the current lockdown status of
-// a device (locked or unlocked). See above comments in lock_device
-// about the device_address argument formatting options.
-#[allow(dead_code)]
-pub fn device_lockdown_status(device_address: &str) -> MlxResult<LockStatus> {
-    let manager = LockdownManager::new()?;
-    let status = manager.get_status(device_address)?;
-    Ok(status)
 }
 
 pub fn handle_profile_sync(

--- a/crates/ssh-console/tests/main.rs
+++ b/crates/ssh-console/tests/main.rs
@@ -35,8 +35,6 @@ use util::ssh_console_test_helper;
 use crate::util::ssh_client::PermissiveSshClient;
 use crate::util::{BaselineTestAssertion, MockBmcType, run_baseline_test_environment};
 
-#[allow(dead_code)]
-static TENANT_SSH_KEY: &str = include_str!("fixtures/tenant_ssh_key");
 static TENANT_SSH_PUBKEY: &str = include_str!("fixtures/tenant_ssh_key.pub");
 
 lazy_static! {


### PR DESCRIPTION
## Description

There are a ton of `#[allow(dead_code)]` annotations for code that isn't dead.

There are also a lot of `#[allow(dead_code)]` annotations for code that should just be deleted (various helper functions.)

With this change, only keep dead code around if it's clear the data model needs a certain field, even if we're not reading it right now (started_at for state controller iterations, etc.)

If there is any code here getting deleted that we want eventually, we should use the git history.
## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes

There's no need to ever preemtively add code to this repo that we're not using.