### PR TITLE
fix(agent): Add missing match block in FNN NVUE policy

### DIFF
--- a/crates/agent/templates/nvue_startup_fnn.conf
+++ b/crates/agent/templates/nvue_startup_fnn.conf
@@ -210,6 +210,8 @@
               {{- end }}
               '65535':
                 action: deny
+                match:
+                  any: {}
         route-map:
           dpu_to_evpn:
             rule:

--- a/crates/agent/templates/tests/full_nvue_startup_fnn_l3.yaml.expected
+++ b/crates/agent/templates/tests/full_nvue_startup_fnn_l3.yaml.expected
@@ -111,6 +111,8 @@
                   10.1.1.1/32: {}
               '65535':
                 action: deny
+                match:
+                  any: {}
         route-map:
           dpu_to_evpn:
             rule:

--- a/crates/agent/templates/tests/nvue_startup_fnn_classic.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_classic.yaml.expected
@@ -143,6 +143,8 @@
                   10.217.5.124/32: {}
               '65535':
                 action: deny
+                match:
+                  any: {}
         route-map:
           dpu_to_evpn:
             rule:

--- a/crates/agent/templates/tests/nvue_startup_fnn_classic_with_empty_nsg_default_deny.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_classic_with_empty_nsg_default_deny.yaml.expected
@@ -151,6 +151,8 @@
                   10.217.5.124/32: {}
               '65535':
                 action: deny
+                match:
+                  any: {}
         route-map:
           dpu_to_evpn:
             rule:

--- a/crates/agent/templates/tests/nvue_startup_quarantined_fnn.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_quarantined_fnn.yaml.expected
@@ -163,6 +163,8 @@
                   10.217.5.124/32: {}
               '65535':
                 action: deny
+                match:
+                  any: {}
         route-map:
           dpu_to_evpn:
             rule:


### PR DESCRIPTION
## Description

https://github.com/NVIDIA/bare-metal-manager-core/pull/457 introduced a new policy rule missing a  match-block.

This PR adds that missing block.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

