### PR TITLE
fix(agent): correct prefix-list action format for DPU_TO_EVPN_DROP_PREFIX_LIST

### DIFF
--- a/crates/agent/templates/nvue_startup_fnn.conf
+++ b/crates/agent/templates/nvue_startup_fnn.conf
@@ -209,8 +209,7 @@
                 {{- end }}
               {{- end }}
               '65535':
-                action:
-                  deny: {}
+                action: deny
         route-map:
           dpu_to_evpn:
             rule:

--- a/crates/agent/templates/tests/full_nvue_startup_fnn_l3.yaml.expected
+++ b/crates/agent/templates/tests/full_nvue_startup_fnn_l3.yaml.expected
@@ -110,8 +110,7 @@
                 match:
                   10.1.1.1/32: {}
               '65535':
-                action:
-                  deny: {}
+                action: deny
         route-map:
           dpu_to_evpn:
             rule:

--- a/crates/agent/templates/tests/nvue_startup_fnn_classic.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_classic.yaml.expected
@@ -142,8 +142,7 @@
                   10.217.5.125/32: {}
                   10.217.5.124/32: {}
               '65535':
-                action:
-                  deny: {}
+                action: deny
         route-map:
           dpu_to_evpn:
             rule:

--- a/crates/agent/templates/tests/nvue_startup_fnn_classic_with_empty_nsg_default_deny.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_classic_with_empty_nsg_default_deny.yaml.expected
@@ -150,8 +150,7 @@
                   10.217.5.125/32: {}
                   10.217.5.124/32: {}
               '65535':
-                action:
-                  deny: {}
+                action: deny
         route-map:
           dpu_to_evpn:
             rule:

--- a/crates/agent/templates/tests/nvue_startup_quarantined_fnn.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_quarantined_fnn.yaml.expected
@@ -162,8 +162,7 @@
                   10.217.5.125/32: {}
                   10.217.5.124/32: {}
               '65535':
-                action:
-                  deny: {}
+                action: deny
         route-map:
           dpu_to_evpn:
             rule:


### PR DESCRIPTION
## Description
- Rule 65535 in the DPU_TO_EVPN_DROP_PREFIX_LIST prefix-list was using route-map object syntax (action: {deny: {}}) instead of the string syntax required by prefix-list rules (action: deny), causing NVUE schema validation to reject the entire network config with the error: Config invalid at router.policy.prefix-list.DPU_TO_EVPN_DROP_PREFIX_LIST.rule.65535.action: {'deny': {}} is not of type 'string'
- This rule was added in #457 to handle the case where no VPCs are configured (making rule 10 conditional), but was copy-pasted from the adjacent route-map section which uses a different schema for action
- Fix updates the template and 4 test expected files

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

