### PR TITLE
fix: bmc-mock: add required MemberId to Assembly

### DIFF
--- a/crates/bmc-mock/src/redfish/assembly.rs
+++ b/crates/bmc-mock/src/redfish/assembly.rs
@@ -75,7 +75,8 @@ impl AssemblyBuilder {
             "Assemblies":
             self.assemblies.into_iter().map(|assembly| {
                 json!({
-                    "@odata.id": format!("{}#/Assemblies/{}", self.odata_id, assembly.member_id)
+                    "@odata.id": format!("{}#/Assemblies/{}", self.odata_id, assembly.member_id),
+                    "MemberId": assembly.member_id,
                 }).patch(assembly.value)
             }).collect::<Vec<_>>()
         })


### PR DESCRIPTION
## Description
MemberId is required for all ReferenceableMember instances. Assembly/Assemblies contains an AssemblyData collection. This PR adds the missing MemberId to AssemblyData.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

