### PR TITLE
TPM Error logging

### DIFF
--- a/crates/api-db/src/machine_topology.rs
+++ b/crates/api-db/src/machine_topology.rs
@@ -93,7 +93,22 @@ pub async fn create_or_update(
         .bind(sqlx::types::Json(&topology_data))
         .fetch_one(txn)
         .await
-        .map_err(|e| DatabaseError::query(query, e))?;
+        .map_err(|e| match &e {
+            sqlx::Error::Database(db_err)
+                if db_err.constraint() == Some("machine_topologies_machine_id_fkey") =>
+            {
+                tracing::error!(
+                    %machine_id,
+                    "Machine discovery failed: hardware reports a different machine id \
+                    (Caused by installing a TPM without force-deleting the machine). Power off the machine, force-delete it, \
+                    then re-ingest."
+                );
+                DatabaseError::FailedPrecondition(format!(
+                    "Machine topology machine_id foreign key violation: {e}"
+                ))
+            }
+            _ => DatabaseError::query(query, e),
+        })?;
 
     Ok(res)
 }

--- a/crates/api/src/tests/machine_states.rs
+++ b/crates/api/src/tests/machine_states.rs
@@ -16,6 +16,7 @@
  */
 use std::collections::HashMap;
 
+use base64::prelude::*;
 use chrono::Duration;
 use common::api_fixtures::dpu::{
     create_dpu_machine, create_dpu_machine_in_waiting_for_network_install,
@@ -41,8 +42,11 @@ use model::machine::{
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{HealthReportOverride, InsertHealthReportOverrideRequest, TpmCaCert, TpmCaCertId};
 use rpc::forge_agent_control_response::Action;
+use rpc::machine_discovery::AttestKeyInfo;
+use rpc::{DiscoveryData, DiscoveryInfo};
 use tonic::{Code, Request};
 
+use crate::handlers::measured_boot::rpc_forge::MachineDiscoveryInfo;
 use crate::state_controller::db_write_batch::DbWriteBatch;
 use crate::state_controller::machine::context::MachineStateHandlerContextObjects;
 use crate::state_controller::machine::handler::{
@@ -1627,5 +1631,46 @@ async fn test_scout_heartbeat_timeout_alert_not_cleared_when_unhealthy_allocatio
     assert!(
         host.health_report_overrides.merges.contains_key("scout"),
         "expected scout_heartbeat_timeout alert to remain when unhealthy allocation is blocked"
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_tpm_logging(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let host_config = env.managed_host_config();
+    let dpu_machine_id = create_dpu_machine(&env, &host_config).await;
+
+    let machine_interface_id = host_discover_dhcp(&env, &host_config, &dpu_machine_id).await;
+
+    // First discovery - establishes the host with the original TPM-based ID
+    host_discover_machine(&env, &host_config, machine_interface_id).await;
+
+    // Second discovery - different TPM EK cert simulates TPM replacement
+    // without force-delete, producing a different stable_machine_id
+    let mut discovery_info =
+        DiscoveryInfo::try_from(model::hardware_info::HardwareInfo::from(&host_config)).unwrap();
+    // Use a different valid EK cert to simulate TPM replacement
+    discovery_info.tpm_ek_certificate =
+        Some(BASE64_STANDARD.encode(common::api_fixtures::tpm_attestation::EK_CERT_SERIALIZED));
+    discovery_info.attest_key_info = Some(AttestKeyInfo {
+        ek_pub: common::api_fixtures::tpm_attestation::EK_PUB_SERIALIZED.to_vec(),
+        ak_pub: common::api_fixtures::tpm_attestation::AK_PUB_SERIALIZED.to_vec(),
+        ak_name: common::api_fixtures::tpm_attestation::AK_NAME_SERIALIZED.to_vec(),
+    });
+    let result = env
+        .api
+        .discover_machine(Request::new(MachineDiscoveryInfo {
+            machine_interface_id: Some(machine_interface_id),
+            discovery_data: Some(DiscoveryData::Info(discovery_info)),
+            create_machine: false,
+        }))
+        .await;
+
+    let err = result.expect_err("Expected FK violation from mismatched TPM");
+    assert_eq!(err.code(), Code::FailedPrecondition);
+    assert!(
+        err.message().contains("machine_id foreign key violation"),
+        "Expected TPM mismatch error, got: {}",
+        err.message()
     );
 }


### PR DESCRIPTION
## Description
Adds better logging for TPM installation errors where a Foreign key violation is seen between the machine_topology table and the machines table 

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
https://github.com/NVIDIA/bare-metal-manager-core/issues/238

## Breaking Changes
- [ ] This PR contains breaking changes


## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes


