### PR TITLE
feat: carbide-fmds standalone service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@ target/*
 !target/aarch64-unknown-linux-gnu/release/forge-dpu-agent
 !target/aarch64-unknown-linux-gnu/release/forge-dpu-otel-agent
 !target/aarch64-unknown-linux-gnu/release/forge-dhcp-server
+!target/aarch64-unknown-linux-gnu/release/carbide-fmds
 .git/
 pxe/mkiso/
 **/.mkosi*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1853,6 +1853,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "carbide-fmds"
+version = "0.0.1"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "axum 0.8.6",
+ "axum-server",
+ "carbide-dpu-agent-utils",
+ "carbide-rpc",
+ "carbide-tls",
+ "carbide-uuid",
+ "carbide-version",
+ "clap",
+ "eyre",
+ "governor",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "nonzero_ext",
+ "prost 0.14.1",
+ "tokio",
+ "tonic 0.14.2",
+ "tonic-prost",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "carbide-health"
 version = "0.0.1"
 dependencies = [

--- a/bluefield/Makefile.toml
+++ b/bluefield/Makefile.toml
@@ -113,6 +113,36 @@ args = [
   "forge-dhcp-server",
 ]
 
+[tasks.build-fmds]
+category = "Build"
+description = "cross compile carbide-fmds locally"
+workspace = false
+script = '''
+docker run --rm -v $REPO_ROOT:/carbide --user $(id -u):$(id -g) \
+    --env CARGO_HOME=/cargo \
+    -v $CARGO_HOME:/cargo \
+    build-artifacts-container-cross-aarch64:latest \
+    "cargo" \
+    "build" \
+    "--release" \
+    "--target=aarch64-unknown-linux-gnu" \
+    "--bin" \
+    "carbide-fmds"
+    docker run --rm -v $REPO_ROOT:/carbide --user $(id -u):$(id -g) build-artifacts-container-cross-aarch64:latest "aarch64-linux-gnu-strip" \
+    "/carbide/target/aarch64-unknown-linux-gnu/release/carbide-fmds"
+'''
+dependencies = [
+  { name = "build-cross-docker-image", path = "${REPO_ROOT}" },
+  { name = "check-cargo-home-set", path = "${REPO_ROOT}" },
+]
+
+[tasks.build-fmds-ci]
+category = "Build"
+workspace = false
+description = "Build carbide-fmds for CI"
+command = "cargo"
+args = ["build", "--release", "--bin", "carbide-fmds"]
+
 [tasks.build-dpu-otel-agent]
 category = "Build"
 description = "cross compile forge-dpu-otel-agent locally"
@@ -524,15 +554,25 @@ script = '''
     helm package ${REPO_ROOT}/bluefield/charts/carbide-dpu-otel-agent -d ${REPO_ROOT}/target/charts/
 '''
 
+[tasks.helm-package-carbide-fmds]
+category = "Build"
+description = "Package the carbide-fmds Helm chart"
+workspace = false
+script = '''
+    mkdir -p ${REPO_ROOT}/target/charts/
+    helm package ${REPO_ROOT}/bluefield/charts/carbide-fmds -d ${REPO_ROOT}/target/charts/
+'''
+
 [tasks.helm-package-all]
 category = "Build"
 description = "Package all Carbide DPF Helm charts"
 workspace = false
 dependencies = [
-    "helm-package-carbide-otelcol",
-    "helm-package-carbide-dpu-agent",
-    "helm-package-carbide-dhcp-server",
-    "helm-package-carbide-dpu-otel-agent",
+  "helm-package-carbide-otelcol",
+  "helm-package-carbide-dpu-agent",
+  "helm-package-carbide-dhcp-server",
+  "helm-package-carbide-dpu-otel-agent",
+  "helm-package-carbide-fmds",
 ]
 
 [tasks.docker-build-otelcol]
@@ -582,13 +622,26 @@ script = '''
 '''
 dependencies = ["build-dpu-otel-agent"]
 
+[tasks.docker-build-fmds]
+category = "Build"
+description = "Build the carbide-fmds container image for arm64"
+workspace = false
+script = '''
+    docker build \
+        -t ${CARBIDE_IMAGE_REGISTRY:-nvcr.io/nvidia/carbide}/carbide-fmds:${DPU_AGENT_PKG_VERSION} \
+        -f ${REPO_ROOT}/bluefield/containers/carbide-fmds/Dockerfile \
+        ${REPO_ROOT}
+'''
+dependencies = ["build-fmds"]
+
 [tasks.docker-build-all]
 category = "Build"
 description = "Build all Carbide DPF container images for arm64"
 workspace = false
 dependencies = [
-    "docker-build-otelcol",
-    "docker-build-dpu-agent",
-    "docker-build-dhcp-server",
-    "docker-build-dpu-otel-agent",
+  "docker-build-otelcol",
+  "docker-build-dpu-agent",
+  "docker-build-dhcp-server",
+  "docker-build-dpu-otel-agent",
+  "docker-build-fmds",
 ]

--- a/bluefield/charts/carbide-fmds/Chart.yaml
+++ b/bluefield/charts/carbide-fmds/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: carbide-fmds
+description: Carbide Forge Metadata Service (FMDS) for serving instance metadata to tenants on DPUs
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+annotations:
+  dpu.nvidia.com/doca-version: ">= 2.9"

--- a/bluefield/charts/carbide-fmds/templates/_helpers.tpl
+++ b/bluefield/charts/carbide-fmds/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "carbide-fmds.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "carbide-fmds.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "carbide-fmds.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "carbide-fmds.labels" -}}
+helm.sh/chart: {{ include "carbide-fmds.chart" . }}
+{{ include "carbide-fmds.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "carbide-fmds.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "carbide-fmds.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/bluefield/charts/carbide-fmds/templates/daemonset.yaml
+++ b/bluefield/charts/carbide-fmds/templates/daemonset.yaml
@@ -1,9 +1,9 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "carbide-dpu-agent.fullname" . }}
+  name: {{ include "carbide-fmds.fullname" . }}
   labels:
-    {{- include "carbide-dpu-agent.labels" . | nindent 4 }}
+    {{- include "carbide-fmds.labels" . | nindent 4 }}
     {{- with .Values.serviceDaemonSet.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -18,7 +18,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "carbide-dpu-agent.selectorLabels" . | nindent 6 }}
+      {{- include "carbide-fmds.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -26,7 +26,7 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "carbide-dpu-agent.selectorLabels" . | nindent 8 }}
+        {{- include "carbide-fmds.selectorLabels" . | nindent 8 }}
         {{- with .Values.serviceDaemonSet.labels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -45,13 +45,28 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-for-certs
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Waiting for forge certificates in /opt/forge ..."
+              while [ ! -f /opt/forge/forge_root.pem ] || [ ! -f /opt/forge/machine_cert.pem ] || [ ! -f /opt/forge/machine_cert.key ]; do
+                sleep 5
+              done
+              echo "Certificates found, starting carbide-fmds."
+          volumeMounts:
+            - name: forge-certs
+              mountPath: /opt/forge
+              readOnly: true
       containers:
-        - name: forge-dpu-agent
+        - name: carbide-fmds
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: ["run", "--enable-metadata-service"]
           {{- with toYaml .Values.serviceDaemonSet.resources }}
           resources:
             limits:
@@ -81,6 +96,7 @@ spec:
           volumeMounts:
             - name: forge-certs
               mountPath: /opt/forge
+              readOnly: true
       volumes:
         - name: forge-certs
           hostPath:

--- a/bluefield/charts/carbide-fmds/values.schema.json
+++ b/bluefield/charts/carbide-fmds/values.schema.json
@@ -1,0 +1,164 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "DPUService Helm Chart Values",
+  "description": "Schema for validating values.yaml for DPUService Helm charts. Note: All Kubernetes resources must include {{ .Release.Name }} in their metadata.name to enable deployment of multiple instances of the service.",
+  "type": "object",
+  "required": ["serviceDaemonSet"],
+  "properties": {
+    "serviceDaemonSet": {
+      "type": "object",
+      "description": "Configuration for the service DaemonSet",
+      "required": ["labels", "annotations", "updateStrategy", "resources"],
+      "properties": {
+        "nodeSelector": {
+          "oneOf": [
+            {
+              "type": "object",
+              "description": "Node selector for the DaemonSet using nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution",
+              "required": ["nodeSelectorTerms"],
+              "properties": {
+                "nodeSelectorTerms": {
+                  "type": "array",
+                  "description": "Required node selector terms, one of which must match for pod scheduling",
+                  "minItems": 1,
+                  "items": {
+                    "type": "object",
+                    "required": ["matchExpressions"],
+                    "properties": {
+                      "matchExpressions": {
+                        "type": "array",
+                        "description": "Node selector requirements by node's labels",
+                        "minItems": 1,
+                        "items": {
+                          "type": "object",
+                          "required": ["key", "operator", "values"],
+                          "properties": {
+                            "key": {
+                              "type": "string",
+                              "description": "The label key that the selector applies to"
+                            },
+                            "operator": {
+                              "type": "string",
+                              "description": "Represents a key's relationship to a set of values",
+                              "enum": ["In", "NotIn", "Exists", "DoesNotExist", "Gt", "Lt"]
+                            },
+                            "values": {
+                              "type": "array",
+                              "description": "An array of string values. If operator is In or NotIn, values array must be non-empty",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "matchFields": {
+                        "type": "array",
+                        "description": "Node selector requirements by node's fields",
+                        "items": {
+                          "type": "object",
+                          "required": ["key", "operator", "values"],
+                          "properties": {
+                            "key": {
+                              "type": "string",
+                              "description": "The label key that the selector applies to"
+                            },
+                            "operator": {
+                              "type": "string",
+                              "description": "Represents a key's relationship to a set of values",
+                              "enum": ["In", "NotIn", "Exists", "DoesNotExist", "Gt", "Lt"]
+                            },
+                            "values": {
+                              "type": "array",
+                              "description": "An array of string values. If operator is In or NotIn, values array must be non-empty",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "type": "null",
+              "description": "Node selector can be null/empty"
+            },
+            {
+              "type": "object",
+              "description": "Node selector can be an empty object",
+              "maxProperties": 0
+            }
+          ]
+        },
+        "labels": {
+          "type": "object",
+          "description": "serviceDaemonSet pod labels",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "annotations": {
+          "type": "object",
+          "description": "serviceDaemonSet pod annotations",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "updateStrategy": {
+          "type": "object",
+          "description": "serviceDaemonSet upgrade strategy configuration",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["RollingUpdate", "OnDelete"]
+            },
+            "rollingUpdate": {
+              "type": "object",
+              "properties": {
+                "maxUnavailable": {
+                  "oneOf": [
+                    { "type": "integer", "minimum": 1 },
+                    { "type": "string" }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "description": "serviceDaemonset pod Resource requests/limits (e.g., CPU, memory)",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "exposedPorts": {
+      "type": "object",
+      "description": "Configuration for exposing ports (optional). If provided, both 'ports' and 'labels' must be specified.",
+      "required": ["ports", "labels"],
+      "properties": {
+        "ports": {
+          "type": "object",
+          "description": "Map of port names to boolean values to enable/disable exposure",
+          "additionalProperties": {
+            "type": "boolean"
+          }
+        },
+        "labels": {
+          "type": "object",
+          "description": "Custom labels for the Service resources to be discovered by the DPUService controller",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/bluefield/charts/carbide-fmds/values.yaml
+++ b/bluefield/charts/carbide-fmds/values.yaml
@@ -1,0 +1,24 @@
+### DPF contract ###
+serviceDaemonSet:
+  nodeSelector:
+  labels: {}
+  annotations: {}
+  updateStrategy: {}
+  resources: {}
+exposedPorts:
+  labels: {}
+  ports: {}
+
+### Service specific values ###
+image:
+  repository: ""
+  pullPolicy: IfNotPresent
+  tag: ""
+imagePullSecrets: []
+podSecurityContext: {}
+securityContext:
+  capabilities:
+    add:
+      - NET_ADMIN
+      - NET_RAW
+tolerations: []

--- a/bluefield/containers/carbide-fmds/Dockerfile
+++ b/bluefield/containers/carbide-fmds/Dockerfile
@@ -1,0 +1,18 @@
+# Runtime image for carbide-fmds on arm64 DPUs.
+#
+# The binary is cross-compiled externally using the
+# build-artifacts-container-cross-aarch64 image and copied into this
+# minimal runtime container.
+
+ARG CC_VERSION=v3.2.1 # NVIDIA Distroless Container version
+ARG TAG=${CC_VERSION}
+ARG IMG=nvcr.io/nvidia/distroless/cc
+ARG DEBUG_DISTROLESS=true
+ARG DISTROLESS_DEBUG_TAG=${DEBUG_DISTROLESS:+"dev"} # 'dev' provides a busybox shell
+
+# NVIDIA Distroless Container
+FROM --platform=linux/arm64 ${IMG}:${TAG}-${DISTROLESS_DEBUG_TAG}
+
+COPY target/aarch64-unknown-linux-gnu/release/carbide-fmds /usr/bin/carbide-fmds
+
+ENTRYPOINT ["/usr/bin/carbide-fmds"]

--- a/crates/agent/src/command_line.rs
+++ b/crates/agent/src/command_line.rs
@@ -298,6 +298,12 @@ pub struct RunOptions {
                 When set, the agent sends config updates via gRPC instead of writing files directly."
     )]
     pub dhcp_grpc_server: Option<String>,
+    #[clap(
+        long,
+        help = "gRPC address of the external FMDS service (e.g. http://localhost:50052). \
+                When set, the agent sends config updates via gRPC instead of running embedded FMDS."
+    )]
+    pub fmds_grpc_server: Option<String>,
 }
 
 #[derive(Parser, Debug)]

--- a/crates/agent/src/fmds_client.rs
+++ b/crates/agent/src/fmds_client.rs
@@ -1,0 +1,140 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use rpc::fmds::fmds_config_service_client::FmdsConfigServiceClient;
+use rpc::fmds::{FmdsConfigUpdate, IbDevice, IbInstance, UpdateConfigRequest};
+use rpc::forge::ManagedHostNetworkConfigResponse;
+use tonic::transport::Channel;
+
+use crate::instance_metadata_endpoint::InstanceMetadataRouterStateImpl;
+use crate::periodic_config_fetcher::InstanceMetadata;
+
+/// FmdsUpdater abstracts over embedded vs external FMDS
+/// updates so the main loop doesn't need to care which
+/// mode it's in. It's all handled in here.
+pub enum FmdsUpdater {
+    /// Embedded will update FMDS state directly within the
+    /// carbide-dpu-agent (because the FMDS listener is in
+    /// the agent).
+    Embedded(Arc<InstanceMetadataRouterStateImpl>),
+    /// External will send FMDS updates to an FMDS server,
+    /// which is colocated on the same DPU, possibly in its
+    /// own container.
+    External(FmdsGrpcClient),
+}
+
+impl FmdsUpdater {
+    pub async fn update(
+        &mut self,
+        instance_data: Option<Arc<InstanceMetadata>>,
+        network_config: Option<Arc<ManagedHostNetworkConfigResponse>>,
+    ) {
+        match self {
+            FmdsUpdater::Embedded(state) => {
+                state.update_instance_data(instance_data);
+                state.update_network_configuration(network_config);
+            }
+            FmdsUpdater::External(client) => {
+                if let Err(err) = client.update_config(&instance_data, &network_config).await {
+                    tracing::error!(
+                        error = format!("{err:#}"),
+                        fmds_address = client.address,
+                        "Failed to send config update to external FMDS"
+                    );
+                }
+            }
+        }
+    }
+}
+
+pub struct FmdsGrpcClient {
+    client: FmdsConfigServiceClient<Channel>,
+    address: String,
+}
+
+impl FmdsGrpcClient {
+    pub async fn connect(address: &str) -> eyre::Result<Self> {
+        let client = FmdsConfigServiceClient::connect(address.to_string()).await?;
+        Ok(Self {
+            client,
+            address: address.to_string(),
+        })
+    }
+
+    async fn update_config(
+        &mut self,
+        instance_data: &Option<Arc<InstanceMetadata>>,
+        network_config: &Option<Arc<ManagedHostNetworkConfigResponse>>,
+    ) -> eyre::Result<()> {
+        let Some(metadata) = instance_data else {
+            return Ok(());
+        };
+
+        let asn = network_config.as_ref().map(|c| c.asn).unwrap_or(0);
+
+        let ib_devices = metadata
+            .ib_devices
+            .as_ref()
+            .map(|devices| {
+                devices
+                    .iter()
+                    .map(|dev| IbDevice {
+                        pf_guid: dev.pf_guid.clone(),
+                        instances: dev
+                            .instances
+                            .iter()
+                            .map(|inst| IbInstance {
+                                ib_partition_id: inst
+                                    .ib_partition_id
+                                    .as_ref()
+                                    .map(|id| id.to_string()),
+                                ib_guid: inst.ib_guid.clone(),
+                                lid: inst.lid,
+                            })
+                            .collect(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let update = FmdsConfigUpdate {
+            address: metadata.address.clone(),
+            hostname: metadata.hostname.clone(),
+            sitename: metadata.sitename.clone(),
+            instance_id: metadata.instance_id,
+            machine_id: metadata.machine_id,
+            user_data: metadata.user_data.clone(),
+            ib_devices,
+            asn,
+        };
+
+        self.client
+            .update_config(tonic::Request::new(UpdateConfigRequest {
+                config_update: Some(update),
+            }))
+            .await?;
+
+        tracing::debug!(
+            fmds_address = self.address,
+            "Sent config update to external FMDS"
+        );
+
+        Ok(())
+    }
+}

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -51,6 +51,7 @@ mod ethernet_virtualization;
 use carbide_uuid::machine::MachineId;
 pub use ethernet_virtualization::FPath;
 pub mod extension_services;
+mod fmds_client;
 
 pub mod duppet;
 mod frr;

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -48,9 +48,9 @@ use crate::dpu::interface::Interface;
 use crate::dpu::route::{DpuRoutePlan, IpRoute, Route};
 use crate::duppet::{SummaryFormat, SyncOptions};
 use crate::ethernet_virtualization::ServiceAddresses;
+use crate::fmds_client::FmdsUpdater;
 use crate::health::HealthCheckParams;
 use crate::host_machine_id::get_host_machine_id_retry;
-use crate::instance_metadata_endpoint::InstanceMetadataRouterStateImpl;
 use crate::instrumentation::{create_metrics, get_dpu_agent_meter};
 use crate::machine_inventory_updater::MachineInventoryUpdaterConfig;
 use crate::network_monitor::{self, NetworkPingerType};
@@ -121,17 +121,34 @@ pub async fn setup_and_run(
     let agent_meter = get_dpu_agent_meter();
     let metrics = create_metrics(agent_meter);
 
-    if options.enable_metadata_service {
-        crate::metadata_service::spawn_metadata_service(
-            agent_config.metadata_service.address.clone(),
-            agent_config.telemetry.metrics_address.clone(),
-            metrics.clone(),
-            instance_metadata_state.clone(),
-        )
-        .unwrap_or_else(|e| {
-            tracing::warn!("Failed to run metadata service: {:#}", e);
-        });
-    }
+    // And now set up our FMDS updater, which will either be our original
+    // embedded server (which spins up a local listener within the DPU agent)
+    // or will talk to an external FMDS server via gRPC (which is colocated
+    // with the agent on the DPU).
+    let fmds_updater = if let Some(ref fmds_addr) = options.fmds_grpc_server {
+        tracing::info!(
+            fmds_address = fmds_addr,
+            "Using FmdsUpdater::External FMDS service"
+        );
+        let fmds_client = crate::fmds_client::FmdsGrpcClient::connect(fmds_addr)
+            .await
+            .wrap_err("Failed to connect to external FMDS service")?;
+        FmdsUpdater::External(fmds_client)
+    } else {
+        if options.enable_metadata_service {
+            crate::metadata_service::spawn_metadata_service(
+                agent_config.metadata_service.address.clone(),
+                agent_config.telemetry.metrics_address.clone(),
+                metrics.clone(),
+                instance_metadata_state.clone(),
+            )
+            .unwrap_or_else(|e| {
+                tracing::warn!("Failed to run metadata service: {:#}", e);
+            });
+        }
+        tracing::info!("Using FmdsUpdater::Embedded FMDS service");
+        FmdsUpdater::Embedded(instance_metadata_state.clone())
+    };
 
     // Some of these metrics only need to be set once, let's take care of them
     // now.
@@ -319,7 +336,7 @@ pub async fn setup_and_run(
         build_version,
         machine_id,
         periodic_config_reader,
-        instance_metadata_state,
+        fmds_updater,
         client_cert_renewer,
         hbn_device_names,
         is_hbn_up: false,
@@ -351,7 +368,7 @@ struct MainLoop {
     factory_mac_address: MacAddress,
     build_version: String,
     periodic_config_reader: Box<periodic_config_fetcher::PeriodicConfigFetcherReader>,
-    instance_metadata_state: Arc<InstanceMetadataRouterStateImpl>,
+    fmds_updater: FmdsUpdater,
     client_cert_renewer: ClientCertRenewer,
     hbn_device_names: HBNDeviceNames,
     is_hbn_up: bool,
@@ -748,10 +765,9 @@ impl MainLoop {
                 // It will guarantee that the Instance Config that is acknowledged to
                 // carbide via the status message is actually visible to the tenant via
                 // FMDS
-                self.instance_metadata_state
-                    .update_instance_data(instance_data.clone());
-                self.instance_metadata_state
-                    .update_network_configuration(Some(conf.clone()));
+                self.fmds_updater
+                    .update(instance_data.clone(), Some(conf.clone()))
+                    .await;
                 status_out.instance_config_version = instance_data
                     .as_ref()
                     .map(|instance| instance.config_version.version_string());

--- a/crates/agent/src/tests/common/mod.rs
+++ b/crates/agent/src/tests/common/mod.rs
@@ -114,6 +114,7 @@ pub fn setup_agent_run_env(
             override_network_virtualization_type: None,
             skip_upgrade_check: false,
             dhcp_grpc_server: None,
+            fmds_grpc_server: None,
         }))),
     };
 

--- a/crates/fmds/Cargo.toml
+++ b/crates/fmds/Cargo.toml
@@ -1,0 +1,64 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[package]
+name = "carbide-fmds"
+version = "0.0.1"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+
+[lib]
+name = "fmds"
+
+[[bin]]
+name = "carbide-fmds"
+path = "src/main.rs"
+
+[dependencies]
+
+# [local-dependencies]
+carbide-dpu-agent-utils = { path = "../dpu-agent-utils" }
+carbide-rpc = { path = "../rpc" }
+carbide-tls = { path = "../tls" }
+carbide-uuid = { path = "../uuid" }
+carbide-version = { path = "../version" }
+
+arc-swap = { workspace = true }
+async-trait = { workspace = true }
+axum = { workspace = true, features = ["macros"] }
+axum-server = { workspace = true }
+clap = { workspace = true }
+eyre = { workspace = true }
+governor = { workspace = true }
+nonzero_ext = { workspace = true }
+tokio = { workspace = true }
+tonic = { workspace = true }
+tonic-prost = { workspace = true }
+prost = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+http-body-util = { workspace = true }
+hyper = { workspace = true }
+hyper-util = { workspace = true, features = ["client-legacy"] }
+uuid = { features = ["v4"], workspace = true }
+
+[build-dependencies]
+carbide-version = { path = "../version" }
+
+[lints]
+workspace = true

--- a/crates/fmds/build.rs
+++ b/crates/fmds/build.rs
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+fn main() {
+    carbide_version::build();
+}

--- a/crates/fmds/src/cfg.rs
+++ b/crates/fmds/src/cfg.rs
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use clap::Parser;
+
+#[derive(Parser)]
+#[clap(name = "carbide-fmds")]
+pub struct Options {
+    #[clap(long, default_value = "false", help = "Print version number and exit")]
+    pub version: bool,
+
+    /// gRPC listen address for receiving config updates from
+    /// carbide-dpu-agent. The tenant should not be able to
+    /// communicate with this address.
+    #[clap(long, default_value = "0.0.0.0:50052")]
+    pub grpc_address: String,
+
+    /// REST listen address for tenant OS metadata queries.
+    #[clap(long, default_value = "0.0.0.0:80")]
+    pub rest_address: String,
+
+    /// Carbide API server address for phone_home.
+    #[clap(long, default_value = "https://carbide-api.forge")]
+    pub forge_api: String,
+
+    /// Path to root CA certificate.
+    /// This will probably be shared with the carbide-dpu-agent.
+    #[clap(long)]
+    pub root_ca: Option<String>,
+
+    /// Path to client certificate.
+    /// This will probably be shared with the carbide-dpu-agent.
+    #[clap(long)]
+    pub client_cert: Option<String>,
+
+    /// Path to client key.
+    /// This will probably be shared with the carbide-dpu-agent.
+    #[clap(long)]
+    pub client_key: Option<String>,
+}
+
+impl Options {
+    pub fn load() -> Self {
+        Self::parse()
+    }
+}

--- a/crates/fmds/src/grpc_server.rs
+++ b/crates/fmds/src/grpc_server.rs
@@ -1,0 +1,209 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use rpc::fmds::fmds_config_service_server::FmdsConfigService;
+use rpc::fmds::{UpdateConfigRequest, UpdateConfigResponse};
+use tonic::{Request, Response, Status};
+
+use crate::state::{FmdsConfig, FmdsState, IBDeviceConfig, IBInstanceConfig};
+
+pub struct FmdsGrpcServer {
+    state: Arc<FmdsState>,
+}
+
+impl FmdsGrpcServer {
+    pub fn new(state: Arc<FmdsState>) -> Self {
+        Self { state }
+    }
+}
+
+#[tonic::async_trait]
+impl FmdsConfigService for FmdsGrpcServer {
+    async fn update_config(
+        &self,
+        request: Request<UpdateConfigRequest>,
+    ) -> Result<Response<UpdateConfigResponse>, Status> {
+        let agent_address = request
+            .remote_addr()
+            .map(|addr| addr.to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+
+        let update = request
+            .into_inner()
+            .config_update
+            .ok_or_else(|| Status::invalid_argument("missing config_update"))?;
+
+        let ib_devices = if update.ib_devices.is_empty() {
+            None
+        } else {
+            Some(
+                update
+                    .ib_devices
+                    .into_iter()
+                    .map(|dev| IBDeviceConfig {
+                        pf_guid: dev.pf_guid,
+                        instances: dev
+                            .instances
+                            .into_iter()
+                            .map(|inst| IBInstanceConfig {
+                                ib_partition_id: inst
+                                    .ib_partition_id
+                                    .and_then(|id| id.parse().ok()),
+                                ib_guid: inst.ib_guid,
+                                lid: inst.lid,
+                            })
+                            .collect(),
+                    })
+                    .collect(),
+            )
+        };
+
+        let config = FmdsConfig {
+            address: update.address,
+            hostname: update.hostname,
+            sitename: update.sitename,
+            instance_id: update.instance_id,
+            machine_id: update.machine_id,
+            user_data: update.user_data,
+            ib_devices,
+            asn: update.asn,
+        };
+
+        self.state.update_config(config);
+
+        tracing::info!(agent_address, "Received config update from agent");
+
+        Ok(Response::new(UpdateConfigResponse {}))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rpc::fmds::{FmdsConfigUpdate, IbDevice, IbInstance};
+
+    use super::*;
+
+    fn make_test_state() -> Arc<FmdsState> {
+        Arc::new(FmdsState::new("https://api.test".to_string(), None))
+    }
+
+    fn make_test_update() -> FmdsConfigUpdate {
+        FmdsConfigUpdate {
+            address: "10.0.0.1".to_string(),
+            hostname: "test-host".to_string(),
+            sitename: Some("test-site".to_string()),
+            instance_id: Some(uuid::uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8").into()),
+            machine_id: Some(
+                "fm100ht6n80e7do39u8gmt7cvhm89pb32st9ngevgdolu542l1nfa4an0rg"
+                    .parse()
+                    .unwrap(),
+            ),
+            user_data: "cloud-init-data".to_string(),
+            ib_devices: vec![],
+            asn: 65000,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_update_config_stores_data() {
+        let state = make_test_state();
+        let server = FmdsGrpcServer::new(state.clone());
+
+        let request = Request::new(UpdateConfigRequest {
+            config_update: Some(make_test_update()),
+        });
+
+        let response = server.update_config(request).await;
+        assert!(response.is_ok());
+
+        let config = state.config.load_full().unwrap();
+        assert_eq!(config.address, "10.0.0.1");
+        assert_eq!(config.hostname, "test-host");
+        assert_eq!(config.sitename.as_deref(), Some("test-site"));
+        assert_eq!(config.asn, 65000);
+    }
+
+    #[tokio::test]
+    async fn test_update_config_missing_config_update() {
+        let state = make_test_state();
+        let server = FmdsGrpcServer::new(state);
+
+        let request = Request::new(UpdateConfigRequest {
+            config_update: None,
+        });
+
+        let response = server.update_config(request).await;
+        assert!(response.is_err());
+        assert_eq!(response.unwrap_err().code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn test_update_config_with_ib_devices() {
+        let state = make_test_state();
+        let server = FmdsGrpcServer::new(state.clone());
+
+        let mut update = make_test_update();
+        update.ib_devices = vec![IbDevice {
+            pf_guid: "pfguid1".to_string(),
+            instances: vec![
+                IbInstance {
+                    ib_partition_id: Some("67e55044-10b1-426f-9247-bb680e5fe0c8".to_string()),
+                    ib_guid: Some("guid1".to_string()),
+                    lid: 42,
+                },
+                IbInstance {
+                    ib_partition_id: None,
+                    ib_guid: Some("guid2".to_string()),
+                    lid: 43,
+                },
+            ],
+        }];
+
+        let request = Request::new(UpdateConfigRequest {
+            config_update: Some(update),
+        });
+
+        server.update_config(request).await.unwrap();
+
+        let config = state.config.load_full().unwrap();
+        let devices = config.ib_devices.as_ref().unwrap();
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0].pf_guid, "pfguid1");
+        assert_eq!(devices[0].instances.len(), 2);
+        assert_eq!(devices[0].instances[0].ib_guid.as_deref(), Some("guid1"));
+        assert_eq!(devices[0].instances[0].lid, 42);
+        assert!(devices[0].instances[0].ib_partition_id.is_some());
+        assert!(devices[0].instances[1].ib_partition_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_update_config_empty_ib_devices_becomes_none() {
+        let state = make_test_state();
+        let server = FmdsGrpcServer::new(state.clone());
+
+        let request = Request::new(UpdateConfigRequest {
+            config_update: Some(make_test_update()),
+        });
+
+        server.update_config(request).await.unwrap();
+
+        let config = state.config.load_full().unwrap();
+        assert!(config.ib_devices.is_none());
+    }
+}

--- a/crates/fmds/src/lib.rs
+++ b/crates/fmds/src/lib.rs
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod cfg;
+pub mod grpc_server;
+pub mod phone_home;
+pub mod rest_server;
+pub mod state;

--- a/crates/fmds/src/main.rs
+++ b/crates/fmds/src/main.rs
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use clap::Parser;
+use fmds::cfg::Options;
+use fmds::grpc_server::FmdsGrpcServer;
+use fmds::rest_server::get_fmds_router;
+use fmds::state::FmdsState;
+use forge_tls::client_config::ClientCert;
+use rpc::fmds::fmds_config_service_server::FmdsConfigServiceServer;
+use rpc::forge_tls_client::ForgeClientConfig;
+
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    let options = Options::parse();
+
+    if options.version {
+        println!("{}", carbide_version::version!());
+        return Ok(());
+    }
+
+    tracing::info!(
+        version = carbide_version::version!(),
+        "Starting carbide-fmds"
+    );
+
+    // Build ForgeClientConfig for phone_home if cert paths are provided
+    let forge_client_config = match (&options.root_ca, &options.client_cert, &options.client_key) {
+        (Some(root_ca), Some(client_cert), Some(client_key)) => {
+            Some(Arc::new(ForgeClientConfig::new(
+                root_ca.clone(),
+                Some(ClientCert {
+                    cert_path: client_cert.clone(),
+                    key_path: client_key.clone(),
+                }),
+            )))
+        }
+        _ => {
+            tracing::warn!(
+                "No TLS credentials provided; phone_home to carbide-api will be unavailable"
+            );
+            None
+        }
+    };
+
+    let state = Arc::new(FmdsState::new(
+        options.forge_api.clone(),
+        forge_client_config,
+    ));
+
+    // Start REST server for tenant metadata queries
+    let rest_state = state.clone();
+    let rest_address = options.rest_address.clone();
+    tokio::spawn(async move {
+        // We serve metadata under both /latest and /2009-04-04 for
+        // compatibility with cloud-init, which uses the AWS EC2 instance
+        // metadata API versioned path format.
+        let router = axum::Router::new()
+            .nest("/latest", get_fmds_router(rest_state.clone()))
+            .nest("/2009-04-04", get_fmds_router(rest_state));
+
+        let addr: std::net::SocketAddr = rest_address.parse().expect("invalid REST address");
+        let server = axum_server::Server::bind(addr);
+
+        tracing::info!(%addr, "REST server listening");
+        if let Err(err) = server.serve(router.into_make_service()).await {
+            tracing::error!("REST server error: {err}");
+        }
+    });
+
+    // Start gRPC server for receiving config updates from agent
+    let grpc_address: std::net::SocketAddr =
+        options.grpc_address.parse().expect("invalid gRPC address");
+
+    let grpc_server = FmdsGrpcServer::new(state);
+
+    tracing::info!(%grpc_address, "gRPC server listening");
+    tonic::transport::Server::builder()
+        .add_service(FmdsConfigServiceServer::new(grpc_server))
+        .serve(grpc_address)
+        .await?;
+
+    Ok(())
+}

--- a/crates/fmds/src/phone_home.rs
+++ b/crates/fmds/src/phone_home.rs
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use eyre::eyre;
+use forge_dpu_agent_utils::utils::create_forge_client;
+use rpc::forge::InstancePhoneHomeLastContactRequest;
+
+use crate::state::FmdsState;
+
+pub async fn phone_home(state: &Arc<FmdsState>) -> Result<(), eyre::Error> {
+    match state.outbound_governor.clone().check() {
+        Ok(_) => {}
+        Err(e) => return Err(eyre!("rate limit exceeded for phone_home; {}\n", e)),
+    };
+
+    let forge_client_config = state
+        .forge_client_config
+        .as_ref()
+        .ok_or_else(|| eyre!("phone_home not configured: no forge client config"))?;
+
+    let mut client = create_forge_client(&state.forge_api, forge_client_config).await?;
+
+    let machine_id = state
+        .machine_id
+        .load_full()
+        .ok_or_else(|| eyre!("phone_home: no machine_id available yet"))?;
+
+    // Look up the instance for this machine
+    let request = tonic::Request::new(*machine_id);
+
+    let response = client.find_instance_by_machine_id(request).await?;
+    let instance = response
+        .into_inner()
+        .instances
+        .first()
+        .cloned()
+        .ok_or_else(|| eyre!("No instance found for machine {}", machine_id))?;
+
+    let instance_id = instance.id;
+
+    let request = tonic::Request::new(InstancePhoneHomeLastContactRequest { instance_id });
+    let response = client
+        .update_instance_phone_home_last_contact(request)
+        .await?;
+    let timestamp = response
+        .into_inner()
+        .timestamp
+        .ok_or_else(|| eyre!("timestamp is empty in response"))?;
+
+    tracing::info!(
+        "Successfully phoned home for Machine {} at {}",
+        machine_id,
+        timestamp,
+    );
+
+    Ok(())
+}

--- a/crates/fmds/src/rest_server.rs
+++ b/crates/fmds/src/rest_server.rs
@@ -1,0 +1,726 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::{get, post};
+
+use crate::state::FmdsState;
+
+const PUBLIC_IPV4_CATEGORY: &str = "public-ipv4";
+const HOSTNAME_CATEGORY: &str = "hostname";
+const SITENAME_CATEGORY: &str = "sitename";
+const USER_DATA_CATEGORY: &str = "user-data";
+const META_DATA_CATEGORY: &str = "meta-data";
+const GUID: &str = "guid";
+const IB_PARTITION: &str = "partition";
+const LID: &str = "lid";
+const DEVICES_CATEGORY: &str = "devices";
+const INFINIBAND_CATEGORY: &str = "infiniband";
+const MACHINE_ID_CATEGORY: &str = "machine-id";
+const INSTANCE_ID_CATEGORY: &str = "instance-id";
+const PHONE_HOME_CATEGORY: &str = "phone_home";
+const ASN_CATEGORY: &str = "asn";
+
+pub fn get_fmds_router(state: Arc<FmdsState>) -> Router {
+    let user_data_router =
+        Router::new().route(&format!("/{USER_DATA_CATEGORY}"), get(get_userdata));
+
+    let ib_router = Router::new()
+        .route(&format!("/{DEVICES_CATEGORY}"), get(get_devices))
+        .route(
+            &format!("/{DEVICES_CATEGORY}/{{device}}"),
+            get(get_instances),
+        )
+        .nest(
+            &format!("/{DEVICES_CATEGORY}/{{device}}"),
+            Router::new()
+                .route("/instances", get(get_instances))
+                .route("/instances/{instance}", get(get_instance_attributes))
+                .route(
+                    "/instances/{instance}/{attribute}",
+                    get(get_instance_attribute),
+                ),
+        );
+
+    let service_router = Router::new()
+        .nest(&format!("/{INFINIBAND_CATEGORY}"), ib_router)
+        .route(&format!("/{PHONE_HOME_CATEGORY}"), post(post_phone_home))
+        .route(&format!("/{INSTANCE_ID_CATEGORY}"), get(get_instance_id))
+        .route(&format!("/{MACHINE_ID_CATEGORY}"), get(get_machine_id))
+        .route("/{category}", get(get_metadata_parameter));
+
+    let metadata_router = Router::new()
+        // The additional ending slash is a cloud init issue as
+        // found when looking at the cloud init src.
+        // https://bugs.launchpad.net/cloud-init/+bug/1356855
+        .route(&format!("/{META_DATA_CATEGORY}/"), get(get_metadata_params))
+        .route(&format!("/{META_DATA_CATEGORY}"), get(get_metadata_params))
+        .nest(&format!("/{META_DATA_CATEGORY}"), service_router);
+
+    Router::new()
+        .merge(metadata_router)
+        .merge(user_data_router)
+        .with_state(state)
+}
+
+async fn get_metadata_parameter(
+    State(state): State<Arc<FmdsState>>,
+    Path(category): Path<String>,
+) -> (StatusCode, String) {
+    extract_metadata(category, &state)
+}
+
+async fn get_userdata(State(state): State<Arc<FmdsState>>) -> (StatusCode, String) {
+    extract_metadata(USER_DATA_CATEGORY.to_string(), &state)
+}
+
+fn extract_metadata(category: String, state: &FmdsState) -> (StatusCode, String) {
+    let config = match state.config.load_full() {
+        Some(config) => config,
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "metadata currently unavailable".to_string(),
+            );
+        }
+    };
+
+    match category.as_str() {
+        PUBLIC_IPV4_CATEGORY => (StatusCode::OK, config.address.clone()),
+        HOSTNAME_CATEGORY => (StatusCode::OK, config.hostname.clone()),
+        SITENAME_CATEGORY => (
+            StatusCode::OK,
+            config.sitename.clone().unwrap_or(String::new()),
+        ),
+        USER_DATA_CATEGORY => (StatusCode::OK, config.user_data.clone()),
+        ASN_CATEGORY => (StatusCode::OK, config.asn.to_string()),
+        _ => (
+            StatusCode::NOT_FOUND,
+            format!("metadata category not found: {category}"),
+        ),
+    }
+}
+
+async fn get_machine_id(State(state): State<Arc<FmdsState>>) -> (StatusCode, String) {
+    let config = match state.config.load_full() {
+        Some(config) => config,
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "metadata currently unavailable".to_string(),
+            );
+        }
+    };
+
+    if let Some(machine_id) = &config.machine_id {
+        (StatusCode::OK, machine_id.to_string())
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            "machine id not available".to_string(),
+        )
+    }
+}
+
+async fn get_instance_id(State(state): State<Arc<FmdsState>>) -> (StatusCode, String) {
+    let config = match state.config.load_full() {
+        Some(config) => config,
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "metadata currently unavailable".to_string(),
+            );
+        }
+    };
+
+    if let Some(instance_id) = &config.instance_id {
+        (StatusCode::OK, instance_id.to_string())
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            "instance id not available".to_string(),
+        )
+    }
+}
+
+async fn get_metadata_params(State(_state): State<Arc<FmdsState>>) -> (StatusCode, String) {
+    (
+        StatusCode::OK,
+        [
+            HOSTNAME_CATEGORY,
+            SITENAME_CATEGORY,
+            MACHINE_ID_CATEGORY,
+            INSTANCE_ID_CATEGORY,
+            ASN_CATEGORY,
+        ]
+        .join("\n"),
+    )
+}
+
+async fn get_devices(State(state): State<Arc<FmdsState>>) -> (StatusCode, String) {
+    let config = match state.config.load_full() {
+        Some(config) => config,
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "metadata currently unavailable".to_string(),
+            );
+        }
+    };
+
+    let mut response = String::new();
+    if let Some(devices) = &config.ib_devices {
+        for (index, device) in devices.iter().enumerate() {
+            response.push_str(&format!("{}={}\n", index, device.pf_guid));
+        }
+        (StatusCode::OK, response)
+    } else {
+        (StatusCode::NOT_FOUND, "devices not available".to_string())
+    }
+}
+
+async fn get_instances(
+    State(state): State<Arc<FmdsState>>,
+    Path(device_index): Path<usize>,
+) -> (StatusCode, String) {
+    let config = match state.config.load_full() {
+        Some(config) => config,
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "metadata currently unavailable".to_string(),
+            );
+        }
+    };
+
+    if let Some(devices) = &config.ib_devices {
+        if devices.len() <= device_index {
+            return (
+                StatusCode::NOT_FOUND,
+                format!("no device at index: {device_index}"),
+            );
+        }
+        let dev = &devices[device_index];
+        let mut response = String::new();
+        for (index, instance) in dev.instances.iter().enumerate() {
+            match &instance.ib_guid {
+                Some(guid) => response.push_str(&format!("{index}={guid}\n")),
+                None => continue,
+            }
+        }
+        (StatusCode::OK, response)
+    } else {
+        (StatusCode::NOT_FOUND, "devices not available".to_string())
+    }
+}
+
+async fn get_instance_attributes(
+    State(state): State<Arc<FmdsState>>,
+    Path((device_index, instance_index)): Path<(usize, usize)>,
+) -> (StatusCode, String) {
+    let config = match state.config.load_full() {
+        Some(config) => config,
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "metadata currently unavailable".to_string(),
+            );
+        }
+    };
+
+    if let Some(devices) = &config.ib_devices {
+        if devices.len() <= device_index {
+            return (
+                StatusCode::NOT_FOUND,
+                format!("no device at index: {device_index}"),
+            );
+        }
+
+        let dev = &devices[device_index];
+        if dev.instances.len() <= instance_index {
+            return (
+                StatusCode::NOT_FOUND,
+                format!("no instance at index: {instance_index}"),
+            );
+        }
+        let inst = &dev.instances[instance_index];
+
+        let mut response = String::new();
+        if inst.ib_guid.is_some() {
+            response += &(GUID.to_owned() + "\n");
+        }
+        if inst.ib_partition_id.is_some() {
+            response += &(IB_PARTITION.to_owned() + "\n");
+        }
+        response.push_str(LID);
+
+        (StatusCode::OK, response)
+    } else {
+        (StatusCode::NOT_FOUND, "devices not available".to_string())
+    }
+}
+
+async fn get_instance_attribute(
+    State(state): State<Arc<FmdsState>>,
+    Path((device_index, instance_index, attribute)): Path<(usize, usize, String)>,
+) -> (StatusCode, String) {
+    let config = match state.config.load_full() {
+        Some(config) => config,
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "metadata currently unavailable".to_string(),
+            );
+        }
+    };
+
+    if let Some(devices) = &config.ib_devices {
+        if devices.len() <= device_index {
+            return (
+                StatusCode::NOT_FOUND,
+                format!("no device at index: {device_index}"),
+            );
+        }
+        let dev = &devices[device_index];
+
+        if dev.instances.len() <= instance_index {
+            return (
+                StatusCode::NOT_FOUND,
+                format!("no instance at index: {instance_index}"),
+            );
+        }
+        let inst = &dev.instances[instance_index];
+
+        match attribute.as_str() {
+            GUID => match &inst.ib_guid {
+                Some(guid) => (StatusCode::OK, guid.clone()),
+                None => (
+                    StatusCode::NOT_FOUND,
+                    format!("guid not found at index: {instance_index}"),
+                ),
+            },
+            IB_PARTITION => match &inst.ib_partition_id {
+                Some(ib_partition_id) => (StatusCode::OK, ib_partition_id.to_string()),
+                None => (
+                    StatusCode::NOT_FOUND,
+                    format!("ib partition not found at index: {instance_index}"),
+                ),
+            },
+            LID => (StatusCode::OK, inst.lid.to_string()),
+            _ => (StatusCode::NOT_FOUND, "no such attribute".to_string()),
+        }
+    } else {
+        (StatusCode::NOT_FOUND, "devices not available".to_string())
+    }
+}
+
+async fn post_phone_home(State(state): State<Arc<FmdsState>>) -> (StatusCode, String) {
+    match crate::phone_home::phone_home(&state).await {
+        Ok(()) => (StatusCode::OK, "successfully phoned home\n".to_string()),
+        Err(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http;
+    use http_body_util::{BodyExt, Full};
+    use hyper::body::Bytes;
+    use hyper_util::rt::TokioExecutor;
+
+    use super::*;
+    use crate::state::{FmdsConfig, IBDeviceConfig, IBInstanceConfig};
+
+    fn make_test_state() -> Arc<FmdsState> {
+        Arc::new(FmdsState::new("https://api.test".to_string(), None))
+    }
+
+    fn make_test_config() -> FmdsConfig {
+        FmdsConfig {
+            address: "10.0.0.1".to_string(),
+            hostname: "test-host".to_string(),
+            sitename: Some("test-site".to_string()),
+            instance_id: Some(uuid::uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8").into()),
+            machine_id: Some(
+                "fm100ht6n80e7do39u8gmt7cvhm89pb32st9ngevgdolu542l1nfa4an0rg"
+                    .parse()
+                    .unwrap(),
+            ),
+            user_data: "cloud-init-data".to_string(),
+            ib_devices: None,
+            asn: 65000,
+        }
+    }
+
+    async fn setup_server(state: Arc<FmdsState>) -> (tokio::task::JoinHandle<()>, u16) {
+        let router = get_fmds_router(state);
+
+        let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 0));
+        let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+        let server_port = listener.local_addr().unwrap().port();
+        let std_listener = listener.into_std().unwrap();
+
+        let server = tokio::spawn(async move {
+            axum_server::Server::from_tcp(std_listener)
+                .serve(router.into_make_service())
+                .await
+                .unwrap();
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        (server, server_port)
+    }
+
+    async fn get_request(port: u16, path: &str) -> (http::StatusCode, String) {
+        let client = hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build_http();
+        let request: hyper::Request<Full<Bytes>> = hyper::Request::builder()
+            .method(hyper::Method::GET)
+            .uri(format!("http://127.0.0.1:{port}/{path}"))
+            .body("".into())
+            .unwrap();
+
+        let response = client.request(request).await.unwrap();
+        let status = response.status();
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let body_str = std::str::from_utf8(&body).unwrap().to_string();
+
+        (status, body_str)
+    }
+
+    // Metadata unavailable (empty state) test.
+    #[tokio::test]
+    async fn test_returns_error_when_no_config() {
+        let state = make_test_state();
+        let (server, port) = setup_server(state).await;
+
+        let (status, body) = get_request(port, "meta-data/hostname").await;
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body, "metadata currently unavailable");
+
+        server.abort();
+    }
+
+    // Test basic metadata fields.
+    #[tokio::test]
+    async fn test_get_hostname() {
+        let state = make_test_state();
+        state.update_config(make_test_config());
+        let (server, port) = setup_server(state).await;
+
+        let (status, body) = get_request(port, "meta-data/hostname").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "test-host");
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_get_public_ipv4() {
+        let state = make_test_state();
+        state.update_config(make_test_config());
+        let (server, port) = setup_server(state).await;
+
+        let (status, body) = get_request(port, "meta-data/public-ipv4").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "10.0.0.1");
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_get_sitename() {
+        let state = make_test_state();
+        state.update_config(make_test_config());
+        let (server, port) = setup_server(state).await;
+
+        let (status, body) = get_request(port, "meta-data/sitename").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "test-site");
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_get_user_data() {
+        let state = make_test_state();
+        state.update_config(make_test_config());
+        let (server, port) = setup_server(state).await;
+
+        let (status, body) = get_request(port, "user-data").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "cloud-init-data");
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_get_asn() {
+        let state = make_test_state();
+        state.update_config(make_test_config());
+        let (server, port) = setup_server(state).await;
+
+        let (status, body) = get_request(port, "meta-data/asn").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "65000");
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_get_instance_id() {
+        let state = make_test_state();
+        state.update_config(make_test_config());
+        let (server, port) = setup_server(state).await;
+
+        let (status, body) = get_request(port, "meta-data/instance-id").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "67e55044-10b1-426f-9247-bb680e5fe0c8");
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_get_machine_id() {
+        let state = make_test_state();
+        state.update_config(make_test_config());
+        let (server, port) = setup_server(state).await;
+
+        let (status, body) = get_request(port, "meta-data/machine-id").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body,
+            "fm100ht6n80e7do39u8gmt7cvhm89pb32st9ngevgdolu542l1nfa4an0rg"
+        );
+
+        server.abort();
+    }
+
+    // Test metadata listing.
+    #[tokio::test]
+    async fn test_get_metadata_listing() {
+        let state = make_test_state();
+        state.update_config(make_test_config());
+        let (server, port) = setup_server(state).await;
+
+        let expected = ["hostname", "sitename", "machine-id", "instance-id", "asn"].join("\n");
+
+        let (status, body) = get_request(port, "meta-data").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, expected);
+
+        // Also check with trailing slash (cloud-init compat).
+        let (status, body) = get_request(port, "meta-data/").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, expected);
+
+        server.abort();
+    }
+
+    // Unknown data category checking.
+    #[tokio::test]
+    async fn test_get_unknown_category() {
+        let state = make_test_state();
+        state.update_config(make_test_config());
+        let (server, port) = setup_server(state).await;
+
+        let (status, _body) = get_request(port, "meta-data/nope").await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+
+        server.abort();
+    }
+
+    // IB device tests.
+    fn config_with_ib_devices() -> FmdsConfig {
+        FmdsConfig {
+            ib_devices: Some(vec![
+                IBDeviceConfig {
+                    pf_guid: "pfguid1".to_string(),
+                    instances: vec![IBInstanceConfig {
+                        ib_partition_id: Some(
+                            "67e55044-10b1-426f-9247-bb680e5fe0c8".parse().unwrap(),
+                        ),
+                        ib_guid: Some("guid1".to_string()),
+                        lid: 42,
+                    }],
+                },
+                IBDeviceConfig {
+                    pf_guid: "pfguid2".to_string(),
+                    instances: vec![IBInstanceConfig {
+                        ib_partition_id: None,
+                        ib_guid: Some("guid2".to_string()),
+                        lid: 43,
+                    }],
+                },
+            ]),
+            ..make_test_config()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_ib_devices() {
+        let state = make_test_state();
+        state.update_config(config_with_ib_devices());
+        let (server, port) = setup_server(state).await;
+
+        let (status, body) = get_request(port, "meta-data/infiniband/devices").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "0=pfguid1\n1=pfguid2\n");
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_get_ib_instances() {
+        let state = make_test_state();
+        state.update_config(config_with_ib_devices());
+        let (server, port) = setup_server(state).await;
+
+        let (status, body) = get_request(port, "meta-data/infiniband/devices/0/instances").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "0=guid1\n");
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_get_ib_instance_attributes() {
+        let state = make_test_state();
+        state.update_config(config_with_ib_devices());
+        let (server, port) = setup_server(state).await;
+
+        let (status, body) = get_request(port, "meta-data/infiniband/devices/0/instances/0").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "guid\npartition\nlid");
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_get_ib_instance_guid() {
+        let state = make_test_state();
+        state.update_config(config_with_ib_devices());
+        let (server, port) = setup_server(state).await;
+
+        let (status, body) =
+            get_request(port, "meta-data/infiniband/devices/0/instances/0/guid").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "guid1");
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_get_ib_instance_lid() {
+        let state = make_test_state();
+        state.update_config(config_with_ib_devices());
+        let (server, port) = setup_server(state).await;
+
+        let (status, body) =
+            get_request(port, "meta-data/infiniband/devices/0/instances/0/lid").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "42");
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_get_ib_device_out_of_range() {
+        let state = make_test_state();
+        state.update_config(config_with_ib_devices());
+        let (server, port) = setup_server(state).await;
+
+        let (status, body) = get_request(port, "meta-data/infiniband/devices/99").await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body, "no device at index: 99");
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_get_ib_instance_out_of_range() {
+        let state = make_test_state();
+        state.update_config(config_with_ib_devices());
+        let (server, port) = setup_server(state).await;
+
+        let (status, body) = get_request(port, "meta-data/infiniband/devices/0/instances/99").await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body, "no instance at index: 99");
+
+        server.abort();
+    }
+
+    // Test integration from gRPC push -> REST read.
+    #[tokio::test]
+    async fn test_grpc_push_then_rest_read() {
+        use rpc::fmds::fmds_config_service_server::FmdsConfigService;
+        use rpc::fmds::{FmdsConfigUpdate, UpdateConfigRequest};
+        use tonic::Request;
+
+        use crate::grpc_server::FmdsGrpcServer;
+
+        let state = make_test_state();
+
+        // Push config via gRPC server (calling the trait method directly).
+        let grpc_server = FmdsGrpcServer::new(state.clone());
+        let update = FmdsConfigUpdate {
+            address: "192.168.1.1".to_string(),
+            hostname: "grpc-pushed-host".to_string(),
+            sitename: Some("grpc-site".to_string()),
+            instance_id: Some(uuid::uuid!("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").into()),
+            machine_id: None,
+            user_data: "grpc-user-data".to_string(),
+            ib_devices: vec![],
+            asn: 12345,
+        };
+        grpc_server
+            .update_config(Request::new(UpdateConfigRequest {
+                config_update: Some(update),
+            }))
+            .await
+            .unwrap();
+
+        // Read via REST
+        let (server, port) = setup_server(state).await;
+
+        let (status, body) = get_request(port, "meta-data/hostname").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "grpc-pushed-host");
+
+        let (status, body) = get_request(port, "meta-data/public-ipv4").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "192.168.1.1");
+
+        let (status, body) = get_request(port, "meta-data/asn").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "12345");
+
+        let (status, body) = get_request(port, "user-data").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "grpc-user-data");
+
+        let (status, body) = get_request(port, "meta-data/instance-id").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+
+        server.abort();
+    }
+}

--- a/crates/fmds/src/state.rs
+++ b/crates/fmds/src/state.rs
@@ -1,0 +1,171 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use arc_swap::ArcSwapOption;
+use carbide_uuid::infiniband::IBPartitionId;
+use carbide_uuid::instance::InstanceId;
+use carbide_uuid::machine::MachineId;
+use governor::middleware::NoOpMiddleware;
+use governor::state::{InMemoryState, NotKeyed};
+use governor::{Quota, RateLimiter, clock};
+use nonzero_ext::nonzero;
+use rpc::forge_tls_client::ForgeClientConfig;
+
+const PHONE_HOME_RATE_LIMIT: Quota = Quota::per_minute(nonzero!(10u32));
+
+/// Shared state between the gRPC server (writer) and REST server (reader).
+pub struct FmdsState {
+    pub config: ArcSwapOption<FmdsConfig>,
+    pub machine_id: ArcSwapOption<MachineId>,
+    pub forge_api: String,
+    pub forge_client_config: Option<Arc<ForgeClientConfig>>,
+    pub outbound_governor:
+        Arc<RateLimiter<NotKeyed, InMemoryState, clock::DefaultClock, NoOpMiddleware>>,
+}
+
+impl FmdsState {
+    pub fn new(forge_api: String, forge_client_config: Option<Arc<ForgeClientConfig>>) -> Self {
+        Self {
+            config: ArcSwapOption::new(None),
+            machine_id: ArcSwapOption::new(None),
+            forge_api,
+            forge_client_config,
+            outbound_governor: Arc::new(RateLimiter::direct(PHONE_HOME_RATE_LIMIT)),
+        }
+    }
+
+    pub fn update_config(&self, config: FmdsConfig) {
+        // Stash the machine_id separately for phone_home lookups.
+        if let Some(ref mid) = config.machine_id {
+            self.machine_id.store(Some(Arc::new(*mid)));
+        }
+        self.config.store(Some(Arc::new(config)));
+    }
+}
+
+/// FmdsConfig is the data FMDS serves to tenants.
+/// Populated from FmdsConfigUpdate proto.
+#[derive(Clone, Debug)]
+pub struct FmdsConfig {
+    pub address: String,
+    pub hostname: String,
+    pub sitename: Option<String>,
+    pub instance_id: Option<InstanceId>,
+    pub machine_id: Option<MachineId>,
+    pub user_data: String,
+    pub ib_devices: Option<Vec<IBDeviceConfig>>,
+    pub asn: u32,
+}
+
+#[derive(Clone, Debug)]
+pub struct IBDeviceConfig {
+    pub pf_guid: String,
+    pub instances: Vec<IBInstanceConfig>,
+}
+
+#[derive(Clone, Debug)]
+pub struct IBInstanceConfig {
+    pub ib_partition_id: Option<IBPartitionId>,
+    pub ib_guid: Option<String>,
+    pub lid: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_test_config() -> FmdsConfig {
+        FmdsConfig {
+            address: "10.0.0.1".to_string(),
+            hostname: "test-host".to_string(),
+            sitename: Some("test-site".to_string()),
+            instance_id: Some(uuid::uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8").into()),
+            machine_id: Some(
+                "fm100ht6n80e7do39u8gmt7cvhm89pb32st9ngevgdolu542l1nfa4an0rg"
+                    .parse()
+                    .unwrap(),
+            ),
+            user_data: "cloud-init-data".to_string(),
+            ib_devices: None,
+            asn: 65000,
+        }
+    }
+
+    #[test]
+    fn test_new_state_starts_empty() {
+        let state = FmdsState::new("https://api.test".to_string(), None);
+        assert!(state.config.load_full().is_none());
+        assert!(state.machine_id.load_full().is_none());
+    }
+
+    #[test]
+    fn test_update_config_stores_config() {
+        let state = FmdsState::new("https://api.test".to_string(), None);
+        let config = make_test_config();
+
+        state.update_config(config);
+
+        let loaded = state.config.load_full().unwrap();
+        assert_eq!(loaded.address, "10.0.0.1");
+        assert_eq!(loaded.hostname, "test-host");
+        assert_eq!(loaded.sitename.as_deref(), Some("test-site"));
+        assert_eq!(loaded.user_data, "cloud-init-data");
+        assert_eq!(loaded.asn, 65000);
+    }
+
+    #[test]
+    fn test_update_config_extracts_machine_id() {
+        let state = FmdsState::new("https://api.test".to_string(), None);
+        let config = make_test_config();
+        let expected_mid = config.machine_id.unwrap();
+
+        state.update_config(config);
+
+        let loaded_mid = state.machine_id.load_full().unwrap();
+        assert_eq!(*loaded_mid, expected_mid);
+    }
+
+    #[test]
+    fn test_update_config_without_machine_id() {
+        let state = FmdsState::new("https://api.test".to_string(), None);
+        let config = FmdsConfig {
+            machine_id: None,
+            ..make_test_config()
+        };
+
+        state.update_config(config);
+
+        assert!(state.config.load_full().is_some());
+        assert!(state.machine_id.load_full().is_none());
+    }
+
+    #[test]
+    fn test_update_config_replaces_previous() {
+        let state = FmdsState::new("https://api.test".to_string(), None);
+
+        state.update_config(make_test_config());
+        assert_eq!(state.config.load_full().unwrap().hostname, "test-host");
+
+        state.update_config(FmdsConfig {
+            hostname: "updated-host".to_string(),
+            ..make_test_config()
+        });
+        assert_eq!(state.config.load_full().unwrap().hostname, "updated-host");
+    }
+}

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -778,6 +778,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "proto/nmx_c.proto",
                 "proto/site_explorer.proto",
                 "proto/dns.proto",
+                "proto/fmds.proto",
             ],
             &["proto"],
         )

--- a/crates/rpc/proto/fmds.proto
+++ b/crates/rpc/proto/fmds.proto
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package fmds;
+
+import "common.proto";
+
+// gRPC service definition that the standalone FMDS service
+// exposes for receiving config updates from carbide-dpu-agent.
+service FmdsConfigService {
+  rpc UpdateConfig(UpdateConfigRequest) returns (UpdateConfigResponse);
+}
+
+message UpdateConfigRequest {
+  FmdsConfigUpdate config_update = 1;
+}
+
+message UpdateConfigResponse {
+}
+
+// FmdsConfigUpdate is the config update pushed from
+// carbide-dpu-agent to the standalone FMDS service.
+// This contains only the fields that FMDS serves to
+// tenants via its REST API, ensuring the data stored
+// within FMDS is targeted specifically for FMDS use.
+message FmdsConfigUpdate {
+  string address = 1;
+  string hostname = 2;
+  optional string sitename = 3;
+  optional common.InstanceId instance_id = 4;
+  optional common.MachineId machine_id = 5;
+  string user_data = 6;
+  repeated IBDevice ib_devices = 7;
+  uint32 asn = 8;
+}
+
+message IBDevice {
+  string pf_guid = 1;
+  repeated IBInstance instances = 2;
+}
+
+message IBInstance {
+  optional string ib_partition_id = 1;
+  optional string ib_guid = 2;
+  uint32 lid = 3;
+}

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -58,7 +58,7 @@ pub use crate::protos::machine_discovery::{
     self, BlockDevice, Cpu, DiscoveryInfo, DmiData, NetworkInterface, NvmeDevice,
     PciDeviceProperties,
 };
-pub use crate::protos::{health, site_explorer};
+pub use crate::protos::{fmds, health, site_explorer};
 
 pub mod errors;
 pub mod forge_tls_client;

--- a/crates/rpc/src/protos/mod.rs
+++ b/crates/rpc/src/protos/mod.rs
@@ -47,6 +47,10 @@ pub mod site_explorer;
 #[rustfmt::skip]
 pub mod dns;
 
+#[allow(non_snake_case, unknown_lints, clippy::all)]
+#[rustfmt::skip]
+pub mod fmds;
+
 #[allow(clippy::all, deprecated)]
 #[rustfmt::skip]
 pub mod forge_api_client;


### PR DESCRIPTION
## Description

This takes care of https://github.com/NVIDIA/ncx-infra-controller-core/issues/677.

Carbide has historically provided FMDS as a component baked into `carbide-dpu-agent`. The agent has a local HTTP listener, and when the tenant OS makes a request, HBN on DPU intercepts it and forwards it to the FMDS listener in the agent.

With [DPF](https://docs.nvidia.com/networking/display/dpf2507) integration work ongoing, we are working to containerize components we historically ran directly on [DPUs](https://www.nvidia.com/en-us/networking/products/data-processing-unit/). One component to this is splitting out FMDS from the `carbifde-dpu-agent` into its own standalone service.

So, this introduces a new standalone `carbide-fmds` service, which, just like it has been in `carbide-dpu-agent`, is a `cloud-init` compatible instance metadata service, allowing tenant instances to discover information about themselves at boot time.

When a tenant OS boots on a machine managed by Carbide, `cloud-init` (or similar tooling) in the tenant OS can hit `http://169.254.169.254/meta-data/` to learn things like:

- `hostname` — what the tenant's hostname should be.
- `public-ipv4` — the tenant's IP address.
- `instance-id` — the tenant's instance UUID.
- `machine-id` — which physical machine it's on.
- `sitename` — which Carbide site.
- `asn` — the BGP ASN for the tenant's network.
- `user-data` — cloud-init user data (scripts, config, SSH keys, etc.).
- `infiniband/devices` — InfiniBand device config (GUIDs, partitions, LIDs) for HPC/AI networking.

And there's `/phone_home` — a POST endpoint the tenant OS hits to tell the Carbide control plane "I'm alive and booted", informing the platform an instance has come online.

With this change, `carbide-dpu-agent` can now "run" FMDS in:
- `::Embedded` -- existing (and default), where it serves it up itself.
- `::External` -- sends FMDS `UpdateConfigRequest` updates to `carbide-fmds` over gRPC.

The `carbide-dpu-agent` will continue to run as-is without any changes, unless you pass `--fmds-grpc-server <server-addr>`, at which point it will then use the new `::External` path.

The `carbide-fmds` service itself has two listeners:
- The tenant-facing HTTP interface for serving up `/meta-data/`.
- The `carbide-dpu-agent` gRPC interface for receiving config updates.

For this, a new `FmdsUpdateConfig` message is being introduced, which contains ONLY the information FMDS needs to serve to tenants, ensuring limited information leaves the `carbide-dpu-agent`; FMDS only gets the specific data it needs to serve to tenants.

One thing to note, for `/phone_home`, we had two options, which Ian and I discussed:
1. `carbide-fmds` could send `/phone_home` pings **back** to the `carbide-dpu-agent`, which would relay them **back** to `carbide-api`. The reason for this would be so we didn't have to deal with credentials to talk to `carbide-api`, and piggy-back on the `carbide-dpu-agent` credentials, but this seemed like a bad reason.
2. `carbide-fmds` would send `/phone_home` pings **directly** to `carbide-api`, and we have to make sure `carbide-fmds` is given credentials.

We decided to go with (2) on this. In this case, there is now a `hostPath` volume shared by `carbide-dpu-agent` and `carbide-fmds` (`/opt/forge`), with an `initContainer` where `carbide-fmds` will wait for `carbide-dpu-agent` to lay down the certificates.

Tests included, and Helm chart included

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

