### PR TITLE
chore: rpc -> api-model plumbing for nvl_logical_partition

### DIFF
--- a/crates/api-db/src/nvl_logical_partition.rs
+++ b/crates/api-db/src/nvl_logical_partition.rs
@@ -15,16 +15,12 @@
  * limitations under the License.
  */
 
-use ::rpc::forge as rpc;
 use carbide_uuid::nvlink::NvLinkLogicalPartitionId;
-use chrono::prelude::*;
 use config_version::ConfigVersion;
-use model::metadata::Metadata;
-use model::tenant::TenantOrganizationId;
-// use futures::StreamExt;
-use serde::{Deserialize, Serialize};
-use sqlx::postgres::PgRow;
-use sqlx::{FromRow, PgConnection, Row};
+use model::nvl_logical_partition::{
+    LogicalPartition, LogicalPartitionSnapshotPgJson, LogicalPartitionState, NewLogicalPartition,
+};
+use sqlx::PgConnection;
 
 use crate::db_read::DbReader;
 use crate::{ColumnInfo, DatabaseError, FilterableQueryBuilder, ObjectColumnFilter};
@@ -51,187 +47,15 @@ impl<'a> ColumnInfo<'a> for NameColumn {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct NewLogicalPartition {
-    pub id: NvLinkLogicalPartitionId,
-    pub config: LogicalPartitionConfig,
-}
+pub async fn create(
+    value: &NewLogicalPartition,
+    txn: &mut PgConnection,
+) -> Result<LogicalPartition, DatabaseError> {
+    let state = LogicalPartitionState::Ready;
+    let config = &value.config;
+    let config_version = ConfigVersion::initial();
 
-impl TryFrom<rpc::NvLinkLogicalPartitionCreationRequest> for NewLogicalPartition {
-    type Error = DatabaseError;
-    fn try_from(value: rpc::NvLinkLogicalPartitionCreationRequest) -> Result<Self, Self::Error> {
-        let id: NvLinkLogicalPartitionId = value.id.unwrap_or_else(|| uuid::Uuid::new_v4().into());
-
-        let conf = value.config.ok_or_else(|| {
-            DatabaseError::InvalidArgument("NvLinkLogicalPartition config is empty".to_string())
-        })?;
-
-        Ok(NewLogicalPartition {
-            id,
-            config: LogicalPartitionConfig::try_from(conf)?,
-        })
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Deserialize)]
-pub struct LogicalPartitionConfig {
-    pub metadata: Metadata,
-    pub tenant_organization_id: TenantOrganizationId,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub struct LogicalPartitionName(String);
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "state", rename_all = "lowercase")]
-pub enum LogicalPartitionState {
-    Provisioning,
-    Ready,
-    Updating,
-    Error,
-    Deleting,
-}
-
-#[derive(Debug, Clone)]
-pub struct LogicalPartition {
-    pub id: NvLinkLogicalPartitionId,
-
-    pub name: String,
-    pub description: String,
-    pub tenant_organization_id: TenantOrganizationId,
-
-    pub config_version: ConfigVersion,
-
-    pub partition_state: LogicalPartitionState,
-
-    pub created: DateTime<Utc>,
-    pub updated: DateTime<Utc>,
-    pub deleted: Option<DateTime<Utc>>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct LogicalPartitionSnapshotPgJson {
-    id: NvLinkLogicalPartitionId,
-    name: String,
-    description: String,
-    tenant_organization_id: TenantOrganizationId,
-    config_version: ConfigVersion,
-    partition_state: LogicalPartitionState,
-    created: DateTime<Utc>,
-    updated: DateTime<Utc>,
-    deleted: Option<DateTime<Utc>>,
-}
-
-impl TryFrom<LogicalPartitionSnapshotPgJson> for LogicalPartition {
-    type Error = sqlx::Error;
-    fn try_from(value: LogicalPartitionSnapshotPgJson) -> sqlx::Result<Self> {
-        Ok(Self {
-            id: value.id,
-            name: value.name,
-            description: value.description,
-            tenant_organization_id: value.tenant_organization_id,
-            config_version: value.config_version,
-            partition_state: value.partition_state,
-            created: value.created,
-            updated: value.updated,
-            deleted: value.deleted,
-        })
-    }
-}
-
-impl<'r> FromRow<'r, PgRow> for LogicalPartitionSnapshotPgJson {
-    fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
-        let json: serde_json::value::Value = row.try_get(0)?;
-        LogicalPartitionSnapshotPgJson::deserialize(json)
-            .map_err(|err| sqlx::Error::Decode(err.into()))
-    }
-}
-
-/// Converts from Protobuf LogicalPartitionCreationRequest into LogicalPartition
-///
-/// Use try_from in order to return a Result where Result is an error if the conversion
-/// from String -> UUID fails
-///
-impl TryFrom<rpc::NvLinkLogicalPartitionConfig> for LogicalPartitionConfig {
-    type Error = DatabaseError;
-
-    fn try_from(conf: rpc::NvLinkLogicalPartitionConfig) -> Result<Self, Self::Error> {
-        if conf.tenant_organization_id.is_empty() {
-            return Err(DatabaseError::InvalidArgument(
-                "NvLinkLogicalPartition organization_id is empty".to_string(),
-            ));
-        }
-
-        let tenant_organization_id =
-            TenantOrganizationId::try_from(conf.tenant_organization_id.clone())
-                .map_err(|_| DatabaseError::InvalidArgument(conf.tenant_organization_id))?;
-
-        Ok(LogicalPartitionConfig {
-            metadata: conf.metadata.unwrap_or_default().try_into()?,
-            tenant_organization_id,
-        })
-    }
-}
-
-///
-/// Marshal a Data Object (LogicalPartition) into an RPC LogicalPartition
-///
-impl TryFrom<LogicalPartition> for rpc::NvLinkLogicalPartition {
-    type Error = DatabaseError;
-    fn try_from(src: LogicalPartition) -> Result<Self, Self::Error> {
-        let mut state = match &src.partition_state {
-            LogicalPartitionState::Provisioning => rpc::TenantState::Provisioning,
-            LogicalPartitionState::Ready => rpc::TenantState::Ready,
-            LogicalPartitionState::Error => rpc::TenantState::Failed, // TODO include cause in rpc
-            LogicalPartitionState::Deleting => rpc::TenantState::Terminating,
-            LogicalPartitionState::Updating => rpc::TenantState::Updating,
-        };
-
-        // If deletion is requested, we immediately overwrite the state to terminating.
-        // Even though the state controller hasn't caught up - it eventually will
-        if is_marked_as_deleted(&src) {
-            state = rpc::TenantState::Terminating;
-        }
-        let status = Some(rpc::NvLinkLogicalPartitionStatus {
-            state: state as i32,
-        });
-
-        let config = rpc::NvLinkLogicalPartitionConfig {
-            metadata: Some(rpc::Metadata {
-                name: src.name,
-                description: src.description,
-                ..Default::default()
-            }),
-            tenant_organization_id: src.tenant_organization_id.to_string(),
-        };
-
-        Ok(rpc::NvLinkLogicalPartition {
-            id: Some(src.id),
-            config_version: src.config_version.version_string(),
-            status,
-            config: Some(config),
-            created: Some(src.created.into()),
-        })
-    }
-}
-
-impl TryFrom<LogicalPartitionConfig> for rpc::NvLinkLogicalPartitionConfig {
-    type Error = DatabaseError;
-    fn try_from(src: LogicalPartitionConfig) -> Result<Self, Self::Error> {
-        Ok(rpc::NvLinkLogicalPartitionConfig {
-            metadata: Some(src.metadata.into()),
-            tenant_organization_id: src.tenant_organization_id.to_string(),
-        })
-    }
-}
-
-impl NewLogicalPartition {
-    pub async fn create(&self, txn: &mut PgConnection) -> Result<LogicalPartition, DatabaseError> {
-        let state = LogicalPartitionState::Ready;
-        let config = &self.config;
-        let config_version = ConfigVersion::initial();
-
-        let query = "INSERT INTO nvlink_logical_partitions (
+    let query = "INSERT INTO nvlink_logical_partitions (
                 id,
                 name,
                 description,
@@ -241,20 +65,19 @@ impl NewLogicalPartition {
             VALUES ($1, $2, $3, $4, $5, $6)
             RETURNING row_to_json(nvlink_logical_partitions.*)";
 
-        let partition: LogicalPartitionSnapshotPgJson = sqlx::query_as(query)
-            .bind(self.id)
-            .bind(&config.metadata.name)
-            .bind(&config.metadata.description)
-            .bind(config.tenant_organization_id.to_string())
-            .bind(config_version)
-            .bind(sqlx::types::Json(&state))
-            .fetch_one(txn)
-            .await
-            .map_err(|e| DatabaseError::new(query, e))?;
-        partition
-            .try_into()
-            .map_err(|e| DatabaseError::new(query, e))
-    }
+    let partition: LogicalPartitionSnapshotPgJson = sqlx::query_as(query)
+        .bind(value.id)
+        .bind(&config.metadata.name)
+        .bind(&config.metadata.description)
+        .bind(config.tenant_organization_id.to_string())
+        .bind(config_version)
+        .bind(sqlx::types::Json(&state))
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::new(query, e))?;
+    partition
+        .try_into()
+        .map_err(|e| DatabaseError::new(query, e))
 }
 
 /// Retrieves the IDs of all NvLink partitions
@@ -362,11 +185,6 @@ pub async fn mark_as_deleted(
         .map_err(|e| DatabaseError::new(query, e))?;
 
     Ok(partition)
-}
-
-/// Returns whether a logical partition was deleted by user
-pub fn is_marked_as_deleted(partition: &LogicalPartition) -> bool {
-    partition.deleted.is_some()
 }
 
 pub async fn update(

--- a/crates/api-db/src/nvl_partition.rs
+++ b/crates/api-db/src/nvl_partition.rs
@@ -15,12 +15,9 @@
  * limitations under the License.
  */
 
-use ::rpc::forge as rpc;
-use carbide_uuid::nvlink::{NvLinkDomainId, NvLinkLogicalPartitionId, NvLinkPartitionId};
-use chrono::prelude::*;
-use serde::{Deserialize, Serialize};
-use sqlx::postgres::PgRow;
-use sqlx::{FromRow, PgConnection, Row};
+use carbide_uuid::nvlink::NvLinkPartitionId;
+use model::nvl_partition::{NewNvlPartition, NvlPartition, NvlPartitionSnapshotPgJson};
+use sqlx::PgConnection;
 
 use crate::db_read::DbReader;
 use crate::{
@@ -38,111 +35,11 @@ impl ColumnInfo<'_> for IdColumn {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct NewNvlPartition {
-    pub id: NvLinkPartitionId,
-    pub name: NvlPartitionName,
-    pub logical_partition_id: NvLinkLogicalPartitionId,
-    pub domain_uuid: NvLinkDomainId,
-    pub nmx_m_id: String,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NvlPartitionStatus {
-    pub partition: String,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, sqlx::Type, sqlx::FromRow)]
-pub struct NvlPartitionName(String);
-
-impl TryFrom<String> for NvlPartitionName {
-    type Error = DatabaseError;
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Ok(NvlPartitionName(value))
-    }
-}
-
-impl From<NvlPartitionName> for String {
-    fn from(value: NvlPartitionName) -> Self {
-        value.0
-    }
-}
-#[derive(Debug, Clone)]
-pub struct NvlPartition {
-    pub id: NvLinkPartitionId,
-    pub nmx_m_id: String,
-    pub domain_uuid: NvLinkDomainId,
-    pub name: NvlPartitionName,
-    pub created: DateTime<Utc>,
-    pub updated: DateTime<Utc>,
-    pub deleted: Option<DateTime<Utc>>,
-    pub logical_partition_id: Option<NvLinkLogicalPartitionId>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct NvlPartitionSnapshotPgJson {
-    id: NvLinkPartitionId,
-    nmx_m_id: String,
-    name: NvlPartitionName,
-    domain_uuid: NvLinkDomainId,
-    created: DateTime<Utc>,
-    updated: DateTime<Utc>,
-    deleted: Option<DateTime<Utc>>,
-
-    logical_partition_id: Option<NvLinkLogicalPartitionId>,
-}
-
-impl TryFrom<NvlPartitionSnapshotPgJson> for NvlPartition {
-    type Error = sqlx::Error;
-    fn try_from(value: NvlPartitionSnapshotPgJson) -> sqlx::Result<Self> {
-        Ok(Self {
-            id: value.id,
-            nmx_m_id: value.nmx_m_id,
-            domain_uuid: value.domain_uuid,
-            name: value.name,
-            created: value.created,
-            updated: value.updated,
-            deleted: value.deleted,
-            logical_partition_id: value.logical_partition_id,
-        })
-    }
-}
-
-impl<'r> FromRow<'r, PgRow> for NvlPartitionSnapshotPgJson {
-    fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
-        let json: serde_json::value::Value = row.try_get(0)?;
-        NvlPartitionSnapshotPgJson::deserialize(json).map_err(|err| sqlx::Error::Decode(err.into()))
-    }
-}
-
-impl<'r> FromRow<'r, PgRow> for NvlPartition {
-    fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
-        let json: serde_json::value::Value = row.try_get(0)?;
-        NvlPartitionSnapshotPgJson::deserialize(json)
-            .map_err(|err| sqlx::Error::Decode(err.into()))?
-            .try_into()
-    }
-}
-
-///
-/// Marshal a Data Object (NvlPartition) into an RPC NvlPartition
-///
-impl TryFrom<NvlPartition> for rpc::NvLinkPartition {
-    type Error = DatabaseError;
-    fn try_from(src: NvlPartition) -> Result<Self, Self::Error> {
-        Ok(rpc::NvLinkPartition {
-            id: Some(src.id),
-            name: src.name.clone().into(),
-            nmx_m_id: src.nmx_m_id,
-            domain_uuid: Some(src.domain_uuid),
-            logical_partition_id: src.logical_partition_id,
-        })
-    }
-}
-
-impl NewNvlPartition {
-    pub async fn create(&self, txn: &mut PgConnection) -> Result<NvlPartition, DatabaseError> {
-        let query = "INSERT INTO nvlink_partitions (
+pub async fn create(
+    value: &NewNvlPartition,
+    txn: &mut PgConnection,
+) -> Result<NvlPartition, DatabaseError> {
+    let query = "INSERT INTO nvlink_partitions (
                 id,
                 nmx_m_id,
                 name,
@@ -151,19 +48,18 @@ impl NewNvlPartition {
             VALUES ($1, $2, $3, $4, $5)
             RETURNING row_to_json(nvlink_partitions.*)";
 
-        let partition: NvlPartitionSnapshotPgJson = sqlx::query_as(query)
-            .bind(self.id)
-            .bind(&self.nmx_m_id)
-            .bind(&self.name.0)
-            .bind(self.domain_uuid)
-            .bind(self.logical_partition_id)
-            .fetch_one(txn)
-            .await
-            .map_err(|e| DatabaseError::new(query, e))?;
-        partition
-            .try_into()
-            .map_err(|e| DatabaseError::new(query, e))
-    }
+    let partition: NvlPartitionSnapshotPgJson = sqlx::query_as(query)
+        .bind(value.id)
+        .bind(&value.nmx_m_id)
+        .bind(value.name.as_str())
+        .bind(value.domain_uuid)
+        .bind(value.logical_partition_id)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::new(query, e))?;
+    partition
+        .try_into()
+        .map_err(|e| DatabaseError::new(query, e))
 }
 
 /// Retrieves the IDs of all NvLink partitions
@@ -259,11 +155,6 @@ pub async fn mark_as_deleted(
     partition
         .try_into()
         .map_err(|e| DatabaseError::new(query, e))
-}
-
-/// Returns whether the NvLink partition was deleted
-pub fn is_marked_as_deleted(partition: &NvlPartition) -> bool {
-    partition.deleted.is_some()
 }
 
 pub async fn final_delete(

--- a/crates/api-model/src/nvl_logical_partition.rs
+++ b/crates/api-model/src/nvl_logical_partition.rs
@@ -15,13 +15,199 @@
  * limitations under the License.
  */
 
+use carbide_uuid::nvlink::NvLinkLogicalPartitionId;
+use chrono::{DateTime, Utc};
+use config_version::ConfigVersion;
+use rpc::errors::RpcDataConversionError;
+use rpc::forge as rpc_forge;
+use serde::{Deserialize, Serialize};
+use sqlx::postgres::PgRow;
+use sqlx::{FromRow, Row};
+
+use crate::metadata::Metadata;
+use crate::tenant::TenantOrganizationId;
+
 #[derive(Clone, Debug, Default)]
 pub struct NvLinkLogicalPartitionSearchFilter {
     pub name: Option<String>,
 }
 
-impl From<rpc::forge::NvLinkLogicalPartitionSearchFilter> for NvLinkLogicalPartitionSearchFilter {
-    fn from(filter: rpc::forge::NvLinkLogicalPartitionSearchFilter) -> Self {
+impl From<rpc_forge::NvLinkLogicalPartitionSearchFilter> for NvLinkLogicalPartitionSearchFilter {
+    fn from(filter: rpc_forge::NvLinkLogicalPartitionSearchFilter) -> Self {
         NvLinkLogicalPartitionSearchFilter { name: filter.name }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NewLogicalPartition {
+    pub id: NvLinkLogicalPartitionId,
+    pub config: LogicalPartitionConfig,
+}
+
+impl TryFrom<rpc_forge::NvLinkLogicalPartitionCreationRequest> for NewLogicalPartition {
+    type Error = RpcDataConversionError;
+    fn try_from(
+        value: rpc_forge::NvLinkLogicalPartitionCreationRequest,
+    ) -> Result<Self, Self::Error> {
+        let id: NvLinkLogicalPartitionId = value.id.unwrap_or_else(|| uuid::Uuid::new_v4().into());
+
+        let conf = value.config.ok_or_else(|| {
+            RpcDataConversionError::InvalidArgument(
+                "NvLinkLogicalPartition config is empty".to_string(),
+            )
+        })?;
+
+        Ok(NewLogicalPartition {
+            id,
+            config: LogicalPartitionConfig::try_from(conf)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct LogicalPartitionConfig {
+    pub metadata: Metadata,
+    pub tenant_organization_id: TenantOrganizationId,
+}
+
+impl TryFrom<rpc_forge::NvLinkLogicalPartitionConfig> for LogicalPartitionConfig {
+    type Error = RpcDataConversionError;
+
+    fn try_from(conf: rpc_forge::NvLinkLogicalPartitionConfig) -> Result<Self, Self::Error> {
+        if conf.tenant_organization_id.is_empty() {
+            return Err(RpcDataConversionError::InvalidArgument(
+                "NvLinkLogicalPartition organization_id is empty".to_string(),
+            ));
+        }
+
+        let tenant_organization_id =
+            TenantOrganizationId::try_from(conf.tenant_organization_id.clone()).map_err(|_| {
+                RpcDataConversionError::InvalidArgument(conf.tenant_organization_id)
+            })?;
+
+        Ok(LogicalPartitionConfig {
+            metadata: conf.metadata.unwrap_or_default().try_into()?,
+            tenant_organization_id,
+        })
+    }
+}
+
+impl TryFrom<LogicalPartitionConfig> for rpc_forge::NvLinkLogicalPartitionConfig {
+    type Error = RpcDataConversionError;
+    fn try_from(src: LogicalPartitionConfig) -> Result<Self, Self::Error> {
+        Ok(rpc_forge::NvLinkLogicalPartitionConfig {
+            metadata: Some(src.metadata.into()),
+            tenant_organization_id: src.tenant_organization_id.to_string(),
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct LogicalPartitionName(String);
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "lowercase")]
+pub enum LogicalPartitionState {
+    Provisioning,
+    Ready,
+    Updating,
+    Error,
+    Deleting,
+}
+
+#[derive(Debug, Clone)]
+pub struct LogicalPartition {
+    pub id: NvLinkLogicalPartitionId,
+
+    pub name: String,
+    pub description: String,
+    pub tenant_organization_id: TenantOrganizationId,
+
+    pub config_version: ConfigVersion,
+
+    pub partition_state: LogicalPartitionState,
+
+    pub created: DateTime<Utc>,
+    pub updated: DateTime<Utc>,
+    pub deleted: Option<DateTime<Utc>>,
+}
+
+/// Returns whether a logical partition was deleted by user
+pub fn is_marked_as_deleted(partition: &LogicalPartition) -> bool {
+    partition.deleted.is_some()
+}
+
+impl TryFrom<LogicalPartition> for rpc_forge::NvLinkLogicalPartition {
+    type Error = RpcDataConversionError;
+    fn try_from(src: LogicalPartition) -> Result<Self, Self::Error> {
+        let mut state = match &src.partition_state {
+            LogicalPartitionState::Provisioning => rpc_forge::TenantState::Provisioning,
+            LogicalPartitionState::Ready => rpc_forge::TenantState::Ready,
+            LogicalPartitionState::Error => rpc_forge::TenantState::Failed,
+            LogicalPartitionState::Deleting => rpc_forge::TenantState::Terminating,
+            LogicalPartitionState::Updating => rpc_forge::TenantState::Updating,
+        };
+
+        if is_marked_as_deleted(&src) {
+            state = rpc_forge::TenantState::Terminating;
+        }
+        let status = Some(rpc_forge::NvLinkLogicalPartitionStatus {
+            state: state as i32,
+        });
+
+        let config = rpc_forge::NvLinkLogicalPartitionConfig {
+            metadata: Some(rpc::Metadata {
+                name: src.name,
+                description: src.description,
+                ..Default::default()
+            }),
+            tenant_organization_id: src.tenant_organization_id.to_string(),
+        };
+
+        Ok(rpc_forge::NvLinkLogicalPartition {
+            id: Some(src.id),
+            config_version: src.config_version.version_string(),
+            status,
+            config: Some(config),
+            created: Some(src.created.into()),
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LogicalPartitionSnapshotPgJson {
+    pub id: NvLinkLogicalPartitionId,
+    pub name: String,
+    pub description: String,
+    pub tenant_organization_id: TenantOrganizationId,
+    pub config_version: ConfigVersion,
+    pub partition_state: LogicalPartitionState,
+    pub created: DateTime<Utc>,
+    pub updated: DateTime<Utc>,
+    pub deleted: Option<DateTime<Utc>>,
+}
+
+impl TryFrom<LogicalPartitionSnapshotPgJson> for LogicalPartition {
+    type Error = sqlx::Error;
+    fn try_from(value: LogicalPartitionSnapshotPgJson) -> sqlx::Result<Self> {
+        Ok(Self {
+            id: value.id,
+            name: value.name,
+            description: value.description,
+            tenant_organization_id: value.tenant_organization_id,
+            config_version: value.config_version,
+            partition_state: value.partition_state,
+            created: value.created,
+            updated: value.updated,
+            deleted: value.deleted,
+        })
+    }
+}
+
+impl<'r> FromRow<'r, PgRow> for LogicalPartitionSnapshotPgJson {
+    fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
+        let json: serde_json::value::Value = row.try_get(0)?;
+        LogicalPartitionSnapshotPgJson::deserialize(json)
+            .map_err(|err| sqlx::Error::Decode(err.into()))
     }
 }

--- a/crates/api-model/src/nvl_partition.rs
+++ b/crates/api-model/src/nvl_partition.rs
@@ -15,17 +15,135 @@
  * limitations under the License.
  */
 
+use carbide_uuid::nvlink::{NvLinkDomainId, NvLinkLogicalPartitionId, NvLinkPartitionId};
+use chrono::{DateTime, Utc};
+use rpc::errors::RpcDataConversionError;
+use rpc::forge as rpc_forge;
+use serde::{Deserialize, Serialize};
+use sqlx::postgres::PgRow;
+use sqlx::{FromRow, Row};
+
 #[derive(Clone, Debug, Default)]
 pub struct NvLinkPartitionSearchFilter {
     pub tenant_organization_id: Option<String>,
     pub name: Option<String>,
 }
 
-impl From<rpc::forge::NvLinkPartitionSearchFilter> for NvLinkPartitionSearchFilter {
-    fn from(filter: rpc::forge::NvLinkPartitionSearchFilter) -> Self {
+impl From<rpc_forge::NvLinkPartitionSearchFilter> for NvLinkPartitionSearchFilter {
+    fn from(filter: rpc_forge::NvLinkPartitionSearchFilter) -> Self {
         NvLinkPartitionSearchFilter {
             tenant_organization_id: filter.tenant_organization_id,
             name: filter.name,
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NewNvlPartition {
+    pub id: NvLinkPartitionId,
+    pub name: NvlPartitionName,
+    pub logical_partition_id: NvLinkLogicalPartitionId,
+    pub domain_uuid: NvLinkDomainId,
+    pub nmx_m_id: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NvlPartitionStatus {
+    pub partition: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, sqlx::Type, sqlx::FromRow)]
+pub struct NvlPartitionName(String);
+
+impl NvlPartitionName {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for NvlPartitionName {
+    type Error = RpcDataConversionError;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Ok(NvlPartitionName(value))
+    }
+}
+
+impl From<NvlPartitionName> for String {
+    fn from(value: NvlPartitionName) -> Self {
+        value.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NvlPartition {
+    pub id: NvLinkPartitionId,
+    pub nmx_m_id: String,
+    pub domain_uuid: NvLinkDomainId,
+    pub name: NvlPartitionName,
+    pub created: DateTime<Utc>,
+    pub updated: DateTime<Utc>,
+    pub deleted: Option<DateTime<Utc>>,
+    pub logical_partition_id: Option<NvLinkLogicalPartitionId>,
+}
+
+/// Returns whether the NvLink partition was deleted
+pub fn is_marked_as_deleted(partition: &NvlPartition) -> bool {
+    partition.deleted.is_some()
+}
+
+impl TryFrom<NvlPartition> for rpc_forge::NvLinkPartition {
+    type Error = RpcDataConversionError;
+    fn try_from(src: NvlPartition) -> Result<Self, Self::Error> {
+        Ok(rpc_forge::NvLinkPartition {
+            id: Some(src.id),
+            name: src.name.clone().into(),
+            nmx_m_id: src.nmx_m_id,
+            domain_uuid: Some(src.domain_uuid),
+            logical_partition_id: src.logical_partition_id,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NvlPartitionSnapshotPgJson {
+    pub id: NvLinkPartitionId,
+    pub nmx_m_id: String,
+    pub name: NvlPartitionName,
+    pub domain_uuid: NvLinkDomainId,
+    pub created: DateTime<Utc>,
+    pub updated: DateTime<Utc>,
+    pub deleted: Option<DateTime<Utc>>,
+    pub logical_partition_id: Option<NvLinkLogicalPartitionId>,
+}
+
+impl TryFrom<NvlPartitionSnapshotPgJson> for NvlPartition {
+    type Error = sqlx::Error;
+    fn try_from(value: NvlPartitionSnapshotPgJson) -> sqlx::Result<Self> {
+        Ok(Self {
+            id: value.id,
+            nmx_m_id: value.nmx_m_id,
+            domain_uuid: value.domain_uuid,
+            name: value.name,
+            created: value.created,
+            updated: value.updated,
+            deleted: value.deleted,
+            logical_partition_id: value.logical_partition_id,
+        })
+    }
+}
+
+impl<'r> FromRow<'r, PgRow> for NvlPartitionSnapshotPgJson {
+    fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
+        let json: serde_json::value::Value = row.try_get(0)?;
+        NvlPartitionSnapshotPgJson::deserialize(json).map_err(|err| sqlx::Error::Decode(err.into()))
+    }
+}
+
+impl<'r> FromRow<'r, PgRow> for NvlPartition {
+    fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
+        let json: serde_json::value::Value = row.try_get(0)?;
+        NvlPartitionSnapshotPgJson::deserialize(json)
+            .map_err(|err| sqlx::Error::Decode(err.into()))?
+            .try_into()
     }
 }

--- a/crates/api/src/handlers/logical_partition.rs
+++ b/crates/api/src/handlers/logical_partition.rs
@@ -16,9 +16,9 @@
  */
 use ::rpc::forge as rpc;
 use config_version::ConfigVersion;
-use db::nvl_logical_partition::{self, NewLogicalPartition};
-use db::{self, ObjectColumnFilter, WithTransaction, instance};
+use db::{self, ObjectColumnFilter, WithTransaction, instance, nvl_logical_partition};
 use futures_util::FutureExt;
+use model::nvl_logical_partition::NewLogicalPartition;
 use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
@@ -44,7 +44,9 @@ pub(crate) async fn create(
     let metadata = req.config.metadata.clone();
     metadata.validate(true).map_err(CarbideError::from)?;
 
-    let resp = req.create(&mut txn).await.map_err(CarbideError::from)?;
+    let resp = nvl_logical_partition::create(&req, &mut txn)
+        .await
+        .map_err(CarbideError::from)?;
     let resp = rpc::NvLinkLogicalPartition::try_from(resp).map(Response::new)?;
     txn.commit().await?;
 

--- a/crates/api/src/nvl_partition_monitor/mod.rs
+++ b/crates/api/src/nvl_partition_monitor/mod.rs
@@ -25,8 +25,8 @@ use chrono::Utc;
 use config_version::Versioned;
 use db::machine::find_machine_ids;
 use db::managed_host::load_by_machine_ids;
-use db::nvl_logical_partition::{IdColumn as LpIdColumn, LogicalPartition};
-use db::nvl_partition::{IdColumn, NvlPartition, NvlPartitionName};
+use db::nvl_logical_partition::IdColumn as LpIdColumn;
+use db::nvl_partition::IdColumn;
 use db::work_lock_manager::WorkLockManagerHandle;
 use db::{self, ObjectColumnFilter, machine};
 use metrics::{AppliedChange, NmxmPartitionOperationStatus, NvlPartitionMonitorMetrics};
@@ -36,6 +36,8 @@ use model::instance::status::nvlink::InstanceNvLinkStatus;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::nvlink::{MachineNvLinkGpuStatusObservation, MachineNvLinkStatusObservation};
 use model::machine::{HostHealthConfig, LoadSnapshotOptions, ManagedHostStateSnapshot};
+use model::nvl_logical_partition::LogicalPartition;
+use model::nvl_partition::{NvlPartition, NvlPartitionName};
 use sqlx::PgPool;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
@@ -160,7 +162,7 @@ impl PartitionProcessingContext {
         if let Some(matching_logical_partition) =
             self.db_nvl_logical_partitions.get(logical_partition_id)
         {
-            if db::nvl_logical_partition::is_marked_as_deleted(matching_logical_partition) {
+            if model::nvl_logical_partition::is_marked_as_deleted(matching_logical_partition) {
                 tracing::error!(
                     "logical partition already marked as deleted, cannot modify physical partition"
                 );
@@ -858,12 +860,12 @@ impl NvlPartitionMonitor {
         &self,
         machine_nvlink_info: HashMap<MachineId, Option<MachineNvLinkInfo>>,
         nmx_m_gpus: &[libnmxm::nmxm_model::Gpu],
-        db_nvl_partitions: Vec<db::nvl_partition::NvlPartition>,
+        db_nvl_partitions: Vec<NvlPartition>,
         nmx_m_partitions: &[libnmxm::nmxm_model::Partition],
         metrics: &mut NvlPartitionMonitorMetrics,
     ) -> CarbideResult<(
         HashMap<MachineId, Option<MachineNvLinkInfo>>,
-        Vec<db::nvl_partition::NvlPartition>,
+        Vec<NvlPartition>,
     )> {
         // Only run once every 15 minutes.
         {
@@ -1847,7 +1849,7 @@ impl NvlPartitionMonitor {
                 match operation.operation_type {
                     NmxmPartitionOperationType::Create => {
                         // Create the nvl partition in the database
-                        let new_partition = db::nvl_partition::NewNvlPartition {
+                        let new_partition = model::nvl_partition::NewNvlPartition {
                             id: NvLinkPartitionId::new(),
                             logical_partition_id,
                             name: NvlPartitionName::try_from(operation.name.clone())?,
@@ -1871,7 +1873,7 @@ impl NvlPartitionMonitor {
                                 }
                             },
                         };
-                        let _partition = new_partition.create(txn).await?;
+                        let _partition = db::nvl_partition::create(&new_partition, txn).await?;
                     }
                     NmxmPartitionOperationType::Remove(_) => {
                         db::nvl_partition::final_delete(
@@ -1897,7 +1899,7 @@ impl NvlPartitionMonitor {
 
         // walk the logical partition list and check if any logical partitions need to be cleaned up
         for lp in db_nvl_logical_partitions {
-            if db::nvl_logical_partition::is_marked_as_deleted(lp) {
+            if model::nvl_logical_partition::is_marked_as_deleted(lp) {
                 tracing::info!(logical_partition_id = %lp.id, "Deleting logical partition");
                 db::nvl_logical_partition::final_delete(lp.id, txn).await?;
             }


### PR DESCRIPTION
## Description

This continues the work from https://github.com/NVIDIA/ncx-infra-controller-core/pull/606, https://github.com/NVIDIA/ncx-infra-controller-core/pull/602, https://github.com/NVIDIA/ncx-infra-controller-core/pull/598, https://github.com/NVIDIA/ncx-infra-controller-core/pull/596, and https://github.com/NVIDIA/ncx-infra-controller-core/pull/608.

TLDR is we've leaked a few things from `::rpc` into the `api-db` layer, which we generally don't want to do, and now that we have `STYLE_GUIDE.md`, it will be good to practice what we preach.

This specific change introduces `nvl_logical_partition` equivalents in `api-model`, with `From`/`TryFrom` impls for the API layer to translate to before passing downstream.

I think there's only a couple of more things and we can remove the `rpc` crate as a dep on `api-db` entirely, should we feel inclined.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

