### PR TITLE
chore: remove stranded HardwareHealth proto from rpc

### DIFF
--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -3894,11 +3894,6 @@ message DpuExtensionServiceComponent {
   string status = 4;
 }
 
-message HardwareHealthReport {
-  common.MachineId machine_id = 1;
-  health.HealthReport report = 2;
-}
-
 message OptionalHealthReport {
   optional health.HealthReport report = 1;
 }


### PR DESCRIPTION
## Description
After removal of HardwareHealth API, HardwareHealth message left

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [x] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

