### PR TITLE
fix(agent): remove ipv4 filter from dpu interface address planning

### DIFF
--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -1008,6 +1008,8 @@ fn effective_virtualization_type(
     Ok(virtualization_type)
 }
 
+// TODO(chet): We'll eventually want a documented IPv6 address we can
+// configure here for tenants to hit FMDS over IPv6.
 async fn plan_fmds_armos_routing(
     interface: &str,
     proposed_routes: &Vec<IpNetwork>,


### PR DESCRIPTION
## Description

Still chipping away at [IPv6 support](https://github.com/NVIDIA/carbide-core/issues/84).

Work thus far has included:
- Moving to `IpNetwork` and `IpAddress` throughout ([#192](https://github.com/NVIDIA/bare-metal-manager-core/pull/192)).
- Accepting IPv6 site prefixes and network segments. ([#204](https://github.com/NVIDIA/bare-metal-manager-core/pull/204)).
- Making the IP allocator family-aware ([#217](https://github.com/NVIDIA/bare-metal-manager-core/pull/217)).
- Making the prefix allocator family-aware ([#237](https://github.com/NVIDIA/bare-metal-manager-core/pull/237)).
- Removing some more API guards and enhancing the `IdentifyAddressFamily` trait ([#324](https://github.com/NVIDIA/bare-metal-manager-core/pull/324)).
- Adding `AAAA` record support to DNS ([#332](https://github.com/NVIDIA/bare-metal-manager-core/pull/332)).
- Backend DHCP plumbing updates ([#335](https://github.com/NVIDIA/bare-metal-manager-core/pull/335)).
- Adding a new `ResourcePoolType::Ipv6` type ([#344](https://github.com/NVIDIA/bare-metal-manager-core/pull/344)).
- Adding a new `ResourcePoolType::Ipv6Prefix` type ([#345](https://github.com/NVIDIA/bare-metal-manager-core/pull/345)).
- Widening agent config types from `Ipv4Addr` to `IpAddr` ([#360](https://github.com/NVIDIA/bare-metal-manager-core/pull/360)).

The previous agent PR widened to `IpAddr` struct types but didn't change any runtime behavior. *This* PR removes the explicit IPv4 filter in DPU interface address management, so that IPv6 addresses assigned to interfaces are actually configured on the hardware (instead of being silently dropped). This change is pretty small, buuuut it's probably worth explaining the mechanics of what's happening:

Behind the scenes, `Interface::plan()` discovers the current address(es) on a DPU interface by running `ip -j addr show dev <iface>`, and then parsing the JSON output (into `IpInterfaceAddress` structs). These structs actually already use `IpAddr` for the `local` field (and `IpNetwork::new()`, which accepts both IPv4 and IPv6 networks). However, after constructing the `IpNetwork`, we'd drop anything that wasn't `.is_ipv4()`, meaning all IPv6 addresses (including link-local `fe80::` addresses) were silently filtered out of the "current" set.

Now, when `carbide-api` "proposes" addresses for a DPU interface, the `carbide-dpu-agent` compares them against the "current" addresses to figure out what needs to be added. With IPv6 having been completely ignored before, the agent had no clue if a v6 address was already present (and not include anything related to v6 in planning).

With the IPv4 check removed, IPv6 addresses now show up in the "current" set, so `find_common_addresses()` can detect if an IPv6 address is already configured (and what to do about it).

Unaffected are:
- The downstream `ip addr add` command -- it already works for v4/v6.
- The `find_common_addresses()` function -- it alerady works on `IpNetwork`.
- The `DpuNetworkInterfacePlan` -- its already uses `Vec<IpNetwork>`.

Confirmed that existing tests still pass (the existing testdata even includes IPv6 addresses, which are no longer filtered out, showing that the additional addresses doesn't affect planning).

Also added a new `plan_includes_ipv6_address` test, which proposes an IPv6 address (`fd00::1/64`) and verifies it now shows up in the `Add` action of the plan.

Left a `TODO(chet)` around `plan_fmds_armos_routing()` -- eventually we'll want to have a documented IPv6 address for the tenant to make FMDS requests using IPv6.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

