### PR TITLE
fix: use `aws_lc_rs` rustls CryptoProvider in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ hyper-rustls = { version = "^0.27" }
 hyper-timeout = { version = "^0.5" }
 hyper-util = { version = "^0.1" }
 
-rustls = { version = "0.23.16" }
+rustls = { version = "0.23.16", features = ["aws_lc_rs"]}
 rustls-pki-types = "1.10.0"
 sqlx = { version = "0.8.3" }
 sqlx-core = { version = "0.8.3" }

--- a/crates/agent/src/tests/common/mod.rs
+++ b/crates/agent/src/tests/common/mod.rs
@@ -158,12 +158,13 @@ fn make_rustls_server_config() -> eyre::Result<ServerConfig> {
         .next()
         .ok_or(eyre::eyre!("No keys in key file"))??;
 
-    let mut server_config =
-        ServerConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
-            .with_safe_default_protocol_versions()
-            .unwrap()
-            .with_no_client_auth()
-            .with_single_cert(certs, key)?;
+    let mut server_config = ServerConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .unwrap()
+    .with_no_client_auth()
+    .with_single_cert(certs, key)?;
     // This is what axum is normally doing for you
     server_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
     Ok(server_config)

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -123,7 +123,7 @@ reqwest = { default-features = false, features = [
 ], workspace = true }
 rsa = { workspace = true }
 rumqttc = { workspace = true }
-rustls = { workspace = true, features = ["default", "ring"] }
+rustls = { workspace = true }
 rustls-pemfile = { workspace = true }
 rustls-pki-types = { workspace = true }
 serde = { features = ["derive"], workspace = true }

--- a/crates/api/src/ib/ufmclient/rest.rs
+++ b/crates/api/src/ib/ufmclient/rest.rs
@@ -427,7 +427,7 @@ struct ExecuteRequestResult {
 
 // Wrap ClientConfig::builder_with_provider() with defaults
 fn rustls_client_builder() -> ConfigBuilder<ClientConfig, WantsVerifier> {
-    ClientConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+    ClientConfig::builder_with_provider(Arc::new(rustls::crypto::aws_lc_rs::default_provider()))
         .with_safe_default_protocol_versions()
         // unwrap safety: the error only comes if the configured protocol versions are
         // invalid, which should never happen with the safe defaults.

--- a/crates/api/src/listener.rs
+++ b/crates/api/src/listener.rs
@@ -93,7 +93,7 @@ fn get_tls_acceptor(tls_config: &ApiTlsConfig) -> Option<TlsAcceptor> {
             None
         })?;
 
-    let crypto_provider = Arc::new(rustls::crypto::ring::default_provider());
+    let crypto_provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
 
     let roots = {
         let mut roots = RootCertStore::empty();

--- a/crates/bmc-mock/Cargo.toml
+++ b/crates/bmc-mock/Cargo.toml
@@ -50,7 +50,7 @@ form_urlencoded = { workspace = true }
 itertools = { workspace = true }
 futures = { workspace = true }
 rand = { workspace = true }
-rustls = { workspace = true, features = ["default", "ring"] }
+rustls = { workspace = true }
 rustls-pemfile = { workspace = true }
 http-body-util = { workspace = true }
 

--- a/crates/bmc-mock/src/tls.rs
+++ b/crates/bmc-mock/src/tls.rs
@@ -121,13 +121,14 @@ pub fn server_config(cert_path: Option<impl AsRef<OsStr>>) -> Result<ServerConfi
         .next()
         .ok_or(Error::NoKeysFound)??;
 
-    let mut server_config =
-        ServerConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
-            .with_safe_default_protocol_versions()
-            .unwrap()
-            .with_no_client_auth()
-            .with_single_cert(certs, key)
-            .map_err(Error::ConfigBuild)?;
+    let mut server_config = ServerConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .unwrap()
+    .with_no_client_auth()
+    .with_single_cert(certs, key)
+    .map_err(Error::ConfigBuild)?;
     // This is what axum is normally doing for you
     server_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
     Ok(server_config)

--- a/crates/dpf-beta/src/bin/api_harness.rs
+++ b/crates/dpf-beta/src/bin/api_harness.rs
@@ -370,7 +370,7 @@ async fn redfish_reboot_host(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    rustls::crypto::ring::default_provider()
+    rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
         .expect("Failed to install default CryptoProvider");
 

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -70,7 +70,7 @@ thiserror = { workspace = true }
 tonic-prost = { workspace = true }
 tonic-prost-build = { workspace = true }
 tryhard = { workspace = true }
-rustls = { workspace = true, features = ["default", "ring"] }
+rustls = { workspace = true }
 async-trait = { workspace = true }
 nonempty = { workspace = true }
 clap = { features = ["derive"], optional = true, workspace = true }

--- a/crates/rpc/src/forge_tls_client.rs
+++ b/crates/rpc/src/forge_tls_client.rs
@@ -566,9 +566,11 @@ impl<'a> ForgeTlsClient<'a> {
         }
 
         let base_config_builder = || {
-            ClientConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
-                .with_safe_default_protocol_versions()
-                .unwrap()
+            ClientConfig::builder_with_provider(Arc::new(
+                rustls::crypto::aws_lc_rs::default_provider(),
+            ))
+            .with_safe_default_protocol_versions()
+            .unwrap()
         };
 
         let tls = {
@@ -870,7 +872,7 @@ mod tests {
         let connector = tower::ServiceBuilder::new()
             .layer_fn(move |s| {
                 let tls = ClientConfig::builder_with_provider(Arc::new(
-                    rustls::crypto::ring::default_provider(),
+                    rustls::crypto::aws_lc_rs::default_provider(),
                 ))
                 .with_safe_default_protocol_versions()
                 .unwrap()

--- a/crates/ssh-console-mock-api-server/Cargo.toml
+++ b/crates/ssh-console-mock-api-server/Cargo.toml
@@ -42,7 +42,7 @@ tokio = { features = ["macros"], workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 eyre = { workspace = true }
-rustls = { workspace = true, features = ["ring"] }
+rustls = { workspace = true }
 rustls-pemfile = { workspace = true }
 
 [build-dependencies]

--- a/crates/ssh-console-mock-api-server/src/lib.rs
+++ b/crates/ssh-console-mock-api-server/src/lib.rs
@@ -89,7 +89,7 @@ impl MockApiServer {
         let key = fs::read(&LOCALHOST_CERTS.server_key)?;
         let identity = Identity::from_pem(cert, key);
         let tls = ServerTlsConfig::new().identity(identity);
-        rustls::crypto::ring::default_provider()
+        rustls::crypto::aws_lc_rs::default_provider()
             .install_default()
             .inspect_err(|crypto_provider| {
                 tracing::warn!("Crypto provider already configured: {crypto_provider:?}")


### PR DESCRIPTION
## Description

The `default` feature of the `rustls` crate uses the `aws_lc_rs` crate, `aws_lc_rs` is a ring-compatible crypto library
https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html 

Some crates were calling `crypto::ring::install_default()` directly which were updated to use `aws_lc_rs`


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes


`aws_lc_rs` also supports FIPS140-3 Cryptogrpahy 
