### PR TITLE
fix: add missing https scheme to carbide-dns CARBIDE_API ConfigMap

### DIFF
--- a/helm/charts/carbide-dns/templates/configmap.yaml
+++ b/helm/charts/carbide-dns/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "carbide-dns.labels" . | nindent 4 }}
 data:
-  CARBIDE_API: {{ printf "carbide-api.%s.svc.cluster.local:%s" (include "carbide-dns.namespace" .) (.Values.config.carbideApiPort | default "1079") | quote }}
+  CARBIDE_API: {{ printf "https://carbide-api.%s.svc.cluster.local:%s" (include "carbide-dns.namespace" .) (.Values.config.carbideApiPort | default "1079") | quote }}
   CARBIDE_API_HOST: {{ printf "carbide-api.%s.svc.cluster.local" (include "carbide-dns.namespace" .) | quote }}
   CARBIDE_API_PORT: {{ .Values.config.carbideApiPort | default "1079" | quote }}
   {{- range $key, $value := .Values.config.extraData }}


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
https://github.com/NVIDIA/bare-metal-manager-core/issues/467

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

