### PR TITLE
fix: doing a little sweep of straggling ipv6 bits

### DIFF
--- a/crates/admin-cli/src/route_server/args.rs
+++ b/crates/admin-cli/src/route_server/args.rs
@@ -40,8 +40,8 @@ pub enum Cmd {
 // file at start.
 #[derive(Parser, Debug)]
 pub struct AddressArgs {
-    #[arg(value_delimiter = ',', help = "Comma-separated list of IPv4 addresses")]
-    pub ip: Vec<std::net::Ipv4Addr>,
+    #[arg(value_delimiter = ',', help = "Comma-separated list of IP addresses")]
+    pub ip: Vec<std::net::IpAddr>,
 
     // The optional source_type to set. If unset, this
     // defaults to admin_api, which is what we'd expect.

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -19,7 +19,7 @@
 //!
 
 use std::collections::HashMap;
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::IpAddr;
 use std::ops::Deref;
 use std::str::FromStr;
 
@@ -298,7 +298,7 @@ pub async fn find(
 
 pub async fn find_by_ip(
     txn: &mut PgConnection,
-    ip: &Ipv4Addr,
+    ip: &IpAddr,
 ) -> Result<Option<Machine>, DatabaseError> {
     lazy_static! {
         static ref query: String = format!(
@@ -517,7 +517,7 @@ pub async fn find_by_query(
         return find_one(txn, &id, MachineSearchConfig::default()).await;
     }
 
-    if let Ok(ip) = Ipv4Addr::from_str(query) {
+    if let Ok(ip) = IpAddr::from_str(query) {
         return find_by_ip(txn, &ip).await;
     }
 

--- a/crates/api/src/handlers/machine_interface.rs
+++ b/crates/api/src/handlers/machine_interface.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::IpAddr;
 use std::str::FromStr;
 
 use ::rpc::forge as rpc;
@@ -38,8 +38,8 @@ pub(crate) async fn find_interfaces(
 
     let mut interfaces: Vec<rpc::MachineInterface> = match (id, ip) {
         (Some(id), _) => vec![db::machine_interface::find_one(&mut txn, id).await?.into()],
-        (None, Some(ip)) => match Ipv4Addr::from_str(ip.as_ref()) {
-            Ok(ip) => match db::machine_interface::find_by_ip(&mut txn, IpAddr::V4(ip)).await? {
+        (None, Some(ip)) => match IpAddr::from_str(ip.as_ref()) {
+            Ok(ip) => match db::machine_interface::find_by_ip(&mut txn, ip).await? {
                 Some(interface) => vec![interface.into()],
                 None => {
                     return Err(CarbideError::internal(format!(


### PR DESCRIPTION
## Description

As part of the [IPv6 support](https://github.com/NVIDIA/carbide-core/issues/84), I noticed a couple of `Ipv4Addr` things that no longer need to be explicitly IPv4 due to all of the other work that has been done thus far ([#192](https://github.com/NVIDIA/bare-metal-manager-core/pull/192), [#204](https://github.com/NVIDIA/bare-metal-manager-core/pull/204), [#217](https://github.com/NVIDIA/bare-metal-manager-core/pull/217), [#237](https://github.com/NVIDIA/bare-metal-manager-core/pull/237), [#324](https://github.com/NVIDIA/bare-metal-manager-core/pull/324), [#332](https://github.com/NVIDIA/bare-metal-manager-core/pull/332), and [#335](https://github.com/NVIDIA/bare-metal-manager-core/pull/335)).

Added a simple `test_find_machine_by_ipv6` unit test to compliment the `test_find_machine` test so we have IPv4 and IPv6 coverage for `find_by_query`.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

