### PR TITLE
chore: move/define search filter types from rpc to api-model

### DIFF
--- a/crates/api-db/src/explored_endpoints.rs
+++ b/crates/api-db/src/explored_endpoints.rs
@@ -117,7 +117,7 @@ impl From<DbExploredEndpoint> for ExploredEndpoint {
 pub async fn find_ips(
     txn: impl DbReader<'_>,
     // filter is currently is empty, so it is a placeholder for the future
-    _filter: ::rpc::site_explorer::ExploredEndpointSearchFilter,
+    _filter: model::site_explorer::ExploredEndpointSearchFilter,
 ) -> Result<Vec<IpAddr>, DatabaseError> {
     #[derive(Debug, Clone, Copy, FromRow)]
     pub struct ExploredEndpointIp(IpAddr);

--- a/crates/api-db/src/explored_managed_host.rs
+++ b/crates/api-db/src/explored_managed_host.rs
@@ -54,7 +54,7 @@ impl From<DbExploredManagedHost> for ExploredManagedHost {
 pub async fn find_ips(
     txn: impl DbReader<'_>,
     // filter is currently is empty, so it is a placeholder for the future
-    _filter: ::rpc::site_explorer::ExploredManagedHostSearchFilter,
+    _filter: model::site_explorer::ExploredManagedHostSearchFilter,
 ) -> Result<Vec<IpAddr>, DatabaseError> {
     #[derive(Debug, Clone, Copy, FromRow)]
     pub struct ExploredManagedHostIp(IpAddr);

--- a/crates/api-db/src/ib_partition.rs
+++ b/crates/api-db/src/ib_partition.rs
@@ -403,7 +403,7 @@ pub async fn for_tenant(
 
 pub async fn find_ids(
     txn: impl DbReader<'_>,
-    filter: rpc::IbPartitionSearchFilter,
+    filter: model::ib_partition::IbPartitionSearchFilter,
 ) -> Result<Vec<IBPartitionId>, DatabaseError> {
     // build query
     let mut builder = sqlx::QueryBuilder::new("SELECT id FROM ib_partitions");

--- a/crates/api-db/src/instance.rs
+++ b/crates/api-db/src/instance.rs
@@ -18,7 +18,6 @@
 use std::ops::DerefMut;
 use std::str::FromStr;
 
-use ::rpc::forge as rpc;
 use carbide_uuid::extension_service::ExtensionServiceId;
 use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::MachineId;
@@ -60,7 +59,7 @@ pub struct InstanceTable {}
 
 pub async fn find_ids(
     txn: impl DbReader<'_>,
-    filter: rpc::InstanceSearchFilter,
+    filter: model::instance::InstanceSearchFilter,
 ) -> Result<Vec<InstanceId>, DatabaseError> {
     let mut builder = sqlx::QueryBuilder::new("SELECT id FROM instances WHERE TRUE "); // The TRUE will be optimized away.
 

--- a/crates/api-db/src/network_segment.rs
+++ b/crates/api-db/src/network_segment.rs
@@ -18,7 +18,6 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 use std::ops::Deref;
 
-use ::rpc::forge as rpc;
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::network::NetworkSegmentId;
 use carbide_uuid::vpc::VpcId;
@@ -259,7 +258,7 @@ pub async fn list_segment_ids(
 
 pub async fn find_ids(
     txn: impl DbReader<'_>,
-    filter: rpc::NetworkSegmentSearchFilter,
+    filter: model::network_segment::NetworkSegmentSearchFilter,
 ) -> Result<Vec<NetworkSegmentId>, DatabaseError> {
     // build query
     let mut builder = sqlx::QueryBuilder::new("SELECT s.id FROM network_segments AS s");

--- a/crates/api-db/src/nvl_logical_partition.rs
+++ b/crates/api-db/src/nvl_logical_partition.rs
@@ -285,7 +285,7 @@ pub async fn for_tenant(
 
 pub async fn find_ids(
     txn: impl DbReader<'_>,
-    filter: rpc::NvLinkLogicalPartitionSearchFilter,
+    filter: model::nvl_logical_partition::NvLinkLogicalPartitionSearchFilter,
 ) -> Result<Vec<NvLinkLogicalPartitionId>, DatabaseError> {
     // build query
     let mut builder = sqlx::QueryBuilder::new("SELECT id FROM nvlink_logical_partitions");

--- a/crates/api-db/src/nvl_partition.rs
+++ b/crates/api-db/src/nvl_partition.rs
@@ -194,7 +194,7 @@ pub async fn for_tenant(
 
 pub async fn find_ids(
     txn: impl DbReader<'_>,
-    filter: rpc::NvLinkPartitionSearchFilter,
+    filter: model::nvl_partition::NvLinkPartitionSearchFilter,
 ) -> Result<Vec<NvLinkPartitionId>, DatabaseError> {
     // build query
     let mut builder = sqlx::QueryBuilder::new("SELECT id FROM nvlink_partitions");

--- a/crates/api-db/src/tenant.rs
+++ b/crates/api-db/src/tenant.rs
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-use ::rpc::forge as rpc;
 use config_version::ConfigVersion;
 use model::metadata::Metadata;
 use model::tenant::{RoutingProfileType, Tenant, TenantPublicKeyValidationRequest};
@@ -136,7 +135,7 @@ pub async fn increment_version<S: AsRef<str>>(
 
 pub async fn find_tenant_organization_ids(
     txn: impl DbReader<'_>,
-    search_config: rpc::TenantSearchFilter,
+    search_config: model::tenant::TenantSearchFilter,
 ) -> Result<Vec<OrganizationID>, DatabaseError> {
     let mut qb = sqlx::QueryBuilder::new("SELECT organization_id FROM tenants");
 

--- a/crates/api-db/src/tenant_keyset.rs
+++ b/crates/api-db/src/tenant_keyset.rs
@@ -38,7 +38,7 @@ pub async fn create(
 
 pub async fn find_ids(
     txn: impl DbReader<'_>,
-    filter: rpc::forge::TenantKeysetSearchFilter,
+    filter: model::tenant::TenantKeysetSearchFilter,
 ) -> Result<Vec<TenantKeysetId>, DatabaseError> {
     // build query
     let mut builder =

--- a/crates/api-db/src/vpc.rs
+++ b/crates/api-db/src/vpc.rs
@@ -16,7 +16,6 @@
  */
 use std::ops::DerefMut;
 
-use ::rpc::forge as rpc;
 use carbide_uuid::network::NetworkSegmentId;
 use carbide_uuid::vpc::VpcId;
 use config_version::ConfigVersion;
@@ -88,7 +87,7 @@ pub async fn persist(
 
 pub async fn find_ids(
     txn: impl DbReader<'_>,
-    filter: rpc::VpcSearchFilter,
+    filter: model::vpc::VpcSearchFilter,
 ) -> Result<Vec<VpcId>, DatabaseError> {
     // build query
     let mut builder = sqlx::QueryBuilder::new("SELECT id FROM vpcs WHERE ");

--- a/crates/api-model/src/ib_partition/mod.rs
+++ b/crates/api-model/src/ib_partition/mod.rs
@@ -24,6 +24,21 @@ use crate::StateSla;
 
 mod slas;
 
+#[derive(Clone, Debug, Default)]
+pub struct IbPartitionSearchFilter {
+    pub tenant_org_id: Option<String>,
+    pub name: Option<String>,
+}
+
+impl From<rpc::forge::IbPartitionSearchFilter> for IbPartitionSearchFilter {
+    fn from(filter: rpc::forge::IbPartitionSearchFilter) -> Self {
+        IbPartitionSearchFilter {
+            tenant_org_id: filter.tenant_org_id,
+            name: filter.name,
+        }
+    }
+}
+
 /// Represents an InfiniBand Partition Key
 /// Partition Keys are 16 bit values valid up to a value of 0x7fff
 /// Partition Keys are serialized as strings, since the hex represenation is

--- a/crates/api-model/src/instance/mod.rs
+++ b/crates/api-model/src/instance/mod.rs
@@ -21,11 +21,30 @@ use config_version::ConfigVersion;
 use rpc::errors::RpcDataConversionError;
 
 use crate::instance::config::InstanceConfig;
-use crate::metadata::Metadata;
+use crate::metadata::{LabelFilter, Metadata};
 
 pub mod config;
 pub mod snapshot;
 pub mod status;
+
+#[derive(Clone, Debug, Default)]
+pub struct InstanceSearchFilter {
+    pub label: Option<LabelFilter>,
+    pub tenant_org_id: Option<String>,
+    pub vpc_id: Option<String>,
+    pub instance_type_id: Option<String>,
+}
+
+impl From<rpc::forge::InstanceSearchFilter> for InstanceSearchFilter {
+    fn from(filter: rpc::forge::InstanceSearchFilter) -> Self {
+        InstanceSearchFilter {
+            label: filter.label.map(LabelFilter::from),
+            tenant_org_id: filter.tenant_org_id,
+            vpc_id: filter.vpc_id,
+            instance_type_id: filter.instance_type_id,
+        }
+    }
+}
 
 pub enum InstanceNetworkSyncStatus {
     InstanceNetworkObservationNotAvailable(Vec<MachineId>),
@@ -65,5 +84,47 @@ impl TryFrom<rpc::InstanceReleaseRequest> for DeleteInstance {
             issue: value.issue,
             is_repair_tenant: value.is_repair_tenant,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rpc::forge as rpc_forge;
+
+    use super::*;
+
+    #[test]
+    fn instance_search_filter_from_rpc_all_fields() {
+        let rpc_filter = rpc_forge::InstanceSearchFilter {
+            label: Some(rpc_forge::Label {
+                key: "env".to_string(),
+                value: Some("staging".to_string()),
+            }),
+            tenant_org_id: Some("org-456".to_string()),
+            vpc_id: Some("vpc-789".to_string()),
+            instance_type_id: Some("type-abc".to_string()),
+        };
+        let filter = InstanceSearchFilter::from(rpc_filter);
+        let label = filter.label.unwrap();
+        assert_eq!(label.key, "env");
+        assert_eq!(label.value, Some("staging".to_string()));
+        assert_eq!(filter.tenant_org_id, Some("org-456".to_string()));
+        assert_eq!(filter.vpc_id, Some("vpc-789".to_string()));
+        assert_eq!(filter.instance_type_id, Some("type-abc".to_string()));
+    }
+
+    #[test]
+    fn instance_search_filter_from_rpc_no_fields() {
+        let rpc_filter = rpc_forge::InstanceSearchFilter {
+            label: None,
+            tenant_org_id: None,
+            vpc_id: None,
+            instance_type_id: None,
+        };
+        let filter = InstanceSearchFilter::from(rpc_filter);
+        assert!(filter.label.is_none());
+        assert!(filter.tenant_org_id.is_none());
+        assert!(filter.vpc_id.is_none());
+        assert!(filter.instance_type_id.is_none());
     }
 }

--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -68,6 +68,8 @@ pub mod network_prefix;
 pub mod network_security_group;
 pub mod network_segment;
 pub mod network_segment_state_history;
+pub mod nvl_logical_partition;
+pub mod nvl_partition;
 pub mod os;
 pub mod power_manager;
 pub mod power_shelf;

--- a/crates/api-model/src/metadata.rs
+++ b/crates/api-model/src/metadata.rs
@@ -151,6 +151,22 @@ impl Metadata {
     }
 }
 
+/// A single label filter used for searching resources by label key and/or value
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LabelFilter {
+    pub key: String,
+    pub value: Option<String>,
+}
+
+impl From<rpc::forge::Label> for LabelFilter {
+    fn from(label: rpc::forge::Label) -> Self {
+        LabelFilter {
+            key: label.key,
+            value: label.value,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -281,5 +297,38 @@ mod tests {
             metadata.validate(true),
             Err(ConfigValidationError::InvalidValue(_))
         ));
+    }
+
+    #[test]
+    fn label_filter_from_rpc_with_value() {
+        let rpc_label = rpc::forge::Label {
+            key: "env".to_string(),
+            value: Some("prod".to_string()),
+        };
+        let filter = LabelFilter::from(rpc_label);
+        assert_eq!(filter.key, "env");
+        assert_eq!(filter.value, Some("prod".to_string()));
+    }
+
+    #[test]
+    fn label_filter_from_rpc_without_value() {
+        let rpc_label = rpc::forge::Label {
+            key: "env".to_string(),
+            value: None,
+        };
+        let filter = LabelFilter::from(rpc_label);
+        assert_eq!(filter.key, "env");
+        assert_eq!(filter.value, None);
+    }
+
+    #[test]
+    fn label_filter_from_rpc_empty_key() {
+        let rpc_label = rpc::forge::Label {
+            key: String::new(),
+            value: Some("prod".to_string()),
+        };
+        let filter = LabelFilter::from(rpc_label);
+        assert!(filter.key.is_empty());
+        assert_eq!(filter.value, Some("prod".to_string()));
     }
 }

--- a/crates/api-model/src/network_segment/mod.rs
+++ b/crates/api-model/src/network_segment/mod.rs
@@ -37,6 +37,21 @@ use crate::network_segment_state_history::NetworkSegmentStateHistory;
 
 mod slas;
 
+#[derive(Clone, Debug, Default)]
+pub struct NetworkSegmentSearchFilter {
+    pub name: Option<String>,
+    pub tenant_org_id: Option<String>,
+}
+
+impl From<rpc::forge::NetworkSegmentSearchFilter> for NetworkSegmentSearchFilter {
+    fn from(filter: rpc::forge::NetworkSegmentSearchFilter) -> Self {
+        NetworkSegmentSearchFilter {
+            name: filter.name,
+            tenant_org_id: filter.tenant_org_id,
+        }
+    }
+}
+
 /// State of a network segment as tracked by the controller
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "state", rename_all = "lowercase")]

--- a/crates/api-model/src/nvl_logical_partition.rs
+++ b/crates/api-model/src/nvl_logical_partition.rs
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#[derive(Clone, Debug, Default)]
+pub struct NvLinkLogicalPartitionSearchFilter {
+    pub name: Option<String>,
+}
+
+impl From<rpc::forge::NvLinkLogicalPartitionSearchFilter> for NvLinkLogicalPartitionSearchFilter {
+    fn from(filter: rpc::forge::NvLinkLogicalPartitionSearchFilter) -> Self {
+        NvLinkLogicalPartitionSearchFilter { name: filter.name }
+    }
+}

--- a/crates/api-model/src/nvl_partition.rs
+++ b/crates/api-model/src/nvl_partition.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#[derive(Clone, Debug, Default)]
+pub struct NvLinkPartitionSearchFilter {
+    pub tenant_organization_id: Option<String>,
+    pub name: Option<String>,
+}
+
+impl From<rpc::forge::NvLinkPartitionSearchFilter> for NvLinkPartitionSearchFilter {
+    fn from(filter: rpc::forge::NvLinkPartitionSearchFilter) -> Self {
+        NvLinkPartitionSearchFilter {
+            tenant_organization_id: filter.tenant_organization_id,
+            name: filter.name,
+        }
+    }
+}

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -45,6 +45,24 @@ use crate::machine::machine_id::{MissingHardwareInfo, from_hardware_info_with_ty
 use crate::power_shelf::power_shelf_id;
 use crate::switch::switch_id;
 
+#[derive(Clone, Debug, Default)]
+pub struct ExploredEndpointSearchFilter {}
+
+impl From<rpc::site_explorer::ExploredEndpointSearchFilter> for ExploredEndpointSearchFilter {
+    fn from(_filter: rpc::site_explorer::ExploredEndpointSearchFilter) -> Self {
+        ExploredEndpointSearchFilter {}
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ExploredManagedHostSearchFilter {}
+
+impl From<rpc::site_explorer::ExploredManagedHostSearchFilter> for ExploredManagedHostSearchFilter {
+    fn from(_filter: rpc::site_explorer::ExploredManagedHostSearchFilter) -> Self {
+        ExploredManagedHostSearchFilter {}
+    }
+}
+
 /// Data that we gathered about a particular endpoint during site exploration
 /// This data is stored as JSON in the Database. Therefore the format can
 /// only be adjusted in a backward compatible fashion.

--- a/crates/api-model/src/tenant/mod.rs
+++ b/crates/api-model/src/tenant/mod.rs
@@ -33,6 +33,32 @@ use sqlx::{FromRow, Row};
 
 use crate::metadata::Metadata;
 
+#[derive(Clone, Debug, Default)]
+pub struct TenantSearchFilter {
+    pub tenant_organization_name: Option<String>,
+}
+
+impl From<rpc::forge::TenantSearchFilter> for TenantSearchFilter {
+    fn from(filter: rpc::forge::TenantSearchFilter) -> Self {
+        TenantSearchFilter {
+            tenant_organization_name: filter.tenant_organization_name,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct TenantKeysetSearchFilter {
+    pub tenant_org_id: Option<String>,
+}
+
+impl From<rpc::forge::TenantKeysetSearchFilter> for TenantKeysetSearchFilter {
+    fn from(filter: rpc::forge::TenantKeysetSearchFilter) -> Self {
+        TenantKeysetSearchFilter {
+            tenant_org_id: filter.tenant_org_id,
+        }
+    }
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum TenantError {
     #[error("Publickey validation fail for instance {0}, key {1}")]

--- a/crates/api-model/src/vpc.rs
+++ b/crates/api-model/src/vpc.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgRow;
 use sqlx::{FromRow, Row};
 
-use crate::metadata::Metadata;
+use crate::metadata::{LabelFilter, Metadata};
 use crate::tenant::RoutingProfileType;
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -57,6 +57,23 @@ pub struct Vpc {
     pub vni: Option<i32>,
     pub metadata: Metadata,
     pub status: Option<VpcStatus>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct VpcSearchFilter {
+    pub name: Option<String>,
+    pub tenant_org_id: Option<String>,
+    pub label: Option<LabelFilter>,
+}
+
+impl From<rpc::forge::VpcSearchFilter> for VpcSearchFilter {
+    fn from(filter: rpc::forge::VpcSearchFilter) -> Self {
+        VpcSearchFilter {
+            name: filter.name,
+            tenant_org_id: filter.tenant_org_id,
+            label: filter.label.map(LabelFilter::from),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -372,5 +389,57 @@ impl From<VpcPeering> for rpc::forge::VpcPeering {
             vpc_id,
             peer_vpc_id,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vpc_search_filter_from_rpc_all_fields() {
+        let rpc_filter = rpc::forge::VpcSearchFilter {
+            name: Some("my-vpc".to_string()),
+            tenant_org_id: Some("org-123".to_string()),
+            label: Some(rpc::forge::Label {
+                key: "env".to_string(),
+                value: Some("prod".to_string()),
+            }),
+        };
+        let filter = VpcSearchFilter::from(rpc_filter);
+        assert_eq!(filter.name, Some("my-vpc".to_string()));
+        assert_eq!(filter.tenant_org_id, Some("org-123".to_string()));
+        let label = filter.label.unwrap();
+        assert_eq!(label.key, "env");
+        assert_eq!(label.value, Some("prod".to_string()));
+    }
+
+    #[test]
+    fn vpc_search_filter_from_rpc_no_fields() {
+        let rpc_filter = rpc::forge::VpcSearchFilter {
+            name: None,
+            tenant_org_id: None,
+            label: None,
+        };
+        let filter = VpcSearchFilter::from(rpc_filter);
+        assert_eq!(filter.name, None);
+        assert_eq!(filter.tenant_org_id, None);
+        assert!(filter.label.is_none());
+    }
+
+    #[test]
+    fn vpc_search_filter_from_rpc_label_key_only() {
+        let rpc_filter = rpc::forge::VpcSearchFilter {
+            name: None,
+            tenant_org_id: None,
+            label: Some(rpc::forge::Label {
+                key: "team".to_string(),
+                value: None,
+            }),
+        };
+        let filter = VpcSearchFilter::from(rpc_filter);
+        let label = filter.label.unwrap();
+        assert_eq!(label.key, "team");
+        assert_eq!(label.value, None);
     }
 }

--- a/crates/api/src/handlers/compute_allocation.rs
+++ b/crates/api/src/handlers/compute_allocation.rs
@@ -452,7 +452,7 @@ pub(crate) async fn update(
         // Now we need to grab the count of instances for the tenant for this instance type.
         // We will need to compare the count against the new allocation total to make sure the
         // total isn't dropping below the count of already-created instances.
-        let filter = rpc::InstanceSearchFilter {
+        let filter = model::instance::InstanceSearchFilter {
             label: None,
             tenant_org_id: Some(req.tenant_organization_id),
             vpc_id: None,
@@ -597,7 +597,7 @@ pub(crate) async fn delete(
         // Now we need to grab the count of instances for the tenant for this instance type.
         // We will need to compare the count against the new allocation total to make sure the
         // total isn't dropping below the count of already-created instances.
-        let filter = rpc::InstanceSearchFilter {
+        let filter = model::instance::InstanceSearchFilter {
             label: None,
             tenant_org_id: Some(req.tenant_organization_id),
             vpc_id: None,

--- a/crates/api/src/handlers/ib_partition.rs
+++ b/crates/api/src/handlers/ib_partition.rs
@@ -96,7 +96,7 @@ pub(crate) async fn find_ids(
 ) -> Result<Response<rpc::IbPartitionIdList>, Status> {
     log_request_data(&request);
 
-    let filter: rpc::IbPartitionSearchFilter = request.into_inner();
+    let filter: model::ib_partition::IbPartitionSearchFilter = request.into_inner().into();
 
     let ib_partition_ids = db::ib_partition::find_ids(&api.database_connection, filter).await?;
 

--- a/crates/api/src/handlers/instance.rs
+++ b/crates/api/src/handlers/instance.rs
@@ -183,7 +183,7 @@ pub(crate) async fn find_ids(
 ) -> Result<Response<rpc::InstanceIdList>, Status> {
     log_request_data(&request);
 
-    let filter: rpc::InstanceSearchFilter = request.into_inner();
+    let filter: model::instance::InstanceSearchFilter = request.into_inner().into();
 
     let instance_ids = db::instance::find_ids(&api.database_connection, filter).await?;
 

--- a/crates/api/src/handlers/logical_partition.rs
+++ b/crates/api/src/handlers/logical_partition.rs
@@ -57,7 +57,8 @@ pub(crate) async fn find_ids(
 ) -> Result<Response<rpc::NvLinkLogicalPartitionIdList>, Status> {
     log_request_data(&request);
 
-    let filter: rpc::NvLinkLogicalPartitionSearchFilter = request.into_inner();
+    let filter: model::nvl_logical_partition::NvLinkLogicalPartitionSearchFilter =
+        request.into_inner().into();
 
     let partition_ids =
         db::nvl_logical_partition::find_ids(&api.database_connection, filter).await?;

--- a/crates/api/src/handlers/network_segment.rs
+++ b/crates/api/src/handlers/network_segment.rs
@@ -34,7 +34,7 @@ pub(crate) async fn find_ids(
 ) -> Result<Response<rpc::NetworkSegmentIdList>, Status> {
     log_request_data(&request);
 
-    let filter: rpc::NetworkSegmentSearchFilter = request.into_inner();
+    let filter: model::network_segment::NetworkSegmentSearchFilter = request.into_inner().into();
 
     let network_segments_ids =
         db::network_segment::find_ids(&api.database_connection, filter).await?;

--- a/crates/api/src/handlers/nvl_partition.rs
+++ b/crates/api/src/handlers/nvl_partition.rs
@@ -27,12 +27,13 @@ pub(crate) async fn find_ids(
 ) -> Result<Response<rpc::NvLinkPartitionIdList>, Status> {
     log_request_data(&request);
 
-    let filter: rpc::NvLinkPartitionSearchFilter = request.into_inner();
+    let rpc_filter: rpc::NvLinkPartitionSearchFilter = request.into_inner();
 
-    if let Some(ref tenant_org_id_str) = filter.tenant_organization_id {
+    if let Some(ref tenant_org_id_str) = rpc_filter.tenant_organization_id {
         log_tenant_organization_id(tenant_org_id_str);
     }
 
+    let filter: model::nvl_partition::NvLinkPartitionSearchFilter = rpc_filter.into();
     let partition_ids = db::nvl_partition::find_ids(&api.database_connection, filter).await?;
 
     Ok(Response::new(rpc::NvLinkPartitionIdList { partition_ids }))

--- a/crates/api/src/handlers/site_explorer.rs
+++ b/crates/api/src/handlers/site_explorer.rs
@@ -32,7 +32,7 @@ pub(crate) async fn find_explored_endpoint_ids(
 ) -> Result<Response<::rpc::site_explorer::ExploredEndpointIdList>, Status> {
     log_request_data(&request);
 
-    let filter: ::rpc::site_explorer::ExploredEndpointSearchFilter = request.into_inner();
+    let filter: model::site_explorer::ExploredEndpointSearchFilter = request.into_inner().into();
 
     let endpoint_ips = db::explored_endpoints::find_ips(&api.database_connection, filter).await?;
 
@@ -87,7 +87,7 @@ pub(crate) async fn find_explored_managed_host_ids(
 ) -> Result<Response<::rpc::site_explorer::ExploredManagedHostIdList>, Status> {
     log_request_data(&request);
 
-    let filter: ::rpc::site_explorer::ExploredManagedHostSearchFilter = request.into_inner();
+    let filter: model::site_explorer::ExploredManagedHostSearchFilter = request.into_inner().into();
 
     let host_ips = db::explored_managed_host::find_ips(&api.database_connection, filter).await?;
 

--- a/crates/api/src/handlers/tenant.rs
+++ b/crates/api/src/handlers/tenant.rs
@@ -189,7 +189,7 @@ pub(crate) async fn update(
     if current_tenant.routing_profile_type != routing_profile_type
         && !db::vpc::find_ids(
             &mut txn,
-            rpc::VpcSearchFilter {
+            model::vpc::VpcSearchFilter {
                 tenant_org_id: Some(organization_id.clone()),
                 ..Default::default()
             },
@@ -266,7 +266,7 @@ pub(crate) async fn find_tenant_organization_ids(
     request: Request<rpc::TenantSearchFilter>,
 ) -> Result<Response<rpc::TenantOrganizationIdList>, Status> {
     crate::api::log_request_data(&request);
-    let search_config = request.into_inner();
+    let search_config: model::tenant::TenantSearchFilter = request.into_inner().into();
     let tenant_org_ids =
         db::tenant::find_tenant_organization_ids(&api.database_connection, search_config).await?;
     Ok(tonic::Response::new(rpc::TenantOrganizationIdList {

--- a/crates/api/src/handlers/tenant_keyset.rs
+++ b/crates/api/src/handlers/tenant_keyset.rs
@@ -66,7 +66,7 @@ pub(crate) async fn find_ids(
 ) -> Result<Response<rpc::TenantKeysetIdList>, Status> {
     log_request_data(&request);
 
-    let filter: rpc::TenantKeysetSearchFilter = request.into_inner();
+    let filter: model::tenant::TenantKeysetSearchFilter = request.into_inner().into();
 
     let keyset_ids = db::tenant_keyset::find_ids(&api.database_connection, filter).await?;
 

--- a/crates/api/src/handlers/vpc.rs
+++ b/crates/api/src/handlers/vpc.rs
@@ -258,7 +258,7 @@ pub(crate) async fn update_virtualization(
 
     let instances = db::instance::find_ids(
         &mut txn,
-        rpc::InstanceSearchFilter {
+        model::instance::InstanceSearchFilter {
             label: None,
             tenant_org_id: None,
             vpc_id: Some(updater.id.to_string()),
@@ -364,7 +364,7 @@ pub(crate) async fn find_ids(
 ) -> Result<Response<rpc::VpcIdList>, Status> {
     log_request_data(&request);
 
-    let filter: rpc::VpcSearchFilter = request.into_inner();
+    let filter: model::vpc::VpcSearchFilter = request.into_inner().into();
 
     let vpc_ids = db::vpc::find_ids(&api.database_connection, filter).await?;
 

--- a/crates/api/src/ib_fabric_monitor/mod.rs
+++ b/crates/api/src/ib_fabric_monitor/mod.rs
@@ -34,13 +34,12 @@ use metrics::{
     AppliedChange, FabricMetrics, IbFabricMonitorMetrics, UfmOperation, UfmOperationStatus,
 };
 use model::ib::{IBNetwork, IBPort, IBPortMembership, IBPortState};
-use model::ib_partition::PartitionKey;
+use model::ib_partition::{IbPartitionSearchFilter, PartitionKey};
 use model::machine::infiniband::{
     MachineIbInterfaceStatusObservation, MachineInfinibandStatusObservation,
 };
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{HostHealthConfig, LoadSnapshotOptions, ManagedHostStateSnapshot};
-use rpc::forge::IbPartitionSearchFilter;
 use sqlx::{PgConnection, PgPool};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;

--- a/crates/api/src/instance/mod.rs
+++ b/crates/api/src/instance/mod.rs
@@ -445,7 +445,7 @@ pub async fn batch_allocate_instances(
         // Now we need to grab the count of instances for the tenant for this instance type.
         // We will need to compare the count+1 against new allocation total to make sure a
         // new instance won't exceed it.
-        let filter = rpc::InstanceSearchFilter {
+        let filter = model::instance::InstanceSearchFilter {
             label: None,
             tenant_org_id: Some(tenant_organization_id.to_string()),
             vpc_id: None,

--- a/crates/api/src/tests/instance.rs
+++ b/crates/api/src/tests/instance.rs
@@ -62,12 +62,10 @@ use model::machine::{
 };
 use model::metadata::Metadata;
 use model::network_security_group::NetworkSecurityGroupStatusObservation;
-use model::network_segment::NetworkSegmentSearchConfig;
+use model::network_segment::{NetworkSegmentSearchConfig, NetworkSegmentSearchFilter};
 use model::vpc::UpdateVpcVirtualization;
 use model::vpc_prefix::VpcPrefixConfig;
-use rpc::forge::{
-    DpuExtensionService, Issue, IssueCategory, NetworkSegmentSearchFilter, TpmCaCert, TpmCaCertId,
-};
+use rpc::forge::{DpuExtensionService, Issue, IssueCategory, TpmCaCert, TpmCaCertId};
 use rpc::{InstanceReleaseRequest, InterfaceFunctionType, Timestamp};
 use sqlx::PgPool;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};


### PR DESCRIPTION
## Description

We've leaked a few things from `::rpc` into the DB layer, which we generally don't want to do, and now that we have `STYLE_GUIDE.md`, it will be good to practice what we preach.

This specific change introduces search filter equivalents in `api-model`, with `From`/`TryFrom` impls for the API layer to translate to before passing downstream.

Added some tests while I was here.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

