### PR TITLE
fix: Cleanup firmware packages after a rack-firmware ID is deleted

### DIFF
--- a/crates/api/src/handlers/rack_firmware.rs
+++ b/crates/api/src/handlers/rack_firmware.rs
@@ -416,6 +416,35 @@ pub async fn delete(
         .await
         .map_err(|e| CarbideError::from(DatabaseError::new("commit delete", e)))?;
 
+    // cleanup of downloaded firmware files
+    let firmware_cache_dir = PathBuf::from("/forge-boot-artifacts/blobs/internal/fw")
+        .join("rack_firmware")
+        .join(&req.id);
+    if let Err(e) = tokio::fs::remove_dir_all(&firmware_cache_dir).await {
+        tracing::warn!(
+            firmware_id = %req.id,
+            "Failed to delete firmware cache directory {}: {}",
+            firmware_cache_dir.display(),
+            e
+        );
+    }
+
+    // cleanup of credentials from Vault
+    let credential_key = CredentialKey::RackFirmware {
+        firmware_id: req.id.clone(),
+    };
+    if let Err(e) = api
+        .credential_manager
+        .delete_credentials(&credential_key)
+        .await
+    {
+        tracing::warn!(
+            firmware_id = %req.id,
+            "Failed to delete credentials from Vault: {}",
+            e
+        );
+    }
+
     Ok(Response::new(()))
 }
 


### PR DESCRIPTION
## Description
When a rack-firmware ID is created, it downloads all necessary packages listed in the JSON. Previously, when this ID was deleted, the firmware packages would be leftover. This PR cleans up those files, and also removes the artifactory token used to download the packages from the vault.  

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

