### PR TITLE
fix: allow direct partition updates

### DIFF
--- a/crates/api-model/src/instance/config/nvlink.rs
+++ b/crates/api-model/src/instance/config/nvlink.rs
@@ -36,25 +36,10 @@ impl InstanceNvLinkConfig {
         Ok(())
     }
 
-    pub fn verify_update_allowed_to(&self, new_config: &Self) -> Result<(), ConfigValidationError> {
-        // If the new config specifies a logical partition ID, it must be the same as the current config if the current config specifies a logical partition ID.
-        for gpu in new_config.gpu_configs.iter() {
-            let current_partition_id = self
-                .gpu_configs
-                .iter()
-                .find(|g| g.device_instance == gpu.device_instance)
-                .and_then(|g| g.logical_partition_id);
-
-            if gpu.logical_partition_id.is_some()
-                && current_partition_id.is_some()
-                && gpu.logical_partition_id != current_partition_id
-            {
-                return Err(ConfigValidationError::InvalidValue(format!(
-                    "GPU {} is already part of a logical partition. Please remove it from the logical partition before adding it to a new one.",
-                    gpu.device_instance
-                )));
-            }
-        }
+    pub fn verify_update_allowed_to(
+        &self,
+        _new_config: &Self,
+    ) -> Result<(), ConfigValidationError> {
         Ok(())
     }
 


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
The partition monitor now supports direct logical partition updates after PR #337 was merged, so the API doesn't need to return an error when a user requests a direct update.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

