### PR TITLE
fix: replace forge_ template keywords with carbide_ in bf.cfg

### DIFF
--- a/book/src/manuals/site-setup.md
+++ b/book/src/manuals/site-setup.md
@@ -78,6 +78,9 @@ The following services are installed during the NICo installation process.
 
   - nvmetal-carbide:v2025.07.04-rc2-0-8-g077781771 (primary carbide-api, plus supporting workloads)
 
+The following are the NICo REST components, sourced from the open-source repository
+[ncx-infra-controller-rest](https://github.com/NVIDIA/ncx-infra-controller-rest):
+
 - **cloud‑api**: cloud-api:v0.2.72 (two replicas)
 
 - **cloud‑workflow**: cloud-workflow:v0.2.30 (cloud‑worker, site‑worker)
@@ -114,7 +117,7 @@ This section provides a high-level order of operations for installing components
 
    - carbide-api and supporting services (DHCP/PXE/DNS/NTP as required)
 
-4.  Carbide REST components
+4.  Carbide REST components (from [ncx-infra-controller-rest](https://github.com/NVIDIA/ncx-infra-controller-rest))
 
     - Deploy cloud‑api, cloud‑workflow (cloud‑worker & site‑worker), and cloud‑cert‑manager (credsmgr)
 

--- a/crates/api/files/bf.cfg
+++ b/crates/api/files/bf.cfg
@@ -1,12 +1,12 @@
 # SFC variables
 ENABLE_BR_HBN=yes
 ENABLE_BR_SFC=yes
-{% if forge_hbn_reps %}
-BR_HBN_REPS={{ forge_hbn_reps }}
+{% if carbide_hbn_reps %}
+BR_HBN_REPS={{ carbide_hbn_reps }}
 {% endif %}
 
-{% if forge_hbn_sfs %}
-BR_HBN_SFS={{ forge_hbn_sfs }}
+{% if carbide_hbn_sfs %}
+BR_HBN_SFS={{ carbide_hbn_sfs }}
 {% endif %}
 
 {{ bmc_fw_update }}
@@ -195,12 +195,12 @@ write_files:
       /opt/mellanox/doca/services/telemetry/import_doca_telemetry.sh
 
 
-      {% if forge_vf_intercept_bridge_name %}
+      {% if carbide_vf_intercept_bridge_name %}
         
         # Create our new bridge
-        ovs-vsctl --may-exist add-br {{ forge_vf_intercept_bridge_name }} -- set bridge {{ forge_vf_intercept_bridge_name }} datapath_type=netdev -- set interface {{ forge_vf_intercept_bridge_name }} mtu_request=9216
+        ovs-vsctl --may-exist add-br {{ carbide_vf_intercept_bridge_name }} -- set bridge {{ carbide_vf_intercept_bridge_name }} datapath_type=netdev -- set interface {{ carbide_vf_intercept_bridge_name }} mtu_request=9216
 
-        {% if forge_vf_intercept_bridge_port %}
+        {% if carbide_vf_intercept_bridge_port %}
 
           # Grab the current port index of the hbn bridge and increment it
           next_br_hbn_ofport_index=$(($(ovs-vsctl get bridge br-hbn external_ids | grep -o '[0-9]*')+1))
@@ -209,37 +209,37 @@ write_files:
           ovs-vsctl set bridge br-hbn external_ids:ofport_index=${next_br_hbn_ofport_index}
 
           # Add the hbn side of our patch port and set its ofport index to match what we set on the hbn bridge
-          ovs-vsctl --may-exist add-port br-hbn {{ forge_vf_intercept_hbn_port }} -- set interface {{ forge_vf_intercept_hbn_port }} type=patch options:peer={{ forge_vf_intercept_bridge_port }} ofport_request="${next_br_hbn_ofport_index}"
+          ovs-vsctl --may-exist add-port br-hbn {{ carbide_vf_intercept_hbn_port }} -- set interface {{ carbide_vf_intercept_hbn_port }} type=patch options:peer={{ carbide_vf_intercept_bridge_port }} ofport_request="${next_br_hbn_ofport_index}"
 
           # Add our side of the patch to our new bridge
-          ovs-vsctl --may-exist add-port {{ forge_vf_intercept_bridge_name }} {{ forge_vf_intercept_bridge_port }} -- set interface {{ forge_vf_intercept_bridge_port }} type=patch options:peer={{ forge_vf_intercept_hbn_port }}
+          ovs-vsctl --may-exist add-port {{ carbide_vf_intercept_bridge_name }} {{ carbide_vf_intercept_bridge_port }} -- set interface {{ carbide_vf_intercept_bridge_port }} type=patch options:peer={{ carbide_vf_intercept_hbn_port }}
 
-          # Adjust the sfc.conf to insert our patch port where {{ forge_vf_intercept_bridge_sf }} used to be
-          sed -i 's/br-hbn~{{ forge_vf_intercept_bridge_sf_representor }}~{{ forge_vf_intercept_bridge_sf_hbn_bridge_representor }}/br-hbn~{{ forge_vf_intercept_hbn_port }}~{{ forge_vf_intercept_bridge_sf_hbn_bridge_representor }}/' /etc/mellanox/sfc.conf
+          # Adjust the sfc.conf to insert our patch port where {{ carbide_vf_intercept_bridge_sf }} used to be
+          sed -i 's/br-hbn~{{ carbide_vf_intercept_bridge_sf_representor }}~{{ carbide_vf_intercept_bridge_sf_hbn_bridge_representor }}/br-hbn~{{ carbide_vf_intercept_hbn_port }}~{{ carbide_vf_intercept_bridge_sf_hbn_bridge_representor }}/' /etc/mellanox/sfc.conf
 
           # Match ofport and ofport_request match so that sfc.sh doesn't error out.
-          ovs-vsctl set interface {{ forge_vf_intercept_bridge_port }} ofport_request=$(ovs-vsctl get interface {{ forge_vf_intercept_bridge_port }} ofport)
+          ovs-vsctl set interface {{ carbide_vf_intercept_bridge_port }} ofport_request=$(ovs-vsctl get interface {{ carbide_vf_intercept_bridge_port }} ofport)
 
           # Clear the related link-propagation line.
-          # We're going to delete the {{ forge_vf_intercept_bridge_sf_representor }}
-          # so we don't need/want its link state to be propagated to {{ forge_vf_intercept_bridge_sf_hbn_bridge_representor }}
-          sed -i ':a;N;$!ba;s/{{ forge_vf_intercept_bridge_sf_representor }}:{{ forge_vf_intercept_bridge_sf_hbn_bridge_representor }}\n*//' /etc/mellanox/sfc.conf
+          # We're going to delete the {{ carbide_vf_intercept_bridge_sf_representor }}
+          # so we don't need/want its link state to be propagated to {{ carbide_vf_intercept_bridge_sf_hbn_bridge_representor }}
+          sed -i ':a;N;$!ba;s/{{ carbide_vf_intercept_bridge_sf_representor }}:{{ carbide_vf_intercept_bridge_sf_hbn_bridge_representor }}\n*//' /etc/mellanox/sfc.conf
 
-          # Now delete {{ forge_vf_intercept_bridge_sf_representor }} from br-hbn
+          # Now delete {{ carbide_vf_intercept_bridge_sf_representor }} from br-hbn
           # OVS will get breaking flows if we leave it dangling. We either need to
           # move it to br-dpu or delete it, and we can delete it because we don't
           # need it.
-          ovs-vsctl --if-exists del-port {{ forge_vf_intercept_bridge_sf_representor }}
+          ovs-vsctl --if-exists del-port {{ carbide_vf_intercept_bridge_sf_representor }}
 
         {% endif %}
       {% endif %}
       
-      {% if forge_host_intercept_bridge_name %}
+      {% if carbide_host_intercept_bridge_name %}
         
         # Create our new bridge
-        ovs-vsctl --may-exist add-br {{ forge_host_intercept_bridge_name }} -- set bridge {{ forge_host_intercept_bridge_name }} datapath_type=netdev
+        ovs-vsctl --may-exist add-br {{ carbide_host_intercept_bridge_name }} -- set bridge {{ carbide_host_intercept_bridge_name }} datapath_type=netdev
 
-        {% if forge_host_intercept_bridge_port %}
+        {% if carbide_host_intercept_bridge_port %}
 
           # Grab the current port index of the hbn bridge and increment it
           next_br_hbn_ofport_index=$(($(ovs-vsctl get bridge br-hbn external_ids | grep -o '[0-9]*')+1))
@@ -248,20 +248,20 @@ write_files:
           ovs-vsctl set bridge br-hbn external_ids:ofport_index=${next_br_hbn_ofport_index}
 
           # Add our patch port to br-hbn and set its ofport index to match what we set on the hbn bridge
-          ovs-vsctl --may-exist add-port br-hbn {{ forge_host_intercept_hbn_port }} -- set interface {{ forge_host_intercept_hbn_port }} type=patch options:peer={{ forge_host_intercept_bridge_port }} ofport_request="${next_br_hbn_ofport_index}" external_ids='{dependencies=pf0hpf_if_r, hbn_netdev=pf0hpf_if, hbn_rep_ofport=pf0hpf_if_r}'
+          ovs-vsctl --may-exist add-port br-hbn {{ carbide_host_intercept_hbn_port }} -- set interface {{ carbide_host_intercept_hbn_port }} type=patch options:peer={{ carbide_host_intercept_bridge_port }} ofport_request="${next_br_hbn_ofport_index}" external_ids='{dependencies=pf0hpf_if_r, hbn_netdev=pf0hpf_if, hbn_rep_ofport=pf0hpf_if_r}'
 
           # Add our side of the patch to our new bridge
-          ovs-vsctl --may-exist add-port {{ forge_host_intercept_bridge_name }} {{ forge_host_intercept_bridge_port }} -- set interface {{ forge_host_intercept_bridge_port }} type=patch options:peer={{ forge_host_intercept_hbn_port }}
+          ovs-vsctl --may-exist add-port {{ carbide_host_intercept_bridge_name }} {{ carbide_host_intercept_bridge_port }} -- set interface {{ carbide_host_intercept_bridge_port }} type=patch options:peer={{ carbide_host_intercept_hbn_port }}
 
           # Match ofport and ofport_request match so that sfc.sh doesn't error out.
-          ovs-vsctl set interface {{ forge_host_intercept_bridge_port }} ofport_request=$(ovs-vsctl get interface {{ forge_host_intercept_bridge_port }} ofport)
+          ovs-vsctl set interface {{ carbide_host_intercept_bridge_port }} ofport_request=$(ovs-vsctl get interface {{ carbide_host_intercept_bridge_port }} ofport)
 
           # Adjust the sfc.conf to insert our patch port where pf0hpf used to be
-          sed -i 's/br-hbn~pf0hpf~pf0hpf_if_r~pf0hpf_if~pf0hpf_if_r/br-hbn~{{ forge_host_intercept_hbn_port }}~pf0hpf_if_r~pf0hpf_if~pf0hpf_if_r/' /etc/mellanox/sfc.conf
+          sed -i 's/br-hbn~pf0hpf~pf0hpf_if_r~pf0hpf_if~pf0hpf_if_r/br-hbn~{{ carbide_host_intercept_hbn_port }}~pf0hpf_if_r~pf0hpf_if~pf0hpf_if_r/' /etc/mellanox/sfc.conf
 
           # Now pop pf0hpf off of br-hbn and attach it to br-host
           ovs-vsctl --if-exists del-port pf0hpf -- \
-            --may-exist add-port {{ forge_host_intercept_bridge_name }} pf0hpf -- \
+            --may-exist add-port {{ carbide_host_intercept_bridge_name }} pf0hpf -- \
             set interface pf0hpf type=dpdk mtu_request=9216 external_ids='{}'
           ovs-vsctl set interface pf0hpf ofport_request=$(ovs-vsctl get interface pf0hpf ofport)
         {% endif %}

--- a/crates/api/src/dpf.rs
+++ b/crates/api/src/dpf.rs
@@ -35,18 +35,18 @@ const API_URL: &str = "https://carbide-api.forge";
 const PXE_URL: &str = "http://carbide-pxe.forge";
 const BMC_FW_UPDATE_KEY: &str = "bmc_fw_update";
 const SECONDS_SINCE_EPOCH_KEY: &str = "seconds_since_epoch";
-const HBN_REPS_KEY: &str = "forge_hbn_reps";
-const HBN_SFS_KEY: &str = "forge_hbn_sfs";
-const VF_INTERCEPT_BRIDGE_NAME_KEY: &str = "forge_vf_intercept_bridge_name";
-const HOST_INTERCEPT_BRIDGE_NAME_KEY: &str = "forge_host_intercept_bridge_name";
-const HOST_INTERCEPT_HBN_PORT_KEY: &str = "forge_host_intercept_hbn_port";
-const HOST_INTERCEPT_BRIDGE_PORT_KEY: &str = "forge_host_intercept_bridge_port";
-const VF_INTERCEPT_HBN_PORT_KEY: &str = "forge_vf_intercept_hbn_port";
-const VF_INTERCEPT_BRIDGE_PORT_KEY: &str = "forge_vf_intercept_bridge_port";
-const VF_INTERCEPT_BRIDGE_SF_REPRESENTOR_KEY: &str = "forge_vf_intercept_bridge_sf_representor";
+const HBN_REPS_KEY: &str = "carbide_hbn_reps";
+const HBN_SFS_KEY: &str = "carbide_hbn_sfs";
+const VF_INTERCEPT_BRIDGE_NAME_KEY: &str = "carbide_vf_intercept_bridge_name";
+const HOST_INTERCEPT_BRIDGE_NAME_KEY: &str = "carbide_host_intercept_bridge_name";
+const HOST_INTERCEPT_HBN_PORT_KEY: &str = "carbide_host_intercept_hbn_port";
+const HOST_INTERCEPT_BRIDGE_PORT_KEY: &str = "carbide_host_intercept_bridge_port";
+const VF_INTERCEPT_HBN_PORT_KEY: &str = "carbide_vf_intercept_hbn_port";
+const VF_INTERCEPT_BRIDGE_PORT_KEY: &str = "carbide_vf_intercept_bridge_port";
+const VF_INTERCEPT_BRIDGE_SF_REPRESENTOR_KEY: &str = "carbide_vf_intercept_bridge_sf_representor";
 const VF_INTERCEPT_BRIDGE_SF_HBN_BRIDGE_REPRESENTOR_KEY: &str =
-    "forge_vf_intercept_bridge_sf_hbn_bridge_representor";
-const VF_INTERCEPT_BRIDGE_SF_KEY: &str = "forge_vf_intercept_bridge_sf";
+    "carbide_vf_intercept_bridge_sf_hbn_bridge_representor";
+const VF_INTERCEPT_BRIDGE_SF_KEY: &str = "carbide_vf_intercept_bridge_sf";
 
 const BFB_PATH: &str = "/public/blobs/internal/aarch64/forge.bfb";
 

--- a/crates/dpf/files/bf.cfg
+++ b/crates/dpf/files/bf.cfg
@@ -1,12 +1,12 @@
 # SFC variables
 ENABLE_BR_HBN=yes
 ENABLE_BR_SFC=yes
-{% if forge_hbn_reps %}
-BR_HBN_REPS={{ forge_hbn_reps }}
+{% if carbide_hbn_reps %}
+BR_HBN_REPS={{ carbide_hbn_reps }}
 {% endif %}
 
-{% if forge_hbn_sfs %}
-BR_HBN_SFS={{ forge_hbn_sfs }}
+{% if carbide_hbn_sfs %}
+BR_HBN_SFS={{ carbide_hbn_sfs }}
 {% endif %}
 
 {{ bmc_fw_update }}
@@ -191,12 +191,12 @@ write_files:
       /opt/mellanox/doca/services/telemetry/import_doca_telemetry.sh
 
 
-      {% if forge_vf_intercept_bridge_name %}
+      {% if carbide_vf_intercept_bridge_name %}
         
         # Create our new bridge
-        ovs-vsctl --may-exist add-br {{ forge_vf_intercept_bridge_name }} -- set bridge {{ forge_vf_intercept_bridge_name }} datapath_type=netdev -- set interface {{ forge_vf_intercept_bridge_name }} mtu_request=9216
+        ovs-vsctl --may-exist add-br {{ carbide_vf_intercept_bridge_name }} -- set bridge {{ carbide_vf_intercept_bridge_name }} datapath_type=netdev -- set interface {{ carbide_vf_intercept_bridge_name }} mtu_request=9216
 
-        {% if forge_vf_intercept_bridge_port %}
+        {% if carbide_vf_intercept_bridge_port %}
 
           # Grab the current port index of the hbn bridge and increment it
           next_br_hbn_ofport_index=$(($(ovs-vsctl get bridge br-hbn external_ids | grep -o '[0-9]*')+1))
@@ -205,37 +205,37 @@ write_files:
           ovs-vsctl set bridge br-hbn external_ids:ofport_index=${next_br_hbn_ofport_index}
 
           # Add the hbn side of our patch port and set its ofport index to match what we set on the hbn bridge
-          ovs-vsctl --may-exist add-port br-hbn {{ forge_vf_intercept_hbn_port }} -- set interface {{ forge_vf_intercept_hbn_port }} type=patch options:peer={{ forge_vf_intercept_bridge_port }} ofport_request="${next_br_hbn_ofport_index}"
+          ovs-vsctl --may-exist add-port br-hbn {{ carbide_vf_intercept_hbn_port }} -- set interface {{ carbide_vf_intercept_hbn_port }} type=patch options:peer={{ carbide_vf_intercept_bridge_port }} ofport_request="${next_br_hbn_ofport_index}"
 
           # Add our side of the patch to our new bridge
-          ovs-vsctl --may-exist add-port {{ forge_vf_intercept_bridge_name }} {{ forge_vf_intercept_bridge_port }} -- set interface {{ forge_vf_intercept_bridge_port }} type=patch options:peer={{ forge_vf_intercept_hbn_port }}
+          ovs-vsctl --may-exist add-port {{ carbide_vf_intercept_bridge_name }} {{ carbide_vf_intercept_bridge_port }} -- set interface {{ carbide_vf_intercept_bridge_port }} type=patch options:peer={{ carbide_vf_intercept_hbn_port }}
 
-          # Adjust the sfc.conf to insert our patch port where {{ forge_vf_intercept_bridge_sf }} used to be
-          sed -i 's/br-hbn~{{ forge_vf_intercept_bridge_sf_representor }}~{{ forge_vf_intercept_bridge_sf_hbn_bridge_representor }}/br-hbn~{{ forge_vf_intercept_hbn_port }}~{{ forge_vf_intercept_bridge_sf_hbn_bridge_representor }}/' /etc/mellanox/sfc.conf
+          # Adjust the sfc.conf to insert our patch port where {{ carbide_vf_intercept_bridge_sf }} used to be
+          sed -i 's/br-hbn~{{ carbide_vf_intercept_bridge_sf_representor }}~{{ carbide_vf_intercept_bridge_sf_hbn_bridge_representor }}/br-hbn~{{ carbide_vf_intercept_hbn_port }}~{{ carbide_vf_intercept_bridge_sf_hbn_bridge_representor }}/' /etc/mellanox/sfc.conf
 
           # Match ofport and ofport_request match so that sfc.sh doesn't error out.
-          ovs-vsctl set interface {{ forge_vf_intercept_bridge_port }} ofport_request=$(ovs-vsctl get interface {{ forge_vf_intercept_bridge_port }} ofport)
+          ovs-vsctl set interface {{ carbide_vf_intercept_bridge_port }} ofport_request=$(ovs-vsctl get interface {{ carbide_vf_intercept_bridge_port }} ofport)
 
           # Clear the related link-propagation line.
-          # We're going to delete the {{ forge_vf_intercept_bridge_sf_representor }}
-          # so we don't need/want its link state to be propagated to {{ forge_vf_intercept_bridge_sf_hbn_bridge_representor }}
-          sed -i ':a;N;$!ba;s/{{ forge_vf_intercept_bridge_sf_representor }}:{{ forge_vf_intercept_bridge_sf_hbn_bridge_representor }}\n*//' /etc/mellanox/sfc.conf
+          # We're going to delete the {{ carbide_vf_intercept_bridge_sf_representor }}
+          # so we don't need/want its link state to be propagated to {{ carbide_vf_intercept_bridge_sf_hbn_bridge_representor }}
+          sed -i ':a;N;$!ba;s/{{ carbide_vf_intercept_bridge_sf_representor }}:{{ carbide_vf_intercept_bridge_sf_hbn_bridge_representor }}\n*//' /etc/mellanox/sfc.conf
 
-          # Now delete {{ forge_vf_intercept_bridge_sf_representor }} from br-hbn
+          # Now delete {{ carbide_vf_intercept_bridge_sf_representor }} from br-hbn
           # OVS will get breaking flows if we leave it dangling. We either need to
           # move it to br-dpu or delete it, and we can delete it because we don't
           # need it.
-          ovs-vsctl --if-exists del-port {{ forge_vf_intercept_bridge_sf_representor }}
+          ovs-vsctl --if-exists del-port {{ carbide_vf_intercept_bridge_sf_representor }}
 
         {% endif %}
       {% endif %}
       
-      {% if forge_host_intercept_bridge_name %}
+      {% if carbide_host_intercept_bridge_name %}
         
         # Create our new bridge
-        ovs-vsctl --may-exist add-br {{ forge_host_intercept_bridge_name }} -- set bridge {{ forge_host_intercept_bridge_name }} datapath_type=netdev
+        ovs-vsctl --may-exist add-br {{ carbide_host_intercept_bridge_name }} -- set bridge {{ carbide_host_intercept_bridge_name }} datapath_type=netdev
 
-        {% if forge_host_intercept_bridge_port %}
+        {% if carbide_host_intercept_bridge_port %}
 
           # Grab the current port index of the hbn bridge and increment it
           next_br_hbn_ofport_index=$(($(ovs-vsctl get bridge br-hbn external_ids | grep -o '[0-9]*')+1))
@@ -244,20 +244,20 @@ write_files:
           ovs-vsctl set bridge br-hbn external_ids:ofport_index=${next_br_hbn_ofport_index}
 
           # Add our patch port to br-hbn and set its ofport index to match what we set on the hbn bridge
-          ovs-vsctl --may-exist add-port br-hbn {{ forge_host_intercept_hbn_port }} -- set interface {{ forge_host_intercept_hbn_port }} type=patch options:peer={{ forge_host_intercept_bridge_port }} ofport_request="${next_br_hbn_ofport_index}" external_ids='{dependencies=pf0hpf_if_r, hbn_netdev=pf0hpf_if, hbn_rep_ofport=pf0hpf_if_r}'
+          ovs-vsctl --may-exist add-port br-hbn {{ carbide_host_intercept_hbn_port }} -- set interface {{ carbide_host_intercept_hbn_port }} type=patch options:peer={{ carbide_host_intercept_bridge_port }} ofport_request="${next_br_hbn_ofport_index}" external_ids='{dependencies=pf0hpf_if_r, hbn_netdev=pf0hpf_if, hbn_rep_ofport=pf0hpf_if_r}'
 
           # Add our side of the patch to our new bridge
-          ovs-vsctl --may-exist add-port {{ forge_host_intercept_bridge_name }} {{ forge_host_intercept_bridge_port }} -- set interface {{ forge_host_intercept_bridge_port }} type=patch options:peer={{ forge_host_intercept_hbn_port }}
+          ovs-vsctl --may-exist add-port {{ carbide_host_intercept_bridge_name }} {{ carbide_host_intercept_bridge_port }} -- set interface {{ carbide_host_intercept_bridge_port }} type=patch options:peer={{ carbide_host_intercept_hbn_port }}
 
           # Match ofport and ofport_request match so that sfc.sh doesn't error out.
-          ovs-vsctl set interface {{ forge_host_intercept_bridge_port }} ofport_request=$(ovs-vsctl get interface {{ forge_host_intercept_bridge_port }} ofport)
+          ovs-vsctl set interface {{ carbide_host_intercept_bridge_port }} ofport_request=$(ovs-vsctl get interface {{ carbide_host_intercept_bridge_port }} ofport)
 
           # Adjust the sfc.conf to insert our patch port where pf0hpf used to be
-          sed -i 's/br-hbn~pf0hpf~pf0hpf_if_r~pf0hpf_if~pf0hpf_if_r/br-hbn~{{ forge_host_intercept_hbn_port }}~pf0hpf_if_r~pf0hpf_if~pf0hpf_if_r/' /etc/mellanox/sfc.conf
+          sed -i 's/br-hbn~pf0hpf~pf0hpf_if_r~pf0hpf_if~pf0hpf_if_r/br-hbn~{{ carbide_host_intercept_hbn_port }}~pf0hpf_if_r~pf0hpf_if~pf0hpf_if_r/' /etc/mellanox/sfc.conf
 
           # Now pop pf0hpf off of br-hbn and attach it to br-host
           ovs-vsctl --if-exists del-port pf0hpf -- \
-            --may-exist add-port {{ forge_host_intercept_bridge_name }} pf0hpf -- \
+            --may-exist add-port {{ carbide_host_intercept_bridge_name }} pf0hpf -- \
             set interface pf0hpf type=dpdk mtu_request=9216 external_ids='{}'
           ovs-vsctl set interface pf0hpf ofport_request=$(ovs-vsctl get interface pf0hpf ofport)
         {% endif %}

--- a/crates/pxe/src/routes/cloud_init.rs
+++ b/crates/pxe/src/routes/cloud_init.rs
@@ -111,64 +111,64 @@ fn user_data_handler(
     );
 
     if let Some(hbn_reps) = hbn_reps {
-        context.insert("forge_hbn_reps".to_string(), hbn_reps);
+        context.insert("carbide_hbn_reps".to_string(), hbn_reps);
     }
 
     if let Some(hbn_sfs) = hbn_sfs {
-        context.insert("forge_hbn_sfs".to_string(), hbn_sfs);
+        context.insert("carbide_hbn_sfs".to_string(), hbn_sfs);
     }
 
     if let Some(vf_intercept_bridge_name) = vf_intercept_bridge_name {
         context.insert(
-            "forge_vf_intercept_bridge_name".to_string(),
+            "carbide_vf_intercept_bridge_name".to_string(),
             vf_intercept_bridge_name,
         );
     }
 
     if let Some(host_intercept_bridge_name) = host_intercept_bridge_name {
         context.insert(
-            "forge_host_intercept_bridge_name".to_string(),
+            "carbide_host_intercept_bridge_name".to_string(),
             host_intercept_bridge_name,
         );
     }
 
     if let Some(host_intercept_bridge_port) = host_intercept_bridge_port {
         context.insert(
-            "forge_host_intercept_hbn_port".to_string(),
+            "carbide_host_intercept_hbn_port".to_string(),
             format!("patch-hbn-{host_intercept_bridge_port}"),
         );
 
         context.insert(
-            "forge_host_intercept_bridge_port".to_string(),
+            "carbide_host_intercept_bridge_port".to_string(),
             host_intercept_bridge_port,
         );
     }
 
     if let Some(vf_intercept_bridge_port) = vf_intercept_bridge_port {
         context.insert(
-            "forge_vf_intercept_hbn_port".to_string(),
+            "carbide_vf_intercept_hbn_port".to_string(),
             format!("patch-hbn-{vf_intercept_bridge_port}"),
         );
 
         context.insert(
-            "forge_vf_intercept_bridge_port".to_string(),
+            "carbide_vf_intercept_bridge_port".to_string(),
             vf_intercept_bridge_port,
         );
     }
 
     if let Some(vf_intercept_bridge_sf) = vf_intercept_bridge_sf {
         context.insert(
-            "forge_vf_intercept_bridge_sf_representor".to_string(),
+            "carbide_vf_intercept_bridge_sf_representor".to_string(),
             format!("{vf_intercept_bridge_sf}_r"),
         );
 
         context.insert(
-            "forge_vf_intercept_bridge_sf_hbn_bridge_representor".to_string(),
+            "carbide_vf_intercept_bridge_sf_hbn_bridge_representor".to_string(),
             format!("{vf_intercept_bridge_sf}_if_r"),
         );
 
         context.insert(
-            "forge_vf_intercept_bridge_sf".to_string(),
+            "carbide_vf_intercept_bridge_sf".to_string(),
             vf_intercept_bridge_sf,
         );
     }


### PR DESCRIPTION
## Summary

Closes #43

- Renamed all `forge_*` Jinja template variable names to `carbide_*` in both `crates/api/files/bf.cfg` and `crates/dpf/files/bf.cfg`
- Updated the corresponding Rust string constants in `crates/api/src/dpf.rs`
- Updated the `context.insert` keys in `crates/pxe/src/routes/cloud_init.rs` to match

**Not changed:** Runtime artifact names (`forge-scout`, `/opt/forge/`, `forge_root.pem`) — these refer to actual binaries and filesystem paths on the DPU and require separate work to rename.

## Test plan

- [ ] Verify bf.cfg template renders correctly with the renamed variables
- [ ] Confirm no remaining `forge_*` template variable mismatches between the templates and Rust context keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)