### PR TITLE
chore: web: Add power action result to UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,6 +1451,7 @@ dependencies = [
  "tracing-subscriber",
  "tss-esapi",
  "url",
+ "urlencoding",
  "uuid",
  "version-compare 0.2.1",
  "x509-parser",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -169,6 +169,7 @@ tracing-subscriber = { features = [
 ], workspace = true }
 tss-esapi = { optional = true, workspace = true }
 url = { features = ["serde"], workspace = true }
+urlencoding = { workspace = true }
 uuid = { features = ["v4", "serde"], workspace = true }
 version-compare = { workspace = true }
 x509-parser = { features = ["verify"], workspace = true }

--- a/crates/api/src/web/explored_endpoint.rs
+++ b/crates/api/src/web/explored_endpoint.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -24,6 +25,7 @@ use axum::extract::{Path as AxumPath, Query, State as AxumState};
 use axum::response::{Html, IntoResponse, Redirect, Response};
 use axum::{Form, Json};
 use hyper::http::StatusCode;
+use itertools::Itertools;
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{self as forgerpc, BmcEndpointRequest, admin_power_control_request};
 use rpc::site_explorer::{
@@ -366,7 +368,7 @@ async fn fetch_explored_endpoints(api: &Api) -> Result<SiteExplorationReport, to
 
 #[derive(Template)]
 #[template(path = "explored_endpoint_detail.html")]
-struct ExploredEndpointDetail {
+struct ExploredEndpointDetail<'a> {
     endpoint: ExploredEndpoint,
     has_exploration_error: bool,
     last_exploration_error: String,
@@ -379,6 +381,70 @@ struct ExploredEndpointDetail {
     report_age: String,
     pause_remediation: bool,
     bmc_action_redirect_to: Option<String>,
+    action_status: Option<ActionStatus<'a>>,
+}
+
+pub(crate) struct ActionStatus<'a> {
+    pub action: Cow<'a, str>,
+    pub class: &'static str,
+    pub message: Cow<'a, str>,
+}
+
+impl ActionStatus<'_> {
+    pub fn from_query(query: &HashMap<String, String>) -> Option<ActionStatus<'_>> {
+        query.get("action_type").map(|action| {
+            let message = query
+                .get("action_message")
+                .map(String::as_str)
+                .unwrap_or(action.as_str());
+            let class = match query.get("action_class").map(String::as_str) {
+                Some("success") => "success",
+                Some("error") => "error",
+                _ => "warning",
+            };
+            ActionStatus {
+                action: Cow::Borrowed(action),
+                message: Cow::Borrowed(message),
+                class,
+            }
+        })
+    }
+
+    pub fn url_cleanup_script() -> &'static str {
+        r#"<script>
+(function() {
+  const url = new URL(window.location.href);
+  url.searchParams.delete('action_type');
+  url.searchParams.delete('action_class');
+  url.searchParams.delete('action_message');
+  const newUrl = url.pathname + url.search + url.hash;
+  window.history.replaceState({}, document.title, newUrl);
+})();
+</script>"#
+    }
+
+    pub fn update_redirect_url(
+        redirect_url: &str,
+        action: &str,
+        class: &str,
+        message: &str,
+    ) -> String {
+        let (base_url, anchor) = match redirect_url.rfind('#') {
+            Some(pos) => (&redirect_url[..pos], &redirect_url[pos..]),
+            None => (redirect_url, ""),
+        };
+        format!(
+            "{base_url}?{}{anchor}",
+            [
+                ("action_type", action),
+                ("action_class", class),
+                ("action_message", message),
+            ]
+            .iter()
+            .map(|(k, v)| format!("{k}={}", urlencoding::encode(v)))
+            .join("&"),
+        )
+    }
 }
 
 struct ExploredEndpointInfo {
@@ -387,7 +453,7 @@ struct ExploredEndpointInfo {
     has_machine: bool,
 }
 
-impl From<ExploredEndpointInfo> for ExploredEndpointDetail {
+impl From<ExploredEndpointInfo> for ExploredEndpointDetail<'_> {
     fn from(endpoint_info: ExploredEndpointInfo) -> Self {
         let report_ref = endpoint_info.endpoint.report.as_ref();
 
@@ -428,6 +494,7 @@ impl From<ExploredEndpointInfo> for ExploredEndpointDetail {
             report_age,
             pause_remediation,
             bmc_action_redirect_to: None,
+            action_status: None,
         }
     }
 }
@@ -463,11 +530,11 @@ pub async fn fetch_explored_endpoint(
 
     Ok(endpoint)
 }
-
 /// View details of an explored endpoint
 pub async fn detail(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(endpoint_ip): AxumPath<String>,
+    Query(params): Query<HashMap<String, String>>,
 ) -> Response {
     let (show_json, endpoint_ip) = match endpoint_ip.strip_suffix(".json") {
         Some(endpoint_ip) => (true, endpoint_ip.to_string()),
@@ -568,7 +635,10 @@ pub async fn detail(
         has_machine,
     };
 
-    let display = ExploredEndpointDetail::from(endpoint_info);
+    let mut display = ExploredEndpointDetail::from(endpoint_info);
+
+    display.action_status = ActionStatus::from_query(&params);
+
     (StatusCode::OK, Html(display.render().unwrap())).into_response()
 }
 
@@ -676,10 +746,16 @@ pub async fn power_control(
 
     let Some(act) = admin_power_control_request::SystemPowerControl::from_str_name(&action) else {
         tracing::error!(endpoint_ip = %endpoint_ip, action = %action, "power_control_endpoint invalid action");
-        return (StatusCode::BAD_REQUEST, "invalid action requested").into_response();
+        let redirect_url = ActionStatus::update_redirect_url(
+            &view_url,
+            "power",
+            "error",
+            "invalid action requested",
+        );
+        return Redirect::to(&redirect_url).into_response();
     };
 
-    if let Err(err) = state
+    match state
         .admin_power_control(tonic::Request::new(rpc::forge::AdminPowerControlRequest {
             machine_id: None,
             bmc_endpoint_request: Some(BmcEndpointRequest {
@@ -691,11 +767,26 @@ pub async fn power_control(
         .await
         .map(|response| response.into_inner())
     {
-        tracing::error!(%err, endpoint_ip = %endpoint_ip, action = %action, "power_control_endpoint");
-        return (StatusCode::INTERNAL_SERVER_ERROR, err.message().to_owned()).into_response();
+        Ok(response) => {
+            let message = response
+                .msg
+                .unwrap_or_else(|| format!("Power action '{}' completed successfully", action));
+            let status = if message.to_lowercase().contains("warning") {
+                "warning"
+            } else {
+                "success"
+            };
+            let redirect_url =
+                ActionStatus::update_redirect_url(&view_url, "power", status, &message);
+            Redirect::to(&redirect_url).into_response()
+        }
+        Err(err) => {
+            tracing::error!(%err, endpoint_ip = %endpoint_ip, action = %action, "power_control_endpoint");
+            let redirect_url =
+                ActionStatus::update_redirect_url(&view_url, "power", "error", err.message());
+            Redirect::to(&redirect_url).into_response()
+        }
     }
-
-    Redirect::to(&view_url).into_response()
 }
 
 #[derive(Deserialize, Debug)]

--- a/crates/api/src/web/machine.rs
+++ b/crates/api/src/web/machine.rs
@@ -19,7 +19,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use askama::Template;
-use axum::extract::{Path as AxumPath, State as AxumState};
+use axum::extract::{Path as AxumPath, Query, State as AxumState};
 use axum::response::{Html, IntoResponse, Redirect, Response};
 use axum::{Form, Json};
 use carbide_uuid::machine::{MachineId, MachineType};
@@ -34,6 +34,7 @@ use utils::managed_host_display::to_time;
 use super::filters;
 use super::machine_state_history::{MachineStateHistoryRecord, MachineStateHistoryTable};
 use crate::api::Api;
+use crate::web::explored_endpoint::ActionStatus;
 
 #[derive(Template)]
 #[template(path = "machine_show.html")]
@@ -431,7 +432,7 @@ pub async fn fetch_machines(
 
 #[derive(Template)]
 #[template(path = "machine_detail.html")]
-struct MachineDetail {
+struct MachineDetail<'a> {
     id: String,
     host_id: String,
     state: String,
@@ -474,6 +475,7 @@ struct MachineDetail {
     instance_type: String,
     has_instance_type: bool,
     nvlink_gpus: Vec<MachineNvLinkGpuDisplay>,
+    action_status: Option<ActionStatus<'a>>,
 }
 
 struct MachineCapability {
@@ -526,7 +528,7 @@ pub struct ValidationRun {
     pub machine_id: String,
 }
 
-impl From<forgerpc::Machine> for MachineDetail {
+impl From<forgerpc::Machine> for MachineDetail<'_> {
     fn from(m: forgerpc::Machine) -> Self {
         let machine_id = m.id.map(|id| id.to_string()).unwrap_or_default();
 
@@ -789,6 +791,7 @@ impl From<forgerpc::Machine> for MachineDetail {
             instance_type_id: m.instance_type_id.unwrap_or_default(),
             instance_type: "".to_string(),
             nvlink_gpus,
+            action_status: None,
         }
     }
 }
@@ -797,6 +800,7 @@ impl From<forgerpc::Machine> for MachineDetail {
 pub async fn detail(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(machine_id): AxumPath<String>,
+    Query(params): Query<HashMap<String, String>>,
 ) -> Response {
     let (show_json, machine_id) = match machine_id.strip_suffix(".json") {
         Some(machine_id) => (true, machine_id.to_string()),
@@ -865,6 +869,7 @@ pub async fn detail(
     };
 
     display.validation_runs = validation_runs;
+    display.action_status = ActionStatus::from_query(&params);
 
     if !display.is_host {
         let request = tonic::Request::new(forgerpc::ManagedHostNetworkConfigRequest {

--- a/crates/api/templates/explored_endpoint_detail.html
+++ b/crates/api/templates/explored_endpoint_detail.html
@@ -113,6 +113,14 @@
 					<br>
 					Last Redfish BMC Powercycle: {{ endpoint.last_redfish_powercycle }}
 				</div>
+				{% if let Some(status) = action_status %}
+				{% if status.action == "power" %}
+				<div>
+					<span class="bubble {{ status.class }}">{{ status.message }}</span>
+				</div>
+				{{ ActionStatus::url_cleanup_script()|safe }}
+				{% endif %}
+				{% endif %}
 				<div>
 					{% set bmc_ip = endpoint.address.clone() %}
 					{% include "power_control.html" %}

--- a/crates/api/templates/machine_detail.html
+++ b/crates/api/templates/machine_detail.html
@@ -212,6 +212,14 @@
 			<div>
 				{% include "power_control.html" %}
 			</div>
+			{% if let Some(status) = action_status %}
+			{% if status.action == "power" %}
+			<div>
+				<span class="bubble {{ status.class }}">{{ status.message }}</span>
+			</div>
+			{{ ActionStatus::url_cleanup_script()|safe }}
+			{% endif %}
+			{% endif %}
 		</td>
 	</tr>
 	<tr>


### PR DESCRIPTION
## Description

Propagate power control action results back to the user interface. Previously, power actions completed silently with just a redirect, leaving users without feedback on success or failure.

Changes:
- Add ActionStatus struct to handle action feedback with type, class (success/warning/error), and message
- Modify power_control handler to capture response from admin_power_control and encode result in redirect URL query parameters
- Update detail handlers to parse action status from query params and pass to templates
- Add JavaScript snippet to clean up query parameters from URL after page load using history.replaceState()
- Display feedback bubble in UI showing action result (success, warning from power manager, or error message)

The approach uses query parameters in the redirect URL to pass state between requests (necessary since load after redirect may hit a different API server), then cleans up the URL client-side for a clean user experience.

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

