### PR TITLE
fix: Enumerate_hardware should not fail on get_nvidia_smi_data failure

### DIFF
--- a/crates/host-support/src/hardware_enumeration.rs
+++ b/crates/host-support/src/hardware_enumeration.rs
@@ -755,8 +755,15 @@ pub fn enumerate_hardware() -> Result<rpc_discovery::DiscoveryInfo, HardwareEnum
     let device_count = enumerator.scan_devices()?.count();
 
     // If there are no GPUs present on the host we do not want to run nvidia-smi as it will fail
+    // we don't want an nvidia-smi failure to prevent agent from registering so we just warn on error.
     let gpus = if device_count > 0 {
-        gpu::get_nvidia_smi_data()?
+        match gpu::get_nvidia_smi_data() {
+            Ok(gpus) => gpus,
+            Err(e) => {
+                tracing::warn!("Could not get GPU data from nvidia-smi: {e}");
+                vec![]
+            }
+        }
     } else {
         tracing::debug!("No GPUs detected, skipping");
         vec![]

--- a/crates/host-support/src/hardware_enumeration.rs
+++ b/crates/host-support/src/hardware_enumeration.rs
@@ -754,13 +754,15 @@ pub fn enumerate_hardware() -> Result<rpc_discovery::DiscoveryInfo, HardwareEnum
 
     let device_count = enumerator.scan_devices()?.count();
 
-    // If there are no GPUs present on the host we do not want to run nvidia-smi as it will fail
-    // we don't want an nvidia-smi failure to prevent agent from registering so we just warn on error.
+    // If there are no GPUs present on the host we do not want to run nvidia-smi as it will fail.
+    // We do not want an nvidia-smi failure to prevent the agent from registering, so on error we log a warning and fall back to an empty GPU list (treated as no GPUs).
     let gpus = if device_count > 0 {
         match gpu::get_nvidia_smi_data() {
             Ok(gpus) => gpus,
             Err(e) => {
-                tracing::warn!("Could not get GPU data from nvidia-smi: {e}");
+                tracing::warn!(
+                    "Could not get GPU data from nvidia-smi for {device_count} detected device(s); treating as no GPUs: {e}"
+                );
                 vec![]
             }
         }


### PR DESCRIPTION
## Description
The enumerate_hardware() function will fail if get_nvidia_smi_data() fails since it does not handle the error.

The pattern seems to be that the function should continue:<br>
- TPM EK certificate: If reading the TPM fails (e.g., no TPM device, permission denied), it logs an error and sets the field to None.
- DPU VPD data: if getting DPU info fails, it logs an error and sets the field to None.
- SMBIOS memory info: if loading the SMBIOS table fails, it logs a warning and falls back to parsing /proc/meminfo instead.
This ensure that get_nvidia_smi_data failure will not stop enumerate_hardware.

Note:
- this was triggered by an update to the Linux host updating the NVIDIA driver but the host having not rebooted there was a mismatch between in-memory and on-disk driver. The result was a failure of get_nvidia_smi_data and a failed test.
- rebooting the machine 'fixed' the test too but it seems like the behavior was incorrect.

Error from logs:<br>
Failed to start DPU agent: registration error: enumerate_hardware failed: 
Command error ... nvidia-smi ... Failed to initialize NVML: Driver/library version mismatch
NVML library version: 570.211

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes:
- [ ] This PR contains breaking changes
- [X] This PR contains a change in behavior!

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)
