### PR TITLE
Fix build-boot-artifacts-x86-host-sa and build-boot-artifacts-bfb-sa stages

### DIFF
--- a/pxe/Makefile.toml
+++ b/pxe/Makefile.toml
@@ -443,7 +443,7 @@ category = "Ephemeral Image"
 script = '''
   PROFILE="scout-oss-x86_64"
   export PATH=${PATH}:/sbin
-  ${REPO_ROOT}/pxe/mkosi/bin/mkosi --profile ${PROFILE} --output-dir=${MKOSI_BUILD_TMP} build
+  ${REPO_ROOT}/pxe/mkosi/bin/mkosi --profile ${PROFILE} --output-dir=${MKOSI_BUILD_TMP} --with-network build
 '''
 
 [tasks.mkosi-build-scout-loader-x86_64]
@@ -712,6 +712,11 @@ script = '''
       EMBED=/src/pxe/ipxe/local/embed.ipxe \
       DEBUG=snp,tls \
       EXTRA_CFLAGS="-Wno-unused-parameter -Wno-unused-variable"
+    docker run --rm -u $(id -u):$(id -g) \
+    -v /etc/passwd:/etc/passwd:ro \
+    -v ${REPO_ROOT}:/src \
+    -w /src/pxe/ipxe/upstream/src \
+    build-artifacts-container-cross-aarch64 \
     make -j \
       CROSS_COMPILE=aarch64-linux-gnu- \
       bin-arm64-efi/golan.efi \


### PR DESCRIPTION
## Description
Fix build process described in the [installation guide](https://github.com/NVIDIA/bare-metal-manager-core/blob/main/docs/installation/ncp.md).
This PR fixes issues in the build process, specifically related to boot artifacts preparation.


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

