### PR TITLE
feat: add periodic dhcp cleanup for stale/leaked addresses

### DIFF
--- a/crates/api-db/src/machine_interface_address.rs
+++ b/crates/api-db/src/machine_interface_address.rs
@@ -71,10 +71,81 @@ pub async fn delete(
         .map_err(|e| DatabaseError::query(query, e))
 }
 
+/// delete_stale_allocations deletes IP address allocations for
+/// interfaces whose `last_dhcp` timestamp is older than `max_age`
+/// ago, scoped to the given network segment types. Used as part
+/// of our periodic cleanup.
+///
+/// When `include_associated` is false (default), only interfaces
+/// with no machine association (machine_id IS NULL) are targeted,
+/// since those are the primary source of leaked allocations.
+/// When true, all stale interfaces are eligible regardless of
+/// machine association.
+///
+/// Returns the number of address rows deleted.
+pub async fn delete_stale_allocations(
+    txn: &mut PgConnection,
+    max_age: std::time::Duration,
+    segment_types: &[NetworkSegmentType],
+    include_associated: bool,
+) -> Result<u64, DatabaseError> {
+    let unassociated_filter = if include_associated {
+        ""
+    } else {
+        "AND mi.machine_id IS NULL"
+    };
+    let query = format!(
+        "DELETE FROM machine_interface_addresses
+        WHERE interface_id IN (
+            SELECT mi.id FROM machine_interfaces mi
+            INNER JOIN network_segments ns ON ns.id = mi.segment_id
+            WHERE mi.last_dhcp IS NOT NULL
+              AND mi.last_dhcp < NOW() - $1::interval
+              AND ns.network_segment_type = ANY($2::network_segment_type_t[])
+              {unassociated_filter}
+        )"
+    );
+    let interval = pg_interval_from_duration(max_age);
+    sqlx::query(&query)
+        .bind(interval)
+        .bind(segment_types)
+        .execute(txn)
+        .await
+        .map(|r| r.rows_affected())
+        .map_err(|e| DatabaseError::query(&query, e))
+}
+
+fn pg_interval_from_duration(d: std::time::Duration) -> sqlx::postgres::types::PgInterval {
+    sqlx::postgres::types::PgInterval {
+        months: 0,
+        days: 0,
+        microseconds: d.as_micros() as i64,
+    }
+}
+
 #[derive(Debug, FromRow)]
 pub struct MachineInterfaceSearchResult {
     pub id: MachineInterfaceId,
     pub machine_id: Option<MachineId>,
     pub name: String,
     pub network_segment_type: NetworkSegmentType,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pg_interval_from_7_days() {
+        let interval = pg_interval_from_duration(std::time::Duration::from_secs(7 * 24 * 3600));
+        assert_eq!(interval.months, 0);
+        assert_eq!(interval.days, 0);
+        assert_eq!(interval.microseconds, 7 * 24 * 3600 * 1_000_000);
+    }
+
+    #[test]
+    fn pg_interval_from_zero() {
+        let interval = pg_interval_from_duration(std::time::Duration::ZERO);
+        assert_eq!(interval.microseconds, 0);
+    }
 }

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -269,6 +269,14 @@ pub struct CarbideConfig {
     #[serde(default)]
     pub machine_updater: MachineUpdater,
 
+    /// dhcp_periodic_cleanup is disabled by ::default(), and
+    /// by adding a config block and setting enable: true, you
+    /// will enable a default cleanup of IP address allocations
+    /// which haven't had a DHCP renewal occur in 7 days. This
+    /// can additional be configured here as well.
+    #[serde(default)]
+    pub dhcp_periodic_cleanup: DhcpPeriodicCleanupConfig,
+
     /// The maximum number of IDs allowed for find_(something)_by_ids APIs
     #[serde(default = "default_max_find_by_ids")]
     pub max_find_by_ids: u32,
@@ -2443,6 +2451,77 @@ impl MachineValidationConfig {
     }
 }
 
+/// DhcpPeriodicCleanupConfig is the config used to define
+/// periodic cleanup of stale DHCP IP allocations.
+/// https://github.com/NVIDIA/ncx-infra-controller-core/issues/662
+///
+/// When a machine interface has not renewed its DHCP lease within
+/// `max_age`, its IP address allocations are released back to the pool.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct DhcpPeriodicCleanupConfig {
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// run_interval controls how often the periodic
+    /// cleanup loop runs.
+    #[serde(
+        default = "DhcpPeriodicCleanupConfig::default_run_interval",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub run_interval: std::time::Duration,
+
+    /// max_age controls the max age of allocations. Allocations with
+    /// `last_dhcp` older than this are considered stale and released.
+    #[serde(
+        default = "DhcpPeriodicCleanupConfig::default_max_age",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub max_age: std::time::Duration,
+
+    /// segment_types controls which network segment types are
+    /// eligible for cleanup. Only interfaces on segments of
+    /// these types will have their stale allocations released.
+    #[serde(default = "DhcpPeriodicCleanupConfig::default_segment_types")]
+    pub segment_types: Vec<model::network_segment::NetworkSegmentType>,
+
+    /// include_associated controls whether interfaces that are
+    /// associated with a known machine (machine_id IS NOT NULL) are
+    /// eligible for cleanup. Defaults to false, meaning only
+    /// unassociated/anonymous interfaces are cleaned up.
+    #[serde(default)]
+    pub include_associated: bool,
+}
+
+impl Default for DhcpPeriodicCleanupConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            run_interval: Self::default_run_interval(),
+            max_age: Self::default_max_age(),
+            segment_types: Self::default_segment_types(),
+            include_associated: false,
+        }
+    }
+}
+
+impl DhcpPeriodicCleanupConfig {
+    const fn default_run_interval() -> std::time::Duration {
+        // Default to running at 1 hour intervals.
+        std::time::Duration::from_secs(3600)
+    }
+
+    const fn default_max_age() -> std::time::Duration {
+        // Default to cleaning up stale allocations 7 days old.
+        std::time::Duration::from_secs(7 * 24 * 3600)
+    }
+
+    fn default_segment_types() -> Vec<model::network_segment::NetworkSegmentType> {
+        vec![model::network_segment::NetworkSegmentType::Underlay]
+    }
+}
+
 /// The VPC isolation behavior enforced within a site.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -4268,5 +4347,81 @@ firmware_url = "https://firmware.example.com/fw-b.bin"
             .unwrap();
 
         assert!(config.supernic_firmware_profiles.is_empty());
+    }
+
+    #[test]
+    fn dhcp_periodic_cleanup_config_defaults() {
+        let config: CarbideConfig = Figment::new()
+            .merge(Toml::file(format!("{TEST_DATA_DIR}/min_config.toml")))
+            .extract()
+            .unwrap();
+
+        assert!(!config.dhcp_periodic_cleanup.enabled);
+        assert_eq!(
+            config.dhcp_periodic_cleanup.run_interval,
+            std::time::Duration::from_secs(3600)
+        );
+        assert_eq!(
+            config.dhcp_periodic_cleanup.max_age,
+            std::time::Duration::from_secs(7 * 24 * 3600)
+        );
+        assert_eq!(
+            config.dhcp_periodic_cleanup.segment_types,
+            vec![model::network_segment::NetworkSegmentType::Underlay]
+        );
+        assert!(!config.dhcp_periodic_cleanup.include_associated);
+    }
+
+    #[test]
+    fn dhcp_periodic_cleanup_config_custom_values() {
+        let config = r#"{"enabled": true, "run_interval": "30m", "max_age": "14d", "segment_types": ["underlay", "admin"], "include_associated": true}"#;
+        let config: DhcpPeriodicCleanupConfig = serde_json::from_str(config).unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.run_interval, std::time::Duration::from_secs(30 * 60));
+        assert_eq!(
+            config.max_age,
+            std::time::Duration::from_secs(14 * 24 * 3600)
+        );
+        assert_eq!(
+            config.segment_types,
+            vec![
+                model::network_segment::NetworkSegmentType::Underlay,
+                model::network_segment::NetworkSegmentType::Admin,
+            ]
+        );
+        assert!(config.include_associated);
+    }
+
+    #[test]
+    fn dhcp_periodic_cleanup_config_serialize_roundtrip() {
+        let input = DhcpPeriodicCleanupConfig {
+            enabled: true,
+            run_interval: std::time::Duration::from_secs(1800),
+            max_age: std::time::Duration::from_secs(604800),
+            segment_types: vec![model::network_segment::NetworkSegmentType::Underlay],
+            include_associated: true,
+        };
+        let config_str = serde_json::to_string(&input).unwrap();
+        let config: DhcpPeriodicCleanupConfig = serde_json::from_str(&config_str).unwrap();
+        assert_eq!(config, input);
+    }
+
+    #[test]
+    fn dhcp_periodic_cleanup_config_partial_uses_defaults() {
+        let config = r#"{"max_age": "3d"}"#;
+        let config: DhcpPeriodicCleanupConfig = serde_json::from_str(config).unwrap();
+        assert!(!config.enabled);
+        assert_eq!(
+            config.run_interval,
+            DhcpPeriodicCleanupConfig::default_run_interval()
+        );
+        assert_eq!(
+            config.max_age,
+            std::time::Duration::from_secs(3 * 24 * 3600)
+        );
+        assert_eq!(
+            config.segment_types,
+            vec![model::network_segment::NetworkSegmentType::Underlay]
+        );
     }
 }

--- a/crates/api/src/dhcp_periodic_cleanup.rs
+++ b/crates/api/src/dhcp_periodic_cleanup.rs
@@ -1,0 +1,106 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::io;
+
+use sqlx::PgPool;
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+
+use crate::cfg::file::DhcpPeriodicCleanupConfig;
+use crate::periodic_timer::PeriodicTimer;
+
+/// DhcpPeriodicCleanup periodically releases IP address allocations
+/// for machine interface addresses that have not renewed their DHCP
+/// lease within the configured `max_age`.
+pub struct DhcpPeriodicCleanup {
+    database_connection: PgPool,
+    config: DhcpPeriodicCleanupConfig,
+}
+
+impl DhcpPeriodicCleanup {
+    pub fn new(database_connection: PgPool, config: DhcpPeriodicCleanupConfig) -> Self {
+        Self {
+            database_connection,
+            config,
+        }
+    }
+
+    pub fn start(
+        self,
+        join_set: &mut JoinSet<()>,
+        cancel_token: CancellationToken,
+    ) -> io::Result<()> {
+        if self.config.enabled {
+            tracing::info!(
+                max_age_secs = self.config.max_age.as_secs(),
+                run_interval_secs = self.config.run_interval.as_secs(),
+                "Starting DHCP periodic cleanup"
+            );
+            join_set
+                .build_task()
+                .name("dhcp_periodic_cleanup")
+                .spawn(async move { self.run(cancel_token).await })?;
+        } else {
+            tracing::info!("DHCP periodic cleanup is disabled");
+        }
+        Ok(())
+    }
+
+    async fn run(&self, cancel_token: CancellationToken) {
+        let timer = PeriodicTimer::new(self.config.run_interval);
+        loop {
+            let tick = timer.tick();
+            if let Err(e) = self.run_single_iteration().await {
+                tracing::warn!("DHCP periodic cleanup error: {e}");
+            }
+
+            tokio::select! {
+                _ = tick.sleep() => {},
+                _ = cancel_token.cancelled() => {
+                    tracing::info!("DHCP periodic cleanup stop was requested");
+                    return;
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn run_single_iteration(&self) -> eyre::Result<()> {
+        let mut txn = self.database_connection.begin().await?;
+        let deleted = db::machine_interface_address::delete_stale_allocations(
+            &mut txn,
+            self.config.max_age,
+            &self.config.segment_types,
+            self.config.include_associated,
+        )
+        .await?;
+
+        txn.commit().await?;
+
+        if deleted > 0 {
+            tracing::info!(
+                deleted,
+                max_age_secs = self.config.max_age.as_secs(),
+                "Released stale DHCP IP allocations"
+            );
+        } else {
+            tracing::trace!("No stale DHCP allocations to clean up");
+        }
+
+        Ok(())
+    }
+}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -72,6 +72,7 @@ mod cfg;
 mod credentials;
 mod db_init;
 mod dhcp;
+mod dhcp_periodic_cleanup;
 mod dpa;
 mod dpf;
 mod dynamic_settings;

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -48,6 +48,7 @@ use tracing_log::AsLog as _;
 use crate::api::Api;
 use crate::api::metrics::ApiMetricsEmitter;
 use crate::cfg::file::{CarbideConfig, ListenMode};
+use crate::dhcp_periodic_cleanup::DhcpPeriodicCleanup;
 use crate::dpa::handler::{DpaInfo, start_dpa_handler};
 use crate::dynamic_settings::DynamicSettings;
 use crate::errors::CarbideError;
@@ -977,6 +978,12 @@ pub async fn initialize_and_start_controllers(
         db_pool.clone(),
         carbide_config.machine_validation_config.clone(),
         meter.clone(),
+    )
+    .start(join_set, cancel_token.clone())?;
+
+    DhcpPeriodicCleanup::new(
+        db_pool.clone(),
+        carbide_config.dhcp_periodic_cleanup.clone(),
     )
     .start(join_set, cancel_token.clone())?;
 

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -85,9 +85,9 @@ use tracing_subscriber::EnvFilter;
 use crate::api::Api;
 use crate::api::metrics::ApiMetricsEmitter;
 use crate::cfg::file::{
-    BomValidationConfig, CarbideConfig, ComputeAllocationEnforcement, DpaConfig,
-    DpaInterfaceStateControllerConfig, DpuConfig as InitialDpuConfig, FirmwareGlobal, FnnConfig,
-    IBFabricConfig, IbFabricDefinition, IbPartitionStateControllerConfig, ListenMode,
+    BomValidationConfig, CarbideConfig, ComputeAllocationEnforcement, DhcpPeriodicCleanupConfig,
+    DpaConfig, DpaInterfaceStateControllerConfig, DpuConfig as InitialDpuConfig, FirmwareGlobal,
+    FnnConfig, IBFabricConfig, IbFabricDefinition, IbPartitionStateControllerConfig, ListenMode,
     MachineStateControllerConfig, MachineUpdater, MachineValidationConfig,
     MeasuredBootMetricsCollectorConfig, MqttAuthConfig, NetworkSecurityGroupConfig,
     NetworkSegmentStateControllerConfig, NvLinkConfig, PowerManagerOptions,
@@ -1213,6 +1213,7 @@ pub fn get_config() -> CarbideConfig {
         arm_pxe_boot_url_override: None,
         supernic_firmware_profiles: HashMap::default(),
         component_manager: None,
+        dhcp_periodic_cleanup: DhcpPeriodicCleanupConfig::default(),
     }
 }
 

--- a/crates/api/src/tests/dhcp_periodic_cleanup.rs
+++ b/crates/api/src/tests/dhcp_periodic_cleanup.rs
@@ -1,0 +1,367 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::str::FromStr;
+use std::time::Duration;
+
+use common::api_fixtures::{FIXTURE_DHCP_RELAY_ADDRESS, create_managed_host, create_test_env};
+use mac_address::MacAddress;
+use model::network_segment::NetworkSegmentType;
+
+use crate::cfg::file::DhcpPeriodicCleanupConfig;
+use crate::dhcp_periodic_cleanup::DhcpPeriodicCleanup;
+use crate::tests::common;
+
+/// Helper to build a cleanup config targeting admin segments (which is
+/// what the test fixture creates for FIXTURE_DHCP_RELAY_ADDRESS).
+fn test_config() -> DhcpPeriodicCleanupConfig {
+    DhcpPeriodicCleanupConfig {
+        enabled: true,
+        run_interval: Duration::from_secs(3600),
+        max_age: Duration::from_secs(7 * 24 * 3600),
+        segment_types: vec![NetworkSegmentType::Admin],
+        include_associated: false,
+    }
+}
+
+#[crate::sqlx_test]
+async fn test_stale_allocation_is_deleted(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let relay: std::net::IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
+
+    // Create an interface (which also allocates an IP address)
+    let mut txn = env.pool.begin().await?;
+    let interface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        MacAddress::from_str("aa:bb:cc:dd:ee:01").unwrap(),
+        relay,
+        None,
+    )
+    .await?;
+    assert!(
+        !interface.addresses.is_empty(),
+        "interface should have an IP"
+    );
+
+    // Set last_dhcp to 8 days ago (stale)
+    let stale_time = chrono::Utc::now() - chrono::Duration::days(8);
+    db::machine_interface::update_last_dhcp(&mut txn, interface.id, Some(stale_time)).await?;
+    txn.commit().await?;
+
+    // Run cleanup with 7-day max_age
+    let cleanup = DhcpPeriodicCleanup::new(env.pool.clone(), test_config());
+    cleanup.run_single_iteration().await?;
+
+    // Verify the address was deleted
+    let mut txn = env.pool.begin().await?;
+    let result =
+        db::machine_interface_address::find_ipv4_for_interface(&mut txn, interface.id).await;
+    assert!(result.is_err(), "address should have been deleted");
+
+    // Verify the interface itself still exists
+    let iface = db::machine_interface::find_one(&mut *txn, interface.id).await?;
+    assert_eq!(iface.id, interface.id, "interface should still exist");
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_recent_allocation_is_preserved(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let relay: std::net::IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
+
+    // Create an interface
+    let mut txn = env.pool.begin().await?;
+    let interface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        MacAddress::from_str("aa:bb:cc:dd:ee:02").unwrap(),
+        relay,
+        None,
+    )
+    .await?;
+    let ip = interface.addresses[0];
+
+    // Set last_dhcp to 1 day ago (recent)
+    let recent_time = chrono::Utc::now() - chrono::Duration::days(1);
+    db::machine_interface::update_last_dhcp(&mut txn, interface.id, Some(recent_time)).await?;
+    txn.commit().await?;
+
+    // Run cleanup with 7-day max_age
+    let cleanup = DhcpPeriodicCleanup::new(env.pool.clone(), test_config());
+    cleanup.run_single_iteration().await?;
+
+    // Verify the address still exists
+    let mut txn = env.pool.begin().await?;
+    let addr =
+        db::machine_interface_address::find_ipv4_for_interface(&mut txn, interface.id).await?;
+    assert_eq!(addr.address, ip, "recent address should be preserved");
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_cleanup_only_deletes_stale_not_recent(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let relay: std::net::IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
+
+    let mut txn = env.pool.begin().await?;
+
+    // Create two interfaces: one stale, one recent
+    let stale_iface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        MacAddress::from_str("aa:bb:cc:dd:ee:03").unwrap(),
+        relay,
+        None,
+    )
+    .await?;
+
+    let recent_iface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        MacAddress::from_str("aa:bb:cc:dd:ee:04").unwrap(),
+        relay,
+        None,
+    )
+    .await?;
+
+    let stale_time = chrono::Utc::now() - chrono::Duration::days(10);
+    let recent_time = chrono::Utc::now() - chrono::Duration::hours(1);
+    db::machine_interface::update_last_dhcp(&mut txn, stale_iface.id, Some(stale_time)).await?;
+    db::machine_interface::update_last_dhcp(&mut txn, recent_iface.id, Some(recent_time)).await?;
+    txn.commit().await?;
+
+    // Run cleanup
+    let cleanup = DhcpPeriodicCleanup::new(env.pool.clone(), test_config());
+    cleanup.run_single_iteration().await?;
+
+    // Stale address should be gone
+    let mut txn = env.pool.begin().await?;
+    assert!(
+        db::machine_interface_address::find_ipv4_for_interface(&mut txn, stale_iface.id)
+            .await
+            .is_err(),
+        "stale address should be deleted"
+    );
+
+    // Recent address should remain
+    assert!(
+        db::machine_interface_address::find_ipv4_for_interface(&mut txn, recent_iface.id)
+            .await
+            .is_ok(),
+        "recent address should be preserved"
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_interface_with_null_last_dhcp_is_not_deleted(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let relay: std::net::IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
+
+    // Create an interface but DON'T set last_dhcp (it will be NULL)
+    let mut txn = env.pool.begin().await?;
+    let interface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        MacAddress::from_str("aa:bb:cc:dd:ee:05").unwrap(),
+        relay,
+        None,
+    )
+    .await?;
+    let ip = interface.addresses[0];
+    txn.commit().await?;
+
+    // Run cleanup
+    let cleanup = DhcpPeriodicCleanup::new(env.pool.clone(), test_config());
+    cleanup.run_single_iteration().await?;
+
+    // Address should still exist (NULL last_dhcp should not be treated as stale)
+    let mut txn = env.pool.begin().await?;
+    let addr =
+        db::machine_interface_address::find_ipv4_for_interface(&mut txn, interface.id).await?;
+    assert_eq!(
+        addr.address, ip,
+        "NULL last_dhcp address should not be deleted"
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_stale_allocation_on_non_matching_segment_type_is_preserved(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let relay: std::net::IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
+
+    // Create a stale interface on the admin segment
+    let mut txn = env.pool.begin().await?;
+    let interface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        MacAddress::from_str("aa:bb:cc:dd:ee:06").unwrap(),
+        relay,
+        None,
+    )
+    .await?;
+    let ip = interface.addresses[0];
+
+    let stale_time = chrono::Utc::now() - chrono::Duration::days(10);
+    db::machine_interface::update_last_dhcp(&mut txn, interface.id, Some(stale_time)).await?;
+    txn.commit().await?;
+
+    // Run cleanup targeting only Underlay segments (fixture is Admin)
+    let cleanup = DhcpPeriodicCleanup::new(
+        env.pool.clone(),
+        DhcpPeriodicCleanupConfig {
+            enabled: true,
+            run_interval: Duration::from_secs(3600),
+            max_age: Duration::from_secs(7 * 24 * 3600),
+            segment_types: vec![NetworkSegmentType::Underlay],
+            include_associated: false,
+        },
+    );
+    cleanup.run_single_iteration().await?;
+
+    // Address should still exist because the segment type doesn't match
+    let mut txn = env.pool.begin().await?;
+    let addr =
+        db::machine_interface_address::find_ipv4_for_interface(&mut txn, interface.id).await?;
+    assert_eq!(
+        addr.address, ip,
+        "admin segment address should not be deleted when only targeting underlay"
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_machine_associated_interface_is_preserved(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    // Create a managed host — this creates a machine with associated interfaces
+    let managed_host = create_managed_host(&env).await;
+
+    // Find the host machine's interfaces
+    let mut txn = env.pool.begin().await?;
+    let interfaces_by_machine =
+        db::machine_interface::find_by_machine_ids(&mut txn, &[managed_host.id]).await?;
+    let interfaces: Vec<_> = interfaces_by_machine
+        .values()
+        .flat_map(|v| v.iter())
+        .collect();
+    assert!(
+        !interfaces.is_empty(),
+        "managed host should have interfaces"
+    );
+
+    // Set last_dhcp to 10 days ago on all interfaces (stale)
+    let stale_time = chrono::Utc::now() - chrono::Duration::days(10);
+    for iface in &interfaces {
+        db::machine_interface::update_last_dhcp(&mut txn, iface.id, Some(stale_time)).await?;
+    }
+    txn.commit().await?;
+
+    // Run cleanup targeting admin segments (which is what the fixture uses)
+    let cleanup = DhcpPeriodicCleanup::new(
+        env.pool.clone(),
+        DhcpPeriodicCleanupConfig {
+            enabled: true,
+            run_interval: Duration::from_secs(3600),
+            max_age: Duration::from_secs(7 * 24 * 3600),
+            segment_types: vec![NetworkSegmentType::Admin],
+            include_associated: false,
+        },
+    );
+    cleanup.run_single_iteration().await?;
+
+    // All addresses should still exist because these interfaces are
+    // associated with a machine (machine_id IS NOT NULL)
+    let mut txn = env.pool.begin().await?;
+    for iface in &interfaces {
+        if !iface.addresses.is_empty() {
+            let addr =
+                db::machine_interface_address::find_ipv4_for_interface(&mut txn, iface.id).await;
+            assert!(
+                addr.is_ok(),
+                "machine-associated interface {} should not be cleaned up",
+                iface.id
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_include_associated_deletes_machine_interfaces(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    // Create a managed host with machine-associated interfaces
+    let managed_host = create_managed_host(&env).await;
+
+    let mut txn = env.pool.begin().await?;
+    let interfaces_by_machine =
+        db::machine_interface::find_by_machine_ids(&mut txn, &[managed_host.id]).await?;
+    let interfaces: Vec<_> = interfaces_by_machine
+        .values()
+        .flat_map(|v| v.iter())
+        .collect();
+    let iface_with_addr = interfaces
+        .iter()
+        .find(|i| !i.addresses.is_empty())
+        .expect("managed host should have an interface with an address");
+
+    // Make it stale
+    let stale_time = chrono::Utc::now() - chrono::Duration::days(10);
+    db::machine_interface::update_last_dhcp(&mut txn, iface_with_addr.id, Some(stale_time)).await?;
+    txn.commit().await?;
+
+    // Run cleanup WITH include_associated = true
+    let cleanup = DhcpPeriodicCleanup::new(
+        env.pool.clone(),
+        DhcpPeriodicCleanupConfig {
+            enabled: true,
+            run_interval: Duration::from_secs(3600),
+            max_age: Duration::from_secs(7 * 24 * 3600),
+            segment_types: vec![NetworkSegmentType::Admin],
+            include_associated: true,
+        },
+    );
+    cleanup.run_single_iteration().await?;
+
+    // Address SHOULD be deleted because include_associated is true
+    let mut txn = env.pool.begin().await?;
+    let result =
+        db::machine_interface_address::find_ipv4_for_interface(&mut txn, iface_with_addr.id).await;
+    assert!(
+        result.is_err(),
+        "machine-associated interface should be cleaned up when include_associated is true"
+    );
+
+    Ok(())
+}

--- a/crates/api/src/tests/mod.rs
+++ b/crates/api/src/tests/mod.rs
@@ -20,6 +20,7 @@ mod connected_device;
 mod create_domain;
 mod credential;
 mod desired_firmware_versions;
+mod dhcp_periodic_cleanup;
 mod dns;
 mod dpa_interfaces;
 mod dpf;


### PR DESCRIPTION
## Description

_Update: We're also discussing the possibility of making this a "soft delete". We'd mark stale allocations as stale, and then iff we run out of address space, we'd sweep/gc anything marked as stale, which would allow us to continue holding onto address allocations until it's absolutely necessary that we need to free up space._

There was some internal discussion that ultimately led to https://github.com/NVIDIA/ncx-infra-controller-core/issues/662 being opened. The issue is that any interface in the L2 domain can get an IP allocated, and if that interface or device isn't deleted through known paths (or it's a device or interface that we'll never even manage to begin with), that IP will continue to persist as allocated to that interface, even if the interface eventually goes offline.

What we're seeing now is that we'll leak IP allocations for interfaces that are long gone, and then we exhaust the prefix, and the only fix is to go in and delete machine interfaces.

Options were:
- Attempt to honor `RELEASE` and `EXPIRE`, but neither of those will have guarantees.
- Have a `Periodic` job that runs to do cleanup

This does the latter by introducing a `DhcpPeriodicCleanup` whose job is to run at T(0) interval and cleanup leases who haven't been updated in T(1) beyond the TTL/lease time.

To start:
- It's disabled by default, we need to set `enable: true` in the Carbide config to enable it.
- It defaults to a 7 day cleanup, so if an IP allocation hasn't been renewed 7 days beyond its TTL/lease time, we will drop the allocation.

I think the idea *might* have been that, one a `machine_interface` has a corresponding `machine_interface_address`, it will ALWAYS have that same address? But I'm not actually sure if that was the intent?

With this, if a machine hasn't sent a DHCP renewal in 7 days (default), then we assume it may never come back, so we drop the address allocation. If it comes back, it will get a different IP. REALLY, if we wanted to honor how DHCP works in general, the machine shouldn't have any guarantees at all if its lease expires, so I think we're being generous here.

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

