### PR TITLE
fix(agent): widen basic agent config types from Ipv4Addr to IpAddr

### DIFF
--- a/crates/agent/src/command_line.rs
+++ b/crates/agent/src/command_line.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
 
 use carbide_uuid::machine::MachineId;
@@ -88,7 +88,7 @@ pub struct NvueOptions {
     pub site_global_vpc_vni: Option<u32>,
 
     #[clap(long)]
-    pub loopback_ip: Ipv4Addr,
+    pub loopback_ip: IpAddr,
 
     #[clap(long)]
     pub asn: u32,
@@ -222,7 +222,7 @@ pub struct FrrOptions {
     #[clap(long)]
     pub asn: u32,
     #[clap(long)]
-    pub loopback_ip: Ipv4Addr,
+    pub loopback_ip: IpAddr,
     #[clap(long, help = "Format is 'id,host_route', e.g. --vlan 1,xyz. Repeats.")]
     pub vlan: Vec<String>,
     #[clap(long, default_value = "etv")]
@@ -243,7 +243,7 @@ pub struct InterfacesOptions {
     #[clap(long, help = "Full path of interfaces file")]
     pub path: String,
     #[clap(long)]
-    pub loopback_ip: Ipv4Addr,
+    pub loopback_ip: IpAddr,
     #[clap(long, help = "Blank for admin network, vxlan48 for tenant networks")]
     pub vni_device: String,
     #[clap(
@@ -261,6 +261,9 @@ pub struct DhcpOptions {
     pub path: String,
     #[clap(long, help = "vlan numeric id. Repeats")]
     pub vlan: Vec<u32>,
+    // Note that these will be staying IPv4 only for now. This
+    // config block is pretty tailored towards DHCPv4, and may
+    // get refactored a bit as part of adding DHCPv6 support.
     #[clap(long, help = "DHCP server IP address. Repeats")]
     pub dhcp: Vec<Ipv4Addr>,
     #[clap(long, help = "Remote ID to be filled in Option 82 - Agent Remote ID")]

--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -143,10 +143,14 @@ struct DhcpServerPaths {
     host_config: FPath,
 }
 
-/// Stores addresses of dependent services that the DHCP module announces
+/// Stores addresses of dependent services that the DHCP module announces.
+/// Note that these can apply to both IPv4 and IPv6; pxe_ip is actually
+/// UEFI HTTP boot in this case, and NTP is still NTP. We should be able
+/// to leverage this struct even in DHCPv6 land (whereas other things don't
+/// really carry through to DHCPv6).
 pub struct ServiceAddresses {
-    pub pxe_ip: Ipv4Addr,
-    pub ntpservers: Vec<Ipv4Addr>,
+    pub pxe_ip: IpAddr,
+    pub ntpservers: Vec<IpAddr>,
     pub nameservers: Vec<IpAddr>,
 }
 
@@ -519,6 +523,9 @@ pub async fn update_traffic_intercept_bridging(
         }
     };
 
+    // IPv4 only for now. Internal HBN bridge plumbing uses 169.254.x.x
+    // link-local addressing for DPU to HBN communication. An IPv6 equivalent
+    // (fe80:: or similar) may be needed in the future for dual-stack bridging.
     let bridge_prefix = bridge_config
         .internal_bridge_routing_prefix
         .parse::<Ipv4Net>()?;
@@ -1029,6 +1036,10 @@ pub async fn reset(
 // 2. Copy dhcp_config file
 // 3. Copy host_config file
 // 4. Reload supervisord
+//
+// This is currently scoped to IPv4 only, and there are
+// a few IPv4-specific checks for things like NTP servers,
+// UEFI HTTP/PXE IP, and nameservers below.
 fn write_dhcp_server_config(
     dhcp_relay_path: &FPath,
     dhcp_server_path: &DhcpServerPaths,
@@ -1093,7 +1104,11 @@ fn write_dhcp_server_config(
 
     let loopback_ip = mh_nc.loopback_ip.parse()?;
 
-    let nameservers = service_addrs
+    // Filter nameservers, NTP servers, and our UEFI HTTP server
+    // addresses to IPv4 for the DHCPv4 server config. Now that
+    // ServiceAddresses holds both families, we need to ensure
+    // DHCPv4 options only carry IPv4 addresses.
+    let nameservers_v4 = service_addrs
         .nameservers
         .iter()
         .filter_map(|x| match x {
@@ -1101,6 +1116,25 @@ fn write_dhcp_server_config(
             _ => None,
         })
         .collect::<Vec<Ipv4Addr>>();
+
+    let ntpservers_v4 = service_addrs
+        .ntpservers
+        .iter()
+        .filter_map(|x| match x {
+            IpAddr::V4(x) => Some(*x),
+            _ => None,
+        })
+        .collect::<Vec<Ipv4Addr>>();
+
+    let pxe_ip_v4 = match service_addrs.pxe_ip {
+        IpAddr::V4(v4) => v4,
+        IpAddr::V6(_) => {
+            return Err(eyre::eyre!(
+                "DHCPv4 server config requires an IPv4 PXE/UEFI HTTP boot address, got {}",
+                service_addrs.pxe_ip
+            ));
+        }
+    };
 
     let mut has_changes = false;
 
@@ -1120,12 +1154,8 @@ fn write_dhcp_server_config(
         Err(err) => tracing::error!("Write DHCP server {}: {err:#}", dhcp_server_path.server),
     }
 
-    let next_contents = dhcp::build_server_config(
-        service_addrs.pxe_ip,
-        service_addrs.ntpservers.clone(),
-        nameservers,
-        loopback_ip,
-    )?;
+    let next_contents =
+        dhcp::build_server_config(pxe_ip_v4, ntpservers_v4, nameservers_v4, loopback_ip)?;
     match write(
         next_contents,
         &dhcp_server_path.config,
@@ -2974,11 +3004,11 @@ mod tests {
         let ip = FPath(PathBuf::from(i.path()));
 
         let service_addrs = ServiceAddresses {
-            pxe_ip: Ipv4Addr::from([10, 0, 0, 1]),
+            pxe_ip: IpAddr::from([10, 0, 0, 1]),
             ntpservers: vec![
-                Ipv4Addr::from([127, 0, 0, 1]),
-                Ipv4Addr::from([127, 0, 0, 2]),
-                Ipv4Addr::from([127, 0, 0, 3]),
+                IpAddr::from([127, 0, 0, 1]),
+                IpAddr::from([127, 0, 0, 2]),
+                IpAddr::from([127, 0, 0, 3]),
             ],
             nameservers: vec![IpAddr::from([10, 1, 1, 1])],
         };
@@ -3042,7 +3072,7 @@ mod tests {
         assert!(host_config_str.contains("mtu: 1500"));
 
         let service_addrs = ServiceAddresses {
-            pxe_ip: Ipv4Addr::from([10, 0, 0, 1]),
+            pxe_ip: IpAddr::from([10, 0, 0, 1]),
             ntpservers: vec![],
             nameservers: vec![IpAddr::from([10, 1, 1, 1])],
         };

--- a/crates/agent/src/frr.rs
+++ b/crates/agent/src/frr.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 
 use gtmpl_derive::Gtmpl;
 
@@ -76,7 +76,7 @@ pub fn blank() -> String {
 /// What we need in order to generate an frr.conf
 pub struct FrrConfig {
     pub asn: u32,
-    pub loopback_ip: Ipv4Addr,
+    pub loopback_ip: IpAddr,
     pub uplinks: Vec<String>,
     pub access_vlans: Vec<FrrVlanConfig>,
     pub vpc_vni: Option<u32>,
@@ -116,6 +116,8 @@ struct TmplFrrConfigParameters {
 
 #[cfg(test)]
 mod tests {
+    use std::net::Ipv4Addr;
+
     use super::{FrrConfig, build};
     use crate::HBNDeviceNames;
 
@@ -128,7 +130,7 @@ mod tests {
                 .iter()
                 .map(|x| x.to_string())
                 .collect(),
-            loopback_ip: [192, 168, 0, 1].into(),
+            loopback_ip: Ipv4Addr::from([192, 168, 0, 1]).into(),
             access_vlans: vec![],
             vpc_vni: None,
             route_servers: vec![],

--- a/crates/agent/src/interfaces.rs
+++ b/crates/agent/src/interfaces.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 
 use gtmpl_derive::Gtmpl;
 use serde::Deserialize;
@@ -55,7 +55,7 @@ pub fn blank() -> String {
 }
 
 pub struct InterfacesConfig {
-    pub loopback_ip: Ipv4Addr,
+    pub loopback_ip: IpAddr,
     pub uplinks: Vec<String>,
     pub vni_device: String,
     pub networks: Vec<Network>,

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashSet;
 use std::ffi::OsStr;
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::IpAddr;
 use std::ops::Add;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -230,13 +230,13 @@ pub async fn setup_and_run(
 
         let nameservers = url_resolver.nameservers();
         ServiceAddresses {
-            pxe_ip,
-            ntpservers,
+            pxe_ip: pxe_ip.into(),
+            ntpservers: ntpservers.into_iter().map(IpAddr::from).collect(),
             nameservers,
         }
     } else {
         ServiceAddresses {
-            pxe_ip: Ipv4Addr::from([127, 0, 0, 1]),
+            pxe_ip: IpAddr::from([127, 0, 0, 1]),
             ntpservers: vec![],
             nameservers: vec![IpAddr::from([127, 0, 0, 1])],
         }

--- a/crates/agent/src/nvue.rs
+++ b/crates/agent/src/nvue.rs
@@ -302,6 +302,9 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
         vf_intercept_hbn_representor_ip,
         public_prefix_internal_next_hop,
         intercept_bridge_prefix_len,
+        // IPv4 only for now. Internal HBN bridge plumbing uses 169.254.x.x
+        // link-local addressing for DPU to HBN communication. An IPv6 equivalent
+        // (fe80:: or similar) may be needed in the future for dual-stack bridging.
     ) = if let Some(bridge_prefix) = conf
         .internal_bridge_routing_prefix
         .map(|p| p.parse::<Ipv4Net>())


### PR DESCRIPTION
## Description

Still chipping away at [IPv6 support](https://github.com/NVIDIA/carbide-core/issues/84).

Work thus far has included:
- Moving to `IpNetwork` and `IpAddress` throughout ([#192](https://github.com/NVIDIA/bare-metal-manager-core/pull/192)).
- Accepting IPv6 site prefixes and network segments. ([#204](https://github.com/NVIDIA/bare-metal-manager-core/pull/204)).
- Making the IP allocator family-aware ([#217](https://github.com/NVIDIA/bare-metal-manager-core/pull/217)).
- Making the prefix allocator family-aware ([#237](https://github.com/NVIDIA/bare-metal-manager-core/pull/237)).
- Removing some more API guards and enhancing the `IdentifyAddressFamily` trait ([#324](https://github.com/NVIDIA/bare-metal-manager-core/pull/324)).
- Adding `AAAA` record support to DNS ([#332](https://github.com/NVIDIA/bare-metal-manager-core/pull/332)).
- Backend DHCP plumbing updates ([#335](https://github.com/NVIDIA/bare-metal-manager-core/pull/335)).
- Adding a new `ResourcePoolType::Ipv6` type ([#344](https://github.com/NVIDIA/bare-metal-manager-core/pull/344)).
- Adding a new `ResourcePoolType::Ipv6Prefix` type ([#345](https://github.com/NVIDIA/bare-metal-manager-core/pull/345)).

All of that work has been on the "core" side -- the API, database, allocator, DNS, resource pools, etc. *This* PR is the first in a new series of changes focused on the agent side. The goal is, of course, to have IPv6 support plumbed through the agent, so it can make its way to HBN (via `nvue`) for configuring addresses, routes, ACLs, BGP, etc.

Similar to "core" efforts, I'm taking a simple starting point by widening from `Ipv4Addr` to `IpAddr` across some of the more low-hanging agent config structs, CLI argument types, and service address types. Just like previous changes being a noop, this is no different, and the test-verified rendered template output remains the same.

Changes included:
- `InterfacesConfig.loopback_ip` going from `Ipv4Addr` to `IpAddr`. This only gets used as `conf.loopback_ip.to_string()` to feed templates.
- `FrrConfig.loopback_ip` going from `Ipv4Addr` to `IpAddr`. Same thing as above -- only used as `conf.loopback_ip.to_string()` to feed templates.
- `loopback_ip` going from `Ipv4Addr` to `IpAddr` in `NvueOptions`, `FrrOptions`, and `InterfacesOptions`. Since these are all parsed via `IpAddr::from_str`, they continued to work as-is.
- `ServiceAddresses.pxe_ip` going from `Ipv4Addr` to `IpAddr`. Despite the field name, this is the UEFI HTTP boot server address, which would carry over to DHCPv6 just fine.
- `ServiceAddresses.ntpservers` going from `Vec<Ipv4Addr>` to `Vec<IpAddr>`. NTP servers are still a DHCPv6 "feature".
- At the `dhcp::build_server_config()` call site, added IPv4 filtering for `pxe_ip`, `ntpservers`, and `nameservers` (which was already filtered) before passing to the DHCPv4 config builder. `ServiceAddresses` now holds both families, but DHCPv4 options can only carry IPv4 addresses.
- Left comments on things that are intentionally staying IPv4 for now -- the `DhcpOptions` CLI struct (DHCPv4-specific), and the internal HBN bridge prefix parsing (`169.254.x.x` link-local plumbing, though an IPv6 equivalent may be needed in the future).

The existing tests (including `test_write_frr`) continue to pass, rendering templates as expected. IPv6 templates are NOT being introduced here yet -- for now, the important bit is widening types to `IpAddr` and making sure it continues to work as a drop-in with IPv4.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

