### PR TITLE
chore: finish rpc -> api modeling; kick rpc out of api-db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,7 +1474,6 @@ dependencies = [
  "carbide-macros",
  "carbide-measured-boot",
  "carbide-network",
- "carbide-rpc",
  "carbide-sqlx-testing",
  "carbide-utils",
  "carbide-uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ hyper-rustls = { version = "^0.27" }
 hyper-timeout = { version = "^0.5" }
 hyper-util = { version = "^0.1" }
 
-rustls = { version = "0.23.16", features = ["aws_lc_rs"]}
+rustls = { version = "0.23.16", features = ["aws_lc_rs"] }
 rustls-pki-types = "1.10.0"
 sqlx = { version = "0.8.3" }
 sqlx-core = { version = "0.8.3" }

--- a/crates/api-db/Cargo.toml
+++ b/crates/api-db/Cargo.toml
@@ -34,7 +34,6 @@ carbide-libmlx = { path = "../libmlx" }
 carbide-network = { path = "../network", features = ["sqlx"] }
 carbide-version = { path = "../version" }
 carbide-health-report = { path = "../health-report" }
-carbide-rpc = { path = "../rpc", features = ["sqlx"] }
 carbide-utils = { path = "../utils", features = ["sqlx"] }
 carbide-uuid = { path = "../uuid", features = ["sqlx"] }
 carbide-measured-boot = { path = "../measured-boot", features = ["sqlx"] }

--- a/crates/api-db/src/lib.rs
+++ b/crates/api-db/src/lib.rs
@@ -107,7 +107,6 @@ use mac_address::MacAddress;
 use model::ConfigValidationError;
 use model::hardware_info::HardwareInfoError;
 use model::tenant::TenantError;
-use rpc::errors::RpcDataConversionError;
 use sqlx::{Acquire, PgPool, PgTransaction, Postgres};
 use tonic::Status;
 
@@ -340,8 +339,6 @@ pub enum DatabaseError {
     },
     #[error("Argument is invalid: {0}")]
     InvalidArgument(String),
-    #[error("Can not convert between RPC data model and internal data model - {0}")]
-    RpcDataConversionError(#[from] RpcDataConversionError),
     #[error("Duplicate MAC address for expected host BMC interface: {0}")]
     ExpectedHostDuplicateMacAddress(MacAddress),
     #[error("Argument is missing in input: {0}")]
@@ -562,7 +559,6 @@ impl From<DatabaseError> for tonic::Status {
                 Status::not_found(format!("{kind} not found: {id}"))
             }
             DatabaseError::ResourceExhausted(kind) => Status::resource_exhausted(kind),
-            DatabaseError::RpcDataConversionError(e) => Status::invalid_argument(e.to_string()),
             error @ DatabaseError::RpcUuidConversionError(_) => {
                 Status::invalid_argument(error.to_string())
             }

--- a/crates/api-db/src/machine_validation_result.rs
+++ b/crates/api-db/src/machine_validation_result.rs
@@ -181,7 +181,7 @@ pub async fn create(value: MachineValidationResult, txn: &mut PgConnection) -> D
 
 pub async fn validate_current_context(
     txn: &mut PgConnection,
-    id: &rpc::Uuid,
+    id: &uuid::Uuid,
 ) -> DatabaseResult<Option<String>> {
     let db_results = find_by(
         txn,

--- a/crates/api-db/src/measured_boot/machine.rs
+++ b/crates/api-db/src/measured_boot/machine.rs
@@ -29,7 +29,6 @@ use measured_boot::journal::MeasurementJournal;
 use measured_boot::machine::CandidateMachine;
 use measured_boot::records::{MeasurementBundleState, MeasurementMachineState};
 use model::machine::topology::TopologyData;
-use rpc::protos::measured_boot::CandidateMachineSummaryPb;
 use serde::Serialize;
 use sqlx::{FromRow, PgConnection};
 
@@ -63,15 +62,6 @@ pub struct CandidateMachineRecord {
 
     // updated is the timestamp this record was updated.
     pub updated: chrono::DateTime<Utc>,
-}
-
-impl From<CandidateMachineRecord> for CandidateMachineSummaryPb {
-    fn from(val: CandidateMachineRecord) -> Self {
-        Self {
-            machine_id: val.machine_id.to_string(),
-            ts: Some(val.created.into()),
-        }
-    }
 }
 
 impl DbTable for CandidateMachineRecord {

--- a/crates/api-db/src/tenant_keyset.rs
+++ b/crates/api-db/src/tenant_keyset.rs
@@ -59,7 +59,7 @@ pub async fn find_ids(
 
 pub async fn find_by_ids(
     txn: impl DbReader<'_>,
-    ids: Vec<rpc::forge::TenantKeysetIdentifier>,
+    ids: Vec<model::tenant::TenantKeysetIdentifier>,
     include_key_data: bool,
 ) -> Result<Vec<TenantKeyset>, DatabaseError> {
     // build query
@@ -67,7 +67,8 @@ pub async fn find_by_ids(
         "SELECT * FROM tenant_keysets WHERE (organization_id, keyset_id) IN ",
     );
     builder.push_tuples(ids.iter(), |mut b, id| {
-        b.push_bind(&id.organization_id).push_bind(&id.keyset_id);
+        b.push_bind(id.organization_id.to_string())
+            .push_bind(&id.keyset_id);
     });
     // execute
     let query = builder.build_query_as();

--- a/crates/api/src/errors.rs
+++ b/crates/api/src/errors.rs
@@ -292,7 +292,6 @@ impl From<DatabaseError> for CarbideError {
             DatabaseError::OnePrimaryInterface => OnePrimaryInterface,
             DatabaseError::ResourceExhausted(e) => ResourceExhausted(e),
             DatabaseError::ResourcePoolError(e) => ResourcePoolError(e),
-            DatabaseError::RpcDataConversionError(e) => RpcDataConversionError(e),
             DatabaseError::RpcUuidConversionError(e) => RpcUuidConversionError(e),
             DatabaseError::Sqlx(e) => DBError(e),
             DatabaseError::TenantError(e) => TenantError(e),

--- a/crates/api/src/handlers/machine_validation.rs
+++ b/crates/api/src/handlers/machine_validation.rs
@@ -122,7 +122,7 @@ pub(crate) async fn mark_machine_validation_complete(
     };
 
     let result =
-        match db::machine_validation_result::validate_current_context(&mut txn, rpc_id).await? {
+        match db::machine_validation_result::validate_current_context(&mut txn, &uuid).await? {
             Some(error_message) => {
                 db::machine::update_failure_details_by_machine_id(
                     &machine_id,

--- a/crates/api/src/handlers/tenant_keyset.rs
+++ b/crates/api/src/handlers/tenant_keyset.rs
@@ -102,6 +102,11 @@ pub(crate) async fn find_by_ids(
         );
     }
 
+    let keyset_ids: Vec<model::tenant::TenantKeysetIdentifier> = keyset_ids
+        .into_iter()
+        .map(|id| id.try_into())
+        .collect::<Result<_, _>>()?;
+
     let keysets =
         db::tenant_keyset::find_by_ids(&api.database_connection, keyset_ids, include_key_data)
             .await;

--- a/crates/api/src/measured_boot/rpc/machine.rs
+++ b/crates/api/src/measured_boot/rpc/machine.rs
@@ -119,7 +119,12 @@ pub async fn handle_list_candidate_machines(
                 message: format!("failed to read records: {e}"),
             })?
             .into_iter()
-            .map(|record| record.into())
+            .map(
+                |record| rpc::protos::measured_boot::CandidateMachineSummaryPb {
+                    machine_id: record.machine_id.to_string(),
+                    ts: Some(record.created.into()),
+                },
+            )
             .collect(),
     })
 }


### PR DESCRIPTION
## Description

This continues the work from https://github.com/NVIDIA/ncx-infra-controller-core/pull/606, https://github.com/NVIDIA/ncx-infra-controller-core/pull/602, https://github.com/NVIDIA/ncx-infra-controller-core/pull/598, https://github.com/NVIDIA/ncx-infra-controller-core/pull/596, https://github.com/NVIDIA/ncx-infra-controller-core/pull/608, and https://github.com/NVIDIA/ncx-infra-controller-core/pull/610.

TLDR is we had leaked a few things from `::rpc` into the `api-db` layer, which we generally don't want to do, and now that we have `STYLE_GUIDE.md`, it was good to practice what we preach.

Everything else has been refactored. This handles the last bit of it, and then kicks `carbide-rpc` out of the `carbide-api-db` crate entirely.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

