### PR TITLE
fix: health service health-report now uses coalescing queue

### DIFF
--- a/crates/health/benches/sink_pipeline.rs
+++ b/crates/health/benches/sink_pipeline.rs
@@ -24,12 +24,18 @@ use carbide_health::endpoint::{BmcAddr, EndpointMetadata, MachineData};
 use carbide_health::metrics::MetricsManager;
 use carbide_health::sink::{
     Classification, CollectorEvent, CompositeDataSink, DataSink, EventContext, HealthOverrideSink,
-    HealthReport, PrometheusSink, SensorHealthData,
+    HealthReport, PrometheusSink, ReportSource, SensorHealthData,
 };
-use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use health_report::HealthReport as CarbideHealthReport;
 use mac_address::MacAddress;
 
 const MACHINE_ID: &str = "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0";
+const MACHINE_IDS: [&str; 3] = [
+    "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0",
+    "fm100htjsaledfasinabqqer70e2ua5ksqj4kfjii0v0a90vulps48c1h7g",
+    "fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30",
+];
 
 struct CountingSink;
 
@@ -41,6 +47,10 @@ impl DataSink for CountingSink {
 }
 
 fn event_context() -> EventContext {
+    event_context_for_machine(MACHINE_ID)
+}
+
+fn event_context_for_machine(machine_id: &str) -> EventContext {
     EventContext {
         endpoint_key: "42:9e:b1:bd:9d:dd".to_string(),
         addr: BmcAddr {
@@ -50,7 +60,7 @@ fn event_context() -> EventContext {
         },
         collector_type: "sensor_collector",
         metadata: Some(EndpointMetadata::Machine(MachineData {
-            machine_id: MACHINE_ID.parse().expect("valid machine id"),
+            machine_id: machine_id.parse().expect("valid machine id"),
             machine_serial: None,
         })),
     }
@@ -176,37 +186,76 @@ fn health_report_with_alerts(alert_count: usize) -> HealthReport {
 }
 
 struct HealthOverrideBenchState {
-    _runtime: tokio::runtime::Runtime,
     sink: HealthOverrideSink,
     context: EventContext,
-    small_event: CollectorEvent,
-    large_event: CollectorEvent,
+    distinct_contexts: Vec<EventContext>,
+    sensor_event: CollectorEvent,
+    leak_event: CollectorEvent,
 }
 
 impl HealthOverrideBenchState {
     fn new() -> Self {
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(2)
-            .enable_all()
-            .build()
-            .expect("runtime should build");
-
-        let sink = {
-            let _guard = runtime.enter();
-            HealthOverrideSink::new_for_bench().expect("bench sink should initialize")
-        };
+        let sink = HealthOverrideSink::new_for_bench().expect("bench sink should initialize");
         let context = event_context();
-        let small_event = CollectorEvent::HealthReport(health_report_with_alerts(1));
-        let large_event = CollectorEvent::HealthReport(health_report_with_alerts(64));
+        let distinct_contexts = MACHINE_IDS
+            .into_iter()
+            .map(event_context_for_machine)
+            .collect();
+        let sensor_event = CollectorEvent::HealthReport(Arc::new(health_report_with_alerts(256)));
+        let leak_event = CollectorEvent::HealthReport(Arc::new(HealthReport {
+            source: ReportSource::TrayLeakDetection,
+            observed_at: Some(chrono::Utc::now()),
+            successes: Vec::new(),
+            alerts: vec![carbide_health::sink::HealthReportAlert {
+                probe_id: carbide_health::sink::Probe::LeakDetection,
+                target: Some("leak-detector".to_string()),
+                message: "leak detected".to_string(),
+                classifications: vec![Classification::Leak],
+            }],
+        }));
 
         Self {
-            _runtime: runtime,
             sink,
             context,
-            small_event,
-            large_event,
+            distinct_contexts,
+            sensor_event,
+            leak_event,
         }
     }
+}
+
+fn filled_health_override_sink(
+    contexts: &[EventContext],
+    event: &CollectorEvent,
+    leak_event: &CollectorEvent,
+) -> HealthOverrideSink {
+    let sink = HealthOverrideSink::new_for_bench().expect("bench sink should initialize");
+    for context in contexts {
+        sink.handle_event(context, event);
+        sink.handle_event(context, leak_event);
+    }
+    sink
+}
+
+fn drain_pending(sink: &HealthOverrideSink) -> usize {
+    let mut drained = 0;
+    while sink.pop_pending_for_bench().is_some() {
+        drained += 1;
+    }
+    drained
+}
+
+fn drain_and_convert_pending(sink: &HealthOverrideSink) -> usize {
+    let mut drained = 0;
+    while let Some((_machine_id, report)) = sink.pop_pending_for_bench() {
+        let converted: CarbideHealthReport = report
+            .as_ref()
+            .try_into()
+            .expect("bench health report conversion should succeed");
+        std::hint::black_box(converted);
+        drained += 1;
+    }
+    drained
 }
 
 fn bench_health_override_sink(c: &mut Criterion) {
@@ -216,27 +265,49 @@ fn bench_health_override_sink(c: &mut Criterion) {
 
     let state = HealthOverrideBenchState::new();
 
-    group.bench_with_input(
-        BenchmarkId::new("enqueue", "small_report"),
-        &state,
-        |b, state| {
-            b.iter(|| {
-                for _ in 0..batch_size {
-                    state.sink.handle_event(&state.context, &state.small_event);
-                }
-            });
-        },
-    );
+    group.bench_with_input(BenchmarkId::new("enqueue", "report"), &state, |b, state| {
+        b.iter(|| {
+            for _ in 0..batch_size {
+                state.sink.handle_event(&state.context, &state.sensor_event);
+            }
+        });
+    });
+
+    group.throughput(Throughput::Elements(6));
+
+    group.bench_with_input(BenchmarkId::new("drain", "report"), &state, |b, state| {
+        b.iter_batched(
+            || {
+                filled_health_override_sink(
+                    &state.distinct_contexts,
+                    &state.sensor_event,
+                    &state.leak_event,
+                )
+            },
+            |sink| {
+                std::hint::black_box(drain_pending(&sink));
+            },
+            BatchSize::SmallInput,
+        );
+    });
 
     group.bench_with_input(
-        BenchmarkId::new("enqueue", "large_report"),
+        BenchmarkId::new("drain_convert", "report"),
         &state,
         |b, state| {
-            b.iter(|| {
-                for _ in 0..batch_size {
-                    state.sink.handle_event(&state.context, &state.large_event);
-                }
-            });
+            b.iter_batched(
+                || {
+                    filled_health_override_sink(
+                        &state.distinct_contexts,
+                        &state.sensor_event,
+                        &state.leak_event,
+                    )
+                },
+                |sink| {
+                    std::hint::black_box(drain_and_convert_pending(&sink));
+                },
+                BatchSize::SmallInput,
+            );
         },
     );
 

--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -54,6 +54,7 @@ root_ca = "/var/run/secrets/spiffe.io/ca.crt"
 client_cert = "/var/run/secrets/spiffe.io/tls.crt"
 client_key = "/var/run/secrets/spiffe.io/tls.key"
 api_url = "https://carbide-api.forge-system.svc.cluster.local:1079"
+workers = 8
 
 # ==============================================================================
 # Rate Limiting

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -124,7 +124,7 @@ pub struct SinksConfig {
 
     /// Health override sink: sends health override events to Carbide API.
     #[serde(alias = "carbide_override")]
-    pub health_override: Configurable<CarbideApiConnectionConfig>,
+    pub health_override: Configurable<HealthOverrideSinkConfig>,
 }
 
 impl Default for SinksConfig {
@@ -132,7 +132,7 @@ impl Default for SinksConfig {
         Self {
             tracing: Configurable::Enabled(TracingSinkConfig::default()),
             prometheus: Configurable::Enabled(PrometheusSinkConfig::default()),
-            health_override: Configurable::Enabled(CarbideApiConnectionConfig::default()),
+            health_override: Configurable::Enabled(HealthOverrideSinkConfig::default()),
         }
     }
 }
@@ -169,6 +169,25 @@ impl Default for CarbideApiConnectionConfig {
             client_cert: "/var/run/secrets/spiffe.io/tls.crt".to_string(),
             client_key: "/var/run/secrets/spiffe.io/tls.key".to_string(),
             api_url: Url::parse("https://carbide-api.forge-system.svc.cluster.local:1079").unwrap(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct HealthOverrideSinkConfig {
+    #[serde(flatten)]
+    pub connection: CarbideApiConnectionConfig,
+
+    /// Number of concurrent workers submitting reports to Carbide API.
+    pub workers: usize,
+}
+
+impl Default for HealthOverrideSinkConfig {
+    fn default() -> Self {
+        Self {
+            connection: CarbideApiConnectionConfig::default(),
+            workers: 4,
         }
     }
 }
@@ -432,6 +451,12 @@ impl Config {
             );
         }
 
+        if let Configurable::Enabled(health_override) = &self.sinks.health_override
+            && health_override.workers == 0
+        {
+            return Err("sinks.health_override.workers must be greater than 0".to_string());
+        }
+
         self.metrics_addr()?;
 
         Ok(())
@@ -524,8 +549,12 @@ mod tests {
             panic!("carbide api empty for sources")
         }
 
-        if let Configurable::Enabled(ref carbide_api) = config.sinks.health_override {
-            assert_eq!(carbide_api.root_ca, "/var/run/secrets/spiffe.io/ca.crt");
+        if let Configurable::Enabled(ref health_override) = config.sinks.health_override {
+            assert_eq!(
+                health_override.connection.root_ca,
+                "/var/run/secrets/spiffe.io/ca.crt"
+            );
+            assert_eq!(health_override.workers, 8);
         } else {
             panic!("health override sink is disabled")
         }
@@ -672,6 +701,14 @@ cache_size = 50
             minimum_alerts_per_report: 0,
         });
         assert!(config.validate().is_err());
+
+        config.processors.leak_detection =
+            Configurable::Enabled(LeakDetectionProcessorConfig::default());
+        config.sinks.health_override = Configurable::Enabled(HealthOverrideSinkConfig {
+            workers: 0,
+            ..HealthOverrideSinkConfig::default()
+        });
+        assert!(config.validate().is_err());
     }
 
     #[test]
@@ -683,5 +720,10 @@ cache_size = 50
         assert_eq!(config.metrics.endpoint, "0.0.0.0:9009");
         assert!(config.rate_limit.is_enabled());
         assert!(config.processors.leak_detection.is_enabled());
+        if let Configurable::Enabled(ref health_override) = config.sinks.health_override {
+            assert_eq!(health_override.workers, 4);
+        } else {
+            panic!("health override sink is disabled");
+        }
     }
 }

--- a/crates/health/src/processor/health_report.rs
+++ b/crates/health/src/processor/health_report.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use std::sync::Arc;
+
 use dashmap::DashMap;
 use nv_redfish::resource::Health as BmcHealth;
 
@@ -216,7 +218,7 @@ impl EventProcessor for HealthReportProcessor {
                     "Sending hardware health report"
                 );
 
-                return vec![CollectorEvent::HealthReport(report)];
+                return vec![CollectorEvent::HealthReport(Arc::new(report))];
             }
             CollectorEvent::Log(_)
             | CollectorEvent::Firmware(_)

--- a/crates/health/src/processor/leak_events.rs
+++ b/crates/health/src/processor/leak_events.rs
@@ -16,6 +16,7 @@
  */
 
 use std::collections::BTreeSet;
+use std::sync::Arc;
 
 use super::{EventContext, EventProcessor};
 use crate::sink::{
@@ -111,7 +112,7 @@ impl EventProcessor for LeakEventProcessor {
             alerts,
         };
 
-        vec![CollectorEvent::HealthReport(leak_report)]
+        vec![CollectorEvent::HealthReport(Arc::new(leak_report))]
     }
 }
 
@@ -157,7 +158,8 @@ mod tests {
             alerts: vec![leak_alert("LeakDetector_Probe")],
         };
 
-        let emitted = processor.process_event(&context(), &CollectorEvent::HealthReport(report));
+        let emitted =
+            processor.process_event(&context(), &CollectorEvent::HealthReport(Arc::new(report)));
         assert_eq!(emitted.len(), 1);
 
         let CollectorEvent::HealthReport(derived) = &emitted[0] else {
@@ -179,7 +181,8 @@ mod tests {
             alerts: vec![leak_alert("LeakDetector_Probe")],
         };
 
-        let emitted = processor.process_event(&context(), &CollectorEvent::HealthReport(report));
+        let emitted =
+            processor.process_event(&context(), &CollectorEvent::HealthReport(Arc::new(report)));
         assert_eq!(emitted.len(), 1);
 
         let CollectorEvent::HealthReport(derived) = &emitted[0] else {

--- a/crates/health/src/sink/events.rs
+++ b/crates/health/src/sink/events.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use std::sync::Arc;
+
 use carbide_uuid::machine::MachineId;
 use health_report::{
     HealthAlertClassification, HealthProbeAlert, HealthProbeId, HealthProbeSuccess,
@@ -129,7 +131,7 @@ pub enum CollectorEvent {
     MetricCollectionEnd,
     Log(Box<LogRecord>),
     Firmware(FirmwareInfo),
-    HealthReport(HealthReport),
+    HealthReport(Arc<HealthReport>),
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
@@ -201,24 +203,25 @@ impl TryFrom<Classification> for HealthAlertClassification {
     }
 }
 
-impl TryFrom<HealthReportSuccess> for HealthProbeSuccess {
+impl TryFrom<&HealthReportSuccess> for HealthProbeSuccess {
     type Error = HealthReportConversionError;
 
-    fn try_from(value: HealthReportSuccess) -> Result<Self, Self::Error> {
+    fn try_from(value: &HealthReportSuccess) -> Result<Self, Self::Error> {
         Ok(Self {
             id: value.probe_id.try_into()?,
-            target: value.target,
+            target: value.target.clone(),
         })
     }
 }
 
-impl TryFrom<HealthReportAlert> for HealthProbeAlert {
+impl TryFrom<&HealthReportAlert> for HealthProbeAlert {
     type Error = HealthReportConversionError;
 
-    fn try_from(value: HealthReportAlert) -> Result<Self, Self::Error> {
+    fn try_from(value: &HealthReportAlert) -> Result<Self, Self::Error> {
         let classifications = value
             .classifications
-            .into_iter()
+            .iter()
+            .copied()
             .map(TryInto::try_into)
             // Marks report as Hardware, used to filter all reports coming from health service.
             .chain(Some(Ok(HealthAlertClassification::hardware())))
@@ -226,19 +229,19 @@ impl TryFrom<HealthReportAlert> for HealthProbeAlert {
 
         Ok(Self {
             id: value.probe_id.try_into()?,
-            target: value.target,
+            target: value.target.clone(),
             in_alert_since: None,
-            message: value.message,
+            message: value.message.clone(),
             tenant_message: None,
             classifications,
         })
     }
 }
 
-impl TryFrom<HealthReport> for CarbideHealthReport {
+impl TryFrom<&HealthReport> for CarbideHealthReport {
     type Error = HealthReportConversionError;
 
-    fn try_from(value: HealthReport) -> Result<Self, Self::Error> {
+    fn try_from(value: &HealthReport) -> Result<Self, Self::Error> {
         let source = format!("hardware-health.{}", value.source.as_str());
 
         Ok(Self {
@@ -247,12 +250,12 @@ impl TryFrom<HealthReport> for CarbideHealthReport {
             observed_at: value.observed_at,
             successes: value
                 .successes
-                .into_iter()
+                .iter()
                 .map(TryInto::try_into)
                 .collect::<Result<Vec<_>, _>>()?,
             alerts: value
                 .alerts
-                .into_iter()
+                .iter()
                 .map(TryInto::try_into)
                 .collect::<Result<Vec<_>, _>>()?,
         })

--- a/crates/health/src/sink/health_override.rs
+++ b/crates/health/src/sink/health_override.rs
@@ -15,25 +15,96 @@
  * limitations under the License.
  */
 
-use std::sync::Arc;
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
 
-use tokio::sync::mpsc;
+use carbide_uuid::machine::MachineId;
+use tokio::sync::Notify;
 
-use super::{CollectorEvent, DataSink, EventContext};
+use super::{CollectorEvent, DataSink, EventContext, HealthReport};
 use crate::HealthError;
 use crate::api_client::ApiClientWrapper;
-use crate::config::CarbideApiConnectionConfig;
+use crate::config::HealthOverrideSinkConfig;
+
+#[derive(Clone)]
 struct HealthOverrideJob {
-    machine_id: carbide_uuid::machine::MachineId,
-    report: health_report::HealthReport,
+    machine_id: MachineId,
+    report: Arc<HealthReport>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct HealthOverrideKey {
+    machine_id: MachineId,
+    source: super::ReportSource,
+}
+
+struct PendingReportsState {
+    reports: HashMap<HealthOverrideKey, HealthOverrideJob>,
+    ready: VecDeque<HealthOverrideKey>,
+}
+
+struct PendingReportsStore {
+    state: Mutex<PendingReportsState>,
+    notify: Notify,
+}
+
+impl PendingReportsStore {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(PendingReportsState {
+                reports: HashMap::new(),
+                ready: VecDeque::new(),
+            }),
+            notify: Notify::new(),
+        }
+    }
+
+    fn save_latest(&self, job: HealthOverrideJob) {
+        let key = HealthOverrideKey {
+            machine_id: job.machine_id,
+            source: job.report.source,
+        };
+
+        {
+            let mut state = self.state.lock().expect("health override mutex poisoned");
+            if let Some(existing) = state.reports.get_mut(&key) {
+                *existing = job;
+            } else {
+                state.reports.insert(key, job);
+                state.ready.push_back(key);
+            }
+        }
+        self.notify.notify_one();
+    }
+
+    async fn next(&self) -> HealthOverrideJob {
+        loop {
+            if let Some(job) = self.pop() {
+                return job;
+            }
+
+            self.notify.notified().await;
+        }
+    }
+
+    fn pop(&self) -> Option<HealthOverrideJob> {
+        let mut state = self.state.lock().expect("health override mutex poisoned");
+        while let Some(key) = state.ready.pop_front() {
+            if let Some(job) = state.reports.remove(&key) {
+                return Some(job);
+            }
+        }
+
+        None
+    }
 }
 
 pub struct HealthOverrideSink {
-    sender: mpsc::UnboundedSender<HealthOverrideJob>,
+    pending_reports: Arc<PendingReportsStore>,
 }
 
 impl HealthOverrideSink {
-    pub fn new(config: &CarbideApiConnectionConfig) -> Result<Self, HealthError> {
+    pub fn new(config: &HealthOverrideSinkConfig) -> Result<Self, HealthError> {
         let handle = tokio::runtime::Handle::try_current().map_err(|error| {
             HealthError::GenericError(format!(
                 "health override sink requires active Tokio runtime: {error}"
@@ -41,42 +112,63 @@ impl HealthOverrideSink {
         })?;
 
         let client = Arc::new(ApiClientWrapper::new(
-            config.root_ca.clone(),
-            config.client_cert.clone(),
-            config.client_key.clone(),
-            &config.api_url,
+            config.connection.root_ca.clone(),
+            config.connection.client_cert.clone(),
+            config.connection.client_key.clone(),
+            &config.connection.api_url,
             false,
         ));
 
-        let (sender, mut receiver) = mpsc::unbounded_channel::<HealthOverrideJob>();
-        let worker_client = Arc::clone(&client);
+        let pending_reports = Arc::new(PendingReportsStore::new());
 
-        handle.spawn(async move {
-            while let Some(job) = receiver.recv().await {
-                if let Err(error) = worker_client
-                    .submit_health_report(&job.machine_id, job.report)
-                    .await
-                {
-                    tracing::warn!(?error, "Failed to submit health override report");
+        for worker_id in 0..config.workers {
+            let worker_client = Arc::clone(&client);
+            let pending_reports = Arc::clone(&pending_reports);
+            handle.spawn(async move {
+                loop {
+                    let job = pending_reports.next().await;
+
+                    match job.report.as_ref().try_into() {
+                        Ok(report) => {
+                            if let Err(error) = worker_client
+                                .submit_health_report(&job.machine_id, report)
+                                .await
+                            {
+                                tracing::warn!(
+                                    ?error,
+                                    worker_id,
+                                    "Failed to submit health override report"
+                                );
+                            }
+                        }
+                        Err(error) => {
+                            tracing::warn!(
+                                ?error,
+                                worker_id,
+                                machine_id = %job.machine_id,
+                                "Failed to convert health override report"
+                            );
+                        }
+                    }
                 }
-            }
-        });
+            });
+        }
 
-        Ok(Self { sender })
+        Ok(Self { pending_reports })
     }
 
     #[cfg(feature = "bench-hooks")]
     pub fn new_for_bench() -> Result<Self, HealthError> {
-        let handle = tokio::runtime::Handle::try_current().map_err(|error| {
-            HealthError::GenericError(format!(
-                "health override sink requires active Tokio runtime: {error}"
-            ))
-        })?;
+        Ok(Self {
+            pending_reports: Arc::new(PendingReportsStore::new()),
+        })
+    }
 
-        let (sender, mut receiver) = mpsc::unbounded_channel::<HealthOverrideJob>();
-        handle.spawn(async move { while receiver.recv().await.is_some() {} });
-
-        Ok(Self { sender })
+    #[cfg(feature = "bench-hooks")]
+    pub fn pop_pending_for_bench(&self) -> Option<(MachineId, Arc<HealthReport>)> {
+        self.pending_reports
+            .pop()
+            .map(|job| (job.machine_id, job.report))
     }
 }
 
@@ -84,18 +176,10 @@ impl DataSink for HealthOverrideSink {
     fn handle_event(&self, context: &EventContext, event: &CollectorEvent) {
         if let CollectorEvent::HealthReport(report) = event {
             if let Some(machine_id) = context.machine_id() {
-                match report.clone().try_into() {
-                    Ok(report) => {
-                        if let Err(error) =
-                            self.sender.send(HealthOverrideJob { machine_id, report })
-                        {
-                            tracing::warn!(?error, "failed to enqueue health override report");
-                        }
-                    }
-                    Err(error) => {
-                        tracing::warn!(?error, report = ?report, "Failed to convert health report");
-                    }
-                }
+                self.pending_reports.save_latest(HealthOverrideJob {
+                    machine_id,
+                    report: Arc::clone(report),
+                });
             } else {
                 tracing::warn!(
                     report = ?report,
@@ -103,5 +187,98 @@ impl DataSink for HealthOverrideSink {
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sink::ReportSource;
+
+    fn report(source: ReportSource) -> HealthReport {
+        HealthReport {
+            source,
+            observed_at: None,
+            successes: Vec::new(),
+            alerts: Vec::new(),
+        }
+    }
+
+    fn machine_id(value: &str) -> MachineId {
+        value.parse().expect("valid machine id")
+    }
+
+    fn report_key(job: &HealthOverrideJob) -> HealthOverrideKey {
+        HealthOverrideKey {
+            machine_id: job.machine_id,
+            source: job.report.source,
+        }
+    }
+
+    #[tokio::test]
+    async fn latest_reports_are_preserved() {
+        let queue = PendingReportsStore::new();
+        let machine_a = machine_id("fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0");
+        let machine_b = machine_id("fm100htjsaledfasinabqqer70e2ua5ksqj4kfjii0v0a90vulps48c1h7g");
+        let machine_c = machine_id("fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30");
+
+        queue.save_latest(HealthOverrideJob {
+            machine_id: machine_a,
+            report: Arc::new(report(ReportSource::BmcSensors)),
+        });
+        queue.save_latest(HealthOverrideJob {
+            machine_id: machine_a,
+            report: Arc::new(report(ReportSource::BmcSensors)),
+        });
+        queue.save_latest(HealthOverrideJob {
+            machine_id: machine_b,
+            report: Arc::new(report(ReportSource::TrayLeakDetection)),
+        });
+        queue.save_latest(HealthOverrideJob {
+            machine_id: machine_c,
+            report: Arc::new(report(ReportSource::BmcSensors)),
+        });
+        queue.save_latest(HealthOverrideJob {
+            machine_id: machine_b,
+            report: Arc::new(report(ReportSource::BmcSensors)),
+        });
+
+        let mut drained = HashMap::new();
+        while let Some(job) = queue.pop() {
+            drained.insert(report_key(&job), job.report.source);
+        }
+
+        assert_eq!(drained.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn reinserting_hot_key_moves_it_to_back() {
+        let queue = PendingReportsStore::new();
+        let machine_a = machine_id("fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0");
+        let machine_b = machine_id("fm100htjsaledfasinabqqer70e2ua5ksqj4kfjii0v0a90vulps48c1h7g");
+
+        queue.save_latest(HealthOverrideJob {
+            machine_id: machine_a,
+            report: Arc::new(report(ReportSource::BmcSensors)),
+        });
+        queue.save_latest(HealthOverrideJob {
+            machine_id: machine_b,
+            report: Arc::new(report(ReportSource::BmcSensors)),
+        });
+
+        let first = queue.pop().unwrap();
+        assert_eq!(first.machine_id, machine_a);
+
+        queue.save_latest(HealthOverrideJob {
+            machine_id: machine_a,
+            report: Arc::new(report(ReportSource::TrayLeakDetection)),
+        });
+
+        let second = queue.pop().unwrap();
+        let third = queue.pop().unwrap();
+
+        assert_eq!(second.machine_id, machine_b);
+        assert_eq!(third.machine_id, machine_a);
+        assert_eq!(third.report.source, ReportSource::TrayLeakDetection);
     }
 }


### PR DESCRIPTION
## Description
Health Service used single unbounded queue, which meant if API is too slow to respond it grew and leaked memory. 

This PR adds coalescing queue which only stores last reports per `id`. This automatically throttle Sink to only produce reports as fast as API can handle it.

It also intoroduces workers count, so it can submit from multiple threads (mostly usefull if there is more than 1 API instance).

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
Criterion shows following results:
```bash
sink_health_override/enqueue/report
                        time:   [978.53 µs 988.74 µs 1.0003 ms]
                        thrpt:  [19.994 Melem/s 20.228 Melem/s 20.439 Melem/s]
                 change:
                        time:   [−1.3991% −0.4695% +0.4203%] (p = 0.32 > 0.05)
                        thrpt:  [−0.4186% +0.4717% +1.4190%]
                        No change in performance detected.
Found 15 outliers among 100 measurements (15.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  11 (11.00%) high severe
sink_health_override/drain/report
                        time:   [354.57 ns 355.91 ns 357.43 ns]
                        thrpt:  [16.787 Melem/s 16.858 Melem/s 16.922 Melem/s]
                 change:
                        time:   [−0.3900% −0.0445% +0.3375%] (p = 0.81 > 0.05)
                        thrpt:  [−0.3363% +0.0445% +0.3915%]
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low mild
  7 (7.00%) high mild
  2 (2.00%) high severe
sink_health_override/drain_convert/v
                        time:   [154.91 µs 155.33 µs 155.84 µs]
                        thrpt:  [38.500 Kelem/s 38.627 Kelem/s 38.733 Kelem/s]
                 change:
                        time:   [+0.3760% +0.9159% +1.4849%] (p = 0.00 < 0.05)
                        thrpt:  [−1.4632% −0.9075% −0.3745%]
                        Change within noise threshold.
Found 12 outliers among 100 measurements (12.00%)
  6 (6.00%) high mild
  6 (6.00%) high severe

```
Which shows what slowest par is the `try_into()` part. Attempts to optimize it lead only to marginal increase in performance (10-20%), but made convert much more complicated, so i we assume what `38Kelem/s` is fine.
