### PR TITLE
chore: bmc-mock: Support nv-redfish BMC access & manager OEM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,6 +995,7 @@ dependencies = [
  "itertools 0.14.0",
  "lazy_static",
  "mac_address",
+ "nv-redfish",
  "rand 0.9.2",
  "regex",
  "rustls 0.23.34",
@@ -1008,6 +1009,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -6422,9 +6424,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f368279cf355ed5c2dda5c5c2a0f2025b5acbf7bbe18621327e6b89159deb9a"
+checksum = "38be633e16be40825aea296d60ceb55792a42c6a891d5f3d32b8bdbb559cdb65"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -6438,9 +6440,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-bmc-http"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428c30ac9b74ce46a174cf27dc1f50a80200119322d924f88fbcdfe4892694bf"
+checksum = "f68344a4dc04ee6c04a3ccbe2e8417d36ea851b3a035f686e92d28b940a6975c"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -6458,9 +6460,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-core"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22874ccf9984c2b04819ff3d5769c14daaa8782d306a041d1029750f54b6aaf2"
+checksum = "3dbb94646a902920f1571f772f580cb7895d8fc7a1404c8c9c78f46c9d24a2b6"
 dependencies = [
  "futures-core",
  "rust_decimal",
@@ -6472,9 +6474,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-csdl-compiler"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfa6586a248272c092203ad43484b4c6758d29c74311a2b717a83b728b870db"
+checksum = "5a1b67170463b61d2357898809955e9e7d03a105548c0f6b8f1153f35ed783fb"
 dependencies = [
  "clap",
  "clap_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ tracing-appender = "0.2.4"
 tracing-opentelemetry = "0.29.0"
 
 # NV-Redfish
-nv-redfish = { version = "0.3.0", features = [
+nv-redfish = { version = "0.4.0", features = [
   "bmc-http",
   "std-redfish",
   "update-service",

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -28,7 +28,7 @@ use config_version::ConfigVersion;
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use libredfish::RedfishError;
-use libredfish::model::oem::nvidia_dpu::NicMode;
+pub use libredfish::model::oem::nvidia_dpu::NicMode;
 use mac_address::MacAddress;
 use regex::Regex;
 use serde::{Deserialize, Serialize};

--- a/crates/bmc-mock/Cargo.toml
+++ b/crates/bmc-mock/Cargo.toml
@@ -53,6 +53,8 @@ rand = { workspace = true }
 rustls = { workspace = true }
 rustls-pemfile = { workspace = true }
 http-body-util = { workspace = true }
+nv-redfish = { workspace = true, features = ["bmc-http"] }
+url = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/bmc-mock/src/bmc_state.rs
+++ b/crates/bmc-mock/src/bmc_state.rs
@@ -26,6 +26,7 @@ use crate::redfish::update_service::UpdateServiceState;
 #[derive(Clone)]
 pub struct BmcState {
     pub bmc_vendor: redfish::oem::BmcVendor,
+    pub bmc_product: Option<&'static str>,
     pub oem_state: redfish::oem::State,
     pub manager: Arc<ManagerState>,
     pub system_state: Arc<SystemState>,

--- a/crates/bmc-mock/src/hw/bluefield3.rs
+++ b/crates/bmc-mock/src/hw/bluefield3.rs
@@ -205,6 +205,7 @@ impl Bluefield3<'_> {
                     .build(),
                 ],
                 firmware_version: "BF-23.10-4",
+                oem: None,
             }],
         }
     }

--- a/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
+++ b/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
@@ -60,6 +60,7 @@ impl DellPowerEdgeR750<'_> {
                     .build(),
                 ],
                 firmware_version: "6.00.30.00",
+                oem: Some(redfish::manager::Oem::Dell),
             }],
         }
     }

--- a/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
+++ b/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
@@ -37,11 +37,13 @@ impl WiwynnGB200Nvl<'_> {
                     id: "BMC_0",
                     eth_interfaces: vec![], // TODO: eth0 / eth1 / hmcusb0 / hostusb0
                     firmware_version: "25.06-2_NV_WW_02",
+                    oem: None,
                 },
                 redfish::manager::SingleConfig {
                     id: "HGX_BMC_0",
                     eth_interfaces: vec![], // TODO: usb0
                     firmware_version: "GB200Nvl-25.06-A",
+                    oem: None,
                 },
             ],
         }
@@ -208,8 +210,29 @@ impl WiwynnGB200Nvl<'_> {
     }
 
     pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+        let fw_inv_builder = |id: &str| {
+            redfish::software_inventory::builder(
+                &redfish::software_inventory::firmware_inventory_resource(id),
+            )
+        };
         redfish::update_service::UpdateServiceConfig {
-            firmware_inventory: vec![],
+            firmware_inventory: [
+                // Different examples from real H/W:
+                ("FW_BMC_0", "25.06-2_NV_WW_02"),
+                ("FW_BMC_1", "    "),
+                ("FW_CPLD_0", "0x00 0x0b 0x03 0x04"),
+                ("FW_ERoT_AP_CFG_0", "0128"),
+                ("NIC_0", "32.47.1026"),
+                ("TPM_Firmware", "15.23"),
+                ("UEFI", "02.04.12-dde0f655"),
+                ("HGX_FW_BMC_0", "GB200Nvl-25.06-A"),
+                ("HGX_FW_CPLD_0", "0.22"),
+                ("HGX_FW_CPU_0", "00000082"),
+                ("HGX_FW_ERoT_BMC_0", "01.04.0031.0000_n04"),
+            ]
+            .iter()
+            .map(|(id, version)| fw_inv_builder(id).version(version).build())
+            .collect(),
         }
     }
 }

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -32,6 +32,7 @@ mod machine_info;
 mod middleware_router;
 mod mock_machine_router;
 mod redfish;
+pub mod test_support;
 pub mod tls;
 
 pub use combined_server::{CombinedServer, ListenerOrAddress};

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -158,6 +158,13 @@ impl HostMachineInfo {
         }
     }
 
+    pub fn bmc_product(&self) -> Option<&'static str> {
+        match self.hw_type {
+            HostHardwareType::DellPowerEdgeR750 => None,
+            HostHardwareType::WiwynnGB200Nvl => Some("GB200 NVL"),
+        }
+    }
+
     pub fn manager_config(&self) -> redfish::manager::Config {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().manager_config(),
@@ -258,6 +265,13 @@ impl MachineInfo {
         match self {
             MachineInfo::Host(h) => h.bmc_vendor(),
             MachineInfo::Dpu(_) => redfish::oem::BmcVendor::Nvidia,
+        }
+    }
+
+    pub fn bmc_product(&self) -> Option<&'static str> {
+        match self {
+            MachineInfo::Host(h) => h.bmc_product(),
+            MachineInfo::Dpu(_) => None,
         }
     }
 

--- a/crates/bmc-mock/src/mock_machine_router.rs
+++ b/crates/bmc-mock/src/mock_machine_router.rs
@@ -70,6 +70,7 @@ pub fn machine_router(
     let chassis_config = machine_info.chassis_config();
     let update_service_config = machine_info.update_service_config();
     let bmc_vendor = machine_info.bmc_vendor();
+    let bmc_product = machine_info.bmc_product();
     let oem_state = machine_info.oem_state();
     let router = Router::new()
         // Couple routes for bug injection.
@@ -103,6 +104,7 @@ pub fn machine_router(
     let injected_bugs = Arc::new(InjectedBugs::default());
     let router = router.with_state(BmcState {
         bmc_vendor,
+        bmc_product,
         oem_state,
         manager,
         system_state,

--- a/crates/bmc-mock/src/redfish/manager.rs
+++ b/crates/bmc-mock/src/redfish/manager.rs
@@ -107,6 +107,30 @@ impl ManagerBuilder {
         self.apply_patch(resource.nav_property("NetworkProtocol"))
     }
 
+    pub fn oem(self, oem: &Oem) -> Self {
+        match oem {
+            Oem::Dell => self.apply_patch(json!({
+                "Oem": {
+                    "Dell": {
+                        // DelliDRACCard is required by libredfish...
+                        "DelliDRACCard": {
+                            "@odata.context": "/redfish/v1/$metadata#DelliDRACCard.DelliDRACCard",
+                            "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCard/iDRAC.Embedded.1-1_0x23_IDRACinfo",
+                            "@odata.type": "#DelliDRACCard.v1_1_0.DelliDRACCard",
+                            "Description": "An instance of DelliDRACCard will have data specific to the Integrated Dell Remote Access Controller (iDRAC) in the managed system.",
+                            "IPMIVersion": "2.0",
+                            "Id": "iDRAC.Embedded.1-1_0x23_IDRACinfo",
+                            "LastSystemInventoryTime": "2026-02-20T04:38:38+00:00",
+                            "LastUpdateTime": "2026-03-06T04:44:21+00:00",
+                            "Name": "DelliDRACCard",
+                            "URLString": "https://10.217.157.137:443"
+                        }
+                    }
+                }
+            })),
+        }
+    }
+
     // TODO: we can use typed UUID here, but all these fields are
     // really not used it just requirements of libredfish model added
     // "just in case"...
@@ -151,14 +175,27 @@ pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
         )
 }
 
+#[derive(Clone, Copy)]
+pub enum Oem {
+    Dell,
+}
+
+impl AsRef<Oem> for Oem {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 pub struct Config {
     pub managers: Vec<SingleConfig>,
 }
 
+#[derive(Clone)]
 pub struct SingleConfig {
     pub id: &'static str,
     pub eth_interfaces: Vec<redfish::ethernet_interface::EthernetInterface>,
     pub firmware_version: &'static str,
+    pub oem: Option<Oem>,
 }
 
 pub struct ManagerState {
@@ -183,17 +220,15 @@ impl ManagerState {
 
 pub struct SingleManagerState {
     id: &'static str,
-    eth_interfaces: Vec<redfish::ethernet_interface::EthernetInterface>,
-    firmware_version: String,
     ipmi_enabled: Arc<atomic::AtomicBool>,
+    config: SingleConfig,
 }
 
 impl SingleManagerState {
     pub fn new(config: &SingleConfig) -> Self {
         Self {
             id: config.id,
-            eth_interfaces: config.eth_interfaces.clone(),
-            firmware_version: config.firmware_version.to_string(),
+            config: config.clone(),
             ipmi_enabled: Arc::new(false.into()),
         }
     }
@@ -224,11 +259,12 @@ async fn get_manager(State(state): State<BmcState>, Path(manager_id): Path<Strin
         ))
         .ethernet_interfaces(redfish::ethernet_interface::manager_collection(&manager_id))
         .enable_reset_action()
-        .firmware_version(&this.firmware_version)
+        .firmware_version(this.config.firmware_version)
         .log_services(redfish::log_service::manager_collection(&manager_id))
         .status(redfish::resource::Status::Ok)
         .uuid("3347314f-c0c6-5080-3410-00354c4c4544")
         .date_time(Utc::now())
+        .maybe_with(ManagerBuilder::oem, &this.config.oem)
         .build()
         .into_ok_response()
 }
@@ -242,6 +278,7 @@ async fn get_ethernet_interface_collection(
     };
 
     let members = this
+        .config
         .eth_interfaces
         .iter()
         .map(|eth| redfish::ethernet_interface::manager_resource(&manager_id, &eth.id).entity_ref())
@@ -258,7 +295,8 @@ async fn get_ethernet_interface(
     let Some(this) = state.manager.find(&manager_id) else {
         return http::not_found();
     };
-    this.eth_interfaces
+    this.config
+        .eth_interfaces
         .iter()
         .find(|eth| eth.id == eth_id)
         .map(|eth| eth.to_json().into_ok_response())

--- a/crates/bmc-mock/src/redfish/service_root.rs
+++ b/crates/bmc-mock/src/redfish/service_root.rs
@@ -53,6 +53,7 @@ async fn get_service_root(State(state): State<BmcState>) -> Response {
     builder(&resource())
         .redfish_version("1.13.1")
         .vendor(state.bmc_vendor.service_root_value())
+        .maybe_with(ServiceRootBuilder::product, &state.bmc_product)
         .account_service(&redfish::account_service::resource())
         .chassis_collection(&redfish::chassis::collection())
         .system_collection(&redfish::computer_system::collection())
@@ -85,6 +86,10 @@ impl ServiceRootBuilder {
 
     pub fn vendor(self, v: &str) -> Self {
         self.add_str_field("Vendor", v)
+    }
+
+    pub fn product(self, v: &str) -> Self {
+        self.add_str_field("Product", v)
     }
 
     pub fn account_service(self, v: &redfish::Resource<'_>) -> Self {

--- a/crates/bmc-mock/src/test_support/axum_http_client.rs
+++ b/crates/bmc-mock/src/test_support/axum_http_client.rs
@@ -1,0 +1,204 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::fmt;
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{HeaderMap, Method, Request, StatusCode};
+use http_body_util::BodyExt;
+use nv_redfish::bmc_http::{BmcCredentials, CacheableError, HttpClient};
+use nv_redfish::core::{BoxTryStream, ModificationResponse, ODataETag};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use tower::ServiceExt;
+use url::Url;
+
+#[derive(Debug)]
+pub enum Error {
+    InvalidResponse {
+        url: Url,
+        status: StatusCode,
+        text: String,
+    },
+    Json(serde_json::Error),
+    Http(axum::http::Error),
+    Cache(String),
+    NotSupported(&'static str),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidResponse { url, status, text } => {
+                write!(f, "invalid response {} {}: {}", status, url, text)
+            }
+            Self::Json(err) => write!(f, "json error: {err}"),
+            Self::Http(err) => write!(f, "http build error: {err}"),
+            Self::Cache(reason) => write!(f, "cache error: {reason}"),
+            Self::NotSupported(what) => write!(f, "not supported in test client: {what}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl CacheableError for Error {
+    fn is_cached(&self) -> bool {
+        matches!(
+            self,
+            Self::InvalidResponse {
+                status: StatusCode::NOT_MODIFIED,
+                ..
+            }
+        )
+    }
+
+    fn cache_miss() -> Self {
+        Self::NotSupported("cache miss")
+    }
+
+    fn cache_error(reason: String) -> Self {
+        Self::Cache(reason)
+    }
+}
+
+#[derive(Clone)]
+pub struct AxumRouterHttpClient {
+    router: Router,
+}
+
+impl AxumRouterHttpClient {
+    pub fn new(router: Router) -> Self {
+        Self { router }
+    }
+
+    fn request_builder(
+        method: Method,
+        url: &Url,
+        _credentials: &BmcCredentials,
+        custom_headers: &HeaderMap,
+    ) -> axum::http::request::Builder {
+        let mut builder = Request::builder().method(method).uri(url.to_string());
+        for (name, value) in custom_headers {
+            builder = builder.header(name, value);
+        }
+        builder
+    }
+
+    async fn call(&self, request: Request<Body>) -> Result<axum::response::Response, Error> {
+        let response = self
+            .router
+            .clone()
+            .oneshot(request)
+            .await
+            .map_err(|_| Error::NotSupported("router service error"))?;
+        Ok(response)
+    }
+
+    async fn response_bytes(
+        response: axum::response::Response,
+    ) -> Result<(StatusCode, HeaderMap, axum::body::Bytes), Error> {
+        let status = response.status();
+        let headers = response.headers().clone();
+        let bytes = response
+            .into_body()
+            .collect()
+            .await
+            .map_err(|_| Error::NotSupported("response body collect error"))?
+            .to_bytes();
+        Ok((status, headers, bytes))
+    }
+}
+
+impl HttpClient for AxumRouterHttpClient {
+    type Error = Error;
+    async fn get<T>(
+        &self,
+        url: Url,
+        credentials: &BmcCredentials,
+        _: Option<ODataETag>,
+        custom_headers: &HeaderMap,
+    ) -> Result<T, Self::Error>
+    where
+        T: DeserializeOwned,
+    {
+        let builder = Self::request_builder(Method::GET, &url, credentials, custom_headers);
+        let request = builder.body(Body::empty()).map_err(Error::Http)?;
+        let response = self.call(request).await?;
+        let (status, _, bytes) = Self::response_bytes(response).await?;
+        if !status.is_success() {
+            return Err(Error::InvalidResponse {
+                url,
+                status,
+                text: String::from_utf8_lossy(&bytes).to_string(),
+            });
+        }
+        let value: serde_json::Value = serde_json::from_slice(&bytes).map_err(Error::Json)?;
+        serde_json::from_value(value).map_err(Error::Json)
+    }
+
+    async fn post<B, T>(
+        &self,
+        _: Url,
+        _: &B,
+        _: &BmcCredentials,
+        _: &HeaderMap,
+    ) -> Result<ModificationResponse<T>, Self::Error>
+    where
+        B: Serialize + Send + Sync,
+        T: DeserializeOwned + Send + Sync,
+    {
+        Err(Error::NotSupported("POST is not supported yet"))
+    }
+
+    async fn patch<B, T>(
+        &self,
+        _: Url,
+        _: ODataETag,
+        _: &B,
+        _: &BmcCredentials,
+        _: &HeaderMap,
+    ) -> Result<ModificationResponse<T>, Self::Error>
+    where
+        B: Serialize + Send + Sync,
+        T: DeserializeOwned + Send + Sync,
+    {
+        Err(Error::NotSupported("PATCH is not supported yet"))
+    }
+
+    async fn delete<T>(
+        &self,
+        _: Url,
+        _: &BmcCredentials,
+        _: &HeaderMap,
+    ) -> Result<ModificationResponse<T>, Self::Error>
+    where
+        T: DeserializeOwned + Send + Sync,
+    {
+        Err(Error::NotSupported("DELETE is not supported yet"))
+    }
+
+    async fn sse<T: Sized + for<'a> serde::Deserialize<'a> + Send + 'static>(
+        &self,
+        _url: Url,
+        _credentials: &BmcCredentials,
+        _custom_headers: &HeaderMap,
+    ) -> Result<BoxTryStream<T, Self::Error>, Self::Error> {
+        Err(Error::NotSupported("SSE stream is not supported yet"))
+    }
+}

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -1,0 +1,164 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use nv_redfish::bmc_http::{BmcCredentials, CacheSettings, HttpBmc};
+use url::Url;
+
+use crate::{
+    DpuFirmwareVersions, DpuMachineInfo, HostHardwareType, HostMachineInfo, MachineInfo,
+    MockPowerState, PowerControl, SetSystemPowerError, SystemPowerControl, machine_router,
+};
+
+pub mod axum_http_client;
+
+use axum_http_client::AxumRouterHttpClient;
+
+#[derive(Debug)]
+struct NoopPowerControl;
+
+impl PowerControl for NoopPowerControl {
+    fn get_power_state(&self) -> MockPowerState {
+        MockPowerState::On
+    }
+
+    fn send_power_command(
+        &self,
+        _reset_type: SystemPowerControl,
+    ) -> Result<(), SetSystemPowerError> {
+        Ok(())
+    }
+}
+
+pub type TestBmc = HttpBmc<AxumRouterHttpClient>;
+
+pub fn wiwynn_gb200_router() -> axum::Router {
+    let dpus = vec![
+        DpuMachineInfo::new(
+            HostHardwareType::WiwynnGB200Nvl,
+            false,
+            DpuFirmwareVersions::default(),
+        ),
+        DpuMachineInfo::new(
+            HostHardwareType::WiwynnGB200Nvl,
+            false,
+            DpuFirmwareVersions::default(),
+        ),
+    ];
+    let machine_info =
+        MachineInfo::Host(HostMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, dpus));
+    machine_router(
+        machine_info,
+        Arc::new(NoopPowerControl),
+        "test-host-id".to_string(),
+    )
+}
+
+pub fn wiwynn_gb200_bmc() -> Arc<TestBmc> {
+    let router = wiwynn_gb200_router();
+    let client = AxumRouterHttpClient::new(router);
+    let endpoint = Url::parse("https://bmc-mock.local").expect("valid URL");
+    let credentials = BmcCredentials::new("root".to_string(), "password".to_string());
+    Arc::new(HttpBmc::new(
+        client,
+        endpoint,
+        credentials,
+        CacheSettings::with_capacity(32),
+    ))
+}
+
+pub fn dell_poweredge_r750_bmc() -> Arc<TestBmc> {
+    let machine_info = MachineInfo::Host(HostMachineInfo::new(
+        HostHardwareType::DellPowerEdgeR750,
+        vec![],
+    ));
+    let router = machine_router(
+        machine_info,
+        Arc::new(NoopPowerControl),
+        "test-host-id".to_string(),
+    );
+    let client = AxumRouterHttpClient::new(router);
+    let endpoint = Url::parse("https://bmc-mock.local").expect("valid URL");
+    let credentials = BmcCredentials::new("root".to_string(), "password".to_string());
+    Arc::new(HttpBmc::new(
+        client,
+        endpoint,
+        credentials,
+        CacheSettings::with_capacity(32),
+    ))
+}
+
+#[cfg(test)]
+mod test {
+
+    use axum::Router;
+    use nv_redfish::bmc_http::{BmcCredentials, HttpClient};
+    use url::Url;
+
+    use super::*;
+    use crate::test_support::axum_http_client::Error;
+
+    #[tokio::test]
+    async fn transport_supports_expand_query_through_mock_expander() {
+        let client = AxumRouterHttpClient::new(wiwynn_gb200_router());
+        let url =
+            Url::parse("https://bmc-mock.local/redfish/v1/Chassis?$expand=.($levels=1)").unwrap();
+
+        let response: serde_json::Value = client
+            .get(
+                url,
+                &BmcCredentials::new("root".to_string(), "password".to_string()),
+                None,
+                &axum::http::HeaderMap::new(),
+            )
+            .await
+            .expect("expanded GET should succeed");
+
+        let members = response
+            .get("Members")
+            .and_then(|m| m.as_array())
+            .expect("expanded response should contain Members array");
+        assert!(!members.is_empty(), "expanded Members must not be empty");
+        assert!(
+            members[0].get("@odata.id").is_some() && members[0].get("Name").is_some(),
+            "expanded member should contain entity fields from expander router"
+        );
+    }
+
+    #[tokio::test]
+    async fn unroutable_request_returns_404_from_transport() {
+        let client = AxumRouterHttpClient::new(Router::new());
+        let url = Url::parse("https://bmc-mock.local/redfish/v1").unwrap();
+        let err = client
+            .get::<serde_json::Value>(
+                url,
+                &BmcCredentials::new("root".to_string(), "password".to_string()),
+                None,
+                &axum::http::HeaderMap::new(),
+            )
+            .await
+            .expect_err("empty router should return transport error");
+
+        match err {
+            Error::InvalidResponse { status, .. } => {
+                assert_eq!(status, axum::http::StatusCode::NOT_FOUND);
+            }
+            other => panic!("expected invalid response error, got: {other}"),
+        }
+    }
+}


### PR DESCRIPTION
## Description
Improvement in bmc-mock:
- Added support of Manager/Oem object (used for Dell)
- Added WIWYNN GB200 firmwares
- Added implementation of nv-redfish BMC access to objects exposed by bmc-mock for test purposes.

Bump nv-redfish version to 0.4.0

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

