### PR TITLE
fix: remove unused IpamPlaceholder

### DIFF
--- a/crates/api/src/web/ipam.rs
+++ b/crates/api/src/web/ipam.rs
@@ -136,12 +136,6 @@ async fn fetch_interfaces(api: Arc<Api>) -> Result<Vec<forgerpc::MachineInterfac
 }
 
 #[derive(Template)]
-#[template(path = "ipam_placeholder.html")]
-struct IpamPlaceholder {
-    section: &'static str,
-}
-
-#[derive(Template)]
 #[template(path = "ipam_dns.html")]
 struct IpamDns {
     zones: Vec<DnsZoneDisplay>,

--- a/crates/api/templates/ipam_placeholder.html
+++ b/crates/api/templates/ipam_placeholder.html
@@ -1,8 +1,0 @@
-{% extends "base.html" %}
-
-{% block title %}IPAM / {{ section }}{% endblock %}
-
-{% block content %}
-<h1>IPAM &rsaquo; {{ section }}</h1>
-<p>This section is under construction.</p>
-{% endblock %}


### PR DESCRIPTION
## Description

I don't know how this actually snuck through -- build + tests passed? All said, it needs to go! This was the old placeholder for the IPAM admin UI section. Now that all of the sub-sections have been filled in, this isn't in use, and is causing errors for being dead code. Removing both the struct and it's associated HTML file.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [x] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

