### PR TITLE
Default agent upgrade policy to UpDown

### DIFF
--- a/crates/api-db/migrations/20260311092600_change_agent_upgrade_policy.sql
+++ b/crates/api-db/migrations/20260311092600_change_agent_upgrade_policy.sql
@@ -1,0 +1,3 @@
+-- After enough issues with UpOnly not syncing agent versions, we've decided UpDown is what we want
+-- everywhere.
+UPDATE dpu_agent_upgrade_policy SET policy = 'UpDown' WHERE policy = 'UpOnly';

--- a/crates/api/src/db_init.rs
+++ b/crates/api/src/db_init.rs
@@ -169,7 +169,7 @@ pub async fn store_initial_dpu_agent_upgrade_policy(
 ) -> Result<(), CarbideError> {
     let mut txn = Transaction::begin(db_pool).await?;
     let initial_policy: AgentUpgradePolicy = initial_dpu_agent_upgrade_policy
-        .unwrap_or(AgentUpgradePolicyChoice::UpOnly)
+        .unwrap_or(AgentUpgradePolicyChoice::UpDown)
         .into();
     let current_policy = dpu_agent_upgrade_policy::get(&mut txn).await?;
     // Only set if the very first time, it's the initial policy


### PR DESCRIPTION
## Description

After enough issues with UpOnly not syncing agent versions, we've decided UpDown is what we want everywhere.

This changes the default to UpDown, and adds a migration to change the value to UpDown on any site this is currently deployed.

## Type of Change
- [ ] **Add** - New feature or capability
- [X] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
nvbugs/5968745

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
I haven't run the full carbide tests locally so I'm not sure if anything asserts on this, if something fails I will update the tests.

