### PR TITLE
chore: Make DbReader a concrete type

### DIFF
--- a/crates/api-db/src/attestation/ek_cert_verification_status.rs
+++ b/crates/api-db/src/attestation/ek_cert_verification_status.rs
@@ -60,7 +60,7 @@ pub async fn get_by_issuer(
 }
 
 pub async fn get_by_machine_id(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     machine_id: MachineId,
 ) -> DatabaseResult<Option<EkCertVerificationStatus>> {
     let query = "SELECT * FROM ek_cert_verification_status WHERE machine_id = ($1)";

--- a/crates/api-db/src/bmc_metadata.rs
+++ b/crates/api-db/src/bmc_metadata.rs
@@ -69,7 +69,7 @@ pub async fn enrich_mac_address(
     let bmc_ip_address = bmc_info.ip.clone().unwrap().parse()?;
     if bmc_info.mac.is_none() {
         if let Some(bmc_machine_interface) =
-            crate::machine_interface::find_by_ip(&mut *txn, bmc_ip_address).await?
+            crate::machine_interface::find_by_ip(&mut txn.into(), bmc_ip_address).await?
         {
             let bmc_mac_address = bmc_machine_interface.mac_address;
 

--- a/crates/api-db/src/db_read.rs
+++ b/crates/api-db/src/db_read.rs
@@ -17,217 +17,79 @@
 
 use futures_util::future::BoxFuture;
 use futures_util::stream::BoxStream;
-use sqlx::{Database, Describe, Either, Execute, PgConnection, PgExecutor, PgPool, Postgres};
+use sqlx::{Database, Describe, Either, Execute, PgConnection, PgPool, PgTransaction, Postgres};
 
-/// A trait describing a database handle intended for use in read-only database operations.
+/// Database handle used for read-only operations.
 ///
-/// A DbReader can be implemented by:
-/// - `&mut PgConnection`
-/// - `&mut PgTransaction`
-/// - `&mut PgPoolReader`
-/// - `&PgPool`
-///
-/// To make a database function accept a DbReader, you have a few options:
-///
-/// # Short-cut: "Leaf" functions that run a single query
-///
-/// For database functions that directly execute exactly one SQL query, or which delegate to exactly
-/// one function that does the same, your function can accept a simple `impl DbReader<'_>`:
-///
-/// ```
-/// use db::db_read::DbReader;
-/// async fn simple_db_func(db: impl DbReader<'_>) -> sqlx::Result<String> {
-///     sqlx::query_scalar("SELECT 'test'").fetch_one(db).await
-/// }
-/// ```
-///
-/// Note, that if you accept an `impl DbReader`, then callers need to re-borrow in order to avoid
-/// moves (`&mut *txn` or `txn.as_mut()`)
-///
-/// # More complex: Functions that run multiple queries or delegate to other functions
-///
-/// An issue with using `impl DbReader<'_>` is that passing it anywhere will move it out, and you
-/// cannot use it again. If you need to pass a DbReader to more than one query, you'll need to use a
-/// `&mut` reference, and make your function generic, with
-/// [HRTB](https://doc.rust-lang.org/nomicon/hrtb.html), and use `&mut *db` to avoid moving the
-/// value:
-///
-/// ```
-/// use db::db_read::DbReader;
-/// async fn two_db_calls<DB>(db: &mut DB) -> sqlx::Result<()>
-/// where
-///     for<'db> &'db mut DB: DbReader<'db>
-/// {
-///     // Use `&mut *db` to avoid moving
-///     sqlx::query_scalar::<_, String>("SELECT 'test'").fetch_one(&mut *db).await?;
-///     sqlx::query_scalar::<_, String>("SELECT 'test'").fetch_one(db).await?;
-///     Ok(())
-/// }
-/// ```
-///
-/// The `for<'db> &'db mut DB: DbReader<'db>` tells rust "I'm taking a `&mut` reference to
-/// something, and the type of that something needs to be such that any `&mut` reference to it
-/// implements the `DbReader` trait." This is because it's reference itself that implements
-/// `DbReader`, not the thing it points to.
-///
-/// # Calling DbReader functions from writer functions
-///
-/// One important use case is calling "read-only" database functions when you're holding a
-/// PgTransaction or PgConnection.
-///
-/// - [`&mut PgTransaction`] A PgTransaction can be passed via `.as_mut()` to turn it into a
-///   `&mut PgConnection` first, which implements DbReader.
-/// - [`&mut PgConnection`] This can be passed unaltered to a function expecting a DbReader, as
-///   PgConnection implements the trait directly.
-///
-/// # Calling DbReader functions with PgPoolReader or a PgPool
-///
-/// Due to sqlx's trait limitations, a `&mut PgPool` cannot implement DbReader, only a
-/// `&PgPool` can. So we have to choose if you want our db functions to take a generic `&mut DB` or a
-/// generic `&DB`. But the former is usable by PgTransaction, PgConnection, and PgPoolReader, but a
-/// `&DB` is only usable by PgPool.
-///
-/// So the guidance is to always accept a `&mut DB`, and if you want to call it from a PgPool, wrap
-/// the PgPool in a PgPoolReader first.
-///
-/// # Complete example
-///
-/// ```
-/// use db::db_read::PgPoolReader;
-///
-/// mod db_funcs {
-///     use db::db_read::DbReader;
-///
-///     // This is callable from any of our db types: PgConnection, PgTransaction, PgPool, and
-///     // PgPoolReader, and is simple to write. But the limitation is that you can only use it
-///     // once, since it is "moved out" the first time it is used.
-///     pub async fn callable_from_everything(db: impl DbReader<'_>) -> sqlx::Result<String> {
-///         sqlx::query_scalar("SELECT 'test'").fetch_one(db).await
-///     }
-///
-///     // This is callable from any `&mut` type: PgConnection, PgTransaction, and PgPoolReader. But
-///     // the downside is that you have to type out the generics and HRTB lines:
-///     pub async fn callable_from_all_but_pgpool<DB>(db: &mut DB) -> sqlx::Result<String>
-///     where
-///         for<'db> &'db mut DB: DbReader<'db>
-///     {
-///         sqlx::query_scalar("SELECT 'test'").fetch_one(db).await
-///     }
-///
-///     /// This is a not-recommended example: It's callable by PgPool, but not PgTransaction,
-///     /// PgConnection, nor PgPoolReader.
-///     pub async fn callable_from_pgpool_only<DB>(db: &DB) -> sqlx::Result<String>
-///     where
-///         for<'db> &'db DB: DbReader<'db>
-///     {
-///         sqlx::query_scalar("SELECT 'test'").fetch_one(db).await
-///     }
-/// }
-///
-/// async fn has_a_transaction(txn: &mut sqlx::PgTransaction<'_>) -> sqlx::Result<()> {
-///     // Transactions always must be passed with `.as_mut()` to convert them to a PgConnection
-///     db_funcs::callable_from_everything(txn.as_mut()).await?;
-///     db_funcs::callable_from_all_but_pgpool(txn.as_mut()).await?;
-///     db_funcs::callable_from_all_but_pgpool(txn.as_mut()).await?;
-///     Ok(())
-/// }
-///
-/// async fn has_a_pg_connection(conn: &mut sqlx::PgConnection) -> sqlx::Result<()> {
-///     // Passing to `impl DbReader<'_>` functions means doing `&mut *` to avoid moving
-///     db_funcs::callable_from_everything(&mut *conn).await?;
-///
-///     // When passing to functions taking `&mut DB` with HRTB, you can just pass the reference
-///     // as-is, and don't need to re-borrow.
-///     db_funcs::callable_from_all_but_pgpool(conn).await?;
-///     db_funcs::callable_from_all_but_pgpool(conn).await?;
-///     Ok(())
-/// }
-///
-/// async fn has_a_pg_pool_reader(pool: &mut PgPoolReader) -> sqlx::Result<()> {
-///     // Passing to `impl DbReader<'_>` functions means doing `&mut *` to avoid moving
-///     db_funcs::callable_from_everything(&mut *pool).await?;
-///
-///     // When passing to functions taking `&mut DB` with HRTB, you can just pass the reference
-///     // as-is, and don't need to re-borrow.
-///     db_funcs::callable_from_all_but_pgpool(pool).await?;
-///     db_funcs::callable_from_all_but_pgpool(pool).await?;
-///     Ok(())
-/// }
-///
-/// async fn has_a_pg_pool(pool: &sqlx::PgPool) -> sqlx::Result<()> {
-///     // Passing to `impl DbReader<'_>` functions means doing `&*` to avoid moving
-///     db_funcs::callable_from_everything(&*pool).await?;
-///
-///     // When passing to functions taking `&DB` with HRTB, you can just pass the reference as-is,
-///     // and don't need to re-borrow.
-///     db_funcs::callable_from_pgpool_only(pool).await?;
-///     db_funcs::callable_from_pgpool_only(pool).await?;
-///     Ok(())
-/// }
-/// ```
-///
-/// # Why go through the effort?
-///
-/// For cases where you're only reading data, in order to avoid long-running work while holding open
-/// a PgConnection or PgTransaction, it is beneficial to pass a reference to the *database pool*
-/// around, rather than a connection or transaction. This avoids consuming database resources until
-/// you actually need to execute a query. Passing a PgConnection or PgTransaction around should be
-/// reserved for cases where we know we need to *write* to the database, where we need to ensure
-/// that it is rolled back on failure, and that multiple writes are committed atomically.
-///
-/// But there's an ergonomics issue with passing a PgPool around: You still need to actually acquire
-/// a connection to call database functions, or create a transaction and immediately commit it. This
-/// gets confusing, because it's not clear from reading the code whether the transaction is being
-/// created because we're actually writing to the database, or if we're just making a transaction so
-/// that we can pass a live PgConnection to a db function.
-///
-/// # Why not have db functions accept PgPool?
-///
-/// If a function accepts a PgPool, then it can *not* be called from a context where we really *do*
-/// want to hold a transaction. If we want to write to data, then in the same transaction read back
-/// the data we just wrote to, the PgPool would check out a new connection to perform the read, and
-/// not see the data that was just written. This means we'd have to have two of every relevant
-/// function: One which takes a PgPool, and one which takes a PgConnection/PgTransaction.
-///
-/// # Why not accept a sqlx::Executor trait instead?
-///
-/// The reason is complicated and comes down to the choices sqlx made for their trait.
-/// [`sqlx::Executor`] is sqlx's way of having functions be agnostic to whether you call it from a
-/// Connection/Transaction or via a Pool. But it has all the same drawbacks as above: If you want
-/// to use it more than once, you need to take a `&mut` reference and use generics and HRTB's. But
-/// it's worse, because if you do take a `&mut` reference, then you *don't* support PgPool, since
-/// PgPool only implements Executor if it's an *immutable* reference.
-///
-/// In addition, the DbReader trait gives us the control to separate read-only functions from
-/// writable ones. This allows cases where we intentionally don't want to be able to write to the
-/// database, by only putting a PgPoolReader in scope instead of a PgPool, preventing any code paths
-/// from writing to the database at all.
-pub trait DbReader<'txn>: PgExecutor<'txn> {}
-
-/// A database handle that can only be sent to database functions accepting a `DbReader` trait. It
-/// cannot be passed to functions expecting a PgConnection or PgTransaction.
-#[derive(Debug, Clone)]
-pub struct PgPoolReader {
-    inner: PgPool,
+/// A DbReader can be converted from a PgPool, a borrowed &PgPool, a &mut PgConnection, or a &mut
+/// PgTransaction, each via the `.as_db_reader()` method from the [`AsDbReader`] trait. Converting
+/// to a DbReader is cheap and involves no allocations.
+#[derive(Debug)]
+pub enum DbReader<'a> {
+    Pool(PgPool),
+    BorrowedPool(&'a PgPool),
+    PgConnection(&'a mut PgConnection),
 }
 
-impl From<PgPool> for PgPoolReader {
+impl<'a> From<PgPool> for DbReader<'a> {
     fn from(pool: PgPool) -> Self {
-        Self { inner: pool }
+        Self::Pool(pool)
     }
 }
 
-impl<'a> DbReader<'a> for &'a mut PgPoolReader {}
-impl<'c> DbReader<'c> for &'c mut PgConnection {}
-impl<'c, 'txn> DbReader<'c> for &'c mut crate::Transaction<'txn> {}
-impl<'c> DbReader<'c> for &'c PgPool {}
-impl AsMut<PgPoolReader> for PgPoolReader {
-    fn as_mut(&mut self) -> &mut PgPoolReader {
-        self
+impl<'a> From<&'a PgPool> for DbReader<'a> {
+    fn from(pool: &'a PgPool) -> Self {
+        Self::BorrowedPool(pool)
     }
 }
 
-impl<'c> sqlx::Executor<'c> for &'c mut PgPoolReader {
+impl<'a> From<&'a mut PgConnection> for DbReader<'a> {
+    fn from(conn: &'a mut PgConnection) -> Self {
+        Self::PgConnection(conn)
+    }
+}
+
+impl<'a, 'txn> From<&'a mut PgTransaction<'txn>> for DbReader<'a> {
+    fn from(txn: &'a mut PgTransaction<'txn>) -> Self {
+        Self::PgConnection(txn.as_mut())
+    }
+}
+
+impl<'a> From<&'a mut crate::Transaction<'a>> for DbReader<'a> {
+    fn from(txn: &'a mut crate::Transaction<'a>) -> Self {
+        Self::PgConnection(txn.as_pgconn())
+    }
+}
+
+pub trait AsDbReader {
+    fn as_db_reader(&mut self) -> DbReader<'_>;
+}
+
+impl AsDbReader for PgConnection {
+    fn as_db_reader(&mut self) -> DbReader<'_> {
+        DbReader::PgConnection(self)
+    }
+}
+
+impl AsDbReader for PgTransaction<'_> {
+    fn as_db_reader(&mut self) -> DbReader<'_> {
+        DbReader::PgConnection(self)
+    }
+}
+
+impl AsDbReader for crate::Transaction<'_> {
+    fn as_db_reader(&mut self) -> DbReader<'_> {
+        DbReader::PgConnection(self.as_pgconn())
+    }
+}
+
+impl AsDbReader for PgPool {
+    fn as_db_reader(&mut self) -> DbReader<'_> {
+        DbReader::BorrowedPool(self)
+    }
+}
+
+impl<'c> sqlx::Executor<'c> for &'c mut DbReader<'_> {
     type Database = Postgres;
 
     fn fetch_many<'e, 'q: 'e, E>(
@@ -244,7 +106,11 @@ impl<'c> sqlx::Executor<'c> for &'c mut PgPoolReader {
         'c: 'e,
         E: 'q + Execute<'q, Self::Database>,
     {
-        self.inner.fetch_many(query)
+        match self {
+            DbReader::Pool(p) => p.fetch_many(query),
+            DbReader::BorrowedPool(p) => p.fetch_many(query),
+            DbReader::PgConnection(c) => c.fetch_many(query),
+        }
     }
 
     fn fetch_optional<'e, 'q: 'e, E>(
@@ -255,7 +121,11 @@ impl<'c> sqlx::Executor<'c> for &'c mut PgPoolReader {
         'c: 'e,
         E: 'q + Execute<'q, Self::Database>,
     {
-        self.inner.fetch_optional(query)
+        match self {
+            DbReader::Pool(p) => p.fetch_optional(query),
+            DbReader::BorrowedPool(p) => p.fetch_optional(query),
+            DbReader::PgConnection(c) => c.fetch_optional(query),
+        }
     }
 
     fn prepare_with<'e, 'q: 'e>(
@@ -266,7 +136,11 @@ impl<'c> sqlx::Executor<'c> for &'c mut PgPoolReader {
     where
         'c: 'e,
     {
-        self.inner.prepare_with(sql, parameters)
+        match self {
+            DbReader::Pool(p) => p.prepare_with(sql, parameters),
+            DbReader::BorrowedPool(p) => p.prepare_with(sql, parameters),
+            DbReader::PgConnection(c) => c.prepare_with(sql, parameters),
+        }
     }
 
     fn describe<'e, 'q: 'e>(
@@ -276,7 +150,11 @@ impl<'c> sqlx::Executor<'c> for &'c mut PgPoolReader {
     where
         'c: 'e,
     {
-        self.inner.describe(sql)
+        match self {
+            DbReader::Pool(p) => p.describe(sql),
+            DbReader::BorrowedPool(p) => p.describe(sql),
+            DbReader::PgConnection(c) => c.describe(sql),
+        }
     }
 }
 

--- a/crates/api-db/src/dns/domain.rs
+++ b/crates/api-db/src/dns/domain.rs
@@ -150,7 +150,7 @@ async fn persist_inner_with_metadata(
 ///
 ///
 pub async fn find_by<'a, C: ColumnInfo<'a, TableType = Domain>>(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     filter: ObjectColumnFilter<'a, C>,
 ) -> Result<Vec<Domain>, DatabaseError> {
     find_all_by(txn, filter, false).await
@@ -158,7 +158,7 @@ pub async fn find_by<'a, C: ColumnInfo<'a, TableType = Domain>>(
 
 /// Similar to [`Domain::find_by`] but lets you specify whether to include deleted results
 pub async fn find_all_by<'a, C: ColumnInfo<'a, TableType = Domain>>(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     filter: ObjectColumnFilter<'a, C>,
     include_deleted: bool,
 ) -> Result<Vec<Domain>, DatabaseError> {
@@ -175,7 +175,7 @@ pub async fn find_all_by<'a, C: ColumnInfo<'a, TableType = Domain>>(
 }
 
 pub async fn find_by_name(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     name: &str,
 ) -> Result<Vec<Domain>, DatabaseError> {
     find_by(txn, ObjectColumnFilter::One(NameColumn, &name)).await
@@ -183,7 +183,7 @@ pub async fn find_by_name(
 
 /// Find the domain with the given ID, even if it is deleted.
 pub async fn find_by_uuid(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     uuid: DomainId,
 ) -> Result<Option<Domain>, DatabaseError> {
     find_all_by(txn, ObjectColumnFilter::One(IdColumn, &uuid), true)

--- a/crates/api-db/src/dns/resource_record.rs
+++ b/crates/api-db/src/dns/resource_record.rs
@@ -76,7 +76,7 @@ impl<'r> FromRow<'r, PgRow> for DbResourceRecord {
 }
 
 pub async fn get_soa_record(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     query_name: &str,
 ) -> Result<Option<DbSoaRecord>, DatabaseError> {
     let domain_name = crate::dns::normalize_domain(query_name);
@@ -89,7 +89,7 @@ pub async fn get_soa_record(
 }
 
 pub async fn find_record(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     query_name: &str,
 ) -> Result<Vec<DbResourceRecord>, DatabaseError> {
     // TODO: Configurable defaults for TTL
@@ -112,7 +112,7 @@ pub async fn find_record(
     Ok(result)
 }
 pub async fn get_all_records(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     query_name: &str,
 ) -> Result<Vec<DbResourceRecord>, DatabaseError> {
     let domain_name = crate::dns::normalize_domain(query_name);

--- a/crates/api-db/src/dpa_interface.rs
+++ b/crates/api-db/src/dpa_interface.rs
@@ -172,7 +172,7 @@ pub async fn update_ip(
         .map_err(|e| DatabaseError::query(builder.sql(), e))
 }
 
-pub async fn find_ids(txn: impl DbReader<'_>) -> Result<Vec<DpaInterfaceId>, DatabaseError> {
+pub async fn find_ids(txn: &mut DbReader<'_>) -> Result<Vec<DpaInterfaceId>, DatabaseError> {
     let query = "SELECT id from dpa_interfaces WHERE deleted is NULL";
 
     let results: Vec<DpaInterfaceId> = {
@@ -188,7 +188,7 @@ pub async fn find_ids(txn: impl DbReader<'_>) -> Result<Vec<DpaInterfaceId>, Dat
 // Given an IP address, find and return the DPA interface that has the given IP
 // as its underlay or overlay IP address.
 pub async fn find_by_ip(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     ipaddr: IpAddr,
 ) -> Result<Vec<DpaInterface>, DatabaseError> {
     let query = "SELECT row_to_json(m.*) from (select * from dpa_interfaces
@@ -213,7 +213,7 @@ pub async fn find_by_ip(
 // Returns exactly one DpaInterface, or an error if none or multiple
 // are found, because multiple would not make sense.
 pub async fn get_for_pci_name(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     machine_id: &MachineId,
     pci_name: &str,
 ) -> Result<DpaInterface, DatabaseError> {
@@ -243,7 +243,7 @@ pub async fn get_for_pci_name(
 // Find a DPA Interface given its mac address. When we receive messages from the MQTT broker,
 // the topic contains the mac address, and we look up the interface based on that mac address.
 pub async fn find_by_mac_addr(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     maddr: &MacAddress,
 ) -> Result<Vec<DpaInterface>, DatabaseError> {
     let query = "SELECT row_to_json(m.*) from (select * from dpa_interfaces WHERE deleted is NULL AND mac_address = $1) m";
@@ -298,7 +298,7 @@ pub async fn update_card_state(
 
 // Used by the machine statemachine controller to find all DPAs associated with a given machine
 pub async fn find_by_machine_id(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     machine_id: MachineId,
 ) -> Result<Vec<DpaInterface>, DatabaseError> {
     let query = "SELECT row_to_json(m.*) from (select * from dpa_interfaces WHERE deleted is NULL AND machine_id = $1) m";
@@ -314,7 +314,7 @@ pub async fn find_by_machine_id(
 }
 
 pub async fn find_by_ids(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     dpa_ids: &[DpaInterfaceId],
     include_history: bool,
 ) -> Result<Vec<DpaInterface>, DatabaseError> {
@@ -458,10 +458,10 @@ pub async fn delete(value: DpaInterface, txn: &mut PgConnection) -> Result<(), D
 // Given the DPA Interface, we know its associated machine ID. From that, we need
 // to find the VPC the machine belongs to. From the VPC, we can find the DPA VNI,
 // which is just the VPC VNI.
-pub async fn get_dpa_vni<DB>(state: &mut DpaInterface, txn: &mut DB) -> Result<i32, eyre::Report>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+pub async fn get_dpa_vni(
+    state: &mut DpaInterface,
+    txn: &mut DbReader<'_>,
+) -> Result<i32, eyre::Report> {
     let machine_id = state.machine_id;
 
     let maybe_snapshot =
@@ -575,6 +575,7 @@ mod test {
     use model::machine::ManagedHostState;
     use model::metadata::Metadata;
 
+    use crate::db_read::AsDbReader;
     use crate::machine;
 
     #[crate::sqlx_test]
@@ -605,12 +606,13 @@ mod test {
 
         let intf = crate::dpa_interface::persist(new_intf, &mut txn).await?;
 
-        let ids = crate::dpa_interface::find_ids(txn.as_mut()).await?;
+        let ids = crate::dpa_interface::find_ids(&mut txn.as_db_reader()).await?;
 
         assert_eq!(ids.len(), 1);
         assert_eq!(ids[0], intf.id);
 
-        let db_intf = crate::dpa_interface::find_by_ids(txn.as_mut(), &[ids[0]], false).await?;
+        let db_intf =
+            crate::dpa_interface::find_by_ids(&mut txn.as_db_reader(), &[ids[0]], false).await?;
 
         assert_eq!(db_intf.len(), 1);
         assert_eq!(db_intf[0].id, intf.id);
@@ -709,7 +711,8 @@ mod test {
         // Verify device_info starts as None, because in this case,
         // one hasn't been reported yet (and also allows for backwards
         // compatibility checks from before this existed).
-        let intfs = crate::dpa_interface::find_by_machine_id(txn.as_mut(), machine_id).await?;
+        let intfs =
+            crate::dpa_interface::find_by_machine_id(&mut txn.as_db_reader(), machine_id).await?;
         assert_eq!(intfs.len(), 1);
         assert!(intfs[0].device_info.is_none());
         assert!(intfs[0].device_info_ts.is_none());
@@ -737,7 +740,8 @@ mod test {
 
         // Read back and verify everything we put into
         // the database came back as we originally put it.
-        let intfs = crate::dpa_interface::find_by_machine_id(txn.as_mut(), machine_id).await?;
+        let intfs =
+            crate::dpa_interface::find_by_machine_id(&mut txn.as_db_reader(), machine_id).await?;
         assert_eq!(intfs.len(), 1);
 
         let info = intfs[0]

--- a/crates/api-db/src/dpu_machine_update.rs
+++ b/crates/api-db/src/dpu_machine_update.rs
@@ -105,7 +105,7 @@ pub async fn get_updated_machines(
     host_health_config: HostHealthConfig,
 ) -> Result<Vec<DpuMachineUpdate>, DatabaseError> {
     let machine_ids = crate::machine::find_machine_ids(
-        &mut *txn,
+        &mut txn.into(),
         MachineSearchConfig {
             include_predicted_host: true,
             ..Default::default()
@@ -113,7 +113,7 @@ pub async fn get_updated_machines(
     )
     .await?;
     let snapshots = crate::managed_host::load_by_machine_ids(
-        txn,
+        &mut txn.into(),
         &machine_ids,
         LoadSnapshotOptions {
             include_history: false,

--- a/crates/api-db/src/expected_machine.rs
+++ b/crates/api-db/src/expected_machine.rs
@@ -28,7 +28,7 @@ use crate::{DatabaseError, DatabaseResult};
 const SQL_VIOLATION_DUPLICATE_MAC: &str = "expected_machines_bmc_mac_address_key";
 
 pub async fn find_by_bmc_mac_address(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     bmc_mac_address: MacAddress,
 ) -> Result<Option<ExpectedMachine>, DatabaseError> {
     let sql = "SELECT * FROM expected_machines WHERE bmc_mac_address=$1";
@@ -40,7 +40,7 @@ pub async fn find_by_bmc_mac_address(
 }
 
 pub async fn find_by_id(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     id: Uuid,
 ) -> Result<Option<ExpectedMachine>, DatabaseError> {
     let sql = "SELECT * FROM expected_machines WHERE id=$1";
@@ -124,7 +124,7 @@ FROM expected_machines em
         .map_err(|err| DatabaseError::query(sql, err))
 }
 
-pub async fn find_all(txn: impl DbReader<'_>) -> DatabaseResult<Vec<ExpectedMachine>> {
+pub async fn find_all(txn: &mut DbReader<'_>) -> DatabaseResult<Vec<ExpectedMachine>> {
     let sql = "SELECT * FROM expected_machines";
     sqlx::query_as(sql)
         .fetch_all(txn)
@@ -132,7 +132,7 @@ pub async fn find_all(txn: impl DbReader<'_>) -> DatabaseResult<Vec<ExpectedMach
         .map_err(|err| DatabaseError::query(sql, err))
 }
 
-pub async fn find_all_linked(txn: impl DbReader<'_>) -> DatabaseResult<Vec<LinkedExpectedMachine>> {
+pub async fn find_all_linked(txn: &mut DbReader<'_>) -> DatabaseResult<Vec<LinkedExpectedMachine>> {
     let sql = r#"
  SELECT
  em.serial_number,
@@ -226,7 +226,7 @@ pub async fn create(
 
 /// find returns an expected machine by id if provided, otherwise by bmc_mac_address.
 pub async fn find(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     req: &ExpectedMachineRequest,
 ) -> DatabaseResult<Option<ExpectedMachine>> {
     if let Some(id) = req.id {
@@ -359,7 +359,7 @@ pub async fn create_missing_from(
     txn: &mut PgConnection,
     expected_machines: &[ExpectedMachine],
 ) -> DatabaseResult<()> {
-    let existing_machines = find_all(&mut *txn).await?;
+    let existing_machines = find_all(&mut txn.into()).await?;
     let existing_map: BTreeMap<String, ExpectedMachine> = existing_machines
         .into_iter()
         .map(|machine| (machine.bmc_mac_address.to_string(), machine))

--- a/crates/api-db/src/explored_endpoints.rs
+++ b/crates/api-db/src/explored_endpoints.rs
@@ -115,7 +115,7 @@ impl From<DbExploredEndpoint> for ExploredEndpoint {
 }
 
 pub async fn find_ips(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     // filter is currently is empty, so it is a placeholder for the future
     _filter: ::rpc::site_explorer::ExploredEndpointSearchFilter,
 ) -> Result<Vec<IpAddr>, DatabaseError> {
@@ -133,7 +133,7 @@ pub async fn find_ips(
 }
 
 pub async fn find_by_ips(
-    db: impl DbReader<'_>,
+    db: &mut DbReader<'_>,
     ips: Vec<IpAddr>,
 ) -> Result<Vec<ExploredEndpoint>, DatabaseError> {
     let query = "SELECT * FROM explored_endpoints WHERE address=ANY($1)";
@@ -147,7 +147,7 @@ pub async fn find_by_ips(
 }
 
 /// find_all returns all explored endpoints that site explorer has been able to probe
-pub async fn find_all(txn: impl DbReader<'_>) -> Result<Vec<ExploredEndpoint>, DatabaseError> {
+pub async fn find_all(txn: &mut DbReader<'_>) -> Result<Vec<ExploredEndpoint>, DatabaseError> {
     let query = "SELECT * FROM explored_endpoints";
 
     sqlx::query_as::<_, DbExploredEndpoint>(query)
@@ -159,7 +159,7 @@ pub async fn find_all(txn: impl DbReader<'_>) -> Result<Vec<ExploredEndpoint>, D
 
 /// find_preingest_not_waiting gets everything that is still in preingestion that isn't waiting for site explorer to refresh it again and isn't in an error state.
 pub async fn find_preingest_not_waiting_not_error(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
 ) -> Result<Vec<ExploredEndpoint>, DatabaseError> {
     let query = "SELECT * FROM explored_endpoints
                         WHERE (preingestion_state IS NULL OR preingestion_state->'state' != '\"complete\"')
@@ -175,7 +175,7 @@ pub async fn find_preingest_not_waiting_not_error(
 
 /// find_preingest_installing returns the endpoints where wew are waiting for firmware installs
 pub async fn find_preingest_installing(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
 ) -> Result<Vec<ExploredEndpoint>, DatabaseError> {
     let query = "SELECT * FROM explored_endpoints WHERE preingestion_state->'state' = '\"upgradefirmwarewait\"'";
 
@@ -217,7 +217,7 @@ pub async fn find_all_by_ip(
 
 pub async fn lookup_vendor_by_ip(
     address: IpAddr,
-    db_reader: impl DbReader<'_>,
+    db_reader: &mut DbReader<'_>,
 ) -> Result<Option<String>, DatabaseError> {
     let query = "SELECT exploration_report ->> 'Vendor' AS vendor FROM explored_endpoints WHERE address = $1";
 
@@ -514,7 +514,7 @@ pub async fn delete_many(
 /// explored_endpoints_mac_addresses_idx, to avoid a full scan of all endpoint reports. Do NOT
 /// change this query without changing the index to match!
 pub async fn find_by_mac_address(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     mac: MacAddress,
 ) -> Result<Vec<ExploredEndpoint>, DatabaseError> {
     let query = r#"

--- a/crates/api-db/src/explored_managed_host.rs
+++ b/crates/api-db/src/explored_managed_host.rs
@@ -52,7 +52,7 @@ impl From<DbExploredManagedHost> for ExploredManagedHost {
 }
 
 pub async fn find_ips(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     // filter is currently is empty, so it is a placeholder for the future
     _filter: ::rpc::site_explorer::ExploredManagedHostSearchFilter,
 ) -> Result<Vec<IpAddr>, DatabaseError> {
@@ -70,7 +70,7 @@ pub async fn find_ips(
 }
 
 pub async fn find_by_ips(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     ips: Vec<IpAddr>,
 ) -> Result<Vec<ExploredManagedHost>, DatabaseError> {
     let query = "SELECT * FROM explored_managed_hosts WHERE host_bmc_ip=ANY($1)";
@@ -83,7 +83,7 @@ pub async fn find_by_ips(
         .map_err(|e| DatabaseError::new("explored_managed_hosts::find_by_ips", e))
 }
 
-pub async fn find_all(txn: impl DbReader<'_>) -> Result<Vec<ExploredManagedHost>, DatabaseError> {
+pub async fn find_all(txn: &mut DbReader<'_>) -> Result<Vec<ExploredManagedHost>, DatabaseError> {
     let query = "SELECT * FROM explored_managed_hosts ORDER by host_bmc_ip ASC";
 
     sqlx::query_as::<_, DbExploredManagedHost>(query)

--- a/crates/api-db/src/extension_service.rs
+++ b/crates/api-db/src/extension_service.rs
@@ -502,7 +502,7 @@ pub async fn find_versions_info(
 /// * `service_id` - The ID of the extension service
 ///
 pub async fn find_all_versions(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     service_id: ExtensionServiceId,
 ) -> DatabaseResult<Vec<ConfigVersion>> {
     let query = "SELECT version FROM extension_service_versions WHERE deleted IS NULL AND service_id = $1 ORDER BY (split_part(split_part(version, '-', 1), 'V', 2))::integer DESC";

--- a/crates/api-db/src/ib_partition.rs
+++ b/crates/api-db/src/ib_partition.rs
@@ -386,7 +386,7 @@ pub async fn list_segment_ids(txn: &mut PgConnection) -> Result<Vec<IBPartitionI
 }
 
 pub async fn for_tenant(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     tenant_organization_id: String,
 ) -> Result<Vec<IBPartition>, DatabaseError> {
     let results: Vec<IBPartition> = {
@@ -402,7 +402,7 @@ pub async fn for_tenant(
 }
 
 pub async fn find_ids(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     filter: rpc::IbPartitionSearchFilter,
 ) -> Result<Vec<IBPartitionId>, DatabaseError> {
     // build query
@@ -432,7 +432,7 @@ pub async fn find_ids(
 }
 
 pub async fn find_by<'a, C: ColumnInfo<'a, TableType = IBPartition>>(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     filter: ObjectColumnFilter<'a, C>,
 ) -> Result<Vec<IBPartition>, DatabaseError> {
     let mut query = FilterableQueryBuilder::new("SELECT * FROM ib_partitions").filter(&filter);
@@ -544,7 +544,7 @@ pub async fn final_delete(
 
 /// Counts the number of instances that reference a given IB partition in their ib_config.
 pub async fn count_instances_referencing_partition(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     partition_id: IBPartitionId,
 ) -> Result<i64, DatabaseError> {
     let query = "

--- a/crates/api-db/src/instance.rs
+++ b/crates/api-db/src/instance.rs
@@ -59,7 +59,7 @@ impl ColumnInfo<'_> for IdColumn {
 pub struct InstanceTable {}
 
 pub async fn find_ids(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     filter: rpc::InstanceSearchFilter,
 ) -> Result<Vec<InstanceId>, DatabaseError> {
     let mut builder = sqlx::QueryBuilder::new("SELECT id FROM instances WHERE TRUE "); // The TRUE will be optimized away.
@@ -135,7 +135,7 @@ WHERE vpc_id = ",
 }
 
 pub async fn find(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     filter: ObjectColumnFilter<'_, IdColumn>,
 ) -> Result<Vec<InstanceSnapshot>, DatabaseError> {
     let mut query = FilterableQueryBuilder::new("SELECT row_to_json(i.*) FROM instances i")
@@ -148,7 +148,7 @@ pub async fn find(
 }
 
 pub async fn find_by_id(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     id: InstanceId,
 ) -> Result<Option<InstanceSnapshot>, DatabaseError> {
     let query = "SELECT row_to_json(i.*) from instances i WHERE id = $1";
@@ -226,7 +226,7 @@ pub async fn find_by_extension_service(
 /// Returns true if any non-deleted instance has this logical partition ID in
 /// config.nvlink.gpu_configs[].logical_partition_id.
 pub async fn any_instance_referencing_nvlink_logical_partition(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     logical_partition_id: &NvLinkLogicalPartitionId,
 ) -> Result<bool, DatabaseError> {
     let query = r#"SELECT EXISTS (

--- a/crates/api-db/src/instance_address.rs
+++ b/crates/api-db/src/instance_address.rs
@@ -37,7 +37,7 @@ use model::network_segment::{
 use sqlx::{FromRow, PgConnection, PgTransaction, query_as};
 
 use super::{ObjectColumnFilter, network_segment};
-use crate::db_read::DbReader;
+use crate::db_read::{AsDbReader, DbReader};
 use crate::ip_allocator::{IpAllocator, UsedIpResolver};
 use crate::{DatabaseError, DatabaseResult, Transaction};
 
@@ -54,7 +54,7 @@ impl super::ColumnInfo<'_> for PrefixColumn {
 }
 
 pub async fn find_by_address(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     address: IpAddr,
 ) -> Result<Option<InstanceAddress>, DatabaseError> {
     let query = "SELECT * FROM instance_addresses WHERE address = $1::inet";
@@ -223,7 +223,7 @@ pub async fn allocate(
     }
 
     let segments = crate::network_segment::find_by(
-        &mut inner_txn,
+        &mut inner_txn.as_db_reader(),
         ObjectColumnFilter::List(network_segment::IdColumn, &segment_ids),
         NetworkSegmentSearchConfig::default(),
     )
@@ -293,7 +293,7 @@ pub async fn allocate(
                 .copied()
                 .collect::<Vec<IpAddr>>();
 
-            let dhcp_handler: Box<dyn UsedIpResolver<PgConnection> + Send> =
+            let dhcp_handler: Box<dyn UsedIpResolver + Send> =
                 Box::new(UsedOverlayNetworkIpResolver {
                     segment_id: segment.id,
                     busy_ips,
@@ -303,7 +303,7 @@ pub async fn allocate(
             // for IPv4, /126 for IPv6) via InstanceInterfaceConfig. For now,
             // the allocator defaults to single-host allocation (/32 or /128).
             let ip_allocator = IpAllocator::new(
-                inner_txn.as_pgconn(),
+                &mut inner_txn.as_db_reader(),
                 segment,
                 dhcp_handler,
                 AddressSelectionStrategy::NextAvailableIp,
@@ -342,10 +342,7 @@ pub struct UsedOverlayNetworkIpResolver {
 }
 
 #[async_trait::async_trait]
-impl<DB> UsedIpResolver<DB> for UsedOverlayNetworkIpResolver
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+impl UsedIpResolver for UsedOverlayNetworkIpResolver {
     // DEPRECATED
     // With the introduction of `used_prefixes()` this is no
     // longer an accurate approach for finding all allocated
@@ -359,7 +356,7 @@ where
     // target the `address` column of the `instance_addresses`
     // table, in which a single /32 is stored (although, as an
     // `inet`, it could techincally also have a prefix length).
-    async fn used_ips(&self, txn: &mut DB) -> Result<Vec<IpAddr>, DatabaseError> {
+    async fn used_ips(&self, txn: &mut DbReader<'_>) -> Result<Vec<IpAddr>, DatabaseError> {
         // IpAddrContainer is a small private struct used
         // for binding the result of the subsequent SQL
         // query, so we can implement FromRow and return
@@ -396,7 +393,7 @@ WHERE network_segments.id = $1::uuid";
     // or a /30 (for FNN prefix allocations), where the `address`
     // column would contain the host IP allocated from the
     // /30 prefix.
-    async fn used_prefixes(&self, txn: &mut DB) -> Result<Vec<IpNetwork>, DatabaseError> {
+    async fn used_prefixes(&self, txn: &mut DbReader<'_>) -> Result<Vec<IpNetwork>, DatabaseError> {
         // IpNetworkContainer is a small private struct used
         // for binding the result of the subsequent SQL
         // query, so we can implement FromRow and return
@@ -545,11 +542,10 @@ pub async fn allocate_svi_ip(
     txn: &mut PgTransaction<'_>,
     segment: &NetworkSegment,
 ) -> DatabaseResult<(NetworkPrefixId, IpAddr)> {
-    let dhcp_handler: Box<dyn UsedIpResolver<PgConnection> + Send> =
-        Box::new(UsedOverlayNetworkIpResolver {
-            segment_id: segment.id,
-            busy_ips: vec![],
-        });
+    let dhcp_handler: Box<dyn UsedIpResolver + Send> = Box::new(UsedOverlayNetworkIpResolver {
+        segment_id: segment.id,
+        busy_ips: vec![],
+    });
 
     // If either requested addresses are auto-generated, we lock the entire table
     let query = "LOCK TABLE instance_addresses IN ACCESS EXCLUSIVE MODE";
@@ -558,8 +554,9 @@ pub async fn allocate_svi_ip(
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
 
+    let mut db_reader = DbReader::from(txn);
     let mut addresses_allocator = IpAllocator::new(
-        txn.as_mut(),
+        &mut db_reader,
         segment,
         dhcp_handler,
         AddressSelectionStrategy::NextAvailableIp,

--- a/crates/api-db/src/ip_allocator.rs
+++ b/crates/api-db/src/ip_allocator.rs
@@ -31,13 +31,10 @@ use crate::db_read::DbReader;
 use crate::{DatabaseError, DatabaseResult};
 
 #[async_trait::async_trait]
-pub trait UsedIpResolver<DB>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+pub trait UsedIpResolver {
     // used_ips is expected to return used (or allocated)
     // IPs as reported by whoever implements this trait.
-    async fn used_ips(&self, txn: &mut DB) -> Result<Vec<IpAddr>, DatabaseError>;
+    async fn used_ips(&self, txn: &mut DbReader<'_>) -> Result<Vec<IpAddr>, DatabaseError>;
 
     // Method to get used/allocated IPs for implementor.
     // Since the allocated IPs may actually be allocated
@@ -46,7 +43,7 @@ where
     // type supports this, since `inet` supports the
     // ability to set a prefix length (with /32 being the
     // implied default).
-    async fn used_prefixes(&self, txn: &mut DB) -> Result<Vec<IpNetwork>, DatabaseError>;
+    async fn used_prefixes(&self, txn: &mut DbReader<'_>) -> Result<Vec<IpNetwork>, DatabaseError>;
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -111,15 +108,12 @@ pub struct IpAllocator {
 }
 
 impl IpAllocator {
-    pub async fn new<DB>(
-        db: &mut DB,
+    pub async fn new(
+        db: &mut DbReader<'_>,
         segment: &NetworkSegment,
-        used_ip_resolver: Box<dyn UsedIpResolver<DB> + Send>,
+        used_ip_resolver: Box<dyn UsedIpResolver + Send>,
         address_strategy: AddressSelectionStrategy,
-    ) -> DatabaseResult<Self>
-    where
-        for<'db> &'db mut DB: DbReader<'db>,
-    {
+    ) -> DatabaseResult<Self> {
         let used_ips = used_ip_resolver.used_prefixes(db).await?;
 
         Ok(IpAllocator {

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -90,8 +90,12 @@ pub async fn get_or_create(
     stable_machine_id: &MachineId,
     interface: &MachineInterfaceSnapshot,
 ) -> DatabaseResult<Machine> {
-    let existing_machine =
-        find_one(&mut *txn, stable_machine_id, MachineSearchConfig::default()).await?;
+    let existing_machine = find_one(
+        &mut txn.into(),
+        stable_machine_id,
+        MachineSearchConfig::default(),
+    )
+    .await?;
     if let Some(machine_id) = interface.machine_id.as_ref() {
         if machine_id != stable_machine_id {
             return Err(DatabaseError::internal(format!(
@@ -150,7 +154,7 @@ pub async fn get_or_create(
 }
 
 pub async fn find_one(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     id: &MachineId,
     search_config: MachineSearchConfig,
 ) -> Result<Option<Machine>, DatabaseError> {
@@ -231,7 +235,7 @@ pub async fn advance(
 /// * `search_config` - A MachineSearchConfig with search options to control the
 ///   records selected
 pub async fn find(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     filter: ObjectFilter<'_, MachineId>,
     search_config: MachineSearchConfig,
 ) -> Result<Vec<Machine>, DatabaseError> {
@@ -321,7 +325,7 @@ pub async fn find_id_by_bmc_ip(
     txn: &mut PgConnection,
     bmc_ip: &IpAddr,
 ) -> Result<Option<MachineId>, DatabaseError> {
-    crate::machine_topology::find_machine_id_by_bmc_ip(txn, &bmc_ip.to_string()).await
+    crate::machine_topology::find_machine_id_by_bmc_ip(&mut txn.into(), &bmc_ip.to_string()).await
 }
 
 /// Finds machines associated with a specified instance type
@@ -485,7 +489,7 @@ pub async fn find_by_mac_address(
 }
 
 pub async fn find_by_loopback_ip(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     loopback_ip: &str,
 ) -> Result<Option<Machine>, DatabaseError> {
     lazy_static! {
@@ -513,7 +517,7 @@ pub async fn find_by_query(
     query: &str,
 ) -> Result<Option<Machine>, DatabaseError> {
     if let Ok(id) = MachineId::from_str(query) {
-        return find_one(txn, &id, MachineSearchConfig::default()).await;
+        return find_one(&mut txn.into(), &id, MachineSearchConfig::default()).await;
     }
 
     if let Ok(ip) = IpAddr::from_str(query) {
@@ -672,7 +676,7 @@ pub async fn find_host_by_dpu_machine_id(
 }
 
 pub async fn lookup_host_machine_ids_by_dpu_ids(
-    conn: impl DbReader<'_>,
+    conn: &mut DbReader<'_>,
     dpu_machine_ids: &[MachineId],
 ) -> Result<Vec<MachineId>, DatabaseError> {
     let query = r#"SELECT mi.machine_id
@@ -1049,7 +1053,7 @@ pub async fn update_agent_reported_inventory(
 }
 
 pub async fn get_all_network_status_observation(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     limit: i64, // return at most this many rows
 ) -> Result<Vec<MachineNetworkStatusObservation>, DatabaseError> {
     let query = "SELECT network_status_observation FROM machines
@@ -1141,7 +1145,13 @@ pub async fn try_sync_stable_id_with_current_machine_id_for_host(
 
     // This is repeated call. Machine is already updated with stable ID.
     if !current_machine_id.machine_type().is_predicted_host() {
-        return match find_one(txn, current_machine_id, MachineSearchConfig::default()).await? {
+        return match find_one(
+            &mut txn.into(),
+            current_machine_id,
+            MachineSearchConfig::default(),
+        )
+        .await?
+        {
             Some(machine) => Ok(machine.id),
             None => Err(DatabaseError::NotFoundError {
                 kind: "machine",
@@ -1295,12 +1305,16 @@ pub async fn create(
         )));
     }
 
-    let machine = find_one(&mut *txn, stable_machine_id, MachineSearchConfig::default())
-        .await?
-        .ok_or_else(|| DatabaseError::NotFoundError {
-            kind: "machine",
-            id: stable_machine_id.to_string(),
-        })?;
+    let machine = find_one(
+        &mut txn.into(),
+        stable_machine_id,
+        MachineSearchConfig::default(),
+    )
+    .await?
+    .ok_or_else(|| DatabaseError::NotFoundError {
+        kind: "machine",
+        id: stable_machine_id.to_string(),
+    })?;
     advance(&machine, txn, &state, None).await?;
 
     // Create a entry in power_options table as well.
@@ -1559,7 +1573,7 @@ pub async fn clear_dpu_reprovisioning_request(
 }
 
 pub async fn list_machines_requested_for_reprovisioning(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
 ) -> Result<Vec<Machine>, DatabaseError> {
     lazy_static! {
         static ref query: String = format!(
@@ -1574,7 +1588,7 @@ pub async fn list_machines_requested_for_reprovisioning(
 }
 
 pub async fn list_machines_requested_for_host_reprovisioning(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
 ) -> Result<Vec<Machine>, DatabaseError> {
     lazy_static! {
         static ref query: String = format!(
@@ -1598,7 +1612,7 @@ pub async fn apply_agent_upgrade_policy(
     if policy == AgentUpgradePolicy::Off {
         return Ok(false);
     }
-    let machine = find_one(&mut *txn, machine_id, MachineSearchConfig::default())
+    let machine = find_one(&mut txn.into(), machine_id, MachineSearchConfig::default())
         .await?
         .ok_or_else(|| DatabaseError::NotFoundError {
             kind: "dpu_machine",
@@ -1649,7 +1663,7 @@ pub async fn set_dpu_agent_upgrade_requested(
 }
 
 pub async fn find_machine_ids(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     search_config: MachineSearchConfig,
 ) -> Result<Vec<MachineId>, DatabaseError> {
     let mut qb = sqlx::QueryBuilder::new("SELECT id FROM machines");
@@ -1730,7 +1744,7 @@ pub async fn update_state(
     new_state: &ManagedHostState,
 ) -> Result<(), DatabaseError> {
     let host = find_one(
-        &mut *txn,
+        &mut txn.into(),
         host_id,
         // TODO(?): Should we be using for_update/row-level locks here?
         // This is a select that's later used for an update on both version
@@ -2137,7 +2151,7 @@ pub async fn update_sku_status_verify_request_time_for_sku(
 }
 
 pub async fn find_machine_ids_by_sku_ids(
-    db_reader: impl DbReader<'_>,
+    db_reader: &mut DbReader<'_>,
     sku_ids: &[String],
 ) -> Result<HashMap<String, Vec<MachineId>>, DatabaseError> {
     let query = r#"SELECT skus.id, COALESCE(m.machine_ids, '[]'::jsonb) as associated_machine_ids
@@ -2179,7 +2193,7 @@ pub async fn find_machine_ids_by_sku_ids(
 }
 
 pub async fn get_network_config(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     machine_id: &MachineId,
 ) -> Result<Versioned<ManagedHostNetworkConfig>, DatabaseError> {
     #[derive(FromRow)]
@@ -2203,7 +2217,7 @@ pub async fn get_network_config(
 }
 
 pub async fn get_quarantine_state(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     machine_id: &MachineId,
 ) -> Result<Option<ManagedHostQuarantineState>, DatabaseError> {
     let network_config = get_network_config(txn, machine_id).await?;
@@ -2216,7 +2230,9 @@ pub async fn set_quarantine_state(
     quarantine_state: ManagedHostQuarantineState,
 ) -> Result<Option<ManagedHostQuarantineState>, DatabaseError> {
     let (mut network_config, network_config_version) =
-        get_network_config(&mut *txn, machine_id).await?.take();
+        get_network_config(&mut txn.into(), machine_id)
+            .await?
+            .take();
     let old_quarantine_state = network_config.quarantine_state.clone();
     network_config.quarantine_state = Some(quarantine_state);
     try_update_network_config(txn, machine_id, network_config_version, &network_config).await?;
@@ -2228,7 +2244,9 @@ pub async fn clear_quarantine_state(
     machine_id: &MachineId,
 ) -> Result<Option<ManagedHostQuarantineState>, DatabaseError> {
     let (mut network_config, network_config_version) =
-        get_network_config(&mut *txn, machine_id).await?.take();
+        get_network_config(&mut txn.into(), machine_id)
+            .await?
+            .take();
     let old_quarantine_state = network_config.quarantine_state.clone();
     network_config.quarantine_state = None;
     try_update_network_config(txn, machine_id, network_config_version, &network_config).await?;
@@ -2322,6 +2340,8 @@ mod test {
     use model::machine::machine_search_config::MachineSearchConfig;
     use model::metadata::Metadata;
 
+    use crate::db_read::AsDbReader;
+
     #[crate::sqlx_test]
 
     async fn test_set_firmware_autoupdate(
@@ -2345,19 +2365,21 @@ mod test {
         txn.commit().await?;
         let mut txn: sqlx::Transaction<'_, sqlx::Postgres> = pool.begin().await.unwrap();
 
-        let host = crate::machine::find_one(&mut *txn, &id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .unwrap();
+        let host =
+            crate::machine::find_one(&mut txn.as_db_reader(), &id, MachineSearchConfig::default())
+                .await
+                .unwrap()
+                .unwrap();
         assert!(host.firmware_autoupdate.is_some());
 
         txn.commit().await?;
         let mut txn: sqlx::Transaction<'_, sqlx::Postgres> = pool.begin().await.unwrap();
         super::set_firmware_autoupdate(&mut txn, &id, None).await?;
-        let host = crate::machine::find_one(&mut *txn, &id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .unwrap();
+        let host =
+            crate::machine::find_one(&mut txn.as_db_reader(), &id, MachineSearchConfig::default())
+                .await
+                .unwrap()
+                .unwrap();
         assert!(host.firmware_autoupdate.is_none());
         Ok(())
     }

--- a/crates/api-db/src/machine_boot_override.rs
+++ b/crates/api-db/src/machine_boot_override.rs
@@ -56,7 +56,7 @@ pub async fn update_or_insert(
     value: &MachineBootOverride,
     txn: &mut PgConnection,
 ) -> DatabaseResult<()> {
-    match find_optional(&mut *txn, value.machine_interface_id).await? {
+    match find_optional(&mut txn.into(), value.machine_interface_id).await? {
         Some(existing_mbo) => {
             let custom_pxe = if value.custom_pxe.is_some() {
                 value.custom_pxe.clone()
@@ -108,7 +108,7 @@ pub async fn clear(
 }
 
 pub async fn find_optional(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     machine_interface_id: MachineInterfaceId,
 ) -> DatabaseResult<Option<MachineBootOverride>> {
     let mut interfaces = find_by(
@@ -126,7 +126,7 @@ pub async fn find_optional(
 }
 
 async fn find_by<'a, C: ColumnInfo<'a, TableType = MachineBootOverride>>(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     filter: ObjectColumnFilter<'a, C>,
 ) -> Result<Vec<MachineBootOverride>, DatabaseError> {
     let mut query =

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -38,7 +38,7 @@ use model::predicted_machine_interface::PredictedMachineInterface;
 use sqlx::{FromRow, PgConnection, PgTransaction};
 
 use super::{ColumnInfo, FilterableQueryBuilder, ObjectColumnFilter};
-use crate::db_read::DbReader;
+use crate::db_read::{AsDbReader, DbReader};
 use crate::ip_allocator::{IpAllocator, UsedIpResolver};
 use crate::{DatabaseError, DatabaseResult, Transaction, network_segment as db_network_segment};
 
@@ -201,14 +201,14 @@ pub async fn associate_interface_with_machine(
 }
 
 pub async fn find_by_mac_address(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     macaddr: MacAddress,
 ) -> Result<Vec<MachineInterfaceSnapshot>, DatabaseError> {
     find_by(txn, ObjectColumnFilter::One(MacAddressColumn, &macaddr)).await
 }
 
 pub async fn find_by_ip(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     ip: IpAddr,
 ) -> Result<Option<MachineInterfaceSnapshot>, DatabaseError> {
     lazy_static! {
@@ -227,7 +227,7 @@ pub async fn find_by_ip(
 }
 
 pub async fn find_all(txn: &mut PgConnection) -> DatabaseResult<Vec<MachineInterfaceSnapshot>> {
-    find_by(txn, ObjectColumnFilter::All::<IdColumn>).await
+    find_by(&mut txn.into(), ObjectColumnFilter::All::<IdColumn>).await
 }
 
 pub async fn find_by_machine_ids(
@@ -237,12 +237,13 @@ pub async fn find_by_machine_ids(
     use itertools::Itertools;
     // The .unwrap() in the `group_map_by` call is ok - because we are only
     // searching for Machines which have associated MachineIds
-    Ok(
-        find_by(txn, ObjectColumnFilter::List(MachineIdColumn, machine_ids))
-            .await?
-            .into_iter()
-            .into_group_map_by(|interface| interface.machine_id.unwrap()),
+    Ok(find_by(
+        &mut txn.into(),
+        ObjectColumnFilter::List(MachineIdColumn, machine_ids),
     )
+    .await?
+    .into_iter()
+    .into_group_map_by(|interface| interface.machine_id.unwrap()))
 }
 
 pub async fn count_by_segment_id(
@@ -260,7 +261,7 @@ pub async fn count_by_segment_id(
 }
 
 pub async fn find_one(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     interface_id: MachineInterfaceId,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
     let mut interfaces = find_by(txn, ObjectColumnFilter::One(IdColumn, &interface_id)).await?;
@@ -295,7 +296,7 @@ pub async fn find_or_create_machine_interface(
             Ok(validate_existing_mac_and_create(&mut *txn, mac_address, relay, host_nic).await?)
         }
         Some(_) => {
-            let mut ifcs = find_by_mac_address(&mut *txn, mac_address).await?;
+            let mut ifcs = find_by_mac_address(&mut txn.into(), mac_address).await?;
             match ifcs.len() {
                 1 => Ok(ifcs.remove(0)),
                 n => {
@@ -321,7 +322,7 @@ pub async fn validate_existing_mac_and_create(
     relay: IpAddr,
     host_nic: Option<ExpectedHostNic>,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
-    let mut existing_mac = find_by_mac_address(&mut *txn, mac_address).await?;
+    let mut existing_mac = find_by_mac_address(&mut txn.into(), mac_address).await?;
     match &existing_mac.len() {
         0 => {
             tracing::debug!(
@@ -464,11 +465,12 @@ async fn create_fast_path(
         {
             Ok(interface_id) => {
                 fast_txn.commit().await?;
-                return Ok(
-                    find_by(txn, ObjectColumnFilter::One(IdColumn, &interface_id))
-                        .await?
-                        .remove(0),
-                );
+                return Ok(find_by(
+                    &mut txn.into(),
+                    ObjectColumnFilter::One(IdColumn, &interface_id),
+                )
+                .await?
+                .remove(0));
             }
             Err(err) if err.is_fqdn_conflict() => {
                 // Another simultaneous create got the same FQDN, try again.
@@ -525,16 +527,15 @@ pub async fn create_slow_path(
         }
     }
 
-    let dhcp_handler: Box<dyn UsedIpResolver<PgConnection> + Send> =
-        Box::new(UsedAdminNetworkIpResolver {
-            segment_id: segment.id,
-            busy_ips: reserved_ips,
-        });
+    let dhcp_handler: Box<dyn UsedIpResolver + Send> = Box::new(UsedAdminNetworkIpResolver {
+        segment_id: segment.id,
+        busy_ips: reserved_ips,
+    });
 
     // Allocate an address from each prefix in the segment. For dual-stack
     // segments this means one IPv4 address and one IPv6 address.
     let allocator = IpAllocator::new(
-        inner_txn.as_pgconn(),
+        &mut inner_txn.as_db_reader(),
         segment,
         dhcp_handler,
         address_strategy,
@@ -558,11 +559,12 @@ pub async fn create_slow_path(
     .await?;
     inner_txn.commit().await?;
 
-    Ok(
-        find_by(txn, ObjectColumnFilter::One(IdColumn, &interface_id))
-            .await?
-            .remove(0),
+    Ok(find_by(
+        &mut txn.into(),
+        ObjectColumnFilter::One(IdColumn, &interface_id),
     )
+    .await?
+    .remove(0))
 }
 
 /// Fast path for single-IP allocation.
@@ -754,17 +756,16 @@ pub async fn allocate_svi_ip(
     txn: &mut PgTransaction<'_>,
     segment: &NetworkSegment,
 ) -> DatabaseResult<(NetworkPrefixId, IpAddr)> {
-    let dhcp_handler: Box<dyn UsedIpResolver<PgConnection> + Send> =
-        Box::new(UsedAdminNetworkIpResolver {
-            segment_id: segment.id,
-            busy_ips: vec![],
-        });
+    let dhcp_handler: Box<dyn UsedIpResolver + Send> = Box::new(UsedAdminNetworkIpResolver {
+        segment_id: segment.id,
+        busy_ips: vec![],
+    });
 
     // Prevent other allocations from happening concurrently in this network segment
     lock_network_segment_exclusive(txn, segment).await?;
 
     let mut addresses_allocator = IpAllocator::new(
-        txn.as_mut(),
+        &mut txn.into(),
         segment,
         dhcp_handler,
         AddressSelectionStrategy::NextAvailableIp,
@@ -788,7 +789,7 @@ pub async fn find_by_ip_or_id(
     interface_id: Option<MachineInterfaceId>,
 ) -> Result<MachineInterfaceSnapshot, DatabaseError> {
     if let Some(remote_ip) = remote_ip
-        && let Some(interface) = find_by_ip(&mut *txn, remote_ip).await?
+        && let Some(interface) = find_by_ip(&mut txn.into(), remote_ip).await?
     {
         // remove debug message by Apr 2024
         tracing::debug!(
@@ -799,7 +800,7 @@ pub async fn find_by_ip_or_id(
         return Ok(interface);
     }
     match interface_id {
-        Some(interface_id) => find_one(txn, interface_id).await,
+        Some(interface_id) => find_one(&mut txn.into(), interface_id).await,
         None => Err(DatabaseError::NotFoundError {
             kind: "machine_interface",
             id: format!("remote_ip={remote_ip:?},interface_id={interface_id:?}"),
@@ -892,7 +893,7 @@ fn address_to_hostname(address: &IpAddr) -> DatabaseResult<String> {
 }
 
 async fn find_by<'a, C: ColumnInfo<'a, TableType = MachineInterfaceSnapshot>>(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     filter: ObjectColumnFilter<'a, C>,
 ) -> Result<Vec<MachineInterfaceSnapshot>, DatabaseError> {
     let mut query = FilterableQueryBuilder::new(MACHINE_INTERFACE_SNAPSHOT_QUERY)
@@ -954,7 +955,7 @@ pub async fn move_predicted_machine_interface_to_machine(
     }
 
     let machine_interface_id = match self::find_by_mac_address(
-        &mut *txn,
+        &mut txn.into(),
         predicted_machine_interface.mac_address,
     )
     .await?
@@ -1121,7 +1122,7 @@ pub async fn delete(
 }
 
 pub async fn delete_by_ip(txn: &mut PgConnection, ip: IpAddr) -> Result<Option<()>, DatabaseError> {
-    let interface = find_by_ip(&mut *txn, ip).await?;
+    let interface = find_by_ip(&mut txn.into(), ip).await?;
 
     let Some(interface) = interface else {
         return Ok(None);
@@ -1133,10 +1134,7 @@ pub async fn delete_by_ip(txn: &mut PgConnection, ip: IpAddr) -> Result<Option<(
 }
 
 #[async_trait::async_trait]
-impl<DB> UsedIpResolver<DB> for UsedAdminNetworkIpResolver
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+impl UsedIpResolver for UsedAdminNetworkIpResolver {
     // DEPRECATED
     // With the introduction of `used_prefixes()` this is no
     // longer an accurate approach for finding all allocated
@@ -1152,7 +1150,7 @@ where
     // target the `address` column of the `machine_interface_addresses`
     // table, in which a single /32 is stored (although, as an
     // `inet`, it could techincally also have a prefix length).
-    async fn used_ips(&self, txn: &mut DB) -> Result<Vec<IpAddr>, DatabaseError> {
+    async fn used_ips(&self, txn: &mut DbReader<'_>) -> Result<Vec<IpAddr>, DatabaseError> {
         // IpAddrContainer is a small private struct used
         // for binding the result of the subsequent SQL
         // query, so we can implement FromRow and return
@@ -1195,7 +1193,7 @@ WHERE network_segments.id = $1::uuid";
     // saying its not implemented for machine_interfaces, BUT,
     // it keeps it cleaner knowing the IpAllocator works via
     // calling used_prefixes() regardless of who is using it.
-    async fn used_prefixes(&self, txn: &mut DB) -> Result<Vec<IpNetwork>, DatabaseError> {
+    async fn used_prefixes(&self, txn: &mut DbReader<'_>) -> Result<Vec<IpNetwork>, DatabaseError> {
         let used_ips = self.used_ips(txn).await?;
         let mut ip_networks: Vec<IpNetwork> = Vec::new();
         for used_ip in used_ips {

--- a/crates/api-db/src/machine_interface_address.rs
+++ b/crates/api-db/src/machine_interface_address.rs
@@ -42,7 +42,7 @@ pub async fn find_ipv4_for_interface(
 }
 
 pub async fn find_by_address(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     address: IpAddr,
 ) -> Result<Option<MachineInterfaceSearchResult>, DatabaseError> {
     let query = "SELECT mi.id, mi.machine_id, ns.name, ns.network_segment_type

--- a/crates/api-db/src/machine_topology.rs
+++ b/crates/api-db/src/machine_topology.rs
@@ -196,7 +196,7 @@ pub async fn find_latest_by_machine_ids(
 }
 
 pub async fn find_machine_id_by_bmc_ip(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     address: &str,
 ) -> Result<Option<MachineId>, DatabaseError> {
     let query = "SELECT machine_id FROM machine_topologies WHERE topology->'bmc_info'->>'ip' = $1";
@@ -220,7 +220,7 @@ pub async fn find_machine_id_by_bmc_mac(
 }
 
 pub async fn find_machine_bmc_pairs(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     bmc_ips: Vec<String>,
 ) -> Result<Vec<(MachineId, String)>, DatabaseError> {
     let query = r#"SELECT machine_id, topology->'bmc_info'->>'ip'
@@ -272,7 +272,7 @@ pub async fn find_machine_bmc_pairs_by_machine_id(
 /// will make this a fast operation that doesn't need to sequentially scan. DO NOT change this
 /// query without also changing the index!
 pub async fn find_by_serial(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     to_find: &str,
 ) -> Result<Vec<MachineId>, DatabaseError> {
     let query = r#"
@@ -300,7 +300,7 @@ pub async fn find_by_serial(
 /// Search the topologyfor a string anywhere in the JSON.
 /// Used by the serial number finder for non-exact matches
 pub async fn find_freetext(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     to_find: &str,
 ) -> Result<Vec<MachineId>, DatabaseError> {
     let query =

--- a/crates/api-db/src/machine_validation.rs
+++ b/crates/api-db/src/machine_validation.rs
@@ -29,7 +29,7 @@ use crate::db_read::DbReader;
 use crate::{DatabaseError, DatabaseResult};
 
 pub async fn find_by(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     filter: ObjectFilter<'_, String>,
     column: &str,
 ) -> Result<Vec<MachineValidation>, DatabaseError> {
@@ -176,14 +176,11 @@ pub async fn create_new_run(
     Ok(id)
 }
 
-pub async fn find<DB>(
-    txn: &mut DB,
+pub async fn find(
+    txn: &mut DbReader<'_>,
     machine_id: &MachineId,
     include_history: bool,
-) -> DatabaseResult<Vec<MachineValidation>>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+) -> DatabaseResult<Vec<MachineValidation>> {
     if include_history {
         return find_by_machine_id(&mut *txn, machine_id).await;
     };
@@ -224,7 +221,7 @@ where
 }
 
 pub async fn find_by_machine_id(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     machine_id: &MachineId,
 ) -> DatabaseResult<Vec<MachineValidation>> {
     find_by(
@@ -236,7 +233,7 @@ pub async fn find_by_machine_id(
 }
 
 pub async fn find_active_machine_validation_by_machine_id(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     machine_id: &MachineId,
 ) -> DatabaseResult<MachineValidation> {
     let ret = find_by_machine_id(txn, machine_id).await?;
@@ -251,7 +248,7 @@ pub async fn find_active_machine_validation_by_machine_id(
 }
 
 pub async fn find_by_id(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     validation_id: &Uuid,
 ) -> DatabaseResult<MachineValidation> {
     let machine_validation =
@@ -265,7 +262,7 @@ pub async fn find_by_id(
     )))
 }
 
-pub async fn find_all(txn: impl DbReader<'_>) -> DatabaseResult<Vec<MachineValidation>> {
+pub async fn find_all(txn: &mut DbReader<'_>) -> DatabaseResult<Vec<MachineValidation>> {
     find_by(txn, ObjectFilter::All, "").await
 }
 

--- a/crates/api-db/src/machine_validation_config.rs
+++ b/crates/api-db/src/machine_validation_config.rs
@@ -22,7 +22,7 @@ use crate::db_read::DbReader;
 use crate::{DatabaseError, DatabaseResult};
 
 pub async fn find_config_by_name(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     name: &str,
 ) -> DatabaseResult<MachineValidationExternalConfig> {
     let query = "SELECT * FROM machine_validation_external_config WHERE name=$1";
@@ -79,7 +79,7 @@ pub async fn create_or_update(
     description: &str,
     data: &Vec<u8>,
 ) -> DatabaseResult<()> {
-    match find_config_by_name(&mut *txn, name).await {
+    match find_config_by_name(&mut txn.into(), name).await {
         Ok(config) => update(txn, name, data, config.version.increment()).await?,
         Err(_) => save(txn, name, description, data).await?,
     };
@@ -87,7 +87,7 @@ pub async fn create_or_update(
 }
 
 pub async fn find_configs(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
 ) -> DatabaseResult<Vec<MachineValidationExternalConfig>> {
     let query = "SELECT * FROM machine_validation_external_config";
 

--- a/crates/api-db/src/machine_validation_result.rs
+++ b/crates/api-db/src/machine_validation_result.rs
@@ -22,14 +22,11 @@ use sqlx::PgConnection;
 use crate::db_read::DbReader;
 use crate::{DatabaseError, DatabaseResult, ObjectFilter, machine_validation_suites};
 
-pub async fn find_by_machine_id<DB>(
-    txn: &mut DB,
+pub async fn find_by_machine_id(
+    txn: &mut DbReader<'_>,
     machine_id: &MachineId,
     include_history: bool,
-) -> DatabaseResult<Vec<MachineValidationResult>>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+) -> DatabaseResult<Vec<MachineValidationResult>> {
     if include_history {
         // Fetch all validation_id from machine_validation table
         let machine_validation = crate::machine_validation::find_by(
@@ -87,7 +84,7 @@ where
 }
 
 async fn find_by(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     filter: ObjectFilter<'_, String>,
     column: &str,
 ) -> Result<Vec<MachineValidationResult>, DatabaseError> {
@@ -180,7 +177,7 @@ pub async fn create(value: MachineValidationResult, txn: &mut PgConnection) -> D
 }
 
 pub async fn validate_current_context(
-    txn: &mut PgConnection,
+    txn: &mut DbReader<'_>,
     id: &rpc::Uuid,
 ) -> DatabaseResult<Option<String>> {
     let db_results = find_by(
@@ -199,7 +196,7 @@ pub async fn validate_current_context(
 }
 
 pub async fn find_by_validation_id(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     id: &uuid::Uuid,
 ) -> DatabaseResult<Vec<MachineValidationResult>> {
     find_by(

--- a/crates/api-db/src/machine_validation_suites.rs
+++ b/crates/api-db/src/machine_validation_suites.rs
@@ -209,7 +209,7 @@ fn build_select_query(
 }
 
 pub async fn find(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     req: rpc::forge::MachineValidationTestsGetRequest,
 ) -> DatabaseResult<Vec<MachineValidationTest>> {
     let query = build_select_query(req, "machine_validation_tests")?;

--- a/crates/api-db/src/managed_host.rs
+++ b/crates/api-db/src/managed_host.rs
@@ -32,21 +32,18 @@ use crate::db_read::DbReader;
 use crate::{DatabaseError, queries};
 
 /// Loads a ManagedHost snapshot from the database
-pub async fn load_snapshot<DB>(
-    txn: &mut DB,
+pub async fn load_snapshot(
+    txn: &mut DbReader<'_>,
     machine_id: &MachineId,
     options: LoadSnapshotOptions,
-) -> Result<Option<ManagedHostStateSnapshot>, DatabaseError>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+) -> Result<Option<ManagedHostStateSnapshot>, DatabaseError> {
     let mut snapshots = load_by_machine_ids(txn, &[*machine_id], options).await?;
     Ok(snapshots.remove(machine_id))
 }
 
 /// Loads all ManagedHosts, including predicted hosts
 pub async fn load_all(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     options: LoadSnapshotOptions,
 ) -> Result<Vec<ManagedHostStateSnapshot>, DatabaseError> {
     let query = managed_host_snapshots_query(&options);
@@ -70,14 +67,11 @@ pub async fn load_all(
 /// The method works for Host and DPU Machine IDs
 /// When used for DPU Machine IDs, the returned HashMap will contain an entry
 /// that maps from the DPU Machine ID to the ManagedHost snapshot
-pub async fn load_by_machine_ids<DB>(
-    txn: &mut DB,
+pub async fn load_by_machine_ids(
+    txn: &mut DbReader<'_>,
     requested_machine_ids: &[MachineId],
     options: LoadSnapshotOptions,
-) -> Result<HashMap<MachineId, ManagedHostStateSnapshot>, DatabaseError>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+) -> Result<HashMap<MachineId, ManagedHostStateSnapshot>, DatabaseError> {
     // Partition the ID's by whether or not they're DPU's.
     let (requested_dpu_ids, requested_host_ids): (Vec<MachineId>, Vec<MachineId>) =
         requested_machine_ids

--- a/crates/api-db/src/measured_boot/bundle.rs
+++ b/crates/api-db/src/measured_boot/bundle.rs
@@ -124,9 +124,11 @@ pub async fn from_id(
     txn: &mut PgConnection,
     bundle_id: MeasurementBundleId,
 ) -> DatabaseResult<MeasurementBundle> {
-    match get_measurement_bundle_by_id(&mut *txn, bundle_id).await? {
+    match get_measurement_bundle_by_id(&mut txn.into(), bundle_id).await? {
         Some(info) => {
-            let values = get_measurement_bundle_values_for_bundle_id(txn, info.bundle_id).await?;
+            let values =
+                get_measurement_bundle_values_for_bundle_id(&mut txn.into(), info.bundle_id)
+                    .await?;
             Ok(from_info_and_values(info, values)?)
         }
         None => Err(DatabaseError::NotFoundError {
@@ -144,7 +146,9 @@ pub async fn from_name(
 ) -> DatabaseResult<MeasurementBundle> {
     match get_measurement_bundle_for_name(txn, bundle_name.clone()).await? {
         Some(info) => {
-            let values = get_measurement_bundle_values_for_bundle_id(txn, info.bundle_id).await?;
+            let values =
+                get_measurement_bundle_values_for_bundle_id(&mut txn.into(), info.bundle_id)
+                    .await?;
             Ok(from_info_and_values(info, values)?)
         }
         None => Err(DatabaseError::NotFoundError {
@@ -162,7 +166,8 @@ pub async fn set_state_for_id(
     state: MeasurementBundleState,
 ) -> DatabaseResult<MeasurementBundle> {
     let info = set_state_for_bundle_id(txn, bundle_id, state).await?;
-    let values = get_measurement_bundle_values_for_bundle_id(txn.as_mut(), info.bundle_id).await?;
+    let values =
+        get_measurement_bundle_values_for_bundle_id(&mut txn.into(), info.bundle_id).await?;
     let bundle = from_info_and_values(info, values)?;
     update_journal(&bundle, txn).await?;
     Ok(bundle)
@@ -170,10 +175,7 @@ pub async fn set_state_for_id(
 
 /// get_all returns all populated MeasurementBundle
 /// models from records in the database.
-pub async fn get_all<DB>(txn: &mut DB) -> DatabaseResult<Vec<MeasurementBundle>>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+pub async fn get_all(txn: &mut DbReader<'_>) -> DatabaseResult<Vec<MeasurementBundle>> {
     let mut res: Vec<MeasurementBundle> = Vec::new();
     let mut bundle_records = get_measurement_bundle_records(&mut *txn).await?;
     for bundle_record in bundle_records.drain(..) {
@@ -194,7 +196,8 @@ pub async fn get_all_for_profile_id(
     let mut bundle_records = get_measurement_bundle_records_for_profile_id(txn, profile_id).await?;
     for bundle_record in bundle_records.drain(..) {
         let values =
-            get_measurement_bundle_values_for_bundle_id(&mut *txn, bundle_record.bundle_id).await?;
+            get_measurement_bundle_values_for_bundle_id(&mut txn.into(), bundle_record.bundle_id)
+                .await?;
         res.push(from_info_and_values(bundle_record, values)?);
     }
     Ok(res)
@@ -289,7 +292,7 @@ pub async fn rename_for_id(
     match info {
         Some(info) => from_info_and_values(
             info,
-            get_measurement_bundle_values_for_bundle_id(txn, bundle_id).await?,
+            get_measurement_bundle_values_for_bundle_id(&mut txn.into(), bundle_id).await?,
         ),
         None => Err(DatabaseError::NotFoundError {
             kind: "MeasurementBundleRecord",
@@ -316,7 +319,8 @@ pub async fn rename_for_name(
                 });
             }
         };
-    let values = get_measurement_bundle_values_for_bundle_id(txn, info.bundle_id).await?;
+    let values =
+        get_measurement_bundle_values_for_bundle_id(&mut txn.into(), info.bundle_id).await?;
     from_info_and_values(info, values)
 }
 
@@ -350,7 +354,7 @@ async fn update_journal(
 ) -> DatabaseResult<Vec<MeasurementJournal>> {
     let machine_state = bundle_state_to_machine_state(&measurement_bundle.state);
 
-    let reports = match_latest_reports(txn.as_mut(), &measurement_bundle.pcr_values()).await?;
+    let reports = match_latest_reports(&mut txn.into(), &measurement_bundle.pcr_values()).await?;
     let mut updates: Vec<MeasurementJournal> = Vec::new();
     for report in reports.iter() {
         let machine = crate::measured_boot::machine::from_id(txn, report.machine_id).await?;
@@ -477,7 +481,7 @@ pub async fn set_state_for_bundle_id(
         // Didn't get one back, which means something happened, as in
         // either the bundle didn't exist, or the state is set to
         // revoked. If it's neither of those cases, that's fun.
-        None => match get_measurement_bundle_by_id(txn, bundle_id).await? {
+        None => match get_measurement_bundle_by_id(&mut txn.into(), bundle_id).await? {
             None => Err(DatabaseError::NotFoundError {
                 kind: "MeasurementBundleRecord",
                 id: bundle_id.to_string(),

--- a/crates/api-db/src/measured_boot/interface/bundle.rs
+++ b/crates/api-db/src/measured_boot/interface/bundle.rs
@@ -190,7 +190,7 @@ pub async fn update_state_for_bundle_id(
 /// for the given `bundle_id`, if it exists. This leverages the generic
 /// get_object_for_id function since its a simple/common pattern.
 pub async fn get_measurement_bundle_by_id(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     bundle_id: MeasurementBundleId,
 ) -> Result<Option<MeasurementBundleRecord>, DatabaseError> {
     common::get_object_for_id(txn, bundle_id)
@@ -205,7 +205,7 @@ pub async fn get_measurement_bundle_for_name(
     txn: &mut PgConnection,
     bundle_name: String,
 ) -> Result<Option<MeasurementBundleRecord>, DatabaseError> {
-    common::get_object_for_unique_column(txn, "name", bundle_name.clone())
+    common::get_object_for_unique_column(&mut txn.into(), "name", bundle_name.clone())
         .await
         .map_err(|e| e.with_op_name("get_measurement_bundle_for_name"))
 }
@@ -214,7 +214,7 @@ pub async fn get_measurement_bundle_for_name(
 /// instances in the database. This leverages the generic get_all_objects
 /// function since its a simple/common pattern.
 pub async fn get_measurement_bundle_records(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
 ) -> Result<Vec<MeasurementBundleRecord>, DatabaseError> {
     common::get_all_objects(txn)
         .await
@@ -228,7 +228,7 @@ pub async fn get_measurement_bundle_records_for_profile_id(
     txn: &mut PgConnection,
     profile_id: MeasurementSystemProfileId,
 ) -> Result<Vec<MeasurementBundleRecord>, DatabaseError> {
-    common::get_objects_where_id(txn, profile_id)
+    common::get_objects_where_id(&mut txn.into(), profile_id)
         .await
         .map_err(|e| e.with_op_name("get_measurement_bundle_records_for_profile_id"))
 }
@@ -237,7 +237,7 @@ pub async fn get_measurement_bundle_records_for_profile_id(
 /// instances in the database. This leverages the generic get_all_objects
 /// function since its a simple/common pattern.
 pub async fn get_measurement_bundles_values(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
 ) -> Result<Vec<MeasurementBundleValueRecord>, DatabaseError> {
     common::get_all_objects(txn)
         .await
@@ -252,7 +252,7 @@ pub async fn get_measurement_bundles_values(
 /// of multiple objects matching a given PgUuid, where
 /// the PgUuid is probably a reference/foreign key.
 pub async fn get_measurement_bundle_values_for_bundle_id(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     bundle_id: MeasurementBundleId,
 ) -> Result<Vec<MeasurementBundleValueRecord>, DatabaseError> {
     common::get_objects_where_id(txn, bundle_id)

--- a/crates/api-db/src/measured_boot/interface/common.rs
+++ b/crates/api-db/src/measured_boot/interface/common.rs
@@ -85,7 +85,7 @@ pub fn generate_name() -> DatabaseResult<String> {
 /// the DbPrimaryUuid and DbTable traits (which are traits defined in this
 /// crate) to build the query.
 pub async fn get_object_for_id<T, R>(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     id: T,
 ) -> Result<Option<R>, DatabaseError>
 where
@@ -105,7 +105,7 @@ where
 /// the DbPrimaryUuid and DbTable traits (which are traits defined in this
 /// crate) to build the query.
 pub async fn get_object_for_unique_column<T, R>(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     col_name: &str,
     value: T,
 ) -> Result<Option<R>, DatabaseError>
@@ -134,7 +134,7 @@ where
 /// Similar to get_object_for_id above, this leverages a mixture of sqlx-based
 /// derive + traits to reduce the use of copy-pasta code + string literals.
 pub async fn get_objects_where_id<T, R>(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     id: T,
 ) -> Result<Vec<R>, DatabaseError>
 where
@@ -160,7 +160,7 @@ where
 /// implementing the crate-specific DbName trait to make this possible,
 /// with the idea of reducing very boilerplate copy-pasta code and string
 /// literals.
-pub async fn get_all_objects<R>(txn: impl DbReader<'_>) -> Result<Vec<R>, DatabaseError>
+pub async fn get_all_objects<R>(txn: &mut DbReader<'_>) -> Result<Vec<R>, DatabaseError>
 where
     R: for<'r> sqlx::FromRow<'r, PgRow> + Send + Unpin + DbTable,
 {

--- a/crates/api-db/src/measured_boot/interface/journal.rs
+++ b/crates/api-db/src/measured_boot/interface/journal.rs
@@ -94,7 +94,7 @@ pub async fn get_measurement_journal_record_by_id(
     txn: &mut PgConnection,
     journal_id: MeasurementJournalId,
 ) -> Result<Option<MeasurementJournalRecord>, DatabaseError> {
-    common::get_object_for_id(txn, journal_id)
+    common::get_object_for_id(&mut txn.into(), journal_id)
         .await
         .map_err(|e| e.with_op_name("get_measurement_journal_record_by_id"))
 }
@@ -107,7 +107,7 @@ pub async fn get_measurement_journal_record_by_report_id(
     txn: &mut PgConnection,
     report_id: MeasurementReportId,
 ) -> Result<Option<MeasurementJournalRecord>, DatabaseError> {
-    common::get_object_for_id(txn, report_id)
+    common::get_object_for_id(&mut txn.into(), report_id)
         .await
         .map_err(|e| e.with_op_name("get_measurement_journal_record_by_report_id"))
 }
@@ -118,7 +118,7 @@ pub async fn get_measurement_journal_record_by_report_id(
 pub async fn get_measurement_journal_records(
     txn: &mut PgConnection,
 ) -> Result<Vec<MeasurementJournalRecord>, DatabaseError> {
-    common::get_all_objects(txn)
+    common::get_all_objects(&mut txn.into())
         .await
         .map_err(|e| e.with_op_name("get_measurement_journal_records"))
 }
@@ -130,7 +130,7 @@ pub async fn get_measurement_journal_records_for_machine_id(
     txn: &mut PgConnection,
     machine_id: MachineId,
 ) -> Result<Vec<MeasurementJournalRecord>, DatabaseError> {
-    common::get_objects_where_id(txn, machine_id)
+    common::get_objects_where_id(&mut txn.into(), machine_id)
         .await
         .map_err(|e| e.with_op_name("get_measurement_journal_records_for_machine_id"))
 }

--- a/crates/api-db/src/measured_boot/interface/machine.rs
+++ b/crates/api-db/src/measured_boot/interface/machine.rs
@@ -33,7 +33,7 @@ use crate::measured_boot::machine::CandidateMachineRecord;
 /// machine ID by checking its most recent bundle (or lack thereof), and
 /// using that result to give it a corresponding MeasurementMachineState.
 pub async fn get_candidate_machine_state(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     machine_id: MachineId,
 ) -> Result<MeasurementMachineState, DatabaseError> {
     Ok(match get_latest_journal_for_id(txn, machine_id).await? {
@@ -45,7 +45,7 @@ pub async fn get_candidate_machine_state(
 /// get_latest_journal_for_id returns the latest journal record for the
 /// provided machine ID.
 pub async fn get_latest_journal_for_id(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     machine_id: MachineId,
 ) -> Result<Option<MeasurementJournalRecord>, DatabaseError> {
     let query = "select distinct on (machine_id) * from measurement_journal where machine_id = $1 order by machine_id,ts desc";
@@ -61,7 +61,7 @@ pub async fn get_candidate_machine_record_by_id(
     txn: &mut PgConnection,
     machine_id: MachineId,
 ) -> Result<Option<CandidateMachineRecord>, DatabaseError> {
-    common::get_object_for_id(txn, machine_id)
+    common::get_object_for_id(&mut txn.into(), machine_id)
         .await
         .map_err(|e| e.with_op_name("get_candidate_machine_record_by_id"))
 }
@@ -69,7 +69,7 @@ pub async fn get_candidate_machine_record_by_id(
 /// get_candidate_machine_records returns all MockMachineRecord rows,
 /// primarily for the purpose of `mock-machine list`.
 pub async fn get_candidate_machine_records(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
 ) -> Result<Vec<CandidateMachineRecord>, DatabaseError> {
     common::get_all_objects(txn)
         .await

--- a/crates/api-db/src/measured_boot/interface/profile.rs
+++ b/crates/api-db/src/measured_boot/interface/profile.rs
@@ -127,7 +127,7 @@ pub async fn rename_profile_for_profile_name(
 
 /// get_all_measurement_profile_records gets all system profile records.
 pub async fn get_all_measurement_profile_records(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
 ) -> Result<Vec<MeasurementSystemProfileRecord>, DatabaseError> {
     common::get_all_objects(txn)
         .await
@@ -141,7 +141,7 @@ pub async fn get_measurement_profile_record_by_id(
     txn: &mut PgConnection,
     profile_id: MeasurementSystemProfileId,
 ) -> Result<Option<MeasurementSystemProfileRecord>, DatabaseError> {
-    common::get_object_for_id(txn, profile_id)
+    common::get_object_for_id(&mut txn.into(), profile_id)
         .await
         .map_err(|e| e.with_op_name("get_measurement_profile_record_by_id"))
 }
@@ -153,7 +153,7 @@ pub async fn get_measurement_profile_record_by_name(
     txn: &mut PgConnection,
     val: String,
 ) -> Result<Option<MeasurementSystemProfileRecord>, DatabaseError> {
-    common::get_object_for_unique_column(txn, "name", val)
+    common::get_object_for_unique_column(&mut txn.into(), "name", val)
         .await
         .map_err(|e| e.with_op_name("get_measurement_profile_record_by_name"))
 }
@@ -280,7 +280,7 @@ fn where_attr_pairs(query: &mut QueryBuilder<'_, Postgres>, values: &HashMap<Str
 /// get_measurement_profile_attrs_for_profile_id returns all profile attribute
 /// records associated with the provided MeasurementSystemProfileId.
 pub async fn get_measurement_profile_attrs_for_profile_id(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     profile_id: MeasurementSystemProfileId,
 ) -> Result<Vec<MeasurementSystemProfileAttrRecord>, DatabaseError> {
     common::get_objects_where_id(txn, profile_id)
@@ -442,7 +442,7 @@ pub async fn import_measurement_system_profiles_attr(
 ///
 /// This is used by the site exporter, as well as for listing all profiles.
 pub async fn export_measurement_profile_records(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
 ) -> Result<Vec<MeasurementSystemProfileRecord>, DatabaseError> {
     common::get_all_objects(txn)
         .await
@@ -455,7 +455,7 @@ pub async fn export_measurement_profile_records(
 /// This is specifically used by the site exporter, since we simply dump all
 /// attributes when doing a site export.
 pub async fn export_measurement_system_profiles_attrs(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
 ) -> Result<Vec<MeasurementSystemProfileAttrRecord>, DatabaseError> {
     common::get_all_objects(txn)
         .await
@@ -467,7 +467,7 @@ pub async fn export_measurement_system_profiles_attrs(
 pub async fn get_all_measurement_profile_attr_records(
     txn: &mut PgConnection,
 ) -> Result<Vec<MeasurementSystemProfileAttrRecord>, DatabaseError> {
-    common::get_all_objects(txn)
+    common::get_all_objects(&mut txn.into())
         .await
         .map_err(|e| e.with_op_name("get_all_measurement_profile_attr_records"))
 }

--- a/crates/api-db/src/measured_boot/interface/report.rs
+++ b/crates/api-db/src/measured_boot/interface/report.rs
@@ -51,7 +51,7 @@ pub fn where_pcr_pairs(query: &mut QueryBuilder<'_, Postgres>, values: &[PcrRegi
 }
 
 pub async fn match_latest_reports(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     values: &[PcrRegisterValue],
 ) -> Result<Vec<MeasurementReportRecord>, DatabaseError> {
     if values.is_empty() {
@@ -152,7 +152,7 @@ async fn insert_measurement_report_value_record(
 pub async fn get_all_measurement_report_records(
     txn: &mut PgConnection,
 ) -> Result<Vec<MeasurementReportRecord>, DatabaseError> {
-    common::get_all_objects(txn)
+    common::get_all_objects(&mut txn.into())
         .await
         .map_err(|e| e.with_op_name("get_all_measurement_report_records"))
 }
@@ -165,7 +165,7 @@ pub async fn get_measurement_report_record_by_id(
     txn: &mut PgConnection,
     report_id: MeasurementReportId,
 ) -> Result<Option<MeasurementReportRecord>, DatabaseError> {
-    common::get_object_for_id(txn, report_id)
+    common::get_object_for_id(&mut txn.into(), report_id)
         .await
         .map_err(|e| e.with_op_name("get_measurement_report_record_by_id"))
 }
@@ -177,7 +177,7 @@ pub async fn get_measurement_report_records_for_machine_id(
     txn: &mut PgConnection,
     machine_id: MachineId,
 ) -> Result<Vec<MeasurementReportRecord>, DatabaseError> {
-    common::get_objects_where_id(txn, machine_id)
+    common::get_objects_where_id(&mut txn.into(), machine_id)
         .await
         .map_err(|e| e.with_op_name("get_measurement_report_records_for_machine_id"))
 }
@@ -192,7 +192,7 @@ pub async fn get_measurement_report_values_for_report_id(
     txn: &mut PgConnection,
     report_id: MeasurementReportId,
 ) -> Result<Vec<MeasurementReportValueRecord>, DatabaseError> {
-    common::get_objects_where_id(txn, report_id)
+    common::get_objects_where_id(&mut txn.into(), report_id)
         .await
         .map_err(|e| e.with_op_name("get_measurement_report_values_for_report_id"))
 }
@@ -251,7 +251,7 @@ pub(crate) async fn update_report_values_tstamp(
 pub async fn get_all_measurement_report_value_records(
     txn: &mut PgConnection,
 ) -> Result<Vec<MeasurementReportValueRecord>, DatabaseError> {
-    common::get_all_objects(txn)
+    common::get_all_objects(&mut txn.into())
         .await
         .map_err(|e| e.with_op_name("get_all_measurement_report_value_records"))
 }

--- a/crates/api-db/src/measured_boot/interface/site.rs
+++ b/crates/api-db/src/measured_boot/interface/site.rs
@@ -78,7 +78,7 @@ pub async fn remove_from_approved_machines_by_machine_id(
 }
 
 pub async fn get_approved_machines(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
 ) -> Result<Vec<MeasurementApprovedMachineRecord>, DatabaseError> {
     common::get_all_objects(txn)
         .await
@@ -89,7 +89,7 @@ pub async fn get_approval_for_machine_id(
     txn: &mut PgConnection,
     machine_id: TrustedMachineId,
 ) -> Result<Option<MeasurementApprovedMachineRecord>, DatabaseError> {
-    common::get_object_for_id(txn, machine_id)
+    common::get_object_for_id(&mut txn.into(), machine_id)
         .await
         .map_err(|e| e.with_op_name("get_approval_for_machine_id"))
 }
@@ -137,7 +137,7 @@ pub async fn remove_from_approved_profiles_by_profile_id(
 }
 
 pub async fn get_approved_profiles(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
 ) -> Result<Vec<MeasurementApprovedProfileRecord>, DatabaseError> {
     common::get_all_objects(txn)
         .await
@@ -158,7 +158,7 @@ pub async fn get_approval_for_profile_id(
 }
 
 pub async fn list_attestation_summary(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
 ) -> Result<Vec<MachineAttestationSummary>, DatabaseError> {
     let query = "select distinct on (mj.machine_id) mj.machine_id, mj.ts, msp.name, mj.bundle_id from measurement_journal mj, measurement_system_profiles msp WHERE mj.profile_id = msp.profile_id order by mj.machine_id, mj.ts desc";
 

--- a/crates/api-db/src/measured_boot/journal.rs
+++ b/crates/api-db/src/measured_boot/journal.rs
@@ -77,7 +77,7 @@ pub async fn delete_where_id(
     }
 }
 
-pub async fn get_all(txn: impl DbReader<'_>) -> DatabaseResult<Vec<MeasurementJournal>> {
+pub async fn get_all(txn: &mut DbReader<'_>) -> DatabaseResult<Vec<MeasurementJournal>> {
     get_measurement_journals(txn).await
 }
 
@@ -175,7 +175,7 @@ pub async fn get_journal_for_report_id(
 /// instances in the database. This leverages the generic get_all_objects
 /// function since its a simple/common pattern.
 async fn get_measurement_journals(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
 ) -> DatabaseResult<Vec<MeasurementJournal>> {
     let journal_records: Vec<MeasurementJournalRecord> = common::get_all_objects(txn).await?;
     let res: Vec<MeasurementJournal> = journal_records
@@ -196,7 +196,7 @@ async fn get_measurement_journals(
 /// get_latest_journal_for_id returns the latest journal record for the
 /// provided machine ID.
 pub async fn get_latest_journal_for_id(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     machine_id: MachineId,
 ) -> DatabaseResult<Option<MeasurementJournal>> {
     let query = "select distinct on (machine_id) * from measurement_journal where machine_id = $1 order by machine_id,ts desc";
@@ -230,7 +230,7 @@ pub async fn get_latest_for_machine_id(
     txn: &mut PgConnection,
     machine_id: MachineId,
 ) -> DatabaseResult<Option<MeasurementJournal>> {
-    get_latest_journal_for_id(txn, machine_id).await
+    get_latest_journal_for_id(&mut txn.into(), machine_id).await
 }
 
 /// get_measurement_journals_for_machine_id returns all fully populated

--- a/crates/api-db/src/measured_boot/machine.rs
+++ b/crates/api-db/src/measured_boot/machine.rs
@@ -97,7 +97,7 @@ pub async fn from_id(
                 ))),
             }?;
 
-            let journal = get_latest_journal_for_id(txn, machine_id).await?;
+            let journal = get_latest_journal_for_id(&mut txn.into(), machine_id).await?;
             let state = machine_state_from_journal(&journal);
 
             Ok(CandidateMachine {
@@ -116,10 +116,7 @@ pub async fn from_id(
     }
 }
 
-pub async fn get_all<DB>(txn: &mut DB) -> DatabaseResult<Vec<CandidateMachine>>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+pub async fn get_all(txn: &mut DbReader<'_>) -> DatabaseResult<Vec<CandidateMachine>> {
     get_candidate_machines(txn).await
 }
 
@@ -147,7 +144,7 @@ pub fn bundle_state_to_machine_state(
 /// machine ID by checking its most recent bundle (or lack thereof), and
 /// using that result to give it a corresponding MeasurementMachineState.
 pub async fn get_measurement_machine_state(
-    db_reader: impl DbReader<'_>,
+    db_reader: &mut DbReader<'_>,
     machine_id: MachineId,
 ) -> Result<MeasurementMachineState, DatabaseError> {
     get_candidate_machine_state(db_reader, machine_id).await
@@ -155,13 +152,10 @@ pub async fn get_measurement_machine_state(
 
 /// get_measurement_bundle_state returns the state of the current bundle
 /// associated with the machine, if one exists.
-pub async fn get_measurement_bundle_state<DB>(
-    db_reader: &mut DB,
+pub async fn get_measurement_bundle_state(
+    db_reader: &mut DbReader<'_>,
     machine_id: &MachineId,
-) -> eyre::Result<Option<MeasurementBundleState>>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+) -> eyre::Result<Option<MeasurementBundleState>> {
     let result = get_latest_journal_for_id(&mut *db_reader, *machine_id).await?;
     if let Some(journal_record) = result
         && let Some(bundle_id) = journal_record.bundle_id
@@ -173,10 +167,7 @@ where
 }
 
 /// get_candidate_machines returns all populated CandidateMachine instances.
-async fn get_candidate_machines<DB>(txn: &mut DB) -> DatabaseResult<Vec<CandidateMachine>>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+async fn get_candidate_machines(txn: &mut DbReader<'_>) -> DatabaseResult<Vec<CandidateMachine>> {
     let mut res: Vec<CandidateMachine> = Vec::new();
     let mut records = get_candidate_machine_records(&mut *txn).await?;
 

--- a/crates/api-db/src/measured_boot/profile.rs
+++ b/crates/api-db/src/measured_boot/profile.rs
@@ -71,7 +71,7 @@ pub async fn match_from_attrs_or_new(
     txn: &mut PgTransaction<'_>,
     attrs: &HashMap<String, String>,
 ) -> DatabaseResult<MeasurementSystemProfile> {
-    match match_profile(txn.as_mut(), attrs).await? {
+    match match_profile(&mut txn.into(), attrs).await? {
         Some(profile_id) => Ok(load_from_id(txn, profile_id).await?),
         None => Ok(new(txn, None, attrs).await?),
     }
@@ -106,7 +106,9 @@ pub async fn load_from_attrs(
     let info = get_measurement_profile_record_by_attrs(txn, attrs).await?;
     match info {
         Some(info) => {
-            let attrs = get_measurement_profile_attrs_for_profile_id(txn, info.profile_id).await?;
+            let attrs =
+                get_measurement_profile_attrs_for_profile_id(&mut txn.into(), info.profile_id)
+                    .await?;
             Ok(Some(MeasurementSystemProfile {
                 profile_id: info.profile_id,
                 name: info.name,
@@ -161,7 +163,7 @@ pub async fn rename_for_id(
     from_info_and_attrs(
         rename_profile_for_profile_id(txn, system_profile_id, new_system_profile_name.clone())
             .await?,
-        get_measurement_profile_attrs_for_profile_id(txn, system_profile_id).await?,
+        get_measurement_profile_attrs_for_profile_id(&mut txn.into(), system_profile_id).await?,
     )
 }
 
@@ -177,14 +179,12 @@ pub async fn rename_for_name(
         new_system_profile_name.clone(),
     )
     .await?;
-    let attrs = get_measurement_profile_attrs_for_profile_id(txn, info.profile_id).await?;
+    let attrs =
+        get_measurement_profile_attrs_for_profile_id(&mut txn.into(), info.profile_id).await?;
     from_info_and_attrs(info, attrs)
 }
 
-pub async fn get_all<DB>(txn: &mut DB) -> DatabaseResult<Vec<MeasurementSystemProfile>>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+pub async fn get_all(txn: &mut DbReader<'_>) -> DatabaseResult<Vec<MeasurementSystemProfile>> {
     get_all_profiles(txn).await
 }
 
@@ -204,13 +204,10 @@ pub async fn get_machines(
 /// The code is written as such to only allow one profile with the same set
 /// of attributes, so if two matching profiles end up existing, it's because
 /// someone was messing around in the tables (or there's a bug).
-async fn match_profile<DB>(
-    txn: &mut DB,
+async fn match_profile(
+    txn: &mut DbReader<'_>,
     attrs: &HashMap<String, String>,
-) -> DatabaseResult<Option<MeasurementSystemProfileId>>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+) -> DatabaseResult<Option<MeasurementSystemProfileId>> {
     // Get all profiles, and figure out which one intersects
     // with the provided attrs. After that, we'll attempt to find the
     // most specific match (if there are multiple matches).
@@ -312,7 +309,9 @@ pub async fn get_measurement_profile_by_id(
 ) -> DatabaseResult<MeasurementSystemProfile> {
     match get_measurement_profile_record_by_id(txn, profile_id).await? {
         Some(info) => {
-            let attrs = get_measurement_profile_attrs_for_profile_id(txn, info.profile_id).await?;
+            let attrs =
+                get_measurement_profile_attrs_for_profile_id(&mut txn.into(), info.profile_id)
+                    .await?;
             Ok(MeasurementSystemProfile {
                 profile_id: info.profile_id,
                 name: info.name,
@@ -335,7 +334,9 @@ pub async fn get_measurement_profile_by_name(
 ) -> DatabaseResult<MeasurementSystemProfile> {
     match get_measurement_profile_record_by_name(txn, name.clone()).await? {
         Some(info) => {
-            let attrs = get_measurement_profile_attrs_for_profile_id(txn, info.profile_id).await?;
+            let attrs =
+                get_measurement_profile_attrs_for_profile_id(&mut txn.into(), info.profile_id)
+                    .await?;
             Ok(MeasurementSystemProfile {
                 profile_id: info.profile_id,
                 name: info.name,
@@ -378,10 +379,9 @@ pub async fn delete_profile_for_name(
     delete_profile_for_id(txn, profile.profile_id).await
 }
 
-pub async fn get_all_profiles<DB>(txn: &mut DB) -> DatabaseResult<Vec<MeasurementSystemProfile>>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+pub async fn get_all_profiles(
+    txn: &mut DbReader<'_>,
+) -> DatabaseResult<Vec<MeasurementSystemProfile>> {
     let mut res: Vec<MeasurementSystemProfile> = Vec::new();
     let mut infos = get_all_measurement_profile_records(&mut *txn).await?;
     for info in infos.drain(..) {
@@ -425,7 +425,7 @@ pub async fn match_from_attrs(
     txn: &mut PgConnection,
     attrs: &HashMap<String, String>,
 ) -> DatabaseResult<Option<MeasurementSystemProfile>> {
-    match match_profile(&mut *txn, attrs).await? {
+    match match_profile(&mut txn.into(), attrs).await? {
         Some(info) => Ok(Some(load_from_id(txn, info).await?)),
         None => Ok(None),
     }

--- a/crates/api-db/src/measured_boot/report.rs
+++ b/crates/api-db/src/measured_boot/report.rs
@@ -95,10 +95,7 @@ pub async fn get_all_for_machine_id(
     get_measurement_reports_for_machine_id(txn, machine_id).await
 }
 
-pub async fn get_all<DB>(txn: &mut DB) -> DatabaseResult<Vec<MeasurementReport>>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+pub async fn get_all(txn: &mut DbReader<'_>) -> DatabaseResult<Vec<MeasurementReport>> {
     get_all_measurement_reports(txn).await
 }
 
@@ -204,10 +201,9 @@ pub async fn create_measurement_report(
 /// get_measurement_reports returns all MeasurementReport
 /// instances in the database. This leverages the generic get_all_objects
 /// function since its a simple/common pattern.
-pub async fn get_all_measurement_reports<DB>(txn: &mut DB) -> DatabaseResult<Vec<MeasurementReport>>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+pub async fn get_all_measurement_reports(
+    txn: &mut DbReader<'_>,
+) -> DatabaseResult<Vec<MeasurementReport>> {
     let report_records: Vec<MeasurementReportRecord> = common::get_all_objects(&mut *txn).await?;
     let mut report_values: Vec<MeasurementReportValueRecord> = common::get_all_objects(txn).await?;
 
@@ -267,7 +263,7 @@ pub async fn get_measurement_reports_for_machine_id(
     machine_id: MachineId,
 ) -> DatabaseResult<Vec<MeasurementReport>> {
     let report_records: Vec<MeasurementReportRecord> =
-        common::get_objects_where_id(&mut *txn, machine_id).await?;
+        common::get_objects_where_id(&mut txn.into(), machine_id).await?;
     let mut res = Vec::<MeasurementReport>::new();
     for report_record in report_records.iter() {
         let values =
@@ -470,7 +466,7 @@ async fn same_as_previous_one(
     values: &[PcrRegisterValue],
 ) -> DatabaseResult<SameOrNot> {
     let latest_journal =
-        match crate::measured_boot::journal::get_latest_journal_for_id(&mut *txn, machine_id)
+        match crate::measured_boot::journal::get_latest_journal_for_id(&mut txn.into(), machine_id)
             .await?
         {
             Some(journal) => journal,

--- a/crates/api-db/src/measured_boot/site.rs
+++ b/crates/api-db/src/measured_boot/site.rs
@@ -48,10 +48,7 @@ pub async fn import(txn: &mut PgConnection, model: &SiteModel) -> DatabaseResult
 }
 
 /// export builds a SiteModel from the records in the database.
-pub async fn export<DB>(txn: &mut DB) -> DatabaseResult<SiteModel>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+pub async fn export(txn: &mut DbReader<'_>) -> DatabaseResult<SiteModel> {
     let measurement_system_profiles = export_measurement_profile_records(&mut *txn).await?;
     let measurement_system_profiles_attrs =
         export_measurement_system_profiles_attrs(&mut *txn).await?;

--- a/crates/api-db/src/network_devices.rs
+++ b/crates/api-db/src/network_devices.rs
@@ -53,14 +53,11 @@ fn get_port_data<'a>(
     Ok(*port_data)
 }
 
-pub async fn find<DB>(
-    txn: &mut DB,
+pub async fn find(
+    txn: &mut DbReader<'_>,
     filter: ObjectFilter<'_, &str>,
     search_config: &NetworkDeviceSearchConfig,
-) -> Result<Vec<NetworkDevice>, DatabaseError>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+) -> Result<Vec<NetworkDevice>, DatabaseError> {
     let base_query = "SELECT * FROM network_devices l {where}".to_owned();
 
     let mut devices = match filter {
@@ -119,7 +116,7 @@ pub async fn get_or_create_network_device(
     data: &LldpSwitchData,
 ) -> Result<NetworkDevice, DatabaseError> {
     let network_device = find(
-        &mut *txn,
+        &mut txn.into(),
         ObjectFilter::One(&data.id),
         &NetworkDeviceSearchConfig::new(false),
     )
@@ -162,13 +159,10 @@ pub async fn cleanup_unused_switches(txn: &mut PgTransaction<'_>) -> Result<(), 
     Ok(())
 }
 
-pub async fn get_topology<DB>(
-    txn: &mut DB,
+pub async fn get_topology(
+    txn: &mut DbReader<'_>,
     filter: ObjectFilter<'_, &str>,
-) -> Result<NetworkTopologyData, DatabaseError>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+) -> Result<NetworkTopologyData, DatabaseError> {
     Ok(NetworkTopologyData {
         network_devices: find(txn, filter, &NetworkDeviceSearchConfig::new(true)).await?,
     })
@@ -258,7 +252,7 @@ pub mod dpu_to_network_device_map {
     }
 
     pub async fn find_by_network_device_id(
-        txn: impl DbReader<'_>,
+        txn: &mut DbReader<'_>,
         device_id: &str,
     ) -> Result<Vec<DpuToNetworkDeviceMap>, DatabaseError> {
         let base_query = "SELECT * FROM port_to_network_device_map l WHERE network_device_id=$1";
@@ -271,7 +265,7 @@ pub mod dpu_to_network_device_map {
     }
 
     pub async fn find_by_dpu_ids(
-        txn: impl DbReader<'_>,
+        txn: &mut DbReader<'_>,
         dpu_ids: &[MachineId],
     ) -> Result<Vec<DpuToNetworkDeviceMap>, DatabaseError> {
         let base_query = "SELECT * FROM port_to_network_device_map l WHERE dpu_id=ANY($1)";

--- a/crates/api-db/src/network_prefix.rs
+++ b/crates/api-db/src/network_prefix.rs
@@ -41,7 +41,7 @@ impl super::ColumnInfo<'_> for SegmentIdColumn {
 
 /// Fetch the prefix that matches, is a subnet of, or contains the given one.
 pub async fn containing_prefix(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     prefix: &str,
 ) -> Result<Vec<NetworkPrefix>, DatabaseError> {
     let query = "select * from network_prefixes where prefix && $1::inet";

--- a/crates/api-db/src/network_segment.rs
+++ b/crates/api-db/src/network_segment.rs
@@ -139,7 +139,7 @@ pub async fn persist(
     crate::network_segment_state_history::persist(txn, segment_id, &initial_state, version).await?;
 
     find_by(
-        txn,
+        &mut txn.into(),
         ObjectColumnFilter::One(IdColumn, &segment_id),
         Default::default(),
     )
@@ -154,7 +154,7 @@ pub async fn persist(
 }
 
 pub async fn for_vpc(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     vpc_id: VpcId,
 ) -> Result<Vec<NetworkSegment>, DatabaseError> {
     lazy_static! {
@@ -258,7 +258,7 @@ pub async fn list_segment_ids(
 }
 
 pub async fn find_ids(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     filter: rpc::NetworkSegmentSearchFilter,
 ) -> Result<Vec<NetworkSegmentId>, DatabaseError> {
     // build query
@@ -287,14 +287,11 @@ pub async fn find_ids(
     Ok(ids)
 }
 
-pub async fn find_by<'a, C: ColumnInfo<'a, TableType = NetworkSegment>, DB>(
-    conn: &mut DB,
+pub async fn find_by<'a, C: ColumnInfo<'a, TableType = NetworkSegment>>(
+    conn: &mut DbReader<'_>,
     filter: ObjectColumnFilter<'a, C>,
     search_config: NetworkSegmentSearchConfig,
-) -> Result<Vec<NetworkSegment>, DatabaseError>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+) -> Result<Vec<NetworkSegment>, DatabaseError> {
     let mut query = FilterableQueryBuilder::new(if search_config.include_history {
         NETWORK_SEGMENT_SNAPSHOT_WITH_HISTORY_QUERY.deref()
     } else {
@@ -373,13 +370,10 @@ pub async fn batch_find_ids_by_machine_ids(
     Ok(result)
 }
 
-async fn update_num_free_ips_into_prefix_list<DB>(
-    conn: &mut DB,
+async fn update_num_free_ips_into_prefix_list(
+    conn: &mut DbReader<'_>,
     all_records: &mut [NetworkSegment],
-) -> Result<(), DatabaseError>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+) -> Result<(), DatabaseError> {
     for record in all_records.iter_mut().filter(|s| !s.prefixes.is_empty()) {
         let mut busy_ips = vec![];
         for prefix in &record.prefixes {
@@ -387,7 +381,7 @@ where
                 busy_ips.push(svi_ip);
             }
         }
-        let dhcp_handler: Box<dyn UsedIpResolver<DB> + Send> = if record.segment_type.is_tenant() {
+        let dhcp_handler: Box<dyn UsedIpResolver + Send> = if record.segment_type.is_tenant() {
             // Note on UsedOverlayNetworkIpResolver:
             // In this case, the IpAllocator isn't being used to iterate to get
             // the next available prefix_length allocation -- it's actually just
@@ -600,13 +594,10 @@ pub async fn admin(txn: &mut PgConnection) -> Result<NetworkSegment, DatabaseErr
 
 /// Are queried segment in ready state?
 /// Returns true if all segments are in Ready state, else false
-pub async fn are_network_segments_ready<DB>(
-    conn: &mut DB,
+pub async fn are_network_segments_ready(
+    conn: &mut DbReader<'_>,
     segment_ids: &[NetworkSegmentId],
-) -> Result<bool, DatabaseError>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+) -> Result<bool, DatabaseError> {
     let segments = find_by(
         conn,
         ObjectColumnFilter::List(IdColumn, segment_ids),

--- a/crates/api-db/src/nvl_logical_partition.rs
+++ b/crates/api-db/src/nvl_logical_partition.rs
@@ -262,7 +262,7 @@ impl NewLogicalPartition {
 /// * `txn` - A reference to a currently open database transaction
 ///
 pub async fn for_tenant(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     tenant_organization_id: String,
 ) -> Result<Vec<LogicalPartition>, DatabaseError> {
     let results: Vec<LogicalPartition> = {
@@ -284,7 +284,7 @@ pub async fn for_tenant(
 }
 
 pub async fn find_ids(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     filter: rpc::NvLinkLogicalPartitionSearchFilter,
 ) -> Result<Vec<NvLinkLogicalPartitionId>, DatabaseError> {
     // build query
@@ -304,7 +304,7 @@ pub async fn find_ids(
 }
 
 pub async fn find_by<'a, C: ColumnInfo<'a, TableType = LogicalPartition>>(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     filter: ObjectColumnFilter<'a, C>,
 ) -> Result<Vec<LogicalPartition>, DatabaseError> {
     let mut query = FilterableQueryBuilder::new(

--- a/crates/api-db/src/nvl_partition.rs
+++ b/crates/api-db/src/nvl_partition.rs
@@ -171,7 +171,7 @@ impl NewNvlPartition {
 /// * `txn` - A reference to a currently open database transaction
 ///
 pub async fn for_tenant(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     tenant_organization_id: String,
 ) -> Result<Vec<NvlPartition>, DatabaseError> {
     let results: Vec<NvlPartition> = {
@@ -193,7 +193,7 @@ pub async fn for_tenant(
 }
 
 pub async fn find_ids(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     filter: rpc::NvLinkPartitionSearchFilter,
 ) -> Result<Vec<NvLinkPartitionId>, DatabaseError> {
     // build query
@@ -224,7 +224,7 @@ pub async fn find_ids(
 }
 
 pub async fn find_by<'a, C: ColumnInfo<'a, TableType = NvlPartition>>(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     filter: ObjectColumnFilter<'a, C>,
 ) -> Result<Vec<NvlPartition>, DatabaseError> {
     let mut query = FilterableQueryBuilder::new(

--- a/crates/api-db/src/rack.rs
+++ b/crates/api-db/src/rack.rs
@@ -52,7 +52,7 @@ pub async fn find_by<'a, C: ColumnInfo<'a, TableType = Rack>>(
         .map_err(|e| DatabaseError::new(query.sql(), e))
 }
 
-pub async fn list(txn: impl DbReader<'_>) -> DatabaseResult<Vec<Rack>> {
+pub async fn list(txn: &mut DbReader<'_>) -> DatabaseResult<Vec<Rack>> {
     let query = "SELECT * from racks where deleted IS NULL".to_string();
     sqlx::query_as(&query)
         .fetch_all(txn)
@@ -60,7 +60,7 @@ pub async fn list(txn: impl DbReader<'_>) -> DatabaseResult<Vec<Rack>> {
         .map_err(|e| DatabaseError::new("racks get", e))
 }
 
-pub async fn get(txn: impl DbReader<'_>, rack_id: RackId) -> DatabaseResult<Rack> {
+pub async fn get(txn: &mut DbReader<'_>, rack_id: RackId) -> DatabaseResult<Rack> {
     let query = "SELECT * from racks l WHERE l.id=$1".to_string();
     sqlx::query_as(&query)
         .bind(rack_id)

--- a/crates/api-db/src/rack_firmware.rs
+++ b/crates/api-db/src/rack_firmware.rs
@@ -188,7 +188,7 @@ impl RackFirmware {
     }
 
     /// Find a Rack firmware configuration by ID
-    pub async fn find_by_id(txn: impl DbReader<'_>, id: &str) -> DatabaseResult<Self> {
+    pub async fn find_by_id(txn: &mut DbReader<'_>, id: &str) -> DatabaseResult<Self> {
         let query = "SELECT * FROM rack_firmware WHERE id = $1";
         let ret = sqlx::query_as(query).bind(id).fetch_one(txn).await;
         ret.map_err(|e| match e {

--- a/crates/api-db/src/redfish_actions.rs
+++ b/crates/api-db/src/redfish_actions.rs
@@ -25,7 +25,7 @@ use crate::db_read::DbReader;
 
 pub async fn list_requests(
     request: rpc::forge::RedfishListActionsRequest,
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
 ) -> Result<Vec<ActionRequest>, DatabaseError> {
     let text_query = format!(
         "SELECT
@@ -99,7 +99,8 @@ pub async fn find_serials(
     ips: &[String],
     txn: &mut PgConnection,
 ) -> Result<HashMap<String, String>, DatabaseError> {
-    let pairs = crate::machine_topology::find_machine_bmc_pairs(&mut *txn, ips.to_vec()).await?;
+    let pairs =
+        crate::machine_topology::find_machine_bmc_pairs(&mut txn.into(), ips.to_vec()).await?;
     if pairs.len() != ips.len() {
         let requested_ips: HashSet<_> = ips.iter().cloned().collect();
         let found_ips: HashSet<_> = pairs.into_iter().map(|p| p.1).collect();

--- a/crates/api-db/src/resource_pool.rs
+++ b/crates/api-db/src/resource_pool.rs
@@ -275,7 +275,7 @@ pub async fn all(txn: &mut PgConnection) -> Result<Vec<ResourcePoolSnapshot>, Da
 
 /// All the resource pool entries for the given value
 pub async fn find_value(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     value: &str,
 ) -> Result<Vec<ResourcePoolEntry>, DatabaseError> {
     let query =

--- a/crates/api-db/src/route_servers.rs
+++ b/crates/api-db/src/route_servers.rs
@@ -66,7 +66,7 @@ pub async fn replace(
 
 // get returns all RouteServer entries, which include the
 // IP address and source_type of the entry.
-pub async fn get(txn: impl DbReader<'_>) -> DatabaseResult<Vec<RouteServer>> {
+pub async fn get(txn: &mut DbReader<'_>) -> DatabaseResult<Vec<RouteServer>> {
     let query = r#"SELECT * FROM route_servers;"#;
     sqlx::query_as(query)
         .fetch_all(txn)
@@ -77,7 +77,7 @@ pub async fn get(txn: impl DbReader<'_>) -> DatabaseResult<Vec<RouteServer>> {
 // find_by_address returns a RouteServer entry matching
 // the provided address, if it exists.
 pub async fn find_by_address(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     address: IpAddr,
 ) -> DatabaseResult<Option<RouteServer>> {
     let query = r#"SELECT * FROM route_servers where address=$1;"#;
@@ -152,6 +152,7 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
+    use crate::db_read::AsDbReader;
 
     // test_ips is a helper function to create test IP addresses,
     // instead of listing all of the IPs to test in a vec, since
@@ -186,7 +187,7 @@ mod tests {
         // Initial sync
         super::replace(&mut txn, &addresses, RouteServerSourceType::ConfigFile).await?;
 
-        let result = super::get(txn.as_mut()).await?;
+        let result = super::get(&mut txn.as_db_reader()).await?;
         assert_eq!(result.len(), 3);
 
         let result_addresses: Vec<IpAddr> = result.iter().map(|rs| rs.address).collect();
@@ -224,13 +225,13 @@ mod tests {
         super::replace(&mut txn, &admin_addresses, RouteServerSourceType::AdminApi).await?;
 
         // Verify we have 5 total entries
-        let all_entries = super::get(txn.as_mut()).await?;
+        let all_entries = super::get(&mut txn.as_db_reader()).await?;
         assert_eq!(all_entries.len(), 5);
 
         // Sync empty array for ConfigFile - should only remove ConfigFile entries
         super::replace(&mut txn, &[], RouteServerSourceType::ConfigFile).await?;
 
-        let remaining_entries = super::get(txn.as_mut()).await?;
+        let remaining_entries = super::get(&mut txn.as_db_reader()).await?;
         assert_eq!(remaining_entries.len(), 2);
 
         // All remaining should be AdminApi
@@ -274,7 +275,7 @@ mod tests {
 
         super::add(&mut txn, &addresses, RouteServerSourceType::ConfigFile).await?;
 
-        let result = super::get(txn.as_mut()).await?;
+        let result = super::get(&mut txn.as_db_reader()).await?;
         assert_eq!(result.len(), 3);
 
         let result_addresses: Vec<IpAddr> = result.iter().map(|rs| rs.address).collect();
@@ -346,7 +347,7 @@ mod tests {
         let to_remove = vec![config_addresses[0], config_addresses[1]];
         super::remove(&mut txn, &to_remove, RouteServerSourceType::ConfigFile).await?;
 
-        let remaining = super::get(txn.as_mut()).await?;
+        let remaining = super::get(&mut txn.as_db_reader()).await?;
         assert_eq!(remaining.len(), 3); // 1 ConfigFile + 2 AdminApi
 
         // Verify correct entries were removed
@@ -368,7 +369,7 @@ mod tests {
         let mut txn = pool.begin().await?;
 
         // Test get when empty
-        let empty_result = super::get(txn.as_mut()).await?;
+        let empty_result = super::get(&mut txn.as_db_reader()).await?;
         assert_eq!(empty_result.len(), 0);
 
         // Add some data
@@ -384,7 +385,7 @@ mod tests {
         super::add(&mut txn, &admin_addresses, RouteServerSourceType::AdminApi).await?;
 
         // Test get returns all entries
-        let result = super::get(txn.as_mut()).await?;
+        let result = super::get(&mut txn.as_db_reader()).await?;
         assert_eq!(result.len(), 3);
 
         // Verify source types are correct
@@ -422,7 +423,7 @@ mod tests {
         // The important thing is that it doesn't panic
         match result {
             Ok(_) => {
-                let entries = super::get(txn.as_mut()).await?;
+                let entries = super::get(&mut txn.as_db_reader()).await?;
                 assert_eq!(entries.len(), 3); // Should only have unique entries
             }
             Err(_) => {
@@ -465,7 +466,7 @@ mod tests {
         )
         .await?;
 
-        let all_entries = super::get(txn.as_mut()).await?;
+        let all_entries = super::get(&mut txn.as_db_reader()).await?;
 
         // Should have 2 new ConfigFile + 2 AdminApi = 4 total
         assert_eq!(all_entries.len(), 4);
@@ -537,13 +538,13 @@ mod tests {
         let to_remove = vec![admin_addresses[0]];
         super::remove(&mut txn, &to_remove, RouteServerSourceType::ConfigFile).await?;
 
-        let remaining = super::get(txn.as_mut()).await?;
+        let remaining = super::get(&mut txn.as_db_reader()).await?;
         assert_eq!(remaining.len(), 5); // All entries should remain
 
         // Now remove with correct source type
         super::remove(&mut txn, &to_remove, RouteServerSourceType::AdminApi).await?;
 
-        let remaining = super::get(txn.as_mut()).await?;
+        let remaining = super::get(&mut txn.as_db_reader()).await?;
         assert_eq!(remaining.len(), 4); // One entry should be removed
 
         Ok(())
@@ -581,7 +582,7 @@ mod tests {
         super::remove(&mut txn, &initial_admin, RouteServerSourceType::AdminApi).await?;
 
         // Final verification
-        let final_entries = super::get(txn.as_mut()).await?;
+        let final_entries = super::get(&mut txn.as_db_reader()).await?;
         assert_eq!(final_entries.len(), 3); // 2 ConfigFile + 1 AdminApi
 
         let config_final: Vec<IpAddr> = final_entries

--- a/crates/api-db/src/site_exploration_report.rs
+++ b/crates/api-db/src/site_exploration_report.rs
@@ -21,10 +21,7 @@ use crate::DatabaseError;
 use crate::db_read::DbReader;
 
 /// Fetches the latest site exploration report from the database
-pub async fn fetch<DB>(db: &mut DB) -> Result<SiteExplorationReport, DatabaseError>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+pub async fn fetch(db: &mut DbReader<'_>) -> Result<SiteExplorationReport, DatabaseError> {
     let endpoints = crate::explored_endpoints::find_all(&mut *db).await?;
     let managed_hosts = crate::explored_managed_host::find_all(db).await?;
     Ok(SiteExplorationReport {

--- a/crates/api-db/src/sku.rs
+++ b/crates/api-db/src/sku.rs
@@ -134,7 +134,7 @@ pub async fn delete(txn: &mut PgConnection, sku_id: &str) -> Result<String, Data
     Ok(id)
 }
 
-pub async fn get_sku_ids(txn: impl DbReader<'_>) -> Result<Vec<String>, DatabaseError> {
+pub async fn get_sku_ids(txn: &mut DbReader<'_>) -> Result<Vec<String>, DatabaseError> {
     let query = "SELECT id FROM machine_skus";
 
     let skus: Vec<(String,)> = sqlx::query_as(query)
@@ -255,14 +255,14 @@ pub async fn replace(txn: &mut PgConnection, sku: &Sku) -> Result<Sku, DatabaseE
 }
 
 pub async fn generate_sku_from_machine(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     machine_id: &MachineId,
 ) -> Result<Sku, DatabaseError> {
     generate_sku_from_machine_at_version(txn, machine_id, CURRENT_SKU_VERSION).await
 }
 
 pub async fn generate_sku_from_machine_at_version(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     machine_id: &MachineId,
     schema_version: u32,
 ) -> Result<Sku, DatabaseError> {
@@ -279,7 +279,7 @@ pub async fn generate_sku_from_machine_at_version(
 }
 
 pub async fn generate_sku_from_machine_at_version_0_or_1(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     machine_id: &MachineId,
     schema_version: u32,
 ) -> Result<Sku, DatabaseError> {
@@ -535,7 +535,7 @@ pub fn generate_base_sku_from_hardware(
 }
 
 pub async fn generate_sku_from_machine_at_version_2(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     machine_id: &MachineId,
 ) -> Result<Sku, DatabaseError> {
     let Some(machine) = crate::machine::find(
@@ -588,7 +588,7 @@ pub async fn generate_sku_from_machine_at_version_2(
 }
 
 pub async fn generate_sku_from_machine_at_version_3(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     machine_id: &MachineId,
 ) -> Result<Sku, DatabaseError> {
     let Some(machine) = crate::machine::find(
@@ -637,7 +637,7 @@ pub async fn generate_sku_from_machine_at_version_3(
 }
 
 pub async fn generate_sku_from_machine_at_version_4(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     machine_id: &MachineId,
 ) -> Result<Sku, DatabaseError> {
     let Some(machine) = machine::find(

--- a/crates/api-db/src/tenant.rs
+++ b/crates/api-db/src/tenant.rs
@@ -135,7 +135,7 @@ pub async fn increment_version<S: AsRef<str>>(
 }
 
 pub async fn find_tenant_organization_ids(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     search_config: rpc::TenantSearchFilter,
 ) -> Result<Vec<OrganizationID>, DatabaseError> {
     let mut qb = sqlx::QueryBuilder::new("SELECT organization_id FROM tenants");
@@ -161,7 +161,7 @@ pub async fn validate_public_key(
     request: &TenantPublicKeyValidationRequest,
     txn: &mut PgConnection,
 ) -> Result<(), DatabaseError> {
-    let instance = crate::instance::find_by_id(&mut *txn, request.instance_id)
+    let instance = crate::instance::find_by_id(&mut txn.into(), request.instance_id)
         .await?
         .ok_or_else(|| DatabaseError::NotFoundError {
             kind: "instance",

--- a/crates/api-db/src/tenant_keyset.rs
+++ b/crates/api-db/src/tenant_keyset.rs
@@ -37,7 +37,7 @@ pub async fn create(
 }
 
 pub async fn find_ids(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     filter: rpc::forge::TenantKeysetSearchFilter,
 ) -> Result<Vec<TenantKeysetId>, DatabaseError> {
     // build query
@@ -58,7 +58,7 @@ pub async fn find_ids(
 }
 
 pub async fn find_by_ids(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     ids: Vec<rpc::forge::TenantKeysetIdentifier>,
     include_key_data: bool,
 ) -> Result<Vec<TenantKeyset>, DatabaseError> {

--- a/crates/api-db/src/vpc.rs
+++ b/crates/api-db/src/vpc.rs
@@ -87,7 +87,7 @@ pub async fn persist(
 }
 
 pub async fn find_ids(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     filter: rpc::VpcSearchFilter,
 ) -> Result<Vec<VpcId>, DatabaseError> {
     // build query
@@ -163,7 +163,7 @@ pub async fn find_ids(
 // Note: Following find function should not be used to search based on vpc labels.
 // Recommended approach to filter by labels is to first find VPC ids.
 pub async fn find_by<'a, C: ColumnInfo<'a, TableType = Vpc>>(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     filter: ObjectColumnFilter<'a, C>,
 ) -> Result<Vec<Vpc>, DatabaseError> {
     let mut query = FilterableQueryBuilder::new("SELECT * FROM vpcs").filter(&filter);
@@ -186,12 +186,12 @@ pub async fn find_by_vni(txn: &mut PgConnection, vni: i32) -> Result<Vec<Vpc>, D
         .map_err(|e| DatabaseError::query(query, e))
 }
 
-pub async fn find_by_name(txn: impl DbReader<'_>, name: &str) -> Result<Vec<Vpc>, DatabaseError> {
+pub async fn find_by_name(txn: &mut DbReader<'_>, name: &str) -> Result<Vec<Vpc>, DatabaseError> {
     find_by(txn, ObjectColumnFilter::One(NameColumn, &name)).await
 }
 
 pub async fn find_by_segment(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     segment_id: NetworkSegmentId,
 ) -> Result<Vpc, DatabaseError> {
     let mut query = FilterableQueryBuilder::new(
@@ -230,8 +230,11 @@ pub async fn update(value: &UpdateVpc, txn: &mut PgConnection) -> DatabaseResult
     let current_version = match value.if_version_match {
         Some(version) => version,
         None => {
-            let vpcs =
-                find_by(&mut *txn, ObjectColumnFilter::One(vpc::IdColumn, &value.id)).await?;
+            let vpcs = find_by(
+                &mut txn.into(),
+                ObjectColumnFilter::One(vpc::IdColumn, &value.id),
+            )
+            .await?;
             if vpcs.len() != 1 {
                 return Err(DatabaseError::FindOneReturnedManyResultsError(
                     value.id.into(),
@@ -288,7 +291,7 @@ pub async fn update_virtualization(
         Some(version) => version,
         None => {
             let vpcs = find_by(
-                txn.as_mut(),
+                &mut txn.into(),
                 ObjectColumnFilter::One(vpc::IdColumn, &value.id),
             )
             .await?;
@@ -326,7 +329,7 @@ pub async fn update_virtualization(
 
     // Update SVI IP for stretchable segments.
     let network_segments = crate::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.into(),
         ObjectColumnFilter::One(network_segment::VpcColumn, &vpc.id),
         model::network_segment::NetworkSegmentSearchConfig::default(),
     )

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -32,7 +32,7 @@ use ::rpc::protos::dns::{
 };
 use ::rpc::protos::{measured_boot as measured_boot_pb, mlx_device as mlx_device_pb};
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
-use db::db_read::PgPoolReader;
+use db::db_read::{AsDbReader, DbReader};
 use db::work_lock_manager::WorkLockManagerHandle;
 use db::{DatabaseError, DatabaseResult, WithTransaction};
 use forge_secrets::certificates::CertificateProvider;
@@ -2993,8 +2993,8 @@ impl Api {
         db::Transaction::begin_with_location(&self.database_connection, loc)
     }
 
-    pub fn db_reader(&self) -> PgPoolReader {
-        self.database_connection.clone().into()
+    pub fn db_reader(&self) -> DbReader<'_> {
+        DbReader::from(&self.database_connection)
     }
 
     // This function can just async when
@@ -3012,22 +3012,25 @@ impl Api {
             let mut txn =
                 db::Transaction::begin_with_location(&self.database_connection, loc).await?;
 
-            let machine = match db::machine::find_one(&mut txn, &machine_id, search_config).await {
-                Err(err) => {
-                    tracing::warn!(%machine_id, error = %err, "failed loading machine");
-                    return Err(CarbideError::InvalidArgument(
-                        "err loading machine".to_string(),
-                    ));
-                }
-                Ok(None) => {
-                    tracing::info!(%machine_id, "machine not found");
-                    return Err(CarbideError::NotFoundError {
-                        kind: "machine",
-                        id: machine_id.to_string(),
-                    });
-                }
-                Ok(Some(m)) => m,
-            };
+            let machine =
+                match db::machine::find_one(&mut txn.as_db_reader(), &machine_id, search_config)
+                    .await
+                {
+                    Err(err) => {
+                        tracing::warn!(%machine_id, error = %err, "failed loading machine");
+                        return Err(CarbideError::InvalidArgument(
+                            "err loading machine".to_string(),
+                        ));
+                    }
+                    Ok(None) => {
+                        tracing::info!(%machine_id, "machine not found");
+                        return Err(CarbideError::NotFoundError {
+                            kind: "machine",
+                            id: machine_id.to_string(),
+                        });
+                    }
+                    Ok(Some(m)) => m,
+                };
             Ok((machine, txn))
         }
     }

--- a/crates/api/src/attestation/measured_boot.rs
+++ b/crates/api/src/attestation/measured_boot.rs
@@ -302,14 +302,11 @@ pub async fn compare_pub_key_against_cert(
     }
 }
 
-pub async fn has_passed_attestation<DB>(
-    db: &mut DB,
+pub async fn has_passed_attestation(
+    db: &mut DbReader<'_>,
     machine_id: &MachineId,
     _report_id: &MeasurementReportId,
-) -> CarbideResult<bool>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+) -> CarbideResult<bool> {
     let measuring_outcome = handle_measuring_state(
         &MeasuringState::WaitingForMeasurements,
         machine_id,

--- a/crates/api/src/attestation/mod.rs
+++ b/crates/api/src/attestation/mod.rs
@@ -19,6 +19,7 @@ pub mod measured_boot;
 
 pub mod tpm_ca_cert;
 use carbide_uuid::machine::MachineId;
+use db::db_read::AsDbReader;
 use db::{ObjectFilter, Transaction};
 pub use measured_boot::*;
 use model::hardware_info::TpmEkCertificate;
@@ -34,7 +35,7 @@ pub async fn get_ek_cert_by_machine_id(
 ) -> CarbideResult<TpmEkCertificate> {
     // fetch machine from the db
     let machine = db::machine::find_one(
-        txn,
+        &mut txn.into(),
         machine_id,
         MachineSearchConfig {
             include_dpus: true,
@@ -66,12 +67,15 @@ pub async fn backfill_ek_cert_status_for_existing_machines(
 
     let mut txn = Transaction::begin(db_pool).await?;
 
-    let machines: Vec<::carbide_uuid::machine::MachineId> =
-        db::machine::find(&mut txn, ObjectFilter::All, MachineSearchConfig::default())
-            .await?
-            .iter()
-            .map(|machine| machine.id)
-            .collect();
+    let machines: Vec<::carbide_uuid::machine::MachineId> = db::machine::find(
+        &mut txn.as_db_reader(),
+        ObjectFilter::All,
+        MachineSearchConfig::default(),
+    )
+    .await?
+    .iter()
+    .map(|machine| machine.id)
+    .collect();
 
     if !machines.is_empty() {
         let topologies =

--- a/crates/api/src/db_init.rs
+++ b/crates/api/src/db_init.rs
@@ -18,6 +18,7 @@
 use std::collections::HashMap;
 
 use carbide_network::virtualization::VpcVirtualizationType;
+use db::db_read::AsDbReader;
 use db::dns::domain;
 use db::vpc::{self};
 use db::{ObjectColumnFilter, Transaction, dpu_agent_upgrade_policy, network_segment};
@@ -40,7 +41,11 @@ pub async fn create_initial_domain(
     domain_name: &str,
 ) -> Result<bool, CarbideError> {
     let mut txn = Transaction::begin(&db_pool).await?;
-    let domains = domain::find_by(&mut txn, ObjectColumnFilter::<domain::IdColumn>::All).await?;
+    let domains = domain::find_by(
+        &mut txn.as_db_reader(),
+        ObjectColumnFilter::<domain::IdColumn>::All,
+    )
+    .await?;
     if domains.is_empty() {
         let domain = NewDomain::new(domain_name);
         db::dns::domain::persist_first(&domain, &mut txn).await?;
@@ -64,7 +69,7 @@ pub async fn create_initial_networks(
 ) -> Result<(), CarbideError> {
     let mut txn = Transaction::begin(db_pool).await?;
     let all_domains = db::dns::domain::find_by(
-        &mut txn,
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::<db::dns::domain::IdColumn>::All,
     )
     .await?;
@@ -99,7 +104,7 @@ pub async fn create_initial_networks(
 pub async fn update_network_segments_svi_ip(db_pool: &Pool<Postgres>) -> Result<(), CarbideError> {
     let mut txn = Transaction::begin(db_pool).await?;
     let all_segments = db::network_segment::find_by(
-        &mut txn,
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::<network_segment::IdColumn>::All,
         model::network_segment::NetworkSegmentSearchConfig::default(),
     )
@@ -112,7 +117,7 @@ pub async fn update_network_segments_svi_ip(db_pool: &Pool<Postgres>) -> Result<
 
     let all_vpcs_ids = all_segments.iter().filter_map(|x| x.vpc_id).collect_vec();
     let all_vpcs = db::vpc::find_by(
-        &mut txn,
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::List(vpc::IdColumn, &all_vpcs_ids),
     )
     .await?;

--- a/crates/api/src/dhcp/discover.rs
+++ b/crates/api/src/dhcp/discover.rs
@@ -138,7 +138,7 @@ async fn handle_dhcp_from_dpa(
         return Ok(None);
     }
 
-    let mut dpa_ifs = db::dpa_interface::find_by_mac_addr(&mut *txn, &macaddr).await?;
+    let mut dpa_ifs = db::dpa_interface::find_by_mac_addr(&mut txn.into(), &macaddr).await?;
 
     if dpa_ifs.len() != 1 {
         // If the MAC address does not belong to any DPA object, len will be 0.
@@ -325,7 +325,7 @@ async fn update_rack_config_predicted_id_with_actual(
     actual: &MachineId,
 ) -> Result<(), CarbideError> {
     // TODO: pass in a rack id query by that when we support multirack, when supported
-    let racks = db::rack::list(&mut *txn).await?;
+    let racks = db::rack::list(&mut txn.into()).await?;
     let rack = match racks.is_empty() {
         false => racks[0].clone(),
         true => {

--- a/crates/api/src/dpa/handler.rs
+++ b/crates/api/src/dpa/handler.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 
 use ::rpc::protos::dpa_rpc::{DpaMetadata, Pfvni, SetVni};
 use config_version::ConfigVersion;
+use db::db_read::AsDbReader;
 use mac_address::MacAddress;
 use model::dpa_interface::DpaInterfaceNetworkStatusObservation;
 use mqttea::client::{ClientOptions, MqtteaClient};
@@ -76,13 +77,14 @@ async fn handle_dpa_message(services: Arc<Api>, message: SetVni, topic: String) 
         }
     };
 
-    let mut dpa_ifs = match db::dpa_interface::find_by_mac_addr(txn.as_mut(), &macaddr).await {
-        Ok(ifs) => ifs,
-        Err(e) => {
-            error!("handle_dpa_message -  Error from find_by_mac_addr {e}");
-            return;
-        }
-    };
+    let mut dpa_ifs =
+        match db::dpa_interface::find_by_mac_addr(&mut txn.as_db_reader(), &macaddr).await {
+            Ok(ifs) => ifs,
+            Err(e) => {
+                error!("handle_dpa_message -  Error from find_by_mac_addr {e}");
+                return;
+            }
+        };
 
     if dpa_ifs.len() != 1 {
         error!(

--- a/crates/api/src/dpa/lockdown.rs
+++ b/crates/api/src/dpa/lockdown.rs
@@ -111,7 +111,8 @@ async fn build_kdf_context(
     pg_pool: &PgPool,
     dpa_interface_id: DpaInterfaceId,
 ) -> Result<KdfContext, eyre::Report> {
-    let interfaces = db::dpa_interface::find_by_ids(pg_pool, &[dpa_interface_id], false).await?;
+    let interfaces =
+        db::dpa_interface::find_by_ids(&mut pg_pool.into(), &[dpa_interface_id], false).await?;
     let dpa_interface = interfaces
         .into_iter()
         .next()

--- a/crates/api/src/dpf.rs
+++ b/crates/api/src/dpf.rs
@@ -341,11 +341,8 @@ async fn enqueue_host(db_pool: &PgPool, node_name: &str, reason: &str) -> Result
     };
 
     let host = {
-        let mut conn = db_pool.acquire().await.map_err(|e| {
-            DpfError::InvalidState(format!("Failed to acquire database connection: {e}"))
-        })?;
         db::machine::find_one(
-            &mut *conn,
+            &mut db_pool.into(),
             &host_machine_id,
             model::machine::machine_search_config::MachineSearchConfig::default(),
         )

--- a/crates/api/src/ethernet_virtualization.rs
+++ b/crates/api/src/ethernet_virtualization.rs
@@ -101,7 +101,7 @@ pub async fn admin_network(
 
     let domain = match admin_segment.subdomain_id {
         Some(domain_id) => {
-            db::dns::domain::find_by_uuid(&mut *txn, domain_id)
+            db::dns::domain::find_by_uuid(&mut txn.into(), domain_id)
                 .await
                 .map_err(CarbideError::from)?
                 .ok_or_else(|| CarbideError::NotFoundError {
@@ -166,9 +166,11 @@ pub async fn admin_network(
     } else {
         match admin_segment.vpc_id {
             Some(vpc_id) => {
-                let mut vpcs =
-                    db::vpc::find_by(&mut *txn, ObjectColumnFilter::One(vpc::IdColumn, &vpc_id))
-                        .await?;
+                let mut vpcs = db::vpc::find_by(
+                    &mut txn.into(),
+                    ObjectColumnFilter::One(vpc::IdColumn, &vpc_id),
+                )
+                .await?;
                 if vpcs.is_empty() {
                     return Err(CarbideError::FindOneReturnedNoResultsError(vpc_id.into()).into());
                 }
@@ -362,9 +364,11 @@ pub async fn tenant_network(
 
     let vpc = match segment.vpc_id {
         Some(vpc_id) => {
-            let mut vpcs =
-                db::vpc::find_by(&mut *txn, ObjectColumnFilter::One(vpc::IdColumn, &vpc_id))
-                    .await?;
+            let mut vpcs = db::vpc::find_by(
+                &mut txn.into(),
+                ObjectColumnFilter::One(vpc::IdColumn, &vpc_id),
+            )
+            .await?;
             if vpcs.is_empty() {
                 return Err(CarbideError::FindOneReturnedNoResultsError(vpc_id.into()).into());
             }

--- a/crates/api/src/handlers/attestation.rs
+++ b/crates/api/src/handlers/attestation.rs
@@ -20,6 +20,7 @@ use config_version::ConfigVersion;
 use db::attestation::spdm::{
     insert_or_update_machine_attestation_request, load_details_for_machine_ids,
 };
+use db::db_read::AsDbReader;
 use itertools::Itertools;
 use model::attestation::spdm::SpdmMachineAttestation;
 use tonic::{Request, Response, Status};
@@ -193,8 +194,12 @@ pub(crate) async fn attest_quote(
     // - if enabled and not successful, send response without certs
     // - else send response with certs
     let attestation_failed = if api.runtime_config.attestation_enabled {
-        !crate::attestation::has_passed_attestation(&mut txn, &machine_id, &report.report_id)
-            .await?
+        !crate::attestation::has_passed_attestation(
+            &mut txn.as_db_reader(),
+            &machine_id,
+            &report.report_id,
+        )
+        .await?
     } else {
         false
     };

--- a/crates/api/src/handlers/bmc_endpoint_explorer.rs
+++ b/crates/api/src/handlers/bmc_endpoint_explorer.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 
 use ::rpc::forge as rpc;
 use carbide_uuid::machine::MachineId;
+use db::db_read::AsDbReader;
 use db::machine_interface::find_by_ip;
 use libredfish::RoleId;
 use mac_address::MacAddress;
@@ -402,7 +403,7 @@ pub(crate) async fn admin_power_control(
         let power_manager_enabled = api.runtime_config.power_manager_options.enabled;
         if power_manager_enabled {
             let snapshot = db::managed_host::load_snapshot(
-                &mut txn,
+                &mut txn.as_db_reader(),
                 &machine_id,
                 LoadSnapshotOptions {
                     include_history: true,
@@ -455,12 +456,11 @@ pub(crate) async fn explore(
         crate::handlers::expected_power_shelf::query(api, bmc_mac_address).await?;
 
     // Look up boot_interface_mac from existing explored endpoint if available
-    let mut txn = api.txn_begin().await?;
-    let boot_interface_mac = db::explored_endpoints::find_by_ips(&mut txn, vec![bmc_addr.ip()])
-        .await?
-        .first()
-        .and_then(|ep| ep.boot_interface_mac);
-    txn.commit().await?;
+    let boot_interface_mac =
+        db::explored_endpoints::find_by_ips(&mut api.db_reader(), vec![bmc_addr.ip()])
+            .await?
+            .first()
+            .and_then(|ep| ep.boot_interface_mac);
 
     let report = api
         .endpoint_explorer
@@ -602,7 +602,7 @@ async fn resolve_bmc_interface(
     if let Some(mac_str) = &request.mac_address {
         bmc_mac_address = mac_str.parse::<MacAddress>().map_err(CarbideError::from)?;
     } else if let Some(bmc_machine_interface) =
-        find_by_ip(&api.database_connection, bmc_addr.ip()).await?
+        find_by_ip(&mut api.db_reader(), bmc_addr.ip()).await?
     {
         bmc_mac_address = bmc_machine_interface.mac_address;
     } else {
@@ -813,7 +813,7 @@ pub(crate) async fn validate_and_complete_bmc_endpoint_request(
     match (bmc_endpoint_request, machine_id) {
         (Some(bmc_endpoint_request), _) => {
             let interface = db::machine_interface::find_by_ip(
-                txn,
+                &mut txn.into(),
                 bmc_endpoint_request.ip_address.parse().unwrap(),
             )
             .await?

--- a/crates/api/src/handlers/bmc_metadata.rs
+++ b/crates/api/src/handlers/bmc_metadata.rs
@@ -95,7 +95,7 @@ pub(crate) async fn get_inner(
     let ip_address = bmc_endpoint_request.ip_address.parse().map_err(|_| {
         CarbideError::internal("Internal error: Stored IP address is invalid".to_string())
     })?;
-    let vendor = db::explored_endpoints::lookup_vendor_by_ip(ip_address, pool).await?;
+    let vendor = db::explored_endpoints::lookup_vendor_by_ip(ip_address, &mut pool.into()).await?;
 
     let (username, password) = match credentials {
         Credentials::UsernamePassword { username, password } => (username, password),

--- a/crates/api/src/handlers/boot_override.rs
+++ b/crates/api/src/handlers/boot_override.rs
@@ -17,6 +17,7 @@
 
 use ::rpc::forge as rpc;
 use carbide_uuid::machine::MachineInterfaceId;
+use db::db_read::AsDbReader;
 use model::machine_boot_override::MachineBootOverride;
 
 use crate::api::Api;
@@ -31,7 +32,12 @@ pub(crate) async fn get(
 
     let mut txn = api.txn_begin().await?;
 
-    let machine_id = match db::machine_interface::find_one(&mut txn, machine_interface_id).await {
+    let machine_id = match db::machine_interface::find_one(
+        &mut txn.as_db_reader(),
+        machine_interface_id,
+    )
+    .await
+    {
         Ok(interface) => interface.machine_id,
         Err(_) => None,
     };
@@ -40,8 +46,11 @@ pub(crate) async fn get(
         crate::api::log_machine_id(&machine_id);
     }
 
-    let mbo = match db::machine_boot_override::find_optional(txn.as_pgconn(), machine_interface_id)
-        .await?
+    let mbo = match db::machine_boot_override::find_optional(
+        &mut txn.as_db_reader(),
+        machine_interface_id,
+    )
+    .await?
     {
         Some(mbo) => mbo,
         None => MachineBootOverride {
@@ -65,11 +74,13 @@ pub(crate) async fn set(
     let mbo: MachineBootOverride = request.into_inner().try_into()?;
     let mut txn = api.txn_begin().await?;
 
-    let machine_id = match db::machine_interface::find_one(&mut txn, mbo.machine_interface_id).await
-    {
-        Ok(interface) => interface.machine_id,
-        Err(_) => None,
-    };
+    let machine_id =
+        match db::machine_interface::find_one(&mut txn.as_db_reader(), mbo.machine_interface_id)
+            .await
+        {
+            Ok(interface) => interface.machine_id,
+            Err(_) => None,
+        };
     match machine_id {
         Some(machine_id) => {
             crate::api::log_machine_id(&machine_id);
@@ -103,7 +114,12 @@ pub(crate) async fn clear(
 
     let mut txn = api.txn_begin().await?;
 
-    let machine_id = match db::machine_interface::find_one(&mut txn, machine_interface_id).await {
+    let machine_id = match db::machine_interface::find_one(
+        &mut txn.as_db_reader(),
+        machine_interface_id,
+    )
+    .await
+    {
         Ok(interface) => interface.machine_id,
         Err(_) => None,
     };

--- a/crates/api/src/handlers/compute_allocation.rs
+++ b/crates/api/src/handlers/compute_allocation.rs
@@ -22,6 +22,7 @@ use ::rpc::forge as rpc;
 use carbide_uuid::compute_allocation::ComputeAllocationId;
 use carbide_uuid::instance_type::InstanceTypeId;
 use config_version::ConfigVersion;
+use db::db_read::AsDbReader;
 use db::{compute_allocation, instance, instance_type, machine};
 use model::compute_allocation::MAX_COMPUTE_ALLOCATION_SIZE;
 use model::metadata::Metadata;
@@ -459,7 +460,9 @@ pub(crate) async fn update(
             instance_type_id: Some(instance_type_id.to_string()),
         };
 
-        let instance_count = instance::find_ids(&mut txn, filter).await?.len();
+        let instance_count = instance::find_ids(&mut txn.as_db_reader(), filter)
+            .await?
+            .len();
 
         if instance_count
             > new_tenant_allocation_total
@@ -604,7 +607,9 @@ pub(crate) async fn delete(
             instance_type_id: Some(allocation.instance_type_id.to_string()),
         };
 
-        let instance_count = instance::find_ids(&mut txn, filter).await?.len();
+        let instance_count = instance::find_ids(&mut txn.as_db_reader(), filter)
+            .await?
+            .len();
 
         if instance_count
             > new_tenant_allocation_total

--- a/crates/api/src/handlers/dns.rs
+++ b/crates/api/src/handlers/dns.rs
@@ -37,7 +37,7 @@ impl From<DnsResourceRecordLookupResponse> for protos::dns::DnsResourceRecordLoo
 }
 
 async fn lookup_soa_record(
-    db: impl DbReader<'_>,
+    db: &mut DbReader<'_>,
     query_name: &str,
 ) -> Result<DnsResourceRecordReply, tonic::Status> {
     tracing::debug!("Looking up SOA record for {}", query_name);
@@ -61,7 +61,7 @@ async fn lookup_soa_record(
 
 /// Returns ALL record types (A, AAAA, CNAME, etc.) - PowerDNS filters to requested type
 async fn lookup_records_by_qname(
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
     query_name: &str,
 ) -> Result<Vec<DnsResourceRecordReply>, tonic::Status> {
     tracing::debug!("Looking up records for {}", query_name);
@@ -114,13 +114,10 @@ async fn lookup_records_by_qname(
 /// 2. If the qname matches a domain we're authoritative for, includes the SOA record
 /// 3. Returns everything - PowerDNS decides what to include in the final packet
 ///
-async fn lookup_any_record<DB>(
-    txn: &mut DB,
+async fn lookup_any_record(
+    txn: &mut DbReader<'_>,
     query_name: &str,
-) -> Result<Vec<DnsResourceRecordReply>, Status>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+) -> Result<Vec<DnsResourceRecordReply>, Status> {
     let mut dns_records: Vec<DnsResourceRecordReply> = Vec::new();
 
     tracing::debug!("Looking up ANY records for {}", query_name);
@@ -194,7 +191,7 @@ pub async fn get_all_domains(
     log_request_data(&_request);
 
     let domains = db::dns::domain::find_by(
-        &api.database_connection,
+        &mut api.db_reader(),
         db::ObjectColumnFilter::<db::dns::domain::IdColumn>::All,
     )
     .await?;
@@ -234,7 +231,7 @@ pub async fn get_all_domain_metadata(
     let domain_name = db::dns::normalize_domain(&metadata_request.domain);
 
     let domains = db::dns::domain::find_by(
-        &api.database_connection,
+        &mut api.db_reader(),
         db::ObjectColumnFilter::<db::dns::domain::NameColumn>::One(
             db::dns::domain::NameColumn,
             &domain_name.as_str(),
@@ -290,12 +287,12 @@ pub async fn lookup_record(
         DnsResourceRecordType::SOA => {
             // SOA queries: only return SOA record for the domain
             let normalized = db::dns::normalize_domain(&qname);
-            let record = lookup_soa_record(&api.database_connection, &normalized).await?;
+            let record = lookup_soa_record(&mut api.db_reader(), &normalized).await?;
             vec![record]
         }
         _ => {
             // For all other types (A, AAAA, MX, CNAME, etc.):
-            lookup_records_by_qname(&api.database_connection, &qname).await?
+            lookup_records_by_qname(&mut api.db_reader(), &qname).await?
         }
     };
 
@@ -388,7 +385,7 @@ pub async fn lookup_record_legacy_compat(
     // Try to find the domain this record belongs to
     // Find all domains and match the longest suffix
     let domains = db::dns::domain::find_by(
-        &api.database_connection,
+        &mut api.db_reader(),
         db::ObjectColumnFilter::<db::dns::domain::IdColumn>::All,
     )
     .await?;

--- a/crates/api/src/handlers/domain.rs
+++ b/crates/api/src/handlers/domain.rs
@@ -61,13 +61,12 @@ pub(crate) async fn update(
         .id
         .ok_or_else(|| CarbideError::MissingArgument("id"))?;
 
-    let mut domain =
-        domain::find_by_uuid(&mut txn, uuid)
-            .await?
-            .ok_or_else(|| CarbideError::NotFoundError {
-                kind: "domain",
-                id: uuid.to_string(),
-            })?;
+    let mut domain = domain::find_by_uuid(&mut txn.as_db_reader(), uuid)
+        .await?
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "domain",
+            id: uuid.to_string(),
+        })?;
 
     domain.name = domain_proto.name;
 
@@ -91,13 +90,12 @@ pub(crate) async fn delete(
     let req = request.into_inner();
     let uuid = req.id.ok_or_else(|| CarbideError::MissingArgument("id"))?;
 
-    let domain =
-        domain::find_by_uuid(&mut txn, uuid)
-            .await?
-            .ok_or_else(|| CarbideError::NotFoundError {
-                kind: "domain",
-                id: uuid.to_string(),
-            })?;
+    let domain = domain::find_by_uuid(&mut txn.as_db_reader(), uuid)
+        .await?
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "domain",
+            id: uuid.to_string(),
+        })?;
 
     // TODO: This needs to validate that nothing references the domain anymore
     // (like NetworkSegments)
@@ -120,15 +118,15 @@ pub(crate) async fn find(
     let domains = match (id, name) {
         (Some(id), _) => {
             domain::find_by(
-                &api.database_connection,
+                &mut api.db_reader(),
                 ObjectColumnFilter::One(domain::IdColumn, &id),
             )
             .await
         }
-        (None, Some(name)) => domain::find_by_name(&api.database_connection, &name).await,
+        (None, Some(name)) => domain::find_by_name(&mut api.db_reader(), &name).await,
         (None, None) => {
             domain::find_by(
-                &api.database_connection,
+                &mut api.db_reader(),
                 ObjectColumnFilter::<domain::IdColumn>::All,
             )
             .await
@@ -156,6 +154,7 @@ use ::rpc::protos::forge::{
     DomainDeletionLegacy, DomainDeletionResultLegacy, DomainLegacy, DomainListLegacy,
     DomainSearchQueryLegacy,
 };
+use db::db_read::AsDbReader;
 
 /// Compatibility adapter for legacy create_domain RPC
 pub async fn create_legacy_compat(

--- a/crates/api/src/handlers/dpa.rs
+++ b/crates/api/src/handlers/dpa.rs
@@ -20,6 +20,7 @@ use std::borrow::Cow;
 use ::rpc::protos::mlx_device as mlx_device_pb;
 use carbide_host_support::dpa_cmds::{DpaCommand, OpCode};
 use carbide_uuid::machine::MachineId;
+use db::db_read::AsDbReader;
 use db::dpa_interface;
 use eyre::eyre;
 use libmlx::device::report::MlxDeviceReport;
@@ -115,7 +116,7 @@ pub(crate) async fn delete(
     // Prepare our txn to grab the NetworkSecurityGroups from the DB
     let mut txn = api.txn_begin().await?;
 
-    let dpa_ifs_int = db::dpa_interface::find_by_ids(&mut txn, &[id], false).await?;
+    let dpa_ifs_int = db::dpa_interface::find_by_ids(&mut txn.as_db_reader(), &[id], false).await?;
 
     let dpa_if_int = match dpa_ifs_int.len() {
         1 => dpa_ifs_int[0].clone(),
@@ -140,7 +141,7 @@ pub(crate) async fn get_all_ids(
 ) -> Result<Response<::rpc::forge::DpaInterfaceIdList>, Status> {
     log_request_data(&request);
 
-    let ids = db::dpa_interface::find_ids(&api.database_connection).await?;
+    let ids = db::dpa_interface::find_ids(&mut api.db_reader()).await?;
 
     Ok(Response::new(::rpc::forge::DpaInterfaceIdList { ids }))
 }
@@ -169,8 +170,7 @@ pub(crate) async fn find_dpa_interfaces_by_ids(
     }
 
     let dpa_ifs_int =
-        db::dpa_interface::find_by_ids(&api.database_connection, &req.ids, req.include_history)
-            .await?;
+        db::dpa_interface::find_by_ids(&mut api.db_reader(), &req.ids, req.include_history).await?;
 
     let rpc_dpa_ifs = dpa_ifs_int
         .into_iter()
@@ -200,7 +200,7 @@ pub(crate) async fn set_dpa_network_observation_status(
     // Prepare our txn to grab the dpa interfaces from the DB
     let mut txn = api.txn_begin().await?;
 
-    let dpa_ifs_int = db::dpa_interface::find_by_ids(&mut txn, &[id], false).await?;
+    let dpa_ifs_int = db::dpa_interface::find_by_ids(&mut txn.as_db_reader(), &[id], false).await?;
 
     if dpa_ifs_int.len() != 1 {
         return Err(CarbideError::InvalidArgument(
@@ -236,7 +236,7 @@ pub(crate) async fn process_scout_req(
         return Ok((Action::Noop, None));
     }
     let dpa_snapshots =
-        db::dpa_interface::find_by_machine_id(&api.database_connection, machine_id).await?;
+        db::dpa_interface::find_by_machine_id(&mut api.db_reader(), machine_id).await?;
 
     if dpa_snapshots.is_empty() {
         tracing::error!(
@@ -518,7 +518,8 @@ async fn process_mlx_observation(
         )));
     };
 
-    let dpa_snapshots = db::dpa_interface::find_by_machine_id(&mut txn, machine_id).await?;
+    let dpa_snapshots =
+        db::dpa_interface::find_by_machine_id(&mut txn.as_db_reader(), machine_id).await?;
 
     if dpa_snapshots.is_empty() {
         tracing::error!(

--- a/crates/api/src/handlers/dpf.rs
+++ b/crates/api/src/handlers/dpf.rs
@@ -17,6 +17,7 @@
 
 use ::rpc::forge as rpc;
 use db::ObjectFilter;
+use db::db_read::AsDbReader;
 use db::managed_host::load_snapshot;
 use model::machine::LoadSnapshotOptions;
 use model::machine::machine_search_config::MachineSearchConfig;
@@ -40,12 +41,16 @@ pub(crate) async fn modify_dpf_state(
     }
 
     let mut txn = api.txn_begin().await?;
-    let machine_snapshot = load_snapshot(&mut txn, &machine_id, LoadSnapshotOptions::default())
-        .await?
-        .ok_or_else(|| CarbideError::NotFoundError {
-            kind: "snapshot",
-            id: machine_id.to_string(),
-        })?;
+    let machine_snapshot = load_snapshot(
+        &mut txn.as_db_reader(),
+        &machine_id,
+        LoadSnapshotOptions::default(),
+    )
+    .await?
+    .ok_or_else(|| CarbideError::NotFoundError {
+        kind: "snapshot",
+        id: machine_id.to_string(),
+    })?;
 
     db::machine::modify_dpf_state(&mut txn, &machine_id, request.dpf_enabled).await?;
 
@@ -79,7 +84,12 @@ pub(crate) async fn get_dpf_state(
         ObjectFilter::List(&request.machine_ids)
     };
 
-    let dpf_states = db::machine::find(&mut txn, filter, MachineSearchConfig::default()).await?;
+    let dpf_states = db::machine::find(
+        &mut txn.as_db_reader(),
+        filter,
+        MachineSearchConfig::default(),
+    )
+    .await?;
     txn.commit().await?;
 
     Ok(Response::new(rpc::DpfStateResponse {

--- a/crates/api/src/handlers/dpu.rs
+++ b/crates/api/src/handlers/dpu.rs
@@ -23,6 +23,7 @@ use ::rpc::errors::RpcDataConversionError;
 use ::rpc::{common as rpc_common, forge as rpc};
 use carbide_network::virtualization::VpcVirtualizationType;
 use carbide_uuid::machine::MachineId;
+use db::db_read::AsDbReader;
 use db::{
     DatabaseError, ObjectColumnFilter, dpu_agent_upgrade_policy, network_security_group,
     network_segment,
@@ -58,7 +59,7 @@ pub(crate) async fn get_managed_host_network_config_inner(
     let mut txn = api.txn_begin().await?;
 
     let snapshot = db::managed_host::load_snapshot(
-        &mut txn,
+        &mut txn.as_db_reader(),
         &dpu_machine_id,
         LoadSnapshotOptions::default().with_host_health(api.runtime_config.host_health),
     )
@@ -91,7 +92,8 @@ pub(crate) async fn get_managed_host_network_config_inner(
         .find(|x| x.primary_interface)
         .ok_or_else(|| CarbideError::internal("Primary Interface is missing.".to_string()))?;
 
-    let primary_dpu = db::machine_interface::find_one(&mut txn, primary_dpu_snapshot.id).await?;
+    let primary_dpu =
+        db::machine_interface::find_one(&mut txn.as_db_reader(), primary_dpu_snapshot.id).await?;
     let is_primary_dpu = primary_dpu
         .attached_dpu_machine_id
         .map(|x| x == dpu_snapshot.id)
@@ -232,7 +234,7 @@ pub(crate) async fn get_managed_host_network_config_inner(
                 // network segment is empty, return error.
                 return Err(CarbideError::NetworkSegmentNotAllocated.into());
             };
-            let vpc = db::vpc::find_by_segment(&mut txn, network_segment_id)
+            let vpc = db::vpc::find_by_segment(&mut txn.as_db_reader(), network_segment_id)
                 .await?;
 
             // We probably shouldn't allow multiple interfaces that are in different VPCs with
@@ -355,7 +357,7 @@ pub(crate) async fn get_managed_host_network_config_inner(
             // instance creation.
             let segment_ids = interfaces.iter().filter_map(|x|x.network_segment_id).collect_vec();
             let segment_details = db::network_segment::find_by(
-                &mut txn,
+                &mut txn.as_db_reader(),
                 ObjectColumnFilter::List(network_segment::IdColumn, &segment_ids),
                 NetworkSegmentSearchConfig::default(),
             ).await?;
@@ -370,7 +372,7 @@ pub(crate) async fn get_managed_host_network_config_inner(
 
             let domain = match segment.subdomain_id {
                 Some(domain_id) => {
-                    db::dns::domain::find_by_uuid(txn.as_pgconn(), domain_id)
+                    db::dns::domain::find_by_uuid(&mut txn.as_db_reader(), domain_id)
                         .await
                         .map_err(CarbideError::from)?
                         .ok_or_else(|| CarbideError::NotFoundError {
@@ -510,7 +512,7 @@ pub(crate) async fn get_managed_host_network_config_inner(
     // entire struct down, and then putting some smarts inside the DPU re: the source_type.
     // Only pass them on if route servers are enabled.
     let route_servers = if api.runtime_config.enable_route_servers {
-        db::route_servers::get(&mut txn)
+        db::route_servers::get(&mut txn.as_db_reader())
             .await?
             .into_iter()
             .map(|rs| rs.address.to_string())
@@ -796,7 +798,7 @@ pub(crate) async fn record_dpu_network_status(
     // Load the DPU Object. We require it to update the health report based
     // on the last report
     let dpu_machine = db::machine::find_one(
-        &mut txn,
+        &mut txn.as_db_reader(),
         &dpu_machine_id,
         MachineSearchConfig {
             include_dpus: true,
@@ -933,8 +935,11 @@ async fn wakeup_host_state_handler_by_dpu_id(
     dpu_machine_id: &MachineId,
 ) -> Result<(), DatabaseError> {
     let mut txn = api.txn_begin().await?;
-    let host_machine =
-        db::machine::lookup_host_machine_ids_by_dpu_ids(&mut txn, &[*dpu_machine_id]).await?;
+    let host_machine = db::machine::lookup_host_machine_ids_by_dpu_ids(
+        &mut txn.as_db_reader(),
+        &[*dpu_machine_id],
+    )
+    .await?;
     txn.rollback().await?;
 
     if let Some(host_machine_id) = host_machine.first() {
@@ -957,7 +962,7 @@ pub(crate) async fn get_all_managed_host_network_status(
     log_request_data(&request);
 
     let all_status =
-        db::machine::get_all_network_status_observation(&api.database_connection, 2000).await?;
+        db::machine::get_all_network_status_observation(&mut api.db_reader(), 2000).await?;
 
     let mut out = Vec::with_capacity(all_status.len());
     for machine_network_status in all_status {
@@ -998,8 +1003,12 @@ pub(crate) async fn dpu_agent_upgrade_check(
 
     let mut txn = api.txn_begin().await?;
 
-    let machine =
-        db::machine::find_one(&mut txn, &machine_id, MachineSearchConfig::default()).await?;
+    let machine = db::machine::find_one(
+        &mut txn.as_db_reader(),
+        &machine_id,
+        MachineSearchConfig::default(),
+    )
+    .await?;
     let machine = machine.ok_or(CarbideError::NotFoundError {
         kind: "dpu",
         id: machine_id.to_string(),
@@ -1075,7 +1084,7 @@ pub(crate) async fn trigger_dpu_reprovisioning(
     let mut txn = api.txn_begin().await?;
 
     let snapshot = db::managed_host::load_snapshot(
-        &mut txn,
+        &mut txn.as_db_reader(),
         &machine_id,
         LoadSnapshotOptions {
             include_history: false,
@@ -1203,7 +1212,7 @@ pub(crate) async fn list_dpu_waiting_for_reprovisioning(
 ) -> Result<Response<rpc::DpuReprovisioningListResponse>, Status> {
     log_request_data(&request);
 
-    let dpus = db::machine::list_machines_requested_for_reprovisioning(&api.database_connection)
+    let dpus = db::machine::list_machines_requested_for_reprovisioning(&mut api.db_reader())
         .await?
         .into_iter()
         .map(

--- a/crates/api/src/handlers/expected_machine.rs
+++ b/crates/api/src/handlers/expected_machine.rs
@@ -16,6 +16,7 @@
  */
 use ::rpc::forge as rpc;
 use carbide_uuid::rack::RackId;
+use db::db_read::AsDbReader;
 use db::rack as db_rack;
 use lazy_static::lazy_static;
 use mac_address::MacAddress;
@@ -49,7 +50,7 @@ pub(crate) async fn get(
         .or(req.bmc_mac_address.map(|m| m.to_string()))
         .unwrap_or_default();
 
-    let expected_machine = db::expected_machine::find(&api.database_connection, &req)
+    let expected_machine = db::expected_machine::find(&mut api.db_reader(), &req)
         .await
         .map_err(CarbideError::from)?
         .ok_or(CarbideError::NotFoundError {
@@ -110,7 +111,7 @@ pub(crate) async fn add(
     db::expected_machine::create(&mut txn, machine).await?;
 
     if let Some(rack_id) = request_rack_id {
-        match db_rack::get(&mut txn, rack_id).await {
+        match db_rack::get(&mut api.db_reader(), rack_id).await {
             Ok(rack) => {
                 let mut config = rack.config.clone();
                 if !config.expected_compute_trays.contains(&parsed_mac) {
@@ -199,7 +200,7 @@ pub(crate) async fn update(
         .map_err(CarbideError::from)?;
 
     if let Some(rack_id) = request_rack_id {
-        match db_rack::get(&mut txn, rack_id).await {
+        match db_rack::get(&mut txn.as_db_reader(), rack_id).await {
             Ok(rack) => {
                 let mut config = rack.config.clone();
                 if !config.expected_compute_trays.contains(&parsed_mac) {
@@ -250,7 +251,7 @@ pub(crate) async fn get_all(
     log_request_data(&request);
 
     let expected_machine_list: Vec<ExpectedMachine> =
-        db::expected_machine::find_all(&api.database_connection).await?;
+        db::expected_machine::find_all(&mut api.db_reader()).await?;
 
     Ok(tonic::Response::new(rpc::ExpectedMachineList {
         expected_machines: expected_machine_list.into_iter().map(Into::into).collect(),
@@ -263,7 +264,7 @@ pub(crate) async fn get_linked(
 ) -> Result<tonic::Response<rpc::LinkedExpectedMachineList>, tonic::Status> {
     log_request_data(&request);
 
-    let out = db::expected_machine::find_all_linked(&api.database_connection).await?;
+    let out = db::expected_machine::find_all_linked(&mut api.db_reader()).await?;
     let list = rpc::LinkedExpectedMachineList {
         expected_machines: out.into_iter().map(|m| m.into()).collect(),
     };
@@ -339,7 +340,7 @@ async fn process_rack_association(
     rack_id: RackId,
     parsed_mac: MacAddress,
 ) -> Result<(), CarbideError> {
-    match db_rack::get(&mut *txn, rack_id).await {
+    match db_rack::get(&mut txn.as_db_reader(), rack_id).await {
         Ok(rack) => {
             let mut config = rack.config.clone();
             if !config.expected_compute_trays.contains(&parsed_mac) {

--- a/crates/api/src/handlers/expected_power_shelf.rs
+++ b/crates/api/src/handlers/expected_power_shelf.rs
@@ -16,6 +16,7 @@
  */
 
 use ::rpc::forge as rpc;
+use db::db_read::AsDbReader;
 use db::{DatabaseError, expected_power_shelf as db_expected_power_shelf};
 use mac_address::MacAddress;
 use model::expected_power_shelf::{ExpectedPowerShelf, ExpectedPowerShelfRequest};
@@ -46,7 +47,7 @@ pub async fn add_expected_power_shelf(
         .map_err(|e| Status::internal(format!("Failed to create expected power shelf: {}", e)))?;
 
     if let Some(rack_id) = request_rack_id {
-        match db::rack::get(txn.as_mut(), rack_id).await {
+        match db::rack::get(&mut txn.as_db_reader(), rack_id).await {
             Ok(rack) => {
                 let mut config = rack.config.clone();
                 if !config.expected_power_shelves.contains(&bmc_mac_address) {

--- a/crates/api/src/handlers/extension_service.rs
+++ b/crates/api/src/handlers/extension_service.rs
@@ -18,6 +18,7 @@ use ::rpc::errors::RpcDataConversionError;
 use ::rpc::forge as rpc;
 use carbide_uuid::extension_service::ExtensionServiceId;
 use config_version::ConfigVersion;
+use db::db_read::AsDbReader;
 use db::{WithTransaction, extension_service, instance};
 use forge_secrets::credentials::{CredentialKey, Credentials};
 use futures_util::FutureExt;
@@ -152,7 +153,7 @@ pub(crate) async fn create(
     };
 
     // Sanity check: A newly created service should have exactly one version
-    let versions = extension_service::find_all_versions(&api.database_connection, service.id)
+    let versions = extension_service::find_all_versions(&mut api.db_reader(), service.id)
         .boxed()
         .await?;
     if versions.len() != 1 || versions.first().unwrap().version_nr() != 1 {
@@ -402,8 +403,7 @@ pub(crate) async fn update(
     };
 
     // Get all active versions for this service to return in the response
-    let versions =
-        extension_service::find_all_versions(&api.database_connection, service_id).await?;
+    let versions = extension_service::find_all_versions(&mut api.db_reader(), service_id).await?;
 
     let response = rpc::DpuExtensionService {
         service_id: service_id.to_string(),
@@ -499,7 +499,8 @@ pub(crate) async fn delete(
     // If no version was actually deleted in the last step, we don't need to do anything
     if !deleted_versions.is_empty() {
         // If the service has no versions left, delete the service
-        let all_versions = extension_service::find_all_versions(&mut txn, service_id).await?;
+        let all_versions =
+            extension_service::find_all_versions(&mut txn.as_db_reader(), service_id).await?;
         if all_versions.is_empty() {
             extension_service::soft_delete_service(&mut txn, service_id).await?;
         } else {

--- a/crates/api/src/handlers/finder.rs
+++ b/crates/api/src/handlers/finder.rs
@@ -122,9 +122,9 @@ pub(crate) async fn identify_serial(
     let req = request.into_inner();
 
     let machine_ids = if req.exact {
-        db::machine_topology::find_by_serial(&api.database_connection, &req.serial_number).await?
+        db::machine_topology::find_by_serial(&mut api.db_reader(), &req.serial_number).await?
     } else {
-        db::machine_topology::find_freetext(&api.database_connection, &req.serial_number).await?
+        db::machine_topology::find_freetext(&mut api.db_reader(), &req.serial_number).await?
     };
 
     if machine_ids.len() > 1 {
@@ -203,7 +203,8 @@ async fn search(
 ) -> Result<Option<rpc::IpAddressMatch>, CarbideError> {
     let addr: IpAddr = ip.parse()?;
 
-    let db = &api.database_connection;
+    let mut db_reader = api.db_reader();
+    let db = &mut db_reader;
 
     use Finder::*;
     let match_result = match finder {
@@ -380,12 +381,12 @@ async fn search(
 }
 
 async fn by_uuid(api: &Api, u: &rpc_common::Uuid) -> Result<Option<rpc::UuidType>, CarbideError> {
-    let db = &api.database_connection;
     let mut db_reader = api.db_reader();
+    let db = &mut db_reader;
 
     if let Ok(ns_id) = NetworkSegmentId::from_str(&u.value) {
         let segments = db::network_segment::find_by(
-            &mut db_reader,
+            db,
             ObjectColumnFilter::List(network_segment::IdColumn, &[ns_id]),
             NetworkSegmentSearchConfig {
                 include_history: false,
@@ -447,7 +448,8 @@ async fn by_mac(
     api: &Api,
     mac: mac_address::MacAddress,
 ) -> Result<Option<(String, rpc::MacOwner)>, DatabaseError> {
-    let db = &api.database_connection;
+    let mut db_reader = api.db_reader();
+    let db = &mut db_reader;
 
     match db::machine_interface::find_by_mac_address(db, mac).await {
         Ok(interfaces) if interfaces.len() == 1 => {

--- a/crates/api/src/handlers/health.rs
+++ b/crates/api/src/handlers/health.rs
@@ -17,6 +17,7 @@
 
 use ::rpc::forge::{self as rpc, HealthReportOverride};
 use carbide_uuid::machine::MachineId;
+use db::db_read::AsDbReader;
 use health_report::OverrideMode;
 use model::machine::machine_search_config::MachineSearchConfig;
 use sqlx::PgConnection;
@@ -35,12 +36,16 @@ pub async fn list_health_report_overrides(
 
     let machine_id = convert_and_log_machine_id(Some(&machine_id.into_inner()))?;
 
-    let host_machine = db::machine::find_one(&mut txn, &machine_id, MachineSearchConfig::default())
-        .await?
-        .ok_or_else(|| CarbideError::NotFoundError {
-            kind: "machine",
-            id: machine_id.to_string(),
-        })?;
+    let host_machine = db::machine::find_one(
+        &mut txn.as_db_reader(),
+        &machine_id,
+        MachineSearchConfig::default(),
+    )
+    .await?
+    .ok_or_else(|| CarbideError::NotFoundError {
+        kind: "machine",
+        id: machine_id.to_string(),
+    })?;
 
     txn.commit().await?;
 
@@ -63,7 +68,7 @@ async fn remove_by_source(
     source: String,
 ) -> Result<(), CarbideError> {
     let host_machine = db::machine::find_one(
-        &mut *txn,
+        &mut txn.as_db_reader(),
         &machine_id,
         MachineSearchConfig {
             // Technically,  an update is going to happen,

--- a/crates/api/src/handlers/host_reprovisioning.rs
+++ b/crates/api/src/handlers/host_reprovisioning.rs
@@ -16,6 +16,7 @@
  */
 use ::rpc::forge as rpc;
 use carbide_uuid::machine::MachineId;
+use db::db_read::AsDbReader;
 use itertools::Itertools;
 use model::machine::LoadSnapshotOptions;
 use tonic::{Request, Response, Status};
@@ -52,13 +53,16 @@ pub(crate) async fn trigger_host_reprovisioning(
 
     let mut txn = api.txn_begin().await?;
 
-    let snapshot =
-        db::managed_host::load_snapshot(&mut txn, &machine_id, LoadSnapshotOptions::default())
-            .await?
-            .ok_or(CarbideError::NotFoundError {
-                kind: "machine",
-                id: machine_id.to_string(),
-            })?;
+    let snapshot = db::managed_host::load_snapshot(
+        &mut txn.as_db_reader(),
+        &machine_id,
+        LoadSnapshotOptions::default(),
+    )
+    .await?
+    .ok_or(CarbideError::NotFoundError {
+        kind: "machine",
+        id: machine_id.to_string(),
+    })?;
 
     if let Some(request) = snapshot.host_snapshot.reprovision_requested
         && request.started_at.is_some()
@@ -95,36 +99,35 @@ pub(crate) async fn list_hosts_waiting_for_reprovisioning(
 ) -> Result<Response<rpc::HostReprovisioningListResponse>, Status> {
     log_request_data(&request);
 
-    let hosts =
-        db::machine::list_machines_requested_for_host_reprovisioning(&api.database_connection)
-            .await?
-            .into_iter()
-            .map(
-                |x| rpc::host_reprovisioning_list_response::HostReprovisioningListItem {
-                    id: Some(x.id),
-                    state: x.current_state().to_string(),
-                    requested_at: x
-                        .reprovision_requested
-                        .as_ref()
-                        .map(|a| a.requested_at.into()),
-                    initiator: x
-                        .reprovision_requested
-                        .as_ref()
-                        .map(|a| a.initiator.clone())
-                        .unwrap_or_default(),
-                    initiated_at: x
-                        .reprovision_requested
-                        .as_ref()
-                        .map(|a| a.started_at.map(|x| x.into()))
-                        .unwrap_or_default(),
-                    user_approval_received: x
-                        .reprovision_requested
-                        .as_ref()
-                        .map(|x| x.user_approval_received)
-                        .unwrap_or_default(),
-                },
-            )
-            .collect_vec();
+    let hosts = db::machine::list_machines_requested_for_host_reprovisioning(&mut api.db_reader())
+        .await?
+        .into_iter()
+        .map(
+            |x| rpc::host_reprovisioning_list_response::HostReprovisioningListItem {
+                id: Some(x.id),
+                state: x.current_state().to_string(),
+                requested_at: x
+                    .reprovision_requested
+                    .as_ref()
+                    .map(|a| a.requested_at.into()),
+                initiator: x
+                    .reprovision_requested
+                    .as_ref()
+                    .map(|a| a.initiator.clone())
+                    .unwrap_or_default(),
+                initiated_at: x
+                    .reprovision_requested
+                    .as_ref()
+                    .map(|a| a.started_at.map(|x| x.into()))
+                    .unwrap_or_default(),
+                user_approval_received: x
+                    .reprovision_requested
+                    .as_ref()
+                    .map(|x| x.user_approval_received)
+                    .unwrap_or_default(),
+            },
+        )
+        .collect_vec();
 
     Ok(Response::new(rpc::HostReprovisioningListResponse { hosts }))
 }

--- a/crates/api/src/handlers/ib_partition.rs
+++ b/crates/api/src/handlers/ib_partition.rs
@@ -16,6 +16,7 @@
  */
 use ::rpc::forge as rpc;
 use db::ObjectColumnFilter;
+use db::db_read::AsDbReader;
 use db::ib_partition::{self, IBPartitionStatus, NewIBPartition};
 use db::resource_pool::ResourcePoolDatabaseError;
 use model::ib::DEFAULT_IB_FABRIC_NAME;
@@ -98,7 +99,7 @@ pub(crate) async fn find_ids(
 
     let filter: rpc::IbPartitionSearchFilter = request.into_inner();
 
-    let ib_partition_ids = db::ib_partition::find_ids(&api.database_connection, filter).await?;
+    let ib_partition_ids = db::ib_partition::find_ids(&mut api.db_reader(), filter).await?;
 
     Ok(Response::new(rpc::IbPartitionIdList { ib_partition_ids }))
 }
@@ -126,7 +127,7 @@ pub(crate) async fn find_by_ids(
     }
 
     let partitions = db::ib_partition::find_by(
-        &api.database_connection,
+        &mut api.db_reader(),
         ObjectColumnFilter::List(ib_partition::IdColumn, &ib_partition_ids),
     )
     .await?;
@@ -153,7 +154,7 @@ pub(crate) async fn delete(
     let uuid = id.ok_or(CarbideError::MissingArgument("id"))?;
 
     let mut segments = db::ib_partition::find_by(
-        &mut txn,
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(ib_partition::IdColumn, &uuid),
     )
     .await?;
@@ -197,7 +198,7 @@ pub(crate) async fn for_tenant(
     };
 
     let results =
-        db::ib_partition::for_tenant(&api.database_connection, _tenant_organization_id).await?;
+        db::ib_partition::for_tenant(&mut api.db_reader(), _tenant_organization_id).await?;
 
     let mut ib_partitions = Vec::with_capacity(results.len());
 

--- a/crates/api/src/handlers/instance.rs
+++ b/crates/api/src/handlers/instance.rs
@@ -21,6 +21,7 @@ use ::rpc::forge::{self as rpc, AdminForceDeleteMachineResponse};
 use carbide_uuid::infiniband::IBPartitionId;
 use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::MachineId;
+use db::db_read::AsDbReader;
 use db::{DatabaseError, WithTransaction, extension_service, network_security_group};
 use forge_secrets::credentials::{BmcCredentialType, CredentialKey};
 use futures_util::FutureExt;
@@ -185,7 +186,7 @@ pub(crate) async fn find_ids(
 
     let filter: rpc::InstanceSearchFilter = request.into_inner();
 
-    let instance_ids = db::instance::find_ids(&api.database_connection, filter).await?;
+    let instance_ids = db::instance::find_ids(&mut api.db_reader(), filter).await?;
 
     Ok(tonic::Response::new(rpc::InstanceIdList { instance_ids }))
 }
@@ -238,7 +239,7 @@ pub(crate) async fn find_by_machine_id(
     let mut txn = api.txn_begin().await?;
 
     let mh_snapshot = match db::managed_host::load_snapshot(
-        &mut txn,
+        &mut txn.as_db_reader(),
         &machine_id,
         LoadSnapshotOptions::default().with_host_health(api.runtime_config.host_health),
     )
@@ -626,7 +627,7 @@ pub(crate) async fn release(
 
     let mut txn = api.txn_begin().await?;
 
-    let instance = db::instance::find_by_id(&mut txn, delete_instance.instance_id)
+    let instance = db::instance::find_by_id(&mut txn.as_db_reader(), delete_instance.instance_id)
         .await?
         .ok_or_else(|| CarbideError::NotFoundError {
             kind: "instance",
@@ -647,7 +648,7 @@ pub(crate) async fn release(
 
         // Get machine details for repair tenant workflow
         let machine = db::machine::find_one(
-            &mut txn,
+            &mut txn.as_db_reader(),
             &instance.machine_id,
             MachineSearchConfig {
                 for_update: false,
@@ -713,7 +714,7 @@ pub(crate) async fn update_phone_home_last_contact(
 
     let mut txn = api.txn_begin().await?;
 
-    let instance = db::instance::find_by_id(&mut txn, instance_id)
+    let instance = db::instance::find_by_id(&mut txn.as_db_reader(), instance_id)
         .await?
         .ok_or_else(|| CarbideError::NotFoundError {
             kind: "instance",
@@ -770,7 +771,7 @@ pub(crate) async fn invoke_power(
         log_machine_id(machine_id);
 
         let snapshot = db::managed_host::load_snapshot(
-            &mut txn,
+            &mut txn.as_db_reader(),
             machine_id,
             LoadSnapshotOptions::default().with_host_health(api.runtime_config.host_health),
         )
@@ -975,7 +976,7 @@ pub(crate) async fn update_operating_system(
 
     let mut txn = api.txn_begin().await?;
 
-    let instance = db::instance::find_by_id(&mut txn, instance_id)
+    let instance = db::instance::find_by_id(&mut txn.as_db_reader(), instance_id)
         .await?
         .ok_or(CarbideError::NotFoundError {
             kind: "instance",
@@ -1000,7 +1001,7 @@ pub(crate) async fn update_operating_system(
     db::instance::update_os(&mut txn, instance.id, expected_version, os).await?;
 
     let mh_snapshot = db::managed_host::load_snapshot(
-        &mut txn,
+        &mut txn.as_db_reader(),
         &instance.machine_id,
         LoadSnapshotOptions::default().with_host_health(api.runtime_config.host_health),
     )
@@ -1059,7 +1060,7 @@ pub(crate) async fn update_instance_config(
 
     let mut txn = api.txn_begin().await?;
 
-    let instance = db::instance::find_by_id(&mut txn, instance_id)
+    let instance = db::instance::find_by_id(&mut txn.as_db_reader(), instance_id)
         .await?
         .ok_or(CarbideError::NotFoundError {
             kind: "instance",
@@ -1070,7 +1071,7 @@ pub(crate) async fn update_instance_config(
     log_tenant_organization_id(instance.config.tenant.tenant_organization_id.as_str());
 
     let mh_snapshot = db::managed_host::load_snapshot(
-        &mut txn,
+        &mut txn.as_db_reader(),
         &instance.machine_id,
         LoadSnapshotOptions::default().with_host_health(api.runtime_config.host_health),
     )
@@ -1223,7 +1224,7 @@ pub(crate) async fn update_instance_config(
     db::instance::update_config(&mut txn, instance.id, expected_version, config, metadata).await?;
 
     let mh_snapshot = db::managed_host::load_snapshot(
-        &mut txn,
+        &mut txn.as_db_reader(),
         &instance.machine_id,
         LoadSnapshotOptions::default().with_host_health(api.runtime_config.host_health),
     )
@@ -1289,7 +1290,7 @@ async fn update_instance_network_config(
         .map_err(CarbideError::from)?;
 
     let mh_snapshot = db::managed_host::load_snapshot(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &instance.machine_id,
         LoadSnapshotOptions::default(),
     )
@@ -1442,7 +1443,7 @@ pub async fn force_delete_instance(
     api: &Api,
     response: &mut AdminForceDeleteMachineResponse,
 ) -> CarbideResult<()> {
-    let instance = db::instance::find_by_id(&api.database_connection, instance_id)
+    let instance = db::instance::find_by_id(&mut api.db_reader(), instance_id)
         .await?
         .ok_or_else(|| {
             CarbideError::internal(format!("Could not find an instance for {instance_id}"))
@@ -1515,7 +1516,7 @@ pub async fn force_delete_instance(
     }
 
     let snapshot = db::managed_host::load_snapshot(
-        &mut txn,
+        &mut txn.as_db_reader(),
         &instance.machine_id,
         LoadSnapshotOptions::default(),
     )

--- a/crates/api/src/handlers/instance_type.rs
+++ b/crates/api/src/handlers/instance_type.rs
@@ -23,6 +23,7 @@ use ::rpc::forge::InstanceTypeAllocationStats;
 use carbide_uuid::instance_type::InstanceTypeId;
 use carbide_uuid::machine::MachineId;
 use config_version::ConfigVersion;
+use db::db_read::AsDbReader;
 use db::{ObjectFilter, compute_allocation, instance, instance_type};
 use model::instance_type::InstanceTypeMachineCapabilityFilter;
 use model::machine::LoadSnapshotOptions;
@@ -198,7 +199,7 @@ pub(crate) async fn find_by_ids(
 
                 // Grab the count of machines in a good state.
                 let good_machine_count: u32 = db::managed_host::load_by_machine_ids(
-                    &mut txn,
+                    &mut txn.as_db_reader(),
                     &instance_type_assoc_details.machine_ids,
                     LoadSnapshotOptions {
                         ..LoadSnapshotOptions::default()
@@ -543,7 +544,7 @@ pub(crate) async fn associate_machines(
     // also get their most recent snapshots so we can check
     // their capabilities.
     let machines = db::machine::find(
-        &mut txn,
+        &mut txn.as_db_reader(),
         ObjectFilter::List(&machine_ids),
         MachineSearchConfig {
             for_update: true,
@@ -631,7 +632,7 @@ pub(crate) async fn remove_machine_association(
     // coordinate with the instance allocation handler and
     // check for the existence of instances.
     let mut machines = db::machine::find(
-        &mut txn,
+        &mut txn.as_db_reader(),
         ObjectFilter::List(&[machine_id]),
         MachineSearchConfig {
             for_update: true,

--- a/crates/api/src/handlers/logical_partition.rs
+++ b/crates/api/src/handlers/logical_partition.rs
@@ -16,6 +16,7 @@
  */
 use ::rpc::forge as rpc;
 use config_version::ConfigVersion;
+use db::db_read::AsDbReader;
 use db::nvl_logical_partition::{self, NewLogicalPartition};
 use db::{self, ObjectColumnFilter, WithTransaction, instance};
 use futures_util::FutureExt;
@@ -59,8 +60,7 @@ pub(crate) async fn find_ids(
 
     let filter: rpc::NvLinkLogicalPartitionSearchFilter = request.into_inner();
 
-    let partition_ids =
-        db::nvl_logical_partition::find_ids(&api.database_connection, filter).await?;
+    let partition_ids = db::nvl_logical_partition::find_ids(&mut api.db_reader(), filter).await?;
 
     Ok(Response::new(rpc::NvLinkLogicalPartitionIdList {
         partition_ids,
@@ -88,7 +88,7 @@ pub(crate) async fn find_by_ids(
     }
 
     let partitions = db::nvl_logical_partition::find_by(
-        &api.database_connection,
+        &mut api.db_reader(),
         ObjectColumnFilter::List(nvl_logical_partition::IdColumn, &partition_ids),
     )
     .await
@@ -116,7 +116,7 @@ pub(crate) async fn delete(
         .ok_or_else(|| CarbideError::MissingArgument("id"))?;
 
     let mut partitions = db::nvl_logical_partition::find_by(
-        &api.database_connection,
+        &mut api.db_reader(),
         ObjectColumnFilter::One(nvl_logical_partition::IdColumn, &id),
     )
     .await
@@ -134,7 +134,7 @@ pub(crate) async fn delete(
     };
 
     // check if any instance's nvlink config  has this logical partition
-    if instance::any_instance_referencing_nvlink_logical_partition(&api.database_connection, &id)
+    if instance::any_instance_referencing_nvlink_logical_partition(&mut api.db_reader(), &id)
         .await
         .map_err(CarbideError::from)?
     {
@@ -172,10 +172,9 @@ pub(crate) async fn for_tenant(
 
     log_tenant_organization_id(&tenant_org_id_str);
 
-    let results =
-        db::nvl_logical_partition::for_tenant(&api.database_connection, tenant_org_id_str)
-            .await
-            .map_err(CarbideError::from)?;
+    let results = db::nvl_logical_partition::for_tenant(&mut api.db_reader(), tenant_org_id_str)
+        .await
+        .map_err(CarbideError::from)?;
 
     let mut partitions = Vec::with_capacity(results.len());
 
@@ -213,7 +212,7 @@ pub(crate) async fn update(
     let mut txn = api.txn_begin().await?;
 
     let mut partitions = db::nvl_logical_partition::find_by(
-        &mut txn,
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(nvl_logical_partition::IdColumn, &id),
     )
     .await

--- a/crates/api/src/handlers/machine.rs
+++ b/crates/api/src/handlers/machine.rs
@@ -22,6 +22,7 @@ use std::str::FromStr;
 use ::rpc::errors::RpcDataConversionError;
 use ::rpc::forge as rpc;
 use carbide_uuid::machine::MachineId;
+use db::db_read::AsDbReader;
 use forge_secrets::credentials::{BmcCredentialType, CredentialKey};
 use itertools::Itertools;
 use libredfish::SystemPowerControl;
@@ -44,8 +45,7 @@ pub(crate) async fn find_machine_ids(
 
     let search_config = request.into_inner().try_into()?;
 
-    let machine_ids =
-        db::machine::find_machine_ids(&api.database_connection, search_config).await?;
+    let machine_ids = db::machine::find_machine_ids(&mut api.db_reader(), search_config).await?;
 
     Ok(Response::new(::rpc::common::MachineIdList {
         machine_ids: machine_ids.into_iter().collect(),
@@ -59,7 +59,7 @@ pub(crate) async fn find_machine_ids_by_bmc_ips(
     log_request_data(&request);
 
     let pairs = db::machine_topology::find_machine_bmc_pairs(
-        &api.database_connection,
+        &mut api.db_reader(),
         request.into_inner().bmc_ips,
     )
     .await?;
@@ -100,7 +100,7 @@ pub(crate) async fn find_machines_by_ids(
     }
 
     let snapshots = db::managed_host::load_by_machine_ids(
-        &mut txn,
+        &mut txn.as_db_reader(),
         &machine_ids,
         LoadSnapshotOptions {
             include_history: request.include_history,
@@ -206,8 +206,12 @@ pub(crate) async fn machine_set_auto_update(
     let mut txn = api.txn_begin().await?;
 
     let machine_id = convert_and_log_machine_id(request.machine_id.as_ref())?;
-    let Some(_machine) =
-        db::machine::find_one(&mut txn, &machine_id, MachineSearchConfig::default()).await?
+    let Some(_machine) = db::machine::find_one(
+        &mut txn.as_db_reader(),
+        &machine_id,
+        MachineSearchConfig::default(),
+    )
+    .await?
     else {
         return Err(Status::not_found("The machine ID was not found"));
     };
@@ -724,7 +728,7 @@ pub async fn get_machine_position_info(
 
     // Find the explored endpoints for those BMC IPs
     let explored_endpoints = db::explored_endpoints::find_by_ips(
-        &mut txn,
+        &mut txn.as_db_reader(),
         pairs
             .iter()
             .filter_map(|(machine_id, ip_opt)| match ip_opt {

--- a/crates/api/src/handlers/machine_discovery.rs
+++ b/crates/api/src/handlers/machine_discovery.rs
@@ -23,6 +23,7 @@ use std::sync::atomic::Ordering;
 pub use ::rpc::forge as rpc;
 use carbide_uuid::nvlink::NvLinkDomainId;
 use db::WithTransaction;
+use db::db_read::AsDbReader;
 use futures_util::FutureExt;
 use model::hardware_info::{GpuPlatformInfo, HardwareInfo, MachineNvLinkInfo, NvLinkGpu};
 use model::machine::machine_id::{from_hardware_info, host_id_from_dpu_hardware_info};
@@ -156,7 +157,7 @@ pub(crate) async fn discover_machine(
             .load(Ordering::Relaxed)
         {
             db::machine::find_one(
-                &mut txn,
+                &mut txn.as_db_reader(),
                 &stable_machine_id,
                 MachineSearchConfig {
                     include_dpus: true,
@@ -191,7 +192,7 @@ pub(crate) async fn discover_machine(
             machine
         } else {
             db::machine::find_one(
-                &mut txn,
+                &mut txn.as_db_reader(),
                 &stable_machine_id,
                 MachineSearchConfig {
                     include_dpus: true,

--- a/crates/api/src/handlers/machine_interface.rs
+++ b/crates/api/src/handlers/machine_interface.rs
@@ -20,6 +20,7 @@ use std::str::FromStr;
 
 use ::rpc::forge as rpc;
 use carbide_uuid::machine::MachineType;
+use db::db_read::AsDbReader;
 use itertools::Itertools;
 use tonic::{Request, Response, Status};
 
@@ -37,9 +38,13 @@ pub(crate) async fn find_interfaces(
     let rpc::InterfaceSearchQuery { id, ip } = request.into_inner();
 
     let mut interfaces: Vec<rpc::MachineInterface> = match (id, ip) {
-        (Some(id), _) => vec![db::machine_interface::find_one(&mut txn, id).await?.into()],
+        (Some(id), _) => vec![
+            db::machine_interface::find_one(&mut txn.as_db_reader(), id)
+                .await?
+                .into(),
+        ],
         (None, Some(ip)) => match IpAddr::from_str(ip.as_ref()) {
-            Ok(ip) => match db::machine_interface::find_by_ip(&mut txn, ip).await? {
+            Ok(ip) => match db::machine_interface::find_by_ip(&mut txn.as_db_reader(), ip).await? {
                 Some(interface) => vec![interface.into()],
                 None => {
                     return Err(CarbideError::internal(format!(
@@ -76,7 +81,8 @@ pub(crate) async fn find_interfaces(
                     "Impossible interface.address array length",
                 ));
             };
-            match db::machine_topology::find_machine_id_by_bmc_ip(txn.as_pgconn(), ip).await {
+            match db::machine_topology::find_machine_id_by_bmc_ip(&mut txn.as_db_reader(), ip).await
+            {
                 Ok(Some(machine_id)) => {
                     let rpc_machine_id = Some(machine_id);
                     interface.is_bmc = Some(true);
@@ -113,7 +119,7 @@ pub(crate) async fn delete_interface(
         return Err(CarbideError::MissingArgument("delete interface.interface_id").into());
     };
 
-    let interface = db::machine_interface::find_one(&mut txn, id).await?;
+    let interface = db::machine_interface::find_one(&mut txn.as_db_reader(), id).await?;
 
     // There should not be any machine associated with this interface.
     if let Some(machine_id) = interface.machine_id {
@@ -124,9 +130,11 @@ pub(crate) async fn delete_interface(
 
     // There should not be any BMC information associated with any machine.
     for address in interface.addresses.iter() {
-        let machine_id =
-            db::machine_topology::find_machine_id_by_bmc_ip(txn.as_pgconn(), &address.to_string())
-                .await?;
+        let machine_id = db::machine_topology::find_machine_id_by_bmc_ip(
+            &mut txn.as_db_reader(),
+            &address.to_string(),
+        )
+        .await?;
 
         if let Some(machine_id) = machine_id {
             return Err(Status::invalid_argument(format!(
@@ -152,7 +160,7 @@ pub(crate) async fn find_mac_address_by_bmc_ip(
     let bmc_ip = req.bmc_ip;
 
     let interface = db::machine_interface::find_by_ip(
-        &api.database_connection,
+        &mut api.db_reader(),
         bmc_ip
             .parse()
             .map_err(|e| tonic::Status::invalid_argument(format!("Invalid IP address: {e}")))?,

--- a/crates/api/src/handlers/machine_quarantine.rs
+++ b/crates/api/src/handlers/machine_quarantine.rs
@@ -61,7 +61,7 @@ pub(crate) async fn get_managed_host_quarantine_state(
     let rpc::GetManagedHostQuarantineStateRequest { machine_id } = request.into_inner();
     let machine_id = convert_and_log_machine_id(machine_id.as_ref())?;
 
-    let quarantine_state = db::machine::get_quarantine_state(&api.database_connection, &machine_id)
+    let quarantine_state = db::machine::get_quarantine_state(&mut api.db_reader(), &machine_id)
         .await?
         .map(Into::into);
 

--- a/crates/api/src/handlers/machine_scout.rs
+++ b/crates/api/src/handlers/machine_scout.rs
@@ -16,6 +16,7 @@
  */
 use ::rpc::forge as rpc;
 use ::rpc::forge_agent_control_response::forge_agent_control_extra_info::KeyValuePair;
+use db::db_read::AsDbReader;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{
     BomValidating, CleanupState, FailureCause, FailureDetails, FailureSource, InstanceState,
@@ -187,7 +188,7 @@ pub(crate) async fn forge_agent_control(
                     )
                     .await?;
                     let machine_validation =
-                        db::machine_validation::find_by_id(&mut txn, id).await?;
+                        db::machine_validation::find_by_id(&mut txn.as_db_reader(), id).await?;
                     (
                         Action::MachineValidation,
                         Some(

--- a/crates/api/src/handlers/machine_validation.rs
+++ b/crates/api/src/handlers/machine_validation.rs
@@ -16,6 +16,7 @@
  */
 use ::rpc::forge::{self as rpc, GetMachineValidationExternalConfigResponse};
 use config_version::ConfigVersion;
+use db::db_read::AsDbReader;
 use db::{self, machine_validation_suites};
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{
@@ -117,26 +118,30 @@ pub(crate) async fn mark_machine_validation_complete(
         None => "Success".to_owned(),
     };
 
-    let result =
-        match db::machine_validation_result::validate_current_context(&mut txn, rpc_id).await? {
-            Some(error_message) => {
-                db::machine::update_failure_details_by_machine_id(
-                    &machine_id,
-                    &mut txn,
-                    FailureDetails {
-                        cause: FailureCause::MachineValidation {
-                            err: error_message.clone(),
-                        },
-                        failed_at: chrono::Utc::now(),
-                        source: FailureSource::Scout,
+    let result = match db::machine_validation_result::validate_current_context(
+        &mut txn.as_db_reader(),
+        rpc_id,
+    )
+    .await?
+    {
+        Some(error_message) => {
+            db::machine::update_failure_details_by_machine_id(
+                &machine_id,
+                &mut txn,
+                FailureDetails {
+                    cause: FailureCause::MachineValidation {
+                        err: error_message.clone(),
                     },
-                )
-                .await?;
-                state = MachineValidationState::Failed;
-                error_message
-            }
-            None => "Success".to_owned(),
-        };
+                    failed_at: chrono::Utc::now(),
+                    source: FailureSource::Scout,
+                },
+            )
+            .await?;
+            state = MachineValidationState::Failed;
+            error_message
+        }
+        None => "Success".to_owned(),
+    };
 
     db::machine_validation::mark_machine_validation_complete(
         &mut txn,
@@ -273,7 +278,7 @@ pub(crate) async fn get_machine_validation_results(
         }
     } else if let Some(validation_id) = validation_id {
         db_results = db::machine_validation_result::find_by_validation_id(
-            &api.database_connection,
+            &mut api.db_reader(),
             &validation_id,
         )
         .await?;
@@ -297,8 +302,7 @@ pub(crate) async fn get_machine_validation_external_config(
 
     let req: rpc::GetMachineValidationExternalConfigRequest = request.into_inner();
     let ret =
-        db::machine_validation_config::find_config_by_name(&api.database_connection, &req.name)
-            .await?;
+        db::machine_validation_config::find_config_by_name(&mut api.db_reader(), &req.name).await?;
 
     Ok(tonic::Response::new(
         GetMachineValidationExternalConfigResponse {
@@ -349,7 +353,7 @@ pub(crate) async fn get_machine_validation_runs(
         }
         None => {
             tracing::info!("no machine ID");
-            db::machine_validation::find_all(&api.database_connection).await
+            db::machine_validation::find_all(&mut api.db_reader()).await
         }
     };
     let ret = db_runs
@@ -380,7 +384,7 @@ pub(crate) async fn on_demand_machine_validation(
             let mut txn = api.txn_begin().await?;
 
             let machine = db::machine::find_one(
-                &mut txn,
+                &mut txn.as_db_reader(),
                 &machine_id,
                 MachineSearchConfig {
                     include_dpus: false,
@@ -468,7 +472,7 @@ pub(crate) async fn get_machine_validation_external_configs(
 ) -> Result<tonic::Response<rpc::GetMachineValidationExternalConfigsResponse>, Status> {
     log_request_data(&request);
 
-    let ret = db::machine_validation_config::find_configs(&api.database_connection).await?;
+    let ret = db::machine_validation_config::find_configs(&mut api.db_reader()).await?;
     Ok(tonic::Response::new(
         rpc::GetMachineValidationExternalConfigsResponse {
             configs: ret
@@ -536,7 +540,7 @@ pub(crate) async fn add_machine_validation_test(
     let mut txn = api.txn_begin().await?;
 
     let tests = machine_validation_suites::find(
-        &mut txn,
+        &mut txn.as_db_reader(),
         rpc::MachineValidationTestsGetRequest {
             test_id: Some(machine_validation_suites::generate_test_id(&req.name)),
             ..rpc::MachineValidationTestsGetRequest::default()
@@ -566,7 +570,7 @@ pub(crate) async fn get_machine_validation_tests(
     log_request_data(&request);
     let req = request.into_inner();
 
-    let tests = machine_validation_suites::find(&api.database_connection, req).await?;
+    let tests = machine_validation_suites::find(&mut api.db_reader(), req).await?;
 
     Ok(tonic::Response::new(
         rpc::MachineValidationTestsGetResponse {
@@ -586,7 +590,7 @@ pub(crate) async fn machine_validation_test_verfied(
     let mut txn = api.txn_begin().await?;
 
     let existing = machine_validation_suites::find(
-        &mut txn,
+        &mut txn.as_db_reader(),
         rpc::MachineValidationTestsGetRequest {
             test_id: Some(req.test_id.clone()),
             version: Some(req.version.clone()),
@@ -613,7 +617,7 @@ pub(crate) async fn machine_validation_test_next_version(
     let mut txn = api.txn_begin().await?;
 
     let existing = machine_validation_suites::find(
-        &mut txn,
+        &mut txn.as_db_reader(),
         rpc::MachineValidationTestsGetRequest {
             test_id: Some(req.test_id.clone()),
             ..rpc::MachineValidationTestsGetRequest::default()
@@ -640,7 +644,7 @@ pub(crate) async fn machine_validation_test_enable_disable_test(
     let mut txn = api.txn_begin().await?;
 
     let existing = machine_validation_suites::find(
-        &mut txn,
+        &mut txn.as_db_reader(),
         rpc::MachineValidationTestsGetRequest {
             test_id: Some(req.test_id.clone()),
             version: Some(req.version.clone()),
@@ -704,9 +708,11 @@ pub async fn apply_config_on_startup(
     let mut txn = api.txn_begin().await?;
 
     // Get all tests from DB
-    let tests =
-        machine_validation_suites::find(&mut txn, rpc::MachineValidationTestsGetRequest::default())
-            .await?;
+    let tests = machine_validation_suites::find(
+        &mut txn.as_db_reader(),
+        rpc::MachineValidationTestsGetRequest::default(),
+    )
+    .await?;
 
     // Create a set of test IDs from config for efficient lookup
     let config_test_ids: std::collections::HashSet<_> =

--- a/crates/api/src/handlers/managed_host.rs
+++ b/crates/api/src/handlers/managed_host.rs
@@ -19,6 +19,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 
 use ::rpc::forge as rpc;
+use db::db_read::AsDbReader;
 use model::machine::machine_search_config::MachineSearchConfig;
 use tonic::{Request, Response, Status};
 
@@ -101,12 +102,16 @@ pub(crate) async fn set_primary_dpu(
 
     // we need to set the boot device or the host will no longer be able to boot.  we need BMC info.
     // the same BMC info is used if a reboot was requested.
-    let machine = db::machine::find_one(&mut txn, &host_machine_id, MachineSearchConfig::default())
-        .await?
-        .ok_or_else(|| CarbideError::NotFoundError {
-            kind: "Machine",
-            id: host_machine_id.to_string(),
-        })?;
+    let machine = db::machine::find_one(
+        &mut txn.as_db_reader(),
+        &host_machine_id,
+        MachineSearchConfig::default(),
+    )
+    .await?
+    .ok_or_else(|| CarbideError::NotFoundError {
+        kind: "Machine",
+        id: host_machine_id.to_string(),
+    })?;
 
     let bmc_addr_str = machine
         .bmc_info
@@ -119,7 +124,7 @@ pub(crate) async fn set_primary_dpu(
     let bmc_addr = IpAddr::from_str(&bmc_addr_str).map_err(CarbideError::AddressParseError)?;
     let bmc_socket_addr = SocketAddr::new(bmc_addr, 443);
 
-    let bmc_interface = db::machine_interface::find_by_ip(&mut txn, bmc_addr)
+    let bmc_interface = db::machine_interface::find_by_ip(&mut txn.as_db_reader(), bmc_addr)
         .await?
         .ok_or_else(|| CarbideError::NotFoundError {
             kind: "BMC Interface",
@@ -167,7 +172,7 @@ pub(crate) async fn set_primary_dpu(
 
     // increment the network config version so that the DPUs pick up their new config
     let (network_config, network_config_version) =
-        db::machine::get_network_config(txn.as_pgconn(), &host_machine_id)
+        db::machine::get_network_config(&mut txn.as_db_reader(), &host_machine_id)
             .await?
             .take();
     db::machine::try_update_network_config(

--- a/crates/api/src/handlers/mlx_admin.rs
+++ b/crates/api/src/handlers/mlx_admin.rs
@@ -1179,7 +1179,7 @@ async fn get_device_lockdown_key(
     //
     // In other words, device_id == pci_name.
     let dpa_interface =
-        db::dpa_interface::get_for_pci_name(&api.database_connection, &machine_id, device_id)
+        db::dpa_interface::get_for_pci_name(&mut api.db_reader(), &machine_id, device_id)
             .await
             .map_err(|e| {
                 Status::not_found(format!(

--- a/crates/api/src/handlers/network_devices.rs
+++ b/crates/api/src/handlers/network_devices.rs
@@ -16,6 +16,7 @@
  */
 use ::rpc::forge as rpc;
 use db::ObjectFilter;
+use db::db_read::AsDbReader;
 use db::network_devices::NetworkDeviceSearchConfig;
 use itertools::Itertools;
 use tonic::{Request, Response, Status};
@@ -36,7 +37,7 @@ pub(crate) async fn get_network_topology(
         None => ObjectFilter::All,
     };
 
-    let data = db::network_devices::get_topology(&mut txn, query).await?;
+    let data = db::network_devices::get_topology(&mut txn.as_db_reader(), query).await?;
 
     txn.commit().await?;
 
@@ -77,7 +78,7 @@ pub(crate) async fn find_connected_devices_by_dpu_machine_ids(
     let dpu_ids = request.into_inner().machine_ids;
 
     let connected_devices = db::network_devices::dpu_to_network_device_map::find_by_dpu_ids(
-        &api.database_connection,
+        &mut api.db_reader(),
         &dpu_ids,
     )
     .await?;

--- a/crates/api/src/handlers/network_segment.rs
+++ b/crates/api/src/handlers/network_segment.rs
@@ -16,6 +16,7 @@
  */
 use ::rpc::forge as rpc;
 use carbide_network::virtualization::VpcVirtualizationType;
+use db::db_read::AsDbReader;
 use db::resource_pool::ResourcePoolDatabaseError;
 use db::{AnnotatedSqlxError, DatabaseError, ObjectColumnFilter, network_segment};
 use model::network_segment::{
@@ -36,8 +37,7 @@ pub(crate) async fn find_ids(
 
     let filter: rpc::NetworkSegmentSearchFilter = request.into_inner();
 
-    let network_segments_ids =
-        db::network_segment::find_ids(&api.database_connection, filter).await?;
+    let network_segments_ids = db::network_segment::find_ids(&mut api.db_reader(), filter).await?;
 
     Ok(Response::new(rpc::NetworkSegmentIdList {
         network_segments_ids,
@@ -130,7 +130,7 @@ pub(crate) async fn create(
     let allocate_svi_ip = if let Some(vpc_id) = new_network_segment.vpc_id {
         if new_network_segment.can_stretch.unwrap_or(true) {
             let vpcs = db::vpc::find_by(
-                &mut txn,
+                &mut txn.as_db_reader(),
                 ObjectColumnFilter::One(db::vpc::IdColumn, &vpc_id),
             )
             .await?;
@@ -167,7 +167,7 @@ pub(crate) async fn delete(
     let segment_id = id.ok_or_else(|| CarbideError::MissingArgument("id"))?;
 
     let mut segments = db::network_segment::find_by(
-        &mut txn,
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(network_segment::IdColumn, &segment_id),
         NetworkSegmentSearchConfig::default(),
     )
@@ -204,7 +204,7 @@ pub(crate) async fn for_vpc(
 
     let uuid = id.ok_or_else(|| CarbideError::InvalidArgument("id".to_string()))?;
 
-    let results = db::network_segment::for_vpc(&api.database_connection, uuid).await?;
+    let results = db::network_segment::for_vpc(&mut api.db_reader(), uuid).await?;
 
     let mut network_segments = Vec::with_capacity(results.len());
 
@@ -252,7 +252,7 @@ pub(crate) async fn save(
     if allocate_svi_ip {
         db::network_segment::allocate_svi_ip(&network_segment, txn).await?;
         let network_segments = db::network_segment::find_by(
-            txn.as_mut(),
+            &mut txn.as_db_reader(),
             ObjectColumnFilter::One(network_segment::IdColumn, &network_segment.id),
             NetworkSegmentSearchConfig::default(),
         )

--- a/crates/api/src/handlers/nvl_partition.rs
+++ b/crates/api/src/handlers/nvl_partition.rs
@@ -33,7 +33,7 @@ pub(crate) async fn find_ids(
         log_tenant_organization_id(tenant_org_id_str);
     }
 
-    let partition_ids = db::nvl_partition::find_ids(&api.database_connection, filter).await?;
+    let partition_ids = db::nvl_partition::find_ids(&mut api.db_reader(), filter).await?;
 
     Ok(Response::new(rpc::NvLinkPartitionIdList { partition_ids }))
 }
@@ -59,7 +59,7 @@ pub(crate) async fn find_by_ids(
     }
 
     let partitions = db::nvl_partition::find_by(
-        &api.database_connection,
+        &mut api.db_reader(),
         ObjectColumnFilter::List(nvl_partition::IdColumn, &partition_ids),
     )
     .await?;
@@ -92,8 +92,7 @@ pub(crate) async fn for_tenant(
 
     log_tenant_organization_id(&tenant_org_id_str);
 
-    let results =
-        db::nvl_partition::for_tenant(&api.database_connection, tenant_org_id_str).await?;
+    let results = db::nvl_partition::for_tenant(&mut api.db_reader(), tenant_org_id_str).await?;
 
     let mut partitions = Vec::with_capacity(results.len());
 

--- a/crates/api/src/handlers/power_options.rs
+++ b/crates/api/src/handlers/power_options.rs
@@ -19,6 +19,7 @@ use std::str::FromStr;
 
 use ::rpc::forge as rpc;
 use db::DatabaseError;
+use db::db_read::AsDbReader;
 use mac_address::MacAddress;
 use model::machine::LoadSnapshotOptions;
 use tonic::{Request, Response, Status};
@@ -81,7 +82,7 @@ pub(crate) async fn update_power_option(
     // if desired_state == Off, maintenance must be set.
     if matches!(desired_power_state, rpc::PowerState::Off) {
         let snapshot = db::managed_host::load_snapshot(
-            &mut txn,
+            &mut txn.as_db_reader(),
             &machine_id,
             LoadSnapshotOptions {
                 include_history: false,
@@ -186,9 +187,11 @@ pub(crate) async fn determine_machine_ingestion_state(
     };
 
     // now check if we have an entry in explored_managed_hosts
-    let explored_managed_hosts =
-        db::explored_managed_host::find_by_ips(txn.as_mut(), vec![explored_endpoint.address])
-            .await?;
+    let explored_managed_hosts = db::explored_managed_host::find_by_ips(
+        &mut txn.as_db_reader(),
+        vec![explored_endpoint.address],
+    )
+    .await?;
 
     if !explored_managed_hosts.is_empty() {
         let machine_created = db::machine::find_id_by_bmc_ip(&mut txn, &explored_endpoint.address)
@@ -267,7 +270,8 @@ async fn find_explored_endpoint(
     txn: &mut sqlx::PgConnection,
     mac_address: &MacAddress,
 ) -> Result<FindExploredEndpoint, CarbideError> {
-    let explored_endpoints = db::explored_endpoints::find_by_mac_address(txn, *mac_address).await?;
+    let explored_endpoints =
+        db::explored_endpoints::find_by_mac_address(&mut txn.as_db_reader(), *mac_address).await?;
 
     let explored_endpoint = match explored_endpoints.len() {
         0 => return Ok(FindExploredEndpoint::NotFound),

--- a/crates/api/src/handlers/pxe.rs
+++ b/crates/api/src/handlers/pxe.rs
@@ -51,7 +51,8 @@ pub(crate) async fn get_cloud_init_instructions(
     let cloud_name = "nvidia".to_string();
     let platform = "forge".to_string();
 
-    let db = &api.database_connection;
+    let mut db_reader = api.db_reader();
+    let db = &mut db_reader;
 
     let ip_str = &request.into_inner().ip;
     let ip: IpAddr = ip_str

--- a/crates/api/src/handlers/rack.rs
+++ b/crates/api/src/handlers/rack.rs
@@ -18,6 +18,7 @@ use std::str::FromStr;
 
 use ::rpc::forge::{self as rpc, HealthReportOverride};
 use carbide_uuid::rack::RackId;
+use db::db_read::AsDbReader;
 use db::{WithTransaction, rack as db_rack};
 use futures_util::FutureExt;
 use health_report::OverrideMode;
@@ -35,12 +36,12 @@ pub async fn get_rack(
     let rack = if let Some(id) = req.id {
         let rack_id = RackId::from_str(&id)
             .map_err(|e| Status::invalid_argument(format!("Invalid rack ID: {}", e)))?;
-        let r = db_rack::get(&api.database_connection, rack_id)
+        let r = db_rack::get(&mut api.db_reader(), rack_id)
             .await
             .map_err(CarbideError::from)?;
         vec![r.into()]
     } else {
-        db_rack::list(&api.database_connection)
+        db_rack::list(&mut api.db_reader())
             .await
             .map_err(CarbideError::from)?
             .into_iter()
@@ -99,7 +100,7 @@ pub async fn delete_rack(
         async move {
             let rack_id = RackId::from_str(&req.id)
                 .map_err(|e| Status::invalid_argument(format!("Invalid rack ID: {}", e)))?;
-            let rack = db_rack::get(txn.as_mut(), rack_id)
+            let rack = db_rack::get(&mut txn.as_db_reader(), rack_id)
                 .await
                 .map_err(|e| Status::internal(format!("Getting rack {}", e)))?;
             db_rack::mark_as_deleted(&rack, txn)
@@ -122,7 +123,7 @@ pub async fn list_rack_health_report_overrides(
         .rack_id
         .ok_or_else(|| CarbideError::MissingArgument("rack_id"))?;
 
-    let rack = db_rack::get(&api.database_connection, rack_id)
+    let rack = db_rack::get(&mut api.db_reader(), rack_id)
         .await
         .map_err(CarbideError::from)?;
 
@@ -167,7 +168,7 @@ pub async fn insert_rack_health_report_override(
 
     let mut txn = api.txn_begin().await?;
 
-    let rack = db_rack::get(&mut txn, rack_id)
+    let rack = db_rack::get(&mut txn.as_db_reader(), rack_id)
         .await
         .map_err(CarbideError::from)?;
 
@@ -200,7 +201,7 @@ pub async fn remove_rack_health_report_override(
 
     let mut txn = api.txn_begin().await?;
 
-    let rack = db_rack::get(&mut txn, rack_id)
+    let rack = db_rack::get(&mut txn.as_db_reader(), rack_id)
         .await
         .map_err(CarbideError::from)?;
 

--- a/crates/api/src/handlers/rack_firmware.rs
+++ b/crates/api/src/handlers/rack_firmware.rs
@@ -362,7 +362,7 @@ pub async fn get(
 ) -> Result<Response<RackFirmware>, Status> {
     let req = request.into_inner();
 
-    let db_config = DbRackFirmware::find_by_id(&api.database_connection, &req.id)
+    let db_config = DbRackFirmware::find_by_id(&mut api.db_reader(), &req.id)
         .await
         .map_err(CarbideError::from)?;
 
@@ -952,7 +952,7 @@ pub async fn apply(
     );
 
     // Get the RackFirmware configuration from the database
-    let fw_config = DbRackFirmware::find_by_id(&api.database_connection, &req.firmware_id)
+    let fw_config = DbRackFirmware::find_by_id(&mut api.db_reader(), &req.firmware_id)
         .await
         .map_err(|e| Status::internal(format!("Failed to get firmware configuration: {}", e)))?;
 
@@ -972,7 +972,7 @@ pub async fn apply(
             serde_json::json!({})
         });
 
-    let rack = db::rack::get(&api.database_connection, rack_id)
+    let rack = db::rack::get(&mut api.db_reader(), rack_id)
         .await
         .map_err(|e| Status::internal(format!("Failed to get rack: {}", e)))?;
 

--- a/crates/api/src/handlers/redfish.rs
+++ b/crates/api/src/handlers/redfish.rs
@@ -106,7 +106,7 @@ pub async fn redfish_list_actions(
 
     let request = request.into_inner();
 
-    let result = list_requests(request, &api.database_connection).await?;
+    let result = list_requests(request, &mut api.db_reader()).await?;
 
     Ok(tonic::Response::new(
         rpc::forge::RedfishListActionsResponse {

--- a/crates/api/src/handlers/route_server.rs
+++ b/crates/api/src/handlers/route_server.rs
@@ -32,7 +32,7 @@ pub(crate) async fn get(
 ) -> Result<tonic::Response<rpc::RouteServerEntries>, Status> {
     log_request_data(&request);
 
-    let route_servers = db::route_servers::get(&api.database_connection).await?;
+    let route_servers = db::route_servers::get(&mut api.db_reader()).await?;
 
     Ok(tonic::Response::new(rpc::RouteServerEntries {
         route_servers: route_servers.into_iter().map(Into::into).collect(),

--- a/crates/api/src/handlers/site_explorer.rs
+++ b/crates/api/src/handlers/site_explorer.rs
@@ -20,6 +20,7 @@ use std::str::FromStr;
 
 use ::rpc::forge::{self as rpc, IsBmcInManagedHostResponse};
 use config_version::ConfigVersion;
+use db::db_read::AsDbReader;
 use tokio::net::lookup_host;
 use tonic::{Request, Response, Status};
 
@@ -34,7 +35,7 @@ pub(crate) async fn find_explored_endpoint_ids(
 
     let filter: ::rpc::site_explorer::ExploredEndpointSearchFilter = request.into_inner();
 
-    let endpoint_ips = db::explored_endpoints::find_ips(&api.database_connection, filter).await?;
+    let endpoint_ips = db::explored_endpoints::find_ips(&mut api.db_reader(), filter).await?;
 
     Ok(Response::new(
         ::rpc::site_explorer::ExploredEndpointIdList {
@@ -69,7 +70,7 @@ pub(crate) async fn find_explored_endpoints_by_ids(
         );
     }
 
-    let result = db::explored_endpoints::find_by_ips(&api.database_connection, ips)
+    let result = db::explored_endpoints::find_by_ips(&mut api.db_reader(), ips)
         .await
         .map(|ep| ::rpc::site_explorer::ExploredEndpointList {
             endpoints: ep
@@ -89,7 +90,7 @@ pub(crate) async fn find_explored_managed_host_ids(
 
     let filter: ::rpc::site_explorer::ExploredManagedHostSearchFilter = request.into_inner();
 
-    let host_ips = db::explored_managed_host::find_ips(&api.database_connection, filter).await?;
+    let host_ips = db::explored_managed_host::find_ips(&mut api.db_reader(), filter).await?;
 
     Ok(Response::new(
         ::rpc::site_explorer::ExploredManagedHostIdList {
@@ -124,7 +125,7 @@ pub(crate) async fn find_explored_managed_hosts_by_ids(
         );
     }
 
-    let result = db::explored_managed_host::find_by_ips(&api.database_connection, ips)
+    let result = db::explored_managed_host::find_by_ips(&mut api.db_reader(), ips)
         .await
         .map(|ep| ::rpc::site_explorer::ExploredManagedHostList {
             managed_hosts: ep
@@ -242,7 +243,7 @@ pub(crate) async fn pause_explored_endpoint_remediation(
 
     // Check if a machine exists for this endpoint
     let in_managed_host =
-        crate::site_explorer::is_endpoint_in_managed_host(bmc_ip, txn.as_pgconn())
+        crate::site_explorer::is_endpoint_in_managed_host(bmc_ip, &mut txn.as_db_reader())
             .await
             .map_err(|e| CarbideError::internal(e.to_string()))?;
 
@@ -281,7 +282,7 @@ pub(crate) async fn is_bmc_in_managed_host(
     };
 
     let in_managed_host =
-        crate::site_explorer::is_endpoint_in_managed_host(bmc_addr.ip(), &api.database_connection)
+        crate::site_explorer::is_endpoint_in_managed_host(bmc_addr.ip(), &mut api.db_reader())
             .await
             .map_err(|e| CarbideError::internal(e.to_string()))?;
 
@@ -313,7 +314,7 @@ pub(crate) async fn delete_explored_endpoint(
 
     // Check if a machine exists for this endpoint
     let in_managed_host =
-        crate::site_explorer::is_endpoint_in_managed_host(bmc_ip, txn.as_pgconn())
+        crate::site_explorer::is_endpoint_in_managed_host(bmc_ip, &mut txn.as_db_reader())
             .await
             .map_err(|e| CarbideError::internal(e.to_string()))?;
 

--- a/crates/api/src/handlers/sku.rs
+++ b/crates/api/src/handlers/sku.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 use carbide_uuid::machine::MachineId;
+use db::db_read::AsDbReader;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{BomValidating, ManagedHostState};
 use model::sku::Sku;
@@ -68,8 +69,11 @@ pub(crate) async fn delete(api: &Api, request: Request<SkuIdList>) -> Result<Res
         return Err(CarbideError::NotImplemented.into());
     }
 
-    let machine_ids =
-        db::machine::find_machine_ids_by_sku_ids(&mut txn, std::slice::from_ref(&sku.id)).await?;
+    let machine_ids = db::machine::find_machine_ids_by_sku_ids(
+        &mut txn.as_db_reader(),
+        std::slice::from_ref(&sku.id),
+    )
+    .await?;
     if machine_ids
         .get(&sku.id)
         .is_some_and(|machine_ids| !machine_ids.is_empty())
@@ -95,7 +99,7 @@ pub(crate) async fn generate_from_machine(
     log_request_data(&request);
     let machine_id = convert_and_log_machine_id(Some(&request.into_inner()))?;
 
-    let sku = db::sku::generate_sku_from_machine(&api.database_connection, &machine_id).await?;
+    let sku = db::sku::generate_sku_from_machine(&mut api.db_reader(), &machine_id).await?;
 
     Ok(Response::new(sku.into()))
 }
@@ -110,8 +114,12 @@ pub(crate) async fn assign_to_machine(
     let sku_machine_pair = request.into_inner();
     let machine_id = convert_and_log_machine_id(sku_machine_pair.machine_id.as_ref())?;
 
-    let machine =
-        db::machine::find_one(&mut txn, &machine_id, MachineSearchConfig::default()).await?;
+    let machine = db::machine::find_one(
+        &mut txn.as_db_reader(),
+        &machine_id,
+        MachineSearchConfig::default(),
+    )
+    .await?;
 
     let machine = machine.ok_or(CarbideError::NotFoundError {
         kind: "machine",
@@ -179,8 +187,12 @@ pub(crate) async fn verify_for_machine(
 
     let mut txn = api.txn_begin().await?;
 
-    let machine =
-        db::machine::find_one(&mut txn, &machine_id, MachineSearchConfig::default()).await?;
+    let machine = db::machine::find_one(
+        &mut txn.as_db_reader(),
+        &machine_id,
+        MachineSearchConfig::default(),
+    )
+    .await?;
 
     let machine = machine.ok_or(CarbideError::NotFoundError {
         kind: "machine",
@@ -218,8 +230,12 @@ pub(crate) async fn remove_sku_association(
 
     let mut txn = api.txn_begin().await?;
 
-    let machine =
-        db::machine::find_one(&mut txn, &machine_id, MachineSearchConfig::default()).await?;
+    let machine = db::machine::find_one(
+        &mut txn.as_db_reader(),
+        &machine_id,
+        MachineSearchConfig::default(),
+    )
+    .await?;
 
     let machine = machine.ok_or(CarbideError::NotFoundError {
         kind: "machine",
@@ -253,7 +269,7 @@ pub(crate) async fn get_all_ids(
     request: Request<()>,
 ) -> Result<Response<::rpc::forge::SkuIdList>, Status> {
     log_request_data(&request);
-    let sku_ids = db::sku::get_sku_ids(&api.database_connection).await?;
+    let sku_ids = db::sku::get_sku_ids(&mut api.db_reader()).await?;
 
     Ok(Response::new(::rpc::forge::SkuIdList {
         ids: sku_ids.into_iter().collect(),
@@ -287,7 +303,7 @@ pub(crate) async fn find_skus_by_ids(
         skus.into_iter().map(std::convert::Into::into).collect();
 
     let mut machine_ids_by_sku_ids =
-        db::machine::find_machine_ids_by_sku_ids(&mut txn, &sku_ids).await?;
+        db::machine::find_machine_ids_by_sku_ids(&mut txn.as_db_reader(), &sku_ids).await?;
     txn.commit().await?;
 
     for rpc_sku in rpc_skus.iter_mut() {

--- a/crates/api/src/handlers/tenant.rs
+++ b/crates/api/src/handlers/tenant.rs
@@ -16,6 +16,7 @@
  */
 use ::rpc::errors::RpcDataConversionError;
 use ::rpc::forge as rpc;
+use db::db_read::AsDbReader;
 use model::ConfigValidationError;
 use model::metadata::Metadata;
 use model::tenant::RoutingProfileType;
@@ -188,7 +189,7 @@ pub(crate) async fn update(
     // and easy to loosen later if we find we need it.
     if current_tenant.routing_profile_type != routing_profile_type
         && !db::vpc::find_ids(
-            &mut txn,
+            &mut txn.as_db_reader(),
             rpc::VpcSearchFilter {
                 tenant_org_id: Some(organization_id.clone()),
                 ..Default::default()
@@ -268,7 +269,7 @@ pub(crate) async fn find_tenant_organization_ids(
     crate::api::log_request_data(&request);
     let search_config = request.into_inner();
     let tenant_org_ids =
-        db::tenant::find_tenant_organization_ids(&api.database_connection, search_config).await?;
+        db::tenant::find_tenant_organization_ids(&mut api.db_reader(), search_config).await?;
     Ok(tonic::Response::new(rpc::TenantOrganizationIdList {
         tenant_organization_ids: tenant_org_ids.into_iter().collect(),
     }))

--- a/crates/api/src/handlers/tenant_keyset.rs
+++ b/crates/api/src/handlers/tenant_keyset.rs
@@ -68,7 +68,7 @@ pub(crate) async fn find_ids(
 
     let filter: rpc::TenantKeysetSearchFilter = request.into_inner();
 
-    let keyset_ids = db::tenant_keyset::find_ids(&api.database_connection, filter).await?;
+    let keyset_ids = db::tenant_keyset::find_ids(&mut api.db_reader(), filter).await?;
 
     Ok(Response::new(rpc::TenantKeysetIdList {
         keyset_ids: keyset_ids
@@ -103,8 +103,7 @@ pub(crate) async fn find_by_ids(
     }
 
     let keysets =
-        db::tenant_keyset::find_by_ids(&api.database_connection, keyset_ids, include_key_data)
-            .await;
+        db::tenant_keyset::find_by_ids(&mut api.db_reader(), keyset_ids, include_key_data).await;
 
     let result = keysets
         .map(|vpc| rpc::TenantKeySetList {

--- a/crates/api/src/handlers/uefi.rs
+++ b/crates/api/src/handlers/uefi.rs
@@ -16,6 +16,7 @@
  */
 use ::rpc::forge as rpc;
 use db::WithTransaction;
+use db::db_read::AsDbReader;
 use futures_util::FutureExt;
 use model::machine::LoadSnapshotOptions;
 use tonic::{Request, Response, Status};
@@ -65,7 +66,7 @@ pub(crate) async fn clear_host_uefi_password(
     }
 
     let snapshot = db::managed_host::load_snapshot(
-        &mut txn,
+        &mut txn.as_db_reader(),
         &machine_id,
         LoadSnapshotOptions {
             include_history: false,
@@ -141,7 +142,7 @@ pub(crate) async fn set_host_uefi_password(
     }
 
     let snapshot = db::managed_host::load_snapshot(
-        &mut txn,
+        &mut txn.as_db_reader(),
         &machine_id,
         LoadSnapshotOptions {
             include_history: false,

--- a/crates/api/src/handlers/vpc.rs
+++ b/crates/api/src/handlers/vpc.rs
@@ -18,6 +18,7 @@ use ::rpc::errors::RpcDataConversionError;
 use ::rpc::forge as rpc;
 use carbide_uuid::network_security_group::NetworkSecurityGroupId;
 use carbide_uuid::vpc::VpcId;
+use db::db_read::AsDbReader;
 use db::resource_pool::ResourcePoolDatabaseError;
 use db::vpc::{self};
 use db::{self, ObjectColumnFilter, network_security_group};
@@ -196,10 +197,12 @@ pub(crate) async fn update(
 
         // Query for the VPC because we need to do
         // some validation against the request.
-        let Some(vpc) = db::vpc::find_by(&mut txn, ObjectColumnFilter::One(vpc::IdColumn, &vpc_id))
-            .await?
-            .pop()
-        else {
+        let Some(vpc) = db::vpc::find_by(
+            &mut txn.as_db_reader(),
+            ObjectColumnFilter::One(vpc::IdColumn, &vpc_id),
+        )
+        .await?
+        .pop() else {
             return Err(CarbideError::NotFoundError {
                 kind: "Vpc",
                 id: vpc_id.to_string(),
@@ -257,7 +260,7 @@ pub(crate) async fn update_virtualization(
     let updater = UpdateVpcVirtualization::try_from(request.into_inner())?;
 
     let instances = db::instance::find_ids(
-        &mut txn,
+        &mut txn.as_db_reader(),
         rpc::InstanceSearchFilter {
             label: None,
             tenant_org_id: None,
@@ -366,7 +369,7 @@ pub(crate) async fn find_ids(
 
     let filter: rpc::VpcSearchFilter = request.into_inner();
 
-    let vpc_ids = db::vpc::find_ids(&api.database_connection, filter).await?;
+    let vpc_ids = db::vpc::find_ids(&mut api.db_reader(), filter).await?;
 
     Ok(Response::new(rpc::VpcIdList { vpc_ids }))
 }
@@ -392,7 +395,7 @@ pub(crate) async fn find_by_ids(
     }
 
     let db_vpcs = db::vpc::find_by(
-        &api.database_connection,
+        &mut api.db_reader(),
         ObjectColumnFilter::List(vpc::IdColumn, &vpc_ids),
     )
     .await;

--- a/crates/api/src/handlers/vpc_peering.rs
+++ b/crates/api/src/handlers/vpc_peering.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use ::db::db_read::AsDbReader;
 use ::db::{ObjectColumnFilter, vpc, vpc_peering as db};
 use ::rpc::forge as rpc;
 use carbide_network::virtualization::VpcVirtualizationType;
@@ -56,14 +57,17 @@ pub async fn create(
             return Err(CarbideError::internal("VPC Peering feature disabled.".to_string()).into());
         }
         Some(VpcPeeringPolicy::Exclusive) => {
-            let vpcs1 =
-                vpc::find_by(&mut txn, ObjectColumnFilter::One(vpc::IdColumn, &vpc_id)).await?;
+            let vpcs1 = vpc::find_by(
+                &mut txn.as_db_reader(),
+                ObjectColumnFilter::One(vpc::IdColumn, &vpc_id),
+            )
+            .await?;
             let vpc1 = vpcs1.first().ok_or_else(|| CarbideError::NotFoundError {
                 kind: "VPC",
                 id: vpc_id.clone().to_string(),
             })?;
             let vpcs2 = vpc::find_by(
-                &mut txn,
+                &mut txn.as_db_reader(),
                 ObjectColumnFilter::One(vpc::IdColumn, &peer_vpc_id),
             )
             .await?;

--- a/crates/api/src/ib_fabric_monitor/mod.rs
+++ b/crates/api/src/ib_fabric_monitor/mod.rs
@@ -26,6 +26,7 @@ use std::time::Duration;
 use carbide_uuid::infiniband::IBPartitionId;
 use carbide_uuid::machine::MachineId;
 use chrono::Utc;
+use db::db_read::AsDbReader;
 use db::ib_partition::IBPartition;
 use db::work_lock_manager::WorkLockManagerHandle;
 use db::{self, DatabaseError};
@@ -442,7 +443,7 @@ impl IbFabricMonitor {
         txn: &mut PgConnection,
     ) -> CarbideResult<HashMap<MachineId, ManagedHostStateSnapshot>> {
         let machine_ids = db::machine::find_machine_ids(
-            &mut *txn,
+            &mut txn.as_db_reader(),
             MachineSearchConfig {
                 include_predicted_host: true,
                 ..Default::default()
@@ -450,7 +451,7 @@ impl IbFabricMonitor {
         )
         .await?;
         db::managed_host::load_by_machine_ids(
-            txn,
+            &mut txn.as_db_reader(),
             &machine_ids,
             LoadSnapshotOptions {
                 include_history: false,
@@ -623,7 +624,7 @@ async fn get_tenant_partitions(
     txn: &mut PgConnection,
 ) -> Result<HashMap<IBPartitionId, IBPartition>, CarbideError> {
     let partition_ids = db::ib_partition::find_ids(
-        &mut *txn,
+        &mut txn.as_db_reader(),
         IbPartitionSearchFilter {
             tenant_org_id: None,
             name: None,
@@ -638,7 +639,7 @@ async fn get_tenant_partitions(
         let page_size = PAGE_SIZE.min(partition_ids.len() - offset);
         let next_ids = &partition_ids[offset..offset + page_size];
         let partition_data = db::ib_partition::find_by(
-            &mut *txn,
+            &mut txn.as_db_reader(),
             db::ObjectColumnFilter::List(db::ib_partition::IdColumn, next_ids),
         )
         .await?;

--- a/crates/api/src/instance/mod.rs
+++ b/crates/api/src/instance/mod.rs
@@ -25,6 +25,7 @@ use carbide_uuid::instance_type::InstanceTypeId;
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::vpc::VpcPrefixId;
 use config_version::ConfigVersion;
+use db::db_read::AsDbReader;
 use db::{
     self, ObjectColumnFilter, ObjectFilter, compute_allocation, extension_service, ib_partition,
     network_security_group,
@@ -452,8 +453,10 @@ pub async fn batch_allocate_instances(
             instance_type_id: Some(instance_type_id.to_string()),
         };
 
-        let new_total_instance_count =
-            req_count + db::instance::find_ids(&mut txn, filter).await?.len();
+        let new_total_instance_count = req_count
+            + db::instance::find_ids(&mut txn.as_db_reader(), filter)
+                .await?
+                .len();
 
         if new_total_instance_count > compute_allocation_total as usize {
             // # enforce_if_present:  Instance type required in creation request.  If allocations are found for instance type ID, enforce it; otherwise, it's like no limits.
@@ -485,7 +488,7 @@ pub async fn batch_allocate_instances(
 
     // Grab a row-level locks on the requested machines
     let machines = db::machine::find(
-        &mut txn,
+        &mut txn.as_db_reader(),
         ObjectFilter::List(&machine_ids),
         MachineSearchConfig {
             for_update: true,
@@ -510,7 +513,7 @@ pub async fn batch_allocate_instances(
 
     // ==== Phase 4: Batch load managed host snapshots ====
     let mut snapshot_map = db::managed_host::load_by_machine_ids(
-        &mut txn,
+        &mut txn.as_db_reader(),
         &machine_ids,
         LoadSnapshotOptions::default().with_host_health(host_health_config),
     )
@@ -884,7 +887,7 @@ pub async fn batch_validate_ib_partition_ownership(
         .collect();
 
     let partitions = db::ib_partition::find_by(
-        txn,
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::List(ib_partition::IdColumn, &unique_partition_ids),
     )
     .await?;

--- a/crates/api/src/ipxe.rs
+++ b/crates/api/src/ipxe.rs
@@ -16,6 +16,7 @@
  */
 use ::rpc::forge as rpc;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId, MachineType};
+use db::db_read::AsDbReader;
 use db::{self};
 use mac_address::MacAddress;
 use model::machine::machine_search_config::MachineSearchConfig;
@@ -147,14 +148,16 @@ exit ||
 
         let mut console = "ttyS0";
         let mut qcow_imager_url = "chain ${base-url}/internal/x86_64/qcow-imager.efi loglevel=7 console=tty0 pci=realloc=off ";
-        let interface = db::machine_interface::find_one(&mut *txn, target.interface_id).await?;
+        let interface =
+            db::machine_interface::find_one(&mut txn.as_db_reader(), target.interface_id).await?;
 
         // This custom pxe is different from a customer instance of pxe. It is more for testing one off
         // changes until a real dev env is established and we can just override our existing code to test
         // It is possible for the pxe to be null if we are only trying to test the user data, and this will
         // follow the same code path and retrieve the non customer pxe
         if let Some(machine_boot_override) =
-            db::machine_boot_override::find_optional(&mut *txn, target.interface_id).await?
+            db::machine_boot_override::find_optional(&mut txn.as_db_reader(), target.interface_id)
+                .await?
             && let Some(custom_pxe) = machine_boot_override.custom_pxe
         {
             return Ok(custom_pxe);
@@ -189,12 +192,13 @@ exit ||
             // - If it's X86 and we have an exploration report, assume it's a Host.
             // - If it's ARM and we have an exploration report, check if the report is a bluefield
             //   model.
-            let Some(endpoint) =
-                db::explored_endpoints::find_by_mac_address(&mut *txn, interface.mac_address)
-                    .await?
-                    .into_iter()
-                    .next()
-            else {
+            let Some(endpoint) = db::explored_endpoints::find_by_mac_address(
+                &mut txn.as_db_reader(),
+                interface.mac_address,
+            )
+            .await?
+            .into_iter()
+            .next() else {
                 // This only happens if someone powered on a host manually before we ingested it,
                 // which is unlikely but possible.
                 tracing::info!(interface = ?interface, "Request for PXE instructions for unknown interface, skipping PXE boot");
@@ -221,12 +225,16 @@ exit ||
             ));
         };
 
-        let machine = db::machine::find_one(&mut *txn, &machine_id, MachineSearchConfig::default())
-            .await
-            .map_err(|e| CarbideError::InvalidArgument(format!("Get machine failed, Error: {e}")))?
-            .ok_or(CarbideError::InvalidArgument(
-                "Invalid machine id. Not found in db.".to_string(),
-            ))?;
+        let machine = db::machine::find_one(
+            &mut txn.as_db_reader(),
+            &machine_id,
+            MachineSearchConfig::default(),
+        )
+        .await
+        .map_err(|e| CarbideError::InvalidArgument(format!("Get machine failed, Error: {e}")))?
+        .ok_or(CarbideError::InvalidArgument(
+            "Invalid machine id. Not found in db.".to_string(),
+        ))?;
 
         tracing::info!(machine_id = %machine.id, interface_id = %target.interface_id, state=%machine.current_state(), "Found existing machine for pxe instructions");
         // DPUs need to boot twice during initial discovery. Both reboots require

--- a/crates/api/src/machine_update_manager/mod.rs
+++ b/crates/api/src/machine_update_manager/mod.rs
@@ -27,6 +27,7 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use carbide_uuid::machine::MachineId;
+use db::db_read::AsDbReader;
 use db::work_lock_manager::WorkLockManagerHandle;
 use db::{DatabaseError, ObjectFilter, Transaction};
 use host_firmware::HostFirmwareUpdate;
@@ -160,7 +161,7 @@ impl MachineUpdateManager {
         txn: &mut PgConnection,
     ) -> CarbideResult<HashMap<MachineId, ManagedHostStateSnapshot>> {
         let machine_ids = db::machine::find_machine_ids(
-            &mut *txn,
+            &mut txn.as_db_reader(),
             MachineSearchConfig {
                 include_predicted_host: true,
                 ..Default::default()
@@ -168,7 +169,7 @@ impl MachineUpdateManager {
         )
         .await?;
         db::managed_host::load_by_machine_ids(
-            txn,
+            &mut txn.as_db_reader(),
             &machine_ids,
             LoadSnapshotOptions {
                 include_history: false,
@@ -302,7 +303,7 @@ impl MachineUpdateManager {
         txn: &mut PgConnection,
     ) -> Result<HashSet<MachineId>, DatabaseError> {
         let machines = db::machine::find(
-            txn,
+            &mut txn.as_db_reader(),
             ObjectFilter::All,
             MachineSearchConfig {
                 include_predicted_host: true,

--- a/crates/api/src/machine_validation/mod.rs
+++ b/crates/api/src/machine_validation/mod.rs
@@ -22,6 +22,7 @@ use std::io;
 use std::sync::Arc;
 
 use db::ObjectFilter;
+use db::db_read::AsDbReader;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
@@ -94,7 +95,7 @@ impl MachineValidationManager {
         let mut txn = db::Transaction::begin(&self.database_connection).await?;
 
         metrics.completed_validation = db::machine_validation::find_by(
-            &mut txn,
+            &mut txn.as_db_reader(),
             ObjectFilter::List(&["Success".to_string()]),
             "state",
         )
@@ -102,14 +103,14 @@ impl MachineValidationManager {
         .len();
 
         metrics.failed_validation = db::machine_validation::find_by(
-            &mut txn,
+            &mut txn.as_db_reader(),
             ObjectFilter::List(&["Failed".to_string()]),
             "state",
         )
         .await?
         .len();
         metrics.in_progress_validation = db::machine_validation::find_by(
-            &mut txn,
+            &mut txn.as_db_reader(),
             ObjectFilter::List(&["InProgress".to_string()]),
             "state",
         )
@@ -117,7 +118,7 @@ impl MachineValidationManager {
         .len();
 
         metrics.tests = db::machine_validation_suites::find(
-            &mut txn,
+            &mut txn.as_db_reader(),
             rpc::forge::MachineValidationTestsGetRequest::default(),
         )
         .await?;

--- a/crates/api/src/measured_boot/metrics_collector/mod.rs
+++ b/crates/api/src/measured_boot/metrics_collector/mod.rs
@@ -28,6 +28,7 @@ use crate::cfg::file::MeasuredBootMetricsCollectorConfig;
 
 pub(crate) mod metrics;
 use carbide_uuid::measured_boot::MeasurementBundleId;
+use db::db_read::AsDbReader;
 use metrics::MeasuredBootMetricsCollectorMetrics;
 
 /// `MeasuredBootMetricsCollector` monitors the state of all measured boot data.
@@ -98,7 +99,7 @@ impl MeasuredBootMetricsCollector {
 
         let mut txn = db::Transaction::begin(&self.database_connection).await?;
 
-        let profiles = db::measured_boot::profile::get_all(&mut txn).await?;
+        let profiles = db::measured_boot::profile::get_all(&mut txn.as_db_reader()).await?;
         for system_profile in profiles.iter() {
             let machines =
                 db::measured_boot::profile::get_machines(system_profile, &mut txn).await?;
@@ -108,7 +109,7 @@ impl MeasuredBootMetricsCollector {
         }
         metrics.num_profiles = profiles.len();
 
-        let bundles = db::measured_boot::bundle::get_all(&mut txn).await?;
+        let bundles = db::measured_boot::bundle::get_all(&mut txn.as_db_reader()).await?;
         let bundle_map: HashMap<MeasurementBundleId, MeasurementBundleState> = bundles
             .iter()
             .map(|bundle| (bundle.bundle_id, bundle.state))
@@ -128,7 +129,7 @@ impl MeasuredBootMetricsCollector {
         }
         metrics.num_bundles = bundles.len();
 
-        let machines = db::measured_boot::machine::get_all(&mut txn).await?;
+        let machines = db::measured_boot::machine::get_all(&mut txn.as_db_reader()).await?;
         for machine in machines.iter() {
             let bundle_state = get_bundle_state(&bundle_map, &machine.journal);
             *metrics

--- a/crates/api/src/measured_boot/rpc/bundle.rs
+++ b/crates/api/src/measured_boot/rpc/bundle.rs
@@ -220,7 +220,7 @@ pub async fn handle_list_measurement_bundles(
     _req: ListMeasurementBundlesRequest,
 ) -> Result<ListMeasurementBundlesResponse, Status> {
     let bundles: Vec<MeasurementBundleRecordPb> =
-        get_measurement_bundle_records(&api.database_connection)
+        get_measurement_bundle_records(&mut api.db_reader())
             .await
             .map_err(|e| Status::internal(format!("{e}")))?
             .into_iter()

--- a/crates/api/src/measured_boot/rpc/journal.rs
+++ b/crates/api/src/measured_boot/rpc/journal.rs
@@ -22,6 +22,7 @@
 use std::str::FromStr;
 
 use carbide_uuid::machine::MachineId;
+use db::db_read::AsDbReader;
 use db::measured_boot::interface::journal::{
     get_measurement_journal_records, get_measurement_journal_records_for_machine_id,
 };
@@ -75,7 +76,7 @@ pub async fn handle_show_measurement_journal(
             }
             show_measurement_journal_request::Selector::LatestForMachineId(machine_id) => {
                 match db::measured_boot::journal::get_latest_journal_for_id(
-                    &mut txn,
+                    &mut txn.as_db_reader(),
                     MachineId::from_str(&machine_id).map_err(|e| {
                         Status::invalid_argument(format!("Could not parse MachineId: {e}"))
                     })?,
@@ -107,7 +108,7 @@ pub async fn handle_show_measurement_journals(
     _req: ShowMeasurementJournalsRequest,
 ) -> Result<ShowMeasurementJournalsResponse, Status> {
     Ok(ShowMeasurementJournalsResponse {
-        journals: db::measured_boot::journal::get_all(&api.database_connection)
+        journals: db::measured_boot::journal::get_all(&mut api.db_reader())
             .await
             .map_err(|e| Status::internal(format!("failed to fetch journals: {e}")))?
             .drain(..)

--- a/crates/api/src/measured_boot/rpc/machine.rs
+++ b/crates/api/src/measured_boot/rpc/machine.rs
@@ -107,7 +107,7 @@ pub async fn handle_list_candidate_machines(
     _req: ListCandidateMachinesRequest,
 ) -> Result<ListCandidateMachinesResponse, Status> {
     Ok(ListCandidateMachinesResponse {
-        machines: get_candidate_machine_records(&api.database_connection)
+        machines: get_candidate_machine_records(&mut api.db_reader())
             .await
             .map_err(|e| Status::internal(format!("failed to read records: {e}")))?
             .into_iter()

--- a/crates/api/src/measured_boot/rpc/profile.rs
+++ b/crates/api/src/measured_boot/rpc/profile.rs
@@ -199,7 +199,7 @@ pub async fn handle_list_measurement_system_profiles(
     _req: ListMeasurementSystemProfilesRequest,
 ) -> Result<ListMeasurementSystemProfilesResponse, Status> {
     let system_profiles: Vec<MeasurementSystemProfileRecordPb> =
-        export_measurement_profile_records(&api.database_connection)
+        export_measurement_profile_records(&mut api.db_reader())
             .await
             .map_err(|e| Status::internal(format!("{e}")))?
             .into_iter()

--- a/crates/api/src/measured_boot/rpc/report.rs
+++ b/crates/api/src/measured_boot/rpc/report.rs
@@ -263,7 +263,7 @@ pub async fn handle_match_measurement_report(
     req: MatchMeasurementReportRequest,
 ) -> Result<MatchMeasurementReportResponse, Status> {
     let pcr_register = PcrRegisterValue::from_pb_vec(req.pcr_values);
-    let mut reports = match_latest_reports(&api.database_connection, &pcr_register)
+    let mut reports = match_latest_reports(&mut api.db_reader(), &pcr_register)
         .await
         .map_err(|e| Status::internal(format!("failure during report matching: {e}")))?;
 

--- a/crates/api/src/measured_boot/rpc/site.rs
+++ b/crates/api/src/measured_boot/rpc/site.rs
@@ -172,7 +172,7 @@ pub async fn handle_list_measurement_trusted_machines(
     _req: ListMeasurementTrustedMachinesRequest,
 ) -> Result<ListMeasurementTrustedMachinesResponse, Status> {
     let approval_records: Vec<MeasurementApprovedMachineRecordPb> =
-        get_approved_machines(&api.database_connection)
+        get_approved_machines(&mut api.db_reader())
             .await
             .map_err(|e| Status::internal(format!("failed to fetch machine approvals: {e}")))?
             .into_iter()
@@ -248,7 +248,7 @@ pub async fn handle_list_measurement_trusted_profiles(
     _req: ListMeasurementTrustedProfilesRequest,
 ) -> Result<ListMeasurementTrustedProfilesResponse, Status> {
     let approval_records: Vec<MeasurementApprovedProfileRecordPb> =
-        get_approved_profiles(&api.database_connection)
+        get_approved_profiles(&mut api.db_reader())
             .await
             .map_err(|e| Status::internal(format!("failed to fetch profile approvals: {e}")))?
             .into_iter()
@@ -262,7 +262,7 @@ pub async fn handle_list_attestation_summary(
     api: &Api,
     _req: ListAttestationSummaryRequest,
 ) -> Result<ListAttestationSummaryResponse, Status> {
-    let attestation_summary = list_attestation_summary(&api.database_connection)
+    let attestation_summary = list_attestation_summary(&mut api.db_reader())
         .await
         .map_err(|e| Status::internal(format!("failed to fetch attestation summary: {e}")))?;
 

--- a/crates/api/src/measured_boot/tests/profile.rs
+++ b/crates/api/src/measured_boot/tests/profile.rs
@@ -38,6 +38,7 @@
 mod tests {
     use std::collections::HashMap;
 
+    use db::db_read::AsDbReader;
     use db::measured_boot::interface::profile::{
         get_all_measurement_profile_attr_records, get_all_measurement_profile_records,
     };
@@ -99,7 +100,7 @@ mod tests {
 
         // Do a little bit of database recon to make
         // sure the expected number of rows are there.
-        let profile1_records = get_all_measurement_profile_records(txn.as_mut()).await?;
+        let profile1_records = get_all_measurement_profile_records(&mut txn.as_db_reader()).await?;
         assert_eq!(profile1_records.len(), 1);
 
         let profile_attr_records = get_all_measurement_profile_attr_records(&mut txn).await?;
@@ -155,7 +156,8 @@ mod tests {
 
         // Do a little bit of database recon to make
         // sure the expected number of rows are there.
-        let profile_both_records = get_all_measurement_profile_records(txn.as_mut()).await?;
+        let profile_both_records =
+            get_all_measurement_profile_records(&mut txn.as_db_reader()).await?;
         assert_eq!(profile_both_records.len(), 2);
 
         let profile_all_attr_records = get_all_measurement_profile_attr_records(&mut txn).await?;

--- a/crates/api/src/measured_boot/tests/report.rs
+++ b/crates/api/src/measured_boot/tests/report.rs
@@ -25,10 +25,11 @@
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Borrow;
     use std::collections::{HashMap, HashSet};
 
     use carbide_uuid::measured_boot::MeasurementReportId;
-    use db::db_read::PgPoolReader;
+    use db::db_read::AsDbReader;
     use db::measured_boot::interface::common::pcr_register_values_to_map;
     use db::measured_boot::interface::report::{
         get_all_measurement_report_records, get_all_measurement_report_value_records,
@@ -209,7 +210,7 @@ mod tests {
         }
 
         // And then get everything thus far.
-        let reports = db::measured_boot::report::get_all(txn.as_mut()).await?;
+        let reports = db::measured_boot::report::get_all(&mut txn.as_db_reader()).await?;
         assert_eq!(reports.len(), 2);
 
         // And now lets do some database record checks.
@@ -375,7 +376,7 @@ mod tests {
         // and make sure everything gets updated accordingly.
         let bundle_full =
             db::measured_boot::report::create_active_bundle(&mut txn, &report, &None).await?;
-        let bundles = db::measured_boot::bundle::get_all(txn.as_mut()).await?;
+        let bundles = db::measured_boot::bundle::get_all(&mut txn.as_db_reader()).await?;
         assert_eq!(bundles.len(), 1);
         let journals =
             db::measured_boot::journal::get_all_for_machine_id(&mut txn, report.machine_id).await?;
@@ -397,7 +398,7 @@ mod tests {
         let bundle_partial =
             db::measured_boot::report::create_active_bundle(&mut txn, &report, &Some(pcr_set))
                 .await?;
-        let bundles = db::measured_boot::bundle::get_all(txn.as_mut()).await?;
+        let bundles = db::measured_boot::bundle::get_all(&mut txn.as_db_reader()).await?;
         assert_eq!(bundles.len(), 2);
         let journals =
             db::measured_boot::journal::get_all_for_machine_id(&mut txn, report.machine_id).await?;
@@ -461,7 +462,7 @@ mod tests {
         )
         .await?;
 
-        let bundles = db::measured_boot::bundle::get_all(txn.as_mut()).await?;
+        let bundles = db::measured_boot::bundle::get_all(&mut txn.as_db_reader()).await?;
         assert_eq!(bundles.len(), 3);
         let journals =
             db::measured_boot::journal::get_all_for_machine_id(&mut txn, report.machine_id).await?;
@@ -551,7 +552,7 @@ mod tests {
         let bundle_partial =
             db::measured_boot::report::create_revoked_bundle(&mut txn, &report, &Some(pcr_set))
                 .await?;
-        let bundles = db::measured_boot::bundle::get_all(txn.as_mut()).await?;
+        let bundles = db::measured_boot::bundle::get_all(&mut txn.as_db_reader()).await?;
         assert_eq!(bundles.len(), 1);
         let journals =
             db::measured_boot::journal::get_all_for_machine_id(&mut txn, report.machine_id).await?;
@@ -646,7 +647,7 @@ mod tests {
         }
 
         // make sure 520 reports have been stored
-        let inserted_reports = db::measured_boot::report::get_all(txn.as_mut()).await?;
+        let inserted_reports = db::measured_boot::report::get_all(&mut txn.as_db_reader()).await?;
         assert_eq!(inserted_reports.len(), 520);
 
         // since the trim operation happens in a separate transaction, we need to commit
@@ -664,7 +665,7 @@ mod tests {
 
         // make sure 500 are remaining
         let remaining_reports =
-            db::measured_boot::report::get_all(&mut PgPoolReader::from(pool)).await?;
+            db::measured_boot::report::get_all(&mut pool.borrow().into()).await?;
         assert_eq!(remaining_reports.len(), 500);
 
         // now make sure the first 20 reports are already gone and the rest are still in

--- a/crates/api/src/network_segment/allocate.rs
+++ b/crates/api/src/network_segment/allocate.rs
@@ -19,6 +19,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use carbide_network::ip::IdentifyAddressFamily;
 use carbide_uuid::network::NetworkSegmentId;
 use carbide_uuid::vpc::{VpcId, VpcPrefixId};
+use db::db_read::AsDbReader;
 use ipnetwork::IpNetwork;
 use itertools::Itertools;
 use model::network_prefix::NewNetworkPrefix;
@@ -201,11 +202,12 @@ impl PrefixAllocator {
 
     pub async fn next_free_prefix(&self, txn: &mut PgConnection) -> CarbideResult<IpNetwork> {
         let vpc_str = self.vpc_prefix.to_string();
-        let used_prefixes = db::network_prefix::containing_prefix(txn, vpc_str.as_str())
-            .await?
-            .iter()
-            .map(|x| x.prefix)
-            .collect_vec();
+        let used_prefixes =
+            db::network_prefix::containing_prefix(&mut txn.as_db_reader(), vpc_str.as_str())
+                .await?
+                .iter()
+                .map(|x| x.prefix)
+                .collect_vec();
 
         // Reminder that `new()` already validated self.prefix > self.vpc_prefix.prefix().
         let total_network_possible: u128 = 1u128 << (self.prefix - self.vpc_prefix.prefix()) as u32;

--- a/crates/api/src/nvl_partition_monitor/mod.rs
+++ b/crates/api/src/nvl_partition_monitor/mod.rs
@@ -23,6 +23,7 @@ use carbide_uuid::machine::MachineId;
 use carbide_uuid::nvlink::{NvLinkDomainId, NvLinkLogicalPartitionId, NvLinkPartitionId};
 use chrono::Utc;
 use config_version::Versioned;
+use db::db_read::AsDbReader;
 use db::machine::find_machine_ids;
 use db::managed_host::load_by_machine_ids;
 use db::nvl_logical_partition::{IdColumn as LpIdColumn, LogicalPartition};
@@ -748,12 +749,17 @@ impl NvlPartitionMonitor {
             &managed_host_snapshots.keys().copied().collect::<Vec<_>>(),
         )
         .await?;
-        let db_nvl_partitions =
-            db::nvl_partition::find_by(&mut txn, ObjectColumnFilter::<IdColumn>::All).await?;
+        let db_nvl_partitions = db::nvl_partition::find_by(
+            &mut txn.as_db_reader(),
+            ObjectColumnFilter::<IdColumn>::All,
+        )
+        .await?;
 
-        let db_nvl_logical_partitions =
-            db::nvl_logical_partition::find_by(&mut txn, ObjectColumnFilter::<LpIdColumn>::All)
-                .await?;
+        let db_nvl_logical_partitions = db::nvl_logical_partition::find_by(
+            &mut txn.as_db_reader(),
+            ObjectColumnFilter::<LpIdColumn>::All,
+        )
+        .await?;
 
         // Don't hold the transaction across unrelated awaits
         txn.commit().await?;
@@ -1911,7 +1917,7 @@ impl NvlPartitionMonitor {
         txn: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     ) -> CarbideResult<HashMap<MachineId, ManagedHostStateSnapshot>> {
         let mnvvl_machine_ids = find_machine_ids(
-            txn.as_mut(),
+            &mut txn.as_db_reader(),
             MachineSearchConfig {
                 mnnvl_only: true,
                 include_predicted_host: true,
@@ -1920,7 +1926,7 @@ impl NvlPartitionMonitor {
         )
         .await?;
         load_by_machine_ids(
-            txn.as_mut(),
+            &mut txn.as_db_reader(),
             mnvvl_machine_ids.as_slice(),
             LoadSnapshotOptions {
                 include_history: false,

--- a/crates/api/src/preingestion_manager/mod.rs
+++ b/crates/api/src/preingestion_manager/mod.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
+use db::db_read::DbReader;
 use db::work_lock_manager::WorkLockManagerHandle;
 use db::{DatabaseError, WithTransaction};
 use forge_secrets::credentials::{BmcCredentialType, CredentialKey, CredentialReader, Credentials};
@@ -164,7 +165,8 @@ impl PreingestionManager {
     /// Returns true if we stopped early due to a timeout.
     pub async fn run_single_iteration(&self) -> CarbideResult<()> {
         let mut metrics = PreingestionMetrics::new();
-        let db = self.database_connection.clone();
+        let mut db_reader = DbReader::from(&self.database_connection);
+        let db = &mut db_reader;
 
         let _work_lock = match self
             .static_info
@@ -184,7 +186,7 @@ impl PreingestionManager {
             }
         };
 
-        let items = db::explored_endpoints::find_preingest_not_waiting_not_error(&db)
+        let items = db::explored_endpoints::find_preingest_not_waiting_not_error(db)
             .boxed()
             .await?;
 
@@ -211,13 +213,13 @@ impl PreingestionManager {
         for endpoint in items.into_iter() {
             let permit = limit_sem.clone().acquire_owned().await.unwrap();
             let static_info = self.static_info.clone();
-            let db = db.clone();
+            let pool = self.database_connection.clone();
             let _abort_handle = task_set
                 .build_task()
                 .name(&format!("preingestion {}", endpoint.address))
                 .spawn(async move {
                     let _permit = permit; // retain semaphore until we're done
-                    one_endpoint(&db, &endpoint, static_info).await
+                    one_endpoint(&pool, &endpoint, static_info).await
                 });
         }
 
@@ -240,10 +242,10 @@ impl PreingestionManager {
         }
 
         metrics.machines_in_preingestion =
-            db::explored_endpoints::find_preingest_not_waiting_not_error(&db)
+            db::explored_endpoints::find_preingest_not_waiting_not_error(db)
                 .await?
                 .len();
-        metrics.waiting_for_installation = db::explored_endpoints::find_preingest_installing(&db)
+        metrics.waiting_for_installation = db::explored_endpoints::find_preingest_installing(db)
             .await?
             .len();
 
@@ -1494,7 +1496,8 @@ impl PreingestionManagerStatic {
         let upgrade_script_state = self.upgrade_script_state.clone();
         let (username, password) = if let Some(credential_reader) = &self.credential_reader {
             // We need to backtrack from the IP address to get the MAC address, which is what the credentials database is keyed on
-            let interface = db::machine_interface::find_by_ip(db, endpoint_address).await?;
+            let interface =
+                db::machine_interface::find_by_ip(&mut db.into(), endpoint_address).await?;
             let Some(interface) = interface else {
                 tracing::warn!(
                     "Unable to run update script for {address}: MAC address not retrievable"

--- a/crates/api/src/redfish.rs
+++ b/crates/api/src/redfish.rs
@@ -111,7 +111,7 @@ pub trait RedfishClientPool: Send + Sync + 'static {
         };
         let ip = addr.ip();
         let port = addr.port();
-        let auth_key = db::machine_interface::find_by_ip(pool, ip)
+        let auth_key = db::machine_interface::find_by_ip(&mut pool.into(), ip)
             .await?
             .ok_or_else(|| {
                 RedfishClientCreationError::MissingArgument(format!(
@@ -135,7 +135,7 @@ pub trait RedfishClientPool: Send + Sync + 'static {
         port: Option<u16>,
         pool: &PgPool,
     ) -> Result<Box<dyn Redfish>, RedfishClientCreationError> {
-        let auth_key = db::machine_interface::find_by_ip(pool, ip)
+        let auth_key = db::machine_interface::find_by_ip(&mut pool.into(), ip)
             .await?
             .ok_or_else(|| {
                 RedfishClientCreationError::MissingArgument(format!(

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -701,7 +701,6 @@ pub async fn initialize_and_start_controllers(
 
     let handler_services = Arc::new(CommonStateHandlerServices {
         db_pool: db_pool.clone(),
-        db_reader: db_pool.clone().into(),
         redfish_client_pool: shared_redfish_pool.clone(),
         ib_fabric_manager: ib_fabric_manager.clone(),
         ib_pools: common_pools.infiniband.clone(),

--- a/crates/api/src/site_explorer/machine_creator.rs
+++ b/crates/api/src/site_explorer/machine_creator.rs
@@ -18,6 +18,7 @@
 use std::sync::Arc;
 
 use carbide_uuid::machine::MachineId;
+use db::db_read::AsDbReader;
 use db::{ObjectColumnFilter, Transaction};
 use librms::RmsApi;
 use model::bmc_info::BmcInfo;
@@ -242,7 +243,7 @@ impl MachineCreator {
         tracing::info!(%machine_id, "Minted predicted host ID for zero-DPU machine");
 
         let existing_machine = db::machine::find_one(
-            &mut *txn,
+            &mut txn.as_db_reader(),
             machine_id,
             MachineSearchConfig {
                 include_predicted_host: true,
@@ -283,7 +284,7 @@ impl MachineCreator {
         // the exploration report
         for mac_address in mac_addresses {
             if let Some(machine_interface) =
-                db::machine_interface::find_by_mac_address(&mut *txn, mac_address)
+                db::machine_interface::find_by_mac_address(&mut txn.as_db_reader(), mac_address)
                     .await?
                     .into_iter()
                     .next()
@@ -410,7 +411,9 @@ impl MachineCreator {
 
         // If machine_interface exists for the DPU and machine_id is not updated, do it now.
         if let Some(oob_net0_mac) = oob_net0_mac {
-            let mi = db::machine_interface::find_by_mac_address(&mut *txn, oob_net0_mac).await?;
+            let mi =
+                db::machine_interface::find_by_mac_address(&mut txn.as_db_reader(), oob_net0_mac)
+                    .await?;
 
             if let Some(interface) = mi.first()
                 && interface.machine_id.is_none()
@@ -448,8 +451,12 @@ impl MachineCreator {
         dpf_enabled: bool,
     ) -> CarbideResult<Option<Machine>> {
         let dpu_machine_id = explored_dpu.report.machine_id.as_ref().unwrap();
-        match db::machine::find_one(&mut *txn, dpu_machine_id, MachineSearchConfig::default())
-            .await?
+        match db::machine::find_one(
+            &mut txn.as_db_reader(),
+            dpu_machine_id,
+            MachineSearchConfig::default(),
+        )
+        .await?
         {
             // Do nothing if machine exists. It'll be reprovisioned via redfish
             Some(_existing_machine) => Ok(None),

--- a/crates/api/src/site_explorer/managed_host.rs
+++ b/crates/api/src/site_explorer/managed_host.rs
@@ -57,7 +57,7 @@ impl<'a> ManagedHost<'a> {
 /// BMC temporarily stops reporting DPUs in its PCIe device list.
 pub async fn is_endpoint_in_managed_host(
     bmc_ip_address: IpAddr,
-    txn: impl DbReader<'_>,
+    txn: &mut DbReader<'_>,
 ) -> Result<bool, DatabaseError> {
     let machine_id =
         db::machine_topology::find_machine_id_by_bmc_ip(txn, &bmc_ip_address.to_string()).await?;

--- a/crates/api/src/site_explorer/mod.rs
+++ b/crates/api/src/site_explorer/mod.rs
@@ -76,6 +76,7 @@ pub mod rms;
 pub use bmc_endpoint_explorer::BmcEndpointExplorer;
 mod boot_order_tracker;
 use boot_order_tracker::BootOrderTracker;
+use db::db_read::AsDbReader;
 
 mod machine_creator;
 pub use machine_creator::MachineCreator;
@@ -327,8 +328,9 @@ impl SiteExplorer {
 
         // Grab them all because we care about everything,
         // not just the subset in the current run.
-        let explored_endpoints = db::explored_endpoints::find_all(txn.as_pgconn()).await?;
-        let explored_managed_hosts = db::explored_managed_host::find_all(txn.as_pgconn()).await?;
+        let explored_endpoints = db::explored_endpoints::find_all(&mut txn.as_db_reader()).await?;
+        let explored_managed_hosts =
+            db::explored_managed_host::find_all(&mut txn.as_db_reader()).await?;
 
         txn.rollback().await?;
 
@@ -345,7 +347,7 @@ impl SiteExplorer {
             let machine_id = db::machine::find_id_by_bmc_ip(&mut txn, &ep.address).await?;
             let machine = match machine_id.as_ref() {
                 Some(id) => db::machine::find(
-                    &mut txn,
+                    &mut txn.as_db_reader(),
                     ObjectFilter::One(*id),
                     MachineSearchConfig {
                         include_dpus: true,
@@ -723,7 +725,9 @@ impl SiteExplorer {
 
         let mac_addresses = report.all_mac_addresses();
         for mac_address in mac_addresses {
-            let mi = db::machine_interface::find_by_mac_address(&mut *txn, mac_address).await?;
+            let mi =
+                db::machine_interface::find_by_mac_address(&mut txn.as_db_reader(), mac_address)
+                    .await?;
             if let Some(interface) = mi.first() {
                 db::machine_interface::associate_interface_with_machine(
                     &interface.id,
@@ -736,7 +740,9 @@ impl SiteExplorer {
 
         let mac_addresses = report.all_mac_addresses();
         for mac_address in mac_addresses {
-            let mi = db::machine_interface::find_by_mac_address(&mut *txn, mac_address).await?;
+            let mi =
+                db::machine_interface::find_by_mac_address(&mut txn.as_db_reader(), mac_address)
+                    .await?;
             if let Some(interface) = mi.first() {
                 db::machine_interface::associate_interface_with_machine(
                     &interface.id,
@@ -748,7 +754,7 @@ impl SiteExplorer {
         }
 
         if let Some(rack_id) = expected_shelf.rack_id {
-            let rack = match db::rack::get(txn.as_mut(), rack_id).await {
+            let rack = match db::rack::get(&mut txn.as_db_reader(), rack_id).await {
                 Ok(rack) => rack,
                 Err(_) => db::rack::create(
                     &mut txn,
@@ -841,7 +847,8 @@ impl SiteExplorer {
             .map_err(|e| CarbideError::InvalidArgument(format!("Invalid MAC address: {}", e)))?;
 
         let interface =
-            db::machine_interface::find_by_mac_address(&mut *txn, host_mac_address).await?;
+            db::machine_interface::find_by_mac_address(&mut txn.as_db_reader(), host_mac_address)
+                .await?;
 
         let (host_nvos_mac_addresses, host_nvos_ip_addresses) =
             if let Some(interface) = interface.first() {
@@ -910,7 +917,9 @@ impl SiteExplorer {
 
         let mac_addresses = explored_endpoint.report.all_mac_addresses();
         for mac_address in mac_addresses {
-            let mi = db::machine_interface::find_by_mac_address(&mut *txn, mac_address).await?;
+            let mi =
+                db::machine_interface::find_by_mac_address(&mut txn.as_db_reader(), mac_address)
+                    .await?;
             if let Some(interface) = mi.first() {
                 db::machine_interface::associate_interface_with_machine(
                     &interface.id,
@@ -1458,9 +1467,9 @@ impl SiteExplorer {
             db::network_segment::list_segment_ids(&mut txn, Some(NetworkSegmentType::Underlay))
                 .await?;
         let interfaces = db::machine_interface::find_all(&mut txn).await?;
-        let explored_endpoints = db::explored_endpoints::find_all(txn.as_pgconn()).await?;
+        let explored_endpoints = db::explored_endpoints::find_all(&mut txn.as_db_reader()).await?;
         let expected_switches = db::expected_switch::find_all(&mut txn).await?;
-        let expected_machines = db::expected_machine::find_all(&mut txn).await?;
+        let expected_machines = db::expected_machine::find_all(&mut txn.as_db_reader()).await?;
         let expected_power_shelves = db::expected_power_shelf::find_all(&mut txn).await?;
 
         let explore_power_shelves_from_static_ip = self
@@ -2231,7 +2240,7 @@ impl SiteExplorer {
         let mut txn = self.txn_begin().await?;
 
         let is_endpoint_in_managed_host =
-            is_endpoint_in_managed_host(bmc_ip_address, txn.as_pgconn()).await?;
+            is_endpoint_in_managed_host(bmc_ip_address, &mut txn.as_db_reader()).await?;
 
         txn.commit().await?;
 
@@ -2351,7 +2360,8 @@ impl SiteExplorer {
     ) -> CarbideResult<MachineInterfaceSnapshot> {
         let mut txn = self.txn_begin().await?;
 
-        let machine_interface = db::machine_interface::find_by_ip(&mut txn, ip_address).await?;
+        let machine_interface =
+            db::machine_interface::find_by_ip(&mut txn.as_db_reader(), ip_address).await?;
 
         txn.commit().await?;
 
@@ -2730,17 +2740,24 @@ pub async fn get_machine_state_by_bmc_ip(
 ) -> Result<String, DatabaseError> {
     let mut txn = Transaction::begin(database_connection).await?;
 
-    let state = match db::machine_topology::find_machine_id_by_bmc_ip(txn.as_pgconn(), bmc_ip)
-        .await?
-    {
-        Some(machine_id) => {
-            match machine::find_one(&mut txn, &machine_id, MachineSearchConfig::default()).await? {
-                Some(machine) => machine.current_state().to_string(),
-                None => String::new(),
+    let state =
+        match db::machine_topology::find_machine_id_by_bmc_ip(&mut txn.as_db_reader(), bmc_ip)
+            .await?
+        {
+            Some(machine_id) => {
+                match machine::find_one(
+                    &mut txn.as_db_reader(),
+                    &machine_id,
+                    MachineSearchConfig::default(),
+                )
+                .await?
+                {
+                    Some(machine) => machine.current_state().to_string(),
+                    None => String::new(),
+                }
             }
-        }
-        None => String::new(),
-    };
+            None => String::new(),
+        };
 
     txn.commit().await?;
 

--- a/crates/api/src/state_controller/common_services.rs
+++ b/crates/api/src/state_controller/common_services.rs
@@ -17,7 +17,7 @@
 
 use std::sync::Arc;
 
-use db::db_read::PgPoolReader;
+use db::db_read::DbReader;
 use libredfish::Redfish;
 use librms::RmsApi;
 use model::machine::Machine;
@@ -36,10 +36,6 @@ use crate::state_controller::state_handler::StateHandlerError;
 pub struct CommonStateHandlerServices {
     /// Postgres database pool
     pub db_pool: PgPool,
-
-    /// Postgres database pool that can be passed directly to read-only db functions without a
-    /// transaction
-    pub db_reader: PgPoolReader,
 
     /// API for interaction with Libredfish
     pub redfish_client_pool: Arc<dyn RedfishClientPool>,
@@ -71,5 +67,9 @@ impl CommonStateHandlerServices {
             .redfish_client_pool
             .create_client_from_machine(machine, &self.db_pool)
             .await?)
+    }
+
+    pub fn db_reader(&self) -> DbReader<'_> {
+        DbReader::from(&self.db_pool)
     }
 }

--- a/crates/api/src/state_controller/dpa_interface/handler.rs
+++ b/crates/api/src/state_controller/dpa_interface/handler.rs
@@ -374,7 +374,7 @@ async fn send_set_vni_command<'a>(
     };
 
     let vni = if needs_vni {
-        match get_dpa_vni(state, &mut services.db_reader).await {
+        match get_dpa_vni(state, &mut services.db_reader()).await {
             Ok(dv) => dv,
             Err(e) => {
                 return Err(StateHandlerError::GenericError(eyre!(

--- a/crates/api/src/state_controller/dpa_interface/io.rs
+++ b/crates/api/src/state_controller/dpa_interface/io.rs
@@ -20,6 +20,7 @@
 use carbide_uuid::dpa_interface::DpaInterfaceId;
 use config_version::{ConfigVersion, Versioned};
 use db::DatabaseError;
+use db::db_read::AsDbReader;
 use model::StateSla;
 use model::controller_outcome::PersistentStateHandlerOutcome;
 use model::dpa_interface::{self, DpaInterface, DpaInterfaceControllerState};
@@ -50,7 +51,7 @@ impl StateControllerIO for DpaInterfaceStateControllerIO {
         &self,
         txn: &mut PgConnection,
     ) -> Result<Vec<Self::ObjectId>, DatabaseError> {
-        db::dpa_interface::find_ids(txn).await
+        db::dpa_interface::find_ids(&mut txn.as_db_reader()).await
     }
 
     /// Loads a state snapshot from the database
@@ -59,7 +60,9 @@ impl StateControllerIO for DpaInterfaceStateControllerIO {
         txn: &mut PgConnection,
         interface_id: &Self::ObjectId,
     ) -> Result<Option<Self::State>, DatabaseError> {
-        let mut interfaces = db::dpa_interface::find_by_ids(txn, &[*interface_id], false).await?;
+        let mut interfaces =
+            db::dpa_interface::find_by_ids(&mut txn.as_db_reader(), &[*interface_id], false)
+                .await?;
         if interfaces.is_empty() {
             tracing::debug!("DPA load_object_state empty ifid: {:#?}", interface_id);
             return Ok(None);

--- a/crates/api/src/state_controller/ib_partition/handler.rs
+++ b/crates/api/src/state_controller/ib_partition/handler.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 use carbide_uuid::infiniband::IBPartitionId;
+use db::db_read::AsDbReader;
 use db::ib_partition::{IBPartition, IBPartitionStatus};
 use model::ib::{DEFAULT_IB_FABRIC_NAME, IBQosConf};
 use model::ib_partition::IBPartitionControllerState;
@@ -97,7 +98,7 @@ impl StateHandler for IBPartitionStateHandler {
                                     let mut txn = ctx.services.db_pool.begin().await?;
                                     let instance_count =
                                         db::ib_partition::count_instances_referencing_partition(
-                                            txn.as_mut(),
+                                            &mut txn.as_db_reader(),
                                             *partition_id,
                                         )
                                         .await?;

--- a/crates/api/src/state_controller/ib_partition/io.rs
+++ b/crates/api/src/state_controller/ib_partition/io.rs
@@ -19,6 +19,7 @@
 
 use carbide_uuid::infiniband::IBPartitionId;
 use config_version::{ConfigVersion, Versioned};
+use db::db_read::AsDbReader;
 use db::ib_partition::IBPartition;
 use db::{self, DatabaseError, ObjectColumnFilter};
 use model::StateSla;
@@ -61,7 +62,7 @@ impl StateControllerIO for IBPartitionStateControllerIO {
         partition_id: &Self::ObjectId,
     ) -> Result<Option<Self::State>, DatabaseError> {
         let mut partitions = db::ib_partition::find_by(
-            txn,
+            &mut txn.as_db_reader(),
             ObjectColumnFilter::One(db::ib_partition::IdColumn, partition_id),
         )
         .await?;

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -27,7 +27,7 @@ use carbide_uuid::machine::MachineId;
 use chrono::{DateTime, Duration, Utc};
 use config_version::{ConfigVersion, Versioned};
 use db::DatabaseError;
-use db::db_read::PgPoolReader;
+use db::db_read::DbReader;
 use eyre::eyre;
 use forge_secrets::credentials::{BmcCredentialType, CredentialKey, CredentialReader, Credentials};
 use futures::TryFutureExt;
@@ -718,7 +718,7 @@ impl MachineStateHandler {
                 let expected_machine = if let Some(bmc_mac) = mh_snapshot.host_snapshot.bmc_info.mac
                 {
                     db::expected_machine::find_by_bmc_mac_address(
-                        &mut ctx.services.db_reader,
+                        &mut ctx.services.db_reader(),
                         bmc_mac,
                     )
                     .await?
@@ -821,8 +821,11 @@ impl MachineStateHandler {
 
                 let bmc_mac = mh_snapshot.host_snapshot.bmc_info.mac;
                 let expected_machine = if let Some(mac) = bmc_mac {
-                    db::expected_machine::find_by_bmc_mac_address(&mut ctx.services.db_reader, mac)
-                        .await?
+                    db::expected_machine::find_by_bmc_mac_address(
+                        &mut ctx.services.db_reader(),
+                        mac,
+                    )
+                    .await?
                 } else {
                     None
                 };
@@ -1090,7 +1093,7 @@ impl MachineStateHandler {
                 if self.host_handler.host_handler_params.attestation_enabled
                     && check_if_should_redo_measurements(
                         &mh_snapshot.host_snapshot.id,
-                        &mut ctx.services.db_reader,
+                        &mut ctx.services.db_reader(),
                     )
                     .await?
                 {
@@ -1559,7 +1562,7 @@ impl MachineStateHandler {
                     | FailureCause::MeasurementsCAValidationFailed { .. } => {
                         if check_if_not_in_original_failure_cause_anymore(
                             &mh_snapshot.host_snapshot.id,
-                            &mut ctx.services.db_reader,
+                            &mut ctx.services.db_reader(),
                             &details.cause,
                             self.host_handler.host_handler_params.attestation_enabled,
                         )
@@ -1668,7 +1671,7 @@ impl MachineStateHandler {
             ManagedHostState::Measuring { measuring_state } => handle_measuring_state(
                 measuring_state,
                 &mh_snapshot.host_snapshot.id,
-                &mut ctx.services.db_reader,
+                &mut ctx.services.db_reader(),
                 self.host_handler.host_handler_params.attestation_enabled,
             )
             .await
@@ -1676,7 +1679,7 @@ impl MachineStateHandler {
             ManagedHostState::PostAssignedMeasuring { measuring_state } => handle_measuring_state(
                 measuring_state,
                 &mh_snapshot.host_snapshot.id,
-                &mut ctx.services.db_reader,
+                &mut ctx.services.db_reader(),
                 self.host_handler.host_handler_params.attestation_enabled,
             )
             .await
@@ -2605,7 +2608,7 @@ fn map_post_assigned_measuring_outcome_to_state_handler_outcome(
 // if everything is ok in general
 async fn check_if_should_redo_measurements(
     machine_id: &MachineId,
-    txn: &mut PgPoolReader,
+    txn: &mut DbReader<'_>,
 ) -> Result<bool, StateHandlerError> {
     let (machine_state, ek_cert_verification_status) =
         get_measuring_prerequisites(machine_id, txn).await?;
@@ -2621,7 +2624,7 @@ async fn check_if_should_redo_measurements(
 
 async fn check_if_not_in_original_failure_cause_anymore(
     machine_id: &MachineId,
-    txn: &mut PgPoolReader,
+    txn: &mut DbReader<'_>,
     original_failure_cause: &FailureCause,
     attestation_enabled: bool,
 ) -> Result<bool, StateHandlerError> {
@@ -4965,7 +4968,7 @@ impl StateHandler for HostMachineStateHandler {
                     match handle_measuring_state(
                         measuring_state,
                         &mh_snapshot.host_snapshot.id,
-                        &mut ctx.services.db_reader,
+                        &mut ctx.services.db_reader(),
                         self.host_handler_params.attestation_enabled,
                     )
                     .await
@@ -5330,7 +5333,7 @@ impl StateHandler for InstanceStateHandler {
 
                     let network_segments_are_ready =
                         db::network_segment::are_network_segments_ready(
-                            &mut ctx.services.db_reader,
+                            &mut ctx.services.db_reader(),
                             &network_segment_ids_with_vpc,
                         )
                         .await?;
@@ -6206,7 +6209,7 @@ async fn handle_instance_network_config_update_request(
             // No network segment is configured with vpc_prefix_id.
             if !network_segment_ids_with_vpc.is_empty() {
                 let network_segments_are_ready = db::network_segment::are_network_segments_ready(
-                    &mut ctx.services.db_reader,
+                    &mut ctx.services.db_reader(),
                     &network_segment_ids_with_vpc,
                 )
                 .await?;
@@ -8790,7 +8793,7 @@ async fn needs_ipmi_restart(
         .ip_addr()
         .map_err(StateHandlerError::GenericError)?;
     let endpoints =
-        db::explored_endpoints::find_by_ips(&mut ctx.services.db_reader, vec![addr]).await?;
+        db::explored_endpoints::find_by_ips(&mut ctx.services.db_reader(), vec![addr]).await?;
     let Some(ep) = endpoints.first() else {
         return Ok(false);
     };
@@ -8883,7 +8886,7 @@ pub async fn find_explored_refreshed_endpoint(
         .map_err(StateHandlerError::GenericError)?;
 
     let endpoint =
-        db::explored_endpoints::find_by_ips(&mut ctx.services.db_reader, vec![addr]).await?;
+        db::explored_endpoints::find_by_ips(&mut ctx.services.db_reader(), vec![addr]).await?;
     let endpoint = endpoint
         .into_iter()
         .next()

--- a/crates/api/src/state_controller/machine/handler/machine_validation.rs
+++ b/crates/api/src/state_controller/machine/handler/machine_validation.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use db::db_read::AsDbReader;
 use libredfish::SystemPowerControl;
 use model::machine::{
     FailureCause, MachineState, MachineValidatingState, ManagedHostState, ManagedHostStateSnapshot,
@@ -42,7 +43,7 @@ pub(crate) async fn handle_machine_validation_state(
             // Handle reboot host case
             handler_host_power_control(mh_snapshot, ctx, SystemPowerControl::ForceRestart).await?;
             let machine_validation =
-                db::machine_validation::find_by_id(&mut ctx.services.db_reader, validation_id)
+                db::machine_validation::find_by_id(&mut ctx.services.db_reader(), validation_id)
                     .await
                     .map_err(|err| StateHandlerError::GenericError(err.into()))?;
 
@@ -100,9 +101,10 @@ pub(crate) async fn handle_machine_validation_state(
                     },
                 )
                 .await?;
-                let machine_validation = db::machine_validation::find_by_id(txn.as_mut(), id)
-                    .await
-                    .map_err(|err| StateHandlerError::GenericError(err.into()))?;
+                let machine_validation =
+                    db::machine_validation::find_by_id(&mut txn.as_db_reader(), id)
+                        .await
+                        .map_err(|err| StateHandlerError::GenericError(err.into()))?;
 
                 *ctx.metrics
                     .last_machine_validation_list
@@ -131,7 +133,7 @@ pub(crate) async fn handle_machine_validation_state(
                         mh_snapshot.host_snapshot.id
                     );
                     let machine_validation =
-                        db::machine_validation::find_by_id(&mut ctx.services.db_reader, id)
+                        db::machine_validation::find_by_id(&mut ctx.services.db_reader(), id)
                             .await
                             .map_err(|err| StateHandlerError::GenericError(err.into()))?;
                     let status = machine_validation.status.clone().unwrap_or_default();
@@ -178,7 +180,7 @@ pub(crate) async fn handle_machine_validation_requested(
         }
         let machine_validation =
             match db::machine_validation::find_active_machine_validation_by_machine_id(
-                txn.as_mut(),
+                &mut txn.as_db_reader(),
                 &mh_snapshot.host_snapshot.id,
             )
             .await

--- a/crates/api/src/state_controller/machine/handler/sku.rs
+++ b/crates/api/src/state_controller/machine/handler/sku.rs
@@ -16,6 +16,7 @@
  */
 
 use chrono::Utc;
+use db::db_read::AsDbReader;
 use health_report::HealthReport;
 use model::machine::{
     BomValidating, BomValidatingContext, MachineState, MachineValidatingState, ManagedHostState,
@@ -91,8 +92,11 @@ async fn match_sku_for_machine(
             })
         })
     {
-        let machine_sku =
-            db::sku::generate_sku_from_machine(&mut *txn, &mh_snapshot.host_snapshot.id).await?;
+        let machine_sku = db::sku::generate_sku_from_machine(
+            &mut txn.as_db_reader(),
+            &mh_snapshot.host_snapshot.id,
+        )
+        .await?;
         let matching_sku = db::sku::find_matching(txn, &machine_sku).await?;
         if matching_sku.is_none() {
             // only update the last attempt if there is no match
@@ -128,7 +132,7 @@ async fn generate_missing_sku_for_machine(
     };
 
     // if there's no expected machine, no SKU in it, or the SKU doesn't match what's assigned to the machine, don't generate a SKU
-    if db::expected_machine::find_by_bmc_mac_address(&mut *txn, bmc_mac_address)
+    if db::expected_machine::find_by_bmc_mac_address(&mut txn.as_db_reader(), bmc_mac_address)
         .await
         .ok()
         .flatten()
@@ -162,7 +166,7 @@ async fn generate_missing_sku_for_machine(
         );
     } else {
         let generated_sku = match db::sku::generate_sku_from_machine(
-            &mut *txn,
+            &mut txn.as_db_reader(),
             &mh_snapshot.host_snapshot.id,
         )
         .await
@@ -556,7 +560,7 @@ pub(crate) async fn handle_bom_validation_state(
                 };
 
                 let actual_sku = db::sku::generate_sku_from_machine_at_version(
-                    txn.as_mut(),
+                    &mut txn.as_db_reader(),
                     &mh_snapshot.host_snapshot.id,
                     expected_sku.schema_version,
                 )

--- a/crates/api/src/state_controller/machine/io.rs
+++ b/crates/api/src/state_controller/machine/io.rs
@@ -19,6 +19,7 @@
 
 use carbide_uuid::machine::MachineId;
 use config_version::{ConfigVersion, Versioned};
+use db::db_read::AsDbReader;
 use db::{self, DatabaseError};
 use model::StateSla;
 use model::controller_outcome::PersistentStateHandlerOutcome;
@@ -60,7 +61,7 @@ impl StateControllerIO for MachineStateControllerIO {
         txn: &mut PgConnection,
     ) -> Result<Vec<Self::ObjectId>, DatabaseError> {
         Ok(db::machine::find_machine_ids(
-            txn,
+            &mut txn.as_db_reader(),
             MachineSearchConfig {
                 include_predicted_host: true,
                 ..Default::default()
@@ -89,7 +90,7 @@ impl StateControllerIO for MachineStateControllerIO {
         }
 
         let mut retstate = db::managed_host::load_snapshot(
-            txn,
+            &mut txn.as_db_reader(),
             machine_id,
             model::machine::LoadSnapshotOptions {
                 include_history: false,
@@ -100,7 +101,8 @@ impl StateControllerIO for MachineStateControllerIO {
         .await?;
 
         if let Some(retstate) = retstate.as_mut() {
-            let dpa_snapshots = db::dpa_interface::find_by_machine_id(txn, *machine_id).await?;
+            let dpa_snapshots =
+                db::dpa_interface::find_by_machine_id(&mut txn.as_db_reader(), *machine_id).await?;
             retstate.dpa_interface_snapshots = dpa_snapshots;
         };
 

--- a/crates/api/src/state_controller/machine/mod.rs
+++ b/crates/api/src/state_controller/machine/mod.rs
@@ -58,13 +58,10 @@ pub fn extra_logfmt_logging_fields() -> Vec<String> {
 /// ComposedState type of thing where I can join across the journal
 /// and bundle to do a single query + return a single ComposedState
 /// that has everything I want.
-async fn get_measurement_failure_cause<DB>(
-    db: &mut DB,
+async fn get_measurement_failure_cause(
+    db: &mut DbReader<'_>,
     machine_id: &MachineId,
-) -> Result<FailureCause, StateHandlerError>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+) -> Result<FailureCause, StateHandlerError> {
     let (_, ek_cert_status) = get_measuring_prerequisites(machine_id, &mut *db).await?;
     if !ek_cert_status.signing_ca_found {
         return Ok(FailureCause::MeasurementsCAValidationFailed {
@@ -107,13 +104,10 @@ pub enum MeasuringOutcome {
     Unsuccessful((FailureDetails, MachineId)),
 }
 
-async fn get_measuring_prerequisites<DB>(
+async fn get_measuring_prerequisites(
     machine_id: &MachineId,
-    db_reader: &mut DB,
-) -> Result<(MeasurementMachineState, EkCertVerificationStatus), StateHandlerError>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+    db_reader: &mut DbReader<'_>,
+) -> Result<(MeasurementMachineState, EkCertVerificationStatus), StateHandlerError> {
     let machine_state = get_measurement_machine_state(&mut *db_reader, *machine_id)
         .await
         .map_err(StateHandlerError::DBError)?;
@@ -136,15 +130,12 @@ where
     Ok((machine_state, ek_cert_verification_status))
 }
 
-pub(crate) async fn handle_measuring_state<DB>(
+pub(crate) async fn handle_measuring_state(
     measuring_state: &MeasuringState,
     machine_id: &MachineId,
-    db: &mut DB,
+    db: &mut DbReader<'_>,
     attestation_enabled: bool,
-) -> Result<MeasuringOutcome, StateHandlerError>
-where
-    for<'db> &'db mut DB: DbReader<'db>,
-{
+) -> Result<MeasuringOutcome, StateHandlerError> {
     if !attestation_enabled {
         return Ok(MeasuringOutcome::PassedOk);
     }

--- a/crates/api/src/state_controller/network_segment/io.rs
+++ b/crates/api/src/state_controller/network_segment/io.rs
@@ -19,6 +19,7 @@
 
 use carbide_uuid::network::NetworkSegmentId;
 use config_version::{ConfigVersion, Versioned};
+use db::db_read::AsDbReader;
 use db::{self, DatabaseError, ObjectColumnFilter};
 use model::StateSla;
 use model::controller_outcome::PersistentStateHandlerOutcome;
@@ -60,7 +61,7 @@ impl StateControllerIO for NetworkSegmentStateControllerIO {
         segment_id: &Self::ObjectId,
     ) -> Result<Option<Self::State>, DatabaseError> {
         let mut segments = db::network_segment::find_by(
-            txn,
+            &mut txn.as_db_reader(),
             ObjectColumnFilter::One(db::network_segment::IdColumn, segment_id),
             model::network_segment::NetworkSegmentSearchConfig {
                 include_num_free_ips: true,

--- a/crates/api/src/state_controller/rack/handler.rs
+++ b/crates/api/src/state_controller/rack/handler.rs
@@ -18,6 +18,7 @@
 use std::cmp::Ordering;
 
 use carbide_uuid::rack::RackId;
+use db::db_read::AsDbReader;
 use db::{expected_machine as db_expected_machine, rack as db_rack};
 use model::machine::{LoadSnapshotOptions, ManagedHostState};
 use model::rack::{
@@ -138,7 +139,7 @@ impl StateHandler for RackStateHandler {
                 let mut txn = ctx.services.db_pool.begin().await?;
                 for machine_id in config.compute_trays.iter() {
                     let mh_snapshot = db::managed_host::load_snapshot(
-                        txn.as_mut(),
+                        &mut txn.as_db_reader(),
                         machine_id,
                         LoadSnapshotOptions {
                             include_history: false,

--- a/crates/api/src/state_controller/rack/io.rs
+++ b/crates/api/src/state_controller/rack/io.rs
@@ -19,6 +19,7 @@
 
 use carbide_uuid::rack::RackId;
 use config_version::{ConfigVersion, Versioned};
+use db::db_read::AsDbReader;
 use db::rack::IdColumn;
 use db::{DatabaseError, ObjectColumnFilter, rack as db_rack};
 use model::StateSla;
@@ -51,7 +52,7 @@ impl StateControllerIO for RackStateControllerIO {
         &self,
         txn: &mut PgConnection,
     ) -> Result<Vec<Self::ObjectId>, DatabaseError> {
-        db_rack::list(txn)
+        db_rack::list(&mut txn.as_db_reader())
             .await
             .map(|racks| racks.into_iter().map(|r| r.id).collect())
     }

--- a/crates/api/src/tests/common/api_fixtures/dpu.rs
+++ b/crates/api/src/tests/common/api_fixtures/dpu.rs
@@ -349,9 +349,13 @@ pub async fn dpu_discover_machine(
 
 // Convenience method for the tests to get a machine's loopback IP
 pub async fn loopback_ip(txn: &mut PgConnection, dpu_machine_id: &MachineId) -> IpAddr {
-    let dpu = db::machine::find_one(txn, dpu_machine_id, MachineSearchConfig::default())
-        .await
-        .unwrap()
-        .unwrap();
+    let dpu = db::machine::find_one(
+        &mut txn.into(),
+        dpu_machine_id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
     dpu.network_config.loopback_ip.unwrap()
 }

--- a/crates/api/src/tests/common/api_fixtures/instance.rs
+++ b/crates/api/src/tests/common/api_fixtures/instance.rs
@@ -22,6 +22,7 @@ use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::network::NetworkSegmentId;
 use carbide_uuid::vpc::VpcPrefixId;
+use db::db_read::AsDbReader;
 use model::instance::config::network::DeviceLocator;
 use model::instance::config::nvlink::InstanceNvLinkConfig;
 use model::instance::snapshot::InstanceSnapshot;
@@ -154,7 +155,7 @@ type Txn<'a> = sqlx::Transaction<'a, sqlx::Postgres>;
 
 impl<'a, 'b> TestInstance<'a, 'b> {
     pub async fn db_instance(&self, txn: &mut Txn<'_>) -> InstanceSnapshot {
-        db::instance::find_by_id(txn.as_mut(), self.id)
+        db::instance::find_by_id(&mut txn.as_db_reader(), self.id)
             .await
             .unwrap()
             .unwrap()

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -33,7 +33,7 @@ use carbide_uuid::machine::MachineId;
 use carbide_uuid::network::NetworkSegmentId;
 use carbide_uuid::vpc::VpcId;
 use chrono::{DateTime, Duration, Utc};
-use db::db_read::PgPoolReader;
+use db::db_read::{AsDbReader, DbReader};
 use db::instance_type::create as create_instance_type;
 use db::network_security_group::create as create_network_security_group;
 use db::work_lock_manager;
@@ -360,7 +360,6 @@ impl TestEnv {
     pub fn state_handler_services(&self) -> CommonStateHandlerServices {
         CommonStateHandlerServices {
             db_pool: self.pool.clone(),
-            db_reader: self.pool.clone().into(),
             redfish_client_pool: self.redfish_sim.clone(),
             ib_fabric_manager: self.ib_fabric_manager.clone(),
             ib_pools: self.common_pools.infiniband.clone(),
@@ -507,7 +506,7 @@ impl TestEnv {
             let mut txn: sqlx::Transaction<'static, sqlx::Postgres> =
                 self.pool.begin().await.unwrap();
             let machine = db::machine::find_one(
-                txn.as_mut(),
+                &mut txn.as_db_reader(),
                 host_machine_id,
                 model::machine::machine_search_config::MachineSearchConfig::default(),
             )
@@ -521,7 +520,7 @@ impl TestEnv {
         }
         let mut txn = self.pool.begin().await.unwrap();
         let machine = db::machine::find_one(
-            txn.as_mut(),
+            &mut txn.as_db_reader(),
             host_machine_id,
             model::machine::machine_search_config::MachineSearchConfig::default(),
         )
@@ -899,8 +898,8 @@ impl TestEnv {
             .unwrap();
     }
 
-    pub fn db_reader(&self) -> PgPoolReader {
-        self.pool.clone().into()
+    pub fn db_reader(&self) -> DbReader<'_> {
+        DbReader::from(&self.pool)
     }
 }
 
@@ -1497,7 +1496,6 @@ pub async fn create_test_env_with_overrides(
 
     let handler_services = Arc::new(CommonStateHandlerServices {
         db_pool: db_pool.clone(),
-        db_reader: db_pool.clone().into(),
         redfish_client_pool: redfish_sim.clone(),
         ib_fabric_manager: ib_fabric_manager.clone(),
         ib_pools: common_pools.infiniband.clone(),
@@ -2576,7 +2574,7 @@ pub async fn update_machine_validation_run(
 }
 
 pub async fn get_vpc_fixture_id(env: &TestEnv) -> VpcId {
-    db::vpc::find_by_name(&env.pool, "test vpc 1")
+    db::vpc::find_by_name(&mut env.db_reader(), "test vpc 1")
         .await
         .unwrap()
         .into_iter()

--- a/crates/api/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/site_explorer.rs
@@ -23,6 +23,7 @@ use carbide_uuid::machine::MachineId;
 use carbide_uuid::power_shelf::{PowerShelfId, PowerShelfIdSource, PowerShelfType};
 use carbide_uuid::rack::RackId;
 use carbide_uuid::switch::{SwitchId, SwitchIdSource, SwitchType};
+use db::db_read::AsDbReader;
 use db::machine_interface::find_by_mac_address;
 use db::{DatabaseError, power_shelf as db_power_shelf, rack as db_rack, switch as db_switch};
 use forge_secrets::credentials::{BmcCredentialType, CredentialKey, Credentials};
@@ -371,9 +372,10 @@ impl<'a> MockExploredHost<'a> {
 
         //run scout discovery for dpu(s)
         for dpu in self.managed_host.dpus.clone() {
-            let machine_interfaces = find_by_mac_address(txn.as_mut(), dpu.oob_mac_address)
-                .await
-                .unwrap();
+            let machine_interfaces =
+                find_by_mac_address(&mut txn.as_db_reader(), dpu.oob_mac_address)
+                    .await
+                    .unwrap();
             let primary_interface = machine_interfaces
                 .iter()
                 .find(|interface| interface.primary_interface)
@@ -453,9 +455,10 @@ impl<'a> MockExploredHost<'a> {
 
         //run scout discovery for dpu(s)
         for dpu in self.managed_host.dpus.clone() {
-            let machine_interfaces = find_by_mac_address(txn.as_mut(), dpu.oob_mac_address)
-                .await
-                .unwrap();
+            let machine_interfaces =
+                find_by_mac_address(&mut txn.as_db_reader(), dpu.oob_mac_address)
+                    .await
+                    .unwrap();
             let primary_interface = machine_interfaces
                 .iter()
                 .find(|interface| interface.primary_interface)
@@ -557,9 +560,10 @@ impl<'a> MockExploredHost<'a> {
 
         //run scout discovery for dpu(s)
         for dpu in self.managed_host.dpus.clone() {
-            let machine_interfaces = find_by_mac_address(txn.as_mut(), dpu.oob_mac_address)
-                .await
-                .unwrap();
+            let machine_interfaces =
+                find_by_mac_address(&mut txn.as_db_reader(), dpu.oob_mac_address)
+                    .await
+                    .unwrap();
             let primary_interface = machine_interfaces
                 .iter()
                 .find(|interface| interface.primary_interface)
@@ -990,7 +994,7 @@ impl<'a> MockExploredHost<'a> {
 
                 let mut txn = self.test_env.pool.begin().await.unwrap();
                 let machine = db::machine::find_one(
-                    txn.as_mut(),
+                    &mut txn.as_db_reader(),
                     &self.dpu_machine_ids[&0],
                     model::machine::machine_search_config::MachineSearchConfig::default(),
                 )
@@ -1117,7 +1121,7 @@ impl<'a> MockExploredHost<'a> {
 
             let mut txn = self.test_env.pool.begin().await.unwrap();
             tracing::info!("generating sku");
-            let sku = db::sku::generate_sku_from_machine(txn.as_mut(), host_machine_id)
+            let sku = db::sku::generate_sku_from_machine(&mut txn.as_db_reader(), host_machine_id)
                 .await
                 .unwrap();
             tracing::info!("creating sku: {}", sku.id);

--- a/crates/api/src/tests/common/api_fixtures/test_machine/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/test_machine/mod.rs
@@ -19,6 +19,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use carbide_uuid::machine::MachineId;
+use db::db_read::AsDbReader;
 use model::machine::{Machine, ManagedHostState};
 use rpc::forge::forge_server::Forge;
 use tonic::Request;
@@ -63,7 +64,7 @@ impl TestMachine {
     }
 
     pub async fn db_machine(&self, txn: &mut Txn<'_>) -> Machine {
-        db::machine::find_one(txn.as_mut(), &self.id, Default::default())
+        db::machine::find_one(&mut txn.as_db_reader(), &self.id, Default::default())
             .await
             .unwrap()
             .unwrap()

--- a/crates/api/src/tests/common/api_fixtures/test_managed_host.rs
+++ b/crates/api/src/tests/common/api_fixtures/test_managed_host.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::MachineId;
-use db::db_read::PgPoolReader;
+use db::db_read::{AsDbReader, DbReader};
 use model::machine::{
     InstanceState, LoadSnapshotOptions, Machine, ManagedHostState, ManagedHostStateSnapshot,
     ReprovisionState,
@@ -61,7 +61,7 @@ impl TestManagedHost {
     }
 
     pub async fn snapshot(&self, txn: &mut Txn<'_>) -> ManagedHostStateSnapshot {
-        db::managed_host::load_snapshot(txn.as_mut(), &self.id, Default::default())
+        db::managed_host::load_snapshot(&mut txn.as_db_reader(), &self.id, Default::default())
             .await
             .unwrap()
             .unwrap()
@@ -140,7 +140,7 @@ impl TestManagedHost {
 pub(crate) trait TestManagedHostSnapshots {
     async fn snapshots(
         &self,
-        txn: &mut PgPoolReader,
+        txn: &mut DbReader<'_>,
         load_options: LoadSnapshotOptions,
     ) -> HashMap<MachineId, ManagedHostStateSnapshot>;
 }
@@ -148,7 +148,7 @@ pub(crate) trait TestManagedHostSnapshots {
 impl TestManagedHostSnapshots for Vec<TestManagedHost> {
     async fn snapshots(
         &self,
-        txn: &mut PgPoolReader,
+        txn: &mut DbReader<'_>,
         load_options: LoadSnapshotOptions,
     ) -> HashMap<MachineId, ManagedHostStateSnapshot> {
         db::managed_host::load_by_machine_ids(

--- a/crates/api/src/tests/create_domain.rs
+++ b/crates/api/src/tests/create_domain.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 use db::ObjectColumnFilter;
+use db::db_read::AsDbReader;
 use model::dns::NewDomain;
 
 use crate::DatabaseError;
@@ -37,7 +38,7 @@ async fn create_delete_valid_domain(pool: sqlx::PgPool) {
     assert!(delete_result.is_ok());
 
     let domains = db::dns::domain::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::<db::dns::domain::IdColumn>::All,
     )
     .await
@@ -100,7 +101,7 @@ async fn find_domain(pool: sqlx::PgPool) {
         .expect("Unable to create transaction on database pool");
 
     let domains = db::dns::domain::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::<db::dns::domain::IdColumn>::All,
     )
     .await

--- a/crates/api/src/tests/dpf/reprovisioning.rs
+++ b/crates/api/src/tests/dpf/reprovisioning.rs
@@ -27,6 +27,7 @@ use std::time::Duration;
 
 use carbide_dpf::DpuPhase;
 use carbide_uuid::machine::MachineId;
+use db::db_read::AsDbReader;
 use model::machine::{
     DpfState, DpuReprovisionStates, InstanceState, ManagedHostState, ReprovisionState,
 };
@@ -149,7 +150,7 @@ async fn dpu_device_names(pool: &sqlx::PgPool, mh: &TestManagedHost) -> HashSet<
     let mut txn = pool.begin().await.unwrap();
     let mut names = HashSet::new();
     for dpu_id in &mh.dpu_ids {
-        let dpu = db::machine::find_one(txn.as_mut(), dpu_id, Default::default())
+        let dpu = db::machine::find_one(&mut txn.as_db_reader(), dpu_id, Default::default())
             .await
             .unwrap()
             .unwrap();

--- a/crates/api/src/tests/dpu_machine_update.rs
+++ b/crates/api/src/tests/dpu_machine_update.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use carbide_uuid::machine::MachineId;
 use common::api_fixtures::{create_managed_host, create_managed_host_multi_dpu, create_test_env};
 use db::DatabaseError;
+use db::db_read::AsDbReader;
 use model::dpu_machine_update::DpuMachineUpdate;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::network::MachineNetworkStatusObservation;
@@ -83,7 +84,7 @@ async fn create_machines(
 pub async fn get_all_snapshots(test_env: &TestEnv) -> HashMap<MachineId, ManagedHostStateSnapshot> {
     let mut txn = test_env.pool.begin().await.unwrap();
     let machine_ids = db::machine::find_machine_ids(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         MachineSearchConfig {
             include_predicted_host: true,
             ..Default::default()
@@ -93,7 +94,7 @@ pub async fn get_all_snapshots(test_env: &TestEnv) -> HashMap<MachineId, Managed
     .unwrap();
 
     db::managed_host::load_by_machine_ids(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &machine_ids,
         LoadSnapshotOptions {
             include_history: false,
@@ -255,7 +256,7 @@ async fn test_find_available_outdated_dpus_multidpu(
     }
 
     let snapshots = db::managed_host::load_by_machine_ids(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &[mh.host().id],
         LoadSnapshotOptions {
             include_history: false,
@@ -301,7 +302,7 @@ async fn test_find_available_outdated_dpus_multidpu_one_under_reprov(
 
     let mut txn = env.pool.begin().await?;
     let snapshots = db::managed_host::load_by_machine_ids(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &[mh.host().id],
         LoadSnapshotOptions {
             include_history: false,
@@ -364,7 +365,7 @@ async fn test_find_available_outdated_dpus_multidpu_both_under_reprov(
 
     let mut txn = env.pool.begin().await?;
     let snapshots = db::managed_host::load_by_machine_ids(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &[mh.host().id],
         LoadSnapshotOptions {
             include_history: false,

--- a/crates/api/src/tests/expected_machine.rs
+++ b/crates/api/src/tests/expected_machine.rs
@@ -17,6 +17,7 @@
 use std::default::Default;
 
 use common::api_fixtures::create_test_env;
+use db::db_read::AsDbReader;
 use db::{self};
 use mac_address::MacAddress;
 use model::expected_machine::{ExpectedMachine, ExpectedMachineData};
@@ -34,7 +35,7 @@ use crate::{CarbideError, DatabaseError};
 async fn get_expected_machine_1(txn: &mut PgConnection) -> Option<ExpectedMachine> {
     let fixture_mac_address = "0a:0b:0c:0d:0e:0f".parse().unwrap();
 
-    db::expected_machine::find_by_bmc_mac_address(txn, fixture_mac_address)
+    db::expected_machine::find_by_bmc_mac_address(&mut txn.as_db_reader(), fixture_mac_address)
         .await
         .unwrap()
 }
@@ -862,22 +863,31 @@ async fn test_with_dpu_serial_numbers(
         .await
         .expect("unable to create transaction on database pool");
 
-    let em0 = db::expected_machine::find_by_bmc_mac_address(txn.as_mut(), fixture_mac_address_0)
-        .await
-        .unwrap()
-        .expect("Expected machine not found");
+    let em0 = db::expected_machine::find_by_bmc_mac_address(
+        &mut txn.as_db_reader(),
+        fixture_mac_address_0,
+    )
+    .await
+    .unwrap()
+    .expect("Expected machine not found");
     assert!(em0.data.fallback_dpu_serial_numbers.is_empty());
 
-    let em3 = db::expected_machine::find_by_bmc_mac_address(txn.as_mut(), fixture_mac_address_3)
-        .await
-        .unwrap()
-        .expect("Expected machine not found");
+    let em3 = db::expected_machine::find_by_bmc_mac_address(
+        &mut txn.as_db_reader(),
+        fixture_mac_address_3,
+    )
+    .await
+    .unwrap()
+    .expect("Expected machine not found");
     assert_eq!(em3.data.fallback_dpu_serial_numbers, vec!["dpu_serial1"]);
 
-    let em4 = db::expected_machine::find_by_bmc_mac_address(txn.as_mut(), fixture_mac_address_4)
-        .await
-        .unwrap()
-        .expect("Expected machine not found");
+    let em4 = db::expected_machine::find_by_bmc_mac_address(
+        &mut txn.as_db_reader(),
+        fixture_mac_address_4,
+    )
+    .await
+    .unwrap()
+    .expect("Expected machine not found");
 
     assert_eq!(
         em4.data.fallback_dpu_serial_numbers,

--- a/crates/api/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api/src/tests/host_bmc_firmware_test.rs
@@ -27,6 +27,7 @@ use common::api_fixtures::instance::TestInstance;
 use common::api_fixtures::{
     self, TestEnv, TestManagedHost, create_test_env_with_overrides, get_config,
 };
+use db::db_read::AsDbReader;
 use db::{self, DatabaseError};
 use model::firmware::{Firmware, FirmwareComponent, FirmwareComponentType, FirmwareEntry};
 use model::instance::status::tenant::TenantState;
@@ -94,7 +95,7 @@ async fn test_preingestion_bmc_upgrade(
     mgr.run_single_iteration().await?;
     let mut txn = pool.begin().await.unwrap();
     assert!(
-        db::explored_endpoints::find_preingest_not_waiting_not_error(txn.as_mut())
+        db::explored_endpoints::find_preingest_not_waiting_not_error(&mut txn.as_db_reader())
             .await?
             .is_empty()
     );
@@ -114,7 +115,7 @@ async fn test_preingestion_bmc_upgrade(
     mgr.run_single_iteration().await?;
 
     assert!(
-        db::explored_endpoints::find_preingest_not_waiting_not_error(txn.as_mut())
+        db::explored_endpoints::find_preingest_not_waiting_not_error(&mut txn.as_db_reader())
             .await?
             .is_empty()
     );
@@ -137,7 +138,8 @@ async fn test_preingestion_bmc_upgrade(
     let mut txn = pool.begin().await.unwrap();
 
     let endpoints =
-        db::explored_endpoints::find_preingest_not_waiting_not_error(txn.as_mut()).await?;
+        db::explored_endpoints::find_preingest_not_waiting_not_error(&mut txn.as_db_reader())
+            .await?;
     assert!(endpoints.len() == 1);
     let endpoint = endpoints.first().unwrap();
     match &endpoint.preingestion_state {
@@ -160,7 +162,7 @@ async fn test_preingestion_bmc_upgrade(
     mgr.run_single_iteration().await?;
 
     let mut txn = pool.begin().await.unwrap();
-    let endpoints = db::explored_endpoints::find_all(txn.as_mut()).await?;
+    let endpoints = db::explored_endpoints::find_all(&mut txn.as_db_reader()).await?;
     assert!(endpoints.len() == 1);
     let endpoint = endpoints.first().unwrap();
     if let PreingestionState::UpgradeFirmwareWait {
@@ -177,7 +179,7 @@ async fn test_preingestion_bmc_upgrade(
     mgr.run_single_iteration().await?;
 
     let mut txn = pool.begin().await.unwrap();
-    let endpoints = db::explored_endpoints::find_all(txn.as_mut()).await?;
+    let endpoints = db::explored_endpoints::find_all(&mut txn.as_db_reader()).await?;
     assert!(endpoints.len() == 1);
     let endpoint = endpoints.first().unwrap();
     let PreingestionState::NewFirmwareReportedWait { .. } = endpoint.preingestion_state else {
@@ -189,7 +191,7 @@ async fn test_preingestion_bmc_upgrade(
     mgr.run_single_iteration().await?;
 
     let mut txn = pool.begin().await.unwrap();
-    let endpoints = db::explored_endpoints::find_all(txn.as_mut()).await?;
+    let endpoints = db::explored_endpoints::find_all(&mut txn.as_db_reader()).await?;
     assert!(endpoints.len() == 1);
     let mut endpoint = endpoints.into_iter().next().unwrap();
 
@@ -212,7 +214,7 @@ async fn test_preingestion_bmc_upgrade(
     mgr.run_single_iteration().await?;
 
     let mut txn = pool.begin().await.unwrap();
-    let endpoints = db::explored_endpoints::find_all(txn.as_mut()).await?;
+    let endpoints = db::explored_endpoints::find_all(&mut txn.as_db_reader()).await?;
     assert!(endpoints.len() == 1);
     let endpoint = endpoints.first().unwrap();
     match &endpoint.preingestion_state {
@@ -230,7 +232,7 @@ async fn test_preingestion_bmc_upgrade(
 
     let mut txn = pool.begin().await.unwrap();
     assert!(
-        db::explored_endpoints::find_preingest_not_waiting_not_error(txn.as_mut())
+        db::explored_endpoints::find_preingest_not_waiting_not_error(&mut txn.as_db_reader())
             .await?
             .is_empty()
     );
@@ -284,7 +286,8 @@ async fn test_preingestion_upgrade_script(
 
     let mut txn = pool.begin().await.unwrap();
     let endpoints =
-        db::explored_endpoints::find_preingest_not_waiting_not_error(txn.as_mut()).await?;
+        db::explored_endpoints::find_preingest_not_waiting_not_error(&mut txn.as_db_reader())
+            .await?;
     assert!(endpoints.len() == 1);
     let endpoint = endpoints.first().unwrap();
     match &endpoint.preingestion_state {
@@ -302,7 +305,8 @@ async fn test_preingestion_upgrade_script(
 
     let mut txn = pool.begin().await.unwrap();
     let endpoints =
-        db::explored_endpoints::find_preingest_not_waiting_not_error(txn.as_mut()).await?;
+        db::explored_endpoints::find_preingest_not_waiting_not_error(&mut txn.as_db_reader())
+            .await?;
     assert!(endpoints.len() == 1);
     let endpoint = endpoints.first().unwrap();
     match &endpoint.preingestion_state {
@@ -522,10 +526,12 @@ async fn test_postingestion_bmc_upgrade(pool: sqlx::PgPool) -> CarbideResult<()>
     };
 
     // "Site explorer" pass
-    let endpoints =
-        db::explored_endpoints::find_by_ips(txn.as_mut(), vec![host.bmc_info.ip_addr().unwrap()])
-            .await
-            .unwrap();
+    let endpoints = db::explored_endpoints::find_by_ips(
+        &mut txn.as_db_reader(),
+        vec![host.bmc_info.ip_addr().unwrap()],
+    )
+    .await
+    .unwrap();
     let mut endpoint = endpoints.into_iter().next().unwrap();
     endpoint.report.service[0].inventories[1].version = Some("1.13.2".to_string());
     endpoint
@@ -643,9 +649,11 @@ async fn test_postingestion_bmc_upgrade(pool: sqlx::PgPool) -> CarbideResult<()>
     };
 
     // "Site explorer" pass to indicate that we're at the desired version
-    let endpoints =
-        db::explored_endpoints::find_by_ips(txn.as_mut(), vec![host.bmc_info.ip_addr().unwrap()])
-            .await?;
+    let endpoints = db::explored_endpoints::find_by_ips(
+        &mut txn.as_db_reader(),
+        vec![host.bmc_info.ip_addr().unwrap()],
+    )
+    .await?;
     let mut endpoint = endpoints.into_iter().next().unwrap();
     endpoint.report.service[0].inventories[0].version = Some("6.00.30.00".to_string());
     endpoint
@@ -985,7 +993,8 @@ async fn test_preingestion_preupdate_powercycling(
     // Expect "reset" the BMC
     let mut txn = pool.begin().await.unwrap();
     let endpoints =
-        db::explored_endpoints::find_preingest_not_waiting_not_error(txn.as_mut()).await?;
+        db::explored_endpoints::find_preingest_not_waiting_not_error(&mut txn.as_db_reader())
+            .await?;
     let endpoint = endpoints.first().unwrap();
     match &endpoint.preingestion_state {
         PreingestionState::InitialReset { phase, .. } => {
@@ -1001,7 +1010,8 @@ async fn test_preingestion_preupdate_powercycling(
     // Expect WaitHostBoot
     let mut txn = pool.begin().await.unwrap();
     let endpoints =
-        db::explored_endpoints::find_preingest_not_waiting_not_error(txn.as_mut()).await?;
+        db::explored_endpoints::find_preingest_not_waiting_not_error(&mut txn.as_db_reader())
+            .await?;
     let endpoint = endpoints.first().unwrap();
     match &endpoint.preingestion_state {
         PreingestionState::InitialReset { phase, .. } => {
@@ -1023,7 +1033,8 @@ async fn test_preingestion_preupdate_powercycling(
     // Recheck versions
     let mut txn = pool.begin().await.unwrap();
     let endpoints =
-        db::explored_endpoints::find_preingest_not_waiting_not_error(txn.as_mut()).await?;
+        db::explored_endpoints::find_preingest_not_waiting_not_error(&mut txn.as_db_reader())
+            .await?;
     let endpoint = endpoints.first().unwrap();
     assert_eq!(
         endpoint.preingestion_state,
@@ -1036,7 +1047,8 @@ async fn test_preingestion_preupdate_powercycling(
     let mut txn = pool.begin().await.unwrap();
 
     let endpoints =
-        db::explored_endpoints::find_preingest_not_waiting_not_error(txn.as_mut()).await?;
+        db::explored_endpoints::find_preingest_not_waiting_not_error(&mut txn.as_db_reader())
+            .await?;
     assert!(endpoints.len() == 1);
     let mut endpoint = endpoints.into_iter().next().unwrap();
     match &endpoint.preingestion_state {
@@ -1080,7 +1092,7 @@ async fn test_preingestion_preupdate_powercycling(
         mgr.run_single_iteration().await?;
 
         let mut txn = pool.begin().await.unwrap();
-        let endpoints = db::explored_endpoints::find_all(txn.as_mut()).await?;
+        let endpoints = db::explored_endpoints::find_all(&mut txn.as_db_reader()).await?;
         assert!(endpoints.len() == 1);
         let mut endpoint = endpoints.into_iter().next().unwrap();
         tracing::debug!("State should be {state:?}");
@@ -1117,7 +1129,7 @@ async fn test_preingestion_preupdate_powercycling(
 
     mgr.run_single_iteration().await?;
     let mut txn = pool.begin().await.unwrap();
-    let endpoints = db::explored_endpoints::find_all(txn.as_mut()).await?;
+    let endpoints = db::explored_endpoints::find_all(&mut txn.as_db_reader()).await?;
     txn.commit().await?;
     assert!(endpoints.len() == 1);
     let endpoint = endpoints.first().unwrap();
@@ -1129,7 +1141,7 @@ async fn test_preingestion_preupdate_powercycling(
     mgr.run_single_iteration().await?;
     let mut txn = pool.begin().await.unwrap();
     assert!(
-        db::explored_endpoints::find_preingest_not_waiting_not_error(txn.as_mut())
+        db::explored_endpoints::find_preingest_not_waiting_not_error(&mut txn.as_db_reader())
             .await?
             .is_empty()
     );
@@ -1417,10 +1429,12 @@ async fn test_instance_upgrading_actual_part_2(
     };
 
     // "Site explorer" pass
-    let endpoints =
-        db::explored_endpoints::find_by_ips(txn.as_mut(), vec![host.bmc_info.ip_addr().unwrap()])
-            .await
-            .unwrap();
+    let endpoints = db::explored_endpoints::find_by_ips(
+        &mut txn.as_db_reader(),
+        vec![host.bmc_info.ip_addr().unwrap()],
+    )
+    .await
+    .unwrap();
     let mut endpoint = endpoints.into_iter().next().unwrap();
     endpoint.report.service[0].inventories[1].version = Some("1.13.2".to_string());
     endpoint
@@ -1586,10 +1600,12 @@ async fn test_instance_upgrading_actual_part_2(
     );
 
     // "Site explorer" pass to indicate that we're at the desired version
-    let endpoints =
-        db::explored_endpoints::find_by_ips(txn.as_mut(), vec![host.bmc_info.ip_addr().unwrap()])
-            .await
-            .unwrap();
+    let endpoints = db::explored_endpoints::find_by_ips(
+        &mut txn.as_db_reader(),
+        vec![host.bmc_info.ip_addr().unwrap()],
+    )
+    .await
+    .unwrap();
     let mut endpoint = endpoints.into_iter().next().unwrap();
     endpoint.report.service[0].inventories[0].version = Some("6.00.30.00".to_string());
     endpoint
@@ -2264,7 +2280,8 @@ async fn test_preingestion_time_sync_reset_flow(
 
     let mut txn = pool.begin().await.unwrap();
     let endpoints =
-        db::explored_endpoints::find_preingest_not_waiting_not_error(txn.as_mut()).await?;
+        db::explored_endpoints::find_preingest_not_waiting_not_error(&mut txn.as_db_reader())
+            .await?;
     assert_eq!(endpoints.len(), 1);
     let endpoint = endpoints.first().unwrap();
     match &endpoint.preingestion_state {
@@ -2285,7 +2302,8 @@ async fn test_preingestion_time_sync_reset_flow(
 
     let mut txn = pool.begin().await.unwrap();
     let endpoints =
-        db::explored_endpoints::find_preingest_not_waiting_not_error(txn.as_mut()).await?;
+        db::explored_endpoints::find_preingest_not_waiting_not_error(&mut txn.as_db_reader())
+            .await?;
     let endpoint = endpoints.first().unwrap();
     match &endpoint.preingestion_state {
         PreingestionState::TimeSyncReset { phase, .. } => {
@@ -2367,7 +2385,7 @@ async fn test_preingestion_time_sync_check_error_fails(
     // The test passes if it doesn't panic - the mock BMC should return valid time
     // and the endpoint should proceed to completion or firmware check
     let mut txn = pool.begin().await.unwrap();
-    let endpoints = db::explored_endpoints::find_all(txn.as_mut()).await?;
+    let endpoints = db::explored_endpoints::find_all(&mut txn.as_db_reader()).await?;
     assert_eq!(endpoints.len(), 1);
     // Just verify we didn't fail - we should be in Complete or some valid state
     let endpoint = &endpoints[0];
@@ -2576,10 +2594,12 @@ async fn test_manual_firmware_upgrade_workflow(pool: sqlx::PgPool) -> CarbideRes
     env.run_machine_state_controller_iteration().await;
 
     // "Site explorer" pass
-    let endpoints =
-        db::explored_endpoints::find_by_ips(txn.as_mut(), vec![host.bmc_info.ip_addr().unwrap()])
-            .await
-            .unwrap();
+    let endpoints = db::explored_endpoints::find_by_ips(
+        &mut txn.as_db_reader(),
+        vec![host.bmc_info.ip_addr().unwrap()],
+    )
+    .await
+    .unwrap();
     let mut endpoint = endpoints.into_iter().next().unwrap();
     endpoint.report.service[0].inventories[0].version = Some("6.00.30.00".to_string());
     endpoint.report.service[0].inventories[1].version = Some("1.13.2".to_string());

--- a/crates/api/src/tests/ib_instance.rs
+++ b/crates/api/src/tests/ib_instance.rs
@@ -1130,9 +1130,12 @@ async fn test_count_instances_referencing_partition(pool: sqlx::PgPool) {
     .await;
 
     // No instances yet — count should be 0
-    let count = db::ib_partition::count_instances_referencing_partition(&env.pool, ib_partition_id)
-        .await
-        .unwrap();
+    let count = db::ib_partition::count_instances_referencing_partition(
+        &mut env.db_reader(),
+        ib_partition_id,
+    )
+    .await
+    .unwrap();
     assert_eq!(count, 0, "No instances should reference the partition yet");
 
     // Create a managed host and an instance with two IB interfaces both
@@ -1163,9 +1166,12 @@ async fn test_count_instances_referencing_partition(pool: sqlx::PgPool) {
         create_instance_with_ib_config(&env, &mh, ib_config, segment_id).await;
 
     // Two interfaces reference the partition, but it's one instance — count should be 1
-    let count = db::ib_partition::count_instances_referencing_partition(&env.pool, ib_partition_id)
-        .await
-        .unwrap();
+    let count = db::ib_partition::count_instances_referencing_partition(
+        &mut env.db_reader(),
+        ib_partition_id,
+    )
+    .await
+    .unwrap();
     assert_eq!(
         count, 1,
         "One instance (with two IB interfaces) should be counted once"
@@ -1181,9 +1187,12 @@ async fn test_count_instances_referencing_partition(pool: sqlx::PgPool) {
     txn.commit().await.unwrap();
 
     // After mark_as_deleted, count should still be 1 (instance row still exists)
-    let count = db::ib_partition::count_instances_referencing_partition(&env.pool, ib_partition_id)
-        .await
-        .unwrap();
+    let count = db::ib_partition::count_instances_referencing_partition(
+        &mut env.db_reader(),
+        ib_partition_id,
+    )
+    .await
+    .unwrap();
     assert_eq!(
         count, 1,
         "Instance marked as deleted should still be counted (cleanup not finished)"
@@ -1202,9 +1211,12 @@ async fn test_count_instances_referencing_partition(pool: sqlx::PgPool) {
         .unwrap();
     txn.commit().await.unwrap();
 
-    let count = db::ib_partition::count_instances_referencing_partition(&env.pool, ib_partition_id)
-        .await
-        .unwrap();
+    let count = db::ib_partition::count_instances_referencing_partition(
+        &mut env.db_reader(),
+        ib_partition_id,
+    )
+    .await
+    .unwrap();
     assert_eq!(
         count, 0,
         "No instances should reference the partition after final delete"
@@ -1424,14 +1436,18 @@ async fn test_count_instances_multi_partition_multi_interface(pool: sqlx::PgPool
         create_ib_partition(&env, "partition_b".to_string(), DEFAULT_TENANT.to_string()).await;
 
     // No instances yet — both counts should be 0
-    let count_a =
-        db::ib_partition::count_instances_referencing_partition(&env.pool, partition_a_id)
-            .await
-            .unwrap();
-    let count_b =
-        db::ib_partition::count_instances_referencing_partition(&env.pool, partition_b_id)
-            .await
-            .unwrap();
+    let count_a = db::ib_partition::count_instances_referencing_partition(
+        &mut env.db_reader(),
+        partition_a_id,
+    )
+    .await
+    .unwrap();
+    let count_b = db::ib_partition::count_instances_referencing_partition(
+        &mut env.db_reader(),
+        partition_b_id,
+    )
+    .await
+    .unwrap();
     assert_eq!(count_a, 0, "No instances should reference partition A yet");
     assert_eq!(count_b, 0, "No instances should reference partition B yet");
 
@@ -1486,14 +1502,18 @@ async fn test_count_instances_multi_partition_multi_interface(pool: sqlx::PgPool
 
     // Partition A: referenced by instance 1 (1 iface) and instance 2 (2 ifaces) → count = 2
     // Partition B: referenced by instance 2 only (1 iface) → count = 1
-    let count_a =
-        db::ib_partition::count_instances_referencing_partition(&env.pool, partition_a_id)
-            .await
-            .unwrap();
-    let count_b =
-        db::ib_partition::count_instances_referencing_partition(&env.pool, partition_b_id)
-            .await
-            .unwrap();
+    let count_a = db::ib_partition::count_instances_referencing_partition(
+        &mut env.db_reader(),
+        partition_a_id,
+    )
+    .await
+    .unwrap();
+    let count_b = db::ib_partition::count_instances_referencing_partition(
+        &mut env.db_reader(),
+        partition_b_id,
+    )
+    .await
+    .unwrap();
     assert_eq!(
         count_a, 2,
         "Both instances reference partition A → count should be 2"
@@ -1512,14 +1532,18 @@ async fn test_count_instances_multi_partition_multi_interface(pool: sqlx::PgPool
         .unwrap();
     txn.commit().await.unwrap();
 
-    let count_a =
-        db::ib_partition::count_instances_referencing_partition(&env.pool, partition_a_id)
-            .await
-            .unwrap();
-    let count_b =
-        db::ib_partition::count_instances_referencing_partition(&env.pool, partition_b_id)
-            .await
-            .unwrap();
+    let count_a = db::ib_partition::count_instances_referencing_partition(
+        &mut env.db_reader(),
+        partition_a_id,
+    )
+    .await
+    .unwrap();
+    let count_b = db::ib_partition::count_instances_referencing_partition(
+        &mut env.db_reader(),
+        partition_b_id,
+    )
+    .await
+    .unwrap();
     assert_eq!(
         count_a, 2,
         "Soft-deleted instance 1 still counted for partition A"
@@ -1545,14 +1569,18 @@ async fn test_count_instances_multi_partition_multi_interface(pool: sqlx::PgPool
 
     // Partition A drops to 1 (only instance 2 remains).
     // Partition B stays at 1 (instance 2 still references it).
-    let count_a =
-        db::ib_partition::count_instances_referencing_partition(&env.pool, partition_a_id)
-            .await
-            .unwrap();
-    let count_b =
-        db::ib_partition::count_instances_referencing_partition(&env.pool, partition_b_id)
-            .await
-            .unwrap();
+    let count_a = db::ib_partition::count_instances_referencing_partition(
+        &mut env.db_reader(),
+        partition_a_id,
+    )
+    .await
+    .unwrap();
+    let count_b = db::ib_partition::count_instances_referencing_partition(
+        &mut env.db_reader(),
+        partition_b_id,
+    )
+    .await
+    .unwrap();
     assert_eq!(
         count_a, 1,
         "After hard-deleting instance 1, only instance 2 references partition A"
@@ -1573,14 +1601,18 @@ async fn test_count_instances_multi_partition_multi_interface(pool: sqlx::PgPool
     txn.commit().await.unwrap();
 
     // Both counts should be 0
-    let count_a =
-        db::ib_partition::count_instances_referencing_partition(&env.pool, partition_a_id)
-            .await
-            .unwrap();
-    let count_b =
-        db::ib_partition::count_instances_referencing_partition(&env.pool, partition_b_id)
-            .await
-            .unwrap();
+    let count_a = db::ib_partition::count_instances_referencing_partition(
+        &mut env.db_reader(),
+        partition_a_id,
+    )
+    .await
+    .unwrap();
+    let count_b = db::ib_partition::count_instances_referencing_partition(
+        &mut env.db_reader(),
+        partition_b_id,
+    )
+    .await
+    .unwrap();
     assert_eq!(
         count_a, 0,
         "No instances reference partition A after both hard-deleted"

--- a/crates/api/src/tests/ib_partition_lifecycle.rs
+++ b/crates/api/src/tests/ib_partition_lifecycle.rs
@@ -18,7 +18,6 @@
 use std::collections::HashMap;
 
 use carbide_uuid::infiniband::IBPartitionId;
-use db::db_read::PgPoolReader;
 use db::ib_partition::{IBPartition, IBPartitionConfig, IBPartitionStatus, NewIBPartition};
 use db::{self, ObjectColumnFilter};
 use model::ib::{IBMtu, IBNetwork, IBQosConf, IBRateLimit, IBServiceLevel};
@@ -461,7 +460,9 @@ async fn test_update_ib_partition(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
     .await?;
     txn.commit().await?;
 
-    let results = db::ib_partition::for_tenant(&pool, FIXTURE_TENANT_ORG_ID.to_string()).await?;
+    let results =
+        db::ib_partition::for_tenant(&mut (&pool).into(), FIXTURE_TENANT_ORG_ID.to_string())
+            .await?;
 
     assert_eq!(results.len(), 1);
     assert_eq!(partition.config, results[0].config);
@@ -495,7 +496,7 @@ async fn test_update_ib_partition(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
     txn.commit().await?;
 
     let partition2 = db::ib_partition::find_by(
-        &mut PgPoolReader::from(pool.clone()),
+        &mut (&pool).into(),
         ObjectColumnFilter::One(db::ib_partition::IdColumn, &partition.id),
     )
     .await?
@@ -670,7 +671,7 @@ async fn test_duplicate_ib_partition(pool: sqlx::PgPool) {
     // we perform status updates, and pkey is part of status.
 
     let mut partition = db::ib_partition::find_by(
-        &mut PgPoolReader::from(pool.clone()),
+        &mut (&pool).into(),
         ObjectColumnFilter::One(db::ib_partition::IdColumn, p2.id.as_ref().unwrap()),
     )
     .await

--- a/crates/api/src/tests/instance.rs
+++ b/crates/api/src/tests/instance.rs
@@ -39,6 +39,7 @@ use common::api_fixtures::{
     persist_machine_validation_result, populate_network_security_groups, site_explorer,
 };
 use config_version::ConfigVersion;
+use db::db_read::AsDbReader;
 use db::instance_address::UsedOverlayNetworkIpResolver;
 use db::ip_allocator::UsedIpResolver;
 use db::network_segment::IdColumn;
@@ -1725,9 +1726,12 @@ async fn test_instance_address_creation(_: PgPoolOptions, options: PgConnectOpti
         segment_id: segment_id_1,
         busy_ips: vec![],
     };
-    let used_ips = allocated_ip_resolver.used_ips(txn.as_mut()).await.unwrap();
+    let used_ips = allocated_ip_resolver
+        .used_ips(&mut txn.as_db_reader())
+        .await
+        .unwrap();
     let used_prefixes = allocated_ip_resolver
-        .used_prefixes(txn.as_mut())
+        .used_prefixes(&mut txn.as_db_reader())
         .await
         .unwrap();
     assert_eq!(1, used_ips.len());
@@ -1740,9 +1744,12 @@ async fn test_instance_address_creation(_: PgPoolOptions, options: PgConnectOpti
         segment_id: segment_id_2,
         busy_ips: vec![],
     };
-    let used_ips = allocated_ip_resolver.used_ips(txn.as_mut()).await.unwrap();
+    let used_ips = allocated_ip_resolver
+        .used_ips(&mut txn.as_db_reader())
+        .await
+        .unwrap();
     let used_prefixes = allocated_ip_resolver
-        .used_prefixes(txn.as_mut())
+        .used_prefixes(&mut txn.as_db_reader())
         .await
         .unwrap();
     assert_eq!(1, used_ips.len());
@@ -2259,7 +2266,7 @@ async fn test_allocate_network_vpc_prefix_id(_: PgPoolOptions, options: PgConnec
     let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
     let env = create_test_env(pool).await;
     env.create_vpc_and_tenant_segment().await;
-    let vpc = db::vpc::find_by_name(&env.pool, "test vpc 1")
+    let vpc = db::vpc::find_by_name(&mut env.db_reader(), "test vpc 1")
         .await
         .unwrap()
         .into_iter()
@@ -2309,7 +2316,7 @@ async fn test_allocate_network_vpc_prefix_id(_: PgPoolOptions, options: PgConnec
 
     let mut txn = env.db_txn().await;
     let network_segment = db::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(
             IdColumn,
             &config.network.interfaces[0].network_segment_id.unwrap(),
@@ -2350,7 +2357,7 @@ async fn test_allocate_and_release_instance_vpc_prefix_id(
         mh.host().db_machine(&mut txn).await.current_state(),
         ManagedHostState::Ready
     ));
-    let mut vpc = db::vpc::find_by_name(&env.pool, "test vpc 1")
+    let mut vpc = db::vpc::find_by_name(&mut env.db_reader(), "test vpc 1")
         .await
         .unwrap();
     let vpc = vpc.remove(0);
@@ -2436,7 +2443,7 @@ async fn test_allocate_and_release_instance_vpc_prefix_id(
         .unwrap();
 
     let ns = db::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(db::network_segment::IdColumn, &ns_id),
         NetworkSegmentSearchConfig::default(),
     )
@@ -2477,7 +2484,7 @@ async fn test_allocate_and_release_instance_vpc_prefix_id(
 
     let mut txn = env.db_txn().await;
     let mut ns = db::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(
             IdColumn,
             &fetched_instance.config.network.interfaces[0]
@@ -2548,7 +2555,7 @@ async fn test_allocate_and_release_instance_vpc_prefix_id(
     // Address is freed during delete
     let mut txn = env.db_txn().await;
     let network_segments = db::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::List(IdColumn, &segment_ids),
         NetworkSegmentSearchConfig::default(),
     )
@@ -2629,7 +2636,7 @@ async fn test_vpc_prefix_handling(pool: PgPool) {
         .unwrap();
 
     let ns1 = db::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(IdColumn, &ns_id),
         NetworkSegmentSearchConfig::default(),
     )
@@ -2656,7 +2663,7 @@ async fn test_vpc_prefix_handling(pool: PgPool) {
         .unwrap();
 
     let ns2 = db::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(IdColumn, &ns_id),
         NetworkSegmentSearchConfig::default(),
     )
@@ -2682,7 +2689,7 @@ async fn test_vpc_prefix_handling(pool: PgPool) {
         .unwrap();
 
     let ns3 = db::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(IdColumn, &ns_id),
         NetworkSegmentSearchConfig::default(),
     )
@@ -2717,7 +2724,7 @@ async fn test_vpc_prefix_handling(pool: PgPool) {
         .unwrap();
 
     let ns4 = db::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(IdColumn, &ns_id),
         NetworkSegmentSearchConfig::default(),
     )
@@ -4141,10 +4148,12 @@ async fn test_update_instance_config_vpc_prefix_network_update_state_machine(
     };
 
     let mut txn = env.db_txn().await;
-    let segments =
-        db::network_segment::find_ids(txn.as_mut(), NetworkSegmentSearchFilter::default())
-            .await
-            .unwrap();
+    let segments = db::network_segment::find_ids(
+        &mut txn.as_db_reader(),
+        NetworkSegmentSearchFilter::default(),
+    )
+    .await
+    .unwrap();
 
     let old_length = segments.len();
     txn.rollback().await.unwrap();
@@ -4169,10 +4178,12 @@ async fn test_update_instance_config_vpc_prefix_network_update_state_machine(
         .await
         .expect("Unable to create transaction on database pool");
 
-    let segments =
-        db::network_segment::find_ids(txn.as_mut(), NetworkSegmentSearchFilter::default())
-            .await
-            .unwrap();
+    let segments = db::network_segment::find_ids(
+        &mut txn.as_db_reader(),
+        NetworkSegmentSearchFilter::default(),
+    )
+    .await
+    .unwrap();
 
     let new_length = segments.len();
     txn.rollback().await.unwrap();
@@ -4239,7 +4250,7 @@ async fn test_allocate_network_multi_dpu_vpc_prefix_id(
     let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
     let env = create_test_env(pool).await;
     env.create_vpc_and_tenant_segment().await;
-    let vpc = db::vpc::find_by_name(&env.pool, "test vpc 1")
+    let vpc = db::vpc::find_by_name(&mut env.db_reader(), "test vpc 1")
         .await
         .unwrap()
         .into_iter()
@@ -4324,7 +4335,7 @@ async fn test_allocate_network_multi_dpu_vpc_prefix_id(
 
     for iface in config.network.interfaces {
         let network_segment = db::network_segment::find_by(
-            txn.as_mut(),
+            &mut txn.as_db_reader(),
             ObjectColumnFilter::One(IdColumn, &iface.network_segment_id.unwrap()),
             NetworkSegmentSearchConfig::default(),
         )

--- a/crates/api/src/tests/instance_allocate.rs
+++ b/crates/api/src/tests/instance_allocate.rs
@@ -361,7 +361,7 @@ async fn test_zero_dpu_instance_allocation_multi_segment_no_network_config(
 
             Ok::<ManagedHostStateSnapshot, eyre::Report>(
                 db::managed_host::load_snapshot(
-                    mock.test_env.pool.begin().await?.deref_mut(),
+                    &mut mock.test_env.db_reader(),
                     &machine_id,
                     Default::default(),
                 )
@@ -422,7 +422,7 @@ async fn test_zero_dpu_instance_allocation_multi_segment_no_network_config(
     );
 
     let host_snapshot_after_allocate = db::managed_host::load_snapshot(
-        env.pool.begin().await?.deref_mut(),
+        &mut env.db_reader(),
         &zero_dpu_host.host_snapshot.id,
         Default::default(),
     )

--- a/crates/api/src/tests/instance_batch_allocate.rs
+++ b/crates/api/src/tests/instance_batch_allocate.rs
@@ -26,6 +26,7 @@ use common::api_fixtures::instance::{
 use common::api_fixtures::{
     TestEnv, create_managed_host, create_test_env, populate_network_security_groups,
 };
+use db::db_read::AsDbReader;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 
 use crate::tests::common;
@@ -69,7 +70,7 @@ async fn test_batch_allocate_instances_success(_: PgPoolOptions, options: PgConn
     for instance in &response.instances {
         let machine_id = *instance.machine_id.as_ref().unwrap();
         let snapshot = db::managed_host::load_snapshot(
-            txn.as_mut(),
+            &mut txn.as_db_reader(),
             &machine_id,
             model::machine::LoadSnapshotOptions::default(),
         )
@@ -149,7 +150,7 @@ async fn test_batch_allocate_instances_rollback_on_failure(
     // Verify that the first instance was NOT created (transaction rolled back)
     let mut txn = env.db_txn().await;
     let snapshot1 = db::managed_host::load_snapshot(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &mh1.host().id,
         model::machine::LoadSnapshotOptions::default(),
     )
@@ -164,7 +165,7 @@ async fn test_batch_allocate_instances_rollback_on_failure(
 
     // Verify that the third instance was also NOT created
     let snapshot2 = db::managed_host::load_snapshot(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &mh2.host().id,
         model::machine::LoadSnapshotOptions::default(),
     )

--- a/crates/api/src/tests/ipxe.rs
+++ b/crates/api/src/tests/ipxe.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use chrono::Utc;
 use common::api_fixtures::{TestEnv, create_test_env};
+use db::db_read::AsDbReader;
 use db::{self};
 use futures_util::FutureExt;
 use mac_address::MacAddress;
@@ -42,7 +43,7 @@ async fn move_machine_to_needed_state(
         .await
         .expect("Unable to create transaction on database pool");
     let machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &machine_id,
         model::machine::machine_search_config::MachineSearchConfig::default(),
     )
@@ -404,7 +405,7 @@ async fn test_cloud_init_when_machine_is_not_created(pool: sqlx::PgPool) {
     // Interface is created. Let's fetch interface id.
     let mut txn = env.pool.begin().await.unwrap();
     let interfaces = db::machine_interface::find_by_mac_address(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         mac_address.parse::<MacAddress>().unwrap(),
     )
     .await

--- a/crates/api/src/tests/machine_admin_force_delete.rs
+++ b/crates/api/src/tests/machine_admin_force_delete.rs
@@ -36,6 +36,7 @@ use common::api_fixtures::{
     create_managed_host_with_dpf, create_test_env, create_test_env_with_overrides, get_config,
     get_instance_type_fixture_id,
 };
+use db::db_read::AsDbReader;
 use model::hardware_info::TpmEkCertificate;
 use model::ib::DEFAULT_IB_FABRIC_NAME;
 use model::machine::machine_search_config::MachineSearchConfig;
@@ -72,7 +73,7 @@ async fn test_admin_force_delete_dpu_only(pool: sqlx::PgPool) {
 
     let mut txn = env.pool.begin().await.unwrap();
     let dpu_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &dpu_machine_id,
         MachineSearchConfig::default(),
     )
@@ -349,10 +350,14 @@ async fn validate_machine_deletion(
     // And it should also be gone on the DB layer
     let mut txn = env.pool.begin().await.unwrap();
     assert!(
-        db::machine::find_one(txn.as_mut(), machine_id, MachineSearchConfig::default())
-            .await
-            .unwrap()
-            .is_none()
+        db::machine::find_one(
+            &mut txn.as_db_reader(),
+            machine_id,
+            MachineSearchConfig::default()
+        )
+        .await
+        .unwrap()
+        .is_none()
     );
     assert!(
         db::machine_topology::find_by_machine_ids(&mut txn, &[*machine_id])

--- a/crates/api/src/tests/machine_boot_override.rs
+++ b/crates/api/src/tests/machine_boot_override.rs
@@ -18,6 +18,7 @@
 use common::api_fixtures::create_test_env;
 use common::api_fixtures::dpu::dpu_discover_dhcp;
 use common::mac_address_pool::DPU_OOB_MAC_ADDRESS_POOL;
+use db::db_read::AsDbReader;
 use rpc::protos::forge::forge_server::Forge;
 
 use crate::DatabaseError;
@@ -46,7 +47,7 @@ async fn only_one_custom_pxe_per_interface(
     .expect("Could not create custom pxe");
 
     let machine_boot_override =
-        db::machine_boot_override::find_optional(txn.as_mut(), new_interface_id)
+        db::machine_boot_override::find_optional(&mut txn.as_db_reader(), new_interface_id)
             .await
             .expect("Could not load custom boot")
             .unwrap();
@@ -86,7 +87,7 @@ async fn confirm_null_fields(pool: sqlx::PgPool) -> Result<(), Box<dyn std::erro
 
     // ensure these stay Nones as we have code that will react to them not being None
     let machine_boot_override =
-        db::machine_boot_override::find_optional(txn.as_mut(), new_interface_id)
+        db::machine_boot_override::find_optional(&mut txn.as_db_reader(), new_interface_id)
             .await
             .expect("Could not load custom boot")
             .unwrap();
@@ -163,7 +164,7 @@ async fn api_set(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
     let mut txn = env.pool.begin().await?;
 
     let machine_boot_override =
-        db::machine_boot_override::find_optional(txn.as_mut(), machine_interface_id)
+        db::machine_boot_override::find_optional(&mut txn.as_db_reader(), machine_interface_id)
             .await
             .expect("Could not load custom boot")
             .unwrap();
@@ -206,7 +207,7 @@ async fn api_clear(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>>
 
     // ensure these stay Nones as we have code that will react to them not being None
     let machine_boot_override =
-        db::machine_boot_override::find_optional(txn.as_mut(), new_interface_id)
+        db::machine_boot_override::find_optional(&mut txn.as_db_reader(), new_interface_id)
             .await
             .expect("Could not load custom boot");
 
@@ -250,7 +251,7 @@ async fn api_update(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
     let mut txn = env.pool.begin().await?;
 
     let machine_boot_override =
-        db::machine_boot_override::find_optional(txn.as_mut(), machine_interface_id)
+        db::machine_boot_override::find_optional(&mut txn.as_db_reader(), machine_interface_id)
             .await
             .expect("Could not load custom boot")
             .unwrap();

--- a/crates/api/src/tests/machine_creator.rs
+++ b/crates/api/src/tests/machine_creator.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::rack::RackId;
+use db::db_read::AsDbReader;
 use itertools::Itertools;
 use mac_address::MacAddress;
 use model::machine::machine_search_config::MachineSearchConfig;
@@ -239,7 +240,7 @@ async fn test_site_explorer_creates_managed_host(
 
     let mut txn = env.pool.begin().await.unwrap();
     let dpu_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         dpu_report.machine_id.as_ref().unwrap(),
         MachineSearchConfig {
             include_predicted_host: true,
@@ -343,7 +344,7 @@ async fn test_site_explorer_creates_managed_host(
     env.run_machine_state_controller_iteration().await;
 
     let dpu_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &dpu_machine.id,
         MachineSearchConfig::default(),
     )
@@ -363,7 +364,7 @@ async fn test_site_explorer_creates_managed_host(
     env.run_machine_state_controller_iteration().await;
 
     let dpu_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &dpu_machine.id,
         MachineSearchConfig::default(),
     )
@@ -383,7 +384,7 @@ async fn test_site_explorer_creates_managed_host(
     env.run_machine_state_controller_iteration().await;
 
     let dpu_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &dpu_machine.id,
         MachineSearchConfig::default(),
     )
@@ -409,7 +410,7 @@ async fn test_site_explorer_creates_managed_host(
     env.run_machine_state_controller_iteration().await;
 
     let dpu_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &dpu_machine.id,
         MachineSearchConfig::default(),
     )
@@ -439,7 +440,7 @@ async fn test_site_explorer_creates_managed_host(
     env.run_machine_state_controller_iteration().await;
     env.run_machine_state_controller_iteration().await;
     let dpu_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &dpu_machine.id,
         MachineSearchConfig::default(),
     )
@@ -466,7 +467,7 @@ async fn test_site_explorer_creates_managed_host(
     env.run_machine_state_controller_iteration().await;
 
     let dpu_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &dpu_machine.id,
         MachineSearchConfig::default(),
     )
@@ -484,7 +485,7 @@ async fn test_site_explorer_creates_managed_host(
     );
 
     let machine_interfaces =
-        db::machine_interface::find_by_mac_address(txn.as_mut(), oob_mac).await?;
+        db::machine_interface::find_by_mac_address(&mut txn.as_db_reader(), oob_mac).await?;
     assert!(!machine_interfaces.is_empty());
     let topologies = db::machine_topology::find_by_machine_ids(&mut txn, &[dpu_machine.id]).await?;
     assert!(topologies.contains_key(&dpu_machine.id));
@@ -521,7 +522,7 @@ async fn test_site_explorer_creates_managed_host(
 
     // Now let's check that DPU and host updated states and updated hardware information.
     let dpu_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &dpu_machine.id,
         MachineSearchConfig::default(),
     )
@@ -532,7 +533,7 @@ async fn test_site_explorer_creates_managed_host(
     assert!(dpu_machine.network_config.loopback_ip.is_some());
 
     let machine_interfaces =
-        db::machine_interface::find_by_mac_address(txn.as_mut(), oob_mac).await?;
+        db::machine_interface::find_by_mac_address(&mut txn.as_db_reader(), oob_mac).await?;
     assert!(
         machine_interfaces[0]
             .machine_id
@@ -541,7 +542,7 @@ async fn test_site_explorer_creates_managed_host(
     );
 
     let host_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &host_machine.id,
         MachineSearchConfig::default(),
     )
@@ -634,7 +635,7 @@ async fn test_site_explorer_creates_multi_dpu_managed_host(
 
         assert!(!response.address.is_empty());
         let oob_interface =
-            db::machine_interface::find_by_mac_address(txn.as_mut(), oob_mac).await?;
+            db::machine_interface::find_by_mac_address(&mut txn.as_db_reader(), oob_mac).await?;
         assert!(oob_interface[0].primary_interface);
         oob_interfaces.push(oob_interface[0].clone());
 
@@ -725,7 +726,7 @@ async fn test_site_explorer_creates_multi_dpu_managed_host(
 
     for dpu in explored_dpus.iter() {
         let dpu_machine = db::machine::find_one(
-            txn.as_mut(),
+            &mut txn.as_db_reader(),
             dpu.report.machine_id.as_ref().unwrap(),
             MachineSearchConfig {
                 include_predicted_host: true,
@@ -950,7 +951,7 @@ async fn test_mi_attach_dpu_if_mi_exists_during_machine_creation(
 
     // Machine interface should not have any machine id associated with it right now.
     let mut txn = env.pool.begin().await?;
-    let mi = db::machine_interface::find_by_mac_address(txn.as_mut(), oob_mac).await?;
+    let mi = db::machine_interface::find_by_mac_address(&mut txn.as_db_reader(), oob_mac).await?;
     assert!(mi[0].attached_dpu_machine_id.is_none());
     assert!(mi[0].machine_id.is_none());
     txn.rollback().await?;
@@ -969,7 +970,7 @@ async fn test_mi_attach_dpu_if_mi_exists_during_machine_creation(
     // At this point, create_managed_host must have updated the associated machine id in
     // machine_interfaces table.
     let mut txn = env.pool.begin().await?;
-    let mi = db::machine_interface::find_by_mac_address(txn.as_mut(), oob_mac).await?;
+    let mi = db::machine_interface::find_by_mac_address(&mut txn.as_db_reader(), oob_mac).await?;
     assert!(mi[0].attached_dpu_machine_id.is_some());
     assert!(mi[0].machine_id.is_some());
     txn.rollback().await?;
@@ -1073,7 +1074,7 @@ async fn test_mi_attach_dpu_if_mi_created_after_machine_creation(
     // any interface as interface does not exist.
     let mut txn = env.pool.begin().await?;
     let machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &dpu_machine_id,
         MachineSearchConfig {
             include_dpus: true,
@@ -1248,7 +1249,7 @@ async fn test_site_explorer_creates_managed_host_with_dpf_disable(
     );
 
     let machines = db::machine::find(
-        &env.pool,
+        &mut env.db_reader(),
         db::ObjectFilter::All,
         MachineSearchConfig {
             include_predicted_host: true,
@@ -1389,7 +1390,7 @@ async fn test_site_explorer_creates_managed_host_with_dpf_enabled(
     );
 
     let machines = db::machine::find(
-        &env.pool,
+        &mut env.db_reader(),
         db::ObjectFilter::All,
         MachineSearchConfig {
             include_predicted_host: true,
@@ -1547,7 +1548,7 @@ async fn test_rms_registration_with_rack_id(
     // (node not found in inventory — needs registration)
     env.run_machine_state_controller_iteration().await;
     let host_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &host_machine.id,
         MachineSearchConfig::default(),
     )
@@ -1563,7 +1564,7 @@ async fn test_rms_registration_with_rack_id(
     // (add_node succeeds)
     env.run_machine_state_controller_iteration().await;
     let host_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &host_machine.id,
         MachineSearchConfig::default(),
     )
@@ -1714,7 +1715,7 @@ async fn test_rms_registration_retries_on_failure(
     // Iteration 1: VerifyRmsMembership -> RegisterRmsMembership (not found)
     env.run_machine_state_controller_iteration().await;
     let host_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &host_machine.id,
         MachineSearchConfig::default(),
     )
@@ -1732,7 +1733,7 @@ async fn test_rms_registration_retries_on_failure(
     // Iteration 2: RegisterRmsMembership stays (add_node fails)
     env.run_machine_state_controller_iteration().await;
     let host_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &host_machine.id,
         MachineSearchConfig::default(),
     )
@@ -1752,7 +1753,7 @@ async fn test_rms_registration_retries_on_failure(
     // Iteration 3: RegisterRmsMembership -> DpuDiscoveringState (succeeds)
     env.run_machine_state_controller_iteration().await;
     let host_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &host_machine.id,
         MachineSearchConfig::default(),
     )
@@ -1907,7 +1908,7 @@ async fn test_rms_verification_failure_paths(
     // Iteration 1: VerifyRmsMembership stays (inventory_get API error)
     env.run_machine_state_controller_iteration().await;
     let host_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &host_machine.id,
         MachineSearchConfig::default(),
     )
@@ -1927,7 +1928,7 @@ async fn test_rms_verification_failure_paths(
     // Iteration 2: VerifyRmsMembership -> RegisterRmsMembership (not found)
     env.run_machine_state_controller_iteration().await;
     let host_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &host_machine.id,
         MachineSearchConfig::default(),
     )
@@ -1942,7 +1943,7 @@ async fn test_rms_verification_failure_paths(
     // Iteration 3: RegisterRmsMembership -> DpuDiscoveringState (succeeds)
     env.run_machine_state_controller_iteration().await;
     let host_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &host_machine.id,
         MachineSearchConfig::default(),
     )

--- a/crates/api/src/tests/machine_dhcp.rs
+++ b/crates/api/src/tests/machine_dhcp.rs
@@ -23,6 +23,7 @@ use carbide_uuid::machine::MachineInterfaceId;
 use common::api_fixtures::{
     FIXTURE_DHCP_RELAY_ADDRESS, TestEnv, create_managed_host, create_test_env, dpu,
 };
+use db::db_read::AsDbReader;
 use db::{self, ObjectColumnFilter, dhcp_entry};
 use itertools::Itertools;
 use mac_address::MacAddress;
@@ -300,7 +301,7 @@ async fn machine_interface_discovery_persists_vendor_strings(
         );
 
         // Also check via the MachineInterface API
-        let iface = db::machine_interface::find_one(txn.as_mut(), *interface_id)
+        let iface = db::machine_interface::find_one(&mut txn.as_db_reader(), *interface_id)
             .await
             .unwrap();
         assert_eq!(iface.vendors, expected);
@@ -408,7 +409,8 @@ async fn test_dhcp_record_address_family(
     // Insert an IPv6 address for the same interface, simulating dual-stack.
     let mut txn = pool.begin().await?;
     let parsed_mac: MacAddress = mac_address.parse().unwrap();
-    let interfaces = db::machine_interface::find_by_mac_address(txn.as_mut(), parsed_mac).await?;
+    let interfaces =
+        db::machine_interface::find_by_mac_address(&mut txn.as_db_reader(), parsed_mac).await?;
     let interface = &interfaces[0];
 
     let ipv6_addr: IpAddr = "fd00::42".parse().unwrap();

--- a/crates/api/src/tests/machine_find.rs
+++ b/crates/api/src/tests/machine_find.rs
@@ -23,6 +23,7 @@ use common::api_fixtures::{create_managed_host, create_test_env, site_explorer};
 use common::mac_address_pool::DPU_OOB_MAC_ADDRESS_POOL;
 use data_encoding::BASE32_DNSSEC;
 use db::ObjectFilter;
+use db::db_read::AsDbReader;
 use itertools::Itertools;
 use mac_address::MacAddress;
 use model::hardware_info::HardwareInfo;
@@ -77,7 +78,7 @@ async fn test_find_machine_by_ip(pool: sqlx::PgPool) {
 
     let mut txn = env.pool.begin().await.unwrap();
     let dpu_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &dpu_machine_id,
         MachineSearchConfig::default(),
     )
@@ -115,7 +116,7 @@ async fn test_find_machine_by_ipv6(pool: sqlx::PgPool) {
 
     let mut txn = env.pool.begin().await.unwrap();
     let dpu_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &dpu_machine_id,
         MachineSearchConfig::default(),
     )
@@ -184,7 +185,7 @@ async fn test_find_machine_by_mac(pool: sqlx::PgPool) {
 
     let mut txn = env.pool.begin().await.unwrap();
     let dpu_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &dpu_machine_id,
         MachineSearchConfig {
             include_history: true,
@@ -225,7 +226,7 @@ async fn test_find_machine_by_hostname(pool: sqlx::PgPool) {
 
     let mut txn = env.pool.begin().await.unwrap();
     let dpu_machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &dpu_machine_id,
         MachineSearchConfig {
             include_history: true,
@@ -299,7 +300,7 @@ async fn test_find_machine_ids_with_and_without_dpus(pool: sqlx::PgPool) {
 #[crate::sqlx_test]
 async fn test_find_all_machines_when_there_arent_any(pool: sqlx::PgPool) {
     let machines = db::machine::find(
-        &pool,
+        &mut pool.clone().as_db_reader(),
         ObjectFilter::All,
         crate::tests::machine_find::MachineSearchConfig {
             include_history: true,
@@ -329,7 +330,7 @@ async fn test_find_machine_ids(pool: sqlx::PgPool) {
     .unwrap();
     let mut txn = env.pool.begin().await.unwrap();
 
-    let machine_ids = db::machine::find_machine_ids(txn.as_mut(), config)
+    let machine_ids = db::machine::find_machine_ids(&mut txn.as_db_reader(), config)
         .await
         .unwrap();
 
@@ -371,7 +372,7 @@ async fn test_find_machine_ids(pool: sqlx::PgPool) {
     };
 
     // Try to find machines for the instance type.
-    let machine_ids = db::machine::find_machine_ids(txn.as_mut(), config)
+    let machine_ids = db::machine::find_machine_ids(&mut txn.as_db_reader(), config)
         .await
         .unwrap();
 
@@ -396,7 +397,7 @@ async fn test_find_dpu_machine_ids(pool: sqlx::PgPool) {
     .unwrap();
     let mut txn = env.pool.begin().await.unwrap();
 
-    let machine_ids = db::machine::find_machine_ids(txn.as_mut(), config)
+    let machine_ids = db::machine::find_machine_ids(&mut txn.as_db_reader(), config)
         .await
         .unwrap();
 
@@ -421,7 +422,7 @@ async fn test_find_predicted_host_machine_ids(pool: sqlx::PgPool) {
     .unwrap();
     let mut txn = env.pool.begin().await.unwrap();
 
-    let machine_ids = db::machine::find_machine_ids(txn.as_mut(), config)
+    let machine_ids = db::machine::find_machine_ids(&mut txn.as_db_reader(), config)
         .await
         .unwrap();
 
@@ -439,7 +440,7 @@ async fn test_find_host_machine_ids_when_predicted(pool: sqlx::PgPool) {
     let _dpu_machine_id = create_dpu_machine(&env, &host_config).await;
     let mut txn = env.pool.begin().await.unwrap();
 
-    let machine_ids = db::machine::find_machine_ids(txn.as_mut(), config)
+    let machine_ids = db::machine::find_machine_ids(&mut txn.as_db_reader(), config)
         .await
         .unwrap();
 
@@ -456,7 +457,7 @@ async fn test_find_host_machine_ids(pool: sqlx::PgPool) {
     let mut txn = env.pool.begin().await.unwrap();
 
     tracing::info!("finding machine ids");
-    let machine_ids = db::machine::find_machine_ids(txn.as_mut(), config)
+    let machine_ids = db::machine::find_machine_ids(&mut txn.as_db_reader(), config)
         .await
         .unwrap();
     assert_eq!(machine_ids.len(), 1);
@@ -483,7 +484,7 @@ async fn test_find_mixed_host_machine_ids(pool: sqlx::PgPool) {
     let mut txn = env.pool.begin().await.unwrap();
 
     tracing::info!("finding machine ids");
-    let machine_ids = db::machine::find_machine_ids(txn.as_mut(), config)
+    let machine_ids = db::machine::find_machine_ids(&mut txn.as_db_reader(), config)
         .await
         .unwrap();
     assert_eq!(machine_ids.len(), 2);

--- a/crates/api/src/tests/machine_health.rs
+++ b/crates/api/src/tests/machine_health.rs
@@ -17,6 +17,7 @@
 
 use std::str::FromStr;
 
+use db::db_read::AsDbReader;
 use db::machine::update_dpu_agent_health_report;
 use db::{self};
 use health_report::OverrideMode;
@@ -626,7 +627,7 @@ async fn test_count_unhealthy_nonupgrading_host_machines(
 
     let mut txn = env.pool.begin().await?;
     let machine_ids = db::machine::find_machine_ids(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         model::machine::machine_search_config::MachineSearchConfig::default(),
     )
     .await?;
@@ -642,7 +643,8 @@ async fn test_count_unhealthy_nonupgrading_host_machines(
         },
     };
     let all_machines =
-        db::managed_host::load_by_machine_ids(txn.as_mut(), &machine_ids, options).await?;
+        db::managed_host::load_by_machine_ids(&mut txn.as_db_reader(), &machine_ids, options)
+            .await?;
 
     assert_eq!(
         db::machine::count_healthy_unhealthy_host_machines(&all_machines),
@@ -673,7 +675,7 @@ async fn test_count_unhealthy_nonupgrading_host_machines(
 
     let mut txn = env.pool.begin().await?;
     let machine_ids = db::machine::find_machine_ids(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         model::machine::machine_search_config::MachineSearchConfig::default(),
     )
     .await?;
@@ -689,7 +691,8 @@ async fn test_count_unhealthy_nonupgrading_host_machines(
         },
     };
     let all_machines =
-        db::managed_host::load_by_machine_ids(txn.as_mut(), &machine_ids, options).await?;
+        db::managed_host::load_by_machine_ids(&mut txn.as_db_reader(), &machine_ids, options)
+            .await?;
 
     assert_eq!(
         db::machine::count_healthy_unhealthy_host_machines(&all_machines),

--- a/crates/api/src/tests/machine_history.rs
+++ b/crates/api/src/tests/machine_history.rs
@@ -16,6 +16,7 @@
  */
 use common::api_fixtures::{create_managed_host, create_test_env};
 use config_version::ConfigVersion;
+use db::db_read::AsDbReader;
 use db::{self};
 use model::machine::{MachineStateHistory, ManagedHostState};
 use rpc::forge::forge_server::Forge;
@@ -65,7 +66,7 @@ async fn test_machine_state_history(pool: sqlx::PgPool) -> Result<(), Box<dyn st
         let mut txn = env.pool.begin().await?;
 
         let machine = db::machine::find_one(
-            txn.as_mut(),
+            &mut txn.as_db_reader(),
             &dpu_machine_id,
             model::machine::machine_search_config::MachineSearchConfig {
                 include_history: true,
@@ -81,7 +82,7 @@ async fn test_machine_state_history(pool: sqlx::PgPool) -> Result<(), Box<dyn st
         );
 
         let machine = db::machine::find_one(
-            txn.as_mut(),
+            &mut txn.as_db_reader(),
             &dpu_machine_id,
             model::machine::machine_search_config::MachineSearchConfig::default(),
         )
@@ -143,7 +144,7 @@ async fn test_machine_state_history(pool: sqlx::PgPool) -> Result<(), Box<dyn st
     let mut txn = env.pool.begin().await?;
 
     let machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &host_machine_id,
         model::machine::machine_search_config::MachineSearchConfig {
             include_history: true,
@@ -170,7 +171,7 @@ async fn test_machine_state_history(pool: sqlx::PgPool) -> Result<(), Box<dyn st
     assert_eq!(result.len(), 250);
 
     let machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &host_machine_id,
         model::machine::machine_search_config::MachineSearchConfig {
             include_history: true,
@@ -244,7 +245,7 @@ async fn test_old_machine_state_history(
         .await?;
 
     let machine = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &host_machine_id,
         model::machine::machine_search_config::MachineSearchConfig {
             include_history: true,

--- a/crates/api/src/tests/machine_interface_addresses.rs
+++ b/crates/api/src/tests/machine_interface_addresses.rs
@@ -18,6 +18,7 @@
 use std::net::IpAddr;
 use std::str::FromStr;
 
+use db::db_read::AsDbReader;
 use ipnetwork::IpNetwork;
 use mac_address::MacAddress;
 use model::address_selection_strategy::AddressSelectionStrategy;
@@ -32,7 +33,7 @@ use crate::tests::common::api_fixtures::create_test_env;
 async fn find_by_address_bmc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env(pool).await;
     let mut txn = env.pool.begin().await?;
-    let domain = db::dns::domain::find_by_name(txn.as_mut(), "dwrt1.com")
+    let domain = db::dns::domain::find_by_name(&mut txn.as_db_reader(), "dwrt1.com")
         .await?
         .into_iter()
         .next()
@@ -70,7 +71,9 @@ async fn find_by_address_bmc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::erro
     .await?;
     let bmc_ip = interface.addresses.iter().find(|x| x.is_ipv4()).copied();
     assert!(bmc_ip.is_some());
-    let res = db::machine_interface_address::find_by_address(txn.as_mut(), bmc_ip.unwrap()).await?;
+    let res =
+        db::machine_interface_address::find_by_address(&mut txn.as_db_reader(), bmc_ip.unwrap())
+            .await?;
     assert!(res.is_some());
     assert_eq!(res.unwrap().id, interface.id);
 

--- a/crates/api/src/tests/machine_interfaces.rs
+++ b/crates/api/src/tests/machine_interfaces.rs
@@ -20,6 +20,7 @@ use std::collections::HashSet;
 use std::str::FromStr;
 
 use common::api_fixtures::{FIXTURE_DHCP_RELAY_ADDRESS, create_test_env};
+use db::db_read::AsDbReader;
 use db::dhcp_entry::DhcpEntry;
 use db::{self, ObjectColumnFilter};
 use itertools::Itertools;
@@ -176,7 +177,7 @@ async fn find_all_interfaces_test_cases(
 
     let network_segment = db::network_segment::admin(&mut txn).await?;
     let domain_ids = db::dns::domain::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::<db::dns::domain::IdColumn>::All,
     )
     .await?;
@@ -258,7 +259,7 @@ async fn find_interfaces_test_cases(pool: sqlx::PgPool) -> Result<(), Box<dyn st
 
     let network_segment = db::network_segment::admin(&mut txn).await?;
     let domain_ids = db::dns::domain::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::<db::dns::domain::IdColumn>::All,
     )
     .await?;
@@ -457,7 +458,7 @@ async fn test_delete_interface(pool: sqlx::PgPool) -> Result<(), Box<dyn std::er
         .unwrap();
 
     let mut txn = env.pool.begin().await?;
-    let _interface = db::machine_interface::find_one(txn.as_mut(), interface_id).await;
+    let _interface = db::machine_interface::find_one(&mut txn.as_db_reader(), interface_id).await;
     assert!(matches!(
         DatabaseError::FindOneReturnedNoResultsError(interface_id.into()),
         _interface

--- a/crates/api/src/tests/machine_network.rs
+++ b/crates/api/src/tests/machine_network.rs
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::ops::DerefMut;
 use std::time::SystemTime;
 
 use ::rpc::forge::{
@@ -444,7 +443,7 @@ async fn test_quarantine_state_crud(pool: sqlx::PgPool) -> Result<(), Box<dyn st
     let (host_machine_id, _dpu_machine_id) = create_managed_host(&env).await.into();
 
     let network_config_version =
-        db::machine::get_network_config(env.pool.begin().await?.deref_mut(), &host_machine_id)
+        db::machine::get_network_config(&mut env.db_reader(), &host_machine_id)
             .await?
             .version;
 
@@ -526,8 +525,7 @@ async fn test_quarantine_state_crud(pool: sqlx::PgPool) -> Result<(), Box<dyn st
 
     // Make sure the version got bumped
     let network_config =
-        db::machine::get_network_config(env.pool.begin().await?.deref_mut(), &host_machine_id)
-            .await?;
+        db::machine::get_network_config(&mut env.db_reader(), &host_machine_id).await?;
     assert_eq!(
         network_config.version.version_nr(),
         network_config_version.version_nr() + 1,
@@ -593,8 +591,7 @@ async fn test_quarantine_state_crud(pool: sqlx::PgPool) -> Result<(), Box<dyn st
 
     // Make sure the version got bumped again
     let network_config =
-        db::machine::get_network_config(env.pool.begin().await?.deref_mut(), &host_machine_id)
-            .await?;
+        db::machine::get_network_config(&mut env.db_reader(), &host_machine_id).await?;
     assert_eq!(
         network_config.version.version_nr(),
         network_config_version.version_nr() + 1,
@@ -656,8 +653,7 @@ async fn test_quarantine_state_crud(pool: sqlx::PgPool) -> Result<(), Box<dyn st
 
     // Make sure the network config version bumps again on clear
     let network_config =
-        db::machine::get_network_config(env.pool.begin().await?.deref_mut(), &host_machine_id)
-            .await?;
+        db::machine::get_network_config(&mut env.db_reader(), &host_machine_id).await?;
     assert_eq!(
         network_config.version.version_nr(),
         network_config_version.version_nr() + 1,

--- a/crates/api/src/tests/machine_power.rs
+++ b/crates/api/src/tests/machine_power.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use db::db_read::AsDbReader;
 use db::managed_host::load_snapshot;
 use db::{self};
 use model::machine::LoadSnapshotOptions;
@@ -137,7 +138,7 @@ async fn test_power_manager_state_machine_desired_on_machine_off(
     assert_eq!(power_entry[0].desired_power_state, PowerState::On);
     assert_eq!(power_entry[0].last_fetched_power_state, PowerState::On);
     let mh_snapshot = load_snapshot(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &host_machine_id,
         LoadSnapshotOptions::default(),
     )
@@ -205,7 +206,7 @@ async fn test_power_manager_state_machine_desired_on_machine_off_counter(
     assert_eq!(power_entry[0].desired_power_state, PowerState::On);
     assert_eq!(power_entry[0].last_fetched_power_state, PowerState::On);
     let mh_snapshot = load_snapshot(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &host_machine_id,
         LoadSnapshotOptions::default(),
     )

--- a/crates/api/src/tests/machine_topology.rs
+++ b/crates/api/src/tests/machine_topology.rs
@@ -20,6 +20,7 @@ use carbide_uuid::machine::{MachineId, MachineType};
 use common::api_fixtures::dpu::create_dpu_machine;
 use common::api_fixtures::host::X86_V1_CPU_INFO_JSON;
 use common::api_fixtures::{create_managed_host, create_test_env};
+use db::db_read::AsDbReader;
 use db::machine_interface::associate_interface_with_dpu_machine;
 use db::machine_topology::test_helpers::{HardwareInfoV1, TopologyDataV1};
 use db::{self, ObjectColumnFilter, network_segment};
@@ -63,7 +64,7 @@ async fn test_crud_machine_topology(pool: sqlx::PgPool) -> Result<(), Box<dyn st
 
     let mut txn = env.pool.begin().await?;
     let segment = db::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(network_segment::IdColumn, &env.admin_segment.unwrap()),
         model::network_segment::NetworkSegmentSearchConfig::default(),
     )
@@ -215,7 +216,7 @@ async fn test_v1_cpu_topology(pool: sqlx::PgPool) -> Result<(), Box<dyn std::err
 
     let mut txn = env.pool.begin().await?;
     let segment = db::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(network_segment::IdColumn, &env.admin_segment.unwrap()),
         model::network_segment::NetworkSegmentSearchConfig::default(),
     )
@@ -379,7 +380,7 @@ async fn test_topology_update_on_machineid_update(pool: sqlx::PgPool) {
         common::api_fixtures::create_managed_host(&env).await.into();
     let mut txn = env.pool.begin().await.unwrap();
     let host = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &host_machine_id,
         MachineSearchConfig::default(),
     )
@@ -405,7 +406,7 @@ async fn test_topology_update_on_machineid_update(pool: sqlx::PgPool) {
         MachineId::from_str("fm100hsag07peffp850l14kvmhrqjf9h6jslilfahaknhvb6sq786c0g3jg").unwrap();
     let mut txn = env.pool.begin().await.unwrap();
     let host = db::machine::find_one(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         &host_machine_id,
         MachineSearchConfig::default(),
     )
@@ -413,10 +414,14 @@ async fn test_topology_update_on_machineid_update(pool: sqlx::PgPool) {
     .unwrap();
     assert!(host.is_none());
 
-    let host = db::machine::find_one(txn.as_mut(), &m_id, MachineSearchConfig::default())
-        .await
-        .unwrap()
-        .unwrap();
+    let host = db::machine::find_one(
+        &mut txn.as_db_reader(),
+        &m_id,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
 
     assert!(host.hardware_info.as_ref().is_some());
 }

--- a/crates/api/src/tests/machine_update_manager.rs
+++ b/crates/api/src/tests/machine_update_manager.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use carbide_uuid::machine::MachineId;
 use common::api_fixtures::create_test_env;
+use db::db_read::AsDbReader;
 use figment::Figment;
 use figment::providers::{Format, Toml};
 use model::dpu_machine_update::DpuMachineUpdate;
@@ -191,11 +192,14 @@ async fn test_remove_machine_update_markers(
         .await
         .unwrap();
 
-    let managed_host =
-        db::managed_host::load_snapshot(txn.as_mut(), &host_machine_id, Default::default())
-            .await
-            .unwrap()
-            .unwrap();
+    let managed_host = db::managed_host::load_snapshot(
+        &mut txn.as_db_reader(),
+        &host_machine_id,
+        Default::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
     assert!(
         !managed_host
             .host_snapshot

--- a/crates/api/src/tests/network_security_group.rs
+++ b/crates/api/src/tests/network_security_group.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use std::borrow::Borrow;
 use std::time::SystemTime;
 
 use carbide_uuid::instance::InstanceId;
@@ -1262,7 +1263,7 @@ async fn test_network_security_group_propagation_impl(
 
     // peek into the db to get the internal id.  note that the state machine has not processed the instance yet
     // so getting the network via the api will not work.
-    let instance = db::instance::find_by_id(&pool, instance_id)
+    let instance = db::instance::find_by_id(&mut pool.borrow().into(), instance_id)
         .await
         .unwrap()
         .unwrap();
@@ -1466,7 +1467,7 @@ async fn test_network_security_group_propagation_impl(
 
     // peek into the db to get the internal id.  note that the state machine has not processed the instance yet
     // so getting the network via the api will not work.
-    let instance = db::instance::find_by_id(&pool, instance_id2)
+    let instance = db::instance::find_by_id(&mut pool.borrow().into(), instance_id2)
         .await
         .unwrap()
         .unwrap();

--- a/crates/api/src/tests/network_segment.rs
+++ b/crates/api/src/tests/network_segment.rs
@@ -27,6 +27,7 @@ use common::network_segment::{
     text_history,
 };
 use db::ObjectColumnFilter;
+use db::db_read::AsDbReader;
 use db::network_segment::VpcColumn;
 use db::vpc::IdColumn;
 use mac_address::MacAddress;
@@ -140,7 +141,7 @@ async fn test_network_segment_delete_fails_with_associated_machine_interface(
 
     let mut txn = env.pool.begin().await?;
     let db_segment = db::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(db::network_segment::IdColumn, &segment.id.unwrap()),
         network_segment::NetworkSegmentSearchConfig::default(),
     )
@@ -304,7 +305,7 @@ async fn test_network_segment_max_history_length(
 
     let mut txn = env.pool.begin().await.unwrap();
     let mut version = db::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(db::network_segment::IdColumn, &segment_id),
         network_segment::NetworkSegmentSearchConfig::default(),
     )
@@ -329,7 +330,7 @@ async fn test_network_segment_max_history_length(
             .unwrap()
         );
         version = db::network_segment::find_by(
-            txn.as_mut(),
+            &mut txn.as_db_reader(),
             ObjectColumnFilter::One(db::network_segment::IdColumn, &segment_id),
             network_segment::NetworkSegmentSearchConfig::default(),
         )
@@ -511,7 +512,7 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
     let search_cfg = NetworkSegmentSearchConfig::default();
     let mut txn = db_pool.begin().await?;
     let num_before = db::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::<db::network_segment::IdColumn>::All,
         search_cfg,
     )
@@ -521,7 +522,7 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
     crate::db_init::create_initial_networks(&env.api, &env.pool, &networks).await?;
     let mut txn = db_pool.begin().await?;
     let num_after = db::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::<db::network_segment::IdColumn>::All,
         search_cfg,
     )
@@ -914,7 +915,7 @@ async fn test_update_svi_ip(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error
 
     let mut txn = env.pool.begin().await?;
     let segments = db::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(VpcColumn, &vpc_id),
         network_segment::NetworkSegmentSearchConfig::default(),
     )
@@ -939,7 +940,7 @@ async fn test_update_svi_ip(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error
     // Already created segments must have SVI allocated.
     let mut txn = env.pool.begin().await?;
     let segments = db::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(VpcColumn, &vpc_id),
         network_segment::NetworkSegmentSearchConfig::default(),
     )
@@ -967,7 +968,7 @@ async fn test_update_svi_ip(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error
 
     let mut txn = env.pool.begin().await?;
     let segments = db::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(VpcColumn, &vpc_id),
         network_segment::NetworkSegmentSearchConfig::default(),
     )
@@ -995,7 +996,7 @@ async fn test_update_svi_ip_admin_segment(
     let admin_segment = db::network_segment::admin(&mut txn).await?;
     assert!(admin_segment.vpc_id.is_some());
     let admin_vpc = db::vpc::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(IdColumn, &admin_segment.vpc_id.unwrap()),
     )
     .await?;
@@ -1022,7 +1023,7 @@ async fn test_update_svi_ip_post_instance_allocation(
 
     let mut txn = env.pool.begin().await?;
     let segments = db::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(db::network_segment::IdColumn, &segment_id),
         network_segment::NetworkSegmentSearchConfig::default(),
     )
@@ -1061,7 +1062,7 @@ async fn test_update_svi_ip_post_instance_allocation(
     // At this moment, the third IP is taken from the tenant subnet for the instance.
     let mut txn = env.pool.begin().await?;
     let mut segment = db::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(db::network_segment::IdColumn, &segment_id),
         network_segment::NetworkSegmentSearchConfig::default(),
     )
@@ -1077,7 +1078,7 @@ async fn test_update_svi_ip_post_instance_allocation(
 
     let mut txn = env.pool.begin().await?;
     let mut segment = db::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(db::network_segment::IdColumn, &segment_id),
         network_segment::NetworkSegmentSearchConfig::default(),
     )

--- a/crates/api/src/tests/power_shelf_state_controller/mod.rs
+++ b/crates/api/src/tests/power_shelf_state_controller/mod.rs
@@ -108,7 +108,6 @@ async fn test_power_shelf_state_transitions(
 
     let handler_services = Arc::new(CommonStateHandlerServices {
         db_pool: pool.clone(),
-        db_reader: pool.clone().into(),
         redfish_client_pool: env.redfish_sim.clone(),
         ib_fabric_manager: env.ib_fabric_manager.clone(),
         ib_pools: env.common_pools.infiniband.clone(),
@@ -183,7 +182,6 @@ async fn test_power_shelf_deletion_flow(
 
     let handler_services = Arc::new(CommonStateHandlerServices {
         db_pool: pool.clone(),
-        db_reader: pool.clone().into(),
         redfish_client_pool: env.redfish_sim.clone(),
         ib_fabric_manager: env.ib_fabric_manager.clone(),
         ib_pools: env.common_pools.infiniband.clone(),
@@ -280,7 +278,6 @@ async fn test_power_shelf_error_state_handling(
 
     let handler_services = Arc::new(CommonStateHandlerServices {
         db_pool: pool.clone(),
-        db_reader: pool.clone().into(),
         redfish_client_pool: env.redfish_sim.clone(),
         ib_fabric_manager: env.ib_fabric_manager.clone(),
         ib_pools: env.common_pools.infiniband.clone(),
@@ -410,7 +407,6 @@ async fn test_power_shelf_deletion_with_state_controller(
 
     let handler_services = Arc::new(CommonStateHandlerServices {
         db_pool: pool.clone(),
-        db_reader: pool.clone().into(),
         redfish_client_pool: env.redfish_sim.clone(),
         ib_fabric_manager: env.ib_fabric_manager.clone(),
         ib_pools: env.common_pools.infiniband.clone(),

--- a/crates/api/src/tests/prevent_duplicate_mac_addresses.rs
+++ b/crates/api/src/tests/prevent_duplicate_mac_addresses.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use db::db_read::AsDbReader;
 use db::{self, ObjectColumnFilter, network_segment};
 use model::address_selection_strategy::AddressSelectionStrategy;
 use model::machine::machine_id::from_hardware_info;
@@ -32,7 +33,7 @@ async fn prevent_duplicate_mac_addresses(
     let mut txn = env.pool.begin().await?;
 
     let network_segment = db::network_segment::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(network_segment::IdColumn, &env.admin_segment.unwrap()),
         model::network_segment::NetworkSegmentSearchConfig::default(),
     )

--- a/crates/api/src/tests/rack_firmware.rs
+++ b/crates/api/src/tests/rack_firmware.rs
@@ -118,7 +118,7 @@ async fn test_create_rack_firmware(pool: sqlx::PgPool) -> Result<(), Box<dyn std
     assert!(!firmware.updated.is_empty());
 
     // Verify database state
-    let db_firmware = DbRackFirmware::find_by_id(&env.pool, firmware_id).await?;
+    let db_firmware = DbRackFirmware::find_by_id(&mut env.db_reader(), firmware_id).await?;
     assert_eq!(db_firmware.id, firmware_id);
     assert!(!db_firmware.available);
     assert!(db_firmware.parsed_components.is_some());
@@ -245,7 +245,7 @@ async fn test_delete_rack_firmware(pool: sqlx::PgPool) -> Result<(), Box<dyn std
     env.api.create_rack_firmware(create_request).await?;
 
     // Verify it exists
-    let firmware = DbRackFirmware::find_by_id(&env.pool, firmware_id).await;
+    let firmware = DbRackFirmware::find_by_id(&mut env.db_reader(), firmware_id).await;
     assert!(firmware.is_ok());
 
     // Delete it
@@ -255,7 +255,7 @@ async fn test_delete_rack_firmware(pool: sqlx::PgPool) -> Result<(), Box<dyn std
     env.api.delete_rack_firmware(delete_request).await?;
 
     // Verify it's gone
-    let firmware = DbRackFirmware::find_by_id(&env.pool, firmware_id).await;
+    let firmware = DbRackFirmware::find_by_id(&mut env.db_reader(), firmware_id).await;
     assert!(firmware.is_err());
 
     Ok(())
@@ -449,7 +449,7 @@ async fn test_rack_firmware_with_multiple_components(
     assert_eq!(firmware.id, firmware_id);
 
     // Verify parsed components
-    let db_firmware = DbRackFirmware::find_by_id(&env.pool, firmware_id).await?;
+    let db_firmware = DbRackFirmware::find_by_id(&mut env.db_reader(), firmware_id).await?;
     assert!(db_firmware.parsed_components.is_some());
 
     let parsed = db_firmware.parsed_components.unwrap();

--- a/crates/api/src/tests/rack_state_controller/mod.rs
+++ b/crates/api/src/tests/rack_state_controller/mod.rs
@@ -21,6 +21,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use carbide_uuid::rack::RackId;
+use db::db_read::AsDbReader;
 use db::rack as db_rack;
 use model::rack::{Rack, RackMaintenanceState, RackReadyState, RackState, RackValidationState};
 use rpc::forge::RackStateHistoryRecord;
@@ -129,7 +130,7 @@ async fn test_can_retrieve_rack_state_history(
         .await?;
 
     // Verify rack exists
-    db_rack::get(&mut *txn, rack_id).await?;
+    db_rack::get(&mut txn.as_db_reader(), rack_id).await?;
 
     // Start the state controller to process the rack while it's active
     let rack_handler = Arc::new(TestRackStateHandler::default());
@@ -202,7 +203,7 @@ async fn test_rack_state_transitions(pool: sqlx::PgPool) -> Result<(), Box<dyn s
         .await?;
 
     // Verify rack exists
-    let rack = db_rack::get(&mut *txn, rack_id).await?;
+    let rack = db_rack::get(&mut txn.as_db_reader(), rack_id).await?;
 
     // Verify initial state is Expected
     assert!(matches!(rack.controller_state.value, RackState::Expected));
@@ -262,7 +263,7 @@ async fn test_rack_deletion_flow(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
         .await?;
 
     // Verify rack exists
-    let rack = db_rack::get(&mut *txn, rack_id).await?;
+    let rack = db_rack::get(&mut txn.as_db_reader(), rack_id).await?;
     assert_eq!(rack.id, rack_id);
 
     // Start the state controller to process the rack while it's active
@@ -395,7 +396,7 @@ async fn test_rack_state_transition_validation(
         .with_rack_id(rack_id)
         .persist(&mut txn)
         .await?;
-    let rack = db_rack::get(&mut *txn, rack_id).await?;
+    let rack = db_rack::get(&mut txn.as_db_reader(), rack_id).await?;
 
     // Verify initial state is Expected
     assert!(matches!(rack.controller_state.value, RackState::Expected));
@@ -419,10 +420,10 @@ async fn test_rack_state_transition_validation(
     ];
 
     for state in states {
-        set_rack_controller_state(pool.acquire().await?.as_mut(), rack_id, state.clone()).await?;
+        set_rack_controller_state(txn.as_mut(), rack_id, state.clone()).await?;
 
         // Verify the state was set correctly
-        let rack = db_rack::get(&pool, rack_id).await?;
+        let rack = db_rack::get(&mut txn.as_db_reader(), rack_id).await?;
         assert!(matches!(rack.controller_state.value, _ if rack.controller_state.value == state));
     }
 

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -24,6 +24,7 @@ use carbide_uuid::network::NetworkSegmentId;
 use common::api_fixtures::TestEnv;
 use common::api_fixtures::endpoint_explorer::MockEndpointExplorer;
 use config_version::ConfigVersion;
+use db::db_read::AsDbReader;
 use db::sku::CURRENT_SKU_VERSION;
 use db::{self, ObjectColumnFilter, ObjectFilter, explored_endpoints as db_explored_endpoints};
 use ipnetwork::IpNetwork;
@@ -254,7 +255,7 @@ async fn test_site_explorer_default_pause_ingestion_and_poweron(
     explorer.run_single_iteration().await.unwrap();
 
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(txn.as_mut())
+    let explored = db::explored_endpoints::find_all(&mut txn.as_db_reader())
         .await
         .unwrap();
     assert_eq!(explored.len(), 1);
@@ -296,9 +297,9 @@ async fn test_site_explorer_default_pause_ingestion_and_poweron(
     );
 
     let machine_snapshots =
-        db::managed_host::load_all(&env.pool, LoadSnapshotOptions::default()).await?;
+        db::managed_host::load_all(&mut env.db_reader(), LoadSnapshotOptions::default()).await?;
     assert_eq!(machine_snapshots.len(), 0);
-    let explored_managed_hosts = db::explored_managed_host::find_all(&env.pool).await?;
+    let explored_managed_hosts = db::explored_managed_host::find_all(&mut env.db_reader()).await?;
     assert_eq!(explored_managed_hosts.len(), 0);
 
     // now flip the flag and run another interation
@@ -330,10 +331,10 @@ async fn test_site_explorer_default_pause_ingestion_and_poweron(
         response.into_inner().machine_ingestion_state()
     );
 
-    let explored_managed_hosts = db::explored_managed_host::find_all(&env.pool).await?;
+    let explored_managed_hosts = db::explored_managed_host::find_all(&mut env.db_reader()).await?;
     assert_eq!(explored_managed_hosts.len(), 1);
     let machine_snapshots =
-        db::managed_host::load_all(&env.pool, LoadSnapshotOptions::default()).await?;
+        db::managed_host::load_all(&mut env.db_reader(), LoadSnapshotOptions::default()).await?;
     assert_eq!(machine_snapshots.len(), 1);
 
     Ok(())
@@ -450,7 +451,7 @@ async fn test_site_explorer_main(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
     explorer.run_single_iteration().await.unwrap();
     // Since we configured a limit of 2 entries, we should have those 2 results now
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(txn.as_mut())
+    let explored = db::explored_endpoints::find_all(&mut txn.as_db_reader())
         .await
         .unwrap();
     txn.commit().await?;
@@ -515,7 +516,7 @@ async fn test_site_explorer_main(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
     explorer.run_single_iteration().await.unwrap();
     // Since we configured a limit of 2 entries, we should have those 2 results now
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(txn.as_mut())
+    let explored = db::explored_endpoints::find_all(&mut txn.as_db_reader())
         .await
         .unwrap();
     txn.commit().await?;
@@ -607,7 +608,7 @@ async fn test_site_explorer_main(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
     explorer.run_single_iteration().await.unwrap();
     explorer.run_single_iteration().await.unwrap();
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(txn.as_mut())
+    let explored = db::explored_endpoints::find_all(&mut txn.as_db_reader())
         .await
         .unwrap();
     assert_eq!(explored.len(), 3);
@@ -949,7 +950,7 @@ async fn test_site_explorer_audit_exploration_results(
     explorer.run_single_iteration().await.unwrap();
 
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(txn.as_mut())
+    let explored = db::explored_endpoints::find_all(&mut txn.as_db_reader())
         .await
         .unwrap();
     txn.commit().await?;
@@ -1122,7 +1123,7 @@ async fn test_site_explorer_reexplore(
     explorer.run_single_iteration().await.unwrap();
     // Since we configured a limit of 1 entries, we should have 1 results now
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(txn.as_mut())
+    let explored = db::explored_endpoints::find_all(&mut txn.as_db_reader())
         .await
         .unwrap();
     txn.commit().await?;
@@ -1145,7 +1146,7 @@ async fn test_site_explorer_reexplore(
 
     // Calling the API should set the `exploration_requested` flag on the endpoint
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(txn.as_mut())
+    let explored = db::explored_endpoints::find_all(&mut txn.as_db_reader())
         .await
         .unwrap();
     txn.commit().await?;
@@ -1157,7 +1158,7 @@ async fn test_site_explorer_reexplore(
     // endpoint - but not find anything new
     explorer.run_single_iteration().await.unwrap();
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(txn.as_mut())
+    let explored = db::explored_endpoints::find_all(&mut txn.as_db_reader())
         .await
         .unwrap();
     txn.commit().await?;
@@ -1190,7 +1191,7 @@ async fn test_site_explorer_reexplore(
     );
 
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(txn.as_mut())
+    let explored = db::explored_endpoints::find_all(&mut txn.as_db_reader())
         .await
         .unwrap();
     txn.commit().await?;
@@ -1209,7 +1210,7 @@ async fn test_site_explorer_reexplore(
         .into_inner();
 
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(txn.as_mut())
+    let explored = db::explored_endpoints::find_all(&mut txn.as_db_reader())
         .await
         .unwrap();
     txn.commit().await?;
@@ -1220,7 +1221,7 @@ async fn test_site_explorer_reexplore(
     // 3rd iteration still yields 1 result
     explorer.run_single_iteration().await.unwrap();
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(txn.as_mut())
+    let explored = db::explored_endpoints::find_all(&mut txn.as_db_reader())
         .await
         .unwrap();
     txn.commit().await?;
@@ -1437,7 +1438,7 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
     // Run site explorer
     explorer.run_single_iteration().await.unwrap();
     let mut txn = env.pool.begin().await?;
-    let explored_endpoints = db::explored_endpoints::find_all(txn.as_mut())
+    let explored_endpoints = db::explored_endpoints::find_all(&mut txn.as_db_reader())
         .await
         .unwrap();
 
@@ -1449,11 +1450,15 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
 
     assert_eq!(explored_endpoints.len(), 2);
 
-    let mut explored_managed_hosts = db::explored_managed_host::find_all(&env.pool).await?;
-    let mut machines =
-        db::machine::find(&env.pool, ObjectFilter::All, MachineSearchConfig::default())
-            .await
-            .unwrap();
+    let mut explored_managed_hosts =
+        db::explored_managed_host::find_all(&mut env.db_reader()).await?;
+    let mut machines = db::machine::find(
+        &mut env.db_reader(),
+        ObjectFilter::All,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap();
 
     // There should be no managed host
     assert_eq!(explored_managed_hosts.len(), 0);
@@ -1461,10 +1466,12 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
 
     // Now update expected_machine entry with fallback_dpu_serial
     let mut txn = env.pool.begin().await?;
-    let mut host1_expected_machine =
-        db::expected_machine::find_by_bmc_mac_address(txn.as_mut(), HOST1_MAC.parse().unwrap())
-            .await?
-            .expect("Expected machine not found");
+    let mut host1_expected_machine = db::expected_machine::find_by_bmc_mac_address(
+        &mut txn.as_db_reader(),
+        HOST1_MAC.parse().unwrap(),
+    )
+    .await?
+    .expect("Expected machine not found");
     host1_expected_machine.data = ExpectedMachineData {
         bmc_username: "user1".to_string(),
         bmc_password: "pw".to_string(),
@@ -1481,10 +1488,14 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
     txn.commit().await?;
 
     explorer.run_single_iteration().await.unwrap();
-    explored_managed_hosts = db::explored_managed_host::find_all(&env.pool).await?;
-    machines = db::machine::find(&env.pool, ObjectFilter::All, MachineSearchConfig::default())
-        .await
-        .unwrap();
+    explored_managed_hosts = db::explored_managed_host::find_all(&mut env.db_reader()).await?;
+    machines = db::machine::find(
+        &mut env.db_reader(),
+        ObjectFilter::All,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap();
 
     // We should see one explored_managed host && 2 machines
     assert_eq!(
@@ -1700,7 +1711,7 @@ async fn test_fetch_host_primary_interface_mac(
 
         assert!(!response.address.is_empty());
         let oob_interface =
-            db::machine_interface::find_by_mac_address(txn.as_mut(), oob_mac).await?;
+            db::machine_interface::find_by_mac_address(&mut txn.as_db_reader(), oob_mac).await?;
         assert!(oob_interface[0].primary_interface);
         oob_interfaces.push(oob_interface[0].clone());
 
@@ -2054,8 +2065,11 @@ async fn test_site_explorer_fixtures_zerodpu_dhcp_before_site_explorer(
             let mac_address = *mock.managed_host.non_dpu_macs.first().unwrap();
             async move {
                 let mut txn = pool.begin().await?;
-                let interfaces =
-                    db::machine_interface::find_by_mac_address(txn.as_mut(), mac_address).await?;
+                let interfaces = db::machine_interface::find_by_mac_address(
+                    &mut txn.as_db_reader(),
+                    mac_address,
+                )
+                .await?;
                 assert_eq!(interfaces.len(), 1);
                 // There should be no machine_id yet as site-explorer has not run
                 assert!(interfaces[0].machine_id.is_none());
@@ -2180,7 +2194,7 @@ async fn test_site_explorer_unknown_vendor(
     explorer.run_single_iteration().await.unwrap();
     // Since we configured a limit of 2 entries, we should have those 2 results now
     let mut txn = env.pool.begin().await?;
-    let explored = db::explored_endpoints::find_all(txn.as_mut())
+    let explored = db::explored_endpoints::find_all(&mut txn.as_db_reader())
         .await
         .unwrap();
     txn.commit().await?;
@@ -2444,7 +2458,7 @@ async fn test_machine_creation_with_sku(
     // Run site explorer
     explorer.run_single_iteration().await.unwrap();
     let mut txn = env.pool.begin().await?;
-    let explored_endpoints = db::explored_endpoints::find_all(txn.as_mut())
+    let explored_endpoints = db::explored_endpoints::find_all(&mut txn.as_db_reader())
         .await
         .unwrap();
 
@@ -2456,9 +2470,13 @@ async fn test_machine_creation_with_sku(
 
     assert_eq!(explored_endpoints.len(), 2);
 
-    let machines = db::machine::find(&env.pool, ObjectFilter::All, MachineSearchConfig::default())
-        .await
-        .unwrap();
+    let machines = db::machine::find(
+        &mut env.db_reader(),
+        ObjectFilter::All,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap();
 
     for m in machines {
         if m.is_dpu() {
@@ -2877,7 +2895,9 @@ async fn test_site_explorer_power_shelf_discovery(
     explorer.run_single_iteration().await.unwrap();
 
     let mut txn = env.pool.begin().await?;
-    let explored = db_explored_endpoints::find_all(txn.as_mut()).await.unwrap();
+    let explored = db_explored_endpoints::find_all(&mut txn.as_db_reader())
+        .await
+        .unwrap();
     txn.commit().await?;
     assert_eq!(explored.len(), 1);
 
@@ -3419,7 +3439,9 @@ async fn test_site_explorer_power_shelf_error_handling(
     explorer.run_single_iteration().await.unwrap();
 
     let mut txn = env.pool.begin().await?;
-    let explored = db_explored_endpoints::find_all(txn.as_mut()).await.unwrap();
+    let explored = db_explored_endpoints::find_all(&mut txn.as_db_reader())
+        .await
+        .unwrap();
     txn.commit().await?;
     assert_eq!(explored.len(), 1);
 
@@ -4460,7 +4482,9 @@ async fn test_site_explorer_power_shelf_discovery_with_static_ip(
     explorer.run_single_iteration().await.unwrap();
 
     let mut txn = env.pool.begin().await?;
-    let explored = db_explored_endpoints::find_all(txn.as_mut()).await.unwrap();
+    let explored = db_explored_endpoints::find_all(&mut txn.as_db_reader())
+        .await
+        .unwrap();
     txn.commit().await?;
     assert_eq!(explored.len(), 1);
 
@@ -4511,7 +4535,7 @@ async fn test_get_machine_position_info(
 
     // Get the existing explored endpoint (created by create_managed_host) and update it with position info
     let mut txn = env.pool.begin().await?;
-    let existing = db::explored_endpoints::find_by_ips(txn.as_mut(), vec![bmc_ip])
+    let existing = db::explored_endpoints::find_by_ips(&mut txn.as_db_reader(), vec![bmc_ip])
         .await?
         .pop()
         .unwrap();

--- a/crates/api/src/tests/sku.rs
+++ b/crates/api/src/tests/sku.rs
@@ -18,6 +18,7 @@ pub mod tests {
     use std::time::Duration;
 
     use carbide_uuid::machine::MachineId;
+    use db::db_read::AsDbReader;
     use db::sku::CURRENT_SKU_VERSION;
     use db::{self, DatabaseError, ObjectFilter, WithTransaction};
     use futures_util::FutureExt;
@@ -314,7 +315,7 @@ pub mod tests {
         machine_id: &MachineId,
     ) -> Result<model::machine::Machine, eyre::Error> {
         db::machine::find(
-            txn,
+            &mut txn.as_db_reader(),
             ObjectFilter::One(*machine_id),
             MachineSearchConfig::default(),
         )
@@ -351,7 +352,7 @@ pub mod tests {
 
         let mut txn = env.pool.begin().await?;
         let machine = db::machine::find(
-            txn.as_mut(),
+            &mut txn.as_db_reader(),
             ObjectFilter::One(machine_id),
             MachineSearchConfig::default(),
         )
@@ -371,7 +372,7 @@ pub mod tests {
 
         // create an older version sku from new topology data will create a backwards compatible sku
         let old_sku = db::sku::generate_sku_from_machine_at_version(
-            txn.as_mut(),
+            &mut txn.as_db_reader(),
             &machine_id,
             old_schema_version,
         )
@@ -459,7 +460,8 @@ pub mod tests {
 
         let expected_sku: Sku = serde_json::de::from_str::<rpc::forge::Sku>(SKU_DATA)?.into();
 
-        let mut actual_sku = db::sku::generate_sku_from_machine(&pool, &machine_id).await?;
+        let mut actual_sku =
+            db::sku::generate_sku_from_machine(&mut env.db_reader(), &machine_id).await?;
         // cheat the created timestamp and id
         actual_sku.id = "sku id".to_string();
         actual_sku.created = expected_sku.created;
@@ -480,14 +482,15 @@ pub mod tests {
         let (machine_id, _dpu_id) = create_managed_host(&env).await.into();
         let mut txn = pool.begin().await?;
 
-        let actual_sku = db::sku::generate_sku_from_machine(txn.as_mut(), &machine_id).await?;
+        let actual_sku =
+            db::sku::generate_sku_from_machine(&mut txn.as_db_reader(), &machine_id).await?;
         db::sku::create(&mut txn, &actual_sku).await?;
         let actual_sku = db::sku::find(&mut txn, &[actual_sku.id]).await?.remove(0);
 
         db::machine::assign_sku(&mut txn, &machine_id, &actual_sku.id).await?;
 
         let machine = db::machine::find(
-            txn.as_mut(),
+            &mut txn.as_db_reader(),
             ObjectFilter::One(machine_id),
             MachineSearchConfig::default(),
         )
@@ -499,7 +502,7 @@ pub mod tests {
         db::machine::unassign_sku(&mut txn, &machine_id).await?;
 
         let machine = db::machine::find(
-            txn.as_mut(),
+            &mut txn.as_db_reader(),
             ObjectFilter::One(machine_id),
             MachineSearchConfig::default(),
         )
@@ -543,7 +546,7 @@ pub mod tests {
         let (machine_id, _dpu_id) = create_managed_host(&env).await.into();
 
         let machine = db::machine::find(
-            &pool,
+            &mut env.db_reader(),
             ObjectFilter::One(machine_id),
             MachineSearchConfig::default(),
         )
@@ -578,7 +581,7 @@ pub mod tests {
         let (machine_id, _dpu_id) = mh.into();
 
         let machine = db::machine::find(
-            &pool,
+            &mut env.db_reader(),
             ObjectFilter::One(machine_id),
             MachineSearchConfig::default(),
         )
@@ -668,7 +671,8 @@ pub mod tests {
 
         let mut txn = pool.begin().await?;
 
-        let actual_sku = db::sku::generate_sku_from_machine(txn.as_mut(), &machine_id).await?;
+        let actual_sku =
+            db::sku::generate_sku_from_machine(&mut txn.as_db_reader(), &machine_id).await?;
         db::sku::create(&mut txn, &actual_sku).await?;
 
         db::machine::assign_sku(&mut txn, &machine_id, &actual_sku.id).await?;
@@ -819,7 +823,8 @@ pub mod tests {
             }
         ));
 
-        let mut sku = db::sku::generate_sku_from_machine(txn.as_mut(), &machine_id).await?;
+        let mut sku =
+            db::sku::generate_sku_from_machine(&mut txn.as_db_reader(), &machine_id).await?;
         sku.id = "no-sku".to_string();
 
         db::sku::create(&mut txn, &sku).await?;
@@ -1107,7 +1112,8 @@ pub mod tests {
 
         let mut txn = pool.begin().await?;
 
-        let actual_sku = db::sku::generate_sku_from_machine(txn.as_mut(), &machine_id).await?;
+        let actual_sku =
+            db::sku::generate_sku_from_machine(&mut txn.as_db_reader(), &machine_id).await?;
         db::sku::create(&mut txn, &actual_sku).await?;
 
         db::machine::assign_sku(&mut txn, &machine_id, &actual_sku.id).await?;
@@ -1514,7 +1520,8 @@ pub mod tests {
 
         let mut txn = pool.begin().await?;
 
-        let actual_sku = db::sku::generate_sku_from_machine(txn.as_mut(), &machine_id).await?;
+        let actual_sku =
+            db::sku::generate_sku_from_machine(&mut txn.as_db_reader(), &machine_id).await?;
         db::sku::create(&mut txn, &actual_sku).await?;
 
         db::machine::assign_sku(&mut txn, &machine_id, &actual_sku.id).await?;
@@ -1562,7 +1569,7 @@ pub mod tests {
 
         // The SKU should have been auto-created and assigned by create_managed_host when BOM validation is enabled
         let machine = db::machine::find(
-            txn.as_mut(),
+            &mut txn.as_db_reader(),
             ObjectFilter::One(machine_id),
             MachineSearchConfig::default(),
         )
@@ -1591,7 +1598,7 @@ pub mod tests {
         txn.commit().await?;
 
         let machine = db::machine::find(
-            &pool,
+            &mut env.db_reader(),
             ObjectFilter::One(machine_id),
             MachineSearchConfig::default(),
         )
@@ -1606,7 +1613,7 @@ pub mod tests {
         env.run_machine_state_controller_iteration().await;
 
         let machine = db::machine::find(
-            &pool,
+            &mut env.db_reader(),
             ObjectFilter::One(machine_id),
             MachineSearchConfig::default(),
         )
@@ -1646,7 +1653,7 @@ pub mod tests {
 
         let mut txn = pool.begin().await?;
         let machine = db::machine::find(
-            txn.as_mut(),
+            &mut txn.as_db_reader(),
             ObjectFilter::One(machine_id),
             MachineSearchConfig::default(),
         )
@@ -1676,7 +1683,7 @@ pub mod tests {
         let mut txn = pool.begin().await?;
 
         let machine = db::machine::find(
-            txn.as_mut(),
+            &mut txn.as_db_reader(),
             ObjectFilter::One(machine_id),
             MachineSearchConfig::default(),
         )
@@ -1726,7 +1733,7 @@ pub mod tests {
         .await;
 
         let machine = db::machine::find(
-            &pool,
+            &mut env.db_reader(),
             ObjectFilter::One(machine_id),
             MachineSearchConfig::default(),
         )
@@ -1781,7 +1788,7 @@ pub mod tests {
         let (machine_id, _dpu_id) = create_managed_host(&env).await.into();
 
         let machine = db::machine::find(
-            &pool,
+            &mut env.db_reader(),
             ObjectFilter::One(machine_id),
             MachineSearchConfig::default(),
         )
@@ -1812,7 +1819,7 @@ pub mod tests {
 
         let sku_ids = vec![assigned_sku_id.clone(), unassigned_sku.id.clone()];
         let machine_ids_by_sku_ids =
-            db::machine::find_machine_ids_by_sku_ids(&pool, &sku_ids).await?;
+            db::machine::find_machine_ids_by_sku_ids(&mut env.db_reader(), &sku_ids).await?;
 
         assert_eq!(machine_ids_by_sku_ids.len(), 2);
 

--- a/crates/api/src/tests/switch.rs
+++ b/crates/api/src/tests/switch.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 use carbide_uuid::switch::SwitchId;
+use db::db_read::AsDbReader;
 use db::switch as db_switch;
 use model::switch::{NewSwitch, SwitchConfig, SwitchControllerState, SwitchStatus};
 use rpc::forge::forge_server::Forge;
@@ -595,7 +596,7 @@ async fn test_find_switch_with_bmc_info(
         .expect("Underlay segment should exist in test env");
 
     let underlay_segments = db_network_segment::find_by(
-        &mut txn,
+        &mut txn.as_db_reader(),
         db::ObjectColumnFilter::One(db_network_segment::IdColumn, &underlay_segment_id),
         Default::default(),
     )

--- a/crates/api/src/tests/switch_state_controller/mod.rs
+++ b/crates/api/src/tests/switch_state_controller/mod.rs
@@ -105,7 +105,6 @@ async fn test_switch_state_transitions(
 
     let handler_services = Arc::new(CommonStateHandlerServices {
         db_pool: pool.clone(),
-        db_reader: pool.clone().into(),
         redfish_client_pool: env.redfish_sim.clone(),
         ib_fabric_manager: env.ib_fabric_manager.clone(),
         ib_pools: env.common_pools.infiniband.clone(),
@@ -176,7 +175,6 @@ async fn test_switch_deletion_flow(pool: sqlx::PgPool) -> Result<(), Box<dyn std
 
     let handler_services = Arc::new(CommonStateHandlerServices {
         db_pool: pool.clone(),
-        db_reader: pool.clone().into(),
         redfish_client_pool: env.redfish_sim.clone(),
         ib_fabric_manager: env.ib_fabric_manager.clone(),
         ib_pools: env.common_pools.infiniband.clone(),
@@ -269,7 +267,6 @@ async fn test_switch_error_state_handling(
 
     let handler_services = Arc::new(CommonStateHandlerServices {
         db_pool: pool.clone(),
-        db_reader: pool.clone().into(),
         redfish_client_pool: env.redfish_sim.clone(),
         ib_fabric_manager: env.ib_fabric_manager.clone(),
         ib_pools: env.common_pools.infiniband.clone(),
@@ -391,7 +388,6 @@ async fn test_switch_deletion_with_state_controller(
 
     let handler_services = Arc::new(CommonStateHandlerServices {
         db_pool: pool.clone(),
-        db_reader: pool.clone().into(),
         redfish_client_pool: env.redfish_sim.clone(),
         ib_fabric_manager: env.ib_fabric_manager.clone(),
         ib_pools: env.common_pools.infiniband.clone(),

--- a/crates/api/src/tests/tpm_ca.rs
+++ b/crates/api/src/tests/tpm_ca.rs
@@ -68,7 +68,7 @@ pub mod tests {
         let mut txn = env.pool.begin().await?;
 
         let segment = db::network_segment::find_by(
-            txn.as_mut(),
+            &mut txn.as_db_reader(),
             ObjectColumnFilter::One(db::network_segment::IdColumn, &env.admin_segment.unwrap()),
             network_segment::NetworkSegmentSearchConfig::default(),
         )
@@ -119,7 +119,7 @@ pub mod tests {
         let mut txn = env.pool.begin().await?;
 
         let segment = db::network_segment::find_by(
-            txn.as_mut(),
+            &mut txn.as_db_reader(),
             ObjectColumnFilter::One(db::network_segment::IdColumn, &env.admin_segment.unwrap()),
             network_segment::NetworkSegmentSearchConfig::default(),
         )
@@ -181,6 +181,7 @@ pub mod tests {
     }
 
     use db::attestation::ek_cert_verification_status;
+    use db::db_read::AsDbReader;
 
     use crate::attestation::match_insert_new_ek_cert_status_against_ca;
 
@@ -262,10 +263,11 @@ pub mod tests {
 
         let mut txn: sqlx::Transaction<'_, sqlx::Postgres> = env.pool.begin().await?;
 
-        let ek_cert_status = ek_cert_verification_status::get_by_machine_id(txn.as_mut(), host_id)
-            .await
-            .expect("Failed: could not make a look up for EkCertVerificationStatus in DB")
-            .expect("Failed: could not find EkCertVerificationStatus for given machine in DB");
+        let ek_cert_status =
+            ek_cert_verification_status::get_by_machine_id(&mut txn.as_db_reader(), host_id)
+                .await
+                .expect("Failed: could not make a look up for EkCertVerificationStatus in DB")
+                .expect("Failed: could not find EkCertVerificationStatus for given machine in DB");
 
         assert!(!ek_cert_status.signing_ca_found);
 
@@ -296,10 +298,11 @@ pub mod tests {
 
         let mut txn: sqlx::Transaction<'_, sqlx::Postgres> = env.pool.begin().await?;
 
-        let ek_cert_status = ek_cert_verification_status::get_by_machine_id(txn.as_mut(), host_id)
-            .await
-            .expect("Failed: could not make a look up for EkCertVerificationStatus in DB")
-            .expect("Failed: could not find EkCertVerificationStatus for given machine in DB");
+        let ek_cert_status =
+            ek_cert_verification_status::get_by_machine_id(&mut txn.as_db_reader(), host_id)
+                .await
+                .expect("Failed: could not make a look up for EkCertVerificationStatus in DB")
+                .expect("Failed: could not find EkCertVerificationStatus for given machine in DB");
 
         assert!(!ek_cert_status.signing_ca_found);
 
@@ -1182,7 +1185,7 @@ pub mod tests {
         let mut txn = env.pool.begin().await?;
 
         let segment = db::network_segment::find_by(
-            txn.as_mut(),
+            &mut txn.as_db_reader(),
             ObjectColumnFilter::One(db::network_segment::IdColumn, &env.admin_segment.unwrap()),
             network_segment::NetworkSegmentSearchConfig::default(),
         )

--- a/crates/api/src/tests/vpc.rs
+++ b/crates/api/src/tests/vpc.rs
@@ -21,6 +21,7 @@ use carbide_network::virtualization::VpcVirtualizationType;
 use carbide_uuid::vpc::VpcId;
 use common::api_fixtures::{create_test_env, populate_network_security_groups};
 use config_version::ConfigVersion;
+use db::db_read::AsDbReader;
 use db::vpc::{self};
 use db::{self, ObjectColumnFilter};
 use model::metadata::Metadata;
@@ -380,7 +381,7 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
     .await?;
 
     let mut vpcs = db::vpc::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(vpc::IdColumn, &no_org_vpc_id),
     )
     .await?;
@@ -403,7 +404,7 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
     .await?;
 
     let mut vpcs = db::vpc::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(vpc::IdColumn, &no_org_vpc_id),
     )
     .await?;
@@ -435,7 +436,7 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
 
     // Check that the data was indeed not touched
     let mut vpcs = db::vpc::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(vpc::IdColumn, &no_org_vpc_id),
     )
     .await?;
@@ -462,7 +463,7 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
     assert_eq!(updated_vpc.version.version_nr(), 5);
 
     let mut vpcs = db::vpc::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(vpc::IdColumn, &no_org_vpc_id),
     )
     .await?;
@@ -475,7 +476,7 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
     assert!(vpc.deleted.is_some());
 
     let vpcs = db::vpc::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(vpc::IdColumn, &vpc.id),
     )
     .await?;
@@ -485,7 +486,11 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
     assert!(vpcs.is_empty());
 
     let mut txn = env.pool.begin().await?;
-    let vpcs = db::vpc::find_by(txn.as_mut(), ObjectColumnFilter::<vpc::IdColumn>::All).await?;
+    let vpcs = db::vpc::find_by(
+        &mut txn.as_db_reader(),
+        ObjectColumnFilter::<vpc::IdColumn>::All,
+    )
+    .await?;
     assert_eq!(vpcs.len(), 1);
     let forge_vpc_id: VpcId = forge_vpc.id.expect("should have id");
     assert_eq!(vpcs[0].id, forge_vpc_id);
@@ -495,7 +500,11 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
     txn.commit().await?;
 
     let mut txn = env.pool.begin().await?;
-    let vpcs = db::vpc::find_by(txn.as_mut(), ObjectColumnFilter::<vpc::IdColumn>::All).await?;
+    let vpcs = db::vpc::find_by(
+        &mut txn.as_db_reader(),
+        ObjectColumnFilter::<vpc::IdColumn>::All,
+    )
+    .await?;
     assert!(vpcs.is_empty());
     txn.commit().await?;
 
@@ -707,7 +716,7 @@ async fn find_vpc_by_id(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Er
     "#).bind(vpc_id).execute(txn.deref_mut()).await?;
 
     let some_vpc = db::vpc::find_by(
-        txn.as_mut(),
+        &mut txn.as_db_reader(),
         ObjectColumnFilter::One(vpc::IdColumn, &vpc_id),
     )
     .await?;

--- a/crates/api/src/tests/vpc_find.rs
+++ b/crates/api/src/tests/vpc_find.rs
@@ -18,6 +18,7 @@ use std::ops::DerefMut;
 
 use ::rpc::forge as rpc;
 use carbide_uuid::vpc::VpcId;
+use db::db_read::AsDbReader;
 use rpc::forge_server::Forge;
 
 use crate::tests::common::api_fixtures::instance::default_tenant_config;
@@ -188,7 +189,7 @@ async fn find_vpc_by_name(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::
         INSERT INTO vpcs (id, name, organization_id, version) VALUES ($1, 'test vpc 1', '2829bbe3-c169-4cd9-8b2a-19a8b1618a93', 'V1-T1666644937952267');
     "#).bind(vpc_id).execute(txn.deref_mut()).await?;
 
-    let some_vpc = db::vpc::find_by_name(txn.as_mut(), "test vpc 1").await?;
+    let some_vpc = db::vpc::find_by_name(&mut txn.as_db_reader(), "test vpc 1").await?;
 
     assert_eq!(1, some_vpc.len());
 
@@ -324,13 +325,13 @@ async fn test_vpc_find_by_segment(pool: sqlx::PgPool) {
     let env = create_test_env(pool).await;
     let segment_id = env.create_vpc_and_tenant_segment().await;
 
-    let vpc_id = db::vpc::find_by_name(&env.pool, "test vpc 1")
+    let vpc_id = db::vpc::find_by_name(&mut env.db_reader(), "test vpc 1")
         .await
         .unwrap()
         .first()
         .unwrap()
         .id;
-    let vpc = db::vpc::find_by_segment(&env.pool, segment_id)
+    let vpc = db::vpc::find_by_segment(&mut env.db_reader(), segment_id)
         .await
         .unwrap();
     assert_eq!(vpc.id.to_string(), vpc_id.to_string());

--- a/crates/api/src/tests/vpc_peering.rs
+++ b/crates/api/src/tests/vpc_peering.rs
@@ -58,7 +58,7 @@ async fn find_vpc_id_by_name(
     env: &TestEnv,
     vpc_name: &str,
 ) -> Result<VpcId, Box<dyn std::error::Error>> {
-    let vpc_id = db::vpc::find_by_name(&env.pool, vpc_name)
+    let vpc_id = db::vpc::find_by_name(&mut env.db_reader(), vpc_name)
         .await?
         .into_iter()
         .next()

--- a/crates/api/src/tests/web/managed_host.rs
+++ b/crates/api/src/tests/web/managed_host.rs
@@ -148,7 +148,7 @@ async fn test_managed_host_row_display(pool: sqlx::PgPool) -> eyre::Result<()> {
         .expect("mock DPU should have gotten a BMC IP");
 
     let snapshots = managed_host::load_all(
-        &env.pool,
+        &mut env.db_reader(),
         LoadSnapshotOptions {
             include_history: false,
             include_instance_data: false,

--- a/crates/api/src/web/managed_host.rs
+++ b/crates/api/src/web/managed_host.rs
@@ -387,7 +387,7 @@ pub async fn show_html(
 ) -> Response {
     let host_health = state.runtime_config.host_health;
     let managed_hosts = match managed_host::load_all(
-        &state.database_connection,
+        &mut state.db_reader(),
         LoadSnapshotOptions {
             include_history: false,
             include_instance_data: false,


### PR DESCRIPTION
## Description
Using a trait with `impl DbReader<'_>` causes all methods in the db crate to be monomorphized into the api crate, which can carry a severe penalty in compilation times, since the api crate cannot simply link to the pre-compiled functions in the db crate. It has to stamp out a monmorphized version of each function it uses.

Instead, if DbReader is a concrete type, a pre-compiled version of each db method can be used, and recompiling the api crate becomes a lot faster.

The downside is that *every* place where we have a PgConnection or PgTransaction, we have to manually convert to a DbReader at the call site, rather than letting PgConnection/PgTransaction implement the DbReader trait directly like we were before. But this is likely worth it, if it helps the compilation times.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes

