### PR TITLE
fix(api): Introduced VPC status property

### DIFF
--- a/crates/admin-cli/src/vpc/cmds.rs
+++ b/crates/admin-cli/src/vpc/cmds.rs
@@ -174,10 +174,9 @@ fn convert_vpc_to_nice_format(vpc: &forgerpc::Vpc) -> CarbideCliResult<String> {
             },
         ),
         ("TENANT KEYSET", vpc.tenant_keyset_id().into()),
-        ("VNI", format!("{}", vpc.vni.unwrap_or_default()).into()),
         (
-            "DPA_VNI",
-            format!("{}", vpc.dpa_vni.unwrap_or_default()).into(),
+            "VNI",
+            format!("{}", vpc.status.and_then(|s| s.vni).unwrap_or_default()).into(),
         ),
         (
             "NW VIRTUALIZATION",

--- a/crates/api-db/migrations/20260213082015_vpc_status.sql
+++ b/crates/api-db/migrations/20260213082015_vpc_status.sql
@@ -1,0 +1,21 @@
+
+-- Add status field to vpcs table.
+ALTER TABLE vpcs ADD COLUMN status JSONB NOT NULL DEFAULT '{}';
+
+-- Add a unique "constraint" similar to the one on
+-- the original VNI column.
+CREATE UNIQUE INDEX "unique_active_vpc_status_vni" ON vpcs(((status->>'vni')::integer)) WHERE deleted is NULL;
+
+-- Set status VNI to the VNIs that are currently assigned.
+UPDATE vpcs v SET status = jsonb_set(status, '{vni}', (v.vni::text)::jsonb, true);
+
+-- Clear the VNI field so it's clear that the VNI in status
+-- was auto-assigned.
+UPDATE vpcs v SET vni = null;
+
+-- Drop dpa_vni column.
+-- VPC VNI is used now.
+ALTER TABLE vpcs DROP COLUMN dpa_vni;
+
+-- Clean up any records for the old column.
+DELETE FROM resource_pool WHERE name='dpa-vni';

--- a/crates/api-db/src/dpa_interface.rs
+++ b/crates/api-db/src/dpa_interface.rs
@@ -411,8 +411,8 @@ pub async fn delete(value: DpaInterface, txn: &mut PgConnection) -> Result<(), D
 // states.
 //
 // Given the DPA Interface, we know its associated machine ID. From that, we need
-// to find the VPC the machine belongs to. From the VPC, we can find the DPA VNI
-// allocated for that VPC.
+// to find the VPC the machine belongs to. From the VPC, we can find the DPA VNI,
+// which is just the VPC VNI.
 pub async fn get_dpa_vni<DB>(state: &mut DpaInterface, txn: &mut DB) -> Result<i32, eyre::Report>
 where
     for<'db> &'db mut DB: DbReader<'db>,
@@ -443,7 +443,7 @@ where
 
     let vpc = crate::vpc::find_by_segment(txn, network_segment_id).await?;
 
-    match vpc.dpa_vni {
+    match vpc.status.as_ref().and_then(|s| s.vni) {
         Some(vni) => {
             if vni == 0 {
                 tracing::warn!("Did not expect DPA VNI to be zero");

--- a/crates/api-db/src/resource_pool.rs
+++ b/crates/api-db/src/resource_pool.rs
@@ -23,8 +23,8 @@ use config_version::ConfigVersion;
 use ipnetwork::Ipv6Network;
 use model::resource_pool;
 use model::resource_pool::common::{
-    CommonPools, DPA_VNI, DpaPools, EXTERNAL_VPC_VNI, EthernetPools, FNN_ASN, IbPools, LOOPBACK_IP,
-    SECONDARY_VTEP_IP, VLANID, VNI, VPC_DPU_LOOPBACK, VPC_VNI,
+    CommonPools, EXTERNAL_VPC_VNI, EthernetPools, FNN_ASN, IbPools, LOOPBACK_IP, SECONDARY_VTEP_IP,
+    VLANID, VNI, VPC_DPU_LOOPBACK, VPC_VNI,
 };
 use model::resource_pool::define::{ResourcePoolDef, ResourcePoolType};
 use model::resource_pool::{
@@ -832,11 +832,6 @@ pub async fn create_common_pools(
     );
     pool_names.extend(pkey_pools.values().map(|pool| pool.name().to_string()));
 
-    let pool_dpa_vni: Arc<ResourcePool<i32>> =
-        Arc::new(ResourcePool::new(DPA_VNI.to_string(), ValueType::Integer));
-
-    pool_names.extend(vec![pool_dpa_vni.name().to_string()]);
-
     // Gather resource pool stats. A different thread sends them to Prometheus.
     let (stop_sender, mut stop_receiver) = oneshot::channel();
     let pool_stats: Arc<Mutex<HashMap<String, ResourcePoolStats>>> =
@@ -876,7 +871,6 @@ pub async fn create_common_pools(
             pool_secondary_vtep_ip,
         },
         infiniband: IbPools { pkey_pools },
-        dpa: DpaPools { pool_dpa_vni },
         pool_stats,
         _stop_sender: stop_sender,
     }))

--- a/crates/api-db/src/vpc_peering.rs
+++ b/crates/api-db/src/vpc_peering.rs
@@ -156,7 +156,7 @@ pub async fn get_vpc_peer_vnis(
     virtualization_types: Vec<VpcVirtualizationType>,
 ) -> Result<Vec<(VpcId, i32)>, DatabaseError> {
     let query = r#"
-            SELECT vpcs.id, vpcs.vni
+            SELECT vpcs.id, (vpcs.status->>'vni')::integer
             FROM vpc_peerings vp
             JOIN vpcs ON vpcs.id = CASE
                 WHEN vp.vpc1_id = $1 THEN vp.vpc2_id

--- a/crates/api-model/src/resource_pool/common.rs
+++ b/crates/api-model/src/resource_pool/common.rs
@@ -42,7 +42,6 @@ pub const FNN_ASN: &str = "fnn-asn";
 /// VPC DPU loopback IP, used as in FNN.
 /// Must match a pool defined in dev/resource_pools.toml
 pub const VPC_DPU_LOOPBACK: &str = "vpc-dpu-lo";
-pub const DPA_VNI: &str = "dpa-vni";
 
 /// IPs used for creating a secondary overlay on
 /// a separate set of VTEPs.  The initial use-case is
@@ -59,16 +58,10 @@ pub fn ib_pkey_pool_name(fabric: &str) -> String {
 pub struct CommonPools {
     pub ethernet: EthernetPools,
     pub infiniband: IbPools,
-    pub dpa: DpaPools,
     pub pool_stats: Arc<Mutex<HashMap<String, ResourcePoolStats>>>,
     /// Instructs the metric task to stop.
     /// We rely on `CommonPools` being dropped to instruct the metric task to stop
     pub _stop_sender: oneshot::Sender<()>,
-}
-
-#[derive(Debug)]
-pub struct DpaPools {
-    pub pool_dpa_vni: Arc<ResourcePool<i32>>,
 }
 
 /// ResourcePools that are used for ethernet virtualization

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -2449,10 +2449,9 @@ fn default_mqtt_broker_port() -> u16 {
     1884
 }
 
-/// DPA (aka Cluster Ineteconnect Network) related configuration
-/// In addition to enabling DPA and specifying
-/// the mqtt endpoint, you need to specify the vni range to
-/// be used by DPA as pools.dpa-vni
+/// DPA (aka Cluster Interconnect Network) related configuration
+/// Enabled DPA, and specifies basic network settings.
+/// The VNI to be used by DPA will be the same as the parent VPC.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct DpaConfig {
     /// Global enable/disable of Cluster Interconnect Network

--- a/crates/api/src/ethernet_virtualization.rs
+++ b/crates/api/src/ethernet_virtualization.rs
@@ -173,7 +173,7 @@ pub async fn admin_network(
                     return Err(CarbideError::FindOneReturnedNoResultsError(vpc_id.into()).into());
                 }
                 let vpc = vpcs.remove(0);
-                match vpc.vni {
+                match vpc.status.and_then(|v| v.vni) {
                     Some(vpc_vni) => {
                         let tenant_loopback_ip =
                             db::vpc_dpu_loopback::get_or_allocate_loopback_ip_for_vpc(
@@ -373,7 +373,10 @@ pub async fn tenant_network(
         None => None,
     };
 
-    let vpc_vni = vpc.as_ref().and_then(|v| v.vni).unwrap_or_default() as u32;
+    let vpc_vni = vpc
+        .as_ref()
+        .and_then(|v| v.status.as_ref().and_then(|vs| vs.vni))
+        .unwrap_or_default() as u32;
 
     let rpc_ft: rpc::InterfaceFunctionType = iface.function_id.function_type().into();
     let svi_ip = get_svi_ip(

--- a/crates/api/src/handlers/dpu.rs
+++ b/crates/api/src/handlers/dpu.rs
@@ -283,7 +283,7 @@ pub(crate) async fn get_managed_host_network_config_inner(
                 }
             };
 
-            vpc_vni = vpc.vni.map(|x|x as u32);
+            vpc_vni = vpc.status.as_ref().and_then(|v| v.vni.map(|x|x as u32));
 
             let suppress_tenant_security_groups = match &snapshot.managed_state {
                 ManagedHostState::Assigned { instance_state } => {

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -749,8 +749,6 @@ pub async fn initialize_and_start_controllers(
         .build_and_spawn()
         .expect("Unable to build NetworkSegmentController");
 
-    let dpa_pool_vni = common_pools.dpa.pool_dpa_vni.clone();
-
     let mut _dpa_interface_state_controller_handle: Option<
         crate::state_controller::controller::StateControllerHandle,
     > = None;
@@ -766,7 +764,7 @@ pub async fn initialize_and_start_controllers(
                 .iteration_config(
                     (&carbide_config.dpa_interface_state_controller.controller).into(),
                 )
-                .state_handler(Arc::new(DpaInterfaceStateHandler::new(dpa_pool_vni)))
+                .state_handler(Arc::new(DpaInterfaceStateHandler::new()))
                 .build_and_spawn()
                 .expect("Unable to build DpaInterfaceStateController"),
         );

--- a/crates/api/src/state_controller/dpa_interface/handler.rs
+++ b/crates/api/src/state_controller/dpa_interface/handler.rs
@@ -25,7 +25,6 @@ use db::dpa_interface::get_dpa_vni;
 use eyre::eyre;
 use model::dpa_interface::DpaLockMode::{Locked, Unlocked};
 use model::dpa_interface::{DpaInterface, DpaInterfaceControllerState};
-use model::resource_pool::ResourcePool;
 use mqttea::MqtteaClient;
 use sqlx::PgTransaction;
 
@@ -38,15 +37,11 @@ use crate::state_controller::state_handler::{
 
 /// The actual Dpa Interface State handler
 #[derive(Debug, Clone)]
-pub struct DpaInterfaceStateHandler {
-    _pool_vni: Arc<ResourcePool<i32>>,
-}
+pub struct DpaInterfaceStateHandler {}
 
 impl DpaInterfaceStateHandler {
-    pub fn new(pool_vni: Arc<ResourcePool<i32>>) -> Self {
-        Self {
-            _pool_vni: pool_vni,
-        }
+    pub fn new() -> Self {
+        Self {}
     }
 
     fn record_metrics(

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -821,10 +821,10 @@ impl TestEnv {
 
         (
             vpc.id,
-            vpc.vni,
+            vpc.status.as_ref().and_then(|s| s.vni),
             tenant_network_id,
             peer_vpc.id,
-            peer_vpc.vni,
+            peer_vpc.status.as_ref().and_then(|s| s.vni),
             peer_tenant_network_id,
         )
     }
@@ -1955,19 +1955,6 @@ fn pool_defs(fabric_len: u8) -> HashMap<String, resource_pool::ResourcePoolDef> 
             ranges: vec![resource_pool::Range {
                 start: 50001.to_string(),
                 end: (50001 + fabric_len as u16 - 1).to_string(),
-                auto_assign: true,
-            }],
-            prefix: None,
-            delegate_prefix_len: None,
-        },
-    );
-    defs.insert(
-        model::resource_pool::common::DPA_VNI.to_string(),
-        resource_pool::ResourcePoolDef {
-            pool_type: resource_pool::ResourcePoolType::Integer,
-            ranges: vec![resource_pool::Range {
-                start: 30001.to_string(),
-                end: (30001 + fabric_len as u16 - 1).to_string(),
                 auto_assign: true,
             }],
             prefix: None,

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -313,6 +313,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "#[derive(serde::Serialize)]",
         )
         .type_attribute("forge.Vpc", "#[derive(serde::Serialize)]")
+        .type_attribute("forge.VpcStatus", "#[derive(serde::Serialize)]")
         .type_attribute("forge.VpcList", "#[derive(serde::Serialize)]")
         .type_attribute(
             "forge.StorageClusterAttributes",

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1125,6 +1125,15 @@ message TenantSearchQuery {
   optional string tenantOrganizationId = 1; // protolint:disable:this FIELD_NAMES_LOWER_SNAKE_CASE
 }
 
+// 
+message VpcStatus {
+  // The actual VNI allocated to the VPC. If a VNI had been
+  // explicitly requested, we'd expect this to match the VNI
+  // of the Vpc message. If not explicitly requested, we'd
+  // expect the VNI of the Vpc message to be unset.
+  optional uint32 vni = 1;
+}
+
 message Vpc {
   common.VpcId id = 1;
   string name = 2;
@@ -1138,19 +1147,30 @@ message Vpc {
   google.protobuf.Timestamp deleted = 6;
 
   optional string tenantKeysetId = 7; // protolint:disable:this FIELD_NAMES_LOWER_SNAKE_CASE
-  optional uint32 vni = 8;
+
+  // We'll keep populating this field but it will come from
+  // status.vni
+  // We'll be able to trim it out later after some deprecation window.
+  optional uint32 deprecated_vni = 8; // Deprecated
+
   optional VpcVirtualizationType network_virtualization_type = 9;
   Metadata metadata = 10;
 
   // Sets the desired NSG ID for a VPC
   optional string network_security_group_id  = 11;
 
-  optional uint32 dpa_vni = 12;
+  // dpa_vni
+  reserved 12;
 
   // The ID of the default NVLink Logical Partition for a VPC
   // This is the NVLink Logical Partition that will be used by default for all instances in the VPC.
   optional common.NVLinkLogicalPartitionId default_nvlink_logical_partition_id = 13;
 
+  optional VpcStatus status = 14;
+
+  // This will only be populated if the VNI was explicitly
+  // requested during creation of the VPC.
+  optional uint32 vni = 15;
 }
 
 message VpcCreationRequest {
@@ -1298,7 +1318,7 @@ message VpcPrefixStatus {
   uint32 total_31_segments = 1;
   uint32 available_31_segments = 2;
   uint64 total_linknet_segments = 3;
-  uint64 available_linknet_segments = 4;
+  uint64 available_linknet_segments = 4; 
 }
 
 message VpcPrefixCreationRequest {


### PR DESCRIPTION
## Description
- Adds a status property to VPC with only an optional vni property for now.
  - status.vni will be populated with the active VNI of the VPC.
    - In the case of an auto-allocated VNI, vpc.vni will be None.
    - In the case of a caller explicitly requesting a VNI during VPC creation, both vpc.vni and vpc.status.vni will match.
- Removes DPA VNI allocation code and cleans up the DB.
  - DPA VNI will now be populated based on VPC VNI in gRPC responses
- Moves the original Vpc.vni proto field to a deprecated_vni field that we will continue to populate using the value of vpc.status.vni
- Adds a new Vpc.vni proto field to hold only the VNI when explicitly requested during VPC creation.
- Re-arranged the VPC creation and vni allocation so we can get rid of an extra DB call
  - Also removed the separate test for duplicate VNI since this is now handled in the test for creating the VPC.

This lets an API consumer know the source of the active VNI (auto/non-auto) and also gives us a place to handle additional dynamic/asynchronously populated fields in the future.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
Related issue: https://github.com/NVIDIA/bare-metal-manager-core/issues/194
