### PR TITLE
chore: use api modeling for rack firmware API management

### DIFF
--- a/crates/api-db/src/rack_firmware.rs
+++ b/crates/api-db/src/rack_firmware.rs
@@ -16,8 +16,7 @@
  */
 
 use chrono::{DateTime, Utc};
-use model::rack_firmware::RackFirmwareApplyHistoryRecord;
-use serde::{Deserialize, Serialize};
+use model::rack_firmware::{RackFirmware, RackFirmwareApplyHistoryRecord};
 use sqlx::Error::RowNotFound;
 use sqlx::postgres::PgRow;
 use sqlx::types::Json;
@@ -63,7 +62,6 @@ impl From<DbRackFirmwareApplyHistoryWithAvailability> for RackFirmwareApplyHisto
     }
 }
 
-/// Record a firmware apply event
 pub async fn record_apply_history(
     txn: &mut PgConnection,
     firmware_id: &str,
@@ -127,141 +125,93 @@ pub async fn list_apply_history(
     Ok(rows.into_iter().map(Into::into).collect())
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RackFirmware {
-    pub id: String,
-    pub config: Json<serde_json::Value>,
-    pub available: bool,
-    pub parsed_components: Option<Json<serde_json::Value>>,
-    pub created: DateTime<Utc>,
-    pub updated: DateTime<Utc>,
+pub async fn create(
+    txn: &mut PgConnection,
+    id: &str,
+    config: serde_json::Value,
+    parsed_components: Option<serde_json::Value>,
+) -> DatabaseResult<RackFirmware> {
+    let query = "INSERT INTO rack_firmware (id, config, parsed_components) VALUES ($1, $2::jsonb, $3::jsonb) RETURNING *";
+
+    sqlx::query_as(query)
+        .bind(id)
+        .bind(Json(config))
+        .bind(parsed_components.map(Json))
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::new(query, e))
 }
 
-impl<'r> FromRow<'r, PgRow> for RackFirmware {
-    fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
-        Ok(RackFirmware {
-            id: row.try_get("id")?,
-            config: row.try_get("config")?,
-            available: row.try_get("available")?,
-            parsed_components: row.try_get("parsed_components")?,
-            created: row.try_get("created")?,
-            updated: row.try_get("updated")?,
-        })
-    }
-}
-impl From<&RackFirmware> for rpc::forge::RackFirmware {
-    fn from(db: &RackFirmware) -> Self {
-        let parsed_components = db
-            .parsed_components
-            .as_ref()
-            .map(|p| p.0.to_string())
-            .unwrap_or_else(|| "{}".to_string());
-
-        rpc::forge::RackFirmware {
-            id: db.id.clone(),
-            config_json: db.config.0.to_string(),
-            available: db.available,
-            created: db.created.format("%Y-%m-%d %H:%M:%S").to_string(),
-            updated: db.updated.format("%Y-%m-%d %H:%M:%S").to_string(),
-            parsed_components,
-        }
-    }
+pub async fn find_by_id(txn: impl DbReader<'_>, id: &str) -> DatabaseResult<RackFirmware> {
+    let query = "SELECT * FROM rack_firmware WHERE id = $1";
+    let ret = sqlx::query_as(query).bind(id).fetch_one(txn).await;
+    ret.map_err(|e| match e {
+        RowNotFound => DatabaseError::NotFoundError {
+            kind: "rack firmware",
+            id: format!("{id:?}"),
+        },
+        _ => DatabaseError::query(query, e),
+    })
 }
 
-impl RackFirmware {
-    /// Create a new Rack firmware configuration
-    pub async fn create(
-        txn: &mut PgConnection,
-        id: &str,
-        config: serde_json::Value,
-        parsed_components: Option<serde_json::Value>,
-    ) -> DatabaseResult<Self> {
-        let query = "INSERT INTO rack_firmware (id, config, parsed_components) VALUES ($1, $2::jsonb, $3::jsonb) RETURNING *";
+pub async fn list_all(
+    txn: &mut PgConnection,
+    only_available: bool,
+) -> DatabaseResult<Vec<RackFirmware>> {
+    let query = if only_available {
+        "SELECT * FROM rack_firmware WHERE available = true ORDER BY created DESC"
+    } else {
+        "SELECT * FROM rack_firmware ORDER BY created DESC"
+    };
 
-        sqlx::query_as(query)
-            .bind(id)
-            .bind(Json(config))
-            .bind(parsed_components.map(Json))
-            .fetch_one(txn)
-            .await
-            .map_err(|e| DatabaseError::new(query, e))
-    }
+    sqlx::query_as(query)
+        .fetch_all(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))
+}
 
-    /// Find a Rack firmware configuration by ID
-    pub async fn find_by_id(txn: impl DbReader<'_>, id: &str) -> DatabaseResult<Self> {
-        let query = "SELECT * FROM rack_firmware WHERE id = $1";
-        let ret = sqlx::query_as(query).bind(id).fetch_one(txn).await;
-        ret.map_err(|e| match e {
-            RowNotFound => DatabaseError::NotFoundError {
-                kind: "rack firmware",
-                id: format!("{id:?}"),
-            },
-            _ => DatabaseError::query(query, e),
-        })
-    }
+pub async fn update_config(
+    txn: &mut PgConnection,
+    id: &str,
+    config: serde_json::Value,
+) -> DatabaseResult<RackFirmware> {
+    let query =
+        "UPDATE rack_firmware SET config = $2::jsonb, updated = NOW() WHERE id = $1 RETURNING *";
 
-    /// List all Rack firmware configurations
-    pub async fn list_all(
-        txn: &mut PgConnection,
-        only_available: bool,
-    ) -> DatabaseResult<Vec<Self>> {
-        let query = if only_available {
-            "SELECT * FROM rack_firmware WHERE available = true ORDER BY created DESC"
-        } else {
-            "SELECT * FROM rack_firmware ORDER BY created DESC"
-        };
+    sqlx::query_as(query)
+        .bind(id)
+        .bind(Json(config))
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::new(query, e))
+}
 
-        sqlx::query_as(query)
-            .fetch_all(txn)
-            .await
-            .map_err(|e| DatabaseError::query(query, e))
-    }
+pub async fn set_available(
+    txn: &mut PgConnection,
+    id: &str,
+    available: bool,
+) -> DatabaseResult<RackFirmware> {
+    let query =
+        "UPDATE rack_firmware SET available = $2, updated = NOW() WHERE id = $1 RETURNING *";
 
-    /// Update the configuration
-    pub async fn update_config(
-        txn: &mut PgConnection,
-        id: &str,
-        config: serde_json::Value,
-    ) -> DatabaseResult<Self> {
-        let query = "UPDATE rack_firmware SET config = $2::jsonb, updated = NOW() WHERE id = $1 RETURNING *";
+    sqlx::query_as(query)
+        .bind(id)
+        .bind(available)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::new(query, e))
+}
 
-        sqlx::query_as(query)
-            .bind(id)
-            .bind(Json(config))
-            .fetch_one(txn)
-            .await
-            .map_err(|e| DatabaseError::new(query, e))
-    }
+pub async fn delete(txn: &mut PgConnection, id: &str) -> DatabaseResult<()> {
+    let query = "DELETE FROM rack_firmware WHERE id = $1 RETURNING id";
 
-    /// Update the available flag
-    pub async fn set_available(
-        txn: &mut PgConnection,
-        id: &str,
-        available: bool,
-    ) -> DatabaseResult<Self> {
-        let query =
-            "UPDATE rack_firmware SET available = $2, updated = NOW() WHERE id = $1 RETURNING *";
+    sqlx::query_as::<_, (String,)>(query)
+        .bind(id)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::new(query, e))?;
 
-        sqlx::query_as(query)
-            .bind(id)
-            .bind(available)
-            .fetch_one(txn)
-            .await
-            .map_err(|e| DatabaseError::new(query, e))
-    }
-
-    /// Delete a Rack firmware configuration
-    pub async fn delete(txn: &mut PgConnection, id: &str) -> DatabaseResult<()> {
-        let query = "DELETE FROM rack_firmware WHERE id = $1 RETURNING id";
-
-        sqlx::query_as::<_, (String,)>(query)
-            .bind(id)
-            .fetch_one(txn)
-            .await
-            .map_err(|e| DatabaseError::new(query, e))?;
-
-        Ok(())
-    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -275,12 +225,10 @@ mod tests {
         let mut txn = pool.begin().await.unwrap();
 
         // Create a firmware config so we can verify the availability join
-        RackFirmware::create(&mut txn, "fw-001", json!({"Id": "fw-001"}), None)
+        create(&mut txn, "fw-001", json!({"Id": "fw-001"}), None)
             .await
             .unwrap();
-        RackFirmware::set_available(&mut txn, "fw-001", true)
-            .await
-            .unwrap();
+        set_available(&mut txn, "fw-001", true).await.unwrap();
 
         // Record two apply events for the same firmware
         record_apply_history(&mut txn, "fw-001", "rack-a", "prod")
@@ -330,12 +278,10 @@ mod tests {
         let mut txn = pool.begin().await.unwrap();
 
         // Create firmware and mark available
-        RackFirmware::create(&mut txn, "fw-002", json!({"Id": "fw-002"}), None)
+        create(&mut txn, "fw-002", json!({"Id": "fw-002"}), None)
             .await
             .unwrap();
-        RackFirmware::set_available(&mut txn, "fw-002", true)
-            .await
-            .unwrap();
+        set_available(&mut txn, "fw-002", true).await.unwrap();
 
         // Record an apply
         record_apply_history(&mut txn, "fw-002", "rack-a", "prod")
@@ -350,7 +296,7 @@ mod tests {
         assert!(before[0].firmware_available);
 
         // Delete the firmware
-        RackFirmware::delete(&mut txn, "fw-002").await.unwrap();
+        delete(&mut txn, "fw-002").await.unwrap();
 
         // History entry still exists but firmware_available is now false
         let after = list_apply_history(&mut txn, Some("fw-002"), &[])

--- a/crates/api-model/src/rack_firmware.rs
+++ b/crates/api-model/src/rack_firmware.rs
@@ -17,6 +17,51 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use sqlx::postgres::PgRow;
+use sqlx::types::Json;
+use sqlx::{FromRow, Row};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RackFirmware {
+    pub id: String,
+    pub config: Json<serde_json::Value>,
+    pub available: bool,
+    pub parsed_components: Option<Json<serde_json::Value>>,
+    pub created: DateTime<Utc>,
+    pub updated: DateTime<Utc>,
+}
+
+impl<'r> FromRow<'r, PgRow> for RackFirmware {
+    fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
+        Ok(RackFirmware {
+            id: row.try_get("id")?,
+            config: row.try_get("config")?,
+            available: row.try_get("available")?,
+            parsed_components: row.try_get("parsed_components")?,
+            created: row.try_get("created")?,
+            updated: row.try_get("updated")?,
+        })
+    }
+}
+
+impl From<&RackFirmware> for rpc::forge::RackFirmware {
+    fn from(db: &RackFirmware) -> Self {
+        let parsed_components = db
+            .parsed_components
+            .as_ref()
+            .map(|p| p.0.to_string())
+            .unwrap_or_else(|| "{}".to_string());
+
+        rpc::forge::RackFirmware {
+            id: db.id.clone(),
+            config_json: db.config.0.to_string(),
+            available: db.available,
+            created: db.created.format("%Y-%m-%d %H:%M:%S").to_string(),
+            updated: db.updated.format("%Y-%m-%d %H:%M:%S").to_string(),
+            parsed_components,
+        }
+    }
+}
 
 /// A record of a rack firmware apply operation
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/api/src/handlers/rack_firmware.rs
+++ b/crates/api/src/handlers/rack_firmware.rs
@@ -18,8 +18,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use db::DatabaseError;
-use db::rack_firmware::RackFirmware as DbRackFirmware;
+use db::{DatabaseError, rack_firmware as rack_firmware_db};
 use forge_secrets::credentials::{CredentialKey, CredentialReader, Credentials};
 use rpc::forge::{
     DeviceUpdateResult, NodeJobInfo, RackFirmware, RackFirmwareApplyRequest,
@@ -327,7 +326,7 @@ pub async fn create(
         .await
         .map_err(|e| CarbideError::from(DatabaseError::new("begin create", e)))?;
 
-    let db_config = DbRackFirmware::create(&mut txn, &id, config, parsed_components).await?;
+    let db_config = rack_firmware_db::create(&mut txn, &id, config, parsed_components).await?;
 
     txn.commit()
         .await
@@ -362,7 +361,7 @@ pub async fn get(
 ) -> Result<Response<RackFirmware>, Status> {
     let req = request.into_inner();
 
-    let db_config = DbRackFirmware::find_by_id(&api.database_connection, &req.id)
+    let db_config = rack_firmware_db::find_by_id(&api.database_connection, &req.id)
         .await
         .map_err(CarbideError::from)?;
 
@@ -382,7 +381,7 @@ pub async fn list(
         .await
         .map_err(|e| CarbideError::from(DatabaseError::new("begin list", e)))?;
 
-    let db_configs = DbRackFirmware::list_all(&mut txn, req.only_available).await?;
+    let db_configs = rack_firmware_db::list_all(&mut txn, req.only_available).await?;
 
     txn.commit()
         .await
@@ -409,7 +408,7 @@ pub async fn delete(
         .await
         .map_err(|e| CarbideError::from(DatabaseError::new("begin delete", e)))?;
 
-    DbRackFirmware::delete(&mut txn, &req.id)
+    rack_firmware_db::delete(&mut txn, &req.id)
         .await
         .map_err(CarbideError::from)?;
 
@@ -952,7 +951,7 @@ pub async fn apply(
     );
 
     // Get the RackFirmware configuration from the database
-    let fw_config = DbRackFirmware::find_by_id(&api.database_connection, &req.firmware_id)
+    let fw_config = rack_firmware_db::find_by_id(&api.database_connection, &req.firmware_id)
         .await
         .map_err(|e| Status::internal(format!("Failed to get firmware configuration: {}", e)))?;
 

--- a/crates/api/src/tests/rack_firmware.rs
+++ b/crates/api/src/tests/rack_firmware.rs
@@ -16,7 +16,6 @@
  */
 
 use common::api_fixtures::create_test_env;
-use db::rack_firmware::RackFirmware as DbRackFirmware;
 use rpc::forge::{
     RackFirmwareCreateRequest, RackFirmwareDeleteRequest, RackFirmwareGetRequest,
     RackFirmwareListRequest,
@@ -118,7 +117,7 @@ async fn test_create_rack_firmware(pool: sqlx::PgPool) -> Result<(), Box<dyn std
     assert!(!firmware.updated.is_empty());
 
     // Verify database state
-    let db_firmware = DbRackFirmware::find_by_id(&env.pool, firmware_id).await?;
+    let db_firmware = db::rack_firmware::find_by_id(&env.pool, firmware_id).await?;
     assert_eq!(db_firmware.id, firmware_id);
     assert!(!db_firmware.available);
     assert!(db_firmware.parsed_components.is_some());
@@ -245,7 +244,7 @@ async fn test_delete_rack_firmware(pool: sqlx::PgPool) -> Result<(), Box<dyn std
     env.api.create_rack_firmware(create_request).await?;
 
     // Verify it exists
-    let firmware = DbRackFirmware::find_by_id(&env.pool, firmware_id).await;
+    let firmware = db::rack_firmware::find_by_id(&env.pool, firmware_id).await;
     assert!(firmware.is_ok());
 
     // Delete it
@@ -255,7 +254,7 @@ async fn test_delete_rack_firmware(pool: sqlx::PgPool) -> Result<(), Box<dyn std
     env.api.delete_rack_firmware(delete_request).await?;
 
     // Verify it's gone
-    let firmware = DbRackFirmware::find_by_id(&env.pool, firmware_id).await;
+    let firmware = db::rack_firmware::find_by_id(&env.pool, firmware_id).await;
     assert!(firmware.is_err());
 
     Ok(())
@@ -303,7 +302,7 @@ async fn test_rack_firmware_full_lifecycle(
 
     // 4. Update availability in database
     let mut txn = env.pool.begin().await?;
-    DbRackFirmware::set_available(&mut txn, firmware_id, true).await?;
+    db::rack_firmware::set_available(&mut txn, firmware_id, true).await?;
     txn.commit().await?;
 
     // 5. Verify availability changed
@@ -449,7 +448,7 @@ async fn test_rack_firmware_with_multiple_components(
     assert_eq!(firmware.id, firmware_id);
 
     // Verify parsed components
-    let db_firmware = DbRackFirmware::find_by_id(&env.pool, firmware_id).await?;
+    let db_firmware = db::rack_firmware::find_by_id(&env.pool, firmware_id).await?;
     assert!(db_firmware.parsed_components.is_some());
 
     let parsed = db_firmware.parsed_components.unwrap();


### PR DESCRIPTION
## Description

This is similar to https://github.com/NVIDIA/ncx-infra-controller-core/pull/602, https://github.com/NVIDIA/ncx-infra-controller-core/pull/598, and https://github.com/NVIDIA/ncx-infra-controller-core/pull/596, in which I'm working through places where we should be implementing our new `STYLE_GUIDE.md` guidelines, and ensuring proper models exist in `api-model` for taking gRPC requests, translating them at the API layer with `From/TryFrom` implementations, and passing them downstream to the `api-db` layer.

Previously there was some modeling *in* the DB layer (with implementations). I'm moving all of that into `api-model`, keeping the `::rpc` stuff away from DB.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

