### PR TITLE
feat: add expected rack component details (rack, power shelf, switch) to the admin UI

### DIFF
--- a/crates/api-db/src/expected_power_shelf.rs
+++ b/crates/api-db/src/expected_power_shelf.rs
@@ -114,9 +114,14 @@ pub async fn find_all_linked(
  eps.serial_number,
  eps.bmc_mac_address,
  ps.id AS power_shelf_id,
- eps.expected_power_shelf_id
+ eps.expected_power_shelf_id,
+ host(ee.address) AS address,
+ eps.rack_id
 FROM expected_power_shelves eps
  LEFT JOIN power_shelves ps ON eps.serial_number = ps.config->>'name'
+ LEFT JOIN machine_interfaces mi ON eps.bmc_mac_address = mi.mac_address
+ LEFT JOIN machine_interface_addresses mia ON mi.id = mia.interface_id
+ LEFT JOIN explored_endpoints ee ON mia.address = ee.address
  ORDER BY eps.bmc_mac_address
  "#;
     sqlx::query_as(sql)

--- a/crates/api-db/src/expected_switch.rs
+++ b/crates/api-db/src/expected_switch.rs
@@ -121,9 +121,14 @@ pub async fn find_all_linked(txn: &mut PgConnection) -> DatabaseResult<Vec<Linke
   es.serial_number,
   es.bmc_mac_address,
   s.id AS switch_id,
-  es.expected_switch_id
+  es.expected_switch_id,
+  host(ee.address) AS address,
+  es.rack_id
  FROM expected_switches es
   LEFT JOIN switches s ON es.serial_number = s.config->>'name'
+  LEFT JOIN machine_interfaces mi ON es.bmc_mac_address = mi.mac_address
+  LEFT JOIN machine_interface_addresses mia ON mi.id = mia.interface_id
+  LEFT JOIN explored_endpoints ee ON mia.address = ee.address
   ORDER BY es.bmc_mac_address
   "#;
     sqlx::query_as(sql)

--- a/crates/api-model/src/expected_power_shelf.rs
+++ b/crates/api-model/src/expected_power_shelf.rs
@@ -126,6 +126,8 @@ pub struct LinkedExpectedPowerShelf {
     pub bmc_mac_address: MacAddress, // from expected_power_shelves table
     pub power_shelf_id: Option<PowerShelfId>, // The power shelf
     pub expected_power_shelf_id: Option<Uuid>, // The expected power shelf ID
+    pub address: Option<String>,     // The explored BMC endpoint IP
+    pub rack_id: Option<RackId>,     // The rack this power shelf belongs to
 }
 
 /// A request to identify an ExpectedPowerShelf by either ID or MAC address.
@@ -171,6 +173,8 @@ impl From<LinkedExpectedPowerShelf> for rpc::forge::LinkedExpectedPowerShelf {
             expected_power_shelf_id: l.expected_power_shelf_id.map(|id| ::rpc::common::Uuid {
                 value: id.to_string(),
             }),
+            explored_endpoint_address: l.address,
+            rack_id: l.rack_id,
         }
     }
 }

--- a/crates/api-model/src/expected_switch.rs
+++ b/crates/api-model/src/expected_switch.rs
@@ -121,6 +121,8 @@ pub struct LinkedExpectedSwitch {
     pub bmc_mac_address: MacAddress, // from expected_switches table
     pub switch_id: Option<SwitchId>, // The switch
     pub expected_switch_id: Option<Uuid>, // The expected switch ID
+    pub address: Option<String>,     // The explored BMC endpoint IP
+    pub rack_id: Option<RackId>,     // The rack this switch belongs to
 }
 
 /// A request to identify an ExpectedSwitch by either ID or MAC address.
@@ -166,6 +168,8 @@ impl From<LinkedExpectedSwitch> for rpc::forge::LinkedExpectedSwitch {
             expected_switch_id: l.expected_switch_id.map(|id| ::rpc::common::Uuid {
                 value: id.to_string(),
             }),
+            explored_endpoint_address: l.address,
+            rack_id: l.rack_id,
         }
     }
 }

--- a/crates/api/src/web/expected_power_shelf.rs
+++ b/crates/api/src/web/expected_power_shelf.rs
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use askama::Template;
+use axum::Json;
+use axum::extract::State as AxumState;
+use axum::response::{Html, IntoResponse, Response};
+use hyper::http::StatusCode;
+use rpc::forge::forge_server::Forge;
+
+use crate::api::Api;
+
+#[derive(Template)]
+#[template(path = "expected_power_shelf.html")]
+struct ExpectedPowerShelves {
+    power_shelves: Vec<ExpectedPowerShelfRow>,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct ExpectedPowerShelfRow {
+    serial_number: String,
+    bmc_mac_address: String,
+    rack_id: String,
+    explored_bmc_ip: String,
+    power_shelf_id: String,
+}
+
+/// Show all expected power shelves.
+pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
+    let power_shelves = match fetch_expected_power_shelves(&state).await {
+        Ok(shelves) => shelves,
+        Err((code, msg)) => return (code, msg).into_response(),
+    };
+    let display = ExpectedPowerShelves { power_shelves };
+    (StatusCode::OK, Html(display.render().unwrap())).into_response()
+}
+
+/// Show all expected power shelves as JSON.
+pub async fn show_json(state: AxumState<Arc<Api>>) -> Response {
+    let power_shelves = match fetch_expected_power_shelves(&state).await {
+        Ok(shelves) => shelves,
+        Err((code, msg)) => return (code, msg).into_response(),
+    };
+    (StatusCode::OK, Json(power_shelves)).into_response()
+}
+
+async fn fetch_expected_power_shelves(
+    api: &Api,
+) -> Result<Vec<ExpectedPowerShelfRow>, (http::StatusCode, String)> {
+    let response = match api
+        .get_all_expected_power_shelves_linked(tonic::Request::new(()))
+        .await
+    {
+        Ok(response) => response.into_inner(),
+        Err(err) => {
+            tracing::error!(%err, "get_all_expected_power_shelves_linked");
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to list expected power shelves".to_string(),
+            ));
+        }
+    };
+
+    let power_shelves = response
+        .expected_power_shelves
+        .into_iter()
+        .map(|eps| ExpectedPowerShelfRow {
+            serial_number: eps.shelf_serial_number,
+            bmc_mac_address: eps.bmc_mac_address,
+            rack_id: eps.rack_id.map(|id| id.to_string()).unwrap_or_default(),
+            explored_bmc_ip: eps.explored_endpoint_address.unwrap_or_default(),
+            power_shelf_id: eps
+                .power_shelf_id
+                .map(|id| id.to_string())
+                .unwrap_or_else(|| "Unlinked".to_string()),
+        })
+        .collect();
+
+    Ok(power_shelves)
+}

--- a/crates/api/src/web/expected_rack.rs
+++ b/crates/api/src/web/expected_rack.rs
@@ -1,0 +1,162 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use askama::Template;
+use axum::Json;
+use axum::extract::State as AxumState;
+use axum::response::{Html, IntoResponse, Response};
+use hyper::http::StatusCode;
+use rpc::forge::forge_server::Forge;
+
+use crate::api::Api;
+
+#[derive(Template)]
+#[template(path = "expected_rack.html")]
+struct ExpectedRacks {
+    racks: Vec<ExpectedRackRow>,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct ExpectedRackRow {
+    rack_id: String,
+    rack_type: String,
+    compute_trays: String,
+    switches: String,
+    power_shelves: String,
+}
+
+/// Show all expected racks.
+pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
+    let racks = match fetch_expected_racks(&state).await {
+        Ok(racks) => racks,
+        Err((code, msg)) => return (code, msg).into_response(),
+    };
+    let display = ExpectedRacks { racks };
+    (StatusCode::OK, Html(display.render().unwrap())).into_response()
+}
+
+/// Show all expected racks as JSON.
+pub async fn show_json(state: AxumState<Arc<Api>>) -> Response {
+    let racks = match fetch_expected_racks(&state).await {
+        Ok(racks) => racks,
+        Err((code, msg)) => return (code, msg).into_response(),
+    };
+    (StatusCode::OK, Json(racks)).into_response()
+}
+
+async fn fetch_expected_racks(
+    api: &Api,
+) -> Result<Vec<ExpectedRackRow>, (http::StatusCode, String)> {
+    let expected_response = match api.get_all_expected_racks(tonic::Request::new(())).await {
+        Ok(response) => response.into_inner(),
+        Err(err) => {
+            tracing::error!(%err, "get_all_expected_racks");
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to list expected racks".to_string(),
+            ));
+        }
+    };
+
+    let rack_response = match api
+        .get_rack(tonic::Request::new(rpc::forge::GetRackRequest { id: None }))
+        .await
+    {
+        Ok(response) => response.into_inner(),
+        Err(err) => {
+            tracing::error!(%err, "get_rack");
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to list racks".to_string(),
+            ));
+        }
+    };
+
+    // Index actual racks by their ID for quick lookup.
+    let racks_by_id: std::collections::HashMap<String, &rpc::forge::Rack> = rack_response
+        .rack
+        .iter()
+        .filter_map(|r| r.id.as_ref().map(|id| (id.to_string(), r)))
+        .collect();
+
+    let rows = expected_response
+        .expected_racks
+        .into_iter()
+        .map(|er| {
+            let rack_id = er
+                .rack_id
+                .as_ref()
+                .map(|id| id.to_string())
+                .unwrap_or_default();
+            let rack_type = er.rack_type;
+
+            // Look up capabilities from the rack type config.
+            let capabilities = api.runtime_config.rack_types.get(&rack_type);
+
+            // Look up the actual rack to count adopted devices.
+            let actual_rack = racks_by_id.get(&rack_id);
+
+            let compute_trays = match (actual_rack, capabilities) {
+                (Some(rack), Some(caps)) => {
+                    format!(
+                        "{}/{}",
+                        rack.expected_compute_trays.len(),
+                        caps.compute.count
+                    )
+                }
+                (None, Some(caps)) => format!("0/{}", caps.compute.count),
+                _ => "?/?".to_string(),
+            };
+
+            let switches = match (actual_rack, capabilities) {
+                (Some(rack), Some(caps)) => {
+                    format!(
+                        "{}/{}",
+                        rack.expected_nvlink_switches.len(),
+                        caps.switch.count
+                    )
+                }
+                (None, Some(caps)) => format!("0/{}", caps.switch.count),
+                _ => "?/?".to_string(),
+            };
+
+            let power_shelves = match (actual_rack, capabilities) {
+                (Some(rack), Some(caps)) => {
+                    format!(
+                        "{}/{}",
+                        rack.expected_power_shelves.len(),
+                        caps.power_shelf.count
+                    )
+                }
+                (None, Some(caps)) => format!("0/{}", caps.power_shelf.count),
+                _ => "?/?".to_string(),
+            };
+
+            ExpectedRackRow {
+                rack_id,
+                rack_type,
+                compute_trays,
+                switches,
+                power_shelves,
+            }
+        })
+        .collect();
+
+    Ok(rows)
+}

--- a/crates/api/src/web/expected_switch.rs
+++ b/crates/api/src/web/expected_switch.rs
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use askama::Template;
+use axum::Json;
+use axum::extract::State as AxumState;
+use axum::response::{Html, IntoResponse, Response};
+use hyper::http::StatusCode;
+use rpc::forge::forge_server::Forge;
+
+use crate::api::Api;
+
+#[derive(Template)]
+#[template(path = "expected_switch.html")]
+struct ExpectedSwitches {
+    switches: Vec<ExpectedSwitchRow>,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct ExpectedSwitchRow {
+    serial_number: String,
+    bmc_mac_address: String,
+    rack_id: String,
+    explored_bmc_ip: String,
+    switch_id: String,
+}
+
+/// Show all expected switches.
+pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
+    let switches = match fetch_expected_switches(&state).await {
+        Ok(switches) => switches,
+        Err((code, msg)) => return (code, msg).into_response(),
+    };
+    let display = ExpectedSwitches { switches };
+    (StatusCode::OK, Html(display.render().unwrap())).into_response()
+}
+
+/// Show all expected switches as JSON.
+pub async fn show_json(state: AxumState<Arc<Api>>) -> Response {
+    let switches = match fetch_expected_switches(&state).await {
+        Ok(switches) => switches,
+        Err((code, msg)) => return (code, msg).into_response(),
+    };
+    (StatusCode::OK, Json(switches)).into_response()
+}
+
+async fn fetch_expected_switches(
+    api: &Api,
+) -> Result<Vec<ExpectedSwitchRow>, (http::StatusCode, String)> {
+    let response = match api
+        .get_all_expected_switches_linked(tonic::Request::new(()))
+        .await
+    {
+        Ok(response) => response.into_inner(),
+        Err(err) => {
+            tracing::error!(%err, "get_all_expected_switches_linked");
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to list expected switches".to_string(),
+            ));
+        }
+    };
+
+    let switches = response
+        .expected_switches
+        .into_iter()
+        .map(|es| ExpectedSwitchRow {
+            serial_number: es.switch_serial_number,
+            bmc_mac_address: es.bmc_mac_address,
+            rack_id: es.rack_id.map(|id| id.to_string()).unwrap_or_default(),
+            explored_bmc_ip: es.explored_endpoint_address.unwrap_or_default(),
+            switch_id: es
+                .switch_id
+                .map(|id| id.to_string())
+                .unwrap_or_else(|| "Unlinked".to_string()),
+        })
+        .collect();
+
+    Ok(switches)
+}

--- a/crates/api/src/web/mod.rs
+++ b/crates/api/src/web/mod.rs
@@ -59,6 +59,9 @@ mod domain;
 mod dpa;
 mod dpu_versions;
 mod expected_machine;
+mod expected_power_shelf;
+mod expected_rack;
+mod expected_switch;
 mod explored_endpoint;
 mod filters;
 mod health;
@@ -418,6 +421,18 @@ pub fn routes(api: Arc<Api>) -> eyre::Result<NormalizePath<Router>> {
             .route(
                 "/expected-machine-definition.json",
                 get(expected_machine::show_expected_machine_raw_json),
+            )
+            .route("/expected-rack", get(expected_rack::show_html))
+            .route("/expected-rack.json", get(expected_rack::show_json))
+            .route("/expected-switch", get(expected_switch::show_html))
+            .route("/expected-switch.json", get(expected_switch::show_json))
+            .route(
+                "/expected-power-shelf",
+                get(expected_power_shelf::show_html),
+            )
+            .route(
+                "/expected-power-shelf.json",
+                get(expected_power_shelf::show_json),
             )
             .route("/network-device", get(network_device::show_html))
             .route("/network-device.json", get(network_device::show_all_json))

--- a/crates/api/templates/base.html
+++ b/crates/api/templates/base.html
@@ -21,16 +21,19 @@
 			<h3>Racks</h3>
 			<ul>
 				<li><a href="/admin/rack">Managed Racks</a></li>
+				<li><a href="/admin/expected-rack">Expected Racks</a></li>
 			</ul>
 			<hr />
 			<h3>Switches</h3>
 			<ul>
 				<li><a href="/admin/switch">Managed Switches</a></li>
+				<li><a href="/admin/expected-switch">Expected Switches</a></li>
 			</ul>
 			<hr />
 			<h3>Power Shelves</h3>
 			<ul>
 				<li><a href="/admin/power-shelf">Managed Power Shelves</a></li>
+				<li><a href="/admin/expected-power-shelf">Expected Power Shelves</a></li>
 			</ul>
 			<hr />
 			<h3>Machines</h3>

--- a/crates/api/templates/expected_power_shelf.html
+++ b/crates/api/templates/expected_power_shelf.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+
+{% block title %}Expected Power Shelves{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="row">
+        <div class="col">
+            <h1>Expected Power Shelves</h1>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col">
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="card-title mb-0">Expected Power Shelves</h5>
+                </div>
+                <div class="card-body">
+                    {% if !power_shelves.is_empty() %}
+                    <div class="table-responsive">
+                        <table class="table table-striped">
+                            <thead>
+                            <tr>
+                                <th>Serial Number</th>
+                                <th>BMC MAC Address</th>
+                                <th>Explored BMC IP</th>
+                                <th>Rack ID</th>
+                                <th>Linked Power Shelf</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {% for shelf in power_shelves %}
+                            <tr>
+                                <td>{{ shelf.serial_number }}</td>
+                                <td>{{ shelf.bmc_mac_address }}</td>
+                                <td>{{ shelf.explored_bmc_ip }}</td>
+                                <td>{{ shelf.rack_id }}</td>
+                                <td>{{ shelf.power_shelf_id }}</td>
+                            </tr>
+                            {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                    {% else %}
+                    <p class="text-muted">No expected power shelves found.</p>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/crates/api/templates/expected_rack.html
+++ b/crates/api/templates/expected_rack.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+
+{% block title %}Expected Racks{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="row">
+        <div class="col">
+            <h1>Expected Racks</h1>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col">
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="card-title mb-0">Expected Racks</h5>
+                </div>
+                <div class="card-body">
+                    {% if !racks.is_empty() %}
+                    <div class="table-responsive">
+                        <table class="table table-striped">
+                            <thead>
+                            <tr>
+                                <th>Rack ID</th>
+                                <th>Rack Type</th>
+                                <th>Compute Trays</th>
+                                <th>Switches</th>
+                                <th>Power Shelves</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {% for rack in racks %}
+                            <tr>
+                                <td>{{ rack.rack_id }}</td>
+                                <td>{{ rack.rack_type }}</td>
+                                <td>{{ rack.compute_trays }}</td>
+                                <td>{{ rack.switches }}</td>
+                                <td>{{ rack.power_shelves }}</td>
+                            </tr>
+                            {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                    {% else %}
+                    <p class="text-muted">No expected racks found.</p>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/crates/api/templates/expected_switch.html
+++ b/crates/api/templates/expected_switch.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+
+{% block title %}Expected Switches{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="row">
+        <div class="col">
+            <h1>Expected Switches</h1>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col">
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="card-title mb-0">Expected Switches</h5>
+                </div>
+                <div class="card-body">
+                    {% if !switches.is_empty() %}
+                    <div class="table-responsive">
+                        <table class="table table-striped">
+                            <thead>
+                            <tr>
+                                <th>Serial Number</th>
+                                <th>BMC MAC Address</th>
+                                <th>Explored BMC IP</th>
+                                <th>Rack ID</th>
+                                <th>Linked Switch</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {% for switch in switches %}
+                            <tr>
+                                <td>{{ switch.serial_number }}</td>
+                                <td>{{ switch.bmc_mac_address }}</td>
+                                <td>{{ switch.explored_bmc_ip }}</td>
+                                <td>{{ switch.rack_id }}</td>
+                                <td>{{ switch.switch_id }}</td>
+                            </tr>
+                            {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                    {% else %}
+                    <p class="text-muted">No expected switches found.</p>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1772,6 +1772,8 @@ message LinkedExpectedPowerShelf {
   string bmc_mac_address = 2; // from expected_power_shelves table
   optional common.PowerShelfId power_shelf_id = 3; // The power shelf
   optional common.UUID expected_power_shelf_id = 4;
+  optional string explored_endpoint_address = 5; // The explored BMC IP
+  optional common.RackId rack_id = 6;
 }
 
 // Describe the desired configuration of a Switch
@@ -1898,6 +1900,8 @@ message LinkedExpectedSwitch {
   string bmc_mac_address = 2; // from expected_switches table
   optional common.SwitchId switch_id = 3; // The switch
   optional common.UUID expected_switch_id = 4;
+  optional string explored_endpoint_address = 5; // The explored BMC IP
+  optional common.RackId rack_id = 6;
 }
 
 message ExpectedRack {


### PR DESCRIPTION
## Description

Now that we're starting to turn up rack components (`Rack`, `PowerShelf`, `Switch`) in Carbide, and since we have `ExpectedRack`, `ExpectedPowerShelf`, and `ExpectedSwitch`, it makes sense to have these available in the admin UI under the `Rack`, `Power Shelf`, and `Switch` sections, which right now just have managed ones, and not the expected details.

This adds all of that, including linked information, and the status of explored/adopted components.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

