### PR TITLE
Fix already-exists logic for CrateCredentials RPC

### DIFF
--- a/crates/api/src/handlers/credential.rs
+++ b/crates/api/src/handlers/credential.rs
@@ -103,7 +103,7 @@ pub(crate) async fn create_credential(
                     credential_type: CredentialType::SiteDefault,
                 })
                 .await)
-                .is_ok()
+                .is_ok_and(|result| result.is_some())
             {
                 // TODO: support reset credential
                 return Err(tonic::Status::already_exists(
@@ -132,7 +132,7 @@ pub(crate) async fn create_credential(
                     credential_type: CredentialType::SiteDefault,
                 })
                 .await
-                .is_ok()
+                .is_ok_and(|result| result.is_some())
             {
                 // TODO: support reset credential
                 return Err(tonic::Status::already_exists(

--- a/crates/api/src/tests/credential.rs
+++ b/crates/api/src/tests/credential.rs
@@ -1,0 +1,115 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use forge_secrets::credentials::{CredentialKey, CredentialReader, CredentialType, Credentials};
+use rpc::forge::forge_server::Forge;
+use rpc::forge::{CredentialCreationRequest, CredentialType as RpcCredentialType};
+use tonic::Code;
+
+use crate::tests::common::api_fixtures::create_test_env;
+
+#[crate::sqlx_test]
+async fn test_create_host_uefi_credential_when_missing(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+
+    let response = env
+        .api
+        .create_credential(tonic::Request::new(CredentialCreationRequest {
+            credential_type: RpcCredentialType::HostUefi.into(),
+            username: None,
+            password: "test-host-uefi-password".to_string(),
+            vendor: None,
+            mac_address: None,
+        }))
+        .await;
+    assert!(response.is_ok());
+
+    let stored = env
+        .test_credential_manager
+        .get_credentials(&CredentialKey::HostUefi {
+            credential_type: CredentialType::SiteDefault,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        stored,
+        Some(Credentials::UsernamePassword {
+            username: "".to_string(),
+            password: "test-host-uefi-password".to_string(),
+        })
+    );
+
+    // A second create should fail because the credential now exists.
+    let second = env
+        .api
+        .create_credential(tonic::Request::new(CredentialCreationRequest {
+            credential_type: RpcCredentialType::HostUefi.into(),
+            username: None,
+            password: "another-password".to_string(),
+            vendor: None,
+            mac_address: None,
+        }))
+        .await;
+    assert!(second.is_err());
+    assert_eq!(second.unwrap_err().code(), Code::AlreadyExists);
+}
+
+#[crate::sqlx_test]
+async fn test_create_dpu_uefi_credential_when_missing(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+
+    let response = env
+        .api
+        .create_credential(tonic::Request::new(CredentialCreationRequest {
+            credential_type: RpcCredentialType::DpuUefi.into(),
+            username: None,
+            password: "test-dpu-uefi-password".to_string(),
+            vendor: None,
+            mac_address: None,
+        }))
+        .await;
+    assert!(response.is_ok());
+
+    let stored = env
+        .test_credential_manager
+        .get_credentials(&CredentialKey::DpuUefi {
+            credential_type: CredentialType::SiteDefault,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        stored,
+        Some(Credentials::UsernamePassword {
+            username: "".to_string(),
+            password: "test-dpu-uefi-password".to_string(),
+        })
+    );
+
+    // A second create should fail because the credential now exists.
+    let second = env
+        .api
+        .create_credential(tonic::Request::new(CredentialCreationRequest {
+            credential_type: RpcCredentialType::DpuUefi.into(),
+            username: None,
+            password: "another-password".to_string(),
+            vendor: None,
+            mac_address: None,
+        }))
+        .await;
+    assert!(second.is_err());
+    assert_eq!(second.unwrap_err().code(), Code::AlreadyExists);
+}

--- a/crates/api/src/tests/mod.rs
+++ b/crates/api/src/tests/mod.rs
@@ -17,6 +17,7 @@
 pub(crate) mod common;
 mod connected_device;
 mod create_domain;
+mod credential;
 mod desired_firmware_versions;
 mod dns;
 mod dpa_interfaces;


### PR DESCRIPTION
## Description
The vault provider was changed back in October to not return an error if vault 404's, but instead return Ok(None).

However the logic in the CreateCredentials handler takes `.is_ok()` to mean the credentials already exist (because at the time, 404's returned an error.)

Fix this by interpreting Ok(None) as meaning the credentials don't exist yet.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
nvbugs/5954802

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [X] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

