### PR TITLE
chore(admin-cli): Args -> From/TryFrom -> Request

### DIFF
--- a/crates/admin-cli/src/compute_allocation/create/args.rs
+++ b/crates/admin-cli/src/compute_allocation/create/args.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use ::rpc::admin_cli::CarbideCliError;
+use ::rpc::forge::{self as forgerpc, CreateComputeAllocationRequest};
 use carbide_uuid::compute_allocation::ComputeAllocationId;
 use clap::Parser;
 
@@ -52,4 +54,33 @@ pub struct Args {
         help = "JSON map of simple key:value pairs to be applied as labels to the compute allocation"
     )]
     pub labels: Option<String>,
+}
+
+impl TryFrom<Args> for CreateComputeAllocationRequest {
+    type Error = CarbideCliError;
+
+    fn try_from(args: Args) -> Result<Self, Self::Error> {
+        let labels = if let Some(labels_json) = args.labels {
+            serde_json::from_str(&labels_json)?
+        } else {
+            vec![]
+        };
+
+        let metadata = forgerpc::Metadata {
+            name: args.name.unwrap_or_default(),
+            description: args.description.unwrap_or_default(),
+            labels,
+        };
+
+        Ok(CreateComputeAllocationRequest {
+            id: args.id,
+            tenant_organization_id: args.tenant_organization_id,
+            metadata: Some(metadata),
+            attributes: Some(forgerpc::ComputeAllocationAttributes {
+                instance_type_id: args.instance_type_id,
+                count: args.count,
+            }),
+            created_by: None,
+        })
+    }
 }

--- a/crates/admin-cli/src/compute_allocation/create/cmd.rs
+++ b/crates/admin-cli/src/compute_allocation/create/cmd.rs
@@ -16,9 +16,7 @@
  */
 
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
-use ::rpc::forge::{
-    CreateComputeAllocationRequest, {self as forgerpc},
-};
+use ::rpc::forge::CreateComputeAllocationRequest;
 
 use super::args::Args;
 use crate::compute_allocation::common::convert_compute_allocations_to_table;
@@ -32,31 +30,8 @@ pub async fn create(
     output_format: OutputFormat,
     api_client: &ApiClient,
 ) -> CarbideCliResult<()> {
-    let labels = if let Some(labels_json) = args.labels {
-        serde_json::from_str(&labels_json)?
-    } else {
-        vec![]
-    };
-
-    let metadata = forgerpc::Metadata {
-        name: args.name.unwrap_or_default(),
-        description: args.description.unwrap_or_default(),
-        labels,
-    };
-
-    let allocation = api_client
-        .0
-        .create_compute_allocation(CreateComputeAllocationRequest {
-            id: args.id,
-            tenant_organization_id: args.tenant_organization_id,
-            metadata: Some(metadata),
-            attributes: Some(forgerpc::ComputeAllocationAttributes {
-                instance_type_id: args.instance_type_id,
-                count: args.count,
-            }),
-            created_by: None,
-        })
-        .await?;
+    let req: CreateComputeAllocationRequest = args.try_into()?;
+    let allocation = api_client.0.create_compute_allocation(req).await?;
     let allocation = allocation.allocation.ok_or(CarbideCliError::Empty)?;
 
     match output_format {

--- a/crates/admin-cli/src/compute_allocation/delete/args.rs
+++ b/crates/admin-cli/src/compute_allocation/delete/args.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use ::rpc::forge::DeleteComputeAllocationRequest;
 use carbide_uuid::compute_allocation::ComputeAllocationId;
 use clap::Parser;
 
@@ -29,4 +30,13 @@ pub struct Args {
         help = "Tenant organization ID for the compute allocation"
     )]
     pub tenant_organization_id: String,
+}
+
+impl From<Args> for DeleteComputeAllocationRequest {
+    fn from(args: Args) -> Self {
+        DeleteComputeAllocationRequest {
+            id: Some(args.id),
+            tenant_organization_id: args.tenant_organization_id,
+        }
+    }
 }

--- a/crates/admin-cli/src/compute_allocation/delete/cmd.rs
+++ b/crates/admin-cli/src/compute_allocation/delete/cmd.rs
@@ -23,13 +23,9 @@ use crate::rpc::ApiClient;
 
 /// Delete a compute allocation.
 pub async fn delete(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    api_client
-        .0
-        .delete_compute_allocation(DeleteComputeAllocationRequest {
-            id: Some(args.id),
-            tenant_organization_id: args.tenant_organization_id,
-        })
-        .await?;
-    println!("Deleted compute allocation {} successfully.", args.id);
+    let id = args.id;
+    let req: DeleteComputeAllocationRequest = args.into();
+    api_client.0.delete_compute_allocation(req).await?;
+    println!("Deleted compute allocation {} successfully.", id);
     Ok(())
 }

--- a/crates/admin-cli/src/compute_allocation/show/args.rs
+++ b/crates/admin-cli/src/compute_allocation/show/args.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use ::rpc::forge::FindComputeAllocationIdsRequest;
 use carbide_uuid::compute_allocation::ComputeAllocationId;
 use clap::Parser;
 
@@ -39,4 +40,14 @@ pub struct Args {
 
     #[clap(long, help = "Optional, instance type ID used to filter results")]
     pub instance_type_id: Option<String>,
+}
+
+impl From<Args> for FindComputeAllocationIdsRequest {
+    fn from(args: Args) -> Self {
+        FindComputeAllocationIdsRequest {
+            name: args.name,
+            tenant_organization_id: args.tenant_organization_id,
+            instance_type_id: args.instance_type_id,
+        }
+    }
 }

--- a/crates/admin-cli/src/compute_allocation/show/cmd.rs
+++ b/crates/admin-cli/src/compute_allocation/show/cmd.rs
@@ -39,15 +39,8 @@ pub async fn show(
             .await?
             .allocations
     } else {
-        let all_ids = api_client
-            .0
-            .find_compute_allocation_ids(FindComputeAllocationIdsRequest {
-                name: args.name,
-                tenant_organization_id: args.tenant_organization_id,
-                instance_type_id: args.instance_type_id,
-            })
-            .await?
-            .ids;
+        let req: FindComputeAllocationIdsRequest = args.into();
+        let all_ids = api_client.0.find_compute_allocation_ids(req).await?.ids;
 
         let mut allocations = Vec::with_capacity(all_ids.len());
 

--- a/crates/admin-cli/src/credential/add_bmc/args.rs
+++ b/crates/admin-cli/src/credential/add_bmc/args.rs
@@ -17,8 +17,10 @@
 
 use clap::Parser;
 use mac_address::MacAddress;
+use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+use rpc::{CredentialType, forge as forgerpc};
 
-use crate::credential::common::BmcCredentialType;
+use crate::credential::common::{BmcCredentialType, password_validator};
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
@@ -35,4 +37,18 @@ pub struct Args {
     pub username: Option<String>,
     #[clap(long, help = "The MAC address of the BMC")]
     pub mac_address: Option<MacAddress>,
+}
+
+impl TryFrom<Args> for forgerpc::CredentialCreationRequest {
+    type Error = CarbideCliError;
+    fn try_from(args: Args) -> CarbideCliResult<Self> {
+        let password = password_validator(args.password)?;
+        Ok(Self {
+            credential_type: CredentialType::from(args.kind).into(),
+            username: args.username,
+            password,
+            mac_address: args.mac_address.map(|mac| mac.to_string()),
+            vendor: None,
+        })
+    }
 }

--- a/crates/admin-cli/src/credential/add_bmc/cmd.rs
+++ b/crates/admin-cli/src/credential/add_bmc/cmd.rs
@@ -16,21 +16,13 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::{CredentialType, forge as forgerpc};
+use ::rpc::forge as forgerpc;
 
 use super::args::Args;
-use crate::credential::common::password_validator;
 use crate::rpc::ApiClient;
 
-pub async fn add_bmc(c: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let password = password_validator(c.password)?;
-    let req = forgerpc::CredentialCreationRequest {
-        credential_type: CredentialType::from(c.kind).into(),
-        username: c.username,
-        password,
-        mac_address: c.mac_address.map(|mac| mac.to_string()),
-        vendor: None,
-    };
+pub async fn add_bmc(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let req: forgerpc::CredentialCreationRequest = data.try_into()?;
     api_client.0.create_credential(req).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/credential/add_dpu_factory_default/args.rs
+++ b/crates/admin-cli/src/credential/add_dpu_factory_default/args.rs
@@ -16,6 +16,7 @@
  */
 
 use clap::Parser;
+use rpc::{CredentialType, forge as forgerpc};
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
@@ -23,4 +24,16 @@ pub struct Args {
     pub username: String,
     #[clap(long, required(true), help = "DPU manufacturer default password")]
     pub password: String,
+}
+
+impl From<Args> for forgerpc::CredentialCreationRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            credential_type: CredentialType::DpuBmcFactoryDefault.into(),
+            username: Some(args.username),
+            password: args.password,
+            mac_address: None,
+            vendor: None,
+        }
+    }
 }

--- a/crates/admin-cli/src/credential/add_dpu_factory_default/cmd.rs
+++ b/crates/admin-cli/src/credential/add_dpu_factory_default/cmd.rs
@@ -16,19 +16,13 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::{CredentialType, forge as forgerpc};
+use ::rpc::forge as forgerpc;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
-pub async fn add_dpu_factory_default(c: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let req = forgerpc::CredentialCreationRequest {
-        credential_type: CredentialType::DpuBmcFactoryDefault.into(),
-        username: Some(c.username),
-        password: c.password,
-        mac_address: None,
-        vendor: None,
-    };
+pub async fn add_dpu_factory_default(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let req: forgerpc::CredentialCreationRequest = data.into();
     api_client.0.create_credential(req).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/credential/add_host_factory_default/args.rs
+++ b/crates/admin-cli/src/credential/add_host_factory_default/args.rs
@@ -16,6 +16,7 @@
  */
 
 use clap::Parser;
+use rpc::{CredentialType, forge as forgerpc};
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
@@ -25,4 +26,16 @@ pub struct Args {
     pub password: String,
     #[clap(long, required(true))]
     pub vendor: bmc_vendor::BMCVendor,
+}
+
+impl From<Args> for forgerpc::CredentialCreationRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            credential_type: CredentialType::HostBmcFactoryDefault.into(),
+            username: Some(args.username),
+            password: args.password,
+            mac_address: None,
+            vendor: Some(args.vendor.to_string()),
+        }
+    }
 }

--- a/crates/admin-cli/src/credential/add_host_factory_default/cmd.rs
+++ b/crates/admin-cli/src/credential/add_host_factory_default/cmd.rs
@@ -16,19 +16,13 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::{CredentialType, forge as forgerpc};
+use ::rpc::forge as forgerpc;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
-pub async fn add_host_factory_default(c: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let req = forgerpc::CredentialCreationRequest {
-        credential_type: CredentialType::HostBmcFactoryDefault.into(),
-        username: Some(c.username),
-        password: c.password,
-        mac_address: None,
-        vendor: Some(c.vendor.to_string()),
-    };
+pub async fn add_host_factory_default(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let req: forgerpc::CredentialCreationRequest = data.into();
     api_client.0.create_credential(req).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/credential/add_nmxm/args.rs
+++ b/crates/admin-cli/src/credential/add_nmxm/args.rs
@@ -16,6 +16,7 @@
  */
 
 use clap::Parser;
+use rpc::{CredentialType, forge as forgerpc};
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
@@ -23,4 +24,16 @@ pub struct Args {
     pub username: String,
     #[clap(long, required(true), help = "password")]
     pub password: String,
+}
+
+impl From<Args> for forgerpc::CredentialCreationRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            credential_type: CredentialType::NmxM.into(),
+            username: Some(args.username),
+            password: args.password,
+            mac_address: None,
+            vendor: None,
+        }
+    }
 }

--- a/crates/admin-cli/src/credential/add_nmxm/cmd.rs
+++ b/crates/admin-cli/src/credential/add_nmxm/cmd.rs
@@ -16,19 +16,13 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::{CredentialType, forge as forgerpc};
+use ::rpc::forge as forgerpc;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
-pub async fn add_nmxm(c: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let req = forgerpc::CredentialCreationRequest {
-        credential_type: CredentialType::NmxM.into(),
-        username: Some(c.username),
-        password: c.password,
-        mac_address: None,
-        vendor: None,
-    };
+pub async fn add_nmxm(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let req: forgerpc::CredentialCreationRequest = data.into();
     api_client.0.create_credential(req).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/credential/add_uefi/args.rs
+++ b/crates/admin-cli/src/credential/add_uefi/args.rs
@@ -16,8 +16,10 @@
  */
 
 use clap::Parser;
+use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+use rpc::{CredentialType, forge as forgerpc};
 
-use crate::credential::common::UefiCredentialType;
+use crate::credential::common::{UefiCredentialType, password_validator};
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
@@ -26,4 +28,21 @@ pub struct Args {
 
     #[clap(long, require_equals(true), help = "The UEFI password")]
     pub password: String,
+}
+
+impl TryFrom<Args> for forgerpc::CredentialCreationRequest {
+    type Error = CarbideCliError;
+    fn try_from(args: Args) -> CarbideCliResult<Self> {
+        let mut password = password_validator(args.password)?;
+        if password.is_empty() {
+            password = forge_secrets::credentials::Credentials::generate_password_no_special_char();
+        }
+        Ok(Self {
+            credential_type: CredentialType::from(args.kind).into(),
+            username: None,
+            password,
+            mac_address: None,
+            vendor: None,
+        })
+    }
 }

--- a/crates/admin-cli/src/credential/add_uefi/cmd.rs
+++ b/crates/admin-cli/src/credential/add_uefi/cmd.rs
@@ -16,26 +16,13 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::{CredentialType, forge as forgerpc};
-use forge_secrets::credentials::Credentials;
+use ::rpc::forge as forgerpc;
 
 use super::args::Args;
-use crate::credential::common::password_validator;
 use crate::rpc::ApiClient;
 
-pub async fn add_uefi(c: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let mut password = password_validator(c.password)?;
-    if password.is_empty() {
-        password = Credentials::generate_password_no_special_char();
-    }
-
-    let req = forgerpc::CredentialCreationRequest {
-        credential_type: CredentialType::from(c.kind).into(),
-        username: None,
-        password,
-        mac_address: None,
-        vendor: None,
-    };
+pub async fn add_uefi(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let req: forgerpc::CredentialCreationRequest = data.try_into()?;
     api_client.0.create_credential(req).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/credential/add_ufm/args.rs
+++ b/crates/admin-cli/src/credential/add_ufm/args.rs
@@ -16,6 +16,10 @@
  */
 
 use clap::Parser;
+use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+use rpc::{CredentialType, forge as forgerpc};
+
+use crate::credential::common::url_validator;
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
@@ -24,4 +28,18 @@ pub struct Args {
 
     #[clap(long, default_value(""), help = "The UFM token")]
     pub token: String,
+}
+
+impl TryFrom<Args> for forgerpc::CredentialCreationRequest {
+    type Error = CarbideCliError;
+    fn try_from(args: Args) -> CarbideCliResult<Self> {
+        let username = url_validator(args.url)?;
+        Ok(Self {
+            credential_type: CredentialType::Ufm.into(),
+            username: Some(username),
+            password: args.token,
+            mac_address: None,
+            vendor: None,
+        })
+    }
 }

--- a/crates/admin-cli/src/credential/add_ufm/cmd.rs
+++ b/crates/admin-cli/src/credential/add_ufm/cmd.rs
@@ -16,22 +16,13 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::{CredentialType, forge as forgerpc};
+use ::rpc::forge as forgerpc;
 
 use super::args::Args;
-use crate::credential::common::url_validator;
 use crate::rpc::ApiClient;
 
-pub async fn add_ufm(c: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let username = url_validator(c.url)?;
-    let password = c.token;
-    let req = forgerpc::CredentialCreationRequest {
-        credential_type: CredentialType::Ufm.into(),
-        username: Some(username),
-        password,
-        mac_address: None,
-        vendor: None,
-    };
+pub async fn add_ufm(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let req: forgerpc::CredentialCreationRequest = data.try_into()?;
     api_client.0.create_credential(req).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/credential/delete_bmc/args.rs
+++ b/crates/admin-cli/src/credential/delete_bmc/args.rs
@@ -17,6 +17,7 @@
 
 use clap::Parser;
 use mac_address::MacAddress;
+use rpc::{CredentialType, forge as forgerpc};
 
 use crate::credential::common::BmcCredentialType;
 
@@ -31,4 +32,14 @@ pub struct Args {
     pub kind: BmcCredentialType,
     #[clap(long, help = "The MAC address of the BMC")]
     pub mac_address: Option<MacAddress>,
+}
+
+impl From<Args> for forgerpc::CredentialDeletionRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            credential_type: CredentialType::from(args.kind).into(),
+            username: None,
+            mac_address: args.mac_address.map(|mac| mac.to_string()),
+        }
+    }
 }

--- a/crates/admin-cli/src/credential/delete_bmc/cmd.rs
+++ b/crates/admin-cli/src/credential/delete_bmc/cmd.rs
@@ -16,17 +16,13 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::{CredentialType, forge as forgerpc};
+use ::rpc::forge as forgerpc;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
-pub async fn delete_bmc(c: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let req = forgerpc::CredentialDeletionRequest {
-        credential_type: CredentialType::from(c.kind).into(),
-        username: None,
-        mac_address: c.mac_address.map(|mac| mac.to_string()),
-    };
+pub async fn delete_bmc(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let req: forgerpc::CredentialDeletionRequest = data.into();
     api_client.0.delete_credential(req).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/credential/delete_nmxm/args.rs
+++ b/crates/admin-cli/src/credential/delete_nmxm/args.rs
@@ -16,9 +16,20 @@
  */
 
 use clap::Parser;
+use rpc::{CredentialType, forge as forgerpc};
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
     #[clap(long, required(true), help = "NmxM url")]
     pub username: String,
+}
+
+impl From<Args> for forgerpc::CredentialDeletionRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            credential_type: CredentialType::NmxM.into(),
+            username: Some(args.username),
+            mac_address: None,
+        }
+    }
 }

--- a/crates/admin-cli/src/credential/delete_nmxm/cmd.rs
+++ b/crates/admin-cli/src/credential/delete_nmxm/cmd.rs
@@ -16,17 +16,13 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::{CredentialType, forge as forgerpc};
+use ::rpc::forge as forgerpc;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
-pub async fn delete_nmxm(c: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let req = forgerpc::CredentialDeletionRequest {
-        credential_type: CredentialType::NmxM.into(),
-        username: Some(c.username),
-        mac_address: None,
-    };
+pub async fn delete_nmxm(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let req: forgerpc::CredentialDeletionRequest = data.into();
     api_client.0.delete_credential(req).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/credential/delete_ufm/args.rs
+++ b/crates/admin-cli/src/credential/delete_ufm/args.rs
@@ -16,9 +16,25 @@
  */
 
 use clap::Parser;
+use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+use rpc::{CredentialType, forge as forgerpc};
+
+use crate::credential::common::url_validator;
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
     #[clap(long, required(true), help = "The UFM url")]
     pub url: String,
+}
+
+impl TryFrom<Args> for forgerpc::CredentialDeletionRequest {
+    type Error = CarbideCliError;
+    fn try_from(args: Args) -> CarbideCliResult<Self> {
+        let username = url_validator(args.url)?;
+        Ok(Self {
+            credential_type: CredentialType::Ufm.into(),
+            username: Some(username),
+            mac_address: None,
+        })
+    }
 }

--- a/crates/admin-cli/src/credential/delete_ufm/cmd.rs
+++ b/crates/admin-cli/src/credential/delete_ufm/cmd.rs
@@ -16,19 +16,13 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::{CredentialType, forge as forgerpc};
+use ::rpc::forge as forgerpc;
 
 use super::args::Args;
-use crate::credential::common::url_validator;
 use crate::rpc::ApiClient;
 
-pub async fn delete_ufm(c: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let username = url_validator(c.url)?;
-    let req = forgerpc::CredentialDeletionRequest {
-        credential_type: CredentialType::Ufm.into(),
-        username: Some(username),
-        mac_address: None,
-    };
+pub async fn delete_ufm(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let req: forgerpc::CredentialDeletionRequest = data.try_into()?;
     api_client.0.delete_credential(req).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/extension_service/create/args.rs
+++ b/crates/admin-cli/src/extension_service/create/args.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+use ::rpc::forge::dpu_extension_service_credential::Type;
 use clap::Parser;
 
 use super::super::common::ExtensionServiceType;
@@ -57,4 +59,51 @@ pub struct Args {
         help = "JSON array containing a defined set of extension observability configs (optional)"
     )]
     pub observability: Option<String>,
+}
+
+impl TryFrom<Args> for ::rpc::forge::CreateDpuExtensionServiceRequest {
+    type Error = CarbideCliError;
+
+    fn try_from(args: Args) -> CarbideCliResult<Self> {
+        let credential =
+            if args.username.is_some() || args.password.is_some() || args.registry_url.is_some() {
+                if args.username.is_none() || args.password.is_none() || args.registry_url.is_none()
+                {
+                    return Err(CarbideCliError::GenericError(
+                    "All of username, password and registry URL are required to create credential"
+                        .to_string(),
+                ));
+                }
+
+                Some(::rpc::forge::DpuExtensionServiceCredential {
+                    registry_url: args.registry_url.unwrap_or_default(),
+                    r#type: Some(Type::UsernamePassword(rpc::forge::UsernamePassword {
+                        username: args.username.unwrap_or_default(),
+                        password: args.password.unwrap_or_default(),
+                    })),
+                })
+            } else {
+                None
+            };
+
+        let observability: Vec<::rpc::forge::DpuExtensionServiceObservabilityConfig> =
+            if let Some(r) = args.observability {
+                serde_json::from_str(&r)?
+            } else {
+                vec![]
+            };
+
+        Ok(Self {
+            service_id: args.service_id,
+            service_name: args.service_name,
+            service_type: args.service_type as i32,
+            tenant_organization_id: args.tenant_organization_id.unwrap_or_default(),
+            data: args.data,
+            description: args.description,
+            credential,
+            observability: Some(::rpc::forge::DpuExtensionServiceObservability {
+                configs: observability,
+            }),
+        })
+    }
 }

--- a/crates/admin-cli/src/extension_service/create/cmd.rs
+++ b/crates/admin-cli/src/extension_service/create/cmd.rs
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
+use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::admin_cli::output::OutputFormat;
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
-use ::rpc::forge::dpu_extension_service_credential::Type;
+use ::rpc::forge::CreateDpuExtensionServiceRequest;
 
 use super::super::show::cmd::convert_extension_services_to_table;
 use super::args::Args;
@@ -30,45 +30,8 @@ pub async fn handle_create(
 ) -> CarbideCliResult<()> {
     let is_json = output_format == OutputFormat::Json;
 
-    let credential =
-        if args.username.is_some() || args.password.is_some() || args.registry_url.is_some() {
-            // This check is for KubernetesPod service credentials, must be modified if we add more service types
-            if args.username.is_none() || args.password.is_none() || args.registry_url.is_none() {
-                return Err(CarbideCliError::GenericError(
-                    "All of username, password and registry URL are required to create credential"
-                        .to_string(),
-                ));
-            }
-
-            Some(::rpc::forge::DpuExtensionServiceCredential {
-                registry_url: args.registry_url.unwrap_or_default(),
-                r#type: Some(Type::UsernamePassword(rpc::forge::UsernamePassword {
-                    username: args.username.unwrap_or_default(),
-                    password: args.password.unwrap_or_default(),
-                })),
-            })
-        } else {
-            None
-        };
-
-    let observability = if let Some(r) = args.observability {
-        serde_json::from_str(&r)?
-    } else {
-        vec![]
-    };
-
-    let extension_service = api_client
-        .create_extension_service(
-            args.service_id,
-            args.service_name,
-            args.tenant_organization_id.unwrap_or_default(),
-            args.service_type as i32,
-            args.description,
-            args.data,
-            credential,
-            observability,
-        )
-        .await?;
+    let req: CreateDpuExtensionServiceRequest = args.try_into()?;
+    let extension_service = api_client.0.create_dpu_extension_service(req).await?;
 
     if is_json {
         println!("{}", serde_json::to_string_pretty(&extension_service)?);

--- a/crates/admin-cli/src/extension_service/delete/args.rs
+++ b/crates/admin-cli/src/extension_service/delete/args.rs
@@ -30,3 +30,12 @@ pub struct Args {
     )]
     pub versions: Vec<String>,
 }
+
+impl From<Args> for ::rpc::forge::DeleteDpuExtensionServiceRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            service_id: args.service_id,
+            versions: args.versions,
+        }
+    }
+}

--- a/crates/admin-cli/src/extension_service/delete/cmd.rs
+++ b/crates/admin-cli/src/extension_service/delete/cmd.rs
@@ -27,13 +27,8 @@ pub async fn handle_delete(
     _output_format: OutputFormat,
     api_client: &ApiClient,
 ) -> CarbideCliResult<()> {
-    api_client
-        .0
-        .delete_dpu_extension_service(DeleteDpuExtensionServiceRequest {
-            service_id: args.service_id,
-            versions: args.versions,
-        })
-        .await?;
+    let req: DeleteDpuExtensionServiceRequest = args.into();
+    api_client.0.delete_dpu_extension_service(req).await?;
 
     println!("Delete successful");
     Ok(())

--- a/crates/admin-cli/src/extension_service/get_version/args.rs
+++ b/crates/admin-cli/src/extension_service/get_version/args.rs
@@ -30,3 +30,12 @@ pub struct Args {
     )]
     pub versions: Vec<String>,
 }
+
+impl From<Args> for ::rpc::forge::GetDpuExtensionServiceVersionsInfoRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            service_id: args.service_id,
+            versions: args.versions,
+        }
+    }
+}

--- a/crates/admin-cli/src/extension_service/get_version/cmd.rs
+++ b/crates/admin-cli/src/extension_service/get_version/cmd.rs
@@ -22,12 +22,10 @@ use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn handle_get_version(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let req: GetDpuExtensionServiceVersionsInfoRequest = args.into();
     let versions = api_client
         .0
-        .get_dpu_extension_service_versions_info(GetDpuExtensionServiceVersionsInfoRequest {
-            service_id: args.service_id,
-            versions: args.versions,
-        })
+        .get_dpu_extension_service_versions_info(req)
         .await?;
 
     println!("{}", serde_json::to_string_pretty(&versions.version_infos)?);

--- a/crates/admin-cli/src/extension_service/show_instances/args.rs
+++ b/crates/admin-cli/src/extension_service/show_instances/args.rs
@@ -25,3 +25,12 @@ pub struct Args {
     #[clap(short = 'v', long, help = "Version string to filter by (optional)")]
     pub version: Option<String>,
 }
+
+impl From<Args> for ::rpc::forge::FindInstancesByDpuExtensionServiceRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            service_id: args.service_id,
+            version: args.version,
+        }
+    }
+}

--- a/crates/admin-cli/src/extension_service/show_instances/cmd.rs
+++ b/crates/admin-cli/src/extension_service/show_instances/cmd.rs
@@ -30,12 +30,10 @@ pub async fn handle_show_instances(
 ) -> CarbideCliResult<()> {
     let is_json = output_format == OutputFormat::Json;
 
+    let req: FindInstancesByDpuExtensionServiceRequest = args.into();
     let response = api_client
         .0
-        .find_instances_by_dpu_extension_service(FindInstancesByDpuExtensionServiceRequest {
-            service_id: args.service_id,
-            version: args.version,
-        })
+        .find_instances_by_dpu_extension_service(req)
         .await?;
 
     if is_json {

--- a/crates/admin-cli/src/extension_service/update/args.rs
+++ b/crates/admin-cli/src/extension_service/update/args.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+use ::rpc::forge::dpu_extension_service_credential::Type;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
@@ -63,4 +65,50 @@ pub struct Args {
         help = "JSON array containing a defined set of extension observability configs (optional)"
     )]
     pub observability: Option<String>,
+}
+
+impl TryFrom<Args> for ::rpc::forge::UpdateDpuExtensionServiceRequest {
+    type Error = CarbideCliError;
+
+    fn try_from(args: Args) -> CarbideCliResult<Self> {
+        let credential =
+            if args.username.is_some() || args.password.is_some() || args.registry_url.is_some() {
+                if args.username.is_none() || args.password.is_none() || args.registry_url.is_none()
+                {
+                    return Err(CarbideCliError::GenericError(
+                    "All of username, password and registry URL are required to create credential"
+                        .to_string(),
+                ));
+                }
+
+                Some(::rpc::forge::DpuExtensionServiceCredential {
+                    registry_url: args.registry_url.unwrap(),
+                    r#type: Some(Type::UsernamePassword(rpc::forge::UsernamePassword {
+                        username: args.username.unwrap(),
+                        password: args.password.unwrap(),
+                    })),
+                })
+            } else {
+                None
+            };
+
+        let observability: Vec<::rpc::forge::DpuExtensionServiceObservabilityConfig> =
+            if let Some(r) = args.observability {
+                serde_json::from_str(&r)?
+            } else {
+                vec![]
+            };
+
+        Ok(Self {
+            service_id: args.service_id,
+            service_name: args.service_name,
+            description: args.description,
+            data: args.data,
+            credential,
+            if_version_ctr_match: args.if_version_ctr_match,
+            observability: Some(::rpc::forge::DpuExtensionServiceObservability {
+                configs: observability,
+            }),
+        })
+    }
 }

--- a/crates/admin-cli/src/extension_service/update/cmd.rs
+++ b/crates/admin-cli/src/extension_service/update/cmd.rs
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
+use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::admin_cli::output::OutputFormat;
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
-use ::rpc::forge::dpu_extension_service_credential::Type;
+use ::rpc::forge::UpdateDpuExtensionServiceRequest;
 
 use super::super::show::cmd::convert_extension_services_to_table;
 use super::args::Args;
@@ -30,43 +30,8 @@ pub async fn handle_update(
 ) -> CarbideCliResult<()> {
     let is_json = output_format == OutputFormat::Json;
 
-    let credential =
-        if args.username.is_some() || args.password.is_some() || args.registry_url.is_some() {
-            if args.username.is_none() || args.password.is_none() || args.registry_url.is_none() {
-                return Err(CarbideCliError::GenericError(
-                    "All of username, password and registry URL are required to create credential"
-                        .to_string(),
-                ));
-            }
-
-            Some(::rpc::forge::DpuExtensionServiceCredential {
-                registry_url: args.registry_url.unwrap(),
-                r#type: Some(Type::UsernamePassword(rpc::forge::UsernamePassword {
-                    username: args.username.unwrap(),
-                    password: args.password.unwrap(),
-                })),
-            })
-        } else {
-            None
-        };
-
-    let observability = if let Some(r) = args.observability {
-        serde_json::from_str(&r)?
-    } else {
-        vec![]
-    };
-
-    let extension_service = api_client
-        .update_extension_service(
-            args.service_id,
-            args.service_name,
-            args.description,
-            args.data,
-            credential,
-            observability,
-            args.if_version_ctr_match,
-        )
-        .await?;
+    let req: UpdateDpuExtensionServiceRequest = args.try_into()?;
+    let extension_service = api_client.0.update_dpu_extension_service(req).await?;
 
     if is_json {
         println!("{}", serde_json::to_string_pretty(&extension_service)?);

--- a/crates/admin-cli/src/host/clear_uefi_password/args.rs
+++ b/crates/admin-cli/src/host/clear_uefi_password/args.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use ::rpc::forge::ClearHostUefiPasswordRequest;
 use clap::Parser;
 
 use crate::machine::MachineQuery;
@@ -26,4 +27,13 @@ use crate::machine::MachineQuery;
 pub struct Args {
     #[clap(flatten)]
     pub inner: MachineQuery,
+}
+
+impl From<Args> for ClearHostUefiPasswordRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            host_id: None,
+            machine_query: Some(args.inner.query),
+        }
+    }
 }

--- a/crates/admin-cli/src/host/clear_uefi_password/cmd.rs
+++ b/crates/admin-cli/src/host/clear_uefi_password/cmd.rs
@@ -18,20 +18,14 @@
 use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge::ClearHostUefiPasswordRequest;
 
-use crate::machine::MachineQuery;
+use super::args::Args;
 use crate::rpc::ApiClient;
 
-pub async fn clear_uefi_password(
-    query: MachineQuery,
-    api_client: &ApiClient,
-) -> CarbideCliResult<()> {
-    let request = ClearHostUefiPasswordRequest {
-        host_id: None,
-        machine_query: Some(query.query.clone()),
-    };
-    let response = api_client.0.clear_host_uefi_password(request).await?;
+pub async fn clear_uefi_password(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let req: ClearHostUefiPasswordRequest = data.into();
+    let response = api_client.0.clear_host_uefi_password(req).await?;
     println!(
-        "successfully cleared UEFI password for host {query:#?}; (jid: {:#?})",
+        "successfully cleared UEFI password for host (jid: {:#?})",
         response.job_id
     );
     Ok(())

--- a/crates/admin-cli/src/host/clear_uefi_password/mod.rs
+++ b/crates/admin-cli/src/host/clear_uefi_password/mod.rs
@@ -26,6 +26,6 @@ use crate::cfg::runtime::RuntimeContext;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
-        cmd::clear_uefi_password(self.inner, &ctx.api_client).await
+        cmd::clear_uefi_password(self, &ctx.api_client).await
     }
 }

--- a/crates/admin-cli/src/host/reprovision/args.rs
+++ b/crates/admin-cli/src/host/reprovision/args.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use ::rpc::forge::host_reprovisioning_request::Mode;
+use ::rpc::forge::{HostReprovisioningRequest, UpdateInitiator};
 use carbide_uuid::machine::MachineId;
 use clap::Parser;
 
@@ -47,6 +49,16 @@ pub struct ReprovisionSet {
     pub update_message: Option<String>,
 }
 
+impl From<&ReprovisionSet> for HostReprovisioningRequest {
+    fn from(args: &ReprovisionSet) -> Self {
+        Self {
+            machine_id: Some(args.id),
+            mode: Mode::Set as i32,
+            initiator: UpdateInitiator::AdminCli as i32,
+        }
+    }
+}
+
 #[derive(Parser, Debug, Clone)]
 pub struct ReprovisionClear {
     #[clap(
@@ -58,6 +70,16 @@ pub struct ReprovisionClear {
 
     #[clap(short, long, action)]
     pub update_firmware: bool,
+}
+
+impl From<ReprovisionClear> for HostReprovisioningRequest {
+    fn from(args: ReprovisionClear) -> Self {
+        Self {
+            machine_id: Some(args.id),
+            mode: Mode::Clear as i32,
+            initiator: UpdateInitiator::AdminCli as i32,
+        }
+    }
 }
 
 #[derive(Parser, Debug, Clone)]

--- a/crates/admin-cli/src/host/reprovision/cmd.rs
+++ b/crates/admin-cli/src/host/reprovision/cmd.rs
@@ -16,25 +16,23 @@
  */
 
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
-use ::rpc::forge::host_reprovisioning_request::Mode;
-use ::rpc::forge::{HostReprovisioningRequest, UpdateInitiator};
+use ::rpc::forge::HostReprovisioningRequest;
 use carbide_uuid::machine::MachineId;
 use prettytable::{Table, row};
 
+use super::args::{ReprovisionClear, ReprovisionSet};
 use crate::machine::{HealthOverrideTemplates, get_health_report};
 use crate::rpc::ApiClient;
 
-pub async fn trigger_reprovisioning(
-    host_id: MachineId,
-    mode: Mode,
+pub async fn trigger_reprovisioning_set(
+    data: ReprovisionSet,
     api_client: &ApiClient,
-    update_message: Option<String>,
 ) -> CarbideCliResult<()> {
-    if let (Mode::Set, Some(update_message)) = (mode, update_message) {
+    if let Some(update_message) = data.update_message.clone() {
         // Set a HostUpdateInProgress health override on the Host
 
         let host_machine = api_client
-            .get_machines_by_ids(&[host_id])
+            .get_machines_by_ids(&[data.id])
             .await?
             .machines
             .into_iter()
@@ -55,18 +53,22 @@ pub async fn trigger_reprovisioning(
         let report = get_health_report(HealthOverrideTemplates::HostUpdate, Some(update_message));
 
         api_client
-            .machine_insert_health_report_override(host_id, report.into(), false)
+            .machine_insert_health_report_override(data.id, report.into(), false)
             .await?;
     }
-    api_client
-        .0
-        .trigger_host_reprovisioning(HostReprovisioningRequest {
-            machine_id: Some(host_id),
-            mode: mode as i32,
-            initiator: UpdateInitiator::AdminCli as i32,
-        })
-        .await?;
 
+    let req: HostReprovisioningRequest = (&data).into();
+    api_client.0.trigger_host_reprovisioning(req).await?;
+
+    Ok(())
+}
+
+pub async fn trigger_reprovisioning_clear(
+    data: ReprovisionClear,
+    api_client: &ApiClient,
+) -> CarbideCliResult<()> {
+    let req: HostReprovisioningRequest = data.into();
+    api_client.0.trigger_host_reprovisioning(req).await?;
     Ok(())
 }
 

--- a/crates/admin-cli/src/host/reprovision/mod.rs
+++ b/crates/admin-cli/src/host/reprovision/mod.rs
@@ -27,24 +27,8 @@ use crate::cfg::runtime::RuntimeContext;
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
         match self {
-            Args::Set(data) => {
-                cmd::trigger_reprovisioning(
-                    data.id,
-                    ::rpc::forge::host_reprovisioning_request::Mode::Set,
-                    &ctx.api_client,
-                    data.update_message,
-                )
-                .await
-            }
-            Args::Clear(data) => {
-                cmd::trigger_reprovisioning(
-                    data.id,
-                    ::rpc::forge::host_reprovisioning_request::Mode::Clear,
-                    &ctx.api_client,
-                    None,
-                )
-                .await
-            }
+            Args::Set(data) => cmd::trigger_reprovisioning_set(data, &ctx.api_client).await,
+            Args::Clear(data) => cmd::trigger_reprovisioning_clear(data, &ctx.api_client).await,
             Args::List => cmd::list_hosts_pending(&ctx.api_client).await,
             Args::MarkManualUpgradeComplete(data) => {
                 cmd::mark_manual_firmware_upgrade_complete(data.id, &ctx.api_client).await

--- a/crates/admin-cli/src/host/set_uefi_password/args.rs
+++ b/crates/admin-cli/src/host/set_uefi_password/args.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use ::rpc::forge::SetHostUefiPasswordRequest;
 use clap::Parser;
 
 use crate::machine::MachineQuery;
@@ -26,4 +27,13 @@ use crate::machine::MachineQuery;
 pub struct Args {
     #[clap(flatten)]
     pub inner: MachineQuery,
+}
+
+impl From<Args> for SetHostUefiPasswordRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            host_id: None,
+            machine_query: Some(args.inner.query),
+        }
+    }
 }

--- a/crates/admin-cli/src/host/set_uefi_password/cmd.rs
+++ b/crates/admin-cli/src/host/set_uefi_password/cmd.rs
@@ -18,20 +18,14 @@
 use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge::SetHostUefiPasswordRequest;
 
-use crate::machine::MachineQuery;
+use super::args::Args;
 use crate::rpc::ApiClient;
 
-pub async fn set_uefi_password(
-    query: MachineQuery,
-    api_client: &ApiClient,
-) -> CarbideCliResult<()> {
-    let request = SetHostUefiPasswordRequest {
-        host_id: None,
-        machine_query: Some(query.query.clone()),
-    };
-    let response = api_client.0.set_host_uefi_password(request).await?;
+pub async fn set_uefi_password(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let req: SetHostUefiPasswordRequest = data.into();
+    let response = api_client.0.set_host_uefi_password(req).await?;
     println!(
-        "successfully set UEFI password for host {query:#?} (jid: {:#?})",
+        "successfully set UEFI password for host (jid: {:#?})",
         response.job_id
     );
     Ok(())

--- a/crates/admin-cli/src/host/set_uefi_password/mod.rs
+++ b/crates/admin-cli/src/host/set_uefi_password/mod.rs
@@ -26,6 +26,6 @@ use crate::cfg::runtime::RuntimeContext;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
-        cmd::set_uefi_password(self.inner, &ctx.api_client).await
+        cmd::set_uefi_password(self, &ctx.api_client).await
     }
 }

--- a/crates/admin-cli/src/instance_type/associate/args.rs
+++ b/crates/admin-cli/src/instance_type/associate/args.rs
@@ -16,6 +16,8 @@
  */
 
 use clap::Parser;
+use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+use rpc::forge::AssociateMachinesWithInstanceTypeRequest;
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
@@ -23,4 +25,21 @@ pub struct Args {
     pub instance_type_id: String,
     #[clap(help = "Machine Ids, separated by comma", value_delimiter = ',')]
     pub machine_ids: Vec<String>,
+}
+
+impl TryFrom<Args> for AssociateMachinesWithInstanceTypeRequest {
+    type Error = CarbideCliError;
+
+    fn try_from(args: Args) -> CarbideCliResult<Self> {
+        if args.machine_ids.is_empty() {
+            return Err(CarbideCliError::GenericError(
+                "Machine ids can not be empty.".to_string(),
+            ));
+        }
+
+        Ok(AssociateMachinesWithInstanceTypeRequest {
+            instance_type_id: args.instance_type_id,
+            machine_ids: args.machine_ids,
+        })
+    }
 }

--- a/crates/admin-cli/src/instance_type/associate/cmd.rs
+++ b/crates/admin-cli/src/instance_type/associate/cmd.rs
@@ -15,25 +15,18 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+use ::rpc::admin_cli::CarbideCliResult;
 use rpc::forge::AssociateMachinesWithInstanceTypeRequest;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn create_association(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    if args.machine_ids.is_empty() {
-        return Err(CarbideCliError::GenericError(
-            "Machine ids can not be empty.".to_string(),
-        ));
-    }
+    let req: AssociateMachinesWithInstanceTypeRequest = args.try_into()?;
 
     api_client
         .0
-        .associate_machines_with_instance_type(AssociateMachinesWithInstanceTypeRequest {
-            instance_type_id: args.instance_type_id,
-            machine_ids: args.machine_ids,
-        })
+        .associate_machines_with_instance_type(req)
         .await?;
 
     println!("Association is created successfully!!");

--- a/crates/admin-cli/src/instance_type/create/args.rs
+++ b/crates/admin-cli/src/instance_type/create/args.rs
@@ -16,6 +16,8 @@
  */
 
 use clap::Parser;
+use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+use rpc::forge::{self as forgerpc, CreateInstanceTypeRequest, InstanceTypeAttributes};
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
@@ -45,4 +47,37 @@ pub struct Args {
         help = "Optional, JSON array containing a set of instance type capability filters"
     )]
     pub desired_capabilities: Option<String>,
+}
+
+impl TryFrom<Args> for CreateInstanceTypeRequest {
+    type Error = CarbideCliError;
+
+    fn try_from(args: Args) -> CarbideCliResult<Self> {
+        let labels = if let Some(l) = args.labels {
+            serde_json::from_str(&l)?
+        } else {
+            vec![]
+        };
+
+        let metadata = forgerpc::Metadata {
+            name: args.name.unwrap_or_default(),
+            description: args.description.unwrap_or_default(),
+            labels,
+        };
+
+        let instance_type_attributes = args
+            .desired_capabilities
+            .map(|d| {
+                serde_json::from_str(&d).map(|desired_capabilities| InstanceTypeAttributes {
+                    desired_capabilities,
+                })
+            })
+            .transpose()?;
+
+        Ok(CreateInstanceTypeRequest {
+            id: args.id,
+            metadata: Some(metadata),
+            instance_type_attributes,
+        })
+    }
 }

--- a/crates/admin-cli/src/instance_type/create/cmd.rs
+++ b/crates/admin-cli/src/instance_type/create/cmd.rs
@@ -16,7 +16,7 @@
  */
 
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
-use ::rpc::forge::{self as forgerpc, CreateInstanceTypeRequest, InstanceTypeAttributes};
+use ::rpc::forge::CreateInstanceTypeRequest;
 
 use super::args::Args;
 use crate::instance_type::common::convert_itypes_to_table;
@@ -32,36 +32,11 @@ pub async fn create(
 ) -> CarbideCliResult<()> {
     let is_json = output_format == OutputFormat::Json;
 
-    let id = args.id;
-
-    let labels = if let Some(l) = args.labels {
-        serde_json::from_str(&l)?
-    } else {
-        vec![]
-    };
-
-    let metadata = forgerpc::Metadata {
-        name: args.name.unwrap_or_default(),
-        description: args.description.unwrap_or_default(),
-        labels,
-    };
-
-    let instance_type_attributes = args
-        .desired_capabilities
-        .map(|d| {
-            serde_json::from_str(&d).map(|desired_capabilities| InstanceTypeAttributes {
-                desired_capabilities,
-            })
-        })
-        .transpose()?;
+    let req: CreateInstanceTypeRequest = args.try_into()?;
 
     let itype = api_client
         .0
-        .create_instance_type(CreateInstanceTypeRequest {
-            id,
-            metadata: Some(metadata),
-            instance_type_attributes,
-        })
+        .create_instance_type(req)
         .await?
         .instance_type
         .ok_or(CarbideCliError::Empty)?;

--- a/crates/admin-cli/src/instance_type/delete/args.rs
+++ b/crates/admin-cli/src/instance_type/delete/args.rs
@@ -16,9 +16,16 @@
  */
 
 use clap::Parser;
+use rpc::forge::DeleteInstanceTypeRequest;
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
     #[clap(short = 'i', long, help = "Instance type ID to delete")]
     pub id: String,
+}
+
+impl From<Args> for DeleteInstanceTypeRequest {
+    fn from(args: Args) -> Self {
+        DeleteInstanceTypeRequest { id: args.id }
+    }
 }

--- a/crates/admin-cli/src/instance_type/delete/cmd.rs
+++ b/crates/admin-cli/src/instance_type/delete/cmd.rs
@@ -23,12 +23,10 @@ use crate::rpc::ApiClient;
 
 /// Delete an instance type.
 pub async fn delete(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    api_client
-        .0
-        .delete_instance_type(DeleteInstanceTypeRequest {
-            id: args.id.clone(),
-        })
-        .await?;
-    println!("Deleted instance type {} successfully.", args.id);
+    let id = args.id.clone();
+    let req: DeleteInstanceTypeRequest = args.into();
+
+    api_client.0.delete_instance_type(req).await?;
+    println!("Deleted instance type {} successfully.", id);
     Ok(())
 }

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -1972,60 +1972,6 @@ impl ApiClient {
         Ok(RemediationList { remediations })
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub async fn create_extension_service(
-        &self,
-        service_id: Option<String>,
-        service_name: String,
-        tenant_organization_id: String,
-        service_type: i32,
-        description: Option<String>,
-        data: String,
-        credential: Option<rpc::DpuExtensionServiceCredential>,
-        observability: Vec<rpc::DpuExtensionServiceObservabilityConfig>,
-    ) -> CarbideCliResult<rpc::DpuExtensionService> {
-        let request = rpc::CreateDpuExtensionServiceRequest {
-            service_id,
-            service_name,
-            service_type,
-            tenant_organization_id,
-            data,
-            description,
-            credential,
-            observability: Some(rpc::DpuExtensionServiceObservability {
-                configs: observability,
-            }),
-        };
-
-        Ok(self.0.create_dpu_extension_service(request).await?)
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub async fn update_extension_service(
-        &self,
-        service_id: String,
-        service_name: Option<String>,
-        description: Option<String>,
-        data: String,
-        credential: Option<rpc::DpuExtensionServiceCredential>,
-        observability: Vec<rpc::DpuExtensionServiceObservabilityConfig>,
-        if_version_ctr_match: Option<i32>,
-    ) -> CarbideCliResult<rpc::DpuExtensionService> {
-        let request = rpc::UpdateDpuExtensionServiceRequest {
-            service_id,
-            service_name,
-            description,
-            data,
-            credential,
-            if_version_ctr_match,
-            observability: Some(rpc::DpuExtensionServiceObservability {
-                configs: observability,
-            }),
-        };
-
-        Ok(self.0.update_dpu_extension_service(request).await?)
-    }
-
     pub async fn find_extension_services(
         &self,
         service_type: Option<i32>,

--- a/crates/admin-cli/src/vpc_peering/create/args.rs
+++ b/crates/admin-cli/src/vpc_peering/create/args.rs
@@ -18,6 +18,7 @@
 use carbide_uuid::vpc::VpcId;
 use carbide_uuid::vpc_peering::VpcPeeringId;
 use clap::Parser;
+use rpc::forge::VpcPeeringCreationRequest;
 
 #[derive(Parser, Debug)]
 pub struct Args {
@@ -29,4 +30,14 @@ pub struct Args {
 
     #[clap(long, help = "Optional desired ID for the VPC peering")]
     pub id: Option<VpcPeeringId>,
+}
+
+impl From<Args> for VpcPeeringCreationRequest {
+    fn from(args: Args) -> Self {
+        VpcPeeringCreationRequest {
+            vpc_id: Some(args.vpc1_id),
+            peer_vpc_id: Some(args.vpc2_id),
+            id: args.id,
+        }
+    }
 }

--- a/crates/admin-cli/src/vpc_peering/create/cmd.rs
+++ b/crates/admin-cli/src/vpc_peering/create/cmd.rs
@@ -24,20 +24,14 @@ use crate::rpc::ApiClient;
 use crate::vpc_peering::convert_vpc_peerings_to_table;
 
 pub async fn create(
-    args: &Args,
+    args: Args,
     output_format: OutputFormat,
     api_client: &ApiClient,
 ) -> CarbideCliResult<()> {
     let is_json = output_format == OutputFormat::Json;
+    let req: VpcPeeringCreationRequest = args.into();
 
-    let vpc_peering = api_client
-        .0
-        .create_vpc_peering(VpcPeeringCreationRequest {
-            vpc_id: Some(args.vpc1_id),
-            peer_vpc_id: Some(args.vpc2_id),
-            id: args.id,
-        })
-        .await?;
+    let vpc_peering = api_client.0.create_vpc_peering(req).await?;
 
     if is_json {
         println!(

--- a/crates/admin-cli/src/vpc_peering/create/mod.rs
+++ b/crates/admin-cli/src/vpc_peering/create/mod.rs
@@ -26,6 +26,6 @@ use crate::cfg::runtime::RuntimeContext;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
-        cmd::create(&self, ctx.config.format, &ctx.api_client).await
+        cmd::create(self, ctx.config.format, &ctx.api_client).await
     }
 }

--- a/crates/admin-cli/src/vpc_prefix/create/args.rs
+++ b/crates/admin-cli/src/vpc_prefix/create/args.rs
@@ -18,6 +18,7 @@
 use carbide_uuid::vpc::{VpcId, VpcPrefixId};
 use clap::Parser;
 use ipnet::IpNet;
+use rpc::forge::VpcPrefixCreationRequest;
 
 #[derive(Parser, Debug)]
 pub struct Args {
@@ -68,4 +69,43 @@ pub struct Args {
         help = "Specify the VpcPrefixId for the API to use instead of it auto-generating one"
     )]
     pub vpc_prefix_id: Option<VpcPrefixId>,
+}
+
+fn parse_label(s: &str) -> rpc::forge::Label {
+    match s.split_once(':') {
+        Some((k, v)) => rpc::forge::Label {
+            key: k.trim().to_string(),
+            value: Some(v.trim().to_string()),
+        },
+        None => rpc::forge::Label {
+            key: s.trim().to_string(),
+            value: None,
+        },
+    }
+}
+
+impl From<Args> for VpcPrefixCreationRequest {
+    fn from(args: Args) -> Self {
+        let labels = args
+            .labels
+            .unwrap_or_default()
+            .iter()
+            .map(|s| parse_label(s))
+            .collect();
+
+        VpcPrefixCreationRequest {
+            id: args.vpc_prefix_id,
+            prefix: String::new(), // Deprecated field
+            name: String::new(),   // Deprecated field
+            vpc_id: Some(args.vpc_id),
+            config: Some(rpc::forge::VpcPrefixConfig {
+                prefix: args.prefix.to_string(),
+            }),
+            metadata: Some(rpc::forge::Metadata {
+                name: args.name,
+                labels,
+                description: args.description.unwrap_or_default(),
+            }),
+        }
+    }
 }

--- a/crates/admin-cli/src/vpc_prefix/create/cmd.rs
+++ b/crates/admin-cli/src/vpc_prefix/create/cmd.rs
@@ -23,61 +23,20 @@ use super::args::Args;
 use crate::rpc::ApiClient;
 use crate::vpc_prefix::show::cmd::ShowOutput;
 
-fn parse_label(s: &str) -> rpc::forge::Label {
-    match s.split_once(':') {
-        Some((k, v)) => rpc::forge::Label {
-            key: k.trim().to_string(),
-            value: Some(v.trim().to_string()),
-        },
-        None => rpc::forge::Label {
-            key: s.trim().to_string(),
-            value: None,
-        },
-    }
-}
-
 pub async fn create(
     args: Args,
     output_format: OutputFormat,
     api_client: &ApiClient,
 ) -> CarbideCliResult<()> {
-    let output = do_create(api_client, args).await?;
+    let req: VpcPrefixCreationRequest = args.into();
+
+    let output = api_client
+        .0
+        .create_vpc_prefix(req)
+        .await
+        .map(ShowOutput::One)?;
 
     output
         .write_output(output_format, ::rpc::admin_cli::Destination::Stdout())
         .map_err(CarbideCliError::from)
-}
-
-async fn do_create(
-    api_client: &ApiClient,
-    create_args: Args,
-) -> Result<ShowOutput, CarbideCliError> {
-    let labels = create_args
-        .labels
-        .unwrap_or_default()
-        .iter()
-        .map(|s| parse_label(s))
-        .collect();
-
-    let new_prefix = VpcPrefixCreationRequest {
-        id: create_args.vpc_prefix_id,
-        prefix: String::new(), // Deprecated field
-        name: String::new(),   // Deprecated field
-        vpc_id: Some(create_args.vpc_id),
-        config: Some(rpc::forge::VpcPrefixConfig {
-            prefix: create_args.prefix.to_string(),
-        }),
-        metadata: Some(rpc::forge::Metadata {
-            name: create_args.name,
-            labels,
-            description: create_args.description.unwrap_or_default(),
-        }),
-    };
-
-    api_client
-        .0
-        .create_vpc_prefix(new_prefix)
-        .await
-        .map(ShowOutput::One)
-        .map_err(Into::into)
 }

--- a/crates/admin-cli/src/vpc_prefix/delete/args.rs
+++ b/crates/admin-cli/src/vpc_prefix/delete/args.rs
@@ -17,9 +17,18 @@
 
 use carbide_uuid::vpc::VpcPrefixId;
 use clap::Parser;
+use rpc::forge::VpcPrefixDeletionRequest;
 
 #[derive(Parser, Debug)]
 pub struct Args {
     #[clap(value_name = "VpcPrefixId")]
     pub vpc_prefix_id: VpcPrefixId,
+}
+
+impl From<Args> for VpcPrefixDeletionRequest {
+    fn from(args: Args) -> Self {
+        VpcPrefixDeletionRequest {
+            id: Some(args.vpc_prefix_id),
+        }
+    }
 }

--- a/crates/admin-cli/src/vpc_prefix/delete/cmd.rs
+++ b/crates/admin-cli/src/vpc_prefix/delete/cmd.rs
@@ -22,9 +22,7 @@ use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn delete(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let delete_prefix = VpcPrefixDeletionRequest {
-        id: Some(args.vpc_prefix_id),
-    };
-    api_client.0.delete_vpc_prefix(delete_prefix).await?;
+    let req: VpcPrefixDeletionRequest = args.into();
+    api_client.0.delete_vpc_prefix(req).await?;
     Ok(())
 }


### PR DESCRIPTION
## Description

In another review, @Matthias247 pointed out that we could/should probably have a pattern where `Args` can just `.into()` (or `.try_into()?`) the underlying `Request` that they exist to populate. Most cases of this are super straightforward, so I'm doing that to some more of them (in addition to the ones I've already implemented).

At the end of the day, a "command" is now something like..

```
let req = args.try_into()?;
let resp = api_client.0.call(req).await?;
..do something w/resp
```

...and probably allows us to get even deeper into how we templatize things in the admin CLI.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

