### PR TITLE
chore: bmc-mock / machine-a-tron: Support LiteOn PowerShelf

### DIFF
--- a/crates/bmc-explorer/tests/powershelf_explore.rs
+++ b/crates/bmc-explorer/tests/powershelf_explore.rs
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#![recursion_limit = "256"]
+
+use bmc_explorer::nv_generate_exploration_report;
+use bmc_mock::test_support;
+use model::site_explorer::EndpointType;
+use tokio::test;
+
+#[test]
+async fn explore_liteon_power_shelf() {
+    let bmc = test_support::liteon_powershelf_bmc();
+    let report = nv_generate_exploration_report(bmc, None).await.unwrap();
+
+    assert_eq!(report.endpoint_type, EndpointType::Bmc);
+    assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Liteon));
+    assert!(!report.systems.is_empty(), "systems must be present");
+    assert!(!report.chassis.is_empty(), "chassis must be present");
+    assert!(
+        report
+            .service
+            .iter()
+            .any(|service| service.id == "FirmwareInventory"),
+        "firmware inventory service must be present"
+    );
+    assert!(
+        report
+            .machine_setup_status
+            .as_ref()
+            .is_some_and(|status| !status.diffs.is_empty() || status.is_done),
+        "machine setup status must be present and structurally valid"
+    );
+}

--- a/crates/bmc-mock/src/hw/liteon_power_shelf.rs
+++ b/crates/bmc-mock/src/hw/liteon_power_shelf.rs
@@ -1,0 +1,116 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+
+use mac_address::MacAddress;
+
+use crate::redfish;
+
+pub struct LiteOnPowerShelf<'a> {
+    pub bmc_mac_address: MacAddress,
+    pub product_serial_number: Cow<'a, str>,
+}
+
+impl LiteOnPowerShelf<'_> {
+    fn sensor_layout() -> redfish::sensor::Layout {
+        redfish::sensor::Layout {
+            temperature: 20,
+            fan: 6,
+            power: 12,
+            current: 12,
+            leak: 0,
+        }
+    }
+
+    pub fn manager_config(&self) -> redfish::manager::Config {
+        redfish::manager::Config {
+            managers: vec![redfish::manager::SingleConfig {
+                id: "bmc",
+                eth_interfaces: vec![
+                    redfish::ethernet_interface::builder(
+                        &redfish::ethernet_interface::manager_resource("bmc", "can0"),
+                    )
+                    .mac_address(MacAddress::new([0, 0, 0, 0, 0, 0]))
+                    .interface_enabled(true)
+                    .build(),
+                    redfish::ethernet_interface::builder(
+                        &redfish::ethernet_interface::manager_resource("bmc", "eth0"),
+                    )
+                    .mac_address(self.bmc_mac_address)
+                    .interface_enabled(true)
+                    .build(),
+                ],
+                firmware_version: "r1.3.9",
+                oem: None,
+            }],
+        }
+    }
+
+    pub fn system_config(&self) -> redfish::computer_system::Config {
+        let system_id = "system";
+
+        redfish::computer_system::Config {
+            systems: vec![redfish::computer_system::SingleSystemConfig {
+                id: Cow::Borrowed(system_id),
+                manufacturer: None,
+                model: None,
+                eth_interfaces: None,
+                serial_number: None,
+                boot_order_mode: redfish::computer_system::BootOrderMode::Generic,
+                power_control: None,
+                chassis: vec!["powershelf".into()],
+                boot_options: None,
+                bios_mode: redfish::computer_system::BiosMode::Generic,
+                oem: redfish::computer_system::Oem::Generic,
+                log_services: None,
+                storage: None,
+                base_bios: Some(
+                    redfish::bios::builder(&redfish::bios::resource(system_id)).build(),
+                ),
+            }],
+        }
+    }
+
+    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+        let chassis_id = "powershelf";
+        redfish::chassis::ChassisConfig {
+            chassis: vec![redfish::chassis::SingleChassisConfig {
+                id: chassis_id.into(),
+                chassis_type: "Shelf".into(),
+                manufacturer: Some("LITE-ON TECHNOLOGY CORP.".into()),
+                part_number: Some("PF-1333-7R".into()),
+                model: Some("PF-1333-7R".into()),
+                serial_number: Some(self.product_serial_number.to_string().into()),
+                network_adapters: None,
+                pcie_devices: None,
+                sensors: Some(redfish::sensor::generate_chassis_sensors(
+                    chassis_id,
+                    Self::sensor_layout(),
+                )),
+                assembly: None,
+                oem: None,
+            }],
+        }
+    }
+
+    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+        redfish::update_service::UpdateServiceConfig {
+            firmware_inventory: vec![],
+        }
+    }
+}

--- a/crates/bmc-mock/src/hw/mod.rs
+++ b/crates/bmc-mock/src/hw/mod.rs
@@ -30,6 +30,9 @@ pub mod dell_poweredge_r750;
 /// Support of Wiwynn GB200 NVL servers.
 pub mod wiwynn_gb200_nvl;
 
+/// Support of LiteOn Power Shelf.
+pub mod liteon_power_shelf;
+
 use bmc_vendor::BMCVendor;
 
 pub fn bmc_vendor_to_udev_dmi(v: BMCVendor) -> &'static str {

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -50,6 +50,8 @@ pub enum HostHardwareType {
     DellPowerEdgeR750,
     #[serde(rename = "wiwynn_gb200_nvl")]
     WiwynnGB200Nvl,
+    #[serde(rename = "liteon_power_shelf")]
+    LiteOnPowerShelf,
 }
 
 #[derive(Debug, Copy, Clone, Default)]

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -112,6 +112,9 @@ impl DpuMachineInfo {
                 nic_mode: self.settings.nic_mode,
             },
             HostHardwareType::WiwynnGB200Nvl => hw::bluefield3::Mode::B3240ColdAisle,
+            HostHardwareType::LiteOnPowerShelf => {
+                panic!("Bluefield3 DPU is defined for LiteOn PowerShelf")
+            }
         };
         let settings = &self.settings;
         hw::bluefield3::Bluefield3 {
@@ -162,6 +165,7 @@ impl HostMachineInfo {
                 redfish::oem::State::DellIdrac(redfish::oem::dell::idrac::IdracState::default())
             }
             HostHardwareType::WiwynnGB200Nvl => redfish::oem::State::Other,
+            HostHardwareType::LiteOnPowerShelf => redfish::oem::State::Other,
         }
     }
 
@@ -169,6 +173,7 @@ impl HostMachineInfo {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => redfish::oem::BmcVendor::Dell,
             HostHardwareType::WiwynnGB200Nvl => redfish::oem::BmcVendor::Wiwynn,
+            HostHardwareType::LiteOnPowerShelf => redfish::oem::BmcVendor::LiteOn,
         }
     }
 
@@ -176,6 +181,7 @@ impl HostMachineInfo {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => None,
             HostHardwareType::WiwynnGB200Nvl => Some("GB200 NVL"),
+            HostHardwareType::LiteOnPowerShelf => None,
         }
     }
 
@@ -183,6 +189,7 @@ impl HostMachineInfo {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().manager_config(),
             HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().manager_config(),
+            HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().manager_config(),
         }
     }
 
@@ -197,6 +204,7 @@ impl HostMachineInfo {
             HostHardwareType::WiwynnGB200Nvl => {
                 self.wiwynn_gb200_nvl().system_config(power_control)
             }
+            HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().system_config(),
         }
     }
 
@@ -204,6 +212,7 @@ impl HostMachineInfo {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().chassis_config(),
             HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().chassis_config(),
+            HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().chassis_config(),
         }
     }
 
@@ -213,6 +222,7 @@ impl HostMachineInfo {
                 self.dell_poweredge_r750().update_service_config()
             }
             HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().update_service_config(),
+            HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().update_service_config(),
         }
     }
 
@@ -220,6 +230,9 @@ impl HostMachineInfo {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().discovery_info(),
             HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().discovery_info(),
+            HostHardwareType::LiteOnPowerShelf => {
+                panic!("discovery_info requested for LiteOn PowerShelf")
+            }
         }
     }
 
@@ -261,6 +274,13 @@ impl HostMachineInfo {
                 .next()
                 .expect("Two DPUs must present for GB200 NVL")
                 .bluefield3(),
+        }
+    }
+
+    fn liteon_power_shelf(&self) -> hw::liteon_power_shelf::LiteOnPowerShelf<'_> {
+        hw::liteon_power_shelf::LiteOnPowerShelf {
+            bmc_mac_address: self.bmc_mac_address,
+            product_serial_number: Cow::Borrowed(&self.serial),
         }
     }
 }

--- a/crates/bmc-mock/src/redfish/computer_system.rs
+++ b/crates/bmc-mock/src/redfish/computer_system.rs
@@ -238,7 +238,6 @@ async fn get_system(State(state): State<BmcState>, Path(system_id): Path<String>
 
     let mut b = builder(&resource(&system_id))
         .ethernet_interfaces(redfish::ethernet_interface::system_collection(&system_id))
-        .boot_options(&redfish::boot_option::collection(&system_id))
         .bios(&redfish::bios::resource(&system_id))
         .secure_boot(&redfish::secure_boot::resource(&system_id))
         .link_chassis(&system_state.config.chassis);
@@ -278,6 +277,11 @@ async fn get_system(State(state): State<BmcState>, Path(system_id): Path<String>
         .flat_map(|chassis| chassis.pcie_devices_resources().into_iter())
         .collect::<Vec<_>>();
 
+    let boot_options = config
+        .boot_options
+        .is_some()
+        .then_some(redfish::boot_option::collection(&system_id));
+
     let log_services = config
         .log_services
         .is_some()
@@ -291,6 +295,7 @@ async fn get_system(State(state): State<BmcState>, Path(system_id): Path<String>
     b.maybe_with(SystemBuilder::serial_number, &config.serial_number)
         .maybe_with(SystemBuilder::manufacturer, &config.manufacturer)
         .maybe_with(SystemBuilder::model, &config.model)
+        .maybe_with(SystemBuilder::boot_options, &boot_options)
         .maybe_with(SystemBuilder::log_services, &log_services)
         .maybe_with(SystemBuilder::storage, &storage)
         .pcie_devices(&pcie_devices)

--- a/crates/bmc-mock/src/redfish/oem/mod.rs
+++ b/crates/bmc-mock/src/redfish/oem/mod.rs
@@ -25,21 +25,23 @@ pub enum BmcVendor {
     Dell,
     Nvidia,
     Wiwynn,
+    LiteOn,
 }
 
 impl BmcVendor {
-    pub fn service_root_value(&self) -> &'static str {
+    pub fn service_root_value(&self) -> Option<&'static str> {
         match self {
-            BmcVendor::Nvidia => "Nvidia",
-            BmcVendor::Dell => "Dell",
-            BmcVendor::Wiwynn => "WIWYNN",
+            BmcVendor::Nvidia => Some("Nvidia"),
+            BmcVendor::Dell => Some("Dell"),
+            BmcVendor::Wiwynn => Some("WIWYNN"),
+            BmcVendor::LiteOn => None,
         }
     }
     // This function creates settings of the resource from the resource
     // id. Real identifier is different for different BMC vendors.
     pub fn make_settings_odata_id(&self, resource: &Resource<'_>) -> String {
         match self {
-            BmcVendor::Nvidia | BmcVendor::Dell | BmcVendor::Wiwynn => {
+            BmcVendor::Nvidia | BmcVendor::Dell | BmcVendor::Wiwynn | BmcVendor::LiteOn => {
                 format!("{}/Settings", resource.odata_id)
             }
         }

--- a/crates/bmc-mock/src/redfish/service_root.rs
+++ b/crates/bmc-mock/src/redfish/service_root.rs
@@ -52,7 +52,10 @@ pub fn builder(resource: &redfish::Resource) -> ServiceRootBuilder {
 async fn get_service_root(State(state): State<BmcState>) -> Response {
     builder(&resource())
         .redfish_version("1.13.1")
-        .vendor(state.bmc_vendor.service_root_value())
+        .maybe_with(
+            ServiceRootBuilder::vendor,
+            &state.bmc_vendor.service_root_value(),
+        )
         .maybe_with(ServiceRootBuilder::product, &state.bmc_product)
         .account_service(&redfish::account_service::resource())
         .chassis_collection(&redfish::chassis::collection())

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -47,22 +47,7 @@ impl PowerControl for NoopPowerControl {
 
 pub type TestBmc = HttpBmc<AxumRouterHttpClient>;
 
-pub fn wiwynn_gb200_router() -> axum::Router {
-    let dpus = vec![
-        DpuMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, DpuSettings::default()),
-        DpuMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, DpuSettings::default()),
-    ];
-    let machine_info =
-        MachineInfo::Host(HostMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, dpus));
-    machine_router(
-        machine_info,
-        Arc::new(NoopPowerControl),
-        "test-host-id".to_string(),
-    )
-}
-
-pub fn wiwynn_gb200_bmc() -> Arc<TestBmc> {
-    let router = wiwynn_gb200_router();
+fn test_bmc(router: axum::Router) -> Arc<TestBmc> {
     let client = AxumRouterHttpClient::new(router);
     let endpoint = Url::parse("https://bmc-mock.local").expect("valid URL");
     let credentials = BmcCredentials::new("root".to_string(), "password".to_string());
@@ -71,48 +56,53 @@ pub fn wiwynn_gb200_bmc() -> Arc<TestBmc> {
         endpoint,
         credentials,
         CacheSettings::with_capacity(32),
+    ))
+}
+
+pub fn wiwynn_gb200_bmc() -> Arc<TestBmc> {
+    test_bmc(machine_router(
+        MachineInfo::Host(HostMachineInfo::new(
+            HostHardwareType::WiwynnGB200Nvl,
+            vec![
+                DpuMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, DpuSettings::default()),
+                DpuMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, DpuSettings::default()),
+            ],
+        )),
+        Arc::new(NoopPowerControl),
+        "test-host-id".to_string(),
+    ))
+}
+
+pub fn liteon_powershelf_bmc() -> Arc<TestBmc> {
+    test_bmc(machine_router(
+        MachineInfo::Host(HostMachineInfo::new(
+            HostHardwareType::LiteOnPowerShelf,
+            vec![],
+        )),
+        Arc::new(NoopPowerControl),
+        "test-host-id".to_string(),
     ))
 }
 
 pub fn dell_poweredge_r750_bmc() -> Arc<TestBmc> {
-    let machine_info = MachineInfo::Host(HostMachineInfo::new(
-        HostHardwareType::DellPowerEdgeR750,
-        vec![],
-    ));
-    let router = machine_router(
-        machine_info,
+    test_bmc(machine_router(
+        MachineInfo::Host(HostMachineInfo::new(
+            HostHardwareType::DellPowerEdgeR750,
+            vec![],
+        )),
         Arc::new(NoopPowerControl),
         "test-host-id".to_string(),
-    );
-    let client = AxumRouterHttpClient::new(router);
-    let endpoint = Url::parse("https://bmc-mock.local").expect("valid URL");
-    let credentials = BmcCredentials::new("root".to_string(), "password".to_string());
-    Arc::new(HttpBmc::new(
-        client,
-        endpoint,
-        credentials,
-        CacheSettings::with_capacity(32),
     ))
 }
 
 pub fn dell_poweredge_r750_bluefield3_bmc(settings: DpuSettings) -> Arc<TestBmc> {
-    let machine_info = MachineInfo::Dpu(DpuMachineInfo::new(
-        HostHardwareType::DellPowerEdgeR750,
-        settings,
-    ));
-    let router = machine_router(
-        machine_info,
+    test_bmc(machine_router(
+        MachineInfo::Dpu(DpuMachineInfo::new(
+            HostHardwareType::DellPowerEdgeR750,
+            settings,
+        )),
         Arc::new(NoopPowerControl),
         "test-dpu-id".to_string(),
-    );
-    let client = AxumRouterHttpClient::new(router);
-    let endpoint = Url::parse("https://bmc-mock.local").expect("valid URL");
-    let credentials = BmcCredentials::new("root".to_string(), "password".to_string());
-    Arc::new(HttpBmc::new(
-        client,
-        endpoint,
-        credentials,
-        CacheSettings::with_capacity(32),
     ))
 }
 
@@ -128,7 +118,14 @@ mod test {
 
     #[tokio::test]
     async fn transport_supports_expand_query_through_mock_expander() {
-        let client = AxumRouterHttpClient::new(wiwynn_gb200_router());
+        let client = AxumRouterHttpClient::new(machine_router(
+            MachineInfo::Host(HostMachineInfo::new(
+                HostHardwareType::DellPowerEdgeR750,
+                vec![],
+            )),
+            Arc::new(NoopPowerControl),
+            "test-host-id".to_string(),
+        ));
         let url =
             Url::parse("https://bmc-mock.local/redfish/v1/Chassis?$expand=.($levels=1)").unwrap();
 


### PR DESCRIPTION
## Description
Added Mock of LiteOn PowerShelf to bmc-mock and to machine-a-tron.

Now one can test powershelves using this simulation with machine-a-tron by adding additional hosts with zero DPU and hw_type "liteon_power_shelf".

bmc-explorer powershelf exploration test added.

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

