### PR TITLE
fix: adding a new ResourcePoolType::Ipv6Prefix for delegations

### DIFF
--- a/crates/api-db/migrations/20260220031300_resource_pool_type_ipv6prefix.sql
+++ b/crates/api-db/migrations/20260220031300_resource_pool_type_ipv6prefix.sql
@@ -1,0 +1,1 @@
+ALTER TYPE resource_pool_type ADD VALUE 'ipv6prefix';

--- a/crates/api-model/src/resource_pool/define.rs
+++ b/crates/api-model/src/resource_pool/define.rs
@@ -24,6 +24,8 @@ pub struct ResourcePoolDef {
     pub prefix: Option<String>,
     #[serde(rename = "type")]
     pub pool_type: ResourcePoolType,
+    #[serde(default)]
+    pub delegate_prefix_len: Option<u8>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
@@ -39,6 +41,7 @@ pub struct Range {
 pub enum ResourcePoolType {
     Ipv4,
     Ipv6,
+    Ipv6Prefix,
     Integer,
 }
 

--- a/crates/api-model/src/resource_pool/mod.rs
+++ b/crates/api-model/src/resource_pool/mod.rs
@@ -148,6 +148,7 @@ pub enum ValueType {
     Integer = 0,
     Ipv4,
     Ipv6,
+    Ipv6Prefix,
 }
 
 impl fmt::Display for ValueType {
@@ -156,6 +157,7 @@ impl fmt::Display for ValueType {
             Self::Integer => write!(f, "Integer"),
             Self::Ipv4 => write!(f, "Ipv4"),
             Self::Ipv6 => write!(f, "Ipv6"),
+            Self::Ipv6Prefix => write!(f, "Ipv6Prefix"),
         }
     }
 }

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -2886,7 +2886,8 @@ mod tests {
             &ResourcePoolDef {
                 ranges: Vec::new(),
                 prefix: Some("10.180.63.0/26".to_string()),
-                pool_type: resource_pool::ResourcePoolType::Ipv4
+                pool_type: resource_pool::ResourcePoolType::Ipv4,
+                delegate_prefix_len: None,
             }
         );
         assert!(pools.get("pkey").is_none());
@@ -3022,7 +3023,8 @@ mod tests {
             &ResourcePoolDef {
                 ranges: Vec::new(),
                 prefix: Some("10.180.62.1/26".to_string()),
-                pool_type: resource_pool::ResourcePoolType::Ipv4
+                pool_type: resource_pool::ResourcePoolType::Ipv4,
+                delegate_prefix_len: None,
             }
         );
         assert_eq!(
@@ -3034,7 +3036,8 @@ mod tests {
                     end: "501".to_string()
                 }],
                 prefix: None,
-                pool_type: resource_pool::ResourcePoolType::Integer
+                pool_type: resource_pool::ResourcePoolType::Integer,
+                delegate_prefix_len: None,
             }
         );
         assert_eq!(
@@ -3291,7 +3294,8 @@ mod tests {
             &ResourcePoolDef {
                 ranges: Vec::new(),
                 prefix: Some("10.180.63.0/26".to_string()),
-                pool_type: resource_pool::ResourcePoolType::Ipv4
+                pool_type: resource_pool::ResourcePoolType::Ipv4,
+                delegate_prefix_len: None,
             }
         );
         assert_eq!(
@@ -3304,7 +3308,8 @@ mod tests {
                     end: "501".to_string()
                 }],
                 prefix: None,
-                pool_type: resource_pool::ResourcePoolType::Integer
+                pool_type: resource_pool::ResourcePoolType::Integer,
+                delegate_prefix_len: None,
             }
         );
         assert_eq!(

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -519,6 +519,7 @@ pub async fn initialize_and_start_controllers(
                     pool_type: model::resource_pool::define::ResourcePoolType::Integer,
                     ranges: x.pkeys.clone(),
                     prefix: None,
+                    delegate_prefix_len: None,
                 },
             )
             .await?;

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -1873,6 +1873,7 @@ fn pool_defs(fabric_len: u8) -> HashMap<String, resource_pool::ResourcePoolDef> 
                 },
             ],
             prefix: None,
+            delegate_prefix_len: None,
         },
     );
     defs.insert(
@@ -1886,6 +1887,7 @@ fn pool_defs(fabric_len: u8) -> HashMap<String, resource_pool::ResourcePoolDef> 
                 end: "10.255.255.127".to_string(),
                 auto_assign: true,
             }],
+            delegate_prefix_len: None,
         },
     );
     defs.insert(
@@ -1895,6 +1897,7 @@ fn pool_defs(fabric_len: u8) -> HashMap<String, resource_pool::ResourcePoolDef> 
             // Must match a network_prefix in fixtures/create_network_segment.sql
             prefix: Some("172.20.0.0/24".to_string()),
             ranges: vec![],
+            delegate_prefix_len: None,
         },
     );
     defs.insert(
@@ -1907,6 +1910,7 @@ fn pool_defs(fabric_len: u8) -> HashMap<String, resource_pool::ResourcePoolDef> 
                 auto_assign: true,
             }],
             prefix: None,
+            delegate_prefix_len: None,
         },
     );
     defs.insert(
@@ -1919,6 +1923,7 @@ fn pool_defs(fabric_len: u8) -> HashMap<String, resource_pool::ResourcePoolDef> 
                 auto_assign: true,
             }],
             prefix: None,
+            delegate_prefix_len: None,
         },
     );
     defs.insert(
@@ -1938,6 +1943,7 @@ fn pool_defs(fabric_len: u8) -> HashMap<String, resource_pool::ResourcePoolDef> 
                 },
             ],
             prefix: None,
+            delegate_prefix_len: None,
         },
     );
 
@@ -1951,6 +1957,7 @@ fn pool_defs(fabric_len: u8) -> HashMap<String, resource_pool::ResourcePoolDef> 
                 auto_assign: true,
             }],
             prefix: None,
+            delegate_prefix_len: None,
         },
     );
     defs.insert(
@@ -1963,6 +1970,7 @@ fn pool_defs(fabric_len: u8) -> HashMap<String, resource_pool::ResourcePoolDef> 
                 auto_assign: true,
             }],
             prefix: None,
+            delegate_prefix_len: None,
         },
     );
     defs.insert(
@@ -1975,6 +1983,7 @@ fn pool_defs(fabric_len: u8) -> HashMap<String, resource_pool::ResourcePoolDef> 
                 auto_assign: true,
             }],
             prefix: None,
+            delegate_prefix_len: None,
         },
     );
     defs.insert(
@@ -1983,6 +1992,7 @@ fn pool_defs(fabric_len: u8) -> HashMap<String, resource_pool::ResourcePoolDef> 
             pool_type: resource_pool::ResourcePoolType::Ipv4,
             prefix: Some("172.30.0.0/24".to_string()),
             ranges: vec![],
+            delegate_prefix_len: None,
         },
     );
     defs

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -4132,6 +4132,7 @@ enum ResourcePoolType {
   Integer = 0;
   Ipv4 = 1;
   Ipv6 = 2;
+  Ipv6Prefix = 3;
 }
 
 message MigrateVpcVniResponse {


### PR DESCRIPTION
## Description

Continuing to chip away at [IPv6 support](https://github.com/NVIDIA/carbide-core/issues/84).

Work thus far has included:
- Moving to `IpNetwork` and `IpAddress` throughout ([#192](https://github.com/NVIDIA/bare-metal-manager-core/pull/192)).
- Accepting IPv6 site prefixes and network segments. ([#204](https://github.com/NVIDIA/bare-metal-manager-core/pull/204)).
- Making the IP allocator family-aware ([#217](https://github.com/NVIDIA/bare-metal-manager-core/pull/217)).
- Making the prefix allocator family-aware ([#237](https://github.com/NVIDIA/bare-metal-manager-core/pull/237)).
- Removing some more API guards and enhancing the `IdentifyAddressFamily` trait ([#324](https://github.com/NVIDIA/bare-metal-manager-core/pull/324)).
- Adding `AAAA` record support to DNS ([#332](https://github.com/NVIDIA/bare-metal-manager-core/pull/332)).
- Backend DHCP plumbing updates ([#335](https://github.com/NVIDIA/bare-metal-manager-core/pull/335)).
- Adding a new `ResourcePoolType::Ipv6Prefix` type ([#344](https://github.com/NVIDIA/bare-metal-manager-core/pull/344)).

*This* PR is a follow-up to the `ResourcePoolType::Ipv6` introduction, adding `ResourcePoolType::Ipv6Prefix` as a new resource pool type alongside the existing `Ipv4`, `Ipv6`, and `Integer` types. Where the `Ipv6` type added support for pools of individual IPv6 addresses, this PR adds pools of entire sub-prefixes (e.g., carving/allocating multiple `/64` sub-prefixes out of a `/48`, or a range of `/120` between two `/120` prefixes.

The idea is we can have a large prefix block that we can effectively allocate delegations from -- whether it's network segment prefixes, point-to-point linknets, or loopback prefix blocks. An example would be we have a `/48`, and then delegate a bunch of `/64` prefixes out of it (65k delegations).

Similar to the previous change to introduce `ResourcePoolType::Ipv6`, this is a completely new type.

Introduced a number of tests, including a test to verify the full lifecycle works to define, populate, allocate, and release. Since the resource pool architecture is designed around generics and string storage (`ResourcePool<T>`, `.populate()`, and `.allocate()`), this was all pretty straightfoward to implement, just like it was for `Ipv6`.

Corresponding changes include:
- The new `Ipv6Prefix` variant to `ResourcePoolType`, both in the protobuf and API model.
- A matching `Ipv6Prefix` variant to `ValueType` for the `resource_pool_type` in Postgres.
- An optional `delegate_prefix_len` to `ResourcePoolDef` for use when allocating sub-prefixes.
- A new `expand_ipv6_prefix_delegation` function, which takes a parent prefix (e.g. `"fd00:abcd::/48"`) and a `delegation_prefix_length` (e.g. `64`), and enumerates all `/64` subprefixes from that `/48`.
- A new `expand_ipv6_prefix_range` function, which takes two prefixes of matching size (e.g. `"fd00::100/120` to `"fd00:300/120"`) and enumerates all of the `/120` prefixes between them. This is to maintain the ability of "range" support for `Ipv6Prefix`, e.g.
  - `expand_ip_range("10.0.0.1", "10.0.0.4")` gives us 3 addresses.
  - `expand_ipv6_range("fd00::1", "fd00::4")` gives us 3 addresses.
  - `expand_ipv6_prefix_range("fd00::100/120", "fd00::300/120")` gives us 2 prefixes.
- Updated `define_by_prefix(...)` so that it now also matches on `ResourcePoolType::Ipv6Prefix`.

All existing tests still passing, and 10 new tests added to cover various angles of this, as well as a full "end to end" test to make sure we can define a pool, allocate an address, and release it. Tests are as follows:
- `test_expand_ipv6_prefix_delegation_48_to_64`: Tests delegation of `/64`'s out of a `/48` (65k prefixes).
- `test_expand_ipv6_prefix_delegation_112_to_120`: Tests delegation of `/120`'s out of a `/112` (256 prefixes).
- `test_expand_ipv6_prefix_delegation_rejects_invalid`: If the delegation prefix is less than the parent prefix, error.
- `test_expand_ipv6_prefix_delegation_rejects_too_large`: Making sure we reject things that would enumerate too many prefixes.
- `test_expand_ipv6_prefix_delegation_rejects_ipv4`: Yell if we get IPv4.
- `test_expand_ipv6_prefix_range`: Enumerate a range of `/120` and make sure the result is correct.
- `test_expand_ipv6_prefix_range_rejects_mismatched_len`: Yell if we get mismatched prefix lengths (and verify it's an `InvalidArgument`).
- `test_expand_ipv6_prefix_range_rejects_unaligned`: If the prefixes aren't aligned, yell with an `InvalidArgument`.
- `test_ipv6_prefix_pool_define_allocate_release`: Run through a full lifecycle: define a `/112` pool with `/120` delegations, then allocate + release.
- `test_ipv6_prefix_pool_define_by_range`: Do the same, but with a range of `/120`, and verify the 16 prefixes are allocated + released.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

