### PR TITLE
chore(machine-a-tron): Add hardware type to TUI machine details

### DIFF
--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -384,6 +384,7 @@ impl DpuMachineHandle {
         let guard = self.0.live_state.read().unwrap();
         HostDetails {
             mat_id: self.0.mat_id,
+            hw_type: None,
             machine_id: guard.observed_machine_id.as_ref().map(|m| m.to_string()),
             mat_state: guard.state_string.clone(),
             api_state: guard.api_state.clone(),

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -420,6 +420,7 @@ impl HostMachine {
 
         HostDetails {
             mat_id: self.mat_id,
+            hw_type: Some(self.host_info.hw_type),
             machine_id: self
                 .live_state
                 .read()

--- a/crates/machine-a-tron/src/tui.rs
+++ b/crates/machine-a-tron/src/tui.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::time::Duration;
 
-use bmc_mock::MockPowerState;
+use bmc_mock::{HostHardwareType, MockPowerState};
 use carbide_uuid::network::NetworkSegmentId;
 use carbide_uuid::vpc::VpcId;
 use crossterm::ExecutableCommand;
@@ -92,6 +92,7 @@ impl SubnetDetails {
 pub struct HostDetails {
     pub mat_id: Uuid,
     pub machine_id: Option<String>,
+    pub hw_type: Option<HostHardwareType>,
     pub power_state: MockPowerState,
     pub mat_state: String,
     pub api_state: String,
@@ -115,20 +116,25 @@ impl HostDetails {
     fn details(&self) -> String {
         let mut result = String::with_capacity(1024);
 
-        result.push_str(&format!("MAT ID: {}\n", self.mat_id));
-        result.push_str(&format!(
-            "Machine ID: {}\n",
-            self.machine_id
-                .as_ref()
-                .map(|id| id.to_string())
-                .unwrap_or_default()
-        ));
-        result.push_str(&format!("Machine IP: {}\n", self.machine_ip));
-        result.push_str(&format!("BMC IP: {}\n", self.oob_ip));
-        result.push_str(&format!("Power State: {}\n", self.power_state));
-        result.push_str(&format!("Booted OS: {}\n", self.booted_os));
-        result.push_str(&format!("MAT State: {}\n", self.mat_state));
-        result.push_str(&format!("API State: {}\n", self.api_state));
+        [
+            &format!("MAT ID: {}\n", self.mat_id),
+            &format!(
+                "Machine ID: {}\n",
+                self.machine_id.as_deref().unwrap_or_default()
+            ),
+            &self
+                .hw_type
+                .map(|t| format!("Hardware type: {t}\n"))
+                .unwrap_or_default(),
+            &format!("Machine IP: {}\n", self.machine_ip),
+            &format!("BMC IP: {}\n", self.oob_ip),
+            &format!("Power State: {}\n", self.power_state),
+            &format!("Booted OS: {}\n", self.booted_os),
+            &format!("MAT State: {}\n", self.mat_state),
+            &format!("API State: {}\n", self.api_state),
+        ]
+        .into_iter()
+        .for_each(|v| result.push_str(v));
 
         if !self.dpus.is_empty() {
             result.push('\n');


### PR DESCRIPTION
## Description
Now machine-a-tron supports handful of different types of hardware and it is useful to see information about hardware type of specific machine in TUI.

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

