### PR TITLE
fix: Get rid of debug_assert calls

### DIFF
--- a/crates/api/src/handlers/expected_machine.rs
+++ b/crates/api/src/handlers/expected_machine.rs
@@ -484,10 +484,7 @@ async fn process_batch_operations(
     let mut results = Vec::new();
 
     if accept_partial {
-        let mut txn: Option<db::Transaction<'_>> = None;
-
         for machine in machines {
-            debug_assert!(txn.is_none());
             let request_id = machine
                 .id
                 .as_ref()
@@ -511,8 +508,8 @@ async fn process_batch_operations(
                 value: id.to_string(),
             });
 
-            txn = match api.txn_begin().await {
-                Ok(txn) => Some(txn),
+            let mut txn = match api.txn_begin().await {
+                Ok(txn) => txn,
                 Err(e) => {
                     results.push(build_failure_result(
                         id,
@@ -521,10 +518,6 @@ async fn process_batch_operations(
                     continue;
                 }
             };
-
-            let mut txn = txn
-                .take()
-                .expect("transaction should be present when beginning per-machine work");
 
             match apply_operation(op, txn.as_pgconn(), machine, id, parsed_mac).await {
                 Ok(_) => match txn.commit().await {

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -23,6 +23,35 @@
 #![cfg_attr(test, allow(txn_held_across_await))]
 #![cfg_attr(test, allow(txn_without_commit))]
 
+#[cfg(test)]
+/// test_assert will run an assertion if we are compiled to run tests, or will print an error otherwise.
+macro_rules! test_assert {
+    ($cond:expr $(,)?) => {
+        assert!($cond);
+    };
+    ($cond:expr, $($arg:tt)+) => {
+        assert!($cond, $($arg)+);
+    };
+}
+
+#[cfg(not(test))]
+/// test_assert will run an assertion if we are compiled to run tests, or will print an error otherwise.
+macro_rules! test_assert {
+    ($cond:expr $(,)?) => {
+        if !$cond {
+            tracing::error!(
+                assertion = stringify!($cond),
+                "test-only assertion failed"
+            );
+        }
+    };
+    ($cond:expr, $($arg:tt)+) => {
+        if !$cond {
+            tracing::error!($($arg)+);
+        }
+    };
+}
+
 // NOTE on pub vs non-pub mods:
 //
 // carbide-api is a CLI crate, not a lib. The only reason we have lib.rs is to export things so that

--- a/crates/api/src/state_controller/controller/processor.rs
+++ b/crates/api/src/state_controller/controller/processor.rs
@@ -543,10 +543,9 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
         .await?;
         txn.commit().await?;
 
-        debug_assert_eq!(
-            object_ids.len(),
-            num_deleted,
-            "Not all objects have been deleted from the database"
+        test_assert!(
+            object_ids.len() == num_deleted,
+            "BUG: Not all objects have been deleted from the database after cleanup"
         );
 
         self.stats_since_last_log.num_deleted_queued_objects += num_deleted;


### PR DESCRIPTION
## Description
We have debug_assert calls firing in production datacenters, presumably because we're running without optimizations for some reason. While we figure out why, switch to using a custom test_assert macro which only fails if running for tests, or logs otherwise.

One of the calls to debug_assert was not necessary at all because it was misusing Option::take() when a simple local variable would have sufficed.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
nvbugs/5944069

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes

The actual problem we saw is in the cleanup_completed_objects, which occasionally has a mismatch in one of our larger environments. But this assertion was basically saying "ensure that we still own each of the object_id's we just ran" (by only deleting where processed_by = self.processor_id), but that isn't always true. The processor is "work-stealing" by design, since acquire_queued_objects will steal any objects that are past `max_object_handling_time * 3`. This means that any time we steal an enqueued object, there might be two processors running that enqueued object. And whatever processor finishes first, will delete the enqueued object, leaving the second processor to not see it get deleted, leading to this issue.

(Long story short, the fact that we have timeouts and work stealing means we can't just crash if the processor no longer "owns" the object ID's it just processed.)