### PR TITLE
chore: bump libredfish to v0.42.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5434,7 +5434,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.42.1#2a90ec8953e213e6f18fed59c568440bb602d3ea"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.42.2#d5087966b23277551c2f2d3c57b9e41360787384"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.42.1" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.42.2" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.3" }
 ansi-to-html = "0.2.2"
 


### PR DESCRIPTION
## Description
This PR bumps libredfish to `v0.42.2` which brings in the following changes:

- fix: remove the logic to disable boot options in machine_setup for Dells by @spydaNVIDIA in https://github.com/NVIDIA/libredfish/pull/42
- fix: [Dell] new volume creation payload + deserialize chassis power_state properly by @krish-nvidia in https://github.com/NVIDIA/libredfish/pull/43

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

