### PR TITLE
Add fix for instances pending network config and add back missing nvlink changes to v0.3.0

### DIFF
--- a/crates/agent/templates/nvue_startup_fnn.conf
+++ b/crates/agent/templates/nvue_startup_fnn.conf
@@ -209,8 +209,7 @@
                 {{- end }}
               {{- end }}
               '65535':
-                action:
-                  deny: {}
+                action: deny
         route-map:
           dpu_to_evpn:
             rule:

--- a/crates/agent/templates/tests/full_nvue_startup_fnn_l3.yaml.expected
+++ b/crates/agent/templates/tests/full_nvue_startup_fnn_l3.yaml.expected
@@ -110,8 +110,7 @@
                 match:
                   10.1.1.1/32: {}
               '65535':
-                action:
-                  deny: {}
+                action: deny
         route-map:
           dpu_to_evpn:
             rule:

--- a/crates/agent/templates/tests/nvue_startup_fnn_classic.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_classic.yaml.expected
@@ -142,8 +142,7 @@
                   10.217.5.125/32: {}
                   10.217.5.124/32: {}
               '65535':
-                action:
-                  deny: {}
+                action: deny
         route-map:
           dpu_to_evpn:
             rule:

--- a/crates/agent/templates/tests/nvue_startup_fnn_classic_with_empty_nsg_default_deny.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_classic_with_empty_nsg_default_deny.yaml.expected
@@ -150,8 +150,7 @@
                   10.217.5.125/32: {}
                   10.217.5.124/32: {}
               '65535':
-                action:
-                  deny: {}
+                action: deny
         route-map:
           dpu_to_evpn:
             rule:

--- a/crates/agent/templates/tests/nvue_startup_quarantined_fnn.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_quarantined_fnn.yaml.expected
@@ -162,8 +162,7 @@
                   10.217.5.125/32: {}
                   10.217.5.124/32: {}
               '65535':
-                action:
-                  deny: {}
+                action: deny
         route-map:
           dpu_to_evpn:
             rule:

--- a/crates/api/src/nvl_partition_monitor/mod.rs
+++ b/crates/api/src/nvl_partition_monitor/mod.rs
@@ -1354,7 +1354,12 @@ impl NvlPartitionMonitor {
                     db_partition_nmx_m_id,
                 )) = partition_ctx.get_db_partition_info(&nmxm_partition.id)
                 else {
-                    tracing::error!("No partition found with nmx_m_id = {}", nmxm_partition.id);
+                    if !is_nmx_m_default_partition(nmxm_partition) {
+                        tracing::error!(
+                            "No partition found with nmx_m_id = {} while processing removal of GPU {gpu:?} in admin network",
+                            nmxm_partition.id,
+                        );
+                    }
                     continue;
                 };
 
@@ -1653,7 +1658,7 @@ impl NvlPartitionMonitor {
                             continue;
                         }
                     };
-                    let result = nmxm_client
+                    let get_operation_result = nmxm_client
                         .get_operation(operation_id.to_string())
                         .await
                         .map_err(|e| {
@@ -1664,10 +1669,10 @@ impl NvlPartitionMonitor {
                             ))
                         })?;
 
-                    match result.status {
+                    match get_operation_result.status {
                         libnmxm::nmxm_model::OperationStatus::Completed => {
                             tracing::info!(
-                                "Operation {operation:?} for logical partition {logical_partition_id} completed successfully"
+                                "Operation {get_operation_result:?} for logical partition {logical_partition_id} completed successfully"
                             );
                             completed_operations_for_this_logical_partition.push(operation.clone());
                             operations_to_remove.push(*logical_partition_id);
@@ -1687,9 +1692,17 @@ impl NvlPartitionMonitor {
                                 .push(start_time.elapsed());
                         }
                         libnmxm::nmxm_model::OperationStatus::Failed => {
-                            tracing::error!(
-                                "Operation {operation:?} for logical partition {logical_partition_id} failed with error"
-                            );
+                            if let Some(result) = get_operation_result.result.as_ref() {
+                                let error = result.error.as_deref().unwrap_or_default();
+                                let error_details = result.details.as_deref().unwrap_or_default();
+                                tracing::error!(
+                                    "Operation {get_operation_result:?} for logical partition {logical_partition_id} failed with error: {error} {error_details}"
+                                );
+                            } else {
+                                tracing::error!(
+                                    "Operation {get_operation_result:?} for logical partition {logical_partition_id} failed with unknown error"
+                                );
+                            }
                             operations_to_remove.push(*logical_partition_id);
 
                             let applied_change = AppliedChange {

--- a/crates/api/src/nvl_partition_monitor/mod.rs
+++ b/crates/api/src/nvl_partition_monitor/mod.rs
@@ -37,6 +37,7 @@ use model::machine::nvlink::{MachineNvLinkGpuStatusObservation, MachineNvLinkSta
 use model::machine::{HostHealthConfig, LoadSnapshotOptions, ManagedHostStateSnapshot};
 use sqlx::PgPool;
 use tokio::sync::oneshot;
+use tracing::Instrument;
 
 use crate::api::TransactionVending;
 use crate::cfg::file::NvLinkConfig;
@@ -677,7 +678,36 @@ impl NvlPartitionMonitor {
 
     pub async fn run_single_iteration(&self) -> CarbideResult<usize> {
         let mut metrics = NvlPartitionMonitorMetrics::new();
+        let span_id: String = format!("{:#x}", u64::from_le_bytes(rand::random::<[u8; 8]>()));
+        let check_nvl_partition_span = tracing::span!(
+            parent: None,
+            tracing::Level::INFO,
+            "nvl_partition_monitor",
+            span_id,
+            otel.status_code = tracing::field::Empty,
+            otel.status_message = tracing::field::Empty,
+            metrics = tracing::field::Empty,
+        );
+        let result = self
+            .run_single_iteration_inner(&mut metrics)
+            .instrument(check_nvl_partition_span.clone())
+            .await;
+        check_nvl_partition_span.record(
+            "otel.status_code",
+            if result.is_ok() { "ok" } else { "error" },
+        );
+        if let Err(ref e) = result {
+            check_nvl_partition_span.record("otel.status_message", format!("{e:?}"));
+        }
+        check_nvl_partition_span.record("metrics", metrics.to_string());
+        self.metric_holder.update_metrics(metrics);
+        result
+    }
 
+    async fn run_single_iteration_inner(
+        &self,
+        metrics: &mut NvlPartitionMonitorMetrics,
+    ) -> CarbideResult<usize> {
         let _lock = match self
             .work_lock_manager_handle
             .try_acquire_lock(Self::ITERATION_WORK_KEY.into())
@@ -696,29 +726,12 @@ impl NvlPartitionMonitor {
             "NvlPartitionMonitor acquired the lock",
         );
 
-        let span_id: String = format!("{:#x}", u64::from_le_bytes(rand::random::<[u8; 8]>()));
-        let check_nvl_partition_span = tracing::span!(
-            parent: None,
-            tracing::Level::INFO,
-            "nvlink_partition_monitor",
-            span_id,
-            otel.status_code = tracing::field::Empty,
-            otel.status_message = tracing::field::Empty,
-            metrics = tracing::field::Empty,
-        );
-
         let nmxm_client = self
             .nmxm_client_pool
             .create_client(&self.config.nmx_m_endpoint, None)
             .await
             .map_err(|e| {
                 metrics.nmxm.connect_error = "Failed to create NMXM client".to_string();
-                check_nvl_partition_span.record("otel.status_code", "error");
-                check_nvl_partition_span.record(
-                    "otel.status_message",
-                    format!("Failed to create NMMX client {e:?}"),
-                );
-
                 CarbideError::internal(format!("Failed to create NMXM client: {e}"))
             })?;
 
@@ -742,24 +755,11 @@ impl NvlPartitionMonitor {
 
         let nmx_m_partitions = nmxm_client.get_partitions_list().await.map_err(|e| {
             metrics.nmxm.connect_error = "Failed to get NMXM partitions list".to_string();
-
-            check_nvl_partition_span.record("otel.status_code", "error");
-            check_nvl_partition_span.record(
-                "otel.status_message",
-                format!("Failed to get NMXM partitions list {e:?}"),
-            );
-
             CarbideError::internal(format!("Failed to get NMXM partitions list: {e}"))
         })?;
 
         let nmx_m_gpus = nmxm_client.get_gpu(None).await.map_err(|e| {
             metrics.nmxm.connect_error = "Failed to get NMXM gpu list".to_string();
-            check_nvl_partition_span.record("otel.status_code", "error");
-            check_nvl_partition_span.record(
-                "otel.status_message",
-                format!("Failed to get NMXM gpu list {e:?}"),
-            );
-
             CarbideError::internal(format!("Failed to get NMXM gpu list: {e}"))
         })?;
 
@@ -771,7 +771,7 @@ impl NvlPartitionMonitor {
                 &nmx_m_gpus,
                 db_nvl_partitions,
                 &nmx_m_partitions,
-                &mut metrics,
+                metrics,
             )
             .await?;
 
@@ -790,10 +790,10 @@ impl NvlPartitionMonitor {
         let observations = self.check_nv_link_partitions(
             &mut partition_processing_context,
             managed_host_snapshots,
-            &mut metrics,
-        );
+            metrics,
+        )?;
 
-        self.record_nvlink_status_observation(observations?).await?;
+        self.record_nvlink_status_observation(observations).await?;
 
         let nmx_m_operations = partition_processing_context.nmx_m_operations;
 
@@ -810,7 +810,7 @@ impl NvlPartitionMonitor {
 
         // Poll NMX-M operation IDs with timeout
         let completed_nmx_m_operations = self
-            .poll_nmx_m_operations_with_timeout(pending_nmx_m_operations, &mut metrics)
+            .poll_nmx_m_operations_with_timeout(pending_nmx_m_operations, metrics)
             .await?;
 
         if !completed_nmx_m_operations.is_empty() {
@@ -823,23 +823,12 @@ impl NvlPartitionMonitor {
         let num_completed_operations = completed_nmx_m_operations.len();
         metrics.num_completed_operations = num_completed_operations;
 
-        check_nvl_partition_span.record("metrics", metrics.to_string());
-
         // Get a fresh list of partitions from NMX-M.
         let nmx_m_partitions = nmxm_client.get_partitions_list().await.map_err(|e| {
             metrics.nmxm.connect_error =
                 "Failed to get NMXM partitions list when updating db".to_string();
-            check_nvl_partition_span.record("otel.status_code", "error");
-            check_nvl_partition_span.record(
-                "otel.status_message",
-                format!("Failed to get NMXM partitions list when updating db {e:?}"),
-            );
             CarbideError::internal(format!("Failed to get NMXM partitions list: {e}"))
         })?;
-
-        check_nvl_partition_span.record("otel.status_code", "ok");
-
-        self.metric_holder.update_metrics(metrics);
 
         // Update db.
         let mut txn = self.db_pool.txn_begin().await?;
@@ -1678,7 +1667,11 @@ impl NvlPartitionMonitor {
                             operations_to_remove.push(*logical_partition_id);
 
                             let applied_change = AppliedChange {
-                                operation: operation.operation_type.clone().into(),
+                                operation: operation
+                                    .original_operation_type
+                                    .clone()
+                                    .unwrap_or_else(|| operation.operation_type.clone())
+                                    .into(),
                                 status: NmxmPartitionOperationStatus::Completed,
                             };
                             *metrics
@@ -1706,7 +1699,11 @@ impl NvlPartitionMonitor {
                             operations_to_remove.push(*logical_partition_id);
 
                             let applied_change = AppliedChange {
-                                operation: operation.operation_type.clone().into(),
+                                operation: operation
+                                    .original_operation_type
+                                    .clone()
+                                    .unwrap_or_else(|| operation.operation_type.clone())
+                                    .into(),
                                 status: NmxmPartitionOperationStatus::Failed,
                             };
                             *metrics
@@ -1730,7 +1727,11 @@ impl NvlPartitionMonitor {
                             operations_to_remove.push(*logical_partition_id);
 
                             let applied_change = AppliedChange {
-                                operation: operation.operation_type.clone().into(),
+                                operation: operation
+                                    .original_operation_type
+                                    .clone()
+                                    .unwrap_or_else(|| operation.operation_type.clone())
+                                    .into(),
                                 status: NmxmPartitionOperationStatus::Cancelled,
                             };
                             *metrics
@@ -1766,7 +1767,11 @@ impl NvlPartitionMonitor {
         for (logical_partition_id, operation) in pending_nmx_m_operations {
             for op in &operation {
                 let applied_change = AppliedChange {
-                    operation: op.operation_type.clone().into(),
+                    operation: op
+                        .original_operation_type
+                        .clone()
+                        .unwrap_or_else(|| op.operation_type.clone())
+                        .into(),
                     status: NmxmPartitionOperationStatus::Timedout,
                 };
                 *metrics

--- a/crates/api/src/nvl_partition_monitor/mod.rs
+++ b/crates/api/src/nvl_partition_monitor/mod.rs
@@ -1435,81 +1435,94 @@ impl NvlPartitionMonitor {
                                 operation.gpu_ids.clone(),
                             )),
                         };
-                        let result =
-                            nmxm_client
-                                .create_partition(Some(request))
-                                .await
-                                .map_err(|e| {
-                                    CarbideError::internal(format!(
-                                        "Failed to create partition: {e}"
-                                    ))
-                                })?;
-                        pending_operations
-                            .entry(logical_partition_id)
-                            .and_modify(|ops| {
-                                ops.push(NmxmPartitionOperation {
-                                    domain_uuid: operation.domain_uuid,
-                                    operation_type: NmxmPartitionOperationType::Pending(
-                                        result.operation_id.clone(),
-                                    ),
-                                    original_operation_type: Some(
-                                        NmxmPartitionOperationType::Create,
-                                    ),
-                                    gpu_ids: operation.gpu_ids.clone(),
-                                    name: operation.name.clone(),
-                                    db_partition_id: operation.db_partition_id,
-                                });
-                            })
-                            .or_insert(vec![NmxmPartitionOperation {
-                                domain_uuid: operation.domain_uuid,
-                                operation_type: NmxmPartitionOperationType::Pending(
-                                    result.operation_id.clone(),
-                                ),
-                                original_operation_type: Some(NmxmPartitionOperationType::Create),
-                                gpu_ids: operation.gpu_ids.clone(),
-                                name: operation.name.clone(),
-                                db_partition_id: operation.db_partition_id,
-                            }]);
+                        match nmxm_client.create_partition(Some(request)).await {
+                            Ok(result) => {
+                                pending_operations
+                                    .entry(logical_partition_id)
+                                    .and_modify(|ops| {
+                                        ops.push(NmxmPartitionOperation {
+                                            domain_uuid: operation.domain_uuid,
+                                            operation_type: NmxmPartitionOperationType::Pending(
+                                                result.operation_id.clone(),
+                                            ),
+                                            original_operation_type: Some(
+                                                NmxmPartitionOperationType::Create,
+                                            ),
+                                            gpu_ids: operation.gpu_ids.clone(),
+                                            name: operation.name.clone(),
+                                            db_partition_id: operation.db_partition_id,
+                                        });
+                                    })
+                                    .or_insert(vec![NmxmPartitionOperation {
+                                        domain_uuid: operation.domain_uuid,
+                                        operation_type: NmxmPartitionOperationType::Pending(
+                                            result.operation_id.clone(),
+                                        ),
+                                        original_operation_type: Some(
+                                            NmxmPartitionOperationType::Create,
+                                        ),
+                                        gpu_ids: operation.gpu_ids.clone(),
+                                        name: operation.name.clone(),
+                                        db_partition_id: operation.db_partition_id,
+                                    }]);
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    %logical_partition_id,
+                                    "Failed to issue create partition to NMX-M, continuing with other operations: {e}"
+                                );
+                            }
+                        }
                     }
                     NmxmPartitionOperationType::Remove(nmx_m_partition_id) => {
                         // Remove from the partition.
 
-                        let result = nmxm_client
+                        match nmxm_client
                             .delete_partition(nmx_m_partition_id.clone())
                             .await
-                            .map_err(|e| {
-                                CarbideError::internal(format!("Failed to create partition: {e}"))
-                            })?;
-                        pending_operations
-                            .entry(logical_partition_id)
-                            .and_modify(|ops| {
-                                ops.push(NmxmPartitionOperation {
-                                    domain_uuid: operation.domain_uuid,
-                                    operation_type: NmxmPartitionOperationType::Pending(
-                                        result.operation_id.clone(),
-                                    ),
-                                    original_operation_type: Some(
-                                        NmxmPartitionOperationType::Remove(
-                                            nmx_m_partition_id.clone(),
+                        {
+                            Ok(result) => {
+                                pending_operations
+                                    .entry(logical_partition_id)
+                                    .and_modify(|ops| {
+                                        ops.push(NmxmPartitionOperation {
+                                            domain_uuid: operation.domain_uuid,
+                                            operation_type: NmxmPartitionOperationType::Pending(
+                                                result.operation_id.clone(),
+                                            ),
+                                            original_operation_type: Some(
+                                                NmxmPartitionOperationType::Remove(
+                                                    nmx_m_partition_id.clone(),
+                                                ),
+                                            ),
+                                            gpu_ids: operation.gpu_ids.clone(),
+                                            name: operation.name.clone(),
+                                            db_partition_id: operation.db_partition_id,
+                                        });
+                                    })
+                                    .or_insert(vec![NmxmPartitionOperation {
+                                        domain_uuid: operation.domain_uuid,
+                                        operation_type: NmxmPartitionOperationType::Pending(
+                                            result.operation_id.clone(),
                                         ),
-                                    ),
-                                    gpu_ids: operation.gpu_ids.clone(),
-                                    name: operation.name.clone(),
-                                    db_partition_id: operation.db_partition_id,
-                                });
-                            })
-                            .or_insert(vec![NmxmPartitionOperation {
-                                domain_uuid: operation.domain_uuid,
-                                operation_type: NmxmPartitionOperationType::Pending(
-                                    result.operation_id.clone(),
-                                ),
-                                original_operation_type: Some(NmxmPartitionOperationType::Remove(
-                                    nmx_m_partition_id.clone(),
-                                )),
-                                gpu_ids: operation.gpu_ids.clone(),
-                                name: operation.name.clone(),
-                                db_partition_id: operation.db_partition_id,
-                            }]);
+                                        original_operation_type: Some(
+                                            NmxmPartitionOperationType::Remove(
+                                                nmx_m_partition_id.clone(),
+                                            ),
+                                        ),
+                                        gpu_ids: operation.gpu_ids.clone(),
+                                        name: operation.name.clone(),
+                                        db_partition_id: operation.db_partition_id,
+                                    }]);
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    %logical_partition_id,
+                                    %nmx_m_partition_id,
+                                    "Failed to issue delete partition to NMX-M, continuing with other operations: {e}"
+                                );
+                            }
+                        }
                     }
                     NmxmPartitionOperationType::RemoveDefaultPartition(nmx_m_partition_id) => {
                         tracing::info!("NOT Removing default partition {nmx_m_partition_id}");
@@ -1562,42 +1575,52 @@ impl NvlPartitionMonitor {
                                 operation.gpu_ids.clone(),
                             )),
                         };
-                        let result = nmxm_client
+                        match nmxm_client
                             .update_partition(nmx_m_partition_id.clone(), request)
                             .await
-                            .map_err(|e| {
-                                CarbideError::internal(format!("Failed to update partition: {e}"))
-                            })?;
-                        pending_operations
-                            .entry(logical_partition_id)
-                            .and_modify(|ops| {
-                                ops.push(NmxmPartitionOperation {
-                                    domain_uuid: operation.domain_uuid,
-                                    operation_type: NmxmPartitionOperationType::Pending(
-                                        result.operation_id.clone(),
-                                    ),
-                                    original_operation_type: Some(
-                                        NmxmPartitionOperationType::Update(
-                                            nmx_m_partition_id.clone(),
+                        {
+                            Ok(result) => {
+                                pending_operations
+                                    .entry(logical_partition_id)
+                                    .and_modify(|ops| {
+                                        ops.push(NmxmPartitionOperation {
+                                            domain_uuid: operation.domain_uuid,
+                                            operation_type: NmxmPartitionOperationType::Pending(
+                                                result.operation_id.clone(),
+                                            ),
+                                            original_operation_type: Some(
+                                                NmxmPartitionOperationType::Update(
+                                                    nmx_m_partition_id.clone(),
+                                                ),
+                                            ),
+                                            gpu_ids: operation.gpu_ids.clone(),
+                                            name: operation.name.clone(),
+                                            db_partition_id: operation.db_partition_id,
+                                        });
+                                    })
+                                    .or_insert(vec![NmxmPartitionOperation {
+                                        domain_uuid: operation.domain_uuid,
+                                        operation_type: NmxmPartitionOperationType::Pending(
+                                            result.operation_id.clone(),
                                         ),
-                                    ),
-                                    gpu_ids: operation.gpu_ids.clone(),
-                                    name: operation.name.clone(),
-                                    db_partition_id: operation.db_partition_id,
-                                });
-                            })
-                            .or_insert(vec![NmxmPartitionOperation {
-                                domain_uuid: operation.domain_uuid,
-                                operation_type: NmxmPartitionOperationType::Pending(
-                                    result.operation_id.clone(),
-                                ),
-                                original_operation_type: Some(NmxmPartitionOperationType::Update(
-                                    nmx_m_partition_id.clone(),
-                                )),
-                                gpu_ids: operation.gpu_ids.clone(),
-                                name: operation.name.clone(),
-                                db_partition_id: operation.db_partition_id,
-                            }]);
+                                        original_operation_type: Some(
+                                            NmxmPartitionOperationType::Update(
+                                                nmx_m_partition_id.clone(),
+                                            ),
+                                        ),
+                                        gpu_ids: operation.gpu_ids.clone(),
+                                        name: operation.name.clone(),
+                                        db_partition_id: operation.db_partition_id,
+                                    }]);
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    %logical_partition_id,
+                                    %nmx_m_partition_id,
+                                    "Failed to issue update partition to NMX-M, continuing with other operations: {e}"
+                                );
+                            }
+                        }
                     }
                     NmxmPartitionOperationType::Pending(_operation_id) => {
                         // This will be handled by the poll_nmx_m_operations_with_timeout function, there should not be any Pending operations in this step.

--- a/crates/api/src/nvl_partition_monitor/mod.rs
+++ b/crates/api/src/nvl_partition_monitor/mod.rs
@@ -1424,13 +1424,13 @@ impl NvlPartitionMonitor {
                 match operation.operation_type {
                     NmxmPartitionOperationType::Create => {
                         // Create the nvl partition.
+                        let name =
+                            format!("{}{}", logical_partition_id, operation.gpu_ids.join(","));
+                        // NMX-M has a limit of 244 characters for the partition name
+                        let name: String = name.chars().take(240).collect();
                         let request = libnmxm::nmxm_model::CreatePartitionRequest {
                             // For integration test to pass, till we can fix SimClient to cache partition info dynamically
-                            name: format!(
-                                "{}{}",
-                                logical_partition_id,
-                                operation.gpu_ids.join(",")
-                            ),
+                            name,
                             members: Box::new(libnmxm::nmxm_model::PartitionMembers::Ids(
                                 operation.gpu_ids.clone(),
                             )),

--- a/crates/api/src/nvlink.rs
+++ b/crates/api/src/nvlink.rs
@@ -117,6 +117,7 @@ pub mod test_support {
         _state: Arc<Mutex<u32>>,
         _partitions: Arc<Mutex<Vec<libnmxm::nmxm_model::Partition>>>,
         _gpus: Arc<Mutex<Vec<libnmxm::nmxm_model::Gpu>>>,
+        _fail_after_n_creates: Option<Arc<Mutex<usize>>>,
     }
 
     impl Default for NmxmSimClient {
@@ -125,13 +126,22 @@ pub mod test_support {
                 _state: Arc::new(Mutex::new(0)),
                 _partitions: Arc::new(Mutex::new(Vec::new())),
                 _gpus: Arc::new(Mutex::new(Self::default_gpus())),
+                _fail_after_n_creates: None,
             }
         }
     }
 
     impl NmxmSimClient {
+        // After n create_requests succeed, they will start failing.
+        pub fn with_fail_after_n_creates(n: usize) -> Self {
+            NmxmSimClient {
+                _fail_after_n_creates: Some(Arc::new(Mutex::new(n))),
+                ..Self::default()
+            }
+        }
+
         pub fn with_default_partition() -> Self {
-            let client = NmxmSimClient::default();
+            let client = Self::default();
             client.create_default_partition(
                 client
                     ._gpus
@@ -617,6 +627,15 @@ pub mod test_support {
             &self,
             _req: Option<libnmxm::nmxm_model::CreatePartitionRequest>,
         ) -> Result<libnmxm::nmxm_model::AsyncResponse, NmxmApiError> {
+            {
+                if let Some(fail_counter) = &self._fail_after_n_creates {
+                    let mut fail_counter = fail_counter.lock().unwrap();
+                    if *fail_counter == 0 {
+                        return Err(NmxmApiError::InvalidArguments);
+                    }
+                    *fail_counter -= 1;
+                }
+            }
             let r = _req.unwrap();
             let mut _p = self._partitions.lock().unwrap();
             let partition = libnmxm::nmxm_model::Partition {
@@ -711,6 +730,7 @@ pub mod test_support {
                 _state: self._state.clone(),
                 _partitions: self._partitions.clone(),
                 _gpus: self._gpus.clone(),
+                _fail_after_n_creates: self._fail_after_n_creates.clone(),
             }))
         }
     }

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -258,6 +258,8 @@ pub struct TestEnvOverrides {
     pub dpf_config: Option<DpfConfig>,
     pub fnn_config: Option<FnnConfig>,
     pub nmxm_default_partition: Option<bool>,
+    // After n create_requests succeed, they will start failing.
+    pub nmxm_fail_after_n_creates: Option<usize>,
 }
 
 impl TestEnvOverrides {
@@ -1269,7 +1271,9 @@ pub async fn create_test_env_with_overrides(
     let certificate_provider = Arc::new(TestCertificateProvider::new());
     let redfish_sim = Arc::new(RedfishSim::default());
     let nmxm_sim: Arc<dyn NmxmClientPool> =
-        Arc::new(if overrides.nmxm_default_partition == Some(true) {
+        Arc::new(if let Some(n) = overrides.nmxm_fail_after_n_creates {
+            NmxmSimClient::with_fail_after_n_creates(n)
+        } else if overrides.nmxm_default_partition == Some(true) {
             NmxmSimClient::with_default_partition()
         } else {
             NmxmSimClient::default()

--- a/crates/api/src/tests/nvl_instance.rs
+++ b/crates/api/src/tests/nvl_instance.rs
@@ -482,6 +482,109 @@ async fn test_with_multiple_nv_link_logical_partitions(pool: sqlx::PgPool) {
 }
 
 #[crate::sqlx_test]
+async fn test_nvl_partition_monitor_adds_successful_partitions_when_some_creates_fail(
+    pool: sqlx::PgPool,
+) {
+    let mut config = common::api_fixtures::get_config();
+    if let Some(nvlink_config) = config.nvlink_config.as_mut() {
+        nvlink_config.enabled = true;
+    }
+
+    // Fail after one create succeeds.
+    let mut overrides = TestEnvOverrides::with_config(config);
+    overrides.nmxm_fail_after_n_creates = Some(1);
+
+    let env = common::api_fixtures::create_test_env_with_overrides(pool.clone(), overrides).await;
+
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+
+    let NvlLogicalPartitionFixture {
+        id: logical_partition_id1,
+        logical_partition: _logical_partition1,
+    } = create_nvl_logical_partition(&env, "test_partition1".to_string()).await;
+    let NvlLogicalPartitionFixture {
+        id: logical_partition_id2,
+        logical_partition: _logical_partition2,
+    } = create_nvl_logical_partition(&env, "test_partition2".to_string()).await;
+
+    let mh = create_managed_host_with_hardware_info_template(
+        &env,
+        HardwareInfoTemplate::Custom(
+            crate::tests::common::api_fixtures::host::GB200_COMPUTE_TRAY_1_INFO_JSON,
+        ),
+    )
+    .await;
+
+    let discovery_info = mh.host().rpc_machine().await.discovery_info.unwrap();
+    let gpus: Vec<Gpu> = discovery_info.gpus.to_vec();
+
+    let nvl_config = rpc::forge::InstanceNvLinkConfig {
+        gpu_configs: gpus
+            .iter()
+            .filter_map(|gpu| {
+                gpu.platform_info.as_ref().map(|platform_info| {
+                    rpc::forge::InstanceNvLinkGpuConfig {
+                        device_instance: platform_info.module_id,
+                        logical_partition_id: None,
+                    }
+                })
+            })
+            .collect(),
+    };
+
+    let (_tinstance, instance) =
+        create_instance_with_nvlink_config(&env, &mh, nvl_config.clone(), segment_id).await;
+
+    let nvl_config = rpc::forge::InstanceNvLinkConfig {
+        gpu_configs: gpus
+            .iter()
+            .filter_map(|gpu| {
+                gpu.platform_info.as_ref().map(|platform_info| {
+                    let nvl_logical_partition_id = if platform_info.module_id > 2 {
+                        Some(logical_partition_id2)
+                    } else {
+                        Some(logical_partition_id1)
+                    };
+                    rpc::forge::InstanceNvLinkGpuConfig {
+                        device_instance: platform_info.module_id,
+                        logical_partition_id: nvl_logical_partition_id,
+                    }
+                })
+            })
+            .collect(),
+    };
+    let mut txn = pool.begin().await.unwrap();
+    update_instance_nvlink_config(
+        &mut txn,
+        &instance.id(),
+        &InstanceNvLinkConfig::try_from(nvl_config).unwrap(),
+    )
+    .await;
+    txn.commit().await.unwrap();
+
+    // The monitor should successfully create one partition, but the second creation should fail.
+    env.run_nvl_partition_monitor_iteration().await;
+    env.run_nvl_partition_monitor_iteration().await;
+
+    let request_all = tonic::Request::new(rpc::forge::NvLinkPartitionSearchFilter {
+        name: None,
+        tenant_organization_id: None,
+    });
+    let ids_all = env
+        .api
+        .find_nv_link_partition_ids(request_all)
+        .await
+        .map(|response| response.into_inner())
+        .unwrap();
+
+    assert_eq!(
+        ids_all.partition_ids.len(),
+        1,
+        "expected exactly one partition in DB when one NMX-M create fails"
+    );
+}
+
+#[crate::sqlx_test]
 async fn test_create_instances_with_nvl_configs_same_logical_partition_different_domains(
     pool: sqlx::PgPool,
 ) {


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
This PR adds https://github.com/NVIDIA/bare-metal-manager-core/pull/538, a formatting fix for DPU_TO_EVPN_DROP_PREFIX_LIST that was causing stuck instances, to v0.3.0. It also adds back 4 NVLink partitioning commits that were present in the v0.2.0 branch but missing in v0.3.0.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

