### PR TITLE
chore: bmc-mock: Dell: ensure that machine FSM detects it as Dell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,6 +1014,7 @@ dependencies = [
  "arc-swap",
  "axum 0.8.6",
  "axum-server",
+ "bmc-vendor",
  "bytes",
  "carbide-rpc",
  "carbide-utils",

--- a/crates/bmc-mock/Cargo.toml
+++ b/crates/bmc-mock/Cargo.toml
@@ -23,6 +23,7 @@ license.workspace = true
 authors.workspace = true
 
 [dependencies]
+bmc-vendor = { path = "../bmc-vendor" }
 carbide-rpc = { path = "../rpc", default-features = false }
 carbide-utils = { path = "../utils", default-features = false }
 

--- a/crates/bmc-mock/src/hw/bluefield3.rs
+++ b/crates/bmc-mock/src/hw/bluefield3.rs
@@ -191,6 +191,7 @@ impl Bluefield3<'_> {
                         entries: vec!["DPU Warm Reset".to_string()],
                     },
                 })),
+                storage: None,
             }],
         }
     }

--- a/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
+++ b/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
@@ -18,6 +18,7 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
+use bmc_vendor::BMCVendor;
 use mac_address::MacAddress;
 use rpc::machine_discovery::{BlockDevice, CpuInfo, DiscoveryInfo, DmiData, MemoryDevice};
 use serde_json::json;
@@ -129,6 +130,11 @@ impl DellPowerEdgeR750<'_> {
                 bios_mode: redfish::computer_system::BiosMode::DellOem,
                 oem: redfish::computer_system::Oem::Generic,
                 log_services: None,
+                // Today carbide need for any Dell to have storage
+                // collection. It tries to find BOSS controller
+                // there. So we provide empty collection to avoid 404
+                // failure.
+                storage: Some(vec![]),
                 base_bios: Some(redfish::bios::builder(&redfish::bios::resource(system_id))
                     .attributes(json!({
                         "BootSeqRetry": "Disabled",
@@ -147,8 +153,7 @@ impl DellPowerEdgeR750<'_> {
                         "HttpDev1EnDis": "Enabled",
                         "PxeDev1EnDis": "Disabled",
                         "HttpDev1Interface": "NIC.Slot.5-1",
-                    }))
-                    .build()),
+                    })).build()),
             }],
         }
     }
@@ -252,20 +257,14 @@ impl DellPowerEdgeR750<'_> {
                 cores: 18,
                 threads: 36,
             }],
-            block_devices: vec![
-                BlockDevice {
+            block_devices: (0..2)
+                .map(|n| BlockDevice {
                     model: "Dell Ent NVMe v2 AGN RI U.2 1.92TB".into(),
                     revision: "2.3.0".into(),
-                    serial: "FAKESERNUM0".into(),
+                    serial: format!("FAKESERNUM{n}"),
                     device_type: "".into(),
-                },
-                BlockDevice {
-                    model: "Dell Ent NVMe v2 AGN RI U.2 1.92TB".into(),
-                    revision: "2.3.0".into(),
-                    serial: "FAKESERNUM1".into(),
-                    device_type: "".into(),
-                },
-            ],
+                })
+                .collect(),
             machine_type: CpuArchitecture::X86_64.to_string(),
             machine_arch: Some(CpuArchitecture::X86_64.into()),
             nvme_devices: vec![],
@@ -278,7 +277,10 @@ impl DellPowerEdgeR750<'_> {
                 board_serial: format!(".{}.FAKESERNUM2.", self.product_serial_number),
                 chassis_serial: self.product_serial_number.to_string(),
                 product_name: "PowerEdge R750".into(),
-                sys_vendor: "Dell".into(),
+                // Logic of machine state handler depends on BMC
+                // vendor that is calculated from dmi_data.sys_vendor
+                // value.
+                sys_vendor: hw::bmc_vendor_to_udev_dmi(BMCVendor::Dell).into(),
             }),
             dpu_info: None,
             gpus: vec![],

--- a/crates/bmc-mock/src/hw/mod.rs
+++ b/crates/bmc-mock/src/hw/mod.rs
@@ -29,3 +29,18 @@ pub mod dell_poweredge_r750;
 
 /// Support of Wiwynn GB200 NVL servers.
 pub mod wiwynn_gb200_nvl;
+
+use bmc_vendor::BMCVendor;
+
+pub fn bmc_vendor_to_udev_dmi(v: BMCVendor) -> &'static str {
+    match v {
+        BMCVendor::Lenovo => "Lenovo",
+        BMCVendor::Dell => "Dell Inc.",
+        BMCVendor::Nvidia => "https://www.mellanox.com",
+        BMCVendor::Supermicro => "Supermicro",
+        BMCVendor::Hpe => "HPE",
+        BMCVendor::LenovoAMI => "Unknown",
+        BMCVendor::Liteon => "Unknown",
+        BMCVendor::Unknown => "Unknown",
+    }
+}

--- a/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
+++ b/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
@@ -108,6 +108,7 @@ impl WiwynnGB200Nvl<'_> {
                             .build(),
                     ),
                     log_services: None,
+                    storage: None,
                 },
                 redfish::computer_system::SingleSystemConfig {
                     id: "HGX_Baseboard_0".into(),
@@ -123,6 +124,7 @@ impl WiwynnGB200Nvl<'_> {
                     bios_mode: redfish::computer_system::BiosMode::Generic,
                     base_bios: None,
                     log_services: None,
+                    storage: None,
                 },
             ],
         }

--- a/crates/bmc-mock/src/redfish/computer_system.rs
+++ b/crates/bmc-mock/src/redfish/computer_system.rs
@@ -109,6 +109,10 @@ pub fn add_routes(r: Router<BmcState>, bmc_vendor: redfish::oem::BmcVendor) -> R
             get(get_log_service_entries),
         )
         .route(
+            &redfish::storage::system_collection(SYSTEM_ID).odata_id,
+            get(get_storage_collection),
+        )
+        .route(
             &bmc_vendor.make_settings_odata_id(&bios),
             patch(patch_bios_settings),
         )
@@ -131,6 +135,7 @@ pub struct SingleSystemConfig {
     pub bios_mode: BiosMode,
     pub base_bios: Option<serde_json::Value>,
     pub log_services: Option<Arc<dyn LogServices>>,
+    pub storage: Option<Vec<redfish::storage::Storage>>,
     pub oem: Oem,
 }
 
@@ -278,10 +283,16 @@ async fn get_system(State(state): State<BmcState>, Path(system_id): Path<String>
         .is_some()
         .then_some(redfish::log_service::system_collection(&system_id));
 
+    let storage = config
+        .storage
+        .is_some()
+        .then_some(redfish::storage::system_collection(&system_id));
+
     b.maybe_with(SystemBuilder::serial_number, &config.serial_number)
         .maybe_with(SystemBuilder::manufacturer, &config.manufacturer)
         .maybe_with(SystemBuilder::model, &config.model)
         .maybe_with(SystemBuilder::log_services, &log_services)
+        .maybe_with(SystemBuilder::storage, &storage)
         .pcie_devices(&pcie_devices)
         .build()
         .into_ok_response()
@@ -577,6 +588,28 @@ async fn get_log_service_entries(
         .unwrap_or_else(http::not_found)
 }
 
+async fn get_storage_collection(
+    State(state): State<BmcState>,
+    Path(system_id): Path<String>,
+) -> Response {
+    state
+        .system_state
+        .find(&system_id)
+        .and_then(|system_state| system_state.config.storage.as_ref())
+        .map(|storage| {
+            let members = storage
+                .iter()
+                .map(|storage| {
+                    redfish::storage::system_resource(&system_id, &storage.id).entity_ref()
+                })
+                .collect::<Vec<_>>();
+            redfish::boot_option::collection(&system_id)
+                .with_members(&members)
+                .into_ok_response()
+        })
+        .unwrap_or_else(http::not_found)
+}
+
 async fn get_bios(State(state): State<BmcState>, Path(system_id): Path<String>) -> Response {
     state
         .system_state
@@ -717,6 +750,10 @@ impl SystemBuilder {
 
     pub fn log_services(self, log_services: &redfish::Collection<'_>) -> Self {
         self.apply_patch(log_services.nav_property("LogServices"))
+    }
+
+    pub fn storage(self, storage: &redfish::Collection<'_>) -> Self {
+        self.apply_patch(storage.nav_property("Storage"))
     }
 
     pub fn link_chassis(self, ids: &[Cow<'static, str>]) -> Self {

--- a/crates/bmc-mock/src/redfish/mod.rs
+++ b/crates/bmc-mock/src/redfish/mod.rs
@@ -35,6 +35,7 @@ pub mod secure_boot;
 pub mod sensor;
 pub mod service_root;
 pub mod software_inventory;
+pub mod storage;
 pub mod task_service;
 pub mod update_service;
 

--- a/crates/bmc-mock/src/redfish/storage.rs
+++ b/crates/bmc-mock/src/redfish/storage.rs
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::borrow::Cow;
+
+use crate::redfish;
+
+pub fn system_collection(system_id: &str) -> redfish::Collection<'static> {
+    let odata_id = format!("/redfish/v1/Systems/{system_id}/Storage");
+    redfish::Collection {
+        odata_id: Cow::Owned(odata_id),
+        odata_type: Cow::Borrowed("#StorageCollection.StorageCollection"),
+        name: Cow::Borrowed("Storage Collection"),
+    }
+}
+
+pub fn system_resource<'a>(system_id: &str, storage_id: &'a str) -> redfish::Resource<'a> {
+    let odata_id = format!("/redfish/v1/Systems/{system_id}/Storage/{storage_id}");
+    redfish::Resource {
+        odata_id: Cow::Owned(odata_id),
+        odata_type: Cow::Borrowed("#Storage.v1_15_0.Storage"),
+        name: Cow::Borrowed("Storage"),
+        id: Cow::Borrowed(storage_id),
+    }
+}
+
+pub struct Storage {
+    pub id: Cow<'static, str>,
+    pub value: serde_json::Value,
+}


### PR DESCRIPTION
## Description
Machine FSM uses DMI sys_vendor string to detect BMC vendor and therefore affects all branches of code that related to vendor check.

This change make sure that Dell machine is recoginized as Dell inside state machine code. Also, it adds empty Storage collection to BMC tree to make prevent 404 errors after instance release.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

