### PR TITLE
feat(secrets): file and env backed providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,7 +844,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -863,6 +863,12 @@ name = "bitfield"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -2217,15 +2223,22 @@ dependencies = [
 name = "carbide-secrets"
 version = "0.0.0"
 dependencies = [
+ "arc-swap",
  "async-trait",
  "bmc-vendor",
  "carbide-rpc",
  "carbide-uuid",
  "eyre",
+ "figment",
  "mac_address",
+ "notify",
  "opentelemetry",
  "rand 0.9.2",
  "serde",
+ "serde_json",
+ "serde_yaml",
+ "serial_test",
+ "tempfile",
  "tokio",
  "tracing",
  "vaultrs",
@@ -3020,7 +3033,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "crossterm_winapi",
  "futures-core",
  "mio",
@@ -3689,7 +3702,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d0546b8d27d77742e0e95cb2e3ff8ebb16e487f093ab7564ca7ece9c9a0421"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "byteorder",
  "lazy_static",
  "ntapi",
@@ -4031,6 +4044,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4255,7 +4277,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "ignore",
  "walkdir",
 ]
@@ -4976,6 +4998,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.10.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5264,6 +5306,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "kube"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5521,7 +5583,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
  "redox_syscall",
 ]
@@ -6042,7 +6104,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e23bebbf3e157c402c4d5ee113233e5e0610cc27453b2f07eefce649c7365dcc"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "byteorder",
  "derive_builder 0.20.2",
  "getset",
@@ -6135,7 +6197,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cfg-if",
  "libc",
 ]
@@ -6146,7 +6208,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -6159,7 +6221,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -6201,6 +6263,33 @@ name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.10.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.10.0",
+]
 
 [[package]]
 name = "nras"
@@ -7299,7 +7388,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "chrono",
  "flate2",
  "hex",
@@ -7313,7 +7402,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "chrono",
  "hex",
 ]
@@ -7494,7 +7583,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "memchr",
  "unicase",
 ]
@@ -7708,7 +7797,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -7729,7 +7818,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -7771,7 +7860,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -7911,7 +8000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4e35aaaa439a5bda2f8d15251bc375e4edfac75f9865734644782c9701b5709"
 dependencies = [
  "ahash 0.8.12",
- "bitflags",
+ "bitflags 2.10.0",
  "instant",
  "no-std-compat",
  "num-traits",
@@ -8054,7 +8143,7 @@ dependencies = [
  "aes",
  "aws-lc-rs",
  "base64ct",
- "bitflags",
+ "bitflags 2.10.0",
  "block-padding",
  "byteorder",
  "bytes",
@@ -8128,7 +8217,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bb94393cafad0530145b8f626d8687f1ee1dedb93d7ba7740d6ae81868b13b5"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "chrono",
  "flurry",
@@ -8237,7 +8326,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -8250,7 +8339,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -8513,7 +8602,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -8526,7 +8615,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -9134,7 +9223,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.10.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -9178,7 +9267,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.10.0",
  "byteorder",
  "chrono",
  "crc",
@@ -10134,7 +10223,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "futures-core",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ netlink-packet-route = "=0.19"
 nix = "0.30.1"
 nonempty = "0.11.0"
 nonzero_ext = "0.3.0"
+notify = "8.2.0"
 num-bigint-dig = "0.8.4"
 num_cpus = "1.16.0"
 oauth2 = { default-features = false, version = "5" }

--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -240,7 +240,7 @@ async fn test_metrics_integration() -> eyre::Result<()> {
         db_pool,
         metrics: _,
         db_url: _,
-        vault_config: _,
+        credential_config: _,
         _vault_handle,
     } = test_env.clone();
 

--- a/crates/api-test-helper/src/api_server.rs
+++ b/crates/api-test-helper/src/api_server.rs
@@ -17,7 +17,7 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
-use forge_secrets::forge_vault::VaultConfig;
+use forge_secrets::CredentialConfig;
 use tokio::sync::oneshot::Sender;
 use tokio_util::sync::CancellationToken;
 use utils::HostPortPair;
@@ -36,7 +36,7 @@ pub struct StartArgs {
     pub firmware_directory: PathBuf,
     pub cancel_token: CancellationToken,
     pub ready_channel: Sender<()>,
-    pub vault_config: VaultConfig,
+    pub credential_config: CredentialConfig,
 }
 
 pub async fn start(
@@ -50,7 +50,7 @@ pub async fn start(
         firmware_directory,
         cancel_token,
         ready_channel,
-        vault_config,
+        credential_config,
     }: StartArgs,
 ) -> eyre::Result<()> {
     let firmware_directory_str = firmware_directory.to_string_lossy();
@@ -276,7 +276,7 @@ pub async fn start(
         0,
         carbide_config_str,
         None,
-        vault_config,
+        credential_config,
         true,
         cancel_token,
         ready_channel,

--- a/crates/api-test-helper/src/utils.rs
+++ b/crates/api-test-helper/src/utils.rs
@@ -22,9 +22,8 @@ use std::time::Duration;
 use std::{env, path};
 
 use eyre::Report;
-use forge_secrets::credentials::{CredentialKey, CredentialProvider, Credentials};
-use forge_secrets::forge_vault;
-use forge_secrets::forge_vault::VaultConfig;
+use forge_secrets::credentials::{CredentialKey, CredentialType, CredentialWriter, Credentials};
+use forge_secrets::{CredentialConfig, VaultConfig, create_credential_manager};
 use metrics_endpoint::MetricsSetup;
 use sqlx::migrate::MigrateDatabase;
 use sqlx::{Pool, Postgres};
@@ -60,7 +59,7 @@ pub struct IntegrationTestEnvironment {
     pub db_url: String,
     pub db_pool: Pool<Postgres>,
     pub metrics: MetricsSetup,
-    pub vault_config: VaultConfig,
+    pub credential_config: CredentialConfig,
     pub _vault_handle: Arc<Vault>,
 }
 
@@ -121,12 +120,15 @@ impl IntegrationTestEnvironment {
 
         let vault = vault::start(vault_addr).await?;
 
-        let vault_config = VaultConfig {
-            address: Some(format!("http://{vault_addr}")),
-            kv_mount_location: Some("secret".to_string()),
-            pki_mount_location: Some("forgeca".to_string()),
-            pki_role_name: Some("forge-cluster".to_string()),
-            token: Some(vault.token.clone()),
+        let credential_config = CredentialConfig {
+            vault: VaultConfig {
+                address: Some(format!("http://{vault_addr}")),
+                kv_mount_location: Some("secret".to_string()),
+                pki_mount_location: Some("forgeca".to_string()),
+                pki_role_name: Some("forge-cluster".to_string()),
+                token: Some(vault.token.clone()),
+            },
+            ..Default::default()
         };
 
         // We have to do [sqlx::test] 's work manually here so that we can use a multi-threaded executor
@@ -138,7 +140,7 @@ impl IntegrationTestEnvironment {
             carbide_api_addrs,
             root_dir,
             carbide_metrics_addrs,
-            vault_config,
+            credential_config,
             db_url,
             db_pool,
             metrics: metrics_endpoint::new_metrics_setup("carbide-api", "forge-system", true)?, // unique to each test
@@ -200,7 +202,7 @@ pub async fn start_api_server(
         root_dir,
         carbide_metrics_addrs,
         metrics,
-        vault_config,
+        credential_config,
         _vault_handle,
     } = test_env;
 
@@ -239,7 +241,7 @@ pub async fn start_api_server(
     // Dependencies: Postgres, Vault and a Redfish BMC
     m.run(&db_pool).await?;
 
-    populate_initial_vault_secrets(&vault_config, &metrics).await?;
+    populate_initial_vault_secrets(&credential_config, &metrics).await?;
 
     let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
     let join_handle = tokio::spawn({
@@ -255,7 +257,7 @@ pub async fn start_api_server(
                 firmware_directory,
                 cancel_token,
                 ready_channel: ready_tx,
-                vault_config,
+                credential_config,
             })
             .await
             .inspect_err(|e| {
@@ -281,12 +283,12 @@ impl ApiServerHandle {
 }
 
 pub async fn populate_initial_vault_secrets(
-    vault_config_overrides: &VaultConfig,
+    credential_config: &CredentialConfig,
     metrics: &MetricsSetup,
 ) -> Result<(), Report> {
-    let vault_client =
-        forge_vault::create_vault_client(vault_config_overrides, metrics.meter.clone())?;
-    vault_client
+    let credential_manager =
+        create_credential_manager(credential_config, metrics.meter.clone()).await?;
+    credential_manager
         .set_credentials(
             &CredentialKey::BmcCredentials {
                 credential_type: forge_secrets::credentials::BmcCredentialType::SiteWideRoot,
@@ -297,10 +299,11 @@ pub async fn populate_initial_vault_secrets(
             },
         )
         .await?;
-    vault_client
+
+    credential_manager
         .set_credentials(
             &CredentialKey::DpuUefi {
-                credential_type: forge_secrets::credentials::CredentialType::SiteDefault,
+                credential_type: CredentialType::SiteDefault,
             },
             &Credentials::UsernamePassword {
                 username: "root".to_string(),
@@ -308,10 +311,11 @@ pub async fn populate_initial_vault_secrets(
             },
         )
         .await?;
-    vault_client
+
+    credential_manager
         .set_credentials(
             &CredentialKey::HostUefi {
-                credential_type: forge_secrets::credentials::CredentialType::SiteDefault,
+                credential_type: CredentialType::SiteDefault,
             },
             &Credentials::UsernamePassword {
                 username: "root".to_string(),

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -37,7 +37,7 @@ use db::db_read::PgPoolReader;
 use db::work_lock_manager::WorkLockManagerHandle;
 use db::{DatabaseError, DatabaseResult, WithTransaction};
 use forge_secrets::certificates::CertificateProvider;
-use forge_secrets::credentials::CredentialProvider;
+use forge_secrets::credentials::CredentialManager;
 use librms::RmsApi;
 use model::machine::Machine;
 use model::machine::machine_search_config::MachineSearchConfig;
@@ -63,7 +63,7 @@ use crate::{CarbideError, CarbideResult};
 
 pub struct Api {
     pub(crate) database_connection: sqlx::PgPool,
-    pub(crate) credential_provider: Arc<dyn CredentialProvider>,
+    pub(crate) credential_manager: Arc<dyn CredentialManager>,
     pub(crate) certificate_provider: Arc<dyn CertificateProvider>,
     pub(crate) redfish_pool: Arc<dyn RedfishClientPool>,
     pub(crate) eth_data: EthVirtData,

--- a/crates/api/src/credentials/mod.rs
+++ b/crates/api/src/credentials/mod.rs
@@ -18,7 +18,7 @@
 use ::rpc::forge::MachineCredentialsUpdateResponse;
 use ::rpc::forge::machine_credentials_update_request::{CredentialPurpose, Credentials};
 use carbide_uuid::machine::MachineId;
-use forge_secrets::credentials::{BmcCredentialType, CredentialKey, CredentialProvider};
+use forge_secrets::credentials::{BmcCredentialType, CredentialKey, CredentialWriter};
 use mac_address::MacAddress;
 
 use crate::{CarbideError, CarbideResult};
@@ -32,7 +32,7 @@ pub struct UpdateCredentials {
 impl UpdateCredentials {
     pub async fn execute(
         &self,
-        credential_provider: &dyn CredentialProvider,
+        credential_writer: &dyn CredentialWriter,
     ) -> CarbideResult<MachineCredentialsUpdateResponse> {
         for credential in self.credentials.iter() {
             let credential_purpose = CredentialPurpose::try_from(credential.credential_purpose)
@@ -58,7 +58,7 @@ impl UpdateCredentials {
                 },
             };
 
-            credential_provider
+            credential_writer
                 .set_credentials(
                     &key,
                     &forge_secrets::credentials::Credentials::UsernamePassword {

--- a/crates/api/src/dpa/lockdown.rs
+++ b/crates/api/src/dpa/lockdown.rs
@@ -11,9 +11,7 @@
  */
 
 use carbide_uuid::dpa_interface::DpaInterfaceId;
-use forge_secrets::credentials::{
-    BmcCredentialType, CredentialKey, CredentialProvider, Credentials,
-};
+use forge_secrets::credentials::{BmcCredentialType, CredentialKey, CredentialReader, Credentials};
 use hkdf::Hkdf;
 use sha2::Sha256;
 use sqlx::PgPool;
@@ -128,12 +126,12 @@ async fn build_kdf_context(
 // fetch_kdf_secret fetches the site-wide root secret from Vault,
 // which is the IKM (Input Key Material) for the KDF.
 async fn fetch_kdf_secret(
-    credential_provider: &dyn CredentialProvider,
+    credential_reader: &dyn CredentialReader,
 ) -> Result<String, eyre::Report> {
     let credential_key = CredentialKey::BmcCredentials {
         credential_type: BmcCredentialType::SiteWideRoot,
     };
-    let credentials = credential_provider
+    let credentials = credential_reader
         .get_credentials(&credential_key)
         .await?
         .ok_or_else(|| eyre::eyre!("SiteWideRoot credentials not found"))?;
@@ -147,10 +145,10 @@ async fn fetch_kdf_secret(
 pub async fn build_supernic_lockdown_key(
     db_reader: &PgPool,
     dpa_interface_id: DpaInterfaceId,
-    credential_provider: &dyn CredentialProvider,
+    credential_reader: &dyn CredentialReader,
 ) -> Result<String, eyre::Report> {
     let ctx = build_kdf_context(db_reader, dpa_interface_id).await?;
-    let secret = fetch_kdf_secret(credential_provider).await?;
+    let secret = fetch_kdf_secret(credential_reader).await?;
     build_lockdown_key(secret.as_bytes(), &ctx, KdfContextVersion::V1)
 }
 

--- a/crates/api/src/handlers/bmc_metadata.rs
+++ b/crates/api/src/handlers/bmc_metadata.rs
@@ -15,9 +15,7 @@
  * limitations under the License.
  */
 use ::rpc::forge as rpc;
-use forge_secrets::credentials::{
-    BmcCredentialType, CredentialKey, CredentialProvider, Credentials,
-};
+use forge_secrets::credentials::{BmcCredentialType, CredentialKey, CredentialReader, Credentials};
 use sqlx::PgPool;
 
 use crate::CarbideError;
@@ -34,7 +32,7 @@ pub(crate) async fn get(
     let response = get_inner(
         request,
         &api.database_connection,
-        api.credential_provider.as_ref(),
+        api.credential_manager.as_ref(),
     )
     .await?;
 
@@ -46,7 +44,7 @@ pub(crate) async fn get(
 pub(crate) async fn get_inner(
     request: rpc::BmcMetaDataGetRequest,
     pool: &PgPool,
-    credential_provider: &dyn CredentialProvider,
+    credential_reader: &dyn CredentialReader,
 ) -> Result<rpc::BmcMetaDataGetResponse, CarbideError> {
     let mut txn = pool.txn_begin().await?;
     let (bmc_endpoint_request, _) = validate_and_complete_bmc_endpoint_request(
@@ -89,7 +87,7 @@ pub(crate) async fn get_inner(
         }
     };
 
-    let credentials = credential_provider
+    let credentials = credential_reader
         .get_credentials(&CredentialKey::BmcCredentials {
             credential_type: BmcCredentialType::BmcRoot { bmc_mac_address },
         })

--- a/crates/api/src/handlers/credential.rs
+++ b/crates/api/src/handlers/credential.rs
@@ -72,7 +72,7 @@ pub(crate) async fn create_credential(
         }
         rpc::CredentialType::Ufm => {
             if let Some(username) = req.username {
-                api.credential_provider
+                api.credential_manager
                     .set_credentials(
                         &CredentialKey::UfmAuth {
                             fabric: DEFAULT_IB_FABRIC_NAME.to_string(),
@@ -98,7 +98,7 @@ pub(crate) async fn create_credential(
         }
         rpc::CredentialType::DpuUefi => {
             if (api
-                .credential_provider
+                .credential_manager
                 .get_credentials(&CredentialKey::DpuUefi {
                     credential_type: CredentialType::SiteDefault,
                 })
@@ -110,7 +110,7 @@ pub(crate) async fn create_credential(
                     "Not support to reset DPU UEFI credential",
                 ));
             }
-            api.credential_provider
+            api.credential_manager
                 .set_credentials(
                     &CredentialKey::DpuUefi {
                         credential_type: CredentialType::SiteDefault,
@@ -127,7 +127,7 @@ pub(crate) async fn create_credential(
         }
         rpc::CredentialType::HostUefi => {
             if api
-                .credential_provider
+                .credential_manager
                 .get_credentials(&CredentialKey::HostUefi {
                     credential_type: CredentialType::SiteDefault,
                 })
@@ -139,7 +139,7 @@ pub(crate) async fn create_credential(
                     "Resetting the Host UEFI credentials in Vault is not supported",
                 ));
             }
-            api.credential_provider
+            api.credential_manager
                 .set_credentials(
                     &CredentialKey::HostUefi {
                         credential_type: CredentialType::SiteDefault,
@@ -162,7 +162,7 @@ pub(crate) async fn create_credential(
                 return Err(tonic::Status::invalid_argument("missing vendor"));
             };
             let vendor: bmc_vendor::BMCVendor = vendor.as_str().into();
-            api.credential_provider
+            api.credential_manager
                 .set_credentials(
                     &CredentialKey::HostRedfish {
                         credential_type: CredentialType::HostHardwareDefault { vendor },
@@ -180,7 +180,7 @@ pub(crate) async fn create_credential(
             let Some(username) = req.username else {
                 return Err(tonic::Status::invalid_argument("missing username"));
             };
-            api.credential_provider
+            api.credential_manager
                 .set_credentials(
                     &CredentialKey::DpuRedfish {
                         credential_type: CredentialType::DpuHardwareDefault,
@@ -219,7 +219,7 @@ pub(crate) async fn create_credential(
         }
         rpc::CredentialType::NmxM => {
             if let Some(username) = req.username {
-                api.credential_provider
+                api.credential_manager
                     .set_credentials(
                         &CredentialKey::NmxM {
                             nmxm_id: DEFAULT_NMX_M_NAME.to_string(),
@@ -263,7 +263,7 @@ pub(crate) async fn delete_credential(
     match credential_type {
         rpc::CredentialType::Ufm => {
             if let Some(username) = req.username {
-                api.credential_provider
+                api.credential_manager
                     .set_credentials(
                         &CredentialKey::UfmAuth {
                             fabric: DEFAULT_IB_FABRIC_NAME.to_string(),
@@ -345,7 +345,7 @@ pub(crate) async fn update_machine_credentials(
     };
 
     Ok(update
-        .execute(api.credential_provider.as_ref())
+        .execute(api.credential_manager.as_ref())
         .await
         .map(Response::new)?)
 }
@@ -385,7 +385,7 @@ pub(crate) async fn get_dpu_ssh_credential(
 
     // Load credentials from Vault
     let credentials = api
-        .credential_provider
+        .credential_manager
         .get_credentials(&CredentialKey::DpuSsh { machine_id })
         .await
         .map_err(|err| CarbideError::internal(format!("Secret manager error: {err}")))?
@@ -439,7 +439,7 @@ pub(crate) async fn delete_bmc_root_credentials_by_mac(
         credential_type: BmcCredentialType::BmcRoot { bmc_mac_address },
     };
 
-    api.credential_provider
+    api.credential_manager
         .delete_credentials(&credential_key)
         .await
         .map_err(|e| CarbideError::internal(format!("Error deleting credential for BMC: {e:?} ")))
@@ -468,7 +468,7 @@ async fn set_bmc_credentials(
     credential_key: &CredentialKey,
     credentials: &Credentials,
 ) -> Result<(), CarbideError> {
-    api.credential_provider
+    api.credential_manager
         .set_credentials(credential_key, credentials)
         .await
         .map_err(|e| CarbideError::internal(format!("Error setting credential for BMC: {e:?} ")))

--- a/crates/api/src/handlers/dpa.rs
+++ b/crates/api/src/handlers/dpa.rs
@@ -305,7 +305,7 @@ async fn build_unlock_command(
     let key = crate::dpa::lockdown::build_supernic_lockdown_key(
         &api.database_connection,
         sn.id,
-        &*api.credential_provider,
+        &*api.credential_manager,
     )
     .await
     .map_err(|e| {
@@ -410,7 +410,7 @@ async fn build_lock_command(
     let key = crate::dpa::lockdown::build_supernic_lockdown_key(
         &api.database_connection,
         sn.id,
-        &*api.credential_provider,
+        &*api.credential_manager,
     )
     .await
     .map_err(|e| {

--- a/crates/api/src/handlers/dpu.rs
+++ b/crates/api/src/handlers/dpu.rs
@@ -575,7 +575,7 @@ pub(crate) async fn get_managed_host_network_config_inner(
                 info.version.version,
             );
             Some(
-                extension_service::get_extension_service_credential(&api.credential_provider, key)
+                extension_service::get_extension_service_credential(&api.credential_manager, key)
                     .await?,
             )
         } else {

--- a/crates/api/src/handlers/extension_service.rs
+++ b/crates/api/src/handlers/extension_service.rs
@@ -103,7 +103,7 @@ pub(crate) async fn create(
     if let Some(credential) = &req.credential {
         create_extension_service_credential(
             &service_type,
-            &api.credential_provider,
+            &api.credential_manager,
             create_extension_service_credential_key(&service_id, initial_version),
             credential,
         )
@@ -137,7 +137,7 @@ pub(crate) async fn create(
                     create_extension_service_credential_key(&service_id, initial_version);
                 // Best effort deletion - log but don't fail the request if deletion fails
                 if let Err(delete_err) =
-                    delete_extension_service_credential(&api.credential_provider, credential_key)
+                    delete_extension_service_credential(&api.credential_manager, credential_key)
                         .await
                 {
                     tracing::warn!(
@@ -284,7 +284,7 @@ pub(crate) async fn update(
         let latest_credential = if latest_version.has_credential {
             Some(
                 get_extension_service_credential(
-                    &api.credential_provider,
+                    &api.credential_manager,
                     create_extension_service_credential_key(&service_id, latest_version.version),
                 )
                 .await?,
@@ -343,7 +343,7 @@ pub(crate) async fn update(
         let vault_credential_created = if let Some(credential) = &req.credential {
             create_extension_service_credential(
                 &current_service.service_type,
-                &api.credential_provider,
+                &api.credential_manager,
                 create_extension_service_credential_key(&service_id, version_change.new),
                 credential,
             )
@@ -383,11 +383,9 @@ pub(crate) async fn update(
                     // vault credential should have also collided above, and we should have already
                     // failed by this point. So it should be safe to delete the vault credential
                     // now.
-                    if let Err(delete_err) = delete_extension_service_credential(
-                        &api.credential_provider,
-                        credential_key,
-                    )
-                    .await
+                    if let Err(delete_err) =
+                        delete_extension_service_credential(&api.credential_manager, credential_key)
+                            .await
                     {
                         tracing::warn!(
                             "Failed to delete credential for extension service {} after transaction failure: {}",
@@ -520,7 +518,7 @@ pub(crate) async fn delete(
 
             // Best effort deletion - log but don't fail if deletion fails
             if let Err(e) =
-                delete_extension_service_credential(&api.credential_provider, credential_key).await
+                delete_extension_service_credential(&api.credential_manager, credential_key).await
             {
                 tracing::warn!(
                     "Failed to delete credential for extension service {} version {}: {}",
@@ -985,7 +983,7 @@ pub(crate) fn create_extension_service_credential_key(
 /// Create the extension service credential in the vault based on the credential type
 async fn create_extension_service_credential(
     service_type: &ExtensionServiceType,
-    credential_provider: &std::sync::Arc<dyn forge_secrets::credentials::CredentialProvider>,
+    credential_writer: &dyn forge_secrets::credentials::CredentialWriter,
     credential_key: CredentialKey,
     credential: &rpc::DpuExtensionServiceCredential,
 ) -> Result<(), CarbideError> {
@@ -1007,7 +1005,7 @@ async fn create_extension_service_credential(
                         password: up.password.clone(),
                     };
 
-                    credential_provider
+                    credential_writer
                         .create_credentials(&credential_key, &cred)
                         .await
                         .map_err(|e| {
@@ -1026,10 +1024,10 @@ async fn create_extension_service_credential(
 
 /// Delete the extension service credential from the vault using the credential key
 async fn delete_extension_service_credential(
-    credential_provider: &std::sync::Arc<dyn forge_secrets::credentials::CredentialProvider>,
+    credential_writer: &dyn forge_secrets::credentials::CredentialWriter,
     credential_key: CredentialKey,
 ) -> Result<(), eyre::Report> {
-    credential_provider
+    credential_writer
         .delete_credentials(&credential_key)
         .await?;
     Ok(())
@@ -1037,10 +1035,10 @@ async fn delete_extension_service_credential(
 
 /// Get the extension service credential from the vault using the credential key
 pub(crate) async fn get_extension_service_credential(
-    credential_provider: &std::sync::Arc<dyn forge_secrets::credentials::CredentialProvider>,
+    credential_reader: &dyn forge_secrets::credentials::CredentialReader,
     credential_key: CredentialKey,
 ) -> Result<rpc::DpuExtensionServiceCredential, CarbideError> {
-    let credential = credential_provider
+    let credential = credential_reader
         .get_credentials(&credential_key)
         .await
         .map_err(|e| CarbideError::Internal {

--- a/crates/api/src/handlers/mlx_admin.rs
+++ b/crates/api/src/handlers/mlx_admin.rs
@@ -1190,7 +1190,7 @@ async fn get_device_lockdown_key(
     let lockdown_key = crate::dpa::lockdown::build_supernic_lockdown_key(
         &api.database_connection,
         dpa_interface.id,
-        &*api.credential_provider,
+        &*api.credential_manager,
     )
     .await
     .map_err(|e| {

--- a/crates/api/src/handlers/rack_firmware.rs
+++ b/crates/api/src/handlers/rack_firmware.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use db::DatabaseError;
 use db::rack_firmware::RackFirmware as DbRackFirmware;
-use forge_secrets::credentials::{CredentialKey, CredentialProvider, Credentials};
+use forge_secrets::credentials::{CredentialKey, CredentialReader, Credentials};
 use rpc::forge::{
     DeviceUpdateResult, NodeJobInfo, RackFirmware, RackFirmwareApplyRequest,
     RackFirmwareApplyResponse, RackFirmwareCreateRequest, RackFirmwareDeleteRequest,
@@ -307,7 +307,7 @@ pub async fn create(
     // Store token in Vault
     tracing::info!("Storing Rack firmware config {} with token in Vault", id);
 
-    api.credential_provider
+    api.credential_manager
         .set_credentials(
             &CredentialKey::RackFirmware {
                 firmware_id: id.clone(),
@@ -341,7 +341,7 @@ pub async fn create(
             spawn_firmware_download_task(
                 id.clone(),
                 parsed_struct,
-                api.credential_provider.clone(),
+                api.credential_manager.clone() as Arc<dyn CredentialReader>,
                 api.database_connection.clone(),
             );
             tracing::info!(
@@ -423,14 +423,14 @@ pub async fn delete(
 fn spawn_firmware_download_task(
     firmware_id: String,
     parsed_components: ParsedFirmwareComponents,
-    credential_provider: Arc<dyn CredentialProvider>,
+    credential_reader: Arc<dyn CredentialReader>,
     database_connection: sqlx::PgPool,
 ) {
     tokio::spawn(async move {
         if let Err(e) = download_firmware_files(
             &firmware_id,
             &parsed_components,
-            credential_provider,
+            &*credential_reader,
             &database_connection,
         )
         .await
@@ -448,11 +448,11 @@ fn spawn_firmware_download_task(
 async fn download_firmware_files(
     firmware_id: &str,
     parsed_components: &ParsedFirmwareComponents,
-    credential_provider: Arc<dyn CredentialProvider>,
+    credential_reader: &dyn CredentialReader,
     database_connection: &sqlx::PgPool,
 ) -> Result<(), String> {
     // Retrieve token from Vault
-    let credentials = credential_provider
+    let credentials = credential_reader
         .get_credentials(&CredentialKey::RackFirmware {
             firmware_id: firmware_id.to_string(),
         })

--- a/crates/api/src/handlers/redfish.rs
+++ b/crates/api/src/handlers/redfish.rs
@@ -24,7 +24,7 @@ use db::redfish_actions::{
     approve_request, delete_request, fetch_request, find_serials, insert_request, list_requests,
     set_applied, update_response,
 };
-use forge_secrets::credentials::CredentialProvider;
+use forge_secrets::credentials::CredentialReader;
 use http::header::CONTENT_TYPE;
 use http::{HeaderMap, HeaderValue, Uri};
 use model::redfish::BMCResponse;
@@ -57,7 +57,7 @@ pub async fn redfish_browse(
     let (metadata, new_uri, headers, http_client) = create_client(
         uri,
         &api.database_connection,
-        api.credential_provider.as_ref(),
+        api.credential_manager.as_ref(),
         &api.dynamic_settings.bmc_proxy,
     )
     .await?;
@@ -247,7 +247,7 @@ pub async fn redfish_apply_action(
         // Spawn off the task to send the request, open a transaction, and store the result.
         tokio::spawn({
             let pool = api.database_connection.clone();
-            let credential_provider = api.credential_provider.clone();
+            let credential_reader = api.credential_manager.clone();
             let bmc_proxy = api.dynamic_settings.bmc_proxy.clone();
             let mut parameters = action_request.parameters.clone();
             async move {
@@ -259,7 +259,7 @@ pub async fn redfish_apply_action(
                     parameters,
                     uri,
                     &pool,
-                    credential_provider.as_ref(),
+                    credential_reader.as_ref(),
                     bmc_proxy.as_ref(),
                     test_behavior,
                 )
@@ -297,13 +297,13 @@ async fn handle_request(
     parameters: String,
     uri: Uri,
     pool: &PgPool,
-    credential_provider: &dyn CredentialProvider,
+    credential_reader: &dyn CredentialReader,
     bmc_proxy: &ArcSwap<Option<HostPortPair>>,
     test_behavior: Option<TestBehavior>,
 ) -> BMCResponse {
     // Allow test mocks for returning errors at defined points
     let (metadata, new_uri, mut headers, http_client) = match (
-        create_client(uri, pool, credential_provider, bmc_proxy).await,
+        create_client(uri, pool, credential_reader, bmc_proxy).await,
         test_behavior.and_then(TestBehavior::into_client_creation_error),
     ) {
         (Ok(tuple), None) => tuple,
@@ -383,7 +383,7 @@ async fn handle_request(
 async fn create_client(
     uri: http::Uri,
     pool: &PgPool,
-    credential_provider: &dyn CredentialProvider,
+    credential_reader: &dyn CredentialReader,
     bmc_proxy: &ArcSwap<Option<HostPortPair>>,
 ) -> Result<
     (
@@ -405,7 +405,7 @@ async fn create_client(
     };
 
     let metadata =
-        crate::handlers::bmc_metadata::get_inner(bmc_metadata_request, pool, credential_provider)
+        crate::handlers::bmc_metadata::get_inner(bmc_metadata_request, pool, credential_reader)
             .await?;
 
     let proxy_address = bmc_proxy.load();

--- a/crates/api/src/ib/mod.rs
+++ b/crates/api/src/ib/mod.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use forge_secrets::credentials::{CredentialKey, CredentialProvider, Credentials};
+use forge_secrets::credentials::{CredentialKey, CredentialReader, Credentials};
 pub use model::ib::{IBMtu, IBRateLimit, IBServiceLevel};
 
 #[cfg(test)]
@@ -48,7 +48,7 @@ pub enum IBFabricManagerType {
 
 pub struct IBFabricManagerImpl {
     config: IBFabricManagerConfig,
-    credential_provider: Arc<dyn CredentialProvider>,
+    credential_reader: Arc<dyn CredentialReader>,
     #[cfg(test)]
     mock_fabric: Arc<mock::MockIBFabric>,
     disable_fabric: Arc<dyn IBFabric>,
@@ -93,7 +93,7 @@ impl Default for IBFabricManagerConfig {
 }
 
 pub fn create_ib_fabric_manager(
-    credential_provider: Arc<dyn CredentialProvider>,
+    credential_reader: Arc<dyn CredentialReader>,
     config: IBFabricManagerConfig,
 ) -> Result<IBFabricManagerImpl, eyre::Report> {
     for (fabric_id, endpoints) in config.endpoints.iter() {
@@ -118,7 +118,7 @@ pub fn create_ib_fabric_manager(
     let disable_fabric = Arc::new(disable::DisableIBFabric {});
 
     Ok(IBFabricManagerImpl {
-        credential_provider,
+        credential_reader,
         config,
         #[cfg(test)]
         mock_fabric,
@@ -152,7 +152,7 @@ impl IBFabricManager for IBFabricManagerImpl {
                     fabric: fabric_name.to_string(),
                 };
                 let credentials = self
-                    .credential_provider
+                    .credential_reader
                     .get_credentials(key)
                     .await
                     .map_err(|err| {

--- a/crates/api/src/ipmitool.rs
+++ b/crates/api/src/ipmitool.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use carbide_uuid::machine::MachineId;
 use eyre::eyre;
-use forge_secrets::credentials::{CredentialKey, CredentialProvider, Credentials};
+use forge_secrets::credentials::{CredentialKey, CredentialReader, Credentials};
 use utils::cmd::{CmdError, CmdResult, TokioCmd};
 
 #[async_trait]
@@ -42,7 +42,7 @@ pub trait IPMITool: Send + Sync + 'static {
 }
 
 pub struct IPMIToolImpl {
-    credential_provider: Arc<dyn CredentialProvider>,
+    credential_reader: Arc<dyn CredentialReader>,
     attempts: u32,
 }
 
@@ -51,9 +51,9 @@ impl IPMIToolImpl {
     const IPMITOOL_BMC_RESET_COMMAND_ARGS: &'static str = "-I lanplus -C 17 bmc reset cold";
     const DPU_LEGACY_IPMITOOL_COMMAND_ARGS: &'static str = "-I lanplus -C 17 raw 0x32 0xA1 0x01";
 
-    pub fn new(credential_provider: Arc<dyn CredentialProvider>, attempts: &Option<u32>) -> Self {
+    pub fn new(credential_reader: Arc<dyn CredentialReader>, attempts: &Option<u32>) -> Self {
         IPMIToolImpl {
-            credential_provider,
+            credential_reader,
             attempts: attempts.unwrap_or(3),
         }
     }
@@ -67,7 +67,7 @@ impl IPMITool for IPMIToolImpl {
         credential_key: &CredentialKey,
     ) -> Result<(), eyre::Report> {
         let credentials = self
-            .credential_provider
+            .credential_reader
             .get_credentials(credential_key)
             .await
             .map_err(|e| {
@@ -92,7 +92,7 @@ impl IPMITool for IPMIToolImpl {
         credential_key: &CredentialKey,
     ) -> Result<(), eyre::Report> {
         let credentials: Credentials = self
-            .credential_provider
+            .credential_reader
             .get_credentials(credential_key)
             .await
             .map_err(|e| {
@@ -199,11 +199,11 @@ impl IPMITool for IPMIToolTestImpl {
 mod test {
     use std::sync::Arc;
 
-    use forge_secrets::credentials::{Credentials, TestCredentialProvider};
+    use forge_secrets::credentials::{Credentials, TestCredentialManager};
 
     #[test]
     pub fn test_ipmitool_new() {
-        let cp = Arc::new(TestCredentialProvider::new(Credentials::UsernamePassword {
+        let cp = Arc::new(TestCredentialManager::new(Credentials::UsernamePassword {
             username: "user".to_string(),
             password: "password".to_string(),
         }));

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -20,7 +20,7 @@ use std::str::FromStr;
 
 use carbide::{Command, Options};
 use clap::CommandFactory;
-use forge_secrets::forge_vault::VaultConfig;
+use forge_secrets::CredentialConfig;
 use sqlx::PgPool;
 use sqlx::postgres::{PgConnectOptions, PgSslMode};
 use tokio_util::sync::CancellationToken;
@@ -71,7 +71,7 @@ async fn main() -> eyre::Result<()> {
                 debug,
                 config_str,
                 site_config_str,
-                VaultConfig::default(),
+                CredentialConfig::default(),
                 false,
                 CancellationToken::new(),
                 ready_tx,

--- a/crates/api/src/nvlink.rs
+++ b/crates/api/src/nvlink.rs
@@ -15,11 +15,9 @@
  * limitations under the License.
  */
 
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use db::DatabaseError;
-use forge_secrets::credentials::{CredentialKey, CredentialProvider, Credentials};
+use forge_secrets::credentials::{CredentialKey, CredentialReader, Credentials};
 use libnmxm::{Nmxm, NmxmApiError};
 
 use crate::handlers::credential::DEFAULT_NMX_M_NAME;
@@ -55,20 +53,20 @@ pub trait NmxmClientPool: Send + Sync + 'static {
 #[derive(Debug)]
 pub struct NmxmClientPoolImpl<C> {
     pool: libnmxm::NmxmClientPool,
-    credential_provider: Arc<C>,
+    credential_reader: C,
 }
 
-impl<C: CredentialProvider + 'static> NmxmClientPoolImpl<C> {
-    pub fn new(credential_provider: Arc<C>, pool: libnmxm::NmxmClientPool) -> Self {
+impl<C: CredentialReader> NmxmClientPoolImpl<C> {
+    pub fn new(credential_reader: C, pool: libnmxm::NmxmClientPool) -> Self {
         NmxmClientPoolImpl {
-            credential_provider,
+            credential_reader,
             pool,
         }
     }
 }
 
 #[async_trait]
-impl<C: CredentialProvider + 'static> NmxmClientPool for NmxmClientPoolImpl<C> {
+impl<C: CredentialReader + 'static> NmxmClientPool for NmxmClientPoolImpl<C> {
     async fn create_client(
         &self,
         endpoint: &str,
@@ -76,7 +74,7 @@ impl<C: CredentialProvider + 'static> NmxmClientPool for NmxmClientPoolImpl<C> {
     ) -> Result<Box<dyn Nmxm>, NvLinkPartitionError> {
         let id = nmxm_id.unwrap_or(DEFAULT_NMX_M_NAME.to_string());
         let credentials = self
-            .credential_provider
+            .credential_reader
             .get_credentials(&CredentialKey::NmxM { nmxm_id: id })
             .await
             .map_err(|e| NvLinkPartitionError::MissingCredentials(eyre::Report::from(e)))?

--- a/crates/api/src/preingestion_manager/mod.rs
+++ b/crates/api/src/preingestion_manager/mod.rs
@@ -23,9 +23,7 @@ use std::time::Duration;
 use chrono::{DateTime, Utc};
 use db::work_lock_manager::WorkLockManagerHandle;
 use db::{DatabaseError, WithTransaction};
-use forge_secrets::credentials::{
-    BmcCredentialType, CredentialKey, CredentialProvider, Credentials,
-};
+use forge_secrets::credentials::{BmcCredentialType, CredentialKey, CredentialReader, Credentials};
 use futures_util::FutureExt;
 use libredfish::model::task::TaskState;
 use libredfish::model::update_service::TransferProtocolType;
@@ -68,7 +66,7 @@ struct PreingestionManagerStatic {
     concurrency_limit: usize,
     hgx_bmc_gpu_reboot_delay: Duration,
     upgrade_script_state: Arc<UpdateScriptManager>,
-    credential_provider: Option<Arc<dyn CredentialProvider>>,
+    credential_reader: Option<Arc<dyn CredentialReader>>,
     work_lock_manager_handle: WorkLockManagerHandle,
 }
 
@@ -86,7 +84,7 @@ impl PreingestionManager {
         meter: Meter,
         downloader: Option<FirmwareDownloader>,
         upload_limiter: Option<Arc<Semaphore>>,
-        credential_provider: Option<Arc<dyn CredentialProvider>>,
+        credential_reader: Option<Arc<dyn CredentialReader>>,
         work_lock_manager_handle: WorkLockManagerHandle,
     ) -> PreingestionManager {
         let hold_period = config
@@ -112,7 +110,7 @@ impl PreingestionManager {
                 upload_limiter: upload_limiter.unwrap_or(Arc::new(Semaphore::new(5))),
                 concurrency_limit: config.firmware_global.concurrency_limit,
                 upgrade_script_state: Default::default(),
-                credential_provider,
+                credential_reader,
                 hgx_bmc_gpu_reboot_delay: config
                     .firmware_global
                     .hgx_bmc_gpu_reboot_delay
@@ -1485,7 +1483,7 @@ impl PreingestionManagerStatic {
         let address = endpoint_address.to_string();
         let script = to_install.script.clone().unwrap_or("/bin/false".into()); // Should always be Some at this point
         let upgrade_script_state = self.upgrade_script_state.clone();
-        let (username, password) = if let Some(credential_provider) = &self.credential_provider {
+        let (username, password) = if let Some(credential_reader) = &self.credential_reader {
             // We need to backtrack from the IP address to get the MAC address, which is what the credentials database is keyed on
             let interface = db::machine_interface::find_by_ip(db, endpoint_address).await?;
             let Some(interface) = interface else {
@@ -1500,7 +1498,7 @@ impl PreingestionManagerStatic {
                     bmc_mac_address: interface.mac_address,
                 },
             };
-            match credential_provider.get_credentials(&key).await {
+            match credential_reader.get_credentials(&key).await {
                 Ok(Some(credentials)) => match credentials {
                     Credentials::UsernamePassword { username, password } => (username, password),
                 },

--- a/crates/api/src/redfish.rs
+++ b/crates/api/src/redfish.rs
@@ -24,7 +24,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use forge_secrets::SecretsError;
 use forge_secrets::credentials::{
-    BmcCredentialType, CredentialKey, CredentialProvider, CredentialType, Credentials,
+    BmcCredentialType, CredentialKey, CredentialReader, CredentialType, Credentials,
 };
 use libredfish::model::BootProgress;
 use libredfish::{Endpoint, PowerState, Redfish, RedfishError, SystemPowerControl};
@@ -93,8 +93,8 @@ pub trait RedfishClientPool: Send + Sync + 'static {
         initialize: bool, // fetch some initial values like system id and manager id
     ) -> Result<Box<dyn Redfish>, RedfishClientCreationError>;
 
-    /// Returns a CredentialProvider for use in setting credentials in the UEFI/BMC.
-    fn credential_provider(&self) -> Arc<dyn CredentialProvider>;
+    /// Returns a CredentialReader for use in setting credentials in the UEFI/BMC.
+    fn credential_reader(&self) -> &dyn CredentialReader;
 
     // MARK: - Default (helper) methods
 
@@ -159,7 +159,7 @@ pub trait RedfishClientPool: Send + Sync + 'static {
         };
 
         let credentials = self
-            .credential_provider()
+            .credential_reader()
             .get_credentials(&credential_key)
             .await?
             .ok_or_else(|| RedfishClientCreationError::MissingCredentials {
@@ -229,7 +229,7 @@ pub trait RedfishClientPool: Send + Sync + 'static {
             // site password is taken from DpuUefi:site_default key
             //
             let credentials = self
-                .credential_provider()
+                .credential_reader()
                 .get_credentials(&CredentialKey::DpuUefi {
                     credential_type: CredentialType::DpuHardwareDefault,
                 })
@@ -247,7 +247,7 @@ pub trait RedfishClientPool: Send + Sync + 'static {
                 credential_type: CredentialType::SiteDefault,
             };
             let credentials = self
-                .credential_provider()
+                .credential_reader()
                 .get_credentials(&credential_key)
                 .await?
                 .ok_or_else(|| RedfishClientCreationError::MissingCredentials {
@@ -263,7 +263,7 @@ pub trait RedfishClientPool: Send + Sync + 'static {
                 credential_type: CredentialType::SiteDefault,
             };
             let credentials = self
-                .credential_provider()
+                .credential_reader()
                 .get_credentials(&credential_key)
                 .await?
                 .ok_or_else(|| RedfishClientCreationError::MissingCredentials {
@@ -306,18 +306,18 @@ pub trait RedfishClientPool: Send + Sync + 'static {
 
 pub struct RedfishClientPoolImpl {
     pool: libredfish::RedfishClientPool,
-    credential_provider: Arc<dyn CredentialProvider>,
+    credential_reader: Arc<dyn CredentialReader>,
     proxy_address: Arc<ArcSwap<Option<HostPortPair>>>,
 }
 
 impl RedfishClientPoolImpl {
     pub fn new(
-        credential_provider: Arc<dyn CredentialProvider>,
+        credential_reader: Arc<dyn CredentialReader>,
         pool: libredfish::RedfishClientPool,
         proxy_address: Arc<ArcSwap<Option<HostPortPair>>>,
     ) -> Self {
         RedfishClientPoolImpl {
-            credential_provider,
+            credential_reader,
             pool,
             proxy_address,
         }
@@ -354,7 +354,7 @@ impl RedfishClientPool for RedfishClientPoolImpl {
             RedfishAuth::Direct(username, password) => (Some(username), Some(password)),
             RedfishAuth::Key(credential_key) => {
                 let credentials = self
-                    .credential_provider
+                    .credential_reader
                     .get_credentials(&credential_key)
                     .await?
                     .ok_or_else(|| RedfishClientCreationError::MissingCredentials {
@@ -409,8 +409,8 @@ impl RedfishClientPool for RedfishClientPoolImpl {
         }
     }
 
-    fn credential_provider(&self) -> Arc<dyn CredentialProvider> {
-        self.credential_provider.clone()
+    fn credential_reader(&self) -> &dyn CredentialReader {
+        &*self.credential_reader
     }
 }
 
@@ -632,7 +632,7 @@ pub mod test_support {
     use std::time::Duration;
 
     use chrono::Utc;
-    use forge_secrets::credentials::TestCredentialProvider;
+    use forge_secrets::credentials::TestCredentialManager;
     use libredfish::model::certificate::Certificate;
     use libredfish::model::component_integrity::{ComponentIntegrities, ComponentIntegrity};
     use libredfish::model::oem::nvidia_dpu::{HostPrivilegeLevel, NicMode};
@@ -680,6 +680,7 @@ pub mod test_support {
     #[derive(Default)]
     pub struct RedfishSim {
         state: Arc<Mutex<RedfishSimState>>,
+        credential_manager: TestCredentialManager,
     }
 
     impl RedfishSim {
@@ -1970,8 +1971,8 @@ pub mod test_support {
             }))
         }
 
-        fn credential_provider(&self) -> Arc<dyn CredentialProvider> {
-            Arc::new(TestCredentialProvider::default())
+        fn credential_reader(&self) -> &dyn CredentialReader {
+            &self.credential_manager
         }
 
         async fn create_client_for_ingested_host(

--- a/crates/api/src/run.rs
+++ b/crates/api/src/run.rs
@@ -18,8 +18,7 @@
 use std::sync::Arc;
 
 use eyre::WrapErr;
-use forge_secrets::forge_vault;
-use forge_secrets::forge_vault::VaultConfig;
+use forge_secrets::{CredentialConfig, create_credential_manager, create_vault_client};
 use tokio::sync::oneshot::Sender;
 use tokio_util::sync::CancellationToken;
 use tracing::subscriber::NoSubscriber;
@@ -36,7 +35,7 @@ pub async fn run(
     debug: u8,
     config_str: String,
     site_config_str: Option<String>,
-    vault_config: VaultConfig,
+    credential_config: CredentialConfig,
     skip_logging_setup: bool,
     cancel_token: CancellationToken,
     ready_channel: Sender<()>,
@@ -128,7 +127,11 @@ pub async fn run(
         "Start carbide-api",
     );
 
-    let vault_client = forge_vault::create_vault_client(&vault_config, metrics.meter.clone())?;
+    let certificate_provider =
+        create_vault_client(&credential_config.vault, metrics.meter.clone())?;
+    let credential_manager =
+        create_credential_manager(&credential_config, metrics.meter.clone()).await?;
+
     let redfish_pool = {
         let rf_pool = libredfish::RedfishClientPool::builder()
             .build()
@@ -176,8 +179,9 @@ pub async fn run(
             }
             (None, None, _) => {} // leave bmc_proxy untouched
         }
+
         let redfish_pool = RedfishClientPoolImpl::new(
-            vault_client.clone(),
+            credential_manager.clone(),
             rf_pool,
             carbide_config.site_explorer.bmc_proxy.clone(),
         );
@@ -189,7 +193,8 @@ pub async fn run(
         metrics.meter,
         dynamic_settings,
         redfish_pool,
-        vault_client,
+        credential_manager,
+        certificate_provider,
         cancel_token,
         ready_channel,
     )

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -26,8 +26,8 @@ use db::{Transaction, work_lock_manager};
 use eyre::WrapErr;
 use figment::Figment;
 use figment::providers::{Env, Format, Toml};
-use forge_secrets::ForgeVaultClient;
-use forge_secrets::credentials::CredentialProvider;
+use forge_secrets::certificates::CertificateProvider;
+use forge_secrets::credentials::{CredentialManager, CredentialReader};
 use futures_util::TryFutureExt;
 use librms::RackManagerClientPool;
 use model::attestation::spdm::VerifierImpl;
@@ -174,7 +174,7 @@ pub fn parse_carbide_config(
 }
 
 pub fn create_ipmi_tool(
-    credential_provider: Arc<dyn CredentialProvider>,
+    credential_reader: Arc<dyn CredentialReader>,
     carbide_config: &CarbideConfig,
 ) -> Arc<dyn IPMITool> {
     if carbide_config
@@ -186,7 +186,7 @@ pub fn create_ipmi_tool(
         Arc::new(IPMIToolTestImpl {})
     } else {
         Arc::new(IPMIToolImpl::new(
-            credential_provider,
+            credential_reader,
             &carbide_config.dpu_ipmi_reboot_attempts,
         ))
     }
@@ -218,17 +218,19 @@ async fn create_and_connect_postgres_pool(config: &CarbideConfig) -> eyre::Resul
         .await?)
 }
 
+#[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all)]
 pub async fn start_api(
     carbide_config: Arc<CarbideConfig>,
     meter: Meter,
     dynamic_settings: DynamicSettings,
     shared_redfish_pool: Arc<dyn RedfishClientPool>,
-    vault_client: Arc<ForgeVaultClient>,
+    credential_manager: Arc<dyn CredentialManager>,
+    certificate_provider: Arc<dyn CertificateProvider>,
     cancel_token: CancellationToken,
     ready_channel: Sender<()>,
 ) -> eyre::Result<()> {
-    let ipmi_tool = create_ipmi_tool(vault_client.clone(), &carbide_config);
+    let ipmi_tool = create_ipmi_tool(credential_manager.clone(), &carbide_config);
 
     let db_pool = create_and_connect_postgres_pool(&carbide_config).await?;
 
@@ -306,7 +308,7 @@ pub async fn start_api(
         db::resource_pool::create_common_pools(db_pool.clone(), ib_fabric_ids).await?;
 
     let ib_fabric_manager_impl = ib::create_ib_fabric_manager(
-        vault_client.clone(),
+        credential_manager.clone(),
         ib::IBFabricManagerConfig {
             endpoints: if ib_config.enabled {
                 carbide_config
@@ -362,7 +364,7 @@ pub async fn start_api(
     let bmc_explorer = Arc::new(BmcEndpointExplorer::new(
         shared_redfish_pool.clone(),
         ipmi_tool.clone(),
-        vault_client.clone(),
+        credential_manager.clone(),
         carbide_config
             .site_explorer
             .rotate_switch_nvos_credentials
@@ -373,14 +375,14 @@ pub async fn start_api(
 
     let nmxm_client_pool =
         libnmxm::NmxmClientPool::builder(nvlink_config.allow_insecure).build()?;
-    let nmxm_pool = NmxmClientPoolImpl::new(vault_client.clone(), nmxm_client_pool);
+    let nmxm_pool = NmxmClientPoolImpl::new(credential_manager.clone(), nmxm_client_pool);
 
     let shared_nmxm_pool: Arc<dyn NmxmClientPool> = Arc::new(nmxm_pool);
 
     let api_service = Arc::new(Api {
-        certificate_provider: vault_client.clone(),
+        certificate_provider,
         common_pools,
-        credential_provider: vault_client,
+        credential_manager,
         database_connection: db_pool.clone(),
         dpu_health_log_limiter: LogLimiter::default(),
         dynamic_settings,
@@ -658,10 +660,7 @@ pub async fn initialize_and_start_controllers(
         let key = forge_secrets::credentials::CredentialKey::BmcCredentials {
             credential_type: forge_secrets::credentials::BmcCredentialType::SiteWideRoot,
         };
-        let credentials = api_service
-            .credential_provider
-            .get_credentials(&key)
-            .await?;
+        let credentials = api_service.credential_manager.get_credentials(&key).await?;
         let Some(forge_secrets::credentials::Credentials::UsernamePassword {
             username: _,
             password,
@@ -721,7 +720,7 @@ pub async fn initialize_and_start_controllers(
                             .instance_autoreboot_period
                             .clone(),
                     )
-                    .credential_provider(api_service.credential_provider.clone())
+                    .credential_reader(api_service.credential_manager.clone())
                     .power_options_config(carbide_config.power_manager_options.clone().into())
                     .dpf_config(crate::state_controller::machine::handler::DpfConfig::from(
                         carbide_config.dpf.clone(),
@@ -907,7 +906,7 @@ pub async fn initialize_and_start_controllers(
         meter.clone(),
         Some(downloader.clone()),
         Some(upload_limiter),
-        Some(api_service.credential_provider.clone()),
+        Some(api_service.credential_manager.clone()),
         work_lock_manager_handle.clone(),
     );
     let _preingestion_manager_stop_handle = preingestion_manager.start()?;

--- a/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
+++ b/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
@@ -19,7 +19,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use forge_secrets::credentials::{CredentialProvider, Credentials};
+use forge_secrets::credentials::{CredentialManager, Credentials};
 use libredfish::model::oem::nvidia_dpu::NicMode;
 use libredfish::model::service_root::RedfishVendor;
 use mac_address::MacAddress;
@@ -57,13 +57,13 @@ impl BmcEndpointExplorer {
     pub fn new(
         redfish_client_pool: Arc<dyn RedfishClientPool>,
         ipmi_tool: Arc<dyn IPMITool>,
-        credential_provider: Arc<dyn CredentialProvider>,
+        credential_manager: Arc<dyn CredentialManager>,
         rotate_switch_nvos_credentials: Arc<AtomicBool>,
     ) -> Self {
         Self {
             redfish_client: RedfishClient::new(redfish_client_pool),
             ipmi_tool,
-            credential_client: CredentialClient::new(credential_provider),
+            credential_client: CredentialClient::new(credential_manager),
             mutex: Arc::new(Mutex::new(())),
             rotate_switch_nvos_credentials,
         }

--- a/crates/api/src/site_explorer/credentials.rs
+++ b/crates/api/src/site_explorer/credentials.rs
@@ -18,7 +18,7 @@
 use std::sync::Arc;
 
 use forge_secrets::credentials::{
-    BmcCredentialType, CredentialKey, CredentialProvider, CredentialType, Credentials,
+    BmcCredentialType, CredentialKey, CredentialManager, CredentialType, Credentials,
 };
 use mac_address::MacAddress;
 use model::site_explorer::EndpointExplorationError;
@@ -40,7 +40,7 @@ pub fn get_bmc_nvos_admin_credential_key(bmc_mac_address: MacAddress) -> Credent
 }
 
 pub struct CredentialClient {
-    credential_provider: Arc<dyn CredentialProvider>,
+    credential_manager: Arc<dyn CredentialManager>,
 }
 
 impl CredentialClient {
@@ -64,7 +64,7 @@ impl CredentialClient {
         credential_key: &CredentialKey,
     ) -> Result<Credentials, EndpointExplorationError> {
         match self
-            .credential_provider
+            .credential_manager
             .get_credentials(credential_key)
             .await
         {
@@ -96,7 +96,7 @@ impl CredentialClient {
         credentials: &Credentials,
     ) -> Result<(), EndpointExplorationError> {
         match self
-            .credential_provider
+            .credential_manager
             .set_credentials(credential_key, credentials)
             .await
         {
@@ -108,10 +108,8 @@ impl CredentialClient {
         }
     }
 
-    pub fn new(credential_provider: Arc<dyn CredentialProvider>) -> Self {
-        Self {
-            credential_provider,
-        }
+    pub fn new(credential_manager: Arc<dyn CredentialManager>) -> Self {
+        Self { credential_manager }
     }
 
     pub async fn check_preconditions(

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -31,9 +31,7 @@ use db::DatabaseError;
 use db::db_read::PgPoolReader;
 use db::machine::mark_machine_ingestion_done_with_dpf;
 use eyre::eyre;
-use forge_secrets::credentials::{
-    BmcCredentialType, CredentialKey, CredentialProvider, Credentials,
-};
+use forge_secrets::credentials::{BmcCredentialType, CredentialKey, CredentialReader, Credentials};
 use futures::TryFutureExt;
 use futures_util::FutureExt;
 use health_report::{
@@ -212,7 +210,7 @@ pub struct MachineStateHandlerBuilder {
     common_pools: Option<Arc<CommonPools>>,
     bom_validation: BomValidationConfig,
     instance_autoreboot_period: Option<TimePeriod>,
-    credential_provider: Option<Arc<dyn CredentialProvider>>,
+    credential_reader: Option<Arc<dyn CredentialReader>>,
     power_options_config: PowerOptionConfig,
     enable_secure_boot: bool,
     hgx_bmc_gpu_reboot_delay: chrono::Duration,
@@ -243,7 +241,7 @@ impl MachineStateHandlerBuilder {
             common_pools: None,
             bom_validation: BomValidationConfig::default(),
             instance_autoreboot_period: None,
-            credential_provider: None,
+            credential_reader: None,
             power_options_config: PowerOptionConfig {
                 enabled: true,
                 next_try_duration_on_success: chrono::Duration::minutes(0),
@@ -264,8 +262,8 @@ impl MachineStateHandlerBuilder {
         self
     }
 
-    pub fn credential_provider(mut self, credential_provider: Arc<dyn CredentialProvider>) -> Self {
-        self.credential_provider = Some(credential_provider);
+    pub fn credential_reader(mut self, credential_reader: Arc<dyn CredentialReader>) -> Self {
+        self.credential_reader = Some(credential_reader);
         self
     }
     pub fn dpu_up_threshold(mut self, dpu_up_threshold: chrono::Duration) -> Self {
@@ -394,7 +392,7 @@ impl MachineStateHandler {
             no_firmware_update_reset_retries: builder.no_firmware_update_reset_retries,
             instance_autoreboot_period: builder.instance_autoreboot_period,
             upgrade_script_state: Default::default(),
-            credential_provider: builder.credential_provider,
+            credential_reader: builder.credential_reader,
             async_firmware_uploader: Arc::new(Default::default()),
             hgx_bmc_gpu_reboot_delay: builder
                 .hgx_bmc_gpu_reboot_delay
@@ -6489,7 +6487,7 @@ struct HostUpgradeState {
     no_firmware_update_reset_retries: bool,
     instance_autoreboot_period: Option<TimePeriod>,
     upgrade_script_state: Arc<UpdateScriptManager>,
-    credential_provider: Option<Arc<dyn CredentialProvider>>,
+    credential_reader: Option<Arc<dyn CredentialReader>>,
     async_firmware_uploader: Arc<AsyncFirmwareUploader>,
     hgx_bmc_gpu_reboot_delay: tokio::time::Duration,
 }
@@ -6923,7 +6921,7 @@ impl HostUpgradeState {
         let address = explored_endpoint.address.to_string().clone();
         let script = to_install.script.unwrap_or("/bin/false".into()); // Should always be Some at this point
         let upgrade_script_state = self.upgrade_script_state.clone();
-        let (username, password) = if let Some(credential_provider) = &self.credential_provider {
+        let (username, password) = if let Some(credential_reader) = &self.credential_reader {
             let bmc_mac_address =
                 state
                     .host_snapshot
@@ -6936,7 +6934,7 @@ impl HostUpgradeState {
             let key = CredentialKey::BmcCredentials {
                 credential_type: BmcCredentialType::BmcRoot { bmc_mac_address },
             };
-            match credential_provider.get_credentials(&key).await {
+            match credential_reader.get_credentials(&key).await {
                 Ok(Some(credentials)) => match credentials {
                     Credentials::UsernamePassword { username, password } => (username, password),
                 },

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -37,8 +37,9 @@ use db::network_security_group::create as create_network_security_group;
 use db::work_lock_manager;
 use dpu::DpuConfig;
 use forge_secrets::credentials::{
-    CredentialKey, CredentialProvider, CredentialType, Credentials, TestCredentialProvider,
+    CompositeCredentialManager, CredentialManager, CredentialReader, TestCredentialManager,
 };
+use forge_secrets::{ChainedCredentialReader, CredentialSnapshot, UsernamePassword};
 use futures::FutureExt as _;
 use health_report::{HealthReport, OverrideMode};
 use ipnetwork::IpNetwork;
@@ -346,7 +347,7 @@ pub struct TestEnv {
     pub underlay_segment: Option<NetworkSegmentId>,
     pub domain: uuid::Uuid,
     pub nvl_partition_monitor: Arc<Mutex<NvlPartitionMonitor>>,
-    pub test_credential_provider: Arc<TestCredentialProvider>,
+    pub test_credential_manager: Arc<TestCredentialManager>,
     pub rms_sim: Arc<RmsSim>,
     pub drop_guard: DropGuard,
 }
@@ -1263,8 +1264,17 @@ pub async fn create_test_env_with_overrides(
     .await
     .expect("work_lock_manager failed to start: no availble connections?");
     let test_meter = TestMeter::default();
-    let credential_provider = Arc::new(TestCredentialProvider::default());
-    populate_default_credentials(credential_provider.as_ref()).await;
+    let credential_manager = Arc::new(TestCredentialManager::default());
+
+    let chained_reader = ChainedCredentialReader::from(vec![
+        Box::new(test_static_credential_snapshot()) as Box<dyn CredentialReader>,
+        Box::new(credential_manager.clone()),
+    ]);
+    let composite_manager: Arc<dyn CredentialManager> = Arc::new(CompositeCredentialManager::new(
+        chained_reader,
+        credential_manager.clone(),
+    ));
+
     let certificate_provider = Arc::new(TestCertificateProvider::new());
     let redfish_sim = Arc::new(RedfishSim::default());
     let nmxm_sim: Arc<dyn NmxmClientPool> =
@@ -1296,7 +1306,7 @@ pub async fn create_test_env_with_overrides(
 
     let ib_config = config.ib_config.clone().unwrap_or_default();
     let ib_fabric_manager_impl = ib::create_ib_fabric_manager(
-        credential_provider.clone(),
+        composite_manager.clone(),
         ib::IBFabricManagerConfig {
             allow_insecure_fabric_configuration: ib_config.allow_insecure,
             endpoints: if ib_config.enabled {
@@ -1390,7 +1400,7 @@ pub async fn create_test_env_with_overrides(
     let bmc_explorer = Arc::new(BmcEndpointExplorer::new(
         redfish_sim.clone(),
         ipmi_tool.clone(),
-        credential_provider.clone(),
+        composite_manager.clone(),
         Arc::new(std::sync::atomic::AtomicBool::new(false)),
     ));
 
@@ -1406,7 +1416,7 @@ pub async fn create_test_env_with_overrides(
     let api = Arc::new(Api {
         kube_client_provider: Arc::new(TestDpfKubeClient {}),
         runtime_config: config.clone(),
-        credential_provider: credential_provider.clone(),
+        credential_manager: composite_manager,
         certificate_provider: certificate_provider.clone(),
         database_connection: db_pool.clone(),
         redfish_pool: redfish_sim.clone(),
@@ -1679,7 +1689,7 @@ pub async fn create_test_env_with_overrides(
         underlay_segment,
         domain: domain.into(),
         nvl_partition_monitor: Arc::new(Mutex::new(nvl_partition_monitor)),
-        test_credential_provider: credential_provider.clone(),
+        test_credential_manager: credential_manager.clone(),
         rms_sim,
         drop_guard: cancel_token.drop_guard(),
     }
@@ -1822,43 +1832,22 @@ pub async fn populate_network_security_groups(api: Arc<Api>) {
     txn.commit().await.unwrap();
 }
 
-async fn populate_default_credentials(credential_provider: &dyn CredentialProvider) {
-    credential_provider
-        .set_credentials(
-            &CredentialKey::DpuRedfish {
-                credential_type: CredentialType::DpuHardwareDefault,
-            },
-            &Credentials::UsernamePassword {
-                username: "root".to_string(),
-                password: "dpuredfish_dpuhardwaredefault".to_string(),
-            },
-        )
-        .await
-        .unwrap();
-    credential_provider
-        .set_credentials(
-            &CredentialKey::DpuRedfish {
-                credential_type: CredentialType::SiteDefault,
-            },
-            &Credentials::UsernamePassword {
-                username: "root".to_string(),
-                password: "dpuredfish_sitedefault".to_string(),
-            },
-        )
-        .await
-        .unwrap();
-    credential_provider
-        .set_credentials(
-            &CredentialKey::HostRedfish {
-                credential_type: CredentialType::SiteDefault,
-            },
-            &Credentials::UsernamePassword {
-                username: "root".to_string(),
-                password: "hostredfish_sitedefault".to_string(),
-            },
-        )
-        .await
-        .unwrap();
+fn test_static_credential_snapshot() -> CredentialSnapshot {
+    CredentialSnapshot {
+        dpu_redfish_factory_default: Some(UsernamePassword {
+            username: "root".to_string(),
+            password: "dpuredfish_dpuhardwaredefault".to_string(),
+        }),
+        dpu_redfish_site_default: Some(UsernamePassword {
+            username: "root".to_string(),
+            password: "dpuredfish_sitedefault".to_string(),
+        }),
+        host_redfish_site_default: Some(UsernamePassword {
+            username: "root".to_string(),
+            password: "hostredfish_sitedefault".to_string(),
+        }),
+        ..Default::default()
+    }
 }
 
 fn pool_defs(fabric_len: u8) -> HashMap<String, resource_pool::ResourcePoolDef> {

--- a/crates/api/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/site_explorer.rs
@@ -1225,7 +1225,7 @@ pub async fn new_mock_host(
         .chain(config.dpus.iter().map(|d| d.bmc_mac_address))
     {
         env.api
-            .credential_provider
+            .credential_manager
             .set_credentials(
                 &CredentialKey::BmcCredentials {
                     credential_type: BmcCredentialType::BmcRoot { bmc_mac_address },
@@ -1685,7 +1685,7 @@ pub async fn new_mock_host_with_dpf(
         .chain(config.dpus.iter().map(|d| d.bmc_mac_address))
     {
         env.api
-            .credential_provider
+            .credential_manager
             .set_credentials(
                 &CredentialKey::BmcCredentials {
                     credential_type: BmcCredentialType::BmcRoot { bmc_mac_address },

--- a/crates/api/src/tests/extension_service.rs
+++ b/crates/api/src/tests/extension_service.rs
@@ -260,7 +260,7 @@ async fn get_credentials_for_extension_service(
 
     let stored_credential = env
         .api
-        .credential_provider
+        .credential_manager
         .get_credentials(&credential_key)
         .await?;
     stored_credential.ok_or_else(|| eyre::eyre!("Could not find the credential"))
@@ -387,7 +387,7 @@ async fn test_extension_service_create_failure(db_pool: sqlx::PgPool) -> Result<
 
     let stored_credential = env
         .api
-        .credential_provider
+        .credential_manager
         .get_credentials(&credential_key)
         .await?
         .expect("creating an extension service should have created a credential");
@@ -404,7 +404,7 @@ async fn test_extension_service_create_failure(db_pool: sqlx::PgPool) -> Result<
 
     let stored_credential_2 = env
         .api
-        .credential_provider
+        .credential_manager
         .get_credentials(&credential_key)
         .await?
         .expect("Failing to create a second extension should not delete existing credentials");
@@ -453,7 +453,7 @@ async fn test_extension_service_update_race_condition(
         .unwrap();
 
     // Make the credential writes slow so that the database can conflict
-    env.test_credential_provider
+    env.test_credential_manager
         .set_credentials_sleep_time_ms
         .store(1000, Ordering::SeqCst);
 
@@ -636,7 +636,7 @@ async fn test_extension_service_create_race_condition(
     };
 
     // Make the credential writes slow so that the database can conflict
-    env.test_credential_provider
+    env.test_credential_manager
         .set_credentials_sleep_time_ms
         .store(1000, Ordering::SeqCst);
 
@@ -1832,7 +1832,7 @@ async fn test_extension_service_create_update_delete_credential(
 
     let stored_credential = env
         .api
-        .credential_provider
+        .credential_manager
         .get_credentials(&credential_key)
         .await?;
 
@@ -1877,7 +1877,7 @@ async fn test_extension_service_create_update_delete_credential(
     };
     let stored_credential = env
         .api
-        .credential_provider
+        .credential_manager
         .get_credentials(&credential_key)
         .await;
     assert!(stored_credential.is_ok());

--- a/crates/bmc-vendor/src/lib.rs
+++ b/crates/bmc-vendor/src/lib.rs
@@ -26,6 +26,7 @@ use libredfish::model::service_root::RedfishVendor;
     Copy,
     Debug,
     Default,
+    Hash,
     Eq,
     PartialEq,
     clap::ValueEnum,

--- a/crates/secrets/Cargo.toml
+++ b/crates/secrets/Cargo.toml
@@ -28,20 +28,29 @@ name = "forge_secrets"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+arc-swap = { workspace = true }
 async-trait = { workspace = true }
 eyre = { workspace = true }
+figment = { features = ["env"], workspace = true }
+mac_address = { features = ["serde"], workspace = true }
+notify = { workspace = true }
 opentelemetry = { workspace = true }
 rand = { workspace = true }
 serde = { features = ["derive"], workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 vaultrs = { workspace = true }
-mac_address = { features = ["serde"], workspace = true }
 
 # [local-dependencies]
 bmc-vendor = { path = "../bmc-vendor" }
 carbide-rpc = { path = "../rpc" }
 carbide-uuid = { path = "../uuid" }
+
+[dev-dependencies]
+serial_test = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/secrets/src/chained_reader.rs
+++ b/crates/secrets/src/chained_reader.rs
@@ -1,0 +1,212 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use async_trait::async_trait;
+
+use crate::SecretsError;
+use crate::credentials::{CredentialKey, CredentialReader, Credentials};
+
+pub struct ChainedCredentialReader(Vec<Box<dyn CredentialReader>>);
+
+impl From<Vec<Box<dyn CredentialReader>>> for ChainedCredentialReader {
+    fn from(providers: Vec<Box<dyn CredentialReader>>) -> Self {
+        Self(providers)
+    }
+}
+
+#[async_trait]
+impl CredentialReader for ChainedCredentialReader {
+    async fn get_credentials(
+        &self,
+        key: &CredentialKey,
+    ) -> Result<Option<Credentials>, SecretsError> {
+        for provider in &self.0 {
+            if let Some(credentials) = provider.get_credentials(key).await? {
+                return Ok(Some(credentials));
+            }
+        }
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use serial_test::serial;
+
+    use super::*;
+    use crate::credentials::{CredentialType, TestCredentialManager};
+    use crate::local_credentials::{
+        EnvCredentials, EnvCredentialsConfig, FileCredentialsConfig, FileCredentialsWatcher,
+    };
+
+    #[tokio::test]
+    async fn empty_chain_returns_none() {
+        let chain: ChainedCredentialReader = vec![].into();
+        let key = CredentialKey::DpuUefi {
+            credential_type: CredentialType::SiteDefault,
+        };
+        let value = chain.get_credentials(&key).await.expect("empty chain");
+        assert_eq!(value, None);
+    }
+
+    #[tokio::test]
+    async fn chained_reader_falls_through_to_last_provider() {
+        let vault = Arc::new(TestCredentialManager::new(Credentials::UsernamePassword {
+            username: "vault-user".to_string(),
+            password: "vault-pass".to_string(),
+        }));
+
+        let chain: ChainedCredentialReader = vec![
+            Box::new(
+                EnvCredentials::new(EnvCredentialsConfig {
+                    prefix: Some("CARBIDE_TEST_FALLTHRU_".to_string()),
+                    ..Default::default()
+                })
+                .expect("create env provider"),
+            ) as Box<dyn CredentialReader>,
+            Box::new(vault),
+        ]
+        .into();
+
+        let key = CredentialKey::DpuUefi {
+            credential_type: CredentialType::SiteDefault,
+        };
+        let value = chain.get_credentials(&key).await.expect("get credentials");
+
+        assert_eq!(
+            value,
+            Some(Credentials::UsernamePassword {
+                username: "vault-user".to_string(),
+                password: "vault-pass".to_string(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn env_takes_precedence_over_file_and_vault() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let file_path = dir.path().join("static-creds.yaml");
+        tokio::fs::write(
+            &file_path,
+            r#"dpu_uefi_site_default:
+  username: file-user
+  password: file-password
+"#,
+        )
+        .await
+        .expect("write static credential file");
+
+        let vault = Arc::new(TestCredentialManager::new(Credentials::UsernamePassword {
+            username: "vault-user".to_string(),
+            password: "vault-password".to_string(),
+        }));
+        let key = CredentialKey::DpuUefi {
+            credential_type: CredentialType::SiteDefault,
+        };
+
+        let env_user = "CARBIDE_TEST_PREC__DPU_UEFI_SITE_DEFAULT__USERNAME";
+        let env_password = "CARBIDE_TEST_PREC__DPU_UEFI_SITE_DEFAULT__PASSWORD";
+        unsafe {
+            std::env::set_var(env_user, "env-user");
+            std::env::set_var(env_password, "env-password");
+        }
+
+        let chain: ChainedCredentialReader = vec![
+            Box::new(
+                EnvCredentials::new(EnvCredentialsConfig {
+                    prefix: Some("CARBIDE_TEST_PREC_".to_string()),
+                    ..Default::default()
+                })
+                .expect("create env provider"),
+            ) as Box<dyn CredentialReader>,
+            Box::new(
+                FileCredentialsWatcher::new(FileCredentialsConfig {
+                    path: Some(file_path.clone()),
+                    poll_interval: Some(Duration::from_millis(250)),
+                    ..Default::default()
+                })
+                .await
+                .expect("create file provider"),
+            ),
+            Box::new(vault.clone()),
+        ]
+        .into();
+
+        let env_value = chain.get_credentials(&key).await.expect("get env value");
+        assert_eq!(
+            env_value,
+            Some(Credentials::UsernamePassword {
+                username: "env-user".to_string(),
+                password: "env-password".to_string(),
+            })
+        );
+
+        unsafe {
+            std::env::remove_var(env_user);
+            std::env::remove_var(env_password);
+        }
+    }
+
+    #[tokio::test]
+    async fn file_takes_precedence_over_vault() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let file_path = dir.path().join("static-creds.yaml");
+        tokio::fs::write(
+            &file_path,
+            r#"dpu_uefi_site_default:
+  username: file-user
+  password: file-password
+"#,
+        )
+        .await
+        .expect("write static credential file");
+
+        let vault = Arc::new(TestCredentialManager::new(Credentials::UsernamePassword {
+            username: "vault-user".to_string(),
+            password: "vault-password".to_string(),
+        }));
+        let key = CredentialKey::DpuUefi {
+            credential_type: CredentialType::SiteDefault,
+        };
+
+        let chain: ChainedCredentialReader = vec![
+            Box::new(
+                FileCredentialsWatcher::new(FileCredentialsConfig {
+                    path: Some(file_path),
+                    poll_interval: Some(Duration::from_millis(250)),
+                    ..Default::default()
+                })
+                .await
+                .expect("create file provider"),
+            ) as Box<dyn CredentialReader>,
+            Box::new(vault),
+        ]
+        .into();
+
+        let file_value = chain.get_credentials(&key).await.expect("get file value");
+        assert_eq!(
+            file_value,
+            Some(Credentials::UsernamePassword {
+                username: "file-user".to_string(),
+                password: "file-password".to_string(),
+            })
+        );
+    }
+}

--- a/crates/secrets/src/credentials.rs
+++ b/crates/secrets/src/credentials.rs
@@ -17,8 +17,8 @@
 use core::fmt;
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::sync::atomic;
 use std::sync::atomic::AtomicU32;
+use std::sync::{Arc, atomic};
 
 use async_trait::async_trait;
 use carbide_uuid::machine::MachineId;
@@ -121,13 +121,26 @@ impl Credentials {
 }
 
 #[async_trait]
-/// Abstract over a credentials provider that functions as a kv map between "key" -> "cred"
-pub trait CredentialProvider: Send + Sync {
+/// Abstract over a credentials reader that functions as a kv map between "key" -> "cred"
+pub trait CredentialReader: Send + Sync {
     async fn get_credentials(
         &self,
         key: &CredentialKey,
     ) -> Result<Option<Credentials>, SecretsError>;
+}
 
+#[async_trait]
+impl<T: CredentialReader + ?Sized> CredentialReader for Arc<T> {
+    async fn get_credentials(
+        &self,
+        key: &CredentialKey,
+    ) -> Result<Option<Credentials>, SecretsError> {
+        (**self).get_credentials(key).await
+    }
+}
+
+#[async_trait]
+pub trait CredentialWriter: Send + Sync {
     async fn set_credentials(
         &self,
         key: &CredentialKey,
@@ -143,15 +156,93 @@ pub trait CredentialProvider: Send + Sync {
     async fn delete_credentials(&self, key: &CredentialKey) -> Result<(), SecretsError>;
 }
 
+#[async_trait]
+impl<T: CredentialWriter + ?Sized> CredentialWriter for Arc<T> {
+    async fn set_credentials(
+        &self,
+        key: &CredentialKey,
+        credentials: &Credentials,
+    ) -> Result<(), SecretsError> {
+        (**self).set_credentials(key, credentials).await
+    }
+
+    async fn create_credentials(
+        &self,
+        key: &CredentialKey,
+        credentials: &Credentials,
+    ) -> Result<(), SecretsError> {
+        (**self).create_credentials(key, credentials).await
+    }
+
+    async fn delete_credentials(&self, key: &CredentialKey) -> Result<(), SecretsError> {
+        (**self).delete_credentials(key).await
+    }
+}
+
+pub trait CredentialManager: CredentialReader + CredentialWriter {}
+
+pub struct CompositeCredentialManager<R, W> {
+    reader: R,
+    writer: W,
+}
+
+impl<R: CredentialReader, W: CredentialWriter> CompositeCredentialManager<R, W> {
+    pub fn new(reader: R, writer: W) -> Self {
+        Self { reader, writer }
+    }
+}
+
+#[async_trait]
+impl<R: CredentialReader, W: CredentialWriter> CredentialReader
+    for CompositeCredentialManager<R, W>
+{
+    async fn get_credentials(
+        &self,
+        key: &CredentialKey,
+    ) -> Result<Option<Credentials>, SecretsError> {
+        self.reader.get_credentials(key).await
+    }
+}
+
+#[async_trait]
+impl<R: CredentialReader, W: CredentialWriter> CredentialWriter
+    for CompositeCredentialManager<R, W>
+{
+    async fn set_credentials(
+        &self,
+        key: &CredentialKey,
+        credentials: &Credentials,
+    ) -> Result<(), SecretsError> {
+        self.writer.set_credentials(key, credentials).await
+    }
+
+    async fn create_credentials(
+        &self,
+        key: &CredentialKey,
+        credentials: &Credentials,
+    ) -> Result<(), SecretsError> {
+        self.writer.create_credentials(key, credentials).await
+    }
+
+    async fn delete_credentials(&self, key: &CredentialKey) -> Result<(), SecretsError> {
+        self.writer.delete_credentials(key).await
+    }
+}
+
+impl<R: CredentialReader, W: CredentialWriter> CredentialManager
+    for CompositeCredentialManager<R, W>
+{
+}
+
 #[derive(Default)]
-pub struct TestCredentialProvider {
+pub struct TestCredentialManager {
     credentials: Mutex<HashMap<String, Credentials>>,
     fallback_credentials: Option<Credentials>,
     pub set_credentials_sleep_time_ms: AtomicU32,
 }
 
-impl TestCredentialProvider {
-    /// Construct a TestCredentialProvider which falls back on a default set of credentials if we
+impl TestCredentialManager {
+    /// Construct a TestCredentialManager which falls back on a default set of credentials if we
     /// can't find matching ones set via set_credentials()
     pub fn new(fallback_credentials: Credentials) -> Self {
         Self {
@@ -163,7 +254,7 @@ impl TestCredentialProvider {
 }
 
 #[async_trait]
-impl CredentialProvider for TestCredentialProvider {
+impl CredentialReader for TestCredentialManager {
     async fn get_credentials(
         &self,
         key: &CredentialKey,
@@ -175,7 +266,10 @@ impl CredentialProvider for TestCredentialProvider {
 
         Ok(cred.cloned())
     }
+}
 
+#[async_trait]
+impl CredentialWriter for TestCredentialManager {
     async fn set_credentials(
         &self,
         key: &CredentialKey,
@@ -222,6 +316,8 @@ impl CredentialProvider for TestCredentialProvider {
         Ok(())
     }
 }
+
+impl CredentialManager for TestCredentialManager {}
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[allow(clippy::enum_variant_names)]
@@ -357,5 +453,78 @@ mod tests {
         assert!(password.chars().any(|c| c.is_lowercase()));
         assert!(password.chars().any(|c| c.is_ascii_digit()));
         assert!(password.chars().any(|c| c.is_ascii_punctuation()));
+    }
+
+    #[test]
+    fn test_generated_password_no_special_char() {
+        let password = Credentials::generate_password_no_special_char();
+        assert_eq!(password.len(), PASSWORD_LEN);
+        assert!(password.chars().any(|c| c.is_uppercase()));
+        assert!(password.chars().any(|c| c.is_lowercase()));
+        assert!(password.chars().any(|c| c.is_ascii_digit()));
+        assert!(password.chars().all(|c| c.is_ascii_alphanumeric()));
+    }
+
+    #[tokio::test]
+    async fn composite_manager_delegates_reads_and_writes() {
+        let reader = TestCredentialManager::new(Credentials::UsernamePassword {
+            username: "read-user".to_string(),
+            password: "read-pass".to_string(),
+        });
+        let writer = TestCredentialManager::default();
+        let composite = CompositeCredentialManager::new(reader, writer);
+
+        let key = CredentialKey::UfmAuth {
+            fabric: "test-fabric".to_string(),
+        };
+
+        let read_result = composite.get_credentials(&key).await.expect("read");
+        assert_eq!(
+            read_result,
+            Some(Credentials::UsernamePassword {
+                username: "read-user".to_string(),
+                password: "read-pass".to_string(),
+            })
+        );
+
+        let write_cred = Credentials::UsernamePassword {
+            username: "written".to_string(),
+            password: "written-pass".to_string(),
+        };
+        composite
+            .set_credentials(&key, &write_cred)
+            .await
+            .expect("write");
+
+        // Reads still return the reader's fallback, not the written value
+        let after_write = composite
+            .get_credentials(&key)
+            .await
+            .expect("read after write");
+        assert_eq!(
+            after_write,
+            Some(Credentials::UsernamePassword {
+                username: "read-user".to_string(),
+                password: "read-pass".to_string(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn create_credentials_rejects_duplicate() {
+        let mgr = TestCredentialManager::default();
+        let key = CredentialKey::UfmAuth {
+            fabric: "dup-test".to_string(),
+        };
+        let cred = Credentials::UsernamePassword {
+            username: "u".to_string(),
+            password: "p".to_string(),
+        };
+
+        mgr.create_credentials(&key, &cred)
+            .await
+            .expect("first create");
+        let result = mgr.create_credentials(&key, &cred).await;
+        assert!(result.is_err());
     }
 }

--- a/crates/secrets/src/forge_vault.rs
+++ b/crates/secrets/src/forge_vault.rs
@@ -38,7 +38,9 @@ use vaultrs::{kv2, pki};
 
 use crate::SecretsError;
 use crate::certificates::{Certificate, CertificateProvider};
-use crate::credentials::{CredentialKey, CredentialProvider, Credentials};
+use crate::credentials::{
+    CredentialKey, CredentialManager, CredentialReader, CredentialWriter, Credentials,
+};
 
 #[derive(Clone, Debug)]
 enum ForgeVaultAuthenticationType {
@@ -509,7 +511,7 @@ impl VaultTask<()> for DeleteCredentialsHelper<'_, '_> {
 }
 
 #[async_trait]
-impl CredentialProvider for ForgeVaultClient {
+impl CredentialReader for ForgeVaultClient {
     async fn get_credentials(
         &self,
         key: &CredentialKey,
@@ -524,7 +526,10 @@ impl CredentialProvider for ForgeVaultClient {
             .execute(vault_client, &self.vault_metrics)
             .await
     }
+}
 
+#[async_trait]
+impl CredentialWriter for ForgeVaultClient {
     async fn set_credentials(
         &self,
         key: &CredentialKey,
@@ -573,6 +578,8 @@ impl CredentialProvider for ForgeVaultClient {
             .await
     }
 }
+
+impl CredentialManager for ForgeVaultClient {}
 
 struct GetCertificateHelper {
     /// Used to form URI-type SANs for this certificate

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -15,12 +15,57 @@
  * limitations under the License.
  */
 use std::fmt::Display;
+use std::sync::Arc;
 
-pub use crate::forge_vault::ForgeVaultClient;
+use opentelemetry::metrics::Meter;
+
+pub use crate::chained_reader::ChainedCredentialReader;
+/// Exposed for `CertificateProvider` usage only. Credential operations should go
+/// through `create_credential_manager` instead of using the vault client directly.
+pub use crate::forge_vault::{ForgeVaultClient, VaultConfig, create_vault_client};
+pub use crate::local_credentials::{
+    CredentialSnapshot, EnvCredentialsConfig, FileCredentialsConfig, UsernamePassword,
+};
 
 pub mod certificates;
+pub(crate) mod chained_reader;
 pub mod credentials;
 pub mod forge_vault;
+pub(crate) mod local_credentials;
+
+use credentials::{CompositeCredentialManager, CredentialManager, CredentialReader};
+use local_credentials::{EnvCredentials, FileCredentialsWatcher};
+
+#[derive(Default, Debug, Clone)]
+pub struct CredentialConfig {
+    pub vault: VaultConfig,
+    pub env: EnvCredentialsConfig,
+    pub file: FileCredentialsConfig,
+}
+
+pub async fn create_credential_manager(
+    config: &CredentialConfig,
+    meter: Meter,
+) -> eyre::Result<Arc<dyn CredentialManager>> {
+    let mut readers: Vec<Box<dyn CredentialReader>> = Vec::new();
+
+    if config.env.enabled() {
+        readers.push(Box::new(EnvCredentials::new(config.env.clone())?));
+    }
+
+    if config.file.enabled() {
+        readers.push(Box::new(
+            FileCredentialsWatcher::new(config.file.clone()).await?,
+        ));
+    }
+
+    let vault_client = create_vault_client(&config.vault, meter)?;
+    readers.push(Box::new(vault_client.clone()));
+
+    let chained = ChainedCredentialReader::from(readers);
+    let composite = CompositeCredentialManager::new(chained, vault_client);
+    Ok(Arc::new(composite))
+}
 
 #[derive(Debug)]
 pub enum SecretsError {

--- a/crates/secrets/src/local_credentials/env.rs
+++ b/crates/secrets/src/local_credentials/env.rs
@@ -1,0 +1,176 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use async_trait::async_trait;
+use figment::Figment;
+use figment::providers::{Env, Serialized};
+use serde::{Deserialize, Serialize};
+
+use super::CredentialSnapshot;
+use crate::SecretsError;
+use crate::credentials::{CredentialKey, CredentialReader, Credentials};
+
+const DEFAULT_ENV_PREFIX: &str = "CARBIDE_STATIC_CREDENTIAL_";
+
+#[derive(Default, Clone, Debug, Deserialize, Serialize)]
+#[serde(default)]
+pub struct EnvCredentialsConfig {
+    pub enabled: Option<bool>,
+    pub prefix: Option<String>,
+}
+
+impl EnvCredentialsConfig {
+    pub fn enabled(&self) -> bool {
+        self.enabled
+            .or_else(|| {
+                std::env::var("CARBIDE_CREDENTIALS_ENV_ENABLED")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+            })
+            .unwrap_or(false)
+    }
+
+    pub fn prefix(&self) -> String {
+        self.prefix
+            .clone()
+            .or_else(|| std::env::var("CARBIDE_CREDENTIALS_ENV_PREFIX").ok())
+            .unwrap_or_else(|| DEFAULT_ENV_PREFIX.to_string())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct EnvCredentials {
+    snapshot: CredentialSnapshot,
+}
+
+impl EnvCredentials {
+    pub fn new(config: EnvCredentialsConfig) -> Result<Self, SecretsError> {
+        let prefix = config.prefix();
+        let env_prefix = format!("{}__", prefix.trim_end_matches('_'));
+        let snapshot: CredentialSnapshot = Figment::new()
+            .merge(Serialized::defaults(CredentialSnapshot::default()))
+            .merge(Env::prefixed(&env_prefix).split("__"))
+            .extract()
+            .map_err(|err| {
+                SecretsError::GenericError(eyre::eyre!(
+                    "invalid static credentials from env prefix {env_prefix}: {err}"
+                ))
+            })?;
+        Ok(Self { snapshot })
+    }
+}
+
+#[async_trait]
+impl CredentialReader for EnvCredentials {
+    async fn get_credentials(
+        &self,
+        key: &CredentialKey,
+    ) -> Result<Option<Credentials>, SecretsError> {
+        Ok(self.snapshot.get_credentials(key))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serial_test::serial;
+
+    use super::*;
+    use crate::credentials::{CredentialKey, CredentialType, Credentials};
+
+    fn env_name(parts: &[&str]) -> String {
+        let mut name = "CARBIDE_STATIC_CREDENTIAL".to_string();
+        for part in parts {
+            name.push_str("__");
+            name.push_str(part);
+        }
+        name
+    }
+
+    #[tokio::test]
+    // Mutates process environment variables. Keep serialized to avoid cross-test interference.
+    #[serial]
+    async fn parses_credentials_from_env_config_style() {
+        let key = CredentialKey::DpuUefi {
+            credential_type: CredentialType::SiteDefault,
+        };
+        let user_env = env_name(&["DPU_UEFI_SITE_DEFAULT", "USERNAME"]);
+        let pass_env = env_name(&["DPU_UEFI_SITE_DEFAULT", "PASSWORD"]);
+
+        unsafe {
+            std::env::set_var(&user_env, "operator");
+            std::env::set_var(&pass_env, "secret");
+        }
+        let provider =
+            EnvCredentials::new(EnvCredentialsConfig::default()).expect("create env provider");
+        let credentials = provider
+            .get_credentials(&key)
+            .await
+            .expect("parse env credentials");
+        unsafe {
+            std::env::remove_var(&user_env);
+            std::env::remove_var(&pass_env);
+        }
+
+        assert_eq!(
+            credentials,
+            Some(Credentials::UsernamePassword {
+                username: "operator".to_string(),
+                password: "secret".to_string(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    // Mutates process environment variables. Keep serialized to avoid cross-test interference.
+    #[serial]
+    async fn snapshots_env_at_startup() {
+        let key = CredentialKey::DpuUefi {
+            credential_type: CredentialType::SiteDefault,
+        };
+        let user_env = env_name(&["DPU_UEFI_SITE_DEFAULT", "USERNAME"]);
+        let pass_env = env_name(&["DPU_UEFI_SITE_DEFAULT", "PASSWORD"]);
+
+        unsafe {
+            std::env::set_var(&user_env, "operator");
+            std::env::set_var(&pass_env, "initial");
+        }
+
+        let provider =
+            EnvCredentials::new(EnvCredentialsConfig::default()).expect("create env provider");
+
+        unsafe {
+            std::env::set_var(&pass_env, "updated");
+        }
+
+        let credentials = provider
+            .get_credentials(&key)
+            .await
+            .expect("read startup snapshot");
+
+        unsafe {
+            std::env::remove_var(&user_env);
+            std::env::remove_var(&pass_env);
+        }
+
+        assert_eq!(
+            credentials,
+            Some(Credentials::UsernamePassword {
+                username: "operator".to_string(),
+                password: "initial".to_string(),
+            })
+        );
+    }
+}

--- a/crates/secrets/src/local_credentials/file.rs
+++ b/crates/secrets/src/local_credentials/file.rs
@@ -1,0 +1,306 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use arc_swap::ArcSwap;
+use async_trait::async_trait;
+use notify::{PollWatcher, RecommendedWatcher, RecursiveMode, Watcher};
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+
+use super::CredentialSnapshot;
+use crate::SecretsError;
+use crate::credentials::{CredentialKey, CredentialReader, Credentials};
+
+const DEFAULT_FILE_POLL_INTERVAL: Duration = Duration::from_secs(60);
+const DEFAULT_CREDENTIALS_FILE_PATH: &str = "secrets.yaml";
+
+#[derive(Default, Clone, Debug, Deserialize, Serialize)]
+pub struct FileCredentialsConfig {
+    pub enabled: Option<bool>,
+    pub path: Option<PathBuf>,
+    pub poll_interval: Option<Duration>,
+}
+
+impl FileCredentialsConfig {
+    pub fn enabled(&self) -> bool {
+        self.enabled
+            .or_else(|| {
+                std::env::var("CARBIDE_CREDENTIALS_FILE_ENABLED")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+            })
+            .unwrap_or(false)
+    }
+
+    pub fn path(&self) -> PathBuf {
+        self.path
+            .clone()
+            .or_else(|| {
+                std::env::var("CARBIDE_CREDENTIALS_FILE_PATH")
+                    .ok()
+                    .map(PathBuf::from)
+            })
+            .unwrap_or_else(|| PathBuf::from(DEFAULT_CREDENTIALS_FILE_PATH))
+    }
+
+    pub fn poll_interval(&self) -> Duration {
+        self.poll_interval.unwrap_or(DEFAULT_FILE_POLL_INTERVAL)
+    }
+}
+
+pub struct FileCredentialsWatcher {
+    credentials: Arc<ArcSwap<CredentialSnapshot>>,
+    _primary_watcher: RecommendedWatcher,
+    _secondary_watcher: PollWatcher,
+}
+
+impl FileCredentialsWatcher {
+    pub async fn new(config: FileCredentialsConfig) -> Result<Self, SecretsError> {
+        let path = config.path();
+        let poll_interval = config.poll_interval();
+        let credentials = Arc::new(ArcSwap::from_pointee(Self::load_file(&path).await?));
+        let (tx, mut rx) = mpsc::channel(4);
+
+        let tx_clone = tx.clone();
+        let mut primary = RecommendedWatcher::new(
+            move |res: notify::Result<notify::Event>| match res {
+                Ok(ref event) if event.kind.is_create() || event.kind.is_modify() => {
+                    if let Err(err) = tx_clone.blocking_send(res) {
+                        tracing::warn!("failed to send static credential watch event: {err}");
+                    }
+                }
+                Ok(_) => {}
+                Err(err) => {
+                    tracing::warn!("primary static credential watcher error: {err}");
+                }
+            },
+            notify::Config::default(),
+        )
+        .map_err(|err| SecretsError::GenericError(err.into()))?;
+
+        primary
+            .watch(&path, RecursiveMode::NonRecursive)
+            .map_err(|err| SecretsError::GenericError(err.into()))?;
+
+        let mut secondary = PollWatcher::new(
+            move |res| {
+                if let Err(err) = tx.blocking_send(res) {
+                    tracing::warn!("failed to send static credential poll event: {err}");
+                }
+            },
+            notify::Config::default()
+                .with_poll_interval(poll_interval)
+                .with_compare_contents(true),
+        )
+        .map_err(|err| SecretsError::GenericError(err.into()))?;
+
+        secondary
+            .watch(&path, RecursiveMode::NonRecursive)
+            .map_err(|err| SecretsError::GenericError(err.into()))?;
+
+        let watched_path = path.clone();
+        let credentials_clone = credentials.clone();
+        tokio::spawn(async move {
+            while let Some(event_result) = rx.recv().await {
+                match event_result {
+                    Ok(event) => {
+                        if !event
+                            .paths
+                            .iter()
+                            .any(|event_path| event_path.file_name() == watched_path.file_name())
+                        {
+                            continue;
+                        }
+
+                        match Self::load_file(&watched_path).await {
+                            Ok(updated) => {
+                                credentials_clone.store(Arc::new(updated));
+                            }
+                            Err(err) => {
+                                tracing::warn!("failed to reload credentials file: {err}");
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        tracing::warn!("credentials file watcher event error: {err}");
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            credentials,
+            _primary_watcher: primary,
+            _secondary_watcher: secondary,
+        })
+    }
+
+    async fn load_file(path: &Path) -> Result<CredentialSnapshot, SecretsError> {
+        let content = tokio::fs::read(path)
+            .await
+            .map_err(|err| SecretsError::GenericError(err.into()))?;
+
+        if let Ok(parsed) = serde_json::from_slice::<CredentialSnapshot>(&content) {
+            return Ok(parsed);
+        }
+
+        let parsed = serde_yaml::from_slice::<CredentialSnapshot>(&content).map_err(|err| {
+            SecretsError::GenericError(eyre::eyre!(
+                "failed to parse static credential file as JSON or YAML: {err}"
+            ))
+        })?;
+        Ok(parsed)
+    }
+}
+
+#[async_trait]
+impl CredentialReader for FileCredentialsWatcher {
+    async fn get_credentials(
+        &self,
+        key: &CredentialKey,
+    ) -> Result<Option<Credentials>, SecretsError> {
+        self.credentials.load().get_credentials(key).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::credentials::{CredentialKey, CredentialType, Credentials};
+
+    #[tokio::test]
+    async fn loads_json_file_and_reloads_on_change() {
+        let dir = tempdir().expect("create temp dir");
+        let file_path = dir.path().join("credentials.json");
+        tokio::fs::write(
+            &file_path,
+            r#"{
+  "dpu_uefi_site_default": {
+    "username": "root",
+    "password": "json1"
+  }
+}"#,
+        )
+        .await
+        .expect("write initial json file");
+
+        let provider = FileCredentialsWatcher::new(FileCredentialsConfig {
+            path: Some(file_path.clone()),
+            poll_interval: Some(Duration::from_secs(1)),
+            ..Default::default()
+        })
+        .await
+        .expect("create file provider");
+
+        let key = CredentialKey::DpuUefi {
+            credential_type: CredentialType::SiteDefault,
+        };
+
+        let first = provider
+            .get_credentials(&key)
+            .await
+            .expect("load first value");
+        assert_eq!(
+            first,
+            Some(Credentials::UsernamePassword {
+                username: "root".to_string(),
+                password: "json1".to_string(),
+            })
+        );
+
+        tokio::fs::write(
+            &file_path,
+            r#"{
+  "dpu_uefi_site_default": {
+    "username": "root",
+    "password": "json2"
+  }
+}"#,
+        )
+        .await
+        .expect("update json file");
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+
+        let second = provider
+            .get_credentials(&key)
+            .await
+            .expect("load reloaded value");
+        assert_eq!(
+            second,
+            Some(Credentials::UsernamePassword {
+                username: "root".to_string(),
+                password: "json2".to_string(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_file_returns_error() {
+        let dir = tempdir().expect("create temp dir");
+        let file_path = dir.path().join("does-not-exist.yaml");
+        let result = FileCredentialsWatcher::new(FileCredentialsConfig {
+            path: Some(file_path),
+            ..Default::default()
+        })
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn loads_yaml_file() {
+        let dir = tempdir().expect("create temp dir");
+        let file_path = dir.path().join("credentials.yaml");
+        tokio::fs::write(
+            &file_path,
+            r#"dpu_uefi_site_default:
+  username: root
+  password: yaml1
+"#,
+        )
+        .await
+        .expect("write yaml file");
+
+        let provider = FileCredentialsWatcher::new(FileCredentialsConfig {
+            path: Some(file_path.clone()),
+            poll_interval: Some(Duration::from_secs(1)),
+            ..Default::default()
+        })
+        .await
+        .expect("create yaml file provider");
+
+        let key = CredentialKey::DpuUefi {
+            credential_type: CredentialType::SiteDefault,
+        };
+
+        let value = provider
+            .get_credentials(&key)
+            .await
+            .expect("load yaml value");
+        assert_eq!(
+            value,
+            Some(Credentials::UsernamePassword {
+                username: "root".to_string(),
+                password: "yaml1".to_string(),
+            })
+        );
+    }
+}

--- a/crates/secrets/src/local_credentials/mod.rs
+++ b/crates/secrets/src/local_credentials/mod.rs
@@ -1,0 +1,311 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::SecretsError;
+use crate::credentials::{CredentialKey, CredentialReader, CredentialType, Credentials};
+
+mod env;
+mod file;
+
+pub use env::{EnvCredentials, EnvCredentialsConfig};
+pub use file::{FileCredentialsConfig, FileCredentialsWatcher};
+
+/// Flat username/password struct for serde compatibility with env vars and
+/// config files, where the externally-tagged `Credentials` enum layout
+/// (`{"UsernamePassword": {...}}`) is not ergonomic.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct UsernamePassword {
+    pub username: String,
+    pub password: String,
+}
+
+impl From<UsernamePassword> for Credentials {
+    fn from(up: UsernamePassword) -> Self {
+        Credentials::UsernamePassword {
+            username: up.username,
+            password: up.password,
+        }
+    }
+}
+
+impl From<Credentials> for UsernamePassword {
+    fn from(creds: Credentials) -> Self {
+        match creds {
+            Credentials::UsernamePassword { username, password } => {
+                UsernamePassword { username, password }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct CredentialSnapshot {
+    pub dpu_redfish_factory_default: Option<UsernamePassword>,
+    pub dpu_redfish_site_default: Option<UsernamePassword>,
+    pub host_redfish_factory_default_by_vendor: HashMap<bmc_vendor::BMCVendor, UsernamePassword>,
+    pub host_redfish_site_default: Option<UsernamePassword>,
+    pub ufm_auth_by_fabric: HashMap<String, UsernamePassword>,
+    pub dpu_uefi_factory_default: Option<UsernamePassword>,
+    pub dpu_uefi_site_default: Option<UsernamePassword>,
+    pub host_uefi_site_default: Option<UsernamePassword>,
+    pub nmxm_auth_by_id: HashMap<String, UsernamePassword>,
+}
+
+impl CredentialSnapshot {
+    pub fn get_credentials(&self, key: &CredentialKey) -> Option<Credentials> {
+        match key {
+            CredentialKey::DpuRedfish { credential_type } => match credential_type {
+                CredentialType::DpuHardwareDefault => {
+                    self.dpu_redfish_factory_default.clone().map(Into::into)
+                }
+                CredentialType::SiteDefault => {
+                    self.dpu_redfish_site_default.clone().map(Into::into)
+                }
+                CredentialType::HostHardwareDefault { .. } => None,
+            },
+            CredentialKey::HostRedfish { credential_type } => match credential_type {
+                CredentialType::HostHardwareDefault { vendor } => self
+                    .host_redfish_factory_default_by_vendor
+                    .get(vendor)
+                    .cloned()
+                    .map(Into::into),
+                CredentialType::SiteDefault => {
+                    self.host_redfish_site_default.clone().map(Into::into)
+                }
+                CredentialType::DpuHardwareDefault => None,
+            },
+            CredentialKey::UfmAuth { fabric } => {
+                self.ufm_auth_by_fabric.get(fabric).cloned().map(Into::into)
+            }
+            CredentialKey::DpuUefi { credential_type } => match credential_type {
+                CredentialType::DpuHardwareDefault => {
+                    self.dpu_uefi_factory_default.clone().map(Into::into)
+                }
+                CredentialType::SiteDefault => self.dpu_uefi_site_default.clone().map(Into::into),
+                CredentialType::HostHardwareDefault { .. } => None,
+            },
+            CredentialKey::HostUefi {
+                credential_type: CredentialType::SiteDefault,
+            } => self.host_uefi_site_default.clone().map(Into::into),
+            CredentialKey::NmxM { nmxm_id } => {
+                self.nmxm_auth_by_id.get(nmxm_id).cloned().map(Into::into)
+            }
+            _ => None,
+        }
+    }
+}
+
+#[async_trait]
+impl CredentialReader for CredentialSnapshot {
+    async fn get_credentials(
+        &self,
+        key: &CredentialKey,
+    ) -> Result<Option<Credentials>, SecretsError> {
+        Ok(CredentialSnapshot::get_credentials(self, key))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::credentials::BmcCredentialType;
+
+    fn up(user: &str, pass: &str) -> UsernamePassword {
+        UsernamePassword {
+            username: user.to_string(),
+            password: pass.to_string(),
+        }
+    }
+
+    fn cred(user: &str, pass: &str) -> Credentials {
+        Credentials::UsernamePassword {
+            username: user.to_string(),
+            password: pass.to_string(),
+        }
+    }
+
+    fn populated_snapshot() -> CredentialSnapshot {
+        let mut host_vendors = HashMap::new();
+        host_vendors.insert(bmc_vendor::BMCVendor::Dell, up("dell-u", "dell-p"));
+
+        let mut ufm = HashMap::new();
+        ufm.insert("fabric-1".to_string(), up("ufm-u", "ufm-p"));
+
+        let mut nmxm = HashMap::new();
+        nmxm.insert("nmxm-1".to_string(), up("nmxm-u", "nmxm-p"));
+
+        CredentialSnapshot {
+            dpu_redfish_factory_default: Some(up("drf-u", "drf-p")),
+            dpu_redfish_site_default: Some(up("drs-u", "drs-p")),
+            host_redfish_factory_default_by_vendor: host_vendors,
+            host_redfish_site_default: Some(up("hrs-u", "hrs-p")),
+            ufm_auth_by_fabric: ufm,
+            dpu_uefi_factory_default: Some(up("duf-u", "duf-p")),
+            dpu_uefi_site_default: Some(up("dus-u", "dus-p")),
+            host_uefi_site_default: Some(up("hus-u", "hus-p")),
+            nmxm_auth_by_id: nmxm,
+        }
+    }
+
+    #[test]
+    fn snapshot_dpu_redfish_factory_default() {
+        let snap = populated_snapshot();
+        let key = CredentialKey::DpuRedfish {
+            credential_type: CredentialType::DpuHardwareDefault,
+        };
+        assert_eq!(snap.get_credentials(&key), Some(cred("drf-u", "drf-p")));
+    }
+
+    #[test]
+    fn snapshot_dpu_redfish_site_default() {
+        let snap = populated_snapshot();
+        let key = CredentialKey::DpuRedfish {
+            credential_type: CredentialType::SiteDefault,
+        };
+        assert_eq!(snap.get_credentials(&key), Some(cred("drs-u", "drs-p")));
+    }
+
+    #[test]
+    fn snapshot_host_redfish_vendor() {
+        let snap = populated_snapshot();
+        let key = CredentialKey::HostRedfish {
+            credential_type: CredentialType::HostHardwareDefault {
+                vendor: bmc_vendor::BMCVendor::Dell,
+            },
+        };
+        assert_eq!(snap.get_credentials(&key), Some(cred("dell-u", "dell-p")));
+    }
+
+    #[test]
+    fn snapshot_host_redfish_unknown_vendor_returns_none() {
+        let snap = populated_snapshot();
+        let key = CredentialKey::HostRedfish {
+            credential_type: CredentialType::HostHardwareDefault {
+                vendor: bmc_vendor::BMCVendor::Lenovo,
+            },
+        };
+        assert_eq!(snap.get_credentials(&key), None);
+    }
+
+    #[test]
+    fn snapshot_host_redfish_site_default() {
+        let snap = populated_snapshot();
+        let key = CredentialKey::HostRedfish {
+            credential_type: CredentialType::SiteDefault,
+        };
+        assert_eq!(snap.get_credentials(&key), Some(cred("hrs-u", "hrs-p")));
+    }
+
+    #[test]
+    fn snapshot_ufm_auth() {
+        let snap = populated_snapshot();
+        let key = CredentialKey::UfmAuth {
+            fabric: "fabric-1".to_string(),
+        };
+        assert_eq!(snap.get_credentials(&key), Some(cred("ufm-u", "ufm-p")));
+    }
+
+    #[test]
+    fn snapshot_ufm_auth_unknown_fabric_returns_none() {
+        let snap = populated_snapshot();
+        let key = CredentialKey::UfmAuth {
+            fabric: "no-such-fabric".to_string(),
+        };
+        assert_eq!(snap.get_credentials(&key), None);
+    }
+
+    #[test]
+    fn snapshot_dpu_uefi_factory_and_site() {
+        let snap = populated_snapshot();
+        let factory = CredentialKey::DpuUefi {
+            credential_type: CredentialType::DpuHardwareDefault,
+        };
+        let site = CredentialKey::DpuUefi {
+            credential_type: CredentialType::SiteDefault,
+        };
+        assert_eq!(snap.get_credentials(&factory), Some(cred("duf-u", "duf-p")));
+        assert_eq!(snap.get_credentials(&site), Some(cred("dus-u", "dus-p")));
+    }
+
+    #[test]
+    fn snapshot_host_uefi_site_default() {
+        let snap = populated_snapshot();
+        let key = CredentialKey::HostUefi {
+            credential_type: CredentialType::SiteDefault,
+        };
+        assert_eq!(snap.get_credentials(&key), Some(cred("hus-u", "hus-p")));
+    }
+
+    #[test]
+    fn snapshot_nmxm() {
+        let snap = populated_snapshot();
+        let key = CredentialKey::NmxM {
+            nmxm_id: "nmxm-1".to_string(),
+        };
+        assert_eq!(snap.get_credentials(&key), Some(cred("nmxm-u", "nmxm-p")));
+    }
+
+    #[test]
+    fn snapshot_unsupported_keys_return_none() {
+        let snap = populated_snapshot();
+        let keys: Vec<CredentialKey> = vec![
+            CredentialKey::BmcCredentials {
+                credential_type: BmcCredentialType::SiteWideRoot,
+            },
+            CredentialKey::ExtensionService {
+                service_id: "svc".to_string(),
+                version: "1".to_string(),
+            },
+            CredentialKey::RackFirmware {
+                firmware_id: "fw".to_string(),
+            },
+        ];
+        for key in &keys {
+            assert_eq!(snap.get_credentials(key), None, "expected None for {key:?}");
+        }
+    }
+
+    #[test]
+    fn snapshot_invalid_type_combos_return_none() {
+        let snap = populated_snapshot();
+        let dpu_redfish_host_hw = CredentialKey::DpuRedfish {
+            credential_type: CredentialType::HostHardwareDefault {
+                vendor: bmc_vendor::BMCVendor::Dell,
+            },
+        };
+        assert_eq!(snap.get_credentials(&dpu_redfish_host_hw), None);
+
+        let host_redfish_dpu_hw = CredentialKey::HostRedfish {
+            credential_type: CredentialType::DpuHardwareDefault,
+        };
+        assert_eq!(snap.get_credentials(&host_redfish_dpu_hw), None);
+    }
+
+    #[test]
+    fn default_snapshot_returns_none_for_all() {
+        let snap = CredentialSnapshot::default();
+        let key = CredentialKey::DpuUefi {
+            credential_type: CredentialType::SiteDefault,
+        };
+        assert_eq!(snap.get_credentials(&key), None);
+    }
+}


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
add in support for env and file backed secret reading. intended to be used with k8s/vault agent file secrets.

splits the vault provider into a reader and writer trait, using each trait where needed. on the read path, a chained reader is used allowing site wide secrets to be provided statically. if not provided still fall back to vault.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

bringing some attention to the env config loading. I kept the same pattern as was there before with vault configs to load from env on access. it seems like we should be loading from the regular config flow though.

Closes https://github.com/NVIDIA/bare-metal-manager-core/issues/357 FORGE-7854