### PR TITLE
fix(api): Fix vpc status migration

### DIFF
--- a/crates/api-db/migrations/20260213082014_vpc_status_fix_pre.sql
+++ b/crates/api-db/migrations/20260213082014_vpc_status_fix_pre.sql
@@ -1,0 +1,8 @@
+-- This fix is being inserted before the previous commit that added
+-- a new status field to VPCs.  We need to safely make sure there are no null
+-- VNI values.
+-- We can exploit the fact that VNIs are unsigned, but the column in postgres is signed.
+-- We set the VNI for any VPCs with a null VNI to a negative number with a subselect
+-- that will keep the values unique by assigning a row number.
+-- Later, we'll clean it up by setting a new status field to '{}' wherever we see a negative VNI.
+UPDATE vpcs v SET vni = v_sub.vni*-1 FROM (select id, ROW_NUMBER() OVER (ORDER BY id) AS vni FROM vpcs WHERE vni IS null) AS v_sub WHERE v.id=v_sub.id;

--- a/crates/api-db/migrations/20260304032808_vpc_status_fix_post.sql
+++ b/crates/api-db/migrations/20260304032808_vpc_status_fix_post.sql
@@ -1,0 +1,4 @@
+-- Clear out any of the negative VNIs
+-- If the VNI is negative, it's because the original VNI
+-- of the VPC was NULL when the new status field was added.
+UPDATE vpcs SET status='{}', vni=NULL WHERE (status->>'vni')::integer < 0;


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->

jsonb_set is a pure SQL function, so attempting to migrate vni to status->vni fails when vni is null because the jsonb_set `new_value` will be null and trigger jsonb_set to return null entirely and fail the query because of the non-NULL constraint on status.

The original migration commit appears in the following tags:
- [v0.5.0-pr](https://github.com/NVIDIA/bare-metal-manager-core/releases/tag/v0.5.0-pr)
- [v0.4.0-rc2](https://github.com/NVIDIA/bare-metal-manager-core/releases/tag/v0.4.0-rc2)
- [v0.4.0-rc1](https://github.com/NVIDIA/bare-metal-manager-core/releases/tag/v0.4.0-rc1)

This issue only applies to legacy deployments as VPC VNI is always assigned now and has been that way for quite a while.

This PR introduces a pre and post migration... migration.  For deployments where the original migration failed, the pre migration will be picked up and applied first ( pre-migration version `20260213082014` is earlier than the original migration version `20260213082015`) by sqlx to ensure that no NULL VNIs exist.  The post migration will then clean any work performed by the pre migration step.  For any deployment where the original migration had no issue, sqlx will still end up running the pre migration, but both the pre and post migrations will be no-ops.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

