### PR TITLE
fix(api): bump librms client to 0.0.5 w/ support for host mac and ip addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5528,8 +5528,8 @@ dependencies = [
 
 [[package]]
 name = "librms"
-version = "0.0.4"
-source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.0.4#67853d59a60bd05ad4f51a69aeb6590e16772fbe"
+version = "0.0.5"
+source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.0.5#d516c7838fa4185ee6e7de426f3c759081624b0a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10033,7 +10033,7 @@ dependencies = [
 [[package]]
 name = "tonic-client-wrapper"
 version = "1.0.0"
-source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.0.4#67853d59a60bd05ad4f51a69aeb6590e16772fbe"
+source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.0.5#d516c7838fa4185ee6e7de426f3c759081624b0a"
 dependencies = [
  "async-trait",
  "heck 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
 libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.43.2" }
-librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.4" }
+librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.5" }
 ansi-to-html = "0.2.2"
 
 tokio = { version = "1", features = ["full", "tracing"] }

--- a/crates/api/src/site_explorer/mod.rs
+++ b/crates/api/src/site_explorer/mod.rs
@@ -40,7 +40,7 @@ use futures_util::{StreamExt, TryFutureExt};
 use itertools::Itertools;
 use libredfish::model::oem::nvidia_dpu::NicMode;
 use librms::RmsApi;
-use librms::protos::rack_manager::NodeType as RmsNodeType;
+use librms::protos::rack_manager::{NewNodeInfo, NodeType as RmsNodeType};
 use mac_address::MacAddress;
 use model::expected_power_shelf::ExpectedPowerShelf;
 use model::expected_switch::ExpectedSwitch;
@@ -772,17 +772,20 @@ impl SiteExplorer {
         // Register the power shelf with Rack Manager if RMS client is available
         if let Some(rms_client) = &self.rms_client {
             if let Some(rack_id) = expected_shelf.rack_id {
-                if let Err(e) = rms::add_node_to_rms(
-                    rms_client.as_ref(),
-                    rack_id,
-                    power_shelf_id.to_string(),
-                    explored_endpoint.address.to_string(),
-                    443,
-                    expected_shelf.bmc_mac_address,
-                    RmsNodeType::Powershelf,
-                )
-                .await
-                {
+                let new_node_info = NewNodeInfo {
+                    rack_id: rack_id.to_string(),
+                    node_id: power_shelf_id.to_string(),
+                    mac_address: expected_shelf.bmc_mac_address.to_string(),
+                    ip_address: explored_endpoint.address.to_string(),
+                    port: 443,
+                    username: None,
+                    password: None,
+                    r#type: Some(RmsNodeType::Powershelf.into()),
+                    vault_path: String::new(),
+                    host_ip_addresses: vec![],
+                    host_mac_addresses: vec![],
+                };
+                if let Err(e) = rms::add_node_to_rms(rms_client.as_ref(), new_node_info).await {
                     tracing::warn!(
                         "Failed to add power shelf {} to Rack Manager: {}",
                         power_shelf_id,
@@ -816,6 +819,35 @@ impl SiteExplorer {
             .begin()
             .await
             .map_err(|e| DatabaseError::new("begin load create_switch", e))?;
+
+        let metadata = expected_switch.metadata.clone();
+
+        let Some(mac_address) = metadata.labels.get("host_mac_address") else {
+            return Err(CarbideError::InvalidArgument(format!(
+                "no host NVOS MAC address found for switch {}",
+                explored_endpoint.address
+            )));
+        };
+
+        let host_mac_address = MacAddress::try_from(mac_address.as_str())
+            .map_err(|e| CarbideError::InvalidArgument(format!("Invalid MAC address: {}", e)))?;
+
+        let interface =
+            db::machine_interface::find_by_mac_address(&mut txn, host_mac_address).await?;
+
+        let (host_nvos_mac_addresses, host_nvos_ip_addresses) =
+            if let Some(interface) = interface.first() {
+                (
+                    vec![mac_address.clone()],
+                    interface
+                        .addresses
+                        .iter()
+                        .map(|ip| ip.to_string())
+                        .collect::<Vec<String>>(),
+                )
+            } else {
+                (vec![], vec![])
+            };
 
         // Generate switch_id similar to machine_id using deterministic hashing
         // Extract switch metadata similar to how machine_id extracts hardware info
@@ -895,17 +927,21 @@ impl SiteExplorer {
         // Register the switch with Rack Manager if RMS client is available
         if let Some(rms_client) = &self.rms_client {
             if let Some(rack_id) = expected_switch.rack_id {
-                if let Err(e) = rms::add_node_to_rms(
-                    rms_client.as_ref(),
-                    rack_id,
-                    switch_id.to_string(),
-                    explored_endpoint.address.to_string(),
-                    443,
-                    expected_switch.bmc_mac_address,
-                    RmsNodeType::Switch,
-                )
-                .await
-                {
+                let bmc_mac_address = expected_switch.bmc_mac_address;
+                let new_node_info = NewNodeInfo {
+                    rack_id: rack_id.to_string(),
+                    node_id: switch_id.to_string(),
+                    mac_address: bmc_mac_address.to_string(),
+                    ip_address: explored_endpoint.address.to_string(),
+                    port: 443,
+                    username: None,
+                    password: None,
+                    r#type: Some(RmsNodeType::Switch.into()),
+                    vault_path: format!("switch_nvos/{bmc_mac_address}/admin"),
+                    host_ip_addresses: host_nvos_ip_addresses,
+                    host_mac_addresses: host_nvos_mac_addresses,
+                };
+                if let Err(e) = rms::add_node_to_rms(rms_client.as_ref(), new_node_info).await {
                     tracing::warn!("Failed to add switch {} to Rack Manager: {}", switch_id, e);
                 } else {
                     tracing::info!(

--- a/crates/api/src/site_explorer/rms.rs
+++ b/crates/api/src/site_explorer/rms.rs
@@ -15,35 +15,15 @@
  * limitations under the License.
  */
 
-use carbide_uuid::rack::RackId;
 use librms::RmsApi;
-use librms::protos::rack_manager::{NewNodeInfo, NodeType as RmsNodeType};
-use mac_address::MacAddress;
+use librms::protos::rack_manager::NewNodeInfo;
 
 use crate::CarbideError;
 
-// Helper function to add a node to the Rack Manager
 pub async fn add_node_to_rms(
     rms_client: &dyn RmsApi,
-    rack_id: RackId,
-    node_id: String,
-    ip_address: String,
-    port: i32,
-    mac_address: MacAddress,
-    node_type: RmsNodeType,
+    new_node_info: NewNodeInfo,
 ) -> Result<(), CarbideError> {
-    let new_node_info = NewNodeInfo {
-        rack_id: rack_id.to_string(),
-        node_id,
-        mac_address: mac_address.to_string(),
-        ip_address,
-        port,
-        username: None,
-        password: None,
-        r#type: Some(node_type.into()),
-        vault_path: "".to_string(),
-    };
-
     let request = librms::protos::rack_manager::AddNodeRequest {
         metadata: None,
         node_info: vec![new_node_info],

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -45,7 +45,7 @@ use libredfish::model::task::TaskState;
 use libredfish::model::update_service::TransferProtocolType;
 use libredfish::{Boot, EnabledDisabled, PowerState, Redfish, RedfishError, SystemPowerControl};
 use librms::RackManagerError;
-use librms::protos::rack_manager::NodeType as RmsNodeType;
+use librms::protos::rack_manager::{NewNodeInfo, NodeType as RmsNodeType};
 use machine_validation::{handle_machine_validation_requested, handle_machine_validation_state};
 use measured_boot::records::MeasurementMachineState;
 use model::DpuModel;
@@ -852,17 +852,20 @@ impl MachineStateHandler {
                 // of an "already exists" error. However, the proto spec doesn't
                 // seem to define this, so once that's sorted, make sure to
                 // integrate that here.
-                match rms::add_node_to_rms(
-                    rms_client.as_ref(),
-                    rack_id,
-                    host_machine_id.to_string(),
-                    bmc_ip,
-                    443,
-                    bmc_mac.unwrap_or_default(),
-                    RmsNodeType::Compute,
-                )
-                .await
-                {
+                let new_node_info = NewNodeInfo {
+                    rack_id: rack_id.to_string(),
+                    node_id: host_machine_id.to_string(),
+                    mac_address: bmc_mac.unwrap_or_default().to_string(),
+                    ip_address: bmc_ip,
+                    port: 443,
+                    username: None,
+                    password: None,
+                    r#type: Some(RmsNodeType::Compute.into()),
+                    vault_path: String::new(),
+                    host_ip_addresses: vec![],
+                    host_mac_addresses: vec![],
+                };
+                match rms::add_node_to_rms(rms_client.as_ref(), new_node_info).await {
                     Ok(()) => {
                         tracing::info!(
                             machine_id = %host_machine_id,


### PR DESCRIPTION
## Description

This pulls in a couple of downstream changes to support the 0.0.5 client, including setting the Vault path for switches (which is actually going to only be a temporary thing, but we still need it for the interim), and passing through the IP and MAC address to node registration (which is also going to actually be something we eventually move away from, but still need it for the interim).

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

