### PR TITLE
feat: add a sub-command `state-history` to show a machine's state history

### DIFF
--- a/crates/admin-cli/src/machine/mod.rs
+++ b/crates/admin-cli/src/machine/mod.rs
@@ -27,6 +27,7 @@ pub mod nvlink_info;
 pub mod positions;
 pub mod reboot;
 pub mod show;
+pub mod state_history;
 
 #[cfg(test)]
 mod tests;
@@ -80,4 +81,6 @@ pub enum Cmd {
     Positions(positions::Args),
     #[clap(subcommand, about = "Update/show NVLink info for an MNNVL machine")]
     NvlinkInfo(nvlink_info::Args),
+    #[clap(about = "Fetch state transition history for one or more machines")]
+    StateHistory(state_history::Args),
 }

--- a/crates/admin-cli/src/machine/state_history/args.rs
+++ b/crates/admin-cli/src/machine/state_history/args.rs
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::machine::MachineId;
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+pub struct Args {
+    #[clap(required = true, help = "Machine IDs to fetch state history for")]
+    pub machines: Vec<MachineId>,
+}

--- a/crates/admin-cli/src/machine/state_history/cmd.rs
+++ b/crates/admin-cli/src/machine/state_history/cmd.rs
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::HashMap;
+use std::pin::Pin;
+
+use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::forge::MachineEvent;
+
+use super::args::Args;
+use crate::rpc::ApiClient;
+use crate::{async_writeln};
+
+pub async fn state_history(
+    args: Args,
+    output_format: &OutputFormat,
+    output_file: &mut Pin<Box<dyn tokio::io::AsyncWrite>>,
+    api_client: &ApiClient,
+) -> CarbideCliResult<()> {
+    let request = ::rpc::forge::MachineStateHistoriesRequest {
+        machine_ids: args.machines.clone(),
+    };
+
+    let mut histories = api_client
+        .0
+        .find_machine_state_histories(request)
+        .await?
+        .histories;
+
+    match output_format {
+        OutputFormat::Json => {
+            let result: HashMap<String, Vec<MachineEvent>> = args
+                .machines
+                .iter()
+                .map(|id| {
+                    let key = id.to_string();
+                    let mut records = histories.remove(&key).unwrap_or_default().records;
+                    records.reverse();
+                    (key, records)
+                })
+                .collect();
+            async_writeln!(output_file, "{}", serde_json::to_string_pretty(&result)?)?;
+        }
+        OutputFormat::AsciiTable => {
+            for machine_id in &args.machines {
+                let key = machine_id.to_string();
+                let mut records = histories.remove(&key).unwrap_or_default().records;
+                records.reverse();
+
+                async_writeln!(output_file, "Machine: {machine_id}")?;
+                if records.is_empty() {
+                    async_writeln!(output_file, "  (no history)")?;
+                } else {
+                    let max_state_len =
+                        records.iter().map(|r| r.event.len()).max().unwrap_or(0).max("State".len());
+                    let max_version_len = records
+                        .iter()
+                        .map(|r| r.version.len())
+                        .max()
+                        .unwrap_or(0)
+                        .max("Version".len());
+                    async_writeln!(
+                        output_file,
+                        "  {:<max_state_len$} {:<max_version_len$} Time",
+                        "State",
+                        "Version"
+                    )?;
+                    for record in &records {
+                        async_writeln!(
+                            output_file,
+                            "  {:<max_state_len$} {:<max_version_len$} {}",
+                            record.event,
+                            record.version,
+                            record.time.unwrap_or_default()
+                        )?;
+                    }
+                }
+                async_writeln!(output_file)?;
+            }
+        }
+        OutputFormat::Csv => {
+            return Err(CarbideCliError::NotImplemented(
+                "CSV formatted output".to_string(),
+            ));
+        }
+        OutputFormat::Yaml => {
+            return Err(CarbideCliError::NotImplemented(
+                "YAML formatted output".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}

--- a/crates/admin-cli/src/machine/state_history/mod.rs
+++ b/crates/admin-cli/src/machine/state_history/mod.rs
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::state_history(self, &ctx.config.format, &mut ctx.output_file, &ctx.api_client).await?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Description
The state transition history information is available in the web-ui. This PR adds a CLI sub-command to `admin-cli` to fetch the information.

example:
```
carbide-admin-cli m state-history <machine_id1> <machine_id2>...
```

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

