### PR TITLE
chore: machine-a-tron: client connect timeout

### DIFF
--- a/crates/machine-a-tron/src/main.rs
+++ b/crates/machine-a-tron/src/main.rs
@@ -104,6 +104,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut forge_client_config =
         ForgeClientConfig::new(forge_root_ca_path.clone(), Some(forge_client_cert));
     forge_client_config.socks_proxy(proxy);
+    forge_client_config.connect_retries_max = Some(60);
+    forge_client_config.connect_retries_interval = Some(Duration::from_secs(1));
 
     let bmc_registration_mode = if app_config.use_single_bmc_mock {
         // Machines will register their BMC's with the shared registry


### PR DESCRIPTION
## Description
By default RPC client retry timeout is set to 20 seconds. If machine-a-tron starts concurrently with carbide-api it sometimes result in additional 20s delay of machine-a-tron start. This PR changes retry timeout to 1 second.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

