### PR TITLE
feat: update libredfish to v0.43.4 and enhance bmc-explorer BIOS attribute handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5605,7 +5605,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.43.3#4d5c14ba784873c4e763c6fa3faf01e2ada665ed"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.43.4#f9a4e74865a87549e22ac8173413c36343f4f234"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.43.3" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.43.4" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.5" }
 ansi-to-html = "0.2.2"
 

--- a/crates/bmc-explorer/src/computer_system.rs
+++ b/crates/bmc-explorer/src/computer_system.rs
@@ -418,6 +418,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
             .map(|actual| match expected.value {
                 hw::BiosAttrValue::Str(v) => actual.str_value() == Some(v),
                 hw::BiosAttrValue::Bool(v) => actual.bool_value() == Some(v),
+                hw::BiosAttrValue::Int(v) => actual.integer_value() == Some(v),
                 hw::BiosAttrValue::AnyStr(v) => v.iter().any(|v| actual.str_value() == Some(v)),
             })
     }
@@ -430,6 +431,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
             && !match expected.value {
                 hw::BiosAttrValue::Bool(v) => actual.bool_value() == Some(v),
                 hw::BiosAttrValue::Str(v) => actual.str_value() == Some(v),
+                hw::BiosAttrValue::Int(v) => actual.integer_value() == Some(v),
                 hw::BiosAttrValue::AnyStr(v) => v.iter().any(|v| actual.str_value() == Some(v)),
             }
         {
@@ -440,6 +442,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
                     .str_value()
                     .map(|v| v.to_string())
                     .or_else(|| actual.bool_value().map(|v| v.to_string()))
+                    .or_else(|| actual.integer_value().map(|v| v.to_string()))
                     .unwrap_or_else(|| "unexpected type".to_string()),
             })
         } else {

--- a/crates/bmc-explorer/src/hw/lenovo_ami.rs
+++ b/crates/bmc-explorer/src/hw/lenovo_ami.rs
@@ -17,9 +17,10 @@
 
 use crate::hw::BiosAttr;
 
-pub const EXPECTED_BIOS_ATTRS: [BiosAttr; 9] = [
+pub const EXPECTED_BIOS_ATTRS: [BiosAttr; 10] = [
     BiosAttr::new_str("VMXEN", "Enable"), // VMX (Intel Virtualization)
     BiosAttr::new_str("PCIS007", "Enabled"), // SR-IOV Support
+    BiosAttr::new_int("LEM0001", 3),      // PXE retry count (remove on future FW update)
     BiosAttr::new_str("NWSK000", "Enabled"), // Network Stack
     BiosAttr::new_str("NWSK001", "Disabled"), // IPv4 PXE Support
     BiosAttr::new_str("NWSK006", "Enabled"), // IPv4 HTTP Support

--- a/crates/bmc-explorer/src/hw/mod.rs
+++ b/crates/bmc-explorer/src/hw/mod.rs
@@ -105,6 +105,12 @@ impl BiosAttr<'_> {
             value: BiosAttrValue::AnyStr(value),
         }
     }
+    pub const fn new_int(key: &'static str, value: i64) -> BiosAttr<'static> {
+        BiosAttr {
+            key,
+            value: BiosAttrValue::Int(value),
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -112,6 +118,7 @@ pub enum BiosAttrValue<'a> {
     Str(&'a str),
     AnyStr(&'a [&'a str]),
     Bool(bool),
+    Int(i64),
 }
 
 impl fmt::Display for BiosAttrValue<'_> {
@@ -119,6 +126,7 @@ impl fmt::Display for BiosAttrValue<'_> {
         match self {
             BiosAttrValue::Str(v) => v.fmt(f),
             BiosAttrValue::Bool(v) => v.fmt(f),
+            BiosAttrValue::Int(v) => v.fmt(f),
             BiosAttrValue::AnyStr(v) => write!(f, "any({})", v.iter().join(",")),
         }
     }

--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -253,7 +253,10 @@ pub(crate) fn hw_type<B: Bmc>(
             "Supermicro" => Some(hw::HwType::Supermicro),
             "HPE" => Some(hw::HwType::Hpe),
             "Nvidia" if system.id().into_inner() == "Bluefield" => Some(hw::HwType::Bluefield),
-            "WIWYNN" | "NVIDIA" if root.product() == Some(Product::new("GB200 NVL")) => {
+            "WIWYNN" | "NVIDIA"
+                if root.product() == Some(Product::new("GB200 NVL"))
+                    || root.product() == Some(Product::new("GB BMC")) =>
+            {
                 Some(hw::HwType::Gb200)
             }
             "NVIDIA" if root.product() == Some(Product::new("P3809")) => Some(hw::HwType::NvSwitch),


### PR DESCRIPTION
## Description
This PR bumps libredfish to `v0.43.4` which brings in the following changes:

- feat: [ami] implement boot_first by @krish-nvidia in https://github.com/NVIDIA/libredfish/pull/50
- fix: limit pxe retry to 3 for AMI + support different GB200 product name by @krish-nvidia in https://github.com/NVIDIA/libredfish/pull/53

This PR also updates the nv-redfish path for parity with those libredfish updates. It now:

- Recognizes `Vendor: NVIDIA` with `Product: GB BMC` as GB200
- Updates AMI machine setup checks to include `LEM0001 = 3` with attribute comparison support for integer values.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

