### PR TITLE
Fix build failure on main after crisscrossed merges

### DIFF
--- a/crates/api/src/state_controller/ib_partition/handler.rs
+++ b/crates/api/src/state_controller/ib_partition/handler.rs
@@ -112,7 +112,7 @@ impl StateHandler for IBPartitionStateHandler {
                                         return Ok(StateHandlerOutcome::wait(format!(
                                             "Waiting for {instance_count} instance(s) to release IB partition"
                                         ))
-                                        .with_txn(Some(txn)));
+                                        .with_txn(txn));
                                     }
 
                                     // Release pkey after ib_partition deleted.


### PR DESCRIPTION
## Description
Looks like a PR merged which passed tests on its own but broke once it merged to main, due to some refactoring around StateHandlerOutcome::with_txn.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes

