### PR TITLE
fix(dpf): transition to dpu state instead of host init on dpf completion

### DIFF
--- a/crates/api/src/state_controller/machine/handler/dpf.rs
+++ b/crates/api/src/state_controller/machine/handler/dpf.rs
@@ -22,7 +22,7 @@ use carbide_uuid::machine::MachineId;
 use libredfish::SystemPowerControl;
 use model::machine::{
     DpfState, DpuInitState, FailureCause, FailureDetails, FailureSource, InstanceState, Machine,
-    MachineState, ManagedHostState, ManagedHostStateSnapshot, ReprovisionState, StateMachineArea,
+    ManagedHostState, ManagedHostStateSnapshot, ReprovisionState, StateMachineArea,
 };
 
 use super::helpers::{DpuInitStateHelper, ManagedHostStateHelper, ReprovisionStateHelper};
@@ -138,16 +138,15 @@ fn update_phase_detail_or_wait(
 }
 
 /// Determine the correct next state when exiting `DeviceReady`, based on
-/// whether we are in initial provisioning (`DPUInit`) or reprovisioning
-/// (`DPUReprovision`).
+/// whether we are in initial provisioning (`DPUInit` -> `WaitingForPlatformConfiguration`)
+/// or reprovisioning (`DPUReprovision`).
 fn waiting_for_ready_exit_state(
     state: &ManagedHostStateSnapshot,
 ) -> Result<ManagedHostState, StateHandlerError> {
     match &state.managed_state {
         ManagedHostState::DPUInit { .. } | ManagedHostState::DpuDiscoveringState { .. } => {
-            Ok(ManagedHostState::HostInit {
-                machine_state: MachineState::EnableIpmiOverLan,
-            })
+            DpuInitState::WaitingForPlatformConfiguration
+                .next_state_with_all_dpus_updated(&state.managed_state)
         }
         ManagedHostState::DPUReprovision { .. }
         | ManagedHostState::Assigned {

--- a/crates/api/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/site_explorer.rs
@@ -406,9 +406,16 @@ impl<'a> MockExploredHost<'a> {
         self.test_env
             .run_machine_state_controller_iteration_until_state_matches(
                 &host_machine_id,
-                10,
-                ManagedHostState::HostInit {
-                    machine_state: MachineState::EnableIpmiOverLan,
+                35,
+                ManagedHostState::DPUInit {
+                    dpu_states: model::machine::DpuInitStates {
+                        states: self
+                            .dpu_machine_ids
+                            .clone()
+                            .into_values()
+                            .map(|machine_id| (machine_id, DpuInitState::WaitingForNetworkConfig))
+                            .collect::<HashMap<MachineId, DpuInitState>>(),
+                    },
                 },
             )
             .await;
@@ -1680,7 +1687,7 @@ pub async fn new_mock_host_with_dpf(
     // these futures. Prior to this we were hitting stack space limits (going over 2MB in stack) in
     // unit tests. This buys us some savings so that we don't have to fiddle with adjusting the
     // default stack size.
-    mock_explored_host
+    mock_explored_host = mock_explored_host
         // ...Then run host BMC's DHCP
         .discover_dhcp_host_bmc(|_, _| Ok(()))
         .boxed()
@@ -1700,7 +1707,16 @@ pub async fn new_mock_host_with_dpf(
         .await?
         .dpu_state_controller_iterations_with_dpf()
         .boxed()
-        .await
+        .await;
+
+    let dpu_ids: Vec<MachineId> = mock_explored_host
+        .dpu_machine_ids
+        .values()
+        .copied()
+        .collect();
+    network_configured(env, &dpu_ids).await;
+
+    mock_explored_host
         .discover_machine(|_, _| Ok(()))
         .boxed()
         .await?

--- a/crates/api/src/tests/dpf/duplicate_events.rs
+++ b/crates/api/src/tests/dpf/duplicate_events.rs
@@ -44,6 +44,17 @@ use crate::tests::common::api_fixtures::{
 const TEST_TIMEOUT: Duration = Duration::from_secs(30);
 const DUPLICATE_ITERATIONS: usize = 10;
 
+fn dpf_left_operator_provisioning_substates(host: &ManagedHostState) -> bool {
+    match host {
+        ManagedHostState::DPUInit { dpu_states } => dpu_states
+            .states
+            .values()
+            .all(|s| !matches!(s, DpuInitState::DpfStates { .. })),
+        ManagedHostState::HostInit { .. } => true,
+        _ => false,
+    }
+}
+
 fn dpf_config() -> crate::cfg::file::DpfConfig {
     crate::cfg::file::DpfConfig {
         enabled: true,
@@ -104,7 +115,8 @@ async fn get_host_state(
 }
 
 /// Many iterations while the device is ready and no reboot is required.
-/// The host must reach Ready and stay there despite repeated processing.
+/// The host must leave DPF `DpfStates` (or enter host init) and stay there
+/// despite repeated processing.
 #[crate::sqlx_test]
 async fn test_duplicate_ready_events_reach_ready(pool: sqlx::PgPool) {
     let mut mock = MockDpfOperations::new();
@@ -141,8 +153,8 @@ async fn test_duplicate_ready_events_reach_ready(pool: sqlx::PgPool) {
 
     let host = get_host_state(&env, &mh).await;
     assert!(
-        !matches!(host, ManagedHostState::DPUInit { .. }),
-        "Host should have transitioned out of DPUInit after {} iterations, got: {:?}",
+        dpf_left_operator_provisioning_substates(&host),
+        "Host should have left DPF operator substates after {} iterations, got: {:?}",
         DUPLICATE_ITERATIONS,
         host
     );
@@ -224,8 +236,8 @@ async fn test_duplicate_reboot_events_send_single_reboot(pool: sqlx::PgPool) {
     );
 }
 
-/// Many iterations after reboot completes. The host must advance
-/// past DPUInit and not regress or panic.
+/// Many iterations after reboot completes. The host must leave DPF `DpfStates`
+/// and not regress or panic.
 #[crate::sqlx_test]
 async fn test_duplicate_events_after_reboot_complete(pool: sqlx::PgPool) {
     let mut mock = MockDpfOperations::new();
@@ -285,8 +297,8 @@ async fn test_duplicate_events_after_reboot_complete(pool: sqlx::PgPool) {
 
     let host = get_host_state(&env, &mh).await;
     assert!(
-        !matches!(host, ManagedHostState::DPUInit { .. }),
-        "Host should have transitioned out of DPUInit after reboot + {} duplicate iterations, got: {:?}",
+        dpf_left_operator_provisioning_substates(&host),
+        "Host should have left DPF operator substates after reboot + {} duplicate iterations, got: {:?}",
         DUPLICATE_ITERATIONS,
         host
     );
@@ -358,8 +370,8 @@ async fn test_duplicate_events_while_not_ready(pool: sqlx::PgPool) {
 
     let host = get_host_state(&env, &mh).await;
     assert!(
-        !matches!(host, ManagedHostState::DPUInit { .. }),
-        "Host should have transitioned out of DPUInit after DPU became ready, got: {:?}",
+        dpf_left_operator_provisioning_substates(&host),
+        "Host should have left DPF operator substates after DPU became ready, got: {:?}",
         host
     );
 }

--- a/crates/api/src/tests/dpf/waiting_for_ready.rs
+++ b/crates/api/src/tests/dpf/waiting_for_ready.rs
@@ -39,6 +39,18 @@ use crate::tests::common::api_fixtures::{
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// True after the DPF `DeviceReady` sync: no DPU remains in `DpfStates`, or host init has started.
+fn dpf_left_operator_provisioning_substates(host: &ManagedHostState) -> bool {
+    match host {
+        ManagedHostState::DPUInit { dpu_states } => dpu_states
+            .states
+            .values()
+            .all(|s| !matches!(s, DpuInitState::DpfStates { .. })),
+        ManagedHostState::HostInit { .. } => true,
+        _ => false,
+    }
+}
+
 /// Set up the initial provisioning expectations shared by all WaitingForReady tests.
 /// Does NOT set up `get_dpu_phase` -- each test configures it to control the
 /// DPU CR phase (the authoritative readiness signal).
@@ -103,7 +115,7 @@ async fn get_host_state(
 
 /// WaitingForReady with reboot required:
 ///   1. Releases maintenance hold, sees reboot required, power-cycles host (ForceOff + On)
-///   2. After reboot_completed, device ready -> HostInit
+///   2. After reboot_completed, device ready -> leaves DPF `DpfStates` (then may advance further)
 #[crate::sqlx_test]
 async fn test_waiting_for_ready_reboot_flow(pool: sqlx::PgPool) {
     let mut mock = MockDpfOperations::new();
@@ -182,8 +194,8 @@ async fn test_waiting_for_ready_reboot_flow(pool: sqlx::PgPool) {
 
     let host = get_host_state(&env, &mh).await;
     assert!(
-        !matches!(host, ManagedHostState::DPUInit { .. }),
-        "Host should have transitioned out of DPUInit, got: {:?}",
+        dpf_left_operator_provisioning_substates(&host),
+        "Host should have left DPF operator substates after DeviceReady, got: {:?}",
         host
     );
 }
@@ -253,8 +265,8 @@ async fn test_waiting_for_ready_no_reboot(pool: sqlx::PgPool) {
 
     let host = get_host_state(&env, &mh).await;
     assert!(
-        !matches!(host, ManagedHostState::DPUInit { .. }),
-        "Host should have transitioned out of DPUInit after DPU Ready, got: {:?}",
+        dpf_left_operator_provisioning_substates(&host),
+        "Host should have left DPF operator substates after DeviceReady, got: {:?}",
         host
     );
 }
@@ -459,8 +471,8 @@ async fn test_waiting_for_ready_host_already_off(pool: sqlx::PgPool) {
 
     let host = get_host_state(&env, &mh).await;
     assert!(
-        !matches!(host, ManagedHostState::DPUInit { .. }),
-        "Host should have transitioned out of DPUInit, got: {:?}",
+        dpf_left_operator_provisioning_substates(&host),
+        "Host should have left DPF operator substates after DeviceReady, got: {:?}",
         host
     );
 }
@@ -650,8 +662,8 @@ async fn test_waiting_for_ready_reboot_proceeds_after_discovery(pool: sqlx::PgPo
 
     let host = get_host_state(&env, &mh).await;
     assert!(
-        !matches!(host, ManagedHostState::DPUInit { .. }),
-        "Host should have transitioned out of DPUInit after single-DPU discovery + reboot, got: {:?}",
+        dpf_left_operator_provisioning_substates(&host),
+        "Host should have left DPF operator substates after DeviceReady, got: {:?}",
         host
     );
 }


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->

transition to dpu state instead of host init on dpf completion. skipping to host init misses some steps.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

