### PR TITLE
fix: add commonName to Helm chart helper template

### DIFF
--- a/helm/charts/carbide-api/templates/_helpers.tpl
+++ b/helm/charts/carbide-api/templates/_helpers.tpl
@@ -47,11 +47,12 @@ Global image reference
 
 {{/*
 Certificate spec
-Usage: {{ include "carbide-api.certificateSpec" (dict "name" "carbide-api-certificate" "cert" .Values.certificate "global" .Values.global) }}
+Usage: {{ include "carbide-api.certificateSpec" (dict "name" "carbide-api-certificate" "cert" .Values.certificate "global" .Values.global "namespace" (include "carbide-api.namespace" .)) }}
 */}}
 {{- define "carbide-api.certificateSpec" -}}
 duration: {{ .global.certificate.duration }}
 renewBefore: {{ .global.certificate.renewBefore }}
+commonName: {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
 dnsNames:
   - {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
   - {{ printf "%s.%s" .cert.serviceName .namespace }}

--- a/helm/charts/carbide-dhcp/templates/_helpers.tpl
+++ b/helm/charts/carbide-dhcp/templates/_helpers.tpl
@@ -51,6 +51,7 @@ Certificate spec
 {{- define "carbide-dhcp.certificateSpec" -}}
 duration: {{ .global.certificate.duration }}
 renewBefore: {{ .global.certificate.renewBefore }}
+commonName: {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
 dnsNames:
   - {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
   - {{ printf "%s.%s" .cert.serviceName .namespace }}

--- a/helm/charts/carbide-dns/templates/_helpers.tpl
+++ b/helm/charts/carbide-dns/templates/_helpers.tpl
@@ -51,6 +51,7 @@ Certificate spec
 {{- define "carbide-dns.certificateSpec" -}}
 duration: {{ .global.certificate.duration }}
 renewBefore: {{ .global.certificate.renewBefore }}
+commonName: {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
 dnsNames:
   - {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
   - {{ printf "%s.%s" .cert.serviceName .namespace }}

--- a/helm/charts/carbide-dsx-exchange-consumer/templates/_helpers.tpl
+++ b/helm/charts/carbide-dsx-exchange-consumer/templates/_helpers.tpl
@@ -51,6 +51,7 @@ Certificate spec
 {{- define "carbide-dsx-exchange-consumer.certificateSpec" -}}
 duration: {{ .global.certificate.duration }}
 renewBefore: {{ .global.certificate.renewBefore }}
+commonName: {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
 dnsNames:
   - {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
   - {{ printf "%s.%s" .cert.serviceName .namespace }}

--- a/helm/charts/carbide-hardware-health/templates/_helpers.tpl
+++ b/helm/charts/carbide-hardware-health/templates/_helpers.tpl
@@ -51,6 +51,7 @@ Certificate spec
 {{- define "carbide-hardware-health.certificateSpec" -}}
 duration: {{ .global.certificate.duration }}
 renewBefore: {{ .global.certificate.renewBefore }}
+commonName: {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
 dnsNames:
   - {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
   - {{ printf "%s.%s" .cert.serviceName .namespace }}

--- a/helm/charts/carbide-pxe/templates/_helpers.tpl
+++ b/helm/charts/carbide-pxe/templates/_helpers.tpl
@@ -51,6 +51,7 @@ Certificate spec
 {{- define "carbide-pxe.certificateSpec" -}}
 duration: {{ .global.certificate.duration }}
 renewBefore: {{ .global.certificate.renewBefore }}
+commonName: {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
 dnsNames:
   - {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
   - {{ printf "%s.%s" .cert.serviceName .namespace }}

--- a/helm/charts/carbide-ssh-console-rs/templates/_helpers.tpl
+++ b/helm/charts/carbide-ssh-console-rs/templates/_helpers.tpl
@@ -51,6 +51,7 @@ Certificate spec
 {{- define "carbide-ssh-console-rs.certificateSpec" -}}
 duration: {{ .global.certificate.duration }}
 renewBefore: {{ .global.certificate.renewBefore }}
+commonName: {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
 dnsNames:
   - {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
   - {{ printf "%s.%s" .cert.serviceName .namespace }}


### PR DESCRIPTION
## Description

This PR fixes Bug #552 by adding a `commonName` field in the Carbide Helm chart's `_helpers.tpl`. The current helper spec generates only `dnsNames` and uris and not `commonName`, which is needed for Vault to work. Vault PKI defaults to `require_cn=true`, causing all certificate requests to fail.

For more information, see the [cert-manager spec](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec). From the [Vault PKI docs](https://developer.hashicorp.com/vault/api-docs/secret/pki): 

```
Note: A value for common_name is required when require_cn is set to true
```

## Changes

- added `commonName` field to helper template spec
- updated the usage documentation

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

