### PR TITLE
Change definition of state controller iteration_latency metrics

### DIFF
--- a/crates/api/src/state_controller/controller/processor.rs
+++ b/crates/api/src/state_controller/controller/processor.rs
@@ -74,7 +74,7 @@ pub(super) struct StateProcessor<IO: StateControllerIO> {
     pub(super) requeue_objects: HashSet<IO::ObjectId>,
     pub(super) task_sender: tokio::sync::mpsc::UnboundedSender<ObjectHandlingTaskResult<IO>>,
     pub(super) task_receiver: tokio::sync::mpsc::UnboundedReceiver<ObjectHandlingTaskResult<IO>>,
-    pub(super) data_since_iteration_start: DataSinceStartOfIteration,
+    pub(super) data_since_iteration_start: DataSinceStartOfEnqueuerIteration,
     /// The last time a log message had been emitted
     pub(super) last_log_time: std::time::Instant,
     pub(super) stats_since_last_log: StatsSinceLastLog,
@@ -95,16 +95,28 @@ pub(super) struct CollectedMetrics<IO: StateControllerIO> {
 }
 
 #[derive(Debug)]
-pub(super) struct DataSinceStartOfIteration {
-    /// The time when the first state state handling task for the iteration was dequeued
+pub(super) struct ProcessorIterationMetrics {
+    /// When the last state processor iteration started
     iteration_started_at: std::time::Instant,
-    iteration_started_at_utc: chrono::DateTime<chrono::Utc>,
 }
 
-impl std::default::Default for DataSinceStartOfIteration {
+impl std::default::Default for ProcessorIterationMetrics {
     fn default() -> Self {
         Self {
             iteration_started_at: std::time::Instant::now(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct DataSinceStartOfEnqueuerIteration {
+    /// The time when the first state state handling task with a certain Iteration ID was dequeued
+    iteration_started_at_utc: chrono::DateTime<chrono::Utc>,
+}
+
+impl std::default::Default for DataSinceStartOfEnqueuerIteration {
+    fn default() -> Self {
+        Self {
             iteration_started_at_utc: chrono::Utc::now(),
         }
     }
@@ -224,6 +236,8 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
         max_completion_wait_time: std::time::Duration,
         allow_requeue: bool,
     ) -> Result<SingleIterationResult, IterationError> {
+        let run_metrics = ProcessorIterationMetrics::default();
+
         let num_dispatched_tasks = self.dequeue_and_dispatch_object_handling_tasks().await?;
         // We are assuming that we dispatch as many tasks that are available and fit into
         // the queue. Therefore its ok to wait until at least one task has been dequeued
@@ -248,6 +262,10 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
         self.emit_metric_if_iteration_changed(&queue_stats);
 
         self.emit_periodic_log_if_necessary();
+
+        if let Some(emitter) = self.metric_emitter.as_ref() {
+            emitter.emit_run_counters_and_histograms(&run_metrics);
+        }
 
         Ok(SingleIterationResult {
             num_dispatched_tasks,
@@ -316,11 +334,7 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
             &aggregate,
         );
 
-        if let Some(emitter) = self.metric_emitter.as_ref() {
-            emitter.emit_iteration_counters_and_histograms(&self.data_since_iteration_start);
-        }
-
-        self.data_since_iteration_start = DataSinceStartOfIteration::default();
+        self.data_since_iteration_start = DataSinceStartOfEnqueuerIteration::default();
 
         self.metric_holder
             .last_iteration_specific_metrics
@@ -807,7 +821,7 @@ async fn process_object<IO: StateControllerIO>(
 
 #[derive(Debug)]
 pub(super) struct ProcessorMetricsEmitter {
-    controller_iteration_latency: Histogram<f64>,
+    iteration_latency: Histogram<f64>,
     dispatched_tasks_counter: Counter<u64>,
     completed_tasks_counter: Counter<u64>,
     requeued_tasks_counter: Counter<u64>,
@@ -818,10 +832,10 @@ impl ProcessorMetricsEmitter {
     pub(super) fn new(object_type: &str, meter: &Meter) -> Self {
         let db = sqlx_query_tracing::DatabaseMetricEmitters::new(meter);
 
-        let controller_iteration_latency = meter
+        let iteration_latency = meter
             .f64_histogram(format!("{object_type}_iteration_latency"))
             .with_description(format!(
-                "The overall time it took to handle state for all {object_type} in the system"
+                "The elapsed time in the last state processor iteration to handle objects of type {object_type}"
             ))
             .with_unit("ms")
             .build();
@@ -848,7 +862,7 @@ impl ProcessorMetricsEmitter {
             .build();
 
         Self {
-            controller_iteration_latency,
+            iteration_latency,
             db,
             dispatched_tasks_counter,
             completed_tasks_counter,
@@ -867,9 +881,9 @@ impl ProcessorMetricsEmitter {
         self.db.emit(db_metrics, attrs);
     }
 
-    fn emit_iteration_counters_and_histograms(&self, iteration_data: &DataSinceStartOfIteration) {
-        self.controller_iteration_latency.record(
-            1000.0 * iteration_data.iteration_started_at.elapsed().as_secs_f64(),
+    fn emit_run_counters_and_histograms(&self, run_metrics: &ProcessorIterationMetrics) {
+        self.iteration_latency.record(
+            1000.0 * run_metrics.iteration_started_at.elapsed().as_secs_f64(),
             &[],
         );
     }

--- a/crates/api/src/tests/metrics_fixtures/test_network_segment_metrics_admin.txt
+++ b/crates/api/src/tests/metrics_fixtures/test_network_segment_metrics_admin.txt
@@ -1,13 +1,3 @@
-# HELP carbide_nvlink_partition_monitor_nmxm_changes_applied_total Number of changes requested to Nmx-M
-# TYPE carbide_nvlink_partition_monitor_nmxm_changes_applied_total counter
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="create",status="false"} 0
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="create",status="true"} 0
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="pending",status="false"} 0
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="pending",status="true"} 0
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="remove",status="false"} 0
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="remove",status="true"} 0
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="update",status="false"} 0
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="update",status="true"} 0
 # HELP carbide_available_ips_count The total number of available ips in the site
 # TYPE carbide_available_ips_count gauge
 carbide_available_ips_count{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="admin"} 253
@@ -20,7 +10,7 @@ carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="unbind_
 # HELP carbide_machines_enqueuer_iteration_latency_milliseconds The overall time it took to enqueue state handling tasks for all carbide_machines in the system
 # TYPE carbide_machines_enqueuer_iteration_latency_milliseconds histogram
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="0"} 0
-carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="5"} 1
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="5"} 2
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="10"} 2
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="25"} 2
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="50"} 2
@@ -35,12 +25,12 @@ carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="5000"} 2
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="7500"} 2
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="10000"} 2
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="+Inf"} 2
-carbide_machines_enqueuer_iteration_latency_milliseconds_sum 10.406267
+carbide_machines_enqueuer_iteration_latency_milliseconds_sum 5.8699069999999995
 carbide_machines_enqueuer_iteration_latency_milliseconds_count 2
 # HELP carbide_machines_handler_latency_in_state_milliseconds The amount of time it took to invoke the state handler for objects of type carbide_machines in a certain state
 # TYPE carbide_machines_handler_latency_in_state_milliseconds histogram
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="0"} 0
-carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="5"} 0
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="5"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="10"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="25"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="50"} 1
@@ -55,10 +45,10 @@ carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",s
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="7500"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="10000"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="+Inf"} 1
-carbide_machines_handler_latency_in_state_milliseconds_sum{state="deleting",substate="drainallocatedips"} 5.474484
+carbide_machines_handler_latency_in_state_milliseconds_sum{state="deleting",substate="drainallocatedips"} 2.845083
 carbide_machines_handler_latency_in_state_milliseconds_count{state="deleting",substate="drainallocatedips"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="0"} 0
-carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="5"} 0
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="5"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="10"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="25"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="50"} 1
@@ -73,28 +63,28 @@ carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",subs
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="7500"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="10000"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="+Inf"} 1
-carbide_machines_handler_latency_in_state_milliseconds_sum{state="ready",substate=""} 5.1987250000000005
+carbide_machines_handler_latency_in_state_milliseconds_sum{state="ready",substate=""} 4.693521
 carbide_machines_handler_latency_in_state_milliseconds_count{state="ready",substate=""} 1
-# HELP carbide_machines_iteration_latency_milliseconds The overall time it took to handle state for all carbide_machines in the system
+# HELP carbide_machines_iteration_latency_milliseconds The elapsed time in the last state processor iteration to handle objects of type carbide_machines
 # TYPE carbide_machines_iteration_latency_milliseconds histogram
 carbide_machines_iteration_latency_milliseconds_bucket{le="0"} 0
 carbide_machines_iteration_latency_milliseconds_bucket{le="5"} 1
-carbide_machines_iteration_latency_milliseconds_bucket{le="10"} 1
+carbide_machines_iteration_latency_milliseconds_bucket{le="10"} 2
 carbide_machines_iteration_latency_milliseconds_bucket{le="25"} 2
-carbide_machines_iteration_latency_milliseconds_bucket{le="50"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="75"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="100"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="250"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="500"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="750"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="1000"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="2500"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="5000"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="7500"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="10000"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="+Inf"} 3
-carbide_machines_iteration_latency_milliseconds_sum 44.459362
-carbide_machines_iteration_latency_milliseconds_count 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="50"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="75"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="100"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="250"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="500"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="750"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="1000"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="2500"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="5000"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="7500"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="10000"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="+Inf"} 2
+carbide_machines_iteration_latency_milliseconds_sum 11.136496999999999
+carbide_machines_iteration_latency_milliseconds_count 2
 # HELP carbide_machines_object_tasks_completed_total The amount of object handling tasks that have been completed for objects of type carbide_machines
 # TYPE carbide_machines_object_tasks_completed_total counter
 carbide_machines_object_tasks_completed_total 2
@@ -137,7 +127,7 @@ carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substat
 carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="7500"} 1
 carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="10000"} 1
 carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="+Inf"} 1
-carbide_machines_time_in_state_seconds_sum{next_state="deleting",next_substate="drainallocatedips",state="ready",substate=""} 0.091039928
+carbide_machines_time_in_state_seconds_sum{next_state="deleting",next_substate="drainallocatedips",state="ready",substate=""} 0.080595331
 carbide_machines_time_in_state_seconds_count{next_state="deleting",next_substate="drainallocatedips",state="ready",substate=""} 1
 # HELP carbide_machines_total The total number of carbide_machines in the system
 # TYPE carbide_machines_total gauge
@@ -145,6 +135,16 @@ carbide_machines_total{fresh="true"} 1
 # HELP carbide_machines_with_state_handling_errors_per_state The number of carbide_machines in the system with a given state that failed state handling
 # TYPE carbide_machines_with_state_handling_errors_per_state gauge
 carbide_machines_with_state_handling_errors_per_state{error="any",fresh="true",state="deleting",substate="drainallocatedips"} 0
+# HELP carbide_nvlink_partition_monitor_nmxm_changes_applied_total Number of changes requested to Nmx-M
+# TYPE carbide_nvlink_partition_monitor_nmxm_changes_applied_total counter
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="create",status="false"} 0
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="create",status="true"} 0
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="pending",status="false"} 0
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="pending",status="true"} 0
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="remove",status="false"} 0
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="remove",status="true"} 0
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="update",status="false"} 0
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="update",status="true"} 0
 # HELP carbide_reserved_ips_count The total number of reserved ips in the site
 # TYPE carbide_reserved_ips_count gauge
 carbide_reserved_ips_count{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="admin"} 1

--- a/crates/api/src/tests/metrics_fixtures/test_network_segment_metrics_tenant.txt
+++ b/crates/api/src/tests/metrics_fixtures/test_network_segment_metrics_tenant.txt
@@ -1,13 +1,3 @@
-# HELP carbide_nvlink_partition_monitor_nmxm_changes_applied_total Number of changes requested to Nmx-M
-# TYPE carbide_nvlink_partition_monitor_nmxm_changes_applied_total counter
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="create",status="false"} 0
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="create",status="true"} 0
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="pending",status="false"} 0
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="pending",status="true"} 0
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="remove",status="false"} 0
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="remove",status="true"} 0
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="update",status="false"} 0
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="update",status="true"} 0
 # HELP carbide_ib_monitor_ufm_changes_applied_total The amount of changes that have been performed at UFM
 # TYPE carbide_ib_monitor_ufm_changes_applied_total counter
 carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="bind_guid_to_pkey",status="error"} 0
@@ -17,7 +7,7 @@ carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="unbind_
 # HELP carbide_machines_enqueuer_iteration_latency_milliseconds The overall time it took to enqueue state handling tasks for all carbide_machines in the system
 # TYPE carbide_machines_enqueuer_iteration_latency_milliseconds histogram
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="0"} 0
-carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="5"} 1
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="5"} 2
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="10"} 2
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="25"} 2
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="50"} 2
@@ -32,12 +22,12 @@ carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="5000"} 2
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="7500"} 2
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="10000"} 2
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="+Inf"} 2
-carbide_machines_enqueuer_iteration_latency_milliseconds_sum 10.540408
+carbide_machines_enqueuer_iteration_latency_milliseconds_sum 6.295765
 carbide_machines_enqueuer_iteration_latency_milliseconds_count 2
 # HELP carbide_machines_handler_latency_in_state_milliseconds The amount of time it took to invoke the state handler for objects of type carbide_machines in a certain state
 # TYPE carbide_machines_handler_latency_in_state_milliseconds histogram
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="0"} 0
-carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="5"} 0
+carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="5"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="10"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="25"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="50"} 1
@@ -52,7 +42,7 @@ carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",s
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="7500"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="10000"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="+Inf"} 1
-carbide_machines_handler_latency_in_state_milliseconds_sum{state="deleting",substate="drainallocatedips"} 5.12397
+carbide_machines_handler_latency_in_state_milliseconds_sum{state="deleting",substate="drainallocatedips"} 1.228648
 carbide_machines_handler_latency_in_state_milliseconds_count{state="deleting",substate="drainallocatedips"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="0"} 0
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="5"} 1
@@ -70,28 +60,28 @@ carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",subs
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="7500"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="10000"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="+Inf"} 1
-carbide_machines_handler_latency_in_state_milliseconds_sum{state="ready",substate=""} 3.9689590000000003
+carbide_machines_handler_latency_in_state_milliseconds_sum{state="ready",substate=""} 4.765817999999999
 carbide_machines_handler_latency_in_state_milliseconds_count{state="ready",substate=""} 1
-# HELP carbide_machines_iteration_latency_milliseconds The overall time it took to handle state for all carbide_machines in the system
+# HELP carbide_machines_iteration_latency_milliseconds The elapsed time in the last state processor iteration to handle objects of type carbide_machines
 # TYPE carbide_machines_iteration_latency_milliseconds histogram
 carbide_machines_iteration_latency_milliseconds_bucket{le="0"} 0
-carbide_machines_iteration_latency_milliseconds_bucket{le="5"} 1
-carbide_machines_iteration_latency_milliseconds_bucket{le="10"} 1
+carbide_machines_iteration_latency_milliseconds_bucket{le="5"} 0
+carbide_machines_iteration_latency_milliseconds_bucket{le="10"} 2
 carbide_machines_iteration_latency_milliseconds_bucket{le="25"} 2
-carbide_machines_iteration_latency_milliseconds_bucket{le="50"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="75"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="100"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="250"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="500"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="750"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="1000"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="2500"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="5000"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="7500"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="10000"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="+Inf"} 3
-carbide_machines_iteration_latency_milliseconds_sum 46.85431
-carbide_machines_iteration_latency_milliseconds_count 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="50"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="75"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="100"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="250"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="500"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="750"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="1000"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="2500"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="5000"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="7500"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="10000"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="+Inf"} 2
+carbide_machines_iteration_latency_milliseconds_sum 12.235358
+carbide_machines_iteration_latency_milliseconds_count 2
 # HELP carbide_machines_object_tasks_completed_total The amount of object handling tasks that have been completed for objects of type carbide_machines
 # TYPE carbide_machines_object_tasks_completed_total counter
 carbide_machines_object_tasks_completed_total 2
@@ -134,7 +124,7 @@ carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substat
 carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="7500"} 1
 carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="10000"} 1
 carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="+Inf"} 1
-carbide_machines_time_in_state_seconds_sum{next_state="deleting",next_substate="drainallocatedips",state="ready",substate=""} 0.085621773
+carbide_machines_time_in_state_seconds_sum{next_state="deleting",next_substate="drainallocatedips",state="ready",substate=""} 0.066087388
 carbide_machines_time_in_state_seconds_count{next_state="deleting",next_substate="drainallocatedips",state="ready",substate=""} 1
 # HELP carbide_machines_total The total number of carbide_machines in the system
 # TYPE carbide_machines_total gauge
@@ -142,3 +132,13 @@ carbide_machines_total{fresh="true"} 1
 # HELP carbide_machines_with_state_handling_errors_per_state The number of carbide_machines in the system with a given state that failed state handling
 # TYPE carbide_machines_with_state_handling_errors_per_state gauge
 carbide_machines_with_state_handling_errors_per_state{error="any",fresh="true",state="deleting",substate="drainallocatedips"} 0
+# HELP carbide_nvlink_partition_monitor_nmxm_changes_applied_total Number of changes requested to Nmx-M
+# TYPE carbide_nvlink_partition_monitor_nmxm_changes_applied_total counter
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="create",status="false"} 0
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="create",status="true"} 0
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="pending",status="false"} 0
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="pending",status="true"} 0
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="remove",status="false"} 0
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="remove",status="true"} 0
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="update",status="false"} 0
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="update",status="true"} 0

--- a/crates/api/src/tests/metrics_fixtures/test_network_segment_metrics_tor.txt
+++ b/crates/api/src/tests/metrics_fixtures/test_network_segment_metrics_tor.txt
@@ -1,13 +1,3 @@
-# HELP carbide_nvlink_partition_monitor_nmxm_changes_applied_total Number of changes requested to Nmx-M
-# TYPE carbide_nvlink_partition_monitor_nmxm_changes_applied_total counter
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="create",status="false"} 0
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="create",status="true"} 0
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="pending",status="false"} 0
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="pending",status="true"} 0
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="remove",status="false"} 0
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="remove",status="true"} 0
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="update",status="false"} 0
-carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="update",status="true"} 0
 # HELP carbide_available_ips_count The total number of available ips in the site
 # TYPE carbide_available_ips_count gauge
 carbide_available_ips_count{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="tor"} 253
@@ -20,7 +10,7 @@ carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="unbind_
 # HELP carbide_machines_enqueuer_iteration_latency_milliseconds The overall time it took to enqueue state handling tasks for all carbide_machines in the system
 # TYPE carbide_machines_enqueuer_iteration_latency_milliseconds histogram
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="0"} 0
-carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="5"} 2
+carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="5"} 1
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="10"} 2
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="25"} 2
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="50"} 2
@@ -35,7 +25,7 @@ carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="5000"} 2
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="7500"} 2
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="10000"} 2
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="+Inf"} 2
-carbide_machines_enqueuer_iteration_latency_milliseconds_sum 8.576246999999999
+carbide_machines_enqueuer_iteration_latency_milliseconds_sum 9.791577
 carbide_machines_enqueuer_iteration_latency_milliseconds_count 2
 # HELP carbide_machines_handler_latency_in_state_milliseconds The amount of time it took to invoke the state handler for objects of type carbide_machines in a certain state
 # TYPE carbide_machines_handler_latency_in_state_milliseconds histogram
@@ -55,7 +45,7 @@ carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",s
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="7500"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="10000"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="deleting",substate="drainallocatedips",le="+Inf"} 1
-carbide_machines_handler_latency_in_state_milliseconds_sum{state="deleting",substate="drainallocatedips"} 3.9417130000000005
+carbide_machines_handler_latency_in_state_milliseconds_sum{state="deleting",substate="drainallocatedips"} 1.657742
 carbide_machines_handler_latency_in_state_milliseconds_count{state="deleting",substate="drainallocatedips"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="0"} 0
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="5"} 0
@@ -73,28 +63,28 @@ carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",subs
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="7500"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="10000"} 1
 carbide_machines_handler_latency_in_state_milliseconds_bucket{state="ready",substate="",le="+Inf"} 1
-carbide_machines_handler_latency_in_state_milliseconds_sum{state="ready",substate=""} 5.230594
+carbide_machines_handler_latency_in_state_milliseconds_sum{state="ready",substate=""} 8.861486
 carbide_machines_handler_latency_in_state_milliseconds_count{state="ready",substate=""} 1
-# HELP carbide_machines_iteration_latency_milliseconds The overall time it took to handle state for all carbide_machines in the system
+# HELP carbide_machines_iteration_latency_milliseconds The elapsed time in the last state processor iteration to handle objects of type carbide_machines
 # TYPE carbide_machines_iteration_latency_milliseconds histogram
 carbide_machines_iteration_latency_milliseconds_bucket{le="0"} 0
 carbide_machines_iteration_latency_milliseconds_bucket{le="5"} 1
 carbide_machines_iteration_latency_milliseconds_bucket{le="10"} 1
 carbide_machines_iteration_latency_milliseconds_bucket{le="25"} 2
-carbide_machines_iteration_latency_milliseconds_bucket{le="50"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="75"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="100"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="250"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="500"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="750"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="1000"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="2500"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="5000"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="7500"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="10000"} 3
-carbide_machines_iteration_latency_milliseconds_bucket{le="+Inf"} 3
-carbide_machines_iteration_latency_milliseconds_sum 42.644988999999995
-carbide_machines_iteration_latency_milliseconds_count 3
+carbide_machines_iteration_latency_milliseconds_bucket{le="50"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="75"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="100"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="250"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="500"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="750"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="1000"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="2500"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="5000"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="7500"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="10000"} 2
+carbide_machines_iteration_latency_milliseconds_bucket{le="+Inf"} 2
+carbide_machines_iteration_latency_milliseconds_sum 19.73192
+carbide_machines_iteration_latency_milliseconds_count 2
 # HELP carbide_machines_object_tasks_completed_total The amount of object handling tasks that have been completed for objects of type carbide_machines
 # TYPE carbide_machines_object_tasks_completed_total counter
 carbide_machines_object_tasks_completed_total 2
@@ -137,7 +127,7 @@ carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substat
 carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="7500"} 1
 carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="10000"} 1
 carbide_machines_time_in_state_seconds_bucket{next_state="deleting",next_substate="drainallocatedips",state="ready",substate="",le="+Inf"} 1
-carbide_machines_time_in_state_seconds_sum{next_state="deleting",next_substate="drainallocatedips",state="ready",substate=""} 0.089736764
+carbide_machines_time_in_state_seconds_sum{next_state="deleting",next_substate="drainallocatedips",state="ready",substate=""} 0.092357396
 carbide_machines_time_in_state_seconds_count{next_state="deleting",next_substate="drainallocatedips",state="ready",substate=""} 1
 # HELP carbide_machines_total The total number of carbide_machines in the system
 # TYPE carbide_machines_total gauge
@@ -145,6 +135,16 @@ carbide_machines_total{fresh="true"} 1
 # HELP carbide_machines_with_state_handling_errors_per_state The number of carbide_machines in the system with a given state that failed state handling
 # TYPE carbide_machines_with_state_handling_errors_per_state gauge
 carbide_machines_with_state_handling_errors_per_state{error="any",fresh="true",state="deleting",substate="drainallocatedips"} 0
+# HELP carbide_nvlink_partition_monitor_nmxm_changes_applied_total Number of changes requested to Nmx-M
+# TYPE carbide_nvlink_partition_monitor_nmxm_changes_applied_total counter
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="create",status="false"} 0
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="create",status="true"} 0
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="pending",status="false"} 0
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="pending",status="true"} 0
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="remove",status="false"} 0
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="remove",status="true"} 0
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="update",status="false"} 0
+carbide_nvlink_partition_monitor_nmxm_changes_applied_total{operation="update",status="true"} 0
 # HELP carbide_reserved_ips_count The total number of reserved ips in the site
 # TYPE carbide_reserved_ips_count gauge
 carbide_reserved_ips_count{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="tor"} 1

--- a/crates/api/src/tests/network_segment.rs
+++ b/crates/api/src/tests/network_segment.rs
@@ -825,12 +825,14 @@ async fn test_network_segment_metrics(
         );
     }
 
+    let actual_metrics = env.test_meter.export_metrics();
+
     assert_eq!(
-        env.test_meter
-            .export_metrics()
-            .parse::<ParsedPrometheusMetrics>()
-            .unwrap(),
-        test_type.fixture()
+        actual_metrics.parse::<ParsedPrometheusMetrics>().unwrap(),
+        test_type.fixture(),
+        "Metrics for test {} are not as expected, Actual metrics are:\n{}",
+        test_type,
+        actual_metrics
     );
 
     Ok(())


### PR DESCRIPTION
## Description

Before the 0.2 release, metrics like `carbide_machines_iteration_latency` measured the time it took to handle the state of all objects of a certain type.

With the 0.2 release, this changed to measure the time between when the periodic enqueuer started a new iteration -which then had the effect of the state processor emitting a new set of metrics.

This change led the metrics show mostly the enqueuer iteration cycle (30s). This metric was not very useful to operators.

With this change, the metric now indicates the latency that of  a single "state processor" run - the time it takes to dequeue pending tasks, dequeue results, and to update metrics if required. This metric is expected to be very short (< 1s), and any elevated latency would indeed be the sign of a performance problem. The metric is thereby much more useful.

## Type of Change

- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

