### PR TITLE
chore: proper grpc -> api modeling for machine validation types

### DIFF
--- a/crates/api-db/src/machine_validation_suites.rs
+++ b/crates/api-db/src/machine_validation_suites.rs
@@ -16,7 +16,10 @@
  */
 
 use config_version::ConfigVersion;
-use model::machine_validation::MachineValidationTest;
+use model::machine_validation::{
+    MachineValidationTest, MachineValidationTestAddRequest, MachineValidationTestUpdatePayload,
+    MachineValidationTestUpdateRequest, MachineValidationTestsGetRequest,
+};
 use regex::Regex;
 use sqlx::PgConnection;
 
@@ -25,7 +28,7 @@ use crate::{DatabaseError, DatabaseResult};
 
 /// Method to generate an SQL update query based on the fields that are `Some`
 fn build_update_query(
-    req: rpc::forge::machine_validation_test_update_request::Payload,
+    req: MachineValidationTestUpdatePayload,
     table: &str,
     version: String,
     test_id: &str,
@@ -87,7 +90,7 @@ fn build_update_query(
 }
 
 fn build_insert_query(
-    req: rpc::forge::MachineValidationTestAddRequest,
+    req: MachineValidationTestAddRequest,
     table: &str,
     version: String,
     test_id: &str,
@@ -158,7 +161,7 @@ fn build_insert_query(
     Ok(query)
 }
 fn build_select_query(
-    req: rpc::forge::MachineValidationTestsGetRequest,
+    req: MachineValidationTestsGetRequest,
     table: &str,
     // version: ConfigVersion,
 ) -> DatabaseResult<String> {
@@ -210,7 +213,7 @@ fn build_select_query(
 
 pub async fn find(
     txn: impl DbReader<'_>,
-    req: rpc::forge::MachineValidationTestsGetRequest,
+    req: MachineValidationTestsGetRequest,
 ) -> DatabaseResult<Vec<MachineValidationTest>> {
     let query = build_select_query(req, "machine_validation_tests")?;
     let ret = sqlx::query_as(&query)
@@ -226,7 +229,7 @@ pub fn generate_test_id(name: &str) -> String {
 
 pub async fn save(
     txn: &mut PgConnection,
-    mut req: rpc::forge::MachineValidationTestAddRequest,
+    mut req: MachineValidationTestAddRequest,
     version: ConfigVersion,
 ) -> DatabaseResult<String> {
     let test_id = generate_test_id(&req.name);
@@ -254,7 +257,7 @@ pub async fn save(
 
 pub async fn update(
     txn: &mut PgConnection,
-    req: rpc::forge::MachineValidationTestUpdateRequest,
+    req: MachineValidationTestUpdateRequest,
 ) -> DatabaseResult<String> {
     let Some(mut payload) = req.payload else {
         return Err(DatabaseError::InvalidArgument(
@@ -286,7 +289,7 @@ pub async fn clone(
     txn: &mut PgConnection,
     test: &MachineValidationTest,
 ) -> DatabaseResult<(String, ConfigVersion)> {
-    let add_req = rpc::forge::MachineValidationTestAddRequest {
+    let add_req = MachineValidationTestAddRequest {
         name: test.name.clone(),
         description: test.description.clone(),
         contexts: test.contexts.clone(),
@@ -316,15 +319,13 @@ pub async fn mark_verified(
     test_id: String,
     version: ConfigVersion,
 ) -> DatabaseResult<String> {
-    let req = rpc::forge::MachineValidationTestUpdateRequest {
+    let req = MachineValidationTestUpdateRequest {
         test_id,
         version: version.version_string(),
-        payload: Some(
-            rpc::forge::machine_validation_test_update_request::Payload {
-                verified: Some(true),
-                ..Default::default()
-            },
-        ),
+        payload: Some(MachineValidationTestUpdatePayload {
+            verified: Some(true),
+            ..Default::default()
+        }),
     };
     update(txn, req).await
 }
@@ -336,16 +337,14 @@ pub async fn enable_disable(
     is_enabled: bool,
     is_verified: bool,
 ) -> DatabaseResult<String> {
-    let req = rpc::forge::MachineValidationTestUpdateRequest {
+    let req = MachineValidationTestUpdateRequest {
         test_id,
         version: version.version_string(),
-        payload: Some(
-            rpc::forge::machine_validation_test_update_request::Payload {
-                is_enabled: Some(is_enabled),
-                verified: Some(is_verified),
-                ..Default::default()
-            },
-        ),
+        payload: Some(MachineValidationTestUpdatePayload {
+            is_enabled: Some(is_enabled),
+            verified: Some(is_verified),
+            ..Default::default()
+        }),
     };
     update(txn, req).await
 }
@@ -364,7 +363,7 @@ mod tests {
 
     #[test]
     fn test_build_select_query_uses_lower_for_strings() {
-        let req = rpc::forge::MachineValidationTestsGetRequest {
+        let req = MachineValidationTestsGetRequest {
             test_id: Some("Forge_MyTest".to_string()),
             ..Default::default()
         };
@@ -381,7 +380,7 @@ mod tests {
 
     #[test]
     fn test_build_select_query_no_lower_for_non_strings() {
-        let req = rpc::forge::MachineValidationTestsGetRequest {
+        let req = MachineValidationTestsGetRequest {
             is_enabled: Some(true),
             ..Default::default()
         };
@@ -394,7 +393,7 @@ mod tests {
 
     #[test]
     fn test_build_select_query_empty_request_returns_all() {
-        let req = rpc::forge::MachineValidationTestsGetRequest::default();
+        let req = MachineValidationTestsGetRequest::default();
         let query = build_select_query(req, "machine_validation_tests").unwrap();
         assert!(
             query.contains("WHERE 1=1"),

--- a/crates/api-model/src/machine_validation.rs
+++ b/crates/api-model/src/machine_validation.rs
@@ -28,6 +28,146 @@ use uuid::Uuid;
 
 use crate::machine::MachineValidationFilter;
 
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct MachineValidationTestAddRequest {
+    pub name: String,
+    pub description: Option<String>,
+    pub contexts: Vec<String>,
+    pub img_name: Option<String>,
+    pub execute_in_host: Option<bool>,
+    pub container_arg: Option<String>,
+    pub command: String,
+    pub args: String,
+    pub extra_err_file: Option<String>,
+    pub external_config_file: Option<String>,
+    pub pre_condition: Option<String>,
+    pub timeout: Option<i64>,
+    pub extra_output_file: Option<String>,
+    pub supported_platforms: Vec<String>,
+    pub read_only: Option<bool>,
+    pub custom_tags: Vec<String>,
+    pub components: Vec<String>,
+    pub is_enabled: Option<bool>,
+}
+
+impl From<rpc::forge::MachineValidationTestAddRequest> for MachineValidationTestAddRequest {
+    fn from(req: rpc::forge::MachineValidationTestAddRequest) -> Self {
+        MachineValidationTestAddRequest {
+            name: req.name,
+            description: req.description,
+            contexts: req.contexts,
+            img_name: req.img_name,
+            execute_in_host: req.execute_in_host,
+            container_arg: req.container_arg,
+            command: req.command,
+            args: req.args,
+            extra_err_file: req.extra_err_file,
+            external_config_file: req.external_config_file,
+            pre_condition: req.pre_condition,
+            timeout: req.timeout,
+            extra_output_file: req.extra_output_file,
+            supported_platforms: req.supported_platforms,
+            read_only: req.read_only,
+            custom_tags: req.custom_tags,
+            components: req.components,
+            is_enabled: req.is_enabled,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct MachineValidationTestUpdatePayload {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub contexts: Vec<String>,
+    pub img_name: Option<String>,
+    pub execute_in_host: Option<bool>,
+    pub container_arg: Option<String>,
+    pub command: Option<String>,
+    pub args: Option<String>,
+    pub extra_err_file: Option<String>,
+    pub external_config_file: Option<String>,
+    pub pre_condition: Option<String>,
+    pub timeout: Option<i64>,
+    pub extra_output_file: Option<String>,
+    pub supported_platforms: Vec<String>,
+    pub verified: Option<bool>,
+    pub custom_tags: Vec<String>,
+    pub components: Vec<String>,
+    pub is_enabled: Option<bool>,
+}
+
+impl From<rpc::forge::machine_validation_test_update_request::Payload>
+    for MachineValidationTestUpdatePayload
+{
+    fn from(p: rpc::forge::machine_validation_test_update_request::Payload) -> Self {
+        MachineValidationTestUpdatePayload {
+            name: p.name,
+            description: p.description,
+            contexts: p.contexts,
+            img_name: p.img_name,
+            execute_in_host: p.execute_in_host,
+            container_arg: p.container_arg,
+            command: p.command,
+            args: p.args,
+            extra_err_file: p.extra_err_file,
+            external_config_file: p.external_config_file,
+            pre_condition: p.pre_condition,
+            timeout: p.timeout,
+            extra_output_file: p.extra_output_file,
+            supported_platforms: p.supported_platforms,
+            verified: p.verified,
+            custom_tags: p.custom_tags,
+            components: p.components,
+            is_enabled: p.is_enabled,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct MachineValidationTestUpdateRequest {
+    pub test_id: String,
+    pub version: String,
+    pub payload: Option<MachineValidationTestUpdatePayload>,
+}
+
+impl From<rpc::forge::MachineValidationTestUpdateRequest> for MachineValidationTestUpdateRequest {
+    fn from(req: rpc::forge::MachineValidationTestUpdateRequest) -> Self {
+        MachineValidationTestUpdateRequest {
+            test_id: req.test_id,
+            version: req.version,
+            payload: req.payload.map(MachineValidationTestUpdatePayload::from),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct MachineValidationTestsGetRequest {
+    pub supported_platforms: Vec<String>,
+    pub contexts: Vec<String>,
+    pub test_id: Option<String>,
+    pub read_only: Option<bool>,
+    pub custom_tags: Vec<String>,
+    pub version: Option<String>,
+    pub is_enabled: Option<bool>,
+    pub verified: Option<bool>,
+}
+
+impl From<rpc::forge::MachineValidationTestsGetRequest> for MachineValidationTestsGetRequest {
+    fn from(req: rpc::forge::MachineValidationTestsGetRequest) -> Self {
+        MachineValidationTestsGetRequest {
+            supported_platforms: req.supported_platforms,
+            contexts: req.contexts,
+            test_id: req.test_id,
+            read_only: req.read_only,
+            custom_tags: req.custom_tags,
+            version: req.version,
+            is_enabled: req.is_enabled,
+            verified: req.verified,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default, strum_macros::EnumString)]
 pub enum MachineValidationState {
     #[default]
@@ -411,5 +551,73 @@ impl TryFrom<rpc::forge::MachineValidationResult> for MachineValidationResult {
             end_time,
             test_id: value.test_id,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tests_get_request_from_rpc() {
+        let rpc_req = rpc::forge::MachineValidationTestsGetRequest {
+            test_id: Some("forge_mytest".to_string()),
+            is_enabled: Some(true),
+            verified: Some(false),
+            ..Default::default()
+        };
+        let req = MachineValidationTestsGetRequest::from(rpc_req);
+        assert_eq!(req.test_id, Some("forge_mytest".to_string()));
+        assert_eq!(req.is_enabled, Some(true));
+        assert_eq!(req.verified, Some(false));
+        assert!(req.version.is_none());
+    }
+
+    #[test]
+    fn tests_get_request_default_serializes_to_all_null_optionals() {
+        let req = MachineValidationTestsGetRequest::default();
+        let json = serde_json::to_value(&req).unwrap();
+        let obj = json.as_object().unwrap();
+        // Optional fields should be null, vec fields should be empty arrays
+        assert!(obj["test_id"].is_null());
+        assert!(obj["is_enabled"].is_null());
+        assert_eq!(obj["supported_platforms"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn test_add_request_from_rpc() {
+        let rpc_req = rpc::forge::MachineValidationTestAddRequest {
+            name: "my_test".to_string(),
+            command: "/bin/test".to_string(),
+            args: "--verbose".to_string(),
+            supported_platforms: vec!["x86_64".to_string()],
+            ..Default::default()
+        };
+        let req = MachineValidationTestAddRequest::from(rpc_req);
+        assert_eq!(req.name, "my_test");
+        assert_eq!(req.command, "/bin/test");
+        assert_eq!(req.supported_platforms, vec!["x86_64"]);
+    }
+
+    #[test]
+    fn test_update_request_from_rpc_with_payload() {
+        let rpc_req = rpc::forge::MachineValidationTestUpdateRequest {
+            test_id: "forge_mytest".to_string(),
+            version: "1".to_string(),
+            payload: Some(
+                rpc::forge::machine_validation_test_update_request::Payload {
+                    verified: Some(true),
+                    is_enabled: Some(false),
+                    ..Default::default()
+                },
+            ),
+        };
+        let req = MachineValidationTestUpdateRequest::from(rpc_req);
+        assert_eq!(req.test_id, "forge_mytest");
+        assert_eq!(req.version, "1");
+        let payload = req.payload.unwrap();
+        assert_eq!(payload.verified, Some(true));
+        assert_eq!(payload.is_enabled, Some(false));
+        assert!(payload.name.is_none());
     }
 }

--- a/crates/api/src/handlers/machine_validation.rs
+++ b/crates/api/src/handlers/machine_validation.rs
@@ -24,6 +24,9 @@ use model::machine::{
 };
 use model::machine_validation::{
     MachineValidation, MachineValidationResult, MachineValidationState, MachineValidationStatus,
+    MachineValidationTestAddRequest as ModelTestAddRequest,
+    MachineValidationTestUpdateRequest as ModelTestUpdateRequest,
+    MachineValidationTestsGetRequest as ModelTestsGetRequest,
 };
 use tonic::{Request, Response, Status};
 use uuid::Uuid;
@@ -516,7 +519,8 @@ pub(crate) async fn update_machine_validation_test(
     //         "Cannot modify read-only test cases",
     //     ));
     // }
-    let test_id = machine_validation_suites::update(&mut txn, req.clone()).await?;
+    let model_req: ModelTestUpdateRequest = req.clone().into();
+    let test_id = machine_validation_suites::update(&mut txn, model_req).await?;
 
     txn.commit().await?;
 
@@ -535,11 +539,12 @@ pub(crate) async fn add_machine_validation_test(
     let req = request.into_inner();
     let mut txn = api.txn_begin().await?;
 
+    let model_req: ModelTestAddRequest = req.into();
     let tests = machine_validation_suites::find(
         &mut txn,
-        rpc::MachineValidationTestsGetRequest {
-            test_id: Some(machine_validation_suites::generate_test_id(&req.name)),
-            ..rpc::MachineValidationTestsGetRequest::default()
+        ModelTestsGetRequest {
+            test_id: Some(machine_validation_suites::generate_test_id(&model_req.name)),
+            ..ModelTestsGetRequest::default()
         },
     )
     .await?;
@@ -547,7 +552,7 @@ pub(crate) async fn add_machine_validation_test(
         return Err(Status::invalid_argument("Name already exists"));
     }
     let version = ConfigVersion::initial();
-    let test_id = machine_validation_suites::save(&mut txn, req, version).await?;
+    let test_id = machine_validation_suites::save(&mut txn, model_req, version).await?;
 
     txn.commit().await?;
 
@@ -564,7 +569,7 @@ pub(crate) async fn get_machine_validation_tests(
     request: tonic::Request<rpc::MachineValidationTestsGetRequest>,
 ) -> Result<tonic::Response<rpc::MachineValidationTestsGetResponse>, Status> {
     log_request_data(&request);
-    let req = request.into_inner();
+    let req: ModelTestsGetRequest = request.into_inner().into();
 
     let tests = machine_validation_suites::find(&api.database_connection, req).await?;
 
@@ -587,10 +592,10 @@ pub(crate) async fn machine_validation_test_verfied(
 
     let existing = machine_validation_suites::find(
         &mut txn,
-        rpc::MachineValidationTestsGetRequest {
+        ModelTestsGetRequest {
             test_id: Some(req.test_id.clone()),
             version: Some(req.version.clone()),
-            ..rpc::MachineValidationTestsGetRequest::default()
+            ..ModelTestsGetRequest::default()
         },
     )
     .await?;
@@ -614,9 +619,9 @@ pub(crate) async fn machine_validation_test_next_version(
 
     let existing = machine_validation_suites::find(
         &mut txn,
-        rpc::MachineValidationTestsGetRequest {
+        ModelTestsGetRequest {
             test_id: Some(req.test_id.clone()),
-            ..rpc::MachineValidationTestsGetRequest::default()
+            ..ModelTestsGetRequest::default()
         },
     )
     .await?;
@@ -641,10 +646,10 @@ pub(crate) async fn machine_validation_test_enable_disable_test(
 
     let existing = machine_validation_suites::find(
         &mut txn,
-        rpc::MachineValidationTestsGetRequest {
+        ModelTestsGetRequest {
             test_id: Some(req.test_id.clone()),
             version: Some(req.version.clone()),
-            ..rpc::MachineValidationTestsGetRequest::default()
+            ..ModelTestsGetRequest::default()
         },
     )
     .await?;
@@ -704,9 +709,7 @@ pub async fn apply_config_on_startup(
     let mut txn = api.txn_begin().await?;
 
     // Get all tests from DB
-    let tests =
-        machine_validation_suites::find(&mut txn, rpc::MachineValidationTestsGetRequest::default())
-            .await?;
+    let tests = machine_validation_suites::find(&mut txn, ModelTestsGetRequest::default()).await?;
 
     // Create a set of test IDs from config for efficient lookup
     let config_test_ids: std::collections::HashSet<_> =

--- a/crates/api/src/machine_validation/mod.rs
+++ b/crates/api/src/machine_validation/mod.rs
@@ -118,7 +118,7 @@ impl MachineValidationManager {
 
         metrics.tests = db::machine_validation_suites::find(
             &mut txn,
-            rpc::forge::MachineValidationTestsGetRequest::default(),
+            model::machine_validation::MachineValidationTestsGetRequest::default(),
         )
         .await?;
         tracing::debug!(


### PR DESCRIPTION
## Description

This follows along with https://github.com/NVIDIA/ncx-infra-controller-core/pull/598 and https://github.com/NVIDIA/ncx-infra-controller-core/pull/596 as part of implementing `STYLE_GUIDE.md` changes.

Underlying TLDR is we've leaked a few things from `::rpc` into the DB layer, which we generally don't want to do, and now that we have `STYLE_GUIDE.md`, it will be good to practice what we preach.

This change is specific to machine validation, introducing gRPC message equivalents in `api-model`, with the expected `From`/`TryFrom` implementations for passing downstream.

Added some tests too.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

