### PR TITLE
fix(api): Add pkey to ib partition status

### DIFF
--- a/crates/admin-cli/src/ib_partition/cmds.rs
+++ b/crates/admin-cli/src/ib_partition/cmds.rs
@@ -104,6 +104,7 @@ fn convert_ib_partitions_to_nice_table(ib_partitions: forgerpc::IbPartitionList)
         "Name",
         "TenantOrg",
         "State",
+        "Requested Pkey",
         "Pkey",
         "Labels",
         "Description",
@@ -134,6 +135,12 @@ fn convert_ib_partitions_to_nice_table(ib_partitions: forgerpc::IbPartitionList)
             .map(|t| t.as_str_name())
             .unwrap_or_default(),
             ib_partition
+                .config
+                .as_ref()
+                .and_then(|s| s.pkey.as_deref())
+                .unwrap_or_default(),
+            labels.join(", "),
+            ib_partition
                 .status
                 .as_ref()
                 .and_then(|s| s.pkey.as_deref())
@@ -157,8 +164,9 @@ fn convert_ib_partition_to_nice_format(
 
     let tenant_organization_id = ib_partition
         .config
-        .unwrap_or_default()
-        .tenant_organization_id;
+        .as_ref()
+        .map(|c| c.tenant_organization_id.as_str())
+        .unwrap_or_default();
     let metadata = ib_partition.metadata;
     let labels = crate::metadata::get_nice_labels_from_rpc_metadata(metadata.as_ref());
 
@@ -183,7 +191,7 @@ fn convert_ib_partition_to_nice_format(
                 .map(|m| m.name.as_str())
                 .unwrap_or_default(),
         ),
-        ("TENANT ORG", &tenant_organization_id),
+        ("TENANT ORG", tenant_organization_id),
         (
             "STATE",
             forgerpc::TenantState::try_from(status.state)
@@ -203,6 +211,14 @@ fn convert_ib_partition_to_nice_format(
                     state_reason.outcome_msg.as_deref().unwrap_or_default()
                 }
             },
+        ),
+        (
+            "REQUESTED PKEY",
+            ib_partition
+                .config
+                .as_ref()
+                .and_then(|c| c.pkey.as_deref())
+                .unwrap_or_default(),
         ),
         ("PKEY", status.pkey.as_deref().unwrap_or_default()),
         ("PARTITION", status.partition.as_deref().unwrap_or_default()),

--- a/crates/api-db/migrations/20260223182201_pkey_source.sql
+++ b/crates/api-db/migrations/20260223182201_pkey_source.sql
@@ -1,0 +1,17 @@
+-- Make pkey nullable because it's an option now.
+-- If explicitly requested, then this column will be set.
+-- If not explicitly requested, then this column will be null,
+-- and the pkey will be auto-allocated and appear in partition status.
+ALTER TABLE ib_partitions ALTER COLUMN pkey DROP NOT NULL;
+
+
+-- Add a unique "constraint" similar to the one on
+-- the original PKEY column.
+CREATE UNIQUE INDEX "unique_ib_partition_status_pkey" ON ib_partitions((status->>'pkey'));
+
+-- Set status PKEY to the PKEYs that are currently assigned.
+UPDATE ib_partitions SET status = jsonb_set(status, '{pkey}', to_jsonb('0x' || to_hex(pkey)), true);
+
+-- Clear the PKEY field so it's clear that the PKEY in status
+-- was auto-assigned.
+UPDATE ib_partitions SET pkey = null;

--- a/crates/api/src/ib_fabric_monitor/mod.rs
+++ b/crates/api/src/ib_fabric_monitor/mod.rs
@@ -255,7 +255,7 @@ impl IbFabricMonitor {
         // more efficient
         let mut partition_ids_by_pkey = HashMap::new();
         for (id, partition) in tenant_partitions.iter() {
-            if let Some(pkey) = partition.config.pkey {
+            if let Some(pkey) = partition.status.as_ref().and_then(|s| s.pkey) {
                 partition_ids_by_pkey.insert(pkey, *id);
             }
         }
@@ -712,7 +712,7 @@ async fn record_machine_infiniband_status_observation(
             let Some(partition_data) = tenant_partitions.get(&iface.ib_partition_id) else {
                 continue;
             };
-            let Some(expected_pkey) = partition_data.config.pkey else {
+            let Some(expected_pkey) = partition_data.status.as_ref().and_then(|s| s.pkey) else {
                 continue;
             };
             expected_pkeys.insert(guid.clone(), expected_pkey);


### PR DESCRIPTION
## Description

- pkey column in ib_partitions is now nullable and will only be populated if a specific PKEY was explicitly requested.
- IBPartition.status.pkey will be populated with the active PKEY of the partition.
- IBPartition.config.pkey will be populated with any requested PKEY.
  - In the case of an auto-allocated PKEY, IBPartition.config.pkey will be None.
  - In the case of a caller explicitly requesting a PKEY during partiton creation, both IBPartition.config.pkey and IBPartition.status.pkey will match.

This lets an API consumer know the source of the active PKEY (auto/non-auto).

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

