### PR TITLE
chore: remove lenovo boot_first workaround in instance invoke_power()

### DIFF
--- a/crates/api/src/handlers/instance.rs
+++ b/crates/api/src/handlers/instance.rs
@@ -948,25 +948,6 @@ pub(crate) async fn invoke_power(
         .await
         .map_err(|e| CarbideError::internal(e.to_string()))?;
 
-    // Lenovo does not yet provide a BMC lockdown so a user could
-    // change the boot order which we set in `libredfish::machine_setup`.
-    // We also can't call `boot_first` for other vendors because lockdown
-    // prevents it.
-    // We use `boot_first` instead of `boot_once` for two reasons:
-    // 1. Reset PXE as first boot option on every Carbide-initiated reboot,
-    //    overriding any user modifications since the last reboot.
-    // 2. Avoid Lenovo's PCIe power reset issue: when `boot_once(Pxe)` is used
-    //    on Assigned/Ready machines, PXE boot will fail (Carbide iPXE returns exit),
-    //    causing Lenovo to reset PCIe power which restarts the DPU.
-    //    With `boot_first`, it falls through to installed OS after all PXE boot
-    //    options are failed.
-    // Note: since no lockdown it can still be modified later by user.
-    if snapshot.host_snapshot.bmc_vendor().is_lenovo() {
-        client
-            .boot_first(libredfish::Boot::Pxe)
-            .await
-            .map_err(CarbideError::from)?;
-    }
     client
         .power(libredfish::SystemPowerControl::ForceRestart)
         .await


### PR DESCRIPTION
## Description
This PR removes the lenovo-specific `boot_first(Pxe)` from the instance `invoke_power()` call.

When neither `boot_with_custom_ipxe` or `run_provisioning_instructions_on_every_boot` flag is set, the user expects a normal OS reboot, not a forced network boot. Boot-order verification and correction for network-boot flows is now handled by the state machine when required, so this lenovo override is unnecessary in the default reboot path.

This covers the following scenarios:

1. Disk first: the customer OS boots immediately.
2. DPU/network first: the host attempts PXE, then exits/falls through to the installed OS.
3. Custom install required, handled by the state machine:
a. If network boot is already first, the state handler proceeds with the install flow.
b. If disk is first, the state handler corrects boot order (making network/DPU first) and then proceeds with the install flow.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
https://github.com/NVIDIA/bare-metal-manager-core/issues/530

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

