### PR TITLE
chore: increase `Assigned/HostPlatformConfiguration` SLA time limit to 90 minutes

### DIFF
--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -2558,6 +2558,9 @@ pub fn state_sla(
                 // Since retries happen after 30min, the occurence of any retry means we exhausted the SLA
                 StateSla::with_sla(std::time::Duration::ZERO, time_in_state)
             }
+            InstanceState::HostPlatformConfiguration { .. } => {
+                StateSla::with_sla(slas::ASSIGNED_HOST_PLATFORM_CONFIGURATION, time_in_state)
+            }
             _ => StateSla::with_sla(slas::ASSIGNED, time_in_state),
         },
         ManagedHostState::WaitingForCleanup { .. } => {

--- a/crates/api-model/src/machine/slas.rs
+++ b/crates/api-model/src/machine/slas.rs
@@ -46,4 +46,7 @@ pub const BOM_VALIDATION: Duration = Duration::from_secs(5 * 60);
 // ASSIGNED state, any substate other than Ready and BootingWithDiscoveryImage
 // Init WaitingForNetworkConfig WaitingForStorageConfig WaitingForRebootToReady SwitchToAdminNetwork WaitingForNetworkReconfig DPUReprovision Failed
 pub const ASSIGNED: Duration = Duration::from_secs(30 * 60);
+
+// ASSIGNED state, HostPlatformConfiguration substate
+pub const ASSIGNED_HOST_PLATFORM_CONFIGURATION: Duration = Duration::from_secs(90 * 60);
 pub const VALIDATION: Duration = Duration::from_secs(30 * 60);


### PR DESCRIPTION
## Description
This state requires the following operations

- power-cycle the host
- CheckHostConfig
- ConfigureBios & PollingBiosSetup
- SetBootOrder

Power-cycle the host and SetBootOrder are time-consuming some-times depending on machine configurations. Some machines could take 20min for first try of SetBootOrder operations. 

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)


## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

