### PR TITLE
fix(api,dhcp): backend dhcp plumbing changes for supporting ipv6

### DIFF
--- a/crates/api-db/src/dhcp_record.rs
+++ b/crates/api-db/src/dhcp_record.rs
@@ -16,6 +16,7 @@
  */
 
 use carbide_uuid::network::NetworkSegmentId;
+use forge_network::ip::IpAddressFamily;
 use mac_address::MacAddress;
 use model::dhcp_record::DhcpRecord;
 use sqlx::PgConnection;
@@ -26,11 +27,13 @@ pub async fn find_by_mac_address(
     txn: &mut PgConnection,
     mac_address: &MacAddress,
     segment_id: &NetworkSegmentId,
+    address_family: IpAddressFamily,
 ) -> Result<DhcpRecord, DatabaseError> {
-    let query = "SELECT * FROM machine_dhcp_records WHERE mac_address = $1::macaddr AND segment_id = $2::uuid";
+    let query = "SELECT * FROM machine_dhcp_records WHERE mac_address = $1::macaddr AND segment_id = $2::uuid AND family(address) = $3";
     sqlx::query_as(query)
         .bind(mac_address)
         .bind(segment_id)
+        .bind(address_family.pg_family())
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))

--- a/crates/dhcp/src/machine.rs
+++ b/crates/dhcp/src/machine.rs
@@ -78,7 +78,9 @@ impl Machine {
     }
 }
 
-/// Get the router address
+/// Get the router address.
+/// This is, and will always be, specific to DHCPv4, as router addresses
+/// in DHCPv6 will come from RAs (Router Advertisements).
 ///
 /// # Safety
 ///
@@ -121,7 +123,10 @@ pub extern "C" fn machine_get_interface_router(ctx: *mut Machine) -> u32 {
     0
 }
 
-/// Invoke the discovery process
+/// Invoke the discovery process.
+/// This function will be specific to IPv4 interface addresses, as this
+/// returns a u32. DHCPv6 integration will need a separate function for
+/// stateful/managed allocations.
 ///
 /// # Safety
 /// This function dereferences a pointer to a Machine object which is an opaque pointer
@@ -308,6 +313,10 @@ pub extern "C" fn machine_get_uuid(ctx: *mut Machine) -> *mut libc::c_char {
     uuid.into_raw()
 }
 
+/// Get the broadcast address.
+///
+/// This is, and will always be, specific to DHCPv4, as broadcast
+/// in DHCPv6 has been completely replaced by multicast.
 #[unsafe(no_mangle)]
 pub extern "C" fn machine_get_broadcast_address(ctx: *mut Machine) -> u32 {
     assert!(!ctx.is_null());
@@ -397,6 +406,8 @@ pub extern "C" fn machine_free_ntpservers(ntpservers: *mut libc::c_char) {
 }
 
 /// Invoke the discovery process
+/// This is, and will always be, specific to DHCPv4, as the subnet
+/// mask in DHCPv6 is now learned via RAs as a prefix.
 ///
 /// # Safety
 ///

--- a/crates/network/src/ip/address_family.rs
+++ b/crates/network/src/ip/address_family.rs
@@ -31,6 +31,15 @@ impl IpAddressFamily {
             IpAddressFamily::Ipv6 => 128,
         }
     }
+
+    /// pg_family returns the Postgre `family()` integer for
+    /// this address family (4 for IPv4, 6 for IPv6).
+    pub const fn pg_family(self) -> i32 {
+        match self {
+            IpAddressFamily::Ipv4 => 4,
+            IpAddressFamily::Ipv6 => 6,
+        }
+    }
 }
 
 pub trait IdentifyAddressFamily {
@@ -123,5 +132,16 @@ mod tests {
         let v6: IpAddr = "fd00::1".parse().unwrap();
         assert_eq!(v4.address_family().interface_prefix_len(), 32);
         assert_eq!(v6.address_family().interface_prefix_len(), 128);
+    }
+
+    #[test]
+    fn test_pg_family() {
+        assert_eq!(IpAddressFamily::Ipv4.pg_family(), 4);
+        assert_eq!(IpAddressFamily::Ipv6.pg_family(), 6);
+
+        let v4: IpAddr = "10.0.0.1".parse().unwrap();
+        let v6: IpAddr = "fd00::1".parse().unwrap();
+        assert_eq!(v4.address_family().pg_family(), 4);
+        assert_eq!(v6.address_family().pg_family(), 6);
     }
 }


### PR DESCRIPTION
## Description

Continuing to chip away at [IPv6 support](https://github.com/NVIDIA/carbide-core/issues/84)!

Work thus far has included:
- Moving to `IpNetwork` and `IpAddress` throughout ([#192](https://github.com/NVIDIA/bare-metal-manager-core/pull/192)).
- Accepting IPv6 site prefixes and network segments. ([#204](https://github.com/NVIDIA/bare-metal-manager-core/pull/204)).
- Making the IP allocator family-aware ([#217](https://github.com/NVIDIA/bare-metal-manager-core/pull/217)).
- Making the prefix allocator family-aware ([#237](https://github.com/NVIDIA/bare-metal-manager-core/pull/237)).
- Removing some more API guards and enhancing the `IdentifyAddressFamily` trait ([#324](https://github.com/NVIDIA/bare-metal-manager-core/pull/324)).
- Adding `AAAA` record support to DNS ([#332](https://github.com/NVIDIA/bare-metal-manager-core/pull/332)).

*This* PR updates the DHCP discovery path to be family-aware, so that DHCPv4 continues to work correctly in dual-stack environments, AND so a future DHCPv6 server can reuse [some of] the same generic code path. Rather than filtering IPv6 out of the `machine_dhcp_records` view (which would prevent reuse), there is now an added an `IpAddressFamily` parameter to the query and derive the family from the relay (`giaddr`) address; DHCPv4 relays are obviously IPv4, and DHCPv6 relays will be IPv6.

This parameter gets plumbed through, starting in `discover_dhcp`, and eventually gets leveraged as part of an updated Postgres query that does a `family(address)` check and compares it to the target `IpAddressFamily`, which we derive from the relay that relayed us the DHCP message. This ensures we can correctly support dual-stack environments.

I don't expect this to be it, either. There will presumably be a fair amount of new code we'll need to add for DHCPv6 support, but I'm hoping we can keep some of the generic flows generic enough to happily handle both.

I also left comments on some existing "DHCPv4" code where it made sense, explaining why it will never be for DHCPv6. There are a lot of differences between the two, and that's going to be worthy of a design doc pretty soon with regards to stateful vs. stateless DHCPv6, if we want to support one or the other or both, and how to implement it in a way that continues to keep dependencies on the underlying physical network down.

*Note that we're still guarding around DPA (just a little more obvious now), since DPA is IPv4 only for the foreseeable future.*

Existing tests continue to pass as expected, which is nice, and I added a new `test_dhcp_record_address-family` test which verifies that the updated `find_by_mac_address` query correctly filters by address family in a dual-stack scenario. The test:
1. Creates a machine via DHCPv4 discovery (gives an IPv4 relay address).
2. Inserts an IPv6 address (`fd00::42`) for the same interface to dual stack it.
3. Queries with `IpAddressFamily::Ipv4` — asserts only the IPv4 record is returned.
4. Queries with `IpAddressFamily::Ipv6` — asserts only the IPv6 record is returned.

And again, reminder that we're not done here. Still much to do!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->