### PR TITLE
Return pxe instructions when machine is in WaitingForManualUpgrade

### DIFF
--- a/crates/api/src/ipxe.rs
+++ b/crates/api/src/ipxe.rs
@@ -20,8 +20,8 @@ use db::{self};
 use mac_address::MacAddress;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{
-    DpuInitState, FailureCause, FailureDetails, InstanceState, ManagedHostState, MeasuringState,
-    ReprovisionState, ValidationState,
+    DpuInitState, FailureCause, FailureDetails, HostReprovisionState, InstanceState,
+    ManagedHostState, MeasuringState, ReprovisionState, ValidationState,
 };
 use model::pxe::PxeInstructionRequest;
 use sqlx::PgConnection;
@@ -441,6 +441,16 @@ exit ||
 
                 _ => error_instructions(machine_id, target.interface_id, machine.current_state()),
             },
+            ManagedHostState::HostReprovision {
+                reprovision_state: HostReprovisionState::WaitingForManualUpgrade { .. },
+                ..
+            } => PxeInstructions::get_pxe_instruction_for_arch(
+                target.arch,
+                target.interface_id,
+                interface.mac_address,
+                console,
+                machine.id.machine_type(),
+            ),
             x => error_instructions(machine_id, target.interface_id, x),
         };
 


### PR DESCRIPTION
## Description
When a machine is in `HostReprovisioning/WaitingForManualUpgrade`, we need to ssh into scout, run some manual commands to upgrade CX7/etc and then AC powercyle it with `ipmitool raw 0x3c 0xA2`. At that point it never comes back to scout currently because iPXE returns error instructions for this state. Fixing this here.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

