### PR TITLE
feat(dpf): hbn init

### DIFF
--- a/bluefield/Makefile.toml
+++ b/bluefield/Makefile.toml
@@ -524,6 +524,15 @@ script = '''
     helm package ${REPO_ROOT}/bluefield/charts/carbide-dpu-otel-agent -d ${REPO_ROOT}/target/charts/
 '''
 
+[tasks.helm-package-doca-hbn]
+category = "Build"
+description = "Package the doca-hbn Helm chart"
+workspace = false
+script = '''
+    mkdir -p ${REPO_ROOT}/target/charts/
+    helm package ${REPO_ROOT}/bluefield/charts/doca-hbn -d ${REPO_ROOT}/target/charts/
+'''
+
 [tasks.helm-package-all]
 category = "Build"
 description = "Package all Carbide DPF Helm charts"
@@ -533,6 +542,7 @@ dependencies = [
     "helm-package-carbide-dpu-agent",
     "helm-package-carbide-dhcp-server",
     "helm-package-carbide-dpu-otel-agent",
+    "helm-package-doca-hbn",
 ]
 
 [tasks.docker-build-otelcol]

--- a/bluefield/charts/doca-hbn/.helmignore
+++ b/bluefield/charts/doca-hbn/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/bluefield/charts/doca-hbn/Chart.yaml
+++ b/bluefield/charts/doca-hbn/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: 3.2.1-doca3.2.1
+description: A Helm chart for DOCA Host-based Networking (HBN) Service
+name: doca-hbn
+type: application
+version: 1.0.5

--- a/bluefield/charts/doca-hbn/README.md
+++ b/bluefield/charts/doca-hbn/README.md
@@ -1,0 +1,53 @@
+# doca-hbn
+
+Vendored copy of the upstream NVIDIA DOCA HBN (Host-Based Networking) Helm chart
+from the NGC registry (`https://helm.ngc.nvidia.com/nvidia/doca`).
+
+- **Chart version**: 1.0.5
+- **App version**: 3.2.1-doca3.2.1
+- **Source**: https://catalog.ngc.nvidia.com/orgs/nvidia/teams/doca/helm-charts/doca-hbn
+- **Upstream reference**: https://github.com/NVIDIA/doca-platform (v25.10.1)
+
+## Carbide modifications
+
+The following values were added to `daemonset.yaml` and `values.yaml` to support
+injecting arbitrary init containers, volume mounts, and volumes without forking
+the rest of the template:
+
+| Value | Description |
+|---|---|
+| `extraInitContainers` | List of init containers inserted before the upstream `hbn-init` container |
+| `extraVolumeMounts` | List of volume mounts appended to the `doca-hbn` container |
+| `extraVolumes` | List of volumes appended to the pod spec |
+
+All three default to `[]`.
+
+### Example
+
+Use an init container to write a config file into a shared `emptyDir` volume,
+then mount that volume into the `doca-hbn` container:
+
+```yaml
+extraInitContainers:
+  - name: write-config
+    image: busybox:latest
+    command:
+      - sh
+      - -c
+      - |
+        cat <<'EOF' > /shared/my-config.yaml
+        key: value
+        setting: enabled
+        EOF
+    volumeMounts:
+      - name: shared-data
+        mountPath: /shared
+
+extraVolumeMounts:
+  - name: shared-data
+    mountPath: /shared
+
+extraVolumes:
+  - name: shared-data
+    emptyDir: {}
+```

--- a/bluefield/charts/doca-hbn/templates/_helpers.tpl
+++ b/bluefield/charts/doca-hbn/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "hbn.name" -}}
+{{- default "hbn" .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "hbn.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default "hbn" .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "hbn.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "hbn.labels" -}}
+helm.sh/chart: {{ include "hbn.chart" . }}
+{{ include "hbn.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "hbn.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "hbn.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "hbn.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "hbn.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+

--- a/bluefield/charts/doca-hbn/templates/config-data.yaml
+++ b/bluefield/charts/doca-hbn/templates/config-data.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "hbn.fullname" . }}-config-data
+  labels:
+  {{- include "hbn.labels" . | nindent 4 }}
+data:
+  {{- if .Values.configuration.perDPUValuesYAML }}
+  per_dpu_values.yaml: | {{ .Values.configuration.perDPUValuesYAML | nindent 4}}
+  {{- end }}
+  {{- if .Values.configuration.startupYAMLJ2 }}
+  startup.yaml.j2: | {{ .Values.configuration.startupYAMLJ2 | nindent 4 }}
+  {{- end }}

--- a/bluefield/charts/doca-hbn/templates/daemonset.yaml
+++ b/bluefield/charts/doca-hbn/templates/daemonset.yaml
@@ -1,0 +1,227 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "hbn.fullname" . }}-ds
+  labels:
+    {{- include "hbn.labels" . | nindent 4 }}
+    {{- with .Values.serviceDaemonSet.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.serviceDaemonSet.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .Values.serviceDaemonSet.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+    {{- include "hbn.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "hbn.selectorLabels" . | nindent 8 }}
+        {{- with .Values.serviceDaemonSet.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- with .Values.serviceDaemonSet.annotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with toYaml .Values.serviceDaemonSet.nodeSelector }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+              {{- . | nindent 12 }}
+      {{- end }}
+      imagePullSecrets: {{ .Values.imagePullSecrets | default list | toJson }}
+      initContainers:
+      {{- /* Carbide: allow injecting arbitrary init containers via values */ -}}
+      {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+      - command: ["/bin/sh", "-c"]
+        args:
+        - |
+          /initbootstrap.sh && \
+          python3 /ovs-cached-mac-flush.py --chroot=/host && \
+          mount -o rw,remount /sys
+          # /sys is mounted in read-only mode therefore we are using remount to change it to read-write mode
+        env:
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: IPAM_IPADDRESS_PATH
+          value: /tmp/init-container-data/ipam-ipaddresses.json
+        - name: HBN_MGMT_INTERFACE_CONFIG_CREATE
+          value: "true"
+        - name: SKIP_GENERATE_STARTUP
+          value: {{ .Values.configuration.skipGenerateStartup | default false | quote }}
+        image: {{ .Values.hbnInit.image.repository | default .Values.image.repository }}:{{ .Values.hbnInit.image.tag | default .Values.image.tag | default .Chart.AppVersion }}
+        imagePullPolicy: {{ .Values.hbnInit.imagePullPolicy }}
+        name: hbn-init
+        resources: {}
+        securityContext: {{- toYaml .Values.hbnInit.containerSecurityContext | nindent 10 }}
+        volumeMounts:
+        - mountPath: /host
+          name: host
+        - mountPath: /tmp/config-data
+          name: config-volume
+        - mountPath: /tmp/init-container-data
+          name: init-container-data
+        - mountPath: /var/run/openvswitch
+          name: openvswitch
+      containers:
+      - name: doca-hbn
+        image: {{ .Values.docaHbn.image.repository | default .Values.image.repository }}:{{ .Values.docaHbn.image.tag | default .Values.image.tag | default .Chart.AppVersion }}
+        imagePullPolicy: {{ .Values.docaHbn.imagePullPolicy }}
+        ports:
+        - containerPort: 8765
+          name: hbn-port
+          protocol: TCP
+        {{- with toYaml .Values.resources }}
+        resources:
+          limits:
+            {{- . | nindent 12 }}
+          requests:
+            {{- . | nindent 12 }}
+        {{- end }}
+        env:
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: IPAM_IPADDRESS_PATH
+          value: /tmp/init-container-data/ipam-ipaddresses.json
+        {{- if .Values.configuration.user.create }}
+        - name: HBN_CREATE_USER
+          value: "true"
+        - name: HBN_USER_NAME
+          value: {{ .Values.configuration.user.username | quote }}
+        - name: HBN_USER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.configuration.user.password.secretName | quote }}
+              key: {{ .Values.configuration.user.password.secretKey | quote }}
+        {{- if .Values.configuration.user.shell }}
+        - name: HBN_USER_SHELL
+          value: {{ .Values.configuration.user.shell | quote }}
+        {{- end }}
+        {{- if .Values.configuration.user.homeDir }}
+        - name: HBN_USER_HOME
+          value: {{ .Values.configuration.user.homeDir | quote }}
+        {{- end }}
+        {{- if .Values.configuration.user.additionalGroups }}
+        - name: HBN_USER_GROUPS
+          value: {{ join "," .Values.configuration.user.additionalGroups | quote }}
+        {{- end }}
+        {{- if .Values.configuration.user.uid }}
+        - name: HBN_USER_UID
+          value: {{ .Values.configuration.user.uid | quote }}
+        {{- end }}
+        {{- if .Values.configuration.user.gid }}
+        - name: HBN_USER_GID
+          value: {{ .Values.configuration.user.gid | quote }}
+        {{- end }}
+        {{- end }}
+        - name: SKIP_GENERATE_STARTUP
+          value: {{ .Values.configuration.skipGenerateStartup | default false | quote }}
+        securityContext: {{- toYaml .Values.docaHbn.containerSecurityContext
+          | nindent 10 }}
+        volumeMounts:
+        - mountPath: /etc/network
+          name: eni
+        - mountPath: /etc/frr
+          name: frr
+        - mountPath: /var/lib/nvue
+          name: nvue
+        - mountPath: /etc/supervisor/conf.d/
+          name: supervisor
+        - mountPath: /etc/nvue.d
+          name: nvuestartup
+        - mountPath: /var/log/hbn
+          name: hbnlogs
+        - mountPath: /var/support
+          name: support
+        - mountPath: /etc/cumulus
+          name: etccumulus
+        - mountPath: /tmp/config-data
+          name: config-volume
+        - mountPath: /tmp/init-container-data
+          name: init-container-data
+        - mountPath: /var/run/openvswitch
+          name: openvswitch
+          readOnly: true
+        {{- /* Carbide: allow injecting arbitrary volume mounts via values */ -}}
+        {{- with .Values.extraVolumeMounts }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      - name: hbn-sidecar
+        command: ["python3", "-u", "/ovs-watcher.py", "--chroot=/host"]
+        image: {{ .Values.hbnSidecar.image.repository | default .Values.image.repository }}:{{ .Values.hbnSidecar.image.tag | default .Values.image.tag | default .Chart.AppVersion }}
+        imagePullPolicy: {{ .Values.hbnSidecar.imagePullPolicy }}
+        securityContext: {{- toYaml .Values.hbnSidecar.containerSecurityContext | nindent 10 }}
+        volumeMounts:
+        - mountPath: /host
+          name: host
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      volumes:
+      - hostPath:
+          path: /var/lib/hbn/etc/network
+          type: DirectoryOrCreate
+        name: eni
+      - hostPath:
+          path: /var/lib/hbn/etc/frr
+          type: DirectoryOrCreate
+        name: frr
+      - hostPath:
+          path: /var/lib/hbn/var/lib/nvue
+          type: DirectoryOrCreate
+        name: nvue
+      - hostPath:
+          path: /var/lib/hbn/etc/supervisor/conf.d
+          type: DirectoryOrCreate
+        name: supervisor
+      - hostPath:
+          path: /var/lib/hbn/etc/nvue.d
+          type: DirectoryOrCreate
+        name: nvuestartup
+      - hostPath:
+          path: /var/log/doca/hbn
+          type: DirectoryOrCreate
+        name: hbnlogs
+      - hostPath:
+          path: /var/lib/hbn/var/support/
+          type: DirectoryOrCreate
+        name: support
+      - hostPath:
+          path: /var/lib/hbn/etc/cumulus
+          type: DirectoryOrCreate
+        name: etccumulus
+      - hostPath:
+          path: /var/lib/hbn
+          type: DirectoryOrCreate
+        name: var-lib-hbn
+      - hostPath:
+          path: /var/run/openvswitch
+          type: Directory
+        name: openvswitch
+      - hostPath:
+          path: /
+        name: host
+      - configMap:
+          name: {{ include "hbn.fullname" . }}-config-data
+        name: config-volume
+      - emptyDir: {}
+        name: init-container-data
+      {{- /* Carbide: allow injecting arbitrary volumes via values */ -}}
+      {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}

--- a/bluefield/charts/doca-hbn/templates/service.yaml
+++ b/bluefield/charts/doca-hbn/templates/service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "hbn.fullname" . }}
+  labels:
+    {{- include "hbn.labels" . | nindent 4 }}
+spec:
+  {{- if not (or (eq .Values.service.type "ClusterIP") (eq .Values.service.type "NodePort")) }}
+  {{- fail "Service type must be either ClusterIP or NodePort" }}
+  {{- end }}
+  type: {{ .Values.service.type }}
+  {{- if eq .Values.service.type "NodePort" }}
+  externalTrafficPolicy: Local
+  {{- end }}
+  internalTrafficPolicy: Local
+  ports:
+    - port: 8765
+      targetPort: 8765
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+      protocol: TCP
+      name: hbn-port
+  selector:
+    {{- include "hbn.selectorLabels" . | nindent 4 }}

--- a/bluefield/charts/doca-hbn/values.yaml
+++ b/bluefield/charts/doca-hbn/values.yaml
@@ -1,0 +1,155 @@
+### DPF contract ###
+
+# configuration for the service
+serviceDaemonSet:
+  # selects nodes on which this service will run by label. Can be set in DPUService `.spec.serviceDaemonSet.nodeSelector`
+  # nodeSelector:
+  #   nodeSelectorTerms:
+  #   - matchExpressions:
+  #       - key: dpu
+  #         operator: In
+  #         values:
+  #           - dpu
+  # labels on the DaemonSet and pod template. Can be set in DPUService `.spec.serviceDaemonSet.labels`
+  labels: {}
+  # annotations on the DaemonSet and pod template. Can be set in DPUService `.spec.serviceDaemonSet.annotations`
+  annotations: {}
+  # updateStrategy on the DaemonSet. Can be set in DPUService `.spec.serviceDaemonSet.updateStrategy.`
+  updateStrategy: {}
+  #  type: RollingUpdate
+  #  rollingUpdate:
+  #    maxUnavailable: 1
+
+# Service configuration
+service:
+  # NodePort configuration (optional)
+  nodePort: null  # Set this value to expose the service via NodePort
+  # Service type (ClusterIP or NodePort)
+  type: ClusterIP
+
+### App sepcific values ###
+
+# resources required by the main HBN container
+resources: {}
+  # memory: 6Gi
+  # nvidia.com/bf_sf: 3
+
+imagePullSecrets: []
+
+# default image settings
+# this image will be used for all containers if they don't have explicit
+# image settings
+image:
+  repository: nvcr.io/nvidia/doca/doca_hbn
+  tag: "" # if not set the .Chart.AppVersion is used
+
+# configuration for docaHbn container.
+docaHbn:
+  image:
+    repository: ""
+    tag: ""
+  imagePullPolicy: IfNotPresent
+  containerSecurityContext:
+    privileged: true
+
+# configurations for hbnInit container.
+hbnInit:
+  image:
+    repository: ""
+    tag: ""
+  imagePullPolicy: IfNotPresent
+  containerSecurityContext:
+    privileged: true
+
+# configuration for hbnSidecar container.
+hbnSidecar:
+  image:
+    repository: ""
+    tag: ""
+  imagePullPolicy: IfNotPresent
+  containerSecurityContext:
+    privileged: true
+
+configuration:
+  # User configuration
+  user:
+    # Enable user creation
+    create: false
+    # Username for the new user
+    username: "hbn"
+    # Password configuration
+    password:
+      # Name of the Kubernetes Secret containing the password
+      secretName: "hbn-user-password"
+      # Key in the secret that contains the password
+      secretKey: "password"
+    # User's shell (optional)
+    shell: "/bin/bash"
+    # User's home directory (optional)
+    homeDir: "/home/hbn"
+    # Additional groups to add the user to (optional)
+    additionalGroups: []
+    # User ID (optional)
+    uid: ""
+    # Group ID (optional)
+    gid: ""
+  # The "perDPUValuesYAML" field should contain a string with a YAML list.
+  # This list is used to compute template values for a specific DPU.
+  # The elements of the list should be sorted by priority, with the first element having
+  # the lowest priority and the last element having the highest priority.
+  # The resulting values for the DPU are computed by traversing the list from the beginning to the end.
+  # Typically, the first element will match all hosts (*) and should contain default values.
+  # More specific selectors should be placed closer to the end of the list.
+  # The resulting values for the hostname will include merged values from all matching patterns,
+  # with values from patterns closer to the end of the list taking precedence.
+  perDPUValuesYAML: ""
+  # perDPUValuesYAML: |
+  #   - hostnamePattern: "*" # match all hosts
+  #     values:
+  #       bgp_peer_group: hbn
+  #       vlan: 100
+  #       bgp_as: 65100
+  #   - hostnamePattern: "*-rack1-dc1-*"
+  #     values:
+  #       vlan: 101
+  #   - hostnamePattern: "*-rack2-dc1-*"
+  #     values:
+  #       vlan: 102
+  #   - hostnamePattern: "*-dc1-*"
+  #     values:
+  #       bgp_as: 65113
+  #   - hostnamePattern: "host1-rack1-dc1-0000-3f-00" # match specific hostname
+  #     values:
+  #       bgp_as: 65200
+  #       vlan: 200
+
+  # JINJA2 template for startup configuration, DPU-specific values computed from `perDPUValuesYAML`
+  # are injected to the template
+  startupYAMLJ2: ""
+  # startupYAMLJ2: |
+  #   - header:
+  #       model: BLUEFIELD
+  #       nvue-api-version: nvue_v1
+  #       rev-id: 1.0
+  #       version: HBN x.x.x
+  #   - set:
+  #       bridge:
+  #         domain:
+  #           br_default:
+  #             vlan:
+  #               '{{ config.vlan }}': {}
+  # Environment variable for skipping startup generation
+  skipGenerateStartup: false
+
+extraInitContainers: []
+# - name: my-init
+#   image: busybox:latest
+#   command: ["sh", "-c", "echo hello"]
+
+extraVolumeMounts: []
+# - name: my-volume
+#   mountPath: /mnt/my-volume
+
+extraVolumes: []
+# - name: my-volume
+#   emptyDir: {}


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->

this adds in a vendored copy of the doca-hbn chart, matching the version of dpf we use, with additional init container and volume mounting support. the intent is to either upstream this support or to add in api functionality to the doca-hbn chart such that we do not need to pass in extra files.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

no testing performed apart from rendering the template. this is an intermediate step. next step is to test out the chart, configured with our additional init container.

