### PR TITLE
chore: bmc-mock: add: chassis OEM and CBC chassis of GB200

### DIFF
--- a/crates/bmc-mock/src/hw/bluefield3.rs
+++ b/crates/bmc-mock/src/hw/bluefield3.rs
@@ -68,6 +68,7 @@ impl Bluefield3<'_> {
                     serial_number: Some(self.product_serial_number.to_string().into()),
                     sensors: None,
                     assembly: None,
+                    oem: None,
                 },
                 redfish::chassis::SingleChassisConfig {
                     id: "Bluefield_ERoT".into(),
@@ -80,6 +81,7 @@ impl Bluefield3<'_> {
                     serial_number: Some("".into()),
                     sensors: None,
                     assembly: None,
+                    oem: None,
                 },
                 redfish::chassis::SingleChassisConfig {
                     id: "CPU_0".into(),
@@ -92,6 +94,7 @@ impl Bluefield3<'_> {
                     pcie_devices: Some(vec![]),
                     sensors: None,
                     assembly: None,
+                    oem: None,
                 },
                 redfish::chassis::SingleChassisConfig {
                     id: "Card1".into(),
@@ -107,6 +110,7 @@ impl Bluefield3<'_> {
                         Self::sensor_layout(),
                     )),
                     assembly: None,
+                    oem: None,
                 },
             ],
         }

--- a/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
+++ b/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
@@ -224,6 +224,7 @@ impl DellPowerEdgeR750<'_> {
                     Self::sensor_layout(),
                 )),
                 assembly: None,
+                oem: None,
             }],
         }
     }

--- a/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
+++ b/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
@@ -134,8 +134,31 @@ impl WiwynnGB200Nvl<'_> {
                 pcie_devices: Some(vec![]),
                 sensors: None,
                 assembly: None,
+                oem: None,
             }
         };
+        let cbc_chassis = |chassis_id: &'static str| redfish::chassis::SingleChassisConfig {
+            id: chassis_id.into(),
+            chassis_type: "Component".into(),
+            manufacturer: Some("Nvidia".into()),
+            part_number: Some("750-0567-002".into()),
+            model: Some("18x1RU CBL Cartridge".into()),
+            serial_number: Some("1821220000000".into()),
+            network_adapters: None,
+            pcie_devices: Some(vec![]),
+            sensors: None,
+            assembly: None,
+            oem: Some(json!({
+                "Nvidia": {
+                    "@odata.type": "#NvidiaChassis.v1_4_0.NvidiaCBCChassis",
+                    "ChassisPhysicalSlotNumber": 24,
+                    "ComputeTrayIndex": 14,
+                    "RevisionId": 2,
+                    "TopologyId": 128
+                }
+            })),
+        };
+
         redfish::chassis::ChassisConfig {
             chassis: vec![
                 redfish::chassis::SingleChassisConfig {
@@ -149,6 +172,7 @@ impl WiwynnGB200Nvl<'_> {
                     pcie_devices: Some(vec![]),
                     sensors: None,
                     assembly: None,
+                    oem: None,
                 },
                 redfish::chassis::SingleChassisConfig {
                     id: "Chassis_0".into(),
@@ -171,7 +195,12 @@ impl WiwynnGB200Nvl<'_> {
                         )
                         .build(),
                     ),
+                    oem: None,
                 },
+                cbc_chassis("CBC_0"),
+                cbc_chassis("CBC_1"),
+                cbc_chassis("CBC_2"),
+                cbc_chassis("CBC_3"),
                 dpu_chassis("Riser_Slot1_BlueField_3_Card", &self.dpu1),
                 dpu_chassis("Riser_Slot2_BlueField_3_Card", &self.dpu2),
             ],


### PR DESCRIPTION
## Description
CBC chassis of GB200 contains physical location of the slots and it is part of site explorer report.
This change adds support of OEM field in Chassis and CBC chassis OEM parameter that simulates GB200 answer.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

