### PR TITLE
feat: add DHCP to new IPAM section in the admin UI

### DIFF
--- a/crates/api/src/web/ipam.rs
+++ b/crates/api/src/web/ipam.rs
@@ -1,0 +1,163 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use askama::Template;
+use axum::Json;
+use axum::extract::State as AxumState;
+use axum::response::{Html, IntoResponse, Response};
+use chrono::{DateTime, Utc};
+use hyper::http::StatusCode;
+use rpc::forge as forgerpc;
+use rpc::forge::forge_server::Forge;
+use utils::models::dhcp::DhcpConfig;
+
+use crate::api::Api;
+
+#[derive(Template)]
+#[template(path = "ipam_dhcp.html")]
+struct IpamDhcp {
+    entries: Vec<DhcpEntryDisplay>,
+    lease_duration_secs: i64,
+}
+
+struct DhcpEntryDisplay {
+    ip_address: String,
+    mac_address: String,
+    machine_id: String,
+    hostname: String,
+    created: String,
+    last_dhcp: String,
+    last_dhcp_rfc3339: String,
+}
+
+impl DhcpEntryDisplay {
+    fn from_interface(mi: forgerpc::MachineInterface) -> Vec<Self> {
+        let created: DateTime<Utc> = mi
+            .created
+            .and_then(|t| t.try_into().ok())
+            .unwrap_or_default();
+        let last_dhcp: Option<DateTime<Utc>> = mi.last_dhcp.and_then(|t| t.try_into().ok());
+
+        let machine_id = mi
+            .machine_id
+            .as_ref()
+            .map(|id| id.to_string())
+            .unwrap_or_default();
+
+        if mi.address.is_empty() {
+            return Vec::new();
+        }
+
+        mi.address
+            .into_iter()
+            .map(|addr| DhcpEntryDisplay {
+                ip_address: addr,
+                mac_address: mi.mac_address.clone(),
+                machine_id: machine_id.clone(),
+                hostname: mi.hostname.clone(),
+                created: created.format("%F %T %Z").to_string(),
+                last_dhcp: last_dhcp
+                    .map(|d| d.format("%F %T %Z").to_string())
+                    .unwrap_or_default(),
+                last_dhcp_rfc3339: last_dhcp.map(|d| d.to_rfc3339()).unwrap_or_default(),
+            })
+            .collect()
+    }
+}
+
+/// DHCP allocations page
+pub async fn dhcp_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+    let interfaces = match fetch_interfaces(state).await {
+        Ok(n) => n,
+        Err(err) => {
+            tracing::error!(%err, "find_interfaces for DHCP");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Error loading DHCP allocations",
+            )
+                .into_response();
+        }
+    };
+
+    let mut entries: Vec<DhcpEntryDisplay> = interfaces
+        .into_iter()
+        .flat_map(DhcpEntryDisplay::from_interface)
+        .collect();
+    entries.sort_by(|a, b| a.ip_address.cmp(&b.ip_address));
+
+    let tmpl = IpamDhcp {
+        entries,
+        lease_duration_secs: DhcpConfig::default().lease_time_secs as i64,
+    };
+    (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
+}
+
+pub async fn dhcp_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+    let interfaces = match fetch_interfaces(state).await {
+        Ok(n) => n,
+        Err(err) => {
+            tracing::error!(%err, "find_interfaces for DHCP JSON");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Error loading DHCP allocations",
+            )
+                .into_response();
+        }
+    };
+    (StatusCode::OK, Json(interfaces)).into_response()
+}
+
+async fn fetch_interfaces(api: Arc<Api>) -> Result<Vec<forgerpc::MachineInterface>, tonic::Status> {
+    let request = tonic::Request::new(forgerpc::InterfaceSearchQuery { id: None, ip: None });
+    let mut out = api
+        .find_interfaces(request)
+        .await
+        .map(|response| response.into_inner())?;
+    out.interfaces
+        .sort_unstable_by(|a, b| a.hostname.cmp(&b.hostname));
+    Ok(out.interfaces)
+}
+
+#[derive(Template)]
+#[template(path = "ipam_placeholder.html")]
+struct IpamPlaceholder {
+    section: &'static str,
+}
+
+/// DNS placeholder page
+pub async fn dns_html() -> Response {
+    let tmpl = IpamPlaceholder { section: "DNS" };
+    (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
+}
+
+/// Underlay Networks placeholder page
+pub async fn underlay_html() -> Response {
+    let tmpl = IpamPlaceholder {
+        section: "Underlay Networks",
+    };
+    (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
+}
+
+/// Overlay Networks placeholder page
+pub async fn overlay_html() -> Response {
+    let tmpl = IpamPlaceholder {
+        section: "Overlay Networks",
+    };
+    (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
+}

--- a/crates/api/src/web/mod.rs
+++ b/crates/api/src/web/mod.rs
@@ -68,6 +68,7 @@ mod ib_partition;
 mod instance;
 mod instance_type;
 mod interface;
+mod ipam;
 mod machine;
 mod machine_state_history;
 mod machine_validation;
@@ -337,6 +338,11 @@ pub fn routes(api: Arc<Api>) -> eyre::Result<NormalizePath<Router>> {
             .route("/interface", get(interface::show_html))
             .route("/interface.json", get(interface::show_all_json))
             .route("/interface/{interface_id}", get(interface::detail))
+            .route("/ipam/dhcp", get(ipam::dhcp_html))
+            .route("/ipam/dhcp.json", get(ipam::dhcp_json))
+            .route("/ipam/dns", get(ipam::dns_html))
+            .route("/ipam/underlay", get(ipam::underlay_html))
+            .route("/ipam/overlay", get(ipam::overlay_html))
             .route("/machine", get(machine::show_all_html))
             .route("/machine.json", get(machine::show_all_json))
             .route("/machine/{machine_id}", get(machine::detail))

--- a/crates/api/templates/base.html
+++ b/crates/api/templates/base.html
@@ -86,6 +86,15 @@
                         </ul>
 			<hr />
 
+			<h3>IPAM</h3>
+			<ul>
+				<li><a href="/admin/ipam/dhcp">DHCP</a></li>
+				<li><a href="/admin/ipam/dns">DNS</a></li>
+				<li><a href="/admin/ipam/underlay">Underlay Networks</a></li>
+				<li><a href="/admin/ipam/overlay">Overlay Networks</a></li>
+			</ul>
+			<hr />
+
 			<h3>Tenant Objects</h3>
 			<ul>
 				<li><a href="/admin/domain">Domains</a></li>

--- a/crates/api/templates/ipam_dhcp.html
+++ b/crates/api/templates/ipam_dhcp.html
@@ -1,0 +1,84 @@
+{% extends "base.html" %}
+
+{% block title %}IPAM / DHCP{% endblock %}
+
+{% block content %}
+<div id="json"><a id="json-link" href="">JSON</a></div>
+<h1>IPAM &rsaquo; DHCP Allocations</h1>
+<p>Showing {{ entries.len() }} address allocations. Default lease duration: {{ lease_duration_secs / 86400 }} days.</p>
+
+<table class="sortable overview">
+	<thead>
+		<tr>
+			<th>IP Address</th>
+			<th>MAC Address</th>
+			<th>Machine ID</th>
+			<th>Hostname</th>
+			<th>Created</th>
+			<th>Last DHCP Renew</th>
+			<th>Time Remaining</th>
+		</tr>
+	</thead>
+	<tbody>
+		{% for entry in entries %}
+			<tr>
+				<td><a href="/admin/search?q={{ entry.ip_address }}">{{ entry.ip_address }}</a></td>
+				<td>{{ entry.mac_address }}</td>
+				<td>{% if !entry.machine_id.is_empty() %}<a href="/admin/machine/{{ entry.machine_id }}">{{ entry.machine_id }}</a>{% endif %}</td>
+				<td>{{ entry.hostname }}</td>
+				<td><span onmouseover="setTitleToLocalizedTime(this)">{{ entry.created }}</span></td>
+				<td>
+					{% if !entry.last_dhcp.is_empty() %}
+						<span onmouseover="setTitleToLocalizedTime(this)">{{ entry.last_dhcp }}</span>
+					{% else %}
+						<span class="muted">Never</span>
+					{% endif %}
+				</td>
+				<td class="time-remaining" data-last-dhcp="{{ entry.last_dhcp_rfc3339 }}" data-lease-secs="{{ lease_duration_secs }}">
+					{% if entry.last_dhcp.is_empty() %}
+						<span class="muted">&mdash;</span>
+					{% endif %}
+				</td>
+			</tr>
+		{% endfor %}
+	</tbody>
+</table>
+{% endblock %}
+
+{% block script %}
+function computeTimeRemaining() {
+	const cells = document.querySelectorAll('.time-remaining');
+	const now = Date.now();
+	cells.forEach(cell => {
+		const lastDhcp = cell.getAttribute('data-last-dhcp');
+		const leaseSecs = parseInt(cell.getAttribute('data-lease-secs'), 10);
+		if (!lastDhcp) return;
+
+		const leaseStart = new Date(lastDhcp).getTime();
+		const leaseEnd = leaseStart + (leaseSecs * 1000);
+		const remaining = leaseEnd - now;
+
+		if (remaining <= 0) {
+			cell.innerHTML = '<span class="bubble error">Expired</span>';
+			return;
+		}
+
+		const days = Math.floor(remaining / 86400000);
+		const hours = Math.floor((remaining % 86400000) / 3600000);
+		const minutes = Math.floor((remaining % 3600000) / 60000);
+
+		let text = '';
+		if (days > 0) text += days + 'd ';
+		if (hours > 0 || days > 0) text += hours + 'h ';
+		text += minutes + 'm';
+
+		if (days < 1) {
+			cell.innerHTML = '<span class="bubble warning">' + text.trim() + '</span>';
+		} else {
+			cell.innerHTML = '<span class="bubble success">' + text.trim() + '</span>';
+		}
+	});
+}
+
+document.addEventListener("DOMContentLoaded", computeTimeRemaining);
+{% endblock %}

--- a/crates/api/templates/ipam_placeholder.html
+++ b/crates/api/templates/ipam_placeholder.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block title %}IPAM / {{ section }}{% endblock %}
+
+{% block content %}
+<h1>IPAM &rsaquo; {{ section }}</h1>
+<p>This section is under construction.</p>
+{% endblock %}


### PR DESCRIPTION
## Description

On numerous occasions, I have wanted to go into the admin UI to look at DHCP lease information directly, but it's not there.

And I wanted to do it again today. And as usual, it's not there.

And I was like well, if it's not there, we should add it.

But what else should we add?

And then I thought, you know, we probably could use an IPAM section in general, and have it be a place to look at:
- DHCP allocations (because we have `carbide-dhcp`).
- Authoritative DNS entries (because we have `carbide-dns`).
- Underlay networks/prefixes (because we manage those).
- Overlay networks/prefixes (and we manage those too).

Right now this is just taking care of the DHCP part, and I'm adding placeholders for DNS and networks.

DHCP details include:
```
struct DhcpEntryDisplay {
    ip_address: String,
    mac_address: String,
    machine_id: String,
    hostname: String,
    created: String,
    last_dhcp: String,
    last_dhcp_rfc3339: String,
}
```

I hope people like this idea, because it's going to make me a lot happier.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

