### PR TITLE
chore: machine-a-tron: remove dependency on libredfish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,7 +1945,6 @@ dependencies = [
  "figment",
  "futures",
  "lazy_static",
- "libredfish",
  "mac_address",
  "rand 0.9.2",
  "ratatui",
@@ -6148,6 +6147,8 @@ name = "nras"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
+ "clap",
  "fmt",
  "jsonwebtoken",
  "mockito",

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 use std::borrow::Cow;
+use std::fmt;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -56,6 +57,16 @@ pub enum MockPowerState {
     PowerCycling {
         since: Instant,
     },
+}
+
+impl fmt::Display for MockPowerState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::On => "On".fmt(f),
+            Self::Off => "Off".fmt(f),
+            Self::PowerCycling { since } => write!(f, "PowerCycling {:?}", since.elapsed()),
+        }
+    }
 }
 
 // Simulate a 5-second power cycle

--- a/crates/machine-a-tron/Cargo.toml
+++ b/crates/machine-a-tron/Cargo.toml
@@ -49,7 +49,6 @@ ratatui = { workspace = true }
 mac_address = { workspace = true }
 futures = { workspace = true }
 figment = { features = ["toml"], workspace = true }
-libredfish = { workspace = true }
 reqwest = { default-features = false, features = [
   "json",
   "rustls-tls",

--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -20,10 +20,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use axum::Router;
-use bmc_mock::{
-    CombinedServer, HostnameQuerying, ListenerOrAddress, MachineInfo, MockPowerState,
-    POWER_CYCLE_DELAY, PowerControl,
-};
+use bmc_mock::{CombinedServer, HostnameQuerying, ListenerOrAddress, MachineInfo, PowerControl};
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
@@ -170,17 +167,3 @@ pub struct BmcMockWrapperHandle {
 /// BmcMockRegistry is shared state that MachineATron's mock hosts can use to register their BMC
 /// mock routers, so that a single shared instance of BMC mock can delegate to them.
 pub type BmcMockRegistry = Arc<RwLock<HashMap<String, Router>>>;
-
-pub fn convert_power_state(val: MockPowerState) -> libredfish::PowerState {
-    match val {
-        MockPowerState::On => libredfish::PowerState::On,
-        MockPowerState::Off => libredfish::PowerState::Off,
-        MockPowerState::PowerCycling { since } => {
-            if since.elapsed() < POWER_CYCLE_DELAY {
-                libredfish::PowerState::Off
-            } else {
-                libredfish::PowerState::On
-            }
-        }
-    }
-}

--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -29,7 +29,6 @@ use tokio::time::Interval;
 use tracing::instrument;
 use uuid::Uuid;
 
-use crate::bmc_mock_wrapper::convert_power_state;
 use crate::config::{MachineATronContext, PersistedDpuMachine};
 use crate::dhcp_wrapper::{DhcpRelayResult, DhcpResponseInfo, DpuDhcpRelay, DpuDhcpRelayServer};
 use crate::host_machine::HandleMessageResult;
@@ -390,7 +389,7 @@ impl DpuMachineHandle {
                 .unwrap_or_default(),
             dpus: Vec::default(),
             booted_os: guard.booted_os.to_string(),
-            power_state: convert_power_state(guard.power_state),
+            power_state: guard.power_state,
         }
     }
 

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -31,7 +31,6 @@ use tracing::instrument;
 use uuid::Uuid;
 
 use crate::api_client::ApiClient;
-use crate::bmc_mock_wrapper::convert_power_state;
 use crate::config::{MachineATronContext, MachineConfig, PersistedHostMachine};
 use crate::dhcp_wrapper::{DhcpRelayResult, DhcpResponseInfo, DpuDhcpRelay};
 use crate::dpu_machine::{DpuMachine, DpuMachineHandle};
@@ -438,7 +437,7 @@ impl HostMachine {
                 .unwrap_or_default(),
             dpus: dpu_details,
             booted_os: live_state.booted_os.to_string(),
-            power_state: convert_power_state(live_state.power_state),
+            power_state: live_state.power_state,
         }
     }
 

--- a/crates/machine-a-tron/src/tui.rs
+++ b/crates/machine-a-tron/src/tui.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::time::Duration;
 
+use bmc_mock::MockPowerState;
 use carbide_uuid::network::NetworkSegmentId;
 use carbide_uuid::vpc::VpcId;
 use crossterm::ExecutableCommand;
@@ -26,7 +27,6 @@ use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
 use futures::StreamExt;
-use libredfish::PowerState;
 use ratatui::prelude::*;
 use ratatui::symbols::DOT;
 use ratatui::widgets::*;
@@ -92,7 +92,7 @@ impl SubnetDetails {
 pub struct HostDetails {
     pub mat_id: Uuid,
     pub machine_id: Option<String>,
-    pub power_state: PowerState,
+    pub power_state: MockPowerState,
     pub mat_state: String,
     pub api_state: String,
     pub oob_ip: String,


### PR DESCRIPTION
## Description
Machine-a-tron converted bmc-mock power state to libredfish power state only to display it in TUI.
This change removes this indirection.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

