### PR TITLE
fix: remove unknown partitions

### DIFF
--- a/crates/api/src/nvl_partition_monitor/metrics.rs
+++ b/crates/api/src/nvl_partition_monitor/metrics.rs
@@ -366,7 +366,7 @@ impl From<NmxmPartitionOperationType> for NmxmPartitionOperations {
         match value {
             NmxmPartitionOperationType::Create => NmxmPartitionOperations::Create,
             NmxmPartitionOperationType::Remove(_) => NmxmPartitionOperations::Remove,
-            NmxmPartitionOperationType::RemoveDefaultPartition(_) => {
+            NmxmPartitionOperationType::RemoveUnknownPartition(_) => {
                 NmxmPartitionOperations::RemoveDefaultPartition
             }
             NmxmPartitionOperationType::Update(_) => NmxmPartitionOperations::Update,

--- a/crates/api/src/nvl_partition_monitor/mod.rs
+++ b/crates/api/src/nvl_partition_monitor/mod.rs
@@ -58,7 +58,7 @@ struct NmxmPartitionOperation {
 enum NmxmPartitionOperationType {
     Create,
     Remove(String), // TODO: create an NmxMId type
-    RemoveDefaultPartition(String),
+    RemoveUnknownPartition(String),
     Update(String),
     Pending(String), // Operation ID
 }
@@ -67,7 +67,7 @@ enum NmxmPartitionOperationType {
 enum GpuAction {
     AddToPartition,
     RemoveFromPartition,
-    RemoveFromDefaultPartition,
+    RemoveFromUnknownPartition,
     NoOp,
 }
 
@@ -102,7 +102,7 @@ pub struct PartitionProcessingContext {
     machine_nvlink_info: HashMap<MachineId, Option<MachineNvLinkInfo>>,
     gpu_to_partition_map: HashMap<String, libnmxm::nmxm_model::Partition>, // NMX-M GPU ID to NMX-M partition
     nmx_m_operations: HashMap<NvLinkLogicalPartitionId, Vec<NmxmPartitionOperation>>,
-    default_partition_removal_operations: HashMap<String, Vec<NmxmPartitionOperation>>,
+    unknown_partition_removal_operations: HashMap<String, Vec<NmxmPartitionOperation>>,
 }
 
 impl PartitionProcessingContext {
@@ -132,7 +132,7 @@ impl PartitionProcessingContext {
             machine_nvlink_info,
             gpu_to_partition_map: gpu_map,
             nmx_m_operations: HashMap::new(),
-            default_partition_removal_operations: HashMap::new(),
+            unknown_partition_removal_operations: HashMap::new(),
         }
     }
     // Build a map from GPU IDs to their partition IDs from NMX-M partitions
@@ -277,7 +277,7 @@ impl PartitionProcessingContext {
         Some(gpus_to_keep)
     }
 
-    fn get_gpus_to_keep_in_default_partition_after_removal(
+    fn get_gpus_to_keep_in_unknown_partition_after_removal(
         &self,
         partition_nmx_m_id: &str,
         gpu_nmx_m_id: &str,
@@ -285,7 +285,7 @@ impl PartitionProcessingContext {
         device_instance: u32,
     ) -> Option<Vec<String>> {
         let gpus_to_keep = match self
-            .default_partition_removal_operations
+            .unknown_partition_removal_operations
             .get(partition_nmx_m_id)
         {
             Some(ops) => {
@@ -328,7 +328,7 @@ impl PartitionProcessingContext {
                 }
             }
             None => {
-                // No removal operations found, so get the GPUs from the default partition.
+                // No removal operations found, so get the GPUs from the unknown partition.
                 match self.nmx_m_partitions.get(partition_nmx_m_id) {
                     Some(p) => match p.members.as_ref() {
                         libnmxm::nmxm_model::PartitionMembers::Ids(ids) => ids
@@ -430,8 +430,8 @@ impl PartitionProcessingContext {
         Ok(())
     }
 
-    // Handle GPU removal from the default partition
-    fn handle_gpu_removal_from_default_partition(
+    // Handle GPU removal from the unknown partition
+    fn handle_gpu_removal_from_unknown_partition(
         &mut self,
         partition_nmx_m_id: &str,
         gpu_nmx_m_id: &str,
@@ -440,7 +440,7 @@ impl PartitionProcessingContext {
         if gpus_to_keep.is_empty() {
             let operation = NmxmPartitionOperation {
                 domain_uuid: None,
-                operation_type: NmxmPartitionOperationType::RemoveDefaultPartition(
+                operation_type: NmxmPartitionOperationType::RemoveUnknownPartition(
                     partition_nmx_m_id.to_string(),
                 ),
                 original_operation_type: None,
@@ -449,14 +449,14 @@ impl PartitionProcessingContext {
                 db_partition_id: None,
             };
 
-            self.default_partition_removal_operations
+            self.unknown_partition_removal_operations
                 .entry(partition_nmx_m_id.to_string())
                 .and_modify(|ops| {
                     if let Some(op) = ops
                         .iter_mut()
                         .find(|op| op.gpu_ids.contains(&gpu_nmx_m_id.to_string()))
                     {
-                        op.operation_type = NmxmPartitionOperationType::RemoveDefaultPartition(
+                        op.operation_type = NmxmPartitionOperationType::RemoveUnknownPartition(
                             partition_nmx_m_id.to_string(),
                         );
                         op.original_operation_type = None;
@@ -475,7 +475,7 @@ impl PartitionProcessingContext {
                 name: "".to_string(),
                 db_partition_id: None,
             };
-            self.default_partition_removal_operations
+            self.unknown_partition_removal_operations
                 .entry(partition_nmx_m_id.to_string())
                 .and_modify(|ops| {
                     if let Some(op) = ops
@@ -1109,20 +1109,31 @@ impl NvlPartitionMonitor {
                                 }
                                 None => {
                                     // TODO: should we add the partition NMX-M ID to the status obs?
-                                    if is_nmx_m_default_partition(&nmxm_partition)
-                                        && instance_gpu_config.is_some()
-                                    {
-                                        tracing::info!(
-                                            "Removing GPU {} in machine {} and instance {} from default partition {}",
+                                    if is_nmx_m_default_partition(&nmxm_partition) {
+                                        if instance_gpu_config.is_some() {
+                                            tracing::info!(
+                                                "Removing GPU {} in machine {} and instance {} from default partition {}",
+                                                nvlink_gpu.nmx_m_id,
+                                                instance.machine_id,
+                                                instance.id,
+                                                nmxm_partition.id
+                                            );
+                                            gpu_action = GpuAction::RemoveFromUnknownPartition;
+                                            gpu_ctx.partition_nmx_m_id = nmxm_partition.id;
+                                        } else {
+                                            // Do nothing if there is no config
+                                            gpu_action = GpuAction::NoOp;
+                                        }
+                                    } else {
+                                        // Monitor does not know about this partition, so just remove the GPU. On the next iteration
+                                        // the monitor will put the GPU in the correct partition (or leave it if the config says no partition)
+                                        tracing::warn!(
+                                            "Removing GPU {} from unknown partition with NMX-M ID {}",
                                             nvlink_gpu.nmx_m_id,
-                                            instance.machine_id,
-                                            instance.id,
                                             nmxm_partition.id
                                         );
-                                        gpu_action = GpuAction::RemoveFromDefaultPartition;
+                                        gpu_action = GpuAction::RemoveFromUnknownPartition;
                                         gpu_ctx.partition_nmx_m_id = nmxm_partition.id;
-                                    } else {
-                                        gpu_action = GpuAction::NoOp;
                                     }
                                 }
                             }
@@ -1183,16 +1194,16 @@ impl NvlPartitionMonitor {
 
                                 partition_ctx.handle_gpu_removal(&gpu_ctx, gpus_to_keep)?;
                             }
-                            GpuAction::RemoveFromDefaultPartition => {
+                            GpuAction::RemoveFromUnknownPartition => {
                                 if let Some(gpus_to_keep) = partition_ctx
-                                    .get_gpus_to_keep_in_default_partition_after_removal(
+                                    .get_gpus_to_keep_in_unknown_partition_after_removal(
                                         &gpu_ctx.partition_nmx_m_id,
                                         &gpu_ctx.gpu_nmx_m_id,
                                         &instance.machine_id,
                                         device_instance,
                                     )
                                 {
-                                    partition_ctx.handle_gpu_removal_from_default_partition(
+                                    partition_ctx.handle_gpu_removal_from_unknown_partition(
                                         &gpu_ctx.partition_nmx_m_id,
                                         &gpu_ctx.gpu_nmx_m_id,
                                         gpus_to_keep,
@@ -1225,7 +1236,7 @@ impl NvlPartitionMonitor {
 
         // Add all default partition removals to the normal list so they get executed.
         for (_partition_nmx_m_id, operations) in
-            partition_ctx.default_partition_removal_operations.iter()
+            partition_ctx.unknown_partition_removal_operations.iter()
         {
             for operation in operations {
                 partition_ctx
@@ -1452,7 +1463,7 @@ impl NvlPartitionMonitor {
                             }
                         }
                     }
-                    NmxmPartitionOperationType::RemoveDefaultPartition(nmx_m_partition_id) => {
+                    NmxmPartitionOperationType::RemoveUnknownPartition(nmx_m_partition_id) => {
                         tracing::info!("NOT Removing default partition {nmx_m_partition_id}");
                         // Remove from the default partition.
                         let result = nmxm_client
@@ -1472,7 +1483,7 @@ impl NvlPartitionMonitor {
                                         result.operation_id.clone(),
                                     ),
                                     original_operation_type: Some(
-                                        NmxmPartitionOperationType::RemoveDefaultPartition(
+                                        NmxmPartitionOperationType::RemoveUnknownPartition(
                                             nmx_m_partition_id.clone(),
                                         ),
                                     ),
@@ -1487,7 +1498,7 @@ impl NvlPartitionMonitor {
                                     result.operation_id.clone(),
                                 ),
                                 original_operation_type: Some(
-                                    NmxmPartitionOperationType::RemoveDefaultPartition(
+                                    NmxmPartitionOperationType::RemoveUnknownPartition(
                                         nmx_m_partition_id.clone(),
                                     ),
                                 ),
@@ -1799,7 +1810,7 @@ impl NvlPartitionMonitor {
                     NmxmPartitionOperationType::Pending(_operation_id) => {
                         // Should be no pending operations in this step.
                     }
-                    NmxmPartitionOperationType::RemoveDefaultPartition(_) => {
+                    NmxmPartitionOperationType::RemoveUnknownPartition(_) => {
                         // No-op, since default partition membership is not tracked in the partitions table. The status observation of the
                         // added/removed GPUs will be updated.
                     }

--- a/crates/api/src/nvlink.rs
+++ b/crates/api/src/nvlink.rs
@@ -137,9 +137,10 @@ pub mod test_support {
             }
         }
 
-        pub fn with_default_partition() -> Self {
+        pub fn with_unknown_partition() -> Self {
             let client = Self::default();
-            client.create_default_partition(
+            client.create_partition(
+                12345,
                 client
                     ._gpus
                     .lock()
@@ -151,11 +152,26 @@ pub mod test_support {
             client
         }
 
-        /// Creates a default partition with partition_id 32766 containing the specified GPU IDs.
-        fn create_default_partition(&self, gpu_ids: Vec<String>) {
+        pub fn with_default_partition() -> Self {
+            let client = Self::default();
+            client.create_partition(
+                32766, // default partition id.
+                client
+                    ._gpus
+                    .lock()
+                    .unwrap()
+                    .iter()
+                    .filter_map(|gpu| gpu.id.clone())
+                    .collect(),
+            );
+            client
+        }
+
+        /// Creates a partition with given partition_id containing the specified GPU IDs.
+        fn create_partition(&self, partition_id: i32, gpu_ids: Vec<String>) {
             let partition = libnmxm::nmxm_model::Partition {
                 id: "default-partition".to_string(),
-                partition_id: 32766,
+                partition_id,
                 name: "Default Partition".to_string(),
                 r#type: libnmxm::nmxm_model::PartitionType::PartitionTypeIDBased,
                 health: libnmxm::nmxm_model::PartitionHealth::PartitionHealthHealthy,

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -261,6 +261,7 @@ pub struct TestEnvOverrides {
     pub dpf_config: Option<DpfConfig>,
     pub fnn_config: Option<FnnConfig>,
     pub nmxm_default_partition: Option<bool>,
+    pub nmxm_unknown_partition: Option<bool>,
     // After n create_requests succeed, they will start failing.
     pub nmxm_fail_after_n_creates: Option<usize>,
 }
@@ -1282,6 +1283,8 @@ pub async fn create_test_env_with_overrides(
             NmxmSimClient::with_fail_after_n_creates(n)
         } else if overrides.nmxm_default_partition == Some(true) {
             NmxmSimClient::with_default_partition()
+        } else if overrides.nmxm_unknown_partition == Some(true) {
+            NmxmSimClient::with_unknown_partition()
         } else {
             NmxmSimClient::default()
         });

--- a/crates/api/src/tests/nvl_instance.rs
+++ b/crates/api/src/tests/nvl_instance.rs
@@ -1528,3 +1528,112 @@ async fn test_create_instance_add_to_existing_partition(pool: sqlx::PgPool) {
     };
     assert_eq!(members.len(), 8);
 }
+
+#[crate::sqlx_test]
+async fn test_create_instance_gpu_in_unknown_partition(pool: sqlx::PgPool) {
+    let mut config = common::api_fixtures::get_config();
+    if let Some(nvlink_config) = config.nvlink_config.as_mut() {
+        nvlink_config.enabled = true;
+    }
+
+    let mut test_overrides = TestEnvOverrides::with_config(config);
+    test_overrides.nmxm_unknown_partition = Some(true);
+    let env =
+        common::api_fixtures::create_test_env_with_overrides(pool.clone(), test_overrides).await;
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+
+    let NvlLogicalPartitionFixture {
+        id: logical_partition_id,
+        logical_partition: _logical_partition,
+    } = create_nvl_logical_partition(&env, "test_partition".to_string()).await;
+
+    let request_logical_ids =
+        tonic::Request::new(rpc::forge::NvLinkLogicalPartitionSearchFilter { name: None });
+
+    let logical_ids_list = env
+        .api
+        .find_nv_link_logical_partition_ids(request_logical_ids)
+        .await
+        .map(|response| response.into_inner())
+        .unwrap();
+    assert_eq!(logical_ids_list.partition_ids.len(), 1);
+
+    // There should be an "unknown" partition in NMX-M
+    let nmxm_sim_client = env
+        .nmxm_sim
+        .create_client("localhost:4010", None)
+        .await
+        .unwrap();
+    let nmx_m_partitions = nmxm_sim_client.get_partitions_list().await.unwrap();
+    assert_eq!(nmx_m_partitions.len(), 1);
+
+    let mh1 = create_managed_host_with_hardware_info_template(
+        &env,
+        HardwareInfoTemplate::Custom(
+            crate::tests::common::api_fixtures::host::GB200_COMPUTE_TRAY_1_INFO_JSON,
+        ),
+    )
+    .await;
+    let machine1 = mh1.host().rpc_machine().await;
+    assert_eq!(&machine1.state, "Ready");
+    let discovery_info1 = machine1.discovery_info.as_ref().unwrap();
+
+    assert_eq!(discovery_info1.gpus.len(), 4);
+
+    let gpus: Vec<Gpu> = discovery_info1.gpus.to_vec();
+    println!("{gpus:?}");
+
+    let nvl_config = rpc::forge::InstanceNvLinkConfig {
+        gpu_configs: gpus
+            .iter()
+            .filter_map(|gpu| {
+                gpu.platform_info.as_ref().map(|platform_info| {
+                    rpc::forge::InstanceNvLinkGpuConfig {
+                        device_instance: platform_info.module_id,
+                        logical_partition_id: Some(logical_partition_id),
+                    }
+                })
+            })
+            .collect(),
+    };
+
+    let (tinstance, instance) =
+        create_instance_with_nvlink_config(&env, &mh1, nvl_config.clone(), segment_id).await;
+
+    let machine1 = mh1.host().rpc_machine().await;
+    assert_eq!(&machine1.state, "Assigned/Ready");
+
+    let check_instance = tinstance.rpc_instance().await;
+    assert_eq!(instance.machine_id(), mh1.id);
+    assert_eq!(instance.status().tenant(), rpc::TenantState::Ready);
+    assert_eq!(instance, check_instance);
+
+    env.run_nvl_partition_monitor_iteration().await;
+
+    let request_all = tonic::Request::new(rpc::forge::NvLinkPartitionSearchFilter {
+        name: None,
+        tenant_organization_id: None,
+    });
+    let ids_all = env
+        .api
+        .find_nv_link_partition_ids(request_all)
+        .await
+        .map(|response| response.into_inner())
+        .unwrap();
+    assert_eq!(ids_all.partition_ids.len(), 1);
+
+    let nmx_m_partitions = nmxm_sim_client.get_partitions_list().await.unwrap();
+    // Should be 2 partitions in NMX-M
+    assert_eq!(nmx_m_partitions.len(), 2);
+    let members = match nmx_m_partitions
+        .iter()
+        .find(|p| p.partition_id != 12345)
+        .unwrap()
+        .members
+        .as_ref()
+    {
+        libnmxm::nmxm_model::PartitionMembers::Ids(ids) => ids,
+        _ => panic!("Expected IDs partition members"),
+    };
+    assert_eq!(members.len(), 4);
+}


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
When the nvlink partition monitor encounters a GPU in a partition it doesn't know about, remove the GPU from it, and remove the partition if it's empty.

This fixes some issues we are seeing where NMX-M sometimes returns an error when the partition monitor tries to create a partition, but ends up creating a partition anyway. This results in the monitor "not knowing" about the partition. If we delete the partition, it allows the monitor to recreate it on the next iteration.


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->
https://github.com/NVIDIA/bare-metal-manager-core/issues/304

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

