### PR TITLE
remove duplicate rms alias

### DIFF
--- a/crates/admin-cli/src/cfg/cli_options.rs
+++ b/crates/admin-cli/src/cfg/cli_options.rs
@@ -283,7 +283,7 @@ pub enum CliCommand {
     )]
     RackFirmware(rack_firmware::Cmd),
 
-    #[clap(about = "RMS Actions", visible_alias = "rms")]
+    #[clap(about = "RMS Actions")]
     Rms(rms::args::RmsAction),
 
     #[clap(about = "Firmware related actions", subcommand)]


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
fixes a crash on startup of the cli for duplicate rms command (due to an alias of the same name)
## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

