### PR TITLE
fix(api): add support for setting a Vault path for RMS node types

### DIFF
--- a/crates/api/src/site_explorer/mod.rs
+++ b/crates/api/src/site_explorer/mod.rs
@@ -40,7 +40,6 @@ use futures_util::{StreamExt, TryFutureExt};
 use itertools::Itertools;
 use libredfish::model::oem::nvidia_dpu::NicMode;
 use librms::RmsApi;
-use librms::protos::rack_manager::NodeType as RmsNodeType;
 use mac_address::MacAddress;
 use model::expected_power_shelf::ExpectedPowerShelf;
 use model::expected_switch::ExpectedSwitch;
@@ -772,14 +771,12 @@ impl SiteExplorer {
         // Register the power shelf with Rack Manager if RMS client is available
         if let Some(rms_client) = &self.rms_client {
             if let Some(rack_id) = expected_shelf.rack_id {
-                if let Err(e) = rms::add_node_to_rms(
+                if let Err(e) = rms::add_power_shelf_to_rms(
                     rms_client.as_ref(),
                     rack_id,
                     power_shelf_id.to_string(),
                     explored_endpoint.address.to_string(),
-                    443,
                     expected_shelf.bmc_mac_address,
-                    RmsNodeType::Powershelf,
                 )
                 .await
                 {
@@ -895,14 +892,12 @@ impl SiteExplorer {
         // Register the switch with Rack Manager if RMS client is available
         if let Some(rms_client) = &self.rms_client {
             if let Some(rack_id) = expected_switch.rack_id {
-                if let Err(e) = rms::add_node_to_rms(
+                if let Err(e) = rms::add_switch_to_rms(
                     rms_client.as_ref(),
                     rack_id,
                     switch_id.to_string(),
                     explored_endpoint.address.to_string(),
-                    443,
                     expected_switch.bmc_mac_address,
-                    RmsNodeType::Switch,
                 )
                 .await
                 {

--- a/crates/api/src/site_explorer/rms.rs
+++ b/crates/api/src/site_explorer/rms.rs
@@ -22,31 +22,15 @@ use mac_address::MacAddress;
 
 use crate::CarbideError;
 
-// Helper function to add a node to the Rack Manager
+const RMS_PORT: i32 = 443;
+
 pub async fn add_node_to_rms(
     rms_client: &dyn RmsApi,
-    rack_id: RackId,
-    node_id: String,
-    ip_address: String,
-    port: i32,
-    mac_address: MacAddress,
-    node_type: RmsNodeType,
+    new_node: NewNodeInfo,
 ) -> Result<(), CarbideError> {
-    let new_node_info = NewNodeInfo {
-        rack_id: rack_id.to_string(),
-        node_id,
-        mac_address: mac_address.to_string(),
-        ip_address,
-        port,
-        username: None,
-        password: None,
-        r#type: Some(node_type.into()),
-        vault_path: "".to_string(),
-    };
-
     let request = librms::protos::rack_manager::AddNodeRequest {
         metadata: None,
-        node_info: vec![new_node_info],
+        node_info: vec![new_node],
     };
     rms_client
         .add_node(request)
@@ -54,4 +38,67 @@ pub async fn add_node_to_rms(
         .map_err(CarbideError::RackManagerError)?;
 
     Ok(())
+}
+
+pub async fn add_switch_to_rms(
+    rms_client: &dyn RmsApi,
+    rack_id: RackId,
+    node_id: String,
+    ip_address: String,
+    mac_address: MacAddress,
+) -> Result<(), CarbideError> {
+    let new_node = NewNodeInfo {
+        rack_id: rack_id.to_string(),
+        node_id,
+        mac_address: mac_address.to_string(),
+        ip_address,
+        port: RMS_PORT,
+        username: None,
+        password: None,
+        r#type: Some(RmsNodeType::Switch.into()),
+        vault_path: format!("switch_nvos/{mac_address}/admin"),
+    };
+    add_node_to_rms(rms_client, new_node).await
+}
+
+pub async fn add_compute_tray_to_rms(
+    rms_client: &dyn RmsApi,
+    rack_id: RackId,
+    node_id: String,
+    ip_address: String,
+    mac_address: MacAddress,
+) -> Result<(), CarbideError> {
+    let new_node = NewNodeInfo {
+        rack_id: rack_id.to_string(),
+        node_id,
+        mac_address: mac_address.to_string(),
+        ip_address,
+        port: RMS_PORT,
+        username: None,
+        password: None,
+        r#type: Some(RmsNodeType::Compute.into()),
+        vault_path: String::new(),
+    };
+    add_node_to_rms(rms_client, new_node).await
+}
+
+pub async fn add_power_shelf_to_rms(
+    rms_client: &dyn RmsApi,
+    rack_id: RackId,
+    node_id: String,
+    ip_address: String,
+    mac_address: MacAddress,
+) -> Result<(), CarbideError> {
+    let new_node = NewNodeInfo {
+        rack_id: rack_id.to_string(),
+        node_id,
+        mac_address: mac_address.to_string(),
+        ip_address,
+        port: RMS_PORT,
+        username: None,
+        password: None,
+        r#type: Some(RmsNodeType::Powershelf.into()),
+        vault_path: String::new(),
+    };
+    add_node_to_rms(rms_client, new_node).await
 }

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -45,7 +45,6 @@ use libredfish::model::task::TaskState;
 use libredfish::model::update_service::TransferProtocolType;
 use libredfish::{Boot, EnabledDisabled, PowerState, Redfish, RedfishError, SystemPowerControl};
 use librms::RackManagerError;
-use librms::protos::rack_manager::NodeType as RmsNodeType;
 use machine_validation::{handle_machine_validation_requested, handle_machine_validation_state};
 use measured_boot::records::MeasurementMachineState;
 use model::DpuModel;
@@ -852,14 +851,12 @@ impl MachineStateHandler {
                 // of an "already exists" error. However, the proto spec doesn't
                 // seem to define this, so once that's sorted, make sure to
                 // integrate that here.
-                match rms::add_node_to_rms(
+                match rms::add_compute_tray_to_rms(
                     rms_client.as_ref(),
                     rack_id,
                     host_machine_id.to_string(),
                     bmc_ip,
-                    443,
                     bmc_mac.unwrap_or_default(),
-                    RmsNodeType::Compute,
                 )
                 .await
                 {


### PR DESCRIPTION
## Description

RMS API calls take a Vault path for node types which says where to store credentials for that node (`::Compute`, `::PowerShelf, `::Switch`). This actually enables us to start setting a path, initially leveraging it for `::Switch`.

While I'm in here, I'm also adding some helpers around the `add_rms_node` helper. It hit the point where I was getting `clippy` warnings for too many arguments, so i'm restructing things accordingly such that `add_rms_node` just takes a `NewNodeInfo` that we construct by variant-specific callers.

`::Compute` and `::PowerShelf` variants continue to take `""` as their Vault path.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

