### PR TITLE
fix: helm chart migration job hook

### DIFF
--- a/helm/charts/carbide-api/templates/configmap.yaml
+++ b/helm/charts/carbide-api/templates/configmap.yaml
@@ -37,6 +37,8 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.envFrom.vaultClusterInfo.configMapName }}
   namespace: {{ include "carbide-api.namespace" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
   labels:
     {{- include "carbide-api.labels" . | nindent 4 }}
 data:
@@ -51,6 +53,8 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.envFrom.databaseConfig.configMapName }}
   namespace: {{ include "carbide-api.namespace" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
   labels:
     {{- include "carbide-api.labels" . | nindent 4 }}
 data:

--- a/helm/charts/carbide-api/templates/migration-job.yaml
+++ b/helm/charts/carbide-api/templates/migration-job.yaml
@@ -7,7 +7,8 @@ metadata:
     {{- include "carbide-api.labels" . | nindent 4 }}
     app: carbide-api-migrate
   annotations:
-    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/sync-wave: "-5"
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation


### PR DESCRIPTION
## Description
Fixes `carbide-api-migrate` (PreSync hook) fails because the `forge-system-carbide-database-config` and `vault-cluster-info` ConfigMaps don't exist yet — they are Helm-managed resources and only get created during the Sync phase, after PreSync hooks have already run.

  **Sync order after this fix:**
  wave -10 → ConfigMaps (vault-cluster-info, forge-system-carbide-database-config)
  wave  -5 → carbide-api-migrate Job (Sync hook, BeforeHookCreation — runs on every sync)
  wave   0 → Deployment, Service, etc.

  The `helm.sh/hook: pre-install,pre-upgrade` annotation is preserved for
  non-ArgoCD Helm deployments.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

