### PR TITLE
chore: prefer struct literals for libmlx struct initialization

### DIFF
--- a/crates/libmlx/build.rs
+++ b/crates/libmlx/build.rs
@@ -317,7 +317,7 @@ fn generate_single_filter_code(filter: &Filter) -> String {
     };
 
     format!(
-        "crate::device::filters::DeviceFilter::new({field_code}, {values_code}, {match_mode_code})",
+        "crate::device::filters::DeviceFilter {{ field: {field_code}, values: {values_code}, match_mode: {match_mode_code} }}",
     )
 }
 

--- a/crates/libmlx/src/device/cmd/device/args.rs
+++ b/crates/libmlx/src/device/cmd/device/args.rs
@@ -141,7 +141,11 @@ pub fn parse_filter_expression(expression: &str) -> Result<DeviceFilter, String>
         MatchMode::Regex
     };
 
-    Ok(DeviceFilter::new(field, values, match_mode))
+    Ok(DeviceFilter {
+        field,
+        values,
+        match_mode,
+    })
 }
 
 // parse_device_field converts a string to a DeviceField enum.

--- a/crates/libmlx/src/device/filters.rs
+++ b/crates/libmlx/src/device/filters.rs
@@ -117,7 +117,11 @@ impl FromStr for DeviceFilter {
             MatchMode::Regex
         };
 
-        Ok(DeviceFilter::new(field, values, match_mode))
+        Ok(DeviceFilter {
+            field,
+            values,
+            match_mode,
+        })
     }
 }
 
@@ -211,48 +215,67 @@ pub struct DeviceFilterSet {
 }
 
 impl DeviceFilter {
-    // new creates a new device filter with the specified parameters.
-    pub fn new(field: DeviceField, values: Vec<String>, match_mode: MatchMode) -> Self {
+    // device_type creates a filter for device type matching.
+    pub fn device_type(values: Vec<String>, match_mode: MatchMode) -> Self {
         Self {
-            field,
+            field: DeviceField::DeviceType,
             values,
             match_mode,
         }
     }
 
-    // device_type creates a filter for device type matching.
-    pub fn device_type(values: Vec<String>, match_mode: MatchMode) -> Self {
-        Self::new(DeviceField::DeviceType, values, match_mode)
-    }
-
     // part_number creates a filter for part number matching.
     pub fn part_number(values: Vec<String>, match_mode: MatchMode) -> Self {
-        Self::new(DeviceField::PartNumber, values, match_mode)
+        Self {
+            field: DeviceField::PartNumber,
+            values,
+            match_mode,
+        }
     }
 
     // firmware_version creates a filter for firmware version matching.
     pub fn firmware_version(values: Vec<String>, match_mode: MatchMode) -> Self {
-        Self::new(DeviceField::FirmwareVersion, values, match_mode)
+        Self {
+            field: DeviceField::FirmwareVersion,
+            values,
+            match_mode,
+        }
     }
 
     // mac_address creates a filter for MAC address matching.
     pub fn mac_address(values: Vec<String>, match_mode: MatchMode) -> Self {
-        Self::new(DeviceField::MacAddress, values, match_mode)
+        Self {
+            field: DeviceField::MacAddress,
+            values,
+            match_mode,
+        }
     }
 
     // description creates a filter for description matching.
     pub fn description(values: Vec<String>, match_mode: MatchMode) -> Self {
-        Self::new(DeviceField::Description, values, match_mode)
+        Self {
+            field: DeviceField::Description,
+            values,
+            match_mode,
+        }
     }
 
     // pci_name creates a filter for PCI name matching.
     pub fn pci_name(values: Vec<String>, match_mode: MatchMode) -> Self {
-        Self::new(DeviceField::PciName, values, match_mode)
+        Self {
+            field: DeviceField::PciName,
+            values,
+            match_mode,
+        }
     }
 
     // status creates a filter for device status matching.
     pub fn status(values: Vec<String>, match_mode: MatchMode) -> Self {
-        Self::new(DeviceField::Status, values, match_mode)
+        Self {
+            field: DeviceField::Status,
+            values,
+            match_mode,
+        }
     }
 
     // matches checks if a device satisfies this filter.

--- a/crates/libmlx/src/registry/registries.rs
+++ b/crates/libmlx/src/registry/registries.rs
@@ -7,7 +7,7 @@ pub static REGISTRIES: Lazy<Vec<crate::variables::registry::MlxVariableRegistry>
         crate::variables::registry::MlxVariableRegistry::new("mlx_generic")
             .with_filters(
                 crate::device::filters::DeviceFilterSet::new()
-                    .with_filter(crate::device::filters::DeviceFilter::new(crate::device::filters::DeviceField::DeviceType, vec!["BlueField2".to_string(), "BlueField3".to_string()], crate::device::filters::MatchMode::Exact))
+                    .with_filter(crate::device::filters::DeviceFilter { field: crate::device::filters::DeviceField::DeviceType, values: vec!["BlueField2".to_string(), "BlueField3".to_string()], match_mode: crate::device::filters::MatchMode::Exact })
             )
             .variables(vec![
                 crate::variables::variable::MlxConfigVariable::builder()

--- a/crates/libmlx/src/runner/applier.rs
+++ b/crates/libmlx/src/runner/applier.rs
@@ -75,7 +75,9 @@ impl MlxConfigApplier {
             .arg("apply")
             .arg(config_file.to_string_lossy().to_string());
 
-        let executor = CommandExecutor::new(&self.options);
+        let executor = CommandExecutor {
+            options: &self.options,
+        };
 
         if self.options.verbose {
             println!("[applier] {spec}");
@@ -101,7 +103,9 @@ impl MlxConfigApplier {
             .arg("--yes")
             .arg("reset");
 
-        let executor = CommandExecutor::new(&self.options);
+        let executor = CommandExecutor {
+            options: &self.options,
+        };
 
         if self.options.verbose {
             println!("[applier] {spec}");

--- a/crates/libmlx/src/runner/command_builder.rs
+++ b/crates/libmlx/src/runner/command_builder.rs
@@ -82,21 +82,14 @@ impl std::fmt::Display for CommandSpec {
 // for different operations (query, set) with proper argument formatting.
 pub struct CommandBuilder<'a> {
     // device is the device identifier (e.g., "01:00.0")
-    device: &'a str,
+    pub device: &'a str,
     // options contains the execution options for running
     // mlxconfig, including specific behaviors, as well
     // as logging.
-    options: &'a ExecOptions,
+    pub options: &'a ExecOptions,
 }
 
 impl<'a> CommandBuilder<'a> {
-    // new creates a new CommandBuilder for the
-    // specified device, with the given execution options
-    // as configured in the parent runner.
-    pub fn new(device: &'a str, options: &'a ExecOptions) -> Self {
-        Self { device, options }
-    }
-
     // build_query_command builds an mlxconfig query command
     // spec, with JSON output configured to specified temp file.
     pub fn build_query_command(

--- a/crates/libmlx/src/runner/executor.rs
+++ b/crates/libmlx/src/runner/executor.rs
@@ -40,16 +40,10 @@ use crate::runner::exec_options::ExecOptions;
 pub struct CommandExecutor<'a> {
     // options contains the execution options controlling retry,
     // timeout, and interactive confirmation behavior.
-    options: &'a ExecOptions,
+    pub options: &'a ExecOptions,
 }
 
 impl<'a> CommandExecutor<'a> {
-    // Creates a new CommandExecutor with the specified options
-    // for how to execute the command.
-    pub fn new(options: &'a ExecOptions) -> Self {
-        Self { options }
-    }
-
     // Executes a command with retry logic, exponential backoff, and timeout
     // handling using backon. Returns the command output on success, or an error
     // if we had to give up after configured retries/timeouts.

--- a/crates/libmlx/src/runner/json_parser.rs
+++ b/crates/libmlx/src/runner/json_parser.rs
@@ -38,11 +38,11 @@ use crate::variables::value::MlxConfigValue;
 pub struct JsonResponseParser<'a> {
     // registry is the registry containing variable definitions
     // for validation.
-    registry: &'a MlxVariableRegistry,
+    pub registry: &'a MlxVariableRegistry,
     // options are the execution options provided by the
     // parent runner, which in this case is primarily used
     // by the JSON parser for logging control.
-    options: &'a ExecOptions,
+    pub options: &'a ExecOptions,
 }
 
 // JsonResponse represents the top-level structure of the
@@ -106,11 +106,6 @@ pub enum JsonValueField {
 }
 
 impl<'a> JsonResponseParser<'a> {
-    // new creates a new JSON parser with registry and options.
-    pub fn new(registry: &'a MlxVariableRegistry, options: &'a ExecOptions) -> Self {
-        Self { registry, options }
-    }
-
     // parse_json_response parses a complete JSON response file from mlxconfig
     // into a QueryResult. It also validates that the device in the response
     // matches the expected device we provided, because if those don't match,
@@ -146,15 +141,15 @@ impl<'a> JsonResponseParser<'a> {
         // converted into properly typed values and such.
         let variables = self.parse_variables(&json_response.device.tlv_configuration)?;
 
-        Ok(QueryResult::new(
-            QueriedDeviceInfo {
+        Ok(QueryResult {
+            device_info: QueriedDeviceInfo {
                 device_id: Some(json_response.device.device),
                 device_type: Some(json_response.device.device_type),
                 part_number: Some(json_response.device.name),
                 description: Some(json_response.device.description),
             },
             variables,
-        ))
+        })
     }
 
     // parse_variables is the thing that actually parses all variables
@@ -214,14 +209,14 @@ impl<'a> JsonResponseParser<'a> {
             self.json_value_to_config_value(registry_var, &json_var.default_value)?;
         let next_value = self.json_value_to_config_value(registry_var, &json_var.next_value)?;
 
-        Ok(QueriedVariable::new(
-            registry_var.clone(),
+        Ok(QueriedVariable {
+            variable: registry_var.clone(),
             current_value,
             default_value,
             next_value,
-            json_var.modified,
-            json_var.read_only,
-        ))
+            modified: json_var.modified,
+            read_only: json_var.read_only,
+        })
     }
 
     // parse_array_variable parses an array variable by collecting
@@ -277,14 +272,14 @@ impl<'a> JsonResponseParser<'a> {
             }
         }
 
-        Ok(QueriedVariable::new(
-            registry_var.clone(),
+        Ok(QueriedVariable {
+            variable: registry_var.clone(),
             current_value,
             default_value,
             next_value,
             modified,
             read_only,
-        ))
+        })
     }
 
     // build_sparse_array_from_json builds a sparse array MlxConfigValue

--- a/crates/libmlx/src/runner/result_types.rs
+++ b/crates/libmlx/src/runner/result_types.rs
@@ -67,30 +67,9 @@ pub struct QueriedVariable {
 }
 
 // QueriedVariable provides a few methods to make
-// working with them easier, including a constructor
-// of course, as well as some wrappers to get at
-// underlying data (such as the variable name).
+// working with them easier, including some wrappers
+// to get at underlying data (such as the variable name).
 impl QueriedVariable {
-    // new creates a new QueriedVariable with
-    // all required parameters.
-    pub fn new(
-        variable: MlxConfigVariable,
-        current_value: MlxConfigValue,
-        default_value: MlxConfigValue,
-        next_value: MlxConfigValue,
-        modified: bool,
-        read_only: bool,
-    ) -> Self {
-        Self {
-            variable,
-            current_value,
-            default_value,
-            next_value,
-            modified,
-            read_only,
-        }
-    }
-
     // name returns the variable name.
     pub fn name(&self) -> &str {
         &self.variable.name
@@ -167,14 +146,6 @@ impl QueriedDeviceInfo {
 }
 
 impl QueryResult {
-    // new creates a new QueryResult.
-    pub fn new(device_info: QueriedDeviceInfo, variables: Vec<QueriedVariable>) -> Self {
-        Self {
-            device_info,
-            variables,
-        }
-    }
-
     // variable_count returns the number of variables
     // in the query result.
     pub fn variable_count(&self) -> usize {
@@ -216,24 +187,6 @@ pub struct SyncResult {
 }
 
 impl SyncResult {
-    // new creates a new SyncResult with everything
-    // needed to populate it.
-    pub fn new(
-        variables_checked: usize,
-        variables_changed: usize,
-        changes_applied: Vec<VariableChange>,
-        execution_time: Duration,
-        query_result: QueryResult,
-    ) -> Self {
-        Self {
-            variables_checked,
-            variables_changed,
-            changes_applied,
-            execution_time,
-            query_result,
-        }
-    }
-
     // summary prints a summary of the sync result -- this
     // is mainly just for the CLI reference example for now.
     pub fn summary(&self) -> String {
@@ -263,21 +216,6 @@ pub struct ComparisonResult {
 }
 
 impl ComparisonResult {
-    // new creates a new ComparisonResult.
-    pub fn new(
-        variables_checked: usize,
-        variables_needing_change: usize,
-        planned_changes: Vec<PlannedChange>,
-        query_result: QueryResult,
-    ) -> Self {
-        Self {
-            variables_checked,
-            variables_needing_change,
-            planned_changes,
-            query_result,
-        }
-    }
-
     // summary prints a summary of the comparison result -- this
     // is mainly just for the CLI reference example for now.
     pub fn summary(&self) -> String {
@@ -304,19 +242,6 @@ pub struct PlannedChange {
 }
 
 impl PlannedChange {
-    // new creates a new PlannedChange.
-    pub fn new(
-        variable_name: String,
-        current_value: MlxConfigValue,
-        desired_value: MlxConfigValue,
-    ) -> Self {
-        Self {
-            variable_name,
-            current_value,
-            desired_value,
-        }
-    }
-
     // description prints a description of the planned change -- this
     // is mainly just for the CLI reference example for now.
     pub fn description(&self) -> String {
@@ -341,19 +266,6 @@ pub struct VariableChange {
 }
 
 impl VariableChange {
-    // new creates a new VariableChange.
-    pub fn new(
-        variable_name: String,
-        old_value: MlxConfigValue,
-        new_value: MlxConfigValue,
-    ) -> Self {
-        Self {
-            variable_name,
-            old_value,
-            new_value,
-        }
-    }
-
     // description prints a description of the change -- this
     // is mainly just for the CLI reference example for now.
     pub fn description(&self) -> String {

--- a/crates/libmlx/src/runner/runner.rs
+++ b/crates/libmlx/src/runner/runner.rs
@@ -191,11 +191,11 @@ impl MlxConfigRunner {
                 // desired value, or if we need to change the next value to our desired
                 // value).
                 if &queried_var.next_value != desired_value {
-                    planned_changes.push(PlannedChange::new(
-                        desired_value.name().to_string(),
-                        queried_var.next_value.clone(),
-                        desired_value.clone(),
-                    ));
+                    planned_changes.push(PlannedChange {
+                        variable_name: desired_value.name().to_string(),
+                        current_value: queried_var.next_value.clone(),
+                        desired_value: desired_value.clone(),
+                    });
                     values_to_set.push(desired_value.clone());
                 }
             }
@@ -238,7 +238,11 @@ impl MlxConfigRunner {
             // Convert planned changes to applied changes.
             planned_changes
                 .into_iter()
-                .map(|pc| VariableChange::new(pc.variable_name, pc.current_value, pc.desired_value))
+                .map(|pc| VariableChange {
+                    variable_name: pc.variable_name,
+                    old_value: pc.current_value,
+                    new_value: pc.desired_value,
+                })
                 .collect()
         };
 
@@ -251,13 +255,13 @@ impl MlxConfigRunner {
             );
         }
 
-        Ok(SyncResult::new(
-            desired_values.len(),
-            changes_applied.len(),
+        Ok(SyncResult {
+            variables_checked: desired_values.len(),
+            variables_changed: changes_applied.len(),
             changes_applied,
             execution_time,
             query_result,
-        ))
+        })
     }
 
     // compare will compare provided values to observed values on the card.
@@ -293,21 +297,21 @@ impl MlxConfigRunner {
                 // defs should *also* match. If it ends up being a problem though,
                 // this can just become .value for each.
                 if &queried_var.next_value != desired_value {
-                    planned_changes.push(PlannedChange::new(
-                        desired_value.name().to_string(),
-                        queried_var.next_value.clone(),
-                        desired_value.clone(),
-                    ));
+                    planned_changes.push(PlannedChange {
+                        variable_name: desired_value.name().to_string(),
+                        current_value: queried_var.next_value.clone(),
+                        desired_value: desired_value.clone(),
+                    });
                 }
             }
         }
 
-        Ok(ComparisonResult::new(
-            desired_values.len(),
-            planned_changes.len(),
+        Ok(ComparisonResult {
+            variables_checked: desired_values.len(),
+            variables_needing_change: planned_changes.len(),
             planned_changes,
             query_result,
-        ))
+        })
     }
 
     // query_variables_internal is an internal method to query
@@ -317,9 +321,14 @@ impl MlxConfigRunner {
         variable_names: &[String],
     ) -> Result<QueryResult, MlxRunnerError> {
         self.validate_device_matches_registry()?;
-        let executor = CommandExecutor::new(&self.options);
+        let executor = CommandExecutor {
+            options: &self.options,
+        };
         let temp_file = executor.create_temp_file(self.get_temp_file_prefix())?;
-        let command_builder = CommandBuilder::new(&self.device, &self.options);
+        let command_builder = CommandBuilder {
+            device: &self.device,
+            options: &self.options,
+        };
         let command_spec = command_builder.build_query_command(variable_names, &temp_file)?;
 
         if self.options.verbose {
@@ -328,7 +337,10 @@ impl MlxConfigRunner {
 
         if !executor.is_dry_run() {
             executor.execute_with_retry(&command_spec)?;
-            let parser = JsonResponseParser::new(&self.registry, &self.options);
+            let parser = JsonResponseParser {
+                registry: &self.registry,
+                options: &self.options,
+            };
             let query_result = parser.parse_json_response(&temp_file, &self.device)?;
             executor.cleanup_temp_file(&temp_file)?;
             Ok(query_result)
@@ -336,7 +348,10 @@ impl MlxConfigRunner {
             executor.execute_dry_run(&command_spec, "query");
             executor.cleanup_temp_file(&temp_file)?;
             // Return empty result for dry run
-            Ok(QueryResult::new(QueriedDeviceInfo::default(), Vec::new()))
+            Ok(QueryResult {
+                device_info: QueriedDeviceInfo::default(),
+                variables: Vec::new(),
+            })
         }
     }
 
@@ -349,7 +364,9 @@ impl MlxConfigRunner {
             return Ok(());
         }
 
-        let executor = CommandExecutor::new(&self.options);
+        let executor = CommandExecutor {
+            options: &self.options,
+        };
 
         // Check for destructive variables if confirmation is enabled
         if self.options.confirm_destructive {
@@ -368,7 +385,10 @@ impl MlxConfigRunner {
             }
         }
 
-        let command_builder = CommandBuilder::new(&self.device, &self.options);
+        let command_builder = CommandBuilder {
+            device: &self.device,
+            options: &self.options,
+        };
         let assignments = command_builder.build_set_assignments(config_values)?;
         let command_spec = command_builder.build_set_command(&assignments)?;
 

--- a/crates/libmlx/tests/runner/command_builder_tests.rs
+++ b/crates/libmlx/tests/runner/command_builder_tests.rs
@@ -28,7 +28,10 @@ use super::common;
 #[test]
 fn test_build_query_command_spec_basic() {
     let options = ExecOptions::default();
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let temp_file = Path::new("/tmp/test.json");
     let variables = vec!["SRIOV_EN".to_string(), "NUM_OF_VFS".to_string()];
@@ -54,7 +57,10 @@ fn test_build_query_command_spec_basic() {
 #[test]
 fn test_build_query_command_spec_empty_variables() {
     let options = ExecOptions::default();
-    let builder = CommandBuilder::new("02:00.0", &options);
+    let builder = CommandBuilder {
+        device: "02:00.0",
+        options: &options,
+    };
 
     let temp_file = Path::new("/tmp/test_empty.json");
     let variables: Vec<String> = vec![];
@@ -73,7 +79,10 @@ fn test_build_query_command_spec_empty_variables() {
 #[test]
 fn test_build_query_command_spec_many_variables() {
     let options = ExecOptions::default();
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let temp_file = Path::new("/tmp/test_many.json");
     let variables = vec![
@@ -94,7 +103,10 @@ fn test_build_query_command_spec_many_variables() {
 #[test]
 fn test_build_set_command_spec_basic() {
     let options = ExecOptions::default();
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let assignments = vec!["SRIOV_EN=true".to_string(), "NUM_OF_VFS=16".to_string()];
 
@@ -112,7 +124,10 @@ fn test_build_set_command_spec_basic() {
 #[test]
 fn test_build_set_command_spec_empty_assignments() {
     let options = ExecOptions::default();
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let assignments: Vec<String> = vec![];
 
@@ -168,7 +183,10 @@ fn test_build_set_assignments_boolean() {
     let config_value = sriov_var.with(true).unwrap();
 
     let options = ExecOptions::default();
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let assignments = builder.build_set_assignments(&[config_value]).unwrap();
 
@@ -183,7 +201,10 @@ fn test_build_set_assignments_integer() {
     let config_value = vfs_var.with(32i64).unwrap();
 
     let options = ExecOptions::default();
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let assignments = builder.build_set_assignments(&[config_value]).unwrap();
 
@@ -198,7 +219,10 @@ fn test_build_set_assignments_enum() {
     let config_value = power_var.with("HIGH").unwrap();
 
     let options = ExecOptions::default();
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let assignments = builder.build_set_assignments(&[config_value]).unwrap();
 
@@ -213,7 +237,10 @@ fn test_build_set_assignments_preset() {
     let config_value = preset_var.with(7u8).unwrap();
 
     let options = ExecOptions::default();
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let assignments = builder.build_set_assignments(&[config_value]).unwrap();
 
@@ -228,7 +255,10 @@ fn test_build_set_assignments_boolean_array_dense() {
     let config_value = gpio_var.with(vec![true, false, true, false]).unwrap();
 
     let options = ExecOptions::default();
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let assignments = builder.build_set_assignments(&[config_value]).unwrap();
 
@@ -247,7 +277,10 @@ fn test_build_set_assignments_boolean_array_sparse() {
     let config_value = gpio_var.with(sparse_values).unwrap();
 
     let options = ExecOptions::default();
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let assignments = builder.build_set_assignments(&[config_value]).unwrap();
 
@@ -267,7 +300,10 @@ fn test_build_set_assignments_integer_array_sparse() {
     let config_value = thermal_var.with(sparse_values).unwrap();
 
     let options = ExecOptions::default();
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let assignments = builder.build_set_assignments(&[config_value]).unwrap();
 
@@ -295,7 +331,10 @@ fn test_build_set_assignments_enum_array_sparse() {
     let config_value = gpio_modes_var.with(sparse_values).unwrap();
 
     let options = ExecOptions::default();
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let assignments = builder.build_set_assignments(&[config_value]).unwrap();
 
@@ -314,7 +353,10 @@ fn test_build_set_assignments_binary_hex() {
     let config_value = uuid_var.with(binary_data).unwrap();
 
     let options = ExecOptions::default();
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let assignments = builder.build_set_assignments(&[config_value]).unwrap();
 
@@ -337,7 +379,10 @@ fn test_build_set_assignments_multiple_variables() {
     ];
 
     let options = ExecOptions::default();
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let assignments = builder.build_set_assignments(&config_values).unwrap();
 
@@ -350,7 +395,10 @@ fn test_build_set_assignments_multiple_variables() {
 #[test]
 fn test_build_set_assignments_empty() {
     let options = ExecOptions::default();
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let assignments = builder.build_set_assignments(&[]).unwrap();
 
@@ -365,7 +413,10 @@ fn test_different_devices() {
     let devices = ["01:00.0", "02:00.0", "03:00.1", "0000:01:00.0"];
 
     for device in &devices {
-        let builder = CommandBuilder::new(device, &options);
+        let builder = CommandBuilder {
+            device,
+            options: &options,
+        };
         let temp_file = Path::new("/tmp/test.json");
         let variables = vec!["TEST_VAR".to_string()];
 
@@ -377,7 +428,10 @@ fn test_different_devices() {
 #[test]
 fn test_verbose_logging() {
     let options = ExecOptions::new().with_verbose(true);
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let temp_file = Path::new("/tmp/test.json");
     let variables = vec!["TEST_VAR".to_string()];
@@ -404,7 +458,10 @@ fn test_command_spec_to_command_conversion() {
 #[test]
 fn test_realistic_mlxconfig_query_spec() {
     let options = ExecOptions::default();
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let variables = vec![
         "SRIOV_EN".to_string(),
@@ -424,7 +481,10 @@ fn test_realistic_mlxconfig_query_spec() {
 #[test]
 fn test_realistic_mlxconfig_set_spec() {
     let options = ExecOptions::default();
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let assignments = vec!["SRIOV_EN=true".to_string(), "NUM_OF_VFS=16".to_string()];
 
@@ -437,7 +497,10 @@ fn test_realistic_mlxconfig_set_spec() {
 #[test]
 fn test_command_spec_args_order() {
     let options = ExecOptions::default();
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let variables = vec!["VAR1".to_string(), "VAR2".to_string()];
     let temp_file = Path::new("/tmp/test.json");
@@ -460,7 +523,10 @@ fn test_command_spec_args_order() {
 #[test]
 fn test_command_spec_complex_path() {
     let options = ExecOptions::default();
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let temp_file = Path::new("/tmp/very/deep/directory/structure/test.json");
     let variables = vec!["TEST_VAR".to_string()];

--- a/crates/libmlx/tests/runner/executor_tests.rs
+++ b/crates/libmlx/tests/runner/executor_tests.rs
@@ -30,7 +30,7 @@ use libmlx::runner::executor::CommandExecutor;
 #[test]
 fn test_create_temp_file() {
     let options = ExecOptions::default();
-    let executor = CommandExecutor::new(&options);
+    let executor = CommandExecutor { options: &options };
 
     let temp_dir = tempfile::tempdir().unwrap();
     let prefix = temp_dir.path().to_str().unwrap();
@@ -57,7 +57,7 @@ fn test_create_temp_file() {
 #[test]
 fn test_cleanup_temp_file_existing() {
     let options = ExecOptions::default();
-    let executor = CommandExecutor::new(&options);
+    let executor = CommandExecutor { options: &options };
 
     let temp_dir = tempfile::tempdir().unwrap();
     let prefix = temp_dir.path().to_str().unwrap();
@@ -73,7 +73,7 @@ fn test_cleanup_temp_file_existing() {
 #[test]
 fn test_cleanup_temp_file_nonexistent() {
     let options = ExecOptions::default();
-    let executor = CommandExecutor::new(&options);
+    let executor = CommandExecutor { options: &options };
 
     let temp_dir = tempfile::tempdir().unwrap();
     let nonexistent_file = temp_dir.path().join("nonexistent.json");
@@ -85,30 +85,41 @@ fn test_cleanup_temp_file_nonexistent() {
 #[test]
 fn test_is_dry_run() {
     let dry_run_options = ExecOptions::new().with_dry_run(true);
-    let executor = CommandExecutor::new(&dry_run_options);
+    let executor = CommandExecutor {
+        options: &dry_run_options,
+    };
     assert!(executor.is_dry_run());
 
     let normal_options = ExecOptions::new().with_dry_run(false);
-    let executor = CommandExecutor::new(&normal_options);
+    let executor = CommandExecutor {
+        options: &normal_options,
+    };
     assert!(!executor.is_dry_run());
 }
 
 #[test]
 fn test_is_verbose() {
     let verbose_options = ExecOptions::new().with_verbose(true);
-    let executor = CommandExecutor::new(&verbose_options);
+    let executor = CommandExecutor {
+        options: &verbose_options,
+    };
     assert!(executor.is_verbose());
 
     let quiet_options = ExecOptions::new().with_verbose(false);
-    let executor = CommandExecutor::new(&quiet_options);
+    let executor = CommandExecutor {
+        options: &quiet_options,
+    };
     assert!(!executor.is_verbose());
 }
 
 #[test]
 fn test_execute_dry_run() {
     let options = ExecOptions::new().with_dry_run(true);
-    let executor = CommandExecutor::new(&options);
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let executor = CommandExecutor { options: &options };
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let assignments = vec!["TEST_VAR=test".to_string()];
     let command_spec = builder.build_set_command(&assignments).unwrap();
@@ -120,7 +131,7 @@ fn test_execute_dry_run() {
 #[test]
 fn test_successful_command_execution() {
     let options = ExecOptions::default();
-    let executor = CommandExecutor::new(&options);
+    let executor = CommandExecutor { options: &options };
 
     // Use a simple command that should always succeed.
     let command_spec = CommandSpec::new("echo").arg("hello");
@@ -134,7 +145,7 @@ fn test_successful_command_execution() {
 fn test_failed_command_execution() {
     // No retries to make the test faster.
     let options = ExecOptions::new().with_retries(0);
-    let executor = CommandExecutor::new(&options);
+    let executor = CommandExecutor { options: &options };
 
     // Use a command that should always fail.
     let command_spec = CommandSpec::new("false");
@@ -147,7 +158,7 @@ fn test_failed_command_execution() {
 fn test_command_not_found() {
     // No retries to make the test faster.
     let options = ExecOptions::new().with_retries(0);
-    let executor = CommandExecutor::new(&options);
+    let executor = CommandExecutor { options: &options };
 
     // Use a command that definitely doesn't exist.
     let command_spec = CommandSpec::new("duppet_is_real_but_not_like_this");
@@ -163,7 +174,7 @@ fn test_timeout_functionality() {
         .with_timeout(Some(Duration::from_millis(100)))
         .with_retries(0); // No retries to make test faster
 
-    let executor = CommandExecutor::new(&options);
+    let executor = CommandExecutor { options: &options };
 
     // Use sleep command that will exceed our timeout.
     let command_spec = CommandSpec::new("sleep").arg("5");
@@ -185,7 +196,7 @@ fn test_no_timeout_successful_execution() {
         .with_timeout(None) // No timeout in this case.
         .with_retries(0);
 
-    let executor = CommandExecutor::new(&options);
+    let executor = CommandExecutor { options: &options };
 
     // Use a command that should complete quickly
     let command_spec = CommandSpec::new("echo").arg("no timeout test");
@@ -201,7 +212,7 @@ fn test_no_timeout_successful_execution() {
 #[test]
 fn test_should_retry_error_classification() {
     let options = ExecOptions::default();
-    let executor = CommandExecutor::new(&options);
+    let executor = CommandExecutor { options: &options };
 
     // Permanent errors should not be retried.
     assert!(
@@ -257,7 +268,7 @@ fn test_exponential_backoff_configuration() {
         .with_max_retry_delay(Duration::from_millis(100))
         .with_retry_multiplier(3.0); // Triple each time
 
-    let executor = CommandExecutor::new(&options);
+    let executor = CommandExecutor { options: &options };
 
     // Test that options are correctly set
     assert_eq!(options.retries, 3);
@@ -281,7 +292,7 @@ fn test_conservative_backoff() {
         .with_retry_multiplier(1.2) // Only 20% increase each time
         .with_retries(2);
 
-    let executor = CommandExecutor::new(&options);
+    let executor = CommandExecutor { options: &options };
 
     // Use a command that should succeed
     let command_spec = CommandSpec::new("echo").arg("conservative test");
@@ -303,7 +314,7 @@ fn test_aggressive_backoff() {
         .with_retry_multiplier(5.0) // 5x increase each time
         .with_retries(2);
 
-    let executor = CommandExecutor::new(&options);
+    let executor = CommandExecutor { options: &options };
 
     // Use a command that should succeed
     let command_spec = CommandSpec::new("echo").arg("aggressive test");
@@ -322,7 +333,7 @@ fn test_retry_logic_with_retries() {
         .with_retries(2)
         .with_retry_delay(Duration::from_millis(10)); // Fast retry for testing
 
-    let executor = CommandExecutor::new(&options);
+    let executor = CommandExecutor { options: &options };
 
     // Command that always fails
     let command_spec = CommandSpec::new("false");
@@ -340,7 +351,7 @@ fn test_retry_logic_eventual_success() {
         .with_retries(1)
         .with_retry_delay(Duration::from_millis(10));
 
-    let executor = CommandExecutor::new(&options);
+    let executor = CommandExecutor { options: &options };
 
     // Use a command that should succeed
     let command_spec = CommandSpec::new("echo").arg("success");
@@ -352,7 +363,7 @@ fn test_retry_logic_eventual_success() {
 #[test]
 fn test_temp_file_unique_names() {
     let options = ExecOptions::default();
-    let executor = CommandExecutor::new(&options);
+    let executor = CommandExecutor { options: &options };
 
     let temp_dir = tempfile::tempdir().unwrap();
     let prefix = temp_dir.path().to_str().unwrap();
@@ -380,7 +391,7 @@ fn test_temp_file_unique_names() {
 #[test]
 fn test_temp_file_directory_creation() {
     let options = ExecOptions::default();
-    let executor = CommandExecutor::new(&options);
+    let executor = CommandExecutor { options: &options };
 
     // Use system temp directory which should always be writable
     let result = executor.create_temp_file("/tmp");
@@ -395,7 +406,7 @@ fn test_temp_file_directory_creation() {
 #[test]
 fn test_temp_file_content_isolation() {
     let options = ExecOptions::default();
-    let executor = CommandExecutor::new(&options);
+    let executor = CommandExecutor { options: &options };
 
     let temp_dir = tempfile::tempdir().unwrap();
     let prefix = temp_dir.path().to_str().unwrap();
@@ -424,8 +435,8 @@ fn test_executor_options_independence() {
     let options1 = ExecOptions::new().with_verbose(true);
     let options2 = ExecOptions::new().with_dry_run(true);
 
-    let executor1 = CommandExecutor::new(&options1);
-    let executor2 = CommandExecutor::new(&options2);
+    let executor1 = CommandExecutor { options: &options1 };
+    let executor2 = CommandExecutor { options: &options2 };
 
     assert!(executor1.is_verbose());
     assert!(!executor1.is_dry_run());
@@ -437,8 +448,11 @@ fn test_executor_options_independence() {
 #[test]
 fn test_mlxconfig_query_command_spec_execution() {
     let options = ExecOptions::new().with_retries(0); // No retries for faster test
-    let _executor = CommandExecutor::new(&options);
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let _executor = CommandExecutor { options: &options };
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let temp_dir = tempfile::tempdir().unwrap();
     let temp_file = temp_dir.path().join("test.json");
@@ -457,8 +471,11 @@ fn test_mlxconfig_query_command_spec_execution() {
 #[test]
 fn test_mlxconfig_set_command_spec_execution() {
     let options = ExecOptions::new().with_retries(0).with_dry_run(true); // Dry run to avoid actual execution
-    let executor = CommandExecutor::new(&options);
-    let builder = CommandBuilder::new("01:00.0", &options);
+    let executor = CommandExecutor { options: &options };
+    let builder = CommandBuilder {
+        device: "01:00.0",
+        options: &options,
+    };
 
     let assignments = vec!["SRIOV_EN=true".to_string()];
     let command_spec = builder.build_set_command(&assignments).unwrap();
@@ -476,7 +493,10 @@ fn test_mlxconfig_set_command_spec_execution() {
 #[test]
 fn test_command_spec_integration_with_builder() {
     let options = ExecOptions::default();
-    let builder = CommandBuilder::new("02:00.0", &options);
+    let builder = CommandBuilder {
+        device: "02:00.0",
+        options: &options,
+    };
 
     // Test that CommandBuilder properly creates CommandSpec objects
     let temp_file = Path::new("/tmp/integration_test.json");
@@ -499,7 +519,7 @@ mod integration_tests {
     #[test]
     fn test_temp_file_lifecycle() {
         let options = ExecOptions::default();
-        let executor = CommandExecutor::new(&options);
+        let executor = CommandExecutor { options: &options };
 
         let temp_dir = tempfile::tempdir().unwrap();
         let prefix = temp_dir.path().to_str().unwrap();
@@ -527,7 +547,9 @@ mod integration_tests {
             .with_retry_delay(Duration::from_millis(100))
             .with_verbose(false);
 
-        let executor = CommandExecutor::new(&production_options);
+        let executor = CommandExecutor {
+            options: &production_options,
+        };
 
         // Test with a command that should succeed
         let command_spec = CommandSpec::new("echo").arg("production test");
@@ -544,7 +566,7 @@ mod integration_tests {
             .with_retries(2)
             .with_retry_delay(Duration::from_millis(5)); // Fast retry
 
-        let executor = CommandExecutor::new(&options);
+        let executor = CommandExecutor { options: &options };
 
         // Use sleep command that will consistently timeout
         let command_spec = CommandSpec::new("sleep").arg("1"); // Sleep for 1 second
@@ -569,7 +591,7 @@ mod integration_tests {
             .with_timeout(Some(Duration::from_secs(5))) // Generous timeout
             .with_retries(1);
 
-        let executor = CommandExecutor::new(&options);
+        let executor = CommandExecutor { options: &options };
 
         // Use a command that should complete quickly
         let command_spec = CommandSpec::new("echo").arg("timeout test success");
@@ -592,7 +614,7 @@ mod integration_tests {
             .with_retry_multiplier(2.0)
             .with_verbose(false); // Reduce noise in test output
 
-        let executor = CommandExecutor::new(&options);
+        let executor = CommandExecutor { options: &options };
 
         // Use a command that will always fail to trigger retries
         let command_spec = CommandSpec::new("false");
@@ -627,7 +649,7 @@ mod integration_tests {
             .with_retry_multiplier(10.0) // High multiplier that would exceed cap
             .with_verbose(false);
 
-        let executor = CommandExecutor::new(&options);
+        let executor = CommandExecutor { options: &options };
 
         // Use a command that will always fail
         let command_spec = CommandSpec::new("false");
@@ -650,8 +672,11 @@ mod integration_tests {
     fn test_builder_executor_integration() {
         // Test the full integration between CommandBuilder and CommandExecutor
         let options = ExecOptions::new().with_dry_run(true); // Dry run for safety
-        let builder = CommandBuilder::new("01:00.0", &options);
-        let executor = CommandExecutor::new(&options);
+        let builder = CommandBuilder {
+            device: "01:00.0",
+            options: &options,
+        };
+        let executor = CommandExecutor { options: &options };
 
         // Test query command flow
         let temp_dir = tempfile::tempdir().unwrap();
@@ -684,7 +709,7 @@ mod integration_tests {
                 .with_retry_delay(Duration::from_millis(10))
                 .with_retry_multiplier(multiplier);
 
-            let executor = CommandExecutor::new(&options);
+            let executor = CommandExecutor { options: &options };
 
             // Use a command that should succeed
             let command_spec = CommandSpec::new("echo").arg(format!("multiplier test {test_name}"));
@@ -702,7 +727,7 @@ mod error_classification_tests {
     #[test]
     fn test_all_permanent_errors() {
         let options = ExecOptions::default();
-        let executor = CommandExecutor::new(&options);
+        let executor = CommandExecutor { options: &options };
 
         // Test all permanent error types
         let permanent_errors = vec![
@@ -750,7 +775,7 @@ mod error_classification_tests {
     #[test]
     fn test_all_transient_errors() {
         let options = ExecOptions::default();
-        let executor = CommandExecutor::new(&options);
+        let executor = CommandExecutor { options: &options };
 
         // Test all transient error types
         let transient_errors = vec![
@@ -801,7 +826,7 @@ mod error_classification_tests {
         ];
 
         for options in edge_cases {
-            let executor = CommandExecutor::new(&options);
+            let executor = CommandExecutor { options: &options };
 
             // Test that all configurations work with a simple command
             let command_spec = CommandSpec::new("echo").arg("edge case test");

--- a/crates/libmlx/tests/runner/json_parser_tests.rs
+++ b/crates/libmlx/tests/runner/json_parser_tests.rs
@@ -31,7 +31,10 @@ use super::common;
 fn test_parse_basic_json_response() {
     let registry = common::create_test_registry();
     let options = ExecOptions::default();
-    let parser = JsonResponseParser::new(&registry, &options);
+    let parser = JsonResponseParser {
+        registry: &registry,
+        options: &options,
+    };
 
     let json_data = common::create_sample_json_response("01:00.0");
 
@@ -75,7 +78,10 @@ fn test_parse_basic_json_response() {
 fn test_parse_array_variables() {
     let registry = common::create_test_registry();
     let options = ExecOptions::default();
-    let parser = JsonResponseParser::new(&registry, &options);
+    let parser = JsonResponseParser {
+        registry: &registry,
+        options: &options,
+    };
 
     let json_data = common::create_array_json_response("01:00.0");
 
@@ -150,7 +156,10 @@ fn test_parse_array_variables() {
 fn test_device_mismatch_error() {
     let registry = common::create_test_registry();
     let options = ExecOptions::default();
-    let parser = JsonResponseParser::new(&registry, &options);
+    let parser = JsonResponseParser {
+        registry: &registry,
+        options: &options,
+    };
 
     let json_data = common::create_sample_json_response("01:00.0");
 
@@ -176,7 +185,10 @@ fn test_device_mismatch_error() {
 fn test_malformed_json() {
     let registry = common::create_test_registry();
     let options = ExecOptions::default();
-    let parser = JsonResponseParser::new(&registry, &options);
+    let parser = JsonResponseParser {
+        registry: &registry,
+        options: &options,
+    };
 
     let malformed_json = r#"{"Device #1": {"invalid": "structure"#;
 
@@ -192,7 +204,10 @@ fn test_malformed_json() {
 fn test_missing_file() {
     let registry = common::create_test_registry();
     let options = ExecOptions::default();
-    let parser = JsonResponseParser::new(&registry, &options);
+    let parser = JsonResponseParser {
+        registry: &registry,
+        options: &options,
+    };
 
     let nonexistent_path = std::path::Path::new("/nonexistent/file.json");
     let result = parser.parse_json_response(nonexistent_path, "01:00.0");
@@ -204,7 +219,10 @@ fn test_missing_file() {
 fn test_boolean_parsing_variations() {
     let registry = common::create_minimal_test_registry();
     let options = ExecOptions::default();
-    let parser = JsonResponseParser::new(&registry, &options);
+    let parser = JsonResponseParser {
+        registry: &registry,
+        options: &options,
+    };
 
     // Test different boolean formats that mlxconfig might return
     let test_cases = vec![
@@ -257,7 +275,10 @@ fn test_boolean_parsing_variations() {
 fn test_enum_parsing_with_parentheses() {
     let registry = common::create_test_registry();
     let options = ExecOptions::default();
-    let parser = JsonResponseParser::new(&registry, &options);
+    let parser = JsonResponseParser {
+        registry: &registry,
+        options: &options,
+    };
 
     let json_data = json!({
         "Device #1": {
@@ -309,7 +330,10 @@ fn test_enum_parsing_with_parentheses() {
 fn test_integer_parsing() {
     let registry = common::create_minimal_test_registry();
     let options = ExecOptions::default();
-    let parser = JsonResponseParser::new(&registry, &options);
+    let parser = JsonResponseParser {
+        registry: &registry,
+        options: &options,
+    };
 
     let json_data = json!({
         "Device #1": {
@@ -352,7 +376,10 @@ fn test_integer_parsing() {
 fn test_sparse_array_with_missing_indices() {
     let registry = common::create_test_registry();
     let options = ExecOptions::default();
-    let parser = JsonResponseParser::new(&registry, &options);
+    let parser = JsonResponseParser {
+        registry: &registry,
+        options: &options,
+    };
 
     // JSON with only some array indices present (simulating sparse array from device)
     let json_data = json!({
@@ -409,7 +436,10 @@ fn test_sparse_array_with_missing_indices() {
 fn test_unknown_variable_in_json() {
     let registry = common::create_minimal_test_registry();
     let options = ExecOptions::default();
-    let parser = JsonResponseParser::new(&registry, &options);
+    let parser = JsonResponseParser {
+        registry: &registry,
+        options: &options,
+    };
 
     let json_data = json!({
         "Device #1": {
@@ -453,7 +483,10 @@ fn test_unknown_variable_in_json() {
 fn test_log_json_output_option() {
     let registry = common::create_test_registry();
     let options = ExecOptions::new().with_log_json_output(true);
-    let parser = JsonResponseParser::new(&registry, &options);
+    let parser = JsonResponseParser {
+        registry: &registry,
+        options: &options,
+    };
 
     let json_data = common::create_sample_json_response("01:00.0");
 
@@ -470,7 +503,10 @@ fn test_log_json_output_option() {
 fn test_array_size_validation() {
     let registry = common::create_test_registry();
     let options = ExecOptions::default();
-    let parser = JsonResponseParser::new(&registry, &options);
+    let parser = JsonResponseParser {
+        registry: &registry,
+        options: &options,
+    };
 
     // Create JSON with array that matches registry size exactly
     // GPIO_ENABLED should have size 4
@@ -538,7 +574,10 @@ fn test_array_size_validation() {
 fn test_read_only_flag_parsing() {
     let registry = common::create_test_registry();
     let options = ExecOptions::default();
-    let parser = JsonResponseParser::new(&registry, &options);
+    let parser = JsonResponseParser {
+        registry: &registry,
+        options: &options,
+    };
 
     let json_data = json!({
         "Device #1": {
@@ -592,7 +631,10 @@ fn test_read_only_flag_parsing() {
 fn test_modified_flag_parsing() {
     let registry = common::create_test_registry();
     let options = ExecOptions::default();
-    let parser = JsonResponseParser::new(&registry, &options);
+    let parser = JsonResponseParser {
+        registry: &registry,
+        options: &options,
+    };
 
     let json_data = json!({
         "Device #1": {

--- a/crates/libmlx/tests/runner/result_types_tests.rs
+++ b/crates/libmlx/tests/runner/result_types_tests.rs
@@ -37,14 +37,14 @@ fn test_queried_variable_construction() {
     let default_value = sriov_var.with(false).unwrap();
     let next_value = sriov_var.with(true).unwrap();
 
-    let queried_var = QueriedVariable::new(
-        sriov_var.clone(),
+    let queried_var = QueriedVariable {
+        variable: sriov_var.clone(),
         current_value,
         default_value,
         next_value,
-        true,  // modified
-        false, // read_only
-    );
+        modified: true,
+        read_only: false,
+    };
 
     assert_eq!(queried_var.name(), "SRIOV_EN");
     assert_eq!(
@@ -65,14 +65,14 @@ fn test_queried_variable_pending_change_detection() {
     let default_value = sriov_var.with(false).unwrap();
     let next_value = sriov_var.with(true).unwrap();
 
-    let queried_var_with_pending = QueriedVariable::new(
-        sriov_var.clone(),
+    let queried_var_with_pending = QueriedVariable {
+        variable: sriov_var.clone(),
         current_value,
         default_value,
         next_value,
-        true,
-        false,
-    );
+        modified: true,
+        read_only: false,
+    };
 
     assert!(queried_var_with_pending.is_pending_change());
 
@@ -81,14 +81,14 @@ fn test_queried_variable_pending_change_detection() {
     let next_value = sriov_var.with(true).unwrap();
     let default_value = sriov_var.with(false).unwrap();
 
-    let queried_var_no_pending = QueriedVariable::new(
-        sriov_var,
+    let queried_var_no_pending = QueriedVariable {
+        variable: sriov_var,
         current_value,
         default_value,
         next_value,
-        true,
-        false,
-    );
+        modified: true,
+        read_only: false,
+    };
 
     assert!(!queried_var_no_pending.is_pending_change());
 }
@@ -102,26 +102,29 @@ fn test_query_result_construction() {
     let sriov_var = registry.get_variable("SRIOV_EN").unwrap().clone();
     let vfs_var = registry.get_variable("NUM_OF_VFS").unwrap().clone();
 
-    let sriov_queried = QueriedVariable::new(
-        sriov_var.clone(),
-        sriov_var.with(true).unwrap(),
-        sriov_var.with(false).unwrap(),
-        sriov_var.with(true).unwrap(),
-        true,
-        false,
-    );
+    let sriov_queried = QueriedVariable {
+        variable: sriov_var.clone(),
+        current_value: sriov_var.with(true).unwrap(),
+        default_value: sriov_var.with(false).unwrap(),
+        next_value: sriov_var.with(true).unwrap(),
+        modified: true,
+        read_only: false,
+    };
 
-    let vfs_queried = QueriedVariable::new(
-        vfs_var.clone(),
-        vfs_var.with(16i64).unwrap(),
-        vfs_var.with(8i64).unwrap(),
-        vfs_var.with(16i64).unwrap(),
-        true,
-        false,
-    );
+    let vfs_queried = QueriedVariable {
+        variable: vfs_var.clone(),
+        current_value: vfs_var.with(16i64).unwrap(),
+        default_value: vfs_var.with(8i64).unwrap(),
+        next_value: vfs_var.with(16i64).unwrap(),
+        modified: true,
+        read_only: false,
+    };
 
     let variables = vec![sriov_queried, vfs_queried];
-    let query_result = QueryResult::new(device_info, variables);
+    let query_result = QueryResult {
+        device_info,
+        variables,
+    };
 
     assert_eq!(query_result.variable_count(), 2);
     assert_eq!(
@@ -145,7 +148,10 @@ fn test_query_result_construction() {
 #[test]
 fn test_sync_result_construction() {
     let device_info = common::create_test_device_info();
-    let query_result = QueryResult::new(device_info, vec![]);
+    let query_result = QueryResult {
+        device_info,
+        variables: vec![],
+    };
     let registry = common::create_test_registry();
 
     // Create proper MlxConfigValue instances for VariableChange
@@ -153,25 +159,25 @@ fn test_sync_result_construction() {
     let vfs_var = registry.get_variable("NUM_OF_VFS").unwrap();
 
     let changes = vec![
-        VariableChange::new(
-            "SRIOV_EN".to_string(),
-            sriov_var.with(false).unwrap(),
-            sriov_var.with(true).unwrap(),
-        ),
-        VariableChange::new(
-            "NUM_OF_VFS".to_string(),
-            vfs_var.with(8i64).unwrap(),
-            vfs_var.with(16i64).unwrap(),
-        ),
+        VariableChange {
+            variable_name: "SRIOV_EN".to_string(),
+            old_value: sriov_var.with(false).unwrap(),
+            new_value: sriov_var.with(true).unwrap(),
+        },
+        VariableChange {
+            variable_name: "NUM_OF_VFS".to_string(),
+            old_value: vfs_var.with(8i64).unwrap(),
+            new_value: vfs_var.with(16i64).unwrap(),
+        },
     ];
 
-    let sync_result = SyncResult::new(
-        5, // variables_checked
-        2, // variables_changed
-        changes,
-        Duration::from_millis(500),
+    let sync_result = SyncResult {
+        variables_checked: 5,
+        variables_changed: 2,
+        changes_applied: changes,
+        execution_time: Duration::from_millis(500),
         query_result,
-    );
+    };
 
     assert_eq!(sync_result.variables_checked, 5);
     assert_eq!(sync_result.variables_changed, 2);
@@ -186,7 +192,10 @@ fn test_sync_result_construction() {
 #[test]
 fn test_comparison_result_construction() {
     let device_info = common::create_test_device_info();
-    let query_result = QueryResult::new(device_info, vec![]);
+    let query_result = QueryResult {
+        device_info,
+        variables: vec![],
+    };
     let registry = common::create_test_registry();
 
     // Create proper MlxConfigValue instances for PlannedChange
@@ -194,24 +203,24 @@ fn test_comparison_result_construction() {
     let power_var = registry.get_variable("POWER_MODE").unwrap();
 
     let planned_changes = vec![
-        PlannedChange::new(
-            "SRIOV_EN".to_string(),
-            sriov_var.with(false).unwrap(),
-            sriov_var.with(true).unwrap(),
-        ),
-        PlannedChange::new(
-            "POWER_MODE".to_string(),
-            power_var.with("LOW").unwrap(),
-            power_var.with("HIGH").unwrap(),
-        ),
+        PlannedChange {
+            variable_name: "SRIOV_EN".to_string(),
+            current_value: sriov_var.with(false).unwrap(),
+            desired_value: sriov_var.with(true).unwrap(),
+        },
+        PlannedChange {
+            variable_name: "POWER_MODE".to_string(),
+            current_value: power_var.with("LOW").unwrap(),
+            desired_value: power_var.with("HIGH").unwrap(),
+        },
     ];
 
-    let comparison_result = ComparisonResult::new(
-        3, // variables_checked
-        2, // variables_needing_change
+    let comparison_result = ComparisonResult {
+        variables_checked: 3,
+        variables_needing_change: 2,
         planned_changes,
         query_result,
-    );
+    };
 
     assert_eq!(comparison_result.variables_checked, 3);
     assert_eq!(comparison_result.variables_needing_change, 2);
@@ -227,11 +236,11 @@ fn test_planned_change_description() {
     let registry = common::create_test_registry();
     let sriov_var = registry.get_variable("SRIOV_EN").unwrap();
 
-    let planned_change = PlannedChange::new(
-        "SRIOV_EN".to_string(),
-        sriov_var.with(false).unwrap(),
-        sriov_var.with(true).unwrap(),
-    );
+    let planned_change = PlannedChange {
+        variable_name: "SRIOV_EN".to_string(),
+        current_value: sriov_var.with(false).unwrap(),
+        desired_value: sriov_var.with(true).unwrap(),
+    };
 
     let description = planned_change.description();
     assert!(description.contains("SRIOV_EN"));
@@ -245,11 +254,11 @@ fn test_variable_change_description() {
     let registry = common::create_test_registry();
     let vfs_var = registry.get_variable("NUM_OF_VFS").unwrap();
 
-    let variable_change = VariableChange::new(
-        "NUM_OF_VFS".to_string(),
-        vfs_var.with(8i64).unwrap(),
-        vfs_var.with(16i64).unwrap(),
-    );
+    let variable_change = VariableChange {
+        variable_name: "NUM_OF_VFS".to_string(),
+        old_value: vfs_var.with(8i64).unwrap(),
+        new_value: vfs_var.with(16i64).unwrap(),
+    };
 
     let description = variable_change.description();
     assert!(description.contains("NUM_OF_VFS"));
@@ -261,7 +270,10 @@ fn test_variable_change_description() {
 #[test]
 fn test_query_result_empty() {
     let device_info = QueriedDeviceInfo::new();
-    let query_result = QueryResult::new(device_info, vec![]);
+    let query_result = QueryResult {
+        device_info,
+        variables: vec![],
+    };
 
     assert_eq!(query_result.variable_count(), 0);
     assert!(query_result.variable_names().is_empty());
@@ -271,15 +283,18 @@ fn test_query_result_empty() {
 #[test]
 fn test_sync_result_no_changes() {
     let device_info = common::create_test_device_info();
-    let query_result = QueryResult::new(device_info, vec![]);
+    let query_result = QueryResult {
+        device_info,
+        variables: vec![],
+    };
 
-    let sync_result = SyncResult::new(
-        5,      // variables_checked
-        0,      // variables_changed
-        vec![], // no changes
-        Duration::from_millis(100),
+    let sync_result = SyncResult {
+        variables_checked: 5,
+        variables_changed: 0,
+        changes_applied: vec![],
+        execution_time: Duration::from_millis(100),
         query_result,
-    );
+    };
 
     assert_eq!(sync_result.variables_checked, 5);
     assert_eq!(sync_result.variables_changed, 0);
@@ -292,14 +307,17 @@ fn test_sync_result_no_changes() {
 #[test]
 fn test_comparison_result_no_changes_needed() {
     let device_info = common::create_test_device_info();
-    let query_result = QueryResult::new(device_info, vec![]);
+    let query_result = QueryResult {
+        device_info,
+        variables: vec![],
+    };
 
-    let comparison_result = ComparisonResult::new(
-        5,      // variables_checked
-        0,      // variables_needing_change
-        vec![], // no planned changes
+    let comparison_result = ComparisonResult {
+        variables_checked: 5,
+        variables_needing_change: 0,
+        planned_changes: vec![],
         query_result,
-    );
+    };
 
     assert_eq!(comparison_result.variables_checked, 5);
     assert_eq!(comparison_result.variables_needing_change, 0);
@@ -318,14 +336,14 @@ fn test_array_values_in_results() {
     let default_array = gpio_var.with(vec![false, false, false, false]).unwrap();
     let next_array = gpio_var.with(vec![true, false, true, false]).unwrap();
 
-    let gpio_queried = QueriedVariable::new(
-        gpio_var,
-        current_array,
-        default_array,
-        next_array,
-        true,
-        false,
-    );
+    let gpio_queried = QueriedVariable {
+        variable: gpio_var,
+        current_value: current_array,
+        default_value: default_array,
+        next_value: next_array,
+        modified: true,
+        read_only: false,
+    };
 
     assert_eq!(gpio_queried.name(), "GPIO_ENABLED");
 
@@ -356,11 +374,11 @@ fn test_enum_values_in_planned_changes() {
     let mut output_full = output_sparse;
     output_full.resize(8, None);
 
-    let planned_change = PlannedChange::new(
-        "GPIO_MODES[0]".to_string(),
-        gpio_modes_var.with(input_full).unwrap(),
-        gpio_modes_var.with(output_full).unwrap(),
-    );
+    let planned_change = PlannedChange {
+        variable_name: "GPIO_MODES[0]".to_string(),
+        current_value: gpio_modes_var.with(input_full).unwrap(),
+        desired_value: gpio_modes_var.with(output_full).unwrap(),
+    };
 
     let description = planned_change.description();
     assert!(description.contains("GPIO_MODES[0]"));
@@ -374,11 +392,11 @@ fn test_preset_values_in_variable_changes() {
     let registry = common::create_test_registry();
     let preset_var = registry.get_variable("PERFORMANCE_PRESET").unwrap();
 
-    let variable_change = VariableChange::new(
-        "PERFORMANCE_PRESET".to_string(),
-        preset_var.with(3u8).unwrap(),
-        preset_var.with(7u8).unwrap(),
-    );
+    let variable_change = VariableChange {
+        variable_name: "PERFORMANCE_PRESET".to_string(),
+        old_value: preset_var.with(3u8).unwrap(),
+        new_value: preset_var.with(7u8).unwrap(),
+    };
 
     let description = variable_change.description();
     assert!(description.contains("PERFORMANCE_PRESET"));
@@ -393,7 +411,10 @@ fn test_device_info_in_query_result() {
         .with_device_type("BlueField3")
         .with_part_number("MCX713106AS-VDAT");
 
-    let query_result = QueryResult::new(device_info, vec![]);
+    let query_result = QueryResult {
+        device_info,
+        variables: vec![],
+    };
 
     assert_eq!(
         query_result.device_info.device_id,
@@ -418,14 +439,14 @@ mod serialization_tests {
         let registry = common::create_test_registry();
         let sriov_var = registry.get_variable("SRIOV_EN").unwrap().clone();
 
-        let queried_var = QueriedVariable::new(
-            sriov_var.clone(),
-            sriov_var.with(true).unwrap(),
-            sriov_var.with(false).unwrap(),
-            sriov_var.with(true).unwrap(),
-            true,
-            false,
-        );
+        let queried_var = QueriedVariable {
+            variable: sriov_var.clone(),
+            current_value: sriov_var.with(true).unwrap(),
+            default_value: sriov_var.with(false).unwrap(),
+            next_value: sriov_var.with(true).unwrap(),
+            modified: true,
+            read_only: false,
+        };
 
         // Should be able to serialize and deserialize
         let json = serde_json::to_string(&queried_var).unwrap();
@@ -439,9 +460,18 @@ mod serialization_tests {
     #[test]
     fn test_sync_result_serialization() {
         let device_info = common::create_test_device_info();
-        let query_result = QueryResult::new(device_info, vec![]);
+        let query_result = QueryResult {
+            device_info,
+            variables: vec![],
+        };
 
-        let sync_result = SyncResult::new(3, 1, vec![], Duration::from_millis(200), query_result);
+        let sync_result = SyncResult {
+            variables_checked: 3,
+            variables_changed: 1,
+            changes_applied: vec![],
+            execution_time: Duration::from_millis(200),
+            query_result,
+        };
 
         let json = serde_json::to_string(&sync_result).unwrap();
         let deserialized: SyncResult = serde_json::from_str(&json).unwrap();

--- a/crates/libmlx/tests/variables/test_registry.rs
+++ b/crates/libmlx/tests/variables/test_registry.rs
@@ -88,11 +88,11 @@ fn test_registry_builder_pattern() {
     let variables = create_test_variables();
     let registry = MlxVariableRegistry::new("builder_test")
         .variables(variables)
-        .with_filter(DeviceFilter::new(
-            DeviceField::DeviceType,
-            vec!["BlueField3".to_string()],
-            MatchMode::Exact,
-        ));
+        .with_filter(DeviceFilter {
+            field: DeviceField::DeviceType,
+            values: vec!["BlueField3".to_string()],
+            match_mode: MatchMode::Exact,
+        });
 
     assert_eq!(registry.name, "builder_test");
     assert_eq!(registry.variables.len(), 4);
@@ -141,11 +141,11 @@ fn test_registry_variable_names() {
 #[test]
 fn test_registry_with_single_filter() {
     let variables = create_test_variables();
-    let filter = DeviceFilter::new(
-        DeviceField::DeviceType,
-        vec!["BlueField3".to_string()],
-        MatchMode::Exact,
-    );
+    let filter = DeviceFilter {
+        field: DeviceField::DeviceType,
+        values: vec!["BlueField3".to_string()],
+        match_mode: MatchMode::Exact,
+    };
 
     let registry = MlxVariableRegistry::new("single_filter_test")
         .variables(variables)
@@ -166,16 +166,16 @@ fn test_registry_with_multiple_filters() {
 
     let registry = MlxVariableRegistry::new("multi_filter_test")
         .variables(variables)
-        .with_filter(DeviceFilter::new(
-            DeviceField::DeviceType,
-            vec!["BlueField3".to_string(), "ConnectX-6".to_string()],
-            MatchMode::Exact,
-        ))
-        .with_filter(DeviceFilter::new(
-            DeviceField::PartNumber,
-            vec!["MCX.*".to_string()],
-            MatchMode::Regex,
-        ));
+        .with_filter(DeviceFilter {
+            field: DeviceField::DeviceType,
+            values: vec!["BlueField3".to_string(), "ConnectX-6".to_string()],
+            match_mode: MatchMode::Exact,
+        })
+        .with_filter(DeviceFilter {
+            field: DeviceField::PartNumber,
+            values: vec!["MCX.*".to_string()],
+            match_mode: MatchMode::Regex,
+        });
 
     assert!(registry.has_filters());
     assert_eq!(registry.filters.as_ref().unwrap().filters.len(), 2);
@@ -190,16 +190,16 @@ fn test_registry_with_filter_set() {
     let variables = create_test_variables();
 
     let mut filter_set = DeviceFilterSet::default();
-    filter_set.add_filter(DeviceFilter::new(
-        DeviceField::DeviceType,
-        vec!["BlueField3".to_string()],
-        MatchMode::Exact,
-    ));
-    filter_set.add_filter(DeviceFilter::new(
-        DeviceField::FirmwareVersion,
-        vec!["28.*.1010".to_string()],
-        MatchMode::Regex,
-    ));
+    filter_set.add_filter(DeviceFilter {
+        field: DeviceField::DeviceType,
+        values: vec!["BlueField3".to_string()],
+        match_mode: MatchMode::Exact,
+    });
+    filter_set.add_filter(DeviceFilter {
+        field: DeviceField::FirmwareVersion,
+        values: vec!["28.*.1010".to_string()],
+        match_mode: MatchMode::Regex,
+    });
 
     let registry = MlxVariableRegistry::new("filter_set_test")
         .variables(variables)
@@ -225,16 +225,16 @@ fn test_registry_device_matching_with_filters() {
     let variables = create_test_variables();
     let registry = MlxVariableRegistry::new("device_match_test")
         .variables(variables)
-        .with_filter(DeviceFilter::new(
-            DeviceField::DeviceType,
-            vec!["BlueField3".to_string()],
-            MatchMode::Exact,
-        ))
-        .with_filter(DeviceFilter::new(
-            DeviceField::PartNumber,
-            vec!["MCX.*".to_string()],
-            MatchMode::Regex,
-        ));
+        .with_filter(DeviceFilter {
+            field: DeviceField::DeviceType,
+            values: vec!["BlueField3".to_string()],
+            match_mode: MatchMode::Exact,
+        })
+        .with_filter(DeviceFilter {
+            field: DeviceField::PartNumber,
+            values: vec!["MCX.*".to_string()],
+            match_mode: MatchMode::Regex,
+        });
 
     // Device that matches both filters
     let matching_device = create_test_device("BlueField3", "MCX623106AS-CDAT", "28.38.1010");
@@ -262,11 +262,11 @@ fn test_registry_filter_summary_with_filters() {
     let variables = create_test_variables();
     let registry = MlxVariableRegistry::new("summary_test")
         .variables(variables)
-        .with_filter(DeviceFilter::new(
-            DeviceField::DeviceType,
-            vec!["BlueField3".to_string()],
-            MatchMode::Exact,
-        ));
+        .with_filter(DeviceFilter {
+            field: DeviceField::DeviceType,
+            values: vec!["BlueField3".to_string()],
+            match_mode: MatchMode::Exact,
+        });
 
     let summary = registry.filter_summary();
     assert!(summary.contains("device_type"));
@@ -303,11 +303,11 @@ fn test_registry_serde_serialization_with_filters() {
     let variables = create_test_variables();
     let registry = MlxVariableRegistry::new("serde_filter_test")
         .variables(variables)
-        .with_filter(DeviceFilter::new(
-            DeviceField::DeviceType,
-            vec!["BlueField3".to_string()],
-            MatchMode::Exact,
-        ));
+        .with_filter(DeviceFilter {
+            field: DeviceField::DeviceType,
+            values: vec!["BlueField3".to_string()],
+            match_mode: MatchMode::Exact,
+        });
 
     // Test JSON serialization with filters
     let json = serde_json::to_string(&registry).expect("JSON serialization failed");
@@ -365,11 +365,11 @@ fn test_registry_clone() {
     let variables = create_test_variables();
     let registry = MlxVariableRegistry::new("clone_test")
         .variables(variables)
-        .with_filter(DeviceFilter::new(
-            DeviceField::DeviceType,
-            vec!["BlueField3".to_string()],
-            MatchMode::Exact,
-        ));
+        .with_filter(DeviceFilter {
+            field: DeviceField::DeviceType,
+            values: vec!["BlueField3".to_string()],
+            match_mode: MatchMode::Exact,
+        });
 
     let cloned = registry.clone();
 
@@ -387,11 +387,11 @@ fn test_registry_debug_formatting() {
     let variables = create_test_variables();
     let registry = MlxVariableRegistry::new("debug_test")
         .variables(variables)
-        .with_filter(DeviceFilter::new(
-            DeviceField::DeviceType,
-            vec!["BlueField3".to_string()],
-            MatchMode::Exact,
-        ));
+        .with_filter(DeviceFilter {
+            field: DeviceField::DeviceType,
+            values: vec!["BlueField3".to_string()],
+            match_mode: MatchMode::Exact,
+        });
 
     let debug_str = format!("{registry:?}");
 


### PR DESCRIPTION
## Description

This is similar to https://github.com/NVIDIA/ncx-infra-controller-core/pull/603. Per our fancy new `STYLE_GUIDE.md`, and really, this is generally what we've tried to do anyway (even though I hadn't done it here), I'm tweaking the `libmlx` modules to prefer using struct literals instead of `::new(..)` constructors for all of the "plain old data" structs being passed around. When I was putting together the `libmlx` crates (which used to be a bunch of individual crates, before I folded them back together), I was going hard OOP w/ constructors for initializing everything. I'm unwinding my poor choices. At the time it seemed nice, but it's really just an unnecessary layer of abstraction that requires someone to then dig to see what `::new(..)` does, and if it doesn't do anything, prefer struct literals.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

