### PR TITLE
don't remove .gitkeep file

### DIFF
--- a/pxe/Makefile.toml
+++ b/pxe/Makefile.toml
@@ -966,16 +966,9 @@ args = [
 [tasks.cleanup-old-debs]
 category = "iPXE Kernel"
 description = "Remove all the old debs in the target folder"
-command = "find"
-args = [
-  "${REPO_ROOT}/pxe/debs",
-  "-type",
-  "f",
-  "-not",
-  "-name",
-  "libnss-exec_0.2.0-1_*.deb",
-  "-delete",
-]
+script = '''
+  find "${REPO_ROOT}/pxe/debs" -type f -not \( -name libnss-exec_0.2.0-1_*.deb -o -name .gitkeep \) -delete
+'''
 
 [tasks.download-debs-for-bfb]
 category = "iPXE Kernel"


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
fixes the clean to not remove the .gitkeep file which then shows up as deleted file in git

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

