### PR TITLE
chore: Backfill rack_id in expected-machines based on label value

### DIFF
--- a/crates/api-db/migrations/20260319120000_backfill_rack_ids_in_expected_machinessql
+++ b/crates/api-db/migrations/20260319120000_backfill_rack_ids_in_expected_machinessql
@@ -1,0 +1,2 @@
+-- Updates the Rack ID in expected machines to value that is specified in the RackIdentifier label
+update expected_machines set rack_id=metadata_labels->>'RackIdentifier' where rack_id IS NULL AND metadata_labels->>'RackIdentifier' is not NULL;


### PR DESCRIPTION
## Description

Populates rack_id based on values already stored in expected machines.

Note:
- This requires a fix for RackId format before getting merged
- All expected-machine generators and definitions should also get updated, so that the changes won't get reverted on the next insertion.

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

