### PR TITLE
chore: prefer CarbideError over tonic::Status for API error handling

### DIFF
--- a/crates/api/src/errors.rs
+++ b/crates/api/src/errors.rs
@@ -239,6 +239,12 @@ pub enum CarbideError {
 
     #[error("DPF error: {0}")]
     DpfError(#[from] carbide_dpf::DpfError),
+
+    #[error("Service unavailable: {0}")]
+    UnavailableError(String),
+
+    #[error("Permission denied: {0}")]
+    PermissionDeniedError(String),
 }
 
 impl From<ModelError> for CarbideError {
@@ -380,6 +386,8 @@ impl From<CarbideError> for tonic::Status {
             error @ CarbideError::ClientCertificateMissingInformation(_) => {
                 Status::unauthenticated(error.to_string())
             }
+            CarbideError::UnavailableError(msg) => Status::unavailable(msg),
+            CarbideError::PermissionDeniedError(msg) => Status::permission_denied(msg),
             other => Status::internal(other.to_string()),
         }
     }
@@ -407,4 +415,18 @@ fn test_dhcp_error_maps_to_resource_exhausted_status() {
     ));
     let status: tonic::Status = err.into();
     assert_eq!(status.code(), tonic::Code::ResourceExhausted);
+}
+
+#[test]
+fn test_unavailable_error_maps_to_unavailable_status() {
+    let err = CarbideError::UnavailableError("service down".into());
+    let status: tonic::Status = err.into();
+    assert_eq!(status.code(), tonic::Code::Unavailable);
+}
+
+#[test]
+fn test_permission_denied_error_maps_to_permission_denied_status() {
+    let err = CarbideError::PermissionDeniedError("not allowed".into());
+    let status: tonic::Status = err.into();
+    assert_eq!(status.code(), tonic::Code::PermissionDenied);
 }

--- a/crates/api/src/ethernet_virtualization.rs
+++ b/crates/api/src/ethernet_virtualization.rs
@@ -29,7 +29,6 @@ use model::network_security_group::{
 use model::network_segment::NetworkSegment;
 use model::resource_pool::common::CommonPools;
 use sqlx::PgConnection;
-use tonic::Status;
 
 use crate::CarbideError;
 use crate::cfg::file::VpcPeeringPolicy;
@@ -92,10 +91,13 @@ pub async fn admin_network(
     let prefix = match admin_segment.prefixes.first() {
         Some(p) => p,
         None => {
-            return Err(Status::internal(format!(
-                "Admin network segment '{}' has no network_prefix, expected 1",
-                admin_segment.id,
-            )));
+            return Err(CarbideError::Internal {
+                message: format!(
+                    "Admin network segment '{}' has no network_prefix, expected 1",
+                    admin_segment.id,
+                ),
+            }
+            .into());
         }
     };
 
@@ -137,12 +139,13 @@ pub async fn admin_network(
     // On the admin network, the interface_prefix is always
     // just going to be a /32 derived from the machine interface
     // address.
-    let address_prefix = IpNetwork::new(address.address, 32).map_err(|e| {
-        Status::internal(format!(
-            "failed to build default admin address prefix for {}/32: {}",
-            address.address, e
-        ))
-    })?;
+    let address_prefix =
+        IpNetwork::new(address.address, 32).map_err(|e| CarbideError::Internal {
+            message: format!(
+                "failed to build default admin address prefix for {}/32: {}",
+                address.address, e
+            ),
+        })?;
 
     let svi_ip = if !fnn_enabled_on_admin {
         None
@@ -153,10 +156,8 @@ pub async fn admin_network(
             true,
             prefix.prefix.prefix(),
         )
-        .map_err(|e| {
-            Status::internal(format!(
-                "failed to configure FlatInterfaceConfig.svi_ip: {e}"
-            ))
+        .map_err(|e| CarbideError::Internal {
+            message: format!("failed to configure FlatInterfaceConfig.svi_ip: {e}"),
         })?
         .map(|ip| ip.to_string())
     };
@@ -260,19 +261,22 @@ pub async fn tenant_network(
         .prefixes
         .iter()
         .find(|prefix| prefix.prefix.is_ipv4())
-        .ok_or_else(|| {
-            Status::internal(format!(
+        .ok_or_else(|| CarbideError::Internal {
+            message: format!(
                 "No IPv4 prefix is available for instance {} on segment {}",
                 instance_id, segment.id
-            ))
+            ),
         })?;
 
-    let address = iface.ip_addrs.get(&v4_prefix.id).ok_or_else(|| {
-        Status::internal(format!(
-            "No IPv4 address is available for instance {} on segment {}",
-            instance_id, segment.id
-        ))
-    })?;
+    let address = iface
+        .ip_addrs
+        .get(&v4_prefix.id)
+        .ok_or_else(|| CarbideError::Internal {
+            message: format!(
+                "No IPv4 address is available for instance {} on segment {}",
+                instance_id, segment.id
+            ),
+        })?;
 
     // Assuming an `address` was found above, look to see if a prefix
     // is explicitly configured here. If not, default to a /32, which
@@ -281,10 +285,8 @@ pub async fn tenant_network(
     //
     // TODO(chet): This can eventually be phased out once all of the
     // InstanceInterfaceConfigs stored contain the prefix.
-    let default_prefix = IpNetwork::new(*address, 32).map_err(|e| {
-        Status::internal(format!(
-            "failed to build default interface_prefix for {address}/32: {e}"
-        ))
+    let default_prefix = IpNetwork::new(*address, 32).map_err(|e| CarbideError::Internal {
+        message: format!("failed to build default interface_prefix for {address}/32: {e}"),
     })?;
 
     let interface_prefix = iface
@@ -385,10 +387,8 @@ pub async fn tenant_network(
         is_l2_segment,
         v4_prefix.prefix.prefix(),
     )
-    .map_err(|e| {
-        Status::internal(format!(
-            "failed to configure FlatInterfaceConfig.svi_ip: {e}"
-        ))
+    .map_err(|e| CarbideError::Internal {
+        message: format!("failed to configure FlatInterfaceConfig.svi_ip: {e}"),
     })?
     .map(|ip| ip.to_string());
 
@@ -409,11 +409,11 @@ pub async fn tenant_network(
                     let network_security_group = network_security_group::find_by_ids(
                         txn,
                         &[vpc_nsg_id.to_owned()],
-                        Some(
-                            &v.tenant_organization_id
-                                .parse()
-                                .map_err(|_| Status::internal("invalid tenant org in VPC data"))?,
-                        ),
+                        Some(&v.tenant_organization_id.parse().map_err(|_| {
+                            CarbideError::Internal {
+                                message: "invalid tenant org in VPC data".to_string(),
+                            }
+                        })?),
                         false,
                     )
                     .await?
@@ -482,10 +482,10 @@ pub async fn tenant_network(
                     )
             })
             .transpose()
-            .map_err(|e: CarbideError| {
-                Status::internal(format!(
+            .map_err(|e: CarbideError| CarbideError::Internal {
+                message: format!(
                     "failed to configure FlatInterfaceConfig.network_security_group: {e}"
-                ))
+                ),
             })?,
         internal_uuid: Some(iface.internal_uuid.into()),
         mtu: u32::try_from(segment.mtu).ok(),

--- a/crates/api/src/handlers/api.rs
+++ b/crates/api/src/handlers/api.rs
@@ -23,6 +23,7 @@ use ::rpc::forge as rpc;
 use tonic::{Request, Response, Status};
 use utils::HostPortPair;
 
+use crate::CarbideError;
 use crate::api::{Api, log_request_data};
 
 pub(crate) fn version(
@@ -72,32 +73,34 @@ pub(crate) fn set_dynamic_config(
     let req = request.into_inner();
     let exp_str = req.expiry.as_deref().unwrap_or("1h");
     let expiry = duration_str::parse(exp_str).map_err(|err| {
-        Status::invalid_argument(format!("Invalid expiry string '{exp_str}'. {err}"))
+        CarbideError::InvalidArgument(format!("Invalid expiry string '{exp_str}'. {err}"))
     })?;
     const MAX_SET_INTERNAL_EXPIRY: Duration = Duration::from_secs(60 * 60 * 60); // 60 hours
     if MAX_SET_INTERNAL_EXPIRY < expiry {
-        return Err(Status::invalid_argument(
-            "Expiry exceeds max allowed of 60 hours",
-        ));
+        return Err(CarbideError::InvalidArgument(
+            "Expiry exceeds max allowed of 60 hours".to_string(),
+        )
+        .into());
     }
     let expire_at = chrono::Utc::now() + expiry;
 
     let Ok(requested_setting) = rpc::ConfigSetting::try_from(req.setting) else {
-        return Err(Status::invalid_argument(format!(
+        return Err(CarbideError::InvalidArgument(format!(
             "Not a supported dynamic config setting: {}",
             req.setting
-        )));
+        ))
+        .into());
     };
 
     if req.value.is_empty() && !matches!(requested_setting, rpc::ConfigSetting::BmcProxy) {
-        return Err(Status::invalid_argument("'value' cannot be empty"));
+        return Err(CarbideError::InvalidArgument("'value' cannot be empty".to_string()).into());
     }
 
     match requested_setting {
         rpc::ConfigSetting::LogFilter => {
             let level = &api.dynamic_settings.log_filter;
             level.update(&req.value, Some(expire_at)).map_err(|err| {
-                Status::invalid_argument(format!(
+                CarbideError::InvalidArgument(format!(
                     "Invalid log filter string '{}'. {err}",
                     req.value
                 ))
@@ -110,7 +113,7 @@ pub(crate) fn set_dynamic_config(
         }
         rpc::ConfigSetting::CreateMachines => {
             let is_enabled = req.value.parse::<bool>().map_err(|err| {
-                Status::invalid_argument(format!(
+                CarbideError::InvalidArgument(format!(
                     "Invalid create_machines string '{}'. {err}",
                     req.value
                 ))
@@ -122,16 +125,17 @@ pub(crate) fn set_dynamic_config(
         }
         rpc::ConfigSetting::BmcProxy => {
             let Some(true) = api.runtime_config.site_explorer.allow_changing_bmc_proxy else {
-                return Err(Status::permission_denied(
-                    "site-explorer.bmc_proxy is not allowed to be changed on this server",
-                ));
+                return Err(CarbideError::PermissionDeniedError(
+                    "site-explorer.bmc_proxy is not allowed to be changed on this server".into(),
+                )
+                .into());
             };
 
             if req.value.is_empty() {
                 api.dynamic_settings.bmc_proxy.store(Arc::new(None))
             } else {
                 let host_port_pair = req.value.parse::<HostPortPair>().map_err(|err| {
-                    Status::invalid_argument(format!(
+                    CarbideError::InvalidArgument(format!(
                         "Invalid bmc_proxy string '{}': {err}",
                         req.value
                     ))
@@ -145,7 +149,7 @@ pub(crate) fn set_dynamic_config(
         }
         rpc::ConfigSetting::TracingEnabled => {
             let enable = req.value.parse().map_err(|_| {
-                Status::invalid_argument(format!(
+                CarbideError::InvalidArgument(format!(
                     "Expected bool for TracingEnabled, got {}",
                     &req.value
                 ))

--- a/crates/api/src/handlers/attestation.rs
+++ b/crates/api/src/handlers/attestation.rs
@@ -124,9 +124,10 @@ pub(crate) async fn attest_quote(
         match db::attestation::secret_ak_pub::get_by_secret(&mut txn, &request.credential).await? {
             Some(entry) => entry.ak_pub,
             None => {
-                return Err(Status::from(CarbideError::AttestQuoteError(
+                return Err(CarbideError::AttestQuoteError(
                     "Could not form SQL query to fetch AK Pub".into(),
-                )));
+                )
+                .into());
             }
         };
 
@@ -181,11 +182,11 @@ pub(crate) async fn attest_quote(
     let report =
         db::measured_boot::report::new(&mut txn, machine_id, pcr_values.into_inner().as_slice())
             .await
-            .map_err(|e| {
-                Status::internal(format!(
+            .map_err(|e| CarbideError::Internal {
+                message: format!(
                     "Failed storing measurement report: (machine_id: {}, err: {})",
                     &machine_id, e
-                ))
+                ),
             })?;
 
     // if the attestation was successful and enabled, we can now vend the certs

--- a/crates/api/src/handlers/bmc_endpoint_explorer.rs
+++ b/crates/api/src/handlers/bmc_endpoint_explorer.rs
@@ -336,7 +336,9 @@ pub(crate) async fn set_dpu_first_boot_order(
         .boot_interface_mac
         .as_ref()
         .filter(|mac| !mac.trim().is_empty())
-        .ok_or_else(|| Status::invalid_argument("boot_interface_mac is required"))?;
+        .ok_or_else(|| {
+            CarbideError::InvalidArgument("boot_interface_mac is required".to_string())
+        })?;
 
     let (bmc_addr, bmc_mac_address) = resolve_bmc_interface(api, &bmc_endpoint_request).await?;
     let machine_interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
@@ -592,10 +594,11 @@ async fn resolve_bmc_interface(
 
     let mut addrs = lookup_host(address).await?;
     let Some(bmc_addr) = addrs.next() else {
-        return Err(Status::invalid_argument(format!(
+        return Err(CarbideError::InvalidArgument(format!(
             "Could not resolve {}. Must be hostname[:port] or IPv4[:port]",
             request.ip_address
-        )));
+        ))
+        .into());
     };
 
     let bmc_mac_address: MacAddress;
@@ -606,9 +609,10 @@ async fn resolve_bmc_interface(
     {
         bmc_mac_address = bmc_machine_interface.mac_address;
     } else {
-        return Err(Status::invalid_argument(format!(
+        return Err(CarbideError::InvalidArgument(format!(
             "could not find a mac address for the specified IP: {request:#?}"
-        )));
+        ))
+        .into());
     };
 
     Ok((bmc_addr, bmc_mac_address))

--- a/crates/api/src/handlers/compute_allocation.rs
+++ b/crates/api/src/handlers/compute_allocation.rs
@@ -73,9 +73,7 @@ pub(crate) async fn create(
         req.tenant_organization_id
             .parse()
             .map_err(|e: InvalidTenantOrg| {
-                Status::from(CarbideError::from(
-                    RpcDataConversionError::InvalidTenantOrg(e.to_string()),
-                ))
+                CarbideError::from(RpcDataConversionError::InvalidTenantOrg(e.to_string()))
             })?;
 
     // Prepare the metadata
@@ -190,9 +188,7 @@ pub(crate) async fn find_ids(
         .map(|i| i.parse::<InstanceTypeId>())
         .transpose()
         .map_err(|e| {
-            Status::from(CarbideError::from(
-                RpcDataConversionError::InvalidInstanceTypeId(e.to_string()),
-            ))
+            CarbideError::from(RpcDataConversionError::InvalidInstanceTypeId(e.to_string()))
         })?
         .map(|i| vec![i]);
 
@@ -203,9 +199,7 @@ pub(crate) async fn find_ids(
             .map(|t| t.parse::<TenantOrganizationId>())
             .transpose()
             .map_err(|e: InvalidTenantOrg| {
-                Status::from(CarbideError::from(
-                    RpcDataConversionError::InvalidTenantOrg(e.to_string()),
-                ))
+                CarbideError::from(RpcDataConversionError::InvalidTenantOrg(e.to_string()))
             })?
             .as_ref(),
         instance_type_ids.as_deref(),
@@ -329,9 +323,7 @@ pub(crate) async fn update(
         req.tenant_organization_id
             .parse()
             .map_err(|e: InvalidTenantOrg| {
-                Status::from(CarbideError::from(
-                    RpcDataConversionError::InvalidTenantOrg(e.to_string()),
-                ))
+                CarbideError::from(RpcDataConversionError::InvalidTenantOrg(e.to_string()))
             })?;
 
     // Look up the ComputeAllocation.  We'll need to check the current
@@ -542,9 +534,7 @@ pub(crate) async fn delete(
         req.tenant_organization_id
             .parse()
             .map_err(|e: InvalidTenantOrg| {
-                Status::from(CarbideError::from(
-                    RpcDataConversionError::InvalidTenantOrg(e.to_string()),
-                ))
+                CarbideError::from(RpcDataConversionError::InvalidTenantOrg(e.to_string()))
             })?;
 
     // Make our DB query for the ComputeAllocation.

--- a/crates/api/src/handlers/credential.rs
+++ b/crates/api/src/handlers/credential.rs
@@ -57,9 +57,9 @@ pub(crate) async fn create_credential(
 
     match credential_type {
         rpc::CredentialType::HostBmc | rpc::CredentialType::Dpubmc => {
-            return Err(tonic::Status::invalid_argument(
-                "Forge no longer maintains separate paths for Host and DPU site-wide BMC root credentials. This has been unified.",
-            ));
+            return Err(CarbideError::InvalidArgument(
+                "Forge no longer maintains separate paths for Host and DPU site-wide BMC root credentials. This has been unified.".into(),
+            ).into());
         }
         rpc::CredentialType::SiteWideBmcRoot => {
             set_sitewide_bmc_root_credentials(api, password)
@@ -93,7 +93,7 @@ pub(crate) async fn create_credential(
             } else if req.username.is_none() && password.is_empty() && req.vendor.is_some() {
                 write_ufm_certs(api, req.vendor.unwrap_or_default()).await?;
             } else {
-                return Err(tonic::Status::invalid_argument("missing UFM Url"));
+                return Err(CarbideError::InvalidArgument("missing UFM Url".to_string()).into());
             }
         }
         rpc::CredentialType::DpuUefi => {
@@ -156,10 +156,10 @@ pub(crate) async fn create_credential(
         }
         rpc::CredentialType::HostBmcFactoryDefault => {
             let Some(username) = req.username else {
-                return Err(tonic::Status::invalid_argument("missing username"));
+                return Err(CarbideError::InvalidArgument("missing username".to_string()).into());
             };
             let Some(vendor) = req.vendor else {
-                return Err(tonic::Status::invalid_argument("missing vendor"));
+                return Err(CarbideError::InvalidArgument("missing vendor".to_string()).into());
             };
             let vendor: bmc_vendor::BMCVendor = vendor.as_str().into();
             api.credential_manager
@@ -178,7 +178,7 @@ pub(crate) async fn create_credential(
         }
         rpc::CredentialType::DpuBmcFactoryDefault => {
             let Some(username) = req.username else {
-                return Err(tonic::Status::invalid_argument("missing username"));
+                return Err(CarbideError::InvalidArgument("missing username".to_string()).into());
             };
             api.credential_manager
                 .set_credentials(
@@ -196,7 +196,7 @@ pub(crate) async fn create_credential(
         }
         rpc::CredentialType::RootBmcByMacAddress => {
             let Some(mac_address) = req.mac_address else {
-                return Err(tonic::Status::invalid_argument("mac address"));
+                return Err(CarbideError::InvalidArgument("mac address".to_string()).into());
             };
 
             let parsed_mac: MacAddress = mac_address
@@ -213,9 +213,10 @@ pub(crate) async fn create_credential(
         }
         rpc::CredentialType::BmcForgeAdminByMacAddress => {
             // TODO: support credential creation for forge-admin
-            return Err(tonic::Status::invalid_argument(
-                "Forge does not support creating forge-admin credentials yet.",
-            ));
+            return Err(CarbideError::InvalidArgument(
+                "Forge does not support creating forge-admin credentials yet.".into(),
+            )
+            .into());
         }
         rpc::CredentialType::NmxM => {
             if let Some(username) = req.username {
@@ -238,7 +239,7 @@ pub(crate) async fn create_credential(
                         ))
                     })?;
             } else {
-                return Err(tonic::Status::invalid_argument("missing username"));
+                return Err(CarbideError::InvalidArgument("missing username".to_string()).into());
             }
         }
     };
@@ -282,7 +283,7 @@ pub(crate) async fn delete_credential(
                         ))
                     })?;
             } else {
-                return Err(tonic::Status::invalid_argument("missing UFM Url"));
+                return Err(CarbideError::InvalidArgument("missing UFM Url".to_string()).into());
             }
         }
         rpc::CredentialType::SiteWideBmcRoot => {
@@ -298,9 +299,10 @@ pub(crate) async fn delete_credential(
                 delete_bmc_root_credentials_by_mac(api, parsed_mac).await?;
             }
             None => {
-                return Err(tonic::Status::invalid_argument(
-                    "request does not specify mac address",
-                ));
+                return Err(CarbideError::InvalidArgument(
+                    "request does not specify mac address".into(),
+                )
+                .into());
             }
         },
         rpc::CredentialType::HostBmc
@@ -364,10 +366,14 @@ pub(crate) async fn get_dpu_ssh_credential(
         Some(machine) => {
             crate::api::log_machine_id(&machine.id);
             if !machine.is_dpu() {
-                return Err(tonic::Status::not_found(format!(
-                    "Searching for machine {} was found for '{query}', but it is not a DPU",
-                    &machine.id
-                )));
+                return Err(CarbideError::NotFoundError {
+                    kind: "dpu",
+                    id: format!(
+                        "Searching for machine {} was found for '{query}', but it is not a DPU",
+                        &machine.id
+                    ),
+                }
+                .into());
             }
             machine.id
         }

--- a/crates/api/src/handlers/dns.rs
+++ b/crates/api/src/handlers/dns.rs
@@ -273,12 +273,12 @@ pub async fn lookup_record(
     );
 
     let rrtype = DnsResourceRecordType::try_from(lookup_request.qtype)
-        .map_err(|e| tonic::Status::invalid_argument(format!("Invalid qtype supplied: {}", e)))?;
+        .map_err(|e| CarbideError::InvalidArgument(format!("Invalid qtype supplied: {}", e)))?;
 
     let qname = lookup_request.qname;
 
     if qname.is_empty() {
-        return Err(Status::invalid_argument("qname cannot be empty"));
+        return Err(CarbideError::InvalidArgument("qname cannot be empty".to_string()).into());
     }
 
     let resource_record: Vec<DnsResourceRecordReply> = match rrtype {
@@ -353,7 +353,7 @@ pub async fn lookup_record_legacy_compat(
     // Check for empty qname early
     if qname.is_empty() {
         tracing::warn!("Received legacy DNS request with empty qname");
-        return Err(Status::invalid_argument("qname cannot be empty"));
+        return Err(CarbideError::InvalidArgument("qname cannot be empty".to_string()).into());
     }
 
     // Convert numeric q_type to string using constants
@@ -369,10 +369,11 @@ pub async fn lookup_record_legacy_compat(
         DNS_QTYPE_SRV => DNS_TYPE_SRV,
         DNS_QTYPE_ANY => DNS_TYPE_ANY,
         _ => {
-            return Err(Status::invalid_argument(format!(
+            return Err(CarbideError::InvalidArgument(format!(
                 "Unsupported DNS record type: {}",
                 q_type
-            )));
+            ))
+            .into());
         }
     }
     .to_string();
@@ -397,7 +398,10 @@ pub async fn lookup_record_legacy_compat(
         .iter()
         .filter(|d| domain_name.ends_with(&d.name))
         .max_by_key(|d| d.name.len())
-        .ok_or_else(|| Status::not_found(format!("No domain found for qname: {}", qname)))?;
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "domain",
+            id: format!("No domain found for qname: {}", qname),
+        })?;
 
     // Convert to new request format
     let lookup_request = protos::dns::DnsResourceRecordLookupRequest {

--- a/crates/api/src/handlers/dpa.rs
+++ b/crates/api/src/handlers/dpa.rs
@@ -621,7 +621,7 @@ pub(crate) async fn publish_mlx_device_report(
     if let Some(report_pb) = req.report {
         let report: MlxDeviceReport = report_pb
             .try_into()
-            .map_err(|e: String| Status::internal(e))?;
+            .map_err(|e: String| CarbideError::Internal { message: e })?;
         tracing::info!(
             "received MlxDeviceReport hostname={} device_count={}",
             report.hostname,

--- a/crates/api/src/handlers/dpf.rs
+++ b/crates/api/src/handlers/dpf.rs
@@ -36,7 +36,7 @@ pub(crate) async fn modify_dpf_state(
     log_machine_id(&machine_id);
 
     if machine_id.machine_type().is_dpu() {
-        return Err(Status::invalid_argument("Only host id is expected!!"));
+        return Err(CarbideError::InvalidArgument("Only host id is expected!!".to_string()).into());
     }
 
     let mut txn = api.txn_begin().await?;
@@ -68,7 +68,9 @@ pub(crate) async fn get_dpf_state(
 
     for machine_id in &request.machine_ids {
         if machine_id.machine_type().is_dpu() {
-            return Err(Status::invalid_argument("Only host id is expected!!"));
+            return Err(
+                CarbideError::InvalidArgument("Only host id is expected!!".to_string()).into(),
+            );
         }
     }
 

--- a/crates/api/src/handlers/dpu.rs
+++ b/crates/api/src/handlers/dpu.rs
@@ -75,9 +75,10 @@ pub(crate) async fn get_managed_host_network_config_inner(
     {
         Some(dpu_snapshot) => dpu_snapshot,
         None => {
-            return Err(Status::failed_precondition(format!(
+            return Err(CarbideError::FailedPrecondition(format!(
                 "DPU {dpu_machine_id} needs discovery.  DPU snapshot not found for managed host"
-            )));
+            ))
+            .into());
         }
     };
 
@@ -100,9 +101,10 @@ pub(crate) async fn get_managed_host_network_config_inner(
     let loopback_ip = match dpu_snapshot.loopback_ip() {
         Some(ip) => ip,
         None => {
-            return Err(Status::failed_precondition(format!(
+            return Err(CarbideError::FailedPrecondition(format!(
                 "DPU {dpu_machine_id} needs discovery. Does not have a loopback IP yet."
-            )));
+            ))
+            .into());
         }
     };
 
@@ -117,9 +119,10 @@ pub(crate) async fn get_managed_host_network_config_inner(
             .secondary_overlay_vtep_ip
             .is_none()
     {
-        return Err(Status::failed_precondition(format!(
+        return Err(CarbideError::FailedPrecondition(format!(
             "DPU {dpu_machine_id} needs discovery. Does not have a secondary VTEP IP yet."
-        )));
+        ))
+        .into());
     };
 
     // its ok if there is no locator here.  if there isn't one, then only the primary dpu is allowed to be configred (checked below)
@@ -363,9 +366,9 @@ pub(crate) async fn get_managed_host_network_config_inner(
             let segment_details = segment_details.iter().map(|x|(x.id, x)).collect::<HashMap<_,_>>();
 
             let Some(segment) = segment_details.get(&network_segment_id) else {
-                return Err(Status::internal(format!(
+                return Err(CarbideError::Internal { message: format!(
                     "Tenant segment id {network_segment_id} is not found in db."
-                )));
+                ) }.into());
             };
 
             let domain = match segment.subdomain_id {
@@ -417,15 +420,15 @@ pub(crate) async fn get_managed_host_network_config_inner(
             ) {
                 // This can not happen as validated during instance creation.
                 let Some(iface_segment) = iface.network_segment_id else {
-                    return Err(Status::internal(format!(
+                    return Err(CarbideError::Internal { message: format!(
                         "Tenant segment is not assigned for iface: {iface:?}."
-                    )));
+                    ) }.into());
                 };
 
                 let Some(segment) = segment_details.get(&iface_segment) else {
-                    return Err(Status::internal(format!(
+                    return Err(CarbideError::Internal { message: format!(
                         "Tenant segment id {iface_segment} is not found in db. Can not fetch the details."
-                    )));
+                    ) }.into());
                 };
 
                 let tenant_interface =
@@ -767,7 +770,9 @@ pub(crate) async fn update_agent_reported_inventory(
 
         txn.commit().await?;
     } else {
-        return Err(Status::invalid_argument("inventory missing from request"));
+        return Err(
+            CarbideError::InvalidArgument("inventory missing from request".to_string()).into(),
+        );
     }
 
     tracing::debug!(
@@ -877,7 +882,7 @@ pub(crate) async fn record_dpu_network_status(
             &mut txn,
             *host_interface_id,
             Some(timestamp.parse().map_err(|e| {
-                Status::invalid_argument(format!("Failed parsing dhcp timestamp: {e}"))
+                CarbideError::InvalidArgument(format!("Failed parsing dhcp timestamp: {e}"))
             })?),
         )
         .await?;
@@ -985,16 +990,18 @@ pub(crate) async fn dpu_agent_upgrade_check(
     })?;
     log_machine_id(&machine_id);
     if !machine_id.machine_type().is_dpu() {
-        return Err(Status::invalid_argument(
-            "Upgrade check can only be performed on DPUs",
-        ));
+        return Err(CarbideError::InvalidArgument(
+            "Upgrade check can only be performed on DPUs".into(),
+        )
+        .into());
     }
 
     // We usually want these two to match
     let agent_version = req.current_agent_version;
     let server_version = carbide_version::v!(build_version);
-    BuildVersion::try_from(server_version)
-        .map_err(|_| Status::internal("Invalid server version, cannot check for upgrade"))?;
+    BuildVersion::try_from(server_version).map_err(|_| CarbideError::Internal {
+        message: "Invalid server version, cannot check for upgrade".into(),
+    })?;
 
     let mut txn = api.txn_begin().await?;
 
@@ -1047,7 +1054,11 @@ pub(crate) async fn dpu_agent_upgrade_policy_action(
     }
 
     let Some(active_policy) = dpu_agent_upgrade_policy::get(&mut txn).await? else {
-        return Err(tonic::Status::not_found("No agent upgrade policy"));
+        return Err(CarbideError::NotFoundError {
+            kind: "agent_upgrade_policy",
+            id: "active".to_string(),
+        }
+        .into());
     };
     txn.commit().await?;
 
@@ -1100,9 +1111,9 @@ pub(crate) async fn trigger_dpu_reprovisioning(
             .classifications
             .contains(&health_report::HealthAlertClassification::prevent_allocations())
     }) {
-        return Err(Status::invalid_argument(
-            "Machine must have a 'HostUpdateInProgress' Health Alert with 'PreventAllocations' classification.",
-        ));
+        return Err(CarbideError::InvalidArgument(
+            "Machine must have a 'HostUpdateInProgress' Health Alert with 'PreventAllocations' classification.".into(),
+        ).into());
     }
 
     if snapshot.dpu_snapshots.iter().any(|ms| {

--- a/crates/api/src/handlers/expected_machine.rs
+++ b/crates/api/src/handlers/expected_machine.rs
@@ -21,7 +21,6 @@ use lazy_static::lazy_static;
 use mac_address::MacAddress;
 use model::expected_machine::{ExpectedMachine, ExpectedMachineData, ExpectedMachineRequest};
 use regex::Regex;
-use tonic::Status;
 use uuid::Uuid;
 
 use crate::CarbideError;
@@ -41,7 +40,7 @@ pub(crate) async fn get(
     let req: ExpectedMachineRequest = request
         .into_inner()
         .try_into()
-        .map_err(|e| Status::invalid_argument(format!("{}", e)))?;
+        .map_err(|e| CarbideError::InvalidArgument(format!("{}", e)))?;
 
     let target_id = req
         .id
@@ -136,7 +135,7 @@ pub(crate) async fn delete(
     let req: ExpectedMachineRequest = request
         .into_inner()
         .try_into()
-        .map_err(|e| Status::invalid_argument(format!("{}", e)))?;
+        .map_err(|e| CarbideError::InvalidArgument(format!("{}", e)))?;
 
     let mut txn = api.txn_begin().await?;
 

--- a/crates/api/src/handlers/expected_power_shelf.rs
+++ b/crates/api/src/handlers/expected_power_shelf.rs
@@ -30,20 +30,25 @@ pub async fn add_expected_power_shelf(
 ) -> Result<Response<()>, Status> {
     let rpc_power_shelf = request.into_inner();
     let request_rack_id = rpc_power_shelf.rack_id;
-    let power_shelf: ExpectedPowerShelf = rpc_power_shelf
-        .try_into()
-        .map_err(|e| Status::invalid_argument(format!("{}", e)))?;
+    let power_shelf: ExpectedPowerShelf =
+        rpc_power_shelf
+            .try_into()
+            .map_err(|e: ::rpc::errors::RpcDataConversionError| {
+                CarbideError::InvalidArgument(e.to_string())
+            })?;
     let bmc_mac_address = power_shelf.bmc_mac_address;
 
     let mut txn = api
         .database_connection
         .begin()
         .await
-        .map_err(|e| Status::internal(format!("Database error: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Database error: {}", e),
+        })?;
 
     db_expected_power_shelf::create(&mut txn, power_shelf)
         .await
-        .map_err(|e| Status::internal(format!("Failed to create expected power shelf: {}", e)))?;
+        .map_err(CarbideError::from)?;
 
     if let Some(rack_id) = request_rack_id {
         let adopted = db::rack::adopt_expected_power_shelf(&mut txn, rack_id, bmc_mac_address)
@@ -58,9 +63,9 @@ pub async fn add_expected_power_shelf(
         }
     }
 
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(format!("Failed to commit transaction: {}", e)))?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: format!("Failed to commit transaction: {}", e),
+    })?;
 
     Ok(Response::new(()))
 }
@@ -69,24 +74,29 @@ pub async fn delete_expected_power_shelf(
     api: &Api,
     request: Request<rpc::ExpectedPowerShelfRequest>,
 ) -> Result<Response<()>, Status> {
-    let req: ExpectedPowerShelfRequest = request
-        .into_inner()
-        .try_into()
-        .map_err(|e| Status::invalid_argument(format!("{}", e)))?;
+    let req: ExpectedPowerShelfRequest =
+        request
+            .into_inner()
+            .try_into()
+            .map_err(|e: ::rpc::errors::RpcDataConversionError| {
+                CarbideError::InvalidArgument(e.to_string())
+            })?;
 
     let mut txn = api
         .database_connection
         .begin()
         .await
-        .map_err(|e| Status::internal(format!("Database error: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Database error: {}", e),
+        })?;
 
     db_expected_power_shelf::delete(&mut txn, &req)
         .await
-        .map_err(|e| Status::internal(format!("Failed to delete expected power shelf: {}", e)))?;
+        .map_err(CarbideError::from)?;
 
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(format!("Failed to commit transaction: {}", e)))?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: format!("Failed to commit transaction: {}", e),
+    })?;
 
     // TODO Add cleanup for rack
 
@@ -97,24 +107,29 @@ pub async fn update_expected_power_shelf(
     api: &Api,
     request: Request<rpc::ExpectedPowerShelf>,
 ) -> Result<Response<()>, Status> {
-    let power_shelf: ExpectedPowerShelf = request
-        .into_inner()
-        .try_into()
-        .map_err(|e| Status::invalid_argument(format!("{}", e)))?;
+    let power_shelf: ExpectedPowerShelf =
+        request
+            .into_inner()
+            .try_into()
+            .map_err(|e: ::rpc::errors::RpcDataConversionError| {
+                CarbideError::InvalidArgument(e.to_string())
+            })?;
 
     let mut txn = api
         .database_connection
         .begin()
         .await
-        .map_err(|e| Status::internal(format!("Database error: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Database error: {}", e),
+        })?;
 
     db_expected_power_shelf::update(&mut txn, &power_shelf)
         .await
-        .map_err(|e| Status::internal(format!("Failed to update expected power shelf: {}", e)))?;
+        .map_err(CarbideError::from)?;
 
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(format!("Failed to commit transaction: {}", e)))?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: format!("Failed to commit transaction: {}", e),
+    })?;
 
     Ok(Response::new(()))
 }
@@ -123,33 +138,37 @@ pub async fn get_expected_power_shelf(
     api: &Api,
     request: Request<rpc::ExpectedPowerShelfRequest>,
 ) -> Result<Response<rpc::ExpectedPowerShelf>, Status> {
-    let req: ExpectedPowerShelfRequest = request
-        .into_inner()
-        .try_into()
-        .map_err(|e| Status::invalid_argument(format!("{}", e)))?;
+    let req: ExpectedPowerShelfRequest =
+        request
+            .into_inner()
+            .try_into()
+            .map_err(|e: ::rpc::errors::RpcDataConversionError| {
+                CarbideError::InvalidArgument(e.to_string())
+            })?;
 
     let mut txn = api
         .database_connection
         .begin()
         .await
-        .map_err(|e| Status::internal(format!("Database error: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Database error: {}", e),
+        })?;
 
     let expected_power_shelf = db_expected_power_shelf::find(&mut txn, &req)
         .await
-        .map_err(|e| Status::internal(format!("Failed to find expected power shelf: {}", e)))?
-        .ok_or_else(|| {
-            Status::not_found(format!(
-                "Expected power shelf not found: {}",
-                req.expected_power_shelf_id
-                    .map(|u| u.to_string())
-                    .or(req.bmc_mac_address.map(|m| m.to_string()))
-                    .unwrap_or_default()
-            ))
+        .map_err(CarbideError::from)?
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "expected_power_shelf",
+            id: req
+                .expected_power_shelf_id
+                .map(|u| u.to_string())
+                .or(req.bmc_mac_address.map(|m| m.to_string()))
+                .unwrap_or_default(),
         })?;
 
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(format!("Failed to commit transaction: {}", e)))?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: format!("Failed to commit transaction: {}", e),
+    })?;
 
     let response = rpc::ExpectedPowerShelf::from(expected_power_shelf);
     Ok(Response::new(response))
@@ -163,15 +182,17 @@ pub async fn get_all_expected_power_shelves(
         .database_connection
         .begin()
         .await
-        .map_err(|e| Status::internal(format!("Database error: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Database error: {}", e),
+        })?;
 
     let expected_power_shelves = db_expected_power_shelf::find_all(&mut txn)
         .await
-        .map_err(|e| Status::internal(format!("Failed to find expected power shelves: {}", e)))?;
+        .map_err(CarbideError::from)?;
 
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(format!("Failed to commit transaction: {}", e)))?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: format!("Failed to commit transaction: {}", e),
+    })?;
 
     let expected_power_shelves: Vec<rpc::ExpectedPowerShelf> = expected_power_shelves
         .into_iter()
@@ -193,28 +214,33 @@ pub async fn replace_all_expected_power_shelves(
         .database_connection
         .begin()
         .await
-        .map_err(|e| Status::internal(format!("Database error: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Database error: {}", e),
+        })?;
 
     // Clear all existing expected power shelves
     db_expected_power_shelf::clear(&mut txn)
         .await
-        .map_err(|e| Status::internal(format!("Failed to clear expected power shelves: {}", e)))?;
+        .map_err(CarbideError::from)?;
 
     // Add all new expected power shelves
     for rpc_power_shelf in req.expected_power_shelves {
-        let power_shelf: ExpectedPowerShelf = rpc_power_shelf
-            .try_into()
-            .map_err(|e| Status::invalid_argument(format!("{}", e)))?;
+        let power_shelf: ExpectedPowerShelf =
+            rpc_power_shelf
+                .try_into()
+                .map_err(|e: ::rpc::errors::RpcDataConversionError| {
+                    CarbideError::InvalidArgument(e.to_string())
+                })?;
         db_expected_power_shelf::create(&mut txn, power_shelf)
             .await
-            .map_err(|e| {
-                Status::internal(format!("Failed to create expected power shelf: {}", e))
+            .map_err(|e| CarbideError::Internal {
+                message: format!("Failed to create expected power shelf: {}", e),
             })?;
     }
 
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(format!("Failed to commit transaction: {}", e)))?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: format!("Failed to commit transaction: {}", e),
+    })?;
 
     Ok(Response::new(()))
 }
@@ -227,15 +253,17 @@ pub async fn delete_all_expected_power_shelves(
         .database_connection
         .begin()
         .await
-        .map_err(|e| Status::internal(format!("Database error: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Database error: {}", e),
+        })?;
 
     db_expected_power_shelf::clear(&mut txn)
         .await
-        .map_err(|e| Status::internal(format!("Failed to clear expected power shelves: {}", e)))?;
+        .map_err(CarbideError::from)?;
 
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(format!("Failed to commit transaction: {}", e)))?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: format!("Failed to commit transaction: {}", e),
+    })?;
 
     Ok(Response::new(()))
 }
@@ -248,20 +276,17 @@ pub async fn get_all_expected_power_shelves_linked(
         .database_connection
         .begin()
         .await
-        .map_err(|e| Status::internal(format!("Database error: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Database error: {}", e),
+        })?;
 
     let linked_expected_power_shelves = db_expected_power_shelf::find_all_linked(&mut txn)
         .await
-        .map_err(|e| {
-            Status::internal(format!(
-                "Failed to find linked expected power shelves: {}",
-                e
-            ))
-        })?;
+        .map_err(CarbideError::from)?;
 
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(format!("Failed to commit transaction: {}", e)))?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: format!("Failed to commit transaction: {}", e),
+    })?;
 
     let linked_expected_power_shelves: Vec<rpc::LinkedExpectedPowerShelf> =
         linked_expected_power_shelves

--- a/crates/api/src/handlers/expected_switch.rs
+++ b/crates/api/src/handlers/expected_switch.rs
@@ -28,10 +28,13 @@ pub async fn add_expected_switch(
     api: &Api,
     request: Request<rpc::ExpectedSwitch>,
 ) -> Result<Response<()>, Status> {
-    let switch: ExpectedSwitch = request
-        .into_inner()
-        .try_into()
-        .map_err(|e| Status::invalid_argument(format!("{}", e)))?;
+    let switch: ExpectedSwitch =
+        request
+            .into_inner()
+            .try_into()
+            .map_err(|e: ::rpc::errors::RpcDataConversionError| {
+                CarbideError::InvalidArgument(e.to_string())
+            })?;
 
     let rack_id = switch.rack_id;
     let bmc_mac_address = switch.bmc_mac_address;
@@ -40,11 +43,13 @@ pub async fn add_expected_switch(
         .database_connection
         .begin()
         .await
-        .map_err(|e| Status::internal(format!("Database error: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Database error: {}", e),
+        })?;
 
     db_expected_switch::create(&mut txn, switch)
         .await
-        .map_err(|e| Status::internal(format!("Failed to create expected switch: {}", e)))?;
+        .map_err(CarbideError::from)?;
 
     if let Some(rack_id) = rack_id {
         let adopted = db_rack::adopt_expected_switch(&mut txn, rack_id, bmc_mac_address)
@@ -52,16 +57,16 @@ pub async fn add_expected_switch(
             .map_err(CarbideError::from)?;
         if !adopted {
             tracing::debug!(
-                "rack {} does not exist yet, switch {} will be adopted later.",
-                rack_id,
-                bmc_mac_address
+                %rack_id,
+                %bmc_mac_address,
+                "rack does not exist yet, switch will be adopted later"
             );
         }
     }
 
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(format!("Failed to commit transaction: {}", e)))?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: format!("Failed to commit transaction: {}", e),
+    })?;
 
     Ok(Response::new(()))
 }
@@ -70,24 +75,29 @@ pub async fn delete_expected_switch(
     api: &Api,
     request: Request<rpc::ExpectedSwitchRequest>,
 ) -> Result<Response<()>, Status> {
-    let req: ExpectedSwitchRequest = request
-        .into_inner()
-        .try_into()
-        .map_err(|e| Status::invalid_argument(format!("{}", e)))?;
+    let req: ExpectedSwitchRequest =
+        request
+            .into_inner()
+            .try_into()
+            .map_err(|e: ::rpc::errors::RpcDataConversionError| {
+                CarbideError::InvalidArgument(e.to_string())
+            })?;
 
     let mut txn = api
         .database_connection
         .begin()
         .await
-        .map_err(|e| Status::internal(format!("Database error: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Database error: {}", e),
+        })?;
 
     db_expected_switch::delete(&mut txn, &req)
         .await
-        .map_err(|e| Status::internal(format!("Failed to delete expected switch: {}", e)))?;
+        .map_err(CarbideError::from)?;
 
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(format!("Failed to commit transaction: {}", e)))?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: format!("Failed to commit transaction: {}", e),
+    })?;
 
     Ok(Response::new(()))
 }
@@ -96,24 +106,29 @@ pub async fn update_expected_switch(
     api: &Api,
     request: Request<rpc::ExpectedSwitch>,
 ) -> Result<Response<()>, Status> {
-    let switch: ExpectedSwitch = request
-        .into_inner()
-        .try_into()
-        .map_err(|e| Status::invalid_argument(format!("{}", e)))?;
+    let switch: ExpectedSwitch =
+        request
+            .into_inner()
+            .try_into()
+            .map_err(|e: ::rpc::errors::RpcDataConversionError| {
+                CarbideError::InvalidArgument(e.to_string())
+            })?;
 
     let mut txn = api
         .database_connection
         .begin()
         .await
-        .map_err(|e| Status::internal(format!("Database error: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Database error: {}", e),
+        })?;
 
     db_expected_switch::update(&mut txn, &switch)
         .await
-        .map_err(|e| Status::internal(format!("Failed to update expected switch: {}", e)))?;
+        .map_err(CarbideError::from)?;
 
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(format!("Failed to commit transaction: {}", e)))?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: format!("Failed to commit transaction: {}", e),
+    })?;
 
     Ok(Response::new(()))
 }
@@ -122,33 +137,37 @@ pub async fn get_expected_switch(
     api: &Api,
     request: Request<rpc::ExpectedSwitchRequest>,
 ) -> Result<Response<rpc::ExpectedSwitch>, Status> {
-    let req: ExpectedSwitchRequest = request
-        .into_inner()
-        .try_into()
-        .map_err(|e| Status::invalid_argument(format!("{}", e)))?;
+    let req: ExpectedSwitchRequest =
+        request
+            .into_inner()
+            .try_into()
+            .map_err(|e: ::rpc::errors::RpcDataConversionError| {
+                CarbideError::InvalidArgument(e.to_string())
+            })?;
 
     let mut txn = api
         .database_connection
         .begin()
         .await
-        .map_err(|e| Status::internal(format!("Database error: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Database error: {}", e),
+        })?;
 
     let expected_switch = db_expected_switch::find(&mut txn, &req)
         .await
-        .map_err(|e| Status::internal(format!("Failed to find expected switch: {}", e)))?
-        .ok_or_else(|| {
-            Status::not_found(format!(
-                "Expected switch not found: {}",
-                req.expected_switch_id
-                    .map(|u| u.to_string())
-                    .or(req.bmc_mac_address.map(|m| m.to_string()))
-                    .unwrap_or_default()
-            ))
+        .map_err(CarbideError::from)?
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "expected_switch",
+            id: req
+                .expected_switch_id
+                .map(|u| u.to_string())
+                .or(req.bmc_mac_address.map(|m| m.to_string()))
+                .unwrap_or_default(),
         })?;
 
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(format!("Failed to commit transaction: {}", e)))?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: format!("Failed to commit transaction: {}", e),
+    })?;
 
     let response = rpc::ExpectedSwitch::from(expected_switch);
     Ok(Response::new(response))
@@ -162,15 +181,17 @@ pub async fn get_all_expected_switches(
         .database_connection
         .begin()
         .await
-        .map_err(|e| Status::internal(format!("Database error: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Database error: {}", e),
+        })?;
 
     let expected_switches = db_expected_switch::find_all(&mut txn)
         .await
-        .map_err(|e| Status::internal(format!("Failed to find expected switches: {}", e)))?;
+        .map_err(CarbideError::from)?;
 
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(format!("Failed to commit transaction: {}", e)))?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: format!("Failed to commit transaction: {}", e),
+    })?;
 
     let expected_switches: Vec<rpc::ExpectedSwitch> = expected_switches
         .into_iter()
@@ -190,26 +211,33 @@ pub async fn replace_all_expected_switches(
         .database_connection
         .begin()
         .await
-        .map_err(|e| Status::internal(format!("Database error: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Database error: {}", e),
+        })?;
 
     // Clear all existing expected switches
     db_expected_switch::clear(&mut txn)
         .await
-        .map_err(|e| Status::internal(format!("Failed to clear expected switches: {}", e)))?;
+        .map_err(CarbideError::from)?;
 
     // Add all new expected switches
     for expected_switch in req.expected_switches {
-        let switch: ExpectedSwitch = expected_switch
-            .try_into()
-            .map_err(|e| Status::invalid_argument(format!("{}", e)))?;
+        let switch: ExpectedSwitch =
+            expected_switch
+                .try_into()
+                .map_err(|e: ::rpc::errors::RpcDataConversionError| {
+                    CarbideError::InvalidArgument(e.to_string())
+                })?;
         db_expected_switch::create(&mut txn, switch)
             .await
-            .map_err(|e| Status::internal(format!("Failed to create expected switch: {}", e)))?;
+            .map_err(|e| CarbideError::Internal {
+                message: format!("Failed to create expected switch: {}", e),
+            })?;
     }
 
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(format!("Failed to commit transaction: {}", e)))?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: format!("Failed to commit transaction: {}", e),
+    })?;
 
     Ok(Response::new(()))
 }
@@ -222,15 +250,17 @@ pub async fn delete_all_expected_switches(
         .database_connection
         .begin()
         .await
-        .map_err(|e| Status::internal(format!("Database error: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Database error: {}", e),
+        })?;
 
     db_expected_switch::clear(&mut txn)
         .await
-        .map_err(|e| Status::internal(format!("Failed to clear expected switches: {}", e)))?;
+        .map_err(CarbideError::from)?;
 
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(format!("Failed to commit transaction: {}", e)))?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: format!("Failed to commit transaction: {}", e),
+    })?;
 
     Ok(Response::new(()))
 }
@@ -243,15 +273,17 @@ pub async fn get_all_expected_switches_linked(
         .database_connection
         .begin()
         .await
-        .map_err(|e| Status::internal(format!("Database error: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Database error: {}", e),
+        })?;
 
     let linked_expected_switches = db_expected_switch::find_all_linked(&mut txn)
         .await
-        .map_err(|e| Status::internal(format!("Failed to find linked expected switches: {}", e)))?;
+        .map_err(CarbideError::from)?;
 
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(format!("Failed to commit transaction: {}", e)))?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: format!("Failed to commit transaction: {}", e),
+    })?;
 
     let linked_expected_switches: Vec<rpc::LinkedExpectedSwitch> = linked_expected_switches
         .into_iter()

--- a/crates/api/src/handlers/extension_service.rs
+++ b/crates/api/src/handlers/extension_service.rs
@@ -482,10 +482,11 @@ pub(crate) async fn delete(
     // lock on the extension service.
     let is_in_use = extension_service::is_service_in_use(&mut txn, service_id, &versions).await?;
     if is_in_use {
-        return Err(Status::from(CarbideError::FailedPrecondition(
+        return Err(CarbideError::FailedPrecondition(
             "One or more extension service version is in use by instances; detach before deleting"
                 .into(),
-        )));
+        )
+        .into());
     }
 
     // Find service versions with credentials
@@ -562,7 +563,7 @@ pub(crate) async fn find_ids(
         None => None,
         Some(v) => {
             let service_type_rpc = rpc::DpuExtensionServiceType::try_from(v)
-                .map_err(|_| CarbideError::InvalidArgument("Invalid service_type".into()))?;
+                .map_err(|_| CarbideError::InvalidArgument("Invalid service_type".to_string()))?;
             Some(ExtensionServiceType::from(service_type_rpc))
         }
     };

--- a/crates/api/src/handlers/finder.rs
+++ b/crates/api/src/handlers/finder.rs
@@ -66,7 +66,7 @@ pub(crate) async fn identify_uuid(
     let req = request.into_inner();
 
     let Some(u) = req.uuid else {
-        return Err(tonic::Status::invalid_argument("UUID missing from query"));
+        return Err(CarbideError::InvalidArgument("UUID missing from query".to_string()).into());
     };
     match by_uuid(api, &u).await {
         Ok(Some(object_type)) => Ok(tonic::Response::new(rpc::IdentifyUuidResponse {
@@ -90,12 +90,12 @@ pub(crate) async fn identify_mac(
     let req = request.into_inner();
 
     if req.mac_address.is_empty() {
-        return Err(tonic::Status::invalid_argument("MAC missing from query"));
+        return Err(CarbideError::InvalidArgument("MAC missing from query".to_string()).into());
     };
     let Ok(mac) = mac_address::MacAddress::from_str(&req.mac_address) else {
-        return Err(tonic::Status::invalid_argument(
-            "Could not parse MAC address",
-        ));
+        return Err(
+            CarbideError::InvalidArgument("Could not parse MAC address".to_string()).into(),
+        );
     };
     match by_mac(api, mac).await {
         Ok(Some((primary_key, object_type))) => {

--- a/crates/api/src/handlers/ib_partition.rs
+++ b/crates/api/src/handlers/ib_partition.rs
@@ -77,9 +77,11 @@ pub(crate) async fn create(
             // is less than <max_partition_per_tenant> by using a sub-select query in a WHERE clause.
             // The 'RowNotFound' error means that the number of existing partitions exceeded the limit
             // and no insert was performed.
-            Status::invalid_argument("Maximum Limit of Infiniband partitions had been reached")
+            CarbideError::InvalidArgument(
+                "Maximum Limit of Infiniband partitions had been reached".into(),
+            )
         } else {
-            CarbideError::from(e).into()
+            CarbideError::from(e)
         }
     })?;
     let resp = rpc::IbPartition::try_from(resp).map(Response::new)?;

--- a/crates/api/src/handlers/identity_config.rs
+++ b/crates/api/src/handlers/identity_config.rs
@@ -109,21 +109,22 @@ pub(crate) async fn get_identity_configuration(
     log_request_data(&request);
 
     if !api.runtime_config.machine_identity.enabled {
-        return Err(Status::from(CarbideError::InvalidArgument(
+        return Err(CarbideError::InvalidArgument(
             "Machine identity must be enabled in site config".to_string(),
-        )));
+        )
+        .into());
     }
 
     let req = request.into_inner();
     let org_id = req.organization_id.trim();
     if org_id.is_empty() {
-        return Err(Status::from(CarbideError::InvalidArgument(
-            "organization_id is required".to_string(),
-        )));
+        return Err(
+            CarbideError::InvalidArgument("organization_id is required".to_string()).into(),
+        );
     }
-    let org_id: TenantOrganizationId = org_id.parse().map_err(|e: InvalidTenantOrg| {
-        Status::from(CarbideError::InvalidArgument(e.to_string()))
-    })?;
+    let org_id: TenantOrganizationId = org_id
+        .parse()
+        .map_err(|e: InvalidTenantOrg| CarbideError::InvalidArgument(e.to_string()))?;
     let org_id_str = org_id.as_str().to_string();
 
     let cfg = api
@@ -134,10 +135,11 @@ pub(crate) async fn get_identity_configuration(
     let cfg = match cfg {
         Some(c) => c,
         None => {
-            return Err(Status::from(CarbideError::NotFoundError {
+            return Err(CarbideError::NotFoundError {
                 kind: "tenant_identity_config",
                 id: org_id_str.clone(),
-            }));
+            }
+            .into());
         }
     };
 
@@ -166,21 +168,22 @@ pub(crate) async fn delete_identity_configuration(
     log_request_data(&request);
 
     if !api.runtime_config.machine_identity.enabled {
-        return Err(Status::from(CarbideError::InvalidArgument(
+        return Err(CarbideError::InvalidArgument(
             "Machine identity must be enabled in site config".to_string(),
-        )));
+        )
+        .into());
     }
 
     let req = request.into_inner();
     let org_id = req.organization_id.trim();
     if org_id.is_empty() {
-        return Err(Status::from(CarbideError::InvalidArgument(
-            "organization_id is required".to_string(),
-        )));
+        return Err(
+            CarbideError::InvalidArgument("organization_id is required".to_string()).into(),
+        );
     }
-    let org_id: TenantOrganizationId = org_id.parse().map_err(|e: InvalidTenantOrg| {
-        Status::from(CarbideError::InvalidArgument(e.to_string()))
-    })?;
+    let org_id: TenantOrganizationId = org_id
+        .parse()
+        .map_err(|e: InvalidTenantOrg| CarbideError::InvalidArgument(e.to_string()))?;
     let org_id_str = org_id.as_str().to_string();
 
     let deleted = api
@@ -197,10 +200,11 @@ pub(crate) async fn delete_identity_configuration(
         .await??;
 
     if !deleted {
-        return Err(Status::from(CarbideError::NotFoundError {
+        return Err(CarbideError::NotFoundError {
             kind: "tenant_identity_config",
             id: org_id_str,
-        }));
+        }
+        .into());
     }
 
     Ok(Response::new(()))
@@ -215,20 +219,17 @@ pub(crate) async fn set_identity_configuration(
     log_request_data(&request);
 
     if !api.runtime_config.machine_identity.enabled {
-        return Err(Status::from(CarbideError::InvalidArgument(
+        return Err(CarbideError::InvalidArgument(
             "Machine identity must be enabled in site config before setting identity configuration"
                 .to_string(),
-        )));
+        )
+        .into());
     }
 
     let req = request.into_inner();
     let config: IdentityConfig = req
         .config
-        .ok_or_else(|| {
-            Status::from(CarbideError::InvalidArgument(
-                "IdentityConfig is required".to_string(),
-            ))
-        })
+        .ok_or_else(|| CarbideError::InvalidArgument("IdentityConfig is required".to_string()))
         .and_then(|c| {
             IdentityConfig::try_from_proto(
                 c,
@@ -236,19 +237,17 @@ pub(crate) async fn set_identity_configuration(
                     api.runtime_config.machine_identity.clone(),
                 ),
             )
-            .map_err(|e: IdentityConfigValidationError| {
-                Status::from(CarbideError::InvalidArgument(e.0))
-            })
+            .map_err(|e: IdentityConfigValidationError| CarbideError::InvalidArgument(e.0))
         })?;
     let org_id = req.organization_id.trim();
     if org_id.is_empty() {
-        return Err(Status::from(CarbideError::InvalidArgument(
-            "organization_id is required".to_string(),
-        )));
+        return Err(
+            CarbideError::InvalidArgument("organization_id is required".to_string()).into(),
+        );
     }
-    let org_id: TenantOrganizationId = org_id.parse().map_err(|e: InvalidTenantOrg| {
-        Status::from(CarbideError::InvalidArgument(e.to_string()))
-    })?;
+    let org_id: TenantOrganizationId = org_id
+        .parse()
+        .map_err(|e: InvalidTenantOrg| CarbideError::InvalidArgument(e.to_string()))?;
     let org_id_str = org_id.as_str().to_string();
 
     let cfg = api
@@ -295,21 +294,22 @@ pub(crate) async fn get_token_delegation(
     log_request_data(&request);
 
     if !api.runtime_config.machine_identity.enabled {
-        return Err(Status::from(CarbideError::InvalidArgument(
+        return Err(CarbideError::InvalidArgument(
             "Machine identity must be enabled in site config".to_string(),
-        )));
+        )
+        .into());
     }
 
     let req = request.into_inner();
     let org_id = req.organization_id.trim();
     if org_id.is_empty() {
-        return Err(Status::from(CarbideError::InvalidArgument(
-            "organization_id is required".to_string(),
-        )));
+        return Err(
+            CarbideError::InvalidArgument("organization_id is required".to_string()).into(),
+        );
     }
-    let org_id: TenantOrganizationId = org_id.parse().map_err(|e: InvalidTenantOrg| {
-        Status::from(CarbideError::InvalidArgument(e.to_string()))
-    })?;
+    let org_id: TenantOrganizationId = org_id
+        .parse()
+        .map_err(|e: InvalidTenantOrg| CarbideError::InvalidArgument(e.to_string()))?;
     let org_id_str = org_id.as_str().to_string();
 
     let cfg = api
@@ -320,20 +320,22 @@ pub(crate) async fn get_token_delegation(
     let cfg = match cfg {
         Some(c) => c,
         None => {
-            return Err(Status::from(CarbideError::NotFoundError {
+            return Err(CarbideError::NotFoundError {
                 kind: "tenant_identity_config",
                 id: org_id_str.clone(),
-            }));
+            }
+            .into());
         }
     };
 
     let (token_endpoint, auth_method) = match (&cfg.token_endpoint, &cfg.auth_method) {
         (Some(te), Some(am)) => (te.clone(), am.as_str()),
         _ => {
-            return Err(Status::from(CarbideError::NotFoundError {
+            return Err(CarbideError::NotFoundError {
                 kind: "token_delegation",
                 id: org_id_str.clone(),
-            }));
+            }
+            .into());
         }
     };
 
@@ -347,9 +349,9 @@ pub(crate) async fn get_token_delegation(
     } else {
         Some(
             stored_to_response_auth_config(auth_method, stored.as_ref()).ok_or_else(|| {
-                Status::from(CarbideError::internal(
+                CarbideError::internal(
                     "Stored auth_method_config does not match auth_method".to_string(),
-                ))
+                )
             })?,
         )
     };
@@ -373,9 +375,10 @@ pub(crate) async fn set_token_delegation(
     log_request_data_redacted(format_token_delegation_request_redacted(request.get_ref()));
 
     if !api.runtime_config.machine_identity.enabled {
-        return Err(Status::from(CarbideError::InvalidArgument(
+        return Err(CarbideError::InvalidArgument(
             "Machine identity must be enabled in site config".to_string(),
-        )));
+        )
+        .into());
     }
 
     let req = request.into_inner();
@@ -383,24 +386,21 @@ pub(crate) async fn set_token_delegation(
         .config
         .as_ref()
         .ok_or_else(|| {
-            Status::from(CarbideError::InvalidArgument(
-                "TokenDelegation config is required".to_string(),
-            ))
+            CarbideError::InvalidArgument("TokenDelegation config is required".to_string())
         })
         .and_then(|c| {
-            TokenDelegation::try_from(c.clone()).map_err(|e: TokenDelegationValidationError| {
-                Status::from(CarbideError::InvalidArgument(e.0))
-            })
+            TokenDelegation::try_from(c.clone())
+                .map_err(|e: TokenDelegationValidationError| CarbideError::InvalidArgument(e.0))
         })?;
     let org_id = req.organization_id.trim();
     if org_id.is_empty() {
-        return Err(Status::from(CarbideError::InvalidArgument(
-            "organization_id is required".to_string(),
-        )));
+        return Err(
+            CarbideError::InvalidArgument("organization_id is required".to_string()).into(),
+        );
     }
-    let org_id: TenantOrganizationId = org_id.parse().map_err(|e: InvalidTenantOrg| {
-        Status::from(CarbideError::InvalidArgument(e.to_string()))
-    })?;
+    let org_id: TenantOrganizationId = org_id
+        .parse()
+        .map_err(|e: InvalidTenantOrg| CarbideError::InvalidArgument(e.to_string()))?;
     let org_id_str = org_id.as_str().to_string();
 
     let cfg = api
@@ -432,9 +432,9 @@ pub(crate) async fn set_token_delegation(
     } else {
         Some(
             stored_to_response_auth_config(auth_method, stored.as_ref()).ok_or_else(|| {
-                Status::from(CarbideError::internal(
+                CarbideError::internal(
                     "Stored auth_method_config does not match auth_method".to_string(),
-                ))
+                )
             })?,
         )
     };
@@ -458,21 +458,22 @@ pub(crate) async fn delete_token_delegation(
     log_request_data(&request);
 
     if !api.runtime_config.machine_identity.enabled {
-        return Err(Status::from(CarbideError::InvalidArgument(
+        return Err(CarbideError::InvalidArgument(
             "Machine identity must be enabled in site config".to_string(),
-        )));
+        )
+        .into());
     }
 
     let req = request.into_inner();
     let org_id = req.organization_id.trim();
     if org_id.is_empty() {
-        return Err(Status::from(CarbideError::InvalidArgument(
-            "organization_id is required".to_string(),
-        )));
+        return Err(
+            CarbideError::InvalidArgument("organization_id is required".to_string()).into(),
+        );
     }
-    let org_id: TenantOrganizationId = org_id.parse().map_err(|e: InvalidTenantOrg| {
-        Status::from(CarbideError::InvalidArgument(e.to_string()))
-    })?;
+    let org_id: TenantOrganizationId = org_id
+        .parse()
+        .map_err(|e: InvalidTenantOrg| CarbideError::InvalidArgument(e.to_string()))?;
 
     api.database_connection
         .with_txn(|txn| {

--- a/crates/api/src/handlers/instance.rs
+++ b/crates/api/src/handlers/instance.rs
@@ -124,9 +124,10 @@ pub(crate) async fn batch_allocate(
     let batch_request = request.into_inner();
 
     if batch_request.instance_requests.is_empty() {
-        return Err(Status::invalid_argument(
-            "Batch request must contain at least one instance",
-        ));
+        return Err(CarbideError::InvalidArgument(
+            "Batch request must contain at least one instance".to_string(),
+        )
+        .into());
     }
 
     tracing::info!(
@@ -678,7 +679,9 @@ pub(crate) async fn release(
             instance.config.tenant.tenant_organization_id.as_str(),
         )
         .await
-        .map_err(|e| Status::internal(e.to_string()))?;
+        .map_err(|e| CarbideError::Internal {
+            message: e.to_string(),
+        })?;
     } else if let Some(issue) = &delete_instance.issue {
         // Instance Release called from the regular tenant (not the Repair tenant) and has an issue to report.
         let auto_repair_enabled = api.runtime_config.auto_machine_repair_plugin.enabled;
@@ -691,7 +694,9 @@ pub(crate) async fn release(
             instance.config.tenant.tenant_organization_id.as_str(),
         )
         .await
-        .map_err(|e| Status::internal(e.to_string()))?;
+        .map_err(|e| CarbideError::Internal {
+            message: e.to_string(),
+        })?;
     }
 
     if instance.deleted.is_some() {
@@ -770,10 +775,11 @@ pub(crate) async fn invoke_power(
         if let Some(machine_id) = &request.machine_id
             && *machine_id != snapshot.host_snapshot.id
         {
-            return Err(Status::invalid_argument(format!(
+            return Err(CarbideError::InvalidArgument(format!(
                 "Instance {} is not hosted on machine {}",
                 instance_id, machine_id
-            )));
+            ))
+            .into());
         }
 
         snapshot
@@ -791,9 +797,10 @@ pub(crate) async fn invoke_power(
             id: machine_id.to_string(),
         })?;
         if snapshot.instance.is_none() {
-            return Err(Status::invalid_argument(format!(
+            return Err(CarbideError::InvalidArgument(format!(
                 "Supplied machine ID does not match an instance: {machine_id}"
-            )));
+            ))
+            .into());
         }
 
         snapshot

--- a/crates/api/src/handlers/instance_type.rs
+++ b/crates/api/src/handlers/instance_type.rs
@@ -171,9 +171,7 @@ pub(crate) async fn find_by_ids(
             req.tenant_organization_id
                 .map(|t| {
                     t.parse().map_err(|e: InvalidTenantOrg| {
-                        Status::from(CarbideError::from(
-                            RpcDataConversionError::InvalidTenantOrg(e.to_string()),
-                        ))
+                        CarbideError::from(RpcDataConversionError::InvalidTenantOrg(e.to_string()))
                     })
                 })
                 .transpose()?

--- a/crates/api/src/handlers/machine.rs
+++ b/crates/api/src/handlers/machine.rs
@@ -209,7 +209,11 @@ pub(crate) async fn machine_set_auto_update(
     let Some(_machine) =
         db::machine::find_one(&mut txn, &machine_id, MachineSearchConfig::default()).await?
     else {
-        return Err(Status::not_found("The machine ID was not found"));
+        return Err(CarbideError::NotFoundError {
+            kind: "machine",
+            id: request.machine_id.unwrap_or_default().to_string(),
+        }
+        .into());
     };
 
     let state = match request.action() {
@@ -497,13 +501,14 @@ pub(crate) async fn admin_force_delete_machine(
         {
             let host_dpf_id = machine
                 .dpf_id()
-                .ok_or_else(|| CarbideError::internal("BMC MAC not set for host".into()))?;
+                .ok_or_else(|| CarbideError::internal("BMC MAC not set for host".to_string()))?;
             let node_name = carbide_dpf::dpu_node_cr_name(&host_dpf_id);
             let dpu_device_names: Vec<String> = dpu_machines
                 .iter()
                 .map(|d| {
-                    d.dpf_id()
-                        .ok_or_else(|| CarbideError::internal("BMC MAC not set for DPU".into()))
+                    d.dpf_id().ok_or_else(|| {
+                        CarbideError::internal("BMC MAC not set for DPU".to_string())
+                    })
                 })
                 .collect::<Result<_, _>>()?;
             ops.force_delete_host(&node_name, &dpu_device_names)

--- a/crates/api/src/handlers/machine_discovery.rs
+++ b/crates/api/src/handlers/machine_discovery.rs
@@ -68,7 +68,9 @@ pub(crate) async fn discover_machine(
         .map(|data| match data {
             rpc::machine_discovery_info::DiscoveryData::Info(info) => info,
         })
-        .ok_or_else(|| Status::invalid_argument("Discovery data is not populated"))?;
+        .ok_or_else(|| {
+            CarbideError::InvalidArgument("Discovery data is not populated".to_string())
+        })?;
     let attest_key_info_opt = discovery_data.attest_key_info.clone();
     let hardware_info = HardwareInfo::try_from(discovery_data).map_err(CarbideError::from)?;
 
@@ -78,7 +80,9 @@ pub(crate) async fn discover_machine(
         && !hardware_info.is_dpu()
         && attest_key_info_opt.is_none()
     {
-        return Err(Status::invalid_argument("AttestKeyInfo is not populated"));
+        return Err(
+            CarbideError::InvalidArgument("AttestKeyInfo is not populated".to_string()).into(),
+        );
     }
 
     // Generate a stable Machine ID based on the hardware information
@@ -165,7 +169,7 @@ pub(crate) async fn discover_machine(
             )
             .await?
             .ok_or_else(|| {
-                Status::invalid_argument(format!(
+                CarbideError::InvalidArgument(format!(
                     "Machine id {stable_machine_id} was not discovered by site-explorer."
                 ))
             })?;
@@ -200,7 +204,7 @@ pub(crate) async fn discover_machine(
             )
             .await?
             .ok_or_else(|| {
-                Status::invalid_argument(format!("Machine id {stable_machine_id} not found."))
+                CarbideError::InvalidArgument(format!("Machine id {stable_machine_id} not found."))
             })?
         };
 
@@ -326,9 +330,10 @@ pub(crate) async fn discover_machine(
     let attest_key_challenge = if api.runtime_config.attestation_enabled && !hardware_info.is_dpu()
     {
         let Some(attest_key_info) = attest_key_info_opt else {
-            return Err(Status::invalid_argument(
-                "Internal Error: This should have been handled above! AttestKeyInfo is not populated.",
-            ));
+            return Err(CarbideError::InvalidArgument(
+                "Internal Error: This should have been handled above! AttestKeyInfo is not populated.".into(),
+            )
+            .into());
         };
 
         tracing::info!(

--- a/crates/api/src/handlers/machine_identity.rs
+++ b/crates/api/src/handlers/machine_identity.rs
@@ -21,6 +21,7 @@
 use ::rpc::forge::{self as rpc, MachineIdentityResponse};
 use tonic::{Request, Response, Status};
 
+use crate::CarbideError;
 use crate::api::{Api, log_request_data};
 use crate::auth::AuthContext;
 
@@ -37,9 +38,10 @@ pub(crate) async fn sign_machine_identity(
     log_request_data(&request);
 
     if !api.runtime_config.machine_identity.enabled {
-        return Err(tonic::Status::unavailable(
-            "Machine identity is disabled in site config",
-        ));
+        return Err(CarbideError::UnavailableError(
+            "Machine identity is disabled in site config".into(),
+        )
+        .into());
     }
 
     let auth_context = request
@@ -55,7 +57,7 @@ pub(crate) async fn sign_machine_identity(
 
     let _machine_id: carbide_uuid::machine::MachineId = machine_id_str
         .parse()
-        .map_err(|e| Status::invalid_argument(format!("Invalid machine ID format: {}", e)))?;
+        .map_err(|e| CarbideError::InvalidArgument(format!("Invalid machine ID format: {}", e)))?;
 
     let req = request.get_ref();
     let _audience = &req.audience; // TODO: Use audience in JWT claims

--- a/crates/api/src/handlers/machine_interface.rs
+++ b/crates/api/src/handlers/machine_interface.rs
@@ -72,9 +72,10 @@ pub(crate) async fn find_interfaces(
         let maybe_a_bmc_interface = interface.primary_interface && interface.address.len() == 1;
         if not_linked_yet && maybe_a_bmc_interface {
             let Some(ip) = interface.address.first() else {
-                return Err(Status::internal(
-                    "Impossible interface.address array length",
-                ));
+                return Err(CarbideError::Internal {
+                    message: "Impossible interface.address array length".into(),
+                }
+                .into());
             };
             match db::machine_topology::find_machine_id_by_bmc_ip(txn.as_pgconn(), ip).await {
                 Ok(Some(machine_id)) => {
@@ -117,9 +118,10 @@ pub(crate) async fn delete_interface(
 
     // There should not be any machine associated with this interface.
     if let Some(machine_id) = interface.machine_id {
-        return Err(Status::invalid_argument(format!(
+        return Err(CarbideError::InvalidArgument(format!(
             "Already a machine {machine_id} is attached to this interface. Delete that first."
-        )));
+        ))
+        .into());
     }
 
     // There should not be any BMC information associated with any machine.
@@ -129,9 +131,10 @@ pub(crate) async fn delete_interface(
                 .await?;
 
         if let Some(machine_id) = machine_id {
-            return Err(Status::invalid_argument(format!(
+            return Err(CarbideError::InvalidArgument(format!(
                 "This looks like a BMC interface and attached with machine: {machine_id}. Delete that first."
-            )));
+            ))
+            .into());
         }
     }
 
@@ -155,7 +158,7 @@ pub(crate) async fn find_mac_address_by_bmc_ip(
         &api.database_connection,
         bmc_ip
             .parse()
-            .map_err(|e| tonic::Status::invalid_argument(format!("Invalid IP address: {e}")))?,
+            .map_err(|e| CarbideError::InvalidArgument(format!("Invalid IP address: {e}")))?,
     )
     .await?
     .ok_or_else(|| CarbideError::NotFoundError {

--- a/crates/api/src/handlers/machine_validation.rs
+++ b/crates/api/src/handlers/machine_validation.rs
@@ -60,15 +60,16 @@ pub(crate) async fn mark_machine_validation_complete(
         Some(machine) => machine,
         None => {
             tracing::error!(%uuid, "validation id not found");
-            return Err(Status::invalid_argument("wrong validation ID"));
+            return Err(CarbideError::InvalidArgument("wrong validation ID".to_string()).into());
         }
     };
 
     if machine.id != machine_id {
         tracing::error!(validation_id = %uuid, machine_id = %machine_id, "Validation ID does not belong to provided Machine ID");
-        return Err(Status::invalid_argument(
-            "Validation ID does not belong to provided Machine ID",
-        ));
+        return Err(CarbideError::InvalidArgument(
+            "Validation ID does not belong to provided Machine ID".to_string(),
+        )
+        .into());
     }
 
     let mut state = MachineValidationState::Success;
@@ -184,7 +185,9 @@ pub(crate) async fn persist_validation_result(
             Some(machine) => machine,
             None => {
                 tracing::error!(%validation_result.validation_id, "validation id not found");
-                return Err(Status::invalid_argument("wrong validation ID"));
+                return Err(
+                    CarbideError::InvalidArgument("wrong validation ID".to_string()).into(),
+                );
             }
         };
     // Check state
@@ -199,7 +202,9 @@ pub(crate) async fn persist_validation_result(
         }
         _ => {
             tracing::error!("invalid host machine state {}", machine.current_state());
-            return Err(Status::invalid_argument("wrong host machine state"));
+            return Err(
+                CarbideError::InvalidArgument("wrong host machine state".to_string()).into(),
+            );
         }
     }
 
@@ -392,7 +397,7 @@ pub(crate) async fn on_demand_machine_validation(
             )
             .await?
             .ok_or_else(|| {
-                Status::invalid_argument(format!("Machine id {machine_id} not found."))
+                CarbideError::InvalidArgument(format!("Machine id {machine_id} not found."))
             })?;
             if machine
                 .on_demand_machine_validation_request
@@ -401,7 +406,7 @@ pub(crate) async fn on_demand_machine_validation(
                 let msg =
                     format!("On demand machine validation for {machine_id} is already scheduled.");
                 tracing::error!(msg);
-                return Err(Status::invalid_argument(msg));
+                return Err(CarbideError::InvalidArgument(msg).into());
             }
             // Check state
             match machine.current_state() {
@@ -415,7 +420,7 @@ pub(crate) async fn on_demand_machine_validation(
                             "On demand machine validation for {machine_id} is already scheduled."
                         );
                         tracing::error!(msg);
-                        return Err(Status::invalid_argument(msg));
+                        return Err(CarbideError::InvalidArgument(msg).into());
                     }
                     let allowed_tests: Vec<String> = req
                         .allowed_tests
@@ -455,13 +460,16 @@ pub(crate) async fn on_demand_machine_validation(
                         machine.current_state()
                     );
                     tracing::warn!(msg);
-                    Err(Status::invalid_argument(msg))
+                    Err(CarbideError::InvalidArgument(msg).into())
                 }
             }
         }
-        rpc::machine_validation_on_demand_request::Action::Stop => Err(Status::invalid_argument(
-            "Cannot stop an on-demand validation request",
-        )),
+        rpc::machine_validation_on_demand_request::Action::Stop => {
+            Err(CarbideError::InvalidArgument(
+                "Cannot stop an on-demand validation request".to_string(),
+            )
+            .into())
+        }
     }
 }
 
@@ -549,7 +557,7 @@ pub(crate) async fn add_machine_validation_test(
     )
     .await?;
     if !tests.is_empty() {
-        return Err(Status::invalid_argument("Name already exists"));
+        return Err(CarbideError::InvalidArgument("Name already exists".to_string()).into());
     }
     let version = ConfigVersion::initial();
     let test_id = machine_validation_suites::save(&mut txn, model_req, version).await?;
@@ -690,7 +698,7 @@ pub(crate) async fn update_machine_validation_run(
         &validation_id,
         req.total
             .try_into()
-            .map_err(|_e| Status::invalid_argument("total"))?,
+            .map_err(|_e| CarbideError::InvalidArgument("total".to_string()))?,
         req.duration_to_complete.unwrap_or_default().seconds,
     )
     .await?;

--- a/crates/api/src/handlers/managed_host.rs
+++ b/crates/api/src/handlers/managed_host.rs
@@ -227,9 +227,10 @@ pub(crate) async fn set_maintenance(
         .load_machine(&machine_id, MachineSearchConfig::default())
         .await?;
     if host_machine.is_dpu() {
-        return Err(Status::invalid_argument(
-            "DPU ID provided. Need managed host.",
-        ));
+        return Err(CarbideError::InvalidArgument(
+            "DPU ID provided. Need managed host.".to_string(),
+        )
+        .into());
     }
     let dpu_machines = db::machine::find_dpus_by_host_machine_id(&mut txn, &machine_id).await?;
     txn.commit().await?;
@@ -238,16 +239,17 @@ pub(crate) async fn set_maintenance(
     match req.operation() {
         rpc::MaintenanceOperation::Enable => {
             let Some(reference) = req.reference else {
-                return Err(Status::invalid_argument(
-                    "Missing reference url".to_string(),
-                ));
+                return Err(
+                    CarbideError::InvalidArgument("Missing reference url".to_string()).into(),
+                );
             };
 
             let reference = reference.trim().to_string();
             if reference.len() < 5 {
-                return Err(Status::invalid_argument(
-                    "Provide some valid reference. Minimum expected length is 5.".to_string(),
-                ));
+                return Err(CarbideError::InvalidArgument(
+                    "Provide some valid reference. Minimum expected length is 5.".into(),
+                )
+                .into());
             }
 
             // Maintenance mode is implemented as a host health override
@@ -283,10 +285,11 @@ pub(crate) async fn set_maintenance(
         rpc::MaintenanceOperation::Disable => {
             for dpu_machine in dpu_machines.iter() {
                 if dpu_machine.reprovision_requested.is_some() {
-                    return Err(Status::invalid_argument(format!(
+                    return Err(CarbideError::InvalidArgument(format!(
                         "Reprovisioning request is set on DPU: {}. Clear it first.",
                         &dpu_machine.id
-                    )));
+                    ))
+                    .into());
                 }
             }
 

--- a/crates/api/src/handlers/measured_boot.rs
+++ b/crates/api/src/handlers/measured_boot.rs
@@ -38,9 +38,10 @@ pub(crate) async fn create_attest_key_bind_challenge(
     )
     .await?;
     if !matched {
-        return Err(Status::from(CarbideError::AttestBindKeyError(
+        return Err(CarbideError::AttestBindKeyError(
             "Certificate's public key did not match EK Pub Key".to_string(),
-        )));
+        )
+        .into());
     }
 
     // generate a secret/credential

--- a/crates/api/src/handlers/mlx_admin.rs
+++ b/crates/api/src/handlers/mlx_admin.rs
@@ -22,6 +22,7 @@ use carbide_uuid::machine::MachineId;
 use libmlx::profile::serialization::SerializableProfile;
 use tonic::{Request, Response, Status};
 
+use crate::CarbideError;
 use crate::api::{Api, log_request_data};
 use crate::handlers::utils::convert_and_log_machine_id;
 
@@ -227,9 +228,11 @@ async fn handle_profile_sync(
 ) -> Result<mlx_device::MlxAdminProfileSyncResponse, Status> {
     // Check if the machine is connected.
     if !api.scout_stream_registry.is_connected(machine_id).await {
-        return Err(Status::not_found(format!(
-            "scout agent on machine is not connected: {machine_id}"
-        )));
+        return Err(CarbideError::NotFoundError {
+            kind: "scout_agent",
+            id: format!("scout agent on machine is not connected: {machine_id}"),
+        }
+        .into());
     }
 
     // Check if mlxconfig profiles are configured.
@@ -237,25 +240,29 @@ async fn handle_profile_sync(
         .runtime_config
         .mlxconfig_profiles
         .as_ref()
-        .ok_or_else(|| Status::not_found("no mlxconfig profiles are configured"))?;
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "mlxconfig_profiles",
+            id: "configured".into(),
+        })?;
 
     // Get the profile from the loaded profiles.
     let profile = profiles
         .get(&profile_name)
-        .ok_or_else(|| Status::not_found(format!("mlxconfig profile not found: {profile_name}")))?;
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "mlxconfig_profile",
+            id: profile_name.clone(),
+        })?;
 
     // Convert MlxConfigProfile to SerializableProfile, then to JSON.
-    let serializable_profile = SerializableProfile::from_profile(profile).map_err(|e| {
-        Status::internal(format!(
-            "failed to convert mlxconfig profile to serializable profile: {e}"
-        ))
-    })?;
+    let serializable_profile =
+        SerializableProfile::from_profile(profile).map_err(|e| CarbideError::Internal {
+            message: format!("failed to convert mlxconfig profile to serializable profile: {e}"),
+        })?;
 
-    let serializable_profile_pb: mlx_device::SerializableMlxConfigProfile =
-        serializable_profile.try_into().map_err(|e| {
-            Status::internal(format!(
-                "failed to convert serializable profile into pb: {e}"
-            ))
+    let serializable_profile_pb: mlx_device::SerializableMlxConfigProfile = serializable_profile
+        .try_into()
+        .map_err(|e| CarbideError::Internal {
+            message: format!("failed to convert serializable profile into pb: {e}"),
         })?;
 
     // Create the request to send to the agent.
@@ -274,14 +281,11 @@ async fn handle_profile_sync(
         .scout_stream_registry
         .send_request(machine_id, request)
         .await
-        .map_err(|status| {
-            Status::new(
-                status.code(),
-                format!(
-                    "error while attempting to sync profile to scout: {}",
-                    status.message()
-                ),
-            )
+        .map_err(|status| CarbideError::Internal {
+            message: format!(
+                "error while attempting to sync profile to scout: {}",
+                status.message()
+            ),
         })?;
 
     // And now extract the response from the scout agent and
@@ -300,18 +304,27 @@ async fn handle_profile_sync(
                 })
             }
             Some(mlx_device::mlx_device_profile_sync_response::Reply::Error(error)) => {
-                Err(Status::internal(format!(
-                    "scout agent returned error syncing profile to device (machine_id={machine_id}, device_id={device_id}, profile_name={profile_name}): {}",
-                    error.message
-                )))
+                Err(CarbideError::Internal {
+                    message: format!(
+                        "scout agent returned error syncing profile to device (machine_id={machine_id}, device_id={device_id}, profile_name={profile_name}): {}",
+                        error.message
+                    ),
+                }
+                .into())
             }
-            None => Err(Status::internal(format!(
-                "scout agent returned empty sync result reply (machine_id={machine_id}, device_id={device_id}, profile_name={profile_name})"
-            ))),
+            None => Err(CarbideError::Internal {
+                message: format!(
+                    "scout agent returned empty sync result reply (machine_id={machine_id}, device_id={device_id}, profile_name={profile_name})"
+                ),
+            }
+            .into()),
         },
-        _ => Err(Status::internal(format!(
-            "unexpected response type from scout agent for profile sync response (machine_id={machine_id}, device_id={device_id}, profile_name={profile_name})"
-        ))),
+        _ => Err(CarbideError::Internal {
+            message: format!(
+                "unexpected response type from scout agent for profile sync response (machine_id={machine_id}, device_id={device_id}, profile_name={profile_name})"
+            ),
+        }
+        .into()),
     }
 }
 
@@ -325,23 +338,30 @@ fn handle_profile_show(
         .runtime_config
         .mlxconfig_profiles
         .as_ref()
-        .ok_or_else(|| Status::not_found("no mlxconfig profiles are configured"))?;
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "mlxconfig_profiles",
+            id: "configured".into(),
+        })?;
 
     // Get the profile from the loaded profiles.
     let profile = profiles
         .get(&profile_name)
-        .ok_or_else(|| Status::not_found(format!("mlxconfig profile not found: {profile_name}")))?;
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "mlxconfig_profile",
+            id: profile_name.clone(),
+        })?;
 
     // Convert MlxConfigProfile to SerializableProfile, then to JSON.
-    let serializable = SerializableProfile::from_profile(profile).map_err(|e| {
-        Status::internal(format!(
-            "failed to convert mlxconfig profile to serializable profile: {e}"
-        ))
-    })?;
+    let serializable =
+        SerializableProfile::from_profile(profile).map_err(|e| CarbideError::Internal {
+            message: format!("failed to convert mlxconfig profile to serializable profile: {e}"),
+        })?;
 
-    let serializable_profile_pb = serializable.try_into().map_err(|e| {
-        Status::internal(format!("failed to serialize serializable profile pb: {e}"))
-    })?;
+    let serializable_profile_pb = serializable
+        .try_into()
+        .map_err(|e| CarbideError::Internal {
+            message: format!("failed to serialize serializable profile pb: {e}"),
+        })?;
 
     Ok(mlx_device::MlxAdminProfileShowResponse {
         serializable_profile: Some(serializable_profile_pb),
@@ -357,9 +377,11 @@ async fn handle_profile_compare(
 ) -> Result<mlx_device::MlxAdminProfileCompareResponse, Status> {
     // Check if the machine is connected.
     if !api.scout_stream_registry.is_connected(machine_id).await {
-        return Err(Status::not_found(format!(
-            "scout agent on machine is not connected: {machine_id}"
-        )));
+        return Err(CarbideError::NotFoundError {
+            kind: "scout_agent",
+            id: format!("scout agent on machine is not connected: {machine_id}"),
+        }
+        .into());
     }
 
     // Check if mlxconfig profiles are configured.
@@ -367,23 +389,30 @@ async fn handle_profile_compare(
         .runtime_config
         .mlxconfig_profiles
         .as_ref()
-        .ok_or_else(|| Status::not_found("no mlxconfig profiles are configured"))?;
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "mlxconfig_profiles",
+            id: "configured".into(),
+        })?;
 
     // Get the profile from the loaded profiles.
     let profile = profiles
         .get(&profile_name)
-        .ok_or_else(|| Status::not_found(format!("mlxconfig profile not found: {profile_name}")))?;
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "mlxconfig_profile",
+            id: profile_name.clone(),
+        })?;
 
     // Convert MlxConfigProfile to SerializableProfile, then to protobuf.
-    let serializable = SerializableProfile::from_profile(profile).map_err(|e| {
-        Status::internal(format!(
-            "failed to convert mlxconfig profile to serializable profile: {e}"
-        ))
-    })?;
+    let serializable =
+        SerializableProfile::from_profile(profile).map_err(|e| CarbideError::Internal {
+            message: format!("failed to convert mlxconfig profile to serializable profile: {e}"),
+        })?;
 
-    let serializable_profile_pb = serializable.try_into().map_err(|e| {
-        Status::internal(format!("failed to serialize serializable profile pb: {e}"))
-    })?;
+    let serializable_profile_pb = serializable
+        .try_into()
+        .map_err(|e| CarbideError::Internal {
+            message: format!("failed to serialize serializable profile pb: {e}"),
+        })?;
 
     // Create the request to send to the agent.
     let request = ScoutStreamScoutBoundMessage::new_flow(
@@ -401,14 +430,11 @@ async fn handle_profile_compare(
         .scout_stream_registry
         .send_request(machine_id, request)
         .await
-        .map_err(|status| {
-            Status::new(
-                status.code(),
-                format!(
-                    "error while attempting to compare profile via scout: {}",
-                    status.message()
-                ),
-            )
+        .map_err(|status| CarbideError::Internal {
+            message: format!(
+                "error while attempting to compare profile via scout: {}",
+                status.message()
+            ),
         })?;
 
     // And now extract the response from the scout agent and
@@ -427,18 +453,27 @@ async fn handle_profile_compare(
                 comparison_result: Some(comparison_result),
             }),
             Some(mlx_device::mlx_device_profile_compare_response::Reply::Error(error)) => {
-                Err(Status::internal(format!(
-                    "scout agent returned error comparing profile to device (machine_id={machine_id}, device_id={device_id}, profile_name={profile_name}): {}",
-                    error.message
-                )))
+                Err(CarbideError::Internal {
+                    message: format!(
+                        "scout agent returned error comparing profile to device (machine_id={machine_id}, device_id={device_id}, profile_name={profile_name}): {}",
+                        error.message
+                    ),
+                }
+                .into())
             }
-            None => Err(Status::internal(format!(
-                "scout agent returned empty compare result reply (machine_id={machine_id}, device_id={device_id}, profile_name={profile_name})"
-            ))),
+            None => Err(CarbideError::Internal {
+                message: format!(
+                    "scout agent returned empty compare result reply (machine_id={machine_id}, device_id={device_id}, profile_name={profile_name})"
+                ),
+            }
+            .into()),
         },
-        _ => Err(Status::internal(format!(
-            "unexpected response type from scout agent for profile compare response (machine_id={machine_id}, device_id={device_id}, profile_name={profile_name})"
-        ))),
+        _ => Err(CarbideError::Internal {
+            message: format!(
+                "unexpected response type from scout agent for profile compare response (machine_id={machine_id}, device_id={device_id}, profile_name={profile_name})"
+            ),
+        }
+        .into()),
     }
 }
 
@@ -449,7 +484,10 @@ fn handle_profile_list(api: &Api) -> Result<mlx_device::MlxAdminProfileListRespo
         .runtime_config
         .mlxconfig_profiles
         .as_ref()
-        .ok_or_else(|| Status::not_found("no mlxconfig profiles are configured"))?;
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "mlxconfig_profiles",
+            id: "configured".into(),
+        })?;
 
     let profile_list: Vec<mlx_device::ProfileSummary> = profiles
         .iter()
@@ -474,9 +512,11 @@ async fn handle_lockdown_lock(
 ) -> Result<mlx_device::MlxAdminLockdownLockResponse, Status> {
     // Check if the machine is connected.
     if !api.scout_stream_registry.is_connected(machine_id).await {
-        return Err(Status::not_found(format!(
-            "scout agent on machine is not connected: {machine_id}"
-        )));
+        return Err(CarbideError::NotFoundError {
+            kind: "scout_agent",
+            id: format!("scout agent on machine is not connected: {machine_id}"),
+        }
+        .into());
     }
 
     let key = get_device_lockdown_key(api, machine_id, &device_id).await?;
@@ -495,14 +535,11 @@ async fn handle_lockdown_lock(
         .scout_stream_registry
         .send_request(machine_id, request)
         .await
-        .map_err(|status| {
-            Status::new(
-                status.code(),
-                format!(
-                    "error while attempting to lockdown::lock via scout: {}",
-                    status.message()
-                ),
-            )
+        .map_err(|status| CarbideError::Internal {
+            message: format!(
+                "error while attempting to lockdown::lock via scout: {}",
+                status.message()
+            ),
         })?;
     match response.payload {
         Some(scout_stream_api_bound_message::Payload::MlxDeviceLockdownResponse(
@@ -514,18 +551,27 @@ async fn handle_lockdown_lock(
                 })
             }
             Some(mlx_device::mlx_device_lockdown_response::Reply::Error(error)) => {
-                Err(Status::internal(format!(
-                    "scout agent returned error fetching lockdown lock status (machine_id={machine_id}, device_id={device_id}): {}",
-                    error.message
-                )))
+                Err(CarbideError::Internal {
+                    message: format!(
+                        "scout agent returned error fetching lockdown lock status (machine_id={machine_id}, device_id={device_id}): {}",
+                        error.message
+                    ),
+                }
+                .into())
             }
-            None => Err(Status::internal(format!(
-                "scout agent returned empty lockdown lock status reply (machine_id={machine_id}, device_id={device_id})"
-            ))),
+            None => Err(CarbideError::Internal {
+                message: format!(
+                    "scout agent returned empty lockdown lock status reply (machine_id={machine_id}, device_id={device_id})"
+                ),
+            }
+            .into()),
         },
-        _ => Err(Status::internal(format!(
-            "unexpected response type from scout agent for lockdown lock status response (machine_id={machine_id}, device_id={device_id})"
-        ))),
+        _ => Err(CarbideError::Internal {
+            message: format!(
+                "unexpected response type from scout agent for lockdown lock status response (machine_id={machine_id}, device_id={device_id})"
+            ),
+        }
+        .into()),
     }
 }
 
@@ -537,9 +583,11 @@ async fn handle_lockdown_unlock(
 ) -> Result<mlx_device::MlxAdminLockdownUnlockResponse, Status> {
     // Check if the machine is connected.
     if !api.scout_stream_registry.is_connected(machine_id).await {
-        return Err(Status::not_found(format!(
-            "scout agent on machine is not connected: {machine_id}"
-        )));
+        return Err(CarbideError::NotFoundError {
+            kind: "scout_agent",
+            id: format!("scout agent on machine is not connected: {machine_id}"),
+        }
+        .into());
     }
 
     let key = get_device_lockdown_key(api, machine_id, &device_id).await?;
@@ -558,14 +606,11 @@ async fn handle_lockdown_unlock(
         .scout_stream_registry
         .send_request(machine_id, request)
         .await
-        .map_err(|status| {
-            Status::new(
-                status.code(),
-                format!(
-                    "error while attempting to lockdown::unlock via scout: {}",
-                    status.message()
-                ),
-            )
+        .map_err(|status| CarbideError::Internal {
+            message: format!(
+                "error while attempting to lockdown::unlock via scout: {}",
+                status.message()
+            ),
         })?;
 
     match response.payload {
@@ -578,18 +623,27 @@ async fn handle_lockdown_unlock(
                 })
             }
             Some(mlx_device::mlx_device_lockdown_response::Reply::Error(error)) => {
-                Err(Status::internal(format!(
-                    "scout agent returned error fetching lockdown unlock status (machine_id={machine_id}, device_id={device_id}): {}",
-                    error.message
-                )))
+                Err(CarbideError::Internal {
+                    message: format!(
+                        "scout agent returned error fetching lockdown unlock status (machine_id={machine_id}, device_id={device_id}): {}",
+                        error.message
+                    ),
+                }
+                .into())
             }
-            None => Err(Status::internal(format!(
-                "scout agent returned empty lockdown unlock status reply (machine_id={machine_id}, device_id={device_id})"
-            ))),
+            None => Err(CarbideError::Internal {
+                message: format!(
+                    "scout agent returned empty lockdown unlock status reply (machine_id={machine_id}, device_id={device_id})"
+                ),
+            }
+            .into()),
         },
-        _ => Err(Status::internal(format!(
-            "unexpected response type from scout agent for lockdown unlock status response (machine_id={machine_id}, device_id={device_id})"
-        ))),
+        _ => Err(CarbideError::Internal {
+            message: format!(
+                "unexpected response type from scout agent for lockdown unlock status response (machine_id={machine_id}, device_id={device_id})"
+            ),
+        }
+        .into()),
     }
 }
 
@@ -601,9 +655,11 @@ async fn handle_lockdown_status(
 ) -> Result<mlx_device::MlxAdminLockdownStatusResponse, Status> {
     // Check if the machine is connected.
     if !api.scout_stream_registry.is_connected(machine_id).await {
-        return Err(Status::not_found(format!(
-            "scout agent on machine is not connected: {machine_id}"
-        )));
+        return Err(CarbideError::NotFoundError {
+            kind: "scout_agent",
+            id: format!("scout agent on machine is not connected: {machine_id}"),
+        }
+        .into());
     }
 
     let request = ScoutStreamScoutBoundMessage::new_flow(
@@ -619,14 +675,11 @@ async fn handle_lockdown_status(
         .scout_stream_registry
         .send_request(machine_id, request)
         .await
-        .map_err(|status| {
-            Status::new(
-                status.code(),
-                format!(
-                    "error while attempting to get lockdown status via scout: {}",
-                    status.message()
-                ),
-            )
+        .map_err(|status| CarbideError::Internal {
+            message: format!(
+                "error while attempting to get lockdown status via scout: {}",
+                status.message()
+            ),
         })?;
 
     match response.payload {
@@ -639,18 +692,27 @@ async fn handle_lockdown_status(
                 })
             }
             Some(mlx_device::mlx_device_lockdown_response::Reply::Error(error)) => {
-                Err(Status::internal(format!(
-                    "scout agent returned error fetching lockdown status (machine_id={machine_id}, device_id={device_id}): {}",
-                    error.message
-                )))
+                Err(CarbideError::Internal {
+                    message: format!(
+                        "scout agent returned error fetching lockdown status (machine_id={machine_id}, device_id={device_id}): {}",
+                        error.message
+                    ),
+                }
+                .into())
             }
-            None => Err(Status::internal(format!(
-                "scout agent returned empty lockdown status reply (machine_id={machine_id}, device_id={device_id})"
-            ))),
+            None => Err(CarbideError::Internal {
+                message: format!(
+                    "scout agent returned empty lockdown status reply (machine_id={machine_id}, device_id={device_id})"
+                ),
+            }
+            .into()),
         },
-        _ => Err(Status::internal(format!(
-            "unexpected response type from scout agent for lockdown status response (machine_id={machine_id}, device_id={device_id})"
-        ))),
+        _ => Err(CarbideError::Internal {
+            message: format!(
+                "unexpected response type from scout agent for lockdown status response (machine_id={machine_id}, device_id={device_id})"
+            ),
+        }
+        .into()),
     }
 }
 
@@ -662,9 +724,11 @@ async fn handle_show_device_info(
 ) -> Result<mlx_device::MlxAdminDeviceInfoResponse, Status> {
     // Check if the machine is connected.
     if !api.scout_stream_registry.is_connected(machine_id).await {
-        return Err(Status::not_found(format!(
-            "scout agent on machine is not connected: {machine_id}"
-        )));
+        return Err(CarbideError::NotFoundError {
+            kind: "scout_agent",
+            id: format!("scout agent on machine is not connected: {machine_id}"),
+        }
+        .into());
     }
 
     let request = ScoutStreamScoutBoundMessage::new_flow(
@@ -679,14 +743,11 @@ async fn handle_show_device_info(
         .scout_stream_registry
         .send_request(machine_id, request)
         .await
-        .map_err(|status| {
-            Status::new(
-                status.code(),
-                format!(
-                    "error requesting device info from scout: {}",
-                    status.message()
-                ),
-            )
+        .map_err(|status| CarbideError::Internal {
+            message: format!(
+                "error requesting device info from scout: {}",
+                status.message()
+            ),
         })?;
 
     match response.payload {
@@ -699,18 +760,27 @@ async fn handle_show_device_info(
                 })
             }
             Some(mlx_device::mlx_device_info_device_response::Reply::Error(error)) => {
-                Err(Status::internal(format!(
-                    "scout agent returned error fetching device info (machine_id={machine_id}, device_id={device_id}): {}",
-                    error.message
-                )))
+                Err(CarbideError::Internal {
+                    message: format!(
+                        "scout agent returned error fetching device info (machine_id={machine_id}, device_id={device_id}): {}",
+                        error.message
+                    ),
+                }
+                .into())
             }
-            None => Err(Status::internal(format!(
-                "scout agent returned empty device info reply (machine_id={machine_id}, device_id={device_id})"
-            ))),
+            None => Err(CarbideError::Internal {
+                message: format!(
+                    "scout agent returned empty device info reply (machine_id={machine_id}, device_id={device_id})"
+                ),
+            }
+            .into()),
         },
-        _ => Err(Status::internal(format!(
-            "unexpected response type from scout agent for device info response (machine_id={machine_id}, device_id={device_id})"
-        ))),
+        _ => Err(CarbideError::Internal {
+            message: format!(
+                "unexpected response type from scout agent for device info response (machine_id={machine_id}, device_id={device_id})"
+            ),
+        }
+        .into()),
     }
 }
 
@@ -721,9 +791,11 @@ async fn handle_show_device_report(
 ) -> Result<mlx_device::MlxAdminDeviceReportResponse, Status> {
     // Check if the machine is connected.
     if !api.scout_stream_registry.is_connected(machine_id).await {
-        return Err(Status::not_found(format!(
-            "scout agent on machine is not connected: {machine_id}"
-        )));
+        return Err(CarbideError::NotFoundError {
+            kind: "scout_agent",
+            id: format!("scout agent on machine is not connected: {machine_id}"),
+        }
+        .into());
     }
 
     let request = ScoutStreamScoutBoundMessage::new_flow(
@@ -736,14 +808,11 @@ async fn handle_show_device_report(
         .scout_stream_registry
         .send_request(machine_id, request)
         .await
-        .map_err(|status| {
-            Status::new(
-                status.code(),
-                format!(
-                    "error requesting device report from scout: {}",
-                    status.message()
-                ),
-            )
+        .map_err(|status| CarbideError::Internal {
+            message: format!(
+                "error requesting device report from scout: {}",
+                status.message()
+            ),
         })?;
 
     match response.payload {
@@ -756,18 +825,27 @@ async fn handle_show_device_report(
                 device_report: Some(device_report),
             }),
             Some(mlx_device::mlx_device_info_report_response::Reply::Error(error)) => {
-                Err(Status::internal(format!(
-                    "scout agent returned error fetching device report (machine_id={machine_id}): {}",
-                    error.message
-                )))
+                Err(CarbideError::Internal {
+                    message: format!(
+                        "scout agent returned error fetching device report (machine_id={machine_id}): {}",
+                        error.message
+                    ),
+                }
+                .into())
             }
-            None => Err(Status::internal(format!(
-                "scout agent returned empty device report reply (machine_id={machine_id})"
-            ))),
+            None => Err(CarbideError::Internal {
+                message: format!(
+                    "scout agent returned empty device report reply (machine_id={machine_id})"
+                ),
+            }
+            .into()),
         },
-        _ => Err(Status::internal(format!(
-            "unexpected response type from scout agent for device report response (machine_id={machine_id})"
-        ))),
+        _ => Err(CarbideError::Internal {
+            message: format!(
+                "unexpected response type from scout agent for device report response (machine_id={machine_id})"
+            ),
+        }
+        .into()),
     }
 }
 
@@ -778,9 +856,11 @@ async fn handle_registry_list(
 ) -> Result<mlx_device::MlxAdminRegistryListResponse, Status> {
     // Check if the machine is connected.
     if !api.scout_stream_registry.is_connected(machine_id).await {
-        return Err(Status::not_found(format!(
-            "scout agent on machine is not connected: {machine_id}"
-        )));
+        return Err(CarbideError::NotFoundError {
+            kind: "scout_agent",
+            id: format!("scout agent on machine is not connected: {machine_id}"),
+        }
+        .into());
     }
 
     let request = ScoutStreamScoutBoundMessage::new_flow(
@@ -794,14 +874,11 @@ async fn handle_registry_list(
         .scout_stream_registry
         .send_request(machine_id, request)
         .await
-        .map_err(|status| {
-            Status::new(
-                status.code(),
-                format!(
-                    "error while attempting to list registry info via scout: {}",
-                    status.message()
-                ),
-            )
+        .map_err(|status| CarbideError::Internal {
+            message: format!(
+                "error while attempting to list registry info via scout: {}",
+                status.message()
+            ),
         })?;
 
     match response.payload {
@@ -816,18 +893,27 @@ async fn handle_registry_list(
                 }),
             }),
             Some(mlx_device::mlx_device_registry_list_response::Reply::Error(error)) => {
-                Err(Status::internal(format!(
-                    "scout agent returned error fetching registry list (machine_id={machine_id}): {}",
-                    error.message
-                )))
+                Err(CarbideError::Internal {
+                    message: format!(
+                        "scout agent returned error fetching registry list (machine_id={machine_id}): {}",
+                        error.message
+                    ),
+                }
+                .into())
             }
-            None => Err(Status::internal(format!(
-                "scout agent returned empty registry list reply (machine_id={machine_id})"
-            ))),
+            None => Err(CarbideError::Internal {
+                message: format!(
+                    "scout agent returned empty registry list reply (machine_id={machine_id})"
+                ),
+            }
+            .into()),
         },
-        _ => Err(Status::internal(
-            "unexpected response type from scout agent for registry list response: {machine_id}",
-        )),
+        _ => Err(CarbideError::Internal {
+            message: format!(
+                "unexpected response type from scout agent for registry list response: {machine_id}"
+            ),
+        }
+        .into()),
     }
 }
 
@@ -839,9 +925,11 @@ async fn handle_registry_show(
 ) -> Result<mlx_device::MlxAdminRegistryShowResponse, Status> {
     // Check if the machine is connected.
     if !api.scout_stream_registry.is_connected(machine_id).await {
-        return Err(Status::not_found(format!(
-            "scout agent on machine is not connected: {machine_id}"
-        )));
+        return Err(CarbideError::NotFoundError {
+            kind: "scout_agent",
+            id: format!("scout agent on machine is not connected: {machine_id}"),
+        }
+        .into());
     }
 
     let request = ScoutStreamScoutBoundMessage::new_flow(
@@ -854,14 +942,11 @@ async fn handle_registry_show(
         .scout_stream_registry
         .send_request(machine_id, request)
         .await
-        .map_err(|status| {
-            Status::new(
-                status.code(),
-                format!(
-                    "error requesting registry info from scout: {}",
-                    status.message()
-                ),
-            )
+        .map_err(|status| CarbideError::Internal {
+            message: format!(
+                "error requesting registry info from scout: {}",
+                status.message()
+            ),
         })?;
 
     match response.payload {
@@ -874,18 +959,27 @@ async fn handle_registry_show(
                 variable_registry: Some(variable_registry),
             }),
             Some(mlx_device::mlx_device_registry_show_response::Reply::Error(error)) => {
-                Err(Status::internal(format!(
-                    "scout agent returned error fetching registry info (machine_id={machine_id}): {}",
-                    error.message
-                )))
+                Err(CarbideError::Internal {
+                    message: format!(
+                        "scout agent returned error fetching registry info (machine_id={machine_id}): {}",
+                        error.message
+                    ),
+                }
+                .into())
             }
-            None => Err(Status::internal(format!(
-                "scout agent returned empty registry info reply (machine_id={machine_id})"
-            ))),
+            None => Err(CarbideError::Internal {
+                message: format!(
+                    "scout agent returned empty registry info reply (machine_id={machine_id})"
+                ),
+            }
+            .into()),
         },
-        _ => Err(Status::internal(format!(
-            "unexpected response type from scout agent for registry info response (machine_id={machine_id})"
-        ))),
+        _ => Err(CarbideError::Internal {
+            message: format!(
+                "unexpected response type from scout agent for registry info response (machine_id={machine_id})"
+            ),
+        }
+        .into()),
     }
 }
 
@@ -899,9 +993,11 @@ async fn handle_config_query(
 ) -> Result<mlx_device::MlxAdminConfigQueryResponse, Status> {
     // Check if the machine is connected.
     if !api.scout_stream_registry.is_connected(machine_id).await {
-        return Err(Status::not_found(format!(
-            "scout agent on machine is not connected: {machine_id}"
-        )));
+        return Err(CarbideError::NotFoundError {
+            kind: "scout_agent",
+            id: format!("scout agent on machine is not connected: {machine_id}"),
+        }
+        .into());
     }
 
     let request = ScoutStreamScoutBoundMessage::new_flow(
@@ -919,14 +1015,11 @@ async fn handle_config_query(
         .scout_stream_registry
         .send_request(machine_id, request)
         .await
-        .map_err(|status| {
-            Status::new(
-                status.code(),
-                format!(
-                    "error while attempting to query config via scout: {}",
-                    status.message()
-                ),
-            )
+        .map_err(|status| CarbideError::Internal {
+            message: format!(
+                "error while attempting to query config via scout: {}",
+                status.message()
+            ),
         })?;
 
     match response.payload {
@@ -944,19 +1037,28 @@ async fn handle_config_query(
                     query_result: Some(query_result),
                 }),
                 Some(mlx_device::mlx_device_config_query_response::Reply::Error(error)) => {
-                    Err(Status::internal(format!(
-                        "scout agent returned error querying config on device (machine_id={machine_id}, device_id={device_id}, registry_name={registry_name}): {}",
-                        error.message
-                    )))
+                    Err(CarbideError::Internal {
+                        message: format!(
+                            "scout agent returned error querying config on device (machine_id={machine_id}, device_id={device_id}, registry_name={registry_name}): {}",
+                            error.message
+                        ),
+                    }
+                    .into())
                 }
-                None => Err(Status::internal(format!(
-                    "scout agent returned empty query result reply (machine_id={machine_id}, device_id={device_id}, registry_name={registry_name})"
-                ))),
+                None => Err(CarbideError::Internal {
+                    message: format!(
+                        "scout agent returned empty query result reply (machine_id={machine_id}, device_id={device_id}, registry_name={registry_name})"
+                    ),
+                }
+                .into()),
             }
         }
-        _ => Err(Status::internal(format!(
-            "unexpected response type from scout agent for config query response (machine_id={machine_id}, device_id={device_id}, registry_name={registry_name})"
-        ))),
+        _ => Err(CarbideError::Internal {
+            message: format!(
+                "unexpected response type from scout agent for config query response (machine_id={machine_id}, device_id={device_id}, registry_name={registry_name})"
+            ),
+        }
+        .into()),
     }
 }
 
@@ -970,9 +1072,11 @@ async fn handle_config_set(
 ) -> Result<mlx_device::MlxAdminConfigSetResponse, Status> {
     // Check if the machine is connected.
     if !api.scout_stream_registry.is_connected(machine_id).await {
-        return Err(Status::not_found(format!(
-            "scout agent on machine is not connected: {machine_id}"
-        )));
+        return Err(CarbideError::NotFoundError {
+            kind: "scout_agent",
+            id: format!("scout agent on machine is not connected: {machine_id}"),
+        }
+        .into());
     }
 
     let request = ScoutStreamScoutBoundMessage::new_flow(
@@ -990,14 +1094,11 @@ async fn handle_config_set(
         .scout_stream_registry
         .send_request(machine_id, request)
         .await
-        .map_err(|status| {
-            Status::new(
-                status.code(),
-                format!(
-                    "error while attempting to set config via scout: {}",
-                    status.message()
-                ),
-            )
+        .map_err(|status| CarbideError::Internal {
+            message: format!(
+                "error while attempting to set config via scout: {}",
+                status.message()
+            ),
         })?;
 
     match response.payload {
@@ -1008,18 +1109,27 @@ async fn handle_config_set(
                 total_applied,
             )) => Ok(mlx_device::MlxAdminConfigSetResponse { total_applied }),
             Some(mlx_device::mlx_device_config_set_response::Reply::Error(error)) => {
-                Err(Status::internal(format!(
-                    "scout agent returned error setting config on device (machine_id={machine_id}, device_id={device_id}): {}",
-                    error.message
-                )))
+                Err(CarbideError::Internal {
+                    message: format!(
+                        "scout agent returned error setting config on device (machine_id={machine_id}, device_id={device_id}): {}",
+                        error.message
+                    ),
+                }
+                .into())
             }
-            None => Err(Status::internal(format!(
-                "scout agent returned empty config set reply (machine_id={machine_id}, device_id={device_id})"
-            ))),
+            None => Err(CarbideError::Internal {
+                message: format!(
+                    "scout agent returned empty config set reply (machine_id={machine_id}, device_id={device_id})"
+                ),
+            }
+            .into()),
         },
-        _ => Err(Status::internal(format!(
-            "unexpected response type from scout agent for config set response (machine_id={machine_id}, device_id={device_id})"
-        ))),
+        _ => Err(CarbideError::Internal {
+            message: format!(
+                "unexpected response type from scout agent for config set response (machine_id={machine_id}, device_id={device_id})"
+            ),
+        }
+        .into()),
     }
 }
 
@@ -1033,9 +1143,11 @@ async fn handle_config_sync(
 ) -> Result<mlx_device::MlxAdminConfigSyncResponse, Status> {
     // Check if the machine is connected.
     if !api.scout_stream_registry.is_connected(machine_id).await {
-        return Err(Status::not_found(format!(
-            "scout agent on machine is not connected: {machine_id}"
-        )));
+        return Err(CarbideError::NotFoundError {
+            kind: "scout_agent",
+            id: format!("scout agent on machine is not connected: {machine_id}"),
+        }
+        .into());
     }
 
     let request = ScoutStreamScoutBoundMessage::new_flow(
@@ -1053,14 +1165,11 @@ async fn handle_config_sync(
         .scout_stream_registry
         .send_request(machine_id, request)
         .await
-        .map_err(|status| {
-            Status::new(
-                status.code(),
-                format!(
-                    "error while attempting to sync config via scout: {}",
-                    status.message()
-                ),
-            )
+        .map_err(|status| CarbideError::Internal {
+            message: format!(
+                "error while attempting to sync config via scout: {}",
+                status.message()
+            ),
         })?;
 
     match response.payload {
@@ -1078,19 +1187,28 @@ async fn handle_config_sync(
                     sync_result: Some(sync_result),
                 }),
                 Some(mlx_device::mlx_device_config_sync_response::Reply::Error(error)) => {
-                    Err(Status::internal(format!(
-                        "scout agent returned error syncing config to device (machine_id={machine_id}, device_id={device_id}): {}",
-                        error.message
-                    )))
+                    Err(CarbideError::Internal {
+                        message: format!(
+                            "scout agent returned error syncing config to device (machine_id={machine_id}, device_id={device_id}): {}",
+                            error.message
+                        ),
+                    }
+                    .into())
                 }
-                None => Err(Status::internal(format!(
-                    "scout agent returned empty sync result reply (machine_id={machine_id}, device_id={device_id})"
-                ))),
+                None => Err(CarbideError::Internal {
+                    message: format!(
+                        "scout agent returned empty sync result reply (machine_id={machine_id}, device_id={device_id})"
+                    ),
+                }
+                .into()),
             }
         }
-        _ => Err(Status::internal(format!(
-            "unexpected response type from scout agent for config sync response (machine_id={machine_id}, device_id={device_id})"
-        ))),
+        _ => Err(CarbideError::Internal {
+            message: format!(
+                "unexpected response type from scout agent for config sync response (machine_id={machine_id}, device_id={device_id})"
+            ),
+        }
+        .into()),
     }
 }
 
@@ -1104,9 +1222,11 @@ async fn handle_config_compare(
 ) -> Result<mlx_device::MlxAdminConfigCompareResponse, Status> {
     // Check if the machine is connected.
     if !api.scout_stream_registry.is_connected(machine_id).await {
-        return Err(Status::not_found(format!(
-            "scout agent on machine is not connected: {machine_id}"
-        )));
+        return Err(CarbideError::NotFoundError {
+            kind: "scout_agent",
+            id: format!("scout agent on machine is not connected: {machine_id}"),
+        }
+        .into());
     }
 
     let request = ScoutStreamScoutBoundMessage::new_flow(
@@ -1124,14 +1244,11 @@ async fn handle_config_compare(
         .scout_stream_registry
         .send_request(machine_id, request)
         .await
-        .map_err(|status| {
-            Status::new(
-                status.code(),
-                format!(
-                    "error while attempting to compare config via scout: {}",
-                    status.message()
-                ),
-            )
+        .map_err(|status| CarbideError::Internal {
+            message: format!(
+                "error while attempting to compare config via scout: {}",
+                status.message()
+            ),
         })?;
 
     match response.payload {
@@ -1149,19 +1266,28 @@ async fn handle_config_compare(
                     comparison_result: Some(comparison_result),
                 }),
                 Some(mlx_device::mlx_device_config_compare_response::Reply::Error(error)) => {
-                    Err(Status::internal(format!(
-                        "scout agent returned error comparing config to device (machine_id={machine_id}, device_id={device_id}, registry_name={registry_name}): {}",
-                        error.message
-                    )))
+                    Err(CarbideError::Internal {
+                        message: format!(
+                            "scout agent returned error comparing config to device (machine_id={machine_id}, device_id={device_id}, registry_name={registry_name}): {}",
+                            error.message
+                        ),
+                    }
+                    .into())
                 }
-                None => Err(Status::internal(format!(
-                    "scout agent returned empty compare result reply (machine_id={machine_id}, device_id={device_id}, registry_name={registry_name})"
-                ))),
+                None => Err(CarbideError::Internal {
+                    message: format!(
+                        "scout agent returned empty compare result reply (machine_id={machine_id}, device_id={device_id}, registry_name={registry_name})"
+                    ),
+                }
+                .into()),
             }
         }
-        _ => Err(Status::internal(format!(
-            "unexpected response type from scout agent for config compare response (machine_id={machine_id}, device_id={device_id}, registry_name={registry_name})"
-        ))),
+        _ => Err(CarbideError::Internal {
+            message: format!(
+                "unexpected response type from scout agent for config compare response (machine_id={machine_id}, device_id={device_id}, registry_name={registry_name})"
+            ),
+        }
+        .into()),
     }
 }
 
@@ -1182,9 +1308,12 @@ async fn get_device_lockdown_key(
         db::dpa_interface::get_for_pci_name(&api.database_connection, &machine_id, device_id)
             .await
             .map_err(|e| {
-                Status::not_found(format!(
-                    "failed to find DPA interface for device (machine_id={machine_id}, device_id={device_id}): {e}"
-                ))
+                CarbideError::NotFoundError {
+                    kind: "dpa_interface",
+                    id: format!(
+                        "failed to find DPA interface for device (machine_id={machine_id}, device_id={device_id}): {e}"
+                    ),
+                }
             })?;
 
     let lockdown_key = crate::dpa::lockdown::build_supernic_lockdown_key(
@@ -1193,10 +1322,10 @@ async fn get_device_lockdown_key(
         &*api.credential_manager,
     )
     .await
-    .map_err(|e| {
-        Status::internal(format!(
+    .map_err(|e| CarbideError::Internal {
+        message: format!(
             "failed to derive lockdown key (machine_id={machine_id}, device_id={device_id}): {e}"
-        ))
+        ),
     })?;
 
     Ok(lockdown_key)

--- a/crates/api/src/handlers/network_security_group.rs
+++ b/crates/api/src/handlers/network_security_group.rs
@@ -92,9 +92,7 @@ pub(crate) async fn create(
         req.tenant_organization_id
             .parse()
             .map_err(|e: InvalidTenantOrg| {
-                Status::from(CarbideError::from(
-                    RpcDataConversionError::InvalidTenantOrg(e.to_string()),
-                ))
+                CarbideError::from(RpcDataConversionError::InvalidTenantOrg(e.to_string()))
             })?;
 
     // Start a new transaction for a db write.
@@ -143,9 +141,7 @@ pub(crate) async fn find_ids(
         .map(|t| t.parse::<TenantOrganizationId>())
         .transpose()
         .map_err(|e: InvalidTenantOrg| {
-            Status::from(CarbideError::from(
-                RpcDataConversionError::InvalidTenantOrg(e.to_string()),
-            ))
+            CarbideError::from(RpcDataConversionError::InvalidTenantOrg(e.to_string()))
         })?;
 
     let mut txn = api.txn_begin().await?;
@@ -215,9 +211,7 @@ pub(crate) async fn find_by_ids(
         .map(|t| t.parse::<TenantOrganizationId>())
         .transpose()
         .map_err(|e: InvalidTenantOrg| {
-            Status::from(CarbideError::from(
-                RpcDataConversionError::InvalidTenantOrg(e.to_string()),
-            ))
+            CarbideError::from(RpcDataConversionError::InvalidTenantOrg(e.to_string()))
         })?;
 
     // Prepare our txn to grab the NetworkSecurityGroups from the DB
@@ -309,9 +303,7 @@ pub(crate) async fn update(
         req.tenant_organization_id
             .parse()
             .map_err(|e: InvalidTenantOrg| {
-                Status::from(CarbideError::from(
-                    RpcDataConversionError::InvalidTenantOrg(e.to_string()),
-                ))
+                CarbideError::from(RpcDataConversionError::InvalidTenantOrg(e.to_string()))
             })?;
 
     // Start a new transaction for a db write.
@@ -423,9 +415,7 @@ pub(crate) async fn delete(
         req.tenant_organization_id
             .parse()
             .map_err(|e: InvalidTenantOrg| {
-                Status::from(CarbideError::from(
-                    RpcDataConversionError::InvalidTenantOrg(e.to_string()),
-                ))
+                CarbideError::from(RpcDataConversionError::InvalidTenantOrg(e.to_string()))
             })?;
 
     // Prepare our txn to delete from the DB

--- a/crates/api/src/handlers/power_options.rs
+++ b/crates/api/src/handlers/power_options.rs
@@ -59,10 +59,10 @@ pub(crate) async fn update_power_option(
 
     let machine_id = req
         .machine_id
-        .ok_or_else(|| Status::invalid_argument("Machine ID is missing"))?;
+        .ok_or_else(|| CarbideError::InvalidArgument("Machine ID is missing".to_string()))?;
 
     if machine_id.machine_type().is_dpu() {
-        return Err(Status::invalid_argument("Only host id is expected!!"));
+        return Err(CarbideError::InvalidArgument("Only host id is expected!!".to_string()).into());
     }
 
     log_machine_id(&machine_id);
@@ -73,7 +73,7 @@ pub(crate) async fn update_power_option(
 
     // This should never happen until machine is not forced-deleted or does not exist.
     let Some(current_power_options) = current_power_state.first() else {
-        return Err(Status::invalid_argument("Only host id is expected!!"));
+        return Err(CarbideError::InvalidArgument("Only host id is expected!!".to_string()).into());
     };
 
     let desired_power_state = req.power_state();
@@ -106,18 +106,20 @@ pub(crate) async fn update_power_option(
                 .classifications
                 .contains(&health_report::HealthAlertClassification::suppress_external_alerting())
         }) {
-            return Err(Status::invalid_argument(
-                "Machine must have a 'Maintenance' Health Alert with 'SupressExternalAlerting' classification.",
-            ));
+            return Err(CarbideError::InvalidArgument(
+                "Machine must have a 'Maintenance' Health Alert with 'SupressExternalAlerting' classification.".into(),
+            )
+            .into());
         }
     }
 
     // To avoid unnecessary version increment.
     let desired_power_state = desired_power_state.into();
     if desired_power_state == current_power_options.desired_power_state {
-        return Err(Status::invalid_argument(format!(
+        return Err(CarbideError::InvalidArgument(format!(
             "Power State is already set as {desired_power_state:?}. No change is performed."
-        )));
+        ))
+        .into());
     }
 
     let updated_value = db::power_options::update_desired_state(

--- a/crates/api/src/handlers/power_shelf.rs
+++ b/crates/api/src/handlers/power_shelf.rs
@@ -19,6 +19,7 @@ use ::rpc::forge as rpc;
 use db::power_shelf as db_power_shelf;
 use tonic::{Request, Response, Status};
 
+use crate::CarbideError;
 use crate::api::Api;
 
 pub async fn find_power_shelf(
@@ -30,7 +31,9 @@ pub async fn find_power_shelf(
         .database_connection
         .begin()
         .await
-        .map_err(|e| Status::internal(format!("Database error: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Database error: {}", e),
+        })?;
 
     // Handle ID search (takes precedence)
     let power_shelf_list = if let Some(id) = query.power_shelf_id {
@@ -40,7 +43,9 @@ pub async fn find_power_shelf(
             db_power_shelf::PowerShelfSearchConfig::default(),
         )
         .await
-        .map_err(|e| Status::internal(format!("Failed to find power shelf: {}", e)))?
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Failed to find power shelf: {}", e),
+        })?
     } else if let Some(name) = query.name {
         // Handle name search
         db_power_shelf::find_by(
@@ -49,7 +54,9 @@ pub async fn find_power_shelf(
             db_power_shelf::PowerShelfSearchConfig::default(),
         )
         .await
-        .map_err(|e| Status::internal(format!("Failed to find power shelf: {}", e)))?
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Failed to find power shelf: {}", e),
+        })?
     } else {
         // No filter - return all
         db_power_shelf::find_by(
@@ -58,18 +65,22 @@ pub async fn find_power_shelf(
             db_power_shelf::PowerShelfSearchConfig::default(),
         )
         .await
-        .map_err(|e| Status::internal(format!("Failed to find power shelf: {}", e)))?
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Failed to find power shelf: {}", e),
+        })?
     };
 
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(format!("Failed to commit transaction: {}", e)))?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: format!("Failed to commit transaction: {}", e),
+    })?;
 
     let power_shelves: Vec<rpc::PowerShelf> = power_shelf_list
         .into_iter()
         .map(rpc::PowerShelf::try_from)
         .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| Status::internal(format!("Failed to convert power shelf: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Failed to convert power shelf: {}", e),
+        })?;
 
     Ok(Response::new(rpc::PowerShelfList { power_shelves }))
 }
@@ -82,14 +93,20 @@ pub async fn delete_power_shelf(
 
     let power_shelf_id = match req.id {
         Some(id) => id,
-        None => return Err(Status::invalid_argument("Power shelf ID is required")),
+        None => {
+            return Err(
+                CarbideError::InvalidArgument("Power shelf ID is required".to_string()).into(),
+            );
+        }
     };
 
     let mut txn = api
         .database_connection
         .begin()
         .await
-        .map_err(|e| Status::internal(format!("Database error: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Database error: {}", e),
+        })?;
 
     let mut power_shelf_list = db_power_shelf::find_by(
         &mut txn,
@@ -97,23 +114,28 @@ pub async fn delete_power_shelf(
         db_power_shelf::PowerShelfSearchConfig::default(),
     )
     .await
-    .map_err(|e| Status::internal(format!("Failed to find power shelf: {}", e)))?;
+    .map_err(|e| CarbideError::Internal {
+        message: format!("Failed to find power shelf: {}", e),
+    })?;
 
     if power_shelf_list.is_empty() {
-        return Err(Status::not_found(format!(
-            "PowerShelf {} not found",
-            power_shelf_id
-        )));
+        return Err(CarbideError::NotFoundError {
+            kind: "power_shelf",
+            id: power_shelf_id.to_string(),
+        }
+        .into());
     }
 
     let power_shelf = power_shelf_list.first_mut().unwrap();
     db_power_shelf::mark_as_deleted(power_shelf, &mut txn)
         .await
-        .map_err(|e| Status::internal(format!("Failed to delete power shelf: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Failed to delete power shelf: {}", e),
+        })?;
 
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(format!("Failed to commit transaction: {}", e)))?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: format!("Failed to commit transaction: {}", e),
+    })?;
 
     Ok(Response::new(rpc::PowerShelfDeletionResult {}))
 }

--- a/crates/api/src/handlers/pxe.rs
+++ b/crates/api/src/handlers/pxe.rs
@@ -56,7 +56,7 @@ pub(crate) async fn get_cloud_init_instructions(
     let ip_str = &request.into_inner().ip;
     let ip: IpAddr = ip_str
         .parse()
-        .map_err(|e| Status::invalid_argument(format!("Failed parsing IP '{ip_str}': {e}")))?;
+        .map_err(|e| CarbideError::InvalidArgument(format!("Failed parsing IP '{ip_str}': {e}")))?;
 
     // Note that this code path supports IPv6 at the *API layer*, but won't be
     // able to be exercised until DHCPv6 is working, which is a whole other thing

--- a/crates/api/src/handlers/rack.rs
+++ b/crates/api/src/handlers/rack.rs
@@ -34,7 +34,7 @@ pub async fn get_rack(
     let req = request.into_inner();
     let rack = if let Some(id) = req.id {
         let rack_id = RackId::from_str(&id)
-            .map_err(|e| Status::invalid_argument(format!("Invalid rack ID: {}", e)))?;
+            .map_err(|e| CarbideError::InvalidArgument(format!("Invalid rack ID: {}", e)))?;
         let r = db_rack::get(&api.database_connection, rack_id)
             .await
             .map_err(CarbideError::from)?;
@@ -98,13 +98,18 @@ pub async fn delete_rack(
     api.with_txn(|txn| {
         async move {
             let rack_id = RackId::from_str(&req.id)
-                .map_err(|e| Status::invalid_argument(format!("Invalid rack ID: {}", e)))?;
-            let rack = db_rack::get(txn.as_mut(), rack_id)
-                .await
-                .map_err(|e| Status::internal(format!("Getting rack {}", e)))?;
+                .map_err(|e| CarbideError::InvalidArgument(format!("Invalid rack ID: {}", e)))?;
+            let rack =
+                db_rack::get(txn.as_mut(), rack_id)
+                    .await
+                    .map_err(|e| CarbideError::Internal {
+                        message: format!("Getting rack {}", e),
+                    })?;
             db_rack::mark_as_deleted(&rack, txn)
                 .await
-                .map_err(|e| Status::internal(format!("Marking rack deleted {}", e)))?;
+                .map_err(|e| CarbideError::Internal {
+                    message: format!("Marking rack deleted {}", e),
+                })?;
             Ok::<_, Status>(())
         }
         .boxed()

--- a/crates/api/src/handlers/rack_firmware.rs
+++ b/crates/api/src/handlers/rack_firmware.rs
@@ -266,20 +266,24 @@ pub async fn create(
 
     // Validate that config_json is valid JSON
     let config: serde_json::Value = serde_json::from_str(&req.config_json)
-        .map_err(|e| Status::invalid_argument(format!("Invalid JSON: {}", e)))?;
+        .map_err(|e| CarbideError::InvalidArgument(format!("Invalid JSON: {}", e)))?;
 
     // Extract ID from JSON - use "Id" field (UUID)
     let id = config
         .get("Id")
         .and_then(|v| v.as_str())
         .ok_or_else(|| {
-            Status::invalid_argument("JSON must contain 'Id' field to use as identifier")
+            CarbideError::InvalidArgument(
+                "JSON must contain 'Id' field to use as identifier".into(),
+            )
         })?
         .to_string();
 
     // Validate token is provided
     if req.artifactory_token.is_empty() {
-        return Err(Status::invalid_argument("Artifactory token is required"));
+        return Err(
+            CarbideError::InvalidArgument("Artifactory token is required".to_string()).into(),
+        );
     }
 
     // Parse firmware components from the JSON
@@ -290,9 +294,11 @@ pub async fn create(
                 parsed.board_skus.len(),
                 id
             );
-            Some(serde_json::to_value(parsed).map_err(|e| {
-                Status::internal(format!("Failed to serialize parsed components: {}", e))
-            })?)
+            Some(
+                serde_json::to_value(parsed).map_err(|e| CarbideError::Internal {
+                    message: format!("Failed to serialize parsed components: {}", e),
+                })?,
+            )
         }
         Err(e) => {
             tracing::warn!(
@@ -318,7 +324,9 @@ pub async fn create(
             },
         )
         .await
-        .map_err(|e| Status::internal(format!("Failed to store token in Vault: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Failed to store token in Vault: {}", e),
+        })?;
 
     let mut txn = api
         .database_connection
@@ -941,7 +949,7 @@ pub async fn apply(
     let req = request.into_inner();
     let rack_id = req
         .rack_id
-        .ok_or_else(|| Status::invalid_argument("rack_id is required"))?;
+        .ok_or_else(|| CarbideError::InvalidArgument("rack_id is required".to_string()))?;
 
     tracing::info!(
         rack_id = %rack_id,
@@ -953,13 +961,16 @@ pub async fn apply(
     // Get the RackFirmware configuration from the database
     let fw_config = rack_firmware_db::find_by_id(&api.database_connection, &req.firmware_id)
         .await
-        .map_err(|e| Status::internal(format!("Failed to get firmware configuration: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Failed to get firmware configuration: {}", e),
+        })?;
 
     if !fw_config.available {
-        return Err(Status::failed_precondition(format!(
+        return Err(CarbideError::FailedPrecondition(format!(
             "Firmware configuration '{}' is not marked as available",
             req.firmware_id
-        )));
+        ))
+        .into());
     }
 
     let parsed_components: serde_json::Value = fw_config
@@ -973,7 +984,9 @@ pub async fn apply(
 
     let rack = db::rack::get(&api.database_connection, rack_id)
         .await
-        .map_err(|e| Status::internal(format!("Failed to get rack: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Failed to get rack: {}", e),
+        })?;
 
     // Convert rack to proto to get device IDs
     let rack_proto: rpc::forge::Rack = rack.into();
@@ -983,10 +996,11 @@ pub async fn apply(
     let has_switches = !rack_proto.expected_nvlink_switches.is_empty();
 
     if !has_compute_trays && !has_power_shelves && !has_switches {
-        return Err(Status::failed_precondition(format!(
+        return Err(CarbideError::FailedPrecondition(format!(
             "Rack '{}' contains no devices",
             rack_id
-        )));
+        ))
+        .into());
     }
 
     tracing::info!(
@@ -1312,13 +1326,13 @@ pub async fn get_job_status(
     let req = request.into_inner();
 
     if req.job_id.is_empty() {
-        return Err(Status::invalid_argument("job_id is required"));
+        return Err(CarbideError::InvalidArgument("job_id is required".to_string()).into());
     }
 
     let rms_client = api
         .rms_client
         .as_ref()
-        .ok_or_else(|| Status::failed_precondition("RMS client not configured"))?;
+        .ok_or_else(|| CarbideError::FailedPrecondition("RMS client not configured".to_string()))?;
 
     let rms_request = librms::protos::rack_manager::GetFirmwareJobStatusRequest {
         metadata: None,
@@ -1328,7 +1342,9 @@ pub async fn get_job_status(
     let rms_response = rms_client
         .get_firmware_job_status(rms_request)
         .await
-        .map_err(|e| Status::internal(format!("RMS API error: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("RMS API error: {}", e),
+        })?;
 
     // Map FirmwareJobState enum to human-readable string
     let state = match rms_response.job_state {

--- a/crates/api/src/handlers/resource_pool.rs
+++ b/crates/api/src/handlers/resource_pool.rs
@@ -36,11 +36,11 @@ pub(crate) async fn grow(
     let mut pools = HashMap::new();
     let table: toml::Table = toml_text
         .parse()
-        .map_err(|e: toml::de::Error| tonic::Status::invalid_argument(e.to_string()))?;
+        .map_err(|e: toml::de::Error| CarbideError::InvalidArgument(e.to_string()))?;
     for (name, def) in table {
         let d: model::resource_pool::ResourcePoolDef = def
             .try_into()
-            .map_err(|e: toml::de::Error| tonic::Status::invalid_argument(e.to_string()))?;
+            .map_err(|e: toml::de::Error| CarbideError::InvalidArgument(e.to_string()))?;
         pools.insert(name, d);
     }
     use db::resource_pool::DefineResourcePoolError as DE;
@@ -49,10 +49,16 @@ pub(crate) async fn grow(
             txn.commit().await?;
             Ok(Response::new(rpc::GrowResourcePoolResponse {}))
         }
-        Err(DE::InvalidArgument(msg)) => Err(tonic::Status::invalid_argument(msg)),
-        Err(DE::InvalidToml(err)) => Err(tonic::Status::invalid_argument(err.to_string())),
-        Err(DE::ResourcePoolError(msg)) => Err(tonic::Status::internal(msg.to_string())),
-        Err(DE::DatabaseError(err)) => Err(tonic::Status::internal(err.to_string())),
+        Err(DE::InvalidArgument(msg)) => Err(CarbideError::InvalidArgument(msg).into()),
+        Err(DE::InvalidToml(err)) => Err(CarbideError::InvalidArgument(err.to_string()).into()),
+        Err(DE::ResourcePoolError(msg)) => Err(CarbideError::Internal {
+            message: msg.to_string(),
+        }
+        .into()),
+        Err(DE::DatabaseError(err)) => Err(CarbideError::Internal {
+            message: err.to_string(),
+        }
+        .into()),
         Err(err @ DE::TooBig(_, _)) => Err(tonic::Status::out_of_range(err.to_string())),
     }
 }

--- a/crates/api/src/handlers/route_server.rs
+++ b/crates/api/src/handlers/route_server.rs
@@ -53,7 +53,7 @@ pub(crate) async fn add(
     let source_type: rpc::RouteServerSourceType = request
         .source_type
         .try_into()
-        .map_err(|_| Status::invalid_argument("source_type"))?;
+        .map_err(|_| CarbideError::InvalidArgument("source_type".to_string()))?;
 
     let mut txn = api.txn_begin().await?;
     db::route_servers::add(&mut txn, &route_servers, source_type.into()).await?;
@@ -76,7 +76,7 @@ pub(crate) async fn remove(
     let source_type: rpc::RouteServerSourceType = request
         .source_type
         .try_into()
-        .map_err(|_| Status::invalid_argument("source_type"))?;
+        .map_err(|_| CarbideError::InvalidArgument("source_type".to_string()))?;
 
     let mut txn = api.txn_begin().await?;
     db::route_servers::remove(&mut txn, &route_servers, source_type.into()).await?;
@@ -100,7 +100,7 @@ pub(crate) async fn replace(
     let source_type: rpc::RouteServerSourceType = request
         .source_type
         .try_into()
-        .map_err(|_| Status::invalid_argument("source_type"))?;
+        .map_err(|_| CarbideError::InvalidArgument("source_type".to_string()))?;
 
     let mut txn = api.txn_begin().await?;
     db::route_servers::replace(&mut txn, &route_servers, source_type.into()).await?;

--- a/crates/api/src/handlers/scout_stream.rs
+++ b/crates/api/src/handlers/scout_stream.rs
@@ -20,6 +20,7 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status, Streaming};
 
+use crate::CarbideError;
 use crate::api::{Api, ScoutStreamType, log_request_data};
 use crate::handlers::utils::convert_and_log_machine_id;
 
@@ -39,7 +40,7 @@ pub(crate) async fn scout_stream(
     let init_message = stream
         .message()
         .await?
-        .ok_or_else(|| Status::invalid_argument("invalid message received"))?;
+        .ok_or_else(|| CarbideError::InvalidArgument("invalid message received".to_string()))?;
 
     // As part of "constructing" the new scout stream, we expect
     // an Init message as the first thing from the client (in this
@@ -49,9 +50,10 @@ pub(crate) async fn scout_stream(
             convert_and_log_machine_id(init.machine_id.as_ref())?
         }
         _ => {
-            return Err(Status::invalid_argument(
-                "first ScoutStream client message must be an Init message",
-            ));
+            return Err(CarbideError::InvalidArgument(
+                "first ScoutStream client message must be an Init message".into(),
+            )
+            .into());
         }
     };
 
@@ -141,9 +143,11 @@ pub async fn ping(
 
     // Check if the machine is connected.
     if !api.scout_stream_registry.is_connected(machine_id).await {
-        return Err(Status::not_found(format!(
-            "scout agent on machine is not connected: {machine_id}"
-        )));
+        return Err(CarbideError::NotFoundError {
+            kind: "scout agent connection",
+            id: machine_id.to_string(),
+        }
+        .into());
     }
 
     let request = rpc::ScoutStreamScoutBoundMessage::new_flow(
@@ -156,14 +160,11 @@ pub async fn ping(
         .scout_stream_registry
         .send_request(machine_id, request)
         .await
-        .map_err(|status| {
-            Status::new(
-                status.code(),
-                format!(
-                    "error while attempting to send ping request to scout: {}",
-                    status.message()
-                ),
-            )
+        .map_err(|status| CarbideError::Internal {
+            message: format!(
+                "error while attempting to send ping request to scout: {}",
+                status.message()
+            ),
         })?;
 
     match response.payload {
@@ -174,18 +175,27 @@ pub async fn ping(
                 Ok(Response::new(rpc::ScoutStreamAdminPingResponse { pong }))
             }
             Some(rpc::scout_stream_agent_ping_response::Reply::Error(error)) => {
-                Err(Status::internal(format!(
-                    "scout agent returned error attempting to ping agent (machine_id={machine_id}): {}",
-                    error.message
-                )))
+                Err(CarbideError::Internal {
+                    message: format!(
+                        "scout agent returned error attempting to ping agent (machine_id={machine_id}): {}",
+                        error.message
+                    ),
+                }
+                .into())
             }
-            None => Err(Status::internal(format!(
-                "scout agent returned empty ping reply (machine_id={machine_id})"
-            ))),
+            None => Err(CarbideError::Internal {
+                message: format!(
+                    "scout agent returned empty ping reply (machine_id={machine_id})"
+                ),
+            }
+            .into()),
         },
-        _ => Err(Status::internal(format!(
-            "unexpected response type from scout agent for ping response (machine_id={machine_id})"
-        ))),
+        _ => Err(CarbideError::Internal {
+            message: format!(
+                "unexpected response type from scout agent for ping response (machine_id={machine_id})"
+            ),
+        }
+        .into()),
     }
 }
 

--- a/crates/api/src/handlers/site_explorer.rs
+++ b/crates/api/src/handlers/site_explorer.rs
@@ -274,10 +274,11 @@ pub(crate) async fn is_bmc_in_managed_host(
 
     let mut addrs = lookup_host(address).await?;
     let Some(bmc_addr) = addrs.next() else {
-        return Err(tonic::Status::invalid_argument(format!(
+        return Err(CarbideError::InvalidArgument(format!(
             "Could not resolve {}. Must be hostname[:port] or IPv4[:port]",
             req.ip_address
-        )));
+        ))
+        .into());
     };
 
     let in_managed_host =

--- a/crates/api/src/handlers/switch.rs
+++ b/crates/api/src/handlers/switch.rs
@@ -19,6 +19,7 @@ use ::rpc::forge as rpc;
 use db::switch as db_switch;
 use tonic::{Request, Response, Status};
 
+use crate::CarbideError;
 use crate::api::Api;
 
 pub async fn find_switch(
@@ -30,7 +31,9 @@ pub async fn find_switch(
         .database_connection
         .begin()
         .await
-        .map_err(|e| Status::internal(format!("Database error: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Database error: {}", e),
+        })?;
 
     // Handle ID search (takes precedence)
     let switch_list = if let Some(id) = query.switch_id {
@@ -40,7 +43,9 @@ pub async fn find_switch(
             db_switch::SwitchSearchConfig::default(),
         )
         .await
-        .map_err(|e| Status::internal(format!("Failed to find switch: {}", e)))?
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Failed to find switch: {}", e),
+        })?
     } else if let Some(name) = query.name {
         // Handle name search
         db_switch::find_by(
@@ -49,7 +54,9 @@ pub async fn find_switch(
             db_switch::SwitchSearchConfig::default(),
         )
         .await
-        .map_err(|e| Status::internal(format!("Failed to find switch: {}", e)))?
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Failed to find switch: {}", e),
+        })?
     } else {
         // No filter - return all
         db_switch::find_by(
@@ -58,13 +65,17 @@ pub async fn find_switch(
             db_switch::SwitchSearchConfig::default(),
         )
         .await
-        .map_err(|e| Status::internal(format!("Failed to find switch: {}", e)))?
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Failed to find switch: {}", e),
+        })?
     };
 
     let bmc_info_map: std::collections::HashMap<String, rpc::BmcInfo> = {
         let rows = db_switch::list_switch_bmc_info(&mut txn)
             .await
-            .map_err(|e| Status::internal(format!("Failed to get switch BMC info: {}", e)))?;
+            .map_err(|e| CarbideError::Internal {
+                message: format!("Failed to get switch BMC info: {}", e),
+            })?;
 
         rows.into_iter()
             .map(|row| {
@@ -82,9 +93,9 @@ pub async fn find_switch(
             .collect()
     };
 
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(format!("Failed to commit transaction: {}", e)))?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: format!("Failed to commit transaction: {}", e),
+    })?;
 
     let switches: Vec<rpc::Switch> = switch_list
         .into_iter()
@@ -98,7 +109,9 @@ pub async fn find_switch(
             })
         })
         .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| Status::internal(format!("Failed to convert switch: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Failed to convert switch: {}", e),
+        })?;
 
     Ok(Response::new(rpc::SwitchList { switches }))
 }
@@ -112,14 +125,18 @@ pub async fn delete_switch(
 
     let switch_id = match req.id {
         Some(id) => id,
-        None => return Err(Status::invalid_argument("Switch ID is required")),
+        None => {
+            return Err(CarbideError::InvalidArgument("Switch ID is required".to_string()).into());
+        }
     };
 
     let mut txn = api
         .database_connection
         .begin()
         .await
-        .map_err(|e| Status::internal(format!("Database error: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Database error: {}", e),
+        })?;
 
     let mut switch_list = db_switch::find_by(
         &mut txn,
@@ -127,20 +144,28 @@ pub async fn delete_switch(
         db_switch::SwitchSearchConfig::default(),
     )
     .await
-    .map_err(|e| Status::internal(format!("Failed to find switch: {}", e)))?;
+    .map_err(|e| CarbideError::Internal {
+        message: format!("Failed to find switch: {}", e),
+    })?;
 
     if switch_list.is_empty() {
-        return Err(Status::not_found(format!("Switch {} not found", switch_id)));
+        return Err(CarbideError::NotFoundError {
+            kind: "switch",
+            id: switch_id.to_string(),
+        }
+        .into());
     }
 
     let switch = switch_list.first_mut().unwrap();
     db_switch::mark_as_deleted(switch, &mut txn)
         .await
-        .map_err(|e| Status::internal(format!("Failed to delete switch: {}", e)))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Failed to delete switch: {}", e),
+        })?;
 
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(format!("Failed to commit transaction: {}", e)))?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: format!("Failed to commit transaction: {}", e),
+    })?;
 
     Ok(Response::new(rpc::SwitchDeletionResult {}))
 }

--- a/crates/api/src/handlers/uefi.rs
+++ b/crates/api/src/handlers/uefi.rs
@@ -59,9 +59,10 @@ pub(crate) async fn clear_host_uefi_password(
     };
 
     if !machine_id.machine_type().is_host() {
-        return Err(Status::invalid_argument(
-            "Carbide only supports clearing the UEFI password on discovered hosts",
-        ));
+        return Err(CarbideError::InvalidArgument(
+            "Carbide only supports clearing the UEFI password on discovered hosts".into(),
+        )
+        .into());
     }
 
     let snapshot = db::managed_host::load_snapshot(
@@ -88,9 +89,11 @@ pub(crate) async fn clear_host_uefi_password(
         .await
         .map_err(|e| {
             tracing::error!("unable to create redfish client: {}", e);
-            Status::internal(format!(
-                "Could not create connection to Redfish API to {machine_id}, check logs"
-            ))
+            CarbideError::Internal {
+                message: format!(
+                    "Could not create connection to Redfish API to {machine_id}, check logs"
+                ),
+            }
         })?;
 
     let job_id: Option<String> =
@@ -135,9 +138,10 @@ pub(crate) async fn set_host_uefi_password(
     };
 
     if !machine_id.machine_type().is_host() {
-        return Err(Status::invalid_argument(
-            "Carbide only supports setting the UEFI password on discovered hosts",
-        ));
+        return Err(CarbideError::InvalidArgument(
+            "Carbide only supports setting the UEFI password on discovered hosts".into(),
+        )
+        .into());
     }
 
     let snapshot = db::managed_host::load_snapshot(
@@ -177,7 +181,9 @@ pub(crate) async fn set_host_uefi_password(
         .await?
         .map_err(|e| {
             tracing::error!("Failed to update bios_password_set_time: {}", e);
-            Status::internal(format!("Failed to update BIOS password timestamp: {e}"))
+            CarbideError::Internal {
+                message: format!("Failed to update BIOS password timestamp: {e}"),
+            }
         })?;
 
     Ok(Response::new(rpc::SetHostUefiPasswordResponse { job_id }))

--- a/crates/api/src/measured_boot/rpc/bundle.rs
+++ b/crates/api/src/measured_boot/rpc/bundle.rs
@@ -59,7 +59,9 @@ pub async fn handle_create_measurement_bundle(
         Some(MeasurementBundleState::from(state)),
     )
     .await
-    .map_err(|e| Status::internal(format!("failed to create new bundle: {e}")))?;
+    .map_err(|e| CarbideError::Internal {
+        message: format!("failed to create new bundle: {e}"),
+    })?;
 
     txn.commit().await?;
     Ok(CreateMeasurementBundleResponse {
@@ -79,19 +81,25 @@ pub async fn handle_delete_measurement_bundle(
         Some(delete_measurement_bundle_request::Selector::BundleId(bundle_uuid)) => {
             db::measured_boot::bundle::delete_for_id(&mut txn, bundle_uuid, false)
                 .await
-                .map_err(|e| Status::internal(format!("deletion failed: {e}")))?
+                .map_err(|e| CarbideError::Internal {
+                    message: format!("deletion failed: {e}"),
+                })?
         }
 
         // Delete for the given bundle name.
         Some(delete_measurement_bundle_request::Selector::BundleName(bundle_name)) => {
             db::measured_boot::bundle::delete_for_name(&mut txn, bundle_name, false)
                 .await
-                .map_err(|e| Status::internal(format!("deletion failed: {e}")))?
+                .map_err(|e| CarbideError::Internal {
+                    message: format!("deletion failed: {e}"),
+                })?
         }
 
         // ID or name is needed.
         None => {
-            return Err(Status::invalid_argument("deletion selector is required"));
+            return Err(
+                CarbideError::InvalidArgument("deletion selector is required".to_string()).into(),
+            );
         }
     };
 
@@ -113,19 +121,25 @@ pub async fn handle_rename_measurement_bundle(
         Some(rename_measurement_bundle_request::Selector::BundleId(bundle_uuid)) => {
             db::measured_boot::bundle::rename_for_id(&mut txn, bundle_uuid, req.new_bundle_name)
                 .await
-                .map_err(|e| Status::internal(format!("rename failed: {e}")))?
+                .map_err(|e| CarbideError::Internal {
+                    message: format!("rename failed: {e}"),
+                })?
         }
 
         // Rename for the given bundle name.
         Some(rename_measurement_bundle_request::Selector::BundleName(bundle_name)) => {
             db::measured_boot::bundle::rename_for_name(&mut txn, bundle_name, req.new_bundle_name)
                 .await
-                .map_err(|e| Status::internal(format!("rename failed: {e}")))?
+                .map_err(|e| CarbideError::Internal {
+                    message: format!("rename failed: {e}"),
+                })?
         }
 
         // ID or name is needed.
         None => {
-            return Err(Status::invalid_argument("rename selector is required"));
+            return Err(
+                CarbideError::InvalidArgument("rename selector is required".to_string()).into(),
+            );
         }
     };
 
@@ -150,19 +164,25 @@ pub async fn handle_update_measurement_bundle(
         Some(update_measurement_bundle_request::Selector::BundleName(bundle_name)) => {
             db::measured_boot::bundle::from_name(&mut txn, bundle_name)
                 .await
-                .map_err(|e| Status::internal(format!("deletion failed: {e}")))?
+                .map_err(|e| CarbideError::Internal {
+                    message: format!("deletion failed: {e}"),
+                })?
                 .bundle_id
         }
         // ID or name is needed.
         None => {
-            return Err(Status::invalid_argument("deletion selector is required"));
+            return Err(
+                CarbideError::InvalidArgument("deletion selector is required".to_string()).into(),
+            );
         }
     };
 
     // And then set it in the database.
     let bundle = db::measured_boot::bundle::set_state_for_id(&mut txn, bundle_id, state.into())
         .await
-        .map_err(|e| Status::internal(format!("failed to update bundle: {e}")))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("failed to update bundle: {e}"),
+        })?;
 
     txn.commit().await?;
     Ok(UpdateMeasurementBundleResponse {
@@ -181,14 +201,22 @@ pub async fn handle_show_measurement_bundle(
         Some(show_measurement_bundle_request::Selector::BundleId(bundle_uuid)) => {
             db::measured_boot::bundle::from_id(&mut txn, bundle_uuid)
                 .await
-                .map_err(|e| Status::internal(format!("{e}")))?
+                .map_err(|e| CarbideError::Internal {
+                    message: format!("{e}"),
+                })?
         }
         Some(show_measurement_bundle_request::Selector::BundleName(bundle_name)) => {
             db::measured_boot::bundle::from_name(&mut txn, bundle_name)
                 .await
-                .map_err(|e| Status::internal(format!("{e}")))?
+                .map_err(|e| CarbideError::Internal {
+                    message: format!("{e}"),
+                })?
         }
-        None => return Err(Status::invalid_argument("selector must be provided")),
+        None => {
+            return Err(
+                CarbideError::InvalidArgument("selector must be provided".to_string()).into(),
+            );
+        }
     };
     txn.commit().await?;
 
@@ -206,7 +234,9 @@ pub async fn handle_show_measurement_bundles(
     Ok(ShowMeasurementBundlesResponse {
         bundles: db::measured_boot::bundle::get_all(&mut api.db_reader())
             .await
-            .map_err(|e| Status::internal(format!("{e}")))?
+            .map_err(|e| CarbideError::Internal {
+                message: format!("{e}"),
+            })?
             .into_iter()
             .map(|bundle| bundle.into())
             .collect(),
@@ -222,7 +252,9 @@ pub async fn handle_list_measurement_bundles(
     let bundles: Vec<MeasurementBundleRecordPb> =
         get_measurement_bundle_records(&api.database_connection)
             .await
-            .map_err(|e| Status::internal(format!("{e}")))?
+            .map_err(|e| CarbideError::Internal {
+                message: format!("{e}"),
+            })?
             .into_iter()
             .map(|record| record.into())
             .collect();
@@ -242,7 +274,9 @@ pub async fn handle_list_measurement_bundle_machines(
         Some(list_measurement_bundle_machines_request::Selector::BundleId(bundle_uuid)) => {
             get_machines_for_bundle_id(&mut txn, bundle_uuid)
                 .await
-                .map_err(|e| Status::internal(format!("{e}")))?
+                .map_err(|e| CarbideError::Internal {
+                    message: format!("{e}"),
+                })?
                 .drain(..)
                 .map(|machine_id| machine_id.to_string())
                 .collect()
@@ -251,13 +285,15 @@ pub async fn handle_list_measurement_bundle_machines(
         Some(list_measurement_bundle_machines_request::Selector::BundleName(bundle_name)) => {
             get_machines_for_bundle_name(&mut txn, bundle_name)
                 .await
-                .map_err(|e| Status::internal(format!("{e}")))?
+                .map_err(|e| CarbideError::Internal {
+                    message: format!("{e}"),
+                })?
                 .drain(..)
                 .map(|machine_id| machine_id.to_string())
                 .collect()
         }
         // ...and it has to be either by ID or name.
-        None => return Err(Status::invalid_argument("selector required")),
+        None => return Err(CarbideError::InvalidArgument("selector required".to_string()).into()),
     };
 
     txn.commit().await?;
@@ -277,7 +313,9 @@ pub async fn handle_find_closest_match(
 
     let report = db::measured_boot::report::from_id(&mut txn, report_id)
         .await
-        .map_err(|e| Status::internal(format!("{e}")))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("{e}"),
+        })?;
 
     // get profile
     let journal =
@@ -285,8 +323,8 @@ pub async fn handle_find_closest_match(
 
     let bundle = match bundle::find_closest_match(
         &mut txn,
-        journal.profile_id.ok_or(Status::invalid_argument(
-            "A journal without profile detected",
+        journal.profile_id.ok_or(CarbideError::InvalidArgument(
+            "A journal without profile detected".into(),
         ))?,
         &report.pcr_values(),
     )

--- a/crates/api/src/measured_boot/rpc/journal.rs
+++ b/crates/api/src/measured_boot/rpc/journal.rs
@@ -50,8 +50,13 @@ pub async fn handle_delete_measurement_journal(
             .ok_or(CarbideError::MissingArgument("journal_id"))?,
     )
     .await
-    .map_err(|e| Status::internal(format!("failed to delete journal: {e}")))?
-    .ok_or(Status::not_found("no journal found with that ID"))?;
+    .map_err(|e| CarbideError::Internal {
+        message: format!("failed to delete journal: {e}"),
+    })?
+    .ok_or(CarbideError::NotFoundError {
+        kind: "journal",
+        id: "unknown".into(),
+    })?;
 
     txn.commit().await?;
     Ok(DeleteMeasurementJournalResponse {
@@ -71,18 +76,21 @@ pub async fn handle_show_measurement_journal(
             show_measurement_journal_request::Selector::JournalId(journal_id) => {
                 db::measured_boot::journal::from_id(&mut txn, journal_id)
                     .await
-                    .map_err(|e| Status::internal(format!("{e}")))?
+                    .map_err(|e| CarbideError::Internal {
+                        message: format!("{e}"),
+                    })?
             }
             show_measurement_journal_request::Selector::LatestForMachineId(machine_id) => {
                 match db::measured_boot::journal::get_latest_journal_for_id(
                     &mut txn,
                     MachineId::from_str(&machine_id).map_err(|e| {
-                        Status::invalid_argument(format!("Could not parse MachineId: {e}"))
+                        CarbideError::InvalidArgument(format!("Could not parse MachineId: {e}"))
                     })?,
                 )
                 .await
-                .map_err(|e| Status::internal(format!("{e}")))?
-                {
+                .map_err(|e| CarbideError::Internal {
+                    message: format!("{e}"),
+                })? {
                     Some(journal) => journal,
                     None => {
                         return Ok(ShowMeasurementJournalResponse { journal: None });
@@ -90,7 +98,11 @@ pub async fn handle_show_measurement_journal(
                 }
             }
         },
-        None => return Err(Status::invalid_argument("selector must be provided")),
+        None => {
+            return Err(
+                CarbideError::InvalidArgument("selector must be provided".to_string()).into(),
+            );
+        }
     };
 
     txn.commit().await?;
@@ -109,7 +121,9 @@ pub async fn handle_show_measurement_journals(
     Ok(ShowMeasurementJournalsResponse {
         journals: db::measured_boot::journal::get_all(&api.database_connection)
             .await
-            .map_err(|e| Status::internal(format!("failed to fetch journals: {e}")))?
+            .map_err(|e| CarbideError::Internal {
+                message: format!("failed to fetch journals: {e}"),
+            })?
             .drain(..)
             .map(|journal| journal.into())
             .collect(),
@@ -126,14 +140,15 @@ pub async fn handle_list_measurement_journal(
 
     let journals: Vec<MeasurementJournalRecordPb> = match &req.selector {
         Some(list_measurement_journal_request::Selector::MachineId(machine_id)) => {
-            let machine_id = MachineId::from_str(machine_id).map_err(|e| {
-                Status::internal(format!("failed to fetch journals for machine: {e}"))
-            })?;
+            let machine_id =
+                MachineId::from_str(machine_id).map_err(|e| CarbideError::Internal {
+                    message: format!("failed to fetch journals for machine: {e}"),
+                })?;
 
             get_measurement_journal_records_for_machine_id(&mut txn, machine_id)
                 .await
-                .map_err(|e| {
-                    Status::internal(format!("failed to fetch journals for machine: {e}"))
+                .map_err(|e| CarbideError::Internal {
+                    message: format!("failed to fetch journals for machine: {e}"),
                 })?
                 .drain(..)
                 .map(|journal| journal.into())
@@ -141,7 +156,9 @@ pub async fn handle_list_measurement_journal(
         }
         None => get_measurement_journal_records(&mut txn)
             .await
-            .map_err(|e| Status::internal(format!("failed to fetch journals: {e}")))?
+            .map_err(|e| CarbideError::Internal {
+                message: format!("failed to fetch journals: {e}"),
+            })?
             .drain(..)
             .map(|journal| journal.into())
             .collect(),

--- a/crates/api/src/measured_boot/rpc/machine.rs
+++ b/crates/api/src/measured_boot/rpc/machine.rs
@@ -49,7 +49,9 @@ pub async fn handle_attest_candidate_machine(
         &PcrRegisterValue::from_pb_vec(req.pcr_values),
     )
     .await
-    .map_err(|e| Status::internal(format!("failed saving measurements: {e}")))?;
+    .map_err(|e| CarbideError::Internal {
+        message: format!("failed saving measurements: {e}"),
+    })?;
 
     txn.commit().await?;
     Ok(AttestCandidateMachineResponse {
@@ -73,10 +75,12 @@ pub async fn handle_show_candidate_machine(
                 })?,
             )
             .await
-            .map_err(|e| Status::internal(format!("{e}")))?
+            .map_err(|e| CarbideError::Internal {
+                message: format!("{e}"),
+            })?
         }
         // Show all system profiles.
-        None => return Err(Status::invalid_argument("selector required")),
+        None => return Err(CarbideError::InvalidArgument("selector required".to_string()).into()),
     };
 
     txn.commit().await?;
@@ -94,7 +98,9 @@ pub async fn handle_show_candidate_machines(
     Ok(ShowCandidateMachinesResponse {
         machines: db::measured_boot::machine::get_all(&mut api.db_reader())
             .await
-            .map_err(|e| Status::internal(format!("{e}")))?
+            .map_err(|e| CarbideError::Internal {
+                message: format!("{e}"),
+            })?
             .into_iter()
             .map(|machine| machine.into())
             .collect(),
@@ -109,7 +115,9 @@ pub async fn handle_list_candidate_machines(
     Ok(ListCandidateMachinesResponse {
         machines: get_candidate_machine_records(&api.database_connection)
             .await
-            .map_err(|e| Status::internal(format!("failed to read records: {e}")))?
+            .map_err(|e| CarbideError::Internal {
+                message: format!("failed to read records: {e}"),
+            })?
             .into_iter()
             .map(|record| record.into())
             .collect(),

--- a/crates/api/src/measured_boot/rpc/profile.rs
+++ b/crates/api/src/measured_boot/rpc/profile.rs
@@ -44,6 +44,7 @@ use rpc::protos::measured_boot::{
 use sqlx::PgConnection;
 use tonic::Status;
 
+use crate::CarbideError;
 use crate::api::Api;
 
 /// handle_create_system_measurement_profile handles the
@@ -66,7 +67,7 @@ pub async fn handle_create_system_measurement_profile(
 
     let system_profile = db::measured_boot::profile::new(&mut txn, req.name, &vals)
         .await
-        .map_err(|e| Status::invalid_argument(e.to_string()))?;
+        .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?;
 
     txn.commit().await?;
     Ok(CreateMeasurementSystemProfileResponse {
@@ -91,7 +92,9 @@ pub async fn handle_rename_measurement_system_profile(
             req.new_profile_name,
         )
         .await
-        .map_err(|e| Status::internal(format!("rename failed: {e}")))?,
+        .map_err(|e| CarbideError::Internal {
+            message: format!("rename failed: {e}"),
+        })?,
 
         // Rename for the given system_profile name.
         Some(rename_measurement_system_profile_request::Selector::ProfileName(
@@ -102,11 +105,15 @@ pub async fn handle_rename_measurement_system_profile(
             req.new_profile_name,
         )
         .await
-        .map_err(|e| Status::internal(format!("rename failed: {e}")))?,
+        .map_err(|e| CarbideError::Internal {
+            message: format!("rename failed: {e}"),
+        })?,
 
         // ID or name is needed.
         None => {
-            return Err(Status::invalid_argument("rename selector is required"));
+            return Err(
+                CarbideError::InvalidArgument("rename selector is required".to_string()).into(),
+            );
         }
     };
 
@@ -133,12 +140,17 @@ pub async fn handle_delete_measurement_system_profile(
             delete_for_name(&mut txn, profile_name).await?
         }
         // Trying to delete a profile without a selector.
-        None => return Err(Status::invalid_argument("profile selector is required")),
+        None => {
+            return Err(
+                CarbideError::InvalidArgument("profile selector is required".to_string()).into(),
+            );
+        }
     };
 
-    let system_profile = profile.ok_or(Status::not_found(
-        "profile not found with provided selector",
-    ))?;
+    let system_profile = profile.ok_or(CarbideError::NotFoundError {
+        kind: "profile",
+        id: "provided selector".to_string(),
+    })?;
 
     txn.commit().await?;
     Ok(DeleteMeasurementSystemProfileResponse {
@@ -158,16 +170,20 @@ pub async fn handle_show_measurement_system_profile(
         Some(show_measurement_system_profile_request::Selector::ProfileId(profile_uuid)) => {
             db::measured_boot::profile::load_from_id(&mut txn, profile_uuid)
                 .await
-                .map_err(|e| Status::internal(format!("{e}")))?
+                .map_err(|e| CarbideError::Internal {
+                    message: format!("{e}"),
+                })?
         }
         // Show a system profile with the given profile name.
         Some(show_measurement_system_profile_request::Selector::ProfileName(profile_name)) => {
             db::measured_boot::profile::load_from_name(&mut txn, profile_name)
                 .await
-                .map_err(|e| Status::internal(format!("{e}")))?
+                .map_err(|e| CarbideError::Internal {
+                    message: format!("{e}"),
+                })?
         }
         // Show all system profiles.
-        None => return Err(Status::invalid_argument("selector required")),
+        None => return Err(CarbideError::InvalidArgument("selector required".to_string()).into()),
     };
     txn.commit().await?;
 
@@ -185,7 +201,9 @@ pub async fn handle_show_measurement_system_profiles(
     Ok(ShowMeasurementSystemProfilesResponse {
         system_profiles: db::measured_boot::profile::get_all(&mut api.db_reader())
             .await
-            .map_err(|e| Status::internal(format!("{e}")))?
+            .map_err(|e| CarbideError::Internal {
+                message: format!("{e}"),
+            })?
             .into_iter()
             .map(|profile| profile.into())
             .collect(),
@@ -201,7 +219,9 @@ pub async fn handle_list_measurement_system_profiles(
     let system_profiles: Vec<MeasurementSystemProfileRecordPb> =
         export_measurement_profile_records(&api.database_connection)
             .await
-            .map_err(|e| Status::internal(format!("{e}")))?
+            .map_err(|e| CarbideError::Internal {
+                message: format!("{e}"),
+            })?
             .into_iter()
             .map(|record| record.into())
             .collect();
@@ -222,17 +242,21 @@ pub async fn handle_list_measurement_system_profile_bundles(
             profile_uuid,
         )) => get_bundles_for_profile_id(&mut txn, profile_uuid)
             .await
-            .map_err(|e| Status::internal(format!("{e}")))?,
+            .map_err(|e| CarbideError::Internal {
+                message: format!("{e}"),
+            })?,
 
         // ...or do it by profile name.
         Some(list_measurement_system_profile_bundles_request::Selector::ProfileName(
             profile_name,
         )) => get_bundles_for_profile_name(&mut txn, profile_name)
             .await
-            .map_err(|e| Status::internal(format!("{e}")))?,
+            .map_err(|e| CarbideError::Internal {
+                message: format!("{e}"),
+            })?,
 
         // ... either a UUID or name is required.
-        None => return Err(Status::invalid_argument("selector required")),
+        None => return Err(CarbideError::InvalidArgument("selector required".to_string()).into()),
     };
 
     txn.commit().await?;
@@ -252,7 +276,9 @@ pub async fn handle_list_measurement_system_profile_machines(
         Some(list_measurement_system_profile_machines_request::Selector::ProfileId(profile_id)) => {
             get_machines_for_profile_id(&mut txn, profile_id)
                 .await
-                .map_err(|e| Status::internal(format!("{e}")))?
+                .map_err(|e| CarbideError::Internal {
+                    message: format!("{e}"),
+                })?
                 .drain(..)
                 .map(|machine_id| machine_id.to_string())
                 .collect()
@@ -262,12 +288,14 @@ pub async fn handle_list_measurement_system_profile_machines(
             profile_name,
         )) => get_machines_for_profile_name(&mut txn, profile_name)
             .await
-            .map_err(|e| Status::internal(format!("{e}")))?
+            .map_err(|e| CarbideError::Internal {
+                message: format!("{e}"),
+            })?
             .drain(..)
             .map(|machine_id| machine_id.to_string())
             .collect(),
         // ...and it has to be either by ID or name.
-        None => return Err(Status::invalid_argument("selector required")),
+        None => return Err(CarbideError::InvalidArgument("selector required".to_string()).into()),
     };
     txn.commit().await?;
 
@@ -282,7 +310,10 @@ async fn delete_for_uuid(
 ) -> Result<Option<MeasurementSystemProfile>, Status> {
     match db::measured_boot::profile::delete_for_id(txn, profile_id).await {
         Ok(optional_profile) => Ok(optional_profile),
-        Err(e) => Err(Status::internal(format!("error deleting profile: {e}"))),
+        Err(e) => Err(CarbideError::Internal {
+            message: format!("error deleting profile: {e}"),
+        }
+        .into()),
     }
 }
 
@@ -294,6 +325,9 @@ async fn delete_for_name(
 ) -> Result<Option<MeasurementSystemProfile>, Status> {
     match db::measured_boot::profile::delete_for_name(txn, profile_name).await {
         Ok(optional_profile) => Ok(optional_profile),
-        Err(e) => Err(Status::internal(format!("error deleting profile: {e}"))),
+        Err(e) => Err(CarbideError::Internal {
+            message: format!("error deleting profile: {e}"),
+        }
+        .into()),
     }
 }

--- a/crates/api/src/measured_boot/rpc/report.rs
+++ b/crates/api/src/measured_boot/rpc/report.rs
@@ -58,7 +58,9 @@ pub async fn handle_create_measurement_report(
         &PcrRegisterValue::from_pb_vec(req.pcr_values),
     )
     .await
-    .map_err(|e| Status::internal(format!("report creation failed: {e}")))?;
+    .map_err(|e| CarbideError::Internal {
+        message: format!("report creation failed: {e}"),
+    })?;
 
     txn.commit().await?;
     Ok(CreateMeasurementReportResponse {
@@ -79,7 +81,9 @@ pub async fn handle_delete_measurement_report(
             .ok_or(CarbideError::MissingArgument("report_id"))?,
     )
     .await
-    .map_err(|e| Status::internal(format!("delete failed: {e}")))?;
+    .map_err(|e| CarbideError::Internal {
+        message: format!("delete failed: {e}"),
+    })?;
 
     txn.commit().await?;
     Ok(DeleteMeasurementReportResponse {
@@ -94,13 +98,12 @@ pub async fn handle_promote_measurement_report(
     req: PromoteMeasurementReportRequest,
 ) -> Result<PromoteMeasurementReportResponse, Status> {
     let mut txn = api.txn_begin().await?;
-    let pcr_set: Option<PcrSet> =
-        match !req.pcr_registers.is_empty() {
-            true => Some(parse_pcr_index_input(&req.pcr_registers).map_err(|e| {
-                Status::invalid_argument(format!("pcr_register parsing failed: {e}"))
-            })?),
-            false => None,
-        };
+    let pcr_set: Option<PcrSet> = match !req.pcr_registers.is_empty() {
+        true => Some(parse_pcr_index_input(&req.pcr_registers).map_err(|e| {
+            CarbideError::InvalidArgument(format!("pcr_register parsing failed: {e}"))
+        })?),
+        false => None,
+    };
 
     let report = db::measured_boot::report::from_id(
         &mut txn,
@@ -108,14 +111,14 @@ pub async fn handle_promote_measurement_report(
             .ok_or(CarbideError::MissingArgument("report_id"))?,
     )
     .await
-    .map_err(|e| Status::internal(format!("promotion failed fetching report: {e}")))?;
+    .map_err(|e| CarbideError::Internal {
+        message: format!("promotion failed fetching report: {e}"),
+    })?;
 
     let bundle = db::measured_boot::report::create_active_bundle(&mut txn, &report, &pcr_set)
         .await
-        .map_err(|e| {
-            Status::internal(format!(
-                "promotion failed promoting into active bundle: {e}"
-            ))
+        .map_err(|e| CarbideError::Internal {
+            message: format!("promotion failed promoting into active bundle: {e}"),
         })?;
 
     txn.commit().await?;
@@ -131,13 +134,12 @@ pub async fn handle_revoke_measurement_report(
     req: RevokeMeasurementReportRequest,
 ) -> Result<RevokeMeasurementReportResponse, Status> {
     let mut txn = api.txn_begin().await?;
-    let pcr_set: Option<PcrSet> =
-        match &req.pcr_registers.len() {
-            n if n < &1 => None,
-            _ => Some(parse_pcr_index_input(&req.pcr_registers).map_err(|e| {
-                Status::invalid_argument(format!("pcr_register parsing failed: {e}"))
-            })?),
-        };
+    let pcr_set: Option<PcrSet> = match &req.pcr_registers.len() {
+        n if n < &1 => None,
+        _ => Some(parse_pcr_index_input(&req.pcr_registers).map_err(|e| {
+            CarbideError::InvalidArgument(format!("pcr_register parsing failed: {e}"))
+        })?),
+    };
 
     let report = db::measured_boot::report::from_id(
         &mut txn,
@@ -145,14 +147,14 @@ pub async fn handle_revoke_measurement_report(
             .ok_or(CarbideError::MissingArgument("report_id"))?,
     )
     .await
-    .map_err(|e| Status::internal(format!("promotion failed fetching report: {e}")))?;
+    .map_err(|e| CarbideError::Internal {
+        message: format!("promotion failed fetching report: {e}"),
+    })?;
 
     let bundle = db::measured_boot::report::create_revoked_bundle(&mut txn, &report, &pcr_set)
         .await
-        .map_err(|e| {
-            Status::internal(format!(
-                "promotion failed promoting into revoked bundle: {e}"
-            ))
+        .map_err(|e| CarbideError::Internal {
+            message: format!("promotion failed promoting into revoked bundle: {e}"),
         })?;
 
     txn.commit().await?;
@@ -176,7 +178,9 @@ pub async fn handle_show_measurement_report_for_id(
                     .ok_or(CarbideError::MissingArgument("report_id"))?,
             )
             .await
-            .map_err(|e| Status::internal(format!("{e}")))?
+            .map_err(|e| CarbideError::Internal {
+                message: format!("{e}"),
+            })?
             .into(),
         ),
     });
@@ -199,7 +203,9 @@ pub async fn handle_show_measurement_reports_for_machine(
             })?,
         )
         .await
-        .map_err(|e| Status::internal(format!("{e}")))?
+        .map_err(|e| CarbideError::Internal {
+            message: format!("{e}"),
+        })?
         .into_iter()
         .map(|report| report.into())
         .collect(),
@@ -217,7 +223,9 @@ pub async fn handle_show_measurement_reports(
     Ok(ShowMeasurementReportsResponse {
         reports: db::measured_boot::report::get_all(&mut api.db_reader())
             .await
-            .map_err(|e| Status::internal(format!("{e}")))?
+            .map_err(|e| CarbideError::Internal {
+                message: format!("{e}"),
+            })?
             .into_iter()
             .map(|report| report.into())
             .collect(),
@@ -240,14 +248,18 @@ pub async fn handle_list_measurement_report(
                 })?,
             )
             .await
-            .map_err(|e| Status::internal(format!("failed loading report records: {e}")))?
+            .map_err(|e| CarbideError::Internal {
+                message: format!("failed loading report records: {e}"),
+            })?
             .into_iter()
             .map(|report| report.into())
             .collect()
         }
         None => get_all_measurement_report_records(&mut txn)
             .await
-            .map_err(|e| Status::internal(format!("failed loading report records: {e}")))?
+            .map_err(|e| CarbideError::Internal {
+                message: format!("failed loading report records: {e}"),
+            })?
             .into_iter()
             .map(|report| report.into())
             .collect(),
@@ -265,7 +277,9 @@ pub async fn handle_match_measurement_report(
     let pcr_register = PcrRegisterValue::from_pb_vec(req.pcr_values);
     let mut reports = match_latest_reports(&api.database_connection, &pcr_register)
         .await
-        .map_err(|e| Status::internal(format!("failure during report matching: {e}")))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("failure during report matching: {e}"),
+        })?;
 
     reports.sort_by(|a, b| a.ts.cmp(&b.ts));
 

--- a/crates/api/src/measured_boot/rpc/site.rs
+++ b/crates/api/src/measured_boot/rpc/site.rs
@@ -64,21 +64,27 @@ pub async fn handle_import_site_measurements(
     // make sure its good).
     let site_model = match &req.model {
         Some(site_model_pb) => SiteModel::from_pb(site_model_pb).map_err(|e| {
-            Status::invalid_argument(format!("input site model failed translation: {e}"))
+            CarbideError::InvalidArgument(format!("input site model failed translation: {e}"))
         })?,
-        None => return Err(Status::invalid_argument("site model cannot be empty")),
+        None => {
+            return Err(
+                CarbideError::InvalidArgument("site model cannot be empty".to_string()).into(),
+            );
+        }
     };
 
     // And now import it!
     let result = db::measured_boot::site::import(&mut txn, &site_model)
         .await
-        .map_err(|e| Status::internal(format!("site import failed: {e}")))
+        .map_err(|e| CarbideError::Internal {
+            message: format!("site import failed: {e}"),
+        })
         .map(|_| ImportSiteMeasurementsResponse {
             result: ImportSiteResult::Success.into(),
         });
 
     txn.commit().await?;
-    result
+    Ok(result?)
 }
 
 /// handle_export_site_measurements handles the ExportSiteMeasurements
@@ -89,12 +95,15 @@ pub async fn handle_export_site_measurements(
 ) -> Result<ExportSiteMeasurementsResponse, Status> {
     let site_model = db::measured_boot::site::export(&mut api.db_reader())
         .await
-        .map_err(|e| Status::internal(format!("export failed: {e}")))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("export failed: {e}"),
+        })?;
 
     Ok(ExportSiteMeasurementsResponse {
         model: Some(
-            SiteModel::to_pb(&site_model)
-                .map_err(|e| Status::internal(format!("model to pb failed: {e}")))?,
+            SiteModel::to_pb(&site_model).map_err(|e| CarbideError::Internal {
+                message: format!("model to pb failed: {e}"),
+            })?,
         ),
     })
 }
@@ -117,7 +126,9 @@ pub async fn handle_add_measurement_trusted_machine(
         Some(req.comments),
     )
     .await
-    .map_err(|e| Status::internal(format!("failed to insert trusted machine approval: {e}")))?;
+    .map_err(|e| CarbideError::Internal {
+        message: format!("failed to insert trusted machine approval: {e}"),
+    })?;
 
     txn.commit().await?;
     Ok(AddMeasurementTrustedMachineResponse {
@@ -138,7 +149,9 @@ pub async fn handle_remove_measurement_trusted_machine(
         Some(remove_measurement_trusted_machine_request::Selector::ApprovalId(approval_uuid)) => {
             remove_from_approved_machines_by_approval_id(&mut txn, approval_uuid)
                 .await
-                .map_err(|e| Status::internal(format!("removal failed: {e}")))?
+                .map_err(|e| CarbideError::Internal {
+                    message: format!("removal failed: {e}"),
+                })?
         }
         // Remove by machine ID.
         Some(remove_measurement_trusted_machine_request::Selector::MachineId(machine_id)) => {
@@ -149,13 +162,16 @@ pub async fn handle_remove_measurement_trusted_machine(
                 })?,
             )
             .await
-            .map_err(|e| Status::internal(format!("removal failed: {e}")))?
+            .map_err(|e| CarbideError::Internal {
+                message: format!("removal failed: {e}"),
+            })?
         }
         // Oops, forgot to set a selector.
         None => {
-            return Err(Status::invalid_argument(
-                "approval or machine ID selector missing",
-            ));
+            return Err(CarbideError::InvalidArgument(
+                "approval or machine ID selector missing".into(),
+            )
+            .into());
         }
     };
 
@@ -174,7 +190,9 @@ pub async fn handle_list_measurement_trusted_machines(
     let approval_records: Vec<MeasurementApprovedMachineRecordPb> =
         get_approved_machines(&api.database_connection)
             .await
-            .map_err(|e| Status::internal(format!("failed to fetch machine approvals: {e}")))?
+            .map_err(|e| CarbideError::Internal {
+                message: format!("failed to fetch machine approvals: {e}"),
+            })?
             .into_iter()
             .map(|record| record.into())
             .collect();
@@ -199,7 +217,9 @@ pub async fn handle_add_measurement_trusted_profile(
         req.comments,
     )
     .await
-    .map_err(|e| Status::internal(format!("failed to insert trusted profile approval: {e}")))?;
+    .map_err(|e| CarbideError::Internal {
+        message: format!("failed to insert trusted profile approval: {e}"),
+    })?;
 
     txn.commit().await?;
     Ok(AddMeasurementTrustedProfileResponse {
@@ -219,19 +239,24 @@ pub async fn handle_remove_measurement_trusted_profile(
         Some(remove_measurement_trusted_profile_request::Selector::ApprovalId(approval_uuid)) => {
             remove_from_approved_profiles_by_approval_id(&mut txn, approval_uuid)
                 .await
-                .map_err(|e| Status::internal(format!("removal failed: {e}")))?
+                .map_err(|e| CarbideError::Internal {
+                    message: format!("removal failed: {e}"),
+                })?
         }
         // Remove by profile ID.
         Some(remove_measurement_trusted_profile_request::Selector::ProfileId(profile_id)) => {
             remove_from_approved_profiles_by_profile_id(&mut txn, profile_id)
                 .await
-                .map_err(|e| Status::internal(format!("removal failed: {e}")))?
+                .map_err(|e| CarbideError::Internal {
+                    message: format!("removal failed: {e}"),
+                })?
         }
         // Oops, forgot to set a selector.
         None => {
-            return Err(Status::invalid_argument(
-                "approval or profile ID selector missing",
-            ));
+            return Err(CarbideError::InvalidArgument(
+                "approval or profile ID selector missing".into(),
+            )
+            .into());
         }
     };
 
@@ -250,7 +275,9 @@ pub async fn handle_list_measurement_trusted_profiles(
     let approval_records: Vec<MeasurementApprovedProfileRecordPb> =
         get_approved_profiles(&api.database_connection)
             .await
-            .map_err(|e| Status::internal(format!("failed to fetch profile approvals: {e}")))?
+            .map_err(|e| CarbideError::Internal {
+                message: format!("failed to fetch profile approvals: {e}"),
+            })?
             .into_iter()
             .map(|record| record.into())
             .collect();
@@ -264,7 +291,9 @@ pub async fn handle_list_attestation_summary(
 ) -> Result<ListAttestationSummaryResponse, Status> {
     let attestation_summary = list_attestation_summary(&api.database_connection)
         .await
-        .map_err(|e| Status::internal(format!("failed to fetch attestation summary: {e}")))?;
+        .map_err(|e| CarbideError::Internal {
+            message: format!("failed to fetch attestation summary: {e}"),
+        })?;
 
     Ok(MachineAttestationSummaryList::to_grpc(&attestation_summary))
 }

--- a/crates/api/src/scout_stream.rs
+++ b/crates/api/src/scout_stream.rs
@@ -30,6 +30,8 @@ use carbide_uuid::machine::MachineId;
 use tokio::sync::{RwLock, mpsc, oneshot};
 use tonic::Status;
 
+use crate::CarbideError;
+
 // AgentConnection represents an active streaming connection to
 // a scout agent. It contains the corresponding machine_id, the
 // channels used to pass messages, and any additional metadata
@@ -150,27 +152,35 @@ impl ConnectionRegistry {
         request: ScoutStreamScoutBoundMessage,
     ) -> Result<ScoutStreamApiBoundMessage, Status> {
         let Some(flow_uuid_pb) = request.flow_uuid.as_ref() else {
-            return Err(Status::internal(format!(
-                "flow_uuid empty for flow with {machine_id}, unable to build flow",
-            )));
+            return Err(CarbideError::Internal {
+                message: format!(
+                    "flow_uuid empty for flow with {machine_id}, unable to build flow",
+                ),
+            }
+            .into());
         };
 
         let flow_uuid: uuid::Uuid = match flow_uuid_pb.clone().try_into() {
             Ok(flow_uuid) => flow_uuid,
             Err(e) => {
-                return Err(Status::internal(format!(
-                    "failed to decode flow_uuid (machine_id={machine_id}): {flow_uuid_pb:?}: {e:?}",
-                )));
+                return Err(CarbideError::Internal {
+                    message: format!(
+                        "failed to decode flow_uuid (machine_id={machine_id}): {flow_uuid_pb:?}: {e:?}",
+                    ),
+                }
+                .into());
             }
         };
 
         let (connection_tx, connection_flows) = {
             let connections = self.connections.read().await;
-            let connection = connections.get(&machine_id).ok_or_else(|| {
-                Status::not_found(format!(
-                    "machine not connected to a scout stream: {machine_id}"
-                ))
-            })?;
+            let connection =
+                connections
+                    .get(&machine_id)
+                    .ok_or_else(|| CarbideError::NotFoundError {
+                        kind: "scout stream connection",
+                        id: machine_id.to_string(),
+                    })?;
             (connection.tx.clone(), Arc::clone(&connection.flows))
         };
 
@@ -192,18 +202,21 @@ impl ConnectionRegistry {
             "sending request to scout agent (machine_id={machine_id}, flow_uuid={flow_uuid})"
         );
 
-        connection_tx.send(Ok(request)).await.map_err(|e| {
-            Status::internal(format!(
-                "failed to send request to scout agent (machine_id={machine_id}, flow_uuid={flow_uuid}): {e}"
-            ))
+        connection_tx.send(Ok(request)).await.map_err(|e| CarbideError::Internal {
+                message: format!(
+                    "failed to send request to scout agent (machine_id={machine_id}, flow_uuid={flow_uuid}): {e}"
+                ),
         })?;
 
         // And now we wait for a response from the agent.
         // TODO(chet): This is where we'd put timeout handling.
-        response_rx.await.map_err(|e| {
-            Status::internal(format!(
-                "response channel error (machine_id={machine_id}, flow_uuid={flow_uuid}): {e}",
-            ))
+        response_rx.await.map_err(|e| -> Status {
+            CarbideError::Internal {
+                message: format!(
+                    "response channel error (machine_id={machine_id}, flow_uuid={flow_uuid}): {e}",
+                ),
+            }
+            .into()
         })
     }
 

--- a/crates/api/src/storage.rs
+++ b/crates/api/src/storage.rs
@@ -19,6 +19,7 @@ use model::tenant::TenantOrganizationId;
 use tonic::{Request, Response, Status};
 use uuid::Uuid;
 
+use crate::CarbideError;
 use crate::api::Api;
 
 // these functions are the grpc api handlers called from api.rs
@@ -30,19 +31,26 @@ pub(crate) async fn create_os_image(
 ) -> Result<Response<crate::api::rpc::OsImage>, Status> {
     let mut txn = api.txn_begin().await?;
     let attrs: OsImageAttributes = OsImageAttributes::try_from(request.into_inner())
-        .map_err(|e| Status::invalid_argument(e.to_string()))?;
+        .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?;
     if attrs.source_url.is_empty() || attrs.digest.is_empty() {
-        return Err(Status::invalid_argument("os_image url or digest is empty"));
+        return Err(
+            CarbideError::InvalidArgument("os_image url or digest is empty".to_string()).into(),
+        );
     }
-    let image = db::os_image::create(&mut txn, &attrs)
-        .await
-        .map_err(|e| Status::internal(e.to_string()))?;
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(e.to_string()))?;
+    let image =
+        db::os_image::create(&mut txn, &attrs)
+            .await
+            .map_err(|e| CarbideError::Internal {
+                message: e.to_string(),
+            })?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: e.to_string(),
+    })?;
 
     let resp: crate::api::rpc::OsImage =
-        rpc::forge::OsImage::try_from(image).map_err(|e| Status::internal(e.to_string()))?;
+        rpc::forge::OsImage::try_from(image).map_err(|e| CarbideError::Internal {
+            message: e.to_string(),
+        })?;
     Ok(Response::new(resp))
 }
 
@@ -54,21 +62,27 @@ pub(crate) async fn list_os_image(
     let tenant: Option<TenantOrganizationId> = match request.into_inner().tenant_organization_id {
         Some(x) => Some(
             TenantOrganizationId::try_from(x)
-                .map_err(|e| Status::invalid_argument(e.to_string()))?,
+                .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?,
         ),
         None => None,
     };
-    let os_images = db::os_image::list(&mut txn, tenant)
-        .await
-        .map_err(|e| Status::internal(e.to_string()))?;
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(e.to_string()))?;
+    let os_images =
+        db::os_image::list(&mut txn, tenant)
+            .await
+            .map_err(|e| CarbideError::Internal {
+                message: e.to_string(),
+            })?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: e.to_string(),
+    })?;
 
     let mut images: Vec<crate::api::rpc::OsImage> = Vec::new();
     for os_image in os_images.iter() {
-        let image = rpc::forge::OsImage::try_from(os_image.clone())
-            .map_err(|e| Status::internal(e.to_string()))?;
+        let image = rpc::forge::OsImage::try_from(os_image.clone()).map_err(|e| {
+            CarbideError::Internal {
+                message: e.to_string(),
+            }
+        })?;
         images.push(image);
     }
     let resp = crate::api::rpc::ListOsImageResponse { images };
@@ -81,16 +95,21 @@ pub(crate) async fn get_os_image(
 ) -> Result<Response<crate::api::rpc::OsImage>, Status> {
     let mut txn = api.txn_begin().await?;
     let image_id: Uuid = Uuid::try_from(request.into_inner())
-        .map_err(|e| Status::invalid_argument(e.to_string()))?;
-    let image = db::os_image::get(&mut txn, image_id)
-        .await
-        .map_err(|e| Status::internal(e.to_string()))?;
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(e.to_string()))?;
+        .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?;
+    let image =
+        db::os_image::get(&mut txn, image_id)
+            .await
+            .map_err(|e| CarbideError::Internal {
+                message: e.to_string(),
+            })?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: e.to_string(),
+    })?;
 
     let resp: crate::api::rpc::OsImage =
-        rpc::forge::OsImage::try_from(image).map_err(|e| Status::internal(e.to_string()))?;
+        rpc::forge::OsImage::try_from(image).map_err(|e| CarbideError::Internal {
+            message: e.to_string(),
+        })?;
     Ok(Response::new(resp))
 }
 
@@ -101,28 +120,33 @@ pub(crate) async fn delete_os_image(
     let mut txn = api.txn_begin().await?;
     let req = request.into_inner();
     if req.id.is_none() {
-        return Err(Status::invalid_argument("os image id missing"));
+        return Err(CarbideError::InvalidArgument("os image id missing".to_string()).into());
     }
-    let image_id: Uuid =
-        Uuid::try_from(req.id.unwrap()).map_err(|e| Status::invalid_argument(e.to_string()))?;
+    let image_id: Uuid = Uuid::try_from(req.id.unwrap())
+        .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?;
     let tenant: TenantOrganizationId = TenantOrganizationId::try_from(req.tenant_organization_id)
-        .map_err(|e| Status::invalid_argument(e.to_string()))?;
-    let image = db::os_image::get(&mut txn, image_id)
-        .await
-        .map_err(|e| Status::internal(e.to_string()))?;
+        .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?;
+    let image =
+        db::os_image::get(&mut txn, image_id)
+            .await
+            .map_err(|e| CarbideError::Internal {
+                message: e.to_string(),
+            })?;
     if image.attributes.tenant_organization_id != tenant {
-        return Err(Status::invalid_argument("os image tenant mismatch"));
+        return Err(CarbideError::InvalidArgument("os image tenant mismatch".to_string()).into());
     }
     if image.status == OsImageStatus::InProgress {
-        return Err(Status::failed_precondition("os image busy"));
+        return Err(CarbideError::FailedPrecondition("os image busy".to_string()).into());
     }
 
     db::os_image::delete(&image, &mut txn)
         .await
-        .map_err(|e| Status::internal(e.to_string()))?;
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(e.to_string()))?;
+        .map_err(|e| CarbideError::Internal {
+            message: e.to_string(),
+        })?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: e.to_string(),
+    })?;
 
     let resp = crate::api::rpc::DeleteOsImageResponse::default();
     Ok(Response::new(resp))
@@ -135,10 +159,12 @@ pub(crate) async fn update_os_image(
     let mut txn = api.txn_begin().await?;
 
     let new_attrs: OsImageAttributes = OsImageAttributes::try_from(request.into_inner())
-        .map_err(|e| Status::invalid_argument(e.to_string()))?;
+        .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?;
     let image = db::os_image::get(&mut txn, new_attrs.id)
         .await
-        .map_err(|e| Status::internal(e.to_string()))?;
+        .map_err(|e| CarbideError::Internal {
+            message: e.to_string(),
+        })?;
     if new_attrs.source_url != image.attributes.source_url
         || new_attrs.digest != image.attributes.digest
         || new_attrs.tenant_organization_id != image.attributes.tenant_organization_id
@@ -147,19 +173,24 @@ pub(crate) async fn update_os_image(
         || new_attrs.rootfs_label != image.attributes.rootfs_label
         || new_attrs.capacity != image.attributes.capacity
     {
-        return Err(Status::invalid_argument(
-            "os_image update read-only attributes changed",
-        ));
+        return Err(CarbideError::InvalidArgument(
+            "os_image update read-only attributes changed".into(),
+        )
+        .into());
     }
     let updated = db::os_image::update(&image, &mut txn, new_attrs)
         .await
-        .map_err(|e| Status::internal(e.to_string()))?;
+        .map_err(|e| CarbideError::Internal {
+            message: e.to_string(),
+        })?;
 
-    txn.commit()
-        .await
-        .map_err(|e| Status::internal(e.to_string()))?;
+    txn.commit().await.map_err(|e| CarbideError::Internal {
+        message: e.to_string(),
+    })?;
 
     let resp: crate::api::rpc::OsImage =
-        rpc::forge::OsImage::try_from(updated).map_err(|e| Status::internal(e.to_string()))?;
+        rpc::forge::OsImage::try_from(updated).map_err(|e| CarbideError::Internal {
+            message: e.to_string(),
+        })?;
     Ok(Response::new(resp))
 }

--- a/crates/api/src/tests/expected_power_shelf.rs
+++ b/crates/api/src/tests/expected_power_shelf.rs
@@ -283,10 +283,7 @@ async fn test_delete_expected_power_shelf_error(pool: sqlx::PgPool) {
 
     assert_eq!(
         err.message().to_string(),
-        format!(
-            "Failed to delete expected power shelf: expected_power_shelf not found: {}",
-            bmc_mac_address
-        )
+        format!("expected_power_shelf not found: {}", bmc_mac_address)
     );
 }
 
@@ -756,7 +753,7 @@ async fn test_delete_expected_power_shelf_by_id(pool: sqlx::PgPool) {
 
     assert_eq!(
         err.message().to_string(),
-        format!("Expected power shelf not found: {}", provided_id)
+        format!("expected_power_shelf not found: {}", provided_id)
     );
 }
 
@@ -923,6 +920,6 @@ async fn test_get_expected_power_shelf_by_id_not_found(pool: sqlx::PgPool) {
 
     assert_eq!(
         err.message().to_string(),
-        format!("Expected power shelf not found: {}", non_existent_id)
+        format!("expected_power_shelf not found: {}", non_existent_id)
     );
 }

--- a/crates/api/src/tests/expected_switch.rs
+++ b/crates/api/src/tests/expected_switch.rs
@@ -437,7 +437,7 @@ async fn test_delete_expected_switch_by_id(pool: sqlx::PgPool) {
 
     assert_eq!(
         err.message().to_string(),
-        format!("Expected switch not found: {}", explicit_id)
+        format!("expected_switch not found: {}", explicit_id)
     );
 }
 
@@ -608,7 +608,7 @@ async fn test_get_expected_switch_by_id_not_found(pool: sqlx::PgPool) {
 
     assert_eq!(
         err.message().to_string(),
-        format!("Expected switch not found: {}", nonexistent_id)
+        format!("expected_switch not found: {}", nonexistent_id)
     );
 }
 
@@ -651,10 +651,7 @@ async fn test_delete_expected_switch_error(pool: sqlx::PgPool) {
 
     assert_eq!(
         err.message().to_string(),
-        format!(
-            "Failed to delete expected switch: expected_switch not found: {}",
-            bmc_mac_address
-        )
+        format!("expected_switch not found: {}", bmc_mac_address)
     );
 }
 


### PR DESCRIPTION
## Description

In our shiny new `STYLE_GUIDE.md`, we mention that the API layer should be returning `CarbideError::` variants and converting `.into()` a `tonic::Status::` variant. And in a couple of PRs I recently did, this came up as well, because everyone is so used to just returning a `tonic::Status::` variant.

Doing a clean sweep and cutting everything over to match the style guide, and then hopefully we won't see much of the old form anymore.

Tests included for a couple of added variants. Everything else was there already.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

