### PR TITLE
fix(api): Make NSG delete return 404 if NSG was already deleted

### DIFF
--- a/crates/api/src/handlers/network_security_group.rs
+++ b/crates/api/src/handlers/network_security_group.rs
@@ -440,8 +440,7 @@ pub(crate) async fn delete(
     let nsg = network_security_group::find_by_ids(
         &mut txn,
         std::slice::from_ref(&id),
-        // We return without error if something wasn't found because it was already soft-deleted,
-        // so we'll check tenant ownership separately from the query here so we don't hide a
+        // We'll check tenant ownership separately from the query here so we don't hide a
         // 404 due to a mismatched tenant.
         None,
         true,
@@ -451,42 +450,45 @@ pub(crate) async fn delete(
 
     // Since we needed to query for the record anyway,
     // we can save ourselves some extra work if it didn't exist.
-    if let Some(nsg) = nsg
-        && nsg.deleted.is_none()
-    {
-        if nsg.tenant_organization_id != tenant_organization_id {
-            return Err(CarbideError::InvalidArgument(format!(
-                "NetworkSecurityGroup `{}` is not owned by Tenant `{}`",
-                nsg.id.clone(),
-                tenant_organization_id.clone()
-            ))
-            .into());
+    let Some(nsg) = nsg else {
+        return Err(CarbideError::NotFoundError {
+            kind: "NetworkSecurityGroup",
+            id: id.to_string(),
         }
+        .into());
+    };
 
-        // Look for any related objects that have this NSG attached.
-        // If an NSG is in use, it must not be deleted.
-        let existing_associated_objects = network_security_group::find_objects_with_attachments(
-            &mut txn,
-            Some(std::slice::from_ref(&id)),
-            Some(&tenant_organization_id),
-        )
-        .await?
-        .pop();
-
-        if existing_associated_objects
-            .map(|a| a.has_attachments())
-            .unwrap_or_default()
-        {
-            return Err(CarbideError::FailedPrecondition(format!(
-                "NetworkSecurityGroup {id} is associated with active objects"
-            ))
-            .into());
-        }
-
-        // Make our DB query to soft delete the NetworkSecurityGroup
-        let _id =
-            network_security_group::soft_delete(&mut txn, &id, &tenant_organization_id).await?;
+    if nsg.tenant_organization_id != tenant_organization_id {
+        return Err(CarbideError::InvalidArgument(format!(
+            "NetworkSecurityGroup `{}` is not owned by Tenant `{}`",
+            nsg.id.clone(),
+            tenant_organization_id.clone()
+        ))
+        .into());
     }
+
+    // Look for any related objects that have this NSG attached.
+    // If an NSG is in use, it must not be deleted.
+    let existing_associated_objects = network_security_group::find_objects_with_attachments(
+        &mut txn,
+        Some(std::slice::from_ref(&id)),
+        Some(&tenant_organization_id),
+    )
+    .await?
+    .pop();
+
+    if existing_associated_objects
+        .map(|a| a.has_attachments())
+        .unwrap_or_default()
+    {
+        return Err(CarbideError::FailedPrecondition(format!(
+            "NetworkSecurityGroup {id} is associated with active objects"
+        ))
+        .into());
+    }
+
+    // Make our DB query to soft delete the NetworkSecurityGroup
+    let _id = network_security_group::soft_delete(&mut txn, &id, &tenant_organization_id).await?;
 
     // Prepare the response message
     let rpc_out = rpc::DeleteNetworkSecurityGroupResponse {};

--- a/crates/api/src/tests/network_security_group.rs
+++ b/crates/api/src/tests/network_security_group.rs
@@ -996,17 +996,20 @@ async fn test_network_security_group_delete(
     assert_eq!(forge_network_security_groups.len(), 0);
 
     // Now try to delete it AGAIN
-    // This should be a no-op that returns without error.
-    let _ = env
-        .api
-        .delete_network_security_group(tonic::Request::new(
-            rpc::forge::DeleteNetworkSecurityGroupRequest {
-                id: good_network_security_group_id.to_string(),
-                tenant_organization_id: default_tenant_org.to_string(),
-            },
-        ))
-        .await
-        .unwrap();
+    // This should fail with NOT FOUND.
+    assert_eq!(
+        env.api
+            .delete_network_security_group(tonic::Request::new(
+                rpc::forge::DeleteNetworkSecurityGroupRequest {
+                    id: good_network_security_group_id.to_string(),
+                    tenant_organization_id: default_tenant_org.to_string(),
+                },
+            ))
+            .await
+            .unwrap_err()
+            .code(),
+        Code::NotFound
+    );
 
     // Now try to delete a network security group with a blank ID.
     let _ = env


### PR DESCRIPTION
## Description
Previously, if an NSG was deleted (which is a soft-delete) and a second delete request arrived, it was being treated as a no-op. 

This PR makes it a NotFound error.

The gRPC API is considered unstable and we only make promises for the bmm-rest API, which will see no behavioral change due to _this_ change in bmm-core, but this can still be considered a breaking change in bmm-core since an OK is now being changed to a NOT FOUND.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [x] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

