### PR TITLE
chore: use the new flow in tenant termination to configure Lenovos to PXE boot into Scout instead of relying on boot_once.

### DIFF
--- a/crates/api/src/redfish.rs
+++ b/crates/api/src/redfish.rs
@@ -461,12 +461,6 @@ pub async fn host_power_control_with_location(
     db::machine::update_reboot_requested_time(&machine.id, txn, action.into()).await?;
     match machine.bmc_vendor() {
         bmc_vendor::BMCVendor::Lenovo => {
-            // Lenovos prepend the users OS to the boot order once it is installed and this cleans up the mess
-            redfish_client
-                .boot_once(libredfish::Boot::Pxe)
-                .await
-                .map_err(CarbideError::RedfishError)?;
-
             redfish_client
                 .power(action)
                 .await

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -9137,8 +9137,8 @@ async fn handle_instance_host_platform_config(
                         mh_snapshot.host_snapshot.id,
                         vendor.to_string()
                     );
-                    // TODO: remove this vendor specific check once we have tested it against Lenovos
-                    !vendor.is_lenovo()
+
+                    true
                 } else {
                     tracing::info!(
                         "Tenant has released {} and the {} has its boot order configured properly",


### PR DESCRIPTION

## Description

Use the new InstanceState::HostPlatformConfiguration states in tenant termination to handle configuring Lenovos to PXE boot when the tenant's OS is prepended to the list. This handles scenarios where the bios config is messed up for one reason or another (pxe is disabled in nvbug-5895434) and allows for better observability into how we are configuring the servers.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
Fixes: https://nvbugspro.nvidia.com/bug/5895434

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

