### PR TITLE
fix: simplify RackId to a newtype over String

### DIFF
--- a/crates/admin-cli/src/expected_rack/show/args.rs
+++ b/crates/admin-cli/src/expected_rack/show/args.rs
@@ -29,8 +29,10 @@ pub struct Args {
 
 impl From<&Args> for Option<rpc::forge::ExpectedRackRequest> {
     fn from(args: &Args) -> Self {
-        args.rack_id.map(|id| rpc::forge::ExpectedRackRequest {
-            rack_id: id.to_string(),
-        })
+        args.rack_id
+            .as_ref()
+            .map(|id| rpc::forge::ExpectedRackRequest {
+                rack_id: id.to_string(),
+            })
     }
 }

--- a/crates/admin-cli/src/expected_rack/show/cmd.rs
+++ b/crates/admin-cli/src/expected_rack/show/cmd.rs
@@ -78,6 +78,7 @@ fn convert_and_print_into_nice_table(
         table.add_row(row![
             expected_rack
                 .rack_id
+                .clone()
                 .map(|r| r.to_string())
                 .unwrap_or_default(),
             expected_rack.rack_type,

--- a/crates/api-db/src/expected_machine.rs
+++ b/crates/api-db/src/expected_machine.rs
@@ -136,7 +136,7 @@ pub async fn find_all(txn: impl DbReader<'_>) -> DatabaseResult<Vec<ExpectedMach
 /// find_all_by_rack_id returns all expected machines for a given rack_id.
 pub async fn find_all_by_rack_id(
     txn: &mut PgConnection,
-    rack_id: RackId,
+    rack_id: &RackId,
 ) -> DatabaseResult<Vec<ExpectedMachine>> {
     let sql = "SELECT * FROM expected_machines WHERE rack_id=$1";
     sqlx::query_as(sql)
@@ -220,7 +220,7 @@ pub async fn create(
         .bind(sqlx::types::Json(&machine.data.metadata.labels))
         .bind(&machine.data.sku_id)
         .bind(sqlx::types::Json(&machine.data.host_nics))
-        .bind(machine.data.rack_id)
+        .bind(&machine.data.rack_id)
         .bind(
             machine
                 .data
@@ -350,7 +350,7 @@ pub async fn update(txn: &mut PgConnection, machine: &ExpectedMachine) -> Databa
         .bind(sqlx::types::Json(&machine.data.metadata.labels))
         .bind(&machine.data.sku_id)
         .bind(sqlx::types::Json(&machine.data.host_nics))
-        .bind(machine.data.rack_id)
+        .bind(&machine.data.rack_id)
         .bind(machine.data.default_pause_ingestion_and_poweron)
         .bind(machine.data.dpf_enabled)
         .bind(&target_id)

--- a/crates/api-db/src/expected_power_shelf.rs
+++ b/crates/api-db/src/expected_power_shelf.rs
@@ -96,7 +96,7 @@ pub async fn find_all(txn: &mut PgConnection) -> DatabaseResult<Vec<ExpectedPowe
 /// find_all_by_rack_id returns all expected power shelves for a given rack_id.
 pub async fn find_all_by_rack_id(
     txn: &mut PgConnection,
-    rack_id: RackId,
+    rack_id: &RackId,
 ) -> DatabaseResult<Vec<ExpectedPowerShelf>> {
     let sql = "SELECT * FROM expected_power_shelves WHERE rack_id=$1";
     sqlx::query_as(sql)
@@ -154,7 +154,7 @@ pub async fn create(
         .bind(&power_shelf.metadata.name)
         .bind(&power_shelf.metadata.description)
         .bind(sqlx::types::Json(&power_shelf.metadata.labels))
-        .bind(power_shelf.rack_id)
+        .bind(&power_shelf.rack_id)
         .fetch_one(txn)
         .await
         .map_err(|err: sqlx::Error| match err {
@@ -274,7 +274,7 @@ pub async fn update(
         .bind(&power_shelf.metadata.name)
         .bind(&power_shelf.metadata.description)
         .bind(sqlx::types::Json(&power_shelf.metadata.labels))
-        .bind(power_shelf.rack_id)
+        .bind(&power_shelf.rack_id)
         .bind(&target_id)
         .execute(&mut *txn)
         .await

--- a/crates/api-db/src/expected_rack.rs
+++ b/crates/api-db/src/expected_rack.rs
@@ -24,7 +24,7 @@ use crate::{DatabaseError, DatabaseResult};
 /// find_by_rack_id finds an expected rack by its rack_id.
 pub async fn find_by_rack_id(
     txn: &mut PgConnection,
-    rack_id: RackId,
+    rack_id: &RackId,
 ) -> Result<Option<ExpectedRack>, DatabaseError> {
     let sql = "SELECT * FROM expected_racks WHERE rack_id=$1";
     sqlx::query_as(sql)
@@ -44,14 +44,14 @@ pub async fn find_all(txn: &mut PgConnection) -> DatabaseResult<Vec<ExpectedRack
 }
 
 /// create creates a new expected rack.
-pub async fn create(txn: &mut PgConnection, rack: ExpectedRack) -> DatabaseResult<ExpectedRack> {
+pub async fn create(txn: &mut PgConnection, rack: &ExpectedRack) -> DatabaseResult<ExpectedRack> {
     let query = "INSERT INTO expected_racks
              (rack_id, rack_type, metadata_name, metadata_description, metadata_labels)
              VALUES
              ($1::varchar, $2::varchar, $3::varchar, $4::varchar, $5::jsonb) RETURNING *";
 
     sqlx::query_as(query)
-        .bind(rack.rack_id)
+        .bind(&rack.rack_id)
         .bind(&rack.rack_type)
         .bind(&rack.metadata.name)
         .bind(&rack.metadata.description)
@@ -70,7 +70,7 @@ pub async fn create(txn: &mut PgConnection, rack: ExpectedRack) -> DatabaseResul
 }
 
 /// delete deletes an expected rack by its rack_id.
-pub async fn delete(txn: &mut PgConnection, rack_id: RackId) -> DatabaseResult<()> {
+pub async fn delete(txn: &mut PgConnection, rack_id: &RackId) -> DatabaseResult<()> {
     let query = "DELETE FROM expected_racks WHERE rack_id=$1";
 
     let result = sqlx::query(query)
@@ -109,7 +109,7 @@ pub async fn update(txn: &mut PgConnection, rack: &ExpectedRack) -> DatabaseResu
         .bind(&rack.metadata.name)
         .bind(&rack.metadata.description)
         .bind(sqlx::types::Json(&rack.metadata.labels))
-        .bind(rack.rack_id)
+        .bind(&rack.rack_id)
         .execute(txn)
         .await
         .map_err(|err| DatabaseError::query(query, err))?;

--- a/crates/api-db/src/expected_switch.rs
+++ b/crates/api-db/src/expected_switch.rs
@@ -105,7 +105,7 @@ pub async fn find_all(txn: &mut PgConnection) -> DatabaseResult<Vec<ExpectedSwit
 /// find_all_by_rack_id returns all expected switches for a given rack_id.
 pub async fn find_all_by_rack_id(
     txn: &mut PgConnection,
-    rack_id: RackId,
+    rack_id: &RackId,
 ) -> DatabaseResult<Vec<ExpectedSwitch>> {
     let sql = "SELECT * FROM expected_switches WHERE rack_id=$1";
     sqlx::query_as(sql)
@@ -177,7 +177,7 @@ pub async fn create(
         .bind(&switch.serial_number)
         .bind(&switch.metadata.name)
         .bind(&switch.metadata.description)
-        .bind(switch.rack_id)
+        .bind(&switch.rack_id)
         .bind(sqlx::types::Json(&switch.metadata.labels))
         .bind(&switch.nvos_username)
         .bind(&switch.nvos_password)
@@ -297,7 +297,7 @@ pub async fn update(txn: &mut PgConnection, switch: &ExpectedSwitch) -> Database
         .bind(&switch.metadata.name)
         .bind(&switch.metadata.description)
         .bind(sqlx::types::Json(&switch.metadata.labels))
-        .bind(switch.rack_id)
+        .bind(&switch.rack_id)
         .bind(&switch.nvos_username)
         .bind(&switch.nvos_password)
         .bind(&target_id)

--- a/crates/api-db/src/rack.rs
+++ b/crates/api-db/src/rack.rs
@@ -60,7 +60,7 @@ pub async fn list(txn: impl DbReader<'_>) -> DatabaseResult<Vec<Rack>> {
         .map_err(|e| DatabaseError::new("racks get", e))
 }
 
-pub async fn get(txn: impl DbReader<'_>, rack_id: RackId) -> DatabaseResult<Rack> {
+pub async fn get(txn: impl DbReader<'_>, rack_id: &RackId) -> DatabaseResult<Rack> {
     let query = "SELECT * from racks l WHERE l.id=$1".to_string();
     sqlx::query_as(&query)
         .bind(rack_id)
@@ -75,7 +75,7 @@ pub async fn get(txn: impl DbReader<'_>, rack_id: RackId) -> DatabaseResult<Rack
 
 pub async fn create(
     txn: &mut PgConnection,
-    rack_id: RackId,
+    rack_id: &RackId,
     expected_compute_trays: Vec<MacAddress>,
     expected_nvlink_switches: Vec<MacAddress>,
     expected_power_shelves: Vec<MacAddress>,
@@ -107,7 +107,7 @@ pub async fn create(
 // only update the config
 pub async fn update(
     txn: &mut PgConnection,
-    rack_id: RackId,
+    rack_id: &RackId,
     config: &RackConfig,
 ) -> DatabaseResult<Rack> {
     let query = "UPDATE racks SET config = $1::json, updated=NOW() WHERE id = $2 RETURNING *";
@@ -126,7 +126,7 @@ pub async fn update(
 /// the rack does not exist (the switch is not adopted).
 pub async fn adopt_expected_switch(
     txn: &mut PgConnection,
-    rack_id: RackId,
+    rack_id: &RackId,
     bmc_mac_address: MacAddress,
 ) -> DatabaseResult<bool> {
     match get(&mut *txn, rack_id).await {
@@ -148,7 +148,7 @@ pub async fn adopt_expected_switch(
 /// the rack does not exist (the machine is not adopted).
 pub async fn adopt_expected_machine(
     txn: &mut PgConnection,
-    rack_id: RackId,
+    rack_id: &RackId,
     bmc_mac_address: MacAddress,
 ) -> DatabaseResult<bool> {
     match get(&mut *txn, rack_id).await {
@@ -170,7 +170,7 @@ pub async fn adopt_expected_machine(
 /// Ok(false) if the rack does not exist (the power shelf is not adopted).
 pub async fn adopt_expected_power_shelf(
     txn: &mut PgConnection,
-    rack_id: RackId,
+    rack_id: &RackId,
     bmc_mac_address: MacAddress,
 ) -> DatabaseResult<bool> {
     match get(&mut *txn, rack_id).await {
@@ -189,7 +189,7 @@ pub async fn adopt_expected_power_shelf(
 
 pub async fn try_update_controller_state(
     txn: &mut PgConnection,
-    rack_id: RackId,
+    rack_id: &RackId,
     expected_version: ConfigVersion,
     new_state: &RackState,
 ) -> DatabaseResult<()> {
@@ -209,7 +209,7 @@ pub async fn try_update_controller_state(
 
 pub async fn update_controller_state_outcome(
     txn: &mut PgConnection,
-    rack_id: RackId,
+    rack_id: &RackId,
     outcome: PersistentStateHandlerOutcome,
 ) -> DatabaseResult<()> {
     sqlx::query("UPDATE racks SET controller_state_outcome = $1 WHERE id = $2")
@@ -225,7 +225,7 @@ pub async fn update_controller_state_outcome(
 pub async fn mark_as_deleted(rack: &Rack, txn: &mut PgConnection) -> DatabaseResult<Rack> {
     let query = "UPDATE racks SET updated=NOW(), deleted=NOW() WHERE id=$1 RETURNING *";
     let updated_rack = sqlx::query_as(query)
-        .bind(rack.id)
+        .bind(&rack.id)
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -233,7 +233,7 @@ pub async fn mark_as_deleted(rack: &Rack, txn: &mut PgConnection) -> DatabaseRes
     Ok(updated_rack)
 }
 
-pub async fn final_delete(txn: &mut PgConnection, rack_id: RackId) -> DatabaseResult<()> {
+pub async fn final_delete(txn: &mut PgConnection, rack_id: &RackId) -> DatabaseResult<()> {
     let query = "DELETE from racks WHERE id=$1";
     sqlx::query(query)
         .bind(rack_id)

--- a/crates/api-db/src/rack_state_history.rs
+++ b/crates/api-db/src/rack_state_history.rs
@@ -59,7 +59,7 @@ pub async fn find_by_rack_ids(
 /// Store each state for debugging purpose.
 pub async fn persist(
     txn: &mut PgConnection,
-    rack_id: RackId,
+    rack_id: &RackId,
     state: &RackState,
     state_version: ConfigVersion,
 ) -> DatabaseResult<RackStateHistory> {

--- a/crates/api/src/dhcp/discover.rs
+++ b/crates/api/src/dhcp/discover.rs
@@ -332,7 +332,7 @@ async fn update_rack_config_predicted_id_with_actual(
             let expected_compute_trays = vec![*parsed_mac];
             #[allow(deprecated)]
             let rack_id: RackId = RackId::default();
-            let rack = db::rack::create(txn, rack_id, expected_compute_trays, vec![], vec![])
+            let rack = db::rack::create(txn, &rack_id, expected_compute_trays, vec![], vec![])
                 .await
                 .map_err(CarbideError::from)?;
             tracing::warn!(
@@ -349,7 +349,7 @@ async fn update_rack_config_predicted_id_with_actual(
         .find(|item| *item == predicted)
     {
         *item = *actual;
-        db::rack::update(txn, rack.id, &config)
+        db::rack::update(txn, &rack.id, &config)
             .await
             .map_err(CarbideError::from)?;
     }

--- a/crates/api/src/handlers/expected_machine.rs
+++ b/crates/api/src/handlers/expected_machine.rs
@@ -86,7 +86,7 @@ pub(crate) async fn add(
         .parse::<MacAddress>()
         .map_err(CarbideError::from)?;
 
-    let request_rack_id = request.rack_id;
+    let request_rack_id = request.rack_id.clone();
     let id = request
         .id
         .as_ref()
@@ -108,7 +108,7 @@ pub(crate) async fn add(
 
     db::expected_machine::create(&mut txn, machine).await?;
 
-    if let Some(rack_id) = request_rack_id {
+    if let Some(ref rack_id) = request_rack_id {
         let adopted = db_rack::adopt_expected_machine(&mut txn, rack_id, parsed_mac)
             .await
             .map_err(CarbideError::from)?;
@@ -174,7 +174,7 @@ pub(crate) async fn update(
         .bmc_mac_address
         .parse::<MacAddress>()
         .map_err(CarbideError::from)?;
-    let request_rack_id = request.rack_id;
+    let request_rack_id = request.rack_id.clone();
     let data: ExpectedMachineData = request.try_into()?;
 
     let machine = ExpectedMachine {
@@ -189,7 +189,7 @@ pub(crate) async fn update(
         .await
         .map_err(CarbideError::from)?;
 
-    if let Some(rack_id) = request_rack_id {
+    if let Some(ref rack_id) = request_rack_id {
         let adopted = db_rack::adopt_expected_machine(&mut txn, rack_id, parsed_mac)
             .await
             .map_err(CarbideError::from)?;
@@ -319,7 +319,7 @@ fn sanitize_expected_machine_and_get_ids(
 /// process_rack_association registers an expected machine MAC with a rack, creating the rack if needed.
 async fn process_rack_association(
     txn: &mut sqlx::PgConnection,
-    rack_id: RackId,
+    rack_id: &RackId,
     parsed_mac: MacAddress,
 ) -> Result<(), CarbideError> {
     let adopted = db_rack::adopt_expected_machine(txn, rack_id, parsed_mac)
@@ -342,7 +342,7 @@ async fn create_expected_machine(
     id: Uuid,
     parsed_mac: MacAddress,
 ) -> Result<(), CarbideError> {
-    let request_rack_id = machine.rack_id;
+    let request_rack_id = machine.rack_id.clone();
     let db_data: ExpectedMachineData = machine.try_into()?;
 
     let expected_machine = ExpectedMachine {
@@ -354,7 +354,7 @@ async fn create_expected_machine(
     db::expected_machine::create(txn, expected_machine).await?;
 
     // Handle rack association
-    if let Some(rack_id) = request_rack_id {
+    if let Some(ref rack_id) = request_rack_id {
         process_rack_association(txn, rack_id, parsed_mac).await?;
     }
 
@@ -368,7 +368,7 @@ async fn update_expected_machine(
     id: Uuid,
     parsed_mac: MacAddress,
 ) -> Result<(), CarbideError> {
-    let request_rack_id = machine.rack_id;
+    let request_rack_id = machine.rack_id.clone();
     let data: ExpectedMachineData = machine.try_into()?;
 
     let expected_machine = ExpectedMachine {
@@ -380,7 +380,7 @@ async fn update_expected_machine(
     db::expected_machine::update(txn, &expected_machine).await?;
 
     // Handle rack association
-    if let Some(rack_id) = request_rack_id {
+    if let Some(ref rack_id) = request_rack_id {
         process_rack_association(txn, rack_id, parsed_mac).await?;
     }
 

--- a/crates/api/src/handlers/expected_power_shelf.rs
+++ b/crates/api/src/handlers/expected_power_shelf.rs
@@ -29,7 +29,7 @@ pub async fn add_expected_power_shelf(
     request: Request<rpc::ExpectedPowerShelf>,
 ) -> Result<Response<()>, Status> {
     let rpc_power_shelf = request.into_inner();
-    let request_rack_id = rpc_power_shelf.rack_id;
+    let request_rack_id = rpc_power_shelf.rack_id.clone();
     let power_shelf: ExpectedPowerShelf =
         rpc_power_shelf
             .try_into()
@@ -50,7 +50,7 @@ pub async fn add_expected_power_shelf(
         .await
         .map_err(CarbideError::from)?;
 
-    if let Some(rack_id) = request_rack_id {
+    if let Some(ref rack_id) = request_rack_id {
         let adopted = db::rack::adopt_expected_power_shelf(&mut txn, rack_id, bmc_mac_address)
             .await
             .map_err(CarbideError::from)?;

--- a/crates/api/src/handlers/expected_rack.rs
+++ b/crates/api/src/handlers/expected_rack.rs
@@ -52,26 +52,25 @@ pub async fn add_expected_rack(
         .into());
     }
 
-    let rack_id = rack.rack_id;
-    let rack_type = rack.rack_type.clone();
-
     let mut txn = api.txn_begin().await?;
 
     // Check if the expected rack already exists.
-    if db_expected_rack::find_by_rack_id(&mut txn, rack_id)
+    if db_expected_rack::find_by_rack_id(&mut txn, &rack.rack_id)
         .await
         .map_err(CarbideError::from)?
         .is_some()
     {
         return Err(CarbideError::AlreadyFoundError {
             kind: "expected_rack",
-            id: rack_id.to_string(),
+            id: rack.rack_id.to_string(),
         }
         .into());
     }
 
     // Create the expected rack record.
-    db_expected_rack::create(&mut txn, rack)
+    let rack_id = &rack.rack_id;
+    let rack_type = rack.rack_type.clone();
+    db_expected_rack::create(&mut txn, &rack)
         .await
         .map_err(CarbideError::from)?;
 
@@ -99,7 +98,7 @@ pub async fn delete_expected_rack(
     let rack_id = RackId::from_str(&req.rack_id)
         .map_err(|e| CarbideError::InvalidArgument(format!("Invalid rack ID: {}", e)))?;
     let mut txn = api.txn_begin().await?;
-    db_expected_rack::delete(&mut txn, rack_id)
+    db_expected_rack::delete(&mut txn, &rack_id)
         .await
         .map_err(CarbideError::from)?;
     txn.commit().await?;
@@ -130,27 +129,25 @@ pub async fn update_expected_rack(
         .into());
     }
 
-    let rack_id = rack.rack_id;
-    let rack_type = rack.rack_type.clone();
-
     let mut txn = api.txn_begin().await?;
-    db_expected_rack::find_by_rack_id(&mut txn, rack_id)
+    db_expected_rack::find_by_rack_id(&mut txn, &rack.rack_id)
         .await
         .map_err(CarbideError::from)?
         .ok_or_else(|| CarbideError::NotFoundError {
             kind: "expected_rack",
-            id: rack_id.to_string(),
+            id: rack.rack_id.to_string(),
         })?;
 
+    let rack_type = rack.rack_type.clone();
     db_expected_rack::update(&mut txn, &rack)
         .await
         .map_err(CarbideError::from)?;
 
     // Update the rack_type name in the rack config.
-    if let Ok(db_rack) = db_rack::get(&mut txn, rack_id).await {
+    if let Ok(db_rack) = db_rack::get(&mut txn, &rack.rack_id).await {
         let mut config = db_rack.config.clone();
         config.rack_type = Some(rack_type);
-        db_rack::update(&mut txn, rack_id, &config)
+        db_rack::update(&mut txn, &rack.rack_id, &config)
             .await
             .map_err(CarbideError::from)?;
     }
@@ -168,7 +165,7 @@ pub async fn get_expected_rack(
     let rack_id = RackId::from_str(&req.rack_id)
         .map_err(|e| CarbideError::InvalidArgument(format!("Invalid rack ID: {}", e)))?;
     let mut txn = api.txn_begin().await?;
-    let expected_rack = db_expected_rack::find_by_rack_id(&mut txn, rack_id)
+    let expected_rack = db_expected_rack::find_by_rack_id(&mut txn, &rack_id)
         .await
         .map_err(CarbideError::from)?
         .ok_or_else(|| CarbideError::NotFoundError {
@@ -219,7 +216,7 @@ pub async fn replace_all_expected_racks(
             .into());
         }
 
-        db_expected_rack::create(&mut txn, rack)
+        db_expected_rack::create(&mut txn, &rack)
             .await
             .map_err(CarbideError::from)?;
     }

--- a/crates/api/src/handlers/expected_switch.rs
+++ b/crates/api/src/handlers/expected_switch.rs
@@ -36,7 +36,7 @@ pub async fn add_expected_switch(
                 CarbideError::InvalidArgument(e.to_string())
             })?;
 
-    let rack_id = switch.rack_id;
+    let rack_id = switch.rack_id.clone();
     let bmc_mac_address = switch.bmc_mac_address;
 
     let mut txn = api
@@ -51,7 +51,7 @@ pub async fn add_expected_switch(
         .await
         .map_err(CarbideError::from)?;
 
-    if let Some(rack_id) = rack_id {
+    if let Some(ref rack_id) = rack_id {
         let adopted = db_rack::adopt_expected_switch(&mut txn, rack_id, bmc_mac_address)
             .await
             .map_err(CarbideError::from)?;

--- a/crates/api/src/handlers/rack.rs
+++ b/crates/api/src/handlers/rack.rs
@@ -35,7 +35,7 @@ pub async fn get_rack(
     let rack = if let Some(id) = req.id {
         let rack_id = RackId::from_str(&id)
             .map_err(|e| CarbideError::InvalidArgument(format!("Invalid rack ID: {}", e)))?;
-        let r = db_rack::get(&api.database_connection, rack_id)
+        let r = db_rack::get(&api.database_connection, &rack_id)
             .await
             .map_err(CarbideError::from)?;
         vec![r.into()]
@@ -100,7 +100,7 @@ pub async fn delete_rack(
             let rack_id = RackId::from_str(&req.id)
                 .map_err(|e| CarbideError::InvalidArgument(format!("Invalid rack ID: {}", e)))?;
             let rack =
-                db_rack::get(txn.as_mut(), rack_id)
+                db_rack::get(txn.as_mut(), &rack_id)
                     .await
                     .map_err(|e| CarbideError::Internal {
                         message: format!("Getting rack {}", e),
@@ -127,7 +127,7 @@ pub async fn list_rack_health_report_overrides(
         .rack_id
         .ok_or_else(|| CarbideError::MissingArgument("rack_id"))?;
 
-    let rack = db_rack::get(&api.database_connection, rack_id)
+    let rack = db_rack::get(&api.database_connection, &rack_id)
         .await
         .map_err(CarbideError::from)?;
 
@@ -172,7 +172,7 @@ pub async fn insert_rack_health_report_override(
 
     let mut txn = api.txn_begin().await?;
 
-    let rack = db_rack::get(&mut txn, rack_id)
+    let rack = db_rack::get(&mut txn, &rack_id)
         .await
         .map_err(CarbideError::from)?;
 
@@ -205,7 +205,7 @@ pub async fn remove_rack_health_report_override(
 
     let mut txn = api.txn_begin().await?;
 
-    let rack = db_rack::get(&mut txn, rack_id)
+    let rack = db_rack::get(&mut txn, &rack_id)
         .await
         .map_err(CarbideError::from)?;
 

--- a/crates/api/src/handlers/rack_firmware.rs
+++ b/crates/api/src/handlers/rack_firmware.rs
@@ -982,7 +982,7 @@ pub async fn apply(
             serde_json::json!({})
         });
 
-    let rack = db::rack::get(&api.database_connection, rack_id)
+    let rack = db::rack::get(&api.database_connection, &rack_id)
         .await
         .map_err(|e| CarbideError::Internal {
             message: format!("Failed to get rack: {}", e),

--- a/crates/api/src/site_explorer/mod.rs
+++ b/crates/api/src/site_explorer/mod.rs
@@ -747,7 +747,7 @@ impl SiteExplorer {
             }
         }
 
-        if let Some(rack_id) = expected_shelf.rack_id {
+        if let Some(ref rack_id) = expected_shelf.rack_id {
             let rack = match db::rack::get(txn.as_mut(), rack_id).await {
                 Ok(rack) => rack,
                 Err(_) => db::rack::create(
@@ -779,7 +779,7 @@ impl SiteExplorer {
 
         // Register the power shelf with Rack Manager if RMS client is available
         if let Some(rms_client) = &self.rms_client {
-            if let Some(rack_id) = expected_shelf.rack_id {
+            if let Some(ref rack_id) = expected_shelf.rack_id {
                 let new_node_info = NewNodeInfo {
                     rack_id: rack_id.to_string(),
                     node_id: power_shelf_id.to_string(),
@@ -934,7 +934,7 @@ impl SiteExplorer {
 
         // Register the switch with Rack Manager if RMS client is available
         if let Some(rms_client) = &self.rms_client {
-            if let Some(rack_id) = expected_switch.rack_id {
+            if let Some(ref rack_id) = expected_switch.rack_id {
                 let bmc_mac_address = expected_switch.bmc_mac_address;
                 let new_node_info = NewNodeInfo {
                     rack_id: rack_id.to_string(),

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -731,7 +731,9 @@ impl MachineStateHandler {
                 // site-explorer machine creation, which then allows us to skip over the
                 // ExpectedMachine lookup. Conceptually, EM == Inventory/Manifest, and the
                 // MH == what we're actually managing.
-                let rack_id = expected_machine.as_ref().and_then(|em| em.data.rack_id);
+                let rack_id = expected_machine
+                    .as_ref()
+                    .and_then(|em| em.data.rack_id.clone());
                 if rack_id.is_none() {
                     tracing::debug!(
                         machine_id = %host_machine_id,
@@ -832,7 +834,9 @@ impl MachineStateHandler {
                 // site-explorer machine creation, which then allows us to skip over the
                 // ExpectedMachine lookup. Conceptually, EM == Inventory/Manifest, and the
                 // MH == what we're actually managing.
-                let rack_id = expected_machine.as_ref().and_then(|em| em.data.rack_id);
+                let rack_id = expected_machine
+                    .as_ref()
+                    .and_then(|em| em.data.rack_id.clone());
                 let Some(rack_id) = rack_id else {
                     tracing::debug!(
                         machine_id = %host_machine_id,

--- a/crates/api/src/state_controller/rack/handler.rs
+++ b/crates/api/src/state_controller/rack/handler.rs
@@ -45,7 +45,7 @@ pub struct RackStateHandler {}
 /// if any devices were adopted (config was changed).
 pub(crate) async fn adopt_dangling_devices(
     pool: &PgPool,
-    id: RackId,
+    id: &RackId,
     config: &mut RackConfig,
 ) -> Result<bool, StateHandlerError> {
     let mut txn = pool.begin().await?;
@@ -178,7 +178,7 @@ pub(crate) fn log_capability_hints(id: &RackId, capabilities: &RackCapabilitiesS
 /// explored and linked to actual machines. Returns (done, optional_txn).
 pub(crate) async fn check_compute_linked(
     pool: &PgPool,
-    id: RackId,
+    id: &RackId,
     config: &mut RackConfig,
 ) -> Result<(bool, Option<PgTransaction<'static>>), StateHandlerError> {
     match config
@@ -226,7 +226,7 @@ pub(crate) async fn check_compute_linked(
 /// been explored and linked.
 pub(crate) async fn check_power_shelves_linked(
     pool: &PgPool,
-    id: RackId,
+    id: &RackId,
     config: &mut RackConfig,
 ) -> Result<bool, StateHandlerError> {
     match config
@@ -332,7 +332,7 @@ impl StateHandler for RackStateHandler {
 
                 // Adopt dangling expected devices that have this rack_id but
                 // haven't been added to the rack config yet.
-                if adopt_dangling_devices(&ctx.services.db_pool, *id, &mut config).await? {
+                if adopt_dangling_devices(&ctx.services.db_pool, id, &mut config).await? {
                     return Ok(StateHandlerOutcome::do_nothing());
                 }
 
@@ -345,9 +345,9 @@ impl StateHandler for RackStateHandler {
 
                 // Check if all expected devices have been explored and linked.
                 let (compute_done, pending_txn) =
-                    check_compute_linked(&ctx.services.db_pool, *id, &mut config).await?;
+                    check_compute_linked(&ctx.services.db_pool, id, &mut config).await?;
                 let ps_done =
-                    check_power_shelves_linked(&ctx.services.db_pool, *id, &mut config).await?;
+                    check_power_shelves_linked(&ctx.services.db_pool, id, &mut config).await?;
                 let switch_done = check_switches_linked(&ctx.services.db_pool, &config).await?;
 
                 if compute_done && ps_done && switch_done {

--- a/crates/api/src/state_controller/rack/io.rs
+++ b/crates/api/src/state_controller/rack/io.rs
@@ -94,11 +94,11 @@ impl StateControllerIO for RackStateControllerIO {
         new_state: &Self::ControllerState,
     ) -> Result<(), DatabaseError> {
         let _updated =
-            db_rack::try_update_controller_state(txn, *rack_id, old_version, new_state).await?;
+            db_rack::try_update_controller_state(txn, rack_id, old_version, new_state).await?;
 
         // Persist state history for debugging purposes
         let _history =
-            db::rack_state_history::persist(txn, *rack_id, new_state, old_version).await?;
+            db::rack_state_history::persist(txn, rack_id, new_state, old_version).await?;
 
         Ok(())
     }
@@ -109,7 +109,7 @@ impl StateControllerIO for RackStateControllerIO {
         rack_id: &Self::ObjectId,
         outcome: PersistentStateHandlerOutcome,
     ) -> Result<(), DatabaseError> {
-        db_rack::update_controller_state_outcome(txn, *rack_id, outcome).await
+        db_rack::update_controller_state_outcome(txn, rack_id, outcome).await
     }
 
     fn metric_state_names(state: &RackState) -> (&'static str, &'static str) {

--- a/crates/api/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/site_explorer.rs
@@ -1522,7 +1522,7 @@ impl Default for TestRackDbBuilder {
             expected_compute_trays: vec![],
             expected_power_shelves: vec![],
             expected_switches: vec![],
-            rack_id: RackId::from(uuid::Uuid::new_v4()),
+            rack_id: RackId::new(uuid::Uuid::new_v4().to_string()),
             rack_type: None,
         }
     }
@@ -1569,7 +1569,7 @@ impl TestRackDbBuilder {
     pub async fn persist(&self, txn: &mut PgConnection) -> Result<RackId, DatabaseError> {
         db_rack::create(
             txn,
-            self.rack_id,
+            &self.rack_id,
             self.expected_compute_trays.clone(),
             self.expected_switches.clone(),
             self.expected_power_shelves.clone(),
@@ -1586,9 +1586,9 @@ impl TestRackDbBuilder {
             rack_type: self.rack_type.clone(),
         };
 
-        db_rack::update(txn, self.rack_id, &cfg).await?;
+        db_rack::update(txn, &self.rack_id, &cfg).await?;
 
-        Ok(self.rack_id)
+        Ok(self.rack_id.clone())
     }
 }
 

--- a/crates/api/src/tests/expected_power_shelf.rs
+++ b/crates/api/src/tests/expected_power_shelf.rs
@@ -188,7 +188,7 @@ async fn test_add_expected_power_shelf(pool: sqlx::PgPool) {
                     },
                 ],
             }),
-            rack_id: Some(RackId::from(uuid::Uuid::new_v4())),
+            rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
         },
     ] {
         env.api
@@ -337,7 +337,7 @@ async fn test_update_expected_power_shelf(pool: sqlx::PgPool) {
                     },
                 ],
             }),
-            rack_id: Some(RackId::from(uuid::Uuid::new_v4())),
+            rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
         },
     ] {
         env.api
@@ -465,7 +465,7 @@ async fn test_replace_all_expected_power_shelves(pool: sqlx::PgPool) {
         shelf_serial_number: "PS-NEW-001".into(),
         ip_address: "192.168.100.1".into(),
         metadata: Some(rpc::Metadata::default()),
-        rack_id: Some(RackId::from(uuid::Uuid::new_v4())),
+        rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
     };
 
     let expected_power_shelf_2 = rpc::forge::ExpectedPowerShelf {
@@ -476,7 +476,7 @@ async fn test_replace_all_expected_power_shelves(pool: sqlx::PgPool) {
         shelf_serial_number: "PS-NEW-002".into(),
         ip_address: "192.168.100.2".into(),
         metadata: Some(rpc::Metadata::default()),
-        rack_id: Some(RackId::from(uuid::Uuid::new_v4())),
+        rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
     };
 
     expected_power_shelf_list
@@ -570,7 +570,7 @@ async fn test_add_expected_power_shelf_with_ip(pool: sqlx::PgPool) {
         shelf_serial_number: "PS-IP-001".into(),
         ip_address: "10.0.0.100".into(),
         metadata: Some(rpc::Metadata::default()),
-        rack_id: Some(RackId::from(uuid::Uuid::new_v4())),
+        rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
     };
 
     env.api

--- a/crates/api/src/tests/expected_rack.rs
+++ b/crates/api/src/tests/expected_rack.rs
@@ -85,7 +85,7 @@ fn config_with_rack_types() -> crate::cfg::file::CarbideConfig {
 }
 
 fn new_rack_id() -> RackId {
-    RackId::from(uuid::Uuid::new_v4())
+    RackId::new(uuid::Uuid::new_v4().to_string())
 }
 
 /// Helper to seed expected racks directly via DB for tests that don't need the API.
@@ -94,8 +94,8 @@ async fn seed_expected_racks(txn: &mut sqlx::PgConnection) -> Vec<RackId> {
 
     db::expected_rack::create(
         txn,
-        model::expected_rack::ExpectedRack {
-            rack_id: ids[0],
+        &model::expected_rack::ExpectedRack {
+            rack_id: ids[0].clone(),
             rack_type: "NVL72".to_string(),
             metadata: model::metadata::Metadata {
                 name: "rack-1".to_string(),
@@ -109,8 +109,8 @@ async fn seed_expected_racks(txn: &mut sqlx::PgConnection) -> Vec<RackId> {
 
     db::expected_rack::create(
         txn,
-        model::expected_rack::ExpectedRack {
-            rack_id: ids[1],
+        &model::expected_rack::ExpectedRack {
+            rack_id: ids[1].clone(),
             rack_type: "NVL72".to_string(),
             metadata: model::metadata::Metadata {
                 name: "rack-2".to_string(),
@@ -124,8 +124,8 @@ async fn seed_expected_racks(txn: &mut sqlx::PgConnection) -> Vec<RackId> {
 
     db::expected_rack::create(
         txn,
-        model::expected_rack::ExpectedRack {
-            rack_id: ids[2],
+        &model::expected_rack::ExpectedRack {
+            rack_id: ids[2].clone(),
             rack_type: "NVL36".to_string(),
             metadata: model::metadata::Metadata {
                 name: "rack-3".to_string(),
@@ -149,7 +149,7 @@ async fn test_db_find_by_rack_id(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
     let mut txn = pool.begin().await?;
     let ids = seed_expected_racks(&mut txn).await;
 
-    let expected_rack = db::expected_rack::find_by_rack_id(&mut txn, ids[0])
+    let expected_rack = db::expected_rack::find_by_rack_id(&mut txn, &ids[0])
         .await?
         .expect("Expected rack not found");
 
@@ -175,7 +175,7 @@ async fn test_db_find_all(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::
 async fn test_db_find_nonexistent(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
     let mut txn = pool.begin().await?;
     let rack_id = new_rack_id();
-    let result = db::expected_rack::find_by_rack_id(&mut txn, rack_id).await?;
+    let result = db::expected_rack::find_by_rack_id(&mut txn, &rack_id).await?;
     assert!(result.is_none());
     Ok(())
 }
@@ -195,8 +195,8 @@ async fn test_db_create_and_find(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
 
     let created = db::expected_rack::create(
         &mut txn,
-        model::expected_rack::ExpectedRack {
-            rack_id,
+        &model::expected_rack::ExpectedRack {
+            rack_id: rack_id.clone(),
             rack_type: "NVL72".to_string(),
             metadata,
         },
@@ -208,7 +208,7 @@ async fn test_db_create_and_find(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
     assert_eq!(created.metadata.name, "test-rack");
     assert_eq!(created.metadata.labels.get("env").unwrap(), "test");
 
-    let found = db::expected_rack::find_by_rack_id(&mut txn, rack_id)
+    let found = db::expected_rack::find_by_rack_id(&mut txn, &rack_id)
         .await?
         .expect("Should find the rack we just created");
 
@@ -225,8 +225,8 @@ async fn test_db_duplicate_create(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
 
     let result = db::expected_rack::create(
         &mut txn,
-        model::expected_rack::ExpectedRack {
-            rack_id: ids[0],
+        &model::expected_rack::ExpectedRack {
+            rack_id: ids[0].clone(),
             rack_type: "NVL72".to_string(),
             metadata: model::metadata::Metadata::default(),
         },
@@ -246,14 +246,14 @@ async fn test_db_update(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Er
     let mut txn = pool.begin().await?;
     let ids = seed_expected_racks(&mut txn).await;
 
-    let expected_rack = db::expected_rack::find_by_rack_id(&mut txn, ids[0])
+    let expected_rack = db::expected_rack::find_by_rack_id(&mut txn, &ids[0])
         .await?
         .expect("Expected rack not found");
 
     assert_eq!(expected_rack.rack_type, "NVL72");
 
     let updated = model::expected_rack::ExpectedRack {
-        rack_id: ids[0],
+        rack_id: ids[0].clone(),
         rack_type: "NVL36".to_string(),
         metadata: model::metadata::Metadata {
             name: "updated-rack".to_string(),
@@ -267,7 +267,7 @@ async fn test_db_update(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Er
     txn.commit().await?;
 
     let mut txn = pool.begin().await?;
-    let found = db::expected_rack::find_by_rack_id(&mut txn, ids[0])
+    let found = db::expected_rack::find_by_rack_id(&mut txn, &ids[0])
         .await?
         .unwrap();
     assert_eq!(found.rack_type, "NVL36");
@@ -281,11 +281,11 @@ async fn test_db_delete(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Er
     let mut txn = pool.begin().await?;
     let ids = seed_expected_racks(&mut txn).await;
 
-    db::expected_rack::delete(&mut txn, ids[0]).await?;
+    db::expected_rack::delete(&mut txn, &ids[0]).await?;
     txn.commit().await?;
 
     let mut txn = pool.begin().await?;
-    let result = db::expected_rack::find_by_rack_id(&mut txn, ids[0]).await?;
+    let result = db::expected_rack::find_by_rack_id(&mut txn, &ids[0]).await?;
     assert!(result.is_none());
 
     Ok(())
@@ -296,7 +296,7 @@ async fn test_db_delete_nonexistent(pool: sqlx::PgPool) -> Result<(), Box<dyn st
     let mut txn = pool.begin().await?;
     let rack_id = new_rack_id();
 
-    let result = db::expected_rack::delete(&mut txn, rack_id).await;
+    let result = db::expected_rack::delete(&mut txn, &rack_id).await;
     assert!(result.is_err(), "Deleting nonexistent rack should fail");
 
     Ok(())
@@ -326,7 +326,7 @@ async fn test_add_expected_rack(pool: sqlx::PgPool) {
 
     let rack_id = new_rack_id();
     let expected_rack = rpc::forge::ExpectedRack {
-        rack_id: Some(rack_id),
+        rack_id: Some(rack_id.clone()),
         rack_type: "NVL72".to_string(),
         metadata: Some(rpc::forge::Metadata {
             name: "test-rack".to_string(),
@@ -364,7 +364,7 @@ async fn test_add_expected_rack_invalid_type(pool: sqlx::PgPool) {
 
     let rack_id = new_rack_id();
     let expected_rack = rpc::forge::ExpectedRack {
-        rack_id: Some(rack_id),
+        rack_id: Some(rack_id.clone()),
         rack_type: "INVALID_TYPE".to_string(),
         metadata: None,
     };
@@ -389,7 +389,7 @@ async fn test_add_expected_rack_empty_type(pool: sqlx::PgPool) {
 
     let rack_id = new_rack_id();
     let expected_rack = rpc::forge::ExpectedRack {
-        rack_id: Some(rack_id),
+        rack_id: Some(rack_id.clone()),
         rack_type: "".to_string(),
         metadata: None,
     };
@@ -458,7 +458,7 @@ async fn test_delete_expected_rack(pool: sqlx::PgPool) {
 
     let rack_id = new_rack_id();
     let expected_rack = rpc::forge::ExpectedRack {
-        rack_id: Some(rack_id),
+        rack_id: Some(rack_id.clone()),
         rack_type: "NVL72".to_string(),
         metadata: None,
     };
@@ -516,7 +516,7 @@ async fn test_update_expected_rack(pool: sqlx::PgPool) {
     // Add a rack first.
     env.api
         .add_expected_rack(tonic::Request::new(rpc::forge::ExpectedRack {
-            rack_id: Some(rack_id),
+            rack_id: Some(rack_id.clone()),
             rack_type: "NVL72".to_string(),
             metadata: Some(rpc::forge::Metadata {
                 name: "original".to_string(),
@@ -529,7 +529,7 @@ async fn test_update_expected_rack(pool: sqlx::PgPool) {
     // Update it.
     env.api
         .update_expected_rack(tonic::Request::new(rpc::forge::ExpectedRack {
-            rack_id: Some(rack_id),
+            rack_id: Some(rack_id.clone()),
             rack_type: "NVL36".to_string(),
             metadata: Some(rpc::forge::Metadata {
                 name: "updated".to_string(),
@@ -566,7 +566,7 @@ async fn test_update_expected_rack_not_found(pool: sqlx::PgPool) {
     let err = env
         .api
         .update_expected_rack(tonic::Request::new(rpc::forge::ExpectedRack {
-            rack_id: Some(rack_id),
+            rack_id: Some(rack_id.clone()),
             rack_type: "NVL72".to_string(),
             metadata: None,
         }))
@@ -626,7 +626,7 @@ async fn test_add_expected_rack_duplicate(pool: sqlx::PgPool) {
 
     let rack_id = new_rack_id();
     let expected_rack = rpc::forge::ExpectedRack {
-        rack_id: Some(rack_id),
+        rack_id: Some(rack_id.clone()),
         rack_type: "NVL72".to_string(),
         metadata: None,
     };
@@ -660,7 +660,7 @@ async fn test_replace_all_expected_racks(pool: sqlx::PgPool) {
     let initial_rack_id = new_rack_id();
     env.api
         .add_expected_rack(tonic::Request::new(rpc::forge::ExpectedRack {
-            rack_id: Some(initial_rack_id),
+            rack_id: Some(initial_rack_id.clone()),
             rack_type: "NVL72".to_string(),
             metadata: None,
         }))
@@ -765,7 +765,7 @@ async fn test_add_expected_rack_creates_rack_entry(pool: sqlx::PgPool) {
     let rack_id = new_rack_id();
     env.api
         .add_expected_rack(tonic::Request::new(rpc::forge::ExpectedRack {
-            rack_id: Some(rack_id),
+            rack_id: Some(rack_id.clone()),
             rack_type: "NVL72".to_string(),
             metadata: None,
         }))
@@ -773,6 +773,6 @@ async fn test_add_expected_rack_creates_rack_entry(pool: sqlx::PgPool) {
         .expect("unable to add expected rack");
 
     // Verify the rack was also created in the racks table with the rack_type set.
-    let rack = db::rack::get(&pool, rack_id).await.unwrap();
+    let rack = db::rack::get(&pool, &rack_id).await.unwrap();
     assert_eq!(rack.config.rack_type.as_deref(), Some("NVL72"));
 }

--- a/crates/api/src/tests/expected_switch.rs
+++ b/crates/api/src/tests/expected_switch.rs
@@ -191,7 +191,7 @@ async fn test_add_expected_switch(pool: sqlx::PgPool) {
                     },
                 ],
             }),
-            rack_id: Some(RackId::from(uuid::Uuid::new_v4())),
+            rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
         },
     ] {
         env.api
@@ -317,7 +317,7 @@ async fn test_update_expected_switch(pool: sqlx::PgPool) {
                     },
                 ],
             }),
-            rack_id: Some(RackId::from(uuid::Uuid::new_v4())),
+            rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
         },
     ] {
         env.api
@@ -771,7 +771,7 @@ async fn test_replace_all_expected_switches(pool: sqlx::PgPool) {
         nvos_username: Some("nvos_new".into()),
         nvos_password: Some("nvos_new_pass".into()),
         metadata: Some(rpc::Metadata::default()),
-        rack_id: Some(RackId::from(uuid::Uuid::new_v4())),
+        rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
     };
 
     let expected_switch_2 = rpc::forge::ExpectedSwitch {
@@ -783,7 +783,7 @@ async fn test_replace_all_expected_switches(pool: sqlx::PgPool) {
         nvos_username: None,
         nvos_password: None,
         metadata: Some(rpc::Metadata::default()),
-        rack_id: Some(RackId::from(uuid::Uuid::new_v4())),
+        rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
     };
 
     expected_switch_list

--- a/crates/api/src/tests/machine_creator.rs
+++ b/crates/api/src/tests/machine_creator.rs
@@ -1495,7 +1495,7 @@ async fn test_rms_registration_with_rack_id(
     };
 
     // Create an expected machine WITH a rack_id in the DB.
-    let rack_id = RackId::from(uuid::Uuid::new_v4());
+    let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
     let mut txn = env.pool.begin().await.unwrap();
     db::expected_machine::create(
         &mut txn,
@@ -1668,7 +1668,7 @@ async fn test_rms_registration_retries_on_failure(
         }],
     };
 
-    let rack_id = RackId::from(uuid::Uuid::new_v4());
+    let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
     let mut txn = env.pool.begin().await.unwrap();
     db::expected_machine::create(
         &mut txn,
@@ -1858,7 +1858,7 @@ async fn test_rms_verification_failure_paths(
         }],
     };
 
-    let rack_id = RackId::from(uuid::Uuid::new_v4());
+    let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
     let mut txn = env.pool.begin().await.unwrap();
     db::expected_machine::create(
         &mut txn,

--- a/crates/api/src/tests/rack_health.rs
+++ b/crates/api/src/tests/rack_health.rs
@@ -77,7 +77,7 @@ async fn test_insert_list_remove_rack_override(
     env.api
         .insert_rack_health_report_override(Request::new(
             rpc_forge::InsertRackHealthReportOverrideRequest {
-                rack_id: Some(rack_id),
+                rack_id: Some(rack_id.clone()),
                 r#override: Some(rpc_forge::HealthReportOverride {
                     report: Some(report.clone().into()),
                     mode: rpc_forge::OverrideMode::Merge as i32,
@@ -90,7 +90,7 @@ async fn test_insert_list_remove_rack_override(
         .api
         .list_rack_health_report_overrides(Request::new(
             rpc_forge::ListRackHealthReportOverridesRequest {
-                rack_id: Some(rack_id),
+                rack_id: Some(rack_id.clone()),
             },
         ))
         .await?
@@ -108,7 +108,7 @@ async fn test_insert_list_remove_rack_override(
     env.api
         .remove_rack_health_report_override(Request::new(
             rpc_forge::RemoveRackHealthReportOverrideRequest {
-                rack_id: Some(rack_id),
+                rack_id: Some(rack_id.clone()),
                 source: "dsx-exchange-consumer".to_string(),
             },
         ))
@@ -118,7 +118,7 @@ async fn test_insert_list_remove_rack_override(
         .api
         .list_rack_health_report_overrides(Request::new(
             rpc_forge::ListRackHealthReportOverridesRequest {
-                rack_id: Some(rack_id),
+                rack_id: Some(rack_id.clone()),
             },
         ))
         .await?
@@ -144,7 +144,7 @@ async fn test_idempotent_insert(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
         env.api
             .insert_rack_health_report_override(Request::new(
                 rpc_forge::InsertRackHealthReportOverrideRequest {
-                    rack_id: Some(rack_id),
+                    rack_id: Some(rack_id.clone()),
                     r#override: Some(rpc_forge::HealthReportOverride {
                         report: Some(report.clone().into()),
                         mode: rpc_forge::OverrideMode::Merge as i32,
@@ -158,7 +158,7 @@ async fn test_idempotent_insert(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
         .api
         .list_rack_health_report_overrides(Request::new(
             rpc_forge::ListRackHealthReportOverridesRequest {
-                rack_id: Some(rack_id),
+                rack_id: Some(rack_id.clone()),
             },
         ))
         .await?
@@ -184,7 +184,7 @@ async fn test_remove_nonexistent_source(
         .api
         .remove_rack_health_report_override(Request::new(
             rpc_forge::RemoveRackHealthReportOverrideRequest {
-                rack_id: Some(rack_id),
+                rack_id: Some(rack_id.clone()),
                 source: "nonexistent-source".to_string(),
             },
         ))
@@ -203,7 +203,7 @@ async fn test_missing_rack_id(pool: sqlx::PgPool) -> Result<(), Box<dyn std::err
         create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
             .await;
 
-    let nonexistent_rack_id = RackId::from(uuid::Uuid::new_v4());
+    let nonexistent_rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
     let report = leak_alert_report("dsx-exchange-consumer");
 
     let result = env
@@ -235,10 +235,10 @@ async fn test_propagation_to_host_aggregate_health(
     let mh = create_managed_host(&env).await;
     let host_machine_id = mh.id;
 
-    let rack_id = RackId::from(uuid::Uuid::new_v4());
+    let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
     let mut txn = pool.acquire().await?;
     TestRackDbBuilder::new()
-        .with_rack_id(rack_id)
+        .with_rack_id(rack_id.clone())
         .persist(&mut txn)
         .await?;
 
@@ -250,14 +250,14 @@ async fn test_propagation_to_host_aggregate_health(
         expected_power_shelves: vec![],
         rack_type: None,
     };
-    db::rack::update(&mut txn, rack_id, &config).await?;
+    db::rack::update(&mut txn, &rack_id, &config).await?;
     drop(txn);
 
     let report = leak_alert_report("dsx-exchange-consumer");
     env.api
         .insert_rack_health_report_override(Request::new(
             rpc_forge::InsertRackHealthReportOverrideRequest {
-                rack_id: Some(rack_id),
+                rack_id: Some(rack_id.clone()),
                 r#override: Some(rpc_forge::HealthReportOverride {
                     report: Some(report.into()),
                     mode: rpc_forge::OverrideMode::Merge as i32,
@@ -303,10 +303,10 @@ async fn test_host_allocatability_blocked_by_rack_override(
     let mh = create_managed_host(&env).await;
     let host_machine_id = mh.id;
 
-    let rack_id = RackId::from(uuid::Uuid::new_v4());
+    let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
     let mut txn = pool.acquire().await?;
     TestRackDbBuilder::new()
-        .with_rack_id(rack_id)
+        .with_rack_id(rack_id.clone())
         .persist(&mut txn)
         .await?;
     let config = RackConfig {
@@ -317,14 +317,14 @@ async fn test_host_allocatability_blocked_by_rack_override(
         expected_power_shelves: vec![],
         rack_type: None,
     };
-    db::rack::update(&mut txn, rack_id, &config).await?;
+    db::rack::update(&mut txn, &rack_id, &config).await?;
     drop(txn);
 
     let report = leak_alert_report("dsx-exchange-consumer");
     env.api
         .insert_rack_health_report_override(Request::new(
             rpc_forge::InsertRackHealthReportOverrideRequest {
-                rack_id: Some(rack_id),
+                rack_id: Some(rack_id.clone()),
                 r#override: Some(rpc_forge::HealthReportOverride {
                     report: Some(report.into()),
                     mode: rpc_forge::OverrideMode::Merge as i32,
@@ -369,10 +369,10 @@ async fn test_host_replace_overrides_rack_alerts(
     )
     .await;
 
-    let rack_id = RackId::from(uuid::Uuid::new_v4());
+    let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
     let mut txn = pool.acquire().await?;
     TestRackDbBuilder::new()
-        .with_rack_id(rack_id)
+        .with_rack_id(rack_id.clone())
         .persist(&mut txn)
         .await?;
     let config = RackConfig {
@@ -383,14 +383,14 @@ async fn test_host_replace_overrides_rack_alerts(
         expected_power_shelves: vec![],
         rack_type: None,
     };
-    db::rack::update(&mut txn, rack_id, &config).await?;
+    db::rack::update(&mut txn, &rack_id, &config).await?;
     drop(txn);
 
     let rack_report = leak_alert_report("dsx-exchange-consumer");
     env.api
         .insert_rack_health_report_override(Request::new(
             rpc_forge::InsertRackHealthReportOverrideRequest {
-                rack_id: Some(rack_id),
+                rack_id: Some(rack_id.clone()),
                 r#override: Some(rpc_forge::HealthReportOverride {
                     report: Some(rack_report.into()),
                     mode: rpc_forge::OverrideMode::Merge as i32,
@@ -445,10 +445,10 @@ async fn test_host_replace_takes_full_precedence_over_rack_replace(
     )
     .await;
 
-    let rack_id = RackId::from(uuid::Uuid::new_v4());
+    let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
     let mut txn = pool.acquire().await?;
     TestRackDbBuilder::new()
-        .with_rack_id(rack_id)
+        .with_rack_id(rack_id.clone())
         .persist(&mut txn)
         .await?;
     let config = RackConfig {
@@ -459,14 +459,14 @@ async fn test_host_replace_takes_full_precedence_over_rack_replace(
         expected_power_shelves: vec![],
         rack_type: None,
     };
-    db::rack::update(&mut txn, rack_id, &config).await?;
+    db::rack::update(&mut txn, &rack_id, &config).await?;
     drop(txn);
 
     let rack_report = leak_alert_report("rack-level-replace");
     env.api
         .insert_rack_health_report_override(Request::new(
             rpc_forge::InsertRackHealthReportOverrideRequest {
-                rack_id: Some(rack_id),
+                rack_id: Some(rack_id.clone()),
                 r#override: Some(rpc_forge::HealthReportOverride {
                     report: Some(rack_report.into()),
                     mode: rpc_forge::OverrideMode::Replace as i32,
@@ -537,7 +537,7 @@ async fn test_dsx_consumer_contract(pool: sqlx::PgPool) -> Result<(), Box<dyn st
     env.api
         .insert_rack_health_report_override(Request::new(
             rpc_forge::InsertRackHealthReportOverrideRequest {
-                rack_id: Some(rack_id),
+                rack_id: Some(rack_id.clone()),
                 r#override: Some(rpc_forge::HealthReportOverride {
                     report: Some(report.into()),
                     mode: rpc_forge::OverrideMode::Merge as i32,
@@ -549,7 +549,7 @@ async fn test_dsx_consumer_contract(pool: sqlx::PgPool) -> Result<(), Box<dyn st
     env.api
         .remove_rack_health_report_override(Request::new(
             rpc_forge::RemoveRackHealthReportOverrideRequest {
-                rack_id: Some(rack_id),
+                rack_id: Some(rack_id.clone()),
                 source: "dsx-exchange-consumer".to_string(),
             },
         ))
@@ -559,7 +559,7 @@ async fn test_dsx_consumer_contract(pool: sqlx::PgPool) -> Result<(), Box<dyn st
         .api
         .list_rack_health_report_overrides(Request::new(
             rpc_forge::ListRackHealthReportOverridesRequest {
-                rack_id: Some(rack_id),
+                rack_id: Some(rack_id.clone()),
             },
         ))
         .await?
@@ -589,7 +589,7 @@ async fn test_rack_health_visible_in_get_rack(
     env.api
         .insert_rack_health_report_override(Request::new(
             rpc_forge::InsertRackHealthReportOverrideRequest {
-                rack_id: Some(rack_id),
+                rack_id: Some(rack_id.clone()),
                 r#override: Some(rpc_forge::HealthReportOverride {
                     report: Some(report.into()),
                     mode: rpc_forge::OverrideMode::Merge as i32,

--- a/crates/api/src/tests/rack_state_controller/fixtures/rack.rs
+++ b/crates/api/src/tests/rack_state_controller/fixtures/rack.rs
@@ -22,7 +22,7 @@ use sqlx::PgConnection;
 /// Helper function to set rack controller state directly in database
 pub async fn set_rack_controller_state(
     txn: &mut PgConnection,
-    rack_id: RackId,
+    rack_id: &RackId,
     state: RackState,
 ) -> Result<(), sqlx::Error> {
     sqlx::query("UPDATE racks SET controller_state = $1 WHERE id = $2")
@@ -37,7 +37,7 @@ pub async fn set_rack_controller_state(
 /// Helper function to mark rack as deleted
 pub async fn mark_rack_as_deleted(
     txn: &mut PgConnection,
-    rack_id: RackId,
+    rack_id: &RackId,
 ) -> Result<(), sqlx::Error> {
     sqlx::query("UPDATE racks SET deleted = NOW() WHERE id = $1")
         .bind(rack_id)

--- a/crates/api/src/tests/rack_state_controller/handler.rs
+++ b/crates/api/src/tests/rack_state_controller/handler.rs
@@ -119,7 +119,7 @@ fn config_with_rack_types() -> crate::cfg::file::CarbideConfig {
 }
 
 fn new_rack_id() -> RackId {
-    RackId::from(uuid::Uuid::new_v4())
+    RackId::new(uuid::Uuid::new_v4().to_string())
 }
 
 fn new_machine_id(seed: u8) -> MachineId {
@@ -155,14 +155,14 @@ async fn test_expected_no_definition_stays_parked(
     // auto-creating the rack before expected_rack arrives).
     db_rack::create(
         &mut txn,
-        rack_id,
+        &rack_id,
         vec![MacAddress::new([0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x50])],
         vec![],
         vec![],
     )
     .await?;
 
-    let mut rack = db_rack::get(&pool, rack_id).await?;
+    let mut rack = db_rack::get(&pool, &rack_id).await?;
     assert!(rack.config.rack_type.is_none());
 
     let handler = RackStateHandler::default();
@@ -210,18 +210,18 @@ async fn test_expected_incomplete_device_counts_stays(
     // but only register 1 compute tray.
     db_rack::create(
         &mut txn,
-        rack_id,
+        &rack_id,
         vec![MacAddress::new([0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x50])],
         vec![],
         vec![],
     )
     .await?;
 
-    let mut rack = db_rack::get(&pool, rack_id).await?;
+    let mut rack = db_rack::get(&pool, &rack_id).await?;
     let mut cfg = rack.config.clone();
     cfg.rack_type = Some("NVL72".to_string());
-    db_rack::update(&mut txn, rack_id, &cfg).await?;
-    rack = db_rack::get(&pool, rack_id).await?;
+    db_rack::update(&mut txn, &rack_id, &cfg).await?;
+    rack = db_rack::get(&pool, &rack_id).await?;
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -273,7 +273,7 @@ async fn test_expected_counts_match_but_not_linked_stays(
     // Create rack with correct device counts matching the definition.
     db_rack::create(
         &mut txn,
-        rack_id,
+        &rack_id,
         vec![mac1, mac2],
         vec![switch_mac],
         vec![ps_mac],
@@ -288,9 +288,9 @@ async fn test_expected_counts_match_but_not_linked_stays(
         expected_power_shelves: vec![ps_mac],
         rack_type: Some("NVL72".to_string()),
     };
-    db_rack::update(&mut txn, rack_id, &cfg).await?;
+    db_rack::update(&mut txn, &rack_id, &cfg).await?;
 
-    let mut rack = db_rack::get(&pool, rack_id).await?;
+    let mut rack = db_rack::get(&pool, &rack_id).await?;
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -340,7 +340,7 @@ async fn test_expected_all_linked_transitions_to_discovering(
     let mut txn = pool.acquire().await?;
 
     // Create rack with a rack_type expecting 2 compute, 0 switches, 0 PS.
-    db_rack::create(&mut txn, rack_id, vec![mac1, mac2], vec![], vec![]).await?;
+    db_rack::create(&mut txn, &rack_id, vec![mac1, mac2], vec![], vec![]).await?;
 
     // Simulate that both compute trays are already linked by setting
     // compute_trays to have 2 entries matching expected_compute_trays.
@@ -355,9 +355,9 @@ async fn test_expected_all_linked_transitions_to_discovering(
         expected_power_shelves: vec![],
         rack_type: Some("Simple".to_string()),
     };
-    db_rack::update(&mut txn, rack_id, &cfg).await?;
+    db_rack::update(&mut txn, &rack_id, &cfg).await?;
 
-    let mut rack = db_rack::get(&pool, rack_id).await?;
+    let mut rack = db_rack::get(&pool, &rack_id).await?;
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -412,7 +412,7 @@ async fn test_expected_more_discovered_than_expected_transitions(
     let mut txn = pool.acquire().await?;
 
     // Rack type "Single" expects 1 compute, 0 switches, 0 PS.
-    db_rack::create(&mut txn, rack_id, vec![mac1], vec![], vec![]).await?;
+    db_rack::create(&mut txn, &rack_id, vec![mac1], vec![], vec![]).await?;
 
     // Simulate more compute_trays discovered than expected_compute_trays.
     let machine_id_1 = new_machine_id(1);
@@ -426,9 +426,9 @@ async fn test_expected_more_discovered_than_expected_transitions(
         expected_power_shelves: vec![],
         rack_type: Some("Single".to_string()),
     };
-    db_rack::update(&mut txn, rack_id, &cfg).await?;
+    db_rack::update(&mut txn, &rack_id, &cfg).await?;
 
-    let mut rack = db_rack::get(&pool, rack_id).await?;
+    let mut rack = db_rack::get(&pool, &rack_id).await?;
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -485,7 +485,7 @@ async fn test_discovering_waits_for_compute_ready(
     // have a managed host record yet.
     let machine_id = new_machine_id(1);
 
-    db_rack::create(&mut txn, rack_id, vec![], vec![], vec![]).await?;
+    db_rack::create(&mut txn, &rack_id, vec![], vec![], vec![]).await?;
 
     let cfg = RackConfig {
         compute_trays: vec![machine_id],
@@ -495,9 +495,9 @@ async fn test_discovering_waits_for_compute_ready(
         expected_power_shelves: vec![],
         rack_type: Some("NVL72".to_string()),
     };
-    db_rack::update(&mut txn, rack_id, &cfg).await?;
+    db_rack::update(&mut txn, &rack_id, &cfg).await?;
 
-    let mut rack = db_rack::get(&pool, rack_id).await?;
+    let mut rack = db_rack::get(&pool, &rack_id).await?;
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -542,7 +542,7 @@ async fn test_discovering_empty_rack_transitions_to_maintenance(
     let mut txn = pool.acquire().await?;
 
     // Create a rack with empty device lists.
-    db_rack::create(&mut txn, rack_id, vec![], vec![], vec![]).await?;
+    db_rack::create(&mut txn, &rack_id, vec![], vec![], vec![]).await?;
 
     let cfg = RackConfig {
         compute_trays: vec![],
@@ -552,9 +552,9 @@ async fn test_discovering_empty_rack_transitions_to_maintenance(
         expected_power_shelves: vec![],
         rack_type: Some("NVL72".to_string()),
     };
-    db_rack::update(&mut txn, rack_id, &cfg).await?;
+    db_rack::update(&mut txn, &rack_id, &cfg).await?;
 
-    let mut rack = db_rack::get(&pool, rack_id).await?;
+    let mut rack = db_rack::get(&pool, &rack_id).await?;
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -596,9 +596,9 @@ async fn test_error_state_does_nothing(
 
     let rack_id = new_rack_id();
     let mut txn = pool.acquire().await?;
-    db_rack::create(&mut txn, rack_id, vec![], vec![], vec![]).await?;
+    db_rack::create(&mut txn, &rack_id, vec![], vec![], vec![]).await?;
 
-    let mut rack = db_rack::get(&pool, rack_id).await?;
+    let mut rack = db_rack::get(&pool, &rack_id).await?;
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -635,9 +635,9 @@ async fn test_maintenance_completed_transitions_to_ready(
 
     let rack_id = new_rack_id();
     let mut txn = pool.acquire().await?;
-    db_rack::create(&mut txn, rack_id, vec![], vec![], vec![]).await?;
+    db_rack::create(&mut txn, &rack_id, vec![], vec![], vec![]).await?;
 
-    let mut rack = db_rack::get(&pool, rack_id).await?;
+    let mut rack = db_rack::get(&pool, &rack_id).await?;
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -688,9 +688,9 @@ async fn test_ready_full_transitions_to_validation(
 
     let rack_id = new_rack_id();
     let mut txn = pool.acquire().await?;
-    db_rack::create(&mut txn, rack_id, vec![], vec![], vec![]).await?;
+    db_rack::create(&mut txn, &rack_id, vec![], vec![], vec![]).await?;
 
-    let mut rack = db_rack::get(&pool, rack_id).await?;
+    let mut rack = db_rack::get(&pool, &rack_id).await?;
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -838,11 +838,11 @@ async fn test_adopt_dangling_devices_no_devices(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let rack_id = new_rack_id();
     let mut txn = pool.acquire().await?;
-    db_rack::create(&mut txn, rack_id, vec![], vec![], vec![]).await?;
+    db_rack::create(&mut txn, &rack_id, vec![], vec![], vec![]).await?;
     drop(txn);
 
     let mut config = RackConfig::default();
-    let changed = handler::adopt_dangling_devices(&pool, rack_id, &mut config).await?;
+    let changed = handler::adopt_dangling_devices(&pool, &rack_id, &mut config).await?;
 
     assert!(!changed, "No dangling devices should mean no changes");
     assert!(config.expected_compute_trays.is_empty());
@@ -882,16 +882,16 @@ async fn test_expected_unknown_rack_type_stays_parked(
 
     let rack_id = new_rack_id();
     let mut txn = pool.acquire().await?;
-    db_rack::create(&mut txn, rack_id, vec![], vec![], vec![]).await?;
+    db_rack::create(&mut txn, &rack_id, vec![], vec![], vec![]).await?;
 
     // Set a rack_type that doesn't exist in the config.
     let cfg = RackConfig {
         rack_type: Some("NonExistentType".to_string()),
         ..Default::default()
     };
-    db_rack::update(&mut txn, rack_id, &cfg).await?;
+    db_rack::update(&mut txn, &rack_id, &cfg).await?;
 
-    let mut rack = db_rack::get(&pool, rack_id).await?;
+    let mut rack = db_rack::get(&pool, &rack_id).await?;
 
     let handler_instance = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -927,7 +927,7 @@ async fn test_expected_config_change_applies_retroactively(
     let mac1 = MacAddress::new([0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x50]);
 
     let mut txn = pool.acquire().await?;
-    db_rack::create(&mut txn, rack_id, vec![mac1], vec![], vec![]).await?;
+    db_rack::create(&mut txn, &rack_id, vec![mac1], vec![], vec![]).await?;
 
     // Register only 1 compute tray with rack_type "NVL72" (needs 2).
     let cfg = RackConfig {
@@ -938,7 +938,7 @@ async fn test_expected_config_change_applies_retroactively(
         expected_power_shelves: vec![],
         rack_type: Some("NVL72".to_string()),
     };
-    db_rack::update(&mut txn, rack_id, &cfg).await?;
+    db_rack::update(&mut txn, &rack_id, &cfg).await?;
     drop(txn);
 
     // validate_device_counts should fail with NVL72 (expects 2 compute).

--- a/crates/api/src/tests/rack_state_controller/mod.rs
+++ b/crates/api/src/tests/rack_state_controller/mod.rs
@@ -132,7 +132,7 @@ async fn test_can_retrieve_rack_state_history(
         .await?;
 
     // Verify rack exists
-    db_rack::get(&mut *txn, rack_id).await?;
+    db_rack::get(&mut *txn, &rack_id).await?;
 
     // Start the state controller to process the rack while it's active
     let rack_handler = Arc::new(TestRackStateHandler::default());
@@ -163,7 +163,7 @@ async fn test_can_retrieve_rack_state_history(
     // get state history
 
     let state_histories_request = rpc::forge::RackStateHistoriesRequest {
-        rack_ids: vec![rack_id],
+        rack_ids: vec![rack_id.clone()],
     };
 
     let result = env
@@ -197,15 +197,15 @@ async fn test_rack_state_transitions(pool: sqlx::PgPool) -> Result<(), Box<dyn s
     let env = create_test_env(pool.clone()).await;
 
     // Create a rack
-    let rack_id = RackId::from(uuid::Uuid::new_v4());
+    let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
     let mut txn = pool.acquire().await?;
     TestRackDbBuilder::new()
-        .with_rack_id(rack_id)
+        .with_rack_id(rack_id.clone())
         .persist(&mut txn)
         .await?;
 
     // Verify rack exists
-    let rack = db_rack::get(&mut *txn, rack_id).await?;
+    let rack = db_rack::get(&mut *txn, &rack_id).await?;
 
     // Verify initial state is Expected
     assert!(matches!(rack.controller_state.value, RackState::Expected));
@@ -257,15 +257,15 @@ async fn test_rack_deletion_flow(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
     let env = create_test_env(pool.clone()).await;
 
     // Create a rack
-    let rack_id = RackId::from(uuid::Uuid::new_v4());
+    let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
     let mut txn = pool.acquire().await?;
     TestRackDbBuilder::new()
-        .with_rack_id(rack_id)
+        .with_rack_id(rack_id.clone())
         .persist(&mut txn)
         .await?;
 
     // Verify rack exists
-    let rack = db_rack::get(&mut *txn, rack_id).await?;
+    let rack = db_rack::get(&mut *txn, &rack_id).await?;
     assert_eq!(rack.id, rack_id);
 
     // Start the state controller to process the rack while it's active
@@ -298,7 +298,7 @@ async fn test_rack_deletion_flow(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
     );
 
     // Mark the rack as deleted
-    mark_rack_as_deleted(pool.acquire().await?.as_mut(), rack_id).await?;
+    mark_rack_as_deleted(pool.acquire().await?.as_mut(), &rack_id).await?;
 
     controller.run_single_iteration().await;
     controller.run_single_iteration().await;
@@ -331,10 +331,10 @@ async fn test_rack_error_state_handling(
     let env = create_test_env(pool.clone()).await;
 
     // Create a rack
-    let rack_id = RackId::from(uuid::Uuid::new_v4());
+    let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
     let mut txn = pool.acquire().await?;
     TestRackDbBuilder::new()
-        .with_rack_id(rack_id)
+        .with_rack_id(rack_id.clone())
         .persist(&mut txn)
         .await?;
 
@@ -344,7 +344,7 @@ async fn test_rack_error_state_handling(
     };
 
     // Update the controller state directly in the database
-    set_rack_controller_state(pool.acquire().await?.as_mut(), rack_id, error_state).await?;
+    set_rack_controller_state(pool.acquire().await?.as_mut(), &rack_id, error_state).await?;
 
     // Start the state controller
     let rack_handler = Arc::new(TestRackStateHandler::default());
@@ -392,13 +392,13 @@ async fn test_rack_state_transition_validation(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Create a rack
-    let rack_id = RackId::from(uuid::Uuid::new_v4());
+    let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
     let mut txn = pool.acquire().await?;
     TestRackDbBuilder::new()
-        .with_rack_id(rack_id)
+        .with_rack_id(rack_id.clone())
         .persist(&mut txn)
         .await?;
-    let rack = db_rack::get(&mut *txn, rack_id).await?;
+    let rack = db_rack::get(&mut *txn, &rack_id).await?;
 
     // Verify initial state is Expected
     assert!(matches!(rack.controller_state.value, RackState::Expected));
@@ -422,10 +422,10 @@ async fn test_rack_state_transition_validation(
     ];
 
     for state in states {
-        set_rack_controller_state(pool.acquire().await?.as_mut(), rack_id, state.clone()).await?;
+        set_rack_controller_state(pool.acquire().await?.as_mut(), &rack_id, state.clone()).await?;
 
         // Verify the state was set correctly
-        let rack = db_rack::get(&pool, rack_id).await?;
+        let rack = db_rack::get(&pool, &rack_id).await?;
         assert!(matches!(rack.controller_state.value, _ if rack.controller_state.value == state));
     }
 
@@ -439,10 +439,10 @@ async fn test_rack_deletion_with_state_controller(
     let env = create_test_env(pool.clone()).await;
 
     // Create a rack
-    let rack_id = RackId::from(uuid::Uuid::new_v4());
+    let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
     let mut txn = pool.acquire().await?;
     TestRackDbBuilder::new()
-        .with_rack_id(rack_id)
+        .with_rack_id(rack_id.clone())
         .persist(&mut txn)
         .await?;
 
@@ -476,7 +476,7 @@ async fn test_rack_deletion_with_state_controller(
     );
 
     // Mark the rack as deleted
-    mark_rack_as_deleted(pool.acquire().await?.as_mut(), rack_id).await?;
+    mark_rack_as_deleted(pool.acquire().await?.as_mut(), &rack_id).await?;
 
     // Let the controller run for a bit more after marking as deleted
     controller.run_single_iteration().await;

--- a/crates/uuid/src/rack/mod.rs
+++ b/crates/uuid/src/rack/mod.rs
@@ -14,17 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::cmp::Ordering;
 use std::fmt;
-use std::fmt::{Debug, Display, Formatter, Write};
+use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
 
-use data_encoding::BASE32_DNSSEC;
 use prost::DecodeError;
 use prost::bytes::{Buf, BufMut};
 use prost::encoding::{DecodeContext, WireType};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 #[cfg(feature = "sqlx")]
 use sqlx::{
     encode::IsNull,
@@ -35,61 +32,72 @@ use sqlx::{
 
 use crate::DbPrimaryUuid;
 
-/// This is a fixed-size hash of the rack hardware.
-pub type HardwareHash = [u8; 32];
-/// This is the base32-encoded representation of the hardware hash. It is a fixed size instead of a
-/// String so that we can implement the Copy trait.
-pub type HardwareIdBase32 = [u8; RACK_ID_HARDWARE_ID_BASE32_LENGTH];
+/// The `RackId` uniquely identifies a rack that is managed by the system.
+///
+/// `RackId` is a newtype over `String`. The value is typically provided by
+/// an external Datacenter Inventory Manager (DCIM) and can be in any format
+/// that the DCIM uses (e.g. "P20", "rack-42-us-west", or the legacy
+/// `ps100...` encoded format).
+#[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RackId(String);
 
-/// The `RackId` uniquely identifies a rack that is managed by the Forge system
-///
-/// `RackId`s are derived from a hardware fingerprint, and are thereby
-/// globally unique.
-///
-/// RackIds are using an encoding which makes them valid DNS names.
-/// This requires the use of lowercase characters only.
-///
-/// Examples for RackIds can be:
-/// - ps100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0
-/// - ps100rtjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0
-/// - ps100hsasb5dsh6e6ogogslpovne4rj82rp9jlf00qd7mcvmaadv85phk3g
-/// - ps100rsasb5dsh6e6ogogslpovne4rj82rp9jlf00qd7mcvmaadv85phk3g
-/// - ps100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
-pub struct RackId {
-    /// The hardware source from which the Rack ID was derived
-    source: RackIdSource,
-    /// The rack hash which was derived via hashing from the hardware piece
-    /// that is indicated in `source`, encoded via base32. Must be valid utf-8.
-    hardware_id: HardwareIdBase32,
-    /// The Type of the Rack
-    ty: RackType,
-}
-
-impl Ord for RackId {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.to_string().cmp(&other.to_string())
+impl RackId {
+    /// Creates a new RackId from any string value.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
     }
-}
 
-impl PartialOrd for RackId {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Default for RackId {
-    #[allow(deprecated)]
-    fn default() -> Self {
-        Self::default()
+    /// Returns the inner string value.
+    pub fn as_str(&self) -> &str {
+        &self.0
     }
 }
 
 impl Debug for RackId {
-    // The derived Debug implementation is messy, just output the string
-    // representation even when debugging.
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Display::fmt(self, f)
+    }
+}
+
+impl Display for RackId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl FromStr for RackId {
+    type Err = RackIdParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err(RackIdParseError::Empty);
+        }
+        Ok(Self(s.to_string()))
+    }
+}
+
+impl From<&str> for RackId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+impl From<String> for RackId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl AsRef<str> for RackId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl DbPrimaryUuid for RackId {
+    fn db_primary_uuid_name() -> &'static str {
+        "rack_id"
     }
 }
 
@@ -100,7 +108,7 @@ impl sqlx::Encode<'_, sqlx::Postgres> for RackId {
         &self,
         buf: &mut <Postgres as Database>::ArgumentBuffer<'_>,
     ) -> Result<IsNull, BoxDynError> {
-        buf.extend(self.to_string().as_bytes());
+        buf.extend(self.0.as_bytes());
         Ok(sqlx::encode::IsNull::No)
     }
 }
@@ -115,7 +123,7 @@ where
         value: <DB as sqlx::database::Database>::ValueRef<'r>,
     ) -> Result<Self, sqlx::error::BoxDynError> {
         let str_id: String = String::decode(value)?;
-        Ok(RackId::from_str(&str_id).map_err(|e| sqlx::Error::Decode(Box::new(e)))?)
+        Ok(RackId(str_id))
     }
 }
 
@@ -153,263 +161,20 @@ impl PgHasArrayType for RackId {
     }
 }
 
-impl RackId {
-    pub fn new(source: RackIdSource, hardware_hash: HardwareHash, ty: RackType) -> RackId {
-        // BASE32_DNSSEC is chosen to just generate lowercase characters and
-        // numbers - which will result in valid DNS names for RackIds.
-        let encoded = BASE32_DNSSEC.encode(&hardware_hash);
-        assert_eq!(encoded.len(), RACK_ID_HARDWARE_ID_BASE32_LENGTH);
-
-        Self {
-            source,
-            hardware_id: encoded.as_bytes().try_into().unwrap(),
-            ty,
-        }
-    }
-
-    /// The hardware source from which the Rack ID was derived
-    pub fn source(&self) -> RackIdSource {
-        self.source
-    }
-
-    /// The type of the Rack
-    pub fn rack_type(&self) -> RackType {
-        self.ty
-    }
-
-    /// Generate Remote ID based on Rack ID.
-    /// Remote Id is inserted by dhcrelay on DPU in each DHCP request sent by host.
-    /// This field is used only for DPU.
-    pub fn remote_id(&self) -> String {
-        let mut hasher = Sha256::new();
-        hasher.update(self.to_string().as_bytes());
-        let hash: [u8; 32] = hasher.finalize().into();
-        BASE32_DNSSEC.encode(&hash)
-    }
-
-    /// NOTE: NEVER USE THIS!
-    /// Tonic's codegen requires all types to implement Default, but there is
-    /// no logical reason to construct a "default" RackId in real code, so
-    /// we simply construct a bogus one here.
-    #[allow(clippy::should_implement_trait)]
-    #[deprecated(
-        note = "Do not use `RackId::default()` directly; only implemented for prost interop"
-    )]
-    pub fn default() -> Self {
-        Self::new(
-            RackIdSource::ProductBoardChassisSerial,
-            [0; 32],
-            RackType::Rack,
-        )
-    }
-}
-
-impl DbPrimaryUuid for RackId {
-    fn db_primary_uuid_name() -> &'static str {
-        "rack_id"
-    }
-}
-
-/// The hardware source from which the Rack ID is derived.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum RackIdSource {
-    /// The Rack ID was generated by hashing the TPM EkCertificate data.
-    Tpm,
-    /// The Rack ID was generated by the concatenation of product, board and chassis serial
-    /// and hashing the resulting value.
-    /// If any of those values is not available in DMI data, an empty
-    /// string will be used instead. At least one serial number must have been
-    /// available to generate this ID.
-    ProductBoardChassisSerial,
-}
-
-impl RackIdSource {
-    /// Returns the character that identifies the source type
-    pub const fn id_char(self) -> char {
-        match self {
-            RackIdSource::Tpm => 't',
-            RackIdSource::ProductBoardChassisSerial => 's',
-        }
-    }
-
-    /// Parses the `RackIdSource` from a character
-    pub fn from_id_char(c: char) -> Option<Self> {
-        match c {
-            c if c == Self::Tpm.id_char() => Some(Self::Tpm),
-            c if c == Self::ProductBoardChassisSerial.id_char() => {
-                Some(Self::ProductBoardChassisSerial)
-            }
-            _ => None,
-        }
-    }
-}
-
-/// Extra flags that are associated with the rack ID
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum RackType {
-    /// The Rack is a Rack
-    Rack,
-    /// The Rack is a Host
-    Host,
-}
-
-impl RackType {
-    /// Returns `true` if the Rack is a Rack
-    pub fn is_rack(self) -> bool {
-        self == RackType::Rack
-    }
-
-    /// Returns `true` if the Rack is a Host
-    pub fn is_host(self) -> bool {
-        self == RackType::Host
-    }
-}
-
-impl std::fmt::Display for RackType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RackType::Rack => f.write_str("Rack"),
-            RackType::Host => f.write_str("Host"),
-        }
-    }
-}
-
-impl RackType {
-    /// Returns the character that identifies the flag
-    pub const fn id_char(self) -> char {
-        match self {
-            RackType::Rack => 'r',
-            RackType::Host => 'h',
-        }
-    }
-
-    /// Parses the `RackType` from a character
-    pub fn from_id_char(c: char) -> Option<Self> {
-        match c {
-            c if c == Self::Rack.id_char() => Some(Self::Rack),
-            c if c == Self::Host.id_char() => Some(Self::Host),
-            _ => None,
-        }
-    }
-}
-
-impl std::fmt::Display for RackId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // `ps` is for power-shelf
-        // `1` is a version identifier
-        // The next 2 bytes `00` are reserved
-        f.write_str("ps100")?;
-        // Write the rack type
-        f.write_char(self.ty.id_char())?;
-        // The next character determines how the RackId is derived (`RackIdSource`)
-        f.write_char(self.source.id_char())?;
-        // Then follows the actual source data. self.hardware_id is guaranteed to have been written
-        // from a valid string, so we can use from_utf8_unchecked.
-        unsafe { f.write_str(std::str::from_utf8_unchecked(self.hardware_id.as_slice())) }
-    }
-}
-
-impl From<uuid::Uuid> for RackId {
-    fn from(value: uuid::Uuid) -> Self {
-        // This is a fallback implementation - in practice, RackId should be created
-        // from hardware hashes, not random UUIDs
-        let mut hasher = Sha256::new();
-        hasher.update(value.as_bytes());
-        let hash: [u8; 32] = hasher.finalize().into();
-
-        Self::new(
-            RackIdSource::Tpm, // Default source
-            hash,
-            RackType::Rack, // Default type
-        )
-    }
-}
-
-/// The length that is used for the prefix in Rack IDs
-pub const RACK_ID_PREFIX_LENGTH: usize = 7;
-
-/// The length of the hardware ID substring embedded in the Rack ID
-///
-/// Since it's a base32 encoded SHA256 (32byte), this makes 52 bytes
-pub const RACK_ID_HARDWARE_ID_BASE32_LENGTH: usize = 52;
-
-/// The length of a valid RackID
-///
-/// It is made up of the prefix length (5 bytes) plus the encoded hardware ID length
-pub const RACK_ID_LENGTH: usize = RACK_ID_PREFIX_LENGTH + RACK_ID_HARDWARE_ID_BASE32_LENGTH;
-
-#[derive(thiserror::Error, Debug, Clone)]
-pub enum RackIdParseError {
-    #[error("The Rack ID has an invalid length of {0}")]
-    Length(usize),
-    #[error("The Rack ID {0} has an invalid prefix")]
-    Prefix(String),
-    #[error("The Rack ID {0} has an invalid encoding")]
-    Encoding(String),
-}
-
-impl FromStr for RackId {
-    type Err = RackIdParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.len() != RACK_ID_LENGTH {
-            return Err(RackIdParseError::Length(s.len()));
-        }
-        // Check for version 1 and 2 reserved bytes
-        if !s.starts_with("ps100") {
-            return Err(RackIdParseError::Prefix(s.to_string()));
-        }
-
-        // Everything after the prefix needs to be valid base32
-        let hardware_id = &s.as_bytes()[RACK_ID_PREFIX_LENGTH..];
-
-        let mut hardware_hash: HardwareHash = [0u8; 32];
-        match BASE32_DNSSEC.decode_mut(hardware_id, &mut hardware_hash) {
-            Err(_) => return Err(RackIdParseError::Encoding(s.to_string())),
-            Ok(size) if size != 32 => return Err(RackIdParseError::Encoding(s.to_string())),
-            _ => {}
-        }
-
-        let ty = RackType::from_id_char(s.as_bytes()[5] as char)
-            .ok_or_else(|| RackIdParseError::Prefix(s.to_string()))?;
-        let source = RackIdSource::from_id_char(s.as_bytes()[6] as char)
-            .ok_or_else(|| RackIdParseError::Prefix(s.to_string()))?;
-
-        Ok(RackId::new(source, hardware_hash, ty))
-    }
-}
-
-impl Serialize for RackId {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.to_string())
-    }
-}
-
-impl<'de> Deserialize<'de> for RackId {
-    fn deserialize<D>(deserializer: D) -> Result<RackId, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        use serde::de::Error;
-
-        let str_value = String::deserialize(deserializer)?;
-        let id = RackId::from_str(&str_value).map_err(|err| Error::custom(err.to_string()))?;
-        Ok(id)
-    }
-}
-
 // Implement [`prost::Message`] manually so that we can be wire-compatible with the
-// `.common.RackId` protobuf message, which is what we actually serialize. Do this by
-// constructing a `legacy_rpc::RackId` and delegate all  [`prost::Message`] methods to it.
+// `.common.RackId` protobuf message, which is defined as:
+//
+// ```protobuf
+// message RackId {
+//     string id = 1;
+// }
+// ```
 impl prost::Message for RackId {
     fn encode_raw(&self, buf: &mut impl BufMut)
     where
         Self: Sized,
     {
-        legacy_rpc::RackId::from(*self).encode_raw(buf);
+        legacy_rpc::RackId::from(self.clone()).encode_raw(buf);
     }
 
     fn merge_field(
@@ -422,20 +187,18 @@ impl prost::Message for RackId {
     where
         Self: Sized,
     {
-        let mut legacy_message = legacy_rpc::RackId::from(*self);
+        let mut legacy_message = legacy_rpc::RackId::from(self.clone());
         legacy_message.merge_field(tag, wire_type, buf, ctx)?;
-        *self = RackId::from_str(&legacy_message.id)
-            .map_err(|_| DecodeError::new(format!("Invalid rack id: {}", legacy_message.id)))?;
+        self.0 = legacy_message.id;
         Ok(())
     }
 
     fn encoded_len(&self) -> usize {
-        legacy_rpc::RackId::from(*self).encoded_len()
+        legacy_rpc::RackId::from(self.clone()).encoded_len()
     }
 
-    #[allow(deprecated)]
     fn clear(&mut self) {
-        *self = RackId::default();
+        self.0.clear();
     }
 }
 
@@ -448,10 +211,6 @@ mod legacy_rpc {
     ///     string id = 1;
     /// }
     /// ```
-    ///
-    /// This allows us to use [`super::RackId`] directly instead of having to convert it
-    /// manually every time, while still interacting with peers that expect a `.common.RackId`
-    /// to be serialized.
     #[derive(prost::Message)]
     pub struct RackId {
         #[prost(string, tag = "1")]
@@ -459,12 +218,16 @@ mod legacy_rpc {
     }
 
     impl From<super::RackId> for RackId {
-        fn from(value: crate::rack::RackId) -> Self {
-            Self {
-                id: value.to_string(),
-            }
+        fn from(value: super::RackId) -> Self {
+            Self { id: value.0 }
         }
     }
+}
+
+#[derive(thiserror::Error, Debug, Clone)]
+pub enum RackIdParseError {
+    #[error("RackId cannot be empty")]
+    Empty,
 }
 
 #[cfg(test)]
@@ -472,7 +235,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_rack_id_round_trip() {
+    fn test_rack_id_round_trip_legacy() {
+        // Legacy ps100-encoded rack IDs should still work.
         let rack_id_str = "ps100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg";
         let rack_id = RackId::from_str(rack_id_str)
             .expect("Should have successfully converted from a valid string");
@@ -481,48 +245,41 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_rack_ids() {
-        match RackId::from_str("ps100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hc") {
-            // one character short
-            Err(RackIdParseError::Length(_)) => {} // Expect an error
-            Ok(_) => panic!("Converting from a too-short rack ID should have failed"),
-            Err(e) => panic!(
-                "Converting from a too-short string should have failed with a length error, got {e}"
-            ),
-        }
+    fn test_rack_id_arbitrary_string() {
+        // DCIM-provided rack IDs can be any non-empty string.
+        let rack_id = RackId::from_str("P20").unwrap();
+        assert_eq!(rack_id.to_string(), "P20");
 
-        match RackId::from_str("PS100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg") {
-            Err(RackIdParseError::Prefix(_)) => {} // Expect an error
-            Ok(_) => {
-                panic!("Converting from a rack ID with an invalid prefix should have failed")
-            }
-            Err(e) => panic!(
-                "Converting from a rack ID with an invalid prefix should have failed with a Prefix error, got {e}"
-            ),
-        }
+        let rack_id = RackId::from_str("rack-42-us-west-2").unwrap();
+        assert_eq!(rack_id.to_string(), "rack-42-us-west-2");
 
-        match RackId::from_str("ps100xt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg") {
-            Err(RackIdParseError::Prefix(_)) => {} // Expect an error
-            Ok(_) => panic!("Converting from a rack ID with type `x` should have failed"),
-            Err(e) => panic!(
-                "Converting from a rack ID with type `x` should have failed with a Prefix error, got {e}"
-            ),
-        }
+        let rack_id = RackId::from_str("i-am-just-a-rack-id").unwrap();
+        assert_eq!(rack_id.to_string(), "i-am-just-a-rack-id");
+    }
 
-        match RackId::from_str("ps100dx038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg") {
-            Err(RackIdParseError::Prefix(_)) => {} // Expect an error
-            Ok(_) => panic!("Converting from a rack ID with source `x` should have failed"),
-            Err(e) => panic!(
-                "Converting from a rack ID with source `x` should have failed with a Prefix error, got {e}"
-            ),
-        }
+    #[test]
+    fn test_rack_id_empty_fails() {
+        assert!(RackId::from_str("").is_err());
+    }
 
-        match RackId::from_str("ps100ht038bg3qsho433vkg684heguv28!qaggmrsh2ugn1qk096n2c6hcg") {
-            Err(RackIdParseError::Encoding(_)) => {} // Expect an error
-            Ok(_) => panic!("Converting from a rack ID with a `!` should have failed"),
-            Err(e) => panic!(
-                "Converting from a rack ID with a `!` should have failed with an Encoding error, got {e}"
-            ),
-        }
+    #[test]
+    fn test_rack_id_serde_round_trip() {
+        let rack_id = RackId::new("my-custom-rack");
+        let json = serde_json::to_string(&rack_id).unwrap();
+        assert_eq!(json, "\"my-custom-rack\"");
+        let deserialized: RackId = serde_json::from_str(&json).unwrap();
+        assert_eq!(rack_id, deserialized);
+    }
+
+    #[test]
+    fn test_rack_id_from_str_impls() {
+        let rack_id: RackId = "test-rack".into();
+        assert_eq!(rack_id.as_str(), "test-rack");
+
+        let rack_id = RackId::from("another-rack");
+        assert_eq!(rack_id.as_str(), "another-rack");
+
+        let rack_id = RackId::from(String::from("string-rack"));
+        assert_eq!(rack_id.as_str(), "string-rack");
     }
 }


### PR DESCRIPTION
## Description

This was discussed at length internally amongst [DSX](https://nvidianews.nvidia.com/news/nvidia-releases-vera-rubin-dsx-ai-factory-reference-design-and-omniverse-dsx-digital-twin-blueprint-with-broad-industry-support) and [NCX](https://docs.nvidia.com/ncx/index.html) teams.

While historically [what is now known as] NICo has always generated its own internal ID for *components*, a rack ID is kind of a grey area between a component and an identifier. You can think of a rack as a supercomputer, or something akin to a blade server, BUT, you can also think of it as a place where components are stored.

With that, we decided the `RackId` should be a `String` whose SoT comes from the DCIM (Datacenter Inventory Manager) system, since that is how the BMS (Building Management System) identifies racks, and events for racks, including things like leak detection.

Instead of NICo generating its own stable `RackId` and maintaining mapping between it's internal rack ID and the DCIM rack ID, it was decided the `RackId` should just come from the DCIM as part of "expected component" ingestion: `ExpectedRack`, `ExpectedMachine`, `ExpectedPowerShelf`, and `ExpectedSwitch` entities will all be enqueued with the DCIM from the `RackId`. This ultimately allows for the DCIM rack ID to be the one and only SoT, and allows for all components in a DSX AI Factory to agree without confusion from alternative IDs.

So, strip away the hardware-backed `RackId` plans, and move towards a newtype over `String`, allowing the DCIM to provide whatever it wants.

This change is backwards compatible:
- The database already stores as text, not a `uuid`, so we don't have to worry about conversion issues.
- We are moving from an "encoded" value to an open `String` value, so even pre-existing encoded `RackIds` work with the `String`-backed newtype.
- The gRPC `common.RackId` is still the same. It was a `String` to begin wtih.
- The JSON serialization of it is still the same. We use `#[serde(transparent)]`, so it's still just `"rack_id": "whatever-id-you-want"`.

The downside is now that it's a `String`, we can't `Copy`, so we have to `.clone()` in certain cases. I pass around by reference as much as I can, but not everywhere.

Also added some tests to ensure:
- The old format still works.
- New strings work.
- Empty strings don't work.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

