### PR TITLE
fix(vault): enforce TLS verification for Vault connections

### DIFF
--- a/crates/api-test-helper/src/utils.rs
+++ b/crates/api-test-helper/src/utils.rs
@@ -122,11 +122,12 @@ impl IntegrationTestEnvironment {
 
         let credential_config = CredentialConfig {
             vault: VaultConfig {
-                address: Some(format!("http://{vault_addr}")),
+                address: Some(format!("https://{vault_addr}")),
                 kv_mount_location: Some("secret".to_string()),
                 pki_mount_location: Some("forgeca".to_string()),
                 pki_role_name: Some("forge-cluster".to_string()),
                 token: Some(vault.token.clone()),
+                vault_cacert: Some(vault.ca_cert.clone()),
             },
             ..Default::default()
         };

--- a/crates/api-test-helper/src/vault.rs
+++ b/crates/api-test-helper/src/vault.rs
@@ -15,7 +15,9 @@
  * limitations under the License.
  */
 use std::net::SocketAddr;
+use std::path::Path;
 use std::process::Stdio;
+use std::time::Duration;
 
 use eyre::Context;
 use tokio::io::AsyncBufReadExt;
@@ -23,11 +25,13 @@ use tokio::process;
 use tokio::sync::oneshot;
 
 const ROOT_TOKEN: &str = "Root Token";
+const VAULT_CACERT_ENV_STRING: &str = "$ export VAULT_CACERT";
 
 #[derive(Debug)]
 pub struct Vault {
     pub process: process::Child,
     pub token: String,
+    pub ca_cert: String,
 }
 
 pub async fn start(addr: SocketAddr) -> Result<Vault, eyre::Report> {
@@ -36,7 +40,7 @@ pub async fn start(addr: SocketAddr) -> Result<Vault, eyre::Report> {
     let mut process =
         tokio::process::Command::new(bins.get("vault").expect("vault command not found in PATH"))
             .arg("server")
-            .arg("-dev")
+            .arg("-dev-tls")
             .arg(format!("-dev-listen-address={addr}"))
             .env_remove("VAULT_ADDR")
             .env_remove("VAULT_CLIENT_KEY")
@@ -51,16 +55,32 @@ pub async fn start(addr: SocketAddr) -> Result<Vault, eyre::Report> {
     let stderr = tokio::io::BufReader::new(process.stderr.take().unwrap());
 
     let (token_tx, token_rx) = oneshot::channel();
+    let (ca_tx, ca_rx) = oneshot::channel();
+
     tokio::spawn(async move {
         let mut lines = stdout.lines();
-        let mut sender = Some(token_tx);
+        let mut token_sender = Some(token_tx);
+        let mut ca_sender = Some(ca_tx);
         while let Some(line) = lines.next_line().await? {
-            let mut parts = line.trim().split(':');
-            if let Some(left) = parts.next()
-                && left == ROOT_TOKEN
-                && let Some(sender) = sender.take()
+            let mut token_parts = line.trim().split(':');
+            let mut ca_parts = line.trim().split('=');
+            if let Some(left) = ca_parts.next()
+                && left == VAULT_CACERT_ENV_STRING
+                && let Some(ca_sender) = ca_sender.take()
             {
-                sender.send(parts.next().unwrap().to_string()).ok();
+                // Vault prints: $ export VAULT_CACERT='/path/to/cert'
+                // Strip the surrounding single quotes that the shell export syntax includes.
+                let raw = ca_parts.next().unwrap();
+                let path = raw.trim_matches('\'').to_string();
+                ca_sender.send(path).ok();
+            }
+            if let Some(left) = token_parts.next()
+                && left == ROOT_TOKEN
+                && let Some(token_sender) = token_sender.take()
+            {
+                token_sender
+                    .send(token_parts.next().unwrap().to_string())
+                    .ok();
             }
             // there's no logger so can't use tracing
             println!("{line}");
@@ -79,5 +99,24 @@ pub async fn start(addr: SocketAddr) -> Result<Vault, eyre::Report> {
 
     // Vault dev prints the token immediately on startup, so block and wait for it
     let token = token_rx.await.context("waiting for vault token")?;
-    Ok(Vault { process, token })
+    let ca_cert = ca_rx.await.context("waiting for vault CA cert")?;
+
+    // Vault announces the cert path in its stdout log before it finishes writing the
+    // file to disk. Poll until the file is present so callers can use it immediately.
+    let cert_ready_deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if Path::new(&ca_cert).exists() {
+            break;
+        }
+        if std::time::Instant::now() >= cert_ready_deadline {
+            eyre::bail!("Vault CA cert never appeared at {ca_cert} after 10 seconds");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    Ok(Vault {
+        process,
+        token,
+        ca_cert,
+    })
 }

--- a/crates/secrets/src/forge_vault.rs
+++ b/crates/secrets/src/forge_vault.rs
@@ -42,6 +42,9 @@ use crate::credentials::{
     CredentialKey, CredentialManager, CredentialReader, CredentialWriter, Credentials,
 };
 
+const DEFAULT_VAULT_CA_PATH: &str = "/var/run/secrets/forge-roots/ca.crt";
+const VAULT_CACERT_ENV_VAR: &str = "VAULT_CACERT";
+
 #[derive(Clone, Debug)]
 enum ForgeVaultAuthenticationType {
     Root(String),
@@ -65,7 +68,38 @@ struct ForgeVaultClientConfig {
     pub kv_mount_location: String,
     pub pki_mount_location: String,
     pub pki_role_name: String,
-    pub vault_root_ca_path: String,
+    vault_root_ca_path: String,
+}
+
+// Resolve Vault CA path from a specified path first, then
+// from `VAULT_CACERT` for local dev flows such as `vault server -dev-tls`.
+fn resolve_vault_root_ca_path(configured_path: &str) -> Result<String, eyre::Report> {
+    if Path::new(configured_path).exists() {
+        return Ok(configured_path.to_string());
+    }
+
+    match env::var(VAULT_CACERT_ENV_VAR) {
+        Ok(env_path) if Path::new(&env_path).exists() => Ok(env_path),
+        Ok(env_path) => {
+            tracing::error!(
+                "VAULT_CACERT={env_path} does not exist. Refusing to connect without TLS verification."
+            );
+            Err(eyre!("Vault root CA not found"))
+        }
+        Err(_) => {
+            tracing::error!(
+                "Vault root CA not found at {}. Refusing to connect without TLS verification.",
+                configured_path
+            );
+            Err(eyre!("Vault root CA not found"))
+        }
+    }
+}
+
+impl ForgeVaultClientConfig {
+    pub fn vault_root_ca_path(&self) -> Result<String, eyre::Report> {
+        resolve_vault_root_ca_path(&self.vault_root_ca_path)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -100,14 +134,11 @@ where
         .address(vault_client_config.vault_address.clone())
         .timeout(Some(Duration::from_secs(60)));
 
-    let vault_client_settings_builder =
-        if Path::new(&vault_client_config.vault_root_ca_path).exists() {
-            vault_client_settings_builder
-                .ca_certs(vec![vault_client_config.vault_root_ca_path.clone()])
-                .verify(true)
-        } else {
-            vault_client_settings_builder.verify(false)
-        };
+    let ca_path = vault_client_config.vault_root_ca_path()?;
+
+    let vault_client_settings_builder = vault_client_settings_builder
+        .ca_certs(vec![ca_path])
+        .verify(true);
 
     Ok(vault_client_settings_builder.build()?)
 }
@@ -692,6 +723,7 @@ pub struct VaultConfig {
     pub pki_mount_location: Option<String>,
     pub pki_role_name: Option<String>,
     pub token: Option<String>,
+    pub vault_cacert: Option<String>,
 }
 
 impl VaultConfig {
@@ -729,13 +761,25 @@ impl VaultConfig {
             .or(env::var("VAULT_TOKEN").ok())
             .context("VAULT_TOKEN")
     }
+
+    pub fn vault_cacert(&self) -> eyre::Result<String> {
+        self.vault_cacert
+            .clone()
+            .or(env::var(VAULT_CACERT_ENV_VAR).ok())
+            .context("VAULT_CACERT")
+    }
 }
 
 pub fn create_vault_client(
     vault_config: &VaultConfig,
     meter: Meter,
 ) -> eyre::Result<Arc<ForgeVaultClient>> {
-    let vault_root_ca_path = "/var/run/secrets/forge-roots/ca.crt".to_string();
+    let configured_ca_path = vault_config
+        .vault_cacert()
+        .unwrap_or_else(|_| DEFAULT_VAULT_CA_PATH.to_string());
+
+    let vault_root_ca_path = resolve_vault_root_ca_path(configured_ca_path.as_str())?;
+
     let service_account_token_path =
         Path::new("/var/run/secrets/kubernetes.io/serviceaccount/token");
     let auth_type = if service_account_token_path.exists() {


### PR DESCRIPTION
Previously, the Vault client silently disabled certificate verification (`verify(false)`) when the CA cert was absent at the default path. This meant misconfigured deployments would silently skip TLS validation.
    
The new `resolve_vault_root_ca_path()` checks the configured CA path first, then falls back to `VAULT_CACERT` (supporting local dev with `vault server -dev-tls`). If neither resolves to an existing file, the client refuses to connect and returns an error rather than degrading to an unverified connection.

Integration tests are updated to launch Vault with `-dev-tls` and supply the generated CA cert path via `VaultConfig.vault_cacert`.
  * Fixes NVBug 5999702
  * integration tests now uses -dev-tls for spawning Vault


