### PR TITLE
feat: securely erase SATA/SAS HDDs during instance deletion (#429)

### DIFF
--- a/crates/api/src/handlers/machine_scout.rs
+++ b/crates/api/src/handlers/machine_scout.rs
@@ -49,34 +49,48 @@ pub(crate) async fn cleanup_machine_completed(
         .load_machine(&machine_id, MachineSearchConfig::default())
         .await?;
 
+    let cleanup_error = [
+        ("NVMe", cleanup_info.nvme.as_ref()),
+        ("HDD/SAS", cleanup_info.hdd.as_ref()),
+    ]
+    .into_iter()
+    .find_map(|(label, result)| {
+        result.and_then(|result| {
+            (rpc::machine_cleanup_info::CleanupResult::Error as i32 == result.result)
+                .then(|| format!("{label} cleanup failed: {}", result.message))
+        })
+    });
+
     // Check if cleanup failed
-    if let Some(ref nvme_result) = cleanup_info.nvme
-        && rpc::machine_cleanup_info::CleanupResult::Error as i32 == nvme_result.result
-    {
-        // NVME Cleanup failed. Move machine to failed state.
+    if let Some(err) = cleanup_error {
+        // Storage cleanup failed. Move machine to failed state.
         tracing::warn!(
             machine_id = %machine_id,
-            error = %nvme_result.message,
-            "NVMe cleanup failed"
+            error = %err,
+            "Storage cleanup failed"
         );
         db::machine::update_failure_details(
             &machine,
             &mut txn,
             FailureDetails {
-                cause: FailureCause::NVMECleanFailed {
-                    err: nvme_result.message.to_string(),
-                },
+                cause: FailureCause::NVMECleanFailed { err },
                 failed_at: chrono::Utc::now(),
                 source: FailureSource::Scout,
             },
         )
         .await?;
     } else {
-        // Cleanup succeeded or was skipped (nvme field not present means scout skipped it)
+        // Cleanup succeeded or was skipped (field not present means scout skipped it)
         if cleanup_info.nvme.is_none() {
             tracing::info!(
                 machine_id = %machine_id,
                 "NVMe cleanup skipped by scout (likely due to safety check)"
+            );
+        }
+        if cleanup_info.hdd.is_none() {
+            tracing::info!(
+                machine_id = %machine_id,
+                "HDD/SAS cleanup skipped by scout (likely due to safety check)"
             );
         }
         // Update cleanup time on success

--- a/crates/api/src/tests/machine_states.rs
+++ b/crates/api/src/tests/machine_states.rs
@@ -565,10 +565,7 @@ async fn test_nvme_clean_failed_state_host(pool: sqlx::PgPool) {
                 message: "test nvme failure".to_string(),
             },
         ),
-        ram: None,
-        mem_overwrite: None,
-        ib: None,
-        result: 0,
+        ..Default::default()
     });
 
     env.api
@@ -609,10 +606,7 @@ async fn test_nvme_clean_failed_state_host(pool: sqlx::PgPool) {
                 message: "test nvme failure".to_string(),
             },
         ),
-        ram: None,
-        mem_overwrite: None,
-        ib: None,
-        result: 0,
+        ..Default::default()
     });
     env.api
         .cleanup_machine_completed(clean_failed_req)
@@ -640,11 +634,7 @@ async fn test_nvme_clean_failed_state_host(pool: sqlx::PgPool) {
     // Now the host cleans up successfully.
     let clean_succeeded_req = tonic::Request::new(rpc::MachineCleanupInfo {
         machine_id: mh.id.into(),
-        nvme: None,
-        ram: None,
-        mem_overwrite: None,
-        ib: None,
-        result: 0,
+        ..Default::default()
     });
     env.api
         .cleanup_machine_completed(clean_succeeded_req)
@@ -661,6 +651,54 @@ async fn test_nvme_clean_failed_state_host(pool: sqlx::PgPool) {
     assert!(matches!(
         host.current_state(),
         ManagedHostState::WaitingForCleanup { .. }
+    ));
+}
+
+#[crate::sqlx_test]
+async fn test_hdd_clean_failed_state_host(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+    let mut txn = env.pool.begin().await.unwrap();
+    let host = mh.host().db_machine(&mut txn).await;
+
+    let clean_failed_req = tonic::Request::new(rpc::MachineCleanupInfo {
+        machine_id: mh.id.into(),
+        hdd: Some(
+            rpc::protos::forge::machine_cleanup_info::CleanupStepResult {
+                result: rpc::protos::forge::machine_cleanup_info::CleanupResult::Error as i32,
+                message: "test hdd failure".to_string(),
+            },
+        ),
+        ..Default::default()
+    });
+
+    env.api
+        .cleanup_machine_completed(clean_failed_req)
+        .await
+        .unwrap();
+
+    update_time_params(
+        &env.pool,
+        &host,
+        1,
+        Some(host.last_reboot_requested.as_ref().unwrap().time - Duration::seconds(59)),
+    )
+    .await;
+    // let state machine check the failure condition.
+    env.run_machine_state_controller_iteration().await;
+
+    let host = mh.host().db_machine(&mut txn).await;
+
+    assert!(matches!(
+        host.current_state(),
+        ManagedHostState::Failed {
+            details: FailureDetails {
+                cause: model::machine::FailureCause::NVMECleanFailed { .. },
+                ..
+            },
+            retry_count: 0,
+            ..
+        }
     ));
 }
 

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -462,7 +462,7 @@ impl ApiClient {
                 result: 0,
                 message: "".to_string(),
             }),
-            result: 0,
+            ..Default::default()
         };
 
         self.0

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -4465,7 +4465,9 @@ message MachineCleanupInfo {
   // EFI variable MemoryOverwriteRequestControl-e20939be-32d4-41be-a150-897f85d49829 must be set to 1
   CleanupStepResult mem_overwrite = 4;
   // Reset IB devices
-  CleanupStepResult ib = 5;
+  CleanupStepResult ib  = 5;
+  // HDD/SSD block device cleanup result
+  CleanupStepResult hdd = 6;
 
   CleanupResult result = 11;
 }

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -3891,7 +3891,9 @@ message MachineCleanupInfo {
   // EFI variable MemoryOverwriteRequestControl-e20939be-32d4-41be-a150-897f85d49829 must be set to 1
   CleanupStepResult mem_overwrite = 4;
   // Reset IB devices
-  CleanupStepResult ib = 5;
+  CleanupStepResult ib  = 5;
+  // HDD/SSD block device cleanup result
+  CleanupStepResult hdd = 6;
 
   CleanupResult result = 11;
 }

--- a/crates/scout/src/deprovision/scrabbing.rs
+++ b/crates/scout/src/deprovision/scrabbing.rs
@@ -63,6 +63,7 @@ fn check_memory_overwrite_efi_var() -> Result<(), CarbideClientError> {
 static NVME_CLI_PROG: &str = "/usr/sbin/nvme";
 static HDPARM_CLI_PROG: &str = "/usr/sbin/hdparm";
 static SG_SANITIZE_CLI_PROG: &str = "/usr/bin/sg_sanitize";
+static DD_CLI_PROG: &str = "/usr/bin/dd";
 static LENOVO_NVMI_CLI_PROG_CANDIDATES: [&str; 4] = [
     "/opt/forge/bin/mnv_cli",
     "/opt/forge/mnv_cli",
@@ -553,7 +554,13 @@ async fn try_ata_secure_erase(devpath: &str) -> Result<(), CarbideClientError> {
 }
 
 async fn try_scsi_sanitize(devpath: &str) -> Result<(), CarbideClientError> {
-    cmdrun::run_prog(SG_SANITIZE_CLI_PROG, ["--block", "-w", devpath]).await?;
+    cmdrun::run_prog(SG_SANITIZE_CLI_PROG, ["-Q", "-w", "-C", devpath]).await?;
+    // Some drives leave LBA 0 as random bytes after a crypto erase rather than zeroing it.
+    // Random data can accidentally match the AHDI (Atari HDD) partition signature, causing
+    // the Linux kernel to create phantom partition entries. Writing one sector of zeros with
+    // oflag=direct bypasses the SAS HBA cache and ensures LBA 0 is clean.
+    let of_arg = format!("of={devpath}");
+    cmdrun::run_prog(DD_CLI_PROG, ["if=/dev/zero", &of_arg, "count=1", "oflag=direct"]).await?;
     Ok(())
 }
 

--- a/crates/scout/src/deprovision/scrabbing.rs
+++ b/crates/scout/src/deprovision/scrabbing.rs
@@ -555,18 +555,27 @@ async fn try_scsi_sanitize(devpath: &str) -> Result<(), CarbideClientError> {
     Ok(())
 }
 
+fn sysfs_path_is_sata(path: &std::path::Path) -> bool {
+    // SATA devices resolve through an ATA host in the sysfs device tree (path contains "/ata").
+    // SAS/SCSI devices do not.
+    path.to_string_lossy().contains("/ata")
+}
+
+fn is_sata_device(devname: &str) -> bool {
+    fs::canonicalize(format!("/sys/block/{devname}"))
+        .map(|p| sysfs_path_is_sata(&p))
+        .unwrap_or(false)
+}
+
 async fn clean_this_block_device(devpath: &str) -> Result<(), CarbideClientError> {
-    match try_ata_secure_erase(devpath).await {
-        Ok(()) => return Ok(()),
-        Err(e) => {
-            tracing::info!(
-                "ATA secure erase not applicable for {}: {}. Trying SCSI sanitize.",
-                devpath,
-                e
-            );
-        }
+    let devname = devpath.trim_start_matches("/dev/");
+    if is_sata_device(devname) {
+        tracing::info!("{} detected as SATA, using ATA Secure Erase", devpath);
+        try_ata_secure_erase(devpath).await
+    } else {
+        tracing::info!("{} detected as SAS/SCSI, using SCSI Sanitize", devpath);
+        try_scsi_sanitize(devpath).await
     }
-    try_scsi_sanitize(devpath).await
 }
 
 async fn all_hdd_cleanup() -> Result<(), CarbideClientError> {
@@ -1236,6 +1245,19 @@ mod tests {
 
         assert!(hdparm_supports_enhanced_erase(with_enhanced));
         assert!(!hdparm_supports_enhanced_erase(without_enhanced));
+    }
+
+    #[test]
+    fn test_sysfs_path_is_sata() {
+        use std::path::Path;
+        // SATA: path contains /ata host component
+        assert!(sysfs_path_is_sata(Path::new(
+            "/sys/devices/pci0000:00/0000:00:17.0/ata1/host0/target0:0:0/0:0:0:0/block/sda"
+        )));
+        // SAS: path goes through SAS host, no /ata component
+        assert!(!sysfs_path_is_sata(Path::new(
+            "/sys/devices/pci0000:00/0000:00:01.0/0000:01:00.0/host0/port-0:0/end_device-0:0/target0:0:0/0:0:0:0/block/sda"
+        )));
     }
 
     #[test]

--- a/crates/scout/src/deprovision/scrabbing.rs
+++ b/crates/scout/src/deprovision/scrabbing.rs
@@ -554,6 +554,7 @@ async fn try_ata_secure_erase(devpath: &str) -> Result<(), CarbideClientError> {
 }
 
 async fn try_scsi_sanitize(devpath: &str) -> Result<(), CarbideClientError> {
+    // The supported SAS fleet uses SEDs; use crypto erase intentionally rather than --block.
     cmdrun::run_prog(SG_SANITIZE_CLI_PROG, ["-Q", "-w", "-C", devpath]).await?;
     // Some drives leave LBA 0 as random bytes after a crypto erase rather than zeroing it.
     // Random data can accidentally match the AHDI (Atari HDD) partition signature, causing
@@ -562,7 +563,13 @@ async fn try_scsi_sanitize(devpath: &str) -> Result<(), CarbideClientError> {
     let of_arg = format!("of={devpath}");
     cmdrun::run_prog(
         DD_CLI_PROG,
-        ["if=/dev/zero", &of_arg, "count=1", "oflag=direct"],
+        [
+            "if=/dev/zero",
+            &of_arg,
+            "bs=4096",
+            "count=1",
+            "oflag=direct",
+        ],
     )
     .await?;
     Ok(())
@@ -592,7 +599,7 @@ async fn clean_this_block_device(devpath: &str) -> Result<(), CarbideClientError
 }
 
 async fn all_hdd_cleanup() -> Result<(), CarbideClientError> {
-    let mut sata_devicepaths: Vec<String> = Vec::new();
+    let mut block_devicepaths: Vec<String> = Vec::new();
     if let Ok(entries) = fs::read_dir("/sys/block") {
         for entry in entries {
             let entry = match entry {
@@ -602,12 +609,12 @@ async fn all_hdd_cleanup() -> Result<(), CarbideClientError> {
             let devname = entry.file_name().to_string_lossy().to_string();
             let devpath = format!("/dev/{devname}");
             if SD_DEV_RE.is_match(&devpath) {
-                sata_devicepaths.push(devpath);
+                block_devicepaths.push(devpath);
             }
         }
     }
 
-    let device_count = sata_devicepaths.len();
+    let device_count = block_devicepaths.len();
     if device_count == 0 {
         tracing::info!("No SATA/SAS block devices found to clean");
         return Ok(());
@@ -616,7 +623,7 @@ async fn all_hdd_cleanup() -> Result<(), CarbideClientError> {
     tracing::info!(device_count, "Starting HDD/SAS cleanup");
     let start_time = std::time::Instant::now();
 
-    let cleanup_futures: Vec<_> = sata_devicepaths
+    let cleanup_futures: Vec<_> = block_devicepaths
         .into_iter()
         .map(|devpath| {
             let device = devpath.clone();

--- a/crates/scout/src/deprovision/scrabbing.rs
+++ b/crates/scout/src/deprovision/scrabbing.rs
@@ -61,6 +61,8 @@ fn check_memory_overwrite_efi_var() -> Result<(), CarbideClientError> {
 }
 
 static NVME_CLI_PROG: &str = "/usr/sbin/nvme";
+static HDPARM_CLI_PROG: &str = "/usr/sbin/hdparm";
+static SG_SANITIZE_CLI_PROG: &str = "/usr/bin/sg_sanitize";
 static LENOVO_NVMI_CLI_PROG_CANDIDATES: [&str; 4] = [
     "/opt/forge/bin/mnv_cli",
     "/opt/forge/mnv_cli",
@@ -79,6 +81,7 @@ lazy_static::lazy_static! {
     static ref NVME_NS_RE: Regex = Regex::new(r".*:(0x[0-9]+)").unwrap();
     static ref NVME_NSID_RE: Regex = Regex::new(r".*nsid:([0-9]+)").unwrap();
     static ref NVME_DEV_RE: Regex = Regex::new(r"/dev/nvme[0-9]+$").unwrap();
+    static ref SD_DEV_RE: Regex = Regex::new(r"/dev/sd[a-z]+$").unwrap();
 }
 
 #[derive(Deserialize, Debug)]
@@ -502,6 +505,161 @@ async fn all_nvme_cleanup() -> Result<(), CarbideClientError> {
     Ok(())
 }
 
+fn hdparm_has_security_section(output: &str) -> bool {
+    output.contains("Security:")
+}
+
+fn hdparm_is_frozen(output: &str) -> bool {
+    output.lines().any(|line| {
+        let trimmed = line.trim();
+        trimmed == "frozen" || (trimmed.ends_with("frozen") && !trimmed.contains("not"))
+    })
+}
+
+fn hdparm_supports_enhanced_erase(output: &str) -> bool {
+    output.contains("supported: enhanced erase")
+}
+
+async fn try_ata_secure_erase(devpath: &str) -> Result<(), CarbideClientError> {
+    let info = cmdrun::run_prog(HDPARM_CLI_PROG, ["-I", devpath]).await?;
+
+    if !hdparm_has_security_section(&info) {
+        return Err(CarbideClientError::GenericError(format!(
+            "Device {} has no ATA Security section; may be SAS/SCSI",
+            devpath
+        )));
+    }
+
+    if hdparm_is_frozen(&info) {
+        return Err(CarbideClientError::GenericError(format!(
+            "Device {} ATA security is frozen; cannot erase without power cycle",
+            devpath
+        )));
+    }
+
+    cmdrun::run_prog(HDPARM_CLI_PROG, ["--security-set-pass", "p", devpath]).await?;
+
+    if hdparm_supports_enhanced_erase(&info) {
+        tracing::info!("Using enhanced erase for {}", devpath);
+        cmdrun::run_prog(HDPARM_CLI_PROG, ["--security-erase-enhanced", "p", devpath]).await?;
+    } else {
+        tracing::info!("Using standard erase for {}", devpath);
+        cmdrun::run_prog(HDPARM_CLI_PROG, ["--security-erase", "p", devpath]).await?;
+    }
+
+    Ok(())
+}
+
+async fn try_scsi_sanitize(devpath: &str) -> Result<(), CarbideClientError> {
+    cmdrun::run_prog(SG_SANITIZE_CLI_PROG, ["--block", "-w", devpath]).await?;
+    Ok(())
+}
+
+async fn clean_this_block_device(devpath: &str) -> Result<(), CarbideClientError> {
+    match try_ata_secure_erase(devpath).await {
+        Ok(()) => return Ok(()),
+        Err(e) => {
+            tracing::info!(
+                "ATA secure erase not applicable for {}: {}. Trying SCSI sanitize.",
+                devpath,
+                e
+            );
+        }
+    }
+    try_scsi_sanitize(devpath).await
+}
+
+async fn all_hdd_cleanup() -> Result<(), CarbideClientError> {
+    let mut sata_devicepaths: Vec<String> = Vec::new();
+    if let Ok(entries) = fs::read_dir("/sys/block") {
+        for entry in entries {
+            let entry = match entry {
+                Ok(o) => o,
+                Err(_) => continue,
+            };
+            let devname = entry.file_name().to_string_lossy().to_string();
+            let devpath = format!("/dev/{devname}");
+            if SD_DEV_RE.is_match(&devpath) {
+                sata_devicepaths.push(devpath);
+            }
+        }
+    }
+
+    let device_count = sata_devicepaths.len();
+    if device_count == 0 {
+        tracing::info!("No SATA/SAS block devices found to clean");
+        return Ok(());
+    }
+
+    tracing::info!(device_count, "Starting HDD/SAS cleanup");
+    let start_time = std::time::Instant::now();
+
+    let cleanup_futures: Vec<_> = sata_devicepaths
+        .into_iter()
+        .map(|devpath| {
+            let device = devpath.clone();
+            let span = tracing::info_span!("hdd_cleanup", device = %devpath);
+
+            tokio::spawn(
+                async move {
+                    let device_start = std::time::Instant::now();
+
+                    tracing::info!("Starting cleanup");
+                    let result = clean_this_block_device(&devpath).await;
+                    let duration = device_start.elapsed();
+
+                    match result {
+                        Ok(()) => {
+                            tracing::info!(?duration, "Cleanup completed successfully");
+                            Ok(())
+                        }
+                        Err(error) => {
+                            tracing::error!(?duration, %error, "Cleanup failed");
+                            Err(CleanupFailure {
+                                device,
+                                duration,
+                                error,
+                            })
+                        }
+                    }
+                }
+                .instrument(span),
+            )
+        })
+        .collect();
+
+    let results = futures_util::future::join_all(cleanup_futures).await;
+    let total_duration = start_time.elapsed();
+
+    let mut errors: Vec<String> = Vec::new();
+    let mut success_count = 0;
+
+    for join_result in results {
+        let cleanup_result = join_result.expect("hdd cleanup task panicked");
+        match cleanup_result {
+            Ok(()) => success_count += 1,
+            Err(failure) => errors.push(format!(
+                "HDD_CLEAN_ERROR (device: {}; duration: {:?}): {}",
+                failure.device, failure.duration, failure.error,
+            )),
+        }
+    }
+
+    tracing::info!(
+        device_count,
+        success_count,
+        error_count = errors.len(),
+        ?total_duration,
+        "HDD/SAS cleanup completed"
+    );
+
+    if !errors.is_empty() {
+        return Err(CarbideClientError::GenericError(errors.join("\n")));
+    }
+
+    Ok(())
+}
+
 // #[derive(Debug)]
 // struct StructOsMemInfo {
 //     mem_total: u64,
@@ -719,17 +877,21 @@ async fn do_cleanup(machine_id: &MachineId) -> CarbideClientResult<rpc::MachineC
         ram: None,
         mem_overwrite: None,
         ib: None,
+        hdd: None,
         result: rpc::machine_cleanup_info::CleanupResult::Ok as _,
     };
 
-    // do nvme cleanup only if stdin is /dev/null. This is because we afraid to cleanum someone's nvme drive.
+    // do nvme/hdd cleanup only if stdin is /dev/null. This is because we afraid to cleanup someone's drives.
     let stdin_link = match fs::read_link("/proc/self/fd/0") {
         Ok(o) => o.to_string_lossy().to_string(),
         Err(_) => "None".to_string(),
     };
 
     if stdin_link == "/dev/null" {
-        match all_nvme_cleanup().await {
+        let (nvme_result, hdd_result) =
+            tokio::join!(all_nvme_cleanup(), all_hdd_cleanup());
+
+        match nvme_result {
             Ok(_) => {
                 cleanup_result.nvme = Some(rpc::machine_cleanup_info::CleanupStepResult {
                     result: rpc::machine_cleanup_info::CleanupResult::Ok as _,
@@ -745,8 +907,25 @@ async fn do_cleanup(machine_id: &MachineId) -> CarbideClientResult<rpc::MachineC
                 cleanup_result.result = rpc::machine_cleanup_info::CleanupResult::Error as _;
             }
         }
+
+        match hdd_result {
+            Ok(_) => {
+                cleanup_result.hdd = Some(rpc::machine_cleanup_info::CleanupStepResult {
+                    result: rpc::machine_cleanup_info::CleanupResult::Ok as _,
+                    message: "OK".to_string(),
+                });
+            }
+            Err(e) => {
+                tracing::error!("{}", e);
+                cleanup_result.hdd = Some(rpc::machine_cleanup_info::CleanupStepResult {
+                    result: rpc::machine_cleanup_info::CleanupResult::Error as _,
+                    message: e.to_string(),
+                });
+                cleanup_result.result = rpc::machine_cleanup_info::CleanupResult::Error as _;
+            }
+        }
     } else {
-        tracing::info!("stdin == {}. Skip nvme cleanup.", stdin_link);
+        tracing::info!("stdin == {}. Skip nvme and HDD cleanup.", stdin_link);
     }
 
     match check_memory_overwrite_efi_var() {
@@ -851,8 +1030,12 @@ pub async fn run_no_api() -> Result<(), CarbideClientError> {
             Ok(_) => tracing::debug!("nvme cleanup OK"),
             Err(e) => tracing::error!("nvme cleanup error: {}", e),
         }
+        match all_hdd_cleanup().await {
+            Ok(_) => tracing::debug!("hdd cleanup OK"),
+            Err(e) => tracing::error!("hdd cleanup error: {}", e),
+        }
     } else {
-        tracing::info!("stdin == {}. Skip nvme cleanup.", stdin_link);
+        tracing::info!("stdin == {}. Skip nvme and HDD cleanup.", stdin_link);
     }
 
     // P1 errors are propagated (fail startup), P2 errors are handled internally in reset_ib_devices()
@@ -1020,5 +1203,55 @@ mod tests {
         let ds_4096 = 12u8;
         let sector_size_4096 = 1u64 << ds_4096;
         assert_eq!(sector_size_4096, 4096);
+    }
+
+    #[test]
+    fn test_hdparm_has_security_section() {
+        let with_security = "ATA device, with non-removable media\nSecurity:\n\tMaster password revision code = 65534\n\tsupported\n\tnot\tlocked\n\tnot\tfrozen\n";
+        let without_security = "ATA device, with non-removable media\nCapabilities:\n\tLBA, IORDY\n";
+
+        assert!(hdparm_has_security_section(with_security));
+        assert!(!hdparm_has_security_section(without_security));
+    }
+
+    #[test]
+    fn test_hdparm_is_frozen_not_frozen() {
+        let not_frozen = "Security:\n\tsupported\n\tnot\tfrozen\n";
+        assert!(!hdparm_is_frozen(not_frozen));
+    }
+
+    #[test]
+    fn test_hdparm_is_frozen_frozen() {
+        let frozen = "Security:\n\tsupported\n\tfrozen\n";
+        assert!(hdparm_is_frozen(frozen));
+    }
+
+    #[test]
+    fn test_hdparm_supports_enhanced_erase() {
+        let with_enhanced =
+            "Security:\n\tsupported\n\tnot\tfrozen\n\tsupported: enhanced erase\n";
+        let without_enhanced = "Security:\n\tsupported\n\tnot\tfrozen\n";
+
+        assert!(hdparm_supports_enhanced_erase(with_enhanced));
+        assert!(!hdparm_supports_enhanced_erase(without_enhanced));
+    }
+
+    #[test]
+    fn test_sata_dev_re_matches_whole_disk() {
+        assert!(SD_DEV_RE.is_match("/dev/sda"));
+        assert!(SD_DEV_RE.is_match("/dev/sdb"));
+        assert!(SD_DEV_RE.is_match("/dev/sdz"));
+    }
+
+    #[test]
+    fn test_sata_dev_re_does_not_match_partitions() {
+        assert!(!SD_DEV_RE.is_match("/dev/sda1"));
+        assert!(!SD_DEV_RE.is_match("/dev/sdb2"));
+    }
+
+    #[test]
+    fn test_sata_dev_re_does_not_match_nvme() {
+        assert!(!SD_DEV_RE.is_match("/dev/nvme0"));
+        assert!(!SD_DEV_RE.is_match("/dev/nvme0n1"));
     }
 }

--- a/crates/scout/src/deprovision/scrabbing.rs
+++ b/crates/scout/src/deprovision/scrabbing.rs
@@ -537,15 +537,17 @@ async fn try_ata_secure_erase(devpath: &str) -> Result<(), CarbideClientError> {
         )));
     }
 
+    if !hdparm_supports_enhanced_erase(&info) {
+        return Err(CarbideClientError::GenericError(format!(
+            "Device {} does not support ATA enhanced erase; non-SED SATA drives are not supported",
+            devpath
+        )));
+    }
+
     cmdrun::run_prog(HDPARM_CLI_PROG, ["--security-set-pass", "p", devpath]).await?;
 
-    if hdparm_supports_enhanced_erase(&info) {
-        tracing::info!("Using enhanced erase for {}", devpath);
-        cmdrun::run_prog(HDPARM_CLI_PROG, ["--security-erase-enhanced", "p", devpath]).await?;
-    } else {
-        tracing::info!("Using standard erase for {}", devpath);
-        cmdrun::run_prog(HDPARM_CLI_PROG, ["--security-erase", "p", devpath]).await?;
-    }
+    tracing::info!("Using enhanced erase for {}", devpath);
+    cmdrun::run_prog(HDPARM_CLI_PROG, ["--security-erase-enhanced", "p", devpath]).await?;
 
     Ok(())
 }

--- a/crates/scout/src/deprovision/scrabbing.rs
+++ b/crates/scout/src/deprovision/scrabbing.rs
@@ -560,7 +560,11 @@ async fn try_scsi_sanitize(devpath: &str) -> Result<(), CarbideClientError> {
     // the Linux kernel to create phantom partition entries. Writing one sector of zeros with
     // oflag=direct bypasses the SAS HBA cache and ensures LBA 0 is clean.
     let of_arg = format!("of={devpath}");
-    cmdrun::run_prog(DD_CLI_PROG, ["if=/dev/zero", &of_arg, "count=1", "oflag=direct"]).await?;
+    cmdrun::run_prog(
+        DD_CLI_PROG,
+        ["if=/dev/zero", &of_arg, "count=1", "oflag=direct"],
+    )
+    .await?;
     Ok(())
 }
 
@@ -906,8 +910,7 @@ async fn do_cleanup(machine_id: &MachineId) -> CarbideClientResult<rpc::MachineC
     };
 
     if stdin_link == "/dev/null" {
-        let (nvme_result, hdd_result) =
-            tokio::join!(all_nvme_cleanup(), all_hdd_cleanup());
+        let (nvme_result, hdd_result) = tokio::join!(all_nvme_cleanup(), all_hdd_cleanup());
 
         match nvme_result {
             Ok(_) => {
@@ -1228,7 +1231,8 @@ mod tests {
     #[test]
     fn test_hdparm_has_security_section() {
         let with_security = "ATA device, with non-removable media\nSecurity:\n\tMaster password revision code = 65534\n\tsupported\n\tnot\tlocked\n\tnot\tfrozen\n";
-        let without_security = "ATA device, with non-removable media\nCapabilities:\n\tLBA, IORDY\n";
+        let without_security =
+            "ATA device, with non-removable media\nCapabilities:\n\tLBA, IORDY\n";
 
         assert!(hdparm_has_security_section(with_security));
         assert!(!hdparm_has_security_section(without_security));
@@ -1248,8 +1252,7 @@ mod tests {
 
     #[test]
     fn test_hdparm_supports_enhanced_erase() {
-        let with_enhanced =
-            "Security:\n\tsupported\n\tnot\tfrozen\n\tsupported: enhanced erase\n";
+        let with_enhanced = "Security:\n\tsupported\n\tnot\tfrozen\n\tsupported: enhanced erase\n";
         let without_enhanced = "Security:\n\tsupported\n\tnot\tfrozen\n";
 
         assert!(hdparm_supports_enhanced_erase(with_enhanced));

--- a/crates/scout/src/deprovision/scrabbing.rs
+++ b/crates/scout/src/deprovision/scrabbing.rs
@@ -555,18 +555,27 @@ async fn try_scsi_sanitize(devpath: &str) -> Result<(), CarbideClientError> {
     Ok(())
 }
 
+fn sysfs_path_is_sata(path: &std::path::Path) -> bool {
+    // SATA devices resolve through an ATA host in the sysfs device tree (path contains "/ata").
+    // SAS/SCSI devices do not.
+    path.to_string_lossy().contains("/ata")
+}
+
+fn is_sata_device(devname: &str) -> bool {
+    fs::canonicalize(format!("/sys/block/{devname}"))
+        .map(|p| sysfs_path_is_sata(&p))
+        .unwrap_or(false)
+}
+
 async fn clean_this_block_device(devpath: &str) -> Result<(), CarbideClientError> {
-    match try_ata_secure_erase(devpath).await {
-        Ok(()) => return Ok(()),
-        Err(e) => {
-            tracing::info!(
-                "ATA secure erase not applicable for {}: {}. Trying SCSI sanitize.",
-                devpath,
-                e
-            );
-        }
+    let devname = devpath.trim_start_matches("/dev/");
+    if is_sata_device(devname) {
+        tracing::info!("{} detected as SATA, using ATA Secure Erase", devpath);
+        try_ata_secure_erase(devpath).await
+    } else {
+        tracing::info!("{} detected as SAS/SCSI, using SCSI Sanitize", devpath);
+        try_scsi_sanitize(devpath).await
     }
-    try_scsi_sanitize(devpath).await
 }
 
 async fn all_hdd_cleanup() -> Result<(), CarbideClientError> {
@@ -1234,6 +1243,19 @@ mod tests {
 
         assert!(hdparm_supports_enhanced_erase(with_enhanced));
         assert!(!hdparm_supports_enhanced_erase(without_enhanced));
+    }
+
+    #[test]
+    fn test_sysfs_path_is_sata() {
+        use std::path::Path;
+        // SATA: path contains /ata host component
+        assert!(sysfs_path_is_sata(Path::new(
+            "/sys/devices/pci0000:00/0000:00:17.0/ata1/host0/target0:0:0/0:0:0:0/block/sda"
+        )));
+        // SAS: path goes through SAS host, no /ata component
+        assert!(!sysfs_path_is_sata(Path::new(
+            "/sys/devices/pci0000:00/0000:00:01.0/0000:01:00.0/host0/port-0:0/end_device-0:0/target0:0:0/0:0:0:0/block/sda"
+        )));
     }
 
     #[test]

--- a/crates/scout/src/deprovision/scrabbing.rs
+++ b/crates/scout/src/deprovision/scrabbing.rs
@@ -61,6 +61,8 @@ fn check_memory_overwrite_efi_var() -> Result<(), CarbideClientError> {
 }
 
 static NVME_CLI_PROG: &str = "/usr/sbin/nvme";
+static HDPARM_CLI_PROG: &str = "/usr/sbin/hdparm";
+static SG_SANITIZE_CLI_PROG: &str = "/usr/bin/sg_sanitize";
 static LENOVO_NVMI_CLI_PROG_CANDIDATES: [&str; 4] = [
     "/opt/forge/bin/mnv_cli",
     "/opt/forge/mnv_cli",
@@ -79,6 +81,7 @@ lazy_static::lazy_static! {
     static ref NVME_NS_RE: Regex = Regex::new(r".*:(0x[0-9]+)").unwrap();
     static ref NVME_NSID_RE: Regex = Regex::new(r".*nsid:([0-9]+)").unwrap();
     static ref NVME_DEV_RE: Regex = Regex::new(r"/dev/nvme[0-9]+$").unwrap();
+    static ref SD_DEV_RE: Regex = Regex::new(r"/dev/sd[a-z]+$").unwrap();
 }
 
 #[derive(Deserialize, Debug)]
@@ -502,6 +505,161 @@ async fn all_nvme_cleanup() -> Result<(), CarbideClientError> {
     Ok(())
 }
 
+fn hdparm_has_security_section(output: &str) -> bool {
+    output.contains("Security:")
+}
+
+fn hdparm_is_frozen(output: &str) -> bool {
+    output.lines().any(|line| {
+        let trimmed = line.trim();
+        trimmed == "frozen" || (trimmed.ends_with("frozen") && !trimmed.contains("not"))
+    })
+}
+
+fn hdparm_supports_enhanced_erase(output: &str) -> bool {
+    output.contains("supported: enhanced erase")
+}
+
+async fn try_ata_secure_erase(devpath: &str) -> Result<(), CarbideClientError> {
+    let info = cmdrun::run_prog(HDPARM_CLI_PROG, ["-I", devpath]).await?;
+
+    if !hdparm_has_security_section(&info) {
+        return Err(CarbideClientError::GenericError(format!(
+            "Device {} has no ATA Security section; may be SAS/SCSI",
+            devpath
+        )));
+    }
+
+    if hdparm_is_frozen(&info) {
+        return Err(CarbideClientError::GenericError(format!(
+            "Device {} ATA security is frozen; cannot erase without power cycle",
+            devpath
+        )));
+    }
+
+    cmdrun::run_prog(HDPARM_CLI_PROG, ["--security-set-pass", "p", devpath]).await?;
+
+    if hdparm_supports_enhanced_erase(&info) {
+        tracing::info!("Using enhanced erase for {}", devpath);
+        cmdrun::run_prog(HDPARM_CLI_PROG, ["--security-erase-enhanced", "p", devpath]).await?;
+    } else {
+        tracing::info!("Using standard erase for {}", devpath);
+        cmdrun::run_prog(HDPARM_CLI_PROG, ["--security-erase", "p", devpath]).await?;
+    }
+
+    Ok(())
+}
+
+async fn try_scsi_sanitize(devpath: &str) -> Result<(), CarbideClientError> {
+    cmdrun::run_prog(SG_SANITIZE_CLI_PROG, ["--block", "-w", devpath]).await?;
+    Ok(())
+}
+
+async fn clean_this_block_device(devpath: &str) -> Result<(), CarbideClientError> {
+    match try_ata_secure_erase(devpath).await {
+        Ok(()) => return Ok(()),
+        Err(e) => {
+            tracing::info!(
+                "ATA secure erase not applicable for {}: {}. Trying SCSI sanitize.",
+                devpath,
+                e
+            );
+        }
+    }
+    try_scsi_sanitize(devpath).await
+}
+
+async fn all_hdd_cleanup() -> Result<(), CarbideClientError> {
+    let mut sata_devicepaths: Vec<String> = Vec::new();
+    if let Ok(entries) = fs::read_dir("/sys/block") {
+        for entry in entries {
+            let entry = match entry {
+                Ok(o) => o,
+                Err(_) => continue,
+            };
+            let devname = entry.file_name().to_string_lossy().to_string();
+            let devpath = format!("/dev/{devname}");
+            if SD_DEV_RE.is_match(&devpath) {
+                sata_devicepaths.push(devpath);
+            }
+        }
+    }
+
+    let device_count = sata_devicepaths.len();
+    if device_count == 0 {
+        tracing::info!("No SATA/SAS block devices found to clean");
+        return Ok(());
+    }
+
+    tracing::info!(device_count, "Starting HDD/SAS cleanup");
+    let start_time = std::time::Instant::now();
+
+    let cleanup_futures: Vec<_> = sata_devicepaths
+        .into_iter()
+        .map(|devpath| {
+            let device = devpath.clone();
+            let span = tracing::info_span!("hdd_cleanup", device = %devpath);
+
+            tokio::spawn(
+                async move {
+                    let device_start = std::time::Instant::now();
+
+                    tracing::info!("Starting cleanup");
+                    let result = clean_this_block_device(&devpath).await;
+                    let duration = device_start.elapsed();
+
+                    match result {
+                        Ok(()) => {
+                            tracing::info!(?duration, "Cleanup completed successfully");
+                            Ok(())
+                        }
+                        Err(error) => {
+                            tracing::error!(?duration, %error, "Cleanup failed");
+                            Err(CleanupFailure {
+                                device,
+                                duration,
+                                error,
+                            })
+                        }
+                    }
+                }
+                .instrument(span),
+            )
+        })
+        .collect();
+
+    let results = futures_util::future::join_all(cleanup_futures).await;
+    let total_duration = start_time.elapsed();
+
+    let mut errors: Vec<String> = Vec::new();
+    let mut success_count = 0;
+
+    for join_result in results {
+        let cleanup_result = join_result.expect("hdd cleanup task panicked");
+        match cleanup_result {
+            Ok(()) => success_count += 1,
+            Err(failure) => errors.push(format!(
+                "HDD_CLEAN_ERROR (device: {}; duration: {:?}): {}",
+                failure.device, failure.duration, failure.error,
+            )),
+        }
+    }
+
+    tracing::info!(
+        device_count,
+        success_count,
+        error_count = errors.len(),
+        ?total_duration,
+        "HDD/SAS cleanup completed"
+    );
+
+    if !errors.is_empty() {
+        return Err(CarbideClientError::GenericError(errors.join("\n")));
+    }
+
+    Ok(())
+}
+
 // #[derive(Debug)]
 // struct StructOsMemInfo {
 //     mem_total: u64,
@@ -719,17 +877,21 @@ async fn do_cleanup(machine_id: &MachineId) -> CarbideClientResult<rpc::MachineC
         ram: None,
         mem_overwrite: None,
         ib: None,
+        hdd: None,
         result: rpc::machine_cleanup_info::CleanupResult::Ok as _,
     };
 
-    // do nvme cleanup only if stdin is /dev/null. This is because we afraid to cleanum someone's nvme drive.
+    // do nvme/hdd cleanup only if stdin is /dev/null. This is because we afraid to cleanup someone's drives.
     let stdin_link = match fs::read_link("/proc/self/fd/0") {
         Ok(o) => o.to_string_lossy().to_string(),
         Err(_) => "None".to_string(),
     };
 
     if stdin_link == "/dev/null" {
-        match all_nvme_cleanup().await {
+        let (nvme_result, hdd_result) =
+            tokio::join!(all_nvme_cleanup(), all_hdd_cleanup());
+
+        match nvme_result {
             Ok(_) => {
                 cleanup_result.nvme = Some(rpc::machine_cleanup_info::CleanupStepResult {
                     result: rpc::machine_cleanup_info::CleanupResult::Ok as _,
@@ -745,8 +907,25 @@ async fn do_cleanup(machine_id: &MachineId) -> CarbideClientResult<rpc::MachineC
                 cleanup_result.result = rpc::machine_cleanup_info::CleanupResult::Error as _;
             }
         }
+
+        match hdd_result {
+            Ok(_) => {
+                cleanup_result.hdd = Some(rpc::machine_cleanup_info::CleanupStepResult {
+                    result: rpc::machine_cleanup_info::CleanupResult::Ok as _,
+                    message: "OK".to_string(),
+                });
+            }
+            Err(e) => {
+                tracing::error!("{}", e);
+                cleanup_result.hdd = Some(rpc::machine_cleanup_info::CleanupStepResult {
+                    result: rpc::machine_cleanup_info::CleanupResult::Error as _,
+                    message: e.to_string(),
+                });
+                cleanup_result.result = rpc::machine_cleanup_info::CleanupResult::Error as _;
+            }
+        }
     } else {
-        tracing::info!("stdin == {}. Skip nvme cleanup.", stdin_link);
+        tracing::info!("stdin == {}. Skip nvme and HDD cleanup.", stdin_link);
     }
 
     match check_memory_overwrite_efi_var() {
@@ -853,8 +1032,12 @@ pub async fn run_no_api(tpm_path: &str) -> Result<(), CarbideClientError> {
             Ok(_) => tracing::debug!("nvme cleanup OK"),
             Err(e) => tracing::error!("nvme cleanup error: {}", e),
         }
+        match all_hdd_cleanup().await {
+            Ok(_) => tracing::debug!("hdd cleanup OK"),
+            Err(e) => tracing::error!("hdd cleanup error: {}", e),
+        }
     } else {
-        tracing::info!("stdin == {}. Skip nvme cleanup.", stdin_link);
+        tracing::info!("stdin == {}. Skip nvme and HDD cleanup.", stdin_link);
     }
 
     // P1 errors are propagated (fail startup), P2 errors are handled internally in reset_ib_devices()
@@ -1022,5 +1205,55 @@ mod tests {
         let ds_4096 = 12u8;
         let sector_size_4096 = 1u64 << ds_4096;
         assert_eq!(sector_size_4096, 4096);
+    }
+
+    #[test]
+    fn test_hdparm_has_security_section() {
+        let with_security = "ATA device, with non-removable media\nSecurity:\n\tMaster password revision code = 65534\n\tsupported\n\tnot\tlocked\n\tnot\tfrozen\n";
+        let without_security = "ATA device, with non-removable media\nCapabilities:\n\tLBA, IORDY\n";
+
+        assert!(hdparm_has_security_section(with_security));
+        assert!(!hdparm_has_security_section(without_security));
+    }
+
+    #[test]
+    fn test_hdparm_is_frozen_not_frozen() {
+        let not_frozen = "Security:\n\tsupported\n\tnot\tfrozen\n";
+        assert!(!hdparm_is_frozen(not_frozen));
+    }
+
+    #[test]
+    fn test_hdparm_is_frozen_frozen() {
+        let frozen = "Security:\n\tsupported\n\tfrozen\n";
+        assert!(hdparm_is_frozen(frozen));
+    }
+
+    #[test]
+    fn test_hdparm_supports_enhanced_erase() {
+        let with_enhanced =
+            "Security:\n\tsupported\n\tnot\tfrozen\n\tsupported: enhanced erase\n";
+        let without_enhanced = "Security:\n\tsupported\n\tnot\tfrozen\n";
+
+        assert!(hdparm_supports_enhanced_erase(with_enhanced));
+        assert!(!hdparm_supports_enhanced_erase(without_enhanced));
+    }
+
+    #[test]
+    fn test_sata_dev_re_matches_whole_disk() {
+        assert!(SD_DEV_RE.is_match("/dev/sda"));
+        assert!(SD_DEV_RE.is_match("/dev/sdb"));
+        assert!(SD_DEV_RE.is_match("/dev/sdz"));
+    }
+
+    #[test]
+    fn test_sata_dev_re_does_not_match_partitions() {
+        assert!(!SD_DEV_RE.is_match("/dev/sda1"));
+        assert!(!SD_DEV_RE.is_match("/dev/sdb2"));
+    }
+
+    #[test]
+    fn test_sata_dev_re_does_not_match_nvme() {
+        assert!(!SD_DEV_RE.is_match("/dev/nvme0"));
+        assert!(!SD_DEV_RE.is_match("/dev/nvme0n1"));
     }
 }

--- a/pxe/mkosi.profiles/scout-oss-aarch64/mkosi.conf
+++ b/pxe/mkosi.profiles/scout-oss-aarch64/mkosi.conf
@@ -51,8 +51,10 @@ Packages=
      nasm
      netcat-openbsd
      net-tools
+     hdparm
      nvme-cli
      openssh-server
+     sg3-utils
      pciutils
      rdma-core
      smartmontools

--- a/pxe/mkosi.profiles/scout-oss-x86_64/mkosi.conf
+++ b/pxe/mkosi.profiles/scout-oss-x86_64/mkosi.conf
@@ -53,8 +53,10 @@ Packages=
      nasm
      netcat-openbsd
      net-tools
+     hdparm
      nvme-cli
      openssh-server
+     sg3-utils
      pciutils
      rdma-core
      smartmontools


### PR DESCRIPTION
## Summary

- Add HDD discovery and secure erasure to the scout deprovision pipeline,
  running in parallel with existing NVMe cleanup via `tokio::join!`
- Detect drive type upfront via sysfs (`/ata` in path = SATA, otherwise SAS)
  to route each device to the correct erase function without spurious failure logs
- SATA SED drives erased via `hdparm --security-erase-enhanced`; non-SED SATA
  drives return an error and hold the machine out of the pool (consistent with SAS policy)
- SAS drives erased via `sg_sanitize --crypto`; LBA 0 is then zeroed with
  `dd oflag=direct` to prevent phantom AHDI partition signatures
- Add `hdd` field (tag 6) to `MachineCleanupInfo` protobuf message
- Add `hdparm` and `sg3-utils` to scout PXE image packages

## Non-SED HDD handling

Non-SED SATA drives do not support the ATA security erase command. The
alternative — a full overwrite — can take many hours on large HDDs and is
not suitable for a deprovision pipeline. Additionally, overwrite carries
security concerns that are too complex to be resolved here. Consistent with
the existing SAS policy, non-SED SATA drives are treated as a failure and
the machine is held out of the pool until the issue is resolved.

## Test plan

- [ ] Verified on real SAS SED hardware: `sg_sanitize --crypto` and `dd` complete
      and no phantom partitions appear after reboot
- [ ] Verified NVMe SSDs are cleaned as expected with no regression
- [ ] Unit tests pass for `sysfs_path_is_sata()` covering both SATA and SAS
      sysfs path patterns