### PR TITLE
fix: use IPMI for lenovo-ami SOL console

### DIFF
--- a/crates/ssh-console/README.md
+++ b/crates/ssh-console/README.md
@@ -119,7 +119,7 @@ instance_id = "d40ad750-b925-4b34-b25a-d7f94458cc9e"
 ip = "127.0.0.1"
 port = 8022
 
-# Valid: "dell", "hpe", "lenovo", "dpu", "nvidia_viking". Affects how BMC escape characters are interpreted, and
+# Valid: "dell", "hpe", "lenovo", "supermicro", "lenovo_ami", "dpu", "nvidia_viking". Affects how BMC escape characters are interpreted, and
 # how the serial console is activated.
 bmc_vendor = "dell"
 

--- a/crates/ssh-console/src/bmc/connection.rs
+++ b/crates/ssh-console/src/bmc/connection.rs
@@ -32,7 +32,7 @@ use crate::bmc::client_pool::BmcPoolMetrics;
 use crate::bmc::connection_impl;
 use crate::bmc::connection_impl::{ipmi, ssh};
 use crate::bmc::message_proxy::{ToBmcMessage, ToFrontendMessage};
-use crate::bmc::vendor::{BmcVendor, BmcVendorDetectionError, SshBmcVendor};
+use crate::bmc::vendor::{BmcVendor, BmcVendorDetectionError, IpmiBmcVendor, SshBmcVendor};
 use crate::config::{Config, ConfigError};
 use crate::shutdown_handle::ShutdownHandle;
 
@@ -166,7 +166,7 @@ pub async fn lookup(
         .id
         .ok_or_else(|| LookupError::MachineMissingId { machine_id })?;
 
-    let bmc_vendor = if machine_id.machine_type().is_dpu() {
+    let mut bmc_vendor = if machine_id.machine_type().is_dpu() {
         BmcVendor::Ssh(SshBmcVendor::Dpu)
     } else {
         BmcVendor::detect_from_api_machine(&machine)
@@ -197,6 +197,39 @@ pub async fn lookup(
     let ip: IpAddr = ip.parse().map_err(|e| LookupError::InvalidBmcMetadata {
         reason: format!("Error parsing IP address {ip:?}: {e:?}"),
     })?;
+
+    // Some Lenovo platforms (for example HS350X V3) do not support SOL over SSH,
+    // so for those we switch to IPMI if site-explorer reports LenovoAMI.
+    // See: https://github.com/NVIDIA/bare-metal-manager-core/issues/528
+    if matches!(bmc_vendor, BmcVendor::Ssh(SshBmcVendor::Lenovo)) {
+        let request = rpc::site_explorer::ExploredEndpointsByIdsRequest {
+            endpoint_ids: vec![ip.to_string()],
+        };
+        let explored_endpoints = forge_api_client
+            .find_explored_endpoints_by_ids(request)
+            .await
+            .map(|response| response.endpoints)
+            .unwrap_or_else(|status| {
+                tracing::debug!(
+                    %machine_id,
+                    bmc_ip = %ip,
+                    ?status,
+                    "Could not query explored endpoint BMC vendor, falling back to DMI detection"
+                );
+                vec![]
+            });
+        let explored_endpoint_bmc_vendor = explored_endpoints
+            .into_iter()
+            .find(|endpoint| endpoint.address == ip.to_string())
+            .and_then(|endpoint| endpoint.report.and_then(|report| report.vendor));
+
+        if explored_endpoint_bmc_vendor
+            .as_deref()
+            .is_some_and(|vendor| vendor.eq_ignore_ascii_case("LenovoAMI"))
+        {
+            bmc_vendor = BmcVendor::Ipmi(IpmiBmcVendor::LenovoAmi);
+        }
+    }
 
     let port = match &bmc_vendor {
         BmcVendor::Ssh(ssh_bmc_vendor) => ssh_port

--- a/crates/ssh-console/src/bmc/vendor.rs
+++ b/crates/ssh-console/src/bmc/vendor.rs
@@ -33,6 +33,7 @@ pub enum BmcVendor {
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum IpmiBmcVendor {
     Supermicro,
+    LenovoAmi,
     NvidiaViking,
 }
 
@@ -40,6 +41,7 @@ impl IpmiBmcVendor {
     pub fn config_string(&self) -> &'static str {
         match self {
             IpmiBmcVendor::Supermicro => "supermicro",
+            IpmiBmcVendor::LenovoAmi => "lenovo_ami",
             IpmiBmcVendor::NvidiaViking => "nvidia_viking",
         }
     }
@@ -110,6 +112,8 @@ impl BmcVendor {
             Some(BmcVendor::Ssh(SshBmcVendor::Dpu))
         } else if s == IpmiBmcVendor::Supermicro.config_string() {
             Some(BmcVendor::Ipmi(IpmiBmcVendor::Supermicro))
+        } else if s == IpmiBmcVendor::LenovoAmi.config_string() {
+            Some(BmcVendor::Ipmi(IpmiBmcVendor::LenovoAmi))
         } else if s == IpmiBmcVendor::NvidiaViking.config_string() {
             Some(BmcVendor::Ipmi(IpmiBmcVendor::NvidiaViking))
         } else {

--- a/crates/ssh-console/src/config.rs
+++ b/crates/ssh-console/src/config.rs
@@ -374,7 +374,7 @@ role_separator = {cert_authorization_keyid_format_role_separator:?}
 # user = "user"                     # User to authenticate as when ssh-console connects to BMC
 # password = "password"             # Password to use when ssh-console connects to BMC
 # ssh_key_path = "/path/to/ssh_key" # Path to an SSH key to use when ssh-console connects to BMC (optional, overrides password.)
-# bmc_vendor = "dell"               # Vendor for this BMC, determines connection behavior (currently supported: "dell", "lenovo", "hpe", "supermicro", "dpu", "nvidia_viking")
+# bmc_vendor = "dell"               # Vendor for this BMC, determines connection behavior (currently supported: "dell", "lenovo", "hpe", "supermicro", "lenovo_ami", "dpu", "nvidia_viking")
 #
 # # [[bmcs]]
 # # ... more bmcs sections can define more than one


### PR DESCRIPTION
## Description
Some Lenovo platforms (HS350X V3) do not support SOL over SSH, so for those we switch to IPMI if site-explorer reports `LenovoAMI` as the BMC vendor. See: https://github.com/NVIDIA/bare-metal-manager-core/issues/528

Note: These machines still report as `Lenovo` in the DMI data.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

