### PR TITLE
fix(api): speed up periodic tasks with a standard PeriodicTimer

### DIFF
--- a/crates/api/src/ib_fabric_monitor/mod.rs
+++ b/crates/api/src/ib_fabric_monitor/mod.rs
@@ -20,6 +20,7 @@ mod metrics;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 use std::sync::Arc;
+use std::time::Duration;
 
 use carbide_uuid::infiniband::IBPartitionId;
 use carbide_uuid::machine::MachineId;
@@ -45,6 +46,7 @@ use tracing::Instrument;
 
 use crate::cfg::file::{CarbideConfig, IbFabricDefinition};
 use crate::ib::{GetPartitionOptions, IBFabricManager, IBFabricManagerType};
+use crate::periodic_timer::PeriodicTimer;
 use crate::{CarbideError, CarbideResult};
 
 /// `IbFabricMonitor` monitors the health of all connected InfiniBand fabrics in periodic intervals
@@ -114,27 +116,26 @@ impl IbFabricMonitor {
 
     async fn run(&self, mut stop_receiver: oneshot::Receiver<i32>) {
         let run_interval = self.fabric_manager.get_config().fabric_manager_run_interval;
+        let timer = PeriodicTimer::new(run_interval);
 
         loop {
-            let sleep_interval = match self.run_single_iteration().await {
+            let mut tick = timer.tick();
+            match self.run_single_iteration().await {
                 Ok(num_changes) => {
                     if num_changes > 0 {
                         // If any change has been applied to the IB fabric,
                         // the status that has been collected in the last iteration is already outdated
                         // Therefore run again as soon as possible.
-                        tokio::time::Duration::from_millis(1000)
-                    } else {
-                        run_interval
+                        tick.set_interval(Duration::from_millis(1000));
                     }
                 }
                 Err(e) => {
                     tracing::warn!("IbFabricMonitor error: {}", e);
-                    run_interval
                 }
-            };
+            }
 
             tokio::select! {
-                _ = tokio::time::sleep(sleep_interval) => {},
+                _ = tick.sleep() => {},
                 _ = &mut stop_receiver => {
                     tracing::info!("IbFabricMonitor stop was requested");
                     return;

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -90,6 +90,7 @@ mod mqtt_state_change_hook;
 mod network_segment;
 mod nvl_partition_monitor;
 mod nvlink;
+mod periodic_timer;
 mod preingestion_manager;
 mod rack;
 mod redfish;

--- a/crates/api/src/machine_update_manager/mod.rs
+++ b/crates/api/src/machine_update_manager/mod.rs
@@ -41,6 +41,7 @@ use self::dpu_nic_firmware::DpuNicFirmwareUpdate;
 use self::metrics::MachineUpdateManagerMetrics;
 use crate::CarbideResult;
 use crate::cfg::file::{CarbideConfig, MaxConcurrentUpdates};
+use crate::periodic_timer::PeriodicTimer;
 
 /// The MachineUpdateManager periodically runs [modules](machine_update_module::MachineUpdateModule) to initiate upgrades of machine components.
 /// On each iteration the MachineUpdateManager will:
@@ -132,13 +133,15 @@ impl MachineUpdateManager {
     }
 
     async fn run(&self, mut stop_receiver: oneshot::Receiver<i32>) {
+        let timer = PeriodicTimer::new(self.run_interval);
         loop {
+            let tick = timer.tick();
             if let Err(e) = self.run_single_iteration().await {
                 tracing::warn!("MachineUpdateManager error: {}", e);
             }
 
             tokio::select! {
-                _ = tokio::time::sleep(self.run_interval) => {},
+                _ = tick.sleep() => {},
                 _ = &mut stop_receiver => {
                     tracing::info!("Machine update manager stop was requested");
                     return;

--- a/crates/api/src/machine_validation/mod.rs
+++ b/crates/api/src/machine_validation/mod.rs
@@ -26,6 +26,7 @@ use tokio::sync::oneshot;
 use self::metrics::MachineValidationMetrics;
 use crate::CarbideResult;
 use crate::cfg::file::MachineValidationConfig;
+use crate::periodic_timer::PeriodicTimer;
 
 pub struct MachineValidationManager {
     database_connection: sqlx::PgPool,
@@ -64,13 +65,15 @@ impl MachineValidationManager {
     }
 
     async fn run(&self, mut stop_receiver: oneshot::Receiver<i32>) {
+        let timer = PeriodicTimer::new(self.config.run_interval);
         loop {
+            let tick = timer.tick();
             if let Err(e) = self.run_single_iteration().await {
                 tracing::warn!("MachineValidationManager error: {}", e);
             }
 
             tokio::select! {
-                _ = tokio::time::sleep(self.config.run_interval) => {},
+                _ = tick.sleep() => {},
                 _ = &mut stop_receiver => {
                     tracing::info!("MachineValidationManager stop was requested");
                     return;

--- a/crates/api/src/nvl_partition_monitor/mod.rs
+++ b/crates/api/src/nvl_partition_monitor/mod.rs
@@ -16,6 +16,7 @@
  */
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::nvlink::{NvLinkDomainId, NvLinkLogicalPartitionId, NvLinkPartitionId};
@@ -38,6 +39,7 @@ use tracing::Instrument;
 use crate::api::TransactionVending;
 use crate::cfg::file::NvLinkConfig;
 use crate::nvlink::NmxmClientPool;
+use crate::periodic_timer::PeriodicTimer;
 use crate::{CarbideError, CarbideResult};
 
 mod metrics;
@@ -643,25 +645,23 @@ impl NvlPartitionMonitor {
     }
 
     pub async fn run(&self, mut stop_receiver: oneshot::Receiver<i32>) {
-        let run_interval = self.config.monitor_run_interval;
+        let timer = PeriodicTimer::new(self.config.monitor_run_interval);
         loop {
-            let sleep_interval = match self.run_single_iteration().await {
+            let mut tick = timer.tick();
+            match self.run_single_iteration().await {
                 Ok(num_changes) => {
                     if num_changes > 0 {
                         // Decrease the interval if changes have been made.
-                        tokio::time::Duration::from_millis(1000)
-                    } else {
-                        run_interval
+                        tick.set_interval(Duration::from_millis(1000));
                     }
                 }
                 Err(e) => {
                     tracing::warn!("NvlPartitionMonitor error: {}", e);
-                    run_interval
                 }
-            };
+            }
 
             tokio::select! {
-                _ = tokio::time::sleep(sleep_interval) => {},
+                _ = tick.sleep() => {},
                 _ = &mut stop_receiver => {
                     tracing::info!("NvlPartitionMonitor stop was requested");
                     return;

--- a/crates/api/src/periodic_timer.rs
+++ b/crates/api/src/periodic_timer.rs
@@ -1,0 +1,160 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::time::{Duration, Instant};
+
+/// PeriodicTimer is a timer for periodic tasks, which tries to maintain
+/// a consistent cycle time in between iterations.
+///
+/// This is achieved by a simple subtraction of the elapsed iteration time
+/// from the run interval, so that the total cycle time stays as close to
+/// interval as possible.
+///
+/// If an iteration takes longer than the interval, the next iteration
+/// starts immediately (sleep time saturates to zero).
+///
+/// Example usage looks like:
+///
+/// ```ignore
+/// let timer = PeriodicTimer::new(Duration::from_secs(30));
+/// loop {
+///     let tick = timer.tick();
+///     ..do your work here.
+///     tick.sleep().await;
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub(crate) struct PeriodicTimer {
+    interval: Duration,
+}
+
+/// Tick tracks a single tick of a PeriodicTimer, and is created
+/// by PeriodicTimer::tick. It records when the tick started, so that
+/// the Tick::sleep routine can subtract the elapsed time from the
+/// configured interval.
+#[derive(Debug)]
+pub(crate) struct Tick {
+    interval: Duration,
+    started_at: Instant,
+}
+
+impl PeriodicTimer {
+    pub(crate) fn new(interval: Duration) -> Self {
+        Self { interval }
+    }
+
+    /// tick() begins a new tick. This is intended to be called
+    /// before running the iteration work, and is used to track
+    /// the time of the iteration.
+    pub(crate) fn tick(&self) -> Tick {
+        Tick {
+            interval: self.interval,
+            started_at: Instant::now(),
+        }
+    }
+}
+
+impl Tick {
+    /// remaining returns how long to sleep so that the total cycle time
+    /// (iteration + sleep) is as close to the configured run interval as
+    /// possible.
+    pub(crate) fn remaining(&self) -> Duration {
+        self.interval.saturating_sub(self.started_at.elapsed())
+    }
+
+    /// sleep sleeps for the remaining time in this Tick.
+    pub(crate) async fn sleep(self) {
+        tokio::time::sleep(self.remaining()).await;
+    }
+
+    /// set_interval override the interval for this Tick only.
+    /// Used in adaptive situations (e.g. ib_fabric_monitor) which may
+    /// want a shorter interval under certain conditions (e.g. when changes
+    /// were detected) while still subtracting elapsed time.
+    pub(crate) fn set_interval(&mut self, interval: Duration) {
+        self.interval = interval;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remaining_subtracts_elapsed_time() {
+        let tick = Tick {
+            interval: Duration::from_secs(30),
+            started_at: Instant::now() - Duration::from_secs(10),
+        };
+        let remaining = tick.remaining();
+        // Should be roughly 20s.
+        assert!(remaining <= Duration::from_secs(21));
+        assert!(remaining >= Duration::from_secs(19));
+    }
+
+    #[test]
+    fn remaining_saturates_to_zero_when_iteration_exceeds_interval() {
+        let tick = Tick {
+            interval: Duration::from_secs(30),
+            started_at: Instant::now() - Duration::from_secs(45),
+        };
+        assert_eq!(tick.remaining(), Duration::ZERO);
+    }
+
+    #[test]
+    fn remaining_is_close_to_interval_when_iteration_is_fast() {
+        let tick = Tick {
+            interval: Duration::from_secs(30),
+            started_at: Instant::now(),
+        };
+        let remaining = tick.remaining();
+        assert!(remaining >= Duration::from_millis(29_900));
+        assert!(remaining <= Duration::from_secs(30));
+    }
+
+    #[test]
+    fn set_interval_overrides_for_single_tick() {
+        let timer = PeriodicTimer::new(Duration::from_secs(30));
+        let mut tick = timer.tick();
+        tick.set_interval(Duration::from_secs(1));
+        let remaining = tick.remaining();
+        assert!(remaining <= Duration::from_secs(1));
+    }
+
+    #[tokio::test]
+    async fn sleep_completes_quickly_when_iteration_exceeds_interval() {
+        let tick = Tick {
+            interval: Duration::from_millis(10),
+            started_at: Instant::now() - Duration::from_millis(100),
+        };
+        let before = Instant::now();
+        tick.sleep().await;
+        // Should return ~immediately.
+        assert!(before.elapsed() < Duration::from_millis(50));
+    }
+
+    #[tokio::test]
+    async fn sleep_waits_for_remaining_time() {
+        let timer = PeriodicTimer::new(Duration::from_millis(100));
+        let tick = timer.tick();
+        let before = Instant::now();
+        tick.sleep().await;
+        let elapsed = before.elapsed();
+        assert!(elapsed >= Duration::from_millis(80));
+        assert!(elapsed < Duration::from_millis(200));
+    }
+}

--- a/crates/api/src/preingestion_manager/mod.rs
+++ b/crates/api/src/preingestion_manager/mod.rs
@@ -41,6 +41,7 @@ use tokio::task::JoinSet;
 
 use crate::cfg::file::{CarbideConfig, FirmwareConfig, FirmwareGlobal};
 use crate::firmware_downloader::FirmwareDownloader;
+use crate::periodic_timer::PeriodicTimer;
 use crate::preingestion_manager::metrics::PreingestionMetrics;
 use crate::redfish::{RedfishClientCreationError, RedfishClientPool};
 use crate::{CarbideError, CarbideResult};
@@ -132,7 +133,9 @@ impl PreingestionManager {
     }
 
     async fn run(&self, mut stop_receiver: oneshot::Receiver<i32>) {
+        let timer = PeriodicTimer::new(self.static_info.run_interval);
         loop {
+            let tick = timer.tick();
             let res = self.run_single_iteration().await;
 
             if let Err(e) = &res {
@@ -142,7 +145,7 @@ impl PreingestionManager {
             // If we were able to go through everything (few or no uploads), or if we ran into a database error,
             // we will wait before checking if new state changes need to happen.
             tokio::select! {
-                _ = tokio::time::sleep(self.static_info.run_interval) => {},
+                _ = tick.sleep() => {},
                 _ = &mut stop_receiver => {
                     tracing::info!("Preingestion manager stop was requested");
                     return;

--- a/crates/api/src/site_explorer/mod.rs
+++ b/crates/api/src/site_explorer/mod.rs
@@ -60,6 +60,7 @@ use tracing::Instrument;
 use version_compare::Cmp;
 
 use crate::cfg::file::{FirmwareConfig, SiteExplorerConfig};
+use crate::periodic_timer::PeriodicTimer;
 use crate::{CarbideError, CarbideResult};
 
 mod endpoint_explorer;
@@ -191,7 +192,9 @@ impl SiteExplorer {
     }
 
     async fn run(&mut self, mut stop_receiver: oneshot::Receiver<i32>) {
+        let timer = PeriodicTimer::new(self.config.run_interval);
         loop {
+            let tick = timer.tick();
             match self.run_single_iteration().await {
                 Ok(identified_hosts) => self
                     .boot_order_tracker
@@ -202,7 +205,7 @@ impl SiteExplorer {
             }
 
             tokio::select! {
-                _ = tokio::time::sleep(self.config.run_interval) => {},
+                _ = tick.sleep() => {},
                 _ = &mut stop_receiver => {
                     tracing::info!("SiteExplorer stop was requested");
                     return;

--- a/crates/api/src/state_controller/controller/periodic_enqueuer.rs
+++ b/crates/api/src/state_controller/controller/periodic_enqueuer.rs
@@ -16,13 +16,14 @@
  */
 
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use ::db::work_lock_manager::WorkLockManagerHandle;
 use opentelemetry::metrics::{Counter, Histogram, Meter};
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 
+use crate::periodic_timer::PeriodicTimer;
 use crate::state_controller::config::IterationConfig;
 use crate::state_controller::controller::{
     ControllerIteration, ControllerIterationId, IterationError, db,
@@ -58,9 +59,10 @@ impl<IO: StateControllerIO> PeriodicEnqueuer<IO> {
     pub(super) async fn run(mut self) {
         let max_jitter = (self.iteration_config.iteration_time.as_millis() / 3) as u64;
         let err_jitter = (self.iteration_config.iteration_time.as_millis() / 5) as u64;
+        let timer = PeriodicTimer::new(self.iteration_config.iteration_time);
 
         loop {
-            let start = Instant::now();
+            let tick = timer.tick();
             let iteration_result = self.run_single_iteration().await;
 
             // We add some jitter before sleeping, to give other controller instances
@@ -79,10 +81,8 @@ impl<IO: StateControllerIO> PeriodicEnqueuer<IO> {
             } else {
                 0
             };
-            let sleep_time = self
-                .iteration_config
-                .iteration_time
-                .saturating_sub(start.elapsed())
+            let sleep_time = tick
+                .remaining()
                 .saturating_add(Duration::from_millis(jitter));
 
             let cancelled_future = self.cancel_token.cancelled();


### PR DESCRIPTION
## Description

This is intended to support https://github.com/NVIDIA/bare-metal-manager-core/issues/446, introducing a `PeriodicTimer` + `Tick` helper that standardizes the periodic execution across different components. We now have:

- `PeriodicTimer::new(interval)` — Create a timer with the desired cycle interval.
- `timer.tick()` — Call before each iteration; returns a `Tick` that records the start time.
- `tick.remaining()` — Returns `interval - elapsed`, saturating to zero.
- `tick.sleep()` — Sleeps for the remaining time.
- `tick.with_interval(override)` — This is for adaptive components that want a different interval for a specific tick (used by `ib_fabric_monitor` and `nvl_partition_monitor`).

Tests included!

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

