### PR TITLE
Update supervisord before stop; don't fetch timestamps when dhcp is not running

### DIFF
--- a/crates/agent/src/dhcp.rs
+++ b/crates/agent/src/dhcp.rs
@@ -41,7 +41,8 @@ pub const RELOAD_CMD: &str = "supervisorctl update";
 pub const RELOAD_DHCP_SERVER: &str =
     "supervisorctl update;supervisorctl restart forge-dhcp-server-default";
 
-pub const STOP_DHCP_SERVER: &str = "supervisorctl update;supervisorctl stop forge-dhcp-server-default";
+pub const STOP_DHCP_SERVER: &str =
+    "supervisorctl update;supervisorctl stop forge-dhcp-server-default";
 
 /// Generate default-forge-dhcp-server.conf
 pub fn build_server_supervisord_config(

--- a/crates/agent/src/dhcp.rs
+++ b/crates/agent/src/dhcp.rs
@@ -41,7 +41,7 @@ pub const RELOAD_CMD: &str = "supervisorctl update";
 pub const RELOAD_DHCP_SERVER: &str =
     "supervisorctl update;supervisorctl restart forge-dhcp-server-default";
 
-pub const STOP_DHCP_SERVER: &str = "supervisorctl stop forge-dhcp-server-default";
+pub const STOP_DHCP_SERVER: &str = "supervisorctl update;supervisorctl stop forge-dhcp-server-default";
 
 /// Generate default-forge-dhcp-server.conf
 pub fn build_server_supervisord_config(

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -481,12 +481,15 @@ impl MainLoop {
             dpu_extension_services: vec![],
         };
 
-        status_out.last_dhcp_requests =
-            fetch_last_dhcp_requests(self.options.dhcp_grpc_server.as_deref()).await;
-
         // `read` does not block
         match self.periodic_config_reader.net_conf_read() {
             Some(conf) => {
+                // DHCP server only runs on the primary dpu or when using the tenant network
+                if !conf.use_admin_network || conf.is_primary_dpu {
+                    status_out.last_dhcp_requests =
+                        fetch_last_dhcp_requests(self.options.dhcp_grpc_server.as_deref()).await;
+                }
+
                 let instance_data = self.periodic_config_reader.meta_data_conf_reader();
 
                 let proposed_routes: Vec<_> = conf


### PR DESCRIPTION
adds "update" to the stop command.  This makes sure that supervisord knows about the dhcp server config before the stop is issued.  this is important on newly provisioned DPUs since the dhcp server config doesn't exist initially.

Also stops fetching the timestamps when dhcp is not running to avoiding noise in the logs

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [X] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

