### PR TITLE
fix(api,dns): adding ipv6 support (AAAA) to carbide-dns flow(s)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6148,6 +6148,8 @@ name = "nras"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
+ "clap",
  "fmt",
  "jsonwebtoken",
  "mockito",

--- a/crates/api-db/migrations/20260218000000_ipv6_dns_aaaa_support.sql
+++ b/crates/api-db/migrations/20260218000000_ipv6_dns_aaaa_support.sql
@@ -1,0 +1,117 @@
+-- Purpose: Update DNS record views to derive q_type from the IP address family
+-- when no explicit record type metadata exists. IPv6 addresses get 'AAAA',
+-- IPv4 addresses get 'A'. Also fixes dns_records_instance hostname formatting
+-- for IPv6 addresses (replace colons with dashes instead of dots with dashes).
+--
+-- The combined dns_records view must be dropped first since it depends on the
+-- sub-views, and the sub-views' q_type column type changes from nullable
+-- varchar(10) (just rt.type_name) to non-nullable varchar(10) (COALESCE).
+
+DROP VIEW IF EXISTS dns_records;
+
+CREATE OR REPLACE VIEW dns_records_adm_combined AS
+SELECT
+    concat(mi.machine_id, '.adm.', d.name, '.') AS q_name,
+    mia.address AS resource_record,
+    COALESCE(rt.type_name, CASE WHEN family(mia.address) = 6 THEN 'AAAA' ELSE 'A' END)::varchar(10) AS q_type,
+    meta.ttl as ttl,
+    d.id as domain_id
+FROM
+    machine_interfaces mi
+    JOIN machine_interface_addresses mia ON (mia.interface_id = mi.id)
+    JOIN domains d ON ((d.id = mi.domain_id)
+            AND (mi.primary_interface = TRUE))
+    LEFT JOIN dns_record_metadata meta ON meta.id = mi.id
+    LEFT JOIN dns_record_types rt ON meta.record_type_id = rt.id
+WHERE (mi.machine_id IS NOT NULL);
+
+
+CREATE OR REPLACE VIEW dns_records_bmc_host_id AS
+SELECT
+    concat(mi.machine_id, '.bmc.', d.name, '.') AS q_name,
+    cast((mt.topology -> 'bmc_info' ->> 'ip') as inet) AS resource_record,
+    COALESCE(rt.type_name, CASE WHEN family(cast((mt.topology -> 'bmc_info' ->> 'ip') as inet)) = 6 THEN 'AAAA' ELSE 'A' END)::varchar(10) AS q_type,
+    meta.ttl as ttl,
+    d.id as domain_id
+FROM
+    machine_interfaces mi
+    JOIN machine_topologies mt ON mi.machine_id = mt.machine_id
+            AND (mi.machine_id != mi.attached_dpu_machine_id)
+    JOIN domains d ON (d.id = mi.domain_id)
+    LEFT JOIN dns_record_metadata meta ON meta.id = mi.id
+    LEFT JOIN dns_record_types rt ON meta.record_type_id = rt.id
+WHERE
+    mi.machine_id IS NOT NULL;
+
+
+CREATE OR REPLACE VIEW dns_records_bmc_dpu_id AS
+SELECT
+    concat(mt.machine_id, '.bmc.', d.name, '.') AS q_name,
+    cast((mt.topology -> 'bmc_info' ->> 'ip') as inet) AS resource_record,
+    COALESCE(rt.type_name, CASE WHEN family(cast((mt.topology -> 'bmc_info' ->> 'ip') as inet)) = 6 THEN 'AAAA' ELSE 'A' END)::varchar(10) AS q_type,
+    meta.ttl as ttl,
+    d.id as domain_id
+FROM
+    machine_interfaces mi
+    JOIN machine_topologies mt ON ((mi.machine_id = mt.machine_id)
+            AND (mi.machine_id = mi.attached_dpu_machine_id))
+    JOIN domains d ON (d.id = mi.domain_id)
+    LEFT JOIN dns_record_metadata meta ON meta.id = mi.id
+    LEFT JOIN dns_record_types rt ON meta.record_type_id = rt.id
+WHERE
+    mi.machine_id IS NOT NULL;
+
+
+CREATE OR REPLACE VIEW dns_records_instance AS
+SELECT
+    CASE
+        WHEN family(ip_addrs.value::inet) = 6 THEN
+            concat(replace(ip_addrs.value::text, ':', '-'), '.', d.name, '.')
+        ELSE
+            concat(regexp_replace(ip_addrs.value::text, '\.', '-', 'g'), '.', d.name, '.')
+    END AS q_name,
+    ip_addrs.value::inet AS resource_record,
+    COALESCE(rt.type_name, CASE WHEN family(ip_addrs.value::inet) = 6 THEN 'AAAA' ELSE 'A' END)::varchar(10) AS q_type,
+    meta.ttl as ttl,
+    d.id as domain_id
+FROM
+    instances i
+JOIN
+    machine_interfaces mi ON i.machine_id = mi.machine_id
+JOIN
+    domains d ON mi.domain_id = d.id
+CROSS JOIN LATERAL
+    jsonb_array_elements(i.network_config::jsonb->'interfaces') AS iface
+CROSS JOIN LATERAL
+    jsonb_each_text(iface->'ip_addrs') AS ip_addrs
+LEFT JOIN
+    dns_record_metadata meta ON meta.id = mi.id
+LEFT JOIN
+    dns_record_types rt ON meta.record_type_id = rt.id
+WHERE
+    iface->'function_id'->>'type' = 'physical';
+
+
+CREATE OR REPLACE VIEW dns_records_shortname_combined AS
+SELECT
+    concat(mi.hostname, '.', d.name, '.') AS q_name,
+    mia.address AS resource_record,
+    COALESCE(rt.type_name, CASE WHEN family(mia.address) = 6 THEN 'AAAA' ELSE 'A' END)::varchar(10) AS q_type,
+    meta.ttl as ttl,
+    d.id as domain_id
+FROM
+    machine_interfaces mi
+    JOIN machine_interface_addresses mia ON (mia.interface_id = mi.id)
+    JOIN domains d ON d.id = mi.domain_id AND mi.primary_interface = TRUE
+    LEFT JOIN dns_record_metadata meta ON meta.id = mi.id
+    LEFT JOIN dns_record_types rt ON meta.record_type_id = rt.id;
+
+-- Re-create the combined dns_records view since it was dropped above.
+-- dns_records_instance is intentionally NOT included (same as current state).
+CREATE OR REPLACE VIEW dns_records AS
+SELECT *
+FROM
+  dns_records_shortname_combined
+  FULL JOIN dns_records_adm_combined USING (q_name, resource_record, q_type, ttl, domain_id)
+  FULL JOIN dns_records_bmc_host_id USING (q_name, resource_record, q_type, ttl, domain_id)
+  FULL JOIN dns_records_bmc_dpu_id USING (q_name, resource_record, q_type, ttl, domain_id);

--- a/crates/api-db/src/dns/resource_record.rs
+++ b/crates/api-db/src/dns/resource_record.rs
@@ -99,7 +99,7 @@ pub async fn find_record(
      resource_record,
      domain_id,
      COALESCE(ttl, 300) as ttl,
-     COALESCE(q_type, 'A') as q_type
+     COALESCE(q_type, CASE WHEN family(resource_record) = 6 THEN 'AAAA' ELSE 'A' END) as q_type
      from dns_records WHERE q_name=$1"#;
 
     tracing::info!("Looking up record using query_name: {}", query_name);
@@ -119,7 +119,7 @@ pub async fn get_all_records(
     let query = r#"
         SELECT dr.q_name, dr.resource_record, dr.domain_id,
                COALESCE(dr.ttl, 300) as ttl,
-               COALESCE(dr.q_type, 'A') as q_type
+               COALESCE(dr.q_type, CASE WHEN family(dr.resource_record) = 6 THEN 'AAAA' ELSE 'A' END) as q_type
         FROM dns_records dr
         JOIN domains d ON d.id = dr.domain_id
         WHERE d.name = $1 AND d.deleted IS NULL


### PR DESCRIPTION
## Description

Continuing to chip away at [IPv6 support](https://github.com/NVIDIA/carbide-core/issues/84)!

Work thus far has included:
- Moving to `IpNetwork` and `IpAddress` throughout ([#192](https://github.com/NVIDIA/bare-metal-manager-core/pull/192)).
- Accepting IPv6 site prefixes and network segments. ([#204](https://github.com/NVIDIA/bare-metal-manager-core/pull/204)).
- Making the IP allocator family-aware ([#217](https://github.com/NVIDIA/bare-metal-manager-core/pull/217)).
- Making the prefix allocator family-aware ([#237](https://github.com/NVIDIA/bare-metal-manager-core/pull/237)).
- Removing some more API guards and enhancing the `IdentifyAddressFamily` trait ([#324](https://github.com/NVIDIA/bare-metal-manager-core/pull/324)).

So, *this* PR enables end-to-end `AAAA` record support (for IPv6 addresses) in the `carbide-dns` layer. Previously, all DNS records defaulted to type `A` regardless of the address family. With this change, the record type is now derived from the IP address (IPv6 addresses produce `AAAA` records, IPv4 addresses produce `A` records).

_Keep in mind that even though we will have IPv6 addresses that we can allocate and resolve, they won't be reachable until we get DHCPv6 changes integrated to actually hand out the IPv6 addresses to their corresponding interfaces._

Now, what's nice in here was the DNS flow(s) were basically `AAAA`-aware throughout, sans the database views and some query defaults, e.g.
- In the `dns-record` crate, `DnsResourceRecordType::AAAA` existed, with `DNS_QTYPE_AAAA = 28`.
- The new PowerDNS backend stuff already correctly routes `AAAA` queries.
- API handlers have already been made agnostic to record type per the prevous PRs.
- Within the model, `q_type` was already a `String` and allowed for working with any type.

Changes here include:
- A SQL migration to switch to a family-aware `q_type`, which involved updating the existing DNS record views to return either `A` or `AAAA`, instead of just `A` like it used to. This includes query defaults/fallback -- if we can't figure it out from the `q_type` or `resource_record`, we'll always fall back to `A`.
- Support for IPv6 hostname formatting -- like how we have `-` separated hostnames for IPv4 addresses, doing something similar for IPv6. Totally not as nice as IPv4, and we can always adjust this later, but it's making me miss our fun friendly names. Examples are `fd00::1` → `fd00--1.example.com` and `2001:db8::8a2e:370:7334` → `2001-db8--8a2e-370-7334.example.com`.
- `AAAA` support in our `dns::legacy` integration -- we now match on `A` or `AAAA` and pass on the matching `q_type`, use `IpAddr` instead of `Ipv4Addr`, and use `RData::A` or `RData::AAAA` with the correct `RecordType`.

DNS Views Updated (for reference):
- `dns_records_adm_combined`
- `dns_records_bmc_host_id`
- `dns_records_bmc_dpu_id`
- `dns_records_shortname_combined`
- `dns_records_instance`

It's worth noting that we do have to DROP the `dns_records` view here and re-create it. However, since this happens during the migration, the API server isn't serving yet, AND since the data is just a view, we're not losing data. It just feels weird to DROP something to me, so I wanted to call it out, even though it has no impact (and has been tested with the existing + additional tests).

Updated the existing `test_dns` test to seet explicit `q_type` values to verify the IPv4 records are still correctly typed, and introduced a new `test_dns_aaaa` test which provides a full end-to-end test for `AAAA` records, where it:
- Creates a managed host.
- Inserts an IPv6 address (`fd00::1`) into `machine_interface_addresses` for the same interface, simulating a dual-stack environment.
- Queries the "admin" view (aka `{machine_id}.adm.{domain}`) and asserts:
  - Both record types returned (`A` + `AAAA`).
  - The `AAAA` record has `content = "fd00::1"`.
  - The `A` record is still present with an IPv4 address
- Queries the fun/friendly name view (`{hostname}.{domain}.`) and asserts the same:
  - `AAAA` record is present with correct content.
  - `A` record is also present.

This exercises the new migration's `dns_records` view (which I mention above), running the new migration and verifying everything is all a-ok.

So yeah, moving along with this. There's still work to do, but each one of these gets us a little bit closer!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

