### PR TITLE
fix: migrate additional read-only paths to DbReader

### DIFF
--- a/crates/api-db/src/dns/domain.rs
+++ b/crates/api-db/src/dns/domain.rs
@@ -183,7 +183,7 @@ pub async fn find_by_name(
 
 /// Find the domain with the given ID, even if it is deleted.
 pub async fn find_by_uuid(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     uuid: DomainId,
 ) -> Result<Option<Domain>, DatabaseError> {
     find_all_by(txn, ObjectColumnFilter::One(IdColumn, &uuid), true)

--- a/crates/api-db/src/dpa_interface.rs
+++ b/crates/api-db/src/dpa_interface.rs
@@ -188,7 +188,7 @@ pub async fn find_ids(txn: impl DbReader<'_>) -> Result<Vec<DpaInterfaceId>, Dat
 // Given an IP address, find and return the DPA interface that has the given IP
 // as its underlay or overlay IP address.
 pub async fn find_by_ip(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     ipaddr: IpAddr,
 ) -> Result<Vec<DpaInterface>, DatabaseError> {
     let query = "SELECT row_to_json(m.*) from (select * from dpa_interfaces
@@ -198,7 +198,7 @@ pub async fn find_by_ip(
         sqlx::query_as(query)
             .bind(ipaddr)
             .bind(ipaddr)
-            .fetch_all(&mut *txn)
+            .fetch_all(txn)
             .await
             .map_err(|e| DatabaseError::query(query, e))?
     };
@@ -243,7 +243,7 @@ pub async fn get_for_pci_name(
 // Find a DPA Interface given its mac address. When we receive messages from the MQTT broker,
 // the topic contains the mac address, and we look up the interface based on that mac address.
 pub async fn find_by_mac_addr(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     maddr: &MacAddress,
 ) -> Result<Vec<DpaInterface>, DatabaseError> {
     let query = "SELECT row_to_json(m.*) from (select * from dpa_interfaces WHERE deleted is NULL AND mac_address = $1) m";
@@ -251,7 +251,7 @@ pub async fn find_by_mac_addr(
     let results: Vec<DpaInterface> = {
         sqlx::query_as(query)
             .bind(maddr)
-            .fetch_all(&mut *txn)
+            .fetch_all(txn)
             .await
             .map_err(|e| DatabaseError::query(query, e))?
     };

--- a/crates/api-db/src/explored_endpoints.rs
+++ b/crates/api-db/src/explored_endpoints.rs
@@ -147,7 +147,7 @@ pub async fn find_by_ips(
 }
 
 /// find_all returns all explored endpoints that site explorer has been able to probe
-pub async fn find_all(txn: &mut PgConnection) -> Result<Vec<ExploredEndpoint>, DatabaseError> {
+pub async fn find_all(txn: impl DbReader<'_>) -> Result<Vec<ExploredEndpoint>, DatabaseError> {
     let query = "SELECT * FROM explored_endpoints";
 
     sqlx::query_as::<_, DbExploredEndpoint>(query)
@@ -514,7 +514,7 @@ pub async fn delete_many(
 /// explored_endpoints_mac_addresses_idx, to avoid a full scan of all endpoint reports. Do NOT
 /// change this query without changing the index to match!
 pub async fn find_by_mac_address(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     mac: MacAddress,
 ) -> Result<Vec<ExploredEndpoint>, DatabaseError> {
     let query = r#"

--- a/crates/api-db/src/instance.rs
+++ b/crates/api-db/src/instance.rs
@@ -135,7 +135,7 @@ WHERE vpc_id = ",
 }
 
 pub async fn find(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     filter: ObjectColumnFilter<'_, IdColumn>,
 ) -> Result<Vec<InstanceSnapshot>, DatabaseError> {
     let mut query = FilterableQueryBuilder::new("SELECT row_to_json(i.*) FROM instances i")

--- a/crates/api-db/src/instance_address.rs
+++ b/crates/api-db/src/instance_address.rs
@@ -54,7 +54,7 @@ impl super::ColumnInfo<'_> for PrefixColumn {
 }
 
 pub async fn find_by_address(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     address: IpAddr,
 ) -> Result<Option<InstanceAddress>, DatabaseError> {
     let query = "SELECT * FROM instance_addresses WHERE address = $1::inet";

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -150,7 +150,7 @@ pub async fn get_or_create(
 }
 
 pub async fn find_one(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     id: &MachineId,
     search_config: MachineSearchConfig,
 ) -> Result<Option<Machine>, DatabaseError> {
@@ -485,7 +485,7 @@ pub async fn find_by_mac_address(
 }
 
 pub async fn find_by_loopback_ip(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     loopback_ip: &str,
 ) -> Result<Option<Machine>, DatabaseError> {
     lazy_static! {
@@ -1295,7 +1295,7 @@ pub async fn create(
         )));
     }
 
-    let machine = find_one(txn, stable_machine_id, MachineSearchConfig::default())
+    let machine = find_one(&mut *txn, stable_machine_id, MachineSearchConfig::default())
         .await?
         .ok_or_else(|| DatabaseError::NotFoundError {
             kind: "machine",
@@ -1598,7 +1598,7 @@ pub async fn apply_agent_upgrade_policy(
     if policy == AgentUpgradePolicy::Off {
         return Ok(false);
     }
-    let machine = find_one(txn, machine_id, MachineSearchConfig::default())
+    let machine = find_one(&mut *txn, machine_id, MachineSearchConfig::default())
         .await?
         .ok_or_else(|| DatabaseError::NotFoundError {
             kind: "dpu_machine",
@@ -1730,7 +1730,7 @@ pub async fn update_state(
     new_state: &ManagedHostState,
 ) -> Result<(), DatabaseError> {
     let host = find_one(
-        txn,
+        &mut *txn,
         host_id,
         // TODO(?): Should we be using for_update/row-level locks here?
         // This is a select that's later used for an update on both version
@@ -2179,7 +2179,7 @@ pub async fn find_machine_ids_by_sku_ids(
 }
 
 pub async fn get_network_config(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     machine_id: &MachineId,
 ) -> Result<Versioned<ManagedHostNetworkConfig>, DatabaseError> {
     #[derive(FromRow)]
@@ -2203,7 +2203,7 @@ pub async fn get_network_config(
 }
 
 pub async fn get_quarantine_state(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     machine_id: &MachineId,
 ) -> Result<Option<ManagedHostQuarantineState>, DatabaseError> {
     let network_config = get_network_config(txn, machine_id).await?;
@@ -2216,7 +2216,7 @@ pub async fn set_quarantine_state(
     quarantine_state: ManagedHostQuarantineState,
 ) -> Result<Option<ManagedHostQuarantineState>, DatabaseError> {
     let (mut network_config, network_config_version) =
-        get_network_config(txn, machine_id).await?.take();
+        get_network_config(&mut *txn, machine_id).await?.take();
     let old_quarantine_state = network_config.quarantine_state.clone();
     network_config.quarantine_state = Some(quarantine_state);
     try_update_network_config(txn, machine_id, network_config_version, &network_config).await?;
@@ -2228,7 +2228,7 @@ pub async fn clear_quarantine_state(
     machine_id: &MachineId,
 ) -> Result<Option<ManagedHostQuarantineState>, DatabaseError> {
     let (mut network_config, network_config_version) =
-        get_network_config(txn, machine_id).await?.take();
+        get_network_config(&mut *txn, machine_id).await?.take();
     let old_quarantine_state = network_config.quarantine_state.clone();
     network_config.quarantine_state = None;
     try_update_network_config(txn, machine_id, network_config_version, &network_config).await?;
@@ -2345,7 +2345,7 @@ mod test {
         txn.commit().await?;
         let mut txn: sqlx::Transaction<'_, sqlx::Postgres> = pool.begin().await.unwrap();
 
-        let host = crate::machine::find_one(&mut txn, &id, MachineSearchConfig::default())
+        let host = crate::machine::find_one(&mut *txn, &id, MachineSearchConfig::default())
             .await
             .unwrap()
             .unwrap();
@@ -2354,7 +2354,7 @@ mod test {
         txn.commit().await?;
         let mut txn: sqlx::Transaction<'_, sqlx::Postgres> = pool.begin().await.unwrap();
         super::set_firmware_autoupdate(&mut txn, &id, None).await?;
-        let host = crate::machine::find_one(&mut txn, &id, MachineSearchConfig::default())
+        let host = crate::machine::find_one(&mut *txn, &id, MachineSearchConfig::default())
             .await
             .unwrap()
             .unwrap();

--- a/crates/api-db/src/machine_boot_override.rs
+++ b/crates/api-db/src/machine_boot_override.rs
@@ -19,6 +19,7 @@ use carbide_uuid::machine::MachineInterfaceId;
 use model::machine_boot_override::MachineBootOverride;
 use sqlx::PgConnection;
 
+use crate::db_read::DbReader;
 use crate::{
     ColumnInfo, DatabaseError, DatabaseResult, FilterableQueryBuilder, ObjectColumnFilter,
 };
@@ -55,7 +56,7 @@ pub async fn update_or_insert(
     value: &MachineBootOverride,
     txn: &mut PgConnection,
 ) -> DatabaseResult<()> {
-    match find_optional(txn, value.machine_interface_id).await? {
+    match find_optional(&mut *txn, value.machine_interface_id).await? {
         Some(existing_mbo) => {
             let custom_pxe = if value.custom_pxe.is_some() {
                 value.custom_pxe.clone()
@@ -107,7 +108,7 @@ pub async fn clear(
 }
 
 pub async fn find_optional(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     machine_interface_id: MachineInterfaceId,
 ) -> DatabaseResult<Option<MachineBootOverride>> {
     let mut interfaces = find_by(
@@ -125,7 +126,7 @@ pub async fn find_optional(
 }
 
 async fn find_by<'a, C: ColumnInfo<'a, TableType = MachineBootOverride>>(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     filter: ObjectColumnFilter<'a, C>,
 ) -> Result<Vec<MachineBootOverride>, DatabaseError> {
     let mut query =

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -201,7 +201,7 @@ pub async fn associate_interface_with_machine(
 }
 
 pub async fn find_by_mac_address(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     macaddr: MacAddress,
 ) -> Result<Vec<MachineInterfaceSnapshot>, DatabaseError> {
     find_by(txn, ObjectColumnFilter::One(MacAddressColumn, &macaddr)).await
@@ -260,7 +260,7 @@ pub async fn count_by_segment_id(
 }
 
 pub async fn find_one(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     interface_id: MachineInterfaceId,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
     let mut interfaces = find_by(txn, ObjectColumnFilter::One(IdColumn, &interface_id)).await?;
@@ -321,7 +321,7 @@ pub async fn validate_existing_mac_and_create(
     relay: IpAddr,
     host_nic: Option<ExpectedHostNic>,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
-    let mut existing_mac = find_by_mac_address(txn, mac_address).await?;
+    let mut existing_mac = find_by_mac_address(&mut *txn, mac_address).await?;
     match &existing_mac.len() {
         0 => {
             tracing::debug!(
@@ -892,7 +892,7 @@ fn address_to_hostname(address: &IpAddr) -> DatabaseResult<String> {
 }
 
 async fn find_by<'a, C: ColumnInfo<'a, TableType = MachineInterfaceSnapshot>>(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     filter: ObjectColumnFilter<'a, C>,
 ) -> Result<Vec<MachineInterfaceSnapshot>, DatabaseError> {
     let mut query = FilterableQueryBuilder::new(MACHINE_INTERFACE_SNAPSHOT_QUERY)
@@ -954,7 +954,7 @@ pub async fn move_predicted_machine_interface_to_machine(
     }
 
     let machine_interface_id = match self::find_by_mac_address(
-        txn,
+        &mut *txn,
         predicted_machine_interface.mac_address,
     )
     .await?

--- a/crates/api-db/src/machine_interface_address.rs
+++ b/crates/api-db/src/machine_interface_address.rs
@@ -21,6 +21,7 @@ use model::network_segment::NetworkSegmentType;
 use sqlx::{FromRow, PgConnection};
 
 use super::DatabaseError;
+use crate::db_read::DbReader;
 
 #[derive(Debug, FromRow, Clone)]
 pub struct MachineInterfaceAddress {
@@ -41,7 +42,7 @@ pub async fn find_ipv4_for_interface(
 }
 
 pub async fn find_by_address(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     address: IpAddr,
 ) -> Result<Option<MachineInterfaceSearchResult>, DatabaseError> {
     let query = "SELECT mi.id, mi.machine_id, ns.name, ns.network_segment_type

--- a/crates/api-db/src/machine_topology.rs
+++ b/crates/api-db/src/machine_topology.rs
@@ -196,7 +196,7 @@ pub async fn find_latest_by_machine_ids(
 }
 
 pub async fn find_machine_id_by_bmc_ip(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     address: &str,
 ) -> Result<Option<MachineId>, DatabaseError> {
     let query = "SELECT machine_id FROM machine_topologies WHERE topology->'bmc_info'->>'ip' = $1";

--- a/crates/api-db/src/machine_validation.rs
+++ b/crates/api-db/src/machine_validation.rs
@@ -176,16 +176,20 @@ pub async fn create_new_run(
     Ok(id)
 }
 
-pub async fn find(
-    txn: &mut PgConnection,
+pub async fn find<DB>(
+    txn: &mut DB,
     machine_id: &MachineId,
     include_history: bool,
-) -> DatabaseResult<Vec<MachineValidation>> {
+) -> DatabaseResult<Vec<MachineValidation>>
+where
+    for<'db> &'db mut DB: DbReader<'db>,
+{
     if include_history {
-        return find_by_machine_id(txn, machine_id).await;
+        return find_by_machine_id(&mut *txn, machine_id).await;
     };
     let machine =
-        match crate::machine::find_one(txn, machine_id, MachineSearchConfig::default()).await {
+        match crate::machine::find_one(&mut *txn, machine_id, MachineSearchConfig::default()).await
+        {
             Err(err) => {
                 tracing::warn!(%machine_id, error = %err, "failed loading machine");
                 return Err(DatabaseError::InvalidArgument(
@@ -208,7 +212,7 @@ pub async fn find(
     let on_demand_machine_validation_id =
         machine.on_demand_machine_validation_id.unwrap_or_default();
     find_by(
-        txn,
+        &mut *txn,
         ObjectFilter::List(&[
             cleanup_machine_validation_id.to_string(),
             discovery_machine_validation_id.to_string(),
@@ -261,7 +265,7 @@ pub async fn find_by_id(
     )))
 }
 
-pub async fn find_all(txn: &mut PgConnection) -> DatabaseResult<Vec<MachineValidation>> {
+pub async fn find_all(txn: impl DbReader<'_>) -> DatabaseResult<Vec<MachineValidation>> {
     find_by(txn, ObjectFilter::All, "").await
 }
 

--- a/crates/api-db/src/machine_validation_result.rs
+++ b/crates/api-db/src/machine_validation_result.rs
@@ -19,13 +19,17 @@ use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine_validation::MachineValidationResult;
 use sqlx::PgConnection;
 
+use crate::db_read::DbReader;
 use crate::{DatabaseError, DatabaseResult, ObjectFilter, machine_validation_suites};
 
-pub async fn find_by_machine_id(
-    txn: &mut PgConnection,
+pub async fn find_by_machine_id<DB>(
+    txn: &mut DB,
     machine_id: &MachineId,
     include_history: bool,
-) -> DatabaseResult<Vec<MachineValidationResult>> {
+) -> DatabaseResult<Vec<MachineValidationResult>>
+where
+    for<'db> &'db mut DB: DbReader<'db>,
+{
     if include_history {
         // Fetch all validation_id from machine_validation table
         let machine_validation = crate::machine_validation::find_by(
@@ -39,10 +43,16 @@ pub async fn find_by_machine_id(
         for item in machine_validation {
             columns.push(item.id.to_string());
         }
-        return find_by(txn, ObjectFilter::List(&columns), "machine_validation_id").await;
+        return find_by(
+            &mut *txn,
+            ObjectFilter::List(&columns),
+            "machine_validation_id",
+        )
+        .await;
     };
     let machine =
-        match crate::machine::find_one(txn, machine_id, MachineSearchConfig::default()).await {
+        match crate::machine::find_one(&mut *txn, machine_id, MachineSearchConfig::default()).await
+        {
             Err(err) => {
                 tracing::warn!(%machine_id, error = %err, "failed loading machine");
                 return Err(DatabaseError::InvalidArgument(
@@ -65,7 +75,7 @@ pub async fn find_by_machine_id(
     let on_demand_machine_validation_id =
         machine.on_demand_machine_validation_id.unwrap_or_default();
     find_by(
-        txn,
+        &mut *txn,
         ObjectFilter::List(&[
             cleanup_machine_validation_id.to_string(),
             discovery_machine_validation_id.to_string(),
@@ -77,7 +87,7 @@ pub async fn find_by_machine_id(
 }
 
 async fn find_by(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     filter: ObjectFilter<'_, String>,
     column: &str,
 ) -> Result<Vec<MachineValidationResult>, DatabaseError> {
@@ -189,7 +199,7 @@ pub async fn validate_current_context(
 }
 
 pub async fn find_by_validation_id(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     id: &uuid::Uuid,
 ) -> DatabaseResult<Vec<MachineValidationResult>> {
     find_by(

--- a/crates/api-db/src/network_prefix.rs
+++ b/crates/api-db/src/network_prefix.rs
@@ -25,6 +25,7 @@ use model::network_prefix::{NetworkPrefix, NewNetworkPrefix};
 use sqlx::PgConnection;
 
 use super::DatabaseError;
+use crate::db_read::DbReader;
 
 #[derive(Clone, Copy)]
 pub struct SegmentIdColumn;
@@ -40,7 +41,7 @@ impl super::ColumnInfo<'_> for SegmentIdColumn {
 
 /// Fetch the prefix that matches, is a subnet of, or contains the given one.
 pub async fn containing_prefix(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     prefix: &str,
 ) -> Result<Vec<NetworkPrefix>, DatabaseError> {
     let query = "select * from network_prefixes where prefix && $1::inet";

--- a/crates/api-db/src/resource_pool.rs
+++ b/crates/api-db/src/resource_pool.rs
@@ -36,6 +36,7 @@ use tokio::sync::oneshot;
 
 use super::BIND_LIMIT;
 use crate::DatabaseError;
+use crate::db_read::DbReader;
 
 /// Put some resources into the pool, so they can be allocated later.
 /// This needs to be called before `allocate` can return anything.
@@ -274,7 +275,7 @@ pub async fn all(txn: &mut PgConnection) -> Result<Vec<ResourcePoolSnapshot>, Da
 
 /// All the resource pool entries for the given value
 pub async fn find_value(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     value: &str,
 ) -> Result<Vec<ResourcePoolEntry>, DatabaseError> {
     let query =

--- a/crates/api-db/src/route_servers.rs
+++ b/crates/api-db/src/route_servers.rs
@@ -77,7 +77,7 @@ pub async fn get(txn: impl DbReader<'_>) -> DatabaseResult<Vec<RouteServer>> {
 // find_by_address returns a RouteServer entry matching
 // the provided address, if it exists.
 pub async fn find_by_address(
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
     address: IpAddr,
 ) -> DatabaseResult<Option<RouteServer>> {
     let query = r#"SELECT * FROM route_servers where address=$1;"#;

--- a/crates/api-db/src/site_exploration_report.rs
+++ b/crates/api-db/src/site_exploration_report.rs
@@ -16,14 +16,17 @@
  */
 
 use model::site_explorer::SiteExplorationReport;
-use sqlx::PgConnection;
 
 use crate::DatabaseError;
+use crate::db_read::DbReader;
 
 /// Fetches the latest site exploration report from the database
-pub async fn fetch(txn: &mut PgConnection) -> Result<SiteExplorationReport, DatabaseError> {
-    let endpoints = crate::explored_endpoints::find_all(txn).await?;
-    let managed_hosts = crate::explored_managed_host::find_all(txn).await?;
+pub async fn fetch<DB>(db: &mut DB) -> Result<SiteExplorationReport, DatabaseError>
+where
+    for<'db> &'db mut DB: DbReader<'db>,
+{
+    let endpoints = crate::explored_endpoints::find_all(&mut *db).await?;
+    let managed_hosts = crate::explored_managed_host::find_all(db).await?;
     Ok(SiteExplorationReport {
         endpoints,
         managed_hosts,

--- a/crates/api/src/dhcp/discover.rs
+++ b/crates/api/src/dhcp/discover.rs
@@ -138,7 +138,7 @@ async fn handle_dhcp_from_dpa(
         return Ok(None);
     }
 
-    let mut dpa_ifs = db::dpa_interface::find_by_mac_addr(txn, &macaddr).await?;
+    let mut dpa_ifs = db::dpa_interface::find_by_mac_addr(&mut *txn, &macaddr).await?;
 
     if dpa_ifs.len() != 1 {
         // If the MAC address does not belong to any DPA object, len will be 0.

--- a/crates/api/src/dpa/handler.rs
+++ b/crates/api/src/dpa/handler.rs
@@ -76,7 +76,7 @@ async fn handle_dpa_message(services: Arc<Api>, message: SetVni, topic: String) 
         }
     };
 
-    let mut dpa_ifs = match db::dpa_interface::find_by_mac_addr(&mut txn, &macaddr).await {
+    let mut dpa_ifs = match db::dpa_interface::find_by_mac_addr(txn.as_mut(), &macaddr).await {
         Ok(ifs) => ifs,
         Err(e) => {
             error!("handle_dpa_message -  Error from find_by_mac_addr {e}");

--- a/crates/api/src/dpf.rs
+++ b/crates/api/src/dpf.rs
@@ -345,7 +345,7 @@ async fn enqueue_host(db_pool: &PgPool, node_name: &str, reason: &str) -> Result
             DpfError::InvalidState(format!("Failed to acquire database connection: {e}"))
         })?;
         db::machine::find_one(
-            &mut conn,
+            &mut *conn,
             &host_machine_id,
             model::machine::machine_search_config::MachineSearchConfig::default(),
         )

--- a/crates/api/src/ethernet_virtualization.rs
+++ b/crates/api/src/ethernet_virtualization.rs
@@ -101,7 +101,7 @@ pub async fn admin_network(
 
     let domain = match admin_segment.subdomain_id {
         Some(domain_id) => {
-            db::dns::domain::find_by_uuid(txn, domain_id)
+            db::dns::domain::find_by_uuid(&mut *txn, domain_id)
                 .await
                 .map_err(CarbideError::from)?
                 .ok_or_else(|| CarbideError::NotFoundError {

--- a/crates/api/src/handlers/boot_override.rs
+++ b/crates/api/src/handlers/boot_override.rs
@@ -40,7 +40,8 @@ pub(crate) async fn get(
         crate::api::log_machine_id(&machine_id);
     }
 
-    let mbo = match db::machine_boot_override::find_optional(&mut txn, machine_interface_id).await?
+    let mbo = match db::machine_boot_override::find_optional(txn.as_pgconn(), machine_interface_id)
+        .await?
     {
         Some(mbo) => mbo,
         None => MachineBootOverride {

--- a/crates/api/src/handlers/dpa.rs
+++ b/crates/api/src/handlers/dpa.rs
@@ -168,19 +168,14 @@ pub(crate) async fn find_dpa_interfaces_by_ids(
         .into());
     }
 
-    // Prepare our txn to grab the NetworkSecurityGroups from the DB
-    let mut txn = api.txn_begin().await?;
-
     let dpa_ifs_int =
-        db::dpa_interface::find_by_ids(&mut txn, &req.ids, req.include_history).await?;
+        db::dpa_interface::find_by_ids(&api.database_connection, &req.ids, req.include_history)
+            .await?;
 
     let rpc_dpa_ifs = dpa_ifs_int
         .into_iter()
         .map(|i| i.into())
         .collect::<Vec<rpc::forge::DpaInterface>>();
-
-    // Commit if nothing has gone wrong up to now
-    txn.commit().await?;
 
     Ok(Response::new(rpc::forge::DpaInterfaceList {
         interfaces: rpc_dpa_ifs,

--- a/crates/api/src/handlers/dpu.rs
+++ b/crates/api/src/handlers/dpu.rs
@@ -370,7 +370,7 @@ pub(crate) async fn get_managed_host_network_config_inner(
 
             let domain = match segment.subdomain_id {
                 Some(domain_id) => {
-                    db::dns::domain::find_by_uuid(&mut txn, domain_id)
+                    db::dns::domain::find_by_uuid(txn.as_pgconn(), domain_id)
                         .await
                         .map_err(CarbideError::from)?
                         .ok_or_else(|| CarbideError::NotFoundError {

--- a/crates/api/src/handlers/finder.rs
+++ b/crates/api/src/handlers/finder.rs
@@ -203,7 +203,7 @@ async fn search(
 ) -> Result<Option<rpc::IpAddressMatch>, CarbideError> {
     let addr: IpAddr = ip.parse()?;
 
-    let mut txn = api.txn_begin().await?;
+    let db = &api.database_connection;
 
     use Finder::*;
     let match_result = match finder {
@@ -222,7 +222,7 @@ async fn search(
 
         // Look for IP address in resource pools
         ResourcePools => {
-            let mut vec_out = db::resource_pool::find_value(&mut txn, ip).await?;
+            let mut vec_out = db::resource_pool::find_value(db, ip).await?;
             let entry = match vec_out.len() {
                 0 => return Ok(None),
                 1 => vec_out.remove(0),
@@ -259,7 +259,7 @@ async fn search(
 
         // Look in instance_addresses
         InstanceAddresses => {
-            let instance_address = db::instance_address::find_by_address(&mut txn, addr).await?;
+            let instance_address = db::instance_address::find_by_address(db, addr).await?;
 
             instance_address.map(|e| {
                 let message = format!(
@@ -276,7 +276,7 @@ async fn search(
 
         // Look in machine_interface_addresses
         MachineAddresses => {
-            let out = db::machine_interface_address::find_by_address(&mut txn, addr).await?;
+            let out = db::machine_interface_address::find_by_address(db, addr).await?;
             out.map(|e| {
                 let message = match e.machine_id.as_ref() {
                     Some(machine_id) => format!(
@@ -298,7 +298,7 @@ async fn search(
 
         // BMC IP of the host
         BmcIp => {
-            let out = db::machine_topology::find_machine_id_by_bmc_ip(&mut txn, ip).await?;
+            let out = db::machine_topology::find_machine_id_by_bmc_ip(db, ip).await?;
             out.map(|machine_id| rpc::IpAddressMatch {
                 ip_type: rpc::IpType::BmcIp as i32,
                 owner_id: Some(machine_id.to_string()),
@@ -306,7 +306,7 @@ async fn search(
             })
         }
         ExploredEndpoint => {
-            let out = db::explored_endpoints::find_by_ips(&mut txn, vec![addr]).await?;
+            let out = db::explored_endpoints::find_by_ips(db, vec![addr]).await?;
             out.first().map(|ee| rpc::IpAddressMatch {
                 ip_type: rpc::IpType::ExploredEndpoint as i32,
                 owner_id: Some(ee.address.to_string()),
@@ -316,7 +316,7 @@ async fn search(
 
         // Loopback IP of a DPU
         LoopbackIp => {
-            let out = db::machine::find_by_loopback_ip(&mut txn, ip).await?;
+            let out = db::machine::find_by_loopback_ip(db, ip).await?;
             out.map(|machine| rpc::IpAddressMatch {
                 ip_type: rpc::IpType::LoopbackIp as i32,
                 owner_id: Some(machine.id.to_string()),
@@ -328,8 +328,7 @@ async fn search(
         NetworkSegment => {
             let host_prefix = addr.address_family().interface_prefix_len();
             let out =
-                db::network_prefix::containing_prefix(&mut txn, &format!("{ip}/{host_prefix}"))
-                    .await?;
+                db::network_prefix::containing_prefix(db, &format!("{ip}/{host_prefix}")).await?;
             out.first().map(|prefix| {
                 let message = format!(
                     "{ip} is in prefix {} of segment {}, gateway {}",
@@ -352,7 +351,7 @@ async fn search(
         // source (via the config TOML), or an "admin" source (via
         // forge-admin-cli).
         RouteServers => {
-            let out = db::route_servers::find_by_address(&mut txn, addr).await?;
+            let out = db::route_servers::find_by_address(db, addr).await?;
             out.map(|route_server| rpc::IpAddressMatch {
                 ip_type: match route_server.source_type {
                     RouteServerSourceType::AdminApi => rpc::IpType::RouteServerFromAdminApi,
@@ -367,7 +366,7 @@ async fn search(
         }
 
         DpaAddresses => {
-            let out = db::dpa_interface::find_by_ip(&mut txn, addr).await?;
+            let out = db::dpa_interface::find_by_ip(db, addr).await?;
 
             out.first().map(|dpa| rpc::IpAddressMatch {
                 ip_type: rpc::IpType::DpaInterface as i32,
@@ -377,18 +376,16 @@ async fn search(
         }
     };
 
-    // not strictly necessary, we could drop the txn and it would rollback
-    txn.commit().await?;
-
     Ok(match_result)
 }
 
 async fn by_uuid(api: &Api, u: &rpc_common::Uuid) -> Result<Option<rpc::UuidType>, CarbideError> {
-    let mut txn = api.txn_begin().await?;
+    let db = &api.database_connection;
+    let mut db_reader = api.db_reader();
 
     if let Ok(ns_id) = NetworkSegmentId::from_str(&u.value) {
         let segments = db::network_segment::find_by(
-            &mut txn,
+            &mut db_reader,
             ObjectColumnFilter::List(network_segment::IdColumn, &[ns_id]),
             NetworkSegmentSearchConfig {
                 include_history: false,
@@ -403,7 +400,7 @@ async fn by_uuid(api: &Api, u: &rpc_common::Uuid) -> Result<Option<rpc::UuidType
 
     if let Ok(instance_id) = InstanceId::from_str(&u.value) {
         let instances = db::instance::find(
-            &mut txn,
+            db,
             ObjectColumnFilter::One(instance::IdColumn, &instance_id),
         )
         .await?;
@@ -413,23 +410,20 @@ async fn by_uuid(api: &Api, u: &rpc_common::Uuid) -> Result<Option<rpc::UuidType
     }
 
     if let Ok(mi_id) = MachineInterfaceId::from_str(&u.value)
-        && db::machine_interface::find_one(&mut txn, mi_id)
-            .await
-            .is_ok()
+        && db::machine_interface::find_one(db, mi_id).await.is_ok()
     {
         return Ok(Some(rpc::UuidType::MachineInterface));
     }
 
     if let Ok(vpc_id) = VpcId::from_str(&u.value) {
-        let vpcs =
-            db::vpc::find_by(&mut txn, ObjectColumnFilter::One(vpc::IdColumn, &vpc_id)).await?;
+        let vpcs = db::vpc::find_by(db, ObjectColumnFilter::One(vpc::IdColumn, &vpc_id)).await?;
         if vpcs.len() == 1 {
             return Ok(Some(rpc::UuidType::Vpc));
         }
     }
 
     if let Ok(id) = DpaInterfaceId::from_str(&u.value) {
-        let dpas = db::dpa_interface::find_by_ids(&mut txn, &[id], false).await?;
+        let dpas = db::dpa_interface::find_by_ids(db, &[id], false).await?;
         if dpas.len() == 1 {
             return Ok(Some(rpc::UuidType::DpaInterfaceId));
         }
@@ -437,7 +431,7 @@ async fn by_uuid(api: &Api, u: &rpc_common::Uuid) -> Result<Option<rpc::UuidType
 
     if let Ok(domain_id) = DomainId::from_str(&u.value) {
         let domains = db::dns::domain::find_by(
-            &mut txn,
+            db,
             ObjectColumnFilter::One(db::dns::domain::IdColumn, &domain_id),
         )
         .await?;
@@ -446,8 +440,6 @@ async fn by_uuid(api: &Api, u: &rpc_common::Uuid) -> Result<Option<rpc::UuidType
         }
     }
 
-    txn.commit().await?;
-
     Ok(None)
 }
 
@@ -455,9 +447,9 @@ async fn by_mac(
     api: &Api,
     mac: mac_address::MacAddress,
 ) -> Result<Option<(String, rpc::MacOwner)>, DatabaseError> {
-    let mut txn = api.txn_begin().await?;
+    let db = &api.database_connection;
 
-    match db::machine_interface::find_by_mac_address(&mut txn, mac).await {
+    match db::machine_interface::find_by_mac_address(db, mac).await {
         Ok(interfaces) if interfaces.len() == 1 => {
             return Ok(Some((
                 interfaces[0].id.to_string(),
@@ -478,7 +470,7 @@ async fn by_mac(
         }
     }
 
-    let endpoints = db::explored_endpoints::find_by_mac_address(&mut txn, mac).await?;
+    let endpoints = db::explored_endpoints::find_by_mac_address(db, mac).await?;
     if endpoints.len() == 1 {
         return Ok(Some((
             endpoints[0].address.to_string(),
@@ -486,7 +478,7 @@ async fn by_mac(
         )));
     }
 
-    let expected = db::expected_machine::find_by_bmc_mac_address(&mut txn, mac).await?;
+    let expected = db::expected_machine::find_by_bmc_mac_address(db, mac).await?;
     if let Some(em) = expected {
         return Ok(Some((
             em.data.serial_number,
@@ -494,7 +486,7 @@ async fn by_mac(
         )));
     }
 
-    match db::dpa_interface::find_by_mac_addr(&mut txn, &mac).await {
+    match db::dpa_interface::find_by_mac_addr(db, &mac).await {
         Ok(ifs) => match ifs.as_slice() {
             [iface] => return Ok(Some((iface.id.to_string(), rpc::MacOwner::DpaInterface))),
             [] => {} // expected, continue to search other object types
@@ -507,7 +499,6 @@ async fn by_mac(
     };
 
     // Any other MAC addresses to search?
-    txn.commit().await?;
 
     Ok(None)
 }

--- a/crates/api/src/handlers/health.rs
+++ b/crates/api/src/handlers/health.rs
@@ -63,7 +63,7 @@ async fn remove_by_source(
     source: String,
 ) -> Result<(), CarbideError> {
     let host_machine = db::machine::find_one(
-        txn,
+        &mut *txn,
         &machine_id,
         MachineSearchConfig {
             // Technically,  an update is going to happen,

--- a/crates/api/src/handlers/machine_interface.rs
+++ b/crates/api/src/handlers/machine_interface.rs
@@ -76,7 +76,7 @@ pub(crate) async fn find_interfaces(
                     "Impossible interface.address array length",
                 ));
             };
-            match db::machine_topology::find_machine_id_by_bmc_ip(&mut txn, ip).await {
+            match db::machine_topology::find_machine_id_by_bmc_ip(txn.as_pgconn(), ip).await {
                 Ok(Some(machine_id)) => {
                     let rpc_machine_id = Some(machine_id);
                     interface.is_bmc = Some(true);
@@ -125,7 +125,8 @@ pub(crate) async fn delete_interface(
     // There should not be any BMC information associated with any machine.
     for address in interface.addresses.iter() {
         let machine_id =
-            db::machine_topology::find_machine_id_by_bmc_ip(&mut txn, &address.to_string()).await?;
+            db::machine_topology::find_machine_id_by_bmc_ip(txn.as_pgconn(), &address.to_string())
+                .await?;
 
         if let Some(machine_id) = machine_id {
             return Err(Status::invalid_argument(format!(

--- a/crates/api/src/handlers/machine_quarantine.rs
+++ b/crates/api/src/handlers/machine_quarantine.rs
@@ -61,13 +61,9 @@ pub(crate) async fn get_managed_host_quarantine_state(
     let rpc::GetManagedHostQuarantineStateRequest { machine_id } = request.into_inner();
     let machine_id = convert_and_log_machine_id(machine_id.as_ref())?;
 
-    let mut txn = api.txn_begin().await?;
-
-    let quarantine_state = db::machine::get_quarantine_state(&mut txn, &machine_id)
+    let quarantine_state = db::machine::get_quarantine_state(&api.database_connection, &machine_id)
         .await?
         .map(Into::into);
-
-    txn.commit().await?;
 
     Ok(Response::new(rpc::GetManagedHostQuarantineStateResponse {
         quarantine_state,

--- a/crates/api/src/handlers/machine_validation.rs
+++ b/crates/api/src/handlers/machine_validation.rs
@@ -258,12 +258,11 @@ pub(crate) async fn get_machine_validation_results(
         }
     };
 
-    let mut txn = api.txn_begin().await?;
-
+    let mut db_reader = api.db_reader();
     let mut db_results: Vec<MachineValidationResult> = Vec::new();
     if let Some(machine_id) = machine_id.as_ref() {
         db_results = db::machine_validation_result::find_by_machine_id(
-            &mut txn,
+            &mut db_reader,
             machine_id,
             req.include_history,
         )
@@ -273,16 +272,17 @@ pub(crate) async fn get_machine_validation_results(
             db_results.retain(|x| x.validation_id == validation_id)
         }
     } else if let Some(validation_id) = validation_id {
-        db_results =
-            db::machine_validation_result::find_by_validation_id(&mut txn, &validation_id).await?;
+        db_results = db::machine_validation_result::find_by_validation_id(
+            &api.database_connection,
+            &validation_id,
+        )
+        .await?;
     }
 
     let vec_rest = db_results
         .into_iter()
         .map(rpc::MachineValidationResult::from)
         .collect();
-
-    txn.commit().await?;
 
     Ok(tonic::Response::new(rpc::MachineValidationResultList {
         results: vec_rest,
@@ -336,13 +336,12 @@ pub(crate) async fn get_machine_validation_runs(
     log_request_data(&request);
     let machine_validation_run_request: rpc::MachineValidationRunListGetRequest =
         request.into_inner();
-    let mut txn = api.txn_begin().await?;
-
+    let mut db_reader = api.db_reader();
     let db_runs = match machine_validation_run_request.machine_id {
         Some(id) => {
             let machine_id = convert_and_log_machine_id(Some(&id))?;
             db::machine_validation::find(
-                &mut txn,
+                &mut db_reader,
                 &machine_id,
                 machine_validation_run_request.include_history,
             )
@@ -350,7 +349,7 @@ pub(crate) async fn get_machine_validation_runs(
         }
         None => {
             tracing::info!("no machine ID");
-            db::machine_validation::find_all(&mut txn).await
+            db::machine_validation::find_all(&api.database_connection).await
         }
     };
     let ret = db_runs
@@ -364,7 +363,6 @@ pub(crate) async fn get_machine_validation_runs(
         )
         .map(Response::new)?;
 
-    txn.commit().await?;
     Ok(ret)
 }
 

--- a/crates/api/src/handlers/managed_host.rs
+++ b/crates/api/src/handlers/managed_host.rs
@@ -167,7 +167,7 @@ pub(crate) async fn set_primary_dpu(
 
     // increment the network config version so that the DPUs pick up their new config
     let (network_config, network_config_version) =
-        db::machine::get_network_config(&mut txn, &host_machine_id)
+        db::machine::get_network_config(txn.as_pgconn(), &host_machine_id)
             .await?
             .take();
     db::machine::try_update_network_config(

--- a/crates/api/src/handlers/pxe.rs
+++ b/crates/api/src/handlers/pxe.rs
@@ -51,7 +51,7 @@ pub(crate) async fn get_cloud_init_instructions(
     let cloud_name = "nvidia".to_string();
     let platform = "forge".to_string();
 
-    let mut txn = api.txn_begin().await?;
+    let db = &api.database_connection;
 
     let ip_str = &request.into_inner().ip;
     let ip: IpAddr = ip_str
@@ -65,10 +65,10 @@ pub(crate) async fn get_cloud_init_instructions(
     // prefix, network segment, and IP allocators behind the scenes for supporting
     // dual stacking interfaces, none of that means much until DHCPv6 is working
     // to actually hand those addresses out.
-    let instructions = match db::instance_address::find_by_address(&mut txn, ip).await? {
+    let instructions = match db::instance_address::find_by_address(db, ip).await? {
         None => {
             // assume there is no instance associated with this IP and check if there is an interface associated with it
-            let machine_interface = db::machine_interface::find_by_ip(&mut txn, ip)
+            let machine_interface = db::machine_interface::find_by_ip(db, ip)
                 .await?
                 .ok_or_else(|| {
                     CarbideError::internal(format!("No machine interface with IP {ip} was found"))
@@ -81,7 +81,7 @@ pub(crate) async fn get_cloud_init_instructions(
                 ))
             })?;
 
-            let domain = db::dns::domain::find_by_uuid(&mut txn, domain_id)
+            let domain = db::dns::domain::find_by_uuid(db, domain_id)
                 .await
                 .map_err(CarbideError::from)?
                 .ok_or_else(|| {
@@ -94,9 +94,7 @@ pub(crate) async fn get_cloud_init_instructions(
             // It is possible for the user data to be null if we are only trying to test the pxe, and this will
             // follow the same code path and retrieve the non custom user data
             let custom_cloud_init =
-                match db::machine_boot_override::find_optional(&mut txn, machine_interface.id)
-                    .await?
-                {
+                match db::machine_boot_override::find_optional(db, machine_interface.id).await? {
                     Some(machine_boot_override) => machine_boot_override.custom_user_data,
                     None => None,
                 };
@@ -168,7 +166,7 @@ pub(crate) async fn get_cloud_init_instructions(
         }
 
         Some(instance_address) => {
-            let instance = db::instance::find_by_id(&mut txn, instance_address.instance_id)
+            let instance = db::instance::find_by_id(db, instance_address.instance_id)
                 .await?
                 .ok_or_else(|| {
                     // Note that this isn't a NotFound error since it indicates an
@@ -190,8 +188,6 @@ pub(crate) async fn get_cloud_init_instructions(
             }
         }
     };
-
-    txn.commit().await?;
 
     Ok(Response::new(instructions))
 }

--- a/crates/api/src/handlers/site_explorer.rs
+++ b/crates/api/src/handlers/site_explorer.rs
@@ -143,11 +143,7 @@ pub(crate) async fn get_site_exploration_report(
 ) -> Result<Response<::rpc::site_explorer::SiteExplorationReport>, Status> {
     log_request_data(&request);
 
-    let mut txn = api.txn_begin().await?;
-
-    let report = db::site_exploration_report::fetch(&mut txn).await?;
-
-    txn.rollback().await?;
+    let report = db::site_exploration_report::fetch(&mut api.db_reader()).await?;
 
     Ok(tonic::Response::new(report.into()))
 }
@@ -245,9 +241,10 @@ pub(crate) async fn pause_explored_endpoint_remediation(
     }
 
     // Check if a machine exists for this endpoint
-    let in_managed_host = crate::site_explorer::is_endpoint_in_managed_host(bmc_ip, &mut txn)
-        .await
-        .map_err(|e| CarbideError::internal(e.to_string()))?;
+    let in_managed_host =
+        crate::site_explorer::is_endpoint_in_managed_host(bmc_ip, txn.as_pgconn())
+            .await
+            .map_err(|e| CarbideError::internal(e.to_string()))?;
 
     if in_managed_host {
         return Err(CarbideError::InvalidArgument(format!(
@@ -283,14 +280,10 @@ pub(crate) async fn is_bmc_in_managed_host(
         )));
     };
 
-    let mut txn = api.txn_begin().await?;
-
     let in_managed_host =
-        crate::site_explorer::is_endpoint_in_managed_host(bmc_addr.ip(), &mut txn)
+        crate::site_explorer::is_endpoint_in_managed_host(bmc_addr.ip(), &api.database_connection)
             .await
             .map_err(|e| CarbideError::internal(e.to_string()))?;
-
-    txn.commit().await?;
 
     Ok(Response::new(IsBmcInManagedHostResponse {
         in_managed_host,
@@ -319,9 +312,10 @@ pub(crate) async fn delete_explored_endpoint(
     }
 
     // Check if a machine exists for this endpoint
-    let in_managed_host = crate::site_explorer::is_endpoint_in_managed_host(bmc_ip, &mut txn)
-        .await
-        .map_err(|e| CarbideError::internal(e.to_string()))?;
+    let in_managed_host =
+        crate::site_explorer::is_endpoint_in_managed_host(bmc_ip, txn.as_pgconn())
+            .await
+            .map_err(|e| CarbideError::internal(e.to_string()))?;
 
     if in_managed_host {
         return Err(CarbideError::InvalidArgument(format!(

--- a/crates/api/src/ipxe.rs
+++ b/crates/api/src/ipxe.rs
@@ -147,14 +147,14 @@ exit ||
 
         let mut console = "ttyS0";
         let mut qcow_imager_url = "chain ${base-url}/internal/x86_64/qcow-imager.efi loglevel=7 console=tty0 pci=realloc=off ";
-        let interface = db::machine_interface::find_one(txn, target.interface_id).await?;
+        let interface = db::machine_interface::find_one(&mut *txn, target.interface_id).await?;
 
         // This custom pxe is different from a customer instance of pxe. It is more for testing one off
         // changes until a real dev env is established and we can just override our existing code to test
         // It is possible for the pxe to be null if we are only trying to test the user data, and this will
         // follow the same code path and retrieve the non customer pxe
         if let Some(machine_boot_override) =
-            db::machine_boot_override::find_optional(txn, target.interface_id).await?
+            db::machine_boot_override::find_optional(&mut *txn, target.interface_id).await?
             && let Some(custom_pxe) = machine_boot_override.custom_pxe
         {
             return Ok(custom_pxe);
@@ -190,7 +190,7 @@ exit ||
             // - If it's ARM and we have an exploration report, check if the report is a bluefield
             //   model.
             let Some(endpoint) =
-                db::explored_endpoints::find_by_mac_address(txn, interface.mac_address)
+                db::explored_endpoints::find_by_mac_address(&mut *txn, interface.mac_address)
                     .await?
                     .into_iter()
                     .next()
@@ -221,7 +221,7 @@ exit ||
             ));
         };
 
-        let machine = db::machine::find_one(txn, &machine_id, MachineSearchConfig::default())
+        let machine = db::machine::find_one(&mut *txn, &machine_id, MachineSearchConfig::default())
             .await
             .map_err(|e| CarbideError::InvalidArgument(format!("Get machine failed, Error: {e}")))?
             .ok_or(CarbideError::InvalidArgument(

--- a/crates/api/src/site_explorer/machine_creator.rs
+++ b/crates/api/src/site_explorer/machine_creator.rs
@@ -242,7 +242,7 @@ impl MachineCreator {
         tracing::info!(%machine_id, "Minted predicted host ID for zero-DPU machine");
 
         let existing_machine = db::machine::find_one(
-            txn,
+            &mut *txn,
             machine_id,
             MachineSearchConfig {
                 include_predicted_host: true,
@@ -283,7 +283,7 @@ impl MachineCreator {
         // the exploration report
         for mac_address in mac_addresses {
             if let Some(machine_interface) =
-                db::machine_interface::find_by_mac_address(txn, mac_address)
+                db::machine_interface::find_by_mac_address(&mut *txn, mac_address)
                     .await?
                     .into_iter()
                     .next()
@@ -410,7 +410,7 @@ impl MachineCreator {
 
         // If machine_interface exists for the DPU and machine_id is not updated, do it now.
         if let Some(oob_net0_mac) = oob_net0_mac {
-            let mi = db::machine_interface::find_by_mac_address(txn, oob_net0_mac).await?;
+            let mi = db::machine_interface::find_by_mac_address(&mut *txn, oob_net0_mac).await?;
 
             if let Some(interface) = mi.first()
                 && interface.machine_id.is_none()
@@ -448,7 +448,9 @@ impl MachineCreator {
         dpf_enabled: bool,
     ) -> CarbideResult<Option<Machine>> {
         let dpu_machine_id = explored_dpu.report.machine_id.as_ref().unwrap();
-        match db::machine::find_one(txn, dpu_machine_id, MachineSearchConfig::default()).await? {
+        match db::machine::find_one(&mut *txn, dpu_machine_id, MachineSearchConfig::default())
+            .await?
+        {
             // Do nothing if machine exists. It'll be reprovisioned via redfish
             Some(_existing_machine) => Ok(None),
             None => match db::machine::create(

--- a/crates/api/src/site_explorer/managed_host.rs
+++ b/crates/api/src/site_explorer/managed_host.rs
@@ -18,8 +18,8 @@ use std::net::IpAddr;
 
 use carbide_uuid::machine::MachineId;
 use db::DatabaseError;
+use db::db_read::DbReader;
 use model::site_explorer::ExploredManagedHost;
-use sqlx::PgConnection;
 
 /// ManagedHost wraps an ExploredManagedHost along with a machine id.
 /// This helper structure is used by the create_managed_host to create a managed host
@@ -57,7 +57,7 @@ impl<'a> ManagedHost<'a> {
 /// BMC temporarily stops reporting DPUs in its PCIe device list.
 pub async fn is_endpoint_in_managed_host(
     bmc_ip_address: IpAddr,
-    txn: &mut PgConnection,
+    txn: impl DbReader<'_>,
 ) -> Result<bool, DatabaseError> {
     let machine_id =
         db::machine_topology::find_machine_id_by_bmc_ip(txn, &bmc_ip_address.to_string()).await?;

--- a/crates/api/src/site_explorer/mod.rs
+++ b/crates/api/src/site_explorer/mod.rs
@@ -327,8 +327,8 @@ impl SiteExplorer {
 
         // Grab them all because we care about everything,
         // not just the subset in the current run.
-        let explored_endpoints = db::explored_endpoints::find_all(&mut txn).await?;
-        let explored_managed_hosts = db::explored_managed_host::find_all(&mut txn).await?;
+        let explored_endpoints = db::explored_endpoints::find_all(txn.as_pgconn()).await?;
+        let explored_managed_hosts = db::explored_managed_host::find_all(txn.as_pgconn()).await?;
 
         txn.rollback().await?;
 
@@ -723,7 +723,7 @@ impl SiteExplorer {
 
         let mac_addresses = report.all_mac_addresses();
         for mac_address in mac_addresses {
-            let mi = db::machine_interface::find_by_mac_address(&mut txn, mac_address).await?;
+            let mi = db::machine_interface::find_by_mac_address(&mut *txn, mac_address).await?;
             if let Some(interface) = mi.first() {
                 db::machine_interface::associate_interface_with_machine(
                     &interface.id,
@@ -736,7 +736,7 @@ impl SiteExplorer {
 
         let mac_addresses = report.all_mac_addresses();
         for mac_address in mac_addresses {
-            let mi = db::machine_interface::find_by_mac_address(&mut txn, mac_address).await?;
+            let mi = db::machine_interface::find_by_mac_address(&mut *txn, mac_address).await?;
             if let Some(interface) = mi.first() {
                 db::machine_interface::associate_interface_with_machine(
                     &interface.id,
@@ -841,7 +841,7 @@ impl SiteExplorer {
             .map_err(|e| CarbideError::InvalidArgument(format!("Invalid MAC address: {}", e)))?;
 
         let interface =
-            db::machine_interface::find_by_mac_address(&mut txn, host_mac_address).await?;
+            db::machine_interface::find_by_mac_address(&mut *txn, host_mac_address).await?;
 
         let (host_nvos_mac_addresses, host_nvos_ip_addresses) =
             if let Some(interface) = interface.first() {
@@ -910,7 +910,7 @@ impl SiteExplorer {
 
         let mac_addresses = explored_endpoint.report.all_mac_addresses();
         for mac_address in mac_addresses {
-            let mi = db::machine_interface::find_by_mac_address(&mut txn, mac_address).await?;
+            let mi = db::machine_interface::find_by_mac_address(&mut *txn, mac_address).await?;
             if let Some(interface) = mi.first() {
                 db::machine_interface::associate_interface_with_machine(
                     &interface.id,
@@ -1458,7 +1458,7 @@ impl SiteExplorer {
             db::network_segment::list_segment_ids(&mut txn, Some(NetworkSegmentType::Underlay))
                 .await?;
         let interfaces = db::machine_interface::find_all(&mut txn).await?;
-        let explored_endpoints = db::explored_endpoints::find_all(&mut txn).await?;
+        let explored_endpoints = db::explored_endpoints::find_all(txn.as_pgconn()).await?;
         let expected_switches = db::expected_switch::find_all(&mut txn).await?;
         let expected_machines = db::expected_machine::find_all(&mut txn).await?;
         let expected_power_shelves = db::expected_power_shelf::find_all(&mut txn).await?;
@@ -2231,7 +2231,7 @@ impl SiteExplorer {
         let mut txn = self.txn_begin().await?;
 
         let is_endpoint_in_managed_host =
-            is_endpoint_in_managed_host(bmc_ip_address, &mut txn).await?;
+            is_endpoint_in_managed_host(bmc_ip_address, txn.as_pgconn()).await?;
 
         txn.commit().await?;
 
@@ -2730,7 +2730,9 @@ pub async fn get_machine_state_by_bmc_ip(
 ) -> Result<String, DatabaseError> {
     let mut txn = Transaction::begin(database_connection).await?;
 
-    let state = match db::machine_topology::find_machine_id_by_bmc_ip(&mut txn, bmc_ip).await? {
+    let state = match db::machine_topology::find_machine_id_by_bmc_ip(txn.as_pgconn(), bmc_ip)
+        .await?
+    {
         Some(machine_id) => {
             match machine::find_one(&mut txn, &machine_id, MachineSearchConfig::default()).await? {
                 Some(machine) => machine.current_state().to_string(),

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -507,7 +507,7 @@ impl TestEnv {
             let mut txn: sqlx::Transaction<'static, sqlx::Postgres> =
                 self.pool.begin().await.unwrap();
             let machine = db::machine::find_one(
-                &mut txn,
+                txn.as_mut(),
                 host_machine_id,
                 model::machine::machine_search_config::MachineSearchConfig::default(),
             )
@@ -521,7 +521,7 @@ impl TestEnv {
         }
         let mut txn = self.pool.begin().await.unwrap();
         let machine = db::machine::find_one(
-            &mut txn,
+            txn.as_mut(),
             host_machine_id,
             model::machine::machine_search_config::MachineSearchConfig::default(),
         )

--- a/crates/api/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/site_explorer.rs
@@ -371,7 +371,7 @@ impl<'a> MockExploredHost<'a> {
 
         //run scout discovery for dpu(s)
         for dpu in self.managed_host.dpus.clone() {
-            let machine_interfaces = find_by_mac_address(&mut txn, dpu.oob_mac_address)
+            let machine_interfaces = find_by_mac_address(txn.as_mut(), dpu.oob_mac_address)
                 .await
                 .unwrap();
             let primary_interface = machine_interfaces
@@ -453,7 +453,7 @@ impl<'a> MockExploredHost<'a> {
 
         //run scout discovery for dpu(s)
         for dpu in self.managed_host.dpus.clone() {
-            let machine_interfaces = find_by_mac_address(&mut txn, dpu.oob_mac_address)
+            let machine_interfaces = find_by_mac_address(txn.as_mut(), dpu.oob_mac_address)
                 .await
                 .unwrap();
             let primary_interface = machine_interfaces
@@ -557,7 +557,7 @@ impl<'a> MockExploredHost<'a> {
 
         //run scout discovery for dpu(s)
         for dpu in self.managed_host.dpus.clone() {
-            let machine_interfaces = find_by_mac_address(&mut txn, dpu.oob_mac_address)
+            let machine_interfaces = find_by_mac_address(txn.as_mut(), dpu.oob_mac_address)
                 .await
                 .unwrap();
             let primary_interface = machine_interfaces
@@ -990,7 +990,7 @@ impl<'a> MockExploredHost<'a> {
 
                 let mut txn = self.test_env.pool.begin().await.unwrap();
                 let machine = db::machine::find_one(
-                    &mut txn,
+                    txn.as_mut(),
                     &self.dpu_machine_ids[&0],
                     model::machine::machine_search_config::MachineSearchConfig::default(),
                 )

--- a/crates/api/src/tests/common/api_fixtures/test_machine/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/test_machine/mod.rs
@@ -63,7 +63,7 @@ impl TestMachine {
     }
 
     pub async fn db_machine(&self, txn: &mut Txn<'_>) -> Machine {
-        db::machine::find_one(txn, &self.id, Default::default())
+        db::machine::find_one(txn.as_mut(), &self.id, Default::default())
             .await
             .unwrap()
             .unwrap()

--- a/crates/api/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api/src/tests/host_bmc_firmware_test.rs
@@ -160,7 +160,7 @@ async fn test_preingestion_bmc_upgrade(
     mgr.run_single_iteration().await?;
 
     let mut txn = pool.begin().await.unwrap();
-    let endpoints = db::explored_endpoints::find_all(&mut txn).await?;
+    let endpoints = db::explored_endpoints::find_all(txn.as_mut()).await?;
     assert!(endpoints.len() == 1);
     let endpoint = endpoints.first().unwrap();
     if let PreingestionState::UpgradeFirmwareWait {
@@ -177,7 +177,7 @@ async fn test_preingestion_bmc_upgrade(
     mgr.run_single_iteration().await?;
 
     let mut txn = pool.begin().await.unwrap();
-    let endpoints = db::explored_endpoints::find_all(&mut txn).await?;
+    let endpoints = db::explored_endpoints::find_all(txn.as_mut()).await?;
     assert!(endpoints.len() == 1);
     let endpoint = endpoints.first().unwrap();
     let PreingestionState::NewFirmwareReportedWait { .. } = endpoint.preingestion_state else {
@@ -189,7 +189,7 @@ async fn test_preingestion_bmc_upgrade(
     mgr.run_single_iteration().await?;
 
     let mut txn = pool.begin().await.unwrap();
-    let endpoints = db::explored_endpoints::find_all(&mut txn).await?;
+    let endpoints = db::explored_endpoints::find_all(txn.as_mut()).await?;
     assert!(endpoints.len() == 1);
     let mut endpoint = endpoints.into_iter().next().unwrap();
 
@@ -212,7 +212,7 @@ async fn test_preingestion_bmc_upgrade(
     mgr.run_single_iteration().await?;
 
     let mut txn = pool.begin().await.unwrap();
-    let endpoints = db::explored_endpoints::find_all(&mut txn).await?;
+    let endpoints = db::explored_endpoints::find_all(txn.as_mut()).await?;
     assert!(endpoints.len() == 1);
     let endpoint = endpoints.first().unwrap();
     match &endpoint.preingestion_state {
@@ -1080,7 +1080,7 @@ async fn test_preingestion_preupdate_powercycling(
         mgr.run_single_iteration().await?;
 
         let mut txn = pool.begin().await.unwrap();
-        let endpoints = db::explored_endpoints::find_all(&mut txn).await?;
+        let endpoints = db::explored_endpoints::find_all(txn.as_mut()).await?;
         assert!(endpoints.len() == 1);
         let mut endpoint = endpoints.into_iter().next().unwrap();
         tracing::debug!("State should be {state:?}");
@@ -1117,7 +1117,7 @@ async fn test_preingestion_preupdate_powercycling(
 
     mgr.run_single_iteration().await?;
     let mut txn = pool.begin().await.unwrap();
-    let endpoints = db::explored_endpoints::find_all(&mut txn).await?;
+    let endpoints = db::explored_endpoints::find_all(txn.as_mut()).await?;
     txn.commit().await?;
     assert!(endpoints.len() == 1);
     let endpoint = endpoints.first().unwrap();
@@ -2367,7 +2367,7 @@ async fn test_preingestion_time_sync_check_error_fails(
     // The test passes if it doesn't panic - the mock BMC should return valid time
     // and the endpoint should proceed to completion or firmware check
     let mut txn = pool.begin().await.unwrap();
-    let endpoints = db::explored_endpoints::find_all(&mut txn).await?;
+    let endpoints = db::explored_endpoints::find_all(txn.as_mut()).await?;
     assert_eq!(endpoints.len(), 1);
     // Just verify we didn't fail - we should be in Complete or some valid state
     let endpoint = &endpoints[0];

--- a/crates/api/src/tests/ipxe.rs
+++ b/crates/api/src/tests/ipxe.rs
@@ -42,7 +42,7 @@ async fn move_machine_to_needed_state(
         .await
         .expect("Unable to create transaction on database pool");
     let machine = db::machine::find_one(
-        &mut txn,
+        txn.as_mut(),
         &machine_id,
         model::machine::machine_search_config::MachineSearchConfig::default(),
     )
@@ -404,7 +404,7 @@ async fn test_cloud_init_when_machine_is_not_created(pool: sqlx::PgPool) {
     // Interface is created. Let's fetch interface id.
     let mut txn = env.pool.begin().await.unwrap();
     let interfaces = db::machine_interface::find_by_mac_address(
-        &mut txn,
+        txn.as_mut(),
         mac_address.parse::<MacAddress>().unwrap(),
     )
     .await

--- a/crates/api/src/tests/machine_admin_force_delete.rs
+++ b/crates/api/src/tests/machine_admin_force_delete.rs
@@ -71,11 +71,14 @@ async fn test_admin_force_delete_dpu_only(pool: sqlx::PgPool) {
     let dpu_machine_id = create_dpu_machine(&env, &host_config).await;
 
     let mut txn = env.pool.begin().await.unwrap();
-    let dpu_machine =
-        db::machine::find_one(&mut txn, &dpu_machine_id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .unwrap();
+    let dpu_machine = db::machine::find_one(
+        txn.as_mut(),
+        &dpu_machine_id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
     assert!(
         !db::machine_state_history::find_by_machine_ids(&mut txn, &[dpu_machine_id])
             .await
@@ -346,7 +349,7 @@ async fn validate_machine_deletion(
     // And it should also be gone on the DB layer
     let mut txn = env.pool.begin().await.unwrap();
     assert!(
-        db::machine::find_one(&mut txn, machine_id, MachineSearchConfig::default())
+        db::machine::find_one(txn.as_mut(), machine_id, MachineSearchConfig::default())
             .await
             .unwrap()
             .is_none()

--- a/crates/api/src/tests/machine_boot_override.rs
+++ b/crates/api/src/tests/machine_boot_override.rs
@@ -46,7 +46,7 @@ async fn only_one_custom_pxe_per_interface(
     .expect("Could not create custom pxe");
 
     let machine_boot_override =
-        db::machine_boot_override::find_optional(&mut txn, new_interface_id)
+        db::machine_boot_override::find_optional(txn.as_mut(), new_interface_id)
             .await
             .expect("Could not load custom boot")
             .unwrap();
@@ -86,7 +86,7 @@ async fn confirm_null_fields(pool: sqlx::PgPool) -> Result<(), Box<dyn std::erro
 
     // ensure these stay Nones as we have code that will react to them not being None
     let machine_boot_override =
-        db::machine_boot_override::find_optional(&mut txn, new_interface_id)
+        db::machine_boot_override::find_optional(txn.as_mut(), new_interface_id)
             .await
             .expect("Could not load custom boot")
             .unwrap();
@@ -163,7 +163,7 @@ async fn api_set(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
     let mut txn = env.pool.begin().await?;
 
     let machine_boot_override =
-        db::machine_boot_override::find_optional(&mut txn, machine_interface_id)
+        db::machine_boot_override::find_optional(txn.as_mut(), machine_interface_id)
             .await
             .expect("Could not load custom boot")
             .unwrap();
@@ -206,7 +206,7 @@ async fn api_clear(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>>
 
     // ensure these stay Nones as we have code that will react to them not being None
     let machine_boot_override =
-        db::machine_boot_override::find_optional(&mut txn, new_interface_id)
+        db::machine_boot_override::find_optional(txn.as_mut(), new_interface_id)
             .await
             .expect("Could not load custom boot");
 
@@ -250,7 +250,7 @@ async fn api_update(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
     let mut txn = env.pool.begin().await?;
 
     let machine_boot_override =
-        db::machine_boot_override::find_optional(&mut txn, machine_interface_id)
+        db::machine_boot_override::find_optional(txn.as_mut(), machine_interface_id)
             .await
             .expect("Could not load custom boot")
             .unwrap();

--- a/crates/api/src/tests/machine_creator.rs
+++ b/crates/api/src/tests/machine_creator.rs
@@ -239,7 +239,7 @@ async fn test_site_explorer_creates_managed_host(
 
     let mut txn = env.pool.begin().await.unwrap();
     let dpu_machine = db::machine::find_one(
-        &mut txn,
+        txn.as_mut(),
         dpu_report.machine_id.as_ref().unwrap(),
         MachineSearchConfig {
             include_predicted_host: true,
@@ -342,11 +342,14 @@ async fn test_site_explorer_creates_managed_host(
     env.run_machine_state_controller_iteration().await;
     env.run_machine_state_controller_iteration().await;
 
-    let dpu_machine =
-        db::machine::find_one(&mut txn, &dpu_machine.id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .unwrap();
+    let dpu_machine = db::machine::find_one(
+        txn.as_mut(),
+        &dpu_machine.id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
 
     assert_eq!(
         dpu_machine.current_state(),
@@ -359,11 +362,14 @@ async fn test_site_explorer_creates_managed_host(
 
     env.run_machine_state_controller_iteration().await;
 
-    let dpu_machine =
-        db::machine::find_one(&mut txn, &dpu_machine.id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .unwrap();
+    let dpu_machine = db::machine::find_one(
+        txn.as_mut(),
+        &dpu_machine.id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
 
     assert_eq!(
         dpu_machine.current_state(),
@@ -376,11 +382,14 @@ async fn test_site_explorer_creates_managed_host(
 
     env.run_machine_state_controller_iteration().await;
 
-    let dpu_machine =
-        db::machine::find_one(&mut txn, &dpu_machine.id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .unwrap();
+    let dpu_machine = db::machine::find_one(
+        txn.as_mut(),
+        &dpu_machine.id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
 
     assert_eq!(
         dpu_machine.current_state(),
@@ -399,11 +408,14 @@ async fn test_site_explorer_creates_managed_host(
 
     env.run_machine_state_controller_iteration().await;
 
-    let dpu_machine =
-        db::machine::find_one(&mut txn, &dpu_machine.id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .unwrap();
+    let dpu_machine = db::machine::find_one(
+        txn.as_mut(),
+        &dpu_machine.id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
 
     assert_eq!(
         dpu_machine.current_state(),
@@ -426,11 +438,14 @@ async fn test_site_explorer_creates_managed_host(
     // CheckSecureBootStatus:
     env.run_machine_state_controller_iteration().await;
     env.run_machine_state_controller_iteration().await;
-    let dpu_machine =
-        db::machine::find_one(&mut txn, &dpu_machine.id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .unwrap();
+    let dpu_machine = db::machine::find_one(
+        txn.as_mut(),
+        &dpu_machine.id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
 
     assert_eq!(
         dpu_machine.current_state(),
@@ -450,11 +465,14 @@ async fn test_site_explorer_creates_managed_host(
     // Wait for installComplete
     env.run_machine_state_controller_iteration().await;
 
-    let dpu_machine =
-        db::machine::find_one(&mut txn, &dpu_machine.id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .unwrap();
+    let dpu_machine = db::machine::find_one(
+        txn.as_mut(),
+        &dpu_machine.id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
 
     assert_eq!(
         dpu_machine.current_state(),
@@ -465,7 +483,8 @@ async fn test_site_explorer_creates_managed_host(
         },
     );
 
-    let machine_interfaces = db::machine_interface::find_by_mac_address(&mut txn, oob_mac).await?;
+    let machine_interfaces =
+        db::machine_interface::find_by_mac_address(txn.as_mut(), oob_mac).await?;
     assert!(!machine_interfaces.is_empty());
     let topologies = db::machine_topology::find_by_machine_ids(&mut txn, &[dpu_machine.id]).await?;
     assert!(topologies.contains_key(&dpu_machine.id));
@@ -501,15 +520,19 @@ async fn test_site_explorer_creates_managed_host(
     assert!(response.machine_id.is_some());
 
     // Now let's check that DPU and host updated states and updated hardware information.
-    let dpu_machine =
-        db::machine::find_one(&mut txn, &dpu_machine.id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .unwrap();
+    let dpu_machine = db::machine::find_one(
+        txn.as_mut(),
+        &dpu_machine.id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
 
     assert!(dpu_machine.network_config.loopback_ip.is_some());
 
-    let machine_interfaces = db::machine_interface::find_by_mac_address(&mut txn, oob_mac).await?;
+    let machine_interfaces =
+        db::machine_interface::find_by_mac_address(txn.as_mut(), oob_mac).await?;
     assert!(
         machine_interfaces[0]
             .machine_id
@@ -517,11 +540,14 @@ async fn test_site_explorer_creates_managed_host(
             .is_some_and(|id| id == &dpu_machine.id)
     );
 
-    let host_machine =
-        db::machine::find_one(&mut txn, &host_machine.id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .unwrap();
+    let host_machine = db::machine::find_one(
+        txn.as_mut(),
+        &host_machine.id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
 
     assert_eq!(
         host_machine.current_state(),
@@ -607,7 +633,8 @@ async fn test_site_explorer_creates_multi_dpu_managed_host(
             .into_inner();
 
         assert!(!response.address.is_empty());
-        let oob_interface = db::machine_interface::find_by_mac_address(&mut txn, oob_mac).await?;
+        let oob_interface =
+            db::machine_interface::find_by_mac_address(txn.as_mut(), oob_mac).await?;
         assert!(oob_interface[0].primary_interface);
         oob_interfaces.push(oob_interface[0].clone());
 
@@ -698,7 +725,7 @@ async fn test_site_explorer_creates_multi_dpu_managed_host(
 
     for dpu in explored_dpus.iter() {
         let dpu_machine = db::machine::find_one(
-            &mut txn,
+            txn.as_mut(),
             dpu.report.machine_id.as_ref().unwrap(),
             MachineSearchConfig {
                 include_predicted_host: true,
@@ -923,7 +950,7 @@ async fn test_mi_attach_dpu_if_mi_exists_during_machine_creation(
 
     // Machine interface should not have any machine id associated with it right now.
     let mut txn = env.pool.begin().await?;
-    let mi = db::machine_interface::find_by_mac_address(&mut txn, oob_mac).await?;
+    let mi = db::machine_interface::find_by_mac_address(txn.as_mut(), oob_mac).await?;
     assert!(mi[0].attached_dpu_machine_id.is_none());
     assert!(mi[0].machine_id.is_none());
     txn.rollback().await?;
@@ -942,7 +969,7 @@ async fn test_mi_attach_dpu_if_mi_exists_during_machine_creation(
     // At this point, create_managed_host must have updated the associated machine id in
     // machine_interfaces table.
     let mut txn = env.pool.begin().await?;
-    let mi = db::machine_interface::find_by_mac_address(&mut txn, oob_mac).await?;
+    let mi = db::machine_interface::find_by_mac_address(txn.as_mut(), oob_mac).await?;
     assert!(mi[0].attached_dpu_machine_id.is_some());
     assert!(mi[0].machine_id.is_some());
     txn.rollback().await?;
@@ -1046,7 +1073,7 @@ async fn test_mi_attach_dpu_if_mi_created_after_machine_creation(
     // any interface as interface does not exist.
     let mut txn = env.pool.begin().await?;
     let machine = db::machine::find_one(
-        &mut txn,
+        txn.as_mut(),
         &dpu_machine_id,
         MachineSearchConfig {
             include_dpus: true,
@@ -1519,11 +1546,14 @@ async fn test_rms_registration_with_rack_id(
     // Iteration 1: VerifyRmsMembership -> RegisterRmsMembership
     // (node not found in inventory — needs registration)
     env.run_machine_state_controller_iteration().await;
-    let host_machine =
-        db::machine::find_one(&mut txn, &host_machine.id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .unwrap();
+    let host_machine = db::machine::find_one(
+        txn.as_mut(),
+        &host_machine.id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
     assert_eq!(
         host_machine.current_state(),
         &ManagedHostState::RegisterRmsMembership,
@@ -1532,11 +1562,14 @@ async fn test_rms_registration_with_rack_id(
     // Iteration 2: RegisterRmsMembership -> DpuDiscoveringState
     // (add_node succeeds)
     env.run_machine_state_controller_iteration().await;
-    let host_machine =
-        db::machine::find_one(&mut txn, &host_machine.id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .unwrap();
+    let host_machine = db::machine::find_one(
+        txn.as_mut(),
+        &host_machine.id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
     assert!(
         matches!(
             host_machine.current_state(),
@@ -1680,11 +1713,14 @@ async fn test_rms_registration_retries_on_failure(
 
     // Iteration 1: VerifyRmsMembership -> RegisterRmsMembership (not found)
     env.run_machine_state_controller_iteration().await;
-    let host_machine =
-        db::machine::find_one(&mut txn, &host_machine.id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .unwrap();
+    let host_machine = db::machine::find_one(
+        txn.as_mut(),
+        &host_machine.id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
     assert_eq!(
         host_machine.current_state(),
         &ManagedHostState::RegisterRmsMembership,
@@ -1695,11 +1731,14 @@ async fn test_rms_registration_retries_on_failure(
 
     // Iteration 2: RegisterRmsMembership stays (add_node fails)
     env.run_machine_state_controller_iteration().await;
-    let host_machine =
-        db::machine::find_one(&mut txn, &host_machine.id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .unwrap();
+    let host_machine = db::machine::find_one(
+        txn.as_mut(),
+        &host_machine.id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
     assert_eq!(
         host_machine.current_state(),
         &ManagedHostState::RegisterRmsMembership,
@@ -1712,11 +1751,14 @@ async fn test_rms_registration_retries_on_failure(
 
     // Iteration 3: RegisterRmsMembership -> DpuDiscoveringState (succeeds)
     env.run_machine_state_controller_iteration().await;
-    let host_machine =
-        db::machine::find_one(&mut txn, &host_machine.id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .unwrap();
+    let host_machine = db::machine::find_one(
+        txn.as_mut(),
+        &host_machine.id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
     assert!(
         matches!(
             host_machine.current_state(),
@@ -1864,11 +1906,14 @@ async fn test_rms_verification_failure_paths(
 
     // Iteration 1: VerifyRmsMembership stays (inventory_get API error)
     env.run_machine_state_controller_iteration().await;
-    let host_machine =
-        db::machine::find_one(&mut txn, &host_machine.id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .unwrap();
+    let host_machine = db::machine::find_one(
+        txn.as_mut(),
+        &host_machine.id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
     assert_eq!(
         host_machine.current_state(),
         &ManagedHostState::VerifyRmsMembership,
@@ -1881,11 +1926,14 @@ async fn test_rms_verification_failure_paths(
 
     // Iteration 2: VerifyRmsMembership -> RegisterRmsMembership (not found)
     env.run_machine_state_controller_iteration().await;
-    let host_machine =
-        db::machine::find_one(&mut txn, &host_machine.id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .unwrap();
+    let host_machine = db::machine::find_one(
+        txn.as_mut(),
+        &host_machine.id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
     assert_eq!(
         host_machine.current_state(),
         &ManagedHostState::RegisterRmsMembership,
@@ -1893,11 +1941,14 @@ async fn test_rms_verification_failure_paths(
 
     // Iteration 3: RegisterRmsMembership -> DpuDiscoveringState (succeeds)
     env.run_machine_state_controller_iteration().await;
-    let host_machine =
-        db::machine::find_one(&mut txn, &host_machine.id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .unwrap();
+    let host_machine = db::machine::find_one(
+        txn.as_mut(),
+        &host_machine.id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
     assert!(
         matches!(
             host_machine.current_state(),

--- a/crates/api/src/tests/machine_dhcp.rs
+++ b/crates/api/src/tests/machine_dhcp.rs
@@ -300,7 +300,7 @@ async fn machine_interface_discovery_persists_vendor_strings(
         );
 
         // Also check via the MachineInterface API
-        let iface = db::machine_interface::find_one(&mut txn, *interface_id)
+        let iface = db::machine_interface::find_one(txn.as_mut(), *interface_id)
             .await
             .unwrap();
         assert_eq!(iface.vendors, expected);
@@ -408,7 +408,7 @@ async fn test_dhcp_record_address_family(
     // Insert an IPv6 address for the same interface, simulating dual-stack.
     let mut txn = pool.begin().await?;
     let parsed_mac: MacAddress = mac_address.parse().unwrap();
-    let interfaces = db::machine_interface::find_by_mac_address(&mut txn, parsed_mac).await?;
+    let interfaces = db::machine_interface::find_by_mac_address(txn.as_mut(), parsed_mac).await?;
     let interface = &interfaces[0];
 
     let ipv6_addr: IpAddr = "fd00::42".parse().unwrap();

--- a/crates/api/src/tests/machine_find.rs
+++ b/crates/api/src/tests/machine_find.rs
@@ -76,11 +76,14 @@ async fn test_find_machine_by_ip(pool: sqlx::PgPool) {
     let dpu_machine_id = create_dpu_machine(&env, &host_config).await;
 
     let mut txn = env.pool.begin().await.unwrap();
-    let dpu_machine =
-        db::machine::find_one(&mut txn, &dpu_machine_id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .unwrap();
+    let dpu_machine = db::machine::find_one(
+        txn.as_mut(),
+        &dpu_machine_id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
     let ip = &dpu_machine.interfaces[0].addresses[0];
 
     let machine = db::machine::find_by_query(&mut txn, &ip.to_string())
@@ -111,11 +114,14 @@ async fn test_find_machine_by_ipv6(pool: sqlx::PgPool) {
     let dpu_machine_id = create_dpu_machine(&env, &host_config).await;
 
     let mut txn = env.pool.begin().await.unwrap();
-    let dpu_machine =
-        db::machine::find_one(&mut txn, &dpu_machine_id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .unwrap();
+    let dpu_machine = db::machine::find_one(
+        txn.as_mut(),
+        &dpu_machine_id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
     let interface_id = dpu_machine.interfaces[0].id;
 
     // Add an IPv6 address to the interface.
@@ -178,7 +184,7 @@ async fn test_find_machine_by_mac(pool: sqlx::PgPool) {
 
     let mut txn = env.pool.begin().await.unwrap();
     let dpu_machine = db::machine::find_one(
-        &mut txn,
+        txn.as_mut(),
         &dpu_machine_id,
         MachineSearchConfig {
             include_history: true,
@@ -219,7 +225,7 @@ async fn test_find_machine_by_hostname(pool: sqlx::PgPool) {
 
     let mut txn = env.pool.begin().await.unwrap();
     let dpu_machine = db::machine::find_one(
-        &mut txn,
+        txn.as_mut(),
         &dpu_machine_id,
         MachineSearchConfig {
             include_history: true,

--- a/crates/api/src/tests/machine_history.rs
+++ b/crates/api/src/tests/machine_history.rs
@@ -65,7 +65,7 @@ async fn test_machine_state_history(pool: sqlx::PgPool) -> Result<(), Box<dyn st
         let mut txn = env.pool.begin().await?;
 
         let machine = db::machine::find_one(
-            &mut txn,
+            txn.as_mut(),
             &dpu_machine_id,
             model::machine::machine_search_config::MachineSearchConfig {
                 include_history: true,
@@ -81,7 +81,7 @@ async fn test_machine_state_history(pool: sqlx::PgPool) -> Result<(), Box<dyn st
         );
 
         let machine = db::machine::find_one(
-            &mut txn,
+            txn.as_mut(),
             &dpu_machine_id,
             model::machine::machine_search_config::MachineSearchConfig::default(),
         )
@@ -143,7 +143,7 @@ async fn test_machine_state_history(pool: sqlx::PgPool) -> Result<(), Box<dyn st
     let mut txn = env.pool.begin().await?;
 
     let machine = db::machine::find_one(
-        &mut txn,
+        txn.as_mut(),
         &host_machine_id,
         model::machine::machine_search_config::MachineSearchConfig {
             include_history: true,
@@ -170,7 +170,7 @@ async fn test_machine_state_history(pool: sqlx::PgPool) -> Result<(), Box<dyn st
     assert_eq!(result.len(), 250);
 
     let machine = db::machine::find_one(
-        &mut txn,
+        txn.as_mut(),
         &host_machine_id,
         model::machine::machine_search_config::MachineSearchConfig {
             include_history: true,
@@ -244,7 +244,7 @@ async fn test_old_machine_state_history(
         .await?;
 
     let machine = db::machine::find_one(
-        &mut txn,
+        txn.as_mut(),
         &host_machine_id,
         model::machine::machine_search_config::MachineSearchConfig {
             include_history: true,

--- a/crates/api/src/tests/machine_interface_addresses.rs
+++ b/crates/api/src/tests/machine_interface_addresses.rs
@@ -70,7 +70,7 @@ async fn find_by_address_bmc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::erro
     .await?;
     let bmc_ip = interface.addresses.iter().find(|x| x.is_ipv4()).copied();
     assert!(bmc_ip.is_some());
-    let res = db::machine_interface_address::find_by_address(&mut txn, bmc_ip.unwrap()).await?;
+    let res = db::machine_interface_address::find_by_address(txn.as_mut(), bmc_ip.unwrap()).await?;
     assert!(res.is_some());
     assert_eq!(res.unwrap().id, interface.id);
 

--- a/crates/api/src/tests/machine_interfaces.rs
+++ b/crates/api/src/tests/machine_interfaces.rs
@@ -457,7 +457,7 @@ async fn test_delete_interface(pool: sqlx::PgPool) -> Result<(), Box<dyn std::er
         .unwrap();
 
     let mut txn = env.pool.begin().await?;
-    let _interface = db::machine_interface::find_one(&mut txn, interface_id).await;
+    let _interface = db::machine_interface::find_one(txn.as_mut(), interface_id).await;
     assert!(matches!(
         DatabaseError::FindOneReturnedNoResultsError(interface_id.into()),
         _interface

--- a/crates/api/src/tests/machine_topology.rs
+++ b/crates/api/src/tests/machine_topology.rs
@@ -378,10 +378,14 @@ async fn test_topology_update_on_machineid_update(pool: sqlx::PgPool) {
     let (host_machine_id, _dpu_machine_id) =
         common::api_fixtures::create_managed_host(&env).await.into();
     let mut txn = env.pool.begin().await.unwrap();
-    let host = db::machine::find_one(&mut txn, &host_machine_id, MachineSearchConfig::default())
-        .await
-        .unwrap()
-        .unwrap();
+    let host = db::machine::find_one(
+        txn.as_mut(),
+        &host_machine_id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
 
     assert!(host.hardware_info.as_ref().is_some());
 
@@ -400,12 +404,16 @@ async fn test_topology_update_on_machineid_update(pool: sqlx::PgPool) {
     let m_id =
         MachineId::from_str("fm100hsag07peffp850l14kvmhrqjf9h6jslilfahaknhvb6sq786c0g3jg").unwrap();
     let mut txn = env.pool.begin().await.unwrap();
-    let host = db::machine::find_one(&mut txn, &host_machine_id, MachineSearchConfig::default())
-        .await
-        .unwrap();
+    let host = db::machine::find_one(
+        txn.as_mut(),
+        &host_machine_id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap();
     assert!(host.is_none());
 
-    let host = db::machine::find_one(&mut txn, &m_id, MachineSearchConfig::default())
+    let host = db::machine::find_one(txn.as_mut(), &m_id, MachineSearchConfig::default())
         .await
         .unwrap()
         .unwrap();

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -254,7 +254,9 @@ async fn test_site_explorer_default_pause_ingestion_and_poweron(
     explorer.run_single_iteration().await.unwrap();
 
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(&mut txn).await.unwrap();
+    let explored = db::explored_endpoints::find_all(txn.as_mut())
+        .await
+        .unwrap();
     assert_eq!(explored.len(), 1);
     assert!(explored[0].pause_ingestion_and_poweron);
 
@@ -448,7 +450,9 @@ async fn test_site_explorer_main(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
     explorer.run_single_iteration().await.unwrap();
     // Since we configured a limit of 2 entries, we should have those 2 results now
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(&mut txn).await.unwrap();
+    let explored = db::explored_endpoints::find_all(txn.as_mut())
+        .await
+        .unwrap();
     txn.commit().await?;
     assert_eq!(explored.len(), 2);
 
@@ -511,7 +515,9 @@ async fn test_site_explorer_main(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
     explorer.run_single_iteration().await.unwrap();
     // Since we configured a limit of 2 entries, we should have those 2 results now
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(&mut txn).await.unwrap();
+    let explored = db::explored_endpoints::find_all(txn.as_mut())
+        .await
+        .unwrap();
     txn.commit().await?;
     assert_eq!(explored.len(), 3);
     let mut versions = Vec::new();
@@ -601,7 +607,9 @@ async fn test_site_explorer_main(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
     explorer.run_single_iteration().await.unwrap();
     explorer.run_single_iteration().await.unwrap();
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(&mut txn).await.unwrap();
+    let explored = db::explored_endpoints::find_all(txn.as_mut())
+        .await
+        .unwrap();
     assert_eq!(explored.len(), 3);
     let mut versions = Vec::new();
     for report in &explored {
@@ -941,7 +949,9 @@ async fn test_site_explorer_audit_exploration_results(
     explorer.run_single_iteration().await.unwrap();
 
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(&mut txn).await.unwrap();
+    let explored = db::explored_endpoints::find_all(txn.as_mut())
+        .await
+        .unwrap();
     txn.commit().await?;
     assert_eq!(explored.len(), 7);
 
@@ -1112,7 +1122,9 @@ async fn test_site_explorer_reexplore(
     explorer.run_single_iteration().await.unwrap();
     // Since we configured a limit of 1 entries, we should have 1 results now
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(&mut txn).await.unwrap();
+    let explored = db::explored_endpoints::find_all(txn.as_mut())
+        .await
+        .unwrap();
     txn.commit().await?;
     assert_eq!(explored.len(), 1);
     let explored_ip = explored[0].address;
@@ -1133,7 +1145,9 @@ async fn test_site_explorer_reexplore(
 
     // Calling the API should set the `exploration_requested` flag on the endpoint
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(&mut txn).await.unwrap();
+    let explored = db::explored_endpoints::find_all(txn.as_mut())
+        .await
+        .unwrap();
     txn.commit().await?;
     for report in &explored {
         assert!(report.exploration_requested);
@@ -1143,7 +1157,9 @@ async fn test_site_explorer_reexplore(
     // endpoint - but not find anything new
     explorer.run_single_iteration().await.unwrap();
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(&mut txn).await.unwrap();
+    let explored = db::explored_endpoints::find_all(txn.as_mut())
+        .await
+        .unwrap();
     txn.commit().await?;
     assert_eq!(explored.len(), 1);
 
@@ -1174,7 +1190,9 @@ async fn test_site_explorer_reexplore(
     );
 
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(&mut txn).await.unwrap();
+    let explored = db::explored_endpoints::find_all(txn.as_mut())
+        .await
+        .unwrap();
     txn.commit().await?;
     for report in &explored {
         assert!(!report.exploration_requested);
@@ -1191,7 +1209,9 @@ async fn test_site_explorer_reexplore(
         .into_inner();
 
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(&mut txn).await.unwrap();
+    let explored = db::explored_endpoints::find_all(txn.as_mut())
+        .await
+        .unwrap();
     txn.commit().await?;
     for report in &explored {
         assert!(report.exploration_requested);
@@ -1200,7 +1220,9 @@ async fn test_site_explorer_reexplore(
     // 3rd iteration still yields 1 result
     explorer.run_single_iteration().await.unwrap();
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(&mut txn).await.unwrap();
+    let explored = db::explored_endpoints::find_all(txn.as_mut())
+        .await
+        .unwrap();
     txn.commit().await?;
     assert_eq!(explored.len(), 1);
 
@@ -1415,7 +1437,9 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
     // Run site explorer
     explorer.run_single_iteration().await.unwrap();
     let mut txn = env.pool.begin().await?;
-    let explored_endpoints = db::explored_endpoints::find_all(&mut txn).await.unwrap();
+    let explored_endpoints = db::explored_endpoints::find_all(txn.as_mut())
+        .await
+        .unwrap();
 
     // Mark explored endpoints as pre-ingestion_complete
     for ee in &explored_endpoints {
@@ -1675,7 +1699,8 @@ async fn test_fetch_host_primary_interface_mac(
             .into_inner();
 
         assert!(!response.address.is_empty());
-        let oob_interface = db::machine_interface::find_by_mac_address(&mut txn, oob_mac).await?;
+        let oob_interface =
+            db::machine_interface::find_by_mac_address(txn.as_mut(), oob_mac).await?;
         assert!(oob_interface[0].primary_interface);
         oob_interfaces.push(oob_interface[0].clone());
 
@@ -2030,7 +2055,7 @@ async fn test_site_explorer_fixtures_zerodpu_dhcp_before_site_explorer(
             async move {
                 let mut txn = pool.begin().await?;
                 let interfaces =
-                    db::machine_interface::find_by_mac_address(&mut txn, mac_address).await?;
+                    db::machine_interface::find_by_mac_address(txn.as_mut(), mac_address).await?;
                 assert_eq!(interfaces.len(), 1);
                 // There should be no machine_id yet as site-explorer has not run
                 assert!(interfaces[0].machine_id.is_none());
@@ -2155,7 +2180,9 @@ async fn test_site_explorer_unknown_vendor(
     explorer.run_single_iteration().await.unwrap();
     // Since we configured a limit of 2 entries, we should have those 2 results now
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(&mut txn).await.unwrap();
+    let explored = db::explored_endpoints::find_all(txn.as_mut())
+        .await
+        .unwrap();
     txn.commit().await?;
     assert_eq!(explored.len(), 1);
     let report = &explored[0];
@@ -2417,7 +2444,9 @@ async fn test_machine_creation_with_sku(
     // Run site explorer
     explorer.run_single_iteration().await.unwrap();
     let mut txn = env.pool.begin().await?;
-    let explored_endpoints = db::explored_endpoints::find_all(&mut txn).await.unwrap();
+    let explored_endpoints = db::explored_endpoints::find_all(txn.as_mut())
+        .await
+        .unwrap();
 
     // Mark explored endpoints as pre-ingestion_complete
     for ee in &explored_endpoints {
@@ -2848,7 +2877,7 @@ async fn test_site_explorer_power_shelf_discovery(
     explorer.run_single_iteration().await.unwrap();
 
     let mut txn = env.pool.begin().await?;
-    let explored = db_explored_endpoints::find_all(&mut txn).await.unwrap();
+    let explored = db_explored_endpoints::find_all(txn.as_mut()).await.unwrap();
     txn.commit().await?;
     assert_eq!(explored.len(), 1);
 
@@ -3390,7 +3419,7 @@ async fn test_site_explorer_power_shelf_error_handling(
     explorer.run_single_iteration().await.unwrap();
 
     let mut txn = env.pool.begin().await?;
-    let explored = db_explored_endpoints::find_all(&mut txn).await.unwrap();
+    let explored = db_explored_endpoints::find_all(txn.as_mut()).await.unwrap();
     txn.commit().await?;
     assert_eq!(explored.len(), 1);
 
@@ -4431,7 +4460,7 @@ async fn test_site_explorer_power_shelf_discovery_with_static_ip(
     explorer.run_single_iteration().await.unwrap();
 
     let mut txn = env.pool.begin().await?;
-    let explored = db_explored_endpoints::find_all(&mut txn).await.unwrap();
+    let explored = db_explored_endpoints::find_all(txn.as_mut()).await.unwrap();
     txn.commit().await?;
     assert_eq!(explored.len(), 1);
 


### PR DESCRIPTION
## Description

@kensimon kicked this off, and I'm helping to contribute keeping the momentum going with the effort. This converts additional read-only paths (places where we do things like `get`, `find`, etc) to take an `impl DbReader`.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

