### PR TITLE
fix: introducing a new ResourcePoolType::Ipv6 type

### DIFF
--- a/crates/api-db/migrations/20260219203700_resource_pool_type_ipv6.sql
+++ b/crates/api-db/migrations/20260219203700_resource_pool_type_ipv6.sql
@@ -1,0 +1,1 @@
+ALTER TYPE resource_pool_type ADD VALUE 'ipv6';

--- a/crates/api-model/src/resource_pool/define.rs
+++ b/crates/api-model/src/resource_pool/define.rs
@@ -38,6 +38,7 @@ pub struct Range {
 #[serde(rename_all = "lowercase")]
 pub enum ResourcePoolType {
     Ipv4,
+    Ipv6,
     Integer,
 }
 

--- a/crates/api-model/src/resource_pool/mod.rs
+++ b/crates/api-model/src/resource_pool/mod.rs
@@ -147,6 +147,7 @@ impl<'r> sqlx::FromRow<'r, sqlx::postgres::PgRow> for ResourcePoolEntry {
 pub enum ValueType {
     Integer = 0,
     Ipv4,
+    Ipv6,
 }
 
 impl fmt::Display for ValueType {
@@ -154,6 +155,7 @@ impl fmt::Display for ValueType {
         match self {
             Self::Integer => write!(f, "Integer"),
             Self::Ipv4 => write!(f, "Ipv4"),
+            Self::Ipv6 => write!(f, "Ipv6"),
         }
     }
 }

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -3098,7 +3098,7 @@ message ManagedHostNetworkConfigResponse {
   // Remote ID. Used by DPU to update host's DHCP request with option 82.
   string remote_id = 15;
 
-  // IPv4 prefixes to be denied in the DPU ACL rules.
+  // IP prefixes to be denied in the DPU ACL rules.
   // This is an old field that was hijacked to hold
   // a combination of site_fabric_prefixes _and_ the
   // actual deny_prefixes.  We need to keep populating it
@@ -3109,10 +3109,10 @@ message ManagedHostNetworkConfigResponse {
   // Network monitor pinger type
   optional string dpu_network_pinger_type = 17;
 
-  // IPv4 prefixes to be denied in the DPU ACL rules.
+  // IP prefixes to be denied in the DPU ACL rules.
   repeated string deny_prefixes = 18;
 
-  // List of IPv4 prefixes (in CIDR notation) that are assigned for tenant
+  // List of IP prefixes (in CIDR notation) that are assigned for tenant
   // use within this site.
   repeated string site_fabric_prefixes = 19;
 
@@ -3184,7 +3184,7 @@ message ManagedHostNetworkConfigResponse {
   //       imports
   optional RoutingProfile routing_profile = 114;
 
-  // List of aggregate IPv4 prefixes (in CIDR notation) that contain prefixes assigned
+  // List of aggregate IP prefixes (in CIDR notation) that contain prefixes assigned
   // to tenants so that they themselves can announce to the DPU.  E.g., BYOIP
   repeated string  anycast_site_prefixes = 115;
 
@@ -3338,7 +3338,7 @@ message FlatInterfaceConfig {
   // then this value is set and specifies the virtual function ID that is configured
   // for this network interface.
   optional uint32 virtual_function_id = 6;
-  // A list of IPv4 prefixes that belong to this VPC. Note this may contain
+  // A list of IP prefixes that belong to this VPC. Note this may contain
   // the prefix from the network segment this interface is attached to (which
   // could be independently derived from the `gateway` field).
   repeated string vpc_prefixes = 7;
@@ -4131,6 +4131,7 @@ message Range {
 enum ResourcePoolType {
   Integer = 0;
   Ipv4 = 1;
+  Ipv6 = 2;
 }
 
 message MigrateVpcVniResponse {


### PR DESCRIPTION
## Description

Continuing to chip away at [IPv6 support](https://github.com/NVIDIA/carbide-core/issues/84).

Work thus far has included:
- Moving to `IpNetwork` and `IpAddress` throughout ([#192](https://github.com/NVIDIA/bare-metal-manager-core/pull/192)).
- Accepting IPv6 site prefixes and network segments. ([#204](https://github.com/NVIDIA/bare-metal-manager-core/pull/204)).
- Making the IP allocator family-aware ([#217](https://github.com/NVIDIA/bare-metal-manager-core/pull/217)).
- Making the prefix allocator family-aware ([#237](https://github.com/NVIDIA/bare-metal-manager-core/pull/237)).
- Removing some more API guards and enhancing the `IdentifyAddressFamily` trait ([#324](https://github.com/NVIDIA/bare-metal-manager-core/pull/324)).
- Adding `AAAA` record support to DNS ([#332](https://github.com/NVIDIA/bare-metal-manager-core/pull/332)).
- Backend DHCP plumbing updates ([#335](https://github.com/NVIDIA/bare-metal-manager-core/pull/335)).

*This* PR adds `ResourcePoolType::Ipv6` as a new resource pool type alongside the existing `Ipv4` and `Integer` types. IPv6 address pools can now be defined via CIDR prefix or explicit range, just like IPv4 pools today.

_Note that while this handles allocating individual IPv6 addresses, there will probably also be a real-world use case for allocating prefixes (think: prefix delegation from a new `ResourcePoolType::Ipv6Prefix`), so I'm planning on doing that next as a separate PR._

No existing pools/logic are changed -- this is a new type in addition to the existing types, making the capability available for when IPv6 loopback pools, VTEP pools, or other IPv6 address pools are needed. Introduced a number of tests, including a test to verify the full lifecycle works to define, populate, allocate, and release. Since the resource pool architecture is designed around generics and string storage (`ResourcePool<T>`, `.populate()`, and `.allocate()`), this was all pretty straightfoward to implement.

Corresponding changes include:
- Adding the new `Ipv6` variant to the `ResourcePoolType` enum.
- Protobuf changes to make sure the `ResourcePoolType` proto enum has a matching variant.
- An equivalent `ValueType` variant.
- A database migration to introduce `"ipv6"` as a new `resource_pool_type`.
- Complimentary `expand_ipv6_prefix()` and `expand_ipv6_range()` functions.
- Wiring in `define_by_prefix` and `define_by_range`.

All existing tests still passing, and 7 new tests added to cover various angles of this, as well as a full "end to end" test to make sure we can define a pool, allocate an address, and release it. Tests are as follows:
- `test_ipv6_pool_define_allocate_release`: This tests the full lifecycle.
- `test_ipv6_pool_define_by_range`: Define pool range of `fd00::1`-`fd00::11` and verify correct number of addresses.
- `test_expand_ipv6_prefix_120`: Make sure a `/120` prefix expands to 255 addresses with the correct start/end IPs.
- `test_expand_ipv6_prefix_rejects_large_prefix`: Make sure a `/64` is rejected because it's too large to enumerate.
- `test_expand_ipv6_prefix_rejects_ipv4`: Make sure an IPv4 prefix is rejected for an IPv6 pool.
- `test_expand_ipv6_range`: Make sure a range of `fd00::1`–`fd00::4` produces 3 correct addresses.
- `test_expand_ipv6_range_rejects_ipv4`: Make sure an IPv4 range is rejected.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

