### PR TITLE
fix: Add IbPortDown alert for machines with down IB ports

### DIFF
--- a/crates/api/src/ib_fabric_monitor/mod.rs
+++ b/crates/api/src/ib_fabric_monitor/mod.rs
@@ -49,6 +49,8 @@ use crate::ib::{GetPartitionOptions, IBFabricManager, IBFabricManagerType};
 use crate::periodic_timer::PeriodicTimer;
 use crate::{CarbideError, CarbideResult};
 
+type SkuInactiveDevicesCache = HashMap<String, Option<HashSet<u32>>>;
+
 /// `IbFabricMonitor` monitors the health of all connected InfiniBand fabrics in periodic intervals
 pub struct IbFabricMonitor {
     db_pool: PgPool,
@@ -324,6 +326,13 @@ impl IbFabricMonitor {
             fabric_data.derive_partitions_by_guid();
         }
 
+        let sku_inactive_cache = preload_sku_inactive_devices(&self.db_pool, &snapshots)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!(error = %e, "Failed to preload SKU inactive devices, will skip IB port monitoring for all machines");
+                HashMap::new()
+            });
+
         let mut reports = Vec::new();
         for (machine, snapshot) in &snapshots {
             let mut snapshot_clone = snapshot.clone();
@@ -333,6 +342,7 @@ impl IbFabricMonitor {
                 &tenant_partitions,
                 &partition_ids_by_pkey,
                 &fabric_data,
+                &sku_inactive_cache,
                 metrics,
             )
             .await
@@ -657,6 +667,7 @@ struct MachineIbStatusEvaluation {
     missing_guid_pkeys: Vec<(String, String, PartitionKey)>,
     unexpected_guid_pkeys: Vec<(String, String, PartitionKey)>,
     unknown_guid_pkeys: Vec<(String, String, PartitionKey)>,
+    down_port_guids: Vec<String>,
 }
 
 async fn record_machine_infiniband_status_observation(
@@ -665,6 +676,7 @@ async fn record_machine_infiniband_status_observation(
     tenant_partitions: &HashMap<IBPartitionId, IBPartition>,
     tenant_partition_ids_by_pkey: &HashMap<PartitionKey, IBPartitionId>,
     data_by_fabric: &HashMap<String, FabricData>,
+    sku_inactive_cache: &SkuInactiveDevicesCache,
     metrics: &mut IbFabricMonitorMetrics,
 ) -> Result<MachineIbStatusEvaluation, CarbideError> {
     let mut result = MachineIbStatusEvaluation::default();
@@ -722,6 +734,43 @@ async fn record_machine_infiniband_status_observation(
             expected_pkeys.insert(guid.clone(), expected_pkey);
         }
     }
+
+    // SKU defines which ports are intentionally disconnected/inactive by hardware design
+    let expected_inactive_devices = get_expected_inactive_devices_from_cache(
+        sku_inactive_cache,
+        mh_snapshot.host_snapshot.hw_sku.as_deref(),
+    );
+
+    // Use GUID as secondary key for stable ordering when slots are identical
+    let mut sorted_ib_interfaces = ib_hw_info.to_vec();
+    sorted_ib_interfaces.sort_by_key(|iface| {
+        (
+            iface
+                .pci_properties
+                .as_ref()
+                .and_then(|p| p.slot.clone())
+                .unwrap_or_default(),
+            iface.guid.clone(), // Stable tie-breaker
+        )
+    });
+
+    let guid_to_index: HashMap<String, u32> = sorted_ib_interfaces
+        .into_iter()
+        .enumerate()
+        .map(|(idx, iface)| (iface.guid, idx as u32))
+        .collect();
+
+    // Fallback for port-down alerting when no SKU is assigned:
+    // use the instance's IB config GUIDs to determine which ports the workload needs
+    let instance_guids: Option<HashSet<String>> = mh_snapshot.instance.as_ref().map(|instance| {
+        instance
+            .config
+            .infiniband
+            .ib_interfaces
+            .iter()
+            .filter_map(|iface| iface.guid.as_ref().map(|g| g.to_lowercase()))
+            .collect()
+    });
 
     // The list of GUIDs that are part of this Machine
     let mut guids: Vec<String> = Vec::new();
@@ -843,21 +892,47 @@ async fn record_machine_infiniband_status_observation(
                     }
                 };
 
-                (
-                    fabric_id,
-                    if port_data.state == Some(IBPortState::Active) {
-                        active_ports += 1;
-                        port_data.lid as u16
-                    } else {
-                        0xffff_u16
-                    },
-                    associated_pkeys,
-                    associated_partition_ids,
-                )
+                let (lid, is_down) = if port_data.state == Some(IBPortState::Active) {
+                    active_ports += 1;
+                    (port_data.lid as u16, false)
+                } else {
+                    // Port is not active - check if we should track it as down
+                    let should_track = should_track_port_as_down(
+                        guid,
+                        &guid_to_index,
+                        expected_inactive_devices.as_ref(),
+                        instance_guids.as_ref(),
+                    );
+                    if should_track {
+                        result.down_port_guids.push(guid.clone());
+                    }
+                    (0xffff_u16, true)
+                };
+
+                if is_down {
+                    tracing::debug!(
+                        machine_id = %machine_id,
+                        guid = %guid,
+                        state = ?port_data.state,
+                        "IB port is not active"
+                    );
+                }
+
+                (fabric_id, lid, associated_pkeys, associated_partition_ids)
             }
             None => {
                 // The port was not found on UFM. In this case we don't even try
                 // to look up associated pkeys
+                // Check if we should track it as down
+                let should_track = should_track_port_as_down(
+                    guid,
+                    &guid_to_index,
+                    expected_inactive_devices.as_ref(),
+                    instance_guids.as_ref(),
+                );
+                if should_track {
+                    result.down_port_guids.push(guid.clone());
+                }
 
                 // TODO: We should differentiate between "Can not communicate with fabric"
                 // and "UFM definitely did not know about this GUID".
@@ -916,6 +991,28 @@ async fn record_machine_infiniband_status_observation(
             write!(&mut msg, "(guid: {guid}, pkey: {pkey})").unwrap();
         }
         tracing::warn!(machine_id = %machine_id, msg);
+    }
+
+    let has_existing_ib_port_down_alert = mh_snapshot
+        .aggregate_health
+        .alerts
+        .iter()
+        .any(|alert| alert.id.as_str() == "IbPortDown");
+
+    if !result.down_port_guids.is_empty() {
+        tracing::warn!(
+            machine_id = %machine_id,
+            down_ports = ?result.down_port_guids,
+            total_ports = guids.len(),
+            "IB port(s) detected as down - setting PreventAllocations alert"
+        );
+        set_ib_port_down_alert(db_pool, machine_id, &result.down_port_guids, guids.len()).await?;
+    } else if has_existing_ib_port_down_alert {
+        tracing::info!(
+            machine_id = %machine_id,
+            "All IB ports are now active - clearing IbPortDown alert"
+        );
+        clear_ib_port_down_alert(db_pool, machine_id).await?;
     }
 
     let cur = MachineInfinibandStatusObservation {
@@ -1002,6 +1099,142 @@ async fn clear_ib_cleanup_alert(
     .map_err(|e| CarbideError::internal(format!("Failed to clear IB cleanup alert: {e}")))?;
 
     Ok(())
+}
+
+const IB_PORT_DOWN_OVERRIDE_SOURCE: &str = "ib-port-down-monitor";
+
+async fn set_ib_port_down_alert(
+    db_pool: &PgPool,
+    machine_id: &MachineId,
+    down_port_guids: &[String],
+    total_ports: usize,
+) -> Result<(), CarbideError> {
+    let mut conn = db_pool
+        .acquire()
+        .await
+        .map_err(|e| DatabaseError::new("acquire connection", e))?;
+
+    let alert =
+        health_report::HealthProbeAlert::ib_port_down(down_port_guids.to_vec(), total_ports);
+    let health_report = health_report::HealthReport {
+        source: IB_PORT_DOWN_OVERRIDE_SOURCE.to_string(),
+        triggered_by: None,
+        observed_at: Some(Utc::now()),
+        successes: vec![],
+        alerts: vec![alert],
+    };
+
+    db::machine::insert_health_report_override(
+        &mut conn,
+        machine_id,
+        OverrideMode::Merge,
+        &health_report,
+        false, // overwrite existing
+    )
+    .await
+    .map_err(|e| CarbideError::internal(format!("Failed to set IB port down alert: {e}")))?;
+
+    Ok(())
+}
+
+async fn clear_ib_port_down_alert(
+    db_pool: &PgPool,
+    machine_id: &MachineId,
+) -> Result<(), CarbideError> {
+    let mut conn = db_pool
+        .acquire()
+        .await
+        .map_err(|e| DatabaseError::new("acquire connection", e))?;
+
+    db::machine::remove_health_report_override(
+        &mut conn,
+        machine_id,
+        OverrideMode::Merge,
+        IB_PORT_DOWN_OVERRIDE_SOURCE,
+    )
+    .await
+    .map_err(|e| CarbideError::internal(format!("Failed to clear IB port down alert: {e}")))?;
+
+    Ok(())
+}
+
+/// Should a down port be tracked for alerting?
+/// Precedence:
+/// 1. SKU exists: track if the port is not in `inactive_devices` (hardware truth)
+/// 2. No SKU, but instance has IB config: track if the port is in the instance's IB config (workload truth)
+/// 3. Neither SKU nor instance IB config: don't track
+fn should_track_port_as_down(
+    guid: &str,
+    guid_to_index: &HashMap<String, u32>,
+    expected_inactive_devices: Option<&HashSet<u32>>,
+    instance_guids: Option<&HashSet<String>>,
+) -> bool {
+    if let Some(expected_inactive) = expected_inactive_devices {
+        let port_index = guid_to_index.get(guid).copied().unwrap_or(u32::MAX);
+        return !expected_inactive.contains(&port_index);
+    }
+
+    if let Some(guids) = instance_guids {
+        return guids.contains(&guid.to_lowercase());
+    }
+
+    false
+}
+
+async fn preload_sku_inactive_devices(
+    db_pool: &PgPool,
+    snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
+) -> Result<SkuInactiveDevicesCache, CarbideError> {
+    let sku_ids: Vec<&str> = snapshots
+        .values()
+        .filter_map(|snap| snap.host_snapshot.hw_sku.as_deref())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    if sku_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let mut conn = db_pool
+        .acquire()
+        .await
+        .map_err(|e| DatabaseError::new("acquire connection", e))?;
+
+    let skus = db::sku::find(&mut conn, &sku_ids)
+        .await
+        .map_err(|e| CarbideError::internal(format!("Failed to load SKUs: {e}")))?;
+
+    let mut cache: SkuInactiveDevicesCache = HashMap::new();
+    for sku in skus {
+        let inactive = if sku.components.infiniband_devices.is_empty() {
+            // SKU has no IB devices - skip monitoring for machines with this SKU
+            None
+        } else {
+            Some(
+                sku.components
+                    .infiniband_devices
+                    .into_iter()
+                    .flat_map(|ib_dev| ib_dev.inactive_devices)
+                    .collect(),
+            )
+        };
+        cache.insert(sku.id, inactive);
+    }
+
+    Ok(cache)
+}
+
+/// Returns:
+/// - None if no SKU assigned, SKU not in cache, or SKU has no IB devices
+///   (in these cases, IB port down monitoring should be skipped)
+/// - Some(set) with the set of port indices expected to be inactive per SKU
+fn get_expected_inactive_devices_from_cache(
+    sku_cache: &SkuInactiveDevicesCache,
+    hw_sku: Option<&str>,
+) -> Option<HashSet<u32>> {
+    let sku_id = hw_sku?;
+    sku_cache.get(sku_id).cloned().flatten()
 }
 
 /// Parse GUIDs from IbCleanupPending alert message
@@ -1098,6 +1331,55 @@ mod tests {
     }
 
     // ============================================================
+    // Unit Tests for HealthProbeAlert::ib_port_down
+    // ============================================================
+
+    #[test]
+    fn test_ib_port_down_alert_single_port() {
+        let alert =
+            health_report::HealthProbeAlert::ib_port_down(vec!["946dae03006104f8".to_string()], 8);
+
+        assert_eq!(alert.id.as_str(), "IbPortDown");
+        assert!(alert.message.contains("1 of 8"));
+        assert!(alert.message.contains("946dae03006104f8"));
+        assert!(
+            alert
+                .classifications
+                .contains(&health_report::HealthAlertClassification::prevent_allocations())
+        );
+    }
+
+    #[test]
+    fn test_ib_port_down_alert_multiple_ports() {
+        let alert = health_report::HealthProbeAlert::ib_port_down(
+            vec![
+                "946dae03006104f8".to_string(),
+                "abc123def4567890".to_string(),
+            ],
+            8,
+        );
+
+        assert_eq!(alert.id.as_str(), "IbPortDown");
+        assert!(alert.message.contains("2 of 8"));
+        assert!(alert.message.contains("946dae03006104f8"));
+        assert!(alert.message.contains("abc123def4567890"));
+        assert!(
+            alert
+                .classifications
+                .contains(&health_report::HealthAlertClassification::prevent_allocations())
+        );
+    }
+
+    #[test]
+    fn test_ib_port_down_alert_has_tenant_message() {
+        let alert =
+            health_report::HealthProbeAlert::ib_port_down(vec!["946dae03006104f8".to_string()], 8);
+
+        assert!(alert.tenant_message.is_some());
+        assert!(alert.tenant_message.as_ref().unwrap().contains("1 port(s)"));
+    }
+
+    // ============================================================
     // Unit Tests for is_pkey_in_managed_range
     // ============================================================
 
@@ -1186,6 +1468,225 @@ mod tests {
         // No ranges configured, nothing is managed
         let pkey = PartitionKey::try_from(256u16).unwrap();
         assert!(!is_pkey_in_managed_range(pkey, &fabric));
+    }
+
+    // ============================================================
+    // Unit Tests for should_track_port_as_down
+    // ============================================================
+
+    // --- SKU takes precedence when present ---
+
+    #[test]
+    fn test_should_track_port_with_sku_not_in_inactive() {
+        let guid_to_index: HashMap<String, u32> =
+            [("guid1".to_string(), 0), ("guid2".to_string(), 1)]
+                .into_iter()
+                .collect();
+        let expected_inactive: HashSet<u32> = [2, 3].into_iter().collect();
+
+        assert!(should_track_port_as_down(
+            "guid1",
+            &guid_to_index,
+            Some(&expected_inactive),
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_should_track_port_with_sku_in_inactive() {
+        let guid_to_index: HashMap<String, u32> = [
+            ("guid1".to_string(), 0),
+            ("guid2".to_string(), 1),
+            ("guid3".to_string(), 2),
+        ]
+        .into_iter()
+        .collect();
+        let expected_inactive: HashSet<u32> = [2].into_iter().collect();
+
+        assert!(!should_track_port_as_down(
+            "guid3",
+            &guid_to_index,
+            Some(&expected_inactive),
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_should_track_port_sku_overrides_instance() {
+        // SKU says port should be up, even though instance doesn't use it -> should track
+        let guid_to_index: HashMap<String, u32> = [
+            ("guid1".to_string(), 0),
+            ("guid2".to_string(), 1),
+            ("guid3".to_string(), 2),
+        ]
+        .into_iter()
+        .collect();
+        let expected_inactive: HashSet<u32> = HashSet::new();
+        let instance_guids: HashSet<String> = ["guid1".to_string(), "guid2".to_string()]
+            .into_iter()
+            .collect();
+
+        // guid3 not used by instance, but SKU says it should be up
+        assert!(should_track_port_as_down(
+            "guid3",
+            &guid_to_index,
+            Some(&expected_inactive),
+            Some(&instance_guids),
+        ));
+    }
+
+    #[test]
+    fn test_should_track_port_sku_inactive_overrides_instance() {
+        // SKU says port is intentionally inactive, even though instance uses it -> should NOT track
+        let guid_to_index: HashMap<String, u32> =
+            [("guid1".to_string(), 0), ("guid2".to_string(), 1)]
+                .into_iter()
+                .collect();
+        let expected_inactive: HashSet<u32> = [1].into_iter().collect();
+        let instance_guids: HashSet<String> = ["guid1".to_string(), "guid2".to_string()]
+            .into_iter()
+            .collect();
+
+        assert!(!should_track_port_as_down(
+            "guid2",
+            &guid_to_index,
+            Some(&expected_inactive),
+            Some(&instance_guids),
+        ));
+    }
+
+    #[test]
+    fn test_should_track_port_all_ports_inactive_by_sku() {
+        let guid_to_index: HashMap<String, u32> =
+            [("guid1".to_string(), 0), ("guid2".to_string(), 1)]
+                .into_iter()
+                .collect();
+        let expected_inactive: HashSet<u32> = [0, 1].into_iter().collect();
+
+        assert!(!should_track_port_as_down(
+            "guid1",
+            &guid_to_index,
+            Some(&expected_inactive),
+            None,
+        ));
+        assert!(!should_track_port_as_down(
+            "guid2",
+            &guid_to_index,
+            Some(&expected_inactive),
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_should_track_port_unknown_guid_with_sku() {
+        // Unknown GUID gets u32::MAX which won't be in inactive_devices -> should track (fail-open)
+        let guid_to_index: HashMap<String, u32> = HashMap::new();
+        let expected_inactive: HashSet<u32> = [0, 1, 2].into_iter().collect();
+
+        assert!(should_track_port_as_down(
+            "unknown_guid",
+            &guid_to_index,
+            Some(&expected_inactive),
+            None,
+        ));
+    }
+
+    // --- Instance fallback when no SKU ---
+
+    #[test]
+    fn test_should_track_port_no_sku_instance_port_in_config() {
+        // No SKU, but instance uses this port -> should track
+        let guid_to_index: HashMap<String, u32> =
+            [("guid1".to_string(), 0), ("guid2".to_string(), 1)]
+                .into_iter()
+                .collect();
+        let instance_guids: HashSet<String> = ["guid1".to_string(), "guid2".to_string()]
+            .into_iter()
+            .collect();
+
+        assert!(should_track_port_as_down(
+            "guid1",
+            &guid_to_index,
+            None,
+            Some(&instance_guids),
+        ));
+    }
+
+    #[test]
+    fn test_should_track_port_no_sku_instance_port_not_in_config() {
+        // No SKU, instance doesn't use this port -> should NOT track
+        let guid_to_index: HashMap<String, u32> = [
+            ("guid1".to_string(), 0),
+            ("guid2".to_string(), 1),
+            ("guid3".to_string(), 2),
+        ]
+        .into_iter()
+        .collect();
+        let instance_guids: HashSet<String> = ["guid1".to_string(), "guid2".to_string()]
+            .into_iter()
+            .collect();
+
+        assert!(!should_track_port_as_down(
+            "guid3",
+            &guid_to_index,
+            None,
+            Some(&instance_guids),
+        ));
+    }
+
+    #[test]
+    fn test_should_track_port_no_sku_instance_case_insensitive() {
+        let guid_to_index: HashMap<String, u32> = [("GUID1".to_string(), 0)].into_iter().collect();
+        let instance_guids: HashSet<String> = ["guid1".to_string()].into_iter().collect();
+
+        assert!(should_track_port_as_down(
+            "GUID1",
+            &guid_to_index,
+            None,
+            Some(&instance_guids),
+        ));
+    }
+
+    #[test]
+    fn test_should_track_port_no_sku_empty_instance_config() {
+        // No SKU, instance has empty IB config -> should NOT track
+        let guid_to_index: HashMap<String, u32> = [("guid1".to_string(), 0)].into_iter().collect();
+        let instance_guids: HashSet<String> = HashSet::new();
+
+        assert!(!should_track_port_as_down(
+            "guid1",
+            &guid_to_index,
+            None,
+            Some(&instance_guids),
+        ));
+    }
+
+    // --- Neither SKU nor instance ---
+
+    #[test]
+    fn test_should_track_port_no_sku_no_instance() {
+        // Neither SKU nor instance -> should NOT track
+        let guid_to_index: HashMap<String, u32> = [("guid1".to_string(), 0)].into_iter().collect();
+
+        assert!(!should_track_port_as_down(
+            "guid1",
+            &guid_to_index,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_should_track_port_sku_no_ib_devices_no_instance() {
+        // SKU has no IB devices (None), no instance -> should NOT track
+        let guid_to_index: HashMap<String, u32> = [("guid1".to_string(), 0)].into_iter().collect();
+
+        assert!(!should_track_port_as_down(
+            "guid1",
+            &guid_to_index,
+            None,
+            None,
+        ));
     }
 
     // ============================================================

--- a/crates/api/src/tests/ib_fabric_monitor.rs
+++ b/crates/api/src/tests/ib_fabric_monitor.rs
@@ -17,7 +17,7 @@
 
 use crate::cfg::file::IBFabricConfig;
 use crate::tests::common;
-use crate::tests::common::api_fixtures::TestEnvOverrides;
+use crate::tests::common::api_fixtures::{TestEnvOverrides, create_managed_host};
 
 #[crate::sqlx_test]
 async fn test_ib_fabric_monitor(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
@@ -102,6 +102,198 @@ async fn test_ib_fabric_monitor(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
             .formatted_metric("carbide_ib_monitor_allow_insecure_fabric_configuration_count")
             .unwrap(),
         r#"{fabric="default"} 0"#
+    );
+
+    Ok(())
+}
+
+/// Test that IB port down detection sets PreventAllocations alert
+/// and clears it when ports recover.
+///
+/// - Machines with down IB ports should have PreventAllocations health alert
+/// - This prevents tenant allocation failures at UFM
+#[crate::sqlx_test]
+async fn test_ib_port_down_sets_prevent_allocations_alert(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = common::api_fixtures::get_config();
+    config.ib_config = Some(IBFabricConfig {
+        enabled: true,
+        ..Default::default()
+    });
+
+    let env = common::api_fixtures::create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config),
+    )
+    .await;
+
+    // Create a managed host with IB interfaces
+    let (host_machine_id, _dpu_machine_id) = create_managed_host(&env).await.into();
+
+    // Assign a SKU to the machine (required for IB port down tracking)
+    // Since BOM validation is disabled in test config, we need to manually assign a SKU
+    {
+        let mut txn = pool.begin().await?;
+        let sku = db::sku::generate_sku_from_machine(txn.as_mut(), &host_machine_id).await?;
+        db::sku::create(&mut txn, &sku).await?;
+        db::machine::assign_sku(txn.as_mut(), &host_machine_id, &sku.id).await?;
+        txn.commit().await?;
+    }
+
+    let machine = env.find_machine(host_machine_id).await.remove(0);
+    let discovery_info = machine.discovery_info.as_ref().unwrap();
+    let guid1 = discovery_info.infiniband_interfaces[0].guid.clone();
+
+    let machine = env.find_machine(host_machine_id).await.remove(0);
+    let health = machine.health.as_ref().expect("Machine should have health");
+    let has_ib_port_down_alert = health.alerts.iter().any(|alert| alert.id == "IbPortDown");
+    assert!(
+        !has_ib_port_down_alert,
+        "Machine should not have IbPortDown alert initially"
+    );
+
+    let ib_manager = env.ib_fabric_manager.get_mock_manager();
+    ib_manager.set_port_state(&guid1, false);
+
+    env.run_ib_fabric_monitor_iteration().await;
+
+    let machine = env.find_machine(host_machine_id).await.remove(0);
+    let health = machine.health.as_ref().expect("Machine should have health");
+    let ib_port_down_alert = health.alerts.iter().find(|alert| alert.id == "IbPortDown");
+    assert!(
+        ib_port_down_alert.is_some(),
+        "Machine should have IbPortDown alert after port goes down"
+    );
+
+    let alert = ib_port_down_alert.unwrap();
+    assert!(
+        alert
+            .classifications
+            .contains(&"PreventAllocations".to_string()),
+        "IbPortDown alert should have PreventAllocations classification"
+    );
+
+    assert!(
+        alert.message.contains(&guid1),
+        "Alert message should contain the down GUID"
+    );
+
+    ib_manager.set_port_state(&guid1, true);
+
+    env.run_ib_fabric_monitor_iteration().await;
+
+    // Verify IbPortDown alert is cleared
+    let machine = env.find_machine(host_machine_id).await.remove(0);
+    let health = machine.health.as_ref().expect("Machine should have health");
+    let has_ib_port_down_alert = health.alerts.iter().any(|alert| alert.id == "IbPortDown");
+    assert!(
+        !has_ib_port_down_alert,
+        "IbPortDown alert should be cleared after port recovers"
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_ib_multiple_ports_down(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = common::api_fixtures::get_config();
+    config.ib_config = Some(IBFabricConfig {
+        enabled: true,
+        ..Default::default()
+    });
+
+    let env = common::api_fixtures::create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config),
+    )
+    .await;
+
+    let (host_machine_id, _dpu_machine_id) = create_managed_host(&env).await.into();
+
+    // Assign a SKU to the machine (required for IB port down tracking)
+    {
+        let mut txn = pool.begin().await?;
+        let sku = db::sku::generate_sku_from_machine(txn.as_mut(), &host_machine_id).await?;
+        db::sku::create(&mut txn, &sku).await?;
+        db::machine::assign_sku(txn.as_mut(), &host_machine_id, &sku.id).await?;
+        txn.commit().await?;
+    }
+
+    let machine = env.find_machine(host_machine_id).await.remove(0);
+    let discovery_info = machine.discovery_info.as_ref().unwrap();
+    let guid1 = discovery_info.infiniband_interfaces[0].guid.clone();
+    let guid2 = discovery_info.infiniband_interfaces[1].guid.clone();
+    let total_ports = discovery_info.infiniband_interfaces.len();
+
+    let ib_manager = env.ib_fabric_manager.get_mock_manager();
+    ib_manager.set_port_state(&guid1, false);
+    ib_manager.set_port_state(&guid2, false);
+
+    env.run_ib_fabric_monitor_iteration().await;
+
+    let machine = env.find_machine(host_machine_id).await.remove(0);
+    let health = machine.health.as_ref().expect("Machine should have health");
+    let ib_port_down_alert = health
+        .alerts
+        .iter()
+        .find(|alert| alert.id == "IbPortDown")
+        .expect("Machine should have IbPortDown alert");
+
+    assert!(
+        ib_port_down_alert.message.contains("2 of"),
+        "Alert should indicate 2 ports are down"
+    );
+    assert!(
+        ib_port_down_alert
+            .message
+            .contains(&format!("{total_ports}")),
+        "Alert should indicate total port count"
+    );
+
+    assert!(
+        ib_port_down_alert.message.contains(&guid1),
+        "Alert message should contain first down GUID"
+    );
+    assert!(
+        ib_port_down_alert.message.contains(&guid2),
+        "Alert message should contain second down GUID"
+    );
+
+    ib_manager.set_port_state(&guid1, true);
+    env.run_ib_fabric_monitor_iteration().await;
+
+    let machine = env.find_machine(host_machine_id).await.remove(0);
+    let health = machine.health.as_ref().expect("Machine should have health");
+    let ib_port_down_alert = health
+        .alerts
+        .iter()
+        .find(|alert| alert.id == "IbPortDown")
+        .expect("Machine should still have IbPortDown alert with one port down");
+
+    assert!(
+        ib_port_down_alert.message.contains("1 of"),
+        "Alert should now indicate 1 port is down"
+    );
+    assert!(
+        !ib_port_down_alert.message.contains(&guid1),
+        "Alert should no longer contain recovered GUID"
+    );
+    assert!(
+        ib_port_down_alert.message.contains(&guid2),
+        "Alert should still contain down GUID"
+    );
+
+    ib_manager.set_port_state(&guid2, true);
+    env.run_ib_fabric_monitor_iteration().await;
+
+    let machine = env.find_machine(host_machine_id).await.remove(0);
+    let health = machine.health.as_ref().expect("Machine should have health");
+    let ib_port_down_alert = health.alerts.iter().find(|alert| alert.id == "IbPortDown");
+
+    assert!(
+        ib_port_down_alert.is_none(),
+        "IbPortDown alert should be cleared when all ports are up"
     );
 
     Ok(())

--- a/crates/api/src/tests/ib_instance.rs
+++ b/crates/api/src/tests/ib_instance.rs
@@ -495,6 +495,20 @@ async fn test_can_not_create_instance_for_inactive_ib_device(pool: sqlx::PgPool)
     let mh = create_managed_host(&env).await;
     let machine = mh.host().rpc_machine().await;
 
+    // Assign a SKU to the machine (required for IbPortDown alert tracking)
+    // BOM validation is disabled in test config, so manually assign a SKU
+    {
+        let mut txn = env.pool.begin().await.unwrap();
+        let sku = db::sku::generate_sku_from_machine(txn.as_mut(), &mh.id)
+            .await
+            .unwrap();
+        db::sku::create(&mut txn, &sku).await.unwrap();
+        db::machine::assign_sku(txn.as_mut(), &mh.id, &sku.id)
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+    }
+
     let discovery_info = machine.discovery_info.as_ref().unwrap();
     // Use only CX7 interfaces in this test
     let device_name = "MT2910 Family [ConnectX-7]".to_string();
@@ -550,12 +564,11 @@ async fn test_can_not_create_instance_for_inactive_ib_device(pool: sqlx::PgPool)
     )
     .await;
 
-    let expected_err = format!("UFM detected inactive state for GUID: {}", guids[1]);
-
+    let expected_err = "Host is not available for allocation due to health probe alert";
     assert!(result.is_err());
     let error = result.expect_err("expected allocation to fail").to_string();
     assert!(
-        error.contains(&expected_err),
+        error.contains(expected_err),
         "Error message should contain '{expected_err}', but is '{error}'"
     );
 }

--- a/crates/health-report/src/lib.rs
+++ b/crates/health-report/src/lib.rs
@@ -484,6 +484,27 @@ impl HealthProbeAlert {
             classifications: vec![HealthAlertClassification::prevent_allocations()],
         }
     }
+
+    pub fn ib_port_down(down_ports: Vec<String>, total_ports: usize) -> Self {
+        let message = format!(
+            "IB port(s) down: {} of {} ports are not active. Down GUIDs: {}",
+            down_ports.len(),
+            total_ports,
+            down_ports.join(", ")
+        );
+        Self {
+            id: HealthProbeId::ib_port_down(),
+            target: None,
+            in_alert_since: Some(chrono::Utc::now()),
+            message,
+            tenant_message: Some(format!(
+                "InfiniBand connectivity issue: {} port(s) are currently unavailable",
+                down_ports.len()
+            )),
+            classifications: vec![HealthAlertClassification::prevent_allocations()],
+        }
+    }
+
     /// Merge a HealthProbeAlert with the report from another probe of the same type
     ///
     /// The function does not check whether the Probe ID and target are equivalent.
@@ -587,6 +608,13 @@ impl HealthProbeId {
     /// This is mandatory if tenant wants to turn off the machine.
     pub fn internal_maintenance() -> Self {
         HealthProbeId("Maintenance".to_string())
+    }
+
+    /// The ID used for IB port down alerts
+    ///
+    /// Used by the IB fabric monitor when ports are detected as down.
+    pub fn ib_port_down() -> Self {
+        HealthProbeId("IbPortDown".to_string())
     }
 }
 
@@ -1387,5 +1415,42 @@ mod tests {
         let mut merged2 = r2.clone();
         merged2.merge(&r1);
         assert_eq!(merged2.observed_at, expected.observed_at);
+    }
+
+    #[test]
+    fn test_ib_port_down_probe_id() {
+        let probe_id = HealthProbeId::ib_port_down();
+        assert_eq!(probe_id.as_str(), "IbPortDown");
+    }
+
+    #[test]
+    fn test_ib_port_down_alert_construction() {
+        let down_ports = vec!["guid1".to_string(), "guid2".to_string()];
+        let alert = HealthProbeAlert::ib_port_down(down_ports, 8);
+
+        assert_eq!(alert.id.as_str(), "IbPortDown");
+        assert!(alert.message.contains("2 of 8"));
+        assert!(alert.message.contains("guid1"));
+        assert!(alert.message.contains("guid2"));
+        assert!(alert.tenant_message.is_some());
+        assert!(
+            alert
+                .classifications
+                .contains(&HealthAlertClassification::prevent_allocations())
+        );
+    }
+
+    #[test]
+    fn test_ib_port_down_alert_prevents_allocations() {
+        let alert = HealthProbeAlert::ib_port_down(vec!["guid1".to_string()], 8);
+        let report = HealthReport {
+            source: "test".to_string(),
+            observed_at: None,
+            successes: vec![],
+            alerts: vec![alert],
+            triggered_by: None,
+        };
+
+        assert!(report.has_classification(&HealthAlertClassification::prevent_allocations()));
     }
 }


### PR DESCRIPTION
## Description

When the IB Fabric Monitor detects ports not in Active state, it now sets a PreventAllocations health alert on the affected machine. This prevents Carbide from attempting to allocate instances on machines with degraded IB connectivity, avoiding SRE alerts.

   Port-down alerting uses a precedence model:
    1. If a machine has a SKU assigned, alert on any down port not in the
       SKU's inactive_devices list (hardware-level truth).
    2. If no SKU but an active instance exists, alert on down ports in the
       instance's IB config.
    3. If neither SKU nor instance, no alert is generated.
    
- Add HealthProbeId::ib_port_down() and HealthProbeAlert::ib_port_down()
- Detect ports not in Active state during IB fabric monitoring
- Set/clear IbPortDown health alert via health report overrides
- Update existing test to expect health alert blocking

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps
-->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->