### PR TITLE
chore(machine-a-tron): Sunset broken response overrides

### DIFF
--- a/crates/machine-a-tron/src/tabs.rs
+++ b/crates/machine-a-tron/src/tabs.rs
@@ -14,14 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::path::PathBuf;
-use std::process::Stdio;
-use std::str::FromStr;
 
-use crossterm::ExecutableCommand;
-use crossterm::event::{EnableMouseCapture, KeyCode, KeyEvent, KeyModifiers};
-use ratatui::Terminal;
-use ratatui::backend::CrosstermBackend;
+use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::widgets::ListState;
 
 use crate::tui::TuiData;
@@ -38,7 +32,6 @@ pub enum Tab {
     Subnets {
         list_state: ListState,
     },
-    Overrides(OverrideState),
 }
 
 impl Default for Tab {
@@ -60,8 +53,7 @@ impl Tab {
             Self::VPCs { .. } => Self::Subnets {
                 list_state: ListState::default(),
             },
-            Self::Subnets { .. } => Self::Overrides(OverrideState::default()),
-            Self::Overrides(_) => Self::Machines {
+            Self::Subnets { .. } => Self::Machines {
                 tab: MachinesTab::default(),
                 list_state: ListState::default(),
                 focused: false,
@@ -70,7 +62,9 @@ impl Tab {
     }
     pub fn prev(&mut self) {
         *self = match self {
-            Self::Machines { .. } => Self::Overrides(OverrideState::default()),
+            Self::Machines { .. } => Self::Subnets {
+                list_state: ListState::default(),
+            },
             Self::VPCs { .. } => Self::Machines {
                 tab: MachinesTab::default(),
                 list_state: ListState::default(),
@@ -79,22 +73,14 @@ impl Tab {
             Self::Subnets { .. } => Self::VPCs {
                 list_state: ListState::default(),
             },
-            Self::Overrides(_) => Self::Subnets {
-                list_state: ListState::default(),
-            },
         }
     }
-    pub fn titles() -> [&'static str; 4] {
-        ["Machines", "VPCs", "Subnets", "Response Overrides"]
+    pub fn titles() -> [&'static str; 3] {
+        ["Machines", "VPCs", "Subnets"]
     }
     /// Returns whether or not the key was handled and whether or not the selected
     /// machine changed.
-    pub fn handle_key(
-        &mut self,
-        terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
-        data: &mut TuiData,
-        key: KeyEvent,
-    ) -> (bool, bool) {
+    pub fn handle_key(&mut self, data: &mut TuiData, key: KeyEvent) -> (bool, bool) {
         if let Tab::Machines {
             focused: true, tab, ..
         } = self
@@ -105,11 +91,6 @@ impl Tab {
             }
             // If it doesn't handle, then we continue handling.
         }
-        if let Tab::Overrides(state) = self
-            && state.handle_key(terminal, data, key)
-        {
-            return (true, false);
-        }
 
         match key.code {
             KeyCode::Up => match self {
@@ -119,7 +100,6 @@ impl Tab {
                 }
                 Tab::VPCs { list_state } => wrap_line(list_state, data.vpc_cache.len(), true),
                 Tab::Subnets { list_state } => wrap_line(list_state, data.subnet_cache.len(), true),
-                Tab::Overrides(_) => {}
             },
             KeyCode::Down => match self {
                 Tab::Machines { list_state, .. } => {
@@ -130,7 +110,6 @@ impl Tab {
                 Tab::Subnets { list_state } => {
                     wrap_line(list_state, data.subnet_cache.len(), false)
                 }
-                Tab::Overrides(_) => {}
             },
             KeyCode::Left => self.prev(),
             KeyCode::Right => self.next(),
@@ -156,237 +135,8 @@ impl From<&Tab> for u8 {
             Tab::Machines { .. } => 0,
             Tab::VPCs { .. } => 1,
             Tab::Subnets { .. } => 2,
-            Tab::Overrides(_) => 3,
         }
     }
-}
-
-#[derive(Default, Clone)]
-pub struct OverrideState {
-    mode: OverrideMode,
-    pub list_state: ListState,
-    pub scroll_offset: u16,
-}
-
-impl OverrideState {
-    pub fn focused(&self) -> bool {
-        matches!(
-            self.mode,
-            OverrideMode::Focused | OverrideMode::Editing { .. }
-        )
-    }
-    pub fn scroll_focused(&self) -> bool {
-        self.mode == OverrideMode::Scrolling
-    }
-    pub fn get_cursor_offset(&self) -> Option<(u16, u16)> {
-        if let OverrideMode::Editing { cursor, .. } = self.mode {
-            Some((cursor as u16, self.list_state.selected().unwrap() as u16))
-        } else {
-            None
-        }
-    }
-    pub fn get_selected(&self) -> Option<usize> {
-        if let OverrideMode::Unfocused = self.mode {
-            return None;
-        }
-        self.list_state.selected()
-    }
-
-    /// Returns if the key was handled.
-    fn handle_key(
-        &mut self,
-        terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
-        data: &mut TuiData,
-        key: KeyEvent,
-    ) -> bool {
-        let start_list_state = self.list_state.selected();
-        match &mut self.mode {
-            OverrideMode::Unfocused => match key.code {
-                KeyCode::Down => {
-                    if !data.overrides.is_empty() {
-                        self.list_state = ListState::default().with_selected(Some(0));
-                    }
-                    self.mode = OverrideMode::Focused
-                }
-                _ => return false,
-            },
-            OverrideMode::Focused => match key.code {
-                KeyCode::Left | KeyCode::Right => return false,
-                KeyCode::Char('i') => {
-                    if let Some(index) = self.list_state.selected() {
-                        self.mode = OverrideMode::Editing {
-                            original_text: data.overrides[index].clone(),
-                            cursor: data.overrides[index].len(),
-                        };
-                    }
-                }
-                KeyCode::Esc => {
-                    self.list_state = ListState::default();
-                    self.mode = OverrideMode::Unfocused
-                }
-                KeyCode::Enter => self.mode = OverrideMode::Scrolling,
-                KeyCode::Up => wrap_line(&mut self.list_state, data.overrides.len(), true),
-                KeyCode::Down => wrap_line(&mut self.list_state, data.overrides.len(), false),
-                KeyCode::Backspace => {
-                    if let Some(index) = self.list_state.selected() {
-                        let path = data.overrides.remove(index);
-                        if let Some(_original) = data.original_routes.get(&path) {
-                            // TODO: cleanup overrides with path.
-                            tracing::error!("Not implemented clear override");
-                        }
-                        if data.overrides.is_empty() {
-                            self.list_state = ListState::default();
-                        } else {
-                            self.list_state.select(Some(index.saturating_sub(1)))
-                        }
-                    }
-                }
-                // Open an editor to modify the MAT response.
-                KeyCode::Char('e') if self.get_selected().is_some() => {
-                    let selected = self.get_selected().unwrap();
-                    let request = |path| {
-                        // TODO: overrides: implement request to the API.
-                        Some(format!(
-                            "TODO not implemented getting routes from path. Path was: {path}"
-                        ))
-                    };
-                    if let Some(response) = request(&data.overrides[selected]) {
-                        let path = format!(
-                            "/tmp/machine-a-tron/rewrite/{}/index.json",
-                            data.overrides[selected]
-                        );
-                        // Save the original in case we remove the override.
-                        data.original_routes
-                            .insert(data.overrides[selected].clone(), response.clone());
-                        let path_buf = PathBuf::from_str(&path).unwrap();
-                        std::fs::create_dir_all(path_buf.parent().unwrap())
-                            .expect("could not create tempfile directory");
-                        std::fs::write(&path, response).expect("could not write to tempfile");
-
-                        // User edits file.
-                        let editor = std::env::var("EDITOR").unwrap_or("/usr/bin/vim".to_string());
-                        std::process::Command::new(editor)
-                            .arg(&path)
-                            .stdin(Stdio::inherit())
-                            .stdout(Stdio::inherit())
-                            .stderr(Stdio::inherit())
-                            .output()
-                            .unwrap();
-
-                        // Reenable mouse capture (editors like helix disable
-                        // capture on exit).
-                        let mut stdout = std::io::stdout();
-                        stdout.execute(EnableMouseCapture).unwrap();
-
-                        // Read back modified response from file.
-                        // TODO: validate the response is valid JSON
-                        // and maybe validate if is valid redfish response.
-                        let content =
-                            std::fs::read_to_string(path).expect("could not read from tempfile");
-                        // TODO: overrides: implement overrides.
-                        tracing::error!(
-                            "Applying overrides is not implemented yet. Content was: {content}"
-                        );
-                    }
-                    // Fully redraw TUI next frame.
-                    terminal.clear().unwrap();
-                }
-                KeyCode::Char('a') => {
-                    let index = self.list_state.selected().map(|i| i + 1).unwrap_or(0);
-                    data.overrides.insert(index, String::new());
-                    self.list_state.select(Some(index));
-                    self.mode = OverrideMode::Editing {
-                        original_text: String::new(),
-                        cursor: 0,
-                    };
-                }
-                _ => return false,
-            },
-            OverrideMode::Editing {
-                original_text,
-                cursor,
-            } => {
-                let index = self
-                    .list_state
-                    .selected()
-                    .expect("if editing overrides, should have selected an option");
-                let target = &mut data.overrides[index];
-                match key.code {
-                    KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                        *target = target.split_at(*cursor).1.to_string();
-                        *cursor = 0
-                    }
-                    KeyCode::Delete => {
-                        target.truncate(*cursor);
-                    }
-                    KeyCode::Char(c) => {
-                        target.insert(*cursor, c);
-                        *cursor += 1;
-                    }
-                    KeyCode::Backspace => {
-                        if !target.is_empty() && *cursor > 0 {
-                            target.remove(*cursor - 1);
-                            *cursor -= 1;
-                        }
-                    }
-                    KeyCode::Left => *cursor = cursor.saturating_sub(1),
-                    KeyCode::Right => *cursor = (*cursor + 1).min(target.len()),
-                    KeyCode::Enter => {
-                        // TODO: handle duplicate overrides
-
-                        // Reset the original override if overriden.
-                        if let Some(original) = data.original_routes.get(original_text) {
-                            // TODO: overrides: clear overrides on original_text
-                            tracing::error!("Not implemented clear override: original {original}");
-                        }
-                        self.mode = OverrideMode::Focused
-                    }
-                    KeyCode::Esc => {
-                        *target = original_text.clone();
-                        self.mode = OverrideMode::Focused
-                    }
-                    // Swallow all other keys.
-                    _ => return true,
-                }
-                // Remove the override if we exited editing mode and the
-                // submitted path is empty.
-                if !matches!(self.mode, OverrideMode::Editing { .. }) && target.is_empty() {
-                    data.overrides.remove(index);
-                    self.list_state.select(if !data.overrides.is_empty() {
-                        self.list_state
-                            .selected()
-                            .map(|i| i.min(data.overrides.len() - 1))
-                    } else {
-                        None
-                    })
-                }
-            }
-            OverrideMode::Scrolling => match key.code {
-                KeyCode::Down => self.scroll_offset = self.scroll_offset.saturating_add(1),
-                KeyCode::Up => self.scroll_offset = self.scroll_offset.saturating_sub(1),
-                KeyCode::Esc => self.mode = OverrideMode::Focused,
-                _ => return false,
-            },
-        }
-        // If we changed which override is selected, then reset preview scroll.
-        if self.list_state.selected() != start_list_state {
-            self.scroll_offset = 0;
-        }
-
-        true
-    }
-}
-
-#[derive(Default, Clone, PartialEq, Eq)]
-enum OverrideMode {
-    #[default]
-    Unfocused,
-    Focused,
-    Editing {
-        original_text: String,
-        cursor: usize,
-    },
-    Scrolling,
 }
 
 #[derive(Default, Clone)]

--- a/crates/machine-a-tron/src/tui.rs
+++ b/crates/machine-a-tron/src/tui.rs
@@ -166,7 +166,6 @@ pub struct TuiData {
     pub subnet_cache: HashMap<NetworkSegmentId, SubnetDetails>,
     pub machine_details: String,
     pub machine_logs: String,
-    pub overrides: Vec<String>,
     pub original_routes: HashMap<String, String>,
 }
 
@@ -187,7 +186,6 @@ impl Tui {
                 subnet_cache: HashMap::default(),
                 machine_details: String::default(),
                 machine_logs: String::default(),
-                overrides: Vec::new(),
                 original_routes: HashMap::new(),
             },
             ui: Tab::default(),
@@ -212,11 +210,7 @@ impl Tui {
         Ok(())
     }
 
-    async fn handle_event(
-        &mut self,
-        terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
-        event: Event,
-    ) -> bool {
+    async fn handle_event(&mut self, event: Event) -> bool {
         let Self {
             data,
             ui,
@@ -226,7 +220,7 @@ impl Tui {
             Event::Key(key) => {
                 // Handle global triggers.
                 if key.kind == event::KeyEventKind::Press {
-                    let (handled, machine_changed) = ui.handle_key(terminal, data, key);
+                    let (handled, machine_changed) = ui.handle_key(data, key);
                     if !handled {
                         match key.code {
                             KeyCode::Char('q') => {
@@ -251,7 +245,6 @@ impl Tui {
             // Interpret scroll as up down arrow keys.
             Event::Mouse(mouse) if mouse.kind == event::MouseEventKind::ScrollUp => {
                 ui.handle_key(
-                    terminal,
                     data,
                     event::KeyEvent::new(KeyCode::Up, KeyModifiers::empty()),
                 )
@@ -259,7 +252,6 @@ impl Tui {
             }
             Event::Mouse(mouse) if mouse.kind == event::MouseEventKind::ScrollDown => {
                 ui.handle_key(
-                    terminal,
                     data,
                     event::KeyEvent::new(KeyCode::Down, KeyModifiers::empty()),
                 )
@@ -444,45 +436,6 @@ impl Tui {
                             .block(Block::default().borders(Borders::ALL).title("Details"));
                         f.render_widget(paragraph, chunks[1]);
                     }
-                    Tab::Overrides(state) => {
-                        let layout = Layout::new(
-                            Direction::Vertical,
-                            [Constraint::Length(3), Constraint::Fill(1)],
-                        )
-                        .split(left_chunks[1]);
-
-                        let p = Paragraph::new("a to add an override path, DEL to remove, i to edit, e to edit the override body").block(Block::bordered().border_style(Style::new().bold()));
-                        f.render_widget(p, layout[0]);
-
-                        if let Some(offset) = state.get_cursor_offset() {
-                            f.set_cursor_position(Position::new(
-                                // Add 1 for border, three for "- /" prefix.
-                                layout[1].x + offset.0 + 4,
-                                // Add 1 for border.
-                                layout[1].y + offset.1 + 1,
-                            ));
-                        }
-
-                        let mut block = Block::default().borders(Borders::ALL);
-                        if state.focused() {
-                            block = block.border_style(Style::new().yellow().bold());
-                        }
-                        let list = List::new(data.overrides.iter().map(|o| format!("- /{o}/index.json")))
-                            .block(block)
-                            .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
-
-                        f.render_stateful_widget(list, layout[1], &mut state.list_state);
-                        if let Some(selected) = state.get_selected() {
-                            let mut block = Block::default().borders(Borders::ALL).title("Response Preview");
-                            if state.scroll_focused() {
-                                block = block.border_style(Style::new().yellow().bold());
-                            }
-
-                            // TODO: make request to redfish using selected override path.
-                            f.render_widget(Paragraph::new(format!("TODO: not implemented yet: selected: {selected}"))
-                                                           .scroll((state.scroll_offset, 0)).block(block), chunks[1]);
-                        }
-                    }
                 }
             })?;
 
@@ -495,7 +448,7 @@ impl Tui {
                 maybe_event = event_stream.next() => {
                     match maybe_event {
                         Some(Ok(event)) => {
-                            list_updated = self.handle_event(&mut terminal, event).await;
+                            list_updated = self.handle_event(event).await;
                         }
                         Some(Err(e)) => tracing::warn!("Error: {:?}", e),
                         None => break,


### PR DESCRIPTION
## Description
Response overrides have been broken for a while since we switched to new way of generation of BMC responses. This PR sunsets it because no request to restore this function.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [x] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

