### PR TITLE
feat(bmc-mock): add NVIDIA DGX H100 hardware support

### DIFF
--- a/crates/bmc-mock/src/bmc_state.rs
+++ b/crates/bmc-mock/src/bmc_state.rs
@@ -27,6 +27,7 @@ use crate::redfish::update_service::UpdateServiceState;
 pub struct BmcState {
     pub bmc_vendor: redfish::oem::BmcVendor,
     pub bmc_product: Option<&'static str>,
+    pub bmc_redfish_version: &'static str,
     pub oem_state: redfish::oem::State,
     pub manager: Arc<ManagerState>,
     pub system_state: Arc<SystemState>,

--- a/crates/bmc-mock/src/http.rs
+++ b/crates/bmc-mock/src/http.rs
@@ -18,7 +18,7 @@
 use axum::body::Body;
 use axum::extract::Request;
 use axum::http::StatusCode;
-use axum::response::Response;
+use axum::response::{IntoResponse, Response};
 use serde_json::json;
 use tower::Service;
 
@@ -26,6 +26,10 @@ use crate::json::JsonExt;
 
 pub(crate) fn not_found() -> Response {
     json!("").into_response(StatusCode::NOT_FOUND)
+}
+
+pub(crate) fn ok_no_content() -> Response {
+    StatusCode::NO_CONTENT.into_response()
 }
 
 /// Wrapper arond axum::Router::call which constructs a new request object. This works

--- a/crates/bmc-mock/src/hw/bluefield3.rs
+++ b/crates/bmc-mock/src/hw/bluefield3.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use mac_address::MacAddress;
 use rpc::machine_discovery::{BlockDevice, CpuInfo, DiscoveryInfo, DmiData, DpuData};
+use rpc::{NetworkInterface, PciDeviceProperties};
 use serde_json::json;
 use utils::models::arch::CpuArchitecture;
 
@@ -201,15 +202,15 @@ impl Bluefield3<'_> {
         redfish::manager::Config {
             managers: vec![redfish::manager::SingleConfig {
                 id: "Bluefield_BMC",
-                eth_interfaces: vec![
+                eth_interfaces: Some(vec![
                     redfish::ethernet_interface::builder(
                         &redfish::ethernet_interface::manager_resource("Bluefield_BMC", "eth0"),
                     )
                     .mac_address(self.bmc_mac_address)
                     .interface_enabled(true)
                     .build(),
-                ],
-                firmware_version: "BF-23.10-4",
+                ]),
+                firmware_version: Some("BF-23.10-4"),
                 oem: None,
             }],
         }
@@ -244,18 +245,33 @@ impl Bluefield3<'_> {
         }
     }
 
-    pub fn host_nic(&self) -> hw::nic::Nic {
+    pub fn host_nic(&self) -> hw::nic::Nic<'static> {
         hw::nic::Nic {
             mac_address: self.host_mac_address,
             // This how it represented on host with number of trailing
             // whitespaces.
-            serial_number: format!("{}                 ", self.product_serial_number),
+            serial_number: Some(format!("{}                 ", self.product_serial_number).into()),
             manufacturer: Some("Mellanox Technologies".into()),
             model: Some("BlueField-3 SmartNIC Main Card".into()),
             description: Some(
                 "MT43244 BlueField-3 integrated ConnectX-7 network controller".into(),
             ),
             part_number: Some(self.part_number().into()),
+            firmware_version: Some(self.firmware_versions.dpu_nic.clone().into()),
+            is_mat_dpu: true,
+        }
+    }
+
+    pub fn host_nic_h100_variant(&self) -> hw::nic::Nic<'static> {
+        hw::nic::Nic {
+            mac_address: self.host_mac_address,
+            // This how it represented on host with number of trailing
+            // whitespaces.
+            serial_number: Some(format!("{}                 ", self.product_serial_number).into()),
+            manufacturer: Some("MLNX".into()),
+            model: Some("D3B6           ".into()),
+            description: None,
+            part_number: Some(format!("{}       ", self.part_number()).into()),
             firmware_version: Some(self.firmware_versions.dpu_nic.clone().into()),
             is_mat_dpu: true,
         }
@@ -313,6 +329,27 @@ impl Bluefield3<'_> {
             tpm_ek_certificate: None,
             tpm_description: None,
             ..Default::default()
+        }
+    }
+
+    pub fn host_nic_discovery_info(
+        &self,
+        path: &str,
+        slot: &str,
+        numa_node: i32,
+    ) -> NetworkInterface {
+        NetworkInterface {
+            mac_address: self.host_mac_address.to_string(),
+            pci_properties: Some(PciDeviceProperties {
+                vendor: "Mellanox Technologies".into(),
+                device: "MT43244 BlueField-3 integrated ConnectX-7 network controller".into(),
+                path: path.into(),
+                numa_node,
+                description: Some(
+                    "MT43244 BlueField-3 integrated ConnectX-7 network controller".into(),
+                ),
+                slot: Some(slot.into()),
+            }),
         }
     }
 

--- a/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
+++ b/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
@@ -29,7 +29,7 @@ use crate::{PowerControl, hw, redfish};
 pub struct DellPowerEdgeR750<'a> {
     pub bmc_mac_address: MacAddress,
     pub product_serial_number: Cow<'a, str>,
-    pub nics: Vec<(hw::nic::SlotNumber, hw::nic::Nic)>,
+    pub nics: Vec<(hw::nic::SlotNumber, hw::nic::Nic<'a>)>,
     pub embedded_nic: EmbeddedNic,
 }
 
@@ -53,15 +53,15 @@ impl DellPowerEdgeR750<'_> {
         redfish::manager::Config {
             managers: vec![redfish::manager::SingleConfig {
                 id: "iDRAC.Embedded.1",
-                eth_interfaces: vec![
+                eth_interfaces: Some(vec![
                     redfish::ethernet_interface::builder(
                         &redfish::ethernet_interface::manager_resource("iDRAC.Embedded.1", "NIC.1"),
                     )
                     .mac_address(self.bmc_mac_address)
                     .interface_enabled(true)
                     .build(),
-                ],
-                firmware_version: "6.00.30.00",
+                ]),
+                firmware_version: Some("6.00.30.00"),
                 oem: Some(redfish::manager::Oem::Dell),
             }],
         }
@@ -184,7 +184,9 @@ impl DellPowerEdgeR750<'_> {
                 .oem(redfish::oem::dell::network_device_function::dell_nic_info(
                     &function_id,
                     *slot,
-                    &nic.serial_number,
+                    nic.serial_number
+                        .as_ref()
+                        .unwrap_or(&Cow::Borrowed("unknown")),
                 ))
                 .build();
             redfish::network_adapter::builder_from_nic(

--- a/crates/bmc-mock/src/hw/liteon_power_shelf.rs
+++ b/crates/bmc-mock/src/hw/liteon_power_shelf.rs
@@ -41,7 +41,7 @@ impl LiteOnPowerShelf<'_> {
         redfish::manager::Config {
             managers: vec![redfish::manager::SingleConfig {
                 id: "bmc",
-                eth_interfaces: vec![
+                eth_interfaces: Some(vec![
                     redfish::ethernet_interface::builder(
                         &redfish::ethernet_interface::manager_resource("bmc", "can0"),
                     )
@@ -54,8 +54,8 @@ impl LiteOnPowerShelf<'_> {
                     .mac_address(self.bmc_mac_address)
                     .interface_enabled(true)
                     .build(),
-                ],
-                firmware_version: "r1.3.9",
+                ]),
+                firmware_version: Some("r1.3.9"),
                 oem: None,
             }],
         }

--- a/crates/bmc-mock/src/hw/mod.rs
+++ b/crates/bmc-mock/src/hw/mod.rs
@@ -36,6 +36,18 @@ pub mod liteon_power_shelf;
 /// Support of NVIDIA Switch ND5200_LD.
 pub mod nvidia_switch_nd5200_ld;
 
+/// Support of NVIDIA DGX H100.
+pub mod nvidia_dgx_h100;
+
+/// Intel E810 NIC.
+pub mod nic_intel_e810;
+
+/// Intel X550 NIC.
+pub mod nic_intel_x550;
+
+/// NVIDIA ConnectX-7.
+pub mod nic_nvidia_cx7;
+
 use bmc_vendor::BMCVendor;
 
 pub fn bmc_vendor_to_udev_dmi(v: BMCVendor) -> &'static str {

--- a/crates/bmc-mock/src/hw/nic.rs
+++ b/crates/bmc-mock/src/hw/nic.rs
@@ -21,20 +21,20 @@ use mac_address::MacAddress;
 use rpc::machine_discovery::{NetworkInterface, PciDeviceProperties};
 pub type SlotNumber = usize;
 
-pub struct Nic {
+pub struct Nic<'a> {
     pub mac_address: MacAddress,
-    pub serial_number: String,
-    pub manufacturer: Option<Cow<'static, str>>,
-    pub model: Option<Cow<'static, str>>,
-    pub description: Option<Cow<'static, str>>,
-    pub part_number: Option<Cow<'static, str>>,
-    pub firmware_version: Option<Cow<'static, str>>,
+    pub serial_number: Option<Cow<'a, str>>,
+    pub manufacturer: Option<Cow<'a, str>>,
+    pub model: Option<Cow<'a, str>>,
+    pub description: Option<Cow<'a, str>>,
+    pub part_number: Option<Cow<'a, str>>,
+    pub firmware_version: Option<Cow<'a, str>>,
     pub is_mat_dpu: bool,
 }
 
-impl Nic {
-    pub fn rooftop(mac: MacAddress) -> Self {
-        let serial_number = format!("RT{}", mac.to_string().replace(':', ""));
+impl Nic<'_> {
+    pub fn rooftop(mac: MacAddress) -> Nic<'static> {
+        let serial_number = Some(format!("RT{}", mac.to_string().replace(':', "")).into());
         Nic {
             manufacturer: Some("Rooftop Technologies".into()),
             model: Some("Rooftop 10 Kilobit Ethernet Adapter".into()),

--- a/crates/bmc-mock/src/hw/nic_intel_e810.rs
+++ b/crates/bmc-mock/src/hw/nic_intel_e810.rs
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use mac_address::MacAddress;
+
+use crate::hw;
+
+// This type describes Intel® Ethernet Network Adapter E810.
+pub struct NicIntelE810 {
+    pub mac_addresses: [MacAddress; 2],
+}
+
+impl NicIntelE810 {
+    pub fn ethernet_nics(&self) -> [hw::nic::Nic<'static>; 2] {
+        // Real serial numbers are MAC address of port0 without ':'.
+        let serial_number = self.mac_addresses[0].to_string().replace(":", "");
+        self.mac_addresses.map(|mac| hw::nic::Nic {
+            mac_address: mac,
+            serial_number: Some(serial_number.clone().into()),
+            manufacturer: None,
+            model: None,
+            description: None,
+            part_number: Some("K91258-010".into()),
+            firmware_version: None,
+            is_mat_dpu: false,
+        })
+    }
+}

--- a/crates/bmc-mock/src/hw/nic_intel_x550.rs
+++ b/crates/bmc-mock/src/hw/nic_intel_x550.rs
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use mac_address::MacAddress;
+use rpc::{NetworkInterface, PciDeviceProperties};
+
+use crate::hw;
+
+// This type describes Intel® Ethernet Network Adapter E810.
+pub struct NicIntelX550 {
+    pub mac_address: MacAddress,
+}
+
+impl NicIntelX550 {
+    pub fn to_nic(&self) -> hw::nic::Nic<'static> {
+        hw::nic::Nic {
+            mac_address: self.mac_address,
+            serial_number: None,
+            manufacturer: None,
+            model: None,
+            description: None,
+            part_number: None,
+            firmware_version: None,
+            is_mat_dpu: false,
+        }
+    }
+
+    pub fn discovery_info(&self, path: &str, slot: &str, numa_node: i32) -> NetworkInterface {
+        NetworkInterface {
+            mac_address: self.mac_address.to_string(),
+            pci_properties: Some(PciDeviceProperties {
+                vendor: "Intel Corporation".into(),
+                device: "Ethernet Controller X550".into(),
+                path: path.into(),
+                numa_node,
+                description: Some("Ethernet Controller X550".into()),
+                slot: Some(slot.into()),
+            }),
+        }
+    }
+}

--- a/crates/bmc-mock/src/hw/nic_nvidia_cx7.rs
+++ b/crates/bmc-mock/src/hw/nic_nvidia_cx7.rs
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+
+use mac_address::MacAddress;
+use rpc::{NetworkInterface, PciDeviceProperties};
+
+use crate::hw;
+
+// This type describes NVIDIA ConnectX-7A Dual Port NIC.
+pub struct NicNvidiaCx7A<'a> {
+    pub serial_number: Cow<'a, str>,
+    pub mac_addresses: [MacAddress; 2],
+}
+
+impl NicNvidiaCx7A<'_> {
+    pub fn ethernet_nics(&self) -> [hw::nic::Nic<'_>; 2] {
+        self.mac_addresses.map(|mac| hw::nic::Nic {
+            mac_address: mac,
+            serial_number: Some(self.serial_number.clone()),
+            manufacturer: Some("MLNX".into()),
+            model: Some("MCX755206AS-692          ".into()),
+            description: None,
+            part_number: Some("CX755206A      ".into()),
+            firmware_version: None,
+            is_mat_dpu: false,
+        })
+    }
+
+    pub fn discovery_info(
+        &self,
+        port: usize,
+        path: &str,
+        slot: &str,
+        numa_node: i32,
+    ) -> NetworkInterface {
+        NetworkInterface {
+            mac_address: self.mac_addresses[port].to_string(),
+            pci_properties: Some(PciDeviceProperties {
+                vendor: "Mellanox Technologies".into(),
+                device: "MT2910 Family [ConnectX-7]".into(),
+                path: path.into(),
+                numa_node,
+                description: Some("MT2910 Family [ConnectX-7]".into()),
+                slot: Some(slot.into()),
+            }),
+        }
+    }
+}
+
+// This type describes NVIDIA ConnectX-7B 4x port NIC Ethernet/IB.
+pub struct NicNvidiaCx7B<'a> {
+    pub serial_number: Cow<'a, str>,
+    pub mac_addresses: [MacAddress; 4],
+}
+
+impl NicNvidiaCx7B<'_> {
+    pub fn ib_nics(&self) -> [hw::nic::Nic<'_>; 4] {
+        self.mac_addresses.map(|mac_address| hw::nic::Nic {
+            mac_address,
+            serial_number: Some(self.serial_number.clone()),
+            manufacturer: Some("MLNX".into()),
+            model: Some("CX750500B".into()),
+            description: None,
+            part_number: Some("MCX750500B-692".into()),
+            firmware_version: None,
+            is_mat_dpu: false,
+        })
+    }
+}

--- a/crates/bmc-mock/src/hw/nvidia_dgx_h100.rs
+++ b/crates/bmc-mock/src/hw/nvidia_dgx_h100.rs
@@ -1,0 +1,553 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use mac_address::MacAddress;
+use rpc::machine_discovery::{CpuInfo, Gpu, InfinibandInterface, MemoryDevice};
+use rpc::{BlockDevice, DiscoveryInfo, DmiData, NetworkInterface, NvmeDevice, PciDeviceProperties};
+use serde_json::json;
+use utils::models::arch::CpuArchitecture;
+
+use crate::json::JsonExt;
+use crate::{PowerControl, hw, redfish};
+
+pub struct NvidiaDgxH100<'a> {
+    pub dgx_system_serial_number: Cow<'a, str>,
+    pub dgx_chassis_serial_number: Cow<'a, str>,
+    pub ib_nics: [hw::nic_nvidia_cx7::NicNvidiaCx7B<'a>; 2],
+    pub mgmt_nic: hw::nic_intel_x550::NicIntelX550,
+    pub dpu: hw::bluefield3::Bluefield3<'a>,
+    pub storage_nic0: hw::nic_nvidia_cx7::NicNvidiaCx7A<'a>,
+    pub storage_nic1: hw::nic_intel_e810::NicIntelE810,
+    pub gpu_serial: [Cow<'a, str>; 8],
+    pub bmc_mac_address_eth0: MacAddress,
+    pub bmc_mac_address_usb0: MacAddress,
+    pub hgx_bmc_mac_address_usb0: MacAddress,
+}
+
+impl NvidiaDgxH100<'_> {
+    pub fn manager_config(&self) -> redfish::manager::Config {
+        let bmc_manager_id = "BMC";
+        let bmc_eth_builder = |eth| {
+            redfish::ethernet_interface::builder(&redfish::ethernet_interface::manager_resource(
+                bmc_manager_id,
+                eth,
+            ))
+        };
+        redfish::manager::Config {
+            managers: vec![
+                redfish::manager::SingleConfig {
+                    id: bmc_manager_id,
+                    eth_interfaces: Some(vec![
+                        bmc_eth_builder("eth0")
+                            .mac_address(self.bmc_mac_address_eth0)
+                            .interface_enabled(true)
+                            .build(),
+                        bmc_eth_builder("usb0")
+                            .mac_address(self.bmc_mac_address_usb0)
+                            .interface_enabled(true)
+                            .build(),
+                    ]),
+                    firmware_version: Some("25.02.12"),
+                    oem: None,
+                },
+                redfish::manager::SingleConfig {
+                    id: "HGX_BMC_0",
+                    eth_interfaces: Some(vec![
+                        redfish::ethernet_interface::builder(
+                            &redfish::ethernet_interface::manager_resource("HGX_BMC_0", "usb0"),
+                        )
+                        .mac_address(self.hgx_bmc_mac_address_usb0)
+                        .interface_enabled(true)
+                        .build(),
+                    ]),
+                    firmware_version: Some("HGX-22.10-1-rc67"),
+                    oem: None,
+                },
+                redfish::manager::SingleConfig {
+                    id: "HGX_FabricManager_0",
+                    eth_interfaces: None,
+                    firmware_version: None,
+                    oem: None,
+                },
+            ],
+        }
+    }
+
+    pub fn system_config(&self, pc: Arc<dyn PowerControl>) -> redfish::computer_system::Config {
+        let system_id = "DGX";
+        let power_control = Some(pc);
+        let storage_nic0_ports = self.storage_nic0.ethernet_nics();
+        let storage_nic1_ports = self.storage_nic1.ethernet_nics();
+
+        let eth_interfaces = Some(
+            [
+                &self.mgmt_nic.to_nic(),
+                &self.dpu.host_nic_h100_variant(),
+                &storage_nic0_ports[0],
+                &storage_nic0_ports[1],
+                &storage_nic1_ports[0],
+                &storage_nic1_ports[1],
+            ]
+            .iter()
+            .enumerate()
+            .map(|(index, nic)| {
+                redfish::ethernet_interface::builder(&redfish::ethernet_interface::system_resource(
+                    system_id,
+                    &format!("EthernetInterface{index}"),
+                ))
+                .mac_address(nic.mac_address)
+                .interface_enabled(false)
+                .build()
+            })
+            .collect(),
+        );
+
+        let boot_options = [
+            &[self.mgmt_nic.to_nic()] as &[hw::nic::Nic],
+            &self.storage_nic0.ethernet_nics(),
+            &self.storage_nic1.ethernet_nics(),
+            &[self.dpu.host_nic_h100_variant()],
+        ]
+        .into_iter()
+        .flatten()
+        .enumerate()
+        .map(|(n, nic)| {
+            let id = format!("{:04X}", n + 10); // Starting with 000A
+            redfish::boot_option::builder(&redfish::boot_option::resource(system_id, &id))
+                .boot_option_reference(&format!("Boot{id}"))
+                // Real DisplayName: "UEFI P0: HTTP IPv4 Nvidia Network Adapter - 94:6D:AE:00:00:00"
+                .display_name(&format!("UEFI Pn: HTTP IPv4 - {}", nic.mac_address))
+                .build()
+        })
+        .chain(std::iter::once(
+            redfish::boot_option::builder(&redfish::boot_option::resource(system_id, "0030"))
+                .boot_option_reference("Boot0030")
+                .display_name("UEFI OS")
+                .build(),
+        ))
+        .collect();
+
+        redfish::computer_system::Config {
+            systems: vec![
+                redfish::computer_system::SingleSystemConfig {
+                    id: system_id.into(),
+                    manufacturer: Some("NVIDIA".into()),
+                    model: Some("DGXH100".into()),
+                    eth_interfaces,
+                    serial_number: Some(self.dgx_system_serial_number.to_string().into()),
+                    boot_order_mode: redfish::computer_system::BootOrderMode::ViaSettings,
+                    power_control,
+                    chassis: vec!["BMC".into()],
+                    boot_options: Some(boot_options),
+                    bios_mode: redfish::computer_system::BiosMode::Generic,
+                    oem: redfish::computer_system::Oem::Generic,
+                    base_bios: Some(base_bios(system_id)),
+                    log_services: None,
+                    storage: None,
+                    secure_boot_available: true,
+                },
+                redfish::computer_system::SingleSystemConfig {
+                    id: "HGX_Baseboard_0".into(),
+                    manufacturer: Some("NVIDIA".into()),
+                    model: None,
+                    chassis: vec!["HGX_BMC_0".into()],
+                    eth_interfaces: None,
+                    power_control: None,
+                    boot_options: None,
+                    serial_number: None,
+                    boot_order_mode: redfish::computer_system::BootOrderMode::Generic,
+                    oem: redfish::computer_system::Oem::Generic,
+                    bios_mode: redfish::computer_system::BiosMode::Generic,
+                    base_bios: None,
+                    log_services: None,
+                    storage: None,
+                    secure_boot_available: false,
+                },
+            ],
+        }
+    }
+
+    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+        let dgx_chassis_id = "DGX";
+        let net_adapter_builder = |id: &str| {
+            redfish::network_adapter::builder(&redfish::network_adapter::chassis_resource(
+                dgx_chassis_id,
+                id,
+            ))
+        };
+        let ib_mapping = [["10", "11", "7", "9"], ["2", "4", "5", "6"]];
+        let ib_nics = self.ib_nics.each_ref().map(|nic| nic.ib_nics());
+        let mut dgx_network_adapters = [
+            ("0", net_adapter_builder("DevType7_NIC0").build()),
+            (
+                "1",
+                redfish::network_adapter::builder_from_nic(
+                    &redfish::network_adapter::chassis_resource(dgx_chassis_id, "DevType7_NIC1"),
+                    &self.dpu.host_nic_h100_variant(),
+                )
+                .build(),
+            ),
+            (
+                "3",
+                redfish::network_adapter::builder_from_nic(
+                    &redfish::network_adapter::chassis_resource(dgx_chassis_id, "DevType7_NIC3"),
+                    &self.storage_nic0.ethernet_nics()[0],
+                )
+                .build(),
+            ),
+            (
+                "8",
+                redfish::network_adapter::builder_from_nic(
+                    &redfish::network_adapter::chassis_resource(dgx_chassis_id, "DevType7_NIC8"),
+                    &self.storage_nic1.ethernet_nics()[0],
+                )
+                .build(),
+            ),
+        ]
+        .into_iter()
+        .chain(ib_nics.into_iter().enumerate().flat_map(|(n1, nics)| {
+            nics.into_iter().enumerate().map(move |(n2, nic)| {
+                let index = ib_mapping[n1][n2];
+                (
+                    index,
+                    redfish::network_adapter::builder_from_nic(
+                        &redfish::network_adapter::chassis_resource(
+                            dgx_chassis_id,
+                            &format!("DevType7_NIC{index}"),
+                        ),
+                        &nic,
+                    )
+                    .build(),
+                )
+            })
+        }))
+        .collect::<Vec<_>>();
+        dgx_network_adapters.sort_by_key(|v| v.0);
+        let dgx_network_adapters = dgx_network_adapters.into_iter().map(|v| v.1).collect();
+        redfish::chassis::ChassisConfig {
+            chassis: [
+                redfish::chassis::SingleChassisConfig {
+                    id: Cow::Borrowed("CPUBaseboard"),
+                    chassis_type: "Component".into(),
+                    manufacturer: Some("NVIDIA".into()),
+                    part_number: Some("965-24387-0002-000".into()),
+                    model: Some("DGXH100".into()),
+                    serial_number: Some(self.dgx_system_serial_number.to_string().into()),
+                    network_adapters: Some(vec![]),
+                    pcie_devices: None,
+                    sensors: Some(redfish::sensor::generate_chassis_sensors(
+                        "CPUBaseboard",
+                        redfish::sensor::Layout {
+                            temperature: 120,
+                            ..Default::default()
+                        },
+                    )),
+                    assembly: None,
+                    oem: None,
+                },
+                redfish::chassis::SingleChassisConfig {
+                    id: dgx_chassis_id.into(),
+                    chassis_type: "Other".into(),
+                    manufacturer: Some("NVIDIA".into()),
+                    part_number: Some("965-24387-0002-000".into()),
+                    model: Some("DGXH100".into()),
+                    serial_number: Some(self.dgx_chassis_serial_number.to_string().into()),
+                    network_adapters: Some(dgx_network_adapters),
+                    pcie_devices: Some(
+                        (0..133)
+                            .map(|n| {
+                                redfish::pcie_device::builder(
+                                    &redfish::pcie_device::chassis_resource(
+                                        dgx_chassis_id,
+                                        &format!("00_00_{n:02X}"),
+                                    ),
+                                )
+                                .build()
+                            })
+                            .collect(),
+                    ),
+                    sensors: Some(redfish::sensor::generate_chassis_sensors(
+                        dgx_chassis_id,
+                        redfish::sensor::Layout {
+                            temperature: 112 + 8, // TEMP_* + TLIMIT_*
+                            fan: 36,              // FAN_*
+                            power: 47,            // PWR_*
+                            current: 3,           // AMP_*
+                            leak: 17,             // VOLT_*
+                                                  // TOTAL: 223 of 253
+                                                  // Omitted: 29
+                                                  //     ENERGY_* = 12,
+                                                  //     HMCReady,
+                                                  //     OVERT_* = 2,
+                                                  //     RST_GB1_GPU,
+                                                  //     SEL_FULLNESS,
+                                                  //     STATUS_* = 12,
+                                                  //     WATCHDOG2
+                        },
+                    )),
+                    assembly: None,
+                    oem: None,
+                },
+            ]
+            .into_iter()
+            .chain((1..=8).map(|index| hgx_gpu_sxm_chassis(index, &self.gpu_serial[index - 1])))
+            .collect(),
+        }
+    }
+
+    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+        redfish::update_service::UpdateServiceConfig {
+            firmware_inventory: [
+                ("CPLDMB_0", "0.2.1.9"), // version required carbide to pass ingestion test in site explorer.
+            ]
+            .iter()
+            .map(|(id, version)| {
+                redfish::software_inventory::builder(
+                    &redfish::software_inventory::firmware_inventory_resource(id),
+                )
+                .version(version)
+                .build()
+            })
+            .collect(),
+        }
+    }
+
+    pub fn discovery_info(&self) -> DiscoveryInfo {
+        DiscoveryInfo {
+            network_interfaces: self.discovery_info_network_interfaces(),
+            infiniband_interfaces: self.discovery_info_ib_interfaces(),
+            cpu_info: vec![CpuInfo {
+                model: "Intel(R) Xeon(R) Platinum 8480CL".into(),
+                vendor: "GenuineIntel".into(),
+                sockets: 2,
+                cores: 56,
+                threads: 112,
+            }],
+            block_devices: (0..2)
+                .map(|n| BlockDevice {
+                    model: "Micron_7450_MTFDKBG1T9TFR".into(),
+                    revision: "E2MU200".into(),
+                    serial: format!("MicronFAKESERNUM{n}"),
+                    device_type: "disk".into(),
+                })
+                .chain((0..8).map(|n| BlockDevice {
+                    model: "KCM6DRUL3T84".into(),
+                    revision: "0107".into(),
+                    serial: format!("KCMFAKESERNUM{n}"),
+                    device_type: "disk".into(),
+                }))
+                .collect(),
+            machine_type: CpuArchitecture::X86_64.to_string(),
+            machine_arch: Some(CpuArchitecture::X86_64.into()),
+            nvme_devices: (0..2)
+                .map(|n| NvmeDevice {
+                    model: "Micron_7450_MTFDKBG1T9TFR".into(),
+                    firmware_rev: "E2MU200".into(),
+                    serial: format!("MicronFAKESERNUM{n}"),
+                })
+                .chain((0..8).map(|n| NvmeDevice {
+                    model: "KCM6DRUL3T84".into(),
+                    firmware_rev: "0107".into(),
+                    serial: format!("KCMFAKESERNUM{n}"),
+                }))
+                .collect(),
+            dmi_data: Some(DmiData {
+                board_name: "DGXH100".into(),
+                board_version: "555.07L01.0001".into(),
+                bios_version: "1.6.7".into(),
+                bios_date: "02/20/2025".into(),
+                product_serial: self.dgx_system_serial_number.to_string(),
+                board_serial: format!("{}.FAKESERNUM1", self.dgx_system_serial_number),
+                chassis_serial: self.dgx_chassis_serial_number.to_string(),
+                product_name: "DGXH100".into(),
+                sys_vendor: "NVIDIA".into(),
+            }),
+            dpu_info: None,
+            gpus: (0..8)
+                .map(|n| {
+                    let pci_bus_id = [
+                        "00000000:1B:00.0",
+                        "00000000:43:00.0",
+                        "00000000:52:00.0",
+                        "00000000:61:00.0",
+                        "00000000:9D:00.0",
+                        "00000000:C3:00.0",
+                        "00000000:D1:00.0",
+                        "00000000:DF:00.0",
+                    ][n];
+                    Gpu {
+                        name: "NVIDIA H100 80GB HBM3".into(),
+                        serial: self.gpu_serial[n].to_string(),
+                        driver_version: "580.126.16".into(),
+                        vbios_version: "96.00.A5.00.01".into(),
+                        inforom_version: "G520.0200.00.05".into(),
+                        total_memory: "81559 MiB".into(),
+                        frequency: "1980 MHz".into(),
+                        pci_bus_id: pci_bus_id.into(),
+                        platform_info: None,
+                    }
+                })
+                .collect(),
+            memory_devices: (0..32)
+                .map(|_| MemoryDevice {
+                    size_mb: Some(65536),
+                    mem_type: Some("DDR5".into()),
+                })
+                .collect(),
+            tpm_ek_certificate: None,
+            tpm_description: None,
+            ..Default::default()
+        }
+    }
+
+    fn discovery_info_network_interfaces(&self) -> Vec<NetworkInterface> {
+        vec![
+            self.mgmt_nic.discovery_info(
+                "/devices/pci0000:00/0000:00:10.0/0000:0b:00.0/net/eno3",
+                "0000:0b:00.0",
+                0,
+            ),
+            self.storage_nic0.discovery_info(
+                0,
+                "/devices/pci0000:24\
+                /0000:24:01.0/0000:25:00.0/0000:26:00.0\
+                /0000:27:00.0/0000:28:00.0/0000:29:00.0\
+                /net/enp41s0f0np0",
+                "0000:29:00.0",
+                0,
+            ),
+            self.storage_nic0.discovery_info(
+                1,
+                "/devices/pci0000:24/0000:24:01.0\
+                /0000:25:00.0/0000:26:00.0/0000:27:00.0\
+                /0000:28:00.0/0000:29:00.1\
+                /net/enp41s0f1np1",
+                "0000:29:00.1",
+                0,
+            ),
+            self.dpu.host_nic_discovery_info(
+                "/devices/pci0000:80/0000:80:05.0/0000:82:00.0/net/ens6np0",
+                "0000:82:00.0",
+                0,
+            ),
+        ]
+    }
+
+    fn discovery_info_ib_interfaces(&self) -> Vec<InfinibandInterface> {
+        self.ib_nics
+            .iter()
+            .flat_map(|nic| nic.ib_nics())
+            .enumerate()
+            .map(|(n, _nic)| {
+                let (bus, numa_node) = [
+                    (0x15, 0),
+                    (0x3d, 0),
+                    (0x4c, 0),
+                    (0x5b, 0),
+                    (0x97, 1),
+                    (0xbd, 1),
+                    (0xcb, 1),
+                    (0xd9, 1),
+                ][n];
+                let device_name = format!("ibp{bus}s0");
+                let path = format!(
+                    "/devices/pci0000:{:02x}/0000:{:02x}:01.0/0000:{:02x}:00.0/\
+                     0000:{:02x}:00.0/0000:{:02x}:00.0/infiniband/{device_name}",
+                    bus,
+                    bus,
+                    bus + 1,
+                    bus + 2,
+                    bus + 3
+                );
+                InfinibandInterface {
+                    pci_properties: Some(PciDeviceProperties {
+                        vendor: "Mellanox Technologies".into(),
+                        device: "MT2910 Family [ConnectX-7]".into(),
+                        path,
+                        numa_node,
+                        description: Some("MT2910 Family [ConnectX-7]".into()),
+                        slot: format!("0000:{:02x}:00.0", bus + 3).into(),
+                    }),
+                    guid: format!("94dae0000000000{n}"),
+                }
+            })
+            .collect()
+    }
+}
+
+fn base_bios(system_id: &str) -> serde_json::Value {
+    redfish::bios::builder(&redfish::bios::resource(system_id))
+        .attributes(json!({
+            "AcpiSpcrConsoleRedirectionEnable": true,
+            "ConsoleRedirectionEnable0": true,
+            "AcpiSpcrPort": "COM0",
+            "AcpiSpcrFlowControl": "None",
+            "AcpiSpcrBaudRate": "115200",
+            "BaudRate0": "115200",
+            "SriovSupport": "Enabled",
+            "VTdSupport": "Enable",
+            "Ipv4Http": "Enabled",
+            "Ipv4Pxe": "Disabled",
+            "Ipv6Http": "Enabled",
+            "Ipv6Pxe": "Disabled",
+            "NvidiaInfiniteboot": "Enable",
+        }))
+        .build()
+        // For some reasons libredfish requires @odata.context. This
+        // patch makes it happy.
+        .patch(json!({
+            "@odata.context": "MakeLibRedfishHappy"
+        }))
+}
+
+fn hgx_gpu_sxm_chassis(index: usize, serial: &str) -> redfish::chassis::SingleChassisConfig {
+    let id = format!("HGX_GPU_SXM_{index}");
+    redfish::chassis::SingleChassisConfig {
+        chassis_type: "Other".into(),
+        manufacturer: Some("NVIDIA".into()),
+        part_number: Some("2330-885-A1".into()),
+        model: Some("H100 80GB HBM3".into()),
+        serial_number: Some(serial.to_string().into()),
+        network_adapters: None,
+        pcie_devices: Some(vec![
+            redfish::pcie_device::builder(&redfish::pcie_device::chassis_resource(
+                &id,
+                &format!("GPU_SXM_{index}"),
+            ))
+            .manufacturer("NVIDIA")
+            .model("H100 80GB HBM3")
+            .part_number("2330-885-A1")
+            .serial_number(serial)
+            .build(),
+        ]),
+        sensors: Some(redfish::sensor::generate_chassis_sensors(
+            &id,
+            redfish::sensor::Layout {
+                temperature: 3,
+                power: 2,
+                leak: 1, // Voltage
+                ..Default::default()
+            },
+        )),
+        id: id.into(),
+        assembly: None,
+        oem: None,
+    }
+}

--- a/crates/bmc-mock/src/hw/nvidia_switch_nd5200_ld.rs
+++ b/crates/bmc-mock/src/hw/nvidia_switch_nd5200_ld.rs
@@ -40,7 +40,7 @@ impl NvidiaSwitchNd5200Ld<'_> {
         redfish::manager::Config {
             managers: vec![redfish::manager::SingleConfig {
                 id: "BMC_0",
-                eth_interfaces: vec![
+                eth_interfaces: Some(vec![
                     eth_builder("eth0")
                         .mac_address(self.bmc_mac_address_eth0)
                         .interface_enabled(true)
@@ -53,8 +53,8 @@ impl NvidiaSwitchNd5200Ld<'_> {
                         .mac_address(self.bmc_mac_address_usb0)
                         .interface_enabled(true)
                         .build(),
-                ],
-                firmware_version: "88.0002.1333",
+                ]),
+                firmware_version: Some("88.0002.1333"),
                 oem: None,
             }],
         }

--- a/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
+++ b/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
@@ -50,14 +50,14 @@ impl WiwynnGB200Nvl<'_> {
             managers: vec![
                 redfish::manager::SingleConfig {
                     id: "BMC_0",
-                    eth_interfaces: vec![], // TODO: eth0 / eth1 / hmcusb0 / hostusb0
-                    firmware_version: "25.06-2_NV_WW_02",
+                    eth_interfaces: Some(vec![]), // TODO: eth0 / eth1 / hmcusb0 / hostusb0
+                    firmware_version: Some("25.06-2_NV_WW_02"),
                     oem: None,
                 },
                 redfish::manager::SingleConfig {
                     id: "HGX_BMC_0",
-                    eth_interfaces: vec![], // TODO: usb0
-                    firmware_version: "GB200Nvl-25.06-A",
+                    eth_interfaces: Some(vec![]), // TODO: usb0
+                    firmware_version: Some("GB200Nvl-25.06-A"),
                     oem: None,
                 },
             ],

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -54,6 +54,8 @@ pub enum HostHardwareType {
     LiteOnPowerShelf,
     #[serde(rename = "nvidia_switch_nd5200_ld")]
     NvidiaSwitchNd5200Ld,
+    #[serde(rename = "nvidia_dgx_h100")]
+    NvidiaDgxH100,
 }
 
 impl fmt::Display for HostHardwareType {
@@ -63,6 +65,22 @@ impl fmt::Display for HostHardwareType {
             Self::WiwynnGB200Nvl => "WIWYNN GB200 NVL".fmt(f),
             Self::LiteOnPowerShelf => "Lite-On Power Shelf".fmt(f),
             Self::NvidiaSwitchNd5200Ld => "NVIDIA Switch ND5200_LD".fmt(f),
+            Self::NvidiaDgxH100 => "NVIDIA DGX H100".fmt(f),
+        }
+    }
+}
+
+impl HostHardwareType {
+    // This function returns how many DPUs must be attached to the
+    // platform. If None than platform can support variable number of
+    // DPUs.
+    pub fn fixed_number_of_dpu(&self) -> Option<u8> {
+        match self {
+            Self::DellPowerEdgeR750 => None,
+            Self::WiwynnGB200Nvl => Some(2),
+            Self::LiteOnPowerShelf => Some(0),
+            Self::NvidiaSwitchNd5200Ld => Some(0),
+            Self::NvidiaDgxH100 => Some(1),
         }
     }
 }

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -108,9 +108,11 @@ impl DpuMachineInfo {
 
     fn bluefield3(&self) -> hw::bluefield3::Bluefield3<'_> {
         let mode = match self.hw_type {
-            HostHardwareType::DellPowerEdgeR750 => hw::bluefield3::Mode::SuperNIC {
-                nic_mode: self.settings.nic_mode,
-            },
+            HostHardwareType::DellPowerEdgeR750 | HostHardwareType::NvidiaDgxH100 => {
+                hw::bluefield3::Mode::SuperNIC {
+                    nic_mode: self.settings.nic_mode,
+                }
+            }
             HostHardwareType::WiwynnGB200Nvl => hw::bluefield3::Mode::B3240ColdAisle,
             HostHardwareType::LiteOnPowerShelf | HostHardwareType::NvidiaSwitchNd5200Ld => {
                 panic!("Bluefield3 DPU is defined for {}", self.hw_type)
@@ -166,6 +168,7 @@ impl HostMachineInfo {
             }
             HostHardwareType::WiwynnGB200Nvl
             | HostHardwareType::LiteOnPowerShelf
+            | HostHardwareType::NvidiaDgxH100
             | HostHardwareType::NvidiaSwitchNd5200Ld => redfish::oem::State::Other,
         }
     }
@@ -178,6 +181,7 @@ impl HostMachineInfo {
             HostHardwareType::NvidiaSwitchNd5200Ld => {
                 redfish::oem::BmcVendor::Nvidia(redfish::oem::NvidiaNamestyle::Uppercase)
             }
+            HostHardwareType::NvidiaDgxH100 => redfish::oem::BmcVendor::Ami,
         }
     }
 
@@ -187,6 +191,17 @@ impl HostMachineInfo {
             HostHardwareType::WiwynnGB200Nvl => Some("GB200 NVL"),
             HostHardwareType::LiteOnPowerShelf => None,
             HostHardwareType::NvidiaSwitchNd5200Ld => Some("P3809"),
+            HostHardwareType::NvidiaDgxH100 => Some("AMI Redfish Server"),
+        }
+    }
+
+    pub fn bmc_redfish_version(&self) -> &'static str {
+        match self.hw_type {
+            HostHardwareType::DellPowerEdgeR750 => "1.18.0",
+            HostHardwareType::WiwynnGB200Nvl => "1.17.0",
+            HostHardwareType::LiteOnPowerShelf => "1.9.0",
+            HostHardwareType::NvidiaSwitchNd5200Ld => "1.17.0",
+            HostHardwareType::NvidiaDgxH100 => "1.11.0",
         }
     }
 
@@ -198,6 +213,7 @@ impl HostMachineInfo {
             HostHardwareType::NvidiaSwitchNd5200Ld => {
                 self.nvidia_switch_nd5200_ld().manager_config()
             }
+            HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().manager_config(),
         }
     }
 
@@ -216,6 +232,7 @@ impl HostMachineInfo {
             HostHardwareType::NvidiaSwitchNd5200Ld => {
                 self.nvidia_switch_nd5200_ld().system_config()
             }
+            HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().system_config(power_control),
         }
     }
 
@@ -227,6 +244,7 @@ impl HostMachineInfo {
             HostHardwareType::NvidiaSwitchNd5200Ld => {
                 self.nvidia_switch_nd5200_ld().chassis_config()
             }
+            HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().chassis_config(),
         }
     }
 
@@ -240,6 +258,7 @@ impl HostMachineInfo {
             HostHardwareType::NvidiaSwitchNd5200Ld => {
                 self.nvidia_switch_nd5200_ld().update_service_config()
             }
+            HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().update_service_config(),
         }
     }
 
@@ -247,6 +266,7 @@ impl HostMachineInfo {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().discovery_info(),
             HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().discovery_info(),
+            HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().discovery_info(),
             HostHardwareType::LiteOnPowerShelf | HostHardwareType::NvidiaSwitchNd5200Ld => {
                 panic!("discovery_info requested for {}", self.hw_type)
             }
@@ -310,6 +330,53 @@ impl HostMachineInfo {
             switch_serial_number: format!("MT{}", next_mac().to_string().replace(':', "")).into(),
         }
     }
+
+    fn nvidia_dgx_h100(&self) -> hw::nvidia_dgx_h100::NvidiaDgxH100<'_> {
+        let storage_nic0_p0_mac = next_mac();
+        let storage_nic0_serial = format!("MT{}", storage_nic0_p0_mac.to_string().replace(":", ""));
+        hw::nvidia_dgx_h100::NvidiaDgxH100 {
+            dgx_system_serial_number: Cow::Borrowed(&self.serial),
+            dgx_chassis_serial_number: Cow::Borrowed("1663223000002"),
+            ib_nics: [
+                hw::nic_nvidia_cx7::NicNvidiaCx7B {
+                    serial_number: "MT2307X00001".into(),
+                    mac_addresses: [(); _].map(|_| next_mac()),
+                },
+                hw::nic_nvidia_cx7::NicNvidiaCx7B {
+                    serial_number: "MT2307X00002".into(),
+                    mac_addresses: [(); _].map(|_| next_mac()),
+                },
+            ],
+            mgmt_nic: hw::nic_intel_x550::NicIntelX550 {
+                mac_address: next_mac(),
+            },
+            storage_nic0: hw::nic_nvidia_cx7::NicNvidiaCx7A {
+                serial_number: storage_nic0_serial.into(),
+                mac_addresses: [(); _].map(|_| next_mac()),
+            },
+            storage_nic1: hw::nic_intel_e810::NicIntelE810 {
+                mac_addresses: [(); _].map(|_| next_mac()),
+            },
+            dpu: self
+                .dpus
+                .first()
+                .expect("Single DPUs must present for H100")
+                .bluefield3(),
+            gpu_serial: [
+                "1652900000001".into(),
+                "1652900000002".into(),
+                "1652900000003".into(),
+                "1652900000004".into(),
+                "1652900000005".into(),
+                "1652900000006".into(),
+                "1652900000007".into(),
+                "1652900000008".into(),
+            ],
+            bmc_mac_address_eth0: next_mac(),
+            bmc_mac_address_usb0: next_mac(),
+            hgx_bmc_mac_address_usb0: next_mac(),
+        }
+    }
 }
 
 impl MachineInfo {
@@ -338,6 +405,13 @@ impl MachineInfo {
             MachineInfo::Dpu(_) => {
                 redfish::oem::BmcVendor::Nvidia(redfish::oem::NvidiaNamestyle::Capitalized)
             }
+        }
+    }
+
+    pub fn bmc_redfish_version(&self) -> &'static str {
+        match self {
+            MachineInfo::Host(h) => h.bmc_redfish_version(),
+            MachineInfo::Dpu(_) => "1.17.0",
         }
     }
 

--- a/crates/bmc-mock/src/mock_machine_router.rs
+++ b/crates/bmc-mock/src/mock_machine_router.rs
@@ -71,6 +71,7 @@ pub fn machine_router(
     let update_service_config = machine_info.update_service_config();
     let bmc_vendor = machine_info.bmc_vendor();
     let bmc_product = machine_info.bmc_product();
+    let bmc_redfish_version = machine_info.bmc_redfish_version();
     let oem_state = machine_info.oem_state();
     let router = Router::new()
         // Couple routes for bug injection.
@@ -105,6 +106,7 @@ pub fn machine_router(
     let router = router.with_state(BmcState {
         bmc_vendor,
         bmc_product,
+        bmc_redfish_version,
         oem_state,
         manager,
         system_state,

--- a/crates/bmc-mock/src/redfish/account_service.rs
+++ b/crates/bmc-mock/src/redfish/account_service.rs
@@ -26,7 +26,7 @@ use serde_json::json;
 
 use crate::bmc_state::BmcState;
 use crate::json::JsonExt;
-use crate::redfish;
+use crate::{http, redfish};
 
 pub fn resource() -> redfish::Resource<'static> {
     redfish::Resource {
@@ -72,7 +72,7 @@ pub async fn get_root() -> Response {
 }
 
 pub async fn patch_root() -> Response {
-    json!({}).into_ok_response()
+    http::ok_no_content()
 }
 
 pub fn account_resource(id: impl Display) -> redfish::Resource<'static> {
@@ -99,7 +99,7 @@ pub async fn create_account(Path(_account_id): Path<String>) -> Response {
 }
 
 pub async fn patch_account(Path(_account_id): Path<String>) -> Response {
-    json!({}).into_ok_response()
+    http::ok_no_content()
 }
 
 pub async fn get_account(Path(account_id): Path<String>) -> Response {

--- a/crates/bmc-mock/src/redfish/boot_option.rs
+++ b/crates/bmc-mock/src/redfish/boot_option.rs
@@ -47,15 +47,20 @@ pub fn builder(resource: &redfish::Resource) -> BootOptionBuilder {
     BootOptionBuilder {
         id: Cow::Owned(resource.id.to_string()),
         value: resource.json_patch(),
+        reference: None,
     }
 }
 
 pub struct BootOption {
     pub id: Cow<'static, str>,
+    pub reference: Option<String>,
     value: serde_json::Value,
 }
 
 impl BootOption {
+    pub fn boot_reference(&self) -> &str {
+        self.reference.as_deref().unwrap_or(&self.id)
+    }
     pub fn to_json(&self) -> serde_json::Value {
         self.value.clone()
     }
@@ -63,6 +68,7 @@ impl BootOption {
 
 pub struct BootOptionBuilder {
     id: Cow<'static, str>,
+    reference: Option<String>,
     value: serde_json::Value,
 }
 
@@ -71,6 +77,7 @@ impl Builder for BootOptionBuilder {
         Self {
             value: self.value.patch(patch),
             id: self.id,
+            reference: self.reference,
         }
     }
 }
@@ -81,7 +88,9 @@ impl BootOptionBuilder {
     }
 
     pub fn boot_option_reference(self, value: &str) -> Self {
-        self.add_str_field("BootOptionReference", value)
+        let mut result = self.add_str_field("BootOptionReference", value);
+        result.reference = Some(value.to_string());
+        result
     }
 
     pub fn uefi_device_path(self, value: &str) -> Self {
@@ -91,6 +100,7 @@ impl BootOptionBuilder {
     pub fn build(self) -> BootOption {
         BootOption {
             id: self.id,
+            reference: self.reference,
             value: self.value,
         }
     }

--- a/crates/bmc-mock/src/redfish/computer_system.rs
+++ b/crates/bmc-mock/src/redfish/computer_system.rs
@@ -258,7 +258,7 @@ async fn get_system(State(state): State<BmcState>, Path(system_id): Path<String>
                     .boot_options
                     .iter()
                     .flatten()
-                    .map(|v| v.id.as_ref())
+                    .map(|v| v.boot_reference())
                     .collect::<Vec<_>>(),
             );
         }
@@ -689,7 +689,7 @@ async fn patch_bios_settings(
                 &mut system_state.bios_overrides.lock().expect("mutex poisoned"),
                 patch_bios_request,
             );
-            json!({}).into_ok_response()
+            http::ok_no_content()
         }
     }
 }

--- a/crates/bmc-mock/src/redfish/manager.rs
+++ b/crates/bmc-mock/src/redfish/manager.rs
@@ -76,7 +76,7 @@ impl Builder for ManagerBuilder {
 }
 
 impl ManagerBuilder {
-    pub fn ethernet_interfaces(self, collection: redfish::Collection<'_>) -> Self {
+    pub fn ethernet_interfaces(self, collection: &redfish::Collection<'_>) -> Self {
         self.apply_patch(collection.nav_property("EthernetInterfaces"))
     }
 
@@ -194,8 +194,8 @@ pub struct Config {
 #[derive(Clone)]
 pub struct SingleConfig {
     pub id: &'static str,
-    pub eth_interfaces: Vec<redfish::ethernet_interface::EthernetInterface>,
-    pub firmware_version: &'static str,
+    pub eth_interfaces: Option<Vec<redfish::ethernet_interface::EthernetInterface>>,
+    pub firmware_version: Option<&'static str>,
     pub oem: Option<Oem>,
 }
 
@@ -258,14 +258,24 @@ async fn get_manager(State(state): State<BmcState>, Path(manager_id): Path<Strin
         .network_protocol(redfish::manager_network_protocol::manager_resource(
             &manager_id,
         ))
-        .ethernet_interfaces(redfish::ethernet_interface::manager_collection(&manager_id))
+        .maybe_with(
+            ManagerBuilder::ethernet_interfaces,
+            &this
+                .config
+                .eth_interfaces
+                .as_ref()
+                .map(|_| redfish::ethernet_interface::manager_collection(&manager_id)),
+        )
         .enable_reset_action()
-        .firmware_version(this.config.firmware_version)
         .log_services(redfish::log_service::manager_collection(&manager_id))
         .status(redfish::resource::Status::Ok)
         .uuid("3347314f-c0c6-5080-3410-00354c4c4544")
         .date_time(Utc::now())
         .maybe_with(ManagerBuilder::oem, &this.config.oem)
+        .maybe_with(
+            ManagerBuilder::firmware_version,
+            &this.config.firmware_version,
+        )
         .build()
         .into_ok_response()
 }
@@ -274,33 +284,38 @@ async fn get_ethernet_interface_collection(
     State(state): State<BmcState>,
     Path(manager_id): Path<String>,
 ) -> Response {
-    let Some(this) = state.manager.find(&manager_id) else {
-        return http::not_found();
-    };
-
-    let members = this
-        .config
-        .eth_interfaces
-        .iter()
-        .map(|eth| redfish::ethernet_interface::manager_resource(&manager_id, &eth.id).entity_ref())
-        .collect::<Vec<_>>();
-    redfish::ethernet_interface::manager_collection(&manager_id)
-        .with_members(&members)
-        .into_ok_response()
+    state
+        .manager
+        .find(&manager_id)
+        .and_then(|manager| manager.config.eth_interfaces.as_ref())
+        .map(|eth_interfaces| {
+            let members = eth_interfaces
+                .iter()
+                .map(|eth| {
+                    redfish::ethernet_interface::manager_resource(&manager_id, &eth.id).entity_ref()
+                })
+                .collect::<Vec<_>>();
+            redfish::ethernet_interface::manager_collection(&manager_id)
+                .with_members(&members)
+                .into_ok_response()
+        })
+        .unwrap_or_else(http::not_found)
 }
 
 async fn get_ethernet_interface(
     State(state): State<BmcState>,
     Path((manager_id, eth_id)): Path<(String, String)>,
 ) -> Response {
-    let Some(this) = state.manager.find(&manager_id) else {
-        return http::not_found();
-    };
-    this.config
-        .eth_interfaces
-        .iter()
-        .find(|eth| eth.id == eth_id)
-        .map(|eth| eth.to_json().into_ok_response())
+    state
+        .manager
+        .find(&manager_id)
+        .and_then(|manager| manager.config.eth_interfaces.as_ref())
+        .and_then(|eth_interfaces| {
+            eth_interfaces
+                .iter()
+                .find(|eth| eth.id == eth_id)
+                .map(|eth| eth.to_json().into_ok_response())
+        })
         .unwrap_or_else(http::not_found)
 }
 

--- a/crates/bmc-mock/src/redfish/network_adapter.rs
+++ b/crates/bmc-mock/src/redfish/network_adapter.rs
@@ -73,8 +73,9 @@ pub fn builder(resource: &redfish::Resource) -> NetworkAdapterBuilder {
 }
 
 pub fn builder_from_nic(resource: &redfish::Resource, nic: &hw::nic::Nic) -> NetworkAdapterBuilder {
-    let b = builder(resource).serial_number(&nic.serial_number);
-    b.maybe_with(NetworkAdapterBuilder::description, &nic.description)
+    builder(resource)
+        .maybe_with(NetworkAdapterBuilder::serial_number, &nic.serial_number)
+        .maybe_with(NetworkAdapterBuilder::description, &nic.description)
         .maybe_with(NetworkAdapterBuilder::manufacturer, &nic.manufacturer)
         .maybe_with(NetworkAdapterBuilder::model, &nic.model)
         .maybe_with(NetworkAdapterBuilder::part_number, &nic.part_number)

--- a/crates/bmc-mock/src/redfish/oem/mod.rs
+++ b/crates/bmc-mock/src/redfish/oem/mod.rs
@@ -26,6 +26,7 @@ pub enum BmcVendor {
     Nvidia(NvidiaNamestyle),
     Wiwynn,
     LiteOn,
+    Ami,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -42,6 +43,7 @@ impl BmcVendor {
             BmcVendor::Dell => Some("Dell"),
             BmcVendor::Wiwynn => Some("WIWYNN"),
             BmcVendor::LiteOn => None,
+            BmcVendor::Ami => Some("AMI"),
         }
     }
     // This function creates settings of the resource from the resource
@@ -50,6 +52,9 @@ impl BmcVendor {
         match self {
             BmcVendor::Nvidia(_) | BmcVendor::Dell | BmcVendor::Wiwynn | BmcVendor::LiteOn => {
                 format!("{}/Settings", resource.odata_id)
+            }
+            BmcVendor::Ami => {
+                format!("{}/SD", resource.odata_id)
             }
         }
     }

--- a/crates/bmc-mock/src/redfish/pcie_device.rs
+++ b/crates/bmc-mock/src/redfish/pcie_device.rs
@@ -54,9 +54,10 @@ pub fn builder(resource: &redfish::Resource) -> PcieDeviceBuilder {
 }
 
 pub fn builder_from_nic(resource: &redfish::Resource, nic: &hw::nic::Nic) -> PcieDeviceBuilder {
-    let b = builder(resource).serial_number(&nic.serial_number);
+    let b = builder(resource);
     let b = if nic.is_mat_dpu { b.mat_dpu() } else { b };
-    b.maybe_with(PcieDeviceBuilder::description, &nic.description)
+    b.maybe_with(PcieDeviceBuilder::serial_number, &nic.serial_number)
+        .maybe_with(PcieDeviceBuilder::description, &nic.description)
         .maybe_with(PcieDeviceBuilder::manufacturer, &nic.manufacturer)
         .maybe_with(PcieDeviceBuilder::model, &nic.model)
         .maybe_with(PcieDeviceBuilder::part_number, &nic.part_number)

--- a/crates/bmc-mock/src/redfish/service_root.rs
+++ b/crates/bmc-mock/src/redfish/service_root.rs
@@ -51,7 +51,7 @@ pub fn builder(resource: &redfish::Resource) -> ServiceRootBuilder {
 
 async fn get_service_root(State(state): State<BmcState>) -> Response {
     builder(&resource())
-        .redfish_version("1.13.1")
+        .redfish_version(state.bmc_redfish_version)
         .maybe_with(
             ServiceRootBuilder::vendor,
             &state.bmc_vendor.service_root_value(),

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -154,7 +154,11 @@ impl HostMachine {
         let mut dpu_dhcp_rx = Some(dpu_dhcp_rx);
         let dpus_in_nic_mode = config.dpus_in_nic_mode;
 
-        let dpu_machines = (1..=config.dpu_per_host_count as u8)
+        let num_dpu = config
+            .hw_type
+            .fixed_number_of_dpu()
+            .unwrap_or(config.dpu_per_host_count as u8);
+        let dpu_machines = (1..=num_dpu)
             .map(|index| {
                 DpuMachine::new(
                     config.hw_type,


### PR DESCRIPTION
## Description

Add mock hardware support for NVIDIA DGX H100 systems including:
- 8x H100 80GB HBM3 GPUs with HGX chassis
- 2x ConnectX-7B quad-port InfiniBand NICs
- 1x ConnectX-7A dual-port storage NIC
- 1x Intel E810 dual-port storage NIC
- 1x Intel X550 management NIC
- 1x BlueField-3 DPU (fixed count of 1)

New NIC hardware modules:
- nic_intel_e810: Intel E810 dual-port NIC
- nic_intel_x550: Intel X550 NIC
- nic_nvidia_cx7: ConnectX-7 variants (CX7A dual-port, CX7B quad-port)

Additional changes:
- Add AMI BMC vendor support with /SD settings path
- Make manager eth_interfaces and firmware_version optional
- Make NIC serial_number optional for Intel NICs without serials
- Add fixed_number_of_dpu() for platforms with fixed DPU count
- Add ok_no_content() helper for PATCH responses returning 204
- Add bmc_redfish_version() per hardware type

## Type of Change
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

