### PR TITLE
chore: add DNS section to the IPAM section in the admin UI

### DIFF
--- a/crates/api-db/src/dns/resource_record.rs
+++ b/crates/api-db/src/dns/resource_record.rs
@@ -111,6 +111,25 @@ pub async fn find_record(
 
     Ok(result)
 }
+pub async fn get_all_records_all_domains(
+    txn: impl DbReader<'_>,
+) -> Result<Vec<DbResourceRecord>, DatabaseError> {
+    let query = r#"
+        SELECT dr.q_name, dr.resource_record, dr.domain_id,
+               COALESCE(dr.ttl, 300) as ttl,
+               COALESCE(dr.q_type, CASE WHEN family(dr.resource_record) = 6 THEN 'AAAA' ELSE 'A' END) as q_type
+        FROM dns_records dr
+        JOIN domains d ON d.id = dr.domain_id
+        WHERE d.deleted IS NULL
+        ORDER BY dr.q_name
+    "#;
+
+    sqlx::query_as::<_, DbResourceRecord>(query)
+        .fetch_all(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
 pub async fn get_all_records(
     txn: impl DbReader<'_>,
     query_name: &str,

--- a/crates/api/src/web/ipam.rs
+++ b/crates/api/src/web/ipam.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use askama::Template;
@@ -140,9 +141,104 @@ struct IpamPlaceholder {
     section: &'static str,
 }
 
-/// DNS placeholder page
-pub async fn dns_html() -> Response {
-    let tmpl = IpamPlaceholder { section: "DNS" };
+#[derive(Template)]
+#[template(path = "ipam_dns.html")]
+struct IpamDns {
+    zones: Vec<DnsZoneDisplay>,
+    records: Vec<DnsRecordDisplay>,
+}
+
+struct DnsZoneDisplay {
+    name: String,
+    soa_serial: String,
+    record_count: usize,
+}
+
+struct DnsRecordDisplay {
+    q_name: String,
+    q_type: String,
+    value: String,
+    ttl: i32,
+    zone: String,
+}
+
+/// DNS records page
+pub async fn dns_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+    // Fetch domains.
+    let domains = match db::dns::domain::find_by(
+        &state.database_connection,
+        db::ObjectColumnFilter::<db::dns::domain::IdColumn>::All,
+    )
+    .await
+    {
+        Ok(d) => d,
+        Err(err) => {
+            tracing::error!(%err, "fetch domains for DNS");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading DNS zones").into_response();
+        }
+    };
+
+    // Fetch all DNS records.
+    let db_records =
+        match db::dns::resource_record::get_all_records_all_domains(&state.database_connection)
+            .await
+        {
+            Ok(r) => r,
+            Err(err) => {
+                tracing::error!(%err, "fetch DNS records");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Error loading DNS records",
+                )
+                    .into_response();
+            }
+        };
+
+    // Build domain ID -> name map, and count records per zone.
+    let domain_name_map: HashMap<String, String> = domains
+        .iter()
+        .map(|d| (d.id.to_string(), d.name.clone()))
+        .collect();
+
+    let mut record_counts: HashMap<String, usize> = HashMap::new();
+    for r in &db_records {
+        *record_counts.entry(r.domain_id.to_string()).or_default() += 1;
+    }
+
+    let zones: Vec<DnsZoneDisplay> = domains
+        .iter()
+        .map(|d| {
+            let soa_serial = d
+                .soa
+                .as_ref()
+                .map(|s| s.0.serial.to_string())
+                .unwrap_or_else(|| "N/A".to_string());
+            DnsZoneDisplay {
+                name: d.name.clone(),
+                soa_serial,
+                record_count: record_counts.get(&d.id.to_string()).copied().unwrap_or(0),
+            }
+        })
+        .collect();
+
+    let records: Vec<DnsRecordDisplay> = db_records
+        .into_iter()
+        .map(|r| {
+            let zone = domain_name_map
+                .get(&r.domain_id.to_string())
+                .cloned()
+                .unwrap_or_default();
+            DnsRecordDisplay {
+                q_name: r.q_name,
+                q_type: r.q_type,
+                value: r.record,
+                ttl: r.ttl,
+                zone,
+            }
+        })
+        .collect();
+
+    let tmpl = IpamDns { zones, records };
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 

--- a/crates/api/templates/ipam_dns.html
+++ b/crates/api/templates/ipam_dns.html
@@ -1,0 +1,86 @@
+{% extends "base.html" %}
+
+{% block title %}IPAM / DNS{% endblock %}
+
+{% block content %}
+<h1>IPAM &rsaquo; DNS</h1>
+
+<h2>Authoritative Zones</h2>
+<table class="sortable overview">
+	<thead>
+		<tr>
+			<th>Zone</th>
+			<th>SOA Serial</th>
+			<th>Records</th>
+		</tr>
+	</thead>
+	<tbody>
+		{% for zone in zones %}
+			<tr>
+				<td>{{ zone.name }}</td>
+				<td>{{ zone.soa_serial }}</td>
+				<td>{{ zone.record_count }}</td>
+			</tr>
+		{% endfor %}
+	</tbody>
+</table>
+
+<h2>DNS Records</h2>
+<p>{{ records.len() }} records across {{ zones.len() }} zone(s).</p>
+
+<input type="text" id="dns-filter" placeholder="Filter by name, type, value, or zone..." style="width: 100%; padding: 8px; margin-bottom: 8px; box-sizing: border-box;">
+
+<table class="sortable overview" id="dns-records-table">
+	<thead>
+		<tr>
+			<th>FQDN</th>
+			<th>Type</th>
+			<th>Value</th>
+			<th>TTL</th>
+			<th>Zone</th>
+		</tr>
+	</thead>
+	<tbody>
+		{% for r in records %}
+			<tr>
+				<td>{{ r.q_name }}</td>
+				<td>{{ r.q_type }}</td>
+				<td><a href="/admin/search?q={{ r.value }}">{{ r.value }}</a></td>
+				<td>{{ r.ttl }}</td>
+				<td>{{ r.zone }}</td>
+			</tr>
+		{% endfor %}
+	</tbody>
+</table>
+
+<p id="dns-filter-count" style="display:none;"></p>
+{% endblock %}
+
+{% block script %}
+(function() {
+	const filterInput = document.getElementById('dns-filter');
+	const table = document.getElementById('dns-records-table');
+	const tbody = table.querySelector('tbody');
+	const rows = Array.from(tbody.querySelectorAll('tr'));
+	const countEl = document.getElementById('dns-filter-count');
+
+	filterInput.addEventListener('input', function() {
+		const terms = this.value.toLowerCase().split(/\s+/).filter(Boolean);
+		let visible = 0;
+
+		rows.forEach(row => {
+			const text = row.textContent.toLowerCase();
+			const match = terms.length === 0 || terms.every(t => text.includes(t));
+			row.style.display = match ? '' : 'none';
+			if (match) visible++;
+		});
+
+		if (terms.length > 0) {
+			countEl.style.display = '';
+			countEl.textContent = 'Showing ' + visible + ' of ' + rows.length + ' records';
+		} else {
+			countEl.style.display = 'none';
+		}
+	});
+})();
+{% endblock %}


### PR DESCRIPTION
## Description

This adds an introductory DNS section to the admin UI that includes:
- Zones we are authoritative for.
- The records we currently serve (including record information).

There will be some iterative improvements here, but I want to get something out for people to work with and look at and go "oh we should do X and Y instead."

Some improvements would probably be:
- Pagination (either server or client side).
- Filtering (either server or client side).
- Better integration with the global search box (if it doesn't exist yet).
- Etc.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

