### PR TITLE
fix(api): removing a few more ipv6 guards in api handlers

### DIFF
--- a/crates/admin-cli/src/ip/args.rs
+++ b/crates/admin-cli/src/ip/args.rs
@@ -26,5 +26,5 @@ pub enum Cmd {
 #[derive(Parser, Debug, Clone)]
 pub struct IpFind {
     /// The IP address we are looking to identify
-    pub ip: std::net::Ipv4Addr,
+    pub ip: std::net::IpAddr,
 }

--- a/crates/admin-cli/src/ip/tests.rs
+++ b/crates/admin-cli/src/ip/tests.rs
@@ -43,7 +43,7 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_find_with_valid_ip ensures find parses valid
+// parse_find_with_valid_ip ensures find parses a valid
 // IPv4 address.
 #[test]
 fn parse_find_with_valid_ip() {
@@ -84,12 +84,13 @@ fn parse_find_invalid_ip_fails() {
     assert!(result.is_err(), "should fail with invalid IP");
 }
 
-// parse_find_ipv6_fails ensures find fails with IPv6
-// (expects IPv4).
+// parse_find_ipv6 ensures find parses a valid IPv6 address.
 #[test]
-fn parse_find_ipv6_fails() {
-    let result = Cmd::try_parse_from(["ip", "find", "::1"]);
-    assert!(result.is_err(), "should fail with IPv6 address");
+fn parse_find_ipv6() {
+    let cmd = Cmd::try_parse_from(["ip", "find", "::1"]).expect("should parse IPv6 address");
+    match cmd {
+        Cmd::Find(args) => assert_eq!(args.ip.to_string(), "::1"),
+    }
 }
 
 // parse_find_missing_ip_fails ensures find requires

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -173,9 +173,7 @@ x509-parser = { features = ["verify"], workspace = true }
 
 [features]
 default = ["linux-build"]
-linux-build = [
-  "tss-esapi",
-]
+linux-build = ["tss-esapi"]
 
 [build-dependencies]
 carbide-version = { path = "../version" }

--- a/crates/api/src/handlers/pxe.rs
+++ b/crates/api/src/handlers/pxe.rs
@@ -57,10 +57,14 @@ pub(crate) async fn get_cloud_init_instructions(
     let ip: IpAddr = ip_str
         .parse()
         .map_err(|e| Status::invalid_argument(format!("Failed parsing IP '{ip_str}': {e}")))?;
-    if ip.is_ipv6() {
-        return Err(CarbideError::internal("IPv6 not supported".to_string()).into());
-    }
 
+    // Note that this code path supports IPv6 at the *API layer*, but won't be
+    // able to be exercised until DHCPv6 is working, which is a whole other thing
+    // we need to work on: machines need an IPv6 address before they can request
+    // cloud-init instructions over IPv6, and while we've made changes to site
+    // prefix, network segment, and IP allocators behind the scenes for supporting
+    // dual stacking interfaces, none of that means much until DHCPv6 is working
+    // to actually hand those addresses out.
     let instructions = match db::instance_address::find_by_address(&mut txn, ip).await? {
         None => {
             // assume there is no instance associated with this IP and check if there is an interface associated with it

--- a/crates/network/src/ip/address_family.rs
+++ b/crates/network/src/ip/address_family.rs
@@ -22,6 +22,17 @@ pub enum IpAddressFamily {
     Ipv6,
 }
 
+impl IpAddressFamily {
+    /// Returns the prefix length for a single interface address in this family
+    /// (32 for IPv4, 128 for IPv6).
+    pub const fn interface_prefix_len(self) -> u8 {
+        match self {
+            IpAddressFamily::Ipv4 => 32,
+            IpAddressFamily::Ipv6 => 128,
+        }
+    }
+}
+
 pub trait IdentifyAddressFamily {
     /// Return the address family for this value.
     fn address_family(&self) -> IpAddressFamily;
@@ -100,5 +111,17 @@ mod tests {
             addr.require_address_family_or_else(IpAddressFamily::Ipv6, |_| 42),
             Err(42)
         )
+    }
+
+    #[test]
+    fn test_interface_prefix_len() {
+        assert_eq!(IpAddressFamily::Ipv4.interface_prefix_len(), 32);
+        assert_eq!(IpAddressFamily::Ipv6.interface_prefix_len(), 128);
+
+        // Also test via the IdentifyAddressFamily trait on IpAddr.
+        let v4: IpAddr = "10.0.0.1".parse().unwrap();
+        let v6: IpAddr = "fd00::1".parse().unwrap();
+        assert_eq!(v4.address_family().interface_prefix_len(), 32);
+        assert_eq!(v6.address_family().interface_prefix_len(), 128);
     }
 }


### PR DESCRIPTION
## Description

Continuing to chip away at [IPv6 support](https://github.com/NVIDIA/carbide-core/issues/84) work.

Work thus far has included:
- Moving to `IpNetwork` and `IpAddress` throughout ([#192](https://github.com/NVIDIA/bare-metal-manager-core/pull/192)).
- Accepting IPv6 site prefixes and network segments. ([#204](https://github.com/NVIDIA/bare-metal-manager-core/pull/204)).
- Making the IP allocator family-aware ([#217](https://github.com/NVIDIA/bare-metal-manager-core/pull/217)).
- Making the prefix allocator family-aware ([#237](https://github.com/NVIDIA/bare-metal-manager-core/pull/237)).

This PR is a little less exciting, and removes a few additional `"if ip.is_ipv6()"` guards at the API layer. With the previous PRs in place to make the backend support dual stack environments, these guards are no longer needed: the downstream code (such as database queries and instance lookups) all work with `IpAddr` and `inet` columns natively.*

*Note: The DPA overlay/underlay guards in `dhcp/discover.rs` are **intentionally kept** here -- DPA will, for the foreseeable future, only support IPv4, because the Algo IP mechanism, and our inference of an underlay IP based on the `giaddr`, is IPv4 only; we don't even know how it will support IPv6 yet.*

Changes here include:
- Removed the IPv6 guard in the address finder `search()` function -- you can search IPv6 addresses for `StaticData`, `ResourcePools`, `InstanceAddresses`, `MachineAddresses`, `BmcIp`, `ExploredEndpoint`, `LoopbackIp`, `NetworkSegment`, `RouteServers`, and `DpaAddresses` (even though DPA won't have an IPv6 address). The match on `NetworkSegment` did get small tweak -- it was hard-coded to `/32`, for single interfaces, so now it will do `/32` or `/128`. In practice, and as we get closer with IPv6, I'm not sure what prefix we'll allocate to single interfaces, so the `/128` will probably change here.
- Removed the IPv6 guard from `get_cloud_init_instructions()` -- all of the downstream code from here is dual stack and supports IPv6. BUT, I did leave a note that, even though everything downstream is IPv6-capable, that it doesn't really mean much until we integrate DHCPv6 support to actually hand out IPv6 addresses, which once we do it, things should "just work".
- A small tweak in `admin-cli` tests around parsing IP addresses. Just made it support IPv6.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

