### PR TITLE
chore: bmc-mock: support generation of discovery data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,6 +1015,8 @@ dependencies = [
  "axum 0.8.6",
  "axum-server",
  "bytes",
+ "carbide-rpc",
+ "carbide-utils",
  "chrono",
  "clap",
  "duration-str",

--- a/crates/bmc-mock/Cargo.toml
+++ b/crates/bmc-mock/Cargo.toml
@@ -23,37 +23,40 @@ license.workspace = true
 authors.workspace = true
 
 [dependencies]
+carbide-rpc = { path = "../rpc", default-features = false }
+carbide-utils = { path = "../utils", default-features = false }
+
 arc-swap = { workspace = true }
 axum = { workspace = true }
 axum-server = { features = ["tls-rustls"], workspace = true }
+bytes = { workspace = true }
+chrono = { workspace = true }
 clap = { workspace = true }
 duration-str = { workspace = true }
-tokio.workspace = true
-tracing = { workspace = true }
-tracing-subscriber = { features = ["env-filter"], workspace = true }
-serde = { features = ["derive"], workspace = true }
-serde_json = { workspace = true }
-thiserror = { workspace = true }
-tar = { workspace = true }
 eyre = { workspace = true }
 flate2 = { workspace = true }
-tower = { workspace = true }
-hyper = { workspace = true }
+form_urlencoded = { workspace = true }
+futures = { workspace = true }
 http-body = { workspace = true }
-regex = { workspace = true }
+http-body-util = { workspace = true }
+hyper = { workspace = true }
+itertools = { workspace = true }
 lazy_static = { workspace = true }
 mac_address = { features = ["serde"], workspace = true }
-chrono = { workspace = true }
-tower-http = { features = ["normalize-path"], workspace = true }
-bytes = { workspace = true }
-form_urlencoded = { workspace = true }
-itertools = { workspace = true }
-futures = { workspace = true }
+nv-redfish = { workspace = true, features = ["bmc-http"] }
 rand = { workspace = true }
+regex = { workspace = true }
 rustls = { workspace = true }
 rustls-pemfile = { workspace = true }
-http-body-util = { workspace = true }
-nv-redfish = { workspace = true, features = ["bmc-http"] }
+serde = { features = ["derive"], workspace = true }
+serde_json = { workspace = true }
+tar = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tower = { workspace = true }
+tower-http = { features = ["normalize-path"], workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { features = ["env-filter"], workspace = true }
 url = { workspace = true }
 
 [lints]

--- a/crates/bmc-mock/src/hw/bluefield3.rs
+++ b/crates/bmc-mock/src/hw/bluefield3.rs
@@ -19,7 +19,9 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use mac_address::MacAddress;
+use rpc::machine_discovery::{BlockDevice, CpuInfo, DiscoveryInfo, DmiData, DpuData};
 use serde_json::json;
+use utils::models::arch::CpuArchitecture;
 
 use crate::{LogService, LogServices, PowerControl, hw, redfish};
 
@@ -212,7 +214,7 @@ impl Bluefield3<'_> {
     }
 
     pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
-        let base_mac = self.host_mac_address.to_string().replace(':', "");
+        let base_mac = self.base_mac().to_string().replace(':', "");
         let sys_image = format!(
             "{}:{}00:00{}:{}",
             &base_mac[0..4],
@@ -257,6 +259,61 @@ impl Bluefield3<'_> {
         }
     }
 
+    pub fn discovery_info(&self) -> DiscoveryInfo {
+        DiscoveryInfo {
+            network_interfaces: vec![],
+            infiniband_interfaces: vec![],
+            cpu_info: vec![CpuInfo {
+                model: "Cortex-A78AE".into(),
+                vendor: "ARM".into(),
+                sockets: 1,
+                cores: 16,
+                threads: 16,
+            }],
+            block_devices: std::iter::once(BlockDevice {
+                model: "KBG40ZPZ128G TOSHIBA MEMORY".into(),
+                revision: "AEGA0103".into(),
+                serial: "FAKESERNUM0".into(),
+                device_type: "disk".into(),
+            })
+            .chain((0..3).map(|_| BlockDevice {
+                model: "NO_MODEL".into(),
+                revision: "NO_REVISION".into(),
+                serial: "NO_SERIAL".into(),
+                device_type: "disk".into(),
+            }))
+            .collect(),
+            machine_type: CpuArchitecture::Aarch64.to_string(),
+            machine_arch: Some(CpuArchitecture::Aarch64.into()),
+            nvme_devices: vec![],
+            dmi_data: Some(DmiData {
+                board_name: "Bluefield-3 DPU".into(),
+                board_version: "AG".into(),
+                bios_version: "4.13.0-26-g337fea6bfd".into(),
+                bios_date: "Nov  3 2025".into(),
+                product_serial: self.product_serial_number.to_string(),
+                board_serial: "Unspecified Base Board Serial Number".into(),
+                chassis_serial: "Unspecified Chassis Board Serial Number".into(),
+                product_name: "BlueField-3 DPU".into(),
+                sys_vendor: "Nvidia".into(),
+            }),
+            dpu_info: Some(DpuData {
+                part_number: self.part_number().into(),
+                part_description: format!("NVIDIA Bluefield-3 {}", self.part_number()),
+                product_version: self.firmware_versions.dpu_nic.clone(),
+                factory_mac_address: self.base_mac().to_string(),
+                firmware_version: self.firmware_versions.dpu_nic.clone(),
+                firmware_date: "11.11.2025".into(),
+                switches: vec![],
+            }),
+            gpus: vec![],
+            memory_devices: vec![],
+            tpm_ek_certificate: None,
+            tpm_description: None,
+            ..Default::default()
+        }
+    }
+
     fn part_number(&self) -> &'static str {
         match self.mode {
             Mode::B3240ColdAisle => "900-9D3B6-00CN-PA0",
@@ -269,6 +326,10 @@ impl Bluefield3<'_> {
             Mode::SuperNIC { nic_mode: true } => "900-9D3B4-00CC-EA0",
             Mode::SuperNIC { nic_mode: false } => "900-9D3B6-00CV-AA0",
         }
+    }
+
+    fn base_mac(&self) -> MacAddress {
+        self.host_mac_address
     }
 
     fn opn(&self) -> &'static str {

--- a/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
+++ b/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
@@ -19,16 +19,16 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use mac_address::MacAddress;
+use rpc::machine_discovery::{BlockDevice, CpuInfo, DiscoveryInfo, DmiData, MemoryDevice};
 use serde_json::json;
+use utils::models::arch::CpuArchitecture;
 
 use crate::{PowerControl, hw, redfish};
-
-pub type SlotNumber = usize;
 
 pub struct DellPowerEdgeR750<'a> {
     pub bmc_mac_address: MacAddress,
     pub product_serial_number: Cow<'a, str>,
-    pub nics: Vec<(SlotNumber, hw::nic::Nic)>,
+    pub nics: Vec<(hw::nic::SlotNumber, hw::nic::Nic)>,
     pub embedded_nic: EmbeddedNic,
 }
 
@@ -234,6 +234,63 @@ impl DellPowerEdgeR750<'_> {
     pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
         redfish::update_service::UpdateServiceConfig {
             firmware_inventory: vec![],
+        }
+    }
+
+    pub fn discovery_info(&self) -> DiscoveryInfo {
+        DiscoveryInfo {
+            network_interfaces: self
+                .nics
+                .iter()
+                .map(|(slot, nic)| nic.discovery_info(*slot))
+                .collect(),
+            infiniband_interfaces: vec![],
+            cpu_info: vec![CpuInfo {
+                model: "Intel(R) Xeon(R) Gold 6354 CPU @ 3.00GHz".into(),
+                vendor: "GenuineIntel".into(),
+                sockets: 2,
+                cores: 18,
+                threads: 36,
+            }],
+            block_devices: vec![
+                BlockDevice {
+                    model: "Dell Ent NVMe v2 AGN RI U.2 1.92TB".into(),
+                    revision: "2.3.0".into(),
+                    serial: "FAKESERNUM0".into(),
+                    device_type: "".into(),
+                },
+                BlockDevice {
+                    model: "Dell Ent NVMe v2 AGN RI U.2 1.92TB".into(),
+                    revision: "2.3.0".into(),
+                    serial: "FAKESERNUM1".into(),
+                    device_type: "".into(),
+                },
+            ],
+            machine_type: CpuArchitecture::X86_64.to_string(),
+            machine_arch: Some(CpuArchitecture::X86_64.into()),
+            nvme_devices: vec![],
+            dmi_data: Some(DmiData {
+                board_name: "01J4WF".into(),
+                board_version: "A05".into(),
+                bios_version: "1.13.2".into(),
+                bios_date: "12/19/2023".into(),
+                product_serial: self.product_serial_number.to_string(),
+                board_serial: format!(".{}.FAKESERNUM2.", self.product_serial_number),
+                chassis_serial: self.product_serial_number.to_string(),
+                product_name: "PowerEdge R750".into(),
+                sys_vendor: "Dell".into(),
+            }),
+            dpu_info: None,
+            gpus: vec![],
+            memory_devices: (0..8)
+                .map(|_| MemoryDevice {
+                    size_mb: Some(16384),
+                    mem_type: Some("DDR4".into()),
+                })
+                .collect(),
+            tpm_ek_certificate: None,
+            tpm_description: None,
+            ..Default::default()
         }
     }
 }

--- a/crates/bmc-mock/src/hw/nic.rs
+++ b/crates/bmc-mock/src/hw/nic.rs
@@ -18,6 +18,8 @@
 use std::borrow::Cow;
 
 use mac_address::MacAddress;
+use rpc::machine_discovery::{NetworkInterface, PciDeviceProperties};
+pub type SlotNumber = usize;
 
 pub struct Nic {
     pub mac_address: MacAddress,
@@ -42,6 +44,30 @@ impl Nic {
             firmware_version: None,
             mac_address: mac,
             is_mat_dpu: false,
+        }
+    }
+
+    pub fn discovery_info(&self, slot: SlotNumber) -> NetworkInterface {
+        let device_name = format!("enp{}s{}np0", slot >> 16, slot & 0xff);
+        let slot = format!("{:04x}:{:02x}:00.0", (slot >> 16), (slot & 0xFF));
+        NetworkInterface {
+            mac_address: self.mac_address.to_string(),
+            pci_properties: Some(PciDeviceProperties {
+                vendor: self
+                    .manufacturer
+                    .as_ref()
+                    .unwrap_or(&Cow::Borrowed(""))
+                    .to_string(),
+                device: self
+                    .model
+                    .as_ref()
+                    .unwrap_or(&Cow::Borrowed(""))
+                    .to_string(),
+                path: format!("/devices/pci0000:00/0000:00:00.0/{slot}/net/{device_name}"),
+                numa_node: 0,
+                description: self.description.as_ref().map(|v| v.to_string()),
+                slot: Some(slot),
+            }),
         }
     }
 }

--- a/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
+++ b/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
@@ -18,7 +18,12 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
+use rpc::machine_discovery::{
+    BlockDevice, CpuInfo, DiscoveryInfo, DmiData, Gpu, GpuPlatformInfo, InfinibandInterface,
+    MemoryDevice, NvmeDevice, PciDeviceProperties,
+};
 use serde_json::json;
+use utils::models::arch::CpuArchitecture;
 
 use crate::{PowerControl, hw, redfish};
 
@@ -246,6 +251,102 @@ impl WiwynnGB200Nvl<'_> {
             .iter()
             .map(|(id, version)| fw_inv_builder(id).version(version).build())
             .collect(),
+        }
+    }
+
+    pub fn discovery_info(&self) -> DiscoveryInfo {
+        DiscoveryInfo {
+            network_interfaces: vec![
+                self.dpu1.host_nic().discovery_info(0x0603),
+                self.dpu2.host_nic().discovery_info(0x1603),
+            ],
+            infiniband_interfaces: (0..4)
+                .map(|n| {
+                    let (domain, numa_node) = [(0x0000, 0), (0x0002, 0), (0x0010, 1), (0x0012, 1)][n];
+                    let device_name = if domain == 0 {
+                        Cow::Borrowed("ibp3s0")
+                    } else {
+                        format!("ibP{domain}p3s0").into()
+                    };
+                    InfinibandInterface {
+                        pci_properties: Some(PciDeviceProperties {
+                            vendor: "Mellanox Technologies".into(),
+                            device: "MT2910 Family [ConnectX-7]".into(),
+                            path: format!("/devices/pci{domain:02x}:00/{domain:02x}:00:00.0/{domain:02x}:01:00.0/{domain:02x}:02:00.0/{domain:02x}:03:00.0/infiniband/{device_name}"),
+                            numa_node,
+                            description: Some("MT2910 Family [ConnectX-7]".into()),
+                            slot: format!("{domain}:03:00.0").into(),
+                        }),
+                        guid: format!("7c8c09000000000{n}"),
+                    }
+                })
+                .collect(),
+            cpu_info: vec![CpuInfo {
+                model: "Neoverse-V2".into(),
+                vendor: "ARM".into(),
+                sockets: 2,
+                cores: 72,
+                threads: 72,
+            }],
+            block_devices: (0..9)
+                .map(|n| BlockDevice {
+                    model: "SAMSUNG MZTL63T8HFLT-00AW7".into(),
+                    revision: "LDDL4U2Q".into(),
+                    serial: format!("BDFAKESERNUM{n}"),
+                    device_type: "disk".into(),
+                })
+                .collect(),
+            machine_type: CpuArchitecture::Aarch64.to_string(),
+            machine_arch: Some(CpuArchitecture::Aarch64.into()),
+            nvme_devices: (0..9)
+                .map(|n| NvmeDevice {
+                    model: "SAMSUNG MZTL63T8HFLT-00AW7".into(),
+                    firmware_rev: "LDDL4U2Q".into(),
+                    serial: format!("BDFAKESERNUM{n}"),
+                })
+                .collect(),
+            dmi_data: Some(DmiData {
+                board_name: "KINABALU BMC CARD".into(),
+                board_version: "PVT".into(),
+                bios_version: "00000083".into(),
+                bios_date: "20260107".into(),
+                product_serial: self.chassis_serial_number.to_string(),
+                board_serial: self.chassis_serial_number.to_string(),
+                chassis_serial: self.chassis_serial_number.to_string(),
+                product_name: "GB200 NVL".into(),
+                sys_vendor: "NVIDIA".into(),
+            }),
+            dpu_info: None,
+            gpus: (0..4).map(|n| {
+                let module_id = [2, 1, 4, 3][n];
+                let pci_bus_id = ["00000008:01:00.0", "00000009:01:00.0", "00000018:01:00.0", "00000019:01:00.0"][n];
+                Gpu {
+                    name: "NVIDIA GB200".into(),
+                    serial: format!("165000000000{n}"),
+                    driver_version: "580.126.16".into(),
+                    vbios_version: "97.00.B9.00.76".into(),
+                    inforom_version: "G548.0201.00.06".into(),
+                    total_memory: "189471 MiB".into(),
+                    frequency: "2062 MHz".into(),
+                    pci_bus_id: pci_bus_id.into(),
+                    platform_info: Some(GpuPlatformInfo {
+                        chassis_serial: format!("182100000000{n}"),
+                        slot_number: 24,
+                        tray_index: 14,
+                        host_id: 1,
+                        module_id,
+                        fabric_guid: format!("0xfeeeeeeeeeeeee{n:02x}"),
+                    })
+                }}).collect(),
+            memory_devices: (0..2)
+                .map(|_| MemoryDevice {
+                    size_mb: Some(491520),
+                    mem_type: Some("LPDDR5".into()),
+                })
+                .collect(),
+            tpm_ek_certificate: None,
+            tpm_description: None,
+            ..Default::default()
         }
     }
 }

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -216,6 +216,13 @@ impl HostMachineInfo {
         }
     }
 
+    pub fn discovery_info(&self) -> rpc::machine_discovery::DiscoveryInfo {
+        match self.hw_type {
+            HostHardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().discovery_info(),
+            HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().discovery_info(),
+        }
+    }
+
     fn dell_poweredge_r750(&self) -> hw::dell_poweredge_r750::DellPowerEdgeR750<'_> {
         let nics = if self.dpus.is_empty() {
             self.non_dpu_mac_address
@@ -350,6 +357,13 @@ impl MachineInfo {
             Some(d.host_mac_address)
         } else {
             None
+        }
+    }
+
+    pub fn discovery_info(&self) -> rpc::machine_discovery::DiscoveryInfo {
+        match self {
+            Self::Host(h) => h.discovery_info(),
+            Self::Dpu(dpu) => dpu.bluefield3().discovery_info(),
         }
     }
 }

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -17,13 +17,14 @@
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use base64::prelude::*;
+use bmc_mock::MachineInfo;
 use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use mac_address::MacAddress;
 use rpc::forge::machine_cleanup_info::CleanupStepResult;
 use rpc::forge::operating_system::Variant;
 use rpc::forge::{
-    ConfigSetting, ExpectedMachine, InlineIpxe, MachineType, MachinesByIdsRequest, OperatingSystem,
+    ConfigSetting, ExpectedMachine, InlineIpxe, MachinesByIdsRequest, OperatingSystem,
     PxeInstructions, SetDynamicConfigRequest,
 };
 use rpc::protos::forge_api_client::ForgeApiClient;
@@ -47,12 +48,7 @@ type ClientApiResult<T> = Result<T, ClientApiError>;
 // Simple wrapper around the inputs to discover_machine so that callers can see the field names
 pub struct MockDiscoveryData {
     pub machine_interface_id: MachineInterfaceId,
-    pub network_interface_macs: Vec<String>,
-    pub product_serial: Option<String>,
-    pub chassis_serial: Option<String>,
     pub tpm_ek_certificate: Option<Vec<u8>>,
-    pub host_mac_address: Option<MacAddress>,
-    pub dpu_nic_version: Option<String>,
 }
 
 static SUBNET_COUNTER: AtomicU32 = AtomicU32::new(0);
@@ -130,82 +126,23 @@ impl ApiClient {
 
     pub async fn discover_machine(
         &self,
-        template_dir: &str,
-        machine_type: MachineType,
+        machine_info: &MachineInfo,
         discovery_data: MockDiscoveryData,
     ) -> ClientApiResult<rpc::forge::MachineDiscoveryResult> {
         let MockDiscoveryData {
             machine_interface_id,
-            network_interface_macs,
-            product_serial,
-            chassis_serial,
-            host_mac_address,
             tpm_ek_certificate,
-            dpu_nic_version,
         } = discovery_data;
-        let json_path = if machine_type == MachineType::Dpu {
-            format!("{template_dir}/dpu_discovery_info.json")
-        } else {
-            format!("{template_dir}/host_discovery_info.json")
-        };
-        let dhcp_string = std::fs::read_to_string(&json_path)
-            .map_err(|e| ClientApiError::ConfigError(format!("Unable to read {json_path}: {e}")))?;
-        let mut discovery_data: rpc::machine_discovery::DiscoveryInfo =
-            serde_json::from_str(&dhcp_string).map_err(|e| {
-                ClientApiError::ConfigError(format!(
-                    "{json_path} does not have correct format: {e}"
-                ))
-            })?;
-
-        if let Some(ref mut dmi_data) = discovery_data.dmi_data {
-            if let Some(product_serial) = product_serial {
-                dmi_data.product_serial = product_serial;
-            }
-            if let Some(chassis_serial) = chassis_serial {
-                dmi_data.chassis_serial = chassis_serial;
-            }
-        }
-        if machine_type == MachineType::Host {
-            discovery_data.tpm_ek_certificate =
+        let mut machine_discovery_info = machine_info.discovery_info();
+        if matches!(machine_info, MachineInfo::Host(_)) {
+            machine_discovery_info.tpm_ek_certificate =
                 Some(BASE64_STANDARD.encode(tpm_ek_certificate.ok_or(
                     ClientApiError::ConfigError("No TPM EK certificate waa supplied".to_string()),
-                )?));
-            discovery_data.dpu_info = None;
-        } else if let Some(ref mut dpu_info) = discovery_data.dpu_info {
-            if let Some(host_mac_address) = host_mac_address {
-                dpu_info.factory_mac_address = host_mac_address.to_string();
-            }
-            if let Some(dpu_nic_version) = dpu_nic_version {
-                dpu_info.firmware_version = dpu_nic_version;
-            }
+                )?))
         }
-        let pci_properties = if machine_type == MachineType::Dpu {
-            None
-        } else {
-            Some(rpc::PciDeviceProperties {
-                vendor: "Mellanox Technologies".into(),
-                device: "0xa2d6".into(),
-                path: "/devices/pci0000:b0/0000:b0:04.0/0000:b1:00.1/net/enp177s0f1np1".into(),
-                numa_node: 1,
-                description: Some(
-                    "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller1".into(),
-                ),
-                slot: None,
-            })
-        };
-        discovery_data.network_interfaces = network_interface_macs
-            .iter()
-            .map(|mac| rpc::machine_discovery::NetworkInterface {
-                mac_address: mac.clone(),
-                pci_properties: pci_properties.clone(),
-            })
-            .collect();
-
         let mdi = rpc::forge::MachineDiscoveryInfo {
             machine_interface_id: Some(machine_interface_id),
-            discovery_data: Some(rpc::forge::machine_discovery_info::DiscoveryData::Info(
-                discovery_data,
-            )),
+            discovery_data: Some(rpc::DiscoveryData::Info(machine_discovery_info)),
             create_machine: true,
         };
 

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -25,11 +25,8 @@ use bmc_mock::{
     PowerControl, SetSystemPowerError, SetSystemPowerResult, SystemPowerControl,
 };
 use carbide_uuid::machine::MachineId;
-use mac_address::MacAddress;
 use rand::Rng;
-use rpc::forge::{
-    MachineArchitecture, MachineDiscoveryResult, MachineType, ManagedHostNetworkConfigResponse,
-};
+use rpc::forge::{MachineArchitecture, MachineDiscoveryResult, ManagedHostNetworkConfigResponse};
 use rpc::forge_agent_control_response::Action;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot};
@@ -714,25 +711,10 @@ impl MachineStateMachine {
             .app_context
             .api_client()
             .discover_machine(
-                &self.config.template_dir,
-                rpc_machine_type(&self.machine_info),
+                &self.machine_info,
                 MockDiscoveryData {
                     machine_interface_id,
-                    network_interface_macs: self
-                        .machine_info
-                        .dhcp_mac_addresses()
-                        .iter()
-                        .map(MacAddress::to_string)
-                        .collect(),
-                    product_serial: Some(self.machine_info.product_serial().clone()),
-                    chassis_serial: Some("Unspecified Chassis Board Serial Number".to_string()),
-                    host_mac_address: self.machine_info.host_mac_address(),
                     tpm_ek_certificate,
-                    dpu_nic_version: if let MachineInfo::Dpu(d) = &self.machine_info {
-                        d.settings.firmware_versions.nic.clone()
-                    } else {
-                        None
-                    },
                 },
             )
             .await?;
@@ -1202,11 +1184,4 @@ pub enum AddressConfigError {
     Io(#[from] std::io::Error),
     #[error("Error running ip command: {0:?}, output: {1:?}")]
     CommandFailure(Box<tokio::process::Command>, std::process::Output),
-}
-
-fn rpc_machine_type(machine_info: &MachineInfo) -> MachineType {
-    match machine_info {
-        MachineInfo::Dpu(_) => MachineType::Dpu,
-        MachineInfo::Host(_) => MachineType::Host,
-    }
 }


### PR DESCRIPTION
## Description
In this change discovery data is generated by hardware-specific code instead of using template. As result GB200 discovery data now is not "Dell" anymore. 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

