### PR TITLE
chore(api): drop a few needless clones before .to_string()

### DIFF
--- a/crates/api/src/handlers/vpc_peering.rs
+++ b/crates/api/src/handlers/vpc_peering.rs
@@ -60,7 +60,7 @@ pub async fn create(
                 vpc::find_by(&mut txn, ObjectColumnFilter::One(vpc::IdColumn, &vpc_id)).await?;
             let vpc1 = vpcs1.first().ok_or_else(|| CarbideError::NotFoundError {
                 kind: "VPC",
-                id: vpc_id.clone().to_string(),
+                id: vpc_id.to_string(),
             })?;
             let vpcs2 = vpc::find_by(
                 &mut txn,
@@ -69,7 +69,7 @@ pub async fn create(
             .await?;
             let vpc2 = vpcs2.first().ok_or_else(|| CarbideError::NotFoundError {
                 kind: "VPC",
-                id: peer_vpc_id.clone().to_string(),
+                id: peer_vpc_id.to_string(),
             })?;
             // If nvue_enabled, then ETHERNET_VIRTUALIZER = ETHERNET_VIRTUALIZER_WITH_NVUE and
             // only type of peering not allowed is between Fnn <-> ETV/ETV_WITH_NVUE

--- a/crates/api/src/ib/ufmclient/mod.rs
+++ b/crates/api/src/ib/ufmclient/mod.rs
@@ -400,7 +400,7 @@ impl Ufm {
         }
 
         let pkey = Pkey {
-            pkey: p.pkey.clone().to_string(),
+            pkey: p.pkey.to_string(),
             ip_over_ib: p.ipoib,
             membership,
             index0,
@@ -429,7 +429,7 @@ impl Ufm {
         }
 
         let pkey = Pkey {
-            pkey: pkey.clone().to_string(),
+            pkey: pkey.to_string(),
             guids,
         };
 

--- a/crates/api/src/tests/power_shelf.rs
+++ b/crates/api/src/tests/power_shelf.rs
@@ -54,7 +54,7 @@ async fn test_find_power_shelf_by_id(pool: sqlx::PgPool) -> Result<(), Box<dyn s
     let found_power_shelf = &power_shelf_list.power_shelves[0];
     assert_eq!(
         found_power_shelf.id.as_ref().unwrap().to_string(),
-        power_shelf_id.clone().to_string()
+        power_shelf_id.to_string()
     );
     assert_eq!(
         found_power_shelf.config.as_ref().unwrap().name,

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -1500,7 +1500,7 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
     );
 
     // Make sure they are the machines we just created
-    let mut bmc_ip_addresses = vec![explored_managed_hosts[0].host_bmc_ip.clone().to_string()];
+    let mut bmc_ip_addresses = vec![explored_managed_hosts[0].host_bmc_ip.to_string()];
     for dpu in explored_managed_hosts[0].clone().dpus {
         bmc_ip_addresses.push(dpu.bmc_ip.to_string())
     }

--- a/crates/api/src/tests/switch.rs
+++ b/crates/api/src/tests/switch.rs
@@ -46,7 +46,7 @@ async fn test_find_switch_by_id(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
     let found_switch = &switch_list.switches[0];
     assert_eq!(
         found_switch.id.as_ref().unwrap().to_string(),
-        switch_id.clone().to_string()
+        switch_id.to_string()
     );
     assert_eq!(
         found_switch.config.as_ref().unwrap().name,


### PR DESCRIPTION
## Description

Don't need these. Noticed them when doing some other work.

Longer technical explanation for those who don't know is that `.to_string()` takes `&self`, and creates a new `String` from it, so we're making a `.clone()` of something that would just be taken as a reference anyway.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

