### PR TITLE
chore: bump libredfish to v0.42.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5438,7 +5438,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.42.0#0fe2273bff6fb43555b1c7f2b460fd20fd5ddd3f"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.42.1#2a90ec8953e213e6f18fed59c568440bb602d3ea"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6148,6 +6148,8 @@ name = "nras"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
+ "clap",
  "fmt",
  "jsonwebtoken",
  "mockito",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.42.0" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.42.1" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.3" }
 ansi-to-html = "0.2.2"
 


### PR DESCRIPTION
## Description
This PR brings in the following changes from libredfish `v0.42.1`:

- fix: new endpoint to fetch lifecycle controller status for dells by @krish-nvidia in https://github.com/NVIDIA/libredfish/pull/41

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

