### PR TITLE
feat: integrate firmware management into the dpa workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,6 +1414,7 @@ dependencies = [
  "carbide-api-model",
  "carbide-health-report",
  "carbide-host-support",
+ "carbide-libmlx",
  "carbide-macros",
  "carbide-measured-boot",
  "carbide-network",
@@ -1484,6 +1485,7 @@ dependencies = [
  "carbide-dpf",
  "carbide-health-report",
  "carbide-host-support",
+ "carbide-libmlx",
  "carbide-network",
  "carbide-rpc",
  "carbide-sqlx-testing",
@@ -1825,6 +1827,7 @@ name = "carbide-host-support"
 version = "0.0.0"
 dependencies = [
  "base64 0.22.1",
+ "carbide-libmlx",
  "carbide-rpc",
  "carbide-tls",
  "carbide-utils",

--- a/crates/api-db/Cargo.toml
+++ b/crates/api-db/Cargo.toml
@@ -30,6 +30,7 @@ name = "db"
 # DO NOT PUT DEPENDENCIES OTHER THAN LOCAL DEPS HERE, THEY SHOULD ALL HAVE 'path =' IN THEM.
 config-version = { path = "../config-version", features = ["sqlx"] }
 carbide-host-support = { path = "../host-support", default-features = false }
+carbide-libmlx = { path = "../libmlx" }
 carbide-network = { path = "../network", features = ["sqlx"] }
 carbide-version = { path = "../version" }
 carbide-health-report = { path = "../health-report" }

--- a/crates/api-db/migrations/20260221211100_device_info_report.sql
+++ b/crates/api-db/migrations/20260221211100_device_info_report.sql
@@ -1,0 +1,7 @@
+-- device_info stores the full MlxDeviceInfo JSON blob as reported by
+-- the device. Contains part_number, psid, fw_version_current, and
+-- other hardware details. Used for firmware config lookup and version
+-- matching. Nullable for backwards compatibility with existing rows.
+ALTER TABLE dpa_interfaces ADD COLUMN IF NOT EXISTS device_info JSONB;
+-- device_info_ts records when the last device info update was received.
+ALTER TABLE dpa_interfaces ADD COLUMN IF NOT EXISTS device_info_ts TIMESTAMPTZ;

--- a/crates/api-db/src/dpa_interface.rs
+++ b/crates/api-db/src/dpa_interface.rs
@@ -22,6 +22,7 @@ use carbide_uuid::dpa_interface::{DpaInterfaceId, NULL_DPA_INTERFACE_ID};
 use carbide_uuid::machine::MachineId;
 use config_version::ConfigVersion;
 use eyre::eyre;
+use libmlx::device::info::MlxDeviceInfo;
 use mac_address::MacAddress;
 use model::controller_outcome::PersistentStateHandlerOutcome;
 use model::dpa_interface::{
@@ -213,11 +214,33 @@ pub async fn find_by_mac_addr(
     Ok(results)
 }
 
+/// update_device_info updates the device_info JSONB column and
+/// timestamp for a DPA interface, storing the full MlxDeviceInfo as
+/// reported by the device. Called on every device report so that the
+/// latest hardware info (part_number, psid, fw_version_current, etc)
+/// is always available.
+pub async fn update_device_info(
+    txn: &mut PgConnection,
+    machine_id: MachineId,
+    pci_name: &str,
+    device_info: &MlxDeviceInfo,
+) -> Result<(), DatabaseError> {
+    let query = "UPDATE dpa_interfaces SET device_info = $1::jsonb, device_info_ts = NOW() WHERE machine_id = $2 AND pci_name = $3 AND deleted IS NULL";
+    sqlx::query(query)
+        .bind(sqlx::types::Json(device_info))
+        .bind(machine_id)
+        .bind(pci_name)
+        .execute(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+    Ok(())
+}
+
 pub async fn update_card_state(
     txn: &mut PgConnection,
     value: DpaInterface,
 ) -> Result<DpaInterfaceId, DatabaseError> {
-    let query = "UPDATE dpa_interfaces SET card_state = $1::json WHERE id = $2::uuid 
+    let query = "UPDATE dpa_interfaces SET card_state = $1::json WHERE id = $2::uuid
                 RETURNING id";
 
     sqlx::query_as(query)
@@ -231,12 +254,12 @@ pub async fn update_card_state(
 // Used by the machine statemachine controller to find all DPAs associated with a given machine
 pub async fn find_by_machine_id(
     txn: impl DbReader<'_>,
-    mid: &MachineId,
+    machine_id: MachineId,
 ) -> Result<Vec<DpaInterface>, DatabaseError> {
     let query = "SELECT row_to_json(m.*) from (select * from dpa_interfaces WHERE deleted is NULL AND machine_id = $1) m";
     let results: Vec<DpaInterface> = {
         sqlx::query_as(query)
-            .bind(mid)
+            .bind(machine_id)
             .fetch_all(txn)
             .await
             .map_err(|e| DatabaseError::query(query, e))?
@@ -501,6 +524,7 @@ mod test {
     use std::str::FromStr;
 
     use carbide_uuid::machine::MachineId;
+    use libmlx::device::info::MlxDeviceInfo;
     use mac_address::MacAddress;
     use model::dpa_interface::NewDpaInterface;
     use model::machine::ManagedHostState;
@@ -545,6 +569,92 @@ mod test {
 
         assert_eq!(db_intf.len(), 1);
         assert_eq!(db_intf[0].id, intf.id);
+
+        Ok(())
+    }
+
+    // test_device_info_roundtrip is a super basic test that inserts
+    // a new DPA + corresponding MlxDeviceInfo (as a JSONB blob) into
+    // the database, and makes sure it gets read back out successfully.
+    // Since this drives things like doing firmware updates, it seemed
+    // like a nice test to have.
+    #[crate::sqlx_test]
+    async fn test_device_info_roundtrip(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut txn = pool.begin().await.unwrap();
+
+        let machine_id =
+            MachineId::from_str("fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30")?;
+        machine::create(
+            &mut txn,
+            None,
+            &machine_id,
+            ManagedHostState::Ready,
+            &Metadata::default(),
+            None,
+            true,
+            2,
+        )
+        .await?;
+
+        let pci_name = "01:00.0";
+        let new_intf = NewDpaInterface {
+            machine_id,
+            mac_address: MacAddress::from_str("00:11:22:33:44:55")?,
+            device_type: "BlueField3".to_string(),
+            pci_name: pci_name.to_string(),
+        };
+
+        crate::dpa_interface::persist(new_intf, &mut txn).await?;
+
+        // Verify device_info starts as None, because in this case,
+        // one hasn't been reported yet (and also allows for backwards
+        // compatibility checks from before this existed).
+        let intfs = crate::dpa_interface::find_by_machine_id(txn.as_mut(), machine_id).await?;
+        assert_eq!(intfs.len(), 1);
+        assert!(intfs[0].device_info.is_none());
+        assert!(intfs[0].device_info_ts.is_none());
+
+        // Store a device info report.
+        let device_info = MlxDeviceInfo {
+            pci_name: pci_name.to_string(),
+            device_type: "BlueField3".to_string(),
+            psid: Some("MT_0000001069".to_string()),
+            device_description: Some(
+                "Nvidia BlueField-3 B3140H E-series HHHL SuperNIC".to_string(),
+            ),
+            part_number: Some("900-9D3D4-00EN-HA0".to_string()),
+            fw_version_current: Some("32.43.1014".to_string()),
+            pxe_version_current: None,
+            uefi_version_current: None,
+            uefi_version_virtio_blk_current: None,
+            uefi_version_virtio_net_current: None,
+            base_mac: Some(MacAddress::from_str("00:11:22:33:44:55")?),
+            status: Some("OK".to_string()),
+        };
+
+        crate::dpa_interface::update_device_info(txn.as_mut(), machine_id, pci_name, &device_info)
+            .await?;
+
+        // Read back and verify everything we put into
+        // the database came back as we originally put it.
+        let intfs = crate::dpa_interface::find_by_machine_id(txn.as_mut(), machine_id).await?;
+        assert_eq!(intfs.len(), 1);
+
+        let info = intfs[0]
+            .device_info
+            .as_ref()
+            .expect("device_info should be set");
+        assert_eq!(info.part_number.as_deref(), Some("900-9D3D4-00EN-HA0"));
+        assert_eq!(info.psid.as_deref(), Some("MT_0000001069"));
+        assert_eq!(info.fw_version_current.as_deref(), Some("32.43.1014"));
+        assert_eq!(info.pci_name, pci_name);
+        assert_eq!(
+            info.base_mac,
+            Some(MacAddress::from_str("00:11:22:33:44:55")?)
+        );
+        assert!(intfs[0].device_info_ts.is_some());
 
         Ok(())
     }

--- a/crates/api-model/Cargo.toml
+++ b/crates/api-model/Cargo.toml
@@ -32,6 +32,7 @@ bmc-vendor = { path = "../bmc-vendor" }
 carbide-dpf = { path = "../dpf" }
 config-version = { path = "../config-version", features = ["sqlx"] }
 carbide-host-support = { path = "../host-support", default-features = false }
+carbide-libmlx = { path = "../libmlx" }
 carbide-network = { path = "../network", features = ["sqlx"] }
 carbide-version = { path = "../version" }
 carbide-health-report = { path = "../health-report" }

--- a/crates/api-model/src/dpa_interface/slas.rs
+++ b/crates/api-model/src/dpa_interface/slas.rs
@@ -19,7 +19,15 @@
 
 use std::time::Duration;
 
+// TODO(chet): Revisit these SLAs -- they seem a little high. Operations
+// like lock/unlock are pretty instantaneous, and profile is ~seconds.
 pub const LOCKING: Duration = Duration::from_secs(15 * 60);
+// ...BUT applying firmware actually can take a while. SuperNIC flashing
+// seems to be roughly 7 minutes to flash then 1 minute to reset, but
+// that's resetting the device, not the entire host. As of now it seems
+// like resetting the device is enough, but we may end up needing to
+// do a full power cycle of the host, which would definitely take a bit.
+pub const APPLY_FIRMWARE: Duration = Duration::from_secs(30 * 60);
 pub const APPLY_PROFILE: Duration = Duration::from_secs(15 * 60);
 pub const UNLOCKING: Duration = Duration::from_secs(15 * 60);
 pub const WAITINGFORSETVNI: Duration = Duration::from_secs(15 * 60);

--- a/crates/api/src/handlers/dpa.rs
+++ b/crates/api/src/handlers/dpa.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use std::borrow::Cow;
+
 use ::rpc::protos::mlx_device as mlx_device_pb;
 use carbide_host_support::dpa_cmds::{DpaCommand, OpCode};
 use carbide_uuid::machine::MachineId;
@@ -225,7 +227,7 @@ pub(crate) async fn process_scout_req(
         return Ok((Action::Noop, None));
     }
     let dpa_snapshots =
-        db::dpa_interface::find_by_machine_id(&api.database_connection, &machine_id).await?;
+        db::dpa_interface::find_by_machine_id(&api.database_connection, machine_id).await?;
 
     if dpa_snapshots.is_empty() {
         tracing::error!(
@@ -239,7 +241,7 @@ pub(crate) async fn process_scout_req(
 
     for sn in &dpa_snapshots {
         let cstate = sn.controller_state.value.clone();
-        let dev_name = &sn.pci_name;
+        let pci_name = &sn.pci_name;
 
         let dpa_cmd = match cstate {
             DpaInterfaceControllerState::Provisioning
@@ -249,57 +251,22 @@ pub(crate) async fn process_scout_req(
             | DpaInterfaceControllerState::WaitingForResetVNI => continue,
 
             DpaInterfaceControllerState::Unlocking => {
-                let key = crate::dpa::lockdown::build_supernic_lockdown_key(
-                    &api.database_connection,
-                    sn.id,
-                    &*api.credential_provider,
-                )
-                .await
-                .map_err(|e| {
-                    CarbideError::GenericErrorFromReport(eyre!(
-                        "failed to build unlock key for DPA {dev_name}: {e}"
-                    ))
-                })?;
-
-                tracing::info!("Unlocking DPA {:#?}", dev_name);
-                DpaCommand {
-                    op: OpCode::Unlock { key },
-                }
+                build_unlock_command(api, sn, machine_id, pci_name).await?
             }
-
+            DpaInterfaceControllerState::ApplyFirmware => {
+                build_apply_firmware_command(api, sn, machine_id, pci_name)
+            }
             DpaInterfaceControllerState::ApplyProfile => {
-                let profstr = api.runtime_config.get_dpa_profile("Bluefield3".to_string());
-                tracing::info!("Applying profile for DPA {:#?}", dev_name);
-                DpaCommand {
-                    op: OpCode::ApplyProfile {
-                        profile_str: profstr,
-                    },
-                }
+                build_apply_profile_command(api, machine_id, pci_name)
             }
-
             DpaInterfaceControllerState::Locking => {
-                let key = crate::dpa::lockdown::build_supernic_lockdown_key(
-                    &api.database_connection,
-                    sn.id,
-                    &*api.credential_provider,
-                )
-                .await
-                .map_err(|e| {
-                    CarbideError::GenericErrorFromReport(eyre!(
-                        "failed to build lock key for DPA {dev_name}: {e}"
-                    ))
-                })?;
-
-                tracing::info!("Locking DPA {:#?}", dev_name);
-                DpaCommand {
-                    op: OpCode::Lock { key },
-                }
+                build_lock_command(api, sn, machine_id, pci_name).await?
             }
         };
 
         match serde_json::to_string(&dpa_cmd) {
             Ok(cmdstr) => pair.push(KeyValuePair {
-                key: dev_name.clone(),
+                key: pci_name.clone(),
                 value: cmdstr,
             }),
             Err(e) => {
@@ -314,6 +281,135 @@ pub(crate) async fn process_scout_req(
     let facr = ForgeAgentControlExtraInfo { pair };
 
     Ok((Action::MlxAction, Some(facr)))
+}
+
+async fn build_unlock_command(
+    api: &Api,
+    sn: &DpaInterface,
+    machine_id: MachineId,
+    pci_name: &str,
+) -> CarbideResult<DpaCommand<'static>> {
+    let key = crate::dpa::lockdown::build_supernic_lockdown_key(
+        &api.database_connection,
+        sn.id,
+        &*api.credential_provider,
+    )
+    .await
+    .map_err(|e| {
+        CarbideError::GenericErrorFromReport(eyre!(
+            "failed to build unlock key for DPA {pci_name}: {e}"
+        ))
+    })?;
+
+    tracing::info!(%machine_id, %pci_name, "Unlocking DPA");
+    Ok(DpaCommand {
+        op: OpCode::Unlock { key },
+    })
+}
+
+fn build_apply_firmware_command<'a>(
+    api: &'a Api,
+    sn: &DpaInterface,
+    machine_id: MachineId,
+    pci_name: &str,
+) -> DpaCommand<'a> {
+    // Look up a FirmwareFlasherProfile for the device's PN:PSID
+    // from the runtime config. If a profile exists and the device
+    // is already at the target version, skip. Otherwise pass the
+    // profile down to scout.
+    let profile = (|| {
+        let Some(device_info) = &sn.device_info else {
+            tracing::warn!(
+                %machine_id, %pci_name,
+                "no device_info available, skipping firmware application"
+            );
+            return None;
+        };
+
+        let (Some(part_number), Some(psid)) = (&device_info.part_number, &device_info.psid) else {
+            tracing::warn!(
+                %machine_id, %pci_name,
+                "device_info missing part_number and/or psid, skipping firmware"
+            );
+            return None;
+        };
+
+        let Some(fw_profile) = api
+            .runtime_config
+            .get_supernic_firmware_profile(part_number, psid)
+        else {
+            tracing::info!(
+                %machine_id, %pci_name, %part_number, %psid,
+                "no firmware profile found, skipping"
+            );
+            return None;
+        };
+
+        if device_info.fw_version_current.as_deref()
+            == Some(fw_profile.firmware_spec.version.as_str())
+        {
+            tracing::info!(
+                %machine_id, %pci_name, %part_number, %psid,
+                observed_fw_version = ?device_info.fw_version_current,
+                expected_fw_version = %fw_profile.firmware_spec.version,
+                "firmware already at target version, skipping"
+            );
+            return None;
+        }
+
+        tracing::info!(
+            %machine_id, %pci_name, %part_number, %psid,
+            observed_fw_version = ?device_info.fw_version_current,
+            expected_fw_version = %fw_profile.firmware_spec.version,
+            "firmware version mismatch, applying firmware"
+        );
+        Some(Cow::Borrowed(fw_profile))
+    })();
+
+    tracing::info!(%machine_id, %pci_name, "ApplyFirmware");
+    DpaCommand {
+        op: OpCode::ApplyFirmware {
+            profile: profile.map(Box::new),
+        },
+    }
+}
+
+fn build_apply_profile_command(
+    api: &Api,
+    machine_id: MachineId,
+    pci_name: &str,
+) -> DpaCommand<'static> {
+    let profstr = api.runtime_config.get_dpa_profile("Bluefield3".to_string());
+    tracing::info!(%machine_id, %pci_name, "Applying DPA profile");
+    DpaCommand {
+        op: OpCode::ApplyProfile {
+            profile_str: profstr,
+        },
+    }
+}
+
+async fn build_lock_command(
+    api: &Api,
+    sn: &DpaInterface,
+    machine_id: MachineId,
+    pci_name: &str,
+) -> CarbideResult<DpaCommand<'static>> {
+    let key = crate::dpa::lockdown::build_supernic_lockdown_key(
+        &api.database_connection,
+        sn.id,
+        &*api.credential_provider,
+    )
+    .await
+    .map_err(|e| {
+        CarbideError::GenericErrorFromReport(eyre!(
+            "failed to build lock key for DPA {pci_name}: {e}"
+        ))
+    })?;
+
+    tracing::info!(%machine_id, %pci_name, "Locking DPA");
+    Ok(DpaCommand {
+        op: OpCode::Lock { key },
+    })
 }
 
 // Find the DPA object in the given vector of DPA objects
@@ -351,7 +447,7 @@ async fn process_mlx_observation(
         )));
     };
 
-    let Some(mid) = rep.machine_id else {
+    let Some(machine_id) = rep.machine_id else {
         tracing::error!(
             "process_mlx_observation without machine_id report: {:#?}",
             rep
@@ -362,16 +458,16 @@ async fn process_mlx_observation(
         )));
     };
 
-    let dpa_snapshots = db::dpa_interface::find_by_machine_id(&mut txn, &mid).await?;
+    let dpa_snapshots = db::dpa_interface::find_by_machine_id(&mut txn, machine_id).await?;
 
     if dpa_snapshots.is_empty() {
         tracing::error!(
             "process_mlx_observation no dpa snapshots for machine: {:#?}",
-            mid
+            machine_id
         );
         return Err(CarbideError::GenericErrorFromReport(eyre!(
             "process_mlx_observation no dpa snapshots for machine: {:#?}",
-            mid
+            machine_id
         )));
     }
 
@@ -396,10 +492,14 @@ async fn process_mlx_observation(
             }
         };
 
+        // Use the latest CardState we pulled from the database. If there
+        // isn't one, then initialize an empty one, for which we will now
+        // update with whatever the current observation is.
         let mut cstate = dpa.card_state.unwrap_or(CardState {
             lockmode: None,
             profile: None,
             profile_synced: None,
+            firmware_report: None,
         });
 
         if obs.lock_status.is_some() {
@@ -420,6 +520,13 @@ async fn process_mlx_observation(
 
         if obs.profile_synced.is_some() {
             cstate.profile_synced = obs.profile_synced;
+        }
+
+        // If the observation contains a FirmwareFlashReport update
+        // in it, then merge it into the latest CardState that we
+        // pulled from the database.
+        if let Some(firmware_report) = obs.firmware_report {
+            cstate.firmware_report = Some(firmware_report.into());
         }
 
         dpa.card_state = Some(cstate);
@@ -468,26 +575,47 @@ pub(crate) async fn publish_mlx_device_report(
         if report.machine_id.is_some() {
             let mut spx_nics: i32 = 0;
 
-            let mid = report.machine_id.unwrap();
+            let machine_id = report.machine_id.unwrap();
 
-            for dev in report.devices {
+            // Go over each of the MlxDeviceInfo reports from the
+            // MlxDeviceReport. Each MlxDeviceInfo corresponds to
+            // an individual device reported by `mlxfwmanager`, with
+            // the MlxDeviceReport being a report of all devices
+            // reporting on a given machine.
+            for device_info in report.devices {
                 // XXX TODO XXX
                 // Change this to base device detection using part numbers rather
                 // than device description.
                 // XXX TODO XXX
-                if dev.device_description.is_some() && dev.base_mac.is_some() {
-                    let descr = dev.device_description.unwrap();
+                if device_info.device_description.is_some() && device_info.base_mac.is_some() {
+                    let descr = device_info.device_description.clone().unwrap();
                     if descr.contains("SuperNIC") {
                         spx_nics += 1;
 
-                        let mac = dev.base_mac.unwrap();
+                        // Pull a few specific parameters out that are consumed
+                        // by NewDpaInterface + used for logging later on. See
+                        // the TODO(chet) below about create_internal behavior.
+                        // I think we can refactor all of this so these hoops
+                        // aren't needed.
+                        let mac_address = device_info.base_mac.unwrap();
+                        let pci_name = device_info.pci_name.clone();
+                        let device_type = device_info.device_type.clone();
                         let dpa_info = NewDpaInterface {
-                            machine_id: mid,
-                            mac_address: mac,
-                            device_type: dev.device_type,
-                            pci_name: dev.pci_name,
+                            machine_id,
+                            device_type,
+                            mac_address,
+                            pci_name: pci_name.clone(),
                         };
 
+                        // TODO(chet): I need to look into this -- this was existing
+                        // code, but, it *looks* like if a DPA doesn't exist yet, we'll
+                        // insert it here, but if it ALREADY exists, we'll just fail?
+                        // ALSO! It looks like there might be another bug of sorts -- I
+                        // don't think we ever reset CardState, so once a card has been
+                        // fully provisioned the first time, CardState will persist, so
+                        // any subsequent flows through the state controller will just
+                        // hop right on through the states since each CardState state
+                        // will already look done?
                         match create_internal(api, dpa_info).await {
                             Ok(dpa_out) => {
                                 tracing::info!("created dpa: {:#?}", dpa_out);
@@ -496,9 +624,56 @@ pub(crate) async fn publish_mlx_device_report(
                                 tracing::info!("create dpa error: {:#?}", e);
                             }
                         }
+
+                        // ...and now update the MlxDeviceInfo for a given device on
+                        // every on every publish_mlx_device_report call, so that
+                        // the latest hardware state for a given device is always
+                        // available. But, look at the TODO(chet) above. I think it
+                        // might be better to refactor this a bit so create_internal
+                        // becomes something like process_device_report and does
+                        // the job of upserting data for the NIC/device.
+                        let mut txn = match api.txn_begin().await {
+                            Ok(txn) => txn,
+                            Err(e) => {
+                                tracing::warn!(
+                                     %mac_address,
+                                     %pci_name, %e,
+                                    "failed to begin txn for device info update"
+                                );
+                                continue;
+                            }
+                        };
+
+                        match dpa_interface::update_device_info(
+                            txn.as_mut(),
+                            machine_id,
+                            &pci_name,
+                            &device_info,
+                        )
+                        .await
+                        {
+                            Ok(()) => {
+                                if let Err(e) = txn.commit().await {
+                                    tracing::warn!(
+                                        %mac_address,
+                                        %pci_name,
+                                        %e,
+                                        "failed to commit device info update"
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    %mac_address,
+                                    %pci_name,
+                                    %e,
+                                    "failed to update device info"
+                                );
+                            }
+                        }
                     }
                 } else {
-                    tracing::warn!("Missing part, device desc or mac: {:#?}", dev);
+                    tracing::warn!("Missing part, device desc or mac: {:#?}", device_info);
                 }
             }
 
@@ -512,6 +687,7 @@ pub(crate) async fn publish_mlx_device_report(
     } else {
         tracing::warn!("no embedded MlxDeviceReport published");
     }
+
     Ok(Response::new(
         mlx_device_pb::PublishMlxDeviceReportResponse {},
     ))

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -163,6 +163,10 @@ pub fn parse_carbide_config(
         }
     }
 
+    // Validate that the firmware profile config keys match their inner
+    // part_number and psid values. Mismatches are logged as warnings.
+    config.validate_supernic_firmware_profiles();
+
     tracing::trace!("Carbide config: {:#?}", config.redacted());
     Ok(Arc::new(config))
 }

--- a/crates/api/src/state_controller/dpa_interface/io.rs
+++ b/crates/api/src/state_controller/dpa_interface/io.rs
@@ -121,6 +121,7 @@ impl StateControllerIO for DpaInterfaceStateControllerIO {
         match state {
             DpaInterfaceControllerState::Provisioning => ("provisioning", ""),
             DpaInterfaceControllerState::Unlocking => ("unlocking", ""),
+            DpaInterfaceControllerState::ApplyFirmware => ("applyfirmware", ""),
             DpaInterfaceControllerState::ApplyProfile => ("locking", ""),
             DpaInterfaceControllerState::Locking => ("locking", ""),
             DpaInterfaceControllerState::Ready => ("ready", ""),

--- a/crates/api/src/state_controller/machine/io.rs
+++ b/crates/api/src/state_controller/machine/io.rs
@@ -100,7 +100,7 @@ impl StateControllerIO for MachineStateControllerIO {
         .await?;
 
         if let Some(retstate) = retstate.as_mut() {
-            let dpa_snapshots = db::dpa_interface::find_by_machine_id(txn, machine_id).await?;
+            let dpa_snapshots = db::dpa_interface::find_by_machine_id(txn, *machine_id).await?;
             retstate.dpa_interface_snapshots = dpa_snapshots;
         };
 

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -1160,6 +1160,7 @@ pub fn get_config() -> CarbideConfig {
         dpf: crate::cfg::file::DpfConfig::default(),
         x86_pxe_boot_url_override: None,
         arm_pxe_boot_url_override: None,
+        supernic_firmware_profiles: HashMap::default(),
     }
 }
 

--- a/crates/host-support/Cargo.toml
+++ b/crates/host-support/Cargo.toml
@@ -31,6 +31,7 @@ name = "carbide_host_support"
 
 # [local-dependencies]
 carbide-tls = { path = "../tls" }
+carbide-libmlx = { path = "../libmlx" }
 logfmt = { path = "../logfmt" }
 carbide-rpc = { path = "../rpc" }
 carbide-utils = { path = "../utils" }

--- a/crates/host-support/src/dpa_cmds.rs
+++ b/crates/host-support/src/dpa_cmds.rs
@@ -15,17 +15,29 @@
  * limitations under the License.
  */
 
+use std::borrow::Cow;
+
+use libmlx::firmware::config::FirmwareFlasherProfile;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
-pub enum OpCode {
+pub enum OpCode<'a> {
     Noop,
-    Unlock { key: String },
-    ApplyProfile { profile_str: String },
-    Lock { key: String },
+    Unlock {
+        key: String,
+    },
+    ApplyProfile {
+        profile_str: String,
+    },
+    Lock {
+        key: String,
+    },
+    ApplyFirmware {
+        profile: Option<Box<Cow<'a, FirmwareFlasherProfile>>>,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct DpaCommand {
-    pub op: OpCode,
+pub struct DpaCommand<'a> {
+    pub op: OpCode<'a>,
 }

--- a/crates/libmlx/src/firmware/config.rs
+++ b/crates/libmlx/src/firmware/config.rs
@@ -16,68 +16,84 @@
  */
 
 // src/config.rs
-// Defines the SupernicFirmwareConfig structure for TOML-based firmware
-// configuration, and provides methods to construct firmware sources
-// from that config.
+// This module defines the firmware configuration types: FirmwareSpec,
+// FlashSpec, FlashOptions, and FirmwareFlasherProfile. I originally had
+// this single SupernicFirmwareConfig type in here, but it started to get
+// kind of messy when I tried to implement it. By breaking it up into a
+// a structured separation of concerns, I ended up with a pretty nice RAII
+// model for initializing a new FirmwareFlasher, and then using the mix
+// of specs + options to drive further operations/management.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+use rpc::protos::mlx_device::{
+    FirmwareFlasherProfile as FirmwareFlasherProfilePb, FirmwareSpec as FirmwareSpecPb,
+    FlashOptions as FlashOptionsPb, FlashSpec as FlashSpecPb,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::firmware::credentials::Credentials;
 use crate::firmware::error::{FirmwareError, FirmwareResult};
+use crate::firmware::reset::DEFAULT_RESET_LEVEL;
 use crate::firmware::source::FirmwareSource;
 
-// SupernicFirmwareConfig is the TOML-serializable configuration for
-// SuperNIC firmware management. In the Carbide API config, this lives
-// under the [supernic_firmware_config] block.
+// FirmwareSpec identifies a firmware target by device identity and
+// version. The part_number and psid identify the hardware the
+// firmware is built for, and the version is the target firmware
+// version. Used to construct a FirmwareFlasher with the aforementioned
+// RAII-esque validation (if the underlying MlxDeviceInfo for the given
+// device_id doesn't match this FirmwareSpec, then we will fail to
+// construct a new FirmwareFlasher).
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SupernicFirmwareConfig {
-    // firmware_url is the location of the firmware binary. Supported
-    // formats:
-    //   - Local path:  /path/to/firmware.signed.bin
-    //   - file:// URL: file:///path/to/firmware.signed.bin
-    //   - HTTPS URL:   https://host/path/to/firmware.signed.bin
-    //   - SSH URL:     ssh://user@host:path/to/firmware.signed.bin
-    pub firmware_url: String,
+pub struct FirmwareSpec {
+    // part_number is the manufacturer part number that the firmware
+    // is built for (e.g., "900-9D3B4-00CV-TA0").
+    pub part_number: String,
+    // psid (Parameter-Set IDentification) identifies the firmware
+    // configuration (e.g., "MT_0000000884").
+    pub psid: String,
+    // version is the target firmware version (e.g., "32.43.1014").
+    pub version: String,
+}
 
+impl FirmwareSpec {
+    // map_key returns a key suitable for indexing firmware specs
+    // by hardware identity, in the format "part_number:psid", like
+    // in the case of the carbide-api runtime config mappings.
+    pub fn map_key(&self) -> String {
+        format!("{}:{}", self.part_number, self.psid)
+    }
+}
+
+// FlashSpec specifies source locations and caching options for
+// flash and verify_image operations. Contains everything needed
+// to download and apply firmware and device config.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlashSpec {
+    // firmware_url is the location of the firmware binary. Supports
+    // local paths, file://, https://, and ssh:// URLs.
+    pub firmware_url: String,
     // firmware_credentials is the optional authentication for
     // downloading the firmware binary.
     pub firmware_credentials: Option<Credentials>,
-
     // device_conf_url is the optional location of the device config
-    // to apply before flashing (e.g., a debug token or mlxconfig
-    // configuration blob). When present, the config is applied via
-    // `mlxconfig apply` before burning the firmware. Supports the
-    // same URL formats as firmware_url.
+    // to apply before flashing. When present, the config is applied
+    // via `mlxconfig apply` before burning the firmware.
+    // Supports the same URL formats as firmware_url.
     pub device_conf_url: Option<String>,
-
     // device_conf_credentials is the optional authentication for
     // downloading the device config.
     pub device_conf_credentials: Option<Credentials>,
-
-    // expected_version is the firmware version string expected after
-    // flashing (e.g., "32.43.1014"). When set, the flasher will
-    // verify the installed version matches after a reset.
-    pub expected_version: Option<String>,
+    // verify_from_cache controls whether verify_image() uses the
+    // cached firmware from cache_dir instead of re-pulling.
+    #[serde(default)]
+    pub verify_from_cache: bool,
+    // cache_dir is the directory for staging downloaded firmware.
+    // Defaults to a temporary directory if not specified.
+    pub cache_dir: Option<PathBuf>,
 }
 
-impl SupernicFirmwareConfig {
-    // from_file reads a SupernicFirmwareConfig from a TOML file.
-    // The file should contain the firmware config fields directly
-    // at the top level (not nested under a section key).
-    pub fn from_file(path: impl AsRef<Path>) -> FirmwareResult<Self> {
-        let content = std::fs::read_to_string(path.as_ref()).map_err(FirmwareError::Io)?;
-        Self::from_toml(&content)
-    }
-
-    // from_toml parses a SupernicFirmwareConfig from a TOML string.
-    pub fn from_toml(toml_str: &str) -> FirmwareResult<Self> {
-        toml::from_str(toml_str).map_err(|e| {
-            FirmwareError::ConfigError(format!("Failed to parse firmware config: {e}"))
-        })
-    }
-
+impl FlashSpec {
     // build_firmware_source constructs a FirmwareSource from the
     // firmware_url and firmware_credentials fields.
     pub fn build_firmware_source(&self) -> FirmwareResult<FirmwareSource> {
@@ -89,8 +105,7 @@ impl SupernicFirmwareConfig {
     }
 
     // build_device_conf_source constructs a FirmwareSource for the
-    // device config, if device_conf_url is configured. Returns None
-    // if no device config is configured.
+    // device config, if device_conf_url is configured.
     pub fn build_device_conf_source(&self) -> FirmwareResult<Option<FirmwareSource>> {
         match &self.device_conf_url {
             Some(url) => {
@@ -102,5 +117,367 @@ impl SupernicFirmwareConfig {
             }
             None => Ok(None),
         }
+    }
+
+    // cache_dir_or_default returns the configured cache directory
+    // or a default temporary directory.
+    pub fn cache_dir_or_default(&self) -> PathBuf {
+        self.cache_dir
+            .clone()
+            .unwrap_or_else(|| std::env::temp_dir().join("mlxconfig-firmware"))
+    }
+}
+
+fn default_reset_level() -> u8 {
+    DEFAULT_RESET_LEVEL
+}
+
+// FlashOptions contains lifecycle flags for the apply() workflow
+// orchestrator, which takes a FirmwareFlasherProfile. This controls
+// which post-flash steps are executed, and their parameters.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlashOptions {
+    // verify_image controls whether the firmware image is verified
+    // against the source binary after flashing.
+    #[serde(default)]
+    pub verify_image: bool,
+    // verify_version controls whether the firmware version on the
+    // device is checked after flashing.
+    #[serde(default)]
+    pub verify_version: bool,
+    // reset controls whether the device is reset via mlxfwreset
+    // after flashing.
+    #[serde(default)]
+    pub reset: bool,
+    // reset_level is the mlxfwreset level to use. Defaults to 3.
+    #[serde(default = "default_reset_level")]
+    pub reset_level: u8,
+}
+
+impl Default for FlashOptions {
+    fn default() -> Self {
+        Self {
+            verify_image: false,
+            verify_version: false,
+            reset: false,
+            reset_level: DEFAULT_RESET_LEVEL,
+        }
+    }
+}
+
+// FirmwareFlasherProfile bundles a FirmwareSpec, FlashSpec, and
+// FlashOptions into a complete firmware management profile. This
+// is the top-level configuration type used in the API runtime config
+// and sent to scout via OpCode::ApplyFirmware.
+//
+// The #[serde(flatten)] attributes allow TOML config to stay flat:
+//   [[supernic_firmware_profiles]]
+//   part_number = "900-9D3B4-00CV-TA0"
+//   psid = "MT_0000000884"
+//   version = "32.43.1014"
+//   firmware_url = "https://..."
+//   reset = true
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FirmwareFlasherProfile {
+    #[serde(flatten)]
+    pub firmware_spec: FirmwareSpec,
+    #[serde(flatten)]
+    pub flash_spec: FlashSpec,
+    #[serde(flatten, default)]
+    pub flash_options: FlashOptions,
+}
+
+impl FirmwareFlasherProfile {
+    // from_file reads a FirmwareFlasherProfile from a TOML file.
+    pub fn from_file(path: impl AsRef<Path>) -> FirmwareResult<Self> {
+        let content = std::fs::read_to_string(path.as_ref()).map_err(FirmwareError::Io)?;
+        Self::from_toml(&content)
+    }
+
+    // from_toml parses a FirmwareFlasherProfile from a TOML string.
+    pub fn from_toml(toml_str: &str) -> FirmwareResult<Self> {
+        toml::from_str(toml_str).map_err(|e| {
+            FirmwareError::ConfigError(format!("Failed to parse firmware profile: {e}"))
+        })
+    }
+}
+
+// From implementations for converting FirmwareSpec
+// to/from a FirmwareSpecPb protobuf message and back.
+impl From<FirmwareSpec> for FirmwareSpecPb {
+    fn from(spec: FirmwareSpec) -> Self {
+        FirmwareSpecPb {
+            part_number: spec.part_number,
+            psid: spec.psid,
+            version: spec.version,
+        }
+    }
+}
+
+impl From<FirmwareSpecPb> for FirmwareSpec {
+    fn from(proto: FirmwareSpecPb) -> Self {
+        FirmwareSpec {
+            part_number: proto.part_number,
+            psid: proto.psid,
+            version: proto.version,
+        }
+    }
+}
+
+// From implementations for converting FlashSpec
+// to/from a FlashSpecPb protobuf message and back.
+impl From<FlashSpec> for FlashSpecPb {
+    fn from(spec: FlashSpec) -> Self {
+        FlashSpecPb {
+            firmware_url: spec.firmware_url,
+            firmware_credentials: spec.firmware_credentials.map(Into::into),
+            device_conf_url: spec.device_conf_url,
+            device_conf_credentials: spec.device_conf_credentials.map(Into::into),
+            verify_from_cache: spec.verify_from_cache,
+            cache_dir: spec.cache_dir.map(|p| p.to_string_lossy().into_owned()),
+        }
+    }
+}
+
+impl TryFrom<FlashSpecPb> for FlashSpec {
+    type Error = String;
+
+    fn try_from(proto: FlashSpecPb) -> Result<Self, Self::Error> {
+        Ok(FlashSpec {
+            firmware_url: proto.firmware_url,
+            firmware_credentials: proto
+                .firmware_credentials
+                .map(TryInto::try_into)
+                .transpose()?,
+            device_conf_url: proto.device_conf_url,
+            device_conf_credentials: proto
+                .device_conf_credentials
+                .map(TryInto::try_into)
+                .transpose()?,
+            verify_from_cache: proto.verify_from_cache,
+            cache_dir: proto.cache_dir.map(PathBuf::from),
+        })
+    }
+}
+
+// From implementations for converting FlashOptions
+// to/from a FlashOptionsPb protobuf message and back.
+impl From<FlashOptions> for FlashOptionsPb {
+    fn from(opts: FlashOptions) -> Self {
+        FlashOptionsPb {
+            verify_image: opts.verify_image,
+            verify_version: opts.verify_version,
+            reset: opts.reset,
+            reset_level: opts.reset_level as u32,
+        }
+    }
+}
+
+impl From<FlashOptionsPb> for FlashOptions {
+    fn from(proto: FlashOptionsPb) -> Self {
+        FlashOptions {
+            verify_image: proto.verify_image,
+            verify_version: proto.verify_version,
+            reset: proto.reset,
+            reset_level: proto.reset_level as u8,
+        }
+    }
+}
+
+// From implementations for converting FirmwareFlasherProfile
+// to/from a FirmwareFlasherProfilePb protobuf message and back.
+impl From<FirmwareFlasherProfile> for FirmwareFlasherProfilePb {
+    fn from(profile: FirmwareFlasherProfile) -> Self {
+        FirmwareFlasherProfilePb {
+            firmware_spec: Some(profile.firmware_spec.into()),
+            flash_spec: Some(profile.flash_spec.into()),
+            flash_options: Some(profile.flash_options.into()),
+        }
+    }
+}
+
+impl TryFrom<FirmwareFlasherProfilePb> for FirmwareFlasherProfile {
+    type Error = String;
+
+    fn try_from(proto: FirmwareFlasherProfilePb) -> Result<Self, Self::Error> {
+        let firmware_spec = proto.firmware_spec.ok_or("missing firmware_spec")?.into();
+        let flash_spec: FlashSpec = proto.flash_spec.ok_or("missing flash_spec")?.try_into()?;
+        let flash_options = proto.flash_options.map(Into::into).unwrap_or_default();
+
+        Ok(FirmwareFlasherProfile {
+            firmware_spec,
+            flash_spec,
+            flash_options,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_firmware_spec_map_key() {
+        let spec = FirmwareSpec {
+            part_number: "900-9D3B4-00CV-TA0".to_string(),
+            psid: "MT_0000000884".to_string(),
+            version: "32.43.1014".to_string(),
+        };
+        assert_eq!(spec.map_key(), "900-9D3B4-00CV-TA0:MT_0000000884");
+    }
+
+    #[test]
+    fn test_firmware_spec_roundtrip() {
+        let original = FirmwareSpec {
+            part_number: "900-9D3B4-00CV-TA0".to_string(),
+            psid: "MT_0000000884".to_string(),
+            version: "32.43.1014".to_string(),
+        };
+        let proto: FirmwareSpecPb = original.clone().into();
+        let converted: FirmwareSpec = proto.into();
+        assert_eq!(original.part_number, converted.part_number);
+        assert_eq!(original.psid, converted.psid);
+        assert_eq!(original.version, converted.version);
+    }
+
+    #[test]
+    fn test_flash_options_default() {
+        let opts = FlashOptions::default();
+        assert!(!opts.verify_image);
+        assert!(!opts.verify_version);
+        assert!(!opts.reset);
+        assert_eq!(opts.reset_level, 3);
+    }
+
+    #[test]
+    fn test_flash_options_roundtrip() {
+        let original = FlashOptions {
+            verify_image: true,
+            verify_version: true,
+            reset: true,
+            reset_level: 5,
+        };
+        let proto: FlashOptionsPb = original.clone().into();
+        let converted: FlashOptions = proto.into();
+        assert_eq!(original.verify_image, converted.verify_image);
+        assert_eq!(original.verify_version, converted.verify_version);
+        assert_eq!(original.reset, converted.reset);
+        assert_eq!(original.reset_level, converted.reset_level);
+    }
+
+    #[test]
+    fn test_profile_full_roundtrip() {
+        let original = FirmwareFlasherProfile {
+            firmware_spec: FirmwareSpec {
+                part_number: "900-9D3B4-00CV-TA0".to_string(),
+                psid: "MT_0000000884".to_string(),
+                version: "32.43.1014".to_string(),
+            },
+            flash_spec: FlashSpec {
+                firmware_url: "https://artifacts.nvidia.com/fw.bin".to_string(),
+                firmware_credentials: Some(Credentials::bearer_token("token123")),
+                device_conf_url: Some("https://artifacts.nvidia.com/debug.conf".to_string()),
+                device_conf_credentials: Some(Credentials::basic_auth("user", "pass")),
+                verify_from_cache: true,
+                cache_dir: Some(PathBuf::from("/var/cache/fw")),
+            },
+            flash_options: FlashOptions {
+                verify_image: true,
+                verify_version: true,
+                reset: true,
+                reset_level: 3,
+            },
+        };
+        let proto: FirmwareFlasherProfilePb = original.clone().into();
+        let converted: FirmwareFlasherProfile = proto.try_into().unwrap();
+
+        assert_eq!(
+            original.firmware_spec.part_number,
+            converted.firmware_spec.part_number
+        );
+        assert_eq!(original.firmware_spec.psid, converted.firmware_spec.psid);
+        assert_eq!(
+            original.firmware_spec.version,
+            converted.firmware_spec.version
+        );
+        assert_eq!(
+            original.flash_spec.firmware_url,
+            converted.flash_spec.firmware_url
+        );
+        assert_eq!(
+            original.flash_spec.device_conf_url,
+            converted.flash_spec.device_conf_url
+        );
+        assert_eq!(
+            original.flash_spec.verify_from_cache,
+            converted.flash_spec.verify_from_cache
+        );
+        assert!(converted.flash_spec.firmware_credentials.is_some());
+        assert!(converted.flash_spec.device_conf_credentials.is_some());
+        assert!(converted.flash_options.verify_image);
+        assert!(converted.flash_options.verify_version);
+        assert!(converted.flash_options.reset);
+        assert_eq!(converted.flash_options.reset_level, 3);
+    }
+
+    #[test]
+    fn test_profile_minimal_roundtrip() {
+        let original = FirmwareFlasherProfile {
+            firmware_spec: FirmwareSpec {
+                part_number: "900-9D3B4-00CV-TA0".to_string(),
+                psid: "MT_0000000884".to_string(),
+                version: "32.43.1014".to_string(),
+            },
+            flash_spec: FlashSpec {
+                firmware_url: "/local/path/fw.bin".to_string(),
+                firmware_credentials: None,
+                device_conf_url: None,
+                device_conf_credentials: None,
+                verify_from_cache: false,
+                cache_dir: None,
+            },
+            flash_options: FlashOptions::default(),
+        };
+        let proto: FirmwareFlasherProfilePb = original.clone().into();
+        let converted: FirmwareFlasherProfile = proto.try_into().unwrap();
+
+        assert_eq!(
+            original.firmware_spec.part_number,
+            converted.firmware_spec.part_number
+        );
+        assert_eq!(
+            original.flash_spec.firmware_url,
+            converted.flash_spec.firmware_url
+        );
+        assert!(converted.flash_spec.firmware_credentials.is_none());
+        assert!(converted.flash_spec.device_conf_url.is_none());
+        assert!(!converted.flash_options.reset);
+        assert!(!converted.flash_options.verify_image);
+        assert!(!converted.flash_options.verify_version);
+        assert_eq!(converted.flash_options.reset_level, 3);
+    }
+
+    #[test]
+    fn test_profile_toml_roundtrip() {
+        let toml_str = r#"
+part_number = "900-9D3B4-00CV-TA0"
+psid = "MT_0000000884"
+version = "32.43.1014"
+firmware_url = "https://artifacts.nvidia.com/fw.bin"
+reset = true
+verify_image = true
+verify_version = true
+"#;
+        let profile = FirmwareFlasherProfile::from_toml(toml_str).unwrap();
+        assert_eq!(profile.firmware_spec.part_number, "900-9D3B4-00CV-TA0");
+        assert_eq!(profile.firmware_spec.version, "32.43.1014");
+        assert_eq!(
+            profile.flash_spec.firmware_url,
+            "https://artifacts.nvidia.com/fw.bin"
+        );
+        assert!(profile.flash_options.reset);
+        assert!(profile.flash_options.verify_image);
+        assert!(profile.flash_options.verify_version);
+        assert_eq!(profile.flash_options.reset_level, 3); // default
     }
 }

--- a/crates/libmlx/src/firmware/credentials.rs
+++ b/crates/libmlx/src/firmware/credentials.rs
@@ -15,6 +15,13 @@
  * limitations under the License.
  */
 
+use rpc::protos::mlx_device::firmware_credentials::CredentialType as CredentialTypePb;
+use rpc::protos::mlx_device::{
+    BasicAuthCredentials as BasicAuthCredentialsPb,
+    BearerTokenCredentials as BearerTokenCredentialsPb,
+    FirmwareCredentials as FirmwareCredentialsPb, HeaderCredentials as HeaderCredentialsPb,
+    SshAgentCredentials as SshAgentCredentialsPb, SshKeyCredentials as SshKeyCredentialsPb,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::firmware::error::{FirmwareError, FirmwareResult};
@@ -113,6 +120,20 @@ impl Credentials {
         Self::SshAgent
     }
 
+    // type_name returns human-readable details for the credential
+    // variant without exposing any underlying secrets. I wanted to
+    // be able to just dump it out but realized that would be unsafe,
+    // since it would also mean dumping out tokens and passwords.
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            Credentials::BearerToken { .. } => "bearer_token",
+            Credentials::BasicAuth { .. } => "basic_auth",
+            Credentials::Header { .. } => "header",
+            Credentials::SshKey { .. } => "ssh_key",
+            Credentials::SshAgent => "ssh_agent",
+        }
+    }
+
     // validate_http returns an error if this credential type is not
     // compatible with HTTP sources.
     pub fn validate_http(&self) -> FirmwareResult<()> {
@@ -137,5 +158,122 @@ impl Credentials {
                 "HTTP credentials cannot be used with SSH sources".to_string(),
             )),
         }
+    }
+}
+
+// From implementations for converting Credentials to/from
+// a FirmwareCredentialsPb protobuf message and back.
+impl From<Credentials> for FirmwareCredentialsPb {
+    fn from(cred: Credentials) -> Self {
+        let credential_type = match cred {
+            Credentials::BearerToken { token } => {
+                CredentialTypePb::BearerToken(BearerTokenCredentialsPb { token })
+            }
+            Credentials::BasicAuth { username, password } => {
+                CredentialTypePb::BasicAuth(BasicAuthCredentialsPb { username, password })
+            }
+            Credentials::Header { name, value } => {
+                CredentialTypePb::Header(HeaderCredentialsPb { name, value })
+            }
+            Credentials::SshKey { path, passphrase } => {
+                CredentialTypePb::SshKey(SshKeyCredentialsPb { path, passphrase })
+            }
+            Credentials::SshAgent => CredentialTypePb::SshAgent(SshAgentCredentialsPb {}),
+        };
+        FirmwareCredentialsPb {
+            credential_type: Some(credential_type),
+        }
+    }
+}
+
+impl TryFrom<FirmwareCredentialsPb> for Credentials {
+    type Error = String;
+
+    fn try_from(proto: FirmwareCredentialsPb) -> Result<Self, Self::Error> {
+        match proto
+            .credential_type
+            .ok_or("Missing credential_type in FirmwareCredentials")?
+        {
+            CredentialTypePb::BearerToken(bt) => Ok(Credentials::BearerToken { token: bt.token }),
+            CredentialTypePb::BasicAuth(ba) => Ok(Credentials::BasicAuth {
+                username: ba.username,
+                password: ba.password,
+            }),
+            CredentialTypePb::Header(h) => Ok(Credentials::Header {
+                name: h.name,
+                value: h.value,
+            }),
+            CredentialTypePb::SshKey(sk) => Ok(Credentials::SshKey {
+                path: sk.path,
+                passphrase: sk.passphrase,
+            }),
+            CredentialTypePb::SshAgent(_) => Ok(Credentials::SshAgent),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_credentials_bearer_token_roundtrip() {
+        let original = Credentials::bearer_token("my-token");
+        let proto: FirmwareCredentialsPb = original.clone().into();
+        let converted: Credentials = proto.try_into().unwrap();
+        match converted {
+            Credentials::BearerToken { token } => assert_eq!(token, "my-token"),
+            _ => panic!("Expected BearerToken"),
+        }
+    }
+
+    #[test]
+    fn test_credentials_basic_auth_roundtrip() {
+        let original = Credentials::basic_auth("user", "pass");
+        let proto: FirmwareCredentialsPb = original.clone().into();
+        let converted: Credentials = proto.try_into().unwrap();
+        match converted {
+            Credentials::BasicAuth { username, password } => {
+                assert_eq!(username, "user");
+                assert_eq!(password, "pass");
+            }
+            _ => panic!("Expected BasicAuth"),
+        }
+    }
+
+    #[test]
+    fn test_credentials_header_roundtrip() {
+        let original = Credentials::header("X-API-Key", "secret");
+        let proto: FirmwareCredentialsPb = original.clone().into();
+        let converted: Credentials = proto.try_into().unwrap();
+        match converted {
+            Credentials::Header { name, value } => {
+                assert_eq!(name, "X-API-Key");
+                assert_eq!(value, "secret");
+            }
+            _ => panic!("Expected Header"),
+        }
+    }
+
+    #[test]
+    fn test_credentials_ssh_key_roundtrip() {
+        let original = Credentials::ssh_key_with_passphrase("/path/to/key", "passphrase");
+        let proto: FirmwareCredentialsPb = original.clone().into();
+        let converted: Credentials = proto.try_into().unwrap();
+        match converted {
+            Credentials::SshKey { path, passphrase } => {
+                assert_eq!(path, "/path/to/key");
+                assert_eq!(passphrase, Some("passphrase".to_string()));
+            }
+            _ => panic!("Expected SshKey"),
+        }
+    }
+
+    #[test]
+    fn test_credentials_ssh_agent_roundtrip() {
+        let original = Credentials::ssh_agent();
+        let proto: FirmwareCredentialsPb = original.clone().into();
+        let converted: Credentials = proto.try_into().unwrap();
+        assert!(matches!(converted, Credentials::SshAgent));
     }
 }

--- a/crates/libmlx/src/firmware/mod.rs
+++ b/crates/libmlx/src/firmware/mod.rs
@@ -20,4 +20,5 @@ pub mod credentials;
 pub mod error;
 pub mod flasher;
 pub mod reset;
+pub mod result;
 pub mod source;

--- a/crates/libmlx/src/firmware/result.rs
+++ b/crates/libmlx/src/firmware/result.rs
@@ -1,0 +1,154 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use rpc::protos::mlx_device::FirmwareFlashReport as FirmwareFlashReportPb;
+use serde::{Deserialize, Serialize};
+
+// FirmwareFlashReport captures the outcome of each step in the
+// firmware flash lifecycle. Built by scout after executing the
+// ApplyFirmware operation and sent back to the API as part of an
+// MlxObservation.
+//
+// Each optional step (reset, verify_image, verify_version) is
+// controlled by the corresponding flag in FlashOptions.
+// A None value means the step was not requested; Some(true/false)
+// means it was attempted and the result.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FirmwareFlashReport {
+    // Whether the firmware was successfully flashed via flint.
+    pub flashed: bool,
+    // Whether the device was successfully reset via mlxfwreset.
+    // None if config.reset was false (not requested).
+    pub reset: Option<bool>,
+    // Whether the firmware image on the device was verified against
+    // the source image via flint verify.
+    // None if config.verify_image was false (not requested).
+    pub verified_image: Option<bool>,
+    // Whether the firmware version on the device matches the expected
+    // version. None if config.verify_version was false (not requested).
+    pub verified_version: Option<bool>,
+    // The firmware version observed on the device after flashing,
+    // queried via mlxfwmanager. None if the device could not be
+    // queried or if the step was not performed.
+    pub observed_version: Option<String>,
+    // The expected firmware version from the config, if one was set.
+    pub expected_version: Option<String>,
+}
+
+// From implementations for converting FirmwareFlashReport
+// to/from a FirmwareFlashReportPb protobuf message and back.
+impl From<FirmwareFlashReport> for FirmwareFlashReportPb {
+    fn from(result: FirmwareFlashReport) -> Self {
+        FirmwareFlashReportPb {
+            flashed: result.flashed,
+            reset: result.reset,
+            verified_image: result.verified_image,
+            verified_version: result.verified_version,
+            observed_version: result.observed_version,
+            expected_version: result.expected_version,
+        }
+    }
+}
+
+impl From<FirmwareFlashReportPb> for FirmwareFlashReport {
+    fn from(proto: FirmwareFlashReportPb) -> Self {
+        FirmwareFlashReport {
+            flashed: proto.flashed,
+            reset: proto.reset,
+            verified_image: proto.verified_image,
+            verified_version: proto.verified_version,
+            observed_version: proto.observed_version,
+            expected_version: proto.expected_version,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_flasher_result_all_steps_success() {
+        let original = FirmwareFlashReport {
+            flashed: true,
+            reset: Some(true),
+            verified_image: Some(true),
+            verified_version: Some(true),
+            observed_version: Some("32.43.1014".to_string()),
+            expected_version: Some("32.43.1014".to_string()),
+        };
+        let proto: FirmwareFlashReportPb = original.clone().into();
+        let converted: FirmwareFlashReport = proto.into();
+
+        assert_eq!(original.flashed, converted.flashed);
+        assert_eq!(original.reset, converted.reset);
+        assert_eq!(original.verified_image, converted.verified_image);
+        assert_eq!(original.verified_version, converted.verified_version);
+        assert_eq!(original.observed_version, converted.observed_version);
+        assert_eq!(original.expected_version, converted.expected_version);
+    }
+
+    #[test]
+    fn test_flasher_result_flash_only() {
+        let original = FirmwareFlashReport {
+            flashed: true,
+            reset: None,
+            verified_image: None,
+            verified_version: None,
+            observed_version: None,
+            expected_version: None,
+        };
+        let proto: FirmwareFlashReportPb = original.clone().into();
+        let converted: FirmwareFlashReport = proto.into();
+
+        assert!(converted.flashed);
+        assert!(converted.reset.is_none());
+        assert!(converted.verified_image.is_none());
+        assert!(converted.verified_version.is_none());
+        assert!(converted.observed_version.is_none());
+    }
+
+    #[test]
+    fn test_flasher_result_partial_failure() {
+        let original = FirmwareFlashReport {
+            flashed: true,
+            reset: Some(false),
+            verified_image: Some(false),
+            verified_version: Some(false),
+            observed_version: Some("32.42.900".to_string()),
+            expected_version: Some("32.43.1014".to_string()),
+        };
+        let proto: FirmwareFlashReportPb = original.clone().into();
+        let converted: FirmwareFlashReport = proto.into();
+
+        assert!(converted.flashed);
+        assert_eq!(converted.reset, Some(false));
+        assert_eq!(converted.verified_image, Some(false));
+        assert_eq!(converted.verified_version, Some(false));
+    }
+
+    #[test]
+    fn test_flasher_result_default() {
+        let report = FirmwareFlashReport::default();
+        assert!(!report.flashed);
+        assert!(report.reset.is_none());
+        assert!(report.verified_image.is_none());
+        assert!(report.verified_version.is_none());
+        assert!(report.observed_version.is_none());
+        assert!(report.expected_version.is_none());
+    }
+}

--- a/crates/libmlx/tests/firmware/test_config.rs
+++ b/crates/libmlx/tests/firmware/test_config.rs
@@ -15,36 +15,56 @@
  * limitations under the License.
  */
 
-use libmlx::firmware::config::SupernicFirmwareConfig;
+use libmlx::firmware::config::FirmwareFlasherProfile;
 
 #[test]
 fn test_minimal_config() {
     let toml = r#"
+part_number = "900-9D3B4-00CV-TA0"
+psid = "MT_0000000884"
+version = "32.43.1014"
 firmware_url = "/opt/firmware/prod.signed.bin"
 "#;
 
-    let config = SupernicFirmwareConfig::from_toml(toml).unwrap();
-    assert_eq!(config.firmware_url, "/opt/firmware/prod.signed.bin");
-    assert!(config.firmware_credentials.is_none());
-    assert!(config.device_conf_url.is_none());
-    assert!(config.device_conf_credentials.is_none());
-    assert!(config.expected_version.is_none());
+    let profile = FirmwareFlasherProfile::from_toml(toml).unwrap();
+    assert_eq!(profile.firmware_spec.part_number, "900-9D3B4-00CV-TA0");
+    assert_eq!(profile.firmware_spec.psid, "MT_0000000884");
+    assert_eq!(profile.firmware_spec.version, "32.43.1014");
+    assert_eq!(
+        profile.flash_spec.firmware_url,
+        "/opt/firmware/prod.signed.bin"
+    );
+    assert!(profile.flash_spec.firmware_credentials.is_none());
+    assert!(profile.flash_spec.device_conf_url.is_none());
+    assert!(profile.flash_spec.device_conf_credentials.is_none());
 }
 
 #[test]
-fn test_config_with_expected_version() {
+fn test_config_with_version_and_options() {
     let toml = r#"
+part_number = "900-9D3B4-00CV-TA0"
+psid = "MT_0000000884"
+version = "32.43.1014"
 firmware_url = "/opt/firmware/prod.signed.bin"
-expected_version = "32.43.1014"
+reset = true
+verify_image = true
+verify_version = true
 "#;
 
-    let config = SupernicFirmwareConfig::from_toml(toml).unwrap();
-    assert_eq!(config.expected_version.as_deref(), Some("32.43.1014"));
+    let profile = FirmwareFlasherProfile::from_toml(toml).unwrap();
+    assert_eq!(profile.firmware_spec.version, "32.43.1014");
+    assert!(profile.flash_options.reset);
+    assert!(profile.flash_options.verify_image);
+    assert!(profile.flash_options.verify_version);
+    assert_eq!(profile.flash_options.reset_level, 3); // default
 }
 
 #[test]
 fn test_config_with_bearer_token() {
     let toml = r#"
+part_number = "900-9D3B4-00CV-TA0"
+psid = "MT_0000000884"
+version = "32.43.1014"
 firmware_url = "https://artifacts.example.com/fw/prod.signed.bin"
 
 [firmware_credentials]
@@ -52,16 +72,19 @@ type = "bearer_token"
 token = "my-secret-token"
 "#;
 
-    let config = SupernicFirmwareConfig::from_toml(toml).unwrap();
-    assert!(config.firmware_credentials.is_some());
+    let profile = FirmwareFlasherProfile::from_toml(toml).unwrap();
+    assert!(profile.flash_spec.firmware_credentials.is_some());
 
-    let source = config.build_firmware_source().unwrap();
+    let source = profile.flash_spec.build_firmware_source().unwrap();
     assert!(source.description().contains("http:"));
 }
 
 #[test]
 fn test_config_with_basic_auth() {
     let toml = r#"
+part_number = "900-9D3B4-00CV-TA0"
+psid = "MT_0000000884"
+version = "32.43.1014"
 firmware_url = "https://internal.example.com/fw/prod.signed.bin"
 
 [firmware_credentials]
@@ -70,13 +93,16 @@ username = "deploy"
 password = "s3cret"
 "#;
 
-    let config = SupernicFirmwareConfig::from_toml(toml).unwrap();
-    assert!(config.firmware_credentials.is_some());
+    let profile = FirmwareFlasherProfile::from_toml(toml).unwrap();
+    assert!(profile.flash_spec.firmware_credentials.is_some());
 }
 
 #[test]
 fn test_config_with_ssh_key() {
     let toml = r#"
+part_number = "900-9D3B4-00CV-TA0"
+psid = "MT_0000000884"
+version = "32.43.1014"
 firmware_url = "ssh://deploy@build-server.example.com:builds/fw/prod.signed.bin"
 
 [firmware_credentials]
@@ -84,31 +110,36 @@ type = "ssh_key"
 path = "/home/deploy/.ssh/id_ed25519"
 "#;
 
-    let config = SupernicFirmwareConfig::from_toml(toml).unwrap();
-    assert!(config.firmware_credentials.is_some());
+    let profile = FirmwareFlasherProfile::from_toml(toml).unwrap();
+    assert!(profile.flash_spec.firmware_credentials.is_some());
 
-    let source = config.build_firmware_source().unwrap();
+    let source = profile.flash_spec.build_firmware_source().unwrap();
     assert!(source.description().contains("ssh://"));
 }
 
 #[test]
 fn test_config_with_ssh_agent() {
     let toml = r#"
+part_number = "900-9D3B4-00CV-TA0"
+psid = "MT_0000000884"
+version = "32.43.1014"
 firmware_url = "ssh://deploy@build-server.example.com:builds/fw/prod.signed.bin"
 
 [firmware_credentials]
 type = "ssh_agent"
 "#;
 
-    let config = SupernicFirmwareConfig::from_toml(toml).unwrap();
-    assert!(config.firmware_credentials.is_some());
+    let profile = FirmwareFlasherProfile::from_toml(toml).unwrap();
+    assert!(profile.flash_spec.firmware_credentials.is_some());
 }
 
 #[test]
 fn test_config_with_device_conf() {
     let toml = r#"
+part_number = "900-9D3B4-00CV-TA0"
+psid = "MT_0000000884"
+version = "32.43.1014"
 firmware_url = "https://artifacts.example.com/fw/debug.signed.bin"
-expected_version = "32.43.1014"
 device_conf_url = "ssh://deploy@build-server.example.com:builds/configs/debug.conf.bin"
 
 [firmware_credentials]
@@ -119,18 +150,18 @@ token = "fw-token"
 type = "ssh_agent"
 "#;
 
-    let config = SupernicFirmwareConfig::from_toml(toml).unwrap();
+    let profile = FirmwareFlasherProfile::from_toml(toml).unwrap();
 
     assert_eq!(
-        config.device_conf_url.as_deref(),
+        profile.flash_spec.device_conf_url.as_deref(),
         Some("ssh://deploy@build-server.example.com:builds/configs/debug.conf.bin")
     );
-    assert!(config.device_conf_credentials.is_some());
+    assert!(profile.flash_spec.device_conf_credentials.is_some());
 
-    let fw_source = config.build_firmware_source().unwrap();
+    let fw_source = profile.flash_spec.build_firmware_source().unwrap();
     assert!(fw_source.description().contains("http:"));
 
-    let conf_source = config.build_device_conf_source().unwrap();
+    let conf_source = profile.flash_spec.build_device_conf_source().unwrap();
     assert!(conf_source.is_some());
     assert!(conf_source.unwrap().description().contains("ssh://"));
 }
@@ -138,11 +169,14 @@ type = "ssh_agent"
 #[test]
 fn test_config_no_device_conf_returns_none() {
     let toml = r#"
+part_number = "900-9D3B4-00CV-TA0"
+psid = "MT_0000000884"
+version = "32.43.1014"
 firmware_url = "/opt/firmware/prod.signed.bin"
 "#;
 
-    let config = SupernicFirmwareConfig::from_toml(toml).unwrap();
-    let conf_source = config.build_device_conf_source().unwrap();
+    let profile = FirmwareFlasherProfile::from_toml(toml).unwrap();
+    let conf_source = profile.flash_spec.build_device_conf_source().unwrap();
     assert!(conf_source.is_none());
 }
 
@@ -152,16 +186,18 @@ fn test_config_invalid_toml() {
 firmware_url = "missing closing quote
 "#;
 
-    let result = SupernicFirmwareConfig::from_toml(toml);
+    let result = FirmwareFlasherProfile::from_toml(toml);
     assert!(result.is_err());
 }
 
 #[test]
 fn test_config_missing_required_field() {
     let toml = r#"
-expected_version = "32.43.1014"
+part_number = "900-9D3B4-00CV-TA0"
+psid = "MT_0000000884"
+version = "32.43.1014"
 "#;
 
-    let result = SupernicFirmwareConfig::from_toml(toml);
+    let result = FirmwareFlasherProfile::from_toml(toml);
     assert!(result.is_err());
 }

--- a/crates/rpc/proto/mlx_device.proto
+++ b/crates/rpc/proto/mlx_device.proto
@@ -363,10 +363,146 @@ message SerializableMlxConfigProfile {
   map<string, string> config = 4;
 }
 
+// FirmwareCredentials represents authentication credentials for
+// accessing firmware or device config resources. Maps to the Rust
+// Credentials enum in libmlx::firmware::credentials.
+message FirmwareCredentials {
+  oneof credential_type {
+    BearerTokenCredentials bearer_token = 1;
+    BasicAuthCredentials basic_auth = 2;
+    HeaderCredentials header = 3;
+    SshKeyCredentials ssh_key = 4;
+    SshAgentCredentials ssh_agent = 5;
+  }
+}
+
+// BearerTokenCredentials uses an Authorization: Bearer <token> header.
+message BearerTokenCredentials {
+  string token = 1;
+}
+
+// BasicAuthCredentials uses HTTP Basic authentication.
+message BasicAuthCredentials {
+  string username = 1;
+  string password = 2;
+}
+
+// HeaderCredentials uses a custom HTTP header for authentication.
+message HeaderCredentials {
+  string name = 1;
+  string value = 2;
+}
+
+// SshKeyCredentials uses a private key file for SSH authentication.
+message SshKeyCredentials {
+  string path = 1;
+  optional string passphrase = 2;
+}
+
+// SshAgentCredentials uses the running SSH agent for authentication.
+message SshAgentCredentials {
+}
+
+// FirmwareSpec identifies a firmware target by device identity
+// (part_number, psid) and the target firmware version. It is
+// used to construct a FirmwareFlasher following an RAII model,
+// where we poll the device to confirm part_number + PSID of
+// the device match that of the spec, otherwise we won't hand
+// back a new flasher. This helps to ensure we will only flash
+// firmware to a device the firmware supports.
+message FirmwareSpec {
+  // part_number is the manufacturer part number for the target device
+  // (e.g., "900-9D3B4-00CV-TA0").
+  string part_number = 1;
+  // psid (Parameter-Set IDentification) identifies the firmware
+  // configuration of the target device (e.g., "MT_0000000884").
+  string psid = 2;
+  // version is the target firmware version string (e.g., "32.43.1014").
+  string version = 3;
+}
+
+// FlashSpec specifies the source locations and caching options for
+// flash and verify_image operations. Passed to flasher.flash() and
+// flasher.verify_image().
+message FlashSpec {
+  // firmware_url is the location of the firmware binary.
+  // Supports local paths, file://, https://, and ssh:// URLs.
+  string firmware_url = 1;
+  // firmware_credentials is the optional authentication for
+  // downloading the firmware binary.
+  optional FirmwareCredentials firmware_credentials = 2;
+  // device_conf_url is the optional location of the device config
+  // to apply before flashing (e.g., a debug token or mlxconfig blob).
+  optional string device_conf_url = 3;
+  // device_conf_credentials is the optional authentication for
+  // downloading the device config.
+  optional FirmwareCredentials device_conf_credentials = 4;
+  // verify_from_cache controls whether verify_image() uses the
+  // cached firmware from cache_dir instead of re-pulling from source.
+  bool verify_from_cache = 5;
+  // cache_dir is the directory for staging downloaded firmware files.
+  // Defaults to a temporary directory if not specified.
+  optional string cache_dir = 6;
+}
+
+// FlashOptions contains lifecycle flags for the apply() orchestrator.
+// Controls which post-flash steps are executed.
+message FlashOptions {
+  // verify_image controls whether the firmware image on the device is
+  // verified against the source binary after flashing. Default is false.
+  bool verify_image = 1;
+  // verify_version controls whether the firmware version on the device
+  // is checked after flashing. Default is false.
+  bool verify_version = 2;
+  // reset controls whether the device is reset via mlxfwreset after
+  // flashing. Default is false.
+  bool reset = 3;
+  // reset_level is the mlxfwreset level to use. Default is 3.
+  uint32 reset_level = 4;
+}
+
+// FirmwareFlasherProfile bundles a FirmwareSpec, FlashSpec, and
+// FlashOptions into a complete firmware management profile. Used by
+// the API runtime config and sent to scout via OpCode::ApplyFirmware.
+message FirmwareFlasherProfile {
+  FirmwareSpec firmware_spec = 1;
+  FlashSpec flash_spec = 2;
+  optional FlashOptions flash_options = 3;
+}
+
 message MlxObservationReport {
   common.MachineId machine_id = 1;
   google.protobuf.Timestamp timestamp = 2;
   repeated MlxObservation observations = 3;
+}
+
+// FirmwareFlashReport captures the outcome of each step in the
+// firmware flash lifecycle: flash, reset, image verification, and
+// version verification. Each optional step (reset, verify_image,
+// verify_version) is controlled by the corresponding flag in
+// SupernicFirmwareConfig. A None value means the step was not
+// requested; Some(true/false) means it was attempted and the result.
+// Sent from scout to the API as part of an MlxObservation after an
+// ApplyFirmware operation.
+message FirmwareFlashReport {
+  // Whether the firmware was successfully flashed via flint.
+  bool flashed = 1;
+  // Whether the device was successfully reset via mlxfwreset.
+  // None if config.reset was false (not requested).
+  optional bool reset = 2;
+  // Whether the firmware image on the device was verified against
+  // the source image via flint verify.
+  // None if config.verify_image was false (not requested).
+  optional bool verified_image = 3;
+  // Whether the firmware version on the device matches the expected
+  // version. None if config.verify_version was false (not requested).
+  optional bool verified_version = 4;
+  // The firmware version observed on the device after flashing,
+  // queried via mlxfwmanager. None if the device could not be queried
+  // or if the step was not performed.
+  optional string observed_version = 5;
+  // The expected firmware version from the config, if one was set.
+  optional string expected_version = 6;
 }
 
 message MlxObservation {
@@ -374,6 +510,10 @@ message MlxObservation {
   optional LockStatus lock_status = 2;
   optional string profile_name = 3;
   optional bool profile_synced = 4;
+  // firmware_report captures the outcome of the firmware flash lifecycle
+  // during the ApplyFirmware state. Each step's report reflects whether
+  // it was requested (via config flags) and whether it succeeded.
+  optional FirmwareFlashReport firmware_report = 5;
 }
 
 // PublishMlxObservationReportRequest is sent by scout or the agent

--- a/crates/scout/src/main.rs
+++ b/crates/scout/src/main.rs
@@ -35,7 +35,8 @@ use rpc::forge::ForgeAgentControlResponse;
 use rpc::forge::forge_agent_control_response::{Action, ForgeAgentControlExtraInfo};
 use rpc::forge_agent_control_response::forge_agent_control_extra_info::KeyValuePair;
 use rpc::protos::mlx_device::{
-    LockStatus, MlxObservation, MlxObservationReport, PublishMlxObservationReportRequest,
+    FirmwareFlashReport as FirmwareFlashReportPb, LockStatus, MlxObservation, MlxObservationReport,
+    PublishMlxObservationReportRequest,
 };
 use rpc::{ForgeScoutErrorReport, forge as rpc_forge};
 pub use scout::{CarbideClientError, CarbideClientResult};
@@ -491,7 +492,7 @@ async fn handle_mlxreport_action(
         // The action is a structure with an OpCode (like Lock/Unlock/ApplyProfile)
         // and an additional optional string (for ApplyProfile)
 
-        let dpa_cmd: DpaCommand = match serde_json::from_str(&action) {
+        let dpa_cmd: DpaCommand<'_> = match serde_json::from_str(&action) {
             Ok(dpc) => dpc,
             Err(e) => {
                 tracing::error!(
@@ -511,6 +512,7 @@ async fn handle_mlxreport_action(
                         lock_status: Some(LockStatus::Locked.into()),
                         profile_name: None,
                         profile_synced: None,
+                        firmware_report: None,
                     };
                     report.observations.push(obs);
                 }
@@ -521,6 +523,51 @@ async fn handle_mlxreport_action(
                     );
                 }
             },
+            // ApplyFirmware attempts to apply the provided FirmwareFlasherProfile
+            // that it gets back from carbide-api. The profile *may* be None, which
+            // could mean no firmware profile was found for the target Part Number
+            // and PSID, or that carbide-api decided there was nothing to do here
+            // (already at target version), or it wants to do a noop pass-through.
+            // If None, scout reports a successful pass-through.
+            //
+            // Otherwise, scout constructs a FirmwareFlasher with new(..) validation
+            // (device hw identity must match the FirmwareSpec), then calls apply()
+            // which orchestrates: flash → reset → verify_image → verify_version.
+            //
+            // If flash() fails, scout does NOT send an observation, which causes
+            // the DpaInterfaceController to remain in ApplyFirmware. On the next
+            // poll, carbide-api will tell scout to try again.
+            //
+            // If flash() succeeds but a later step fails (reset, verify), scout
+            // still sends the partial result so the API has visibility into what
+            // happened. The state controller checks flashed && reset before
+            // transitioning, so a partial failure stays in ApplyFirmware.
+            OpCode::ApplyFirmware { profile } => {
+                let firmware_report = match profile {
+                    Some(profile) => mlx_device::apply_firmware(&dev_pci_name, &profile).await,
+                    None => {
+                        // No firmware profile was provided. Report a pass-through
+                        // so the state controller transitions past ApplyFirmware.
+                        tracing::info!(
+                            device = %dev_pci_name,
+                            "no firmware profile, skipping"
+                        );
+                        Some(FirmwareFlashReportPb {
+                            flashed: true,
+                            ..Default::default()
+                        })
+                    }
+                };
+
+                let obs = MlxObservation {
+                    device_info: Some(dev.into()),
+                    lock_status: None,
+                    profile_name: None,
+                    profile_synced: None,
+                    firmware_report,
+                };
+                report.observations.push(obs);
+            }
             OpCode::ApplyProfile { profile_str } => {
                 // XXX TODO XXX
                 // Call appropriate mlx routine to apply profile and handle errors
@@ -530,6 +577,7 @@ async fn handle_mlxreport_action(
                     lock_status: None,
                     profile_name: Some(profile_str),
                     profile_synced: Some(true),
+                    firmware_report: None,
                 };
                 report.observations.push(obs);
             }
@@ -540,6 +588,7 @@ async fn handle_mlxreport_action(
                         lock_status: Some(LockStatus::Unlocked.into()),
                         profile_name: None,
                         profile_synced: None,
+                        firmware_report: None,
                     };
                     report.observations.push(obs);
                 }

--- a/crates/scout/src/mlx_device.rs
+++ b/crates/scout/src/mlx_device.rs
@@ -16,13 +16,15 @@
  */
 
 use ::rpc::protos::mlx_device::{
-    MlxDeviceReport as MlxDeviceReportPb, PublishMlxDeviceReportRequest,
-    PublishMlxDeviceReportResponse, PublishMlxObservationReportRequest,
-    PublishMlxObservationReportResponse,
+    FirmwareFlashReport as FirmwareFlashReportPb, MlxDeviceReport as MlxDeviceReportPb,
+    PublishMlxDeviceReportRequest, PublishMlxDeviceReportResponse,
+    PublishMlxObservationReportRequest, PublishMlxObservationReportResponse,
 };
 use carbide_uuid::machine::MachineId;
 use libmlx::device::discovery;
 use libmlx::device::report::MlxDeviceReport;
+use libmlx::firmware::config::FirmwareFlasherProfile;
+use libmlx::firmware::flasher::FirmwareFlasher;
 use libmlx::lockdown::error::MlxResult;
 use libmlx::lockdown::lockdown::{LockdownManager, StatusReport};
 use libmlx::profile::error::MlxProfileError;
@@ -1024,6 +1026,87 @@ pub fn handle_config_compare(
                     ),
                 ),
             }
+        }
+    }
+}
+
+// apply_firmware executes the full firmware flash lifecycle for a device
+// using the provided FirmwareFlasherProfile. Returns Some(report) on
+// success (including partial success where flash worked but a post-flash
+// step failed), or None if the flasher couldn't be created or the flash
+// itself failed.
+pub async fn apply_firmware(
+    device: &str,
+    profile: &FirmwareFlasherProfile,
+) -> Option<FirmwareFlashReportPb> {
+    let firmware_credential_type = profile
+        .flash_spec
+        .firmware_credentials
+        .as_ref()
+        .map(|c| c.type_name())
+        .unwrap_or("none");
+
+    let device_conf_credential_type = profile
+        .flash_spec
+        .device_conf_credentials
+        .as_ref()
+        .map(|c| c.type_name())
+        .unwrap_or("none");
+
+    tracing::info!(
+        device = %device,
+        part_number = %profile.firmware_spec.part_number,
+        psid = %profile.firmware_spec.psid,
+        firmware_url = %profile.flash_spec.firmware_url,
+        firmware_credential_type,
+        device_conf_url = profile.flash_spec.device_conf_url.as_deref().unwrap_or("none"),
+        device_conf_credential_type,
+        target_version = %profile.firmware_spec.version,
+        "applying firmware"
+    );
+
+    // Initialize a new FirmwareFlasher, leveraging new(..)
+    // to validate the device identity matches FirmwareSpec.
+    let flasher = match FirmwareFlasher::new(device, &profile.firmware_spec) {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::error!(
+                device = %device,
+                part_number = %profile.firmware_spec.part_number,
+                psid = %profile.firmware_spec.psid,
+                %e,
+                "failed to create FirmwareFlasher"
+            );
+            return None;
+        }
+    };
+
+    // ...and now that we've got our FirmwareFlasher, lets take
+    // the FirmwareFlasherProfile we got from carbide-api and
+    // execute the full firmware lifecycle.
+    match flasher.apply(profile).await {
+        Ok(result) => {
+            tracing::info!(
+                device = %device,
+                part_number = %profile.firmware_spec.part_number,
+                psid = %profile.firmware_spec.psid,
+                firmware_url = %profile.flash_spec.firmware_url,
+                target_version = %profile.firmware_spec.version,
+                "firmware flash successful"
+            );
+            Some(result.into())
+        }
+        Err(e) => {
+            tracing::error!(
+                device = %device,
+                part_number = %profile.firmware_spec.part_number,
+                psid = %profile.firmware_spec.psid,
+                firmware_url = %profile.flash_spec.firmware_url,
+                target_version = %profile.firmware_spec.version,
+                %e,
+                "firmware flash failed"
+            );
+            None
         }
     }
 }


### PR DESCRIPTION
## Description

This builds on the [libmlx::firmware work](https://github.com/NVIDIA/bare-metal-manager-core/pull/278) to integrate SuperNIC firmware management into the DPA provisioning workflow (it's been sitting there as a `TODO` placeholder). SuperNIC firmware management should ultimately be decoupled from the DPA provisioning workflow, but for now this is where it goes, and we can fiddle with provisioning workflow refactoring later.

High level changes include:
1. Introducing a new `ApplyFirmware` state + corresponding `OpCode` within the `scout` <-> DPA Controller flow.
1. Mapping a `(Part Number, PSID)` to a firmware config in the Carbide TOML file.
2. Adding corresponding `MlxDeviceInfo` report storage to the `dpa_interfaces` table, which gives us access to `part_number`, `psid`, current fimrware version, etc.

When it comes to the workflow:
1. We'll look up the target interface part number + PSID.
2. We'll check the `runtime_config` if a `SupernicFirmwareConfig` has been defined for it.
3. We'll either set `Some(config)` or `None` depending on what we found.
4. If there's config to apply, we'll send it down to `scout`.
5. `scout` will take the `FirmwareFlasherProfile` it received and send it to a `FirmwareFlasher`, which will then flash + reset + verify and return a response back to the API.

I feng shui'd a few things around config(s) structure in the `libmlx::firmware` module, which had kind of a rippling effect throughout other things (including a bunch of `From` implementations for passing to/from `.proto` messages), but I'm a lot happier with the structure now as opposed to what it was before -- namely initializing a new flasher with a `FirmwareSpec`, and using that to validate against the target device's `MlxDeviceInfo`, before handing back a valid flasher.

Existing tests updated as needed, and new tests introduced.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

