### PR TITLE
chore: cleaning up examples of is_some() + unwrap()

### DIFF
--- a/crates/admin-cli/src/extension_service/cmds.rs
+++ b/crates/admin-cli/src/extension_service/cmds.rs
@@ -93,25 +93,24 @@ pub async fn handle_update(
 ) -> CarbideCliResult<()> {
     let is_json = output_format == OutputFormat::Json;
 
-    let credential =
-        if args.username.is_some() || args.password.is_some() || args.registry_url.is_some() {
-            if args.username.is_none() || args.password.is_none() || args.registry_url.is_none() {
-                return Err(CarbideCliError::GenericError(
-                    "All of username, password and registry URL are required to create credential"
-                        .to_string(),
-                ));
-            }
-
+    let credential = match (args.username, args.password, args.registry_url) {
+        (Some(username), Some(password), Some(registry_url)) => {
             Some(::rpc::forge::DpuExtensionServiceCredential {
-                registry_url: args.registry_url.unwrap(),
+                registry_url,
                 r#type: Some(Type::UsernamePassword(rpc::forge::UsernamePassword {
-                    username: args.username.unwrap(),
-                    password: args.password.unwrap(),
+                    username,
+                    password,
                 })),
             })
-        } else {
-            None
-        };
+        }
+        (None, None, None) => None,
+        _ => {
+            return Err(CarbideCliError::GenericError(
+                "All of username, password and registry URL are required to create credential"
+                    .to_string(),
+            ));
+        }
+    };
 
     let observability = if let Some(r) = args.observability {
         serde_json::from_str(&r)?

--- a/crates/agent/src/duppet/sync.rs
+++ b/crates/agent/src/duppet/sync.rs
@@ -315,11 +315,9 @@ pub fn maybe_update_file_permissions(
 ) -> io::Result<bool> {
     // If not configured to manage the mode,
     // just return nothing was changed.
-    if expected_mode.is_none() {
+    let Some(expected_mode) = expected_mode else {
         return Ok(false);
-    }
-
-    let expected_mode = expected_mode.unwrap();
+    };
     let file = File::open(path)?;
     let metadata = file.metadata()?;
     let mut perms = metadata.permissions();

--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -1420,10 +1420,13 @@ fn parse_fdb(fdb_json: &str) -> eyre::Result<HashMap<u32, Vec<Fdb>>> {
     let all_fdb: Vec<Fdb> = serde_json::from_str(fdb_json)?;
     let mut out: HashMap<u32, Vec<Fdb>> = HashMap::new();
     for fdb in all_fdb.into_iter() {
-        if fdb.vlan.is_none() || fdb.state == "permanent" {
+        let Some(vlan) = fdb.vlan else {
+            continue;
+        };
+        if fdb.state == "permanent" {
             continue;
         }
-        out.entry(fdb.vlan.unwrap())
+        out.entry(vlan)
             .and_modify(|v| v.push(fdb.clone()))
             .or_insert_with(|| vec![fdb]);
     }

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -654,32 +654,27 @@ impl CarbideConfig {
     }
 
     pub fn is_dpa_enabled(&self) -> bool {
-        if self.dpa_config.is_none() {
+        let Some(conf) = &self.dpa_config else {
             return false;
-        }
-
-        let conf = self.dpa_config.clone().unwrap();
+        };
 
         conf.enabled
     }
 
     pub fn get_dpa_subnet_ip(&self) -> Result<Ipv4Addr, eyre::Report> {
-        if self.dpa_config.is_none() {
+        let Some(conf) = &self.dpa_config else {
             tracing::error!("get_dpa_subnet_ip: DPA config missing");
             return Err(eyre::eyre!("get_dpa_subnet_ip: DPA config missing"));
-        }
+        };
 
-        let conf = self.dpa_config.clone().unwrap();
         Ok(conf.subnet_ip)
     }
 
     pub fn get_dpa_subnet_mask(&self) -> Result<i32, eyre::Report> {
-        if self.dpa_config.is_none() {
+        let Some(conf) = &self.dpa_config else {
             tracing::error!("get_dpa_subnet_mask: DPA config missing");
             return Err(eyre::eyre!("get_dpa_subnet_mask: DPA config missing"));
-        }
-
-        let conf = self.dpa_config.clone().unwrap();
+        };
 
         Ok(conf.subnet_mask)
     }

--- a/crates/measured-boot/src/site.rs
+++ b/crates/measured-boot/src/site.rs
@@ -180,11 +180,7 @@ impl MachineAttestationSummaryList {
                 .iter()
                 .map(|e| MachineAttestationSummaryPb {
                     machine_id: e.machine_id.to_string(),
-                    bundle_id: if e.bundle_id.is_none() {
-                        None
-                    } else {
-                        Some(e.bundle_id.unwrap())
-                    },
+                    bundle_id: e.bundle_id,
                     profile_name: e.profile_name.clone(),
                     ts: Some(e.ts.into()),
                 })
@@ -204,14 +200,13 @@ impl MachineAttestationSummaryList {
                 })?,
                 bundle_id: pb.bundle_id,
                 profile_name: pb.profile_name.clone(),
-                ts: if pb.ts.is_none() {
-                    chrono::DateTime::<Utc>::default()
-                } else {
-                    chrono::DateTime::<Utc>::try_from(pb.ts.unwrap()).map_err(|err| {
+                ts: match pb.ts {
+                    Some(ts) => chrono::DateTime::<Utc>::try_from(ts).map_err(|err| {
                         super::Error::RpcConversion(format!(
                             "Could not deserialize ListAttestationSummaryResponse(timestamp): {err}"
                         ))
-                    })?
+                    })?,
+                    None => chrono::DateTime::<Utc>::default(),
                 },
             });
         }

--- a/crates/scout/src/main.rs
+++ b/crates/scout/src/main.rs
@@ -441,11 +441,10 @@ async fn handle_mlxreport_action(
     machine_id: &MachineId,
     data: Option<ForgeAgentControlExtraInfo>,
 ) {
-    if data.is_none() {
+    let Some(ed) = data else {
         tracing::error!("handle_mlxreport_action Did not expect extra data to be empty");
         return;
-    }
-    let ed = data.unwrap();
+    };
 
     // The Extra data is an array of key value pairs.
     // The key is the pci_name of a DPA NIC.

--- a/crates/secrets/src/forge_vault.rs
+++ b/crates/secrets/src/forge_vault.rs
@@ -607,8 +607,8 @@ impl VaultTask<Certificate> for GetCertificateHelper {
             trust_domain, namespace, self.unique_identifier,
         );
 
-        let ttl = if self.ttl.is_some() {
-            self.ttl.clone().unwrap()
+        let ttl = if let Some(ttl) = self.ttl.clone() {
+            ttl
         } else {
             // this is to setup a baseline skew of between 60 - 100% of 30 days,
             // so that not all boxes will renew (or expire) at the same time.

--- a/crates/ssh-console/src/bmc/vendor.rs
+++ b/crates/ssh-console/src/bmc/vendor.rs
@@ -227,12 +227,11 @@ impl EscapeSequence {
     ) -> (Cow<'a, [u8]>, bool) {
         // Helper to lazily get &mut Vec<u8>
         fn get_buf<'b>(out: &'b mut Option<Vec<u8>>, input: &[u8], idx: usize) -> &'b mut Vec<u8> {
-            if out.is_none() {
+            out.get_or_insert_with(|| {
                 let mut v = Vec::with_capacity(input.len());
                 v.extend_from_slice(&input[..idx]);
-                *out = Some(v);
-            }
-            out.as_mut().unwrap()
+                v
+            })
         }
 
         match self {


### PR DESCRIPTION
## Description

I noticed a few of these last week when I was doing some other work, and figured I'd sweep through and find ~most remaining examples of this. Insetad of `x.is_some()` followed by `let y = x.unwrap()`, just use `if let Some(..)`, and a few other pattern adjustments (including some similar `.is_none()` use-cases).

All existing tests contiuning to pass. I checked to see if I needed to add any additional test coverage here but it all appears covered.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->