### PR TITLE
Implement firmware upgrade in scout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2256,6 +2256,7 @@ dependencies = [
 name = "carbide-scout"
 version = "0.0.1"
 dependencies = [
+ "axum 0.8.6",
  "carbide-host-support",
  "carbide-libmlx",
  "carbide-machine-validation",
@@ -2278,7 +2279,9 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "smbios-lib",
+ "tempfile",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -4111,6 +4111,7 @@ message ForgeAgentControlResponse {
     LOGERROR = 6; // Log error.
     MACHINE_VALIDATION = 7; // Machine validation.
     MLX_ACTION = 8; // MlxAction for DPA NICs
+    FIRMWARE_UPGRADE = 9; // Firmware upgrade through scout
   }
   Action action = 1;
 

--- a/crates/scout/Cargo.toml
+++ b/crates/scout/Cargo.toml
@@ -66,9 +66,14 @@ reqwest = { default-features = false, features = [
   "rustls-tls",
   "stream",
 ], workspace = true }
+sha2 = { workspace = true }
+tempfile = { workspace = true }
 futures-util = { workspace = true }
 prost-types = { workspace = true }
 x509-parser = { workspace = true }
+
+[dev-dependencies]
+axum = { workspace = true }
 
 [build-dependencies]
 carbide-version = { path = "../version" }

--- a/crates/scout/src/firmware_upgrade.rs
+++ b/crates/scout/src/firmware_upgrade.rs
@@ -1,0 +1,508 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use futures_util::TryStreamExt;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+const SCRIPT_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(30);
+const DOWNLOAD_MAX_RETRIES: u32 = 3;
+
+// FirmwareUpgradeTask represents the JSON payload received from
+// carbide-api via ForgeAgentControl when Action::FirmwareUpgrade is set.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FirmwareUpgradeTask {
+    pub component_type: String,
+    pub target_version: String,
+    pub script: FileArtifact,
+    pub execution_timeout_seconds: u32,
+    pub artifact_download_timeout_seconds: u32,
+    pub file_artifacts: Vec<FileArtifact>,
+}
+
+// FileArtifact represents a file to download with its expected checksum.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FileArtifact {
+    pub url: String,
+    pub sha256: String,
+}
+
+// FirmwareUpgradeResult captures the outcome of a firmware upgrade execution.
+// Fields will be used when ReportScoutFirmwareUpgradeStatus RPC is implemented.
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub struct FirmwareUpgradeResult {
+    pub success: bool,
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+    pub error: String,
+}
+
+// handle_firmware_upgrade downloads file artifacts and a script from carbide-api,
+// then executes the script on the host.
+pub async fn handle_firmware_upgrade(
+    client: &reqwest::Client,
+    task: &FirmwareUpgradeTask,
+) -> FirmwareUpgradeResult {
+    match run_firmware_upgrade(client, task).await {
+        Ok(result) => result,
+        Err(e) => FirmwareUpgradeResult {
+            success: false,
+            exit_code: -1,
+            stdout: String::new(),
+            stderr: String::new(),
+            error: format!("firmware upgrade failed: {e}"),
+        },
+    }
+}
+
+async fn run_firmware_upgrade(
+    client: &reqwest::Client,
+    task: &FirmwareUpgradeTask,
+) -> Result<FirmwareUpgradeResult, Box<dyn std::error::Error>> {
+    tracing::info!(
+        "[firmware_upgrade] starting for component={} version={}",
+        task.component_type,
+        task.target_version,
+    );
+
+    let work_dir = tempfile::tempdir()?;
+
+    let download_timeout = Duration::from_secs(task.artifact_download_timeout_seconds.into());
+
+    // Download the script and verify its checksum.
+    let script_path = tokio::time::timeout(
+        SCRIPT_DOWNLOAD_TIMEOUT,
+        download_file_with_retries(client, &task.script.url, work_dir.path()),
+    )
+    .await
+    .map_err(|_| {
+        format!(
+            "script download timed out after {} seconds",
+            SCRIPT_DOWNLOAD_TIMEOUT.as_secs()
+        )
+    })??;
+    let actual = sha256_file(&script_path).await?;
+    if actual != task.script.sha256 {
+        return Err(format!(
+            "checksum mismatch for script {}: expected {}, got {actual}",
+            task.script.url, task.script.sha256
+        )
+        .into());
+    }
+    tracing::info!(
+        "[firmware_upgrade] script downloaded and verified: {:?}",
+        script_path
+    );
+
+    // Download file artifacts and verify checksums.
+    let download_dir = work_dir.path().join("downloads");
+    tokio::fs::create_dir_all(&download_dir).await?;
+    for artifact in &task.file_artifacts {
+        let dest = tokio::time::timeout(
+            download_timeout,
+            download_file_with_retries(client, &artifact.url, &download_dir),
+        )
+        .await
+        .map_err(|_| {
+            format!(
+                "download timed out for {} after {} seconds",
+                artifact.url, task.artifact_download_timeout_seconds
+            )
+        })??;
+        let actual = sha256_file(&dest).await?;
+        if actual != artifact.sha256 {
+            return Err(format!(
+                "checksum mismatch for {}: expected {}, got {actual}",
+                artifact.url, artifact.sha256
+            )
+            .into());
+        }
+        tracing::info!("[firmware_upgrade] checksum verified for {}", artifact.url);
+    }
+
+    tracing::info!(
+        "[firmware_upgrade] files downloaded. Executing script {:?}",
+        script_path,
+    );
+
+    // Execute the script with env vars for context.
+    // kill_on_drop ensures the child process is terminated if the timeout fires,
+    // preventing orphaned processes and races with tempdir cleanup.
+    let child = tokio::process::Command::new("sh")
+        .arg(&script_path)
+        .env("DOWNLOAD_DIR", &download_dir)
+        .env("COMPONENT_TYPE", &task.component_type)
+        .env("TARGET_VERSION", &task.target_version)
+        .current_dir(work_dir.path())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()?;
+
+    let timeout = std::time::Duration::from_secs(task.execution_timeout_seconds.into());
+    let result = tokio::time::timeout(timeout, child.wait_with_output()).await;
+
+    match result {
+        Ok(Ok(output)) => {
+            let stdout = String::from_utf8(output.stdout)
+                .unwrap_or_else(|e| String::from_utf8_lossy(&e.into_bytes()).into_owned());
+            let stderr = String::from_utf8(output.stderr)
+                .unwrap_or_else(|e| String::from_utf8_lossy(&e.into_bytes()).into_owned());
+            let exit_code = output.status.code().unwrap_or(-1);
+            let success = output.status.success();
+
+            if !stdout.is_empty() {
+                tracing::info!("[firmware_upgrade] stdout: {stdout}");
+            }
+            if !stderr.is_empty() {
+                tracing::warn!("[firmware_upgrade] stderr: {stderr}");
+            }
+
+            Ok(FirmwareUpgradeResult {
+                success,
+                exit_code,
+                stdout,
+                stderr,
+                error: String::new(),
+            })
+        }
+        Ok(Err(e)) => Err(format!("failed to execute script: {e}").into()),
+        Err(_) => Ok(FirmwareUpgradeResult {
+            success: false,
+            exit_code: -1,
+            stdout: String::new(),
+            stderr: String::new(),
+            error: format!(
+                "script timed out after {} seconds",
+                task.execution_timeout_seconds
+            ),
+        }),
+    }
+}
+
+async fn download_file_with_retries(
+    client: &reqwest::Client,
+    url: &str,
+    target_dir: &Path,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let url_owned = url.to_string();
+    let result = tryhard::retry_fn(|| download_file(client, &url_owned, target_dir))
+        .retries(DOWNLOAD_MAX_RETRIES)
+        .exponential_backoff(Duration::from_secs(1))
+        .on_retry(|attempt, next_delay, error| {
+            let delay = next_delay.unwrap_or_default();
+            tracing::warn!(
+                "[firmware_upgrade] download attempt {attempt} failed for {}: {error}, retrying in {delay:?}",
+                url_owned
+            );
+            std::future::ready(())
+        })
+        .await?;
+    Ok(result)
+}
+
+// download_file downloads a file from the given URL into the target directory,
+// preserving the filename from the URL path.
+async fn download_file(
+    client: &reqwest::Client,
+    url: &str,
+    target_dir: &Path,
+) -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
+    let parsed = reqwest::Url::parse(url)?;
+    let segment = parsed
+        .path_segments()
+        .and_then(|mut s| s.next_back())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| format!("cannot extract filename from URL: {url}"))?;
+
+    let filename = Path::new(segment)
+        .file_name()
+        .ok_or_else(|| format!("invalid filename in URL: {url}"))?;
+
+    let dest = target_dir.join(filename);
+
+    tracing::info!("[firmware_upgrade] downloading {url} -> {dest:?}");
+
+    let response = client.get(url).send().await?.error_for_status()?;
+    let mut stream = response.bytes_stream();
+
+    let mut file = tokio::fs::File::create(&dest).await?;
+    while let Some(chunk) = stream.try_next().await? {
+        file.write_all(&chunk).await?;
+    }
+    file.flush().await?;
+
+    Ok(dest)
+}
+
+async fn sha256_file(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
+    let mut file = tokio::fs::File::open(path).await?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        let n = file.read(&mut buf).await?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::Router;
+    use axum::routing::get;
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    // start_file_server spins up a lightweight HTTP server that serves
+    // static content at the given routes. Returns the base URL.
+    async fn start_file_server(routes: Vec<(&'static str, &'static str)>) -> String {
+        let mut app = Router::new();
+        for (path, body) in routes {
+            app = app.route(path, get(move || async move { body }));
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        format!("http://{addr}")
+    }
+
+    fn sha256_hex(data: &str) -> String {
+        format!("{:x}", Sha256::digest(data.as_bytes()))
+    }
+
+    fn script_artifact(base: &str, path: &str, content: &str) -> FileArtifact {
+        FileArtifact {
+            url: format!("{base}{path}"),
+            sha256: sha256_hex(content),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_successful_upgrade() {
+        let script = "#!/bin/sh\necho \"upgrade complete\"";
+        let firmware_content = "binary-data";
+        let base = start_file_server(vec![
+            ("/scripts/upgrade.sh", script),
+            ("/firmware/blob.bin", firmware_content),
+        ])
+        .await;
+
+        let task = FirmwareUpgradeTask {
+            component_type: "cpld".into(),
+            target_version: "1.2.3".into(),
+            script: script_artifact(&base, "/scripts/upgrade.sh", script),
+            execution_timeout_seconds: 30,
+            artifact_download_timeout_seconds: 30,
+            file_artifacts: vec![FileArtifact {
+                url: format!("{base}/firmware/blob.bin"),
+                sha256: sha256_hex(firmware_content),
+            }],
+        };
+
+        let result = handle_firmware_upgrade(&reqwest::Client::new(), &task).await;
+
+        assert!(
+            result.success,
+            "expected success, got error: {}",
+            result.error
+        );
+        assert_eq!(result.exit_code, 0);
+        assert!(result.stdout.contains("upgrade complete"));
+        assert!(result.error.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_script_failure_returns_exit_code() {
+        let script = "#!/bin/sh\necho \"something went wrong\" >&2\nexit 42";
+        let base = start_file_server(vec![("/scripts/fail.sh", script)]).await;
+
+        let task = FirmwareUpgradeTask {
+            component_type: "bios".into(),
+            target_version: "2.0.0".into(),
+            script: script_artifact(&base, "/scripts/fail.sh", script),
+            execution_timeout_seconds: 30,
+            artifact_download_timeout_seconds: 30,
+            file_artifacts: vec![],
+        };
+
+        let result = handle_firmware_upgrade(&reqwest::Client::new(), &task).await;
+
+        assert!(!result.success);
+        assert_eq!(result.exit_code, 42);
+        assert!(result.stderr.contains("something went wrong"));
+    }
+
+    #[tokio::test]
+    async fn test_script_timeout() {
+        let script = "#!/bin/sh\nsleep 60";
+        let base = start_file_server(vec![("/scripts/slow.sh", script)]).await;
+
+        let task = FirmwareUpgradeTask {
+            component_type: "cpld".into(),
+            target_version: "1.0.0".into(),
+            script: script_artifact(&base, "/scripts/slow.sh", script),
+            execution_timeout_seconds: 1,
+            artifact_download_timeout_seconds: 30,
+            file_artifacts: vec![],
+        };
+
+        let result = handle_firmware_upgrade(&reqwest::Client::new(), &task).await;
+
+        assert!(!result.success);
+        assert!(result.error.contains("timed out"));
+    }
+
+    #[tokio::test]
+    async fn test_script_receives_env_vars() {
+        let script =
+            "#!/bin/sh\necho \"comp=$COMPONENT_TYPE ver=$TARGET_VERSION dir=$DOWNLOAD_DIR\"";
+        let base = start_file_server(vec![("/scripts/env.sh", script)]).await;
+
+        let task = FirmwareUpgradeTask {
+            component_type: "cpldmb".into(),
+            target_version: "3.4.5".into(),
+            script: script_artifact(&base, "/scripts/env.sh", script),
+            execution_timeout_seconds: 30,
+            artifact_download_timeout_seconds: 30,
+            file_artifacts: vec![],
+        };
+
+        let result = handle_firmware_upgrade(&reqwest::Client::new(), &task).await;
+
+        assert!(result.success, "error: {}", result.error);
+        assert!(result.stdout.contains("comp=cpldmb"));
+        assert!(result.stdout.contains("ver=3.4.5"));
+        assert!(result.stdout.contains("dir="));
+    }
+
+    #[tokio::test]
+    async fn test_download_failure() {
+        let base = start_file_server(vec![]).await;
+
+        let task = FirmwareUpgradeTask {
+            component_type: "cpld".into(),
+            target_version: "1.0.0".into(),
+            script: FileArtifact {
+                url: format!("{base}/scripts/nonexistent.sh"),
+                sha256: "doesntmatter".into(),
+            },
+            execution_timeout_seconds: 30,
+            artifact_download_timeout_seconds: 30,
+            file_artifacts: vec![],
+        };
+
+        let result = handle_firmware_upgrade(&reqwest::Client::new(), &task).await;
+
+        assert!(!result.success);
+        assert!(!result.error.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_checksum_mismatch() {
+        let script = "#!/bin/sh\necho ok";
+        let base = start_file_server(vec![
+            ("/scripts/upgrade.sh", script),
+            ("/firmware/fw.bin", "actual-content"),
+        ])
+        .await;
+
+        let task = FirmwareUpgradeTask {
+            component_type: "cpld".into(),
+            target_version: "1.0.0".into(),
+            script: script_artifact(&base, "/scripts/upgrade.sh", script),
+            execution_timeout_seconds: 30,
+            artifact_download_timeout_seconds: 30,
+            file_artifacts: vec![FileArtifact {
+                url: format!("{base}/firmware/fw.bin"),
+                sha256: "bad_checksum".to_string(),
+            }],
+        };
+
+        let result = handle_firmware_upgrade(&reqwest::Client::new(), &task).await;
+
+        assert!(!result.success);
+        assert!(result.error.contains("checksum mismatch"));
+    }
+
+    #[tokio::test]
+    async fn test_script_checksum_mismatch() {
+        let script = "#!/bin/sh\necho ok";
+        let base = start_file_server(vec![("/scripts/upgrade.sh", script)]).await;
+
+        let task = FirmwareUpgradeTask {
+            component_type: "cpld".into(),
+            target_version: "1.0.0".into(),
+            script: FileArtifact {
+                url: format!("{base}/scripts/upgrade.sh"),
+                sha256: "bad_checksum".into(),
+            },
+            execution_timeout_seconds: 30,
+            artifact_download_timeout_seconds: 30,
+            file_artifacts: vec![],
+        };
+
+        let result = handle_firmware_upgrade(&reqwest::Client::new(), &task).await;
+
+        assert!(!result.success);
+        assert!(result.error.contains("checksum mismatch for script"));
+    }
+
+    #[tokio::test]
+    async fn test_task_json_ser_deser_roundtrip() {
+        let task = FirmwareUpgradeTask {
+            component_type: "cpld".into(),
+            target_version: "1.2.3".into(),
+            script: FileArtifact {
+                url: "http://example.com/script.sh".into(),
+                sha256: "scripthash".into(),
+            },
+            execution_timeout_seconds: 300,
+            artifact_download_timeout_seconds: 120,
+            file_artifacts: vec![FileArtifact {
+                url: "http://example.com/fw.bin".into(),
+                sha256: "abc123".into(),
+            }],
+        };
+
+        let json = serde_json::to_string(&task).unwrap();
+        let parsed: FirmwareUpgradeTask = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.component_type, "cpld");
+        assert_eq!(parsed.target_version, "1.2.3");
+        assert_eq!(parsed.script.url, "http://example.com/script.sh");
+        assert_eq!(parsed.script.sha256, "scripthash");
+        assert_eq!(parsed.execution_timeout_seconds, 300);
+        assert_eq!(parsed.artifact_download_timeout_seconds, 120);
+        assert_eq!(parsed.file_artifacts.len(), 1);
+        assert_eq!(parsed.file_artifacts[0].url, "http://example.com/fw.bin");
+        assert_eq!(parsed.file_artifacts[0].sha256, "abc123");
+    }
+}

--- a/crates/scout/src/main.rs
+++ b/crates/scout/src/main.rs
@@ -50,6 +50,7 @@ mod cfg;
 mod client;
 mod deprovision;
 mod discovery;
+mod firmware_upgrade;
 mod machine_validation;
 mod mlx_device;
 mod register;
@@ -427,8 +428,68 @@ async fn handle_action(
             handle_mlxreport_action(config, machine_id, controller_response.data).await;
             return Ok(());
         }
+        Action::FirmwareUpgrade => {
+            handle_firmware_upgrade_action(config, machine_id, controller_response.data).await?;
+        }
     }
     Ok(())
+}
+
+// handle_firmware_upgrade_action processes a firmware upgrade task received
+// from carbide-api via ForgeAgentControl. The task data is a JSON-serialized
+// FirmwareUpgradeTask in the "firmware_upgrade_task" key-value pair.
+async fn handle_firmware_upgrade_action(
+    _config: &Options,
+    _machine_id: &MachineId,
+    data: Option<ForgeAgentControlExtraInfo>,
+) -> Result<(), CarbideClientError> {
+    let extra = data.ok_or_else(|| {
+        CarbideClientError::GenericError("firmware upgrade action missing extra data".to_string())
+    })?;
+
+    let task_json = extra
+        .pair
+        .iter()
+        .find(|kv| kv.key == "firmware_upgrade_task")
+        .map(|kv| &kv.value)
+        .ok_or_else(|| {
+            CarbideClientError::GenericError(
+                "firmware upgrade action missing firmware_upgrade_task key".to_string(),
+            )
+        })?;
+
+    let task: firmware_upgrade::FirmwareUpgradeTask =
+        serde_json::from_str(task_json).map_err(|e| {
+            CarbideClientError::GenericError(format!("failed to parse firmware upgrade task: {e}"))
+        })?;
+
+    let http_client = reqwest::Client::builder().no_proxy().build().map_err(|e| {
+        CarbideClientError::GenericError(format!("failed to build HTTP client: {e}"))
+    })?;
+
+    tracing::info!(
+        "[firmware_upgrade] received upgrade task for component={} version={}",
+        task.component_type,
+        task.target_version,
+    );
+
+    let result = firmware_upgrade::handle_firmware_upgrade(&http_client, &task).await;
+
+    // TODO: Report upgrade status back to carbide-api via ReportScoutFirmwareUpgradeStatus RPC when it is ready.
+
+    if result.success {
+        tracing::info!(
+            "[firmware_upgrade] completed successfully for component={} version={}",
+            task.component_type,
+            task.target_version,
+        );
+        Ok(())
+    } else {
+        Err(CarbideClientError::GenericError(format!(
+            "[firmware_upgrade] failed for component={} version={}: {}",
+            task.component_type, task.target_version, result.error,
+        )))
+    }
 }
 
 // carbide sent us an Action::MlxReport command in response to our


### PR DESCRIPTION
## Description
This is an alternative to https://github.com/NVIDIA/ncx-infra-controller-core/pull/484 which is approved but not merged yet.

One question remaining is whether we want to use the stream or polling approach for upgrading the firmware. That PR uses the stream approach but @Matthias247 mentioned that since upgrade is a long process the polling approach could be a better approach than streaming.

This PR does that - uses the polling approach to upgrade firmware. If we prefer this approach I will close the other PR.

The whole upgrade-through-scout needs changes on both carbide-api and scout, so I will be coming back to these parts of the codebase to fill up the blanks (marked with TODOs) later once the dependencies are done. This is also the reason why I haven't yet done an integration test and thus some small details may be wrong. They will be fixed once I do an integration test with the whole flow.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

