### PR TITLE
chore(admin-cli): more Args -> From/TryFrom -> Request

### DIFF
--- a/crates/admin-cli/src/bmc_machine/admin_power_control/args.rs
+++ b/crates/admin-cli/src/bmc_machine/admin_power_control/args.rs
@@ -16,6 +16,7 @@
  */
 
 use clap::Parser;
+use rpc::forge as forgerpc;
 
 use crate::bmc_machine::common::AdminPowerControlAction;
 
@@ -25,4 +26,15 @@ pub struct Args {
     pub machine: String,
     #[clap(long, help = "Power control action")]
     pub action: AdminPowerControlAction,
+}
+
+impl From<Args> for forgerpc::AdminPowerControlRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            bmc_endpoint_request: None,
+            machine_id: Some(args.machine),
+            action: forgerpc::admin_power_control_request::SystemPowerControl::from(args.action)
+                .into(),
+        }
+    }
 }

--- a/crates/admin-cli/src/bmc_machine/admin_power_control/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/admin_power_control/cmd.rs
@@ -21,8 +21,6 @@ use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn admin_power_control(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    api_client
-        .admin_power_control(None, Some(args.machine), args.action.into())
-        .await?;
+    api_client.0.admin_power_control(args).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/bmc_machine/bmc_reset/args.rs
+++ b/crates/admin-cli/src/bmc_machine/bmc_reset/args.rs
@@ -16,6 +16,7 @@
  */
 
 use clap::Parser;
+use rpc::forge as forgerpc;
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
@@ -23,4 +24,14 @@ pub struct Args {
     pub machine: String,
     #[clap(short, long, help = "Use ipmitool")]
     pub use_ipmitool: bool,
+}
+
+impl From<Args> for forgerpc::AdminBmcResetRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            bmc_endpoint_request: None,
+            machine_id: Some(args.machine),
+            use_ipmitool: args.use_ipmitool,
+        }
+    }
 }

--- a/crates/admin-cli/src/bmc_machine/bmc_reset/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/bmc_reset/cmd.rs
@@ -21,8 +21,6 @@ use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn bmc_reset(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    api_client
-        .bmc_reset(None, Some(args.machine), args.use_ipmitool)
-        .await?;
+    api_client.0.admin_bmc_reset(args).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/bmc_machine/create_bmc_user/args.rs
+++ b/crates/admin-cli/src/bmc_machine/create_bmc_user/args.rs
@@ -17,6 +17,7 @@
 
 use clap::Parser;
 use mac_address::MacAddress;
+use rpc::forge as forgerpc;
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
@@ -41,4 +42,25 @@ pub struct Args {
         help = "Role of new BMC account ('administrator', 'operator', 'readonly', 'noaccess')"
     )]
     pub role_id: Option<String>,
+}
+
+impl From<Args> for forgerpc::CreateBmcUserRequest {
+    fn from(args: Args) -> Self {
+        let bmc_endpoint_request = if args.ip_address.is_some() || args.mac_address.is_some() {
+            Some(forgerpc::BmcEndpointRequest {
+                ip_address: args.ip_address.unwrap_or_default(),
+                mac_address: args.mac_address.map(|mac| mac.to_string()),
+            })
+        } else {
+            None
+        };
+
+        Self {
+            bmc_endpoint_request,
+            machine_id: args.machine,
+            create_username: args.username,
+            create_password: args.password,
+            create_role_id: args.role_id,
+        }
+    }
 }

--- a/crates/admin-cli/src/bmc_machine/create_bmc_user/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/create_bmc_user/cmd.rs
@@ -21,15 +21,6 @@ use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn create_bmc_user(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    api_client
-        .create_bmc_user(
-            args.ip_address,
-            args.mac_address,
-            args.machine,
-            args.username,
-            args.password,
-            args.role_id,
-        )
-        .await?;
+    api_client.0.create_bmc_user(args).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/bmc_machine/delete_bmc_user/args.rs
+++ b/crates/admin-cli/src/bmc_machine/delete_bmc_user/args.rs
@@ -17,6 +17,7 @@
 
 use clap::Parser;
 use mac_address::MacAddress;
+use rpc::forge as forgerpc;
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
@@ -29,4 +30,23 @@ pub struct Args {
 
     #[clap(long, short, help = "Username of BMC account to delete")]
     pub username: String,
+}
+
+impl From<Args> for forgerpc::DeleteBmcUserRequest {
+    fn from(args: Args) -> Self {
+        let bmc_endpoint_request = if args.ip_address.is_some() || args.mac_address.is_some() {
+            Some(forgerpc::BmcEndpointRequest {
+                ip_address: args.ip_address.unwrap_or_default(),
+                mac_address: args.mac_address.map(|mac| mac.to_string()),
+            })
+        } else {
+            None
+        };
+
+        Self {
+            bmc_endpoint_request,
+            machine_id: args.machine,
+            delete_username: args.username,
+        }
+    }
 }

--- a/crates/admin-cli/src/bmc_machine/delete_bmc_user/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/delete_bmc_user/cmd.rs
@@ -21,13 +21,6 @@ use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn delete_bmc_user(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    api_client
-        .delete_bmc_user(
-            args.ip_address,
-            args.mac_address,
-            args.machine,
-            args.username,
-        )
-        .await?;
+    api_client.0.delete_bmc_user(args).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/bmc_machine/is_infinite_boot_enabled/args.rs
+++ b/crates/admin-cli/src/bmc_machine/is_infinite_boot_enabled/args.rs
@@ -16,6 +16,7 @@
  */
 
 use clap::Parser;
+use rpc::forge as forgerpc;
 
 use crate::bmc_machine::common::InfiniteBootArgs;
 
@@ -26,4 +27,13 @@ use crate::bmc_machine::common::InfiniteBootArgs;
 pub struct Args {
     #[clap(flatten)]
     pub inner: InfiniteBootArgs,
+}
+
+impl From<Args> for forgerpc::IsInfiniteBootEnabledRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            bmc_endpoint_request: None,
+            machine_id: Some(args.inner.machine),
+        }
+    }
 }

--- a/crates/admin-cli/src/bmc_machine/is_infinite_boot_enabled/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/is_infinite_boot_enabled/cmd.rs
@@ -17,16 +17,11 @@
 
 use ::rpc::admin_cli::CarbideCliResult;
 
-use crate::bmc_machine::common::InfiniteBootArgs;
+use super::args::Args;
 use crate::rpc::ApiClient;
 
-pub async fn is_infinite_boot_enabled(
-    args: InfiniteBootArgs,
-    api_client: &ApiClient,
-) -> CarbideCliResult<()> {
-    let response = api_client
-        .is_infinite_boot_enabled(None, Some(args.machine))
-        .await?;
+pub async fn is_infinite_boot_enabled(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let response = api_client.0.is_infinite_boot_enabled(args).await?;
     match response.is_enabled {
         Some(true) => println!("Enabled"),
         Some(false) => println!("Disabled"),

--- a/crates/admin-cli/src/bmc_machine/is_infinite_boot_enabled/mod.rs
+++ b/crates/admin-cli/src/bmc_machine/is_infinite_boot_enabled/mod.rs
@@ -26,6 +26,6 @@ use crate::cfg::runtime::RuntimeContext;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
-        cmd::is_infinite_boot_enabled(self.inner, &ctx.api_client).await
+        cmd::is_infinite_boot_enabled(self, &ctx.api_client).await
     }
 }

--- a/crates/admin-cli/src/bmc_machine/lockdown_status/args.rs
+++ b/crates/admin-cli/src/bmc_machine/lockdown_status/args.rs
@@ -17,9 +17,19 @@
 
 use carbide_uuid::machine::MachineId;
 use clap::Parser;
+use rpc::forge as forgerpc;
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
     #[clap(long, help = "ID of the machine to check lockdown status")]
     pub machine: MachineId,
+}
+
+impl From<Args> for forgerpc::LockdownStatusRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            bmc_endpoint_request: None,
+            machine_id: Some(args.machine),
+        }
+    }
 }

--- a/crates/admin-cli/src/bmc_machine/lockdown_status/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/lockdown_status/cmd.rs
@@ -21,7 +21,7 @@ use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn lockdown_status(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let response = api_client.lockdown_status(None, args.machine).await?;
+    let response = api_client.0.lockdown_status(args).await?;
     // Convert status enum to string
     let status_str = match response.status {
         0 => "Enabled",  // InternalLockdownStatus::ENABLED

--- a/crates/admin-cli/src/boot_override/clear/args.rs
+++ b/crates/admin-cli/src/boot_override/clear/args.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use carbide_uuid::machine::MachineInterfaceId;
 use clap::Parser;
 
 use crate::boot_override::common::BootOverride;
@@ -26,4 +27,10 @@ use crate::boot_override::common::BootOverride;
 pub struct Args {
     #[clap(flatten)]
     pub inner: BootOverride,
+}
+
+impl From<Args> for MachineInterfaceId {
+    fn from(args: Args) -> Self {
+        args.inner.interface_id
+    }
 }

--- a/crates/admin-cli/src/boot_override/clear/cmd.rs
+++ b/crates/admin-cli/src/boot_override/clear/cmd.rs
@@ -17,13 +17,10 @@
 
 use ::rpc::admin_cli::CarbideCliResult;
 
-use crate::boot_override::common::BootOverride;
+use super::args::Args;
 use crate::rpc::ApiClient;
 
-pub async fn clear(args: BootOverride, api_client: &ApiClient) -> CarbideCliResult<()> {
-    api_client
-        .0
-        .clear_machine_boot_override(args.interface_id)
-        .await?;
+pub async fn clear(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    api_client.0.clear_machine_boot_override(args).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/boot_override/clear/mod.rs
+++ b/crates/admin-cli/src/boot_override/clear/mod.rs
@@ -26,6 +26,6 @@ use crate::cfg::runtime::RuntimeContext;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
-        cmd::clear(self.inner, &ctx.api_client).await
+        cmd::clear(self, &ctx.api_client).await
     }
 }

--- a/crates/admin-cli/src/boot_override/get/args.rs
+++ b/crates/admin-cli/src/boot_override/get/args.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use carbide_uuid::machine::MachineInterfaceId;
 use clap::Parser;
 
 use crate::boot_override::common::BootOverride;
@@ -26,4 +27,10 @@ use crate::boot_override::common::BootOverride;
 pub struct Args {
     #[clap(flatten)]
     pub inner: BootOverride,
+}
+
+impl From<Args> for MachineInterfaceId {
+    fn from(args: Args) -> Self {
+        args.inner.interface_id
+    }
 }

--- a/crates/admin-cli/src/boot_override/get/cmd.rs
+++ b/crates/admin-cli/src/boot_override/get/cmd.rs
@@ -17,14 +17,11 @@
 
 use ::rpc::admin_cli::CarbideCliResult;
 
-use crate::boot_override::common::BootOverride;
+use super::args::Args;
 use crate::rpc::ApiClient;
 
-pub async fn get(args: BootOverride, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let mbo = api_client
-        .0
-        .get_machine_boot_override(args.interface_id)
-        .await?;
+pub async fn get(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let mbo = api_client.0.get_machine_boot_override(args).await?;
 
     tracing::info!(
         "{}",

--- a/crates/admin-cli/src/boot_override/get/mod.rs
+++ b/crates/admin-cli/src/boot_override/get/mod.rs
@@ -26,6 +26,6 @@ use crate::cfg::runtime::RuntimeContext;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
-        cmd::get(self.inner, &ctx.api_client).await
+        cmd::get(self, &ctx.api_client).await
     }
 }

--- a/crates/admin-cli/src/boot_override/set/args.rs
+++ b/crates/admin-cli/src/boot_override/set/args.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+use ::rpc::forge::MachineBootOverride;
 use carbide_uuid::machine::MachineInterfaceId;
 use clap::Parser;
 
@@ -25,4 +27,28 @@ pub struct Args {
     pub custom_pxe: Option<String>,
     #[clap(short = 'u', long)]
     pub custom_user_data: Option<String>,
+}
+
+impl TryFrom<Args> for MachineBootOverride {
+    type Error = CarbideCliError;
+
+    fn try_from(args: Args) -> CarbideCliResult<Self> {
+        if args.custom_pxe.is_none() && args.custom_user_data.is_none() {
+            return Err(CarbideCliError::GenericError(
+                "Either custom pxe or custom user data is required".to_owned(),
+            ));
+        }
+
+        let custom_pxe = args.custom_pxe.map(std::fs::read_to_string).transpose()?;
+        let custom_user_data = args
+            .custom_user_data
+            .map(std::fs::read_to_string)
+            .transpose()?;
+
+        Ok(MachineBootOverride {
+            machine_interface_id: Some(args.interface_id),
+            custom_pxe,
+            custom_user_data,
+        })
+    }
 }

--- a/crates/admin-cli/src/boot_override/set/cmd.rs
+++ b/crates/admin-cli/src/boot_override/set/cmd.rs
@@ -15,41 +15,14 @@
  * limitations under the License.
  */
 
-use std::path::PathBuf;
-
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge::MachineBootOverride;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn set(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    if args.custom_pxe.is_none() && args.custom_user_data.is_none() {
-        return Err(CarbideCliError::GenericError(
-            "Either custom pxe or custom user data is required".to_owned(),
-        ));
-    }
-
-    let custom_pxe_path = args.custom_pxe.map(PathBuf::from);
-    let custom_user_data_path = args.custom_user_data.map(PathBuf::from);
-
-    let custom_pxe = match &custom_pxe_path {
-        Some(path) => Some(std::fs::read_to_string(path)?),
-        None => None,
-    };
-
-    let custom_user_data = match &custom_user_data_path {
-        Some(path) => Some(std::fs::read_to_string(path)?),
-        None => None,
-    };
-
-    api_client
-        .0
-        .set_machine_boot_override(MachineBootOverride {
-            machine_interface_id: Some(args.interface_id),
-            custom_pxe,
-            custom_user_data,
-        })
-        .await?;
+    let req: MachineBootOverride = args.try_into()?;
+    api_client.0.set_machine_boot_override(req).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/compute_allocation/delete/cmd.rs
+++ b/crates/admin-cli/src/compute_allocation/delete/cmd.rs
@@ -16,7 +16,6 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::forge::DeleteComputeAllocationRequest;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
@@ -24,8 +23,7 @@ use crate::rpc::ApiClient;
 /// Delete a compute allocation.
 pub async fn delete(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
     let id = args.id;
-    let req: DeleteComputeAllocationRequest = args.into();
-    api_client.0.delete_compute_allocation(req).await?;
+    api_client.0.delete_compute_allocation(args).await?;
     println!("Deleted compute allocation {} successfully.", id);
     Ok(())
 }

--- a/crates/admin-cli/src/compute_allocation/show/cmd.rs
+++ b/crates/admin-cli/src/compute_allocation/show/cmd.rs
@@ -16,7 +16,7 @@
  */
 
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
-use ::rpc::forge::{FindComputeAllocationIdsRequest, FindComputeAllocationsByIdsRequest};
+use ::rpc::forge::FindComputeAllocationsByIdsRequest;
 
 use super::args::Args;
 use crate::compute_allocation::common::convert_compute_allocations_to_table;
@@ -39,8 +39,7 @@ pub async fn show(
             .await?
             .allocations
     } else {
-        let req: FindComputeAllocationIdsRequest = args.into();
-        let all_ids = api_client.0.find_compute_allocation_ids(req).await?.ids;
+        let all_ids = api_client.0.find_compute_allocation_ids(args).await?.ids;
 
         let mut allocations = Vec::with_capacity(all_ids.len());
 

--- a/crates/admin-cli/src/credential/add_bmc/cmd.rs
+++ b/crates/admin-cli/src/credential/add_bmc/cmd.rs
@@ -22,7 +22,9 @@ use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn add_bmc(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let req: forgerpc::CredentialCreationRequest = data.try_into()?;
-    api_client.0.create_credential(req).await?;
+    api_client
+        .0
+        .create_credential(forgerpc::CredentialCreationRequest::try_from(data)?)
+        .await?;
     Ok(())
 }

--- a/crates/admin-cli/src/credential/add_dpu_factory_default/cmd.rs
+++ b/crates/admin-cli/src/credential/add_dpu_factory_default/cmd.rs
@@ -16,13 +16,11 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::forge as forgerpc;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn add_dpu_factory_default(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let req: forgerpc::CredentialCreationRequest = data.into();
-    api_client.0.create_credential(req).await?;
+    api_client.0.create_credential(data).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/credential/add_host_factory_default/cmd.rs
+++ b/crates/admin-cli/src/credential/add_host_factory_default/cmd.rs
@@ -16,13 +16,11 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::forge as forgerpc;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn add_host_factory_default(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let req: forgerpc::CredentialCreationRequest = data.into();
-    api_client.0.create_credential(req).await?;
+    api_client.0.create_credential(data).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/credential/add_nmxm/cmd.rs
+++ b/crates/admin-cli/src/credential/add_nmxm/cmd.rs
@@ -16,13 +16,11 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::forge as forgerpc;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn add_nmxm(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let req: forgerpc::CredentialCreationRequest = data.into();
-    api_client.0.create_credential(req).await?;
+    api_client.0.create_credential(data).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/credential/add_uefi/cmd.rs
+++ b/crates/admin-cli/src/credential/add_uefi/cmd.rs
@@ -22,7 +22,9 @@ use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn add_uefi(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let req: forgerpc::CredentialCreationRequest = data.try_into()?;
-    api_client.0.create_credential(req).await?;
+    api_client
+        .0
+        .create_credential(forgerpc::CredentialCreationRequest::try_from(data)?)
+        .await?;
     Ok(())
 }

--- a/crates/admin-cli/src/credential/add_ufm/cmd.rs
+++ b/crates/admin-cli/src/credential/add_ufm/cmd.rs
@@ -22,7 +22,9 @@ use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn add_ufm(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let req: forgerpc::CredentialCreationRequest = data.try_into()?;
-    api_client.0.create_credential(req).await?;
+    api_client
+        .0
+        .create_credential(forgerpc::CredentialCreationRequest::try_from(data)?)
+        .await?;
     Ok(())
 }

--- a/crates/admin-cli/src/credential/delete_bmc/cmd.rs
+++ b/crates/admin-cli/src/credential/delete_bmc/cmd.rs
@@ -16,13 +16,11 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::forge as forgerpc;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn delete_bmc(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let req: forgerpc::CredentialDeletionRequest = data.into();
-    api_client.0.delete_credential(req).await?;
+    api_client.0.delete_credential(data).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/credential/delete_nmxm/cmd.rs
+++ b/crates/admin-cli/src/credential/delete_nmxm/cmd.rs
@@ -16,13 +16,11 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::forge as forgerpc;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn delete_nmxm(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let req: forgerpc::CredentialDeletionRequest = data.into();
-    api_client.0.delete_credential(req).await?;
+    api_client.0.delete_credential(data).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/credential/delete_ufm/cmd.rs
+++ b/crates/admin-cli/src/credential/delete_ufm/cmd.rs
@@ -22,7 +22,9 @@ use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn delete_ufm(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let req: forgerpc::CredentialDeletionRequest = data.try_into()?;
-    api_client.0.delete_credential(req).await?;
+    api_client
+        .0
+        .delete_credential(forgerpc::CredentialDeletionRequest::try_from(data)?)
+        .await?;
     Ok(())
 }

--- a/crates/admin-cli/src/dpa/ensure/args.rs
+++ b/crates/admin-cli/src/dpa/ensure/args.rs
@@ -29,3 +29,14 @@ pub struct Args {
     #[clap(help = "PCI name (e.g. 5e:00.0)")]
     pub pci_name: String,
 }
+
+impl From<Args> for ::rpc::forge::DpaInterfaceCreationRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            machine_id: Some(args.machine_id),
+            mac_addr: args.mac_addr,
+            device_type: args.device_type,
+            pci_name: args.pci_name,
+        }
+    }
+}

--- a/crates/admin-cli/src/dpa/ensure/cmd.rs
+++ b/crates/admin-cli/src/dpa/ensure/cmd.rs
@@ -33,18 +33,11 @@ use crate::rpc::ApiClient;
 // interface if it doesn't exist, or return the existing
 // interface otherwise.
 pub async fn ensure(
-    args: &Args,
+    args: Args,
     output_format: OutputFormat,
     api_client: &ApiClient,
 ) -> CarbideCliResult<()> {
-    let request = forgerpc::DpaInterfaceCreationRequest {
-        machine_id: Some(args.machine_id),
-        mac_addr: args.mac_addr.clone(),
-        device_type: args.device_type.clone(),
-        pci_name: args.pci_name.clone(),
-    };
-
-    let interface = api_client.0.ensure_dpa_interface(request).await?;
+    let interface = api_client.0.ensure_dpa_interface(args).await?;
 
     if output_format == OutputFormat::Json {
         println!("{}", serde_json::to_string_pretty(&interface)?);

--- a/crates/admin-cli/src/dpa/ensure/mod.rs
+++ b/crates/admin-cli/src/dpa/ensure/mod.rs
@@ -26,6 +26,6 @@ use crate::cfg::runtime::RuntimeContext;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
-        cmd::ensure(&self, ctx.config.format, &ctx.api_client).await
+        cmd::ensure(self, ctx.config.format, &ctx.api_client).await
     }
 }

--- a/crates/admin-cli/src/dpf/common.rs
+++ b/crates/admin-cli/src/dpf/common.rs
@@ -17,9 +17,30 @@
 
 use carbide_uuid::machine::MachineId;
 use clap::Parser;
+use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug)]
 pub struct DpfQuery {
     #[clap(help = "Host machine id")]
     pub host: Option<MachineId>,
+}
+
+impl TryFrom<&DpfQuery> for MachineId {
+    type Error = CarbideCliError;
+
+    fn try_from(query: &DpfQuery) -> CarbideCliResult<Self> {
+        let Some(host) = query.host else {
+            return Err(CarbideCliError::GenericError(
+                "Host id is required!!".to_string(),
+            ));
+        };
+
+        if host.machine_type() == carbide_uuid::machine::MachineType::Dpu {
+            return Err(CarbideCliError::GenericError(
+                "Only host id is expected!!".to_string(),
+            ));
+        }
+
+        Ok(host)
+    }
 }

--- a/crates/admin-cli/src/dpf/enable/cmd.rs
+++ b/crates/admin-cli/src/dpf/enable/cmd.rs
@@ -16,7 +16,7 @@
  */
 
 use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
-use rpc::admin_cli::CarbideCliError;
+use carbide_uuid::machine::MachineId;
 
 use crate::dpf::common::DpfQuery;
 use crate::rpc::ApiClient;
@@ -27,17 +27,7 @@ pub async fn modify_dpf_state(
     api_client: &ApiClient,
     enabled: bool,
 ) -> CarbideCliResult<()> {
-    let Some(host) = query.host else {
-        return Err(CarbideCliError::GenericError(
-            "Host id is required!!".to_string(),
-        ));
-    };
-
-    if host.machine_type() == carbide_uuid::machine::MachineType::Dpu {
-        return Err(CarbideCliError::GenericError(
-            "Only host id is expected!!".to_string(),
-        ));
-    }
+    let host: MachineId = query.try_into()?;
     api_client.modify_dpf_state(host, enabled).await?;
     println!("DPF state modified for machine {host} with state {enabled} successfully!!",);
     Ok(())

--- a/crates/admin-cli/src/dpu_remediation/approve/args.rs
+++ b/crates/admin-cli/src/dpu_remediation/approve/args.rs
@@ -17,9 +17,18 @@
 
 use carbide_uuid::dpu_remediations::RemediationId;
 use clap::Parser;
+use rpc::forge::ApproveRemediationRequest;
 
 #[derive(Parser, Debug)]
 pub struct Args {
     #[clap(help = "The id of the remediation to approve", long)]
     pub id: RemediationId,
+}
+
+impl From<Args> for ApproveRemediationRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            remediation_id: Some(args.id),
+        }
+    }
 }

--- a/crates/admin-cli/src/dpu_remediation/approve/cmd.rs
+++ b/crates/admin-cli/src/dpu_remediation/approve/cmd.rs
@@ -16,22 +16,17 @@
  */
 
 use ::rpc::admin_cli::CarbideCliError;
-use rpc::forge::ApproveRemediationRequest;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn approve_dpu_remediation(
-    approve_remediation: Args,
+    data: Args,
     api_client: &ApiClient,
 ) -> Result<(), CarbideCliError> {
-    api_client
-        .0
-        .approve_remediation(ApproveRemediationRequest {
-            remediation_id: Some(approve_remediation.id),
-        })
-        .await?;
+    let id = data.id;
+    api_client.0.approve_remediation(data).await?;
 
-    tracing::info!("Approved remediation with id: {:?}", approve_remediation.id);
+    tracing::info!("Approved remediation with id: {:?}", id);
     Ok(())
 }

--- a/crates/admin-cli/src/dpu_remediation/disable/args.rs
+++ b/crates/admin-cli/src/dpu_remediation/disable/args.rs
@@ -17,9 +17,18 @@
 
 use carbide_uuid::dpu_remediations::RemediationId;
 use clap::Parser;
+use rpc::forge::DisableRemediationRequest;
 
 #[derive(Parser, Debug)]
 pub struct Args {
     #[clap(help = "The id of the remediation to disable", long)]
     pub id: RemediationId,
+}
+
+impl From<Args> for DisableRemediationRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            remediation_id: Some(args.id),
+        }
+    }
 }

--- a/crates/admin-cli/src/dpu_remediation/disable/cmd.rs
+++ b/crates/admin-cli/src/dpu_remediation/disable/cmd.rs
@@ -16,22 +16,17 @@
  */
 
 use ::rpc::admin_cli::CarbideCliError;
-use rpc::forge::DisableRemediationRequest;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn disable_dpu_remediation(
-    disable_remediation: Args,
+    data: Args,
     api_client: &ApiClient,
 ) -> Result<(), CarbideCliError> {
-    api_client
-        .0
-        .disable_remediation(DisableRemediationRequest {
-            remediation_id: Some(disable_remediation.id),
-        })
-        .await?;
+    let id = data.id;
+    api_client.0.disable_remediation(data).await?;
 
-    tracing::info!("Disabled remediation with id: {:?}", disable_remediation.id);
+    tracing::info!("Disabled remediation with id: {:?}", id);
     Ok(())
 }

--- a/crates/admin-cli/src/dpu_remediation/enable/args.rs
+++ b/crates/admin-cli/src/dpu_remediation/enable/args.rs
@@ -17,9 +17,18 @@
 
 use carbide_uuid::dpu_remediations::RemediationId;
 use clap::Parser;
+use rpc::forge::EnableRemediationRequest;
 
 #[derive(Parser, Debug)]
 pub struct Args {
     #[clap(help = "The id of the remediation to enable", long)]
     pub id: RemediationId,
+}
+
+impl From<Args> for EnableRemediationRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            remediation_id: Some(args.id),
+        }
+    }
 }

--- a/crates/admin-cli/src/dpu_remediation/enable/cmd.rs
+++ b/crates/admin-cli/src/dpu_remediation/enable/cmd.rs
@@ -16,22 +16,17 @@
  */
 
 use ::rpc::admin_cli::CarbideCliError;
-use rpc::forge::EnableRemediationRequest;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn enable_dpu_remediation(
-    enable_remediation: Args,
+    data: Args,
     api_client: &ApiClient,
 ) -> Result<(), CarbideCliError> {
-    api_client
-        .0
-        .enable_remediation(EnableRemediationRequest {
-            remediation_id: Some(enable_remediation.id),
-        })
-        .await?;
+    let id = data.id;
+    api_client.0.enable_remediation(data).await?;
 
-    tracing::info!("Enabled remediation with id: {:?}", enable_remediation.id);
+    tracing::info!("Enabled remediation with id: {:?}", id);
     Ok(())
 }

--- a/crates/admin-cli/src/dpu_remediation/revoke/args.rs
+++ b/crates/admin-cli/src/dpu_remediation/revoke/args.rs
@@ -17,9 +17,18 @@
 
 use carbide_uuid::dpu_remediations::RemediationId;
 use clap::Parser;
+use rpc::forge::RevokeRemediationRequest;
 
 #[derive(Parser, Debug)]
 pub struct Args {
     #[clap(help = "The id of the remediation to revoke", long)]
     pub id: RemediationId,
+}
+
+impl From<Args> for RevokeRemediationRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            remediation_id: Some(args.id),
+        }
+    }
 }

--- a/crates/admin-cli/src/dpu_remediation/revoke/cmd.rs
+++ b/crates/admin-cli/src/dpu_remediation/revoke/cmd.rs
@@ -16,22 +16,17 @@
  */
 
 use ::rpc::admin_cli::CarbideCliError;
-use rpc::forge::RevokeRemediationRequest;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn revoke_dpu_remediation(
-    revoke_remediation: Args,
+    data: Args,
     api_client: &ApiClient,
 ) -> Result<(), CarbideCliError> {
-    api_client
-        .0
-        .revoke_remediation(RevokeRemediationRequest {
-            remediation_id: Some(revoke_remediation.id),
-        })
-        .await?;
+    let id = data.id;
+    api_client.0.revoke_remediation(data).await?;
 
-    tracing::info!("Revoked remediation with id: {:?}", revoke_remediation.id);
+    tracing::info!("Revoked remediation with id: {:?}", id);
     Ok(())
 }

--- a/crates/admin-cli/src/extension_service/create/cmd.rs
+++ b/crates/admin-cli/src/extension_service/create/cmd.rs
@@ -17,7 +17,6 @@
 
 use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::admin_cli::output::OutputFormat;
-use ::rpc::forge::CreateDpuExtensionServiceRequest;
 
 use super::super::show::cmd::convert_extension_services_to_table;
 use super::args::Args;
@@ -30,7 +29,7 @@ pub async fn handle_create(
 ) -> CarbideCliResult<()> {
     let is_json = output_format == OutputFormat::Json;
 
-    let req: CreateDpuExtensionServiceRequest = args.try_into()?;
+    let req: ::rpc::forge::CreateDpuExtensionServiceRequest = args.try_into()?;
     let extension_service = api_client.0.create_dpu_extension_service(req).await?;
 
     if is_json {

--- a/crates/admin-cli/src/extension_service/delete/cmd.rs
+++ b/crates/admin-cli/src/extension_service/delete/cmd.rs
@@ -17,7 +17,6 @@
 
 use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::admin_cli::output::OutputFormat;
-use ::rpc::forge::DeleteDpuExtensionServiceRequest;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
@@ -27,8 +26,7 @@ pub async fn handle_delete(
     _output_format: OutputFormat,
     api_client: &ApiClient,
 ) -> CarbideCliResult<()> {
-    let req: DeleteDpuExtensionServiceRequest = args.into();
-    api_client.0.delete_dpu_extension_service(req).await?;
+    api_client.0.delete_dpu_extension_service(args).await?;
 
     println!("Delete successful");
     Ok(())

--- a/crates/admin-cli/src/extension_service/get_version/cmd.rs
+++ b/crates/admin-cli/src/extension_service/get_version/cmd.rs
@@ -16,16 +16,14 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::forge::GetDpuExtensionServiceVersionsInfoRequest;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn handle_get_version(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let req: GetDpuExtensionServiceVersionsInfoRequest = args.into();
     let versions = api_client
         .0
-        .get_dpu_extension_service_versions_info(req)
+        .get_dpu_extension_service_versions_info(args)
         .await?;
 
     println!("{}", serde_json::to_string_pretty(&versions.version_infos)?);

--- a/crates/admin-cli/src/extension_service/show_instances/cmd.rs
+++ b/crates/admin-cli/src/extension_service/show_instances/cmd.rs
@@ -17,7 +17,7 @@
 
 use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::admin_cli::output::OutputFormat;
-use ::rpc::forge::{FindInstancesByDpuExtensionServiceRequest, InstanceDpuExtensionServiceInfo};
+use ::rpc::forge::InstanceDpuExtensionServiceInfo;
 use prettytable::{Table, row};
 
 use super::args::Args;
@@ -30,10 +30,9 @@ pub async fn handle_show_instances(
 ) -> CarbideCliResult<()> {
     let is_json = output_format == OutputFormat::Json;
 
-    let req: FindInstancesByDpuExtensionServiceRequest = args.into();
     let response = api_client
         .0
-        .find_instances_by_dpu_extension_service(req)
+        .find_instances_by_dpu_extension_service(args)
         .await?;
 
     if is_json {

--- a/crates/admin-cli/src/extension_service/update/cmd.rs
+++ b/crates/admin-cli/src/extension_service/update/cmd.rs
@@ -17,7 +17,6 @@
 
 use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::admin_cli::output::OutputFormat;
-use ::rpc::forge::UpdateDpuExtensionServiceRequest;
 
 use super::super::show::cmd::convert_extension_services_to_table;
 use super::args::Args;
@@ -30,7 +29,7 @@ pub async fn handle_update(
 ) -> CarbideCliResult<()> {
     let is_json = output_format == OutputFormat::Json;
 
-    let req: UpdateDpuExtensionServiceRequest = args.try_into()?;
+    let req: ::rpc::forge::UpdateDpuExtensionServiceRequest = args.try_into()?;
     let extension_service = api_client.0.update_dpu_extension_service(req).await?;
 
     if is_json {

--- a/crates/admin-cli/src/host/clear_uefi_password/cmd.rs
+++ b/crates/admin-cli/src/host/clear_uefi_password/cmd.rs
@@ -16,14 +16,12 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::forge::ClearHostUefiPasswordRequest;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn clear_uefi_password(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let req: ClearHostUefiPasswordRequest = data.into();
-    let response = api_client.0.clear_host_uefi_password(req).await?;
+    let response = api_client.0.clear_host_uefi_password(data).await?;
     println!(
         "successfully cleared UEFI password for host (jid: {:#?})",
         response.job_id

--- a/crates/admin-cli/src/host/set_uefi_password/cmd.rs
+++ b/crates/admin-cli/src/host/set_uefi_password/cmd.rs
@@ -16,14 +16,12 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::forge::SetHostUefiPasswordRequest;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn set_uefi_password(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let req: SetHostUefiPasswordRequest = data.into();
-    let response = api_client.0.set_host_uefi_password(req).await?;
+    let response = api_client.0.set_host_uefi_password(data).await?;
     println!(
         "successfully set UEFI password for host (jid: {:#?})",
         response.job_id

--- a/crates/admin-cli/src/instance_type/associate/cmd.rs
+++ b/crates/admin-cli/src/instance_type/associate/cmd.rs
@@ -16,14 +16,12 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use rpc::forge::AssociateMachinesWithInstanceTypeRequest;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn create_association(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let req: AssociateMachinesWithInstanceTypeRequest = args.try_into()?;
-
+    let req: ::rpc::forge::AssociateMachinesWithInstanceTypeRequest = args.try_into()?;
     api_client
         .0
         .associate_machines_with_instance_type(req)

--- a/crates/admin-cli/src/instance_type/create/cmd.rs
+++ b/crates/admin-cli/src/instance_type/create/cmd.rs
@@ -16,7 +16,6 @@
  */
 
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
-use ::rpc::forge::CreateInstanceTypeRequest;
 
 use super::args::Args;
 use crate::instance_type::common::convert_itypes_to_table;
@@ -32,8 +31,7 @@ pub async fn create(
 ) -> CarbideCliResult<()> {
     let is_json = output_format == OutputFormat::Json;
 
-    let req: CreateInstanceTypeRequest = args.try_into()?;
-
+    let req: ::rpc::forge::CreateInstanceTypeRequest = args.try_into()?;
     let itype = api_client
         .0
         .create_instance_type(req)

--- a/crates/admin-cli/src/instance_type/delete/cmd.rs
+++ b/crates/admin-cli/src/instance_type/delete/cmd.rs
@@ -16,7 +16,6 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::forge::DeleteInstanceTypeRequest;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
@@ -24,9 +23,7 @@ use crate::rpc::ApiClient;
 /// Delete an instance type.
 pub async fn delete(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
     let id = args.id.clone();
-    let req: DeleteInstanceTypeRequest = args.into();
-
-    api_client.0.delete_instance_type(req).await?;
+    api_client.0.delete_instance_type(args).await?;
     println!("Deleted instance type {} successfully.", id);
     Ok(())
 }

--- a/crates/admin-cli/src/ip/find/args.rs
+++ b/crates/admin-cli/src/ip/find/args.rs
@@ -22,3 +22,11 @@ pub struct Args {
     /// The IP address we are looking to identify
     pub ip: std::net::IpAddr,
 }
+
+impl From<Args> for ::rpc::forge::FindIpAddressRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            ip: args.ip.to_string(),
+        }
+    }
+}

--- a/crates/admin-cli/src/ip/find/cmd.rs
+++ b/crates/admin-cli/src/ip/find/cmd.rs
@@ -16,16 +16,12 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::forge as forgerpc;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn find(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let req = forgerpc::FindIpAddressRequest {
-        ip: args.ip.to_string(),
-    };
-    let resp = api_client.0.find_ip_address(req).await?;
+    let resp = api_client.0.find_ip_address(args).await?;
     for r in resp.matches {
         tracing::info!("{}", r.message);
     }

--- a/crates/admin-cli/src/jump/cmds.rs
+++ b/crates/admin-cli/src/jump/cmds.rs
@@ -176,7 +176,7 @@ pub async fn jump(args: Cmd, ctx: &mut RuntimeContext) -> color_eyre::Result<()>
                     )
                     .await?
                 }
-                ResourcePool => resource_pool::list(&ctx.api_client).await?,
+                ResourcePool => resource_pool::list(Default::default(), &ctx.api_client).await?,
                 DpaInterface =>  {
                     dpa::show(
                         &ShowDpa {

--- a/crates/admin-cli/src/measurement/bundle/args.rs
+++ b/crates/admin-cli/src/measurement/bundle/args.rs
@@ -28,6 +28,17 @@
  *  - `bundle list machines`: List all matchines matching a given bundle.
 */
 
+use std::str::FromStr;
+
+use ::rpc::admin_cli::CarbideCliError;
+use ::rpc::protos::measured_boot::{
+    CreateMeasurementBundleRequest, DeleteMeasurementBundleRequest, FindClosestBundleMatchRequest,
+    ListMeasurementBundleMachinesRequest, MeasurementBundleStatePb, RenameMeasurementBundleRequest,
+    ShowMeasurementBundleRequest, UpdateMeasurementBundleRequest,
+    delete_measurement_bundle_request, list_measurement_bundle_machines_request,
+    rename_measurement_bundle_request, show_measurement_bundle_request,
+    update_measurement_bundle_request,
+};
 use carbide_uuid::measured_boot::{
     MeasurementBundleId, MeasurementReportId, MeasurementSystemProfileId,
 };
@@ -36,7 +47,7 @@ use measured_boot::pcr::PcrRegisterValue;
 use measured_boot::records::MeasurementBundleState;
 
 use crate::cfg::measurement::parse_pcr_register_values;
-use crate::measurement::global::cmds::IdNameIdentifier;
+use crate::measurement::global::cmds::{IdNameIdentifier, IdentifierType, get_identifier};
 
 /// CmdBundle provides a container for the `bundle` subcommand, which itself
 /// contains other subcommands for working with profiles.
@@ -248,4 +259,164 @@ pub enum FindClosestMatch {
 pub struct ReportId {
     #[clap(help = "Report ID.")]
     pub id: MeasurementReportId,
+}
+
+impl From<Create> for CreateMeasurementBundleRequest {
+    fn from(create: Create) -> Self {
+        let state: MeasurementBundleStatePb = match create.state {
+            Some(input_state) => input_state.into(),
+            None => MeasurementBundleStatePb::Active,
+        };
+        Self {
+            name: Some(create.name),
+            profile_id: Some(create.profile_id),
+            pcr_values: create.values.into_iter().map(Into::into).collect(),
+            state: state.into(),
+        }
+    }
+}
+
+impl From<Delete> for DeleteMeasurementBundleRequest {
+    fn from(delete: Delete) -> Self {
+        Self {
+            selector: Some(delete_measurement_bundle_request::Selector::BundleId(
+                delete.bundle_id,
+            )),
+        }
+    }
+}
+
+impl TryFrom<Rename> for RenameMeasurementBundleRequest {
+    type Error = CarbideCliError;
+    fn try_from(rename: Rename) -> Result<Self, Self::Error> {
+        let selector = match get_identifier(&rename)? {
+            IdentifierType::ForId => {
+                let bundle_id = MeasurementBundleId::from_str(&rename.identifier)
+                    .map_err(|e| CarbideCliError::GenericError(e.to_string()))?;
+                Some(rename_measurement_bundle_request::Selector::BundleId(
+                    bundle_id,
+                ))
+            }
+            IdentifierType::ForName => Some(
+                rename_measurement_bundle_request::Selector::BundleName(rename.identifier),
+            ),
+            IdentifierType::Detect => match MeasurementBundleId::from_str(&rename.identifier) {
+                Ok(bundle_id) => Some(rename_measurement_bundle_request::Selector::BundleId(
+                    bundle_id,
+                )),
+                Err(_) => Some(rename_measurement_bundle_request::Selector::BundleName(
+                    rename.identifier,
+                )),
+            },
+        };
+        Ok(Self {
+            new_bundle_name: rename.new_bundle_name,
+            selector,
+        })
+    }
+}
+
+impl TryFrom<SetState> for UpdateMeasurementBundleRequest {
+    type Error = CarbideCliError;
+    fn try_from(set_state: SetState) -> Result<Self, Self::Error> {
+        let state: MeasurementBundleStatePb = set_state.state.into();
+        let selector = match get_identifier(&set_state)? {
+            IdentifierType::ForId => {
+                let bundle_id = MeasurementBundleId::from_str(&set_state.identifier)
+                    .map_err(|e| CarbideCliError::GenericError(e.to_string()))?;
+                Some(update_measurement_bundle_request::Selector::BundleId(
+                    bundle_id,
+                ))
+            }
+            IdentifierType::ForName => Some(
+                update_measurement_bundle_request::Selector::BundleName(set_state.identifier),
+            ),
+            IdentifierType::Detect => match MeasurementBundleId::from_str(&set_state.identifier) {
+                Ok(bundle_id) => Some(update_measurement_bundle_request::Selector::BundleId(
+                    bundle_id,
+                )),
+                Err(_) => Some(update_measurement_bundle_request::Selector::BundleName(
+                    set_state.identifier,
+                )),
+            },
+        };
+        Ok(Self {
+            state: state.into(),
+            selector,
+        })
+    }
+}
+
+impl TryFrom<Show> for ShowMeasurementBundleRequest {
+    type Error = CarbideCliError;
+    fn try_from(show: Show) -> Result<Self, Self::Error> {
+        let identifier_type = get_identifier(&show)?;
+        let identifier = show
+            .identifier
+            .ok_or(CarbideCliError::GenericError(String::from(
+                "identifier expected to be set here",
+            )))?;
+        let selector = match identifier_type {
+            IdentifierType::ForId => {
+                let bundle_id = MeasurementBundleId::from_str(&identifier)
+                    .map_err(|e| CarbideCliError::GenericError(e.to_string()))?;
+                Some(show_measurement_bundle_request::Selector::BundleId(
+                    bundle_id,
+                ))
+            }
+            IdentifierType::ForName => Some(show_measurement_bundle_request::Selector::BundleName(
+                identifier,
+            )),
+            IdentifierType::Detect => match MeasurementBundleId::from_str(&identifier) {
+                Ok(bundle_id) => Some(show_measurement_bundle_request::Selector::BundleId(
+                    bundle_id,
+                )),
+                Err(_) => Some(show_measurement_bundle_request::Selector::BundleName(
+                    identifier,
+                )),
+            },
+        };
+        Ok(Self { selector })
+    }
+}
+
+impl TryFrom<ListMachines> for ListMeasurementBundleMachinesRequest {
+    type Error = CarbideCliError;
+    fn try_from(list_machines: ListMachines) -> Result<Self, Self::Error> {
+        let selector = match get_identifier(&list_machines)? {
+            IdentifierType::ForId => {
+                let bundle_id = MeasurementBundleId::from_str(&list_machines.identifier)
+                    .map_err(|e| CarbideCliError::GenericError(e.to_string()))?;
+                Some(list_measurement_bundle_machines_request::Selector::BundleId(bundle_id))
+            }
+            IdentifierType::ForName => Some(
+                list_measurement_bundle_machines_request::Selector::BundleName(
+                    list_machines.identifier,
+                ),
+            ),
+            IdentifierType::Detect => {
+                match MeasurementBundleId::from_str(&list_machines.identifier) {
+                    Ok(bundle_id) => Some(
+                        list_measurement_bundle_machines_request::Selector::BundleId(bundle_id),
+                    ),
+                    Err(_) => Some(
+                        list_measurement_bundle_machines_request::Selector::BundleName(
+                            list_machines.identifier,
+                        ),
+                    ),
+                }
+            }
+        };
+        Ok(Self { selector })
+    }
+}
+
+impl From<FindClosestMatch> for FindClosestBundleMatchRequest {
+    fn from(args: FindClosestMatch) -> Self {
+        match args {
+            FindClosestMatch::Report(report_id) => Self {
+                report_id: Some(report_id.id),
+            },
+        }
+    }
 }

--- a/crates/admin-cli/src/measurement/bundle/cmds.rs
+++ b/crates/admin-cli/src/measurement/bundle/cmds.rs
@@ -23,15 +23,10 @@ use std::str::FromStr;
 
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, ToTable, cli_output};
 use ::rpc::protos::measured_boot::{
-    CreateMeasurementBundleRequest, DeleteMeasurementBundleRequest, FindClosestBundleMatchRequest,
-    ListMeasurementBundleMachinesRequest, MeasurementBundleStatePb, RenameMeasurementBundleRequest,
+    ListMeasurementBundleMachinesRequest, RenameMeasurementBundleRequest,
     ShowMeasurementBundleRequest, UpdateMeasurementBundleRequest,
-    delete_measurement_bundle_request, list_measurement_bundle_machines_request,
-    rename_measurement_bundle_request, show_measurement_bundle_request,
-    update_measurement_bundle_request,
 };
 use carbide_uuid::machine::MachineId;
-use carbide_uuid::measured_boot::MeasurementBundleId;
 use measured_boot::bundle::MeasurementBundle;
 use measured_boot::records::MeasurementBundleRecord;
 use serde::Serialize;
@@ -39,7 +34,6 @@ use serde::Serialize;
 use crate::measurement::bundle::args::{
     CmdBundle, Create, Delete, FindClosestMatch, List, ListMachines, Rename, SetState, Show,
 };
-use crate::measurement::global::cmds::{IdentifierType, get_identifier};
 use crate::measurement::{MachineIdList, global};
 use crate::rpc::ApiClient;
 
@@ -129,22 +123,7 @@ pub async fn create_for_id(
     grpc_conn: &ApiClient,
     create: Create,
 ) -> CarbideCliResult<MeasurementBundle> {
-    // Prepare.
-    let state: MeasurementBundleStatePb = match create.state {
-        Some(input_state) => input_state.into(),
-        None => MeasurementBundleStatePb::Active,
-    };
-
-    // Request.
-    let request = CreateMeasurementBundleRequest {
-        name: Some(create.name),
-        profile_id: Some(create.profile_id),
-        pcr_values: create.values.into_iter().map(Into::into).collect(),
-        state: state.into(),
-    };
-
-    // Response.
-    let response = grpc_conn.0.create_measurement_bundle(request).await?;
+    let response = grpc_conn.0.create_measurement_bundle(create).await?;
 
     MeasurementBundle::from_grpc(response.bundle.as_ref())
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
@@ -152,15 +131,7 @@ pub async fn create_for_id(
 
 /// delete deletes a measurement bundle with the provided ID.
 pub async fn delete(grpc_conn: &ApiClient, delete: Delete) -> CarbideCliResult<MeasurementBundle> {
-    // Request.
-    let request = DeleteMeasurementBundleRequest {
-        selector: Some(delete_measurement_bundle_request::Selector::BundleId(
-            delete.bundle_id,
-        )),
-    };
-
-    // Response.
-    let response = grpc_conn.0.delete_measurement_bundle(request).await?;
+    let response = grpc_conn.0.delete_measurement_bundle(delete).await?;
 
     MeasurementBundle::from_grpc(response.bundle.as_ref())
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
@@ -168,36 +139,10 @@ pub async fn delete(grpc_conn: &ApiClient, delete: Delete) -> CarbideCliResult<M
 
 /// rename renames a measurement bundle with the provided name or ID.
 pub async fn rename(grpc_conn: &ApiClient, rename: Rename) -> CarbideCliResult<MeasurementBundle> {
-    // Prepare.
-    let selector = match get_identifier(&rename)? {
-        IdentifierType::ForId => {
-            let bundle_id = MeasurementBundleId::from_str(&rename.identifier)
-                .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))?;
-            Some(rename_measurement_bundle_request::Selector::BundleId(
-                bundle_id,
-            ))
-        }
-        IdentifierType::ForName => Some(rename_measurement_bundle_request::Selector::BundleName(
-            rename.identifier,
-        )),
-        IdentifierType::Detect => match MeasurementBundleId::from_str(&rename.identifier) {
-            Ok(bundle_id) => Some(rename_measurement_bundle_request::Selector::BundleId(
-                bundle_id,
-            )),
-            Err(_) => Some(rename_measurement_bundle_request::Selector::BundleName(
-                rename.identifier,
-            )),
-        },
-    };
-
-    // Request.
-    let request = RenameMeasurementBundleRequest {
-        new_bundle_name: rename.new_bundle_name,
-        selector,
-    };
-
-    // Response.
-    let response = grpc_conn.0.rename_measurement_bundle(request).await?;
+    let response = grpc_conn
+        .0
+        .rename_measurement_bundle(RenameMeasurementBundleRequest::try_from(rename)?)
+        .await?;
 
     MeasurementBundle::from_grpc(response.bundle.as_ref())
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
@@ -208,38 +153,10 @@ pub async fn set_state(
     grpc_conn: &ApiClient,
     set_state: SetState,
 ) -> CarbideCliResult<MeasurementBundle> {
-    // Prepare.
-    let state: MeasurementBundleStatePb = set_state.state.into();
-
-    let selector = match get_identifier(&set_state)? {
-        IdentifierType::ForId => {
-            let bundle_id = MeasurementBundleId::from_str(&set_state.identifier)
-                .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))?;
-            Some(update_measurement_bundle_request::Selector::BundleId(
-                bundle_id,
-            ))
-        }
-        IdentifierType::ForName => Some(update_measurement_bundle_request::Selector::BundleName(
-            set_state.identifier,
-        )),
-        IdentifierType::Detect => match MeasurementBundleId::from_str(&set_state.identifier) {
-            Ok(bundle_id) => Some(update_measurement_bundle_request::Selector::BundleId(
-                bundle_id,
-            )),
-            Err(_) => Some(update_measurement_bundle_request::Selector::BundleName(
-                set_state.identifier,
-            )),
-        },
-    };
-
-    // Request.
-    let request = UpdateMeasurementBundleRequest {
-        state: state.into(),
-        selector,
-    };
-
-    // Response.
-    let response = grpc_conn.0.update_measurement_bundle(request).await?;
+    let response = grpc_conn
+        .0
+        .update_measurement_bundle(UpdateMeasurementBundleRequest::try_from(set_state)?)
+        .await?;
 
     MeasurementBundle::from_grpc(response.bundle.as_ref())
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
@@ -250,40 +167,10 @@ pub async fn show_by_id_or_name(
     grpc_conn: &ApiClient,
     show: Show,
 ) -> CarbideCliResult<MeasurementBundle> {
-    let identifier_type = get_identifier(&show)?;
-    // Prepare.
-    let identifier = show
-        .identifier
-        .ok_or(CarbideCliError::GenericError(String::from(
-            "identifier expected to be set here",
-        )))?;
-
-    let selector = match identifier_type {
-        IdentifierType::ForId => {
-            let bundle_id = MeasurementBundleId::from_str(&identifier)
-                .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))?;
-            Some(show_measurement_bundle_request::Selector::BundleId(
-                bundle_id,
-            ))
-        }
-        IdentifierType::ForName => Some(show_measurement_bundle_request::Selector::BundleName(
-            identifier,
-        )),
-        IdentifierType::Detect => match MeasurementBundleId::from_str(&identifier) {
-            Ok(bundle_id) => Some(show_measurement_bundle_request::Selector::BundleId(
-                bundle_id,
-            )),
-            Err(_) => Some(show_measurement_bundle_request::Selector::BundleName(
-                identifier,
-            )),
-        },
-    };
-
-    // Request.
-    let request = ShowMeasurementBundleRequest { selector };
-
-    // Response.
-    let response = grpc_conn.0.show_measurement_bundle(request).await?;
+    let response = grpc_conn
+        .0
+        .show_measurement_bundle(ShowMeasurementBundleRequest::try_from(show)?)
+        .await?;
 
     MeasurementBundle::from_grpc(response.bundle.as_ref())
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
@@ -332,38 +219,12 @@ pub async fn list_machines(
     grpc_conn: &ApiClient,
     list_machines: ListMachines,
 ) -> CarbideCliResult<MachineIdList> {
-    // Prepare.
-    let selector = match get_identifier(&list_machines)? {
-        IdentifierType::ForId => {
-            let bundle_id = MeasurementBundleId::from_str(&list_machines.identifier)
-                .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))?;
-            Some(list_measurement_bundle_machines_request::Selector::BundleId(bundle_id))
-        }
-        IdentifierType::ForName => Some(
-            list_measurement_bundle_machines_request::Selector::BundleName(
-                list_machines.identifier,
-            ),
-        ),
-        IdentifierType::Detect => match MeasurementBundleId::from_str(&list_machines.identifier) {
-            Ok(bundle_id) => {
-                Some(list_measurement_bundle_machines_request::Selector::BundleId(bundle_id))
-            }
-            Err(_) => Some(
-                list_measurement_bundle_machines_request::Selector::BundleName(
-                    list_machines.identifier,
-                ),
-            ),
-        },
-    };
-
-    // Request.
-    let request = ListMeasurementBundleMachinesRequest { selector };
-
-    // Response.
     Ok(MachineIdList(
         grpc_conn
             .0
-            .list_measurement_bundle_machines(request)
+            .list_measurement_bundle_machines(ListMeasurementBundleMachinesRequest::try_from(
+                list_machines,
+            )?)
             .await?
             .machine_ids
             .iter()
@@ -379,16 +240,7 @@ pub async fn find_closest_match(
     grpc_conn: &ApiClient,
     args: FindClosestMatch,
 ) -> CarbideCliResult<Option<MeasurementBundle>> {
-    // At the moment, the request only contains report id
-    // but this can be expanded to contain journal id also
-    let request = match args {
-        FindClosestMatch::Report(report_id) => FindClosestBundleMatchRequest {
-            report_id: Some(report_id.id),
-        },
-    };
-
-    // Response.
-    let response = grpc_conn.0.find_closest_bundle_match(request).await?;
+    let response = grpc_conn.0.find_closest_bundle_match(args).await?;
 
     if response.bundle.is_none() {
         return Ok(None);

--- a/crates/admin-cli/src/measurement/journal/args.rs
+++ b/crates/admin-cli/src/measurement/journal/args.rs
@@ -25,6 +25,11 @@
  *  - `journal promote`: Promote the report from a journal entry into a bundle.
 */
 
+use ::rpc::admin_cli::CarbideCliError;
+use ::rpc::protos::measured_boot::{
+    DeleteMeasurementJournalRequest, ListMeasurementJournalRequest, ShowMeasurementJournalRequest,
+    list_measurement_journal_request, show_measurement_journal_request,
+};
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::measured_boot::MeasurementJournalId;
 use clap::Parser;
@@ -85,4 +90,38 @@ pub struct Promote {
     )]
     #[arg(value_parser = parse_pcr_index_input)]
     pub pcr_registers: Option<PcrSet>,
+}
+
+impl From<Delete> for DeleteMeasurementJournalRequest {
+    fn from(delete: Delete) -> Self {
+        Self {
+            journal_id: Some(delete.journal_id),
+        }
+    }
+}
+
+impl TryFrom<Show> for ShowMeasurementJournalRequest {
+    type Error = CarbideCliError;
+    fn try_from(show: Show) -> Result<Self, Self::Error> {
+        let journal_id = show
+            .journal_id
+            .ok_or(CarbideCliError::GenericError(String::from(
+                "journal_id must be set to get a journal",
+            )))?;
+        Ok(Self {
+            selector: Some(show_measurement_journal_request::Selector::JournalId(
+                journal_id,
+            )),
+        })
+    }
+}
+
+impl From<List> for ListMeasurementJournalRequest {
+    fn from(list: List) -> Self {
+        Self {
+            selector: list.machine_id.map(|machine_id| {
+                list_measurement_journal_request::Selector::MachineId(machine_id.to_string())
+            }),
+        }
+    }
 }

--- a/crates/admin-cli/src/measurement/journal/cmds.rs
+++ b/crates/admin-cli/src/measurement/journal/cmds.rs
@@ -22,10 +22,7 @@
 use ::rpc::admin_cli::{
     CarbideCliError, CarbideCliResult, ToTable, cli_output, just_print_summary,
 };
-use ::rpc::protos::measured_boot::{
-    DeleteMeasurementJournalRequest, ListMeasurementJournalRequest, ShowMeasurementJournalRequest,
-    list_measurement_journal_request, show_measurement_journal_request,
-};
+use ::rpc::protos::measured_boot::ShowMeasurementJournalRequest;
 use measured_boot::bundle::MeasurementBundle;
 use measured_boot::journal::MeasurementJournal;
 use measured_boot::records::MeasurementJournalRecord;
@@ -88,13 +85,7 @@ pub async fn dispatch(
 ///
 /// `journal delete <journal-id>`
 pub async fn delete(grpc_conn: &ApiClient, delete: Delete) -> CarbideCliResult<MeasurementJournal> {
-    // Request.
-    let request = DeleteMeasurementJournalRequest {
-        journal_id: Some(delete.journal_id),
-    };
-
-    // Response.
-    let response = grpc_conn.0.delete_measurement_journal(request).await?;
+    let response = grpc_conn.0.delete_measurement_journal(delete).await?;
 
     MeasurementJournal::from_grpc(response.journal.as_ref())
         .map_err(|e| CarbideCliError::GenericError(e.to_string()))
@@ -104,27 +95,10 @@ pub async fn delete(grpc_conn: &ApiClient, delete: Delete) -> CarbideCliResult<M
 ///
 /// `journal show <journal-id>`
 pub async fn show_by_id(grpc_conn: &ApiClient, show: Show) -> CarbideCliResult<MeasurementJournal> {
-    // Prepare.
-    // TODO(chet): This exists just because of how I'm dispatching
-    // commands, since &Show gets reused for showing all (where journal_id
-    // is unset, or showing a specific journal ID). Ultimately this
-    // shouldn't ever actually get hit, but it exists just incase. That
-    // said, I should look into see if I can just have clap validate this.
-    let Some(journal_id) = show.journal_id else {
-        return Err(CarbideCliError::GenericError(String::from(
-            "journal_id must be set to get a journal",
-        )));
-    };
-
-    // Request.
-    let request = ShowMeasurementJournalRequest {
-        selector: Some(show_measurement_journal_request::Selector::JournalId(
-            journal_id,
-        )),
-    };
-
-    // Response.
-    let response = grpc_conn.0.show_measurement_journal(request).await?;
+    let response = grpc_conn
+        .0
+        .show_measurement_journal(ShowMeasurementJournalRequest::try_from(show)?)
+        .await?;
 
     MeasurementJournal::from_grpc(response.journal.as_ref())
         .map_err(|e| CarbideCliError::GenericError(e.to_string()))
@@ -159,21 +133,10 @@ pub async fn list(
     grpc_conn: &ApiClient,
     list: List,
 ) -> CarbideCliResult<MeasurementJournalRecordList> {
-    // Request.
-    let request = match list.machine_id {
-        Some(machine_id) => ListMeasurementJournalRequest {
-            selector: Some(list_measurement_journal_request::Selector::MachineId(
-                machine_id.to_string(),
-            )),
-        },
-        None => ListMeasurementJournalRequest { selector: None },
-    };
-
-    // Response.
     Ok(MeasurementJournalRecordList(
         grpc_conn
             .0
-            .list_measurement_journal(request)
+            .list_measurement_journal(list)
             .await?
             .journals
             .drain(..)

--- a/crates/admin-cli/src/measurement/machine/args.rs
+++ b/crates/admin-cli/src/measurement/machine/args.rs
@@ -26,6 +26,10 @@
  *  - `mock-machine list``: Lists all mock machines.
 */
 
+use ::rpc::admin_cli::CarbideCliError;
+use ::rpc::protos::measured_boot::{
+    AttestCandidateMachineRequest, ShowCandidateMachineRequest, show_candidate_machine_request,
+};
 use carbide_uuid::machine::MachineId;
 use clap::Parser;
 use measured_boot::pcr::PcrRegisterValue;
@@ -75,4 +79,29 @@ pub struct List {}
 pub struct Show {
     #[clap(help = "The machine ID to show.")]
     pub machine_id: Option<MachineId>,
+}
+
+impl From<Attest> for AttestCandidateMachineRequest {
+    fn from(attest: Attest) -> Self {
+        Self {
+            machine_id: attest.machine_id.to_string(),
+            pcr_values: attest.values.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl TryFrom<Show> for ShowCandidateMachineRequest {
+    type Error = CarbideCliError;
+    fn try_from(show: Show) -> Result<Self, Self::Error> {
+        let machine_id = show
+            .machine_id
+            .ok_or(CarbideCliError::GenericError(String::from(
+                "machine_id must be set to get a machine",
+            )))?;
+        Ok(Self {
+            selector: Some(show_candidate_machine_request::Selector::MachineId(
+                machine_id.to_string(),
+            )),
+        })
+    }
 }

--- a/crates/admin-cli/src/measurement/machine/cmds.rs
+++ b/crates/admin-cli/src/measurement/machine/cmds.rs
@@ -20,9 +20,7 @@
 //!
 
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, ToTable, cli_output};
-use ::rpc::protos::measured_boot::{
-    AttestCandidateMachineRequest, ShowCandidateMachineRequest, show_candidate_machine_request,
-};
+use ::rpc::protos::measured_boot::ShowCandidateMachineRequest;
 use measured_boot::machine::CandidateMachine;
 use measured_boot::records::CandidateMachineSummary;
 use measured_boot::report::MeasurementReport;
@@ -75,14 +73,7 @@ pub async fn dispatch(
 /// attest sends attestation data for the given machine ID, as in, PCR
 /// register + value pairings, which results in a journal entry being made.
 pub async fn attest(grpc_conn: &ApiClient, attest: Attest) -> CarbideCliResult<MeasurementReport> {
-    // Request.
-    let request = AttestCandidateMachineRequest {
-        machine_id: attest.machine_id.to_string(),
-        pcr_values: attest.values.into_iter().map(Into::into).collect(),
-    };
-
-    // Response.
-    let response = grpc_conn.0.attest_candidate_machine(request).await?;
+    let response = grpc_conn.0.attest_candidate_machine(attest).await?;
 
     MeasurementReport::from_grpc(response.report.as_ref())
         .map_err(|e| CarbideCliError::GenericError(e.to_string()))
@@ -90,27 +81,10 @@ pub async fn attest(grpc_conn: &ApiClient, attest: Attest) -> CarbideCliResult<M
 
 /// show_by_id shows all info about a given machine ID.
 pub async fn show_by_id(grpc_conn: &ApiClient, show: Show) -> CarbideCliResult<CandidateMachine> {
-    // Prepare.
-    // TODO(chet): This exists just because of how I'm dispatching
-    // commands, since &Show gets reused for showing all (where machine_id
-    // is unset, or showing a specific machine ID). Ultimately this
-    // shouldn't ever actually get hit, but it exists just incase. That
-    // said, I should look into see if I can just have clap validate this.
-    let Some(machine_id) = show.machine_id else {
-        return Err(CarbideCliError::GenericError(String::from(
-            "machine_id must be set to get a machine",
-        )));
-    };
-
-    // Request.
-    let request = ShowCandidateMachineRequest {
-        selector: Some(show_candidate_machine_request::Selector::MachineId(
-            machine_id.to_string(),
-        )),
-    };
-
-    // Response.
-    let response = grpc_conn.0.show_candidate_machine(request).await?;
+    let response = grpc_conn
+        .0
+        .show_candidate_machine(ShowCandidateMachineRequest::try_from(show)?)
+        .await?;
 
     CandidateMachine::from_grpc(response.machine.as_ref())
         .map_err(|e| CarbideCliError::GenericError(e.to_string()))

--- a/crates/admin-cli/src/measurement/profile/args.rs
+++ b/crates/admin-cli/src/measurement/profile/args.rs
@@ -28,10 +28,22 @@
  *  - `profile list machines`: List all machines for a given profile.
 */
 
+use std::str::FromStr;
+
+use ::rpc::admin_cli::CarbideCliError;
+use ::rpc::protos::measured_boot::{
+    CreateMeasurementSystemProfileRequest, DeleteMeasurementSystemProfileRequest, KvPair,
+    ListMeasurementSystemProfileBundlesRequest, ListMeasurementSystemProfileMachinesRequest,
+    RenameMeasurementSystemProfileRequest, ShowMeasurementSystemProfileRequest,
+    delete_measurement_system_profile_request, list_measurement_system_profile_bundles_request,
+    list_measurement_system_profile_machines_request, rename_measurement_system_profile_request,
+    show_measurement_system_profile_request,
+};
+use carbide_uuid::measured_boot::MeasurementSystemProfileId;
 use clap::Parser;
 
-use crate::cfg::measurement::{KvPair, parse_colon_pairs};
-use crate::measurement::global::cmds::IdNameIdentifier;
+use crate::cfg::measurement::{KvPair as CfgKvPair, parse_colon_pairs};
+use crate::measurement::global::cmds::{IdNameIdentifier, IdentifierType, get_identifier};
 
 // CmdProfile provides a container for the `profile`
 // subcommand, which itself contains other subcommands
@@ -84,7 +96,7 @@ pub struct Create {
         help = "A comma-separated list of additional k:v,k:v,... attributes to set."
     )]
     #[arg(value_parser = parse_colon_pairs)]
-    pub extra_attrs: Vec<KvPair>,
+    pub extra_attrs: Vec<CfgKvPair>,
 }
 
 /// Delete a profile by ID or name.
@@ -228,5 +240,190 @@ impl IdNameIdentifier for ListMachines {
 
     fn is_name(&self) -> bool {
         self.is_name
+    }
+}
+
+impl From<Create> for CreateMeasurementSystemProfileRequest {
+    fn from(create: Create) -> Self {
+        let extra_attrs = create
+            .extra_attrs
+            .into_iter()
+            .map(|kv_pair| KvPair {
+                key: kv_pair.key,
+                value: kv_pair.value,
+            })
+            .collect();
+        Self {
+            name: Some(create.name),
+            vendor: create.vendor,
+            product: create.product,
+            extra_attrs,
+        }
+    }
+}
+
+impl TryFrom<Delete> for DeleteMeasurementSystemProfileRequest {
+    type Error = CarbideCliError;
+    fn try_from(delete: Delete) -> Result<Self, Self::Error> {
+        let selector = match get_identifier(&delete)? {
+            IdentifierType::ForId => {
+                let profile_id = MeasurementSystemProfileId::from_str(&delete.identifier)
+                    .map_err(|e| CarbideCliError::GenericError(e.to_string()))?;
+                Some(delete_measurement_system_profile_request::Selector::ProfileId(profile_id))
+            }
+            IdentifierType::ForName => Some(
+                delete_measurement_system_profile_request::Selector::ProfileName(delete.identifier),
+            ),
+            IdentifierType::Detect => {
+                match MeasurementSystemProfileId::from_str(&delete.identifier) {
+                    Ok(profile_id) => Some(
+                        delete_measurement_system_profile_request::Selector::ProfileId(profile_id),
+                    ),
+                    Err(_) => Some(
+                        delete_measurement_system_profile_request::Selector::ProfileName(
+                            delete.identifier,
+                        ),
+                    ),
+                }
+            }
+        };
+        Ok(Self { selector })
+    }
+}
+
+impl TryFrom<Rename> for RenameMeasurementSystemProfileRequest {
+    type Error = CarbideCliError;
+    fn try_from(rename: Rename) -> Result<Self, Self::Error> {
+        let selector = match get_identifier(&rename)? {
+            IdentifierType::ForId => {
+                let profile_id = MeasurementSystemProfileId::from_str(&rename.identifier)
+                    .map_err(|e| CarbideCliError::GenericError(e.to_string()))?;
+                Some(rename_measurement_system_profile_request::Selector::ProfileId(profile_id))
+            }
+            IdentifierType::ForName => Some(
+                rename_measurement_system_profile_request::Selector::ProfileName(rename.identifier),
+            ),
+            IdentifierType::Detect => {
+                match MeasurementSystemProfileId::from_str(&rename.identifier) {
+                    Ok(profile_id) => Some(
+                        rename_measurement_system_profile_request::Selector::ProfileId(profile_id),
+                    ),
+                    Err(_) => Some(
+                        rename_measurement_system_profile_request::Selector::ProfileName(
+                            rename.identifier,
+                        ),
+                    ),
+                }
+            }
+        };
+        Ok(Self {
+            new_profile_name: rename.new_profile_name,
+            selector,
+        })
+    }
+}
+
+impl TryFrom<Show> for ShowMeasurementSystemProfileRequest {
+    type Error = CarbideCliError;
+    fn try_from(show: Show) -> Result<Self, Self::Error> {
+        let identifier_type = get_identifier(&show)?;
+        let identifier = show
+            .identifier
+            .ok_or(CarbideCliError::GenericError(String::from(
+                "identifier expected to be set here",
+            )))?;
+        let selector = match identifier_type {
+            IdentifierType::ForId => {
+                let profile_id = MeasurementSystemProfileId::from_str(&identifier)
+                    .map_err(|e| CarbideCliError::GenericError(e.to_string()))?;
+                Some(show_measurement_system_profile_request::Selector::ProfileId(profile_id))
+            }
+            IdentifierType::ForName => {
+                Some(show_measurement_system_profile_request::Selector::ProfileName(identifier))
+            }
+            IdentifierType::Detect => match MeasurementSystemProfileId::from_str(&identifier) {
+                Ok(profile_id) => {
+                    Some(show_measurement_system_profile_request::Selector::ProfileId(profile_id))
+                }
+                Err(_) => {
+                    Some(show_measurement_system_profile_request::Selector::ProfileName(identifier))
+                }
+            },
+        };
+        Ok(Self { selector })
+    }
+}
+
+impl TryFrom<ListBundles> for ListMeasurementSystemProfileBundlesRequest {
+    type Error = CarbideCliError;
+    fn try_from(list_bundles: ListBundles) -> Result<Self, Self::Error> {
+        let selector = match get_identifier(&list_bundles)? {
+            IdentifierType::ForId => {
+                let profile_id = MeasurementSystemProfileId::from_str(&list_bundles.identifier)
+                    .map_err(|e| CarbideCliError::GenericError(e.to_string()))?;
+                Some(
+                    list_measurement_system_profile_bundles_request::Selector::ProfileId(
+                        profile_id,
+                    ),
+                )
+            }
+            IdentifierType::ForName => Some(
+                list_measurement_system_profile_bundles_request::Selector::ProfileName(
+                    list_bundles.identifier,
+                ),
+            ),
+            IdentifierType::Detect => {
+                match MeasurementSystemProfileId::from_str(&list_bundles.identifier) {
+                    Ok(profile_id) => Some(
+                        list_measurement_system_profile_bundles_request::Selector::ProfileId(
+                            profile_id,
+                        ),
+                    ),
+                    Err(_) => Some(
+                        list_measurement_system_profile_bundles_request::Selector::ProfileName(
+                            list_bundles.identifier,
+                        ),
+                    ),
+                }
+            }
+        };
+        Ok(Self { selector })
+    }
+}
+
+impl TryFrom<ListMachines> for ListMeasurementSystemProfileMachinesRequest {
+    type Error = CarbideCliError;
+    fn try_from(list_machines: ListMachines) -> Result<Self, Self::Error> {
+        let selector = match get_identifier(&list_machines)? {
+            IdentifierType::ForId => {
+                let profile_id = MeasurementSystemProfileId::from_str(&list_machines.identifier)
+                    .map_err(|e| CarbideCliError::GenericError(e.to_string()))?;
+                Some(
+                    list_measurement_system_profile_machines_request::Selector::ProfileId(
+                        profile_id,
+                    ),
+                )
+            }
+            IdentifierType::ForName => Some(
+                list_measurement_system_profile_machines_request::Selector::ProfileName(
+                    list_machines.identifier,
+                ),
+            ),
+            IdentifierType::Detect => {
+                match MeasurementSystemProfileId::from_str(&list_machines.identifier) {
+                    Ok(profile_id) => Some(
+                        list_measurement_system_profile_machines_request::Selector::ProfileId(
+                            profile_id,
+                        ),
+                    ),
+                    Err(_) => Some(
+                        list_measurement_system_profile_machines_request::Selector::ProfileName(
+                            list_machines.identifier,
+                        ),
+                    ),
+                }
+            }
+        };
+        Ok(Self { selector })
     }
 }

--- a/crates/admin-cli/src/measurement/profile/cmds.rs
+++ b/crates/admin-cli/src/measurement/profile/cmds.rs
@@ -23,20 +23,16 @@ use std::str::FromStr;
 
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, ToTable, cli_output};
 use ::rpc::protos::measured_boot::{
-    CreateMeasurementSystemProfileRequest, DeleteMeasurementSystemProfileRequest, KvPair,
-    ListMeasurementSystemProfileBundlesRequest, ListMeasurementSystemProfileMachinesRequest,
-    RenameMeasurementSystemProfileRequest, ShowMeasurementSystemProfileRequest,
-    delete_measurement_system_profile_request, list_measurement_system_profile_bundles_request,
-    list_measurement_system_profile_machines_request, rename_measurement_system_profile_request,
-    show_measurement_system_profile_request,
+    DeleteMeasurementSystemProfileRequest, ListMeasurementSystemProfileBundlesRequest,
+    ListMeasurementSystemProfileMachinesRequest, RenameMeasurementSystemProfileRequest,
+    ShowMeasurementSystemProfileRequest,
 };
 use carbide_uuid::machine::MachineId;
-use carbide_uuid::measured_boot::{MeasurementBundleId, MeasurementSystemProfileId};
+use carbide_uuid::measured_boot::MeasurementBundleId;
 use measured_boot::profile::MeasurementSystemProfile;
 use measured_boot::records::MeasurementSystemProfileRecord;
 use serde::Serialize;
 
-use crate::measurement::global::cmds::{IdentifierType, get_identifier};
 use crate::measurement::profile::args::{
     CmdProfile, Create, Delete, List, ListBundles, ListMachines, Rename, Show,
 };
@@ -119,28 +115,9 @@ pub async fn create(
     grpc_conn: &ApiClient,
     create: Create,
 ) -> CarbideCliResult<MeasurementSystemProfile> {
-    // Prepare.
-    let extra_attrs = create
-        .extra_attrs
-        .into_iter()
-        .map(|kv_pair| KvPair {
-            key: kv_pair.key,
-            value: kv_pair.value,
-        })
-        .collect();
-
-    // Request.
-    let request = CreateMeasurementSystemProfileRequest {
-        name: Some(create.name),
-        vendor: create.vendor,
-        product: create.product,
-        extra_attrs,
-    };
-
-    // Response.
     let response = grpc_conn
         .0
-        .create_measurement_system_profile(request)
+        .create_measurement_system_profile(create)
         .await?;
 
     MeasurementSystemProfile::from_grpc(response.system_profile.as_ref())
@@ -153,34 +130,9 @@ pub async fn delete(
     grpc_conn: &ApiClient,
     delete: Delete,
 ) -> CarbideCliResult<MeasurementSystemProfile> {
-    // Prepare.
-    let selector = match get_identifier(&delete)? {
-        IdentifierType::ForId => {
-            let profile_id: MeasurementSystemProfileId =
-                MeasurementSystemProfileId::from_str(&delete.identifier)
-                    .map_err(|e| CarbideCliError::GenericError(e.to_string()))?;
-            Some(delete_measurement_system_profile_request::Selector::ProfileId(profile_id))
-        }
-        IdentifierType::ForName => Some(
-            delete_measurement_system_profile_request::Selector::ProfileName(delete.identifier),
-        ),
-        IdentifierType::Detect => match MeasurementSystemProfileId::from_str(&delete.identifier) {
-            Ok(profile_id) => {
-                Some(delete_measurement_system_profile_request::Selector::ProfileId(profile_id))
-            }
-            Err(_) => Some(
-                delete_measurement_system_profile_request::Selector::ProfileName(delete.identifier),
-            ),
-        },
-    };
-
-    // Request.
-    let request = DeleteMeasurementSystemProfileRequest { selector };
-
-    // Response.
     let response = grpc_conn
         .0
-        .delete_measurement_system_profile(request)
+        .delete_measurement_system_profile(DeleteMeasurementSystemProfileRequest::try_from(delete)?)
         .await?;
 
     MeasurementSystemProfile::from_grpc(response.system_profile.as_ref())
@@ -192,35 +144,9 @@ pub async fn rename(
     grpc_conn: &ApiClient,
     rename: Rename,
 ) -> CarbideCliResult<MeasurementSystemProfile> {
-    let selector = match get_identifier(&rename)? {
-        IdentifierType::ForId => {
-            let profile_id = MeasurementSystemProfileId::from_str(&rename.identifier)
-                .map_err(|e| CarbideCliError::GenericError(e.to_string()))?;
-            Some(rename_measurement_system_profile_request::Selector::ProfileId(profile_id))
-        }
-        IdentifierType::ForName => Some(
-            rename_measurement_system_profile_request::Selector::ProfileName(rename.identifier),
-        ),
-        IdentifierType::Detect => match MeasurementSystemProfileId::from_str(&rename.identifier) {
-            Ok(profile_id) => {
-                Some(rename_measurement_system_profile_request::Selector::ProfileId(profile_id))
-            }
-            Err(_) => Some(
-                rename_measurement_system_profile_request::Selector::ProfileName(rename.identifier),
-            ),
-        },
-    };
-
-    // Request.
-    let request = RenameMeasurementSystemProfileRequest {
-        new_profile_name: rename.new_profile_name,
-        selector,
-    };
-
-    // Response.
     let response = grpc_conn
         .0
-        .rename_measurement_system_profile(request)
+        .rename_measurement_system_profile(RenameMeasurementSystemProfileRequest::try_from(rename)?)
         .await?;
 
     MeasurementSystemProfile::from_grpc(response.profile.as_ref())
@@ -252,39 +178,10 @@ pub async fn show_by_id_or_name(
     grpc_conn: &ApiClient,
     show: Show,
 ) -> CarbideCliResult<MeasurementSystemProfile> {
-    let identifier_type = get_identifier(&show)?;
-    // Prepare.
-    let identifier = show
-        .identifier
-        .ok_or(CarbideCliError::GenericError(String::from(
-            "identifier expected to be set here",
-        )))?;
-
-    let selector = match identifier_type {
-        IdentifierType::ForId => {
-            let profile_id: MeasurementSystemProfileId =
-                MeasurementSystemProfileId::from_str(&identifier)
-                    .map_err(|e| CarbideCliError::GenericError(e.to_string()))?;
-            Some(show_measurement_system_profile_request::Selector::ProfileId(profile_id))
-        }
-        IdentifierType::ForName => {
-            Some(show_measurement_system_profile_request::Selector::ProfileName(identifier))
-        }
-        IdentifierType::Detect => match MeasurementSystemProfileId::from_str(&identifier) {
-            Ok(profile_id) => {
-                Some(show_measurement_system_profile_request::Selector::ProfileId(profile_id))
-            }
-            Err(_) => {
-                Some(show_measurement_system_profile_request::Selector::ProfileName(identifier))
-            }
-        },
-    };
-
-    // Request.
-    let request = ShowMeasurementSystemProfileRequest { selector };
-
-    // Response.
-    let response = grpc_conn.0.show_measurement_system_profile(request).await?;
+    let response = grpc_conn
+        .0
+        .show_measurement_system_profile(ShowMeasurementSystemProfileRequest::try_from(show)?)
+        .await?;
 
     MeasurementSystemProfile::from_grpc(response.system_profile.as_ref())
         .map_err(|e| CarbideCliError::GenericError(e.to_string()))
@@ -317,43 +214,12 @@ pub async fn list_bundles_for_id_or_name(
     grpc_conn: &ApiClient,
     list_bundles: ListBundles,
 ) -> CarbideCliResult<MeasurementBundleIdList> {
-    // Prepare.
-    let selector = match get_identifier(&list_bundles)? {
-        IdentifierType::ForId => {
-            let profile_id: MeasurementSystemProfileId =
-                MeasurementSystemProfileId::from_str(&list_bundles.identifier)
-                    .map_err(|e| CarbideCliError::GenericError(e.to_string()))?;
-            Some(list_measurement_system_profile_bundles_request::Selector::ProfileId(profile_id))
-        }
-        IdentifierType::ForName => Some(
-            list_measurement_system_profile_bundles_request::Selector::ProfileName(
-                list_bundles.identifier,
-            ),
-        ),
-        IdentifierType::Detect => {
-            match MeasurementSystemProfileId::from_str(&list_bundles.identifier) {
-                Ok(profile_id) => Some(
-                    list_measurement_system_profile_bundles_request::Selector::ProfileId(
-                        profile_id,
-                    ),
-                ),
-                Err(_) => Some(
-                    list_measurement_system_profile_bundles_request::Selector::ProfileName(
-                        list_bundles.identifier,
-                    ),
-                ),
-            }
-        }
-    };
-
-    // Request.
-    let request = ListMeasurementSystemProfileBundlesRequest { selector };
-
-    // Response.
     Ok(MeasurementBundleIdList(
         grpc_conn
             .0
-            .list_measurement_system_profile_bundles(request)
+            .list_measurement_system_profile_bundles(
+                ListMeasurementSystemProfileBundlesRequest::try_from(list_bundles)?,
+            )
             .await?
             .bundle_ids,
     ))
@@ -366,43 +232,12 @@ pub async fn list_machines_for_id_or_name(
     grpc_conn: &ApiClient,
     list_machines: ListMachines,
 ) -> CarbideCliResult<MachineIdList> {
-    // Prepare.
-    let selector = match get_identifier(&list_machines)? {
-        IdentifierType::ForId => {
-            let profile_id: MeasurementSystemProfileId =
-                MeasurementSystemProfileId::from_str(&list_machines.identifier)
-                    .map_err(|e| CarbideCliError::GenericError(e.to_string()))?;
-            Some(list_measurement_system_profile_machines_request::Selector::ProfileId(profile_id))
-        }
-        IdentifierType::ForName => Some(
-            list_measurement_system_profile_machines_request::Selector::ProfileName(
-                list_machines.identifier,
-            ),
-        ),
-        IdentifierType::Detect => {
-            match MeasurementSystemProfileId::from_str(&list_machines.identifier) {
-                Ok(profile_id) => Some(
-                    list_measurement_system_profile_machines_request::Selector::ProfileId(
-                        profile_id,
-                    ),
-                ),
-                Err(_) => Some(
-                    list_measurement_system_profile_machines_request::Selector::ProfileName(
-                        list_machines.identifier,
-                    ),
-                ),
-            }
-        }
-    };
-
-    // Request.
-    let request = ListMeasurementSystemProfileMachinesRequest { selector };
-
-    // Response.
     Ok(MachineIdList(
         grpc_conn
             .0
-            .list_measurement_system_profile_machines(request)
+            .list_measurement_system_profile_machines(
+                ListMeasurementSystemProfileMachinesRequest::try_from(list_machines)?,
+            )
             .await?
             .machine_ids
             .iter()

--- a/crates/admin-cli/src/measurement/report/args.rs
+++ b/crates/admin-cli/src/measurement/report/args.rs
@@ -31,6 +31,12 @@
  *  - `report match``
 */
 
+use ::rpc::protos::measured_boot::{
+    CreateMeasurementReportRequest, DeleteMeasurementReportRequest, ListMeasurementReportRequest,
+    MatchMeasurementReportRequest, PromoteMeasurementReportRequest, RevokeMeasurementReportRequest,
+    ShowMeasurementReportForIdRequest, ShowMeasurementReportsForMachineRequest,
+    list_measurement_report_request,
+};
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::measured_boot::MeasurementReportId;
 use clap::Parser;
@@ -203,4 +209,79 @@ pub struct Match {
     )]
     #[arg(value_parser = parse_pcr_register_values)]
     pub values: Vec<PcrRegisterValue>,
+}
+
+impl From<Create> for CreateMeasurementReportRequest {
+    fn from(create: Create) -> Self {
+        Self {
+            machine_id: create.machine_id.to_string(),
+            pcr_values: create.values.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<Delete> for DeleteMeasurementReportRequest {
+    fn from(delete: Delete) -> Self {
+        Self {
+            report_id: Some(delete.report_id),
+        }
+    }
+}
+
+impl From<Promote> for PromoteMeasurementReportRequest {
+    fn from(promote: Promote) -> Self {
+        Self {
+            report_id: Some(promote.report_id),
+            pcr_registers: match &promote.pcr_registers {
+                None => "".to_string(),
+                Some(pcr_set) => pcr_set.to_string(),
+            },
+        }
+    }
+}
+
+impl From<Revoke> for RevokeMeasurementReportRequest {
+    fn from(revoke: Revoke) -> Self {
+        Self {
+            report_id: Some(revoke.report_id),
+            pcr_registers: match &revoke.pcr_registers {
+                None => "".to_string(),
+                Some(pcr_set) => pcr_set.to_string(),
+            },
+        }
+    }
+}
+
+impl From<ShowForId> for ShowMeasurementReportForIdRequest {
+    fn from(show_for_id: ShowForId) -> Self {
+        Self {
+            report_id: Some(show_for_id.report_id),
+        }
+    }
+}
+
+impl From<ShowForMachine> for ShowMeasurementReportsForMachineRequest {
+    fn from(show_for_machine: ShowForMachine) -> Self {
+        Self {
+            machine_id: show_for_machine.machine_id,
+        }
+    }
+}
+
+impl From<ListMachines> for ListMeasurementReportRequest {
+    fn from(list_machines: ListMachines) -> Self {
+        Self {
+            selector: Some(list_measurement_report_request::Selector::MachineId(
+                list_machines.machine_id.to_string(),
+            )),
+        }
+    }
+}
+
+impl From<Match> for MatchMeasurementReportRequest {
+    fn from(match_args: Match) -> Self {
+        Self {
+            pcr_values: match_args.values.into_iter().map(Into::into).collect(),
+        }
+    }
 }

--- a/crates/admin-cli/src/measurement/report/cmds.rs
+++ b/crates/admin-cli/src/measurement/report/cmds.rs
@@ -20,12 +20,7 @@
 //!
 
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, ToTable, cli_output};
-use ::rpc::protos::measured_boot::{
-    CreateMeasurementReportRequest, DeleteMeasurementReportRequest, ListMeasurementReportRequest,
-    MatchMeasurementReportRequest, PromoteMeasurementReportRequest, RevokeMeasurementReportRequest,
-    ShowMeasurementReportForIdRequest, ShowMeasurementReportsForMachineRequest,
-    list_measurement_report_request,
-};
+use ::rpc::protos::measured_boot::ListMeasurementReportRequest;
 use measured_boot::bundle::MeasurementBundle;
 use measured_boot::records::MeasurementReportRecord;
 use measured_boot::report::MeasurementReport;
@@ -126,14 +121,7 @@ pub async fn create_for_id(
     grpc_conn: &ApiClient,
     create: Create,
 ) -> CarbideCliResult<MeasurementReport> {
-    // Request.
-    let request = CreateMeasurementReportRequest {
-        machine_id: create.machine_id.to_string(),
-        pcr_values: create.values.into_iter().map(Into::into).collect(),
-    };
-
-    // Response.
-    let response = grpc_conn.0.create_measurement_report(request).await?;
+    let response = grpc_conn.0.create_measurement_report(create).await?;
 
     MeasurementReport::from_grpc(response.report.as_ref())
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
@@ -141,13 +129,7 @@ pub async fn create_for_id(
 
 /// delete deletes a measurement report with the provided ID.
 pub async fn delete(grpc_conn: &ApiClient, delete: Delete) -> CarbideCliResult<MeasurementReport> {
-    // Request.
-    let request = DeleteMeasurementReportRequest {
-        report_id: Some(delete.report_id),
-    };
-
-    // Response.
-    let response = grpc_conn.0.delete_measurement_report(request).await?;
+    let response = grpc_conn.0.delete_measurement_report(delete).await?;
 
     MeasurementReport::from_grpc(response.report.as_ref())
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
@@ -160,17 +142,7 @@ pub async fn promote(
     grpc_conn: &ApiClient,
     promote: Promote,
 ) -> CarbideCliResult<MeasurementBundle> {
-    // Request.
-    let request = PromoteMeasurementReportRequest {
-        report_id: Some(promote.report_id),
-        pcr_registers: match &promote.pcr_registers {
-            None => "".to_string(),
-            Some(pcr_set) => pcr_set.to_string(),
-        },
-    };
-
-    // Response.
-    let response = grpc_conn.0.promote_measurement_report(request).await?;
+    let response = grpc_conn.0.promote_measurement_report(promote).await?;
 
     MeasurementBundle::from_grpc(response.bundle.as_ref())
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
@@ -182,17 +154,7 @@ pub async fn promote(
 ///
 /// `journal revoke <journal-id> [pcr-selector]`
 pub async fn revoke(grpc_conn: &ApiClient, revoke: Revoke) -> CarbideCliResult<MeasurementBundle> {
-    // Request.
-    let request = RevokeMeasurementReportRequest {
-        report_id: Some(revoke.report_id),
-        pcr_registers: match &revoke.pcr_registers {
-            None => "".to_string(),
-            Some(pcr_set) => pcr_set.to_string(),
-        },
-    };
-
-    // Response.
-    let response = grpc_conn.0.revoke_measurement_report(request).await?;
+    let response = grpc_conn.0.revoke_measurement_report(revoke).await?;
 
     MeasurementBundle::from_grpc(response.bundle.as_ref())
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
@@ -203,13 +165,10 @@ pub async fn show_for_id(
     grpc_conn: &ApiClient,
     show_for_id: ShowForId,
 ) -> CarbideCliResult<MeasurementReport> {
-    // Request.
-    let request = ShowMeasurementReportForIdRequest {
-        report_id: Some(show_for_id.report_id),
-    };
-
-    // Response.
-    let response = grpc_conn.0.show_measurement_report_for_id(request).await?;
+    let response = grpc_conn
+        .0
+        .show_measurement_report_for_id(show_for_id)
+        .await?;
 
     MeasurementReport::from_grpc(response.report.as_ref())
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
@@ -220,16 +179,10 @@ pub async fn show_for_machine(
     grpc_conn: &ApiClient,
     show_for_machine: ShowForMachine,
 ) -> CarbideCliResult<MeasurementReportList> {
-    // Request.
-    let request = ShowMeasurementReportsForMachineRequest {
-        machine_id: show_for_machine.machine_id.to_string(),
-    };
-
-    // Response.
     Ok(MeasurementReportList(
         grpc_conn
             .0
-            .show_measurement_reports_for_machine(request)
+            .show_measurement_reports_for_machine(show_for_machine)
             .await?
             .reports
             .into_iter()
@@ -284,18 +237,10 @@ pub async fn list_machines(
     grpc_conn: &ApiClient,
     list_machines: ListMachines,
 ) -> CarbideCliResult<MeasurementReportRecordList> {
-    // Request.
-    let request = ListMeasurementReportRequest {
-        selector: Some(list_measurement_report_request::Selector::MachineId(
-            list_machines.machine_id.to_string(),
-        )),
-    };
-
-    // Response.
     Ok(MeasurementReportRecordList(
         grpc_conn
             .0
-            .list_measurement_report(request)
+            .list_measurement_report(list_machines)
             .await?
             .reports
             .into_iter()
@@ -314,16 +259,10 @@ pub async fn match_values(
     grpc_conn: &ApiClient,
     match_args: Match,
 ) -> CarbideCliResult<MeasurementReportRecordList> {
-    // Request.
-    let request = MatchMeasurementReportRequest {
-        pcr_values: match_args.values.into_iter().map(Into::into).collect(),
-    };
-
-    // Response.
     Ok(MeasurementReportRecordList(
         grpc_conn
             .0
-            .match_measurement_report(request)
+            .match_measurement_report(match_args)
             .await?
             .reports
             .into_iter()

--- a/crates/admin-cli/src/measurement/site/args.rs
+++ b/crates/admin-cli/src/measurement/site/args.rs
@@ -29,6 +29,12 @@
  *  - `site trusted-profile list`: List all trusted profile approvals.
 */
 
+use ::rpc::protos::measured_boot::{
+    AddMeasurementTrustedMachineRequest, AddMeasurementTrustedProfileRequest,
+    MeasurementApprovedTypePb, RemoveMeasurementTrustedMachineRequest,
+    RemoveMeasurementTrustedProfileRequest, remove_measurement_trusted_machine_request,
+    remove_measurement_trusted_profile_request,
+};
 use carbide_uuid::measured_boot::{
     MeasurementApprovedMachineId, MeasurementApprovedProfileId, MeasurementSystemProfileId,
     TrustedMachineId,
@@ -211,3 +217,75 @@ pub struct RemoveProfileByProfileId {
 /// ListProfiles is used to list all active profile approvals.
 #[derive(Parser, Debug)]
 pub struct ListProfiles {}
+
+impl From<ApproveMachine> for AddMeasurementTrustedMachineRequest {
+    fn from(approve: ApproveMachine) -> Self {
+        let approval_type: MeasurementApprovedTypePb = approve.approval_type.into();
+        Self {
+            machine_id: approve.machine_id.to_string(),
+            approval_type: approval_type.into(),
+            pcr_registers: approve.pcr_registers.unwrap_or_default(),
+            comments: approve.comments.unwrap_or_default(),
+        }
+    }
+}
+
+impl From<RemoveMachineByApprovalId> for RemoveMeasurementTrustedMachineRequest {
+    fn from(by_approval_id: RemoveMachineByApprovalId) -> Self {
+        Self {
+            selector: Some(
+                remove_measurement_trusted_machine_request::Selector::ApprovalId(
+                    by_approval_id.approval_id,
+                ),
+            ),
+        }
+    }
+}
+
+impl From<RemoveMachineByMachineId> for RemoveMeasurementTrustedMachineRequest {
+    fn from(by_machine_id: RemoveMachineByMachineId) -> Self {
+        Self {
+            selector: Some(
+                remove_measurement_trusted_machine_request::Selector::MachineId(
+                    by_machine_id.machine_id.to_string(),
+                ),
+            ),
+        }
+    }
+}
+
+impl From<ApproveProfile> for AddMeasurementTrustedProfileRequest {
+    fn from(approve: ApproveProfile) -> Self {
+        let approval_type: MeasurementApprovedTypePb = approve.approval_type.into();
+        Self {
+            profile_id: Some(approve.profile_id),
+            approval_type: approval_type.into(),
+            pcr_registers: approve.pcr_registers,
+            comments: approve.comments,
+        }
+    }
+}
+
+impl From<RemoveProfileByApprovalId> for RemoveMeasurementTrustedProfileRequest {
+    fn from(by_approval_id: RemoveProfileByApprovalId) -> Self {
+        Self {
+            selector: Some(
+                remove_measurement_trusted_profile_request::Selector::ApprovalId(
+                    by_approval_id.approval_id,
+                ),
+            ),
+        }
+    }
+}
+
+impl From<RemoveProfileByProfileId> for RemoveMeasurementTrustedProfileRequest {
+    fn from(by_profile_id: RemoveProfileByProfileId) -> Self {
+        Self {
+            selector: Some(
+                remove_measurement_trusted_profile_request::Selector::ProfileId(
+                    by_profile_id.profile_id,
+                ),
+            ),
+        }
+    }
+}

--- a/crates/admin-cli/src/measurement/site/cmds.rs
+++ b/crates/admin-cli/src/measurement/site/cmds.rs
@@ -23,12 +23,7 @@ use std::fs::File;
 use std::io::BufReader;
 
 use ::rpc::admin_cli::{CarbideCliResult, ToTable, cli_output, set_summary};
-use ::rpc::protos::measured_boot::{
-    AddMeasurementTrustedMachineRequest, AddMeasurementTrustedProfileRequest,
-    ImportSiteMeasurementsRequest, MeasurementApprovedTypePb,
-    RemoveMeasurementTrustedMachineRequest, RemoveMeasurementTrustedProfileRequest,
-    remove_measurement_trusted_machine_request, remove_measurement_trusted_profile_request,
-};
+use ::rpc::protos::measured_boot::ImportSiteMeasurementsRequest;
 use measured_boot::records::{MeasurementApprovedMachineRecord, MeasurementApprovedProfileRecord};
 use measured_boot::site::{ImportResult, SiteModel};
 use serde::Serialize;
@@ -173,21 +168,8 @@ pub async fn approve_machine(
     grpc_conn: &ApiClient,
     approve: ApproveMachine,
 ) -> CarbideCliResult<MeasurementApprovedMachineRecord> {
-    // Prepare.
-    let approval_type: MeasurementApprovedTypePb = approve.approval_type.into();
+    let response = grpc_conn.0.add_measurement_trusted_machine(approve).await?;
 
-    // Request.
-    let request = AddMeasurementTrustedMachineRequest {
-        machine_id: approve.machine_id.to_string(),
-        approval_type: approval_type.into(),
-        pcr_registers: approve.pcr_registers.unwrap_or_default(),
-        comments: approve.comments.unwrap_or_default(),
-    };
-
-    // Response.
-    let response = grpc_conn.0.add_measurement_trusted_machine(request).await?;
-
-    // Process and return.
     MeasurementApprovedMachineRecord::from_grpc(response.approval_record.as_ref())
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
@@ -198,22 +180,11 @@ pub async fn remove_machine_by_approval_id(
     grpc_conn: &ApiClient,
     by_approval_id: RemoveMachineByApprovalId,
 ) -> CarbideCliResult<MeasurementApprovedMachineRecord> {
-    // Request.
-    let request = RemoveMeasurementTrustedMachineRequest {
-        selector: Some(
-            remove_measurement_trusted_machine_request::Selector::ApprovalId(
-                by_approval_id.approval_id,
-            ),
-        ),
-    };
-
-    // Response.
     let response = grpc_conn
         .0
-        .remove_measurement_trusted_machine(request)
+        .remove_measurement_trusted_machine(by_approval_id)
         .await?;
 
-    // Process and return.
     MeasurementApprovedMachineRecord::from_grpc(response.approval_record.as_ref())
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
@@ -224,22 +195,11 @@ pub async fn remove_machine_by_machine_id(
     grpc_conn: &ApiClient,
     by_machine_id: RemoveMachineByMachineId,
 ) -> CarbideCliResult<MeasurementApprovedMachineRecord> {
-    // Request
-    let request = RemoveMeasurementTrustedMachineRequest {
-        selector: Some(
-            remove_measurement_trusted_machine_request::Selector::MachineId(
-                by_machine_id.machine_id.to_string(),
-            ),
-        ),
-    };
-
-    // Response
     let response = grpc_conn
         .0
-        .remove_measurement_trusted_machine(request)
+        .remove_measurement_trusted_machine(by_machine_id)
         .await?;
 
-    // Process and return.
     MeasurementApprovedMachineRecord::from_grpc(response.approval_record.as_ref())
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
@@ -268,19 +228,8 @@ pub async fn approve_profile(
     grpc_conn: &ApiClient,
     approve: ApproveProfile,
 ) -> CarbideCliResult<MeasurementApprovedProfileRecord> {
-    // Request.
-    let approval_type: MeasurementApprovedTypePb = approve.approval_type.into();
-    let request = AddMeasurementTrustedProfileRequest {
-        profile_id: Some(approve.profile_id),
-        approval_type: approval_type.into(),
-        pcr_registers: approve.pcr_registers.as_ref().cloned(),
-        comments: approve.comments.as_ref().cloned(),
-    };
+    let response = grpc_conn.0.add_measurement_trusted_profile(approve).await?;
 
-    // Response.
-    let response = grpc_conn.0.add_measurement_trusted_profile(request).await?;
-
-    // Process and return.
     MeasurementApprovedProfileRecord::from_grpc(response.approval_record.as_ref())
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
@@ -291,22 +240,11 @@ pub async fn remove_profile_by_approval_id(
     grpc_conn: &ApiClient,
     by_approval_id: RemoveProfileByApprovalId,
 ) -> CarbideCliResult<MeasurementApprovedProfileRecord> {
-    // Request.
-    let request = RemoveMeasurementTrustedProfileRequest {
-        selector: Some(
-            remove_measurement_trusted_profile_request::Selector::ApprovalId(
-                by_approval_id.approval_id,
-            ),
-        ),
-    };
-
-    // Response.
     let response = grpc_conn
         .0
-        .remove_measurement_trusted_profile(request)
+        .remove_measurement_trusted_profile(by_approval_id)
         .await?;
 
-    // Process and return.
     MeasurementApprovedProfileRecord::from_grpc(response.approval_record.as_ref())
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
@@ -317,22 +255,11 @@ pub async fn remove_profile_by_profile_id(
     grpc_conn: &ApiClient,
     by_profile_id: RemoveProfileByProfileId,
 ) -> CarbideCliResult<MeasurementApprovedProfileRecord> {
-    // Request.
-    let request = RemoveMeasurementTrustedProfileRequest {
-        selector: Some(
-            remove_measurement_trusted_profile_request::Selector::ProfileId(
-                by_profile_id.profile_id,
-            ),
-        ),
-    };
-
-    // Response.
     let response = grpc_conn
         .0
-        .remove_measurement_trusted_profile(request)
+        .remove_measurement_trusted_profile(by_profile_id)
         .await?;
 
-    // Process and return.
     MeasurementApprovedProfileRecord::from_grpc(response.approval_record.as_ref())
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }

--- a/crates/admin-cli/src/network_devices/show/args.rs
+++ b/crates/admin-cli/src/network_devices/show/args.rs
@@ -34,3 +34,14 @@ pub struct Args {
     )]
     pub id: String,
 }
+
+impl From<Args> for ::rpc::forge::NetworkTopologyRequest {
+    fn from(args: Args) -> Self {
+        let id = if args.all || args.id.is_empty() {
+            None
+        } else {
+            Some(args.id)
+        };
+        Self { id }
+    }
+}

--- a/crates/admin-cli/src/network_devices/show/cmd.rs
+++ b/crates/admin-cli/src/network_devices/show/cmd.rs
@@ -18,7 +18,6 @@
 use std::fmt::Write;
 
 use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
-use ::rpc::forge::NetworkTopologyRequest;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
@@ -28,16 +27,7 @@ pub async fn handle_show(
     query: Args,
     api_client: &ApiClient,
 ) -> CarbideCliResult<()> {
-    let id: Option<String> = if query.all || query.id.is_empty() {
-        None
-    } else {
-        Some(query.id)
-    };
-
-    let devices = api_client
-        .0
-        .get_network_topology(NetworkTopologyRequest { id })
-        .await?;
+    let devices = api_client.0.get_network_topology(query).await?;
 
     match output_format {
         OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&devices)?),

--- a/crates/admin-cli/src/network_security_group/create/args.rs
+++ b/crates/admin-cli/src/network_security_group/create/args.rs
@@ -16,6 +16,10 @@
  */
 
 use clap::Parser;
+use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+use rpc::forge::{
+    self as forgerpc, CreateNetworkSecurityGroupRequest, NetworkSecurityGroupAttributes,
+};
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
@@ -59,4 +63,38 @@ pub struct Args {
         help = "Optional, JSON array containing a defined set of network security group rules"
     )]
     pub rules: Option<String>,
+}
+
+impl TryFrom<Args> for CreateNetworkSecurityGroupRequest {
+    type Error = CarbideCliError;
+
+    fn try_from(args: Args) -> CarbideCliResult<Self> {
+        let labels = if let Some(l) = args.labels {
+            serde_json::from_str(&l)?
+        } else {
+            vec![]
+        };
+
+        let metadata = forgerpc::Metadata {
+            name: args.name.unwrap_or_default(),
+            description: args.description.unwrap_or_default(),
+            labels,
+        };
+
+        let rules = if let Some(r) = args.rules {
+            serde_json::from_str(&r)?
+        } else {
+            vec![]
+        };
+
+        Ok(CreateNetworkSecurityGroupRequest {
+            id: args.id,
+            tenant_organization_id: args.tenant_organization_id,
+            metadata: Some(metadata),
+            network_security_group_attributes: Some(NetworkSecurityGroupAttributes {
+                stateful_egress: args.stateful_egress,
+                rules,
+            }),
+        })
+    }
 }

--- a/crates/admin-cli/src/network_security_group/create/cmd.rs
+++ b/crates/admin-cli/src/network_security_group/create/cmd.rs
@@ -16,7 +16,6 @@
  */
 
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
-use ::rpc::forge::{self as forgerpc};
 
 use super::args::Args;
 use crate::network_security_group::common::convert_nsgs_to_table;
@@ -32,35 +31,13 @@ pub async fn create(
 ) -> CarbideCliResult<()> {
     let is_json = output_format == OutputFormat::Json;
 
-    let id = args.id;
-
-    let labels = if let Some(l) = args.labels {
-        serde_json::from_str(&l)?
-    } else {
-        vec![]
-    };
-
-    let metadata = forgerpc::Metadata {
-        name: args.name.unwrap_or_default(),
-        description: args.description.unwrap_or_default(),
-        labels,
-    };
-
-    let rules = if let Some(r) = args.rules {
-        serde_json::from_str(&r)?
-    } else {
-        vec![]
-    };
-
+    let req: ::rpc::forge::CreateNetworkSecurityGroupRequest = args.try_into()?;
     let nsg = api_client
-        .create_network_security_group(
-            id,
-            args.tenant_organization_id,
-            metadata,
-            args.stateful_egress,
-            rules,
-        )
-        .await?;
+        .0
+        .create_network_security_group(req)
+        .await?
+        .network_security_group
+        .ok_or(CarbideCliError::Empty)?;
 
     if is_json {
         println!(

--- a/crates/admin-cli/src/network_security_group/delete/args.rs
+++ b/crates/admin-cli/src/network_security_group/delete/args.rs
@@ -16,6 +16,7 @@
  */
 
 use clap::Parser;
+use rpc::forge::DeleteNetworkSecurityGroupRequest;
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
@@ -28,4 +29,13 @@ pub struct Args {
         help = "Tenant organization ID of the network security group"
     )]
     pub tenant_organization_id: String,
+}
+
+impl From<Args> for DeleteNetworkSecurityGroupRequest {
+    fn from(args: Args) -> Self {
+        DeleteNetworkSecurityGroupRequest {
+            id: args.id,
+            tenant_organization_id: args.tenant_organization_id,
+        }
+    }
 }

--- a/crates/admin-cli/src/network_security_group/delete/cmd.rs
+++ b/crates/admin-cli/src/network_security_group/delete/cmd.rs
@@ -16,20 +16,14 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::forge::DeleteNetworkSecurityGroupRequest;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 /// Delete a network security group.
 pub async fn delete(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    api_client
-        .0
-        .delete_network_security_group(DeleteNetworkSecurityGroupRequest {
-            id: args.id.clone(),
-            tenant_organization_id: args.tenant_organization_id,
-        })
-        .await?;
-    println!("Deleted network security group {} successfully.", args.id);
+    let id = args.id.clone();
+    api_client.0.delete_network_security_group(args).await?;
+    println!("Deleted network security group {} successfully.", id);
     Ok(())
 }

--- a/crates/admin-cli/src/network_segment/delete/args.rs
+++ b/crates/admin-cli/src/network_segment/delete/args.rs
@@ -23,3 +23,9 @@ pub struct Args {
     #[clap(long, help = "Id of the network segment")]
     pub id: NetworkSegmentId,
 }
+
+impl From<Args> for ::rpc::forge::NetworkSegmentDeletionRequest {
+    fn from(args: Args) -> Self {
+        Self { id: Some(args.id) }
+    }
+}

--- a/crates/admin-cli/src/network_segment/delete/cmd.rs
+++ b/crates/admin-cli/src/network_segment/delete/cmd.rs
@@ -16,7 +16,6 @@
  */
 
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
-use ::rpc::forge::NetworkSegmentDeletionRequest;
 
 use super::args::Args;
 use crate::cfg::runtime::RuntimeContext;
@@ -28,9 +27,6 @@ pub async fn handle_delete(args: Args, ctx: &mut RuntimeContext) -> CarbideCliRe
                 .to_owned(),
         ));
     }
-    ctx.api_client
-        .0
-        .delete_network_segment(NetworkSegmentDeletionRequest { id: Some(args.id) })
-        .await?;
+    ctx.api_client.0.delete_network_segment(args).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/nvl_logical_partition/create/args.rs
+++ b/crates/admin-cli/src/nvl_logical_partition/create/args.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use ::rpc::forge as forgerpc;
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
@@ -23,4 +24,24 @@ pub struct Args {
     pub name: String,
     #[clap(short = 't', long, help = "tenant organization id of the partition")]
     pub tenant_organization_id: String,
+}
+
+impl From<Args> for forgerpc::NvLinkLogicalPartitionCreationRequest {
+    fn from(args: Args) -> Self {
+        let metadata = forgerpc::Metadata {
+            name: args.name,
+            labels: vec![forgerpc::Label {
+                key: "cloud-unsafe-op".to_string(),
+                value: Some("true".to_string()),
+            }],
+            ..Default::default()
+        };
+        Self {
+            config: Some(forgerpc::NvLinkLogicalPartitionConfig {
+                metadata: Some(metadata),
+                tenant_organization_id: args.tenant_organization_id,
+            }),
+            id: None,
+        }
+    }
 }

--- a/crates/admin-cli/src/nvl_logical_partition/create/cmd.rs
+++ b/crates/admin-cli/src/nvl_logical_partition/create/cmd.rs
@@ -16,35 +16,11 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::forge as forgerpc;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn handle_create(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    create_logical_partition(args, api_client).await?;
-    Ok(())
-}
-
-pub async fn create_logical_partition(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let metadata = forgerpc::Metadata {
-        name: args.name,
-        labels: vec![forgerpc::Label {
-            key: "cloud-unsafe-op".to_string(),
-            value: Some("true".to_string()),
-        }],
-        ..Default::default()
-    };
-    let request = forgerpc::NvLinkLogicalPartitionCreationRequest {
-        config: Some(forgerpc::NvLinkLogicalPartitionConfig {
-            metadata: Some(metadata),
-            tenant_organization_id: args.tenant_organization_id,
-        }),
-        id: None,
-    };
-    let _partition = api_client
-        .0
-        .create_nv_link_logical_partition(request)
-        .await?;
+    api_client.0.create_nv_link_logical_partition(args).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/nvl_logical_partition/delete/args.rs
+++ b/crates/admin-cli/src/nvl_logical_partition/delete/args.rs
@@ -15,10 +15,24 @@
  * limitations under the License.
  */
 
+use ::rpc::admin_cli::CarbideCliError;
+use ::rpc::forge as forgerpc;
+use carbide_uuid::nvlink::NvLinkLogicalPartitionId;
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
     #[clap(short = 'n', long, help = "name of the partition")]
     pub name: String,
+}
+
+impl TryFrom<Args> for forgerpc::NvLinkLogicalPartitionDeletionRequest {
+    type Error = CarbideCliError;
+
+    fn try_from(args: Args) -> Result<Self, Self::Error> {
+        let uuid: NvLinkLogicalPartitionId = uuid::Uuid::parse_str(&args.name)
+            .map_err(|_| CarbideCliError::GenericError("UUID Conversion failed.".to_string()))?
+            .into();
+        Ok(Self { id: Some(uuid) })
+    }
 }

--- a/crates/admin-cli/src/nvl_logical_partition/delete/cmd.rs
+++ b/crates/admin-cli/src/nvl_logical_partition/delete/cmd.rs
@@ -15,26 +15,13 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
-use ::rpc::forge as forgerpc;
-use carbide_uuid::nvlink::NvLinkLogicalPartitionId;
+use ::rpc::admin_cli::CarbideCliResult;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn handle_delete(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    delete_logical_partition(args, api_client).await?;
-    Ok(())
-}
-
-pub async fn delete_logical_partition(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let uuid: NvLinkLogicalPartitionId = uuid::Uuid::parse_str(&args.name)
-        .map_err(|_| CarbideCliError::GenericError("UUID Conversion failed.".to_string()))?
-        .into();
-    let request = forgerpc::NvLinkLogicalPartitionDeletionRequest { id: Some(uuid) };
-    let _partition = api_client
-        .0
-        .delete_nv_link_logical_partition(request)
-        .await?;
+    let req: ::rpc::forge::NvLinkLogicalPartitionDeletionRequest = args.try_into()?;
+    api_client.0.delete_nv_link_logical_partition(req).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/os_image/create/args.rs
+++ b/crates/admin-cli/src/os_image/create/args.rs
@@ -16,6 +16,10 @@
  */
 
 use clap::Parser;
+use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+use rpc::forge as forgerpc;
+
+use crate::os_image::common::str_to_rpc_uuid;
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
@@ -73,4 +77,29 @@ pub struct Args {
     pub bootfs_id: Option<String>,
     #[clap(long, help = "UUID of the image EFI filesystem (/boot/efi)")]
     pub efifs_id: Option<String>,
+}
+
+impl TryFrom<Args> for forgerpc::OsImageAttributes {
+    type Error = CarbideCliError;
+
+    fn try_from(args: Args) -> CarbideCliResult<Self> {
+        let id = str_to_rpc_uuid(&args.id)?;
+        Ok(forgerpc::OsImageAttributes {
+            id: Some(id),
+            source_url: args.url,
+            digest: args.digest,
+            tenant_organization_id: args.tenant_org_id,
+            create_volume: args.create_volume.unwrap_or(false),
+            name: args.name,
+            description: args.description,
+            auth_type: args.auth_type,
+            auth_token: args.auth_token,
+            rootfs_id: args.rootfs_id,
+            rootfs_label: args.rootfs_label,
+            boot_disk: args.boot_disk,
+            capacity: args.capacity,
+            bootfs_id: args.bootfs_id,
+            efifs_id: args.efifs_id,
+        })
+    }
 }

--- a/crates/admin-cli/src/os_image/create/cmd.rs
+++ b/crates/admin-cli/src/os_image/create/cmd.rs
@@ -16,31 +16,12 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::forge as forgerpc;
 
 use super::args::Args;
-use crate::os_image::common::str_to_rpc_uuid;
 use crate::rpc::ApiClient;
 
 pub async fn create(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let id = str_to_rpc_uuid(&args.id)?;
-    let image_attrs = forgerpc::OsImageAttributes {
-        id: Some(id),
-        source_url: args.url,
-        digest: args.digest,
-        tenant_organization_id: args.tenant_org_id,
-        create_volume: args.create_volume.unwrap_or(false),
-        name: args.name,
-        description: args.description,
-        auth_type: args.auth_type,
-        auth_token: args.auth_token,
-        rootfs_id: args.rootfs_id,
-        rootfs_label: args.rootfs_label,
-        boot_disk: args.boot_disk,
-        capacity: args.capacity,
-        bootfs_id: args.bootfs_id,
-        efifs_id: args.efifs_id,
-    };
+    let image_attrs: ::rpc::forge::OsImageAttributes = args.try_into()?;
     let image = api_client.0.create_os_image(image_attrs).await?;
     if let Some(x) = image.attributes {
         if let Some(y) = x.id {

--- a/crates/admin-cli/src/os_image/delete/args.rs
+++ b/crates/admin-cli/src/os_image/delete/args.rs
@@ -16,6 +16,10 @@
  */
 
 use clap::Parser;
+use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+use rpc::forge::DeleteOsImageRequest;
+
+use crate::os_image::common::str_to_rpc_uuid;
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
@@ -27,4 +31,16 @@ pub struct Args {
         help = "Tenant organization identifier of OS image to delete."
     )]
     pub tenant_org_id: String,
+}
+
+impl TryFrom<Args> for DeleteOsImageRequest {
+    type Error = CarbideCliError;
+
+    fn try_from(args: Args) -> CarbideCliResult<Self> {
+        let id = str_to_rpc_uuid(&args.id)?;
+        Ok(DeleteOsImageRequest {
+            id: Some(id),
+            tenant_organization_id: args.tenant_org_id,
+        })
+    }
 }

--- a/crates/admin-cli/src/os_image/delete/cmd.rs
+++ b/crates/admin-cli/src/os_image/delete/cmd.rs
@@ -19,18 +19,12 @@ use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge::DeleteOsImageRequest;
 
 use super::args::Args;
-use crate::os_image::common::str_to_rpc_uuid;
 use crate::rpc::ApiClient;
 
 pub async fn delete(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let id = str_to_rpc_uuid(&args.id)?;
-    api_client
-        .0
-        .delete_os_image(DeleteOsImageRequest {
-            id: Some(id.clone()),
-            tenant_organization_id: args.tenant_org_id,
-        })
-        .await?;
+    let req: DeleteOsImageRequest = args.try_into()?;
+    let id = req.id.clone().expect("id is always set by TryFrom<Args>");
+    api_client.0.delete_os_image(req).await?;
     println!("OS image {id} deleted successfully.");
     Ok(())
 }

--- a/crates/admin-cli/src/os_image/show/args.rs
+++ b/crates/admin-cli/src/os_image/show/args.rs
@@ -16,6 +16,9 @@
  */
 
 use clap::Parser;
+use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+
+use crate::os_image::common::str_to_rpc_uuid;
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
@@ -27,4 +30,26 @@ pub struct Args {
         help = "Tenant organization identifier to filter OS images listing."
     )]
     pub tenant_org_id: Option<String>,
+}
+
+/// Represents the parsed query for the show command.
+pub enum ShowQuery {
+    /// Show a single OS image by its UUID.
+    Single(::rpc::common::Uuid),
+    /// List OS images, optionally filtered by tenant organization ID.
+    List(Option<String>),
+}
+
+impl TryFrom<Args> for ShowQuery {
+    type Error = CarbideCliError;
+
+    fn try_from(args: Args) -> CarbideCliResult<Self> {
+        match args.id {
+            Some(id) => {
+                let uuid = str_to_rpc_uuid(&id)?;
+                Ok(ShowQuery::Single(uuid))
+            }
+            None => Ok(ShowQuery::List(args.tenant_org_id)),
+        }
+    }
 }

--- a/crates/admin-cli/src/os_image/show/cmd.rs
+++ b/crates/admin-cli/src/os_image/show/cmd.rs
@@ -17,8 +17,7 @@
 
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
 
-use super::args::Args;
-use crate::os_image::common::str_to_rpc_uuid;
+use super::args::{Args, ShowQuery};
 use crate::rpc::ApiClient;
 
 pub async fn show(
@@ -27,15 +26,12 @@ pub async fn show(
     api_client: &ApiClient,
     _page_size: usize,
 ) -> CarbideCliResult<()> {
+    let query: ShowQuery = args.try_into()?;
     let is_json = output_format == OutputFormat::Json;
-    let mut images = Vec::new();
-    if let Some(x) = args.id {
-        let id = str_to_rpc_uuid(&x)?;
-        let image = api_client.0.get_os_image(id).await?;
-        images.push(image);
-    } else {
-        images = api_client.list_os_image(args.tenant_org_id).await?;
-    }
+    let images = match query {
+        ShowQuery::Single(id) => vec![api_client.0.get_os_image(id).await?],
+        ShowQuery::List(tenant_org_id) => api_client.list_os_image(tenant_org_id).await?,
+    };
     if is_json {
         println!(
             "{}",

--- a/crates/admin-cli/src/os_image/update/args.rs
+++ b/crates/admin-cli/src/os_image/update/args.rs
@@ -16,6 +16,9 @@
  */
 
 use clap::Parser;
+use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+
+use crate::os_image::common::str_to_rpc_uuid;
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
@@ -41,4 +44,28 @@ pub struct Args {
         help = "Optional, Authentication token, usually in base64."
     )]
     pub auth_token: Option<String>,
+}
+
+/// Parsed update request with a validated UUID.
+pub struct UpdateRequest {
+    pub id: ::rpc::common::Uuid,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub auth_type: Option<String>,
+    pub auth_token: Option<String>,
+}
+
+impl TryFrom<Args> for UpdateRequest {
+    type Error = CarbideCliError;
+
+    fn try_from(args: Args) -> CarbideCliResult<Self> {
+        let id = str_to_rpc_uuid(&args.id)?;
+        Ok(UpdateRequest {
+            id,
+            name: args.name,
+            description: args.description,
+            auth_type: args.auth_type,
+            auth_token: args.auth_token,
+        })
+    }
 }

--- a/crates/admin-cli/src/os_image/update/cmd.rs
+++ b/crates/admin-cli/src/os_image/update/cmd.rs
@@ -17,19 +17,18 @@
 
 use ::rpc::admin_cli::CarbideCliResult;
 
-use super::args::Args;
-use crate::os_image::common::str_to_rpc_uuid;
+use super::args::{Args, UpdateRequest};
 use crate::rpc::ApiClient;
 
 pub async fn update(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let id = str_to_rpc_uuid(&args.id)?;
+    let req: UpdateRequest = args.try_into()?;
     let image = api_client
         .update_os_image(
-            id,
-            args.auth_type,
-            args.auth_token,
-            args.name,
-            args.description,
+            req.id,
+            req.auth_type,
+            req.auth_token,
+            req.name,
+            req.description,
         )
         .await?;
     if let Some(x) = image.attributes {

--- a/crates/admin-cli/src/power_shelf/list/args.rs
+++ b/crates/admin-cli/src/power_shelf/list/args.rs
@@ -19,3 +19,12 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 pub struct Args;
+
+impl From<Args> for ::rpc::forge::PowerShelfQuery {
+    fn from(_args: Args) -> Self {
+        Self {
+            name: None,
+            power_shelf_id: None,
+        }
+    }
+}

--- a/crates/admin-cli/src/power_shelf/list/cmd.rs
+++ b/crates/admin-cli/src/power_shelf/list/cmd.rs
@@ -17,15 +17,11 @@
 
 use color_eyre::Result;
 
+use super::args::Args;
 use crate::rpc::ApiClient;
 
-pub async fn list_power_shelves(api_client: &ApiClient) -> Result<()> {
-    let query = rpc::forge::PowerShelfQuery {
-        name: None,
-        power_shelf_id: None,
-    };
-
-    let response = api_client.0.find_power_shelves(query).await?;
+pub async fn list_power_shelves(data: Args, api_client: &ApiClient) -> Result<()> {
+    let response = api_client.0.find_power_shelves(data).await?;
 
     let power_shelves = response.power_shelves;
 

--- a/crates/admin-cli/src/power_shelf/list/mod.rs
+++ b/crates/admin-cli/src/power_shelf/list/mod.rs
@@ -26,7 +26,7 @@ use crate::cfg::runtime::RuntimeContext;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
-        cmd::list_power_shelves(&ctx.api_client).await?;
+        cmd::list_power_shelves(self, &ctx.api_client).await?;
         Ok(())
     }
 }

--- a/crates/admin-cli/src/power_shelf/show/args.rs
+++ b/crates/admin-cli/src/power_shelf/show/args.rs
@@ -15,10 +15,37 @@
  * limitations under the License.
  */
 
+use std::str::FromStr;
+
+use carbide_uuid::power_shelf::PowerShelfId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
 pub struct Args {
     #[clap(help = "Power shelf ID or name to show (leave empty for all)")]
     pub identifier: Option<String>,
+}
+
+impl From<Args> for ::rpc::forge::PowerShelfQuery {
+    fn from(args: Args) -> Self {
+        match args.identifier {
+            Some(id) if !id.is_empty() => {
+                // Try to parse as PowerShelfId, otherwise treat as name.
+                match PowerShelfId::from_str(&id) {
+                    Ok(power_shelf_id) => Self {
+                        name: None,
+                        power_shelf_id: Some(power_shelf_id),
+                    },
+                    Err(_) => Self {
+                        name: Some(id),
+                        power_shelf_id: None,
+                    },
+                }
+            }
+            _ => Self {
+                name: None,
+                power_shelf_id: None,
+            },
+        }
+    }
 }

--- a/crates/admin-cli/src/power_shelf/show/cmd.rs
+++ b/crates/admin-cli/src/power_shelf/show/cmd.rs
@@ -15,9 +15,6 @@
  * limitations under the License.
  */
 
-use std::str::FromStr;
-
-use carbide_uuid::power_shelf::PowerShelfId;
 use color_eyre::Result;
 use rpc::admin_cli::{CarbideCliResult, OutputFormat};
 use rpc::forge::PowerShelf;
@@ -171,30 +168,7 @@ pub async fn handle_show(
     output_format: OutputFormat,
     api_client: &ApiClient,
 ) -> CarbideCliResult<()> {
-    let query = match args.identifier {
-        Some(id) if !id.is_empty() => {
-            // Try to parse as PowerShelfId, otherwise treat as name.
-            match PowerShelfId::from_str(&id) {
-                Ok(power_shelf_id) => rpc::forge::PowerShelfQuery {
-                    name: None,
-                    power_shelf_id: Some(power_shelf_id),
-                },
-                Err(_) => rpc::forge::PowerShelfQuery {
-                    name: Some(id),
-                    power_shelf_id: None,
-                },
-            }
-        }
-        _ => {
-            // No identifier provided, list all
-            rpc::forge::PowerShelfQuery {
-                name: None,
-                power_shelf_id: None,
-            }
-        }
-    };
-
-    let response = api_client.0.find_power_shelves(query).await?;
+    let response = api_client.0.find_power_shelves(args).await?;
     let power_shelves = response.power_shelves;
 
     show_power_shelves(power_shelves, output_format).ok();

--- a/crates/admin-cli/src/rack/delete/args.rs
+++ b/crates/admin-cli/src/rack/delete/args.rs
@@ -24,3 +24,11 @@ pub struct Args {
     )]
     pub identifier: String,
 }
+
+impl From<Args> for ::rpc::forge::DeleteRackRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            id: args.identifier,
+        }
+    }
+}

--- a/crates/admin-cli/src/rack/delete/cmd.rs
+++ b/crates/admin-cli/src/rack/delete/cmd.rs
@@ -21,9 +21,6 @@ use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn delete_rack(api_client: &ApiClient, delete_opts: Args) -> Result<()> {
-    let query = rpc::forge::DeleteRackRequest {
-        id: delete_opts.identifier,
-    };
-    api_client.0.delete_rack(query).await?;
+    api_client.0.delete_rack(delete_opts).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/rack/show/args.rs
+++ b/crates/admin-cli/src/rack/show/args.rs
@@ -22,3 +22,11 @@ pub struct Args {
     #[clap(help = "Rack ID or name to show (leave empty for all)")]
     pub identifier: Option<String>,
 }
+
+impl From<Args> for ::rpc::forge::GetRackRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            id: args.identifier,
+        }
+    }
+}

--- a/crates/admin-cli/src/rack/show/cmd.rs
+++ b/crates/admin-cli/src/rack/show/cmd.rs
@@ -21,10 +21,7 @@ use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn show_rack(api_client: &ApiClient, show_opts: Args) -> Result<()> {
-    let query = rpc::forge::GetRackRequest {
-        id: show_opts.identifier,
-    };
-    let response = api_client.0.get_rack(query).await?;
+    let response = api_client.0.get_rack(show_opts).await?;
     let racks = response.rack;
     if racks.is_empty() {
         println!("No racks found");

--- a/crates/admin-cli/src/rack_firmware/apply/args.rs
+++ b/crates/admin-cli/src/rack_firmware/apply/args.rs
@@ -29,3 +29,13 @@ pub struct Args {
     #[clap(help = "Firmware type: dev or prod", value_parser = ["dev", "prod"])]
     pub firmware_type: String,
 }
+
+impl From<Args> for rpc::forge::RackFirmwareApplyRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            rack_id: Some(args.rack_id),
+            firmware_id: args.firmware_id,
+            firmware_type: args.firmware_type,
+        }
+    }
+}

--- a/crates/admin-cli/src/rack_firmware/apply/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/apply/cmd.rs
@@ -31,15 +31,9 @@ pub async fn apply(
         opts.firmware_id, opts.firmware_type, opts.rack_id
     );
 
-    let request = rpc::forge::RackFirmwareApplyRequest {
-        rack_id: Some(opts.rack_id),
-        firmware_id: opts.firmware_id,
-        firmware_type: opts.firmware_type,
-    };
-
     let response = api_client
         .0
-        .apply_rack_firmware(request)
+        .apply_rack_firmware(opts)
         .await
         .map_err(CarbideCliError::from)?;
 

--- a/crates/admin-cli/src/rack_firmware/create/args.rs
+++ b/crates/admin-cli/src/rack_firmware/create/args.rs
@@ -17,6 +17,7 @@
 
 use std::path::PathBuf;
 
+use ::rpc::admin_cli::CarbideCliError;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
@@ -25,4 +26,27 @@ pub struct Args {
     pub json_file: PathBuf,
     #[clap(help = "Artifactory token for downloading firmware files")]
     pub artifactory_token: String,
+}
+
+impl TryFrom<Args> for rpc::forge::RackFirmwareCreateRequest {
+    type Error = CarbideCliError;
+
+    fn try_from(args: Args) -> Result<Self, Self::Error> {
+        let config_json = std::fs::read_to_string(&args.json_file).map_err(|e| {
+            CarbideCliError::GenericError(format!(
+                "Failed to read file {}: {}",
+                args.json_file.display(),
+                e
+            ))
+        })?;
+
+        // Check that the JSON is valid
+        serde_json::from_str::<serde_json::Value>(&config_json)
+            .map_err(|e| CarbideCliError::GenericError(format!("Invalid JSON in file: {}", e)))?;
+
+        Ok(Self {
+            config_json,
+            artifactory_token: args.artifactory_token,
+        })
+    }
 }

--- a/crates/admin-cli/src/rack_firmware/create/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/create/cmd.rs
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-use std::fs;
-
 use ::rpc::admin_cli::{CarbideCliError, OutputFormat};
 
 use super::args::Args;
@@ -27,24 +25,7 @@ pub async fn create(
     format: OutputFormat,
     api_client: &ApiClient,
 ) -> Result<(), CarbideCliError> {
-    // Read JSON file
-    let config_json = fs::read_to_string(&opts.json_file).map_err(|e| {
-        CarbideCliError::GenericError(format!(
-            "Failed to read file {}: {}",
-            opts.json_file.display(),
-            e
-        ))
-    })?;
-
-    // Check that the JSON is valid
-    serde_json::from_str::<serde_json::Value>(&config_json)
-        .map_err(|e| CarbideCliError::GenericError(format!("Invalid JSON in file: {}", e)))?;
-
-    let request = rpc::forge::RackFirmwareCreateRequest {
-        config_json,
-        artifactory_token: opts.artifactory_token,
-    };
-
+    let request: rpc::forge::RackFirmwareCreateRequest = opts.try_into()?;
     let result = api_client.0.create_rack_firmware(request).await?;
 
     if format == OutputFormat::Json {

--- a/crates/admin-cli/src/rack_firmware/delete/args.rs
+++ b/crates/admin-cli/src/rack_firmware/delete/args.rs
@@ -22,3 +22,9 @@ pub struct Args {
     #[clap(help = "ID of the configuration to delete")]
     pub id: String,
 }
+
+impl From<Args> for rpc::forge::RackFirmwareDeleteRequest {
+    fn from(args: Args) -> Self {
+        Self { id: args.id }
+    }
+}

--- a/crates/admin-cli/src/rack_firmware/delete/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/delete/cmd.rs
@@ -21,10 +21,9 @@ use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn delete(opts: Args, api_client: &ApiClient) -> Result<(), CarbideCliError> {
-    let id = opts.id;
-    let request = rpc::forge::RackFirmwareDeleteRequest { id: id.clone() };
+    let id = opts.id.clone();
 
-    match api_client.0.delete_rack_firmware(request).await {
+    match api_client.0.delete_rack_firmware(opts).await {
         Ok(_) => {
             println!("Deleted Rack firmware configuration: {}", id);
         }

--- a/crates/admin-cli/src/rack_firmware/get/args.rs
+++ b/crates/admin-cli/src/rack_firmware/get/args.rs
@@ -22,3 +22,9 @@ pub struct Args {
     #[clap(help = "ID of the configuration to retrieve")]
     pub id: String,
 }
+
+impl From<Args> for rpc::forge::RackFirmwareGetRequest {
+    fn from(args: Args) -> Self {
+        Self { id: args.id }
+    }
+}

--- a/crates/admin-cli/src/rack_firmware/get/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/get/cmd.rs
@@ -26,10 +26,9 @@ pub async fn get(
     format: OutputFormat,
     api_client: &ApiClient,
 ) -> Result<(), CarbideCliError> {
-    let id = opts.id;
-    let request = rpc::forge::RackFirmwareGetRequest { id: id.clone() };
+    let id = opts.id.clone();
 
-    let result = match api_client.0.get_rack_firmware(request).await {
+    let result = match api_client.0.get_rack_firmware(opts).await {
         Ok(response) => response,
         Err(status) if status.code() == tonic::Code::NotFound => {
             return Err(CarbideCliError::GenericError(format!(

--- a/crates/admin-cli/src/rack_firmware/history/args.rs
+++ b/crates/admin-cli/src/rack_firmware/history/args.rs
@@ -25,3 +25,12 @@ pub struct Args {
     #[clap(long, help = "Filter by rack ID(s)")]
     pub rack_id: Vec<String>,
 }
+
+impl From<Args> for rpc::forge::RackFirmwareHistoryRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            firmware_id: args.firmware_id.unwrap_or_default(),
+            rack_ids: args.rack_id,
+        }
+    }
+}

--- a/crates/admin-cli/src/rack_firmware/history/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/history/cmd.rs
@@ -26,12 +26,7 @@ pub async fn history(
     format: OutputFormat,
     api_client: &ApiClient,
 ) -> Result<(), CarbideCliError> {
-    let request = rpc::forge::RackFirmwareHistoryRequest {
-        firmware_id: opts.firmware_id.unwrap_or_default(),
-        rack_ids: opts.rack_id,
-    };
-
-    let result = api_client.0.get_rack_firmware_history(request).await?;
+    let result = api_client.0.get_rack_firmware_history(opts).await?;
 
     if format == OutputFormat::Json {
         // Flatten to map<rack_id, Vec<record>> for serialization

--- a/crates/admin-cli/src/rack_firmware/list/args.rs
+++ b/crates/admin-cli/src/rack_firmware/list/args.rs
@@ -22,3 +22,11 @@ pub struct Args {
     #[clap(long, help = "Show only available configurations")]
     pub only_available: bool,
 }
+
+impl From<Args> for rpc::forge::RackFirmwareListRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            only_available: args.only_available,
+        }
+    }
+}

--- a/crates/admin-cli/src/rack_firmware/list/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/list/cmd.rs
@@ -26,11 +26,7 @@ pub async fn list(
     format: OutputFormat,
     api_client: &ApiClient,
 ) -> Result<(), CarbideCliError> {
-    let request = rpc::forge::RackFirmwareListRequest {
-        only_available: opts.only_available,
-    };
-
-    let result = api_client.0.list_rack_firmware(request).await?;
+    let result = api_client.0.list_rack_firmware(opts).await?;
 
     if format == OutputFormat::Json {
         println!("{}", serde_json::to_string_pretty(&result.configs)?);

--- a/crates/admin-cli/src/rack_firmware/status/args.rs
+++ b/crates/admin-cli/src/rack_firmware/status/args.rs
@@ -22,3 +22,11 @@ pub struct Args {
     #[clap(help = "Job ID to check status for (from apply output)")]
     pub job_id: String,
 }
+
+impl From<Args> for rpc::forge::RackFirmwareJobStatusRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            job_id: args.job_id,
+        }
+    }
+}

--- a/crates/admin-cli/src/rack_firmware/status/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/status/cmd.rs
@@ -25,13 +25,9 @@ pub async fn get_job_status(
     format: OutputFormat,
     api_client: &ApiClient,
 ) -> Result<(), CarbideCliError> {
-    let request = rpc::forge::RackFirmwareJobStatusRequest {
-        job_id: opts.job_id,
-    };
-
     let response = api_client
         .0
-        .get_rack_firmware_job_status(request)
+        .get_rack_firmware_job_status(opts)
         .await
         .map_err(CarbideCliError::from)?;
 

--- a/crates/admin-cli/src/resource_pool/grow/args.rs
+++ b/crates/admin-cli/src/resource_pool/grow/args.rs
@@ -26,3 +26,12 @@ pub struct Args {
     #[clap(short, long)]
     pub filename: String,
 }
+
+impl TryFrom<Args> for ::rpc::forge::GrowResourcePoolRequest {
+    type Error = std::io::Error;
+
+    fn try_from(args: Args) -> Result<Self, Self::Error> {
+        let text = std::fs::read_to_string(&args.filename)?;
+        Ok(Self { text })
+    }
+}

--- a/crates/admin-cli/src/resource_pool/grow/cmd.rs
+++ b/crates/admin-cli/src/resource_pool/grow/cmd.rs
@@ -15,17 +15,13 @@
  * limitations under the License.
  */
 
-use std::fs;
-
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::forge as forgerpc;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
-pub async fn grow(data: &Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let defs = fs::read_to_string(&data.filename)?;
-    let rpc_req = forgerpc::GrowResourcePoolRequest { text: defs };
+pub async fn grow(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let rpc_req: ::rpc::forge::GrowResourcePoolRequest = data.try_into()?;
     api_client.0.admin_grow_resource_pool(rpc_req).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/resource_pool/grow/mod.rs
+++ b/crates/admin-cli/src/resource_pool/grow/mod.rs
@@ -26,6 +26,6 @@ use crate::cfg::runtime::RuntimeContext;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
-        cmd::grow(&self, &ctx.api_client).await
+        cmd::grow(self, &ctx.api_client).await
     }
 }

--- a/crates/admin-cli/src/resource_pool/list/args.rs
+++ b/crates/admin-cli/src/resource_pool/list/args.rs
@@ -17,5 +17,13 @@
 
 use clap::Parser;
 
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Default)]
 pub struct Args;
+
+impl From<Args> for ::rpc::forge::ListResourcePoolsRequest {
+    fn from(_args: Args) -> Self {
+        Self {
+            auto_assignable: None,
+        }
+    }
+}

--- a/crates/admin-cli/src/resource_pool/list/cmd.rs
+++ b/crates/admin-cli/src/resource_pool/list/cmd.rs
@@ -16,18 +16,13 @@
  */
 
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
-use ::rpc::forge as forgerpc;
 use prettytable::{Table, row};
 
+use super::args::Args;
 use crate::rpc::ApiClient;
 
-pub async fn list(api_client: &ApiClient) -> CarbideCliResult<()> {
-    let response = api_client
-        .0
-        .admin_list_resource_pools(forgerpc::ListResourcePoolsRequest {
-            auto_assignable: None,
-        })
-        .await?;
+pub async fn list(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let response = api_client.0.admin_list_resource_pools(data).await?;
     if response.pools.is_empty() {
         println!("No resource pools defined");
         return Err(CarbideCliError::Empty);

--- a/crates/admin-cli/src/resource_pool/list/mod.rs
+++ b/crates/admin-cli/src/resource_pool/list/mod.rs
@@ -26,6 +26,6 @@ use crate::cfg::runtime::RuntimeContext;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
-        cmd::list(&ctx.api_client).await
+        cmd::list(self, &ctx.api_client).await
     }
 }

--- a/crates/admin-cli/src/rms/args.rs
+++ b/crates/admin-cli/src/rms/args.rs
@@ -54,6 +54,15 @@ pub struct PowerOnSequence {
     pub rack_id: String,
 }
 
+impl From<PowerOnSequence> for librms::protos::rack_manager::GetRackPowerOnSequenceRequest {
+    fn from(args: PowerOnSequence) -> Self {
+        Self {
+            metadata: None,
+            rack_id: args.rack_id,
+        }
+    }
+}
+
 #[derive(Parser, Debug, Clone)]
 pub struct PowerState {
     #[clap(help = "Rack ID to get power sequence for")]
@@ -62,10 +71,30 @@ pub struct PowerState {
     pub node_id: String,
 }
 
+impl From<PowerState> for librms::protos::rack_manager::GetPowerStateRequest {
+    fn from(args: PowerState) -> Self {
+        Self {
+            metadata: None,
+            node_id: args.node_id,
+            rack_id: args.rack_id,
+        }
+    }
+}
+
 #[derive(Parser, Debug, Clone)]
 pub struct FirmwareInventory {
     #[clap(help = "Rack ID to get power sequence for")]
     pub rack_id: String,
     #[clap(help = "Node ID to get firmware inventory for")]
     pub node_id: String,
+}
+
+impl From<FirmwareInventory> for librms::protos::rack_manager::GetNodeFirmwareInventoryRequest {
+    fn from(args: FirmwareInventory) -> Self {
+        Self {
+            metadata: None,
+            node_id: args.node_id,
+            rack_id: args.rack_id,
+        }
+    }
 }

--- a/crates/admin-cli/src/rms/cmds.rs
+++ b/crates/admin-cli/src/rms/cmds.rs
@@ -29,39 +29,25 @@ pub async fn get_all_inventory(rms_client: &Arc<dyn RmsApi>) -> eyre::Result<()>
 }
 
 pub async fn power_on_sequence(
-    args: &PowerOnSequence,
+    args: PowerOnSequence,
     rms_client: &Arc<dyn RmsApi>,
 ) -> eyre::Result<()> {
-    let cmd = librms::protos::rack_manager::GetRackPowerOnSequenceRequest {
-        metadata: None,
-        rack_id: args.rack_id.clone(),
-    };
-    let response = rms_client.get_rack_power_on_sequence(cmd).await?;
+    let response = rms_client.get_rack_power_on_sequence(args.into()).await?;
     println!("{}", serde_json::to_string_pretty(&response)?);
     Ok(())
 }
 
-pub async fn power_state(args: &PowerState, rms_client: &Arc<dyn RmsApi>) -> eyre::Result<()> {
-    let cmd = librms::protos::rack_manager::GetPowerStateRequest {
-        metadata: None,
-        node_id: args.node_id.clone(),
-        rack_id: args.rack_id.clone(),
-    };
-    let response = rms_client.get_power_state(cmd).await?;
+pub async fn power_state(args: PowerState, rms_client: &Arc<dyn RmsApi>) -> eyre::Result<()> {
+    let response = rms_client.get_power_state(args.into()).await?;
     println!("{}", serde_json::to_string_pretty(&response)?);
     Ok(())
 }
 
 pub async fn get_firmware_inventory(
-    args: &FirmwareInventory,
+    args: FirmwareInventory,
     rms_client: &Arc<dyn RmsApi>,
 ) -> eyre::Result<()> {
-    let cmd = librms::protos::rack_manager::GetNodeFirmwareInventoryRequest {
-        metadata: None,
-        node_id: args.node_id.clone(),
-        rack_id: args.rack_id.clone(),
-    };
-    let response = rms_client.get_node_firmware_inventory(cmd).await?;
+    let response = rms_client.get_node_firmware_inventory(args.into()).await?;
     println!("{}", serde_json::to_string_pretty(&response)?);
     Ok(())
 }

--- a/crates/admin-cli/src/rms/mod.rs
+++ b/crates/admin-cli/src/rms/mod.rs
@@ -62,8 +62,8 @@ pub async fn action(action: RmsAction, config: &CliOptions) -> color_eyre::Resul
 
     match action.command {
         Cmd::Inventory => cmds::get_all_inventory(&rms_client).await,
-        Cmd::PowerOnSequence(ref args) => cmds::power_on_sequence(args, &rms_client).await,
-        Cmd::PowerState(ref args) => cmds::power_state(args, &rms_client).await,
-        Cmd::FirmwareInventory(ref args) => cmds::get_firmware_inventory(args, &rms_client).await,
+        Cmd::PowerOnSequence(args) => cmds::power_on_sequence(args, &rms_client).await,
+        Cmd::PowerState(args) => cmds::power_state(args, &rms_client).await,
+        Cmd::FirmwareInventory(args) => cmds::get_firmware_inventory(args, &rms_client).await,
     }
 }

--- a/crates/admin-cli/src/route_server/add/cmd.rs
+++ b/crates/admin-cli/src/route_server/add/cmd.rs
@@ -16,19 +16,12 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::forge as rpc;
 
 use crate::route_server::common::AddressArgs;
 use crate::rpc::ApiClient;
 
 pub async fn add(args: AddressArgs, api_client: &ApiClient) -> CarbideCliResult<()> {
-    api_client
-        .0
-        .add_route_servers(rpc::RouteServers {
-            route_servers: args.ip.iter().map(ToString::to_string).collect(),
-            source_type: args.source_type as i32,
-        })
-        .await?;
+    api_client.0.add_route_servers(args).await?;
 
     Ok(())
 }

--- a/crates/admin-cli/src/route_server/common.rs
+++ b/crates/admin-cli/src/route_server/common.rs
@@ -41,3 +41,12 @@ pub struct AddressArgs {
     )]
     pub source_type: RouteServerSourceType,
 }
+
+impl From<AddressArgs> for ::rpc::forge::RouteServers {
+    fn from(args: AddressArgs) -> Self {
+        Self {
+            route_servers: args.ip.iter().map(ToString::to_string).collect(),
+            source_type: args.source_type as i32,
+        }
+    }
+}

--- a/crates/admin-cli/src/route_server/remove/cmd.rs
+++ b/crates/admin-cli/src/route_server/remove/cmd.rs
@@ -16,19 +16,12 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::forge as rpc;
 
 use crate::route_server::common::AddressArgs;
 use crate::rpc::ApiClient;
 
 pub async fn remove(args: AddressArgs, api_client: &ApiClient) -> CarbideCliResult<()> {
-    api_client
-        .0
-        .remove_route_servers(rpc::RouteServers {
-            route_servers: args.ip.iter().map(ToString::to_string).collect(),
-            source_type: args.source_type as i32,
-        })
-        .await?;
+    api_client.0.remove_route_servers(args).await?;
 
     Ok(())
 }

--- a/crates/admin-cli/src/route_server/replace/cmd.rs
+++ b/crates/admin-cli/src/route_server/replace/cmd.rs
@@ -16,19 +16,12 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::forge as rpc;
 
 use crate::route_server::common::AddressArgs;
 use crate::rpc::ApiClient;
 
 pub async fn replace(args: AddressArgs, api_client: &ApiClient) -> CarbideCliResult<()> {
-    api_client
-        .0
-        .replace_route_servers(rpc::RouteServers {
-            route_servers: args.ip.iter().map(ToString::to_string).collect(),
-            source_type: args.source_type as i32,
-        })
-        .await?;
+    api_client.0.replace_route_servers(args).await?;
 
     Ok(())
 }

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -20,8 +20,8 @@ use std::collections::HashMap;
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge::instance_interface_config::NetworkDetails;
 use ::rpc::forge::{
-    self as rpc, BmcEndpointRequest, CreateNetworkSecurityGroupRequest,
-    FindInstanceTypesByIdsRequest, FindNetworkSecurityGroupsByIdsRequest, GetDpfStateRequest,
+    self as rpc, BmcEndpointRequest, FindInstanceTypesByIdsRequest,
+    FindNetworkSecurityGroupsByIdsRequest, GetDpfStateRequest,
     GetNetworkSecurityGroupAttachmentsRequest, GetNetworkSecurityGroupPropagationStatusRequest,
     IdentifySerialRequest, MachineHardwareInfo, MachineHardwareInfoUpdateType,
     ModifyDpfStateRequest, NetworkPrefix, NetworkSecurityGroupAttributes,
@@ -339,20 +339,6 @@ impl ApiClient {
             }),
         };
         Ok(self.0.insert_health_report_override(request).await?)
-    }
-
-    pub async fn bmc_reset(
-        &self,
-        bmc_endpoint_request: Option<BmcEndpointRequest>,
-        machine_id: Option<String>,
-        use_ipmitool: bool,
-    ) -> CarbideCliResult<rpc::AdminBmcResetResponse> {
-        let request = rpc::AdminBmcResetRequest {
-            bmc_endpoint_request,
-            machine_id,
-            use_ipmitool,
-        };
-        Ok(self.0.admin_bmc_reset(request).await?)
     }
 
     pub async fn admin_power_control(
@@ -1508,31 +1494,6 @@ impl ApiClient {
         Ok(self.0.update_machine_metadata(request).await?)
     }
 
-    pub async fn create_network_security_group(
-        &self,
-        id: Option<String>,
-        tenant_organization_id: String,
-        metadata: rpc::Metadata,
-        stateful_egress: bool,
-        rules: Vec<rpc::NetworkSecurityGroupRuleAttributes>,
-    ) -> CarbideCliResult<rpc::NetworkSecurityGroup> {
-        let request = CreateNetworkSecurityGroupRequest {
-            id,
-            tenant_organization_id,
-            metadata: Some(metadata),
-            network_security_group_attributes: Some(NetworkSecurityGroupAttributes {
-                stateful_egress,
-                rules,
-            }),
-        };
-
-        let response = self.0.create_network_security_group(request).await?;
-
-        response
-            .network_security_group
-            .ok_or(CarbideCliError::Empty)
-    }
-
     pub async fn get_single_network_security_group(
         &self,
         id: String,
@@ -1832,57 +1793,6 @@ impl ApiClient {
             .map_err(CarbideCliError::ApiInvocationError)
     }
 
-    pub async fn create_bmc_user(
-        &self,
-        ip_address: Option<String>,
-        mac_address: Option<MacAddress>,
-        machine_id: Option<String>,
-        create_username: String,
-        create_password: String,
-        create_role_id: Option<String>,
-    ) -> CarbideCliResult<rpc::CreateBmcUserResponse> {
-        let bmc_endpoint_request = if ip_address.is_some() || mac_address.is_some() {
-            Some(rpc::BmcEndpointRequest {
-                ip_address: ip_address.unwrap_or_default(),
-                mac_address: mac_address.map(|mac| mac.to_string()),
-            })
-        } else {
-            None
-        };
-
-        let request = rpc::CreateBmcUserRequest {
-            bmc_endpoint_request,
-            machine_id,
-            create_username,
-            create_password,
-            create_role_id,
-        };
-        Ok(self.0.create_bmc_user(request).await?)
-    }
-    pub async fn delete_bmc_user(
-        &self,
-        ip_address: Option<String>,
-        mac_address: Option<MacAddress>,
-        machine_id: Option<String>,
-        delete_username: String,
-    ) -> CarbideCliResult<rpc::DeleteBmcUserResponse> {
-        let bmc_endpoint_request = if ip_address.is_some() || mac_address.is_some() {
-            Some(rpc::BmcEndpointRequest {
-                ip_address: ip_address.unwrap_or_default(),
-                mac_address: mac_address.map(|mac| mac.to_string()),
-            })
-        } else {
-            None
-        };
-
-        let request = rpc::DeleteBmcUserRequest {
-            bmc_endpoint_request,
-            machine_id,
-            delete_username,
-        };
-        Ok(self.0.delete_bmc_user(request).await?)
-    }
-
     pub async fn enable_infinite_boot(
         &self,
         bmc_endpoint_request: Option<BmcEndpointRequest>,
@@ -1893,18 +1803,6 @@ impl ApiClient {
             machine_id,
         };
         Ok(self.0.enable_infinite_boot(request).await?)
-    }
-
-    pub async fn is_infinite_boot_enabled(
-        &self,
-        bmc_endpoint_request: Option<BmcEndpointRequest>,
-        machine_id: Option<String>,
-    ) -> CarbideCliResult<rpc::IsInfiniteBootEnabledResponse> {
-        let request = rpc::IsInfiniteBootEnabledRequest {
-            bmc_endpoint_request,
-            machine_id,
-        };
-        Ok(self.0.is_infinite_boot_enabled(request).await?)
     }
 
     pub async fn lockdown(
@@ -1919,18 +1817,6 @@ impl ApiClient {
             action: Some(action as i32),
         };
         Ok(self.0.lockdown(request).await?)
-    }
-
-    pub async fn lockdown_status(
-        &self,
-        bmc_endpoint_request: Option<BmcEndpointRequest>,
-        machine_id: MachineId,
-    ) -> CarbideCliResult<::rpc::site_explorer::LockdownStatus> {
-        let request = rpc::LockdownStatusRequest {
-            bmc_endpoint_request,
-            machine_id: Some(machine_id),
-        };
-        Ok(self.0.lockdown_status(request).await?)
     }
 
     pub async fn get_remediation(

--- a/crates/admin-cli/src/switch/list/args.rs
+++ b/crates/admin-cli/src/switch/list/args.rs
@@ -19,3 +19,12 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 pub struct Args;
+
+impl From<Args> for ::rpc::forge::SwitchQuery {
+    fn from(_args: Args) -> Self {
+        Self {
+            name: None,
+            switch_id: None,
+        }
+    }
+}

--- a/crates/admin-cli/src/switch/list/cmd.rs
+++ b/crates/admin-cli/src/switch/list/cmd.rs
@@ -19,15 +19,11 @@ use std::borrow::Cow;
 
 use color_eyre::Result;
 
+use super::args::Args;
 use crate::rpc::ApiClient;
 
-pub async fn list_switches(api_client: &ApiClient) -> Result<()> {
-    let query = rpc::forge::SwitchQuery {
-        name: None,
-        switch_id: None,
-    };
-
-    let response = api_client.0.find_switches(query).await?;
+pub async fn list_switches(data: Args, api_client: &ApiClient) -> Result<()> {
+    let response = api_client.0.find_switches(data).await?;
 
     let switches = response.switches;
 

--- a/crates/admin-cli/src/switch/list/mod.rs
+++ b/crates/admin-cli/src/switch/list/mod.rs
@@ -26,7 +26,7 @@ use crate::cfg::runtime::RuntimeContext;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
-        cmd::list_switches(&ctx.api_client).await?;
+        cmd::list_switches(self, &ctx.api_client).await?;
         Ok(())
     }
 }

--- a/crates/admin-cli/src/switch/show/args.rs
+++ b/crates/admin-cli/src/switch/show/args.rs
@@ -15,10 +15,37 @@
  * limitations under the License.
  */
 
+use std::str::FromStr;
+
+use carbide_uuid::switch::SwitchId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
 pub struct Args {
     #[clap(help = "Switch ID or name to show (leave empty for all)")]
     pub identifier: Option<String>,
+}
+
+impl From<Args> for ::rpc::forge::SwitchQuery {
+    fn from(args: Args) -> Self {
+        match args.identifier {
+            Some(id) if !id.is_empty() => {
+                // Try to parse as SwitchId, otherwise treat as name
+                match SwitchId::from_str(&id) {
+                    Ok(switch_id) => Self {
+                        name: None,
+                        switch_id: Some(switch_id),
+                    },
+                    Err(_) => Self {
+                        name: Some(id),
+                        switch_id: None,
+                    },
+                }
+            }
+            _ => Self {
+                name: None,
+                switch_id: None,
+            },
+        }
+    }
 }

--- a/crates/admin-cli/src/switch/show/cmd.rs
+++ b/crates/admin-cli/src/switch/show/cmd.rs
@@ -16,9 +16,7 @@
  */
 
 use std::borrow::Cow;
-use std::str::FromStr;
 
-use carbide_uuid::switch::SwitchId;
 use color_eyre::Result;
 use rpc::admin_cli::{CarbideCliResult, OutputFormat};
 use rpc::forge::Switch;
@@ -134,30 +132,7 @@ pub async fn handle_show(
     output_format: OutputFormat,
     api_client: &ApiClient,
 ) -> CarbideCliResult<()> {
-    let query = match args.identifier {
-        Some(id) if !id.is_empty() => {
-            // Try to parse as SwitchId, otherwise treat as name
-            match SwitchId::from_str(&id) {
-                Ok(switch_id) => rpc::forge::SwitchQuery {
-                    name: None,
-                    switch_id: Some(switch_id),
-                },
-                Err(_) => rpc::forge::SwitchQuery {
-                    name: Some(id),
-                    switch_id: None,
-                },
-            }
-        }
-        _ => {
-            // No identifier provided, list all
-            rpc::forge::SwitchQuery {
-                name: None,
-                switch_id: None,
-            }
-        }
-    };
-
-    let response = api_client.0.find_switches(query).await?;
+    let response = api_client.0.find_switches(args).await?;
     let switches = response.switches;
 
     show_switches(switches, output_format).ok();

--- a/crates/admin-cli/src/tenant/show/args.rs
+++ b/crates/admin-cli/src/tenant/show/args.rs
@@ -16,9 +16,18 @@
  */
 
 use clap::Parser;
+use rpc::forge::FindTenantRequest;
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
     #[clap(help = "Optional, tenant org ID to restrict the search")]
     pub tenant_org: Option<String>,
+}
+
+impl From<&Args> for Option<FindTenantRequest> {
+    fn from(args: &Args) -> Self {
+        args.tenant_org.as_ref().map(|id| FindTenantRequest {
+            tenant_organization_id: id.clone(),
+        })
+    }
 }

--- a/crates/admin-cli/src/tenant/show/cmd.rs
+++ b/crates/admin-cli/src/tenant/show/cmd.rs
@@ -18,7 +18,7 @@
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
 use ::rpc::forge as forgerpc;
 use prettytable::{Table, row};
-use rpc::forge::{FindTenantRequest, TenantByOrganizationIdsRequest};
+use rpc::forge::TenantByOrganizationIdsRequest;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
@@ -79,12 +79,13 @@ pub async fn show(
     api_client: &ApiClient,
     page_size: usize,
 ) -> CarbideCliResult<()> {
-    let tenants = if let Some(id) = args.tenant_org {
+    let req: Option<rpc::forge::FindTenantRequest> = (&args).into();
+
+    let tenants = if let Some(req) = req {
+        let id = req.tenant_organization_id.clone();
         let tenant = api_client
             .0
-            .find_tenant(FindTenantRequest {
-                tenant_organization_id: id.clone(),
-            })
+            .find_tenant(req)
             .await?
             .tenant
             .ok_or(CarbideCliError::TenantNotFound(id))?;

--- a/crates/admin-cli/src/tenant_keyset/show/args.rs
+++ b/crates/admin-cli/src/tenant_keyset/show/args.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use ::rpc::admin_cli::CarbideCliError;
+use ::rpc::forge as forgerpc;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
@@ -27,4 +29,26 @@ pub struct Args {
 
     #[clap(short, long, help = "The Tenant Org ID to query")]
     pub tenant_org_id: Option<String>,
+}
+
+impl TryFrom<&Args> for Option<forgerpc::TenantKeysetIdentifier> {
+    type Error = CarbideCliError;
+
+    fn try_from(args: &Args) -> Result<Self, Self::Error> {
+        if args.id.is_empty() {
+            return Ok(None);
+        }
+
+        let split_id = args.id.split('/').collect::<Vec<&str>>();
+        if split_id.len() != 2 {
+            return Err(CarbideCliError::GenericError(
+                "Invalid format for Tenant KeySet ID".to_string(),
+            ));
+        }
+
+        Ok(Some(forgerpc::TenantKeysetIdentifier {
+            organization_id: split_id[0].to_string(),
+            keyset_id: split_id[1].to_string(),
+        }))
+    }
 }

--- a/crates/admin-cli/src/tenant_keyset/show/cmd.rs
+++ b/crates/admin-cli/src/tenant_keyset/show/cmd.rs
@@ -31,11 +31,14 @@ pub async fn show(
     page_size: usize,
 ) -> CarbideCliResult<()> {
     let is_json = output_format == OutputFormat::Json;
-    if args.id.is_empty() {
+    let identifier: Option<forgerpc::TenantKeysetIdentifier> = (&args).try_into()?;
+
+    if let Some(identifier) = identifier {
+        show_keyset_details(identifier, is_json, api_client).await?;
+    } else {
         show_keysets(is_json, api_client, page_size, args.tenant_org_id).await?;
-        return Ok(());
     }
-    show_keyset_details(args.id, is_json, api_client).await?;
+
     Ok(())
 }
 
@@ -58,24 +61,11 @@ async fn show_keysets(
 }
 
 async fn show_keyset_details(
-    id: String,
+    identifier: forgerpc::TenantKeysetIdentifier,
     json: bool,
     api_client: &ApiClient,
 ) -> CarbideCliResult<()> {
-    let split_id = id.split('/').collect::<Vec<&str>>();
-    if split_id.len() != 2 {
-        return Err(CarbideCliError::GenericError(
-            "Invalid format for Tenant KeySet ID".to_string(),
-        ));
-    }
-    let identifier = forgerpc::TenantKeysetIdentifier {
-        organization_id: split_id[0].to_string(),
-        keyset_id: split_id[1].to_string(),
-    };
-    let keysets = match api_client.get_one_keyset(identifier).await {
-        Ok(keysets) => keysets,
-        Err(e) => return Err(e),
-    };
+    let keysets = api_client.get_one_keyset(identifier).await?;
 
     if keysets.keyset.len() != 1 {
         return Err(CarbideCliError::GenericError(

--- a/crates/admin-cli/src/vpc_peering/create/cmd.rs
+++ b/crates/admin-cli/src/vpc_peering/create/cmd.rs
@@ -17,7 +17,6 @@
 
 use ::rpc::admin_cli::output::OutputFormat;
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
-use rpc::forge::VpcPeeringCreationRequest;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
@@ -29,9 +28,8 @@ pub async fn create(
     api_client: &ApiClient,
 ) -> CarbideCliResult<()> {
     let is_json = output_format == OutputFormat::Json;
-    let req: VpcPeeringCreationRequest = args.into();
 
-    let vpc_peering = api_client.0.create_vpc_peering(req).await?;
+    let vpc_peering = api_client.0.create_vpc_peering(args).await?;
 
     if is_json {
         println!(

--- a/crates/admin-cli/src/vpc_prefix/create/cmd.rs
+++ b/crates/admin-cli/src/vpc_prefix/create/cmd.rs
@@ -17,7 +17,6 @@
 
 use ::rpc::admin_cli::output::{FormattedOutput, OutputFormat};
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
-use rpc::forge::VpcPrefixCreationRequest;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
@@ -28,11 +27,9 @@ pub async fn create(
     output_format: OutputFormat,
     api_client: &ApiClient,
 ) -> CarbideCliResult<()> {
-    let req: VpcPrefixCreationRequest = args.into();
-
     let output = api_client
         .0
-        .create_vpc_prefix(req)
+        .create_vpc_prefix(args)
         .await
         .map(ShowOutput::One)?;
 

--- a/crates/admin-cli/src/vpc_prefix/delete/cmd.rs
+++ b/crates/admin-cli/src/vpc_prefix/delete/cmd.rs
@@ -16,13 +16,11 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use rpc::forge::VpcPrefixDeletionRequest;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn delete(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let req: VpcPrefixDeletionRequest = args.into();
-    api_client.0.delete_vpc_prefix(req).await?;
+    api_client.0.delete_vpc_prefix(args).await?;
     Ok(())
 }


### PR DESCRIPTION
Continuation of https://github.com/NVIDIA/ncx-infra-controller-core/pull/628. Wanted to do a bit first, and then do some more here, mainly since it's a lot to look at.

TLDR is that we have a pattern where `Args` can just `.into()` (or `.try_into()?`) the underlying `Request` that they exist for. These next refactorings are also pretty straightforward, but I had punted them to a separate PR because some of them weren't AS straightforward as the original ones.

At the end of the day, a "command" is now something like..

```
let req = args.try_into()?;
let resp = api_client.0.call(req).await?;
..do something w/resp
```

..or in many cases (thanks @poroh for the callout here)..
```
api_client.0.call(args).await?;
```

...and probably allows us to get even deeper into how we templatize things in the admin CLI.

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

