### PR TITLE
fix: dhcp option 93 has wrong type, tests fixes

### DIFF
--- a/crates/dhcp/build.rs
+++ b/crates/dhcp/build.rs
@@ -51,6 +51,7 @@ fn main() {
         .compile("keashim");
 
     println!("cargo:rerun-if-changed=src/kea/callouts.cc");
+    println!("cargo:rerun-if-changed=src/kea/callouts.h");
     println!("cargo:rerun-if-changed=src/kea/loader.cc");
     println!("cargo:rerun-if-changed=src/kea/logger.cc");
     println!("cargo:rerun-if-changed=src/kea/carbide_rust.h");

--- a/crates/dhcp/src/kea/callouts.cc
+++ b/crates/dhcp/src/kea/callouts.cc
@@ -217,10 +217,15 @@ update_discovery_parameters(DiscoveryBuilderFFI *discovery, int option,
 
 DiscoveryBuilderResult
 update_discovery_parameters(DiscoveryBuilderFFI *discovery, int option,
-                            boost::shared_ptr<OptionUint16> option_val) {
+                            boost::shared_ptr<OptionUint16Array> option_val) {
   switch (option) {
-  case DHO_SYSTEM:
-    return discovery_set_client_system(discovery, option_val->getValue());
+  case DHO_SYSTEM: {
+    const auto &architectures = option_val->getValues();
+    if (!architectures.empty()) {
+      return discovery_set_client_system(discovery, architectures.front());
+    }
+    break;
+  }
   }
 
   return DiscoveryBuilderResult::Success;
@@ -418,7 +423,7 @@ int pkt4_receive(CalloutHandle &handle) {
    * in order to figure out which filname to give back
    */
   if (builder_result == DiscoveryBuilderResult::Success) {
-    builder_result = update_discovery_parameters<OptionUint16>(
+    builder_result = update_discovery_parameters<OptionUint16Array>(
         query4_ptr, discovery.get(), DHO_SYSTEM);
   }
 

--- a/crates/dhcp/src/kea/callouts.h
+++ b/crates/dhcp/src/kea/callouts.h
@@ -18,6 +18,7 @@
 #include <dhcp/option_custom.h>
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #include <dhcp/option_int.h>
+#include <dhcp/option_int_array.h>
 #pragma GCC diagnostic pop
 
 using namespace isc::hooks;

--- a/crates/dhcp/src/mock_api_server.rs
+++ b/crates/dhcp/src/mock_api_server.rs
@@ -212,6 +212,9 @@ impl MockAPIServer {
                     ))
                 }
             }
+            "/forge.Forge/Echo" => respond(rpc::EchoResponse {
+                message: "dhcp_echo".into(),
+            }),
             "/forge.Forge/Version" => respond(rpc::BuildInfo::default()),
             _ => panic!("DHCP -> API wrong uri: {}", req.uri().path()),
         }

--- a/crates/dhcp/tests/booturl.rs
+++ b/crates/dhcp/tests/booturl.rs
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 use std::net::UdpSocket;
-use std::thread;
 use std::time::Duration;
 
 use dhcp::mock_api_server;
@@ -49,22 +48,11 @@ fn test_booturl_internal_with_mtu() -> Result<(), eyre::Report> {
     socket.connect(format!("127.0.0.1:{dhcp_in_port}"))?;
     socket.set_read_timeout(Some(READ_TIMEOUT))?;
 
-    // The first packet doesn't get a response. I don't know why. dhcp-relay also sends two.
-    // So sacrifice a packet, and wait to be sure it's the first packet received by Kea.
     {
-        let mut msg = DHCPFactory::discover(0);
+        let mut msg = DHCPFactory::discover(1);
         msg.set_xid(0);
         let pkt = DHCPFactory::encode(msg)?;
         socket.send(&pkt)?;
-    }
-
-    thread::sleep(Duration::from_millis(20));
-
-    {
-        let mut msg = DHCPFactory::discover(1);
-        msg.set_xid(1);
-        let pkt = DHCPFactory::encode(msg).unwrap();
-        socket.send(&pkt).unwrap();
     }
 
     let mut recv_buf = [0u8; 1500]; // packet is 470 bytes, but allow for full MTU
@@ -123,22 +111,11 @@ fn test_booturl_from_api() -> Result<(), eyre::Report> {
     socket.connect(format!("127.0.0.1:{dhcp_in_port}"))?;
     socket.set_read_timeout(Some(READ_TIMEOUT))?;
 
-    // The first packet doesn't get a response. I don't know why. dhcp-relay also sends two.
-    // So sacrifice a packet, and wait to be sure it's the first packet received by Kea.
     {
         let mut msg = DHCPFactory::discover(0xAA);
         msg.set_xid(0);
         let pkt = DHCPFactory::encode(msg)?;
         socket.send(&pkt)?;
-    }
-
-    thread::sleep(Duration::from_millis(20));
-
-    {
-        let mut msg = DHCPFactory::discover(0xAA);
-        msg.set_xid(1);
-        let pkt = DHCPFactory::encode(msg).unwrap();
-        socket.send(&pkt).unwrap();
     }
 
     let mut recv_buf = [0u8; 1500]; // packet is 470 bytes, but allow for full MTU

--- a/crates/dhcp/tests/common/kea.rs
+++ b/crates/dhcp/tests/common/kea.rs
@@ -142,20 +142,20 @@ impl Kea {
             "valid-lifetime": 3600,
             "hooks-libraries": [
                 {
-                    "library": hook_lib,
-                    "parameters": {
-                        "carbide-api-url": api_server_url,
+                        "library": hook_lib,
+                        "parameters": {
+                            "carbide-api-url": api_server_url,
                         "carbide-metrics-endpoint": "[::]:1089",
-                        "carbide-nameservers": "1.1.1.1,8.8.8.8",
-                        "carbide-provisioning-server-ipv4": "127.0.0.1"
-                    }
+                            "carbide-nameservers": "1.1.1.1,8.8.8.8",
+                            "carbide-provisioning-server-ipv4": "127.0.0.1"
+                        }
                 }
             ],
             "subnet4": [
                 {
                     "subnet": "0.0.0.0/0",
                     "pools": [{
-                        "pool": "0.0.0.0-255.255.255.255"
+                        "pool": "0.0.0.1-255.255.255.254"
                     }]
                 }
             ],

--- a/crates/dhcp/tests/multithreaded_kea_test.rs
+++ b/crates/dhcp/tests/multithreaded_kea_test.rs
@@ -64,14 +64,6 @@ fn test_real_kea_multithreaded() -> Result<(), eyre::Report> {
     socket.connect(format!("127.0.0.1:{dhcp_in_port}"))?;
     socket.set_read_timeout(Some(READ_TIMEOUT))?;
 
-    // The first packet doesn't get a response. I don't know why. dhcp-relay also sends two.
-    // So sacrifice a packet, and wait to be sure it's the first packet received by Kea.
-    let mut msg = DHCPFactory::discover(0);
-    msg.set_xid(0);
-    let pkt = DHCPFactory::encode(msg)?;
-    socket.send(&pkt)?;
-    thread::sleep(Duration::from_millis(20));
-
     let socket = Arc::new(socket);
     let recv_packets = Arc::new(AtomicU64::new(0));
     thread::scope(|s| {
@@ -85,7 +77,6 @@ fn test_real_kea_multithreaded() -> Result<(), eyre::Report> {
 
         // Multiple send threads
 
-        // Start from 1 because idx 0 was the sacrifice
         for idx in 1..=NUM_THREADS {
             let inner_socket = socket.clone();
             let s_should_stop = should_stop.clone();
@@ -155,7 +146,7 @@ fn test_real_kea_multithreaded() -> Result<(), eyre::Report> {
 
     // Each thread only triggered one backend call because the other messages used the cache.
     let api_calls = api_server.calls_for(mock_api_server::ENDPOINT_DISCOVER_DHCP) as u8;
-    assert_eq!(api_calls, NUM_THREADS + 1); // +1 for the sacrificial message
+    assert_eq!(api_calls, NUM_THREADS);
 
     Ok(())
 }


### PR DESCRIPTION
## Description
DHCP Server usesd wrong type for the `DHO_SYSTEM` which should be `OptionIntArray<uint16_t>` https://github.com/isc-projects/kea/blob/master/src/lib/dhcp/tests/libdhcp%2B%2B_unittest.cc#L2806

Also should fix test issue where KEA DHCP started at 0.0.0.0, which leads to first packet not returning.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

