### PR TITLE
fix: Add nl2doca restart after nv config apply in dpu agent

### DIFF
--- a/crates/agent/src/nvue.rs
+++ b/crates/agent/src/nvue.rs
@@ -816,6 +816,19 @@ async fn run_apply(hbn_root: &Path, path: &Path) -> eyre::Result<()> {
         tracing::info!("nv config apply: {stdout}");
     }
 
+    // Restart nl2doca
+    // This is a workaround for a bug in versions of HBN 3.2.0 and older that
+    // will sometimes lead to loss of connectivity when switch over to an L3 evpn overlay.
+    let stdout = super::hbn::run_in_container(
+        &container_id,
+        &["supervisorctl", "restart", "nl2doca"],
+        false,
+    )
+    .await?;
+    if !stdout.is_empty() {
+        tracing::info!("nl2doca restart: {stdout}");
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Description
This adds an nl2doca restart as a workaround for a bug in versions of HBN 3.2.0 and older that will sometimes lead to loss of connectivity when switching over to an L3 evpn overlay.

The nl2doca is best-effort.  We don't require that it succeeds.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

