### PR TITLE
chore(admin-cli): last round of Args -> From/TryFrom -> Request

### DIFF
--- a/crates/admin-cli/src/credential/generate_ufm_cert/args.rs
+++ b/crates/admin-cli/src/credential/generate_ufm_cert/args.rs
@@ -16,6 +16,7 @@
  */
 
 use clap::Parser;
+use rpc::{CredentialType, forge as forgerpc};
 
 use crate::credential::common::DEFAULT_IB_FABRIC_NAME;
 
@@ -23,4 +24,16 @@ use crate::credential::common::DEFAULT_IB_FABRIC_NAME;
 pub struct Args {
     #[clap(long, default_value_t = DEFAULT_IB_FABRIC_NAME.to_string(), help = "Infiniband fabric.")]
     pub fabric: String,
+}
+
+impl From<Args> for forgerpc::CredentialCreationRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            credential_type: CredentialType::Ufm.into(),
+            username: None,
+            password: "".to_string(),
+            mac_address: None,
+            vendor: Some(args.fabric),
+        }
+    }
 }

--- a/crates/admin-cli/src/credential/generate_ufm_cert/cmd.rs
+++ b/crates/admin-cli/src/credential/generate_ufm_cert/cmd.rs
@@ -16,19 +16,11 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::{CredentialType, forge as forgerpc};
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
-pub async fn generate_ufm_cert(c: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let req = forgerpc::CredentialCreationRequest {
-        credential_type: CredentialType::Ufm.into(),
-        username: None,
-        password: "".to_string(),
-        mac_address: None,
-        vendor: Some(c.fabric),
-    };
-    api_client.0.create_credential(req).await?;
+pub async fn generate_ufm_cert(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    api_client.0.create_credential(args).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/dpu/agent_upgrade_policy/args.rs
+++ b/crates/admin-cli/src/dpu/agent_upgrade_policy/args.rs
@@ -16,11 +16,24 @@
  */
 
 use clap::{Parser, ValueEnum};
+use rpc::forge::DpuAgentUpgradePolicyRequest;
 
 #[derive(Parser, Debug)]
 pub struct Args {
     #[clap(long)]
     pub set: Option<AgentUpgradePolicyChoice>,
+}
+
+impl From<Args> for DpuAgentUpgradePolicyRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            new_policy: args.set.map(|choice| match choice {
+                AgentUpgradePolicyChoice::Off => rpc::forge::AgentUpgradePolicy::Off as i32,
+                AgentUpgradePolicyChoice::UpOnly => rpc::forge::AgentUpgradePolicy::UpOnly as i32,
+                AgentUpgradePolicyChoice::UpDown => rpc::forge::AgentUpgradePolicy::UpDown as i32,
+            }),
+        }
+    }
 }
 
 // Should match api/src/model/machine/upgrade_policy.rs AgentUpgradePolicy

--- a/crates/admin-cli/src/dpu/agent_upgrade_policy/cmd.rs
+++ b/crates/admin-cli/src/dpu/agent_upgrade_policy/cmd.rs
@@ -17,44 +17,22 @@
 
 use ::rpc::admin_cli::CarbideCliResult;
 
-use super::args::AgentUpgradePolicyChoice;
+use super::args::{AgentUpgradePolicyChoice, Args};
 use crate::rpc::ApiClient;
 
-pub async fn agent_upgrade_policy(
-    api_client: &ApiClient,
-    set: Option<AgentUpgradePolicyChoice>,
-) -> CarbideCliResult<()> {
-    let rpc_choice = set.map(|cmd_line_policy| match cmd_line_policy {
-        AgentUpgradePolicyChoice::Off => rpc::forge::AgentUpgradePolicy::Off,
-        AgentUpgradePolicyChoice::UpOnly => rpc::forge::AgentUpgradePolicy::UpOnly,
-        AgentUpgradePolicyChoice::UpDown => rpc::forge::AgentUpgradePolicy::UpDown,
-    });
-    handle_agent_upgrade_policy(api_client, rpc_choice).await
-}
+pub async fn agent_upgrade_policy(api_client: &ApiClient, args: Args) -> CarbideCliResult<()> {
+    let is_set = args.set.is_some();
+    let resp = api_client.0.dpu_agent_upgrade_policy_action(args).await?;
+    let policy: AgentUpgradePolicyChoice = resp.active_policy.into();
 
-pub async fn handle_agent_upgrade_policy(
-    api_client: &ApiClient,
-    action: Option<::rpc::forge::AgentUpgradePolicy>,
-) -> CarbideCliResult<()> {
-    match action {
-        None => {
-            let resp = api_client
-                .0
-                .dpu_agent_upgrade_policy_action(rpc::forge::DpuAgentUpgradePolicyRequest {
-                    new_policy: None,
-                })
-                .await?;
-            let policy: AgentUpgradePolicyChoice = resp.active_policy.into();
-            tracing::info!("{policy}");
-        }
-        Some(choice) => {
-            let resp = api_client.0.dpu_agent_upgrade_policy_action(choice).await?;
-            let policy: AgentUpgradePolicyChoice = resp.active_policy.into();
-            tracing::info!(
-                "Policy is now: {policy}. Update succeeded? {}.",
-                resp.did_change,
-            );
-        }
+    if is_set {
+        tracing::info!(
+            "Policy is now: {policy}. Update succeeded? {}.",
+            resp.did_change
+        );
+    } else {
+        tracing::info!("{policy}");
     }
+
     Ok(())
 }

--- a/crates/admin-cli/src/dpu/agent_upgrade_policy/mod.rs
+++ b/crates/admin-cli/src/dpu/agent_upgrade_policy/mod.rs
@@ -26,6 +26,6 @@ use crate::cfg::runtime::RuntimeContext;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
-        cmd::agent_upgrade_policy(&ctx.api_client, self.set).await
+        cmd::agent_upgrade_policy(&ctx.api_client, self).await
     }
 }

--- a/crates/admin-cli/src/dpu/reprovision/args.rs
+++ b/crates/admin-cli/src/dpu/reprovision/args.rs
@@ -17,6 +17,8 @@
 
 use carbide_uuid::machine::MachineId;
 use clap::Parser;
+use rpc::forge::dpu_reprovisioning_request::Mode;
+use rpc::forge::{DpuReprovisioningRequest, UpdateInitiator};
 
 #[derive(Parser, Debug)]
 pub enum Args {
@@ -50,6 +52,18 @@ pub struct DpuReprovisionSet {
     pub update_message: Option<String>,
 }
 
+impl From<&DpuReprovisionSet> for DpuReprovisioningRequest {
+    fn from(args: &DpuReprovisionSet) -> Self {
+        Self {
+            dpu_id: Some(args.id),
+            machine_id: Some(args.id),
+            mode: Mode::Set as i32,
+            initiator: UpdateInitiator::AdminCli as i32,
+            update_firmware: args.update_firmware,
+        }
+    }
+}
+
 #[derive(Parser, Debug)]
 pub struct DpuReprovisionClear {
     #[clap(
@@ -63,6 +77,18 @@ pub struct DpuReprovisionClear {
     pub update_firmware: bool,
 }
 
+impl From<&DpuReprovisionClear> for DpuReprovisioningRequest {
+    fn from(args: &DpuReprovisionClear) -> Self {
+        Self {
+            dpu_id: Some(args.id),
+            machine_id: Some(args.id),
+            mode: Mode::Clear as i32,
+            initiator: UpdateInitiator::AdminCli as i32,
+            update_firmware: args.update_firmware,
+        }
+    }
+}
+
 #[derive(Parser, Debug)]
 pub struct DpuReprovisionRestart {
     #[clap(
@@ -74,4 +100,16 @@ pub struct DpuReprovisionRestart {
 
     #[clap(short, long, action)]
     pub update_firmware: bool,
+}
+
+impl From<&DpuReprovisionRestart> for DpuReprovisioningRequest {
+    fn from(args: &DpuReprovisionRestart) -> Self {
+        Self {
+            dpu_id: Some(args.id),
+            machine_id: Some(args.id),
+            mode: Mode::Restart as i32,
+            initiator: UpdateInitiator::AdminCli as i32,
+            update_firmware: args.update_firmware,
+        }
+    }
 }

--- a/crates/admin-cli/src/dpu/reprovision/cmd.rs
+++ b/crates/admin-cli/src/dpu/reprovision/cmd.rs
@@ -16,9 +16,8 @@
  */
 
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
-use ::rpc::forge::dpu_reprovisioning_request::Mode;
-use ::rpc::forge::{DpuReprovisioningRequest, UpdateInitiator};
-use carbide_uuid::machine::{MachineId, MachineType};
+use ::rpc::forge::DpuReprovisioningRequest;
+use carbide_uuid::machine::MachineType;
 use prettytable::{Table, row};
 
 use super::args::Args;
@@ -28,106 +27,85 @@ use crate::rpc::ApiClient;
 pub async fn reprovision(api_client: &ApiClient, reprov: Args) -> CarbideCliResult<()> {
     match reprov {
         Args::Set(data) => {
-            trigger_reprovisioning(
-                data.id,
-                Mode::Set,
-                data.update_firmware,
-                api_client,
-                data.update_message,
-            )
-            .await
+            if let Some(update_message) = &data.update_message {
+                apply_health_override(api_client, data.id, update_message.clone()).await?;
+            }
+            let req: DpuReprovisioningRequest = (&data).into();
+            api_client.0.trigger_dpu_reprovisioning(req).await?;
+            Ok(())
         }
         Args::Clear(data) => {
-            trigger_reprovisioning(data.id, Mode::Clear, data.update_firmware, api_client, None)
-                .await
+            let req: DpuReprovisioningRequest = (&data).into();
+            api_client.0.trigger_dpu_reprovisioning(req).await?;
+            Ok(())
         }
         Args::List => list_dpus_pending(api_client).await,
         Args::Restart(data) => {
-            trigger_reprovisioning(
-                data.id,
-                Mode::Restart,
-                data.update_firmware,
-                api_client,
-                None,
-            )
-            .await
+            let req: DpuReprovisioningRequest = (&data).into();
+            api_client.0.trigger_dpu_reprovisioning(req).await?;
+            Ok(())
         }
     }
 }
 
-pub async fn trigger_reprovisioning(
-    id: MachineId,
-    mode: Mode,
-    update_firmware: bool,
+async fn apply_health_override(
     api_client: &ApiClient,
-    update_message: Option<String>,
+    id: carbide_uuid::machine::MachineId,
+    update_message: String,
 ) -> CarbideCliResult<()> {
-    if let (Mode::Set, Some(update_message)) = (mode, update_message) {
-        // Set a HostUpdateInProgress health override on the Host
-        let host_id = match id.machine_type() {
-            MachineType::Host => Some(id),
-            MachineType::Dpu => {
-                let machine = api_client
-                    .get_machines_by_ids(&[id])
-                    .await?
-                    .machines
-                    .into_iter()
-                    .next();
-
-                if let Some(host_id) = machine.map(|x| x.associated_host_machine_id) {
-                    host_id
-                } else {
-                    return Err(CarbideCliError::GenericError(format!(
-                        "Could not find host attached with dpu {id}",
-                    )));
-                }
-            }
-            _ => {
-                return Err(CarbideCliError::GenericError(format!(
-                    "Invalid machine ID for reprevisioning, only Hosts and DPUs are supported: {update_message}"
-                )));
-            }
-        };
-
-        // Check host must not have host-update override
-        if let Some(host_machine_id) = &host_id {
-            let host_machine = api_client
-                .get_machines_by_ids(&[*host_machine_id])
+    // Set a HostUpdateInProgress health override on the Host
+    let host_id = match id.machine_type() {
+        MachineType::Host => Some(id),
+        MachineType::Dpu => {
+            let machine = api_client
+                .get_machines_by_ids(&[id])
                 .await?
                 .machines
                 .into_iter()
                 .next();
 
-            if let Some(host_machine) = host_machine
-                && host_machine
-                    .health_overrides
-                    .iter()
-                    .any(|or| or.source == "host-update")
-            {
+            if let Some(host_id) = machine.map(|x| x.associated_host_machine_id) {
+                host_id
+            } else {
                 return Err(CarbideCliError::GenericError(format!(
-                    "Host machine: {:?} already has a \"host-update\" override.",
-                    host_machine.id,
+                    "Could not find host attached with dpu {id}",
                 )));
             }
-
-            let report =
-                get_health_report(HealthOverrideTemplates::HostUpdate, Some(update_message));
-
-            api_client
-                .machine_insert_health_report_override(*host_machine_id, report.into(), false)
-                .await?;
         }
+        _ => {
+            return Err(CarbideCliError::GenericError(format!(
+                "Invalid machine ID for reprevisioning, only Hosts and DPUs are supported: {update_message}"
+            )));
+        }
+    };
+
+    // Check host must not have host-update override
+    if let Some(host_machine_id) = &host_id {
+        let host_machine = api_client
+            .get_machines_by_ids(&[*host_machine_id])
+            .await?
+            .machines
+            .into_iter()
+            .next();
+
+        if let Some(host_machine) = host_machine
+            && host_machine
+                .health_overrides
+                .iter()
+                .any(|or| or.source == "host-update")
+        {
+            return Err(CarbideCliError::GenericError(format!(
+                "Host machine: {:?} already has a \"host-update\" override.",
+                host_machine.id,
+            )));
+        }
+
+        let report = get_health_report(HealthOverrideTemplates::HostUpdate, Some(update_message));
+
+        api_client
+            .machine_insert_health_report_override(*host_machine_id, report.into(), false)
+            .await?;
     }
-    api_client
-        .0
-        .trigger_dpu_reprovisioning(DpuReprovisioningRequest {
-            dpu_id: Some(id),
-            machine_id: Some(id),
-            mode: mode as i32,
-            initiator: UpdateInitiator::AdminCli as i32,
-            update_firmware,
-        })
-        .await?;
 
     Ok(())
 }

--- a/crates/admin-cli/src/expected_rack/delete/cmd.rs
+++ b/crates/admin-cli/src/expected_rack/delete/cmd.rs
@@ -15,14 +15,11 @@
  * limitations under the License.
  */
 
-use rpc::forge::ExpectedRackRequest;
-
 use super::Args;
 use crate::rpc::ApiClient;
 
 /// delete deletes an expected rack by its rack_id.
 pub async fn delete(data: Args, api_client: &ApiClient) -> color_eyre::Result<()> {
-    let req: ExpectedRackRequest = data.into();
-    api_client.0.delete_expected_rack(req).await?;
+    api_client.0.delete_expected_rack(data).await?;
     Ok(())
 }

--- a/crates/admin-cli/src/host/reprovision/cmd.rs
+++ b/crates/admin-cli/src/host/reprovision/cmd.rs
@@ -67,8 +67,7 @@ pub async fn trigger_reprovisioning_clear(
     data: ReprovisionClear,
     api_client: &ApiClient,
 ) -> CarbideCliResult<()> {
-    let req: HostReprovisioningRequest = data.into();
-    api_client.0.trigger_host_reprovisioning(req).await?;
+    api_client.0.trigger_host_reprovisioning(data).await?;
     Ok(())
 }
 

--- a/crates/admin-cli/src/instance_type/disassociate/args.rs
+++ b/crates/admin-cli/src/instance_type/disassociate/args.rs
@@ -17,9 +17,18 @@
 
 use carbide_uuid::machine::MachineId;
 use clap::Parser;
+use rpc::forge::RemoveMachineInstanceTypeAssociationRequest;
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
     #[clap(help = "Machine Id")]
     pub machine_id: MachineId,
+}
+
+impl From<&Args> for RemoveMachineInstanceTypeAssociationRequest {
+    fn from(args: &Args) -> Self {
+        Self {
+            machine_id: args.machine_id.to_string(),
+        }
+    }
 }

--- a/crates/admin-cli/src/instance_type/disassociate/cmd.rs
+++ b/crates/admin-cli/src/instance_type/disassociate/cmd.rs
@@ -16,7 +16,6 @@
  */
 
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
-use carbide_uuid::machine::MachineId;
 use rpc::TenantState;
 use rpc::forge::RemoveMachineInstanceTypeAssociationRequest;
 
@@ -45,7 +44,7 @@ pub async fn remove_association(
         Removing instance type will create a mismatch between cloud and carbide. If you are sure, run this command again with --cloud-unsafe-op=<username> flag before `instance-type`."#.to_string(),
         ));
                     }
-                    remove_association_api(api_client, args.machine_id).await?;
+                    remove_association_api(api_client, &args).await?;
                     return Ok(());
                 }
                 _ => {}
@@ -55,7 +54,7 @@ pub async fn remove_association(
             "A instance is already allocated to this machine. You can remove an instance-type association only in Teminating state.".to_string(),
         ));
     } else {
-        remove_association_api(api_client, args.machine_id).await?;
+        remove_association_api(api_client, &args).await?;
     }
 
     Ok(())
@@ -63,13 +62,12 @@ pub async fn remove_association(
 
 async fn remove_association_api(
     api_client: &ApiClient,
-    machine_id: MachineId,
+    args: &Args,
 ) -> Result<(), CarbideCliError> {
+    let req: RemoveMachineInstanceTypeAssociationRequest = args.into();
     api_client
         .0
-        .remove_machine_instance_type_association(RemoveMachineInstanceTypeAssociationRequest {
-            machine_id: machine_id.to_string(),
-        })
+        .remove_machine_instance_type_association(req)
         .await?;
     println!("Association is removed successfully!!");
     Ok(())

--- a/crates/admin-cli/src/machine/force_delete/args.rs
+++ b/crates/admin-cli/src/machine/force_delete/args.rs
@@ -16,6 +16,7 @@
  */
 
 use clap::Parser;
+use rpc::forge::AdminForceDeleteMachineRequest;
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
@@ -55,4 +56,15 @@ pub struct Args {
         help = "Delete machine with allocated instance. This flag acknowledges destroying the user instance as well."
     )]
     pub allow_delete_with_instance: bool,
+}
+
+impl From<&Args> for AdminForceDeleteMachineRequest {
+    fn from(args: &Args) -> Self {
+        Self {
+            host_query: args.machine.clone(),
+            delete_interfaces: args.delete_interfaces,
+            delete_bmc_interfaces: args.delete_bmc_interfaces,
+            delete_bmc_credentials: args.delete_bmc_credentials,
+        }
+    }
 }

--- a/crates/admin-cli/src/machine/force_delete/cmd.rs
+++ b/crates/admin-cli/src/machine/force_delete/cmd.rs
@@ -46,15 +46,8 @@ pub async fn force_delete(mut query: Args, api_client: &ApiClient) -> CarbideCli
     }
 
     loop {
-        let response = api_client
-            .0
-            .admin_force_delete_machine(AdminForceDeleteMachineRequest {
-                host_query: query.machine.clone(),
-                delete_interfaces: query.delete_interfaces,
-                delete_bmc_interfaces: query.delete_bmc_interfaces,
-                delete_bmc_credentials: query.delete_bmc_credentials,
-            })
-            .await?;
+        let req: AdminForceDeleteMachineRequest = (&query).into();
+        let response = api_client.0.admin_force_delete_machine(req).await?;
         println!(
             "Force delete response: {}",
             serde_json::to_string_pretty(&response)?

--- a/crates/admin-cli/src/managed_host/maintenance/args.rs
+++ b/crates/admin-cli/src/managed_host/maintenance/args.rs
@@ -17,6 +17,7 @@
 
 use carbide_uuid::machine::MachineId;
 use clap::Parser;
+use rpc::forge as forgerpc;
 
 /// Enable or disable maintenance mode on a managed host.
 /// To list machines in maintenance mode use `forge-admin-cli mh show --all --fix`
@@ -42,8 +43,28 @@ pub struct MaintenanceOn {
     pub reference: String,
 }
 
+impl From<MaintenanceOn> for forgerpc::MaintenanceRequest {
+    fn from(args: MaintenanceOn) -> Self {
+        Self {
+            operation: forgerpc::MaintenanceOperation::Enable.into(),
+            host_id: Some(args.host),
+            reference: Some(args.reference),
+        }
+    }
+}
+
 #[derive(Parser, Debug)]
 pub struct MaintenanceOff {
     #[clap(long, required(true), help = "Managed Host ID")]
     pub host: MachineId,
+}
+
+impl From<MaintenanceOff> for forgerpc::MaintenanceRequest {
+    fn from(args: MaintenanceOff) -> Self {
+        Self {
+            operation: forgerpc::MaintenanceOperation::Disable.into(),
+            host_id: Some(args.host),
+            reference: None,
+        }
+    }
 }

--- a/crates/admin-cli/src/managed_host/maintenance/cmd.rs
+++ b/crates/admin-cli/src/managed_host/maintenance/cmd.rs
@@ -18,32 +18,14 @@
 use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge as forgerpc;
 
-use super::args::{Args, MaintenanceOff, MaintenanceOn};
+use super::args::Args;
 use crate::rpc::ApiClient;
 
-pub async fn maintenance_on(api_client: &ApiClient, args: MaintenanceOn) -> CarbideCliResult<()> {
-    let req = forgerpc::MaintenanceRequest {
-        operation: forgerpc::MaintenanceOperation::Enable.into(),
-        host_id: Some(args.host),
-        reference: Some(args.reference),
-    };
-    api_client.0.set_maintenance(req).await?;
-    Ok(())
-}
-
-pub async fn maintenance_off(api_client: &ApiClient, args: MaintenanceOff) -> CarbideCliResult<()> {
-    let req = forgerpc::MaintenanceRequest {
-        operation: forgerpc::MaintenanceOperation::Disable.into(),
-        host_id: Some(args.host),
-        reference: None,
-    };
-    api_client.0.set_maintenance(req).await?;
-    Ok(())
-}
-
 pub async fn maintenance(api_client: &ApiClient, action: Args) -> CarbideCliResult<()> {
-    match action {
-        Args::On(args) => maintenance_on(api_client, args).await,
-        Args::Off(args) => maintenance_off(api_client, args).await,
-    }
+    let req: forgerpc::MaintenanceRequest = match action {
+        Args::On(args) => args.into(),
+        Args::Off(args) => args.into(),
+    };
+    api_client.0.set_maintenance(req).await?;
+    Ok(())
 }

--- a/crates/admin-cli/src/managed_host/power_options/args.rs
+++ b/crates/admin-cli/src/managed_host/power_options/args.rs
@@ -17,6 +17,7 @@
 
 use carbide_uuid::machine::MachineId;
 use clap::{Parser, ValueEnum};
+use rpc::forge::{self as forgerpc, PowerOptionUpdateRequest};
 
 #[derive(Parser, Debug)]
 pub enum Args {
@@ -40,6 +41,20 @@ pub struct UpdatePowerOptions {
     pub machine: MachineId,
     #[clap(long, short, help = "Desired Power State")]
     pub desired_power_state: DesiredPowerState,
+}
+
+impl From<UpdatePowerOptions> for PowerOptionUpdateRequest {
+    fn from(args: UpdatePowerOptions) -> Self {
+        let power_state = match args.desired_power_state {
+            DesiredPowerState::On => forgerpc::PowerState::On,
+            DesiredPowerState::Off => forgerpc::PowerState::Off,
+            DesiredPowerState::PowerManagerDisabled => forgerpc::PowerState::PowerManagerDisabled,
+        };
+        Self {
+            machine_id: Some(args.machine),
+            power_state: power_state as i32,
+        }
+    }
 }
 
 #[derive(ValueEnum, Parser, Debug, Clone, PartialEq)]

--- a/crates/admin-cli/src/managed_host/power_options/cmd.rs
+++ b/crates/admin-cli/src/managed_host/power_options/cmd.rs
@@ -20,9 +20,9 @@ use std::fmt::Write;
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
 use mac_address::MacAddress;
 use prettytable::{Cell, Row, Table};
-use rpc::forge::{BmcEndpointRequest, PowerOptionUpdateRequest, PowerOptions};
+use rpc::forge::{BmcEndpointRequest, PowerOptions};
 
-use super::args::{DesiredPowerState, ShowPowerOptions, UpdatePowerOptions};
+use super::args::{ShowPowerOptions, UpdatePowerOptions};
 use crate::rpc::ApiClient;
 
 pub async fn power_options_show(
@@ -212,19 +212,7 @@ pub async fn update_power_option(
     args: UpdatePowerOptions,
     api_client: &ApiClient,
 ) -> CarbideCliResult<()> {
-    let power_state = match args.desired_power_state {
-        DesiredPowerState::On => ::rpc::forge::PowerState::On,
-        DesiredPowerState::Off => ::rpc::forge::PowerState::Off,
-        DesiredPowerState::PowerManagerDisabled => ::rpc::forge::PowerState::PowerManagerDisabled,
-    };
-    let updated_power_option = api_client
-        .0
-        .update_power_option(PowerOptionUpdateRequest {
-            machine_id: Some(args.machine),
-            power_state: power_state as i32,
-        })
-        .await?
-        .response;
+    let updated_power_option = api_client.0.update_power_option(args).await?.response;
     println!("Power options updated successfully!!");
     println!("Updated power options are");
     power_options_show_one(

--- a/crates/admin-cli/src/managed_host/quarantine/args.rs
+++ b/crates/admin-cli/src/managed_host/quarantine/args.rs
@@ -17,6 +17,7 @@
 
 use carbide_uuid::machine::MachineId;
 use clap::Parser;
+use rpc::forge as forgerpc;
 
 /// Enable or disable quarantine mode on a managed host.
 #[derive(Parser, Debug)]
@@ -41,8 +42,28 @@ pub struct QuarantineOn {
     pub reason: String,
 }
 
+impl From<QuarantineOn> for forgerpc::SetManagedHostQuarantineStateRequest {
+    fn from(args: QuarantineOn) -> Self {
+        Self {
+            machine_id: Some(args.host),
+            quarantine_state: Some(forgerpc::ManagedHostQuarantineState {
+                mode: forgerpc::ManagedHostQuarantineMode::BlockAllTraffic as i32,
+                reason: Some(args.reason),
+            }),
+        }
+    }
+}
+
 #[derive(Parser, Debug)]
 pub struct QuarantineOff {
     #[clap(long, required(true), help = "Managed Host ID")]
     pub host: MachineId,
+}
+
+impl From<QuarantineOff> for forgerpc::ClearManagedHostQuarantineStateRequest {
+    fn from(args: QuarantineOff) -> Self {
+        Self {
+            machine_id: Some(args.host),
+        }
+    }
 }

--- a/crates/admin-cli/src/managed_host/quarantine/cmd.rs
+++ b/crates/admin-cli/src/managed_host/quarantine/cmd.rs
@@ -16,21 +16,13 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::forge as forgerpc;
 
 use super::args::{Args, QuarantineOff, QuarantineOn};
 use crate::rpc::ApiClient;
 
 pub async fn quarantine_on(api_client: &ApiClient, args: QuarantineOn) -> CarbideCliResult<()> {
     let host = args.host;
-    let req = forgerpc::SetManagedHostQuarantineStateRequest {
-        machine_id: Some(args.host),
-        quarantine_state: Some(forgerpc::ManagedHostQuarantineState {
-            mode: forgerpc::ManagedHostQuarantineMode::BlockAllTraffic as i32,
-            reason: Some(args.reason),
-        }),
-    };
-    let prior_state = api_client.0.set_managed_host_quarantine_state(req).await?;
+    let prior_state = api_client.0.set_managed_host_quarantine_state(args).await?;
     println!(
         "quarantine set for host {}, prior state: {:?}",
         host, prior_state.prior_quarantine_state
@@ -40,12 +32,9 @@ pub async fn quarantine_on(api_client: &ApiClient, args: QuarantineOn) -> Carbid
 
 pub async fn quarantine_off(api_client: &ApiClient, args: QuarantineOff) -> CarbideCliResult<()> {
     let host = args.host;
-    let req = forgerpc::ClearManagedHostQuarantineStateRequest {
-        machine_id: Some(host),
-    };
     let prior_state = api_client
         .0
-        .clear_managed_host_quarantine_state(req)
+        .clear_managed_host_quarantine_state(args)
         .await?;
     println!(
         "quarantine set for host {}, prior state: {:?}",

--- a/crates/admin-cli/src/managed_host/set_primary_dpu/args.rs
+++ b/crates/admin-cli/src/managed_host/set_primary_dpu/args.rs
@@ -17,6 +17,7 @@
 
 use carbide_uuid::machine::MachineId;
 use clap::Parser;
+use rpc::forge as forgerpc;
 
 #[derive(Parser, Debug)]
 pub struct Args {
@@ -26,4 +27,14 @@ pub struct Args {
     pub dpu_machine_id: MachineId,
     #[clap(long, help = "Reboot the host after the update")]
     pub reboot: bool,
+}
+
+impl From<Args> for forgerpc::SetPrimaryDpuRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            host_machine_id: Some(args.host_machine_id),
+            dpu_machine_id: Some(args.dpu_machine_id),
+            reboot: args.reboot,
+        }
+    }
 }

--- a/crates/admin-cli/src/managed_host/set_primary_dpu/cmd.rs
+++ b/crates/admin-cli/src/managed_host/set_primary_dpu/cmd.rs
@@ -16,19 +16,11 @@
  */
 
 use ::rpc::admin_cli::CarbideCliResult;
-use ::rpc::forge as forgerpc;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn set_primary_dpu(api_client: &ApiClient, args: Args) -> CarbideCliResult<()> {
-    api_client
-        .0
-        .set_primary_dpu(forgerpc::SetPrimaryDpuRequest {
-            host_machine_id: Some(args.host_machine_id),
-            dpu_machine_id: Some(args.dpu_machine_id),
-            reboot: args.reboot,
-        })
-        .await?;
+    api_client.0.set_primary_dpu(args).await?;
     Ok(())
 }


### PR DESCRIPTION
## Description

This is the follow up to https://github.com/NVIDIA/ncx-infra-controller-core/pull/628 and https://github.com/NVIDIA/ncx-infra-controller-core/pull/633. The first two rounds were pretty simple, with most `Args` -> `Request` conversions generally just being a simple 1:1.

These are a bit more complex, where the `Args` aren't always 1:1, and might instead just be a subset, where some of the extra args are used to control the flow of the command handler.

It's nothing crazy, but I was just targeting low hanging fruit first, and was punting on these.

It's worth noting there ARE some remaining commands I didn't touch. Those have `Request` instances that aren't ONLY backed by `Args`, so it's not actually possible to have them use this pattern.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

