### PR TITLE
fix: remove terminated extension services from instance config

### DIFF
--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -5434,9 +5434,25 @@ impl StateHandler for InstanceStateHandler {
                         return Ok(StateHandlerOutcome::transition(next_state));
                     }
 
-                    let mut txn = ctx.services.db_pool.begin().await?;
-                    let extension_services_status =
-                        get_extension_services_status(mh_snapshot, instance, &mut txn).await?;
+                    let mut extension_services_status =
+                        get_extension_services_status(mh_snapshot, instance);
+                    let txn = if extension_services_status.configs_synced == SyncState::Synced
+                        && !extension_services_status
+                            .get_terminated_service_ids()
+                            .is_empty()
+                    {
+                        let mut txn = ctx.services.db_pool.begin().await?;
+                        cleanup_terminated_extension_services(
+                            instance,
+                            &mut extension_services_status,
+                            txn.as_mut(),
+                        )
+                        .await?;
+
+                        Some(txn)
+                    } else {
+                        None
+                    };
                     let outcome = match extension_service::compute_extension_services_readiness(&extension_services_status) {
                                 ExtensionServicesReadiness::Ready => {
                                     let next_state = ManagedHostState::Assigned {
@@ -5461,7 +5477,10 @@ impl StateHandler for InstanceStateHandler {
                                     )
                                 }
                             };
-                    Ok(outcome.with_txn(txn))
+                    Ok(match txn {
+                        Some(txn) => outcome.with_txn(txn),
+                        None => outcome,
+                    })
                 }
                 InstanceState::WaitingForRebootToReady => {
                     // If custom_pxe_reboot_requested is set, this reboot was triggered by
@@ -5505,6 +5524,33 @@ impl StateHandler for InstanceStateHandler {
                             },
                         };
                         return Ok(StateHandlerOutcome::transition(next_state));
+                    }
+
+                    // Run cleanup here so fully terminated extension services are
+                    // removed from persisted instance config.
+                    let mut txn_opt = None;
+                    if !instance
+                        .config
+                        .extension_services
+                        .service_configs
+                        .is_empty()
+                    {
+                        let mut extension_services_status =
+                            get_extension_services_status(mh_snapshot, instance);
+                        if extension_services_status.configs_synced == SyncState::Synced
+                            && !extension_services_status
+                                .get_terminated_service_ids()
+                                .is_empty()
+                        {
+                            let mut txn = ctx.services.db_pool.begin().await?;
+                            cleanup_terminated_extension_services(
+                                instance,
+                                &mut extension_services_status,
+                                txn.as_mut(),
+                            )
+                            .await?;
+                            txn_opt = Some(txn);
+                        }
                     }
 
                     let reprov_can_be_started =
@@ -5606,7 +5652,11 @@ impl StateHandler for InstanceStateHandler {
                             }
                         };
 
-                        let mut txn = ctx.services.db_pool.begin().await?;
+                        let mut txn = if let Some(txn) = txn_opt.take() {
+                            txn
+                        } else {
+                            ctx.services.db_pool.begin().await?
+                        };
 
                         if host_firmware_requested {
                             let health_override =
@@ -5638,6 +5688,8 @@ impl StateHandler for InstanceStateHandler {
                         }
 
                         Ok(StateHandlerOutcome::transition(next_state).with_txn(txn))
+                    } else if let Some(txn) = txn_opt {
+                        Ok(StateHandlerOutcome::do_nothing().with_txn(txn))
                     } else {
                         Ok(StateHandlerOutcome::do_nothing())
                     }
@@ -6133,56 +6185,63 @@ impl StateHandler for InstanceStateHandler {
 
 // Gets extension services status from DB, checks if any removed services are fully terminated
 // across all DPUs, if so, remove them from the instance config in the DB(without updating the version).
-async fn get_extension_services_status(
+fn get_extension_services_status(
     mh_snapshot: &ManagedHostStateSnapshot,
     instance: &InstanceSnapshot,
-    txn: &mut PgConnection,
-) -> Result<InstanceExtensionServicesStatus, StateHandlerError> {
+) -> InstanceExtensionServicesStatus {
     let (_, dpu_id_to_device_map) = mh_snapshot
         .host_snapshot
         .get_dpu_device_and_id_mappings()
         .unwrap_or_else(|_| (HashMap::default(), HashMap::default()));
 
     // Gather instance extension services status from all DPU observations
-    let mut extension_services_status =
-        InstanceExtensionServicesStatus::from_config_and_observations(
-            &dpu_id_to_device_map,
-            Versioned::new(
-                &instance.config.extension_services,
-                instance.extension_services_config_version,
-            ),
-            &instance.observations.extension_services,
-        );
+    InstanceExtensionServicesStatus::from_config_and_observations(
+        &dpu_id_to_device_map,
+        Versioned::new(
+            &instance.config.extension_services,
+            instance.extension_services_config_version,
+        ),
+        &instance.observations.extension_services,
+    )
+}
 
-    if extension_services_status.configs_synced == SyncState::Synced {
-        let terminated_service_ids = extension_services_status.get_terminated_service_ids();
-        if !terminated_service_ids.is_empty() {
-            tracing::info!(
-                instance_id = %instance.id,
-                service_ids = ?terminated_service_ids,
-                "Cleaning up fully terminated extension services from instance config"
-            );
-            let new_config = instance
-                .config
-                .extension_services
-                .remove_terminated_services(&terminated_service_ids);
-
-            db::instance::update_extension_services_config(
-                txn,
-                instance.id,
-                instance.extension_services_config_version,
-                &new_config,
-                false,
-            )
-            .await?;
-
-            extension_services_status
-                .extension_services
-                .retain(|svc| !terminated_service_ids.contains(&svc.service_id));
-        }
+async fn cleanup_terminated_extension_services(
+    instance: &InstanceSnapshot,
+    extension_services_status: &mut InstanceExtensionServicesStatus,
+    txn: &mut PgConnection,
+) -> Result<(), StateHandlerError> {
+    if extension_services_status.configs_synced != SyncState::Synced {
+        return Ok(());
     }
 
-    Ok(extension_services_status)
+    let terminated_service_ids = extension_services_status.get_terminated_service_ids();
+    if terminated_service_ids.is_empty() {
+        return Ok(());
+    }
+
+    tracing::info!(
+        instance_id = %instance.id,
+        service_ids = ?terminated_service_ids,
+        "Cleaning up fully terminated extension services from instance config"
+    );
+    let new_config = instance
+        .config
+        .extension_services
+        .remove_terminated_services(&terminated_service_ids);
+
+    db::instance::update_extension_services_config(
+        txn,
+        instance.id,
+        instance.extension_services_config_version,
+        &new_config,
+        false,
+    )
+    .await?;
+
+    extension_services_status
+        .extension_services
+        .retain(|svc| !terminated_service_ids.contains(&svc.service_id));
+    Ok(())
 }
 
 async fn handle_instance_network_config_update_request(

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -2070,6 +2070,17 @@ pub async fn network_configured_with_health(
     dpu_machine_id: &MachineId,
     dpu_health: Option<rpc::health::HealthReport>,
 ) {
+    network_configured_with_health_and_ext_services(env, dpu_machine_id, dpu_health, None).await
+}
+
+/// Fake an iteration of forge-dpu-agent requesting network config, applying it, and reporting back.
+/// When reporting back, the health and extension services statuses reported by the DPU can be overrridden
+pub async fn network_configured_with_health_and_ext_services(
+    env: &TestEnv,
+    dpu_machine_id: &MachineId,
+    dpu_health: Option<rpc::health::HealthReport>,
+    extension_services_state: Option<rpc::forge::DpuExtensionServiceDeploymentStatus>,
+) {
     let network_config = env
         .api
         .get_managed_host_network_config(Request::new(
@@ -2160,9 +2171,9 @@ pub async fn network_configured_with_health(
                     service_type: extension_service.service_type,
                     service_name: "".to_string(),
                     version: extension_service.version.to_string(),
-                    state:
-                        rpc::forge::DpuExtensionServiceDeploymentStatus::DpuExtensionServiceRunning
-                            as i32,
+                    state: extension_services_state.unwrap_or(
+                        rpc::forge::DpuExtensionServiceDeploymentStatus::DpuExtensionServiceRunning,
+                    ) as i32,
                     components: vec![],
                     message: "".to_string(),
                     removed: extension_service.removed.clone(),

--- a/crates/api/src/tests/instance.rs
+++ b/crates/api/src/tests/instance.rs
@@ -36,7 +36,8 @@ use common::api_fixtures::tpm_attestation::{CA_CERT_SERIALIZED, EK_CERT_SERIALIZ
 use common::api_fixtures::{
     TestEnvOverrides, create_managed_host, create_test_env, create_test_env_with_overrides, dpu,
     get_config, get_vpc_fixture_id, inject_machine_measurements, network_configured_with_health,
-    persist_machine_validation_result, populate_network_security_groups, site_explorer,
+    network_configured_with_health_and_ext_services, persist_machine_validation_result,
+    populate_network_security_groups, site_explorer,
 };
 use config_version::ConfigVersion;
 use db::instance_address::UsedOverlayNetworkIpResolver;
@@ -5869,6 +5870,172 @@ async fn test_update_instance_with_extension_services(
     assert!(
         err.message()
             .starts_with("Duplicate extension services in configuration. Only one version of each service is allowed.")
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_extension_service_removed_after_all_dpus_report_terminated(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
+    let env = create_test_env(pool).await;
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+    let mh = create_managed_host(&env).await;
+
+    let (_, service2, _) = create_dpu_extension_services(&env).await?;
+    let service2_version = service2
+        .latest_version_info
+        .as_ref()
+        .unwrap()
+        .version
+        .clone();
+
+    let config = rpc::InstanceConfig {
+        tenant: Some(default_tenant_config()),
+        os: Some(default_os_config()),
+        network: Some(single_interface_network_config(segment_id)),
+        infiniband: None,
+        network_security_group_id: None,
+        nvlink: None,
+        dpu_extension_services: Some(rpc::forge::InstanceDpuExtensionServicesConfig {
+            service_configs: vec![rpc::forge::InstanceDpuExtensionServiceConfig {
+                service_id: service2.service_id.clone(),
+                version: service2_version,
+            }],
+        }),
+    };
+
+    let tinstance = mh.instance_builer(&env).config(config).build().await;
+    let instance_id = tinstance.id;
+
+    // Explicitly mock healthy/running extension-service status from the DPU.
+    network_configured_with_health_and_ext_services(&env, &mh.dpu().id, None, None).await;
+
+    // Remove all extension services from desired config.
+    env.api
+        .update_instance_config(Request::new(rpc::forge::InstanceConfigUpdateRequest {
+            if_version_match: None,
+            config: Some(rpc::InstanceConfig {
+                tenant: Some(default_tenant_config()),
+                os: Some(default_os_config()),
+                network: Some(single_interface_network_config(segment_id)),
+                infiniband: None,
+                network_security_group_id: None,
+                nvlink: None,
+                dpu_extension_services: Some(rpc::forge::InstanceDpuExtensionServicesConfig {
+                    service_configs: vec![],
+                }),
+            }),
+            instance_id: Some(instance_id),
+            metadata: Some(rpc::forge::Metadata {
+                name: "newinstance".to_string(),
+                description: "desc".to_string(),
+                labels: vec![],
+            }),
+        }))
+        .await?;
+
+    // Update instance config should not change the instance state from Ready
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &mh.host().id,
+        10,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::Ready,
+        },
+    )
+    .await;
+
+    let rpc_instance = tinstance.rpc_instance().await.into_inner();
+
+    // Since the extension services are removed from the instance config, the config should be empty.
+    assert!(
+        rpc_instance
+            .config
+            .unwrap()
+            .dpu_extension_services
+            .is_none()
+    );
+
+    // At this point, since DPUs have not reported any extension services, the tenant state should
+    // be in Configuring state.
+    let rpc_status = rpc_instance.status.unwrap();
+    assert_eq!(
+        rpc_status.tenant.unwrap().state,
+        rpc::TenantState::Configuring as i32
+    );
+
+    // The extension services status should still be tracked until fully terminated.
+    let dpu_extension_services_status = rpc_status.dpu_extension_services.unwrap();
+    assert_eq!(
+        dpu_extension_services_status.dpu_extension_services.len(),
+        1
+    );
+    assert_eq!(
+        dpu_extension_services_status.configs_synced,
+        rpc::forge::SyncState::Pending as i32
+    );
+    // The status should be Unknown until the DPU reports the status.
+    assert_eq!(
+        dpu_extension_services_status.dpu_extension_services[0].deployment_status,
+        rpc::forge::DpuExtensionServiceDeploymentStatus::DpuExtensionServiceUnknown as i32
+    );
+
+    // Mock DPU reporting removed services as fully terminated.
+    // Instance should be in Ready state after this.
+    // Tenant state should be Ready.
+    // Instance config and status should no long have the extension services.
+    network_configured_with_health_and_ext_services(
+        &env,
+        &mh.dpu().id,
+        None,
+        Some(rpc::forge::DpuExtensionServiceDeploymentStatus::DpuExtensionServiceTerminated),
+    )
+    .await;
+
+    // Let state handler process cleanup and persist instance extension-services config.
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.db_txn().await;
+    let snapshot = mh.snapshot(&mut txn).await;
+    let instance_snapshot = snapshot.instance.unwrap();
+
+    // The extension services should be removed from the instance config.
+    assert!(
+        instance_snapshot
+            .config
+            .extension_services
+            .service_configs
+            .is_empty(),
+        "Instance config should not have extension services"
+    );
+
+    // However, the observations should still be in record.
+    assert!(!instance_snapshot.observations.extension_services.is_empty(),);
+
+    let rpc_instance = tinstance.rpc_instance().await.into_inner();
+    assert!(
+        rpc_instance
+            .config
+            .unwrap()
+            .dpu_extension_services
+            .is_none()
+    );
+
+    // The tenant status should now be Ready.
+    let rpc_status = rpc_instance.status.unwrap();
+    assert_eq!(
+        rpc_status.tenant.unwrap().state,
+        rpc::TenantState::Ready as i32
+    );
+    assert!(
+        rpc_status
+            .dpu_extension_services
+            .unwrap()
+            .dpu_extension_services
+            .is_empty()
     );
 
     Ok(())


### PR DESCRIPTION
## Description
Fixes a gap where extension services marked for removal were not cleaned up from instance config even after all DPUs reported successful termination.

Previously, terminated extension service cleanup was only executed in the `WaitingForExtensionServicesConfig` instance state; however, extension service config updates do not transition the machine out of Ready (only tenant state moves to `Configuring`). This change adds instance extension service config cleanup in the `Ready` state so terminated services can be cleaned up. 

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

