### PR TITLE
Hold metrics in state controller for a configurable period

### DIFF
--- a/crates/api-test-helper/src/api_server.rs
+++ b/crates/api-test-helper/src/api_server.rs
@@ -216,6 +216,8 @@ pub async fn start(
         processor_dispatch_interval = "500ms"
         max_object_handling_time = "180s"
         max_concurrency = 10
+        metric_emission_interval = "1s"
+        metric_hold_time = "2s"
 
         [network_segment_state_controller]
         network_segment_drain_time = "60s"
@@ -225,12 +227,16 @@ pub async fn start(
         processor_dispatch_interval = "500ms"
         max_object_handling_time = "180s"
         max_concurrency = 10
+        metric_emission_interval = "1s"
+        metric_hold_time = "2s"
 
         [ib_partition_state_controller.controller]
         iteration_time = "20s"
         processor_dispatch_interval = "2s"
         max_object_handling_time = "180s"
         max_concurrency = 10
+        metric_emission_interval = "1s"
+        metric_hold_time = "2s"
 
         [host_models]
 

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -979,6 +979,28 @@ pub struct StateControllerConfig {
         serialize_with = "as_std_duration"
     )]
     pub processor_log_interval: std::time::Duration,
+
+    /// Configures how often the state handling processor will reassess metrics and emit them.
+    /// Calculating aggregate metrics is expensive (all object metrics need to be traversed).
+    /// Therefore this should not happen much more frequently than the observabilty system
+    /// will access them.
+    #[serde(
+        default = "StateControllerConfig::metric_emission_interval",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub metric_emission_interval: std::time::Duration,
+
+    /// Configures for how long metrics for each object managed by the state controller
+    /// will show up before they get evicted.
+    /// The duration of this needs to be longer than the time between state handler
+    /// invocations for the object
+    #[serde(
+        default = "StateControllerConfig::metric_hold_time",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub metric_hold_time: std::time::Duration,
 }
 
 impl StateControllerConfig {
@@ -998,6 +1020,14 @@ impl StateControllerConfig {
         std::time::Duration::from_secs(60)
     }
 
+    pub const fn metric_emission_interval() -> std::time::Duration {
+        std::time::Duration::from_secs(60)
+    }
+
+    pub const fn metric_hold_time() -> std::time::Duration {
+        std::time::Duration::from_secs(5 * 60)
+    }
+
     pub const fn max_concurrency_default() -> usize {
         10
     }
@@ -1011,6 +1041,8 @@ impl Default for StateControllerConfig {
             processor_dispatch_interval: Self::processor_dispatch_interval_default(),
             processor_log_interval: Self::processor_log_interval_default(),
             max_concurrency: Self::max_concurrency_default(),
+            metric_emission_interval: Self::metric_emission_interval(),
+            metric_hold_time: Self::metric_hold_time(),
         }
     }
 }
@@ -1023,6 +1055,8 @@ impl From<&StateControllerConfig> for IterationConfig {
             max_concurrency: config.max_concurrency,
             processor_dispatch_interval: config.processor_dispatch_interval,
             processor_log_interval: config.processor_log_interval,
+            metric_emission_interval: config.metric_emission_interval,
+            metric_hold_time: config.metric_hold_time,
         }
     }
 }
@@ -2746,6 +2780,8 @@ mod tests {
                 max_concurrency: 10,
                 processor_dispatch_interval: std::time::Duration::from_secs(2),
                 processor_log_interval: std::time::Duration::from_secs(60),
+                metric_emission_interval: std::time::Duration::from_secs(60),
+                metric_hold_time: std::time::Duration::from_secs(5 * 60),
             },
             dpu_wait_time: Duration::minutes(20),
             power_down_wait: Duration::seconds(10),
@@ -2785,6 +2821,8 @@ mod tests {
                         max_concurrency: 13,
                         processor_dispatch_interval: std::time::Duration::from_secs(2),
                         processor_log_interval: std::time::Duration::from_secs(60),
+                        metric_emission_interval: std::time::Duration::from_secs(60),
+                        metric_hold_time: std::time::Duration::from_secs(5 * 60),
                     }
                 },
                 dpu_wait_time: Duration::minutes(20),
@@ -2831,6 +2869,8 @@ mod tests {
                         max_concurrency: 13,
                         processor_dispatch_interval: std::time::Duration::from_secs(2),
                         processor_log_interval: std::time::Duration::from_secs(60),
+                        metric_emission_interval: std::time::Duration::from_secs(60),
+                        metric_hold_time: std::time::Duration::from_secs(5 * 60),
                     }
                 },
                 network_segment_drain_time: Duration::minutes(21),
@@ -2852,7 +2892,7 @@ mod tests {
         let config_str = serde_json::to_string(&input).unwrap();
         assert_eq!(
             config_str,
-            r#"{"iteration_time":"30s","max_object_handling_time":"180s","max_concurrency":10,"processor_dispatch_interval":"2s","processor_log_interval":"60s"}"#
+            r#"{"iteration_time":"30s","max_object_handling_time":"180s","max_concurrency":10,"processor_dispatch_interval":"2s","processor_log_interval":"60s","metric_emission_interval":"60s","metric_hold_time":"300s"}"#
         );
         let config: StateControllerConfig = serde_json::from_str(&config_str).unwrap();
         assert_eq!(config, input);
@@ -2866,11 +2906,13 @@ mod tests {
             max_concurrency: 33,
             processor_dispatch_interval: std::time::Duration::from_secs(2),
             processor_log_interval: std::time::Duration::from_secs(60),
+            metric_emission_interval: std::time::Duration::from_secs(60),
+            metric_hold_time: std::time::Duration::from_secs(5 * 60),
         };
         let config_str = serde_json::to_string(&input).unwrap();
         assert_eq!(
             config_str,
-            r#"{"iteration_time":"11s","max_object_handling_time":"22s","max_concurrency":33,"processor_dispatch_interval":"2s","processor_log_interval":"60s"}"#
+            r#"{"iteration_time":"11s","max_object_handling_time":"22s","max_concurrency":33,"processor_dispatch_interval":"2s","processor_log_interval":"60s","metric_emission_interval":"60s","metric_hold_time":"300s"}"#
         );
         let config: StateControllerConfig = serde_json::from_str(&config_str).unwrap();
         assert_eq!(config, input);
@@ -3042,6 +3084,8 @@ mod tests {
                     max_concurrency: 22,
                     processor_dispatch_interval: std::time::Duration::from_secs(2),
                     processor_log_interval: std::time::Duration::from_secs(60),
+                    metric_emission_interval: std::time::Duration::from_secs(60),
+                    metric_hold_time: std::time::Duration::from_secs(5 * 60),
                 },
                 dpu_wait_time: Duration::minutes(7),
                 power_down_wait: Duration::seconds(17),
@@ -3060,6 +3104,8 @@ mod tests {
                     max_concurrency: 1888,
                     processor_dispatch_interval: std::time::Duration::from_secs(2),
                     processor_log_interval: std::time::Duration::from_secs(60),
+                    metric_emission_interval: std::time::Duration::from_secs(60),
+                    metric_hold_time: std::time::Duration::from_secs(5 * 60),
                 },
             }
         );
@@ -3072,6 +3118,8 @@ mod tests {
                     max_concurrency: 1777,
                     processor_dispatch_interval: std::time::Duration::from_secs(2),
                     processor_log_interval: std::time::Duration::from_secs(60),
+                    metric_emission_interval: std::time::Duration::from_secs(60),
+                    metric_hold_time: std::time::Duration::from_secs(5 * 60),
                 },
             }
         );
@@ -3209,6 +3257,8 @@ mod tests {
                     max_concurrency: 999,
                     processor_dispatch_interval: std::time::Duration::from_secs(2),
                     processor_log_interval: std::time::Duration::from_secs(60),
+                    metric_emission_interval: std::time::Duration::from_secs(60),
+                    metric_hold_time: std::time::Duration::from_secs(5 * 60),
                 },
                 dpu_wait_time: Duration::minutes(3),
                 power_down_wait: Duration::seconds(13),
@@ -3227,6 +3277,8 @@ mod tests {
                     max_concurrency: 888,
                     processor_dispatch_interval: std::time::Duration::from_secs(2),
                     processor_log_interval: std::time::Duration::from_secs(60),
+                    metric_emission_interval: std::time::Duration::from_secs(60),
+                    metric_hold_time: std::time::Duration::from_secs(5 * 60),
                 },
             }
         );
@@ -3239,6 +3291,8 @@ mod tests {
                     max_concurrency: 777,
                     processor_dispatch_interval: std::time::Duration::from_secs(2),
                     processor_log_interval: std::time::Duration::from_secs(60),
+                    metric_emission_interval: std::time::Duration::from_secs(60),
+                    metric_hold_time: std::time::Duration::from_secs(5 * 60),
                 },
             }
         );
@@ -3481,6 +3535,8 @@ mod tests {
                     max_concurrency: 22,
                     processor_dispatch_interval: std::time::Duration::from_secs(2),
                     processor_log_interval: std::time::Duration::from_secs(60),
+                    metric_emission_interval: std::time::Duration::from_secs(60),
+                    metric_hold_time: std::time::Duration::from_secs(5 * 60),
                 },
                 dpu_wait_time: Duration::minutes(7),
                 power_down_wait: Duration::seconds(17),
@@ -3499,6 +3555,8 @@ mod tests {
                     max_concurrency: 1888,
                     processor_dispatch_interval: std::time::Duration::from_secs(2),
                     processor_log_interval: std::time::Duration::from_secs(60),
+                    metric_emission_interval: std::time::Duration::from_secs(60),
+                    metric_hold_time: std::time::Duration::from_secs(5 * 60),
                 },
             }
         );
@@ -3511,6 +3569,8 @@ mod tests {
                     max_concurrency: 1777,
                     processor_dispatch_interval: std::time::Duration::from_secs(2),
                     processor_log_interval: std::time::Duration::from_secs(60),
+                    metric_emission_interval: std::time::Duration::from_secs(60),
+                    metric_hold_time: std::time::Duration::from_secs(5 * 60),
                 },
             }
         );

--- a/crates/api/src/state_controller/config.rs
+++ b/crates/api/src/state_controller/config.rs
@@ -43,6 +43,18 @@ pub struct IterationConfig {
 
     /// Configures how often the state handling processor will emit periodic log messages
     pub processor_log_interval: Duration,
+
+    /// Configures how often the state handling processor will reassess metrics and emit them.
+    /// Calculating aggregate metrics is expensive (all object metrics need to be traversed).
+    /// Therefore this should not happen much more frequently than the observabilty system
+    /// will access them.
+    pub metric_emission_interval: std::time::Duration,
+
+    /// Configures for how long metrics for each object managed by the state controller
+    /// will show up before they get evicted.
+    /// The duration of this needs to be longer than the time between state handler
+    /// invocations for the object
+    pub metric_hold_time: std::time::Duration,
 }
 
 impl Default for IterationConfig {
@@ -57,6 +69,8 @@ impl Default for IterationConfig {
             max_concurrency: 10,
             processor_log_interval: Duration::from_secs(60),
             processor_dispatch_interval: Duration::from_secs(2),
+            metric_emission_interval: Duration::from_secs(60),
+            metric_hold_time: Duration::from_secs(5 * 60),
         }
     }
 }

--- a/crates/api/src/state_controller/controller.rs
+++ b/crates/api/src/state_controller/controller.rs
@@ -113,8 +113,16 @@ impl<IO: StateControllerIO> StateController<IO> {
     /// Enqueues state handling tasks for all objects and processes them
     #[cfg(test)]
     pub async fn run_single_iteration_ext(&mut self, allow_requeue: bool) {
-        let enqueuer_result = self.enqueuer.run_single_iteration().await;
+        // Delete stale object metrics - e.g. from predicted hosts
+        // They make assertions on actually still valid metrics more tricky
+        self.processor.object_metrics.clear();
+
+        let _enqueuer_result = self.enqueuer.run_single_iteration().await;
         loop {
+            // Prevent metric emission - we only emit them a single time after the loop
+            // That cuts down the noise in tests
+            self.processor.last_metric_emission_time = std::time::Instant::now();
+
             if let Err(err) = self
                 .processor
                 .run_single_iteration(std::time::Duration::MAX, allow_requeue)
@@ -127,8 +135,7 @@ impl<IO: StateControllerIO> StateController<IO> {
             }
         }
         // Immediately emit the latest set of metrics
-        self.processor
-            .emit_metrics_for_iteration(enqueuer_result.iteration.map(|iteration| iteration.id));
+        self.processor.emit_metrics();
     }
 }
 

--- a/crates/api/src/state_controller/controller/builder.rs
+++ b/crates/api/src/state_controller/controller/builder.rs
@@ -170,7 +170,11 @@ impl<IO: StateControllerIO> Builder<IO> {
 
         // This defines the shared storage location for metrics between the state handler
         // and the OTEL framework
-        let metric_holder = Arc::new(MetricHolder::new(meter.clone(), &controller_name));
+        let metric_holder = Arc::new(MetricHolder::new(
+            meter.clone(),
+            &controller_name,
+            self.iteration_config.metric_hold_time,
+        ));
 
         let work_lock_manager_handle = self.work_lock_manager_handle.take().ok_or(
             StateControllerBuildError::MissingArgument("work_lock_manager_handle"),
@@ -212,16 +216,15 @@ impl<IO: StateControllerIO> Builder<IO> {
             metric_emitter: processor_metric_emitter,
             metric_holder,
             state_change_emitter: self.state_change_emitter,
-            published_metrics_iteration_id: None,
             in_flight: HashSet::new(),
             completed_objects: HashSet::new(),
             requeue_objects: HashSet::new(),
             task_sender,
             task_receiver,
-            data_since_iteration_start: Default::default(),
             object_metrics: Default::default(),
             last_log_time: std::time::Instant::now(),
             stats_since_last_log: Default::default(),
+            last_metric_emission_time: std::time::Instant::now(),
             processor_span,
             processor_id,
         };

--- a/crates/api/src/state_controller/controller/db.rs
+++ b/crates/api/src/state_controller/controller/db.rs
@@ -17,8 +17,6 @@
 
 //! Database access methods used in the StateController framework
 
-use std::fmt::Write;
-
 use db::work_lock_manager::{AcquireLockError, WorkLockManagerHandle};
 use db::{BIND_LIMIT, DatabaseError};
 use sqlx::{PgConnection, PgPool};
@@ -41,11 +39,13 @@ async fn create_iteration(
 }
 
 /// Loads the given amount iterations, starting by the newest iteration
+#[cfg(test)]
 pub async fn fetch_iterations(
     txn: &mut PgConnection,
     table_id: &str,
     limit: Option<usize>,
 ) -> Result<Vec<ControllerIteration>, DatabaseError> {
+    use std::fmt::Write;
     let mut query = format!("SELECT * FROM {table_id} ORDER BY id DESC");
     if let Some(limit) = limit {
         write!(&mut query, " LIMIT {limit}").unwrap();

--- a/crates/api/src/state_controller/controller/processor.rs
+++ b/crates/api/src/state_controller/controller/processor.rs
@@ -29,7 +29,6 @@ use tracing::Instrument;
 use super::db;
 use crate::logging::sqlx_query_tracing::{self, SqlxQueryDataAggregation};
 use crate::state_controller::config::IterationConfig;
-use crate::state_controller::controller::ControllerIterationId;
 use crate::state_controller::db_write_batch::DbWriteBatch;
 use crate::state_controller::io::StateControllerIO;
 use crate::state_controller::metrics::{
@@ -60,8 +59,6 @@ pub(super) struct StateProcessor<IO: StateControllerIO> {
     pub(super) metric_holder: Arc<MetricHolder<IO>>,
 
     pub(super) object_metrics: HashMap<IO::ObjectId, CollectedMetrics<IO>>,
-    /// The iteration ID for which metrics have been passed towards `metric_holder`
-    pub(super) published_metrics_iteration_id: Option<ControllerIterationId>,
     pub(super) cancel_token: CancellationToken,
     pub(super) iteration_config: IterationConfig,
     /// IDs of objects where the task handler is currently executed
@@ -74,9 +71,10 @@ pub(super) struct StateProcessor<IO: StateControllerIO> {
     pub(super) requeue_objects: HashSet<IO::ObjectId>,
     pub(super) task_sender: tokio::sync::mpsc::UnboundedSender<ObjectHandlingTaskResult<IO>>,
     pub(super) task_receiver: tokio::sync::mpsc::UnboundedReceiver<ObjectHandlingTaskResult<IO>>,
-    pub(super) data_since_iteration_start: DataSinceStartOfEnqueuerIteration,
     /// The last time a log message had been emitted
     pub(super) last_log_time: std::time::Instant,
+    /// The last time aggregate metrics had been emitted
+    pub(super) last_metric_emission_time: std::time::Instant,
     pub(super) stats_since_last_log: StatsSinceLastLog,
     pub(super) processor_span: tracing::Span,
     /// Globally unique ID that identifies the state controller (and processor) working on objects
@@ -91,7 +89,7 @@ pub(super) struct ObjectHandlingTaskResult<IO: StateControllerIO> {
 
 pub(super) struct CollectedMetrics<IO: StateControllerIO> {
     metrics: ObjectHandlerMetrics<IO>,
-    refreshed_in_current_iteration: bool,
+    collected_at: std::time::Instant,
 }
 
 #[derive(Debug)]
@@ -104,20 +102,6 @@ impl std::default::Default for ProcessorIterationMetrics {
     fn default() -> Self {
         Self {
             iteration_started_at: std::time::Instant::now(),
-        }
-    }
-}
-
-#[derive(Debug)]
-pub(super) struct DataSinceStartOfEnqueuerIteration {
-    /// The time when the first state state handling task with a certain Iteration ID was dequeued
-    iteration_started_at_utc: chrono::DateTime<chrono::Utc>,
-}
-
-impl std::default::Default for DataSinceStartOfEnqueuerIteration {
-    fn default() -> Self {
-        Self {
-            iteration_started_at_utc: chrono::Utc::now(),
         }
     }
 }
@@ -147,15 +131,6 @@ pub(super) struct StatsSinceLastLog {
     num_requeued_objects: usize,
     /// The aggregated sqlx metrics at the last time logs had been emitted
     db_query_metrics: SqlxQueryDataAggregation,
-}
-
-#[derive(Debug, Default, Clone)]
-struct QueueStats {
-    /// The ID of the latest iteration that had been started
-    #[allow(dead_code)]
-    latest_iteration: Option<ControllerIterationId>,
-    /// The ID of the last iteration (before the most recent one)
-    previous_iteration: Option<ControllerIterationId>,
 }
 
 impl<IO: StateControllerIO> StateProcessor<IO> {
@@ -258,9 +233,7 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
         // the old entries from the DB first.
         self.requeue_transitioned_objects().await?;
 
-        let queue_stats = self.gather_queue_stats().await?;
-        self.emit_metric_if_iteration_changed(&queue_stats);
-
+        self.emit_metrics_if_necessary();
         self.emit_periodic_log_if_necessary();
 
         if let Some(emitter) = self.metric_emitter.as_ref() {
@@ -273,68 +246,43 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
         })
     }
 
-    async fn gather_queue_stats(&self) -> Result<QueueStats, IterationError> {
-        // We don't need a transaction for a pulling stats
-        let mut conn = self.pool.acquire().await?;
-        let iterations =
-            db::fetch_iterations(&mut conn, IO::DB_ITERATION_ID_TABLE_NAME, Some(2)).await?;
-        let latest_iteration = iterations.first().cloned().map(|iteration| iteration.id);
-        let previous_iteration = if iterations.len() >= 2 {
-            Some(iterations[1].id)
-        } else {
-            None
-        };
-
-        Ok(QueueStats {
-            latest_iteration,
-            previous_iteration,
-        })
-    }
-
-    /// Publishes metrics for the previous iteration ID.
-    /// Since we want the metrics to be emitted on time (coordinated across multiple
-    /// state controller instances), we won't wait until all tasks are finished.
-    fn emit_metric_if_iteration_changed(&mut self, stats: &QueueStats) {
-        self.emit_metrics_for_iteration(stats.previous_iteration);
-    }
-
-    /// Publishes metrics for a certain iteration ID, based on all data that is currently
-    /// known within that iteration.
-    /// If the target ID is `None`, an empty set of metrics will be emitted.
-    pub(super) fn emit_metrics_for_iteration(
-        &mut self,
-        finished_iteration_id: Option<ControllerIterationId>,
-    ) {
-        if self.published_metrics_iteration_id == finished_iteration_id {
-            // Metrics are already published
+    /// Periodically calculates aggregate metrics for all objects that have been processed
+    /// and makes them available for the metrics subsystem.
+    fn emit_metrics_if_necessary(&mut self) {
+        // Aggregate metrics are only recalculated in certain periods to reduce load
+        let now = std::time::Instant::now();
+        if now
+            < self
+                .last_metric_emission_time
+                .checked_add(self.iteration_config.metric_emission_interval)
+                .unwrap_or(now)
+        {
             return;
         }
-        self.published_metrics_iteration_id = finished_iteration_id;
+
+        self.emit_metrics();
+    }
+
+    /// Calculates aggregate metrics for all objects that have been processed
+    /// and makes them available for the metrics subsystem.
+    /// Evicts metrics for objects that are older than the desired hold period
+    pub(super) fn emit_metrics(&mut self) {
+        let now = std::time::Instant::now();
+        self.last_metric_emission_time = now;
 
         let mut aggregate = IterationMetrics::<IO>::default();
         for object_metrics in self.object_metrics.values() {
             aggregate.merge_object_handling_metrics(&object_metrics.metrics);
         }
 
-        // Remove metrics that have not been refreshed in the last iteration
-        // Metrics that have gathered in this iteration will carry forward forward
-        // for one more iteration.
-        // This prevents the race condition where handlers for some objects already
-        // finish processing for iteration N+1 before metrics for iteration N are emitted.
-        // In that case the metrics for iteration N+1 would be lost.
+        // Remove metrics that have not been refreshed for the configured time
+        let min_age = now
+            .checked_sub(self.iteration_config.metric_hold_time)
+            .unwrap_or(now);
         self.object_metrics
-            .retain(|_object_id, metrics| metrics.refreshed_in_current_iteration);
-        for object_metrics in self.object_metrics.values_mut() {
-            object_metrics.refreshed_in_current_iteration = false;
-        }
+            .retain(|_object_id, metrics| metrics.collected_at >= min_age);
 
-        emit_iteration_log(
-            finished_iteration_id,
-            self.data_since_iteration_start.iteration_started_at_utc,
-            &aggregate,
-        );
-
-        self.data_since_iteration_start = DataSinceStartOfEnqueuerIteration::default();
+        emit_object_metrics_as_log(&aggregate);
 
         self.metric_holder
             .last_iteration_specific_metrics
@@ -408,9 +356,10 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
         tokio::select! {
             biased;
             num_received = self.task_receiver.recv_many(&mut finished_tasks, finished_tasks_capacity) => {
+                let now = std::time::Instant::now();
                 for _ in 0 .. num_received {
                     let finished_task = finished_tasks.pop().expect("Object handling task finished");
-                    self.process_object_handling_task_result(finished_task, allow_requeue);
+                    self.process_object_handling_task_result(finished_task, allow_requeue, now);
                     total_completions += 1;
                 }
             }
@@ -594,6 +543,7 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
         &mut self,
         task_result: ObjectHandlingTaskResult<IO>,
         allow_requeue: bool,
+        collected_at: std::time::Instant,
     ) {
         // We don't remove objects from the database here but store them first
         // and remove them later in order to not forget about these in case there
@@ -615,7 +565,7 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
             task_result.object_id.clone(),
             CollectedMetrics {
                 metrics: task_result.metrics,
-                refreshed_in_current_iteration: true,
+                collected_at,
             },
         );
     }
@@ -889,18 +839,8 @@ impl ProcessorMetricsEmitter {
     }
 }
 
-/// Emits the metrics that had been collected during a state controller iteration
-/// as a single log line.
-fn emit_iteration_log<IO: StateControllerIO>(
-    iteration_id: Option<ControllerIterationId>,
-    iteration_processing_started_at: chrono::DateTime<chrono::Utc>,
-    iteration_metrics: &IterationMetrics<IO>,
-) {
-    let timing_start_time = format!("{:?}", iteration_processing_started_at);
-    let elapsed = chrono::Utc::now().signed_duration_since(iteration_processing_started_at);
-    let timing_elapsed_us = elapsed.num_microseconds().unwrap_or_default().to_string();
-    let iteration_id = iteration_id.map(|id| id.0).unwrap_or_default().to_string();
-
+/// Emits the aggregate metrics that had been collected as a single log line.
+fn emit_object_metrics_as_log<IO: StateControllerIO>(iteration_metrics: &IterationMetrics<IO>) {
     let mut total_objects = 0;
     let mut states: HashMap<String, usize> = HashMap::new();
     let mut states_above_sla: HashMap<String, usize> = HashMap::new();
@@ -933,5 +873,5 @@ fn emit_iteration_log<IO: StateControllerIO>(
         serde_json::to_string(&states_above_sla).unwrap_or_else(|_| "{}".to_string());
     let error_types = serde_json::to_string(&error_types).unwrap_or_else(|_| "{}".to_string());
 
-    tracing::info!(name: "state_controller_iteration", controller = IO::LOG_SPAN_CONTROLLER_NAME, %iteration_id, %total_objects, %states, %states_above_sla, %error_types, %timing_start_time, %timing_elapsed_us);
+    tracing::info!(name: "state_controller_object_metrics", controller = IO::LOG_SPAN_CONTROLLER_NAME, %total_objects, %states, %states_above_sla, %error_types);
 }

--- a/crates/api/src/state_controller/metrics.rs
+++ b/crates/api/src/state_controller/metrics.rs
@@ -33,13 +33,6 @@ pub(crate) struct FullState {
     pub(crate) substate: &'static str,
 }
 
-// This attributes defines whether we captured the metrics recently,
-// where recently here means in the last Minute. in the case multiple
-// state controllers run in a 3 control plane cluster, this will help
-// differentiating the metrics from a node which has recently acted on
-// objects from metrics that are more outdated
-const MAX_FRESH_DURATION: Duration = Duration::from_secs(60);
-
 /// The result of the state handler processing the state of a single object
 ///
 /// These metrics are emitted for all types of state controllers
@@ -562,12 +555,18 @@ pub struct MetricHolder<IO: StateControllerIO> {
 }
 
 impl<IO: StateControllerIO> MetricHolder<IO> {
-    pub fn new(meter: Option<Meter>, object_type_for_metrics: &str) -> Self {
+    pub fn new(
+        meter: Option<Meter>,
+        object_type_for_metrics: &str,
+        metric_hold_time: std::time::Duration,
+    ) -> Self {
+        // The metrics need to show up in the observability system for a longer time than the configured refresh time.
+        let fresh_period = metric_hold_time.saturating_add(std::time::Duration::from_secs(60));
         let last_iteration_common_metrics =
-            SharedMetricsHolder::<CommonIterationMetrics>::with_fresh_period(MAX_FRESH_DURATION);
+            SharedMetricsHolder::<CommonIterationMetrics>::with_fresh_period(fresh_period);
         let last_iteration_specific_metrics = SharedMetricsHolder::<
             <IO::MetricsEmitter as MetricsEmitter>::IterationMetrics,
-        >::with_fresh_period(MAX_FRESH_DURATION);
+        >::with_fresh_period(fresh_period);
 
         let emitter = meter.as_ref().map(|meter| {
             Arc::new(StateProcessorMetricEmitter::new(

--- a/crates/api/src/tests/state_controller.rs
+++ b/crates/api/src/tests/state_controller.rs
@@ -912,6 +912,7 @@ async fn test_state_handler_metrics_are_stable(pool: sqlx::PgPool) -> eyre::Resu
         .iteration_config(IterationConfig {
             iteration_time: ITERATION_TIME,
             processor_dispatch_interval: std::time::Duration::from_millis(10),
+            metric_emission_interval: std::time::Duration::from_millis(10),
             max_concurrency: num_objects,
             ..Default::default()
         })


### PR DESCRIPTION
## Description

In release 0.2 to 0.4, metrics in the state controller would have been hold for the duration of 2 "enqueuer" iterations, where one enqueuer iteration is typically 30s. If they have not been refreshed by then, they would get evicted.

This change makes the metric hold period independent of the enqueuer iteration time, and sets it to a default of 5minutes. This means only if the state handler for an object has not been invoked again within 5 minutes, it would disappear from metrics. This will make metrics more stable for environments with slow state handler invocations.

Note: With this change, predicted machines will also still show up in metrics as seperate entities after they transitioned into regular machines for the configured hold period (5min). Thereby the amount of hosts in a site could be shown as higher than the actual amount of hosts during ingestion times.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

Bug 5937771

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes


