### PR TITLE
chore: bmc-mock / machine-a-tron: Support NVIDIA Switch

### DIFF
--- a/crates/bmc-explorer/tests/nvidia_switch_explore.rs
+++ b/crates/bmc-explorer/tests/nvidia_switch_explore.rs
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#![recursion_limit = "256"]
+
+use bmc_explorer::nv_generate_exploration_report;
+use bmc_mock::test_support;
+use model::site_explorer::EndpointType;
+use tokio::test;
+
+#[test]
+async fn explore_nvidia_switch() {
+    let bmc = test_support::nvidia_switch_nd5200_ld_bmc();
+    let report = nv_generate_exploration_report(bmc, None).await.unwrap();
+
+    assert_eq!(report.endpoint_type, EndpointType::Bmc);
+    assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Nvidia));
+    assert!(!report.systems.is_empty(), "systems must be present");
+    assert!(!report.chassis.is_empty(), "chassis must be present");
+    assert!(
+        report
+            .service
+            .iter()
+            .any(|service| service.id == "FirmwareInventory"),
+        "firmware inventory service must be present"
+    );
+    assert!(
+        report
+            .machine_setup_status
+            .as_ref()
+            .is_some_and(|status| !status.diffs.is_empty() || status.is_done),
+        "machine setup status must be present and structurally valid"
+    );
+}

--- a/crates/bmc-mock/src/hw/bluefield3.rs
+++ b/crates/bmc-mock/src/hw/bluefield3.rs
@@ -192,6 +192,7 @@ impl Bluefield3<'_> {
                     },
                 })),
                 storage: None,
+                secure_boot_available: true,
             }],
         }
     }

--- a/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
+++ b/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
@@ -135,6 +135,7 @@ impl DellPowerEdgeR750<'_> {
                 // there. So we provide empty collection to avoid 404
                 // failure.
                 storage: Some(vec![]),
+                secure_boot_available: true,
                 base_bios: Some(redfish::bios::builder(&redfish::bios::resource(system_id))
                     .attributes(json!({
                         "BootSeqRetry": "Disabled",

--- a/crates/bmc-mock/src/hw/liteon_power_shelf.rs
+++ b/crates/bmc-mock/src/hw/liteon_power_shelf.rs
@@ -82,6 +82,7 @@ impl LiteOnPowerShelf<'_> {
                 base_bios: Some(
                     redfish::bios::builder(&redfish::bios::resource(system_id)).build(),
                 ),
+                secure_boot_available: false,
             }],
         }
     }

--- a/crates/bmc-mock/src/hw/mod.rs
+++ b/crates/bmc-mock/src/hw/mod.rs
@@ -33,6 +33,9 @@ pub mod wiwynn_gb200_nvl;
 /// Support of LiteOn Power Shelf.
 pub mod liteon_power_shelf;
 
+/// Support of NVIDIA Switch ND5200_LD.
+pub mod nvidia_switch_nd5200_ld;
+
 use bmc_vendor::BMCVendor;
 
 pub fn bmc_vendor_to_udev_dmi(v: BMCVendor) -> &'static str {

--- a/crates/bmc-mock/src/hw/nvidia_switch_nd5200_ld.rs
+++ b/crates/bmc-mock/src/hw/nvidia_switch_nd5200_ld.rs
@@ -1,0 +1,195 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+
+use mac_address::MacAddress;
+
+use crate::redfish;
+
+pub struct NvidiaSwitchNd5200Ld<'a> {
+    pub bmc_mac_address_eth0: MacAddress,
+    pub bmc_mac_address_eth1: MacAddress,
+    pub bmc_mac_address_usb0: MacAddress,
+    pub bmc_serial_number: Cow<'a, str>,
+    pub switch_serial_number: Cow<'a, str>,
+}
+
+impl NvidiaSwitchNd5200Ld<'_> {
+    pub fn manager_config(&self) -> redfish::manager::Config {
+        let manager_id = "BMC_0";
+        let eth_builder = |eth| {
+            redfish::ethernet_interface::builder(&redfish::ethernet_interface::manager_resource(
+                manager_id, eth,
+            ))
+        };
+        redfish::manager::Config {
+            managers: vec![redfish::manager::SingleConfig {
+                id: "BMC_0",
+                eth_interfaces: vec![
+                    eth_builder("eth0")
+                        .mac_address(self.bmc_mac_address_eth0)
+                        .interface_enabled(true)
+                        .build(),
+                    eth_builder("eth1")
+                        .mac_address(self.bmc_mac_address_eth1)
+                        .interface_enabled(true)
+                        .build(),
+                    eth_builder("usb0")
+                        .mac_address(self.bmc_mac_address_usb0)
+                        .interface_enabled(true)
+                        .build(),
+                ],
+                firmware_version: "88.0002.1333",
+                oem: None,
+            }],
+        }
+    }
+
+    pub fn system_config(&self) -> redfish::computer_system::Config {
+        let system_id = "System_0";
+
+        redfish::computer_system::Config {
+            systems: vec![redfish::computer_system::SingleSystemConfig {
+                id: Cow::Borrowed(system_id),
+                manufacturer: None,
+                model: None,
+                eth_interfaces: None,
+                serial_number: None,
+                boot_order_mode: redfish::computer_system::BootOrderMode::Generic,
+                power_control: None,
+                chassis: vec!["BMC_eeprom".into()],
+                boot_options: None,
+                bios_mode: redfish::computer_system::BiosMode::Generic,
+                oem: redfish::computer_system::Oem::Generic,
+                log_services: None,
+                storage: Some(vec![]),
+                base_bios: None,
+                secure_boot_available: false,
+            }],
+        }
+    }
+
+    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+        redfish::chassis::ChassisConfig {
+            chassis: [
+                redfish::chassis::SingleChassisConfig {
+                    id: "BMC_eeprom".into(),
+                    chassis_type: "Module".into(),
+                    manufacturer: Some("NVIDIA".into()),
+                    part_number: Some("692-13809-1404-000".into()),
+                    model: Some("P3809".into()),
+                    serial_number: Some(self.bmc_serial_number.to_string().into()), // 1320325107073
+                    network_adapters: None,
+                    pcie_devices: None,
+                    sensors: Some(vec![]),
+                    assembly: None,
+                    oem: None,
+                },
+                redfish::chassis::SingleChassisConfig {
+                    id: "CPLD_0".into(),
+                    chassis_type: "Module".into(),
+                    manufacturer: Some("Lattice".into()),
+                    part_number: Some("".into()),
+                    model: Some("LCMXO3D-9400HC-5BG256C".into()),
+                    serial_number: Some("CPLDSerialNumber".into()),
+                    network_adapters: None,
+                    pcie_devices: Some(vec![]),
+                    sensors: Some(vec![]),
+                    assembly: None,
+                    oem: None,
+                },
+                redfish::chassis::SingleChassisConfig {
+                    id: "MGX_BMC_0".into(),
+                    chassis_type: "Component".into(),
+                    manufacturer: Some("NVIDIA".into()),
+                    part_number: Some("692-13809-1404-000".into()),
+                    model: Some("P3809".into()),
+                    serial_number: Some(self.bmc_serial_number.to_string().into()),
+                    network_adapters: None,
+                    pcie_devices: Some(vec![]),
+                    sensors: Some(redfish::sensor::generate_chassis_sensors(
+                        "MGX_BMC_0",
+                        redfish::sensor::Layout {
+                            temperature: 1,
+                            ..Default::default()
+                        },
+                    )),
+                    assembly: None,
+                    oem: None,
+                },
+            ]
+            .into_iter()
+            .chain(
+                [
+                    "MGX_ERoT_BMC_0",
+                    "MGX_ERoT_CPU_0",
+                    "MGX_ERoT_FPGA_0",
+                    "MGX_ERoT_NVSwitch_0",
+                    "MGX_ERoT_NVSwitch_1",
+                ]
+                .into_iter()
+                .enumerate()
+                .map(|(n, erot_chassis_id)| {
+                    redfish::chassis::SingleChassisConfig {
+                        id: erot_chassis_id.into(),
+                        chassis_type: "Component".into(),
+                        manufacturer: Some("NVIDIA".into()),
+                        part_number: None,
+                        model: None,
+                        serial_number: Some(format!("0xFEEEEEEE{n:04X}").into()),
+                        network_adapters: None,
+                        pcie_devices: None,
+                        sensors: None,
+                        assembly: None,
+                        oem: None,
+                    }
+                }),
+            )
+            .chain((0..2).map(|n| {
+                let chassis_id = format!("MGX_NVSwitch_{n}");
+                redfish::chassis::SingleChassisConfig {
+                    chassis_type: "Component".into(),
+                    manufacturer: Some("NVIDIA".into()),
+                    part_number: Some("920-9K36W-00MV-GS0".into()),
+                    model: Some("N5200_LD".into()),
+                    serial_number: Some(self.switch_serial_number.to_string().into()),
+                    network_adapters: None,
+                    pcie_devices: Some(vec![]),
+                    sensors: Some(redfish::sensor::generate_chassis_sensors(
+                        &chassis_id,
+                        redfish::sensor::Layout {
+                            temperature: 1,
+                            power: 1,
+                            ..Default::default()
+                        },
+                    )),
+                    assembly: None,
+                    oem: None,
+                    id: chassis_id.into(),
+                }
+            }))
+            .collect(),
+        }
+    }
+
+    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+        redfish::update_service::UpdateServiceConfig {
+            firmware_inventory: vec![],
+        }
+    }
+}

--- a/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
+++ b/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
@@ -109,6 +109,7 @@ impl WiwynnGB200Nvl<'_> {
                     ),
                     log_services: None,
                     storage: None,
+                    secure_boot_available: true,
                 },
                 redfish::computer_system::SingleSystemConfig {
                     id: "HGX_Baseboard_0".into(),
@@ -125,6 +126,7 @@ impl WiwynnGB200Nvl<'_> {
                     base_bios: None,
                     log_services: None,
                     storage: None,
+                    secure_boot_available: false,
                 },
             ],
         }

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -52,6 +52,19 @@ pub enum HostHardwareType {
     WiwynnGB200Nvl,
     #[serde(rename = "liteon_power_shelf")]
     LiteOnPowerShelf,
+    #[serde(rename = "nvidia_switch_nd5200_ld")]
+    NvidiaSwitchNd5200Ld,
+}
+
+impl fmt::Display for HostHardwareType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::DellPowerEdgeR750 => "Dell PowerEdge R750".fmt(f),
+            Self::WiwynnGB200Nvl => "WIWYNN GB200 NVL".fmt(f),
+            Self::LiteOnPowerShelf => "Lite-On Power Shelf".fmt(f),
+            Self::NvidiaSwitchNd5200Ld => "NVIDIA Switch ND5200_LD".fmt(f),
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone, Default)]

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -112,8 +112,8 @@ impl DpuMachineInfo {
                 nic_mode: self.settings.nic_mode,
             },
             HostHardwareType::WiwynnGB200Nvl => hw::bluefield3::Mode::B3240ColdAisle,
-            HostHardwareType::LiteOnPowerShelf => {
-                panic!("Bluefield3 DPU is defined for LiteOn PowerShelf")
+            HostHardwareType::LiteOnPowerShelf | HostHardwareType::NvidiaSwitchNd5200Ld => {
+                panic!("Bluefield3 DPU is defined for {}", self.hw_type)
             }
         };
         let settings = &self.settings;
@@ -164,8 +164,9 @@ impl HostMachineInfo {
             HostHardwareType::DellPowerEdgeR750 => {
                 redfish::oem::State::DellIdrac(redfish::oem::dell::idrac::IdracState::default())
             }
-            HostHardwareType::WiwynnGB200Nvl => redfish::oem::State::Other,
-            HostHardwareType::LiteOnPowerShelf => redfish::oem::State::Other,
+            HostHardwareType::WiwynnGB200Nvl
+            | HostHardwareType::LiteOnPowerShelf
+            | HostHardwareType::NvidiaSwitchNd5200Ld => redfish::oem::State::Other,
         }
     }
 
@@ -174,6 +175,9 @@ impl HostMachineInfo {
             HostHardwareType::DellPowerEdgeR750 => redfish::oem::BmcVendor::Dell,
             HostHardwareType::WiwynnGB200Nvl => redfish::oem::BmcVendor::Wiwynn,
             HostHardwareType::LiteOnPowerShelf => redfish::oem::BmcVendor::LiteOn,
+            HostHardwareType::NvidiaSwitchNd5200Ld => {
+                redfish::oem::BmcVendor::Nvidia(redfish::oem::NvidiaNamestyle::Uppercase)
+            }
         }
     }
 
@@ -182,6 +186,7 @@ impl HostMachineInfo {
             HostHardwareType::DellPowerEdgeR750 => None,
             HostHardwareType::WiwynnGB200Nvl => Some("GB200 NVL"),
             HostHardwareType::LiteOnPowerShelf => None,
+            HostHardwareType::NvidiaSwitchNd5200Ld => Some("P3809"),
         }
     }
 
@@ -190,6 +195,9 @@ impl HostMachineInfo {
             HostHardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().manager_config(),
             HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().manager_config(),
             HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().manager_config(),
+            HostHardwareType::NvidiaSwitchNd5200Ld => {
+                self.nvidia_switch_nd5200_ld().manager_config()
+            }
         }
     }
 
@@ -205,6 +213,9 @@ impl HostMachineInfo {
                 self.wiwynn_gb200_nvl().system_config(power_control)
             }
             HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().system_config(),
+            HostHardwareType::NvidiaSwitchNd5200Ld => {
+                self.nvidia_switch_nd5200_ld().system_config()
+            }
         }
     }
 
@@ -213,6 +224,9 @@ impl HostMachineInfo {
             HostHardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().chassis_config(),
             HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().chassis_config(),
             HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().chassis_config(),
+            HostHardwareType::NvidiaSwitchNd5200Ld => {
+                self.nvidia_switch_nd5200_ld().chassis_config()
+            }
         }
     }
 
@@ -223,6 +237,9 @@ impl HostMachineInfo {
             }
             HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().update_service_config(),
             HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().update_service_config(),
+            HostHardwareType::NvidiaSwitchNd5200Ld => {
+                self.nvidia_switch_nd5200_ld().update_service_config()
+            }
         }
     }
 
@@ -230,8 +247,8 @@ impl HostMachineInfo {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().discovery_info(),
             HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().discovery_info(),
-            HostHardwareType::LiteOnPowerShelf => {
-                panic!("discovery_info requested for LiteOn PowerShelf")
+            HostHardwareType::LiteOnPowerShelf | HostHardwareType::NvidiaSwitchNd5200Ld => {
+                panic!("discovery_info requested for {}", self.hw_type)
             }
         }
     }
@@ -283,6 +300,16 @@ impl HostMachineInfo {
             product_serial_number: Cow::Borrowed(&self.serial),
         }
     }
+
+    fn nvidia_switch_nd5200_ld(&self) -> hw::nvidia_switch_nd5200_ld::NvidiaSwitchNd5200Ld<'_> {
+        hw::nvidia_switch_nd5200_ld::NvidiaSwitchNd5200Ld {
+            bmc_mac_address_eth0: next_mac(),
+            bmc_mac_address_eth1: next_mac(),
+            bmc_mac_address_usb0: next_mac(),
+            bmc_serial_number: Cow::Borrowed(&self.serial),
+            switch_serial_number: format!("MT{}", next_mac().to_string().replace(':', "")).into(),
+        }
+    }
 }
 
 impl MachineInfo {
@@ -308,7 +335,9 @@ impl MachineInfo {
     pub fn bmc_vendor(&self) -> redfish::oem::BmcVendor {
         match self {
             MachineInfo::Host(h) => h.bmc_vendor(),
-            MachineInfo::Dpu(_) => redfish::oem::BmcVendor::Nvidia,
+            MachineInfo::Dpu(_) => {
+                redfish::oem::BmcVendor::Nvidia(redfish::oem::NvidiaNamestyle::Capitalized)
+            }
         }
     }
 

--- a/crates/bmc-mock/src/redfish/computer_system.rs
+++ b/crates/bmc-mock/src/redfish/computer_system.rs
@@ -136,6 +136,7 @@ pub struct SingleSystemConfig {
     pub base_bios: Option<serde_json::Value>,
     pub log_services: Option<Arc<dyn LogServices>>,
     pub storage: Option<Vec<redfish::storage::Storage>>,
+    pub secure_boot_available: bool,
     pub oem: Oem,
 }
 
@@ -236,11 +237,7 @@ async fn get_system(State(state): State<BmcState>, Path(system_id): Path<String>
         return http::not_found();
     };
 
-    let mut b = builder(&resource(&system_id))
-        .ethernet_interfaces(redfish::ethernet_interface::system_collection(&system_id))
-        .bios(&redfish::bios::resource(&system_id))
-        .secure_boot(&redfish::secure_boot::resource(&system_id))
-        .link_chassis(&system_state.config.chassis);
+    let mut b = builder(&resource(&system_id)).link_chassis(&system_state.config.chassis);
 
     let config = &system_state.config;
 
@@ -252,17 +249,19 @@ async fn get_system(State(state): State<BmcState>, Path(system_id): Path<String>
         b = b.power_state(state)
     }
 
-    if let Some(boot_order) = system_state.boot_order_override() {
-        b = b.boot_order(&boot_order.iter().map(String::as_str).collect::<Vec<_>>());
-    } else {
-        b = b.boot_order(
-            &config
-                .boot_options
-                .iter()
-                .flatten()
-                .map(|v| v.id.as_ref())
-                .collect::<Vec<_>>(),
-        );
+    if config.boot_options.is_some() {
+        if let Some(boot_order) = system_state.boot_order_override() {
+            b = b.boot_order(&boot_order.iter().map(String::as_str).collect::<Vec<_>>());
+        } else {
+            b = b.boot_order(
+                &config
+                    .boot_options
+                    .iter()
+                    .flatten()
+                    .map(|v| v.id.as_ref())
+                    .collect::<Vec<_>>(),
+            );
+        }
     }
 
     b = match config.oem {
@@ -277,10 +276,20 @@ async fn get_system(State(state): State<BmcState>, Path(system_id): Path<String>
         .flat_map(|chassis| chassis.pcie_devices_resources().into_iter())
         .collect::<Vec<_>>();
 
+    let bios = config
+        .base_bios
+        .is_some()
+        .then_some(redfish::bios::resource(&system_id));
+
     let boot_options = config
         .boot_options
         .is_some()
         .then_some(redfish::boot_option::collection(&system_id));
+
+    let ethernet_interfaces = config
+        .eth_interfaces
+        .is_some()
+        .then_some(redfish::ethernet_interface::system_collection(&system_id));
 
     let log_services = config
         .log_services
@@ -292,12 +301,19 @@ async fn get_system(State(state): State<BmcState>, Path(system_id): Path<String>
         .is_some()
         .then_some(redfish::storage::system_collection(&system_id));
 
+    let secure_boot = config
+        .secure_boot_available
+        .then_some(redfish::secure_boot::resource(&system_id));
+
     b.maybe_with(SystemBuilder::serial_number, &config.serial_number)
         .maybe_with(SystemBuilder::manufacturer, &config.manufacturer)
         .maybe_with(SystemBuilder::model, &config.model)
+        .maybe_with(SystemBuilder::bios, &bios)
         .maybe_with(SystemBuilder::boot_options, &boot_options)
+        .maybe_with(SystemBuilder::ethernet_interfaces, &ethernet_interfaces)
         .maybe_with(SystemBuilder::log_services, &log_services)
         .maybe_with(SystemBuilder::storage, &storage)
+        .maybe_with(SystemBuilder::secure_boot, &secure_boot)
         .pcie_devices(&pcie_devices)
         .build()
         .into_ok_response()
@@ -713,7 +729,7 @@ impl SystemBuilder {
         self.add_str_field("Model", v)
     }
 
-    pub fn ethernet_interfaces(self, v: redfish::Collection<'_>) -> Self {
+    pub fn ethernet_interfaces(self, v: &redfish::Collection<'_>) -> Self {
         self.apply_patch(v.nav_property("EthernetInterfaces"))
     }
 

--- a/crates/bmc-mock/src/redfish/oem/mod.rs
+++ b/crates/bmc-mock/src/redfish/oem/mod.rs
@@ -23,15 +23,22 @@ use crate::redfish::Resource;
 #[derive(Clone, Copy, Debug)]
 pub enum BmcVendor {
     Dell,
-    Nvidia,
+    Nvidia(NvidiaNamestyle),
     Wiwynn,
     LiteOn,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum NvidiaNamestyle {
+    Uppercase,
+    Capitalized,
 }
 
 impl BmcVendor {
     pub fn service_root_value(&self) -> Option<&'static str> {
         match self {
-            BmcVendor::Nvidia => Some("Nvidia"),
+            BmcVendor::Nvidia(NvidiaNamestyle::Capitalized) => Some("Nvidia"),
+            BmcVendor::Nvidia(NvidiaNamestyle::Uppercase) => Some("NVIDIA"),
             BmcVendor::Dell => Some("Dell"),
             BmcVendor::Wiwynn => Some("WIWYNN"),
             BmcVendor::LiteOn => None,
@@ -41,7 +48,7 @@ impl BmcVendor {
     // id. Real identifier is different for different BMC vendors.
     pub fn make_settings_odata_id(&self, resource: &Resource<'_>) -> String {
         match self {
-            BmcVendor::Nvidia | BmcVendor::Dell | BmcVendor::Wiwynn | BmcVendor::LiteOn => {
+            BmcVendor::Nvidia(_) | BmcVendor::Dell | BmcVendor::Wiwynn | BmcVendor::LiteOn => {
                 format!("{}/Settings", resource.odata_id)
             }
         }

--- a/crates/bmc-mock/src/redfish/sensor.rs
+++ b/crates/bmc-mock/src/redfish/sensor.rs
@@ -52,7 +52,7 @@ pub fn builder(resource: &redfish::Resource) -> SensorBuilder {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct Layout {
     pub temperature: usize,
     pub fan: usize,

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -84,6 +84,17 @@ pub fn liteon_powershelf_bmc() -> Arc<TestBmc> {
     ))
 }
 
+pub fn nvidia_switch_nd5200_ld_bmc() -> Arc<TestBmc> {
+    test_bmc(machine_router(
+        MachineInfo::Host(HostMachineInfo::new(
+            HostHardwareType::NvidiaSwitchNd5200Ld,
+            vec![],
+        )),
+        Arc::new(NoopPowerControl),
+        "test-host-id".to_string(),
+    ))
+}
+
 pub fn dell_poweredge_r750_bmc() -> Arc<TestBmc> {
     test_bmc(machine_router(
         MachineInfo::Host(HostMachineInfo::new(


### PR DESCRIPTION
## Description
Adding support of NVIDIA switch in BMC mock and machine-a-tron. Now anybody can test their code related to switches locally but with caution that simulation can have gap.

BMC exploration test of NVIDIA switch is added as well.

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

