### PR TITLE
Fix txn_held_across_await in build_supernic_lockdown_key

### DIFF
--- a/crates/api/src/dpa/lockdown.rs
+++ b/crates/api/src/dpa/lockdown.rs
@@ -16,7 +16,7 @@ use forge_secrets::credentials::{
 };
 use hkdf::Hkdf;
 use sha2::Sha256;
-use sqlx::PgConnection;
+use sqlx::PgPool;
 
 // LOCKDOWN_KEY_LENGTH is the max length of the supported
 // key by a Mellanox device. As of now it's a 64-bit key,
@@ -110,10 +110,10 @@ pub fn derive_candidate_keys(
 // from the database and builds a KdfContext from its hardware-
 // derived fields (MAC address and MachineId).
 async fn build_kdf_context(
-    txn: &mut PgConnection,
+    pg_pool: &PgPool,
     dpa_interface_id: DpaInterfaceId,
 ) -> Result<KdfContext, eyre::Report> {
-    let interfaces = db::dpa_interface::find_by_ids(txn, &[dpa_interface_id], false).await?;
+    let interfaces = db::dpa_interface::find_by_ids(pg_pool, &[dpa_interface_id], false).await?;
     let dpa_interface = interfaces
         .into_iter()
         .next()
@@ -144,13 +144,12 @@ async fn fetch_kdf_secret(
 
 // build_supernic_lockdown_key builds a single lockdown key using
 // the latest KdfContextVersion. Use this for locking a card.
-#[allow(txn_held_across_await)]
 pub async fn build_supernic_lockdown_key(
-    txn: &mut PgConnection,
+    db_reader: &PgPool,
     dpa_interface_id: DpaInterfaceId,
     credential_provider: &dyn CredentialProvider,
 ) -> Result<String, eyre::Report> {
-    let ctx = build_kdf_context(txn, dpa_interface_id).await?;
+    let ctx = build_kdf_context(db_reader, dpa_interface_id).await?;
     let secret = fetch_kdf_secret(credential_provider).await?;
     build_lockdown_key(secret.as_bytes(), &ctx, KdfContextVersion::V1)
 }

--- a/crates/api/src/handlers/machine_scout.rs
+++ b/crates/api/src/handlers/machine_scout.rs
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 use ::rpc::forge as rpc;
 use ::rpc::forge_agent_control_response::forge_agent_control_extra_info::KeyValuePair;
 use model::machine::machine_search_config::MachineSearchConfig;
@@ -130,13 +129,16 @@ pub(crate) async fn forge_agent_control(
 
     // Respond based on machine current state
     let state = host_machine.current_state();
-    let (action, action_data) = if is_dpu {
-        get_action_for_dpu_state(state, &machine_id).map_err(CarbideError::from)?
+
+    let (action, action_data, maybe_pending_txn) = if is_dpu {
+        let (action, action_data) =
+            get_action_for_dpu_state(state, &machine_id).map_err(CarbideError::from)?;
+        (action, action_data, Some(txn))
     } else {
         match state {
             ManagedHostState::HostInit {
                 machine_state: MachineState::Init,
-            } => (Action::Retry, None),
+            } => (Action::Retry, None, Some(txn)),
             ManagedHostState::Validation {
                 validation_state:
                     ValidationState::MachineValidation {
@@ -196,11 +198,12 @@ pub(crate) async fn forge_agent_control(
                                 .to_vec(),
                             },
                         ),
+                        Some(txn),
                     )
                 } else {
                     // This avoids sending Machine validation command scout
                     tracing::info!("Skipped machine validation",);
-                    (Action::Noop, None)
+                    (Action::Noop, None, Some(txn))
                 }
             }
             ManagedHostState::HostInit {
@@ -213,7 +216,7 @@ pub(crate) async fn forge_agent_control(
                         ..
                     },
                 ..
-            } => (Action::Discovery, None),
+            } => (Action::Discovery, None, Some(txn)),
             // If the API is configured with attestation_enabled, and
             // the machine has been Discovered (and progressed on to the
             // point where it is WaitingForMeasurements), then let Scout (or
@@ -221,7 +224,7 @@ pub(crate) async fn forge_agent_control(
             // to be sent.
             ManagedHostState::Measuring {
                 measuring_state: MeasuringState::WaitingForMeasurements,
-            } => (Action::Measure, None),
+            } => (Action::Measure, None, Some(txn)),
             ManagedHostState::WaitingForCleanup {
                 cleanup_state: CleanupState::HostCleanup { .. },
             }
@@ -243,9 +246,9 @@ pub(crate) async fn forge_agent_control(
                 // Check scout has already cleaned up the machine
                 if last_cleanup_time.unwrap_or_default() > state_version.timestamp() {
                     tracing::info!("Cleanup is already done");
-                    (Action::Noop, None)
+                    (Action::Noop, None, Some(txn))
                 } else {
-                    (Action::Reset, None)
+                    (Action::Reset, None, Some(txn))
                 }
             }
             ManagedHostState::BomValidating {
@@ -259,20 +262,24 @@ pub(crate) async fn forge_agent_control(
                 if machine.last_discovery_time.unwrap_or_default()
                     < machine.current_version().timestamp()
                 {
-                    (Action::Discovery, None)
+                    (Action::Discovery, None, Some(txn))
                 } else {
-                    (Action::Noop, None)
+                    (Action::Noop, None, Some(txn))
                 }
             }
             ManagedHostState::Assigned {
                 instance_state: InstanceState::WaitingForDpaToBeReady,
-            } => match crate::handlers::dpa::process_scout_req(api, &mut txn, machine_id).await {
-                Ok((action, einfo)) => (action, einfo),
-                Err(e) => {
-                    tracing::error!("Error returned from process_scout_req: {e}");
-                    (Action::Noop, None)
+            } => {
+                // Commit the transaction now, to avoid holding across an unrelated await point
+                txn.commit().await?;
+                match crate::handlers::dpa::process_scout_req(api, machine_id).await {
+                    Ok((action, einfo)) => (action, einfo, None),
+                    Err(e) => {
+                        tracing::error!("Error returned from process_scout_req: {e}");
+                        (Action::Noop, None, None)
+                    }
                 }
-            },
+            }
 
             _ => {
                 // Later this might go to site admin dashboard for manual intervention
@@ -282,17 +289,20 @@ pub(crate) async fn forge_agent_control(
                     %state,
                     "forge agent control",
                 );
-                (Action::Noop, None)
+                (Action::Noop, None, Some(txn))
             }
         }
     };
+
     tracing::info!(
         machine_id = %machine.id,
         action = action.as_str_name(),
         "forge agent control",
     );
 
-    txn.commit().await?;
+    if let Some(txn) = maybe_pending_txn {
+        txn.commit().await?;
+    }
 
     Ok(Response::new(rpc::ForgeAgentControlResponse {
         action: action as i32,


### PR DESCRIPTION
## Description
Since this method reads from the database before fetching a credential key, use a PgPool instead of a PgConnection to do the reading, so that we don't need to hold a connection or transaction open while fetching the credentials.

This involves porting some functions from db::dpa_interface to use DbReader instead of PgConnection, so that build_supernic_lockdown_key can call them with a PgPool.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes
