### PR TITLE
chore: Simplify linux-build flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,7 +1450,6 @@ dependencies = [
  "tonic 0.14.2",
  "tracing",
  "tracing-subscriber",
- "tss-esapi",
  "uuid",
  "version-compare 0.2.1",
 ]
@@ -1636,7 +1635,6 @@ name = "carbide-dns"
 version = "0.0.1"
 dependencies = [
  "async-trait",
- "carbide-host-support",
  "carbide-rpc",
  "carbide-tls",
  "carbide-version",
@@ -2298,15 +2296,8 @@ dependencies = [
 name = "carbide-systemd"
 version = "0.0.0"
 dependencies = [
- "carbide-host-support",
- "carbide-rpc",
  "eyre",
- "rand 0.9.2",
- "serde",
- "serde_json",
- "thiserror 2.0.17",
  "tokio",
- "tonic 0.14.2",
  "tracing",
 ]
 

--- a/crates/api-db/Cargo.toml
+++ b/crates/api-db/Cargo.toml
@@ -76,20 +76,10 @@ tokio = { workspace = true }
 toml = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
-tss-esapi = { optional = true, workspace = true }
 uuid = { features = ["v4", "serde"], workspace = true }
 hickory-proto = { workspace = true }
 version-compare = { workspace = true }
 #these are alphabetized
-
-[features]
-default = ["linux-build"]
-linux-build = [
-  "tss-esapi",
-  "carbide-sqlx-testing/linux-build",
-  "carbide-host-support/linux-build",
-  "carbide-api-model/linux-build",
-]
 
 [build-dependencies]
 carbide-version = { path = "../version" }
@@ -97,7 +87,7 @@ carbide-version = { path = "../version" }
 [dev-dependencies]
 lazy_static = { workspace = true }
 carbide-macros = { path = "../macros" }
-carbide-sqlx-testing = { path = "../sqlx-testing", default-features = false }
+carbide-sqlx-testing = { path = "../sqlx-testing" }
 tracing-subscriber = { workspace = true }
 ctor = { workspace = true }
 

--- a/crates/api-db/src/attestation/mod.rs
+++ b/crates/api-db/src/attestation/mod.rs
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-#[cfg(feature = "linux-build")]
 pub mod secret_ak_pub;
 
 pub mod ek_cert_verification_status;

--- a/crates/api-integration-tests/Cargo.toml
+++ b/crates/api-integration-tests/Cargo.toml
@@ -46,7 +46,3 @@ tracing = { workspace = true }
 
 [lints]
 workspace = true
-
-[features]
-default = ["linux-build"]
-linux-build = ["carbide-api-test-helper/linux-build"]

--- a/crates/api-model/Cargo.toml
+++ b/crates/api-model/Cargo.toml
@@ -83,14 +83,6 @@ version-compare = { workspace = true }
 tokio = { workspace = true }
 #these are alphabetized
 
-[features]
-default = ["linux-build"]
-linux-build = [
-  "tss-esapi",
-  "carbide-sqlx-testing/linux-build",
-  "carbide-host-support/linux-build",
-]
-
 [build-dependencies]
 carbide-version = { path = "../version" }
 

--- a/crates/api-model/src/hardware_info.rs
+++ b/crates/api-model/src/hardware_info.rs
@@ -17,16 +17,13 @@
 
 //! Describes hardware that is discovered by Forge
 
-#[cfg(not(feature = "linux-build"))]
-use std::collections::HashSet;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 use ::rpc::errors::RpcDataConversionError;
 use base64::prelude::*;
-#[cfg(feature = "linux-build")]
-use carbide_host_support::hardware_enumeration::aggregate_cpus;
+use carbide_host_support::cpu::aggregate_cpus;
 use carbide_uuid::nvlink::NvLinkDomainId;
 use forge_network::{MELLANOX_SF_VF_MAC_ADDRESS_IN, MELLANOX_SF_VF_MAC_ADDRESS_OUT};
 use mac_address::{MacAddress, MacParseError};
@@ -65,24 +62,6 @@ struct HardwareInfoDeserialized {
     cpus: Vec<Cpu>, // Deprecated in favor of `cpu_info`
     #[serde(default)]
     tpm_description: Option<TpmDescription>,
-}
-
-#[cfg(not(feature = "linux-build"))]
-fn aggregate_cpus(cpus: &[rpc::machine_discovery::Cpu]) -> Vec<rpc::machine_discovery::CpuInfo> {
-    if cpus.is_empty() {
-        return Vec::new();
-    }
-
-    let socket_count = HashSet::<_>::from_iter(cpus.iter().map(|cpu| cpu.socket)).len();
-    let core_count = HashSet::<_>::from_iter(cpus.iter().map(|cpu| (cpu.socket, cpu.core))).len();
-
-    vec![rpc::machine_discovery::CpuInfo {
-        model: cpus[0].model.clone(),
-        vendor: cpus[0].vendor.clone(),
-        sockets: socket_count as u32,
-        cores: core_count as u32,
-        threads: cpus.len() as u32,
-    }]
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/api-test-helper/Cargo.toml
+++ b/crates/api-test-helper/Cargo.toml
@@ -76,6 +76,3 @@ carbide-version = { path = "../version" }
 
 [lints]
 workspace = true
-
-[features]
-linux-build = ["carbide-api/linux-build"]

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -175,10 +175,6 @@ x509-parser = { features = ["verify"], workspace = true }
 default = ["linux-build"]
 linux-build = [
   "tss-esapi",
-  "carbide-sqlx-testing/linux-build",
-  "carbide-host-support/linux-build",
-  "carbide-api-model/linux-build",
-  "carbide-api-db/linux-build",
 ]
 
 [build-dependencies]

--- a/crates/api/src/attestation/mod.rs
+++ b/crates/api/src/attestation/mod.rs
@@ -15,20 +15,12 @@
  * limitations under the License.
  */
 
-#[cfg(feature = "linux-build")]
 pub mod measured_boot;
-#[cfg(feature = "linux-build")]
-#[cfg(test)]
-pub use measured_boot::do_compare_pub_key_against_cert;
-#[cfg(feature = "linux-build")]
-pub use measured_boot::{
-    cli_make_cred, compare_pub_key_against_cert, event_log_to_string, has_passed_attestation,
-    verify_pcr_hash, verify_quote_state, verify_signature,
-};
 
 pub mod tpm_ca_cert;
 use carbide_uuid::machine::MachineId;
 use db::{ObjectFilter, Transaction};
+pub use measured_boot::*;
 use model::hardware_info::TpmEkCertificate;
 use model::machine::machine_search_config::MachineSearchConfig;
 use sqlx::{PgConnection, Pool, Postgres};

--- a/crates/api/src/handlers/attestation.rs
+++ b/crates/api/src/handlers/attestation.rs
@@ -23,13 +23,7 @@ use db::attestation::spdm::{
 use itertools::Itertools;
 use model::attestation::spdm::SpdmMachineAttestation;
 use tonic::{Request, Response, Status};
-#[cfg(feature = "linux-build")]
-use tss_esapi::{
-    structures::{Attest, Public as TssPublic, Signature},
-    traits::UnMarshall,
-};
 
-#[cfg(feature = "linux-build")]
 use crate::CarbideError;
 use crate::api::{Api, log_request_data};
 use crate::handlers::utils::convert_and_log_machine_id;
@@ -112,7 +106,6 @@ pub(crate) async fn list_machines_under_attestation(
     }))
 }
 
-#[cfg(feature = "linux-build")]
 pub(crate) async fn attest_quote(
     api: &Api,
     request: Request<rpc::AttestQuoteRequest>,
@@ -137,38 +130,31 @@ pub(crate) async fn attest_quote(
             }
         };
 
-    let ak_pub = TssPublic::unmarshall(ak_pub_bytes.as_slice())
-        .map_err(|e| CarbideError::AttestQuoteError(format!("Could not unmarshal AK Pub: {e}")))?;
-
-    let attest = Attest::unmarshall(&request.attestation).map_err(|e| {
-        CarbideError::AttestQuoteError(format!("Could not unmarshall Attest struct: {e}"))
-    })?;
-
-    let signature = Signature::unmarshall(&request.signature).map_err(|e| {
-        CarbideError::AttestQuoteError(format!("Could not unmarshall Signature struct: {e}"))
-    })?;
-
     // Make sure sure the signature can at least be verified
     // as valid or invalid. If it can't be verified in any
     // way at all, return an error.
-    let signature_valid =
-        crate::attestation::verify_signature(&ak_pub, &request.attestation, &signature)
-            .inspect_err(|_| {
-                tracing::warn!(
-                    "PCR signature verification failed (event log: {})",
-                    crate::attestation::event_log_to_string(&request.event_log)
-                );
-            })?;
+    let signature_valid = crate::attestation::verify_signature(
+        &ak_pub_bytes,
+        &request.attestation,
+        &request.signature,
+    )
+    .inspect_err(|_| {
+        tracing::warn!(
+            "PCR signature verification failed (event log: {})",
+            crate::attestation::event_log_to_string(&request.event_log)
+        );
+    })?;
 
     // Make sure we can verify the the PCR hash one way
     // or another. If it can't be, return an error.
-    let pcr_hash_matches = crate::attestation::verify_pcr_hash(&attest, &request.pcr_values)
-        .inspect_err(|_| {
-            tracing::warn!(
-                "PCR hash verification failed (event log: {})",
-                crate::attestation::event_log_to_string(&request.event_log)
-            );
-        })?;
+    let pcr_hash_matches =
+        crate::attestation::verify_pcr_hash(&request.attestation, &request.pcr_values)
+            .inspect_err(|_| {
+                tracing::warn!(
+                    "PCR hash verification failed (event log: {})",
+                    crate::attestation::event_log_to_string(&request.event_log)
+                );
+            })?;
 
     // And now pass on through the computed signature
     // validity and PCR hash match to see if execution can
@@ -249,12 +235,4 @@ pub(crate) async fn attest_quote(
         success: true,
         machine_certificate: Some(certificate.into()),
     }))
-}
-
-#[cfg(not(feature = "linux-build"))]
-pub(crate) async fn attest_quote(
-    _api: &Api,
-    _request: Request<rpc::AttestQuoteRequest>,
-) -> std::result::Result<Response<rpc::AttestQuoteResponse>, Status> {
-    unimplemented!()
 }

--- a/crates/api/src/handlers/mod.rs
+++ b/crates/api/src/handlers/mod.rs
@@ -49,7 +49,6 @@ pub mod machine_quarantine;
 pub mod machine_scout;
 pub mod machine_validation;
 pub mod managed_host;
-#[cfg(feature = "linux-build")]
 pub mod measured_boot;
 pub mod mlx_admin;
 pub mod network_devices;

--- a/crates/api/src/tests/common/api_fixtures/tpm_attestation.rs
+++ b/crates/api/src/tests/common/api_fixtures/tpm_attestation.rs
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+// Some data is used only by linux-build tests, but it's not worth peppering #[cfg] lines everywhere
+#![cfg_attr(not(feature = "linux-build"), allow(dead_code))]
+
 pub const AK_PUB_SERIALIZED: [u8; 280] = [
     0, 1, 0, 11, 0, 5, 0, 114, 0, 0, 0, 16, 0, 22, 0, 11, 8, 0, 0, 0, 0, 0, 1, 0, 197, 213, 201,
     224, 218, 94, 188, 183, 101, 132, 200, 245, 5, 232, 37, 49, 46, 89, 171, 230, 112, 64, 108, 96,
@@ -249,7 +252,6 @@ pub const EK_PUB_SERIALIZED: [u8; 314] = [
     37, 35, 105, 163, 200, 56, 233, 254, 7, 165, 40, 33, 189, 226, 206, 145,
 ];
 
-#[cfg(feature = "linux-build")]
 // attestation as it is sent from scout to carbide
 pub const ATTEST_SERIALIZED: [u8; 129] = [
     255, 84, 67, 71, 128, 24, 0, 34, 0, 11, 86, 42, 234, 64, 215, 49, 217, 219, 109, 205, 122, 208,
@@ -260,7 +262,6 @@ pub const ATTEST_SERIALIZED: [u8; 129] = [
     55, 215, 242, 130, 251, 89, 92, 188, 251, 113, 20, 127, 251, 198, 74, 188,
 ];
 
-#[cfg(feature = "linux-build")]
 // signature as it is sent from scout to carbide
 pub const SIGNATURE_SERIALIZED: [u8; 262] = [
     0, 22, 0, 11, 1, 0, 81, 47, 118, 82, 6, 100, 40, 191, 204, 125, 109, 165, 201, 104, 63, 55,
@@ -278,7 +279,6 @@ pub const SIGNATURE_SERIALIZED: [u8; 262] = [
     233, 168, 30, 69, 134, 181, 227, 106, 220, 218, 166, 242, 45, 93,
 ];
 
-#[cfg(feature = "linux-build")]
 pub const SIGNATURE_SERIALIZED_INVALID: [u8; 262] = [
     0, 22, 0, 11, 1, 0, 171, 33, 190, 68, 89, 71, 190, 125, 172, 120, 100, 63, 101, 236, 168, 171,
     90, 209, 161, 89, 156, 193, 87, 74, 57, 203, 179, 84, 240, 213, 128, 158, 39, 132, 212, 18, 25,
@@ -295,14 +295,12 @@ pub const SIGNATURE_SERIALIZED_INVALID: [u8; 262] = [
     50, 240, 53, 223, 9, 213, 255, 190, 231, 214, 11, 126, 155, 19, 190,
 ];
 
-#[cfg(feature = "linux-build")]
 // credential as it is sent from scout to carbide
 pub const CRED_SERIALIZED: [u8; 32] = [
     47, 191, 142, 91, 237, 86, 32, 168, 119, 196, 199, 149, 110, 183, 182, 192, 193, 99, 101, 208,
     107, 198, 254, 254, 10, 146, 61, 122, 138, 2, 82, 79,
 ];
 
-#[cfg(feature = "linux-build")]
 // pcr values as those are sent from scout to carbide
 pub const PCR_VALUES: [[u8; 32]; 12] = [
     [
@@ -355,20 +353,17 @@ pub const PCR_VALUES: [[u8; 32]; 12] = [
     ],
 ];
 
-#[cfg(feature = "linux-build")]
 // serialized version of the cryptographic name (i.e. some SHA) of the AK
 pub const AK_NAME: [u8; 34] = [
     0, 11, 156, 103, 195, 162, 106, 182, 77, 69, 39, 156, 55, 160, 196, 165, 213, 65, 105, 238,
     251, 75, 243, 144, 166, 24, 132, 177, 159, 77, 184, 23, 17, 253,
 ];
 
-#[cfg(feature = "linux-build")]
 // a credential
 pub const SESSION_KEY: [u8; 14] = [
     141, 70, 165, 215, 36, 253, 82, 215, 110, 6, 82, 11, 100, 242,
 ];
 
-#[cfg(feature = "linux-build")]
 pub const AK_PUB_SERIALIZED_2: [u8; 280] = [
     0, 1, 0, 11, 0, 5, 0, 114, 0, 0, 0, 16, 0, 22, 0, 11, 8, 0, 0, 0, 0, 0, 1, 0, 183, 98, 82, 64,
     227, 242, 101, 235, 94, 190, 115, 98, 139, 145, 176, 117, 64, 80, 27, 131, 8, 234, 223, 32, 34,
@@ -386,7 +381,6 @@ pub const AK_PUB_SERIALIZED_2: [u8; 280] = [
     42, 41, 68, 177,
 ];
 
-#[cfg(feature = "linux-build")]
 pub const SIGNATURE_SERIALIZED_2: [u8; 262] = [
     0, 22, 0, 11, 1, 0, 171, 33, 190, 68, 89, 71, 190, 125, 172, 120, 100, 63, 101, 236, 168, 171,
     90, 209, 161, 89, 156, 193, 87, 74, 57, 203, 179, 84, 240, 213, 128, 158, 39, 132, 212, 18, 25,
@@ -403,7 +397,6 @@ pub const SIGNATURE_SERIALIZED_2: [u8; 262] = [
     50, 240, 53, 223, 9, 213, 255, 190, 231, 214, 11, 126, 155, 19, 190,
 ];
 
-#[cfg(feature = "linux-build")]
 pub const ATTEST_SERIALIZED_2: [u8; 129] = [
     255, 84, 67, 71, 128, 24, 0, 34, 0, 11, 131, 45, 55, 82, 140, 235, 232, 215, 180, 133, 115,
     220, 203, 79, 13, 153, 10, 168, 230, 203, 59, 199, 64, 128, 150, 218, 164, 66, 52, 72, 227,
@@ -413,7 +406,6 @@ pub const ATTEST_SERIALIZED_2: [u8; 129] = [
     128, 145, 55, 215, 242, 130, 251, 89, 92, 188, 251, 113, 20, 127, 251, 198, 74, 188,
 ];
 
-#[cfg(feature = "linux-build")]
 pub const PCR_VALUES_SHORT: [[u8; 32]; 2] = [
     [
         164, 126, 4, 71, 192, 152, 159, 113, 199, 82, 135, 160, 29, 112, 174, 109, 44, 162, 41,
@@ -425,7 +417,6 @@ pub const PCR_VALUES_SHORT: [[u8; 32]; 2] = [
     ],
 ];
 
-#[cfg(feature = "linux-build")]
 pub const ATTEST_SERIALIZED_SHORT: [u8; 129] = [
     255, 84, 67, 71, 128, 24, 0, 34, 0, 11, 44, 93, 55, 234, 83, 198, 195, 90, 85, 14, 189, 234,
     103, 243, 125, 164, 152, 193, 21, 104, 96, 147, 159, 210, 223, 11, 3, 238, 198, 190, 62, 99, 0,

--- a/crates/certs/Cargo.toml
+++ b/crates/certs/Cargo.toml
@@ -34,7 +34,7 @@ tonic = { workspace = true }
 tracing = { workspace = true }
 
 # [local-dependencies]
-carbide-host-support = { path = "../host-support" }
+carbide-host-support = { path = "../host-support", default-features = false }
 carbide-tls = { path = "../tls" }
 carbide-rpc = { path = "../rpc" }
 

--- a/crates/dns/Cargo.toml
+++ b/crates/dns/Cargo.toml
@@ -47,7 +47,6 @@ trust-dns-resolver = { workspace = true }
 
 # [local-dependencies]
 dns-record = { path = "../dns-record" }
-carbide-host-support = { path = "../host-support" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 toml = { workspace = true }

--- a/crates/dpu-otel-agent/Cargo.toml
+++ b/crates/dpu-otel-agent/Cargo.toml
@@ -46,7 +46,7 @@ typed-builder = { workspace = true }
 
 # [local-dependencies]
 carbide-certs = { path = "../certs" }
-carbide-host-support = { path = "../host-support" }
+carbide-host-support = { path = "../host-support", default-features = false }
 carbide-systemd = { path = "../systemd" }
 carbide-tls = { path = "../tls" }
 carbide-rpc = { path = "../rpc" }

--- a/crates/host-support/src/cpu.rs
+++ b/crates/host-support/src/cpu.rs
@@ -1,0 +1,106 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::collections::{HashMap, HashSet};
+
+use ::rpc::machine_discovery as rpc_discovery;
+
+pub fn aggregate_cpus(cpus: &[rpc_discovery::Cpu]) -> Vec<rpc_discovery::CpuInfo> {
+    //
+    //  Process CPU data
+    //
+
+    // This logic is ported from forge-cloud/cloud-backend. The handling of multiple CPU models on
+    // a single machine is possibly misleading, but possibly it handles some future build, and it
+    // accumulates all the info in any case. This function should return a vector with only one
+    // CpuInfo.
+    //
+    // Number of unique sockets is cpu count.
+    // Highest core number + 1 is the number of cores per socket.
+    // Highest Number + 1 is total thread count, which
+    // we'll divide by number of sockets later.
+
+    let mut cpu_map = HashMap::<String, CpuAccumulator>::new();
+    let mut cpu_socket_set = HashSet::<(String, u32)>::new();
+    // Go through the CPUs listed in the hardware info and accumulate the details.
+    for cpu in cpus.iter() {
+        match cpu_map.get_mut(&cpu.model) {
+            None => {
+                // Insert into the socket map so we don't keep incrementing cpu count
+                // as we look for threads and cores.
+                cpu_socket_set.insert((cpu.model.clone(), cpu.socket));
+
+                cpu_map.insert(
+                    cpu.model.clone(),
+                    CpuAccumulator {
+                        model: cpu.model.clone(),
+                        vendor: cpu.vendor.clone(),
+                        sockets: 1,
+                        cores: cpu.core + 1,
+                        threads: cpu.number + 1,
+                    },
+                );
+            }
+            Some(accumulator) => {
+                // If the socket hasn't been seen yet (i.e., if it's new to the set),
+                // increment the cpu count.
+                if cpu_socket_set.insert((cpu.model.clone(), cpu.socket)) {
+                    accumulator.sockets += 1;
+                }
+
+                let core_count = cpu.core + 1;
+                if core_count > accumulator.cores {
+                    accumulator.cores = core_count;
+                }
+
+                let thread_count = cpu.number + 1;
+                if thread_count > accumulator.threads {
+                    accumulator.threads = thread_count;
+                }
+            }
+        };
+    }
+
+    let mut values: Vec<&CpuAccumulator> = cpu_map.values().collect();
+    values.sort_by_key(|v| &v.model);
+    values
+        .into_iter()
+        .map(rpc_discovery::CpuInfo::from)
+        .collect()
+}
+
+// Same as rpc_discovery::CpuInfo but with total thread count before computing threads per socket
+pub(crate) struct CpuAccumulator {
+    model: String,
+    vendor: String,
+    sockets: u32,
+    cores: u32,
+    threads: u32,
+}
+
+impl From<&CpuAccumulator> for rpc_discovery::CpuInfo {
+    fn from(src: &CpuAccumulator) -> Self {
+        let threads_per_socket = src.threads.checked_div(src.sockets).unwrap_or(0);
+
+        rpc_discovery::CpuInfo {
+            model: src.model.clone(),
+            vendor: src.vendor.clone(),
+            sockets: src.sockets,
+            cores: src.cores,
+            threads: threads_per_socket,
+        }
+    }
+}

--- a/crates/host-support/src/hardware_enumeration.rs
+++ b/crates/host-support/src/hardware_enumeration.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fmt::Write;
 use std::fs;
 use std::fs::File;
@@ -33,6 +33,8 @@ use rpc::machine_discovery::MemoryDevice;
 use tracing::warn;
 use uname::uname;
 use utils::{BF2_PRODUCT_NAME, BF3_PRODUCT_NAME};
+
+use crate::cpu::aggregate_cpus;
 
 pub mod dpu;
 mod gpu;
@@ -65,15 +67,6 @@ pub enum HardwareEnumerationError {
 }
 
 pub type HardwareEnumerationResult<T> = Result<T, HardwareEnumerationError>;
-
-// Same as rpc_discovery::CpuInfo but with total thread count before computing threads per socket
-struct CpuAccumulator {
-    model: String,
-    vendor: String,
-    sockets: u32,
-    cores: u32,
-    threads: u32,
-}
 
 pub const LINK_TYPE_P1: &str = "LINK_TYPE_P1";
 
@@ -283,84 +276,6 @@ pub fn discovery_ibs() -> HardwareEnumerationResult<Vec<rpc_discovery::Infiniban
         }
     }
     Ok(ibs)
-}
-
-impl From<&CpuAccumulator> for rpc_discovery::CpuInfo {
-    fn from(src: &CpuAccumulator) -> Self {
-        let threads_per_socket = src.threads.checked_div(src.sockets).unwrap_or(0);
-
-        rpc_discovery::CpuInfo {
-            model: src.model.clone(),
-            vendor: src.vendor.clone(),
-            sockets: src.sockets,
-            cores: src.cores,
-            threads: threads_per_socket,
-        }
-    }
-}
-
-pub fn aggregate_cpus(cpus: &[rpc_discovery::Cpu]) -> Vec<rpc_discovery::CpuInfo> {
-    //
-    //  Process CPU data
-    //
-
-    // This logic is ported from forge-cloud/cloud-backend. The handling of multiple CPU models on
-    // a single machine is possibly misleading, but possibly it handles some future build, and it
-    // accumulates all the info in any case. This function should return a vector with only one
-    // CpuInfo.
-    //
-    // Number of unique sockets is cpu count.
-    // Highest core number + 1 is the number of cores per socket.
-    // Highest Number + 1 is total thread count, which
-    // we'll divide by number of sockets later.
-
-    let mut cpu_map = HashMap::<String, CpuAccumulator>::new();
-    let mut cpu_socket_set = HashSet::<(String, u32)>::new();
-    // Go through the CPUs listed in the hardware info and accumulate the details.
-    for cpu in cpus.iter() {
-        match cpu_map.get_mut(&cpu.model) {
-            None => {
-                // Insert into the socket map so we don't keep incrementing cpu count
-                // as we look for threads and cores.
-                cpu_socket_set.insert((cpu.model.clone(), cpu.socket));
-
-                cpu_map.insert(
-                    cpu.model.clone(),
-                    CpuAccumulator {
-                        model: cpu.model.clone(),
-                        vendor: cpu.vendor.clone(),
-                        sockets: 1,
-                        cores: cpu.core + 1,
-                        threads: cpu.number + 1,
-                    },
-                );
-            }
-            Some(accumulator) => {
-                // If the socket hasn't been seen yet (i.e., if it's new to the set),
-                // increment the cpu count.
-                if cpu_socket_set.insert((cpu.model.clone(), cpu.socket)) {
-                    accumulator.sockets += 1;
-                }
-
-                let core_count = cpu.core + 1;
-                if core_count > accumulator.cores {
-                    accumulator.cores = core_count;
-                }
-
-                let thread_count = cpu.number + 1;
-                if thread_count > accumulator.threads {
-                    accumulator.threads = thread_count;
-                }
-            }
-        };
-    }
-
-    let mut values: Vec<&CpuAccumulator> = cpu_map.values().collect();
-    values.sort_by_key(|v| &v.model);
-    values
-        .into_iter()
-        .map(rpc_discovery::CpuInfo::from)
-        .collect()
 }
 
 // `lscpu` fields in exact case-sensitive form

--- a/crates/host-support/src/lib.rs
+++ b/crates/host-support/src/lib.rs
@@ -26,6 +26,7 @@ use tracing_subscriber::prelude::*;
 use tracing_subscriber::util::SubscriberInitExt;
 
 pub mod agent_config;
+pub mod cpu;
 pub mod dpa_cmds;
 #[cfg(feature = "linux-build")]
 pub mod hardware_enumeration;

--- a/crates/pxe/Cargo.toml
+++ b/crates/pxe/Cargo.toml
@@ -28,7 +28,7 @@ path = "src/main.rs"
 
 [dependencies]
 # [begin-local-dependencies]
-carbide-host-support = { path = "../host-support" }
+carbide-host-support = { path = "../host-support", default-features = false }
 carbide-tls = { path = "../tls" }
 carbide-version = { path = "../version" }
 carbide-rpc = { path = "../rpc" }

--- a/crates/sqlx-testing/Cargo.toml
+++ b/crates/sqlx-testing/Cargo.toml
@@ -32,8 +32,5 @@ tokio = { workspace = true }
 # [local-dependencies]
 carbide-api-db = { path = "../api-db", default-features = false }
 
-[features]
-linux-build = ["carbide-api-db/linux-build"]
-
 [lints]
 workspace = true

--- a/crates/systemd/Cargo.toml
+++ b/crates/systemd/Cargo.toml
@@ -27,17 +27,10 @@ name = "carbide_systemd"
 
 [dependencies]
 eyre = { workspace = true }
-rand = { workspace = true }
-serde = { features = ["derive"], workspace = true }
-serde_json = { workspace = true }
-thiserror = { workspace = true }
 tokio = { workspace = true }
-tonic = { workspace = true }
 tracing = { workspace = true }
 
 # [local-dependencies]
-carbide-host-support = { path = "../host-support" }
-carbide-rpc = { path = "../rpc" }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Description

This cuts back on the propagation of the linux-build feature flag across a bunch of projects, by targeting the feature flag to only where it's needed:

- Isolate libudev depdendencies: We need a small helper function aggregate_cpus in host_support::hardware_enumeration, but that doesn't actually depend on libudev or procfs, so we can split it out into its own module. Only scout and dpu-agent should actually depend on host_support::hardware_enumeration

- Isolate functions that actually require tss-esapi into a single module in carbide-api (attestation::measured_boot::linux), and have stub versions of those functions which accept raw `&[u8]` slices, and only require the tss_esapi types if the feature flag is enabled. This makes it so only the attestation_measured_boot module (and its tests) need to guard on the linux-build flag. Everything else can just call those functions normally (with byte slices instead of the unmarshaled types) and the server will simply return an error if the flag is disabled.

- Get rid of a lot of the hoops we had to jump through to conditionally call linux-build code, now that the dependencies are properly isolated.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
This should make it a lot easier to not accidentally break the non-linux build (see #298 for a recent example) because we don't need to do so many `#[cfg(feature = "linux-build")]` lines everywhere... The only part that cares about linux-build should be the code that actually cares about the linux-only bits.