### PR TITLE
fix(api): introduce "ensure" for supernic/dpa device info updates

### DIFF
--- a/crates/admin-cli/src/dpa/args.rs
+++ b/crates/admin-cli/src/dpa/args.rs
@@ -16,16 +16,31 @@
  */
 
 use carbide_uuid::dpa_interface::DpaInterfaceId;
+use carbide_uuid::machine::MachineId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
 pub enum Cmd {
     #[clap(about = "Display Dpa information")]
     Show(ShowDpa),
+    #[clap(about = "Ensure a DPA interface exists (creates if missing, returns existing)")]
+    Ensure(EnsureDpa),
 }
 
 #[derive(Parser, Debug)]
 pub struct ShowDpa {
     #[clap(help = "The DPA Interface ID to query, leave empty for all (default)")]
     pub id: Option<DpaInterfaceId>,
+}
+
+#[derive(Parser, Debug)]
+pub struct EnsureDpa {
+    #[clap(help = "Machine ID")]
+    pub machine_id: MachineId,
+    #[clap(help = "MAC address (e.g. 00:11:22:33:44:55)")]
+    pub mac_addr: String,
+    #[clap(help = "Device type (e.g. BlueField3)")]
+    pub device_type: String,
+    #[clap(help = "PCI name (e.g. 5e:00.0)")]
+    pub pci_name: String,
 }

--- a/crates/admin-cli/src/dpa/mod.rs
+++ b/crates/admin-cli/src/dpa/mod.rs
@@ -39,6 +39,7 @@ impl Dispatch for Cmd {
                 )
                 .await
             }
+            Cmd::Ensure(args) => cmds::ensure(&args, ctx.config.format, &ctx.api_client).await,
         }
     }
 }

--- a/crates/admin-cli/src/dpa/tests.rs
+++ b/crates/admin-cli/src/dpa/tests.rs
@@ -54,5 +54,32 @@ fn parse_show_no_args() {
         Cmd::Show(args) => {
             assert!(args.id.is_none());
         }
+        other => panic!("expected Show, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_ensure_args() {
+    let cmd = Cmd::try_parse_from([
+        "dpa",
+        "ensure",
+        "fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30",
+        "00:11:22:33:44:55",
+        "BlueField3",
+        "01:00.0",
+    ])
+    .expect("should parse ensure");
+
+    match cmd {
+        Cmd::Ensure(args) => {
+            assert_eq!(
+                args.machine_id.to_string(),
+                "fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30"
+            );
+            assert_eq!(args.mac_addr, "00:11:22:33:44:55");
+            assert_eq!(args.device_type, "BlueField3");
+            assert_eq!(args.pci_name, "01:00.0");
+        }
+        other => panic!("expected Ensure, got {other:?}"),
     }
 }

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -2419,6 +2419,13 @@ impl Forge for Api {
         crate::handlers::dpa::find_dpa_interfaces_by_ids(self, request).await
     }
 
+    async fn ensure_dpa_interface(
+        &self,
+        request: Request<rpc::DpaInterfaceCreationRequest>,
+    ) -> Result<Response<rpc::DpaInterface>, Status> {
+        crate::handlers::dpa::ensure(self, request).await
+    }
+
     // create_dpa_interface is mainly for debugging purposes. In practice,
     // when the scout reports its inventory, we will create DPA interfaces
     // for DPA NICs reported in the inventory.

--- a/crates/api/src/auth/internal_rbac_rules.rs
+++ b/crates/api/src/auth/internal_rbac_rules.rs
@@ -81,6 +81,7 @@ impl InternalRBACRules {
         x.perm("GetAllDpaInterfaceIds", vec![ForgeAdminCLI, SiteAgent]);
         x.perm("FindDpaInterfacesByIds", vec![ForgeAdminCLI, SiteAgent]);
         x.perm("CreateDpaInterface", vec![]);
+        x.perm("EnsureDpaInterface", vec![]);
         x.perm("DeleteDpaInterface", vec![]);
         x.perm("SetDpaNetworkObservationStatus", vec![]);
         x.perm(

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -613,6 +613,7 @@ service Forge {
   rpc FindDpaInterfacesByIds(DpaInterfacesByIdsRequest) returns (DpaInterfaceList);
   // XXX TODO XXX Remove the calls below, as they are only for debug testing
   rpc CreateDpaInterface(DpaInterfaceCreationRequest) returns (DpaInterface);
+  rpc EnsureDpaInterface(DpaInterfaceCreationRequest) returns (DpaInterface);
   rpc DeleteDpaInterface(DpaInterfaceDeletionRequest) returns (DpaInterfaceDeletionResult);
   rpc SetDpaNetworkObservationStatus(DpaNetworkObservationSetRequest) returns (DpaInterface);
 


### PR DESCRIPTION
## Description

When I was integrating the `ApplyFirmware` management into the DPA/SuperNIC workflow in [#323](https://github.com/NVIDIA/bare-metal-manager-core/pull/323), I noticed that every time `scout` sends in a device report for the host (via `publish_mlx_device_report`), it calls `create_internal` for every device/interface, but it doesn't check if the device is there already, so we'll either just error (or end up with a bunch of duplicate interfaces).

This introduces + wires in a new `ensure()` function (and corresponding debug gRPC handler like we have for the others) that will attempt to insert a new interface and return it, or, if it already exists, it will simply return the existing interface.

I then use that "ensured" interface data as the source of truth for subsequent parts of the workflow.

Also added a `NewDpaInterface::from_device_info(MachineId, &MlxDeviceInfo)` constructor while I was in here.

Tests included!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

