### PR TITLE
Make controller panics propagate to the main task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,6 +1474,7 @@ dependencies = [
  "sqlx",
  "temp-dir",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -1555,6 +1556,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/crates/api-integration-tests/Cargo.toml
+++ b/crates/api-integration-tests/Cargo.toml
@@ -41,6 +41,7 @@ serde_json = { workspace = true }
 sqlx = { workspace = true, features = ["postgres"] }
 temp-dir = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 tracing = { workspace = true }
 #these are alphabetized
 

--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -33,6 +33,7 @@ use futures::future::join_all;
 use itertools::Itertools;
 use sqlx::{Postgres, Row};
 use tokio::time::sleep;
+use tokio_util::sync::CancellationToken;
 
 #[ctor::ctor]
 fn setup() {
@@ -74,6 +75,7 @@ async fn test_integration() -> eyre::Result<()> {
 
     // Begin the integration test by starting an API server. This will be shared between multiple
     // individual machine-a-tron-based tests, which can run in parallel against the same instance.
+    let cancel_token = CancellationToken::new();
     let (server_handle_1, server_handle_2) = (
         utils::start_api_server(
             test_env.clone(),
@@ -84,6 +86,7 @@ async fn test_integration() -> eyre::Result<()> {
             empty_firmware_dir.path().to_owned(),
             0,
             true,
+            cancel_token.clone(),
         )
         .await?,
         utils::start_api_server(
@@ -95,6 +98,7 @@ async fn test_integration() -> eyre::Result<()> {
             empty_firmware_dir.path().to_owned(),
             1,
             true,
+            cancel_token.clone(),
         )
         .await?,
     );
@@ -154,8 +158,9 @@ async fn test_integration() -> eyre::Result<()> {
 
     generate_core_metric_docs(&test_env.carbide_metrics_addrs);
 
-    server_handle_1.stop().await?;
-    server_handle_2.stop().await?;
+    cancel_token.cancel();
+    server_handle_1.wait().await?;
+    server_handle_2.wait().await?;
     test_env.db_pool.close().await;
     bmc_mock_handle.stop().await?;
     Ok(())
@@ -260,6 +265,7 @@ async fn test_metrics_integration() -> eyre::Result<()> {
 
     // Begin the integration test by starting an API server. This will be shared between multiple
     // individual machine-a-tron-based tests, which can run in parallel against the same instance.
+    let cancel_token = CancellationToken::new();
     let server_handle = utils::start_api_server(
         test_env.clone(),
         Some(HostPortPair::HostAndPort(
@@ -269,6 +275,7 @@ async fn test_metrics_integration() -> eyre::Result<()> {
         empty_firmware_dir.path().to_owned(),
         0,
         true,
+        cancel_token.clone(),
     )
     .await?;
 
@@ -410,7 +417,8 @@ async fn test_metrics_integration() -> eyre::Result<()> {
 
     sleep(time::Duration::from_millis(500)).await;
     bmc_mock_handle.stop().await?;
-    server_handle.stop().await?;
+    cancel_token.cancel();
+    server_handle.wait().await?;
     db_pool.close().await;
     Ok(())
 }

--- a/crates/api-test-helper/Cargo.toml
+++ b/crates/api-test-helper/Cargo.toml
@@ -45,22 +45,23 @@ serde = { features = ["derive"], workspace = true }
 serde_json = { workspace = true }
 serial_test = { workspace = true }
 sqlx = { workspace = true, features = [
-  "runtime-tokio-rustls",
-  "mac_address",
-  "ipnetwork",
-  "uuid",
-  "migrate",
-  "postgres",
-  "chrono",
-  "macros",
-  "json",
+    "runtime-tokio-rustls",
+    "mac_address",
+    "ipnetwork",
+    "uuid",
+    "migrate",
+    "postgres",
+    "chrono",
+    "macros",
+    "json",
 ] }
 tempfile = { workspace = true }
 tokio.workspace = true
+tokio-util.workspace = true
 tracing = { workspace = true }
 tracing-subscriber = { features = [
-  "env-filter",
-  "local-time",
+    "env-filter",
+    "local-time",
 ], workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }

--- a/crates/api-test-helper/src/api_server.rs
+++ b/crates/api-test-helper/src/api_server.rs
@@ -18,7 +18,8 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use forge_secrets::forge_vault::VaultConfig;
-use tokio::sync::oneshot::{Receiver, Sender};
+use tokio::sync::oneshot::Sender;
+use tokio_util::sync::CancellationToken;
 use utils::HostPortPair;
 
 use crate::utils::LOCALHOST_CERTS;
@@ -33,7 +34,7 @@ pub struct StartArgs {
     pub db_url: String,
     pub bmc_proxy: Option<HostPortPair>,
     pub firmware_directory: PathBuf,
-    pub stop_channel: Receiver<()>,
+    pub cancel_token: CancellationToken,
     pub ready_channel: Sender<()>,
     pub vault_config: VaultConfig,
 }
@@ -47,7 +48,7 @@ pub async fn start(
         db_url,
         bmc_proxy,
         firmware_directory,
-        stop_channel,
+        cancel_token,
         ready_channel,
         vault_config,
     }: StartArgs,
@@ -277,7 +278,7 @@ pub async fn start(
         None,
         vault_config,
         true,
-        stop_channel,
+        cancel_token,
         ready_channel,
     )
     .await

--- a/crates/api-test-helper/src/utils.rs
+++ b/crates/api-test-helper/src/utils.rs
@@ -28,9 +28,9 @@ use forge_secrets::forge_vault::VaultConfig;
 use metrics_endpoint::MetricsSetup;
 use sqlx::migrate::MigrateDatabase;
 use sqlx::{Pool, Postgres};
-use tokio::sync::oneshot::Sender;
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
+use tokio_util::sync::CancellationToken;
 use utils::HostPortPair;
 
 use crate::api_server::StartArgs;
@@ -190,6 +190,7 @@ pub async fn start_api_server(
     firmware_directory: PathBuf,
     addr_index: usize,
     put_dev_bin_in_path: bool,
+    cancel_token: CancellationToken,
 ) -> eyre::Result<ApiServerHandle> {
     // Destructure into vars to save typing
     let IntegrationTestEnvironment {
@@ -240,10 +241,10 @@ pub async fn start_api_server(
 
     populate_initial_vault_secrets(&vault_config, &metrics).await?;
 
-    let (stop_tx, stop_rx) = tokio::sync::oneshot::channel();
     let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
     let join_handle = tokio::spawn({
         let root_dir = root_dir.clone();
+        let cancel_token = cancel_token.clone();
         async move {
             api_server::start(StartArgs {
                 addr: carbide_api_addrs[addr_index],
@@ -252,7 +253,7 @@ pub async fn start_api_server(
                 db_url,
                 bmc_proxy,
                 firmware_directory,
-                stop_channel: stop_rx,
+                cancel_token,
                 ready_channel: ready_tx,
                 vault_config,
             })
@@ -265,25 +266,17 @@ pub async fn start_api_server(
 
     ready_rx.await.unwrap();
 
-    Ok(ApiServerHandle {
-        stop_channel: Some(stop_tx),
-        join_handle,
-    })
+    Ok(ApiServerHandle { join_handle })
 }
 
 /// When dropped, this will invalidate the API server.
 pub struct ApiServerHandle {
-    stop_channel: Option<Sender<()>>,
     join_handle: JoinHandle<eyre::Result<()>>,
 }
 
 impl ApiServerHandle {
-    pub async fn stop(mut self) -> eyre::Result<()> {
-        if let Some(stop_channel) = self.stop_channel.take() {
-            stop_channel.send(()).unwrap();
-        };
-        self.join_handle.await??;
-        Ok(())
+    pub async fn wait(self) -> eyre::Result<()> {
+        self.join_handle.await.expect("task panicked")
     }
 }
 

--- a/crates/api/src/listener.rs
+++ b/crates/api/src/listener.rs
@@ -30,9 +30,10 @@ use rustls::server::WebPkiClientVerifier;
 use rustls_pki_types::CertificateDer;
 use tokio::net::TcpListener;
 use tokio::select;
-use tokio::sync::oneshot::{Receiver, Sender};
+use tokio::sync::oneshot::Sender;
 use tokio_rustls::TlsAcceptor;
 use tokio_rustls::rustls::{RootCertStore, ServerConfig};
+use tokio_util::sync::CancellationToken;
 use tonic_reflection::server::Builder;
 use tower_http::add_extension::AddExtensionLayer;
 use tower_http::auth::AsyncRequireAuthorizationLayer;
@@ -183,7 +184,7 @@ pub async fn listen_and_serve(
     listen_port: SocketAddr,
     auth_config: &Option<AuthConfig>,
     meter: Meter,
-    mut stop_channel: Receiver<()>,
+    cancel_token: CancellationToken,
     ready_channel: Sender<()>,
 ) -> eyre::Result<()> {
     let api_reflection_service = Builder::configure()
@@ -298,7 +299,7 @@ pub async fn listen_and_serve(
     loop {
         let incoming_connection = select! {
             incoming_connection = listener.accept() => incoming_connection,
-            _ = &mut stop_channel => {
+            _ = cancel_token.cancelled() => {
                 tracing::info!("carbide-api shutting down");
                 return Ok(());
             }

--- a/crates/api/src/logging/metrics_endpoint.rs
+++ b/crates/api/src/logging/metrics_endpoint.rs
@@ -29,7 +29,7 @@ use hyper_util::rt::TokioIo;
 use prometheus::proto::MetricFamily;
 use prometheus::{Encoder, TextEncoder};
 use tokio::net::TcpListener;
-use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
 
 /// Request handler
 fn handle_metrics_request(
@@ -104,7 +104,7 @@ pub struct MetricsEndpointConfig {
 /// Start a HTTP endpoint which exposes metrics using the provided configuration
 pub async fn run_metrics_endpoint(
     config: &MetricsEndpointConfig,
-    mut stop_rx: oneshot::Receiver<()>,
+    cancel_token: CancellationToken,
 ) -> eyre::Result<()> {
     let handler_state = Arc::new(MetricsHandlerState {
         registry: config.registry.clone(),
@@ -132,7 +132,7 @@ pub async fn run_metrics_endpoint(
                     }),
                 ));
             },
-            _ = &mut stop_rx => {
+            _ = cancel_token.cancelled() => {
                 break
             }
         }

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -23,6 +23,7 @@ use clap::CommandFactory;
 use forge_secrets::forge_vault::VaultConfig;
 use sqlx::PgPool;
 use sqlx::postgres::{PgConnectOptions, PgSslMode};
+use tokio_util::sync::CancellationToken;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
@@ -65,7 +66,6 @@ async fn main() -> eyre::Result<()> {
                 None
             };
 
-            let (_stop_tx, stop_rx) = tokio::sync::oneshot::channel();
             let (ready_tx, _ready_rx) = tokio::sync::oneshot::channel();
             carbide::run(
                 debug,
@@ -73,7 +73,7 @@ async fn main() -> eyre::Result<()> {
                 site_config_str,
                 VaultConfig::default(),
                 false,
-                stop_rx,
+                CancellationToken::new(),
                 ready_tx,
             )
             .await?;

--- a/crates/api/src/run.rs
+++ b/crates/api/src/run.rs
@@ -20,8 +20,8 @@ use std::sync::Arc;
 use eyre::WrapErr;
 use forge_secrets::forge_vault;
 use forge_secrets::forge_vault::VaultConfig;
-use tokio::sync::oneshot;
-use tokio::sync::oneshot::{Receiver, Sender};
+use tokio::sync::oneshot::Sender;
+use tokio_util::sync::CancellationToken;
 use tracing::subscriber::NoSubscriber;
 use utils::HostPortPair;
 
@@ -38,7 +38,7 @@ pub async fn run(
     site_config_str: Option<String>,
     vault_config: VaultConfig,
     skip_logging_setup: bool,
-    stop_channel: Receiver<()>,
+    cancel_token: CancellationToken,
     ready_channel: Sender<()>,
 ) -> eyre::Result<()> {
     let carbide_config = setup::parse_carbide_config(config_str, site_config_str)?;
@@ -85,7 +85,6 @@ pub async fn run(
     create_metric_for_spancount_reader(&metrics.meter, tconf.spancount_reader);
 
     // Spin up the webserver which servers `/metrics` requests
-    let (metrics_stop_tx, metrics_stop_rx) = oneshot::channel();
     if let Some(metrics_address) = carbide_config.metrics_endpoint {
         // If a replacement prefix for "carbide_" is configured, also emit metrics under that
         let additional_prefix = carbide_config
@@ -94,18 +93,21 @@ pub async fn run(
             .map(|alt_prefix| ("carbide_".to_string(), alt_prefix));
         tokio::task::Builder::new()
             .name("metrics_endpoint")
-            .spawn(async move {
-                if let Err(e) = run_metrics_endpoint(
-                    &MetricsEndpointConfig {
-                        address: metrics_address,
-                        registry: metrics.registry,
-                        additional_prefix,
-                    },
-                    metrics_stop_rx,
-                )
-                .await
-                {
-                    tracing::error!("Metrics endpoint failed with error: {}", e);
+            .spawn({
+                let cancel_token = cancel_token.clone();
+                async move {
+                    if let Err(e) = run_metrics_endpoint(
+                        &MetricsEndpointConfig {
+                            address: metrics_address,
+                            registry: metrics.registry,
+                            additional_prefix,
+                        },
+                        cancel_token,
+                    )
+                    .await
+                    {
+                        tracing::error!("Metrics endpoint failed with error: {}", e);
+                    }
                 }
             })?;
     }
@@ -182,28 +184,13 @@ pub async fn run(
         Arc::new(redfish_pool)
     };
 
-    // Split stop_channel into a task which will stop both the API server and metrics server
-    let (api_stop_tx, api_stop_rx) = oneshot::channel();
-    tokio::spawn(async move {
-        stop_channel.await.inspect_err(|error| {
-            tracing::error!(%error, "error waiting on stop channel");
-        })?;
-        _ = metrics_stop_tx.send(()).inspect_err(|_| {
-            tracing::error!("could not send stop signal to metrics server. already stopped?");
-        });
-        _ = api_stop_tx.send(()).inspect_err(|_| {
-            tracing::error!("could not send stop signal to api server. already stopped?");
-        });
-        Ok::<(), eyre::Report>(())
-    });
-
     setup::start_api(
         carbide_config,
         metrics.meter,
         dynamic_settings,
         redfish_pool,
         vault_client,
-        api_stop_rx,
+        cancel_token,
         ready_channel,
     )
     .await

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -39,8 +39,9 @@ use model::route_server::RouteServerSourceType;
 use opentelemetry::metrics::Meter;
 use sqlx::postgres::PgSslMode;
 use sqlx::{ConnectOptions, PgPool};
-use tokio::sync::oneshot::{Receiver, Sender};
-use tokio::sync::{Semaphore, oneshot};
+use tokio::sync::Semaphore;
+use tokio::sync::oneshot::Sender;
+use tokio_util::sync::CancellationToken;
 use tracing_log::AsLog as _;
 
 use crate::api::Api;
@@ -70,7 +71,7 @@ use crate::redfish::RedfishClientPool;
 use crate::scout_stream::ConnectionRegistry;
 use crate::site_explorer::{BmcEndpointExplorer, SiteExplorer};
 use crate::state_controller::common_services::CommonStateHandlerServices;
-use crate::state_controller::controller::{Enqueuer, StateController};
+use crate::state_controller::controller::{Enqueuer, StateController, StateControllerHandleSet};
 use crate::state_controller::dpa_interface::handler::DpaInterfaceStateHandler;
 use crate::state_controller::dpa_interface::io::DpaInterfaceStateControllerIO;
 use crate::state_controller::ib_partition::handler::IBPartitionStateHandler;
@@ -224,7 +225,7 @@ pub async fn start_api(
     dynamic_settings: DynamicSettings,
     shared_redfish_pool: Arc<dyn RedfishClientPool>,
     vault_client: Arc<ForgeVaultClient>,
-    stop_channel: Receiver<()>,
+    cancel_token: CancellationToken,
     ready_channel: Sender<()>,
 ) -> eyre::Result<()> {
     let ipmi_tool = create_ipmi_tool(vault_client.clone(), &carbide_config);
@@ -397,17 +398,16 @@ pub async fn start_api(
         metric_emitter: ApiMetricsEmitter::new(&meter),
     });
 
-    let (controllers_stop_tx, controllers_stop_rx) = oneshot::channel();
     let controllers_handle = if carbide_config.listen_only {
         tracing::info!("Not starting background services, as listen_only=true");
-        tokio::spawn(controllers_stop_rx.map_err(|_| eyre::eyre!("joining noop task")))
+        None
     } else {
-        tokio::spawn(initialize_and_start_controllers(
+        Some(tokio::spawn(initialize_and_start_controllers(
             api_service.clone(),
             meter.clone(),
             ipmi_tool.clone(),
-            controllers_stop_rx,
-        ))
+            cancel_token.clone(),
+        )))
     };
 
     listener::listen_and_serve(
@@ -416,20 +416,28 @@ pub async fn start_api(
         carbide_config.listen,
         &carbide_config.auth,
         meter,
-        stop_channel,
+        cancel_token,
         ready_channel,
     )
     .await?;
 
-    controllers_stop_tx.send(()).ok();
-    controllers_handle.await?
+    // The controllers use a cloned CancellationToken from `cancel_token`, and the only way for
+    // listen_and_serve to have completed is for it to have ben canceled. That same token also
+    // cancels the controllers, so just wait for it here.
+    if let Some(controllers_handle) = controllers_handle {
+        controllers_handle
+            .await
+            .expect("controller task panicked")?;
+    };
+
+    Ok(())
 }
 
 pub async fn initialize_and_start_controllers(
     api_service: Arc<Api>,
     meter: Meter,
     ipmi_tool: Arc<dyn IPMITool>,
-    stop_rx: oneshot::Receiver<()>,
+    cancel_token: CancellationToken,
 ) -> eyre::Result<()> {
     let Api {
         runtime_config: carbide_config,
@@ -669,67 +677,73 @@ pub async fn initialize_and_start_controllers(
         }
     }
 
+    let mut state_controller_handles = StateControllerHandleSet::new();
+
     // handles need to be stored in a variable
     // If they are assigned to _ then the destructor will be immediately called
-    let _machine_state_controller_handle = StateController::<MachineStateControllerIO>::builder()
-        .database(db_pool.clone(), work_lock_manager_handle.clone())
-        .meter("carbide_machines", meter.clone())
-        .processor_id(state_controller_id.clone())
-        .services(handler_services.clone())
-        .iteration_config((&carbide_config.machine_state_controller.controller).into())
-        .state_handler(Arc::new(
-            MachineStateHandlerBuilder::builder()
-                .dpu_up_threshold(carbide_config.machine_state_controller.dpu_up_threshold)
-                .dpu_nic_firmware_reprovision_update_enabled(
-                    carbide_config
-                        .dpu_config
-                        .dpu_nic_firmware_reprovision_update_enabled,
-                )
-                .dpu_enable_secure_boot(carbide_config.dpu_config.dpu_enable_secure_boot)
-                .dpu_wait_time(carbide_config.machine_state_controller.dpu_wait_time)
-                .power_down_wait(carbide_config.machine_state_controller.power_down_wait)
-                .failure_retry_time(carbide_config.machine_state_controller.failure_retry_time)
-                .scout_reporting_timeout(
-                    carbide_config
-                        .machine_state_controller
-                        .scout_reporting_timeout,
-                )
-                .hardware_models(carbide_config.get_firmware_config())
-                .firmware_downloader(&downloader)
-                .attestation_enabled(carbide_config.attestation_enabled)
-                .upload_limiter(upload_limiter.clone())
-                .machine_validation_config(carbide_config.machine_validation_config.clone())
-                .common_pools(common_pools.clone())
-                .bom_validation(carbide_config.bom_validation)
-                .no_firmware_update_reset_retries(carbide_config.firmware_global.no_reset_retries)
-                .instance_autoreboot_period(
-                    carbide_config
-                        .machine_updater
-                        .instance_autoreboot_period
-                        .clone(),
-                )
-                .credential_provider(api_service.credential_provider.clone())
-                .power_options_config(carbide_config.power_manager_options.clone().into())
-                .dpf_config(crate::state_controller::machine::handler::DpfConfig::from(
-                    carbide_config.dpf.clone(),
-                    Arc::new(carbide_dpf::Production {}) as Arc<dyn carbide_dpf::KubeImpl>,
-                ))
-                .build(),
-        ))
-        .io(Arc::new(MachineStateControllerIO {
-            host_health: HostHealthConfig {
-                hardware_health_reports: carbide_config.host_health.hardware_health_reports,
-                dpu_agent_version_staleness_threshold: carbide_config
-                    .host_health
-                    .dpu_agent_version_staleness_threshold,
-                prevent_allocations_on_stale_dpu_agent_version: carbide_config
-                    .host_health
-                    .prevent_allocations_on_stale_dpu_agent_version,
-            },
-        }))
-        .state_change_emitter(state_change_emitter)
-        .build_and_spawn()
-        .expect("Unable to build MachineStateController");
+    state_controller_handles.push(
+        StateController::<MachineStateControllerIO>::builder()
+            .database(db_pool.clone(), work_lock_manager_handle.clone())
+            .meter("carbide_machines", meter.clone())
+            .processor_id(state_controller_id.clone())
+            .services(handler_services.clone())
+            .iteration_config((&carbide_config.machine_state_controller.controller).into())
+            .state_handler(Arc::new(
+                MachineStateHandlerBuilder::builder()
+                    .dpu_up_threshold(carbide_config.machine_state_controller.dpu_up_threshold)
+                    .dpu_nic_firmware_reprovision_update_enabled(
+                        carbide_config
+                            .dpu_config
+                            .dpu_nic_firmware_reprovision_update_enabled,
+                    )
+                    .dpu_enable_secure_boot(carbide_config.dpu_config.dpu_enable_secure_boot)
+                    .dpu_wait_time(carbide_config.machine_state_controller.dpu_wait_time)
+                    .power_down_wait(carbide_config.machine_state_controller.power_down_wait)
+                    .failure_retry_time(carbide_config.machine_state_controller.failure_retry_time)
+                    .scout_reporting_timeout(
+                        carbide_config
+                            .machine_state_controller
+                            .scout_reporting_timeout,
+                    )
+                    .hardware_models(carbide_config.get_firmware_config())
+                    .firmware_downloader(&downloader)
+                    .attestation_enabled(carbide_config.attestation_enabled)
+                    .upload_limiter(upload_limiter.clone())
+                    .machine_validation_config(carbide_config.machine_validation_config.clone())
+                    .common_pools(common_pools.clone())
+                    .bom_validation(carbide_config.bom_validation)
+                    .no_firmware_update_reset_retries(
+                        carbide_config.firmware_global.no_reset_retries,
+                    )
+                    .instance_autoreboot_period(
+                        carbide_config
+                            .machine_updater
+                            .instance_autoreboot_period
+                            .clone(),
+                    )
+                    .credential_provider(api_service.credential_provider.clone())
+                    .power_options_config(carbide_config.power_manager_options.clone().into())
+                    .dpf_config(crate::state_controller::machine::handler::DpfConfig::from(
+                        carbide_config.dpf.clone(),
+                        Arc::new(carbide_dpf::Production {}) as Arc<dyn carbide_dpf::KubeImpl>,
+                    ))
+                    .build(),
+            ))
+            .io(Arc::new(MachineStateControllerIO {
+                host_health: HostHealthConfig {
+                    hardware_health_reports: carbide_config.host_health.hardware_health_reports,
+                    dpu_agent_version_staleness_threshold: carbide_config
+                        .host_health
+                        .dpu_agent_version_staleness_threshold,
+                    prevent_allocations_on_stale_dpu_agent_version: carbide_config
+                        .host_health
+                        .prevent_allocations_on_stale_dpu_agent_version,
+                },
+            }))
+            .state_change_emitter(state_change_emitter)
+            .build_and_spawn(cancel_token.clone())
+            .expect("Unable to build MachineStateController"),
+    );
 
     let sc_pool_vlan_id = common_pools.ethernet.pool_vlan_id.clone();
     let sc_pool_vni = common_pools.ethernet.pool_vni.clone();
@@ -739,25 +753,23 @@ pub async fn initialize_and_start_controllers(
         .meter("carbide_network_segments", meter.clone())
         .processor_id(state_controller_id.clone())
         .services(handler_services.clone());
-    let _network_segment_controller_handle = ns_builder
-        .iteration_config((&carbide_config.network_segment_state_controller.controller).into())
-        .state_handler(Arc::new(NetworkSegmentStateHandler::new(
-            carbide_config
-                .network_segment_state_controller
-                .network_segment_drain_time,
-            sc_pool_vlan_id,
-            sc_pool_vni,
-        )))
-        .build_and_spawn()
-        .expect("Unable to build NetworkSegmentController");
-
-    let mut _dpa_interface_state_controller_handle: Option<
-        crate::state_controller::controller::StateControllerHandle,
-    > = None;
+    state_controller_handles.push(
+        ns_builder
+            .iteration_config((&carbide_config.network_segment_state_controller.controller).into())
+            .state_handler(Arc::new(NetworkSegmentStateHandler::new(
+                carbide_config
+                    .network_segment_state_controller
+                    .network_segment_drain_time,
+                sc_pool_vlan_id,
+                sc_pool_vni,
+            )))
+            .build_and_spawn(cancel_token.clone())
+            .expect("Unable to build NetworkSegmentController"),
+    );
 
     if carbide_config.is_dpa_enabled() {
         tracing::info!("Starting DpaInterfaceStateController as dpa is enabled");
-        _dpa_interface_state_controller_handle = Some(
+        state_controller_handles.push(
             StateController::<DpaInterfaceStateControllerIO>::builder()
                 .database(db_pool.clone(), work_lock_manager_handle.clone())
                 .meter("carbide_dpa_interfaces", meter.clone())
@@ -767,7 +779,7 @@ pub async fn initialize_and_start_controllers(
                     (&carbide_config.dpa_interface_state_controller.controller).into(),
                 )
                 .state_handler(Arc::new(DpaInterfaceStateHandler::new()))
-                .build_and_spawn()
+                .build_and_spawn(cancel_token.clone())
                 .expect("Unable to build DpaInterfaceStateController"),
         );
     }
@@ -781,21 +793,23 @@ pub async fn initialize_and_start_controllers(
 
         let verifier = Arc::new(VerifierImpl::default());
 
-        let _spdm_state_controller_handle = StateController::<SpdmStateControllerIO>::builder()
-            .database(db_pool.clone(), work_lock_manager_handle.clone())
-            .meter("carbide_spdm_attestation", meter.clone())
-            .processor_id(state_controller_id.clone())
-            .services(handler_services.clone())
-            .iteration_config((&carbide_config.spdm_state_controller.controller).into())
-            .state_handler(Arc::new(SpdmAttestationStateHandler::new(
-                verifier,
-                nras_config,
-            )))
-            .build_and_spawn()
-            .expect("Unable to build SpdmStateController");
+        state_controller_handles.push(
+            StateController::<SpdmStateControllerIO>::builder()
+                .database(db_pool.clone(), work_lock_manager_handle.clone())
+                .meter("carbide_spdm_attestation", meter.clone())
+                .processor_id(state_controller_id.clone())
+                .services(handler_services.clone())
+                .iteration_config((&carbide_config.spdm_state_controller.controller).into())
+                .state_handler(Arc::new(SpdmAttestationStateHandler::new(
+                    verifier,
+                    nras_config,
+                )))
+                .build_and_spawn(cancel_token.clone())
+                .expect("Unable to build SpdmStateController"),
+        )
     }
 
-    let _ib_partition_controller_handle =
+    state_controller_handles.push(
         StateController::<IBPartitionStateControllerIO>::builder()
             .database(db_pool.clone(), work_lock_manager_handle.clone())
             .meter("carbide_ib_partitions", meter.clone())
@@ -803,37 +817,44 @@ pub async fn initialize_and_start_controllers(
             .services(handler_services.clone())
             .iteration_config((&carbide_config.ib_partition_state_controller.controller).into())
             .state_handler(Arc::new(IBPartitionStateHandler::default()))
-            .build_and_spawn()
-            .expect("Unable to build IBPartitionStateController");
+            .build_and_spawn(cancel_token.clone())
+            .expect("Unable to build IBPartitionStateController"),
+    );
 
-    let _power_shelf_controller_handle = StateController::<PowerShelfStateControllerIO>::builder()
-        .database(db_pool.clone(), work_lock_manager_handle.clone())
-        .meter("carbide_power_shelves", meter.clone())
-        .processor_id(state_controller_id.clone())
-        .services(handler_services.clone())
-        .iteration_config((&carbide_config.power_shelf_state_controller.controller).into())
-        .state_handler(Arc::new(PowerShelfStateHandler::default()))
-        .build_and_spawn()
-        .expect("Unable to build PowerShelfStateController");
+    state_controller_handles.push(
+        StateController::<PowerShelfStateControllerIO>::builder()
+            .database(db_pool.clone(), work_lock_manager_handle.clone())
+            .meter("carbide_power_shelves", meter.clone())
+            .processor_id(state_controller_id.clone())
+            .services(handler_services.clone())
+            .iteration_config((&carbide_config.power_shelf_state_controller.controller).into())
+            .state_handler(Arc::new(PowerShelfStateHandler::default()))
+            .build_and_spawn(cancel_token.clone())
+            .expect("Unable to build PowerShelfStateController"),
+    );
 
-    let _rack_controller_handle = StateController::<RackStateControllerIO>::builder()
-        .database(db_pool.clone(), work_lock_manager_handle.clone())
-        .meter("carbide_racks", meter.clone())
-        .processor_id(state_controller_id.clone())
-        .services(handler_services.clone())
-        .state_handler(Arc::new(RackStateHandler::default()))
-        .build_and_spawn()
-        .expect("Unable to build RackStateController");
+    state_controller_handles.push(
+        StateController::<RackStateControllerIO>::builder()
+            .database(db_pool.clone(), work_lock_manager_handle.clone())
+            .meter("carbide_racks", meter.clone())
+            .processor_id(state_controller_id.clone())
+            .services(handler_services.clone())
+            .state_handler(Arc::new(RackStateHandler::default()))
+            .build_and_spawn(cancel_token.clone())
+            .expect("Unable to build RackStateController"),
+    );
 
-    let _switch_controller_handle = StateController::<SwitchStateControllerIO>::builder()
-        .database(db_pool.clone(), work_lock_manager_handle.clone())
-        .meter("carbide_switches", meter.clone())
-        .processor_id(state_controller_id.clone())
-        .services(handler_services.clone())
-        .iteration_config((&carbide_config.switch_state_controller.controller).into())
-        .state_handler(Arc::new(SwitchStateHandler::default()))
-        .build_and_spawn()
-        .expect("Unable to build SwitchStateController");
+    state_controller_handles.push(
+        StateController::<SwitchStateControllerIO>::builder()
+            .database(db_pool.clone(), work_lock_manager_handle.clone())
+            .meter("carbide_switches", meter.clone())
+            .processor_id(state_controller_id.clone())
+            .services(handler_services.clone())
+            .iteration_config((&carbide_config.switch_state_controller.controller).into())
+            .state_handler(Arc::new(SwitchStateHandler::default()))
+            .build_and_spawn(cancel_token.clone())
+            .expect("Unable to build SwitchStateController"),
+    );
 
     let ib_fabric_monitor = IbFabricMonitor::new(
         db_pool.clone(),
@@ -914,11 +935,11 @@ pub async fn initialize_and_start_controllers(
     )
     .await?;
 
-    // We have to sleep until the calling thread stops us, or else all the handles get dropped and
-    // the background tasks terminate.
-    stop_rx
-        .await
-        .context("error reading from stop channel, calling thread likely panicked")
+    // Block until all controllers are finished. They were constructed with `cancel_token` as their
+    // cancellation token, which means this will return once they've all gracefully returned after
+    // being canceled.
+    state_controller_handles.wait_all().await;
+    Ok(())
 }
 
 /// Constructs a context map for bf.cfg Tera template from CarbideConfig.

--- a/crates/api/src/state_controller/controller.rs
+++ b/crates/api/src/state_controller/controller.rs
@@ -20,7 +20,7 @@ use ::db::work_lock_manager::WorkLock;
 use chrono::{DateTime, Utc};
 use sqlx::postgres::PgRow;
 use sqlx::{FromRow, Row};
-use tokio_util::sync::CancellationToken;
+use tokio::task::JoinSet;
 
 use crate::state_controller::controller::periodic_enqueuer::PeriodicEnqueuer;
 use crate::state_controller::io::StateControllerIO;
@@ -30,6 +30,7 @@ mod builder;
 pub mod db;
 mod enqueuer;
 pub use enqueuer::Enqueuer;
+
 pub mod periodic_enqueuer;
 pub mod processor;
 
@@ -147,12 +148,36 @@ enum IterationError {
 
 /// A remote handle for the state controller
 pub struct StateControllerHandle {
-    /// Instructs the state conroller to stop.
-    stop_token: CancellationToken,
+    /// Wait on this to ensure all tasks complete. It will return nothing, but panic if any of the
+    /// tasks panicked.
+    join_set: JoinSet<()>,
 }
 
-impl Drop for StateControllerHandle {
-    fn drop(&mut self) {
-        self.stop_token.cancel();
+impl StateControllerHandle {
+    pub async fn wait(self) {
+        self.join_set.join_all().await;
+    }
+}
+
+#[derive(Default)]
+pub struct StateControllerHandleSet {
+    handles: Vec<StateControllerHandle>,
+}
+
+impl StateControllerHandleSet {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn push(&mut self, handle: StateControllerHandle) {
+        self.handles.push(handle);
+    }
+
+    pub async fn wait_all(self) {
+        let mut join_set = JoinSet::new();
+        for handle in self.handles {
+            join_set.spawn(handle.wait());
+        }
+        join_set.join_all().await;
     }
 }

--- a/crates/api/src/state_controller/controller/builder.rs
+++ b/crates/api/src/state_controller/controller/builder.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use db::work_lock_manager::WorkLockManagerHandle;
 use opentelemetry::metrics::Meter;
+use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
 use crate::state_controller::config::IterationConfig;
@@ -37,8 +38,6 @@ use crate::state_controller::state_handler::{
 
 /// The return value of `[Builder::build_internal]`
 struct BuildOrSpawn<IO: StateControllerIO> {
-    /// Instructs the processor and enqueuer to stop.
-    stop_token: CancellationToken,
     controller_name: String,
     controller: StateController<IO>,
 }
@@ -102,8 +101,9 @@ impl<IO: StateControllerIO> Builder<IO> {
     #[cfg(test)]
     pub fn build_for_manual_iterations(
         self,
+        cancel_token: CancellationToken,
     ) -> Result<StateController<IO>, StateControllerBuildError> {
-        let build_or_spawn = self.build_internal()?;
+        let build_or_spawn = self.build_internal(cancel_token)?;
         Ok(build_or_spawn.controller)
     }
 
@@ -112,30 +112,37 @@ impl<IO: StateControllerIO> Builder<IO> {
     ///
     /// The state controller will continue to run as long as the returned `StateControllerHandle`
     /// is kept alive.
-    pub fn build_and_spawn(self) -> Result<StateControllerHandle, StateControllerBuildError> {
-        let build_or_spawn = self.build_internal()?;
+    pub fn build_and_spawn(
+        self,
+        cancel_token: CancellationToken,
+    ) -> Result<StateControllerHandle, StateControllerBuildError> {
+        let build_or_spawn = self.build_internal(cancel_token)?;
+        let mut join_set = JoinSet::new();
 
-        tokio::task::Builder::new()
+        join_set
+            .build_task()
             .name(&format!(
                 "state_controller_periodic_enqueuer {}",
                 build_or_spawn.controller_name
             ))
             .spawn(async move { build_or_spawn.controller.enqueuer.run().await })?;
 
-        tokio::task::Builder::new()
+        join_set
+            .build_task()
             .name(&format!(
                 "state_processor {}",
                 build_or_spawn.controller_name
             ))
             .spawn(async move { build_or_spawn.controller.processor.run().await })?;
 
-        Ok(StateControllerHandle {
-            stop_token: build_or_spawn.stop_token,
-        })
+        Ok(StateControllerHandle { join_set })
     }
 
     /// Builds a [`StateController`] with all configured options
-    fn build_internal(mut self) -> Result<BuildOrSpawn<IO>, StateControllerBuildError> {
+    fn build_internal(
+        mut self,
+        cancel_token: CancellationToken,
+    ) -> Result<BuildOrSpawn<IO>, StateControllerBuildError> {
         let database = self
             .database
             .take()
@@ -148,8 +155,6 @@ impl<IO: StateControllerIO> Builder<IO> {
 
         let object_type_for_metrics = self.object_type_for_metrics.take();
         let meter = self.meter.take();
-
-        let stop_token = CancellationToken::new();
 
         if self.iteration_config.max_concurrency == 0 {
             return Err(StateControllerBuildError::MissingArgument(
@@ -178,7 +183,7 @@ impl<IO: StateControllerIO> Builder<IO> {
         let enqueuer = PeriodicEnqueuer::<IO> {
             pool: database.clone(),
             work_lock_manager_handle,
-            stop_token: stop_token.clone(),
+            cancel_token: cancel_token.clone(),
             metric_emitter: period_enqueuer_metric_emitter,
             iteration_config: self.iteration_config,
             io: self.io.clone().unwrap_or_default(),
@@ -199,7 +204,7 @@ impl<IO: StateControllerIO> Builder<IO> {
 
         let processor = StateProcessor::<IO> {
             pool: database,
-            stop_token: stop_token.clone(),
+            cancel_token,
             iteration_config: self.iteration_config,
             handler_services: services,
             io: self.io.unwrap_or_default(),
@@ -229,7 +234,6 @@ impl<IO: StateControllerIO> Builder<IO> {
         Ok(BuildOrSpawn {
             controller,
             controller_name,
-            stop_token,
         })
     }
 

--- a/crates/api/src/state_controller/controller/periodic_enqueuer.rs
+++ b/crates/api/src/state_controller/controller/periodic_enqueuer.rs
@@ -38,7 +38,7 @@ pub(super) struct PeriodicEnqueuer<IO: StateControllerIO> {
     pub(super) work_lock_manager_handle: WorkLockManagerHandle,
     pub(super) io: Arc<IO>,
     pub(super) metric_emitter: Option<EnqueuerMetricsEmitter>,
-    pub(super) stop_token: CancellationToken,
+    pub(super) cancel_token: CancellationToken,
     pub(super) iteration_config: IterationConfig,
 }
 
@@ -85,7 +85,7 @@ impl<IO: StateControllerIO> PeriodicEnqueuer<IO> {
                 .saturating_sub(start.elapsed())
                 .saturating_add(Duration::from_millis(jitter));
 
-            let cancelled_future = self.stop_token.cancelled();
+            let cancelled_future = self.cancel_token.cancelled();
             tokio::pin!(cancelled_future);
             tokio::select! {
                 biased;

--- a/crates/api/src/state_controller/controller/processor.rs
+++ b/crates/api/src/state_controller/controller/processor.rs
@@ -62,7 +62,7 @@ pub(super) struct StateProcessor<IO: StateControllerIO> {
     pub(super) object_metrics: HashMap<IO::ObjectId, CollectedMetrics<IO>>,
     /// The iteration ID for which metrics have been passed towards `metric_holder`
     pub(super) published_metrics_iteration_id: Option<ControllerIterationId>,
-    pub(super) stop_token: CancellationToken,
+    pub(super) cancel_token: CancellationToken,
     pub(super) iteration_config: IterationConfig,
     /// IDs of objects where the task handler is currently executed
     pub(super) in_flight: HashSet<IO::ObjectId>,
@@ -189,7 +189,7 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
             use rand::Rng;
             let sleep_time = next_dispatch_at.saturating_duration_since(std::time::Instant::now());
             if !sleep_time.is_zero() {
-                let cancelled_future = self.stop_token.cancelled();
+                let cancelled_future = self.cancel_token.cancelled();
                 tokio::pin!(cancelled_future);
                 tokio::select! {
                         biased;
@@ -199,7 +199,7 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
                     }
                     _ = tokio::time::sleep(sleep_time) => {},
                 }
-            } else if self.stop_token.is_cancelled() {
+            } else if self.cancel_token.is_cancelled() {
                 tracing::info!(
                     controller = IO::LOG_SPAN_CONTROLLER_NAME,
                     "State processor stop was requested"
@@ -401,7 +401,7 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
                 }
             }
             _ = tokio::time::sleep(max_duration) => {
-                // Timeout
+                tracing::error!(in_flight=self.in_flight.len(), "Timed out waiting for state controller object handling tasks to complete")
             }
         };
 

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -74,6 +74,7 @@ use site_explorer::new_host_with_machine_validation;
 use sqlx::PgPool;
 use sqlx::postgres::PgConnectOptions;
 use tokio::sync::Mutex;
+use tokio_util::sync::{CancellationToken, DropGuard};
 use tonic::Request;
 use tracing_subscriber::EnvFilter;
 
@@ -347,6 +348,7 @@ pub struct TestEnv {
     pub nvl_partition_monitor: Arc<Mutex<NvlPartitionMonitor>>,
     pub test_credential_provider: Arc<TestCredentialProvider>,
     pub rms_sim: Arc<RmsSim>,
+    pub drop_guard: DropGuard,
 }
 
 impl TestEnv {
@@ -1479,6 +1481,7 @@ pub async fn create_test_env_with_overrides(
     });
 
     let state_controller_id = uuid::Uuid::new_v4().to_string();
+    let cancel_token = CancellationToken::new();
 
     let machine_controller = StateController::<MachineStateControllerIO>::builder()
         .database(db_pool.clone(), work_lock_manager_handle.clone())
@@ -1489,7 +1492,7 @@ pub async fn create_test_env_with_overrides(
         .io(Arc::new(MachineStateControllerIO {
             host_health: config.host_health,
         }))
-        .build_for_manual_iterations()
+        .build_for_manual_iterations(cancel_token.clone())
         .expect("Unable to build state controller");
 
     let spdm_controller = StateController::<SpdmStateControllerIO>::builder()
@@ -1499,7 +1502,7 @@ pub async fn create_test_env_with_overrides(
         .services(handler_services.clone())
         .state_handler(Arc::new(spdm_swap.clone()))
         .io(Arc::new(SpdmStateControllerIO {}))
-        .build_for_manual_iterations()
+        .build_for_manual_iterations(cancel_token.clone())
         .expect("Unable to build spdm state controller");
 
     let ib_swap = SwapHandler {
@@ -1512,7 +1515,7 @@ pub async fn create_test_env_with_overrides(
         .processor_id(state_controller_id.clone())
         .services(handler_services.clone())
         .state_handler(Arc::new(ib_swap.clone()))
-        .build_for_manual_iterations()
+        .build_for_manual_iterations(cancel_token.clone())
         .expect("Unable to build state controller");
 
     let network_swap = SwapHandler {
@@ -1531,7 +1534,7 @@ pub async fn create_test_env_with_overrides(
         .processor_id(state_controller_id.clone())
         .services(handler_services.clone())
         .state_handler(Arc::new(network_swap.clone()))
-        .build_for_manual_iterations()
+        .build_for_manual_iterations(cancel_token.clone())
         .expect("Unable to build state controller");
 
     let power_shelf_controller = StateController::builder()
@@ -1540,7 +1543,7 @@ pub async fn create_test_env_with_overrides(
         .processor_id(state_controller_id.clone())
         .services(handler_services.clone())
         .state_handler(Arc::new(PowerShelfStateHandler::default()))
-        .build_for_manual_iterations()
+        .build_for_manual_iterations(cancel_token.clone())
         .expect("Unable to build PowerShelfStateController");
 
     let switch_controller = StateController::builder()
@@ -1549,7 +1552,7 @@ pub async fn create_test_env_with_overrides(
         .processor_id(state_controller_id.clone())
         .services(handler_services.clone())
         .state_handler(Arc::new(SwitchStateHandler::default()))
-        .build_for_manual_iterations()
+        .build_for_manual_iterations(cancel_token.clone())
         .expect("Unable to build state controller");
 
     let fake_endpoint_explorer = MockEndpointExplorer {
@@ -1678,6 +1681,7 @@ pub async fn create_test_env_with_overrides(
         nvl_partition_monitor: Arc::new(Mutex::new(nvl_partition_monitor)),
         test_credential_provider: credential_provider.clone(),
         rms_sim,
+        drop_guard: cancel_token.drop_guard(),
     }
 }
 

--- a/crates/api/src/tests/power_shelf_state_controller/mod.rs
+++ b/crates/api/src/tests/power_shelf_state_controller/mod.rs
@@ -24,6 +24,7 @@ use carbide_uuid::power_shelf::PowerShelfId;
 use db::power_shelf as db_power_shelf;
 use model::power_shelf::{PowerShelf, PowerShelfControllerState};
 use rpc::forge::forge_server::Forge;
+use tokio_util::sync::CancellationToken;
 
 use crate::state_controller::config::IterationConfig;
 use crate::state_controller::controller::StateController;
@@ -116,6 +117,7 @@ async fn test_power_shelf_state_transitions(
         rms_client: None,
     });
 
+    let cancel_token = CancellationToken::new();
     let handle = StateController::<PowerShelfStateControllerIO>::builder()
         .iteration_config(IterationConfig {
             iteration_time: ITERATION_TIME,
@@ -126,12 +128,12 @@ async fn test_power_shelf_state_transitions(
         .processor_id(uuid::Uuid::new_v4().to_string())
         .services(handler_services.clone())
         .state_handler(power_shelf_handler.clone())
-        .build_and_spawn()
+        .build_and_spawn(cancel_token.clone())
         .unwrap();
 
     tokio::time::sleep(TEST_TIME).await;
-    drop(handle);
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    cancel_token.cancel();
+    handle.wait().await;
 
     // Verify that the handler was called
     let count = power_shelf_handler.count.load(Ordering::SeqCst);
@@ -189,6 +191,7 @@ async fn test_power_shelf_deletion_flow(
         rms_client: None,
     });
 
+    let cancel_token = CancellationToken::new();
     let handle = StateController::<PowerShelfStateControllerIO>::builder()
         .iteration_config(IterationConfig {
             iteration_time: ITERATION_TIME,
@@ -199,7 +202,7 @@ async fn test_power_shelf_deletion_flow(
         .processor_id(uuid::Uuid::new_v4().to_string())
         .services(handler_services.clone())
         .state_handler(power_shelf_handler.clone())
-        .build_and_spawn()
+        .build_and_spawn(cancel_token.clone())
         .unwrap();
 
     // Let the controller process the active power shelf
@@ -223,8 +226,8 @@ async fn test_power_shelf_deletion_flow(
 
     // Let the controller run for a bit more after deletion
     tokio::time::sleep(TEST_TIME).await;
-    drop(handle);
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    cancel_token.cancel();
+    handle.wait().await;
 
     // Verify that the handler count didn't increase significantly after deletion
     // (since deleted power shelves should not be processed)
@@ -284,6 +287,7 @@ async fn test_power_shelf_error_state_handling(
         rms_client: None,
     });
 
+    let cancel_token = CancellationToken::new();
     let handle = StateController::<PowerShelfStateControllerIO>::builder()
         .iteration_config(IterationConfig {
             iteration_time: ITERATION_TIME,
@@ -294,12 +298,12 @@ async fn test_power_shelf_error_state_handling(
         .processor_id(uuid::Uuid::new_v4().to_string())
         .services(handler_services.clone())
         .state_handler(power_shelf_handler.clone())
-        .build_and_spawn()
+        .build_and_spawn(cancel_token.clone())
         .unwrap();
 
     tokio::time::sleep(TEST_TIME).await;
-    drop(handle);
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    cancel_token.cancel();
+    handle.wait().await;
 
     // Verify that the handler was called even in error state
     let count = power_shelf_handler.count.load(Ordering::SeqCst);
@@ -412,6 +416,7 @@ async fn test_power_shelf_deletion_with_state_controller(
         rms_client: None,
     });
 
+    let cancel_token = CancellationToken::new();
     let handle = StateController::<PowerShelfStateControllerIO>::builder()
         .iteration_config(IterationConfig {
             iteration_time: ITERATION_TIME,
@@ -422,7 +427,7 @@ async fn test_power_shelf_deletion_with_state_controller(
         .processor_id(uuid::Uuid::new_v4().to_string())
         .services(handler_services.clone())
         .state_handler(power_shelf_handler.clone())
-        .build_and_spawn()
+        .build_and_spawn(cancel_token.clone())
         .unwrap();
 
     // Let the controller run for a bit to process the active power shelf
@@ -440,7 +445,8 @@ async fn test_power_shelf_deletion_with_state_controller(
 
     // Let the controller run for a bit more after marking as deleted
     tokio::time::sleep(TEST_TIME).await;
-    drop(handle);
+    cancel_token.cancel();
+    handle.wait().await;
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     // Verify that the handler count didn't increase significantly after marking as deleted

--- a/crates/api/src/tests/rack_state_controller/mod.rs
+++ b/crates/api/src/tests/rack_state_controller/mod.rs
@@ -25,6 +25,7 @@ use db::rack as db_rack;
 use model::rack::{Rack, RackMaintenanceState, RackReadyState, RackState, RackValidationState};
 use rpc::forge::RackStateHistoryRecord;
 use rpc::forge::forge_server::Forge;
+use tokio_util::sync::CancellationToken;
 
 use crate::state_controller::config::IterationConfig;
 use crate::state_controller::controller::StateController;
@@ -136,6 +137,7 @@ async fn test_can_retrieve_rack_state_history(
 
     let handler_services = Arc::new(env.state_handler_services());
 
+    let cancel_token = CancellationToken::new();
     let mut controller = StateController::<RackStateControllerIO>::builder()
         .iteration_config(IterationConfig {
             iteration_time: ITERATION_TIME,
@@ -146,7 +148,7 @@ async fn test_can_retrieve_rack_state_history(
         .processor_id(uuid::Uuid::new_v4().to_string())
         .services(handler_services)
         .state_handler(rack_handler)
-        .build_for_manual_iterations()
+        .build_for_manual_iterations(cancel_token.clone())
         .unwrap();
 
     // iterate a few times to get state history
@@ -211,6 +213,7 @@ async fn test_rack_state_transitions(pool: sqlx::PgPool) -> Result<(), Box<dyn s
 
     let handler_services = Arc::new(env.state_handler_services());
 
+    let cancel_token = CancellationToken::new();
     let mut controller = StateController::<RackStateControllerIO>::builder()
         .iteration_config(IterationConfig {
             iteration_time: ITERATION_TIME,
@@ -221,7 +224,7 @@ async fn test_rack_state_transitions(pool: sqlx::PgPool) -> Result<(), Box<dyn s
         .processor_id(uuid::Uuid::new_v4().to_string())
         .services(handler_services.clone())
         .state_handler(rack_handler.clone())
-        .build_for_manual_iterations()
+        .build_for_manual_iterations(cancel_token.clone())
         .unwrap();
 
     // iterate a few times
@@ -268,6 +271,7 @@ async fn test_rack_deletion_flow(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
 
     let handler_services = Arc::new(env.state_handler_services());
 
+    let cancel_token = CancellationToken::new();
     let mut controller = StateController::<RackStateControllerIO>::builder()
         .iteration_config(IterationConfig {
             iteration_time: ITERATION_TIME,
@@ -278,7 +282,7 @@ async fn test_rack_deletion_flow(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
         .processor_id(uuid::Uuid::new_v4().to_string())
         .services(handler_services.clone())
         .state_handler(rack_handler.clone())
-        .build_for_manual_iterations()
+        .build_for_manual_iterations(cancel_token.clone())
         .unwrap();
 
     controller.run_single_iteration().await;
@@ -345,6 +349,7 @@ async fn test_rack_error_state_handling(
 
     let handler_services = Arc::new(env.state_handler_services());
 
+    let cancel_token = CancellationToken::new();
     let mut controller = StateController::<RackStateControllerIO>::builder()
         .iteration_config(IterationConfig {
             iteration_time: ITERATION_TIME,
@@ -355,7 +360,7 @@ async fn test_rack_error_state_handling(
         .processor_id(uuid::Uuid::new_v4().to_string())
         .services(handler_services.clone())
         .state_handler(rack_handler.clone())
-        .build_for_manual_iterations()
+        .build_for_manual_iterations(cancel_token.clone())
         .unwrap();
 
     controller.run_single_iteration().await;
@@ -444,6 +449,7 @@ async fn test_rack_deletion_with_state_controller(
 
     let handler_services = Arc::new(env.state_handler_services());
 
+    let cancel_token = CancellationToken::new();
     let mut controller = StateController::<RackStateControllerIO>::builder()
         .iteration_config(IterationConfig {
             iteration_time: ITERATION_TIME,
@@ -454,7 +460,7 @@ async fn test_rack_deletion_with_state_controller(
         .processor_id(uuid::Uuid::new_v4().to_string())
         .services(handler_services.clone())
         .state_handler(rack_handler.clone())
-        .build_for_manual_iterations()
+        .build_for_manual_iterations(cancel_token.clone())
         .unwrap();
 
     controller.run_single_iteration().await;

--- a/crates/api/src/tests/state_controller.rs
+++ b/crates/api/src/tests/state_controller.rs
@@ -28,9 +28,12 @@ use model::controller_outcome::PersistentStateHandlerOutcome;
 use serde::{self, Deserialize, Serialize};
 use sqlx::postgres::PgRow;
 use sqlx::{FromRow, PgConnection, Row};
+use tokio_util::sync::CancellationToken;
 
 use crate::state_controller::config::IterationConfig;
-use crate::state_controller::controller::{self, Enqueuer, QueuedObject, StateController};
+use crate::state_controller::controller::{
+    self, Enqueuer, QueuedObject, StateController, StateControllerHandleSet,
+};
 use crate::state_controller::io::StateControllerIO;
 use crate::state_controller::metrics::NoopMetricsEmitter;
 use crate::state_controller::state_change_emitter::{
@@ -434,6 +437,9 @@ impl StateHandlerContextObjects for TestStateControllerContextObjects {
     type ObjectMetrics = ();
 }
 
+#[derive(Debug, Default)]
+struct PanicInListObjectsStateControllerIO;
+
 async fn create_test_state_controller_tables(pool: &sqlx::PgPool) {
     let mut txn = pool.begin().await.unwrap();
 
@@ -612,6 +618,107 @@ impl StateControllerIO for TestStateControllerIO {
     }
 }
 
+#[async_trait::async_trait]
+impl StateControllerIO for PanicInListObjectsStateControllerIO {
+    type ObjectId = String;
+    type State = TestObject;
+    type ControllerState = TestObjectControllerState;
+    type MetricsEmitter = NoopMetricsEmitter;
+    type ContextObjects = TestStateControllerContextObjects;
+
+    const DB_ITERATION_ID_TABLE_NAME: &'static str = "test_state_controller_iteration_ids";
+    const DB_QUEUED_OBJECTS_TABLE_NAME: &'static str = "test_state_controller_queued_objects";
+
+    const LOG_SPAN_CONTROLLER_NAME: &'static str = "test_state_controller";
+
+    async fn list_objects(
+        &self,
+        _txn: &mut PgConnection,
+    ) -> Result<Vec<Self::ObjectId>, DatabaseError> {
+        panic!("test panic from list_objects");
+    }
+
+    async fn load_object_state(
+        &self,
+        _txn: &mut PgConnection,
+        _object_id: &Self::ObjectId,
+    ) -> Result<Option<Self::State>, DatabaseError> {
+        unreachable!("load_object_state should never be called in this test")
+    }
+
+    async fn load_controller_state(
+        &self,
+        _txn: &mut PgConnection,
+        _object_id: &Self::ObjectId,
+        _state: &Self::State,
+    ) -> Result<Versioned<Self::ControllerState>, DatabaseError> {
+        unreachable!("load_controller_state should never be called in this test")
+    }
+
+    async fn persist_controller_state(
+        &self,
+        _txn: &mut PgConnection,
+        _object_id: &Self::ObjectId,
+        _old_version: ConfigVersion,
+        _new_state: &Self::ControllerState,
+    ) -> Result<(), DatabaseError> {
+        unreachable!("persist_controller_state should never be called in this test")
+    }
+
+    async fn persist_outcome(
+        &self,
+        _txn: &mut PgConnection,
+        _object_id: &Self::ObjectId,
+        _outcome: PersistentStateHandlerOutcome,
+    ) -> Result<(), DatabaseError> {
+        unreachable!("persist_outcome should never be called in this test")
+    }
+
+    fn metric_state_names(state: &TestObjectControllerState) -> (&'static str, &'static str) {
+        TestStateControllerIO::metric_state_names(state)
+    }
+
+    fn state_sla(state: &Versioned<Self::ControllerState>) -> StateSla {
+        TestStateControllerIO::state_sla(state)
+    }
+}
+
+#[crate::sqlx_test]
+async fn test_state_controller_handle_set_wait_all_propagates_panic(
+    pool: sqlx::PgPool,
+) -> eyre::Result<()> {
+    create_test_state_controller_tables(&pool).await;
+    let work_lock_manager_handle =
+        db::work_lock_manager::start(pool.clone(), Default::default()).await?;
+
+    let cancel_token = CancellationToken::new();
+    let handle = StateController::<PanicInListObjectsStateControllerIO>::builder()
+        .iteration_config(IterationConfig {
+            iteration_time: Duration::from_millis(10),
+            processor_dispatch_interval: Duration::from_millis(10),
+            ..Default::default()
+        })
+        .database(pool.clone(), work_lock_manager_handle.clone())
+        .processor_id(uuid::Uuid::new_v4().to_string())
+        .services(Arc::new(()))
+        .state_handler(Arc::new(TestTransitionStateHandler))
+        .build_and_spawn(cancel_token.clone())?;
+
+    let mut handles = StateControllerHandleSet::new();
+    handles.push(handle);
+
+    let wait_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        tokio::spawn(async move { handles.wait_all().await }),
+    )
+    .await
+    .expect("timed out waiting for wait_all to return");
+
+    assert!(wait_result.expect_err("wait_all should panic").is_panic());
+
+    Ok(())
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct TestConcurrencyStateHandler {
     /// The total count for the handler
@@ -670,7 +777,8 @@ async fn test_multiple_state_controllers_schedule_object_only_once(
 
     // We build multiple state controllers. But since only one should act at a time,
     // the count should still not increase
-    let mut handles = Vec::new();
+    let mut handles = StateControllerHandleSet::new();
+    let cancel_token = CancellationToken::new();
     for _ in 0..10 {
         handles.push(
             StateController::<TestStateControllerIO>::builder()
@@ -683,15 +791,14 @@ async fn test_multiple_state_controllers_schedule_object_only_once(
                 .processor_id(uuid::Uuid::new_v4().to_string())
                 .services(Arc::new(()))
                 .state_handler(state_handler.clone())
-                .build_and_spawn()
+                .build_and_spawn(cancel_token.clone())
                 .unwrap(),
         );
     }
 
     tokio::time::sleep(TEST_TIME).await;
-    drop(handles);
-    // Wait some extra time until the controller background task shuts down
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    cancel_token.cancel();
+    handles.wait_all().await;
 
     let count = state_handler.count.load(Ordering::SeqCst) as f64;
     assert!(
@@ -800,7 +907,8 @@ async fn test_state_handler_metrics_are_stable(pool: sqlx::PgPool) -> eyre::Resu
     const TEST_TIME: Duration = Duration::from_secs(10);
     let start_time = std::time::Instant::now();
 
-    let _handle = StateController::<TestStateControllerIO>::builder()
+    let cancel_token = CancellationToken::new();
+    let handle = StateController::<TestStateControllerIO>::builder()
         .iteration_config(IterationConfig {
             iteration_time: ITERATION_TIME,
             processor_dispatch_interval: std::time::Duration::from_millis(10),
@@ -812,7 +920,7 @@ async fn test_state_handler_metrics_are_stable(pool: sqlx::PgPool) -> eyre::Resu
         .processor_id(uuid::Uuid::new_v4().to_string())
         .services(Arc::new(()))
         .state_handler(state_handler.clone())
-        .build_and_spawn()
+        .build_and_spawn(cancel_token.clone())
         .unwrap();
 
     // Check metrics periodically. We always expect to see 100 objects
@@ -826,6 +934,8 @@ async fn test_state_handler_metrics_are_stable(pool: sqlx::PgPool) -> eyre::Resu
             start_time.elapsed().as_secs_f32()
         );
     }
+    cancel_token.cancel();
+    handle.wait().await;
 
     Ok(())
 }
@@ -896,7 +1006,7 @@ async fn test_state_change_emitter_emits_events_on_transitions(
         .services(Arc::new(()))
         .state_handler(Arc::new(TestTransitionStateHandler))
         .state_change_emitter(emitter)
-        .build_for_manual_iterations()?;
+        .build_for_manual_iterations(CancellationToken::new())?;
 
     // Run first iteration: A -> B
     controller.run_single_iteration().await;
@@ -951,7 +1061,7 @@ async fn test_state_controller_manual_enqueuing(pool: sqlx::PgPool) -> eyre::Res
         .processor_id(uuid::Uuid::new_v4().to_string())
         .services(Arc::new(()))
         .state_handler(Arc::new(TestTransitionStateHandler))
-        .build_for_manual_iterations()?;
+        .build_for_manual_iterations(CancellationToken::new())?;
 
     // Transition A -> B, but no re-enqueuing
     controller.run_single_iteration_ext(false).await;

--- a/crates/api/src/tests/switch_state_controller/mod.rs
+++ b/crates/api/src/tests/switch_state_controller/mod.rs
@@ -24,6 +24,7 @@ use carbide_uuid::switch::SwitchId;
 use db::switch as db_switch;
 use model::switch::{Switch, SwitchControllerState};
 use rpc::forge::forge_server::Forge;
+use tokio_util::sync::CancellationToken;
 
 use crate::state_controller::common_services::CommonStateHandlerServices;
 use crate::state_controller::config::IterationConfig;
@@ -113,6 +114,7 @@ async fn test_switch_state_transitions(
         rms_client: None,
     });
 
+    let cancel_token = CancellationToken::new();
     let handle = StateController::<SwitchStateControllerIO>::builder()
         .iteration_config(IterationConfig {
             iteration_time: ITERATION_TIME,
@@ -123,12 +125,12 @@ async fn test_switch_state_transitions(
         .processor_id(uuid::Uuid::new_v4().to_string())
         .services(handler_services.clone())
         .state_handler(switch_handler.clone())
-        .build_and_spawn()
+        .build_and_spawn(cancel_token.clone())
         .unwrap();
 
     tokio::time::sleep(TEST_TIME).await;
-    drop(handle);
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    cancel_token.cancel();
+    handle.wait().await;
 
     // Verify that the handler was called
     let count = switch_handler.count.load(Ordering::SeqCst);
@@ -182,6 +184,7 @@ async fn test_switch_deletion_flow(pool: sqlx::PgPool) -> Result<(), Box<dyn std
         rms_client: None,
     });
 
+    let cancel_token = CancellationToken::new();
     let handle = StateController::<SwitchStateControllerIO>::builder()
         .iteration_config(IterationConfig {
             iteration_time: ITERATION_TIME,
@@ -192,7 +195,7 @@ async fn test_switch_deletion_flow(pool: sqlx::PgPool) -> Result<(), Box<dyn std
         .processor_id(uuid::Uuid::new_v4().to_string())
         .services(handler_services.clone())
         .state_handler(switch_handler.clone())
-        .build_and_spawn()
+        .build_and_spawn(cancel_token.clone())
         .unwrap();
 
     // Let the controller process the active switch
@@ -214,10 +217,9 @@ async fn test_switch_deletion_flow(pool: sqlx::PgPool) -> Result<(), Box<dyn std
         .delete_switch(tonic::Request::new(delete_request))
         .await?;
 
-    // Let the controller run for a bit more after deletion
     tokio::time::sleep(TEST_TIME).await;
-    drop(handle);
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    cancel_token.cancel();
+    handle.wait().await;
 
     // Verify that the handler count didn't increase significantly after deletion
     // (since deleted switches should not be processed)
@@ -274,6 +276,7 @@ async fn test_switch_error_state_handling(
         rms_client: None,
     });
 
+    let cancel_token = CancellationToken::new();
     let handle = StateController::<SwitchStateControllerIO>::builder()
         .iteration_config(IterationConfig {
             iteration_time: ITERATION_TIME,
@@ -284,12 +287,12 @@ async fn test_switch_error_state_handling(
         .processor_id(uuid::Uuid::new_v4().to_string())
         .services(handler_services.clone())
         .state_handler(switch_handler.clone())
-        .build_and_spawn()
+        .build_and_spawn(cancel_token.clone())
         .unwrap();
 
     tokio::time::sleep(TEST_TIME).await;
-    drop(handle);
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    cancel_token.cancel();
+    handle.wait().await;
 
     // Verify that the handler was called even in error state
     let count = switch_handler.count.load(Ordering::SeqCst);
@@ -394,6 +397,7 @@ async fn test_switch_deletion_with_state_controller(
         rms_client: None,
     });
 
+    let cancel_token = CancellationToken::new();
     let handle = StateController::<SwitchStateControllerIO>::builder()
         .iteration_config(IterationConfig {
             iteration_time: ITERATION_TIME,
@@ -404,7 +408,7 @@ async fn test_switch_deletion_with_state_controller(
         .processor_id(uuid::Uuid::new_v4().to_string())
         .services(handler_services.clone())
         .state_handler(switch_handler.clone())
-        .build_and_spawn()
+        .build_and_spawn(cancel_token.clone())
         .unwrap();
 
     // Let the controller run for a bit to process the active switch
@@ -422,8 +426,8 @@ async fn test_switch_deletion_with_state_controller(
 
     // Let the controller run for a bit more after marking as deleted
     tokio::time::sleep(TEST_TIME).await;
-    drop(handle);
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    cancel_token.cancel();
+    handle.wait().await;
 
     // Verify that the handler count didn't increase significantly after marking as deleted
     // (since deleted switches should not be processed)


### PR DESCRIPTION
## Description
Tokio does not crash the process if an individual task panics. This has caused issues in environments where a controller task panics and just no longer runs, with the rest of the process continuing without it. This is not what we want: If a controller panics due to a bug, the whole process should crash so it can be restarted, so that we don't end up running at reduced functionality.

To make this work, use a JoinSet when spawning tasks in each state controller, and combine them into a single StateControllerHandleSet. Then in the main api entry point in run.rs, wait on the StateControllerHandleSet before returning. This will cause any panics in these sets to propagate to whatever is waiting.

For this to work, the meaning of what a "StateControllerHandle" is now inverted: It used to be wrapper around a oneshot::Sender<()> so that when the handle is dropped, the controller work is cancelled. But now, it's a wrapper around a single JoinSet for that task.

So to still support stopping state controllers, use a CancellationToken instead. Cancellation tokens can be cloned, and form a sort of "tree", where a token in one place can be cloned for use in subordinate tasks. When a token is cancelled, all nodes under it in the tree are cancelled. So this just means we have to call cancel() in one place, and all background tasks cloned from that token will observe their tokens as cancelled.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [X] Unit tests added/updated
- [X] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

