### PR TITLE
chore: clean up a few struct literal stragglers

### DIFF
--- a/crates/agent/src/acl.rs
+++ b/crates/agent/src/acl.rs
@@ -21,13 +21,7 @@ use ipnetwork::Ipv4Network;
 // A representation of a rules file that can be placed in the policy.d
 // directory
 pub struct RulesFile {
-    iptables_rules: IpTablesRuleset,
-}
-
-impl RulesFile {
-    pub fn new(iptables_rules: IpTablesRuleset) -> Self {
-        Self { iptables_rules }
-    }
+    pub iptables_rules: IpTablesRuleset,
 }
 
 // FIXME: Display is probably not quite the right interface to implement
@@ -43,13 +37,7 @@ impl Display for RulesFile {
 
 // The ordered rules that live within an `[iptables]` section.
 pub struct IpTablesRuleset {
-    rules: Vec<IpTablesRule>,
-}
-
-impl IpTablesRuleset {
-    pub fn new_with_rules(rules: Vec<IpTablesRule>) -> Self {
-        Self { rules }
-    }
+    pub rules: Vec<IpTablesRule>,
 }
 
 impl Display for IpTablesRuleset {

--- a/crates/agent/src/acl_rules.rs
+++ b/crates/agent/src/acl_rules.rs
@@ -39,7 +39,7 @@ pub struct InterfaceRules {
 /// Generate /etc/cumulus/acl/policy.d/60-forge.rules
 pub fn build(conf: AclConfig) -> Result<String, eyre::Report> {
     let iptables_rules = make_forge_rules(conf);
-    let rules_file = RulesFile::new(iptables_rules);
+    let rules_file = RulesFile { iptables_rules };
 
     let mut file_contents = rules_file.to_string();
     append_arp_suppression_contents(&mut file_contents);
@@ -71,7 +71,7 @@ fn make_forge_rules(acl_config: AclConfig) -> IpTablesRuleset {
 
     rules.push(make_block_nvued_rule());
 
-    IpTablesRuleset::new_with_rules(rules)
+    IpTablesRuleset { rules }
 }
 
 // Create the Forge ruleset for a specific tenant-facing interface.

--- a/crates/agent/src/lldp.rs
+++ b/crates/agent/src/lldp.rs
@@ -53,13 +53,6 @@ pub struct LldpdConfigFileWriter {
 }
 
 impl LldpdConfigFileWriter {
-    pub fn new(filename: PathBuf, header_comments: Vec<String>) -> Self {
-        Self {
-            filename,
-            header_comments,
-        }
-    }
-
     pub fn ensure_file(&self, config: &LldpConfig) -> eyre::Result<bool> {
         let file_contents = self.render_contents(config);
         let mut config_file = crate::agent_platform::ManagedFile::new(self.filename.to_owned());
@@ -101,9 +94,10 @@ impl LldpdConfigFileWriter {
 
 impl Default for LldpdConfigFileWriter {
     fn default() -> Self {
-        let filename = "/etc/lldpd.d/forge.conf".into();
-        let header_comment = vec!["This file is managed by the Forge DPU agent".into()];
-        Self::new(filename, header_comment)
+        Self {
+            filename: "/etc/lldpd.d/forge.conf".into(),
+            header_comments: vec!["This file is managed by the Forge DPU agent".into()],
+        }
     }
 }
 

--- a/crates/api/src/mqtt_state_change_hook/hook.rs
+++ b/crates/api/src/mqtt_state_change_hook/hook.rs
@@ -117,8 +117,11 @@ impl MqttStateChangeHook {
 impl StateChangeHook<MachineId, ManagedHostState> for MqttStateChangeHook {
     fn on_state_changed(&self, event: &StateChangeEvent<'_, MachineId, ManagedHostState>) {
         // Serialize immediately to avoid cloning state
-        let message =
-            ManagedHostStateChangeMessage::new(event.object_id, event.new_state, event.timestamp);
+        let message = ManagedHostStateChangeMessage {
+            machine_id: event.object_id,
+            managed_host_state: event.new_state,
+            timestamp: event.timestamp,
+        };
         let topic = Self::build_topic(event.object_id);
 
         match message.to_json_bytes() {

--- a/crates/api/src/mqtt_state_change_hook/message.rs
+++ b/crates/api/src/mqtt_state_change_hook/message.rs
@@ -37,19 +37,6 @@ pub struct ManagedHostStateChangeMessage<'a> {
 }
 
 impl<'a> ManagedHostStateChangeMessage<'a> {
-    /// Create a new message from the given state change data.
-    pub fn new(
-        machine_id: &'a MachineId,
-        state: &'a ManagedHostState,
-        timestamp: DateTime<Utc>,
-    ) -> Self {
-        Self {
-            machine_id,
-            timestamp,
-            managed_host_state: state,
-        }
-    }
-
     /// Serialize the message to JSON bytes for MQTT publishing.
     pub fn to_json_bytes(&self) -> Result<Vec<u8>, serde_json::Error> {
         serde_json::to_vec(self)
@@ -73,7 +60,11 @@ mod tests {
         let state = ManagedHostState::Ready;
         let timestamp = Utc::now();
 
-        let message = ManagedHostStateChangeMessage::new(&machine_id, &state, timestamp);
+        let message = ManagedHostStateChangeMessage {
+            machine_id: &machine_id,
+            managed_host_state: &state,
+            timestamp,
+        };
         let json = message.to_json_bytes().unwrap();
         let parsed: serde_json::Value = serde_json::from_slice(&json).unwrap();
 
@@ -91,7 +82,11 @@ mod tests {
         };
         let timestamp = Utc::now();
 
-        let message = ManagedHostStateChangeMessage::new(&machine_id, &state, timestamp);
+        let message = ManagedHostStateChangeMessage {
+            machine_id: &machine_id,
+            managed_host_state: &state,
+            timestamp,
+        };
         let json = message.to_json_bytes().unwrap();
         let parsed: serde_json::Value = serde_json::from_slice(&json).unwrap();
 
@@ -106,7 +101,11 @@ mod tests {
         let state = ManagedHostState::Ready;
         let timestamp = Utc::now();
 
-        let message = ManagedHostStateChangeMessage::new(&machine_id, &state, timestamp);
+        let message = ManagedHostStateChangeMessage {
+            machine_id: &machine_id,
+            managed_host_state: &state,
+            timestamp,
+        };
         let json = message.to_json_bytes().unwrap();
         let parsed: serde_json::Value = serde_json::from_slice(&json).unwrap();
 

--- a/crates/api/src/tests/mqtt_state_change_hook.rs
+++ b/crates/api/src/tests/mqtt_state_change_hook.rs
@@ -41,7 +41,11 @@ fn test_message_json_structure() {
     let state = ManagedHostState::Ready;
     let timestamp = Utc::now();
 
-    let message = ManagedHostStateChangeMessage::new(&machine_id, &state, timestamp);
+    let message = ManagedHostStateChangeMessage {
+        machine_id: &machine_id,
+        managed_host_state: &state,
+        timestamp,
+    };
     let json = message
         .to_json_bytes()
         .expect("serialization should succeed");
@@ -68,7 +72,11 @@ fn test_complex_state_has_nested_fields() {
     };
     let timestamp = Utc::now();
 
-    let message = ManagedHostStateChangeMessage::new(&machine_id, &state, timestamp);
+    let message = ManagedHostStateChangeMessage {
+        machine_id: &machine_id,
+        managed_host_state: &state,
+        timestamp,
+    };
     let json = message.to_json_bytes().unwrap();
     let parsed: serde_json::Value = serde_json::from_slice(&json).unwrap();
 
@@ -84,7 +92,11 @@ fn test_timestamp_format() {
     let state = ManagedHostState::Ready;
     let timestamp = Utc::now();
 
-    let message = ManagedHostStateChangeMessage::new(&machine_id, &state, timestamp);
+    let message = ManagedHostStateChangeMessage {
+        machine_id: &machine_id,
+        managed_host_state: &state,
+        timestamp,
+    };
     let json = message.to_json_bytes().unwrap();
     let parsed: serde_json::Value = serde_json::from_slice(&json).unwrap();
 

--- a/crates/health/src/lib.rs
+++ b/crates/health/src/lib.rs
@@ -216,7 +216,10 @@ pub async fn run_service(config: Config) -> Result<(), HealthError> {
 
     let join_discovery: tokio::task::JoinHandle<Result<(), HealthError>> = tokio::spawn({
         let config = config_arc.clone();
-        let shard_manager = ShardManager::new(config.shard, config.shards_count);
+        let shard_manager = ShardManager {
+            shard: config.shard,
+            shards_count: config.shards_count,
+        };
         let limiter: Arc<dyn RateLimiter> =
             if let Configurable::Enabled(rate_limit) = &config.rate_limit {
                 Arc::new(BucketLimiter::new(

--- a/crates/health/src/sharding.rs
+++ b/crates/health/src/sharding.rs
@@ -18,18 +18,11 @@
 use crate::endpoint::BmcAddr;
 
 pub struct ShardManager {
-    shard: usize,
-    shards_count: usize,
+    pub shard: usize,
+    pub shards_count: usize,
 }
 
 impl ShardManager {
-    pub fn new(shard: usize, shards_count: usize) -> Self {
-        Self {
-            shard,
-            shards_count,
-        }
-    }
-
     /// Check if this shard should monitor a BMC endpoint.
     pub fn should_monitor(&self, endpoint: &BmcAddr) -> bool {
         self.should_monitor_key(&endpoint.hash_key())
@@ -70,7 +63,10 @@ mod tests {
 
     #[test]
     fn test_single_shard() {
-        let manager = ShardManager::new(0, 1);
+        let manager = ShardManager {
+            shard: 0,
+            shards_count: 1,
+        };
         let endpoint = BmcAddr {
             ip: "10.0.0.1".parse().unwrap(),
             port: Some(443),
@@ -92,9 +88,18 @@ mod tests {
             mac: MacAddress::from_str("42:9e:b2:bd:9d:dd").unwrap(),
         };
 
-        let manager0 = ShardManager::new(0, 3);
-        let manager1 = ShardManager::new(1, 3);
-        let manager2 = ShardManager::new(2, 3);
+        let manager0 = ShardManager {
+            shard: 0,
+            shards_count: 3,
+        };
+        let manager1 = ShardManager {
+            shard: 1,
+            shards_count: 3,
+        };
+        let manager2 = ShardManager {
+            shard: 2,
+            shards_count: 3,
+        };
 
         // Each endpoint should be assigned to exactly one pod
         let mut count1 = 0;
@@ -137,7 +142,10 @@ mod tests {
         for key in [key1, key2] {
             let mut count = 0;
             for shard in 0..3 {
-                let manager = ShardManager::new(shard, 3);
+                let manager = ShardManager {
+                    shard,
+                    shards_count: 3,
+                };
                 if manager.should_monitor_key(key) {
                     count += 1;
                 }
@@ -152,7 +160,10 @@ mod tests {
 
     #[test]
     fn test_should_monitor_key_consistency() {
-        let manager = ShardManager::new(0, 3);
+        let manager = ShardManager {
+            shard: 0,
+            shards_count: 3,
+        };
         let key = "AA:BB:CC:DD:EE:FF";
         assert_eq!(
             manager.should_monitor_key(key),

--- a/crates/machine-validation/src/lib.rs
+++ b/crates/machine-validation/src/lib.rs
@@ -45,7 +45,7 @@ pub struct MachineValidationOptions {
 }
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MachineValidation {
-    options: MachineValidationOptions,
+    pub options: MachineValidationOptions,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -111,7 +111,7 @@ impl MachineValidationManager {
         uuid: String,
         machine_validation_filter: MachineValidationFilter,
     ) -> Result<(), MachineValidationError> {
-        let mc = MachineValidation::new(options);
+        let mc = MachineValidation { options };
 
         let tests = mc
             .clone()

--- a/crates/machine-validation/src/machine_validation.rs
+++ b/crates/machine-validation/src/machine_validation.rs
@@ -32,15 +32,12 @@ use crate::{
     IMAGE_LIST_FILE, MACHINE_VALIDATION_IMAGE_FILE, MACHINE_VALIDATION_IMAGE_PATH,
     MACHINE_VALIDATION_RUNNER_BASE_PATH, MACHINE_VALIDATION_RUNNER_TAG, MACHINE_VALIDATION_SERVER,
     MachineValidation, MachineValidationError, MachineValidationFilter, MachineValidationManager,
-    MachineValidationOptions, SCHME,
+    SCHME,
 };
 pub const MAX_STRING_STD_SIZE: usize = 1024 * 1024; // 1MB in bytes;
 pub const DEFAULT_TIMEOUT: u64 = 3600;
 
 impl MachineValidation {
-    pub fn new(options: MachineValidationOptions) -> Self {
-        MachineValidation { options }
-    }
     pub(crate) async fn get_container_auth_config(self) -> Result<(), MachineValidationError> {
         let file_name = "/root/.docker/config.json".to_string();
         match self

--- a/crates/mqttea/src/registry/core.rs
+++ b/crates/mqttea/src/registry/core.rs
@@ -77,7 +77,11 @@ impl MqttRegistry {
         };
 
         // Create registry entry with all components.
-        let entry = MqttRegistryEntry::new(info, serialize_handler, deserialize_handler);
+        let entry = MqttRegistryEntry {
+            message_type_info: info,
+            serialize_handler,
+            deserialize_handler,
+        };
 
         // Store complete entry.
         self.entries.insert(type_name.to_string(), entry);

--- a/crates/mqttea/src/registry/entry.rs
+++ b/crates/mqttea/src/registry/entry.rs
@@ -55,19 +55,6 @@ impl std::fmt::Debug for MqttRegistryEntry {
 }
 
 impl MqttRegistryEntry {
-    // new creates a new registry entry with all required components.
-    pub fn new(
-        message_type_info: MessageTypeInfo,
-        serialize_handler: SerializeHandler,
-        deserialize_handler: DeserializeHandler,
-    ) -> Self {
-        Self {
-            message_type_info,
-            serialize_handler,
-            deserialize_handler,
-        }
-    }
-
     // type_name returns the human-readable type name for this entry.
     pub fn type_name(&self) -> &str {
         &self.message_type_info.type_name

--- a/crates/mqttea/src/registry/types.rs
+++ b/crates/mqttea/src/registry/types.rs
@@ -89,21 +89,6 @@ pub type DeserializeHandler =
     Box<dyn Fn(&[u8]) -> Result<Box<dyn std::any::Any + Send>, MqtteaClientError> + Send + Sync>;
 
 impl MessageTypeInfo {
-    // new creates a new MessageTypeInfo with specified configuration.
-    pub fn new(
-        type_name: String,
-        patterns: Vec<String>,
-        publish_options: Option<PublishOptions>,
-        format: SerializationFormat,
-    ) -> Self {
-        Self {
-            type_name,
-            patterns,
-            publish_options,
-            format,
-        }
-    }
-
     // has_pattern checks if this message type is registered
     // for a specific pattern. Useful for validating registration state
     // and debugging pattern conflicts.

--- a/crates/mqttea/tests/registry.rs
+++ b/crates/mqttea/tests/registry.rs
@@ -603,12 +603,12 @@ fn test_get_type_info_methods() {
 // Tests for MessageTypeInfo utility methods
 #[test]
 fn test_message_type_info_methods() {
-    let info = MessageTypeInfo::new(
-        "TestType".to_string(),
-        vec!["pattern1".to_string(), "pattern2".to_string()],
-        Some(PublishOptions::default().with_qos(QoS::AtLeastOnce)),
-        SerializationFormat::Json,
-    );
+    let info = MessageTypeInfo {
+        type_name: "TestType".to_string(),
+        patterns: vec!["pattern1".to_string(), "pattern2".to_string()],
+        publish_options: Some(PublishOptions::default().with_qos(QoS::AtLeastOnce)),
+        format: SerializationFormat::Json,
+    };
 
     assert_eq!(info.pattern_count(), 2);
     assert!(info.has_pattern("pattern1"));
@@ -622,12 +622,12 @@ fn test_message_type_info_methods() {
 
 #[test]
 fn test_message_type_info_no_qos_override() {
-    let info = MessageTypeInfo::new(
-        "TestType".to_string(),
-        vec!["pattern".to_string()],
-        None,
-        SerializationFormat::Raw,
-    );
+    let info = MessageTypeInfo {
+        type_name: "TestType".to_string(),
+        patterns: vec!["pattern".to_string()],
+        publish_options: None,
+        format: SerializationFormat::Raw,
+    };
 
     assert!(!info.uses_qos_override());
     assert_eq!(info.effective_qos(QoS::ExactlyOnce), QoS::ExactlyOnce); // Uses default


### PR DESCRIPTION
## Description

This is similar to https://github.com/NVIDIA/ncx-infra-controller-core/pull/601, just doing it for the other stragglers (wanted to group all of the `libmlx` stuff together).

Underlying TLDR is that this is per our new `STYLE_GUIDE.md`, and to prefer using struct literals instead of `::new(..)` constructors for all of the "plain old data" structs being passed around.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

