### PR TITLE
feat(web): Add spinner and status feedback for BMC actions

### DIFF
--- a/crates/api/src/web/action_status.rs
+++ b/crates/api/src/web/action_status.rs
@@ -1,0 +1,154 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+use itertools::Itertools;
+
+// Adds handler to submit button that:
+//  1. Schedules immediately disabling all input elements (Footgun: disabled inputs are not sent as form data).
+//  2. Hides previous error
+//  3. Shows spinner
+pub fn action_spinner_script(id: &str) -> String {
+    const HANDLER: &str = r#"function() {
+  document.querySelectorAll('a, input, select, #json-link').forEach(el => el.classList.add('disabled'));
+  const actionCell = this.closest('.action-cell');
+  if (actionCell) {
+     actionCell.querySelector('.action-spinner')?.style.setProperty('visibility', 'visible');
+     actionCell.querySelector('#action-cell-status')?.style.setProperty('visibility', 'hidden');
+  }
+}"#;
+    format!(
+        "<script>document.getElementById('{id}').addEventListener('submit', {HANDLER});</script>"
+    )
+}
+
+#[derive(PartialEq, Eq)]
+pub(crate) enum Type {
+    Power,
+    ResetBmc,
+    MachineSetup,
+    SetDpuFirstBootOrder,
+}
+
+impl Type {
+    pub fn from_query(query: &HashMap<String, String>) -> Option<Self> {
+        query
+            .get("action_type")
+            .map(String::as_str)
+            .and_then(|action| match action {
+                "power" => Some(Type::Power),
+                "reset_bmc" => Some(Type::ResetBmc),
+                "machine_setup" => Some(Type::MachineSetup),
+                "set_dpu_first_boot_order" => Some(Type::SetDpuFirstBootOrder),
+                _ => None,
+            })
+    }
+    pub fn to_query(&self) -> (&'static str, &'static str) {
+        (
+            "action_type",
+            match self {
+                Type::Power => "power",
+                Type::ResetBmc => "reset_bmc",
+                Type::MachineSetup => "machine_setup",
+                Type::SetDpuFirstBootOrder => "set_dpu_first_boot_order",
+            },
+        )
+    }
+}
+
+pub(crate) enum Class {
+    Success,
+    Warning,
+    Error,
+}
+
+impl Class {
+    pub fn from_query(query: &HashMap<String, String>) -> Self {
+        match query.get("action_class").map(String::as_str) {
+            Some("success") => Self::Success,
+            Some("error") => Self::Error,
+            _ => Self::Warning,
+        }
+    }
+
+    pub fn to_query(&self) -> (&'static str, &'static str) {
+        ("action_class", self.as_str())
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Error => "error",
+            Self::Warning => "warning",
+        }
+    }
+}
+
+pub(crate) struct ActionStatus<'a> {
+    pub action: Type,
+    pub class: Class,
+    pub message: Cow<'a, str>,
+}
+
+impl ActionStatus<'_> {
+    pub fn from_query(query: &HashMap<String, String>) -> Option<ActionStatus<'_>> {
+        Type::from_query(query).map(|action| {
+            let message = query
+                .get("action_message")
+                .map(String::as_str)
+                .unwrap_or(action.to_query().1);
+            ActionStatus {
+                action,
+                message: Cow::Borrowed(message),
+                class: Class::from_query(query),
+            }
+        })
+    }
+
+    pub fn url_cleanup_script() -> &'static str {
+        r#"<script>
+(function() {
+  const url = new URL(window.location.href);
+  url.searchParams.delete('action_type');
+  url.searchParams.delete('action_class');
+  url.searchParams.delete('action_message');
+  const newUrl = url.pathname + url.search + url.hash;
+  window.history.replaceState({}, document.title, newUrl);
+})();
+</script>"#
+    }
+
+    pub fn update_redirect_url(&self, redirect_url: &str) -> String {
+        let (base_url, anchor) = match redirect_url.rfind('#') {
+            Some(pos) => (&redirect_url[..pos], &redirect_url[pos..]),
+            None => (redirect_url, ""),
+        };
+        format!(
+            "{base_url}?{}{anchor}",
+            [
+                self.action.to_query(),
+                self.class.to_query(),
+                ("action_message", &self.message),
+            ]
+            .iter()
+            .map(|(k, v)| format!("{k}={}", urlencoding::encode(v)))
+            .join("&"),
+        )
+    }
+}

--- a/crates/api/src/web/explored_endpoint.rs
+++ b/crates/api/src/web/explored_endpoint.rs
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -25,7 +24,6 @@ use axum::extract::{Path as AxumPath, Query, State as AxumState};
 use axum::response::{Html, IntoResponse, Redirect, Response};
 use axum::{Form, Json};
 use hyper::http::StatusCode;
-use itertools::Itertools;
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{self as forgerpc, BmcEndpointRequest, admin_power_control_request};
 use rpc::site_explorer::{
@@ -36,6 +34,7 @@ use serde::Deserialize;
 
 use super::filters;
 use crate::api::Api;
+use crate::web::action_status::{self, ActionStatus};
 
 #[derive(Template)]
 #[template(path = "explored_endpoints_show.html")]
@@ -384,69 +383,6 @@ struct ExploredEndpointDetail<'a> {
     action_status: Option<ActionStatus<'a>>,
 }
 
-pub(crate) struct ActionStatus<'a> {
-    pub action: Cow<'a, str>,
-    pub class: &'static str,
-    pub message: Cow<'a, str>,
-}
-
-impl ActionStatus<'_> {
-    pub fn from_query(query: &HashMap<String, String>) -> Option<ActionStatus<'_>> {
-        query.get("action_type").map(|action| {
-            let message = query
-                .get("action_message")
-                .map(String::as_str)
-                .unwrap_or(action.as_str());
-            let class = match query.get("action_class").map(String::as_str) {
-                Some("success") => "success",
-                Some("error") => "error",
-                _ => "warning",
-            };
-            ActionStatus {
-                action: Cow::Borrowed(action),
-                message: Cow::Borrowed(message),
-                class,
-            }
-        })
-    }
-
-    pub fn url_cleanup_script() -> &'static str {
-        r#"<script>
-(function() {
-  const url = new URL(window.location.href);
-  url.searchParams.delete('action_type');
-  url.searchParams.delete('action_class');
-  url.searchParams.delete('action_message');
-  const newUrl = url.pathname + url.search + url.hash;
-  window.history.replaceState({}, document.title, newUrl);
-})();
-</script>"#
-    }
-
-    pub fn update_redirect_url(
-        redirect_url: &str,
-        action: &str,
-        class: &str,
-        message: &str,
-    ) -> String {
-        let (base_url, anchor) = match redirect_url.rfind('#') {
-            Some(pos) => (&redirect_url[..pos], &redirect_url[pos..]),
-            None => (redirect_url, ""),
-        };
-        format!(
-            "{base_url}?{}{anchor}",
-            [
-                ("action_type", action),
-                ("action_class", class),
-                ("action_message", message),
-            ]
-            .iter()
-            .map(|(k, v)| format!("{k}={}", urlencoding::encode(v)))
-            .join("&"),
-        )
-    }
-}
-
 struct ExploredEndpointInfo {
     endpoint: ExploredEndpoint,
     credentials_set: String,
@@ -746,12 +682,12 @@ pub async fn power_control(
 
     let Some(act) = admin_power_control_request::SystemPowerControl::from_str_name(&action) else {
         tracing::error!(endpoint_ip = %endpoint_ip, action = %action, "power_control_endpoint invalid action");
-        let redirect_url = ActionStatus::update_redirect_url(
-            &view_url,
-            "power",
-            "error",
-            "invalid action requested",
-        );
+        let redirect_url = ActionStatus {
+            action: action_status::Type::Power,
+            class: action_status::Class::Error,
+            message: "invalid action requested".into(),
+        }
+        .update_redirect_url(&view_url);
         return Redirect::to(&redirect_url).into_response();
     };
 
@@ -771,19 +707,28 @@ pub async fn power_control(
             let message = response
                 .msg
                 .unwrap_or_else(|| format!("Power action '{}' completed successfully", action));
-            let status = if message.to_lowercase().contains("warning") {
-                "warning"
+            // TODO: API should be more explicit about what is warning what is just info in message.
+            let class = if message.to_lowercase().contains("warning") {
+                action_status::Class::Warning
             } else {
-                "success"
+                action_status::Class::Success
             };
-            let redirect_url =
-                ActionStatus::update_redirect_url(&view_url, "power", status, &message);
+            let redirect_url = ActionStatus {
+                action: action_status::Type::Power,
+                class,
+                message: message.into(),
+            }
+            .update_redirect_url(&view_url);
             Redirect::to(&redirect_url).into_response()
         }
         Err(err) => {
             tracing::error!(%err, endpoint_ip = %endpoint_ip, action = %action, "power_control_endpoint");
-            let redirect_url =
-                ActionStatus::update_redirect_url(&view_url, "power", "error", err.message());
+            let redirect_url = ActionStatus {
+                action: action_status::Type::Power,
+                class: action_status::Class::Error,
+                message: err.message().into(),
+            }
+            .update_redirect_url(&view_url);
             Redirect::to(&redirect_url).into_response()
         }
     }
@@ -809,7 +754,7 @@ pub async fn bmc_reset(
         _ => false,
     };
 
-    if let Err(err) = state
+    match state
         .admin_bmc_reset(tonic::Request::new(rpc::forge::AdminBmcResetRequest {
             machine_id: None,
             bmc_endpoint_request: Some(BmcEndpointRequest {
@@ -821,11 +766,26 @@ pub async fn bmc_reset(
         .await
         .map(|response| response.into_inner())
     {
-        tracing::error!(%err, endpoint_ip = %endpoint_ip, use_ipmi = %use_ipmi, "bmc_reset_endpoint");
-        return (StatusCode::INTERNAL_SERVER_ERROR, err.message().to_owned()).into_response();
+        Ok(_response) => {
+            let redirect_url = ActionStatus {
+                action: action_status::Type::ResetBmc,
+                class: action_status::Class::Success,
+                message: "BMC reset initiated successfully".into(),
+            }
+            .update_redirect_url(&view_url);
+            Redirect::to(&redirect_url).into_response()
+        }
+        Err(err) => {
+            tracing::error!(%err, endpoint_ip = %endpoint_ip, use_ipmi = %use_ipmi, "bmc_reset_endpoint");
+            let redirect_url = ActionStatus {
+                action: action_status::Type::ResetBmc,
+                class: action_status::Class::Error,
+                message: err.message().into(),
+            }
+            .update_redirect_url(&view_url);
+            Redirect::to(&redirect_url).into_response()
+        }
     }
-
-    Redirect::to(&view_url).into_response()
 }
 
 #[derive(Deserialize, Debug)]
@@ -987,19 +947,19 @@ pub async fn machine_setup(
         .filter(|mac| !mac.trim().is_empty())
         .map(|mac| mac.trim().to_string());
 
-    // Validate MAC address format if provided
     if let Some(ref mac) = boot_interface_mac
         && mac.parse::<mac_address::MacAddress>().is_err()
     {
         tracing::error!(endpoint_ip = %endpoint_ip, mac_address = %mac, "Invalid MAC address format");
-        return (
-            StatusCode::BAD_REQUEST,
-            "Invalid MAC address format. Expected format: 00:11:22:33:44:55",
-        )
-            .into_response();
+        let status = ActionStatus {
+            action: action_status::Type::MachineSetup,
+            class: action_status::Class::Error,
+            message: "Invalid MAC address format. Expected format: 00:11:22:33:44:55".into(),
+        };
+        return Redirect::to(&status.update_redirect_url(&view_url)).into_response();
     }
 
-    if let Err(err) = state
+    let redirect_url = match state
         .machine_setup(tonic::Request::new(rpc::forge::MachineSetupRequest {
             machine_id: None,
             bmc_endpoint_request: Some(BmcEndpointRequest {
@@ -1011,11 +971,24 @@ pub async fn machine_setup(
         .await
         .map(|response| response.into_inner())
     {
-        tracing::error!(%err, endpoint_ip = %endpoint_ip, "bmc_machine_setup");
-        return (StatusCode::INTERNAL_SERVER_ERROR, err.message().to_owned()).into_response();
-    }
+        Ok(_) => ActionStatus {
+            action: action_status::Type::MachineSetup,
+            class: action_status::Class::Success,
+            message: "Machine setup completed successfully".into(),
+        }
+        .update_redirect_url(&view_url),
+        Err(err) => {
+            tracing::error!(%err, endpoint_ip = %endpoint_ip, "bmc_machine_setup");
+            ActionStatus {
+                action: action_status::Type::MachineSetup,
+                class: action_status::Class::Error,
+                message: err.message().into(),
+            }
+            .update_redirect_url(&view_url)
+        }
+    };
 
-    Redirect::to(&view_url).into_response()
+    Redirect::to(&redirect_url).into_response()
 }
 
 pub async fn set_dpu_first_boot_order(

--- a/crates/api/src/web/machine.rs
+++ b/crates/api/src/web/machine.rs
@@ -34,7 +34,7 @@ use utils::managed_host_display::to_time;
 use super::filters;
 use super::machine_state_history::{MachineStateHistoryRecord, MachineStateHistoryTable};
 use crate::api::Api;
-use crate::web::explored_endpoint::ActionStatus;
+use crate::web::action_status::{self, ActionStatus};
 
 #[derive(Template)]
 #[template(path = "machine_show.html")]
@@ -1013,9 +1013,9 @@ pub async fn set_dpu_first_boot_order(
     AxumPath(machine_id): AxumPath<String>,
     Form(form): Form<SetDpuFirstBootOrderAction>,
 ) -> Response {
-    let view_url = format!("/admin/machine/{machine_id}");
+    let view_url = format!("/admin/machine/{machine_id}#bmc_info_view");
 
-    if let Err(err) = state
+    let redirect_url = match state
         .set_dpu_first_boot_order(tonic::Request::new(
             rpc::forge::SetDpuFirstBootOrderRequest {
                 machine_id: None,
@@ -1028,9 +1028,22 @@ pub async fn set_dpu_first_boot_order(
         ))
         .await
     {
-        tracing::error!(%err, "set_dpu_first_boot_order failed");
-        return (StatusCode::INTERNAL_SERVER_ERROR, err.message().to_owned()).into_response();
-    }
+        Ok(_) => ActionStatus {
+            action: action_status::Type::SetDpuFirstBootOrder,
+            class: action_status::Class::Success,
+            message: "Boot order set successfully".into(),
+        }
+        .update_redirect_url(&view_url),
+        Err(err) => {
+            tracing::error!(%err, "set_dpu_first_boot_order failed");
+            ActionStatus {
+                action: action_status::Type::SetDpuFirstBootOrder,
+                class: action_status::Class::Error,
+                message: err.message().into(),
+            }
+            .update_redirect_url(&view_url)
+        }
+    };
 
-    Redirect::to(&view_url).into_response()
+    Redirect::to(&redirect_url).into_response()
 }

--- a/crates/api/src/web/mod.rs
+++ b/crates/api/src/web/mod.rs
@@ -51,6 +51,7 @@ use crate::api::Api;
 use crate::auth::{AuthContext, Principal};
 use crate::cfg::file::CarbideConfig;
 
+mod action_status;
 mod attestation;
 mod auth;
 mod compute_allocation;

--- a/crates/api/templates/bmc_reset.html
+++ b/crates/api/templates/bmc_reset.html
@@ -9,3 +9,4 @@
 	{% endif %}
 	<input type="submit" value="Reset BMC">
 </form>
+{{ action_status::action_spinner_script("bmcreset_action")|safe }}

--- a/crates/api/templates/explored_endpoint_detail.html
+++ b/crates/api/templates/explored_endpoint_detail.html
@@ -114,13 +114,14 @@
 					Last Redfish BMC Powercycle: {{ endpoint.last_redfish_powercycle }}
 				</div>
 				{% if let Some(status) = action_status %}
-				{% if status.action == "power" %}
-				<div>
-					<span class="bubble {{ status.class }}">{{ status.message }}</span>
+				{% if status.action == action_status::Type::Power %}
+				<div id="action-cell-status">
+					<span class="bubble {{ status.class.as_str() }}">{{ status.message }}</span>
 				</div>
 				{{ ActionStatus::url_cleanup_script()|safe }}
 				{% endif %}
 				{% endif %}
+				<span class="action-spinner"></span>
 				<div>
 					{% set bmc_ip = endpoint.address.clone() %}
 					{% include "power_control.html" %}
@@ -135,6 +136,15 @@
 					<br>
 					Last IPMI BMC Reset: {{ endpoint.last_ipmitool_bmc_reset }}
 				</div>
+				{% if let Some(status) = action_status %}
+				{% if status.action == action_status::Type::ResetBmc %}
+				<div id="action-cell-status">
+					<span class="bubble {{ status.class.as_str() }}">{{ status.message }}</span>
+				</div>
+				{{ ActionStatus::url_cleanup_script()|safe }}
+				{% endif %}
+				{% endif %}
+				<span class="action-spinner"></span>
 				<div>
 					{% set bmc_ip = endpoint.address.clone() %}
 					{% include "bmc_reset.html" %}
@@ -147,20 +157,28 @@
 				<div>
 					<span class="bubble {% if machine_setup_status == "OK" %}success{% else %}error{% endif %}">{{ machine_setup_status }}</span>
 				</div>
-						<div>
-				<form id="machine_setup" method="POST" action="/admin/explored-endpoint/{{ endpoint.address }}/machine-setup">
-					<div style="display: flex; gap: 8px; align-items: center;">
-						{% if is_dell_endpoint %}
-						<input type="text" id="boot_interface_mac" name="boot_interface_mac" 
-							   placeholder="Boot Interface MAC"
-							   title="Enter a valid MAC address (e.g. 00:11:22:33:44:55)"
-							   required>
-						{% endif %}
-						<input type="submit" value="Machine Setup" class="disabled">
-					</div>
-				</form>
-
-			</div>
+				{% if let Some(status) = action_status %}
+				{% if status.action == action_status::Type::MachineSetup %}
+				<div id="action-cell-status">
+					<span class="bubble {{ status.class.as_str() }}">{{ status.message }}</span>
+				</div>
+				{{ ActionStatus::url_cleanup_script()|safe }}
+				{% endif %}
+				{% endif %}
+				<div>
+					<form id="machine_setup" method="POST" action="/admin/explored-endpoint/{{ endpoint.address }}/machine-setup">
+						<div style="display: flex; gap: 8px; align-items: center;">
+							{% if is_dell_endpoint %}
+							<input type="text" id="boot_interface_mac" name="boot_interface_mac" 
+								placeholder="Boot Interface MAC"
+								title="Enter a valid MAC address (e.g. 00:11:22:33:44:55)"
+								required>
+							{% endif %}
+							<input type="submit" value="Machine Setup" class="disabled">
+						</div>
+					</form>
+					{{ action_status::action_spinner_script("machine_setup")|safe }}
+				</div>
 			</td>
 		</tr>
 		<tr>
@@ -269,20 +287,25 @@
 		<tr><th>Power State</th><td>{{ "{:?}"|format(system.power_state()) }}</td></tr>
 		<tr>
 			<th>Boot Order</th>
-			<td>
-				<div style="margin-bottom: 12px;">
-					<form id="set_first_boot_order" method="POST" action="/admin/explored-endpoint/{{ endpoint.address }}/set-dpu-first-boot-order" onsubmit="reminder(event)">
-						<div style="display: flex; gap: 8px; align-items: center;">
-							<input type="text" name="boot_interface_mac" 
-								   placeholder="Boot Interface MAC"
-								   title="Enter a valid MAC address (e.g. 00:11:22:33:44:55)"
-								   style="width: 200px;"
-								   required>
-							<input type="submit" value="Set First">
-							{% include "restart_reminder.html" %}
-						</div>
-					</form>
+			<td class="action-cell" style="display: table-cell">
+				<div></div>
+				<div style="display: flex">
+					<div style="margin-bottom: 12px;">
+						<form id="set_first_boot_order" method="POST" action="/admin/explored-endpoint/{{ endpoint.address }}/set-dpu-first-boot-order" onsubmit="action_reminder(event)">
+							<div style="display: flex; gap: 8px; align-items: center;">
+								<input type="text" name="boot_interface_mac" 
+								       placeholder="Boot Interface MAC"
+								       title="Enter a valid MAC address (e.g. 00:11:22:33:44:55)"
+								       style="width: 200px;"
+								       required>
+								<input type="submit" value="Set First">
+							</div>
+						</form>
+						{{ action_status::action_spinner_script("set_first_boot_order")|safe }}
+					</div>
+					<span class="action-spinner"></span>
 				</div>
+				{% include "restart_reminder.html" %}
 				<div style="max-height: 300px; overflow: auto;">
 					<pre><code>{{ system.boot_order|boot_order_fmt }}</code></pre>
 				</div>

--- a/crates/api/templates/machine_detail.html
+++ b/crates/api/templates/machine_detail.html
@@ -212,10 +212,11 @@
 			<div>
 				{% include "power_control.html" %}
 			</div>
+			<span class="action-spinner"></span>
 			{% if let Some(status) = action_status %}
-			{% if status.action == "power" %}
-			<div>
-				<span class="bubble {{ status.class }}">{{ status.message }}</span>
+			{% if status.action == action_status::Type::Power %}
+			<div id="action-cell-status">
+				<span class="bubble {{ status.class.as_str() }}">{{ status.message }}</span>
 			</div>
 			{{ ActionStatus::url_cleanup_script()|safe }}
 			{% endif %}
@@ -229,6 +230,15 @@
 			<div>
 				{% include "bmc_reset.html" %}
 			</div>
+			<span class="action-spinner"></span>
+			{% if let Some(status) = action_status %}
+			{% if status.action == action_status::Type::ResetBmc %}
+			<div id="action-cell-status">
+				<span class="bubble {{ status.class.as_str() }}">{{ status.message }}</span>
+			</div>
+			{{ ActionStatus::url_cleanup_script()|safe }}
+			{% endif %}
+			{% endif %}
 		</td>
 	</tr>
 	{% if is_host %}
@@ -236,8 +246,8 @@
 		<th>Boot Order</th>
 		<td class="action-cell">
 			<div></div>
-			<div style="display: flex; align-items: center; gap: 8px;">
-				<form id="set_dpu_first_boot_order" method="POST" action="/admin/machine/{{ id }}/set-dpu-first-boot-order" onsubmit="reminder(event)">
+			<div>
+				<form id="set_dpu_first_boot_order" method="POST" action="/admin/machine/{{ id }}/set-dpu-first-boot-order" onsubmit="action_reminder(event)">
 					<input type="hidden" name="bmc_ip" value="{{ bmc_info.ip|option_fmt }}">
 					{% for interface in interfaces %}
 						{% if interface.primary == "true" %}
@@ -246,8 +256,18 @@
 					{% endfor %}
 					<input type="submit" value="Set DPU first">
 				</form>
-				{% include "restart_reminder.html" %}
+				{{ action_status::action_spinner_script("set_dpu_first_boot_order")|safe }}
 			</div>
+			<span class="action-spinner"></span>
+			{% include "restart_reminder.html" %}
+			{% if let Some(status) = action_status %}
+			{% if status.action == action_status::Type::SetDpuFirstBootOrder %}
+			<div id="action-cell-status">
+				<span class="bubble {{ status.class.as_str() }}">{{ status.message }}</span>
+			</div>
+			{{ ActionStatus::url_cleanup_script()|safe }}
+			{% endif %}
+			{% endif %}
 		</td>
 	</tr>
 	{% endif %}

--- a/crates/api/templates/power_control.html
+++ b/crates/api/templates/power_control.html
@@ -19,3 +19,4 @@
 	{% endif %}
 	<input type="submit" value="Submit">
 </form>
+{{ action_status::action_spinner_script("powercontrol_action")|safe }}

--- a/crates/api/templates/restart_reminder.html
+++ b/crates/api/templates/restart_reminder.html
@@ -1,29 +1,17 @@
-
-    <div class="notification-banner">
-        This operation will require rebooting the host.
-    </div>
-
-    <script>
-        function reminder(event) {
-            event.preventDefault();
-
-            const form = event.target;
-            const container = form.parentElement;
-            const notification = container.querySelector('.notification-banner');
-            
-            if (notification) {
-                notification.style.display = 'inline-block';
-                notification.style.opacity = 1;
-
-                // Start fade-out after 1.75 seconds
-                setTimeout(() => {
-                    notification.style.opacity = 0;
-                }, 1750);
-
-                // Submit form after 2.4 seconds
-                setTimeout(() => {
-                    form.submit();
-                }, 2400);
-            }
-        }
-    </script>
+<div class="action-restart-notification-reminder">
+	This operation will require rebooting the host.
+</div>
+<script>
+	function action_reminder(event) {
+		event.preventDefault();
+		const notification = event.target.closest('.action-cell')?.querySelector('.action-restart-notification-reminder');
+		if (notification) {
+			notification.style.display = 'inline-block';
+			notification.style.opacity = 1;
+			// Start fade-out after 1.75 seconds
+			setTimeout(() => notification.style.opacity = 0, 1750);
+			// Submit form after 2.4 seconds
+			setTimeout(() => event.target.submit(), 2400);
+		}
+	}
+</script>

--- a/crates/api/templates/static/carbide.css
+++ b/crates/api/templates/static/carbide.css
@@ -623,7 +623,7 @@ input[type="submit"]:hover:not(.disabled) {
 }
 
 /* Notification banner for restart reminders */
-.notification-banner {
+.action-restart-notification-reminder {
   display: none;
   min-height: 30px;
   padding: 8px 12px;
@@ -1313,6 +1313,35 @@ pre:not(div[style*="overflow: auto"] > pre):not(td > div > pre) {
   overflow: auto;
 }
 
+/* Style for spinner in UI */
+.action-spinner {
+  display: inline-block;
+  visibility: hidden;
+  width: 16px;
+  height: 16px;
+  min-height: 16px;
+  min-width: 16px;
+  margin: 5px;
+  border: 2px solid #ccc;
+  border-top-color: #333;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+a.disabled,
+input.disabled,
+select.disabled {
+  background-color: rgba(113, 128, 150, 0.1) !important;
+  color: var(--text-muted) !important;
+  border-color: var(--text-muted) !important;
+  cursor: not-allowed;
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
 
 /* ------------------------------------------------------------------------
    Tab System


### PR DESCRIPTION
## Description

- Extract ActionStatus into dedicated module (action_status.rs)
- Add loading spinner for power control, BMC reset, machine setup,
  and boot order actions
- Show success/error status bubbles after action completes
- Disable all interactive elements during form submission to prevent
  double-clicks and accidental navigation
- Add .action-spinner CSS with proper sizing for flex containers
- Add .disabled class for visual feedback on disabled links/inputs
- Rename reminder() to action_reminder() and update notification class

## Type of Change
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

