### PR TITLE
add ac powercycle if machine does not power on

### DIFF
--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1952,6 +1952,9 @@ pub enum InstanceState {
 pub enum HostPlatformConfigurationState {
     PowerCycle {
         power_on: bool,
+        /// Number of times we have sent power-on and are still waiting for the host to come up.
+        #[serde(default)]
+        power_on_retry_count: u32,
     },
     UnlockHost {
         #[serde(default)]

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -83,6 +83,7 @@ use tokio::sync::Semaphore;
 use tracing::instrument;
 use version_compare::Cmp;
 
+use crate::CarbideError;
 use crate::cfg::file::{
     BomValidationConfig, CarbideConfig, FirmwareConfig, MachineValidationConfig,
     PowerManagerOptions, TimePeriod,
@@ -5590,6 +5591,7 @@ impl StateHandler for InstanceStateHandler {
                                     platform_config_state:
                                         HostPlatformConfigurationState::PowerCycle {
                                             power_on: power_state == libredfish::PowerState::Off,
+                                            power_on_retry_count: 0,
                                         },
                                 },
                             }
@@ -9100,7 +9102,10 @@ async fn handle_instance_host_platform_config(
         .await?;
 
     let instance_state = match platform_config_state {
-        HostPlatformConfigurationState::PowerCycle { power_on } => {
+        HostPlatformConfigurationState::PowerCycle {
+            power_on,
+            power_on_retry_count,
+        } => {
             let power_state = redfish_client.get_power_state().await.map_err(|e| {
                 StateHandlerError::RedfishError {
                     operation: "get_power_state",
@@ -9117,6 +9122,7 @@ async fn handle_instance_host_platform_config(
                             instance_state: InstanceState::HostPlatformConfiguration {
                                 platform_config_state: HostPlatformConfigurationState::PowerCycle {
                                     power_on: true,
+                                    power_on_retry_count: 4,
                                 },
                             },
                         },
@@ -9171,7 +9177,41 @@ async fn handle_instance_host_platform_config(
                 ));
             }
 
-            // Host is still off, issue power on command
+            // Host is still off. Every 5th retry use AC power cycle instead of On.
+            let next_retry = power_on_retry_count + 1;
+            if next_retry % 5 == 0 {
+                match host_power_control(
+                    redfish_client.as_ref(),
+                    &mh_snapshot.host_snapshot,
+                    SystemPowerControl::ACPowercycle,
+                    ctx,
+                )
+                .await
+                {
+                    Ok(()) => {
+                        return Ok(StateHandlerOutcome::transition(
+                            ManagedHostState::Assigned {
+                                instance_state: InstanceState::HostPlatformConfiguration {
+                                    platform_config_state:
+                                        HostPlatformConfigurationState::PowerCycle {
+                                            power_on: true,
+                                            power_on_retry_count: next_retry,
+                                        },
+                                },
+                            },
+                        ));
+                    }
+                    Err(CarbideError::RedfishError(RedfishError::NotSupported(_))) => {
+                        // if not supported, just power on
+                        tracing::info!("AC Powercycle not supported, skipping to power on");
+                    }
+                    Err(e) => {
+                        // TODO: Dell's return a generic error if in lockdown which needs to be changed in Redfish SDK
+                        tracing::warn!("Failed to AC Powercycle host, skipping to power on: {e}");
+                    }
+                };
+            }
+
             host_power_control(
                 redfish_client.as_ref(),
                 &mh_snapshot.host_snapshot,
@@ -9179,14 +9219,24 @@ async fn handle_instance_host_platform_config(
                 ctx,
             )
             .await
-            .map_err(|e| {
-                StateHandlerError::GenericError(eyre!("failed to power on host: {}", e))
-            })?;
+            .map_err(|e| StateHandlerError::GenericError(eyre!("failed to power on host: {e}")))?;
 
-            return Ok(StateHandlerOutcome::wait(format!(
-                "waiting for {} to power ON; current power state: {}",
-                mh_snapshot.host_snapshot.id, power_state
-            )));
+            tracing::info!(
+                host_id = %mh_snapshot.host_snapshot.id,
+                power_on_retry_count = next_retry,
+                %power_state,
+                "waiting for host to power ON"
+            );
+            return Ok(StateHandlerOutcome::transition(
+                ManagedHostState::Assigned {
+                    instance_state: InstanceState::HostPlatformConfiguration {
+                        platform_config_state: HostPlatformConfigurationState::PowerCycle {
+                            power_on: true,
+                            power_on_retry_count: next_retry,
+                        },
+                    },
+                },
+            ));
         }
         HostPlatformConfigurationState::UnlockHost { unlock_host_state } => {
             match unlock_host_state {

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -9122,7 +9122,7 @@ async fn handle_instance_host_platform_config(
                             instance_state: InstanceState::HostPlatformConfiguration {
                                 platform_config_state: HostPlatformConfigurationState::PowerCycle {
                                     power_on: true,
-                                    power_on_retry_count: 4,
+                                    power_on_retry_count: 0,
                                 },
                             },
                         },


### PR DESCRIPTION
## Description
after every 5 attempts to power on a machine do a AC powercycle if the machine supports it.

This is to work around a bug in Lenovo BMCs.  after turning off the machine, the redfish request to power it on succeeds, but doesn't actually do anything.

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

Tested against a Dell for the happy path and when the retry hits 5.  Dell's do not support power cycle while locked down, but libredfish returns a generic error, so any error continues to power on the machine

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
5975063

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

