### PR TITLE
fix(agent): make internal services resolver + `ServiceAddresses` dual-stack

### DIFF
--- a/crates/agent/src/util.rs
+++ b/crates/agent/src/util.rs
@@ -17,7 +17,7 @@
 use std::fmt::Write;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::IpAddr;
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -134,16 +134,13 @@ impl UrlResolver {
     /// Input name should be hostname, not url.
     /// valid: carbide-pxe.forge, nvidia.com, www.nvidia.com
     /// Invalid: https://www.nvidia.com/extra/uri
-    pub async fn resolve(&mut self, name: &str) -> Result<Vec<Ipv4Addr>, eyre::Report> {
+    pub async fn resolve(&mut self, name: &str) -> Result<Vec<IpAddr>, eyre::Report> {
         let ip = self
             .resolver
             .call(Name::from_str(name)?)
             .await?
-            .filter_map(|x| match x.ip() {
-                IpAddr::V4(x) => Some(x),
-                _ => None,
-            })
-            .collect::<Vec<Ipv4Addr>>();
+            .map(|x| x.ip())
+            .collect::<Vec<IpAddr>>();
 
         Ok(ip)
     }


### PR DESCRIPTION
## Description

Still chipping away at [IPv6 support](https://github.com/NVIDIA/carbide-core/issues/84).

Work thus far has included:
- Moving to `IpNetwork` and `IpAddress` throughout ([#192](https://github.com/NVIDIA/bare-metal-manager-core/pull/192)).
- Accepting IPv6 site prefixes and network segments. ([#204](https://github.com/NVIDIA/bare-metal-manager-core/pull/204)).
- Making the IP allocator family-aware ([#217](https://github.com/NVIDIA/bare-metal-manager-core/pull/217)).
- Making the prefix allocator family-aware ([#237](https://github.com/NVIDIA/bare-metal-manager-core/pull/237)).
- Removing some more API guards and enhancing the `IdentifyAddressFamily` trait ([#324](https://github.com/NVIDIA/bare-metal-manager-core/pull/324)).
- Adding `AAAA` record support to DNS ([#332](https://github.com/NVIDIA/bare-metal-manager-core/pull/332)).
- Backend DHCP plumbing updates ([#335](https://github.com/NVIDIA/bare-metal-manager-core/pull/335)).
- Adding a new `ResourcePoolType::Ipv6` type ([#344](https://github.com/NVIDIA/bare-metal-manager-core/pull/344)).
- Adding a new `ResourcePoolType::Ipv6Prefix` type ([#345](https://github.com/NVIDIA/bare-metal-manager-core/pull/345)).
- Widening agent config types from `Ipv4Addr` to `IpAddr` ([#360](https://github.com/NVIDIA/bare-metal-manager-core/pull/360)).
- Removing IPv4 filter from DPU interface address planning ([#372](https://github.com/NVIDIA/bare-metal-manager-core/pull/372)).

*This* PR tweaks an area in the agent where IPv6 DNS results were being discarded. Our use of `UrlResolver` performs DNS lookups for internal services (e.g. `carbide-pxe.forge` and `carbide-ntp.forge`), but `resolve()` had a `filter_map` that only kept IPv4 IPs (even though the underlying resolver crate already was returning `A` and `AAAA`, and other `ServiceAddresses` fields were already `Vec<IpAddr>`).

With this change, all three `ServiceAddresses` fields are now `Vec<IpAddr>` across the board, and `write_dhcp_server_config()` is the single boundary where protocol-specific IPv4 filtering happens. Because of this, I'm renaming it to `write_dhcp_v4_server_config()`. Eventually we'll also want a `write_dhcp_v6_server_config()` that takes the same `ServerAddresses` to generate a corresponding DHCPv6 config.

Existing tests updated (and passing), and added a test for a case where we ONLY get back IPv6 addresses (which would be impressive)!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->