### PR TITLE
Fix: 5968806: Use Option<T> for the dpf_enabled flag to avoid sending default value to server.

### DIFF
--- a/crates/admin-cli/src/expected_machines/add/args.rs
+++ b/crates/admin-cli/src/expected_machines/add/args.rs
@@ -109,9 +109,8 @@ pub struct Args {
         action = clap::ArgAction::Set,
         value_name = "DPF_ENABLED",
         help = "DPF enable/disable for this machine. Default is updated as true.",
-        default_value_t = true
     )]
-    pub dpf_enabled: bool,
+    pub dpf_enabled: Option<bool>,
 }
 
 impl Args {
@@ -158,7 +157,9 @@ impl TryFrom<Args> for rpc::forge::ExpectedMachine {
             host_nics,
             rack_id: value.rack_id,
             default_pause_ingestion_and_poweron: value.default_pause_ingestion_and_poweron,
-            dpf_enabled: value.dpf_enabled,
+            #[allow(deprecated)]
+            dpf_enabled: value.dpf_enabled.unwrap_or_default(),
+            is_dpf_enabled: value.dpf_enabled,
         })
     }
 }

--- a/crates/admin-cli/src/expected_machines/common.rs
+++ b/crates/admin-cli/src/expected_machines/common.rs
@@ -37,7 +37,7 @@ pub struct ExpectedMachineJson {
     pub host_nics: Vec<rpc::forge::ExpectedHostNic>,
     pub rack_id: Option<RackId>,
     pub default_pause_ingestion_and_poweron: Option<bool>,
-    pub dpf_enabled: bool,
+    pub dpf_enabled: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/admin-cli/src/expected_machines/patch/args.rs
+++ b/crates/admin-cli/src/expected_machines/patch/args.rs
@@ -132,9 +132,8 @@ pub struct Args {
         action = clap::ArgAction::Set,
         value_name = "DPF_ENABLED",
         help = "DPF enable/disable for this machine. Default is updated as true.",
-        default_value_t = true
     )]
-    pub dpf_enabled: bool,
+    pub dpf_enabled: Option<bool>,
 }
 
 impl Args {

--- a/crates/admin-cli/src/expected_machines/show/cmd.rs
+++ b/crates/admin-cli/src/expected_machines/show/cmd.rs
@@ -133,7 +133,7 @@ async fn convert_and_print_into_nice_table(
         "Labels",
         "SKU ID",
         "Pause On Ingestion",
-        "DPF State",
+        "DPF Enabled",
     ]);
 
     for expected_machine in &expected_machines.expected_machines {
@@ -189,7 +189,12 @@ async fn convert_and_print_into_nice_table(
             labels.join(", "),
             expected_machine.sku_id.as_deref().unwrap_or_default(),
             default_pause_ingestion_and_poweron,
-            expected_machine.dpf_enabled.to_string(),
+            // is_dpf_enabled will be None only for the servers where old proto file is used.
+            #[allow(deprecated)]
+            expected_machine
+                .is_dpf_enabled
+                .unwrap_or(expected_machine.dpf_enabled)
+                .to_string(),
         ]);
     }
 

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -480,7 +480,7 @@ impl ApiClient {
         sku_id: Option<String>,
         rack_id: Option<RackId>,
         default_pause_ingestion_and_poweron: Option<bool>,
-        dpf_enabled: bool,
+        dpf_enabled: Option<bool>,
     ) -> Result<(), CarbideCliError> {
         let expected_machine = self
             .0
@@ -540,7 +540,9 @@ impl ApiClient {
             host_nics: expected_machine.host_nics,
             rack_id: rack_id.or(expected_machine.rack_id),
             default_pause_ingestion_and_poweron,
-            dpf_enabled,
+            #[allow(deprecated)]
+            dpf_enabled: dpf_enabled.unwrap_or_default(),
+            is_dpf_enabled: dpf_enabled,
         };
 
         Ok(self.0.update_expected_machine(request).await?)
@@ -634,7 +636,9 @@ impl ApiClient {
                     rack_id: machine.rack_id,
                     default_pause_ingestion_and_poweron: machine
                         .default_pause_ingestion_and_poweron,
-                    dpf_enabled: machine.dpf_enabled,
+                    #[allow(deprecated)]
+                    dpf_enabled: machine.dpf_enabled.unwrap_or_default(),
+                    is_dpf_enabled: machine.dpf_enabled,
                 })
                 .collect(),
         };

--- a/crates/api-db/migrations/20260311120000_dpf_enabled_nullable.sql
+++ b/crates/api-db/migrations/20260311120000_dpf_enabled_nullable.sql
@@ -1,0 +1,3 @@
+-- Make dpf_enabled nullable to allow an unset/optional state
+ALTER TABLE expected_machines ALTER COLUMN dpf_enabled DROP NOT NULL;
+ALTER TABLE expected_machines ALTER COLUMN dpf_enabled DROP DEFAULT;

--- a/crates/api-db/src/expected_machine.rs
+++ b/crates/api-db/src/expected_machine.rs
@@ -212,7 +212,7 @@ pub async fn create(
             .bind(sqlx::types::Json(data.host_nics))
             .bind(data.rack_id)
             .bind(data.default_pause_ingestion_and_poweron.unwrap_or(false))
-            .bind(data.dpf_enabled)
+            .bind(data.dpf_enabled.unwrap_or_default())
             .fetch_one(txn)
             .await
             .map_err(|err: sqlx::Error| match err {
@@ -235,7 +235,7 @@ pub async fn create(
             .bind(sqlx::types::Json(data.host_nics))
             .bind(data.rack_id)
             .bind(data.default_pause_ingestion_and_poweron.unwrap_or(false))
-            .bind(data.dpf_enabled)
+            .bind(data.dpf_enabled.unwrap_or_default())
             .fetch_one(txn)
             .await
             .map_err(|err: sqlx::Error| match err {
@@ -300,7 +300,7 @@ pub async fn update<'a>(
     txn: &mut PgConnection,
     data: ExpectedMachineData,
 ) -> DatabaseResult<&'a mut ExpectedMachine> {
-    let query = "UPDATE expected_machines SET bmc_username=$1, bmc_password=$2, serial_number=$3, fallback_dpu_serial_numbers=$4, metadata_name=$5, metadata_description=$6, metadata_labels=$7, sku_id=$8, host_nics=$9::jsonb, rack_id=$10, default_pause_ingestion_and_poweron=COALESCE($11, default_pause_ingestion_and_poweron), dpf_enabled=$12 WHERE bmc_mac_address=$13 RETURNING bmc_mac_address";
+    let query = "UPDATE expected_machines SET bmc_username=$1, bmc_password=$2, serial_number=$3, fallback_dpu_serial_numbers=$4, metadata_name=$5, metadata_description=$6, metadata_labels=$7, sku_id=$8, host_nics=$9::jsonb, rack_id=$10, default_pause_ingestion_and_poweron=COALESCE($11, default_pause_ingestion_and_poweron), dpf_enabled=COALESCE($12, dpf_enabled) WHERE bmc_mac_address=$13 RETURNING bmc_mac_address";
 
     let _: () = sqlx::query_as(query)
         .bind(&data.bmc_username)
@@ -335,7 +335,7 @@ pub async fn update_by_id(
     id: Uuid,
     data: ExpectedMachineData,
 ) -> DatabaseResult<()> {
-    let query = "UPDATE expected_machines SET bmc_username=$1, bmc_password=$2, serial_number=$3, fallback_dpu_serial_numbers=$4, metadata_name=$5, metadata_description=$6, metadata_labels=$7, sku_id=$8, host_nics=$9::jsonb, rack_id=$10, default_pause_ingestion_and_poweron=COALESCE($11, default_pause_ingestion_and_poweron), dpf_enabled=$12 WHERE id=$13 RETURNING id";
+    let query = "UPDATE expected_machines SET bmc_username=$1, bmc_password=$2, serial_number=$3, fallback_dpu_serial_numbers=$4, metadata_name=$5, metadata_description=$6, metadata_labels=$7, sku_id=$8, host_nics=$9::jsonb, rack_id=$10, default_pause_ingestion_and_poweron=COALESCE($11, default_pause_ingestion_and_poweron), dpf_enabled=COALESCE($12, dpf_enabled) WHERE id=$13 RETURNING id";
 
     let _: () = sqlx::query_as(query)
         .bind(&data.bmc_username)

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -66,8 +66,7 @@ pub struct ExpectedMachineData {
     pub host_nics: Vec<ExpectedHostNic>,
     pub rack_id: Option<RackId>,
     pub default_pause_ingestion_and_poweron: Option<bool>,
-    #[serde(default)]
-    pub dpf_enabled: bool,
+    pub dpf_enabled: Option<bool>,
 }
 // Important : new fields for expected machine (and data) should be optional _and_ serde(default),
 // unless you want to go update all the files in each production deployment that autoload
@@ -154,7 +153,10 @@ impl From<ExpectedMachine> for rpc::forge::ExpectedMachine {
             default_pause_ingestion_and_poweron: expected_machine
                 .data
                 .default_pause_ingestion_and_poweron,
-            dpf_enabled: expected_machine.data.dpf_enabled,
+            // This should be removed after few releases.
+            #[allow(deprecated)]
+            dpf_enabled: expected_machine.data.dpf_enabled.unwrap_or_default(),
+            is_dpf_enabled: expected_machine.data.dpf_enabled,
         }
     }
 }
@@ -199,7 +201,7 @@ impl TryFrom<rpc::forge::ExpectedMachine> for ExpectedMachineData {
             host_nics: em.host_nics.into_iter().map(|nic| nic.into()).collect(),
             rack_id: em.rack_id,
             default_pause_ingestion_and_poweron: em.default_pause_ingestion_and_poweron,
-            dpf_enabled: em.dpf_enabled,
+            dpf_enabled: em.is_dpf_enabled,
         })
     }
 }

--- a/crates/api/src/site_explorer/machine_creator.rs
+++ b/crates/api/src/site_explorer/machine_creator.rs
@@ -115,7 +115,7 @@ impl MachineCreator {
             Some(m) => (
                 Some(&m.data.metadata),
                 m.data.sku_id.as_ref(),
-                m.data.dpf_enabled,
+                m.data.dpf_enabled.unwrap_or_default(),
             ),
             None => (None, None, true),
         };

--- a/crates/api/src/tests/expected_machine.rs
+++ b/crates/api/src/tests/expected_machine.rs
@@ -82,7 +82,7 @@ async fn test_duplicate_fail_create(pool: sqlx::PgPool) -> Result<(), Box<dyn st
             default_pause_ingestion_and_poweron: None,
             host_nics: vec![],
             rack_id: None,
-            dpf_enabled: true,
+            dpf_enabled: Some(true),
         },
     )
     .await;
@@ -182,7 +182,7 @@ async fn test_add_expected_machine(pool: sqlx::PgPool) {
                 value: Uuid::new_v4().to_string(),
             }),
             default_pause_ingestion_and_poweron: Some(true),
-            dpf_enabled: false,
+            is_dpf_enabled: Some(false),
             ..Default::default()
         },
         rpc::forge::ExpectedMachine {
@@ -196,6 +196,8 @@ async fn test_add_expected_machine(pool: sqlx::PgPool) {
                 value: Uuid::new_v4().to_string(),
             }),
             default_pause_ingestion_and_poweron: Some(false),
+            is_dpf_enabled: Some(true),
+            #[allow(deprecated)]
             dpf_enabled: true,
             ..Default::default()
         },
@@ -223,6 +225,7 @@ async fn test_add_expected_machine(pool: sqlx::PgPool) {
             }),
             sku_id: Some("sku_id".to_string()),
             default_pause_ingestion_and_poweron: None,
+            is_dpf_enabled: Some(false),
             ..Default::default()
         },
     ]
@@ -263,9 +266,17 @@ async fn test_add_expected_machine(pool: sqlx::PgPool) {
         assert_eq!(retrieved_expected_machine, expected_machine.clone());
 
         if idx != 1 {
-            assert!(!retrieved_expected_machine.dpf_enabled);
+            assert!(
+                !retrieved_expected_machine
+                    .is_dpf_enabled
+                    .unwrap_or_default()
+            );
         } else {
-            assert!(retrieved_expected_machine.dpf_enabled);
+            assert!(
+                retrieved_expected_machine
+                    .is_dpf_enabled
+                    .unwrap_or_default()
+            );
         }
     }
 }
@@ -502,6 +513,7 @@ async fn test_replace_all_expected_machines(pool: sqlx::PgPool) {
         chassis_serial_number: "SERIAL_NEW".into(),
         metadata: Some(rpc::Metadata::default()),
         default_pause_ingestion_and_poweron: Some(true),
+        is_dpf_enabled: Some(false),
         ..Default::default()
     };
 
@@ -512,6 +524,7 @@ async fn test_replace_all_expected_machines(pool: sqlx::PgPool) {
         chassis_serial_number: "SERIAL_NEW".into(),
         metadata: Some(rpc::Metadata::default()),
         default_pause_ingestion_and_poweron: Some(false),
+        is_dpf_enabled: Some(false),
         ..Default::default()
     };
 
@@ -522,6 +535,7 @@ async fn test_replace_all_expected_machines(pool: sqlx::PgPool) {
         chassis_serial_number: "SERIAL_NEW".into(),
         metadata: Some(rpc::Metadata::default()),
         default_pause_ingestion_and_poweron: None,
+        is_dpf_enabled: Some(false),
         ..Default::default()
     };
 
@@ -711,6 +725,8 @@ async fn test_add_expected_machine_dpu_serials(pool: sqlx::PgPool) {
         default_pause_ingestion_and_poweron: Some(true),
         host_nics: vec![],
         rack_id: None,
+        is_dpf_enabled: Some(true),
+        #[allow(deprecated)]
         dpf_enabled: true,
     };
 
@@ -753,7 +769,8 @@ async fn test_add_and_update_expected_machine_with_invalid_metadata(pool: sqlx::
             default_pause_ingestion_and_poweron: None,
             host_nics: vec![],
             rack_id: None,
-            dpf_enabled: true,
+            is_dpf_enabled: Some(true),
+            ..Default::default()
         };
 
         let err = env
@@ -786,7 +803,8 @@ async fn test_add_and_update_expected_machine_with_invalid_metadata(pool: sqlx::
         default_pause_ingestion_and_poweron: None,
         host_nics: vec![],
         rack_id: None,
-        dpf_enabled: true,
+        is_dpf_enabled: Some(true),
+        ..Default::default()
     };
 
     env.api
@@ -807,7 +825,8 @@ async fn test_add_and_update_expected_machine_with_invalid_metadata(pool: sqlx::
             default_pause_ingestion_and_poweron: None,
             host_nics: vec![],
             rack_id: None,
-            dpf_enabled: true,
+            is_dpf_enabled: Some(true),
+            ..Default::default()
         };
 
         let err = env
@@ -882,7 +901,8 @@ async fn test_add_expected_machine_duplicate_dpu_serials(pool: sqlx::PgPool) {
         default_pause_ingestion_and_poweron: None,
         host_nics: vec![],
         rack_id: None,
-        dpf_enabled: true,
+        is_dpf_enabled: Some(true),
+        ..Default::default()
     };
 
     assert!(
@@ -1745,4 +1765,118 @@ async fn test_batch_update_expected_machines_partial_results(pool: sqlx::PgPool)
         .await
         .expect("should find machine 3");
     assert_eq!(machine3.into_inner().bmc_username, "admin3_updated");
+}
+
+// test_patch_dpf_enabled_null_stays_null verifies that when dpf_enabled is NULL
+// in the DB and an update is applied with is_dpf_enabled: None, the value remains NULL.
+#[crate::sqlx_test()]
+async fn test_patch_dpf_enabled_none_to_false(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let bmc_mac_address = "AA:BB:CC:DD:EE:F0";
+
+    // Create machine with dpf_enabled = null (is_dpf_enabled: None)
+    env.api
+        .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+            bmc_mac_address: bmc_mac_address.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: "SN-DPF-NULL".into(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            is_dpf_enabled: None,
+            ..Default::default()
+        }))
+        .await
+        .expect("unable to add expected machine");
+
+    // Patch (update) with is_dpf_enabled: None — should keep dpf_enabled as NULL
+    let mut updated = env
+        .api
+        .get_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachineRequest {
+            bmc_mac_address: bmc_mac_address.to_string(),
+            id: None,
+        }))
+        .await
+        .expect("unable to fetch expected machine")
+        .into_inner();
+
+    // default should be updated as false
+    assert_eq!(updated.is_dpf_enabled, Some(false),);
+
+    updated.id = None;
+    updated.bmc_username = "ADMIN_PATCHED".into();
+    updated.is_dpf_enabled = None;
+
+    env.api
+        .update_expected_machine(tonic::Request::new(updated))
+        .await
+        .expect("unable to update expected machine");
+
+    let retrieved = env
+        .api
+        .get_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachineRequest {
+            bmc_mac_address: bmc_mac_address.to_string(),
+            id: None,
+        }))
+        .await
+        .expect("unable to fetch expected machine after update")
+        .into_inner();
+
+    assert_eq!(retrieved.is_dpf_enabled, Some(false),);
+}
+
+// test_patch_dpf_enabled_true_stays_true_when_patched_with_null verifies that when
+// dpf_enabled is true in the DB and an update is applied with is_dpf_enabled: None,
+// the value remains true (not overwritten to NULL).
+#[crate::sqlx_test()]
+async fn test_patch_dpf_enabled_true_stays_true_when_patched_with_null(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let bmc_mac_address = "AA:BB:CC:DD:EE:F1";
+
+    // Create machine with dpf_enabled = true
+    env.api
+        .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+            bmc_mac_address: bmc_mac_address.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: "SN-DPF-TRUE".into(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            is_dpf_enabled: Some(true),
+            ..Default::default()
+        }))
+        .await
+        .expect("unable to add expected machine");
+
+    // Patch (update) with is_dpf_enabled: None — should preserve dpf_enabled = true
+    let mut updated = env
+        .api
+        .get_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachineRequest {
+            bmc_mac_address: bmc_mac_address.to_string(),
+            id: None,
+        }))
+        .await
+        .expect("unable to fetch expected machine")
+        .into_inner();
+
+    assert_eq!(updated.is_dpf_enabled, Some(true),);
+
+    updated.id = None;
+    updated.bmc_username = "ADMIN_PATCHED".into();
+    updated.is_dpf_enabled = None;
+
+    env.api
+        .update_expected_machine(tonic::Request::new(updated))
+        .await
+        .expect("unable to update expected machine");
+
+    let retrieved = env
+        .api
+        .get_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachineRequest {
+            bmc_mac_address: bmc_mac_address.to_string(),
+            id: None,
+        }))
+        .await
+        .expect("unable to fetch expected machine after update")
+        .into_inner();
+
+    assert_eq!(retrieved.is_dpf_enabled, Some(true),);
 }

--- a/crates/api/src/tests/machine_creator.rs
+++ b/crates/api/src/tests/machine_creator.rs
@@ -1204,7 +1204,7 @@ async fn test_site_explorer_creates_managed_host_with_dpf_disable(
         id: Some(uuid::Uuid::new_v4()),
         bmc_mac_address: mock_host.bmc_mac_address,
         data: model::expected_machine::ExpectedMachineData {
-            dpf_enabled: false,
+            dpf_enabled: None,
             ..Default::default()
         },
     };
@@ -1345,7 +1345,7 @@ async fn test_site_explorer_creates_managed_host_with_dpf_enabled(
         id: Some(uuid::Uuid::new_v4()),
         bmc_mac_address: mock_host.bmc_mac_address,
         data: model::expected_machine::ExpectedMachineData {
-            dpf_enabled: true,
+            dpf_enabled: Some(true),
             ..Default::default()
         },
     };

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -1403,7 +1403,7 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
             default_pause_ingestion_and_poweron: None,
             host_nics: vec![],
             rack_id: None,
-            dpf_enabled: true,
+            dpf_enabled: Some(true),
         },
     )
     .await?;
@@ -1452,7 +1452,7 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
             default_pause_ingestion_and_poweron: None,
             host_nics: vec![],
             rack_id: None,
-            dpf_enabled: true,
+            dpf_enabled: Some(true),
         },
     )
     .await?;
@@ -2408,7 +2408,7 @@ async fn test_machine_creation_with_sku(
             default_pause_ingestion_and_poweron: None,
             host_nics: vec![],
             rack_id: None,
-            dpf_enabled: true,
+            dpf_enabled: Some(true),
         },
     )
     .await?;
@@ -2537,7 +2537,7 @@ async fn test_expected_machine_device_type_metrics(
             default_pause_ingestion_and_poweron: None,
             host_nics: vec![],
             rack_id: None,
-            dpf_enabled: true,
+            dpf_enabled: Some(true),
         },
     )
     .await?;
@@ -2556,7 +2556,7 @@ async fn test_expected_machine_device_type_metrics(
             default_pause_ingestion_and_poweron: None,
             host_nics: vec![],
             rack_id: None,
-            dpf_enabled: true,
+            dpf_enabled: Some(true),
         },
     )
     .await?;
@@ -2575,7 +2575,7 @@ async fn test_expected_machine_device_type_metrics(
             default_pause_ingestion_and_poweron: None,
             host_nics: vec![],
             rack_id: None,
-            dpf_enabled: true,
+            dpf_enabled: Some(true),
         },
     )
     .await?;

--- a/crates/api/src/tests/sku.rs
+++ b/crates/api/src/tests/sku.rs
@@ -793,7 +793,7 @@ pub mod tests {
                 default_pause_ingestion_and_poweron: None,
                 host_nics: vec![],
                 rack_id: None,
-                dpf_enabled: true,
+                dpf_enabled: Some(true),
             },
         )
         .await?;
@@ -882,7 +882,7 @@ pub mod tests {
                 default_pause_ingestion_and_poweron: None,
                 host_nics: vec![],
                 rack_id: None,
-                dpf_enabled: true,
+                dpf_enabled: Some(true),
             },
         )
         .await?;
@@ -946,7 +946,7 @@ pub mod tests {
                 default_pause_ingestion_and_poweron: None,
                 host_nics: vec![],
                 rack_id: None,
-                dpf_enabled: true,
+                dpf_enabled: Some(true),
             },
         )
         .await?;
@@ -1027,7 +1027,7 @@ pub mod tests {
                 default_pause_ingestion_and_poweron: None,
                 host_nics: vec![],
                 rack_id: None,
-                dpf_enabled: true,
+                dpf_enabled: Some(true),
             },
         )
         .await?;
@@ -1459,7 +1459,7 @@ pub mod tests {
                 default_pause_ingestion_and_poweron: None,
                 host_nics: vec![],
                 rack_id: None,
-                dpf_enabled: true,
+                dpf_enabled: Some(true),
             },
         )
         .await?;

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -558,7 +558,9 @@ impl ApiClient {
                 host_nics: vec![],
                 rack_id: None,
                 default_pause_ingestion_and_poweron: None,
+                #[allow(deprecated)]
                 dpf_enabled: true,
+                is_dpf_enabled: Some(true),
             })
             .await
             .map_err(ClientApiError::InvocationError)

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -4588,7 +4588,9 @@ message ExpectedMachine {
   repeated ExpectedHostNic host_nics = 9;
   optional common.RackId rack_id = 10;
   optional bool default_pause_ingestion_and_poweron = 11;
-  bool dpf_enabled = 12;
+  // deprecated
+  bool dpf_enabled = 12 [deprecated = true];
+  optional bool is_dpf_enabled = 13;
 }
 
 message ExpectedMachineRequest {


### PR DESCRIPTION
## Description
Use Option<T> for the dpf_enabled flag to avoid sending default value to server.

1. Any EM which is already created and dpf_enabled is not updated will be updated as dpf_enabled false.
2. If during add, dpf_enabled is not mentioned, will be updated as false.
3. if during patching, dpf_enabled is not provided, the value will remain unchanged.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
[NVBUG-5968806](https://nvbugspro.nvidia.com/bug/5968806)

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

