### PR TITLE
chore(admin-cli): migrate `bmc-machine` command group to `Dispatch` + `Run`

### DIFF
--- a/crates/admin-cli/src/bmc_machine/admin_power_control/args.rs
+++ b/crates/admin-cli/src/bmc_machine/admin_power_control/args.rs
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use clap::Parser;
+
+use crate::bmc_machine::common::AdminPowerControlAction;
+
+#[derive(Parser, Debug, Clone)]
+pub struct Args {
+    #[clap(long, help = "ID of the machine to reboot")]
+    pub machine: String,
+    #[clap(long, help = "Power control action")]
+    pub action: AdminPowerControlAction,
+}

--- a/crates/admin-cli/src/bmc_machine/admin_power_control/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/admin_power_control/cmd.rs
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::CarbideCliResult;
+
+use super::args::Args;
+use crate::rpc::ApiClient;
+
+pub async fn admin_power_control(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    api_client
+        .admin_power_control(None, Some(args.machine), args.action.into())
+        .await?;
+    Ok(())
+}

--- a/crates/admin-cli/src/bmc_machine/admin_power_control/mod.rs
+++ b/crates/admin-cli/src/bmc_machine/admin_power_control/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::admin_power_control(self, &ctx.api_client).await
+    }
+}

--- a/crates/admin-cli/src/bmc_machine/bmc_reset/args.rs
+++ b/crates/admin-cli/src/bmc_machine/bmc_reset/args.rs
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use clap::Parser;
+
+#[derive(Parser, Debug, Clone)]
+pub struct Args {
+    #[clap(long, help = "ID of the machine to reboot")]
+    pub machine: String,
+    #[clap(short, long, help = "Use ipmitool")]
+    pub use_ipmitool: bool,
+}

--- a/crates/admin-cli/src/bmc_machine/bmc_reset/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/bmc_reset/cmd.rs
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::CarbideCliResult;
+
+use super::args::Args;
+use crate::rpc::ApiClient;
+
+pub async fn bmc_reset(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    api_client
+        .bmc_reset(None, Some(args.machine), args.use_ipmitool)
+        .await?;
+    Ok(())
+}

--- a/crates/admin-cli/src/bmc_machine/bmc_reset/mod.rs
+++ b/crates/admin-cli/src/bmc_machine/bmc_reset/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::bmc_reset(self, &ctx.api_client).await
+    }
+}

--- a/crates/admin-cli/src/bmc_machine/common.rs
+++ b/crates/admin-cli/src/bmc_machine/common.rs
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use clap::{Parser, ValueEnum};
+
+#[derive(ValueEnum, Parser, Debug, Clone)]
+pub enum AdminPowerControlAction {
+    On,
+    GracefulShutdown,
+    ForceOff,
+    GracefulRestart,
+    ForceRestart,
+    ACPowercycle,
+}
+
+impl From<AdminPowerControlAction> for rpc::forge::admin_power_control_request::SystemPowerControl {
+    fn from(c_type: AdminPowerControlAction) -> Self {
+        match c_type {
+            AdminPowerControlAction::On => {
+                rpc::forge::admin_power_control_request::SystemPowerControl::On
+            }
+            AdminPowerControlAction::GracefulShutdown => {
+                rpc::forge::admin_power_control_request::SystemPowerControl::GracefulShutdown
+            }
+            AdminPowerControlAction::ForceOff => {
+                rpc::forge::admin_power_control_request::SystemPowerControl::ForceOff
+            }
+            AdminPowerControlAction::GracefulRestart => {
+                rpc::forge::admin_power_control_request::SystemPowerControl::GracefulRestart
+            }
+            AdminPowerControlAction::ForceRestart => {
+                rpc::forge::admin_power_control_request::SystemPowerControl::ForceRestart
+            }
+            AdminPowerControlAction::ACPowercycle => {
+                rpc::forge::admin_power_control_request::SystemPowerControl::AcPowercycle
+            }
+        }
+    }
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct InfiniteBootArgs {
+    #[clap(long, help = "ID of the machine to enable/query infinite boot")]
+    pub machine: String,
+    #[clap(short, long, help = "Issue reboot to apply BIOS change")]
+    pub reboot: bool,
+}

--- a/crates/admin-cli/src/bmc_machine/create_bmc_user/args.rs
+++ b/crates/admin-cli/src/bmc_machine/create_bmc_user/args.rs
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use clap::Parser;
+use mac_address::MacAddress;
+
+#[derive(Parser, Debug, Clone)]
+pub struct Args {
+    #[clap(long, short, help = "IP of the BMC where we want to create a new user")]
+    pub ip_address: Option<String>,
+    #[clap(long, help = "MAC of the BMC where we want to create a new user")]
+    pub mac_address: Option<MacAddress>,
+    #[clap(
+        long,
+        short,
+        help = "ID of the machine where we want to create a new user"
+    )]
+    pub machine: Option<String>,
+
+    #[clap(long, short, help = "Username of new BMC account")]
+    pub username: String,
+    #[clap(long, short, help = "Password of new BMC account")]
+    pub password: String,
+    #[clap(
+        long,
+        short,
+        help = "Role of new BMC account ('administrator', 'operator', 'readonly', 'noaccess')"
+    )]
+    pub role_id: Option<String>,
+}

--- a/crates/admin-cli/src/bmc_machine/create_bmc_user/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/create_bmc_user/cmd.rs
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::CarbideCliResult;
+
+use super::args::Args;
+use crate::rpc::ApiClient;
+
+pub async fn create_bmc_user(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    api_client
+        .create_bmc_user(
+            args.ip_address,
+            args.mac_address,
+            args.machine,
+            args.username,
+            args.password,
+            args.role_id,
+        )
+        .await?;
+    Ok(())
+}

--- a/crates/admin-cli/src/bmc_machine/create_bmc_user/mod.rs
+++ b/crates/admin-cli/src/bmc_machine/create_bmc_user/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::create_bmc_user(self, &ctx.api_client).await
+    }
+}

--- a/crates/admin-cli/src/bmc_machine/delete_bmc_user/args.rs
+++ b/crates/admin-cli/src/bmc_machine/delete_bmc_user/args.rs
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use clap::Parser;
+use mac_address::MacAddress;
+
+#[derive(Parser, Debug, Clone)]
+pub struct Args {
+    #[clap(long, short, help = "IP of the BMC where we want to delete a user")]
+    pub ip_address: Option<String>,
+    #[clap(long, help = "MAC of the BMC where we want to delete a user")]
+    pub mac_address: Option<MacAddress>,
+    #[clap(long, short, help = "ID of the machine where we want to delete a user")]
+    pub machine: Option<String>,
+
+    #[clap(long, short, help = "Username of BMC account to delete")]
+    pub username: String,
+}

--- a/crates/admin-cli/src/bmc_machine/delete_bmc_user/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/delete_bmc_user/cmd.rs
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::CarbideCliResult;
+
+use super::args::Args;
+use crate::rpc::ApiClient;
+
+pub async fn delete_bmc_user(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    api_client
+        .delete_bmc_user(
+            args.ip_address,
+            args.mac_address,
+            args.machine,
+            args.username,
+        )
+        .await?;
+    Ok(())
+}

--- a/crates/admin-cli/src/bmc_machine/delete_bmc_user/mod.rs
+++ b/crates/admin-cli/src/bmc_machine/delete_bmc_user/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::delete_bmc_user(self, &ctx.api_client).await
+    }
+}

--- a/crates/admin-cli/src/bmc_machine/enable_infinite_boot/args.rs
+++ b/crates/admin-cli/src/bmc_machine/enable_infinite_boot/args.rs
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use clap::Parser;
+
+use crate::bmc_machine::common::InfiniteBootArgs;
+
+// EnableInfiniteBootArgs wraps the shared InfiniteBootArgs as a subcommand
+// specific newtype to allow sharing of InfiniteBootArgs, and still
+// providing a subcommand-specific Run trait implementation.
+#[derive(Parser, Debug, Clone)]
+pub struct Args {
+    #[clap(flatten)]
+    pub inner: InfiniteBootArgs,
+}

--- a/crates/admin-cli/src/bmc_machine/enable_infinite_boot/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/enable_infinite_boot/cmd.rs
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::CarbideCliResult;
+
+use crate::bmc_machine::common::{AdminPowerControlAction, InfiniteBootArgs};
+use crate::rpc::ApiClient;
+
+pub async fn enable_infinite_boot(
+    args: InfiniteBootArgs,
+    api_client: &ApiClient,
+) -> CarbideCliResult<()> {
+    let machine = args.machine;
+    api_client
+        .enable_infinite_boot(None, Some(machine.clone()))
+        .await?;
+    if args.reboot {
+        api_client
+            .admin_power_control(
+                None,
+                Some(machine),
+                AdminPowerControlAction::ForceRestart.into(),
+            )
+            .await?;
+    }
+    Ok(())
+}

--- a/crates/admin-cli/src/bmc_machine/enable_infinite_boot/mod.rs
+++ b/crates/admin-cli/src/bmc_machine/enable_infinite_boot/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::enable_infinite_boot(self.inner, &ctx.api_client).await
+    }
+}

--- a/crates/admin-cli/src/bmc_machine/is_infinite_boot_enabled/args.rs
+++ b/crates/admin-cli/src/bmc_machine/is_infinite_boot_enabled/args.rs
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use clap::Parser;
+
+use crate::bmc_machine::common::InfiniteBootArgs;
+
+// IsInfiniteBootEnabledArgs wraps the shared InfiniteBootArgs as a subcommand
+// specific newtype to allow sharing of InfiniteBootArgs, and still
+// providing a subcommand-specific Run trait implementation.
+#[derive(Parser, Debug, Clone)]
+pub struct Args {
+    #[clap(flatten)]
+    pub inner: InfiniteBootArgs,
+}

--- a/crates/admin-cli/src/bmc_machine/is_infinite_boot_enabled/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/is_infinite_boot_enabled/cmd.rs
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::CarbideCliResult;
+
+use crate::bmc_machine::common::InfiniteBootArgs;
+use crate::rpc::ApiClient;
+
+pub async fn is_infinite_boot_enabled(
+    args: InfiniteBootArgs,
+    api_client: &ApiClient,
+) -> CarbideCliResult<()> {
+    let response = api_client
+        .is_infinite_boot_enabled(None, Some(args.machine))
+        .await?;
+    match response.is_enabled {
+        Some(true) => println!("Enabled"),
+        Some(false) => println!("Disabled"),
+        None => println!("Unknown"),
+    }
+    Ok(())
+}

--- a/crates/admin-cli/src/bmc_machine/is_infinite_boot_enabled/mod.rs
+++ b/crates/admin-cli/src/bmc_machine/is_infinite_boot_enabled/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::is_infinite_boot_enabled(self.inner, &ctx.api_client).await
+    }
+}

--- a/crates/admin-cli/src/bmc_machine/lockdown/args.rs
+++ b/crates/admin-cli/src/bmc_machine/lockdown/args.rs
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::machine::MachineId;
+use clap::Parser;
+
+#[derive(Parser, Debug, Clone)]
+pub struct Args {
+    #[clap(long, help = "ID of the machine to enable/disable lockdown")]
+    pub machine: MachineId,
+    #[clap(short, long, help = "Issue reboot to apply lockdown change")]
+    pub reboot: bool,
+    #[clap(
+        long,
+        conflicts_with = "disable",
+        required_unless_present = "disable",
+        help = "Enable lockdown"
+    )]
+    pub enable: bool,
+    #[clap(
+        long,
+        conflicts_with = "enable",
+        required_unless_present = "enable",
+        help = "Disable lockdown"
+    )]
+    pub disable: bool,
+}

--- a/crates/admin-cli/src/bmc_machine/lockdown/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/lockdown/cmd.rs
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+use ::rpc::forge as forgerpc;
+
+use super::args::Args;
+use crate::bmc_machine::common::AdminPowerControlAction;
+use crate::rpc::ApiClient;
+
+pub async fn lockdown(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let machine = args.machine;
+    let action = if args.enable {
+        forgerpc::LockdownAction::Enable
+    } else if args.disable {
+        forgerpc::LockdownAction::Disable
+    } else {
+        return Err(CarbideCliError::GenericError(
+            "Either --enable or --disable must be specified".to_string(),
+        ));
+    };
+
+    api_client.lockdown(None, machine, action).await?;
+
+    let action_str = if args.enable { "enabled" } else { "disabled" };
+
+    if args.reboot {
+        api_client
+            .admin_power_control(
+                None,
+                Some(machine.to_string()),
+                AdminPowerControlAction::ForceRestart.into(),
+            )
+            .await?;
+        println!(
+            "Lockdown {} and reboot initiated to apply the change.",
+            action_str
+        );
+    } else {
+        println!(
+            "Lockdown {}. Please reboot the machine to apply the change.",
+            action_str
+        );
+    }
+    Ok(())
+}

--- a/crates/admin-cli/src/bmc_machine/lockdown/mod.rs
+++ b/crates/admin-cli/src/bmc_machine/lockdown/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::lockdown(self, &ctx.api_client).await
+    }
+}

--- a/crates/admin-cli/src/bmc_machine/lockdown_status/args.rs
+++ b/crates/admin-cli/src/bmc_machine/lockdown_status/args.rs
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::machine::MachineId;
+use clap::Parser;
+
+#[derive(Parser, Debug, Clone)]
+pub struct Args {
+    #[clap(long, help = "ID of the machine to check lockdown status")]
+    pub machine: MachineId,
+}

--- a/crates/admin-cli/src/bmc_machine/lockdown_status/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/lockdown_status/cmd.rs
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::CarbideCliResult;
+
+use super::args::Args;
+use crate::rpc::ApiClient;
+
+pub async fn lockdown_status(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let response = api_client.lockdown_status(None, args.machine).await?;
+    // Convert status enum to string
+    let status_str = match response.status {
+        0 => "Enabled",  // InternalLockdownStatus::ENABLED
+        1 => "Partial",  // InternalLockdownStatus::PARTIAL
+        2 => "Disabled", // InternalLockdownStatus::DISABLED
+        _ => "Unknown",
+    };
+    println!("{}: {}", status_str, response.message);
+    Ok(())
+}

--- a/crates/admin-cli/src/bmc_machine/lockdown_status/mod.rs
+++ b/crates/admin-cli/src/bmc_machine/lockdown_status/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::lockdown_status(self, &ctx.api_client).await
+    }
+}

--- a/crates/admin-cli/src/bmc_machine/mod.rs
+++ b/crates/admin-cli/src/bmc_machine/mod.rs
@@ -15,33 +15,56 @@
  * limitations under the License.
  */
 
-pub mod args;
-pub mod cmds;
+mod admin_power_control;
+mod bmc_reset;
+pub(crate) mod common;
+mod create_bmc_user;
+mod delete_bmc_user;
+mod enable_infinite_boot;
+mod is_infinite_boot_enabled;
+mod lockdown;
+mod lockdown_status;
 
 #[cfg(test)]
 mod tests;
 
 use ::rpc::admin_cli::CarbideCliResult;
-pub use args::Cmd;
+use clap::Parser;
 
 use crate::cfg::dispatch::Dispatch;
+use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
 
+#[derive(Parser, Debug, Clone)]
+#[clap(rename_all = "kebab_case")]
+pub enum Cmd {
+    #[clap(about = "Reset BMC")]
+    BmcReset(bmc_reset::Args),
+    #[clap(about = "Redfish Power Control")]
+    AdminPowerControl(admin_power_control::Args),
+    CreateBmcUser(create_bmc_user::Args),
+    DeleteBmcUser(delete_bmc_user::Args),
+    #[clap(about = "Enable infinite boot")]
+    EnableInfiniteBoot(enable_infinite_boot::Args),
+    #[clap(about = "Check if infinite boot is enabled")]
+    IsInfiniteBootEnabled(is_infinite_boot_enabled::Args),
+    #[clap(about = "Enable or disable lockdown")]
+    Lockdown(lockdown::Args),
+    #[clap(about = "Check lockdown status")]
+    LockdownStatus(lockdown_status::Args),
+}
+
 impl Dispatch for Cmd {
-    async fn dispatch(self, ctx: RuntimeContext) -> CarbideCliResult<()> {
+    async fn dispatch(self, mut ctx: RuntimeContext) -> CarbideCliResult<()> {
         match self {
-            Cmd::BmcReset(args) => cmds::bmc_reset(args, &ctx.api_client).await,
-            Cmd::AdminPowerControl(args) => cmds::admin_power_control(args, &ctx.api_client).await,
-            Cmd::CreateBmcUser(args) => cmds::create_bmc_user(args, &ctx.api_client).await,
-            Cmd::DeleteBmcUser(args) => cmds::delete_bmc_user(args, &ctx.api_client).await,
-            Cmd::EnableInfiniteBoot(args) => {
-                cmds::enable_infinite_boot(args, &ctx.api_client).await
-            }
-            Cmd::IsInfiniteBootEnabled(args) => {
-                cmds::is_infinite_boot_enabled(args, &ctx.api_client).await
-            }
-            Cmd::Lockdown(args) => cmds::lockdown(args, &ctx.api_client).await,
-            Cmd::LockdownStatus(args) => cmds::lockdown_status(args, &ctx.api_client).await,
+            Cmd::BmcReset(args) => args.run(&mut ctx).await,
+            Cmd::AdminPowerControl(args) => args.run(&mut ctx).await,
+            Cmd::CreateBmcUser(args) => args.run(&mut ctx).await,
+            Cmd::DeleteBmcUser(args) => args.run(&mut ctx).await,
+            Cmd::EnableInfiniteBoot(args) => args.run(&mut ctx).await,
+            Cmd::IsInfiniteBootEnabled(args) => args.run(&mut ctx).await,
+            Cmd::Lockdown(args) => args.run(&mut ctx).await,
+            Cmd::LockdownStatus(args) => args.run(&mut ctx).await,
         }
     }
 }

--- a/crates/admin-cli/src/bmc_machine/tests.rs
+++ b/crates/admin-cli/src/bmc_machine/tests.rs
@@ -27,7 +27,8 @@
 
 use clap::{CommandFactory, Parser};
 
-use super::args::*;
+use super::common::AdminPowerControlAction;
+use super::*;
 
 // Define a basic/working MachineId for testing.
 const TEST_MACHINE_ID: &str = "fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg";


### PR DESCRIPTION
## Description

A `Dispatch` trait was recently introduced that is used by both `main.rs` for dispatching to command groups (which can also dispatch to nested command groups), and now we have a `Run` trait for dispatch handlers to run the actual command, which was introduced in [this PR](https://github.com/NVIDIA/bare-metal-manager-core/pull/375), which explains what is being done here.

That initial PR only pulled in the `credential` command group (*you can see how it looks [here](https://github.com/NVIDIA/bare-metal-manager-core/tree/main/crates/admin-cli/src/credential)*) to keep the PR easier to understand. I'm now going to start pulling in other command group refactors to fit the pattern. I'll probably make the PRs bigger and bigger as I do more and more, but it's nice to be able to look at the single-group refactors for what they are.

The following have been updated so far:
- `credential` -- [#375](https://github.com/NVIDIA/bare-metal-manager-core/pull/375)
- `sku` -- [#382](https://github.com/NVIDIA/bare-metal-manager-core/pull/382)

..and this one is for `bmc_machine`. Again, will probably start to batch them together later, but single modules make it easier to refer back to later if needed.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

