### PR TITLE
fix: bmc-explorer: Bluefield: do not require system eth interfaces

### DIFF
--- a/crates/bmc-explorer/src/computer_system.rs
+++ b/crates/bmc-explorer/src/computer_system.rs
@@ -327,13 +327,11 @@ impl<B: Bmc> ExploredComputerSystem<B> {
             // interface from boot options as workaround.
             if let Some(oob_iface) = self.oob_interface_from_boot_options()? {
                 result.push(oob_iface);
-                Ok(result)
             } else {
-                Err(Error::BmcNotProvided("oob interface for dpu"))
+                tracing::warn!("Error getting OOB interface for the DPU");
             }
-        } else {
-            Ok(result)
         }
+        Ok(result)
     }
 
     fn oob_interface_from_boot_options(&self) -> Result<Option<ModelEthernetInterface>, Error<B>> {

--- a/crates/bmc-explorer/tests/bluefield3_explore.rs
+++ b/crates/bmc-explorer/tests/bluefield3_explore.rs
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#![recursion_limit = "256"]
+
+use bmc_explorer::nv_generate_exploration_report;
+use bmc_mock::{DpuSettings, test_support};
+use model::site_explorer::EndpointType;
+use tokio::test;
+
+#[test]
+async fn explore_bluefield3_baseline() {
+    let bmc = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default());
+    let report = nv_generate_exploration_report(bmc, None).await.unwrap();
+
+    assert_eq!(report.endpoint_type, EndpointType::Bmc);
+    assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Nvidia));
+    assert!(!report.systems.is_empty(), "systems must be present");
+    assert!(!report.chassis.is_empty(), "chassis must be present");
+    assert!(
+        report
+            .service
+            .iter()
+            .any(|service| service.id == "FirmwareInventory"),
+        "firmware inventory service must be present"
+    );
+    assert!(
+        report
+            .machine_setup_status
+            .as_ref()
+            .is_some_and(|status| !status.diffs.is_empty() || status.is_done),
+        "machine setup status must be present and structurally valid"
+    );
+}
+
+#[test]
+async fn explore_bluefield3_without_system_eth_interfaces() {
+    let settings = DpuSettings {
+        exposes_oob_eth: false,
+        ..Default::default()
+    };
+    let bmc = test_support::dell_poweredge_r750_bluefield3_bmc(settings);
+    let report = nv_generate_exploration_report(bmc, None).await.unwrap();
+    assert_eq!(report.endpoint_type, EndpointType::Bmc);
+    assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Nvidia));
+    assert_eq!(
+        report
+            .systems
+            .first()
+            .map(|v| v.ethernet_interfaces.is_empty()),
+        Some(true)
+    );
+}

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -36,7 +36,9 @@ pub mod test_support;
 pub mod tls;
 
 pub use combined_server::{CombinedServer, ListenerOrAddress};
-pub use machine_info::{DpuFirmwareVersions, DpuMachineInfo, HostMachineInfo, MachineInfo};
+pub use machine_info::{
+    DpuFirmwareVersions, DpuMachineInfo, DpuSettings, HostMachineInfo, MachineInfo,
+};
 pub use mock_machine_router::{
     BmcCommand, SetSystemPowerError, SetSystemPowerResult, machine_router,
 };

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -51,8 +51,8 @@ pub struct DpuMachineInfo {
     pub host_mac_address: MacAddress,
     pub oob_mac_address: MacAddress,
     pub serial: String,
-    pub nic_mode: bool,
-    pub firmware_versions: DpuFirmwareVersions,
+    #[serde(flatten)]
+    pub settings: DpuSettings,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -63,22 +63,36 @@ pub struct DpuFirmwareVersions {
     pub nic: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DpuSettings {
+    pub nic_mode: bool,
+    pub firmware_versions: DpuFirmwareVersions,
+    #[serde(default = "default_true")]
+    pub exposes_oob_eth: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for DpuSettings {
+    fn default() -> Self {
+        Self {
+            nic_mode: false,
+            firmware_versions: Default::default(),
+            exposes_oob_eth: true,
+        }
+    }
+}
+
 impl Default for DpuMachineInfo {
     fn default() -> Self {
-        Self::new(
-            HostHardwareType::DellPowerEdgeR750,
-            false,
-            Default::default(),
-        )
+        Self::new(HostHardwareType::DellPowerEdgeR750, DpuSettings::default())
     }
 }
 
 impl DpuMachineInfo {
-    pub fn new(
-        hw_type: HostHardwareType,
-        nic_mode: bool,
-        firmware_versions: DpuFirmwareVersions,
-    ) -> Self {
+    pub fn new(hw_type: HostHardwareType, settings: DpuSettings) -> Self {
         let bmc_mac_address = next_mac();
         let host_mac_address = next_mac();
         let oob_mac_address = next_mac();
@@ -87,8 +101,7 @@ impl DpuMachineInfo {
             bmc_mac_address,
             host_mac_address,
             oob_mac_address,
-            nic_mode,
-            firmware_versions,
+            settings,
             serial: format!("MT{}", oob_mac_address.to_string().replace(':', "")),
         }
     }
@@ -96,21 +109,22 @@ impl DpuMachineInfo {
     fn bluefield3(&self) -> hw::bluefield3::Bluefield3<'_> {
         let mode = match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => hw::bluefield3::Mode::SuperNIC {
-                nic_mode: self.nic_mode,
+                nic_mode: self.settings.nic_mode,
             },
             HostHardwareType::WiwynnGB200Nvl => hw::bluefield3::Mode::B3240ColdAisle,
         };
+        let settings = &self.settings;
         hw::bluefield3::Bluefield3 {
             host_mac_address: self.host_mac_address,
             bmc_mac_address: self.bmc_mac_address,
-            oob_mac_address: Some(self.oob_mac_address),
+            oob_mac_address: settings.exposes_oob_eth.then_some(self.oob_mac_address),
             mode,
             product_serial_number: Cow::Borrowed(&self.serial),
             firmware_versions: hw::bluefield3::FirmwareVersions {
-                bmc: self.firmware_versions.bmc.clone().unwrap_or_default(),
-                uefi: self.firmware_versions.uefi.clone().unwrap_or_default(),
-                erot: self.firmware_versions.cec.clone().unwrap_or_default(),
-                dpu_nic: self.firmware_versions.nic.clone().unwrap_or_default(),
+                bmc: settings.firmware_versions.bmc.clone().unwrap_or_default(),
+                uefi: settings.firmware_versions.uefi.clone().unwrap_or_default(),
+                erot: settings.firmware_versions.cec.clone().unwrap_or_default(),
+                dpu_nic: settings.firmware_versions.nic.clone().unwrap_or_default(),
             },
         }
     }
@@ -250,7 +264,7 @@ impl MachineInfo {
             MachineInfo::Host(host) => host.oem_state(),
             MachineInfo::Dpu(dpu) => redfish::oem::State::NvidiaBluefield(
                 redfish::oem::nvidia::bluefield::BluefieldState::new(
-                    dpu.nic_mode,
+                    dpu.settings.nic_mode,
                     dpu.host_mac_address,
                 ),
             ),

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -20,11 +20,11 @@ use std::sync::Arc;
 use nv_redfish::bmc_http::{BmcCredentials, CacheSettings, HttpBmc};
 use url::Url;
 
+use crate::machine_info::DpuSettings;
 use crate::{
-    DpuFirmwareVersions, DpuMachineInfo, HostHardwareType, HostMachineInfo, MachineInfo,
-    MockPowerState, PowerControl, SetSystemPowerError, SystemPowerControl, machine_router,
+    DpuMachineInfo, HostHardwareType, HostMachineInfo, MachineInfo, MockPowerState, PowerControl,
+    SetSystemPowerError, SystemPowerControl, machine_router,
 };
-
 pub mod axum_http_client;
 
 use axum_http_client::AxumRouterHttpClient;
@@ -49,16 +49,8 @@ pub type TestBmc = HttpBmc<AxumRouterHttpClient>;
 
 pub fn wiwynn_gb200_router() -> axum::Router {
     let dpus = vec![
-        DpuMachineInfo::new(
-            HostHardwareType::WiwynnGB200Nvl,
-            false,
-            DpuFirmwareVersions::default(),
-        ),
-        DpuMachineInfo::new(
-            HostHardwareType::WiwynnGB200Nvl,
-            false,
-            DpuFirmwareVersions::default(),
-        ),
+        DpuMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, DpuSettings::default()),
+        DpuMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, DpuSettings::default()),
     ];
     let machine_info =
         MachineInfo::Host(HostMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, dpus));
@@ -91,6 +83,27 @@ pub fn dell_poweredge_r750_bmc() -> Arc<TestBmc> {
         machine_info,
         Arc::new(NoopPowerControl),
         "test-host-id".to_string(),
+    );
+    let client = AxumRouterHttpClient::new(router);
+    let endpoint = Url::parse("https://bmc-mock.local").expect("valid URL");
+    let credentials = BmcCredentials::new("root".to_string(), "password".to_string());
+    Arc::new(HttpBmc::new(
+        client,
+        endpoint,
+        credentials,
+        CacheSettings::with_capacity(32),
+    ))
+}
+
+pub fn dell_poweredge_r750_bluefield3_bmc(settings: DpuSettings) -> Arc<TestBmc> {
+    let machine_info = MachineInfo::Dpu(DpuMachineInfo::new(
+        HostHardwareType::DellPowerEdgeR750,
+        settings,
+    ));
+    let router = machine_router(
+        machine_info,
+        Arc::new(NoopPowerControl),
+        "test-dpu-id".to_string(),
     );
     let client = AxumRouterHttpClient::new(router);
     let endpoint = Url::parse("https://bmc-mock.local").expect("valid URL");

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use bmc_mock::{DpuMachineInfo, HostHardwareType, HostMachineInfo};
+use bmc_mock::{DpuMachineInfo, DpuSettings, HostHardwareType, HostMachineInfo};
 use carbide_uuid::machine::MachineId;
 use clap::Parser;
 use duration_str::deserialize_duration;
@@ -336,12 +336,12 @@ pub struct PersistedDpuMachine {
     pub host_mac_address: MacAddress,
     pub oob_mac_address: MacAddress,
     pub serial: String,
-    pub nic_mode: bool,
-    pub firmware_versions: bmc_mock::DpuFirmwareVersions,
     pub installed_os: OsImage,
     pub dpu_index: u8,
     pub machine_dhcp_id: Uuid,
     pub bmc_dhcp_id: Uuid,
+    #[serde(flatten)]
+    pub settings: DpuSettings,
 }
 
 impl From<PersistedDpuMachine> for DpuMachineInfo {
@@ -352,8 +352,7 @@ impl From<PersistedDpuMachine> for DpuMachineInfo {
             host_mac_address: value.host_mac_address,
             oob_mac_address: value.oob_mac_address,
             serial: value.serial,
-            nic_mode: value.nic_mode,
-            firmware_versions: value.firmware_versions,
+            settings: value.settings,
         }
     }
 }

--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 use bmc_mock::{
-    BmcCommand, DpuMachineInfo, HostHardwareType, MachineInfo, SetSystemPowerResult,
+    BmcCommand, DpuMachineInfo, DpuSettings, HostHardwareType, MachineInfo, SetSystemPowerResult,
     SystemPowerControl,
 };
 use eyre::Context;
@@ -77,8 +77,7 @@ impl DpuMachine {
             host_mac_address: persisted_dpu_machine.host_mac_address,
             oob_mac_address: persisted_dpu_machine.oob_mac_address,
             serial: persisted_dpu_machine.serial.clone(),
-            nic_mode: persisted_dpu_machine.nic_mode,
-            firmware_versions: persisted_dpu_machine.firmware_versions.clone(),
+            settings: persisted_dpu_machine.settings.clone(),
         };
         let state_machine = MachineStateMachine::from_persisted(
             PersistedMachine::Dpu(persisted_dpu_machine),
@@ -129,8 +128,14 @@ impl DpuMachine {
             .unwrap_or_default()
             .fill_missing_from_desired_firmware(&app_context.desired_firmware_versions);
 
-        let dpu_info =
-            DpuMachineInfo::new(hw_type, config.dpus_in_nic_mode, firmware_versions.into());
+        let dpu_info = DpuMachineInfo::new(
+            hw_type,
+            DpuSettings {
+                nic_mode: config.dpus_in_nic_mode,
+                firmware_versions: firmware_versions.into(),
+                ..Default::default()
+            },
+        );
         let state_machine = MachineStateMachine::new(
             MachineInfo::Dpu(dpu_info.clone()),
             config,
@@ -354,7 +359,7 @@ impl DpuMachineHandle {
         // Whether we are up and booted to the agent OS (or if we're nic mode, we don't have to be
         // booted to any OS.)
         live_state.is_up
-            && (self.0.dpu_info.nic_mode
+            && (self.0.dpu_info.settings.nic_mode
                 || matches!(live_state.booted_os.0, Some(OsImage::DpuAgent)))
     }
 
@@ -413,8 +418,7 @@ impl DpuMachineHandle {
             host_mac_address: self.0.dpu_info.host_mac_address,
             oob_mac_address: self.0.dpu_info.oob_mac_address,
             serial: self.0.dpu_info.serial.clone(),
-            nic_mode: self.0.dpu_info.nic_mode,
-            firmware_versions: self.0.dpu_info.firmware_versions.clone(),
+            settings: self.0.dpu_info.settings.clone(),
             installed_os: self.0.live_state.read().unwrap().installed_os,
             dpu_index: self.0.dpu_index,
             bmc_dhcp_id: self.0.bmc_dhcp_id,

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -729,7 +729,7 @@ impl MachineStateMachine {
                     host_mac_address: self.machine_info.host_mac_address(),
                     tpm_ek_certificate,
                     dpu_nic_version: if let MachineInfo::Dpu(d) = &self.machine_info {
-                        d.firmware_versions.nic.clone()
+                        d.settings.firmware_versions.nic.clone()
                     } else {
                         None
                     },


### PR DESCRIPTION
## Description
This is fix for nv-redfish exploration mode of site-explorer:
- Libredfish version of site explorer only logs error if no OOB interfaces found for DPU.
- Nv-redfish version in this case returned exploration error.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

