### PR TITLE
chore(api): doc comments for all config file entries + README.md

### DIFF
--- a/crates/api/src/cfg/README.md
+++ b/crates/api/src/cfg/README.md
@@ -1,0 +1,355 @@
+# Carbide API Configuration Reference
+
+This document describes every section and field in the `nico-api-config.toml`
+configuration file, which is deserialized into `CarbideConfig` (defined in
+`file.rs`). Fields are listed in declaration order. Defaults are noted where
+applicable.
+
+---
+
+## `CarbideConfig` (top-level)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `listen` | `SocketAddr` | `[::]:1079` | Socket address for the gRPC API server. |
+| `listen_only` | `bool` | `false` | Run passively (no background services, RPC/web only). Used in dev mode. |
+| `metrics_endpoint` | `Option<SocketAddr>` | — | Socket address for the Prometheus `/metrics` HTTP server. |
+| `alt_metric_prefix` | `Option<String>` | — | Alternative metric prefix emitted alongside `carbide_` for dashboard migration. |
+| `database_url` | `String` | **required** | Postgres connection string for all persistent state. |
+| `max_database_connections` | `u32` | `1000` | Maximum database connection pool size. |
+| `ib_config` | `Option<IBFabricConfig>` | — | InfiniBand fabric configuration (see [IBFabricConfig](#ibfabricconfig)). |
+| `asn` | `u32` | **required** | Autonomous System Number, fixed per environment. Used by nico-dpu-agent for `frr.conf` BGP routing. |
+| `dhcp_servers` | `Vec<String>` | `[]` | DHCP server addresses announced to DPUs during network provisioning. |
+| `route_servers` | `Vec<String>` | `[]` | Route server IPs for L2VPN Ethernet Virtual network support. |
+| `enable_route_servers` | `bool` | `false` | Enables route server injection into DPU FRR configs for L2VPN. |
+| `deny_prefixes` | `Vec<Ipv4Network>` | `[]` | IPv4 CIDR prefixes that tenant instances are blocked from reaching. Generates iptables DROP rules and nvue ACL policies. |
+| `site_fabric_prefixes` | `Vec<IpNetwork>` | `[]` | IP prefixes (v4/v6) assigned for tenant use within this site. |
+| `anycast_site_prefixes` | `Vec<Ipv4Network>` | `[]` | Aggregate IPv4 prefixes containing tenant-announced prefixes (e.g., BYOIP). |
+| `common_tenant_host_asn` | `Option<u32>` | — | ASN that tenants use to peer with the DPU. If unset, any ASN is accepted. |
+| `vpc_isolation_behavior` | `VpcIsolationBehaviorType` | `MutualIsolation` | VPC isolation policy: `mutual_isolation` or `open`. |
+| `dpu_network_monitor_pinger_type` | `Option<String>` | — | Pinger implementation type (e.g., `"OobNetBind"`) for DPU link health checks. |
+| `tls` | `Option<TlsConfig>` | — | TLS certificate/key paths (see [TlsConfig](#tlsconfig)). |
+| `listen_mode` | `ListenMode` | `Tls` | Transport mode: `plaintext_http1`, `plaintext_http2`, or `tls`. |
+| `auth` | `Option<AuthConfig>` | — | Authentication/authorization settings (see [AuthConfig](#authconfig)). |
+| `pools` | `Option<HashMap<String, ResourcePoolDef>>` | — | Resource pools that allocate IPs, VNIs, etc. Required but `Option` for partial-config merging. |
+| `networks` | `Option<HashMap<String, NetworkDefinition>>` | — | Networks created at startup. Alternative: `CreateNetworkSegment` gRPC. |
+| `dpu_ipmi_tool_impl` | `Option<String>` | — | IPMI tool implementation for DPU power control (`"prod"` or `"fake"`). |
+| `dpu_ipmi_reboot_attempts` | `Option<u32>` | — | Retry count when IPMI errors during DPU reboot. |
+| `ib_fabrics` | `HashMap<String, IbFabricDefinition>` | `{}` | InfiniBand fabrics managed by the site. Currently only one fabric is supported. |
+| `initial_domain_name` | `Option<String>` | — | Domain to create if none exist. Most sites use a single domain. |
+| `initial_dpu_agent_upgrade_policy` | `Option<AgentUpgradePolicyChoice>` | — | Policy for nico-dpu-agent upgrades. Also settable via `nico-admin-cli`. |
+| `max_concurrent_machine_updates` | `Option<i32>` | — | **Deprecated.** Use `machine_updater` instead. |
+| `machine_update_run_interval` | `Option<u64>` | — | Interval (seconds) at which the machine update manager checks for updates. |
+| `site_explorer` | `SiteExplorerConfig` | *(see below)* | SiteExplorer hardware discovery settings (see [SiteExplorerConfig](#siteexplorerconfig)). |
+| `nvue_enabled` | `bool` | `true` | DPU agent uses NVUE for config instead of writing files directly. |
+| `vpc_peering_policy` | `Option<VpcPeeringPolicy>` | — | Policy for VPC peering based on network virtualization type at creation time. |
+| `vpc_peering_policy_on_existing` | `Option<VpcPeeringPolicy>` | — | Policy for whether existing VPC peerings should be active. |
+| `attestation_enabled` | `bool` | `false` | Enables TPM-based machine attestation (adds `Measuring` state before `Ready`). |
+| `tpm_required` | `bool` | `true` | Require TPM module for machine registration. **Testing only** when `false`. |
+| `machine_state_controller` | `MachineStateControllerConfig` | *(see below)* | Machine state controller timing (see [MachineStateControllerConfig](#machinestatecontrollerconfig)). |
+| `network_segment_state_controller` | `NetworkSegmentStateControllerConfig` | *(see below)* | Network segment state controller timing. |
+| `ib_partition_state_controller` | `IbPartitionStateControllerConfig` | *(see below)* | IB partition state controller timing. |
+| `dpa_interface_state_controller` | `DpaInterfaceStateControllerConfig` | *(see below)* | DPA interface state controller timing. |
+| `rack_state_controller` | `RackStateControllerConfig` | *(see below)* | Rack state controller timing. |
+| `power_shelf_state_controller` | `PowerShelfStateControllerConfig` | *(see below)* | Power shelf state controller timing. |
+| `switch_state_controller` | `SwitchStateControllerConfig` | *(see below)* | Switch state controller timing. |
+| `spdm_state_controller` | `SpdmStateControllerConfig` | *(see below)* | SPDM state controller timing. |
+| `host_models` | `HashMap<String, Firmware>` | `{}` | Maps host model identifiers to firmware definitions for BMC/UEFI/NIC upgrades. |
+| `firmware_global` | `FirmwareGlobal` | *(see below)* | Global firmware update settings (see [FirmwareGlobal](#firmwareglobal)). |
+| `machine_updater` | `MachineUpdater` | *(see below)* | Machine update policies (see [MachineUpdater](#machineupdater)). |
+| `max_find_by_ids` | `u32` | `100` | Max IDs accepted by `find_*_by_ids` APIs. |
+| `network_security_group` | `NetworkSecurityGroupConfig` | *(see below)* | NSG settings (see [NetworkSecurityGroupConfig](#networksecuritygroupconfig)). |
+| `min_dpu_functioning_links` | `Option<u32>` | — | Minimum functioning DPU links for healthy status. If unset, all must work. |
+| `host_health` | `HostHealthConfig` | *(default)* | Host health monitoring thresholds for hardware health and DPU agent compliance. |
+| `internet_l3_vni` | `u32` | `100001` | Network infrastructure-provided L3 VNI for FNN VPC Internet connectivity. Combined with `datacenter_asn` for route-target. |
+| `measured_boot_collector` | `MeasuredBootMetricsCollectorConfig` | *(see below)* | Measured boot metrics exporter (see [MeasuredBootMetricsCollectorConfig](#measuredbootmetricscollectorconfig)). |
+| `machine_validation_config` | `MachineValidationConfig` | *(see below)* | Machine validation tests (see [MachineValidationConfig](#machinevalidationconfig)). |
+| `machine_identity` | `MachineIdentityConfig` | *(see below)* | SPIFFE JWT-SVID machine identity (see [MachineIdentityConfig](#machineidentityconfig)). |
+| `bypass_rbac` | `bool` | `false` | Disables RBAC enforcement. **Testing/dev only.** |
+| `dpu_config` | `DpuConfig` | *(see below)* | DPU firmware and provisioning (see [DpuConfig](#dpuconfig)). |
+| `fnn` | `Option<FnnConfig>` | — | FNN L3 VNI overlay networking (see [FnnConfig](#fnnconfig)). |
+| `bom_validation` | `BomValidationConfig` | *(see below)* | BOM/SKU validation (see [BomValidationConfig](#bomvalidationconfig)). |
+| `bios_profiles` | `BiosProfileVendor` | *(default)* | BIOS profiles by vendor/model for Redfish BIOS management. |
+| `selected_profile` | `BiosProfileType` | *(default)* | Default BIOS profile type applied to machines. |
+| `dpa_config` | `Option<DpaConfig>` | — | Cluster Interconnect (east-west Ethernet) config (see [DpaConfig](#dpaconfig)). |
+| `dsx_exchange_event_bus` | `Option<DsxExchangeEventBusConfig>` | — | MQTT event bus for publishing state transitions (see [DsxExchangeEventBusConfig](#dsxexchangeeventbusconfig)). |
+| `datacenter_asn` | `u32` | `11414` | Datacenter ASN used by FNN for DC-specific route targets. |
+| `nvlink_config` | `Option<NvLinkConfig>` | — | NvLink partitioning via NMX-M (see [NvLinkConfig](#nvlinkconfig)). |
+| `power_manager_options` | `PowerManagerOptions` | *(see below)* | Power management timing (see [PowerManagerOptions](#powermanageroptions)). |
+| `sitename` | `Option<String>` | — | Human-readable site name exposed to tenants via FMDS. |
+| `auto_machine_repair_plugin` | `AutoMachineRepairPluginConfig` | *(default)* | Auto-repair configuration for failed machines. |
+| `vmaas_config` | `Option<VmaasConfig>` | — | VMaaS configuration for VM system integration. |
+| `mlxconfig_profiles` | `Option<HashMap<String, MlxConfigProfile>>` | — | Named Mellanox NIC register configuration profiles for superNIC firmware flashing. TOML key: `mlx-config-profiles`. |
+| `rack_management_enabled` | `bool` | `false` | Standalone infrastructure manager mode for GB200/GB300/VR144. See doc comment for full behavioral changes. |
+| `force_dpu_nic_mode` | `bool` | `false` | Treat DPUs as regular NICs (skip managed DPU config). For dev labs with BF DPUs. |
+| `rms_api_url` | `Option<String>` | — | Rack Manager Service API URL for rack-level firmware and power operations. |
+| `rack_types` | `RackTypeConfig` | *(default)* | Rack type definitions referenced by expected racks. |
+| `use_onboard_nic` | `Arc<AtomicBool>` | `false` | Use host onboard NIC instead of DPU NICs. Dynamically toggleable. |
+| `spdm` | `SpdmConfig` | *(see below)* | SPDM hardware attestation (see [SpdmConfig](#spdmconfig)). |
+| `site_global_vpc_vni` | `Option<u32>` | — | Forces all VRFs to share a single VNI (Cumulus Linux route-leaking workaround). Limits DPU to one VRF. |
+| `dpf` | `DpfConfig` | *(see below)* | DPF (DPU Platform Framework) Kubernetes deployment (see [DpfConfig](#dpfconfig)). |
+| `x86_pxe_boot_url_override` | `Option<String>` | — | Override PXE boot URL for x86 machines. |
+| `arm_pxe_boot_url_override` | `Option<String>` | — | Override PXE boot URL for ARM machines. |
+| `compute_allocation_enforcement` | `ComputeAllocationEnforcement` | `WarnOnly` | Controls enforcement of compute allocations on new instance requests. |
+| `supernic_firmware_profiles` | nested `HashMap` | `{}` | SuperNIC firmware profiles keyed by `part_number` then `PSID`. |
+| `component_manager` | `Option<ComponentManagerConfig>` | — | Component manager for NvLink switches and power shelves. |
+
+---
+
+## Sub-Structs
+
+### `TlsConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `root_cafile_path` | `String` | `""` | Root CA certificate for client validation. |
+| `identity_pemfile_path` | `String` | `""` | Server identity certificate PEM. |
+| `identity_keyfile_path` | `String` | `""` | Server identity private key. |
+| `admin_root_cafile_path` | `String` | `""` | Admin root CA for admin client validation. |
+
+### `AuthConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `permissive_mode` | `bool` | — | Enable permissive authorization (dev mode). |
+| `casbin_policy_file` | `Option<PathBuf>` | — | Path to Casbin CSV policy file. |
+| `cli_certs` | `Option<AllowedCertCriteria>` | — | Additional allowed cert criteria for nico-admin-cli. |
+| `trust` | `Option<TrustConfig>` | — | SPIFFE trust domain and allowed paths for client certs. |
+
+### `IBFabricConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `bool` | `false` | Enables InfiniBand fabric management. |
+| `max_partition_per_tenant` | `i32` | `31` | Maximum IB partitions per tenant (1-31). |
+| `allow_insecure` | `bool` | `false` | Allow insecure fabric configs that skip tenant isolation. |
+| `mtu` | `IBMtu` | *(default)* | MTU for IB fabric traffic. |
+| `rate_limit` | `IBRateLimit` | *(default)* | Rate limit for IB traffic. |
+| `service_level` | `IBServiceLevel` | *(default)* | QoS service level for IB packets. |
+| `fabric_monitor_run_interval` | `Duration` | `60s` | Interval for the IB fabric monitor. |
+
+### `NvLinkConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `bool` | `false` | Enables NvLink partitioning. |
+| `monitor_run_interval` | `Duration` | `60s` | NvLink monitor polling interval. |
+| `nmx_m_operation_timeout` | `Duration` | `10s` | Timeout for pending NMX-M operations. |
+| `nmx_m_endpoint` | `String` | `"localhost"` | NMX-M endpoint (host:port). |
+| `allow_insecure` | `bool` | `false` | Skip TLS verification for NMX-M. |
+
+### `SiteExplorerConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `bool` | `true` | Enables hardware discovery. |
+| `run_interval` | `Duration` | `120s` | Interval between exploration runs. |
+| `concurrent_explorations` | `u64` | `30` | Max nodes explored in parallel. |
+| `explorations_per_run` | `u64` | `90` | Max nodes explored per run. |
+| `create_machines` | `bool` | `true` | Auto-create ManagedHost state machines. Dynamically toggleable. |
+| `machines_created_per_run` | `u64` | `4` | Max ManagedHosts created per run. |
+| `rotate_switch_nvos_credentials` | `bool` | `false` | Auto-rotate switch NVOS admin credentials. |
+| `override_target_ip` | `Option<String>` | — | **Deprecated.** Use `bmc_proxy`. Debug BMC IP override. |
+| `override_target_port` | `Option<u16>` | — | **Deprecated.** Use `bmc_proxy`. Debug BMC port override. |
+| `allow_zero_dpu_hosts` | `bool` | `false` | Allow hosts with zero DPUs (set `false` in prod). |
+| `bmc_proxy` | `HostPortPair` | — | BMC proxy host:port for integration testing/dev. |
+| `allow_changing_bmc_proxy` | `Option<bool>` | *(auto)* | Allow runtime changes to `bmc_proxy`. Auto-detected from initial config. |
+| `reset_rate_limit` | `Duration` | `1h` | Minimum time between SiteExplorer-initiated BMC resets. |
+| `admin_segment_type_non_dpu` | `bool` | `false` | Non-DPU hosts use `HostInband` admin segment type. |
+| `allocate_secondary_vtep_ip` | `bool` | `false` | Allocate secondary VTEP IP for GENEVE traffic intercept. |
+| `create_power_shelves` | `bool` | `false` | Auto-create Power Shelf state machines. |
+| `explore_power_shelves_from_static_ip` | `bool` | `false` | Discover power shelves via static IP. |
+| `power_shelves_created_per_run` | `u64` | `1` | Max power shelves created per run. |
+| `create_switches` | `bool` | `false` | Auto-create Switch state machines. |
+| `switches_created_per_run` | `u64` | `9` | Max switches created per run. |
+| `use_onboard_nic` | `bool` | `false` | Use onboard NIC instead of DPU NICs. |
+| `explore_mode` | `SiteExplorerExploreMode` | `LibRedfish` | Redfish backend: `libredfish`, `nv-redfish`, or `compare-result`. |
+
+### `StateControllerConfig`
+
+Shared by all `*StateControllerConfig` structs (machine, network segment, IB
+partition, DPA interface, rack, power shelf, switch, SPDM).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `iteration_time` | `Duration` | `30s` | Target duration for one state controller iteration. |
+| `max_object_handling_time` | `Duration` | `3m` | Timeout for evaluating/advancing a single object's state. |
+| `max_concurrency` | `usize` | `10` | Max objects advanced in parallel. |
+| `processor_dispatch_interval` | `Duration` | `2s` | Max wait time when checking for and dispatching new tasks. |
+| `processor_log_interval` | `Duration` | `60s` | How often the processor emits log messages. |
+| `metric_emission_interval` | `Duration` | `60s` | How often aggregate metrics are recalculated. |
+| `metric_hold_time` | `Duration` | `5m` | How long per-object metrics are held before eviction. |
+
+### `MachineStateControllerConfig`
+
+Extends `StateControllerConfig` with:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `dpu_wait_time` | `Duration` | `5m` | Time before a DPU is considered definitively down. |
+| `power_down_wait` | `Duration` | `2m` | Wait after power-down before powering on. |
+| `failure_retry_time` | `Duration` | `30m` | Time before re-triggering reboot if machine hasn't called back. |
+| `dpu_up_threshold` | `Duration` | `5m` | Max time without DPU health report before assuming it's down. |
+| `scout_reporting_timeout` | `Duration` | `5m` | Duration without scout report before host is unhealthy. |
+| `uefi_boot_wait` | `Duration` | `5m` | Wait time for UEFI boot completion after host reboot. |
+
+### `NetworkSegmentStateControllerConfig`
+
+Extends `StateControllerConfig` with:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `network_segment_drain_time` | `Duration` | `5m` | Time a network segment must have 0 allocated IPs before release. |
+
+### `FirmwareGlobal`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `autoupdate` | `bool` | `false` | Enable automatic host firmware updates. |
+| `host_enable_autoupdate` | `Vec<String>` | `[]` | Host models to force-enable autoupdate. |
+| `host_disable_autoupdate` | `Vec<String>` | `[]` | Host models to force-disable autoupdate. |
+| `run_interval` | `Duration` | `30s` | Firmware manager polling interval. |
+| `max_uploads` | `usize` | `4` | Max concurrent firmware uploads. |
+| `concurrency_limit` | `usize` | `16` | Max concurrent firmware flashing operations. |
+| `firmware_directory` | `PathBuf` | `/opt/carbide/firmware` | Firmware binary storage directory. |
+| `host_firmware_upgrade_retry_interval` | `Duration` | `60m` | Retry delay for failed host firmware upgrades. |
+| `instance_updates_manual_tagging` | `bool` | `true` | Require manual tagging before firmware updates. |
+| `no_reset_retries` | `bool` | `false` | Disable retry logic after BMC resets. |
+| `hgx_bmc_gpu_reboot_delay` | `Duration` | `30s` | Delay after GPU reboot before HGX BMC access. |
+| `requires_manual_upgrade` | `bool` | `false` | Force all firmware upgrades to require admin approval. |
+
+### `MachineUpdater`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `instance_autoreboot_period` | `Option<TimePeriod>` | — | UTC time window for automatic machine reboots. |
+| `max_concurrent_machine_updates_absolute` | `Option<i32>` | — | Hard cap on concurrent machine updates. |
+| `max_concurrent_machine_updates_percent` | `Option<i32>` | — | Percentage cap on concurrent updates (lesser of absolute/percent is used). |
+
+### `PowerManagerOptions`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `bool` | `false` | Enable power management. |
+| `next_try_duration_on_success` | `Duration` | `5m` | Retry interval after successful power operation. |
+| `next_try_duration_on_failure` | `Duration` | `2m` | Retry interval after failed power operation. |
+| `wait_duration_until_host_reboot` | `Duration` | `15m` | Wait after power-down before powering on host. |
+
+### `DpuConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `dpu_nic_firmware_initial_update_enabled` | `bool` | `false` | Enable DPU NIC firmware updates on initial discovery. |
+| `dpu_nic_firmware_reprovision_update_enabled` | `bool` | `true` | Enable DPU NIC firmware updates on reprovisioning. |
+| `dpu_models` | `HashMap<String, Firmware>` | *(BF2+BF3 defaults)* | DPU model firmware definitions. |
+| `dpu_nic_firmware_update_versions` | `Vec<String>` | *(BF2+BF3 NIC versions)* | DPU NIC firmware version strings. |
+| `dpu_enable_secure_boot` | `bool` | `false` | Enable secure boot flow for DPU provisioning via Redfish. |
+
+### `NetworkSecurityGroupConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_network_security_group_size` | `u32` | `200` | Max expanded rules per NSG. |
+| `stateful_acls_enabled` | `bool` | `true` | Enable stateful ACLs (toggled on DPU via nvue). |
+| `policy_overrides` | `Vec<NetworkSecurityGroupRule>` | `[]` | NSG rules injected before user-defined rules. |
+
+### `FnnConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `admin_vpc` | `Option<AdminFnnConfig>` | — | FNN configuration for the admin network VPC. |
+| `common_internal_route_target` | `Option<RouteTargetConfig>` | — | Double-tag for internal tenant routes (consumed by the network infrastructure). |
+| `additional_route_target_imports` | `Vec<RouteTargetConfig>` | `[]` | Extra route targets imported on DPU VRFs. |
+| `routing_profiles` | `HashMap<String, FnnRoutingProfileConfig>` | `{}` | Named per-VPC routing profiles. |
+
+### `DpaConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `bool` | `false` | Enable Cluster Interconnect Network. |
+| `mqtt_endpoint` | `String` | `"mqtt.nico"` | MQTT broker host for DPA. |
+| `mqtt_broker_port` | `u16` | `1884` | MQTT broker port. |
+| `subnet_ip` | `Ipv4Addr` | `0.0.0.0` | Base IPv4 address of the DPA subnet. |
+| `subnet_mask` | `i32` | `0` | CIDR prefix length for the DPA subnet. |
+| `hb_interval` | `Duration` | `2m` | Heartbeat interval for DPA health checks. |
+| `auth` | `MqttAuthConfig` | *(none)* | MQTT authentication settings. |
+
+### `DsxExchangeEventBusConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `bool` | `false` | Enable the DSX Exchange Event Bus. |
+| `mqtt_endpoint` | `String` | `"mqtt.nico"` | MQTT broker host. |
+| `mqtt_broker_port` | `u16` | `1884` | MQTT broker port. |
+| `publish_timeout` | `Duration` | `1s` | Timeout for MQTT publish operations. |
+| `queue_capacity` | `usize` | `1024` | Event buffer size (events dropped when full). |
+| `auth` | `MqttAuthConfig` | *(none)* | MQTT authentication settings. |
+
+### `DpfConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `bool` | `false` | Enable DPF Kubernetes deployment. |
+| `bfb_url` | `String` | `""` | BlueField firmware bundle URL. |
+| `deployment_name` | `Option<String>` | — | Kubernetes deployment name. |
+| `services` | `Option<Vec<DpfServiceConfig>>` | — | Additional Helm services. |
+
+### `SpdmConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `bool` | `false` | Enable SPDM hardware attestation. |
+| `nras_config` | `Option<nras::Config>` | — | NRAS configuration for secure boot verification. |
+
+### `MachineIdentityConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `bool` | `true` | Master switch for machine identity APIs. |
+| `algorithm` | `String` | `"ES256"` | Signing algorithm for per-org keys. |
+| `token_ttl_min_sec` | `u32` | `60` | Minimum token TTL in seconds. |
+| `token_ttl_max_sec` | `u32` | `86400` | Maximum token TTL in seconds. |
+| `token_endpoint_http_proxy` | `Option<String>` | — | HTTP proxy for token endpoint calls (SSRF mitigation). |
+
+### `MeasuredBootMetricsCollectorConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `bool` | `false` | Enable measured boot metrics export. |
+| `run_interval` | `Duration` | `60s` | Polling interval for boot measurement data. |
+
+### `MachineValidationConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `bool` | `false` | Enable machine validation tests. |
+| `test_selection_mode` | `MachineValidationTestSelectionMode` | `Default` | `Default`, `EnableAll`, or `DisableAll`. |
+| `run_interval` | `Duration` | `60s` | Validation check interval. |
+| `tests` | `Vec<MachineValidationTestConfig>` | `[]` | Per-test enable/disable overrides. |
+
+### `BomValidationConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `bool` | `false` | Enable BOM/SKU validation. |
+| `ignore_unassigned_machines` | `bool` | `false` | Let machines without a SKU bypass validation. |
+| `allow_allocation_on_validation_failure` | `bool` | `false` | Keep machines allocatable even when validation fails. |
+| `find_match_interval` | `Duration` | `5m` | Interval between SKU match attempts. |
+| `auto_generate_missing_sku` | `bool` | `false` | Auto-create missing SKUs from expected machines. |
+| `auto_generate_missing_sku_interval` | `Duration` | `5m` | Interval between auto-generate attempts. |
+
+### `MqttAuthConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `auth_mode` | `MqttAuthMode` | `None` | `none`, `basic_auth`, or `oauth2`. |
+| `oauth2` | `Option<MqttOAuth2Config>` | — | OAuth2 settings (required when `auth_mode` is `oauth2`). |
+
+### `MqttOAuth2Config`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `token_url` | `String` | **required** | OAuth2 token endpoint URL. |
+| `scopes` | `Vec<String>` | `[]` | OAuth2 scopes to request. |
+| `http_timeout` | `Duration` | `30s` | Token endpoint HTTP timeout. |
+| `username` | `String` | `"oauth2token"` | Username in MQTT CONNECT packet. |

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -64,66 +64,76 @@ static BF3_BMC: &str = "BF-25.10-9";
 static BF3_CEC: &str = "00.02.0195.0000_n02";
 static BF3_UEFI: &str = "4.13.0-26-g337fea6bfd";
 
-/// carbide-api configuration file content
+/// nico-api configuration file content
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CarbideConfig {
-    /// The socket address that is used for the gRPC API server
+    /// Socket address for the gRPC API server, used by
+    /// clients and nico-admin-cli to connect.
+    /// Default is `[::]:1079`.
     #[serde(default = "default_listen")]
     pub listen: SocketAddr,
 
-    /// Set to true to run this instance "passively", ie. don't start any background services and
-    /// just listen for rpc/web connections. This is used in development mode when you want to run
-    /// an additional carbide instance, against a cluster that is already running a "full" carbide
-    /// instance.
+    /// Run this instance passively: no background services,
+    /// just listen for RPC/web connections. Used in dev mode
+    /// when running a second nico instance against a
+    /// cluster that already has a "full" instance.
     #[serde(default)]
     pub listen_only: bool,
 
-    /// The socket address that is used for the HTTP server which serves
-    /// prometheus metrics under /metrics
+    /// Socket address for the HTTP server that serves
+    /// Prometheus metrics under `/metrics`.
     pub metrics_endpoint: Option<SocketAddr>,
 
-    /// An alternative prefix under which metrics will be emitted besides `carbide_`.
-    /// Setting this flag will allow to dual emit metrics to migrate dashboards and alerts.
-    /// Note that seting the flag will load to increased load on the observability system.
+    /// Alternative metric prefix emitted alongside `carbide_`,
+    /// used for dual-emitting while migrating dashboards and
+    /// alerts. Increases observability system load.
     pub alt_metric_prefix: Option<String>,
 
-    /// A connection string for the utilized postgres database
+    /// Postgres connection string used by the API server
+    /// for all persistent state.
     pub database_url: String,
 
-    /// The maximum size of the database connection pool
+    /// Maximum size of the database connection pool.
+    /// Default is 1000.
     #[serde(default = "default_max_database_connections")]
     pub max_database_connections: u32,
 
-    /// IB fabric related configuration
+    /// InfiniBand fabric configuration, used by the IB
+    /// fabric manager for partition and UFM management.
     pub ib_config: Option<IBFabricConfig>,
 
-    /// ASN: Autonomous System Number
-    /// Fixed per environment. Used by forge-dpu-agent to write frr.conf (routing).
+    /// Autonomous System Number, fixed per environment.
+    /// Used by nico-dpu-agent to write `frr.conf` for
+    /// BGP routing.
     pub asn: u32,
 
-    /// List of DHCP servers that should be announced
+    /// DHCP server addresses announced to DPUs during
+    /// network provisioning.
     #[serde(default)]
     pub dhcp_servers: Vec<String>,
 
-    /// Comma-separated list of route server IP addresses. Optional, only for L2VPN (Eth Virt).
+    /// Route server IP addresses for L2VPN (Ethernet
+    /// Virtual) network support on DPUs.
     #[serde(default)]
     pub route_servers: Vec<String>,
 
+    /// Enables route server injection into DPU FRR
+    /// configs for L2VPN Ethernet Virtual networks.
     #[serde(default)]
     pub enable_route_servers: bool,
 
     /// List of IPv4 prefixes (in CIDR notation) that tenant instances are not allowed to talk to.
-    ///
-    /// TODO(chet): For now, this remains `Vec<Ipv4Network>`, because the dpu-agent consumers
-    /// that process deny prefixes are IPv4-only (and I'll do it in another PR):
-    /// - `crates/agent/src/acl_rules.rs` parses rules into `Ipv4Network` and generates
-    ///   iptables DROP rules via `make_deny_prefix_rules(&[Ipv4Network], ...)`
-    /// - nvue templates (in `nvue_startup_fnn.conf` and `nvue_startup_etv.conf`) render these
-    ///   prefixes under a "p0000_deny_prefixes_ipv4" ACL policy with `type: ipv4`.
-    ///
-    /// Updating to support `Vec<IpNetwork>` requires the agent to generate parallel IPv6 deny
-    /// rules (I think via ip6tables / `type: ipv6` ACL policy), similar to how NSG rules already
-    /// handle the `ipv6: bool` split.
+    //
+    // TODO(chet): For now, this remains `Vec<Ipv4Network>`, because the dpu-agent consumers
+    // that process deny prefixes are IPv4-only (and I'll do it in another PR):
+    // - `crates/agent/src/acl_rules.rs` parses rules into `Ipv4Network` and generates
+    //   iptables DROP rules via `make_deny_prefix_rules(&[Ipv4Network], ...)`
+    // - nvue templates (in `nvue_startup_fnn.conf` and `nvue_startup_etv.conf`) render these
+    //   prefixes under a "p0000_deny_prefixes_ipv4" ACL policy with `type: ipv4`.
+    //
+    // Updating to support `Vec<IpNetwork>` requires the agent to generate parallel IPv6 deny
+    // rules (I think via ip6tables / `type: ipv6` ACL policy), similar to how NSG rules already
+    // handle the `ipv6: bool` split.
     #[serde(default)]
     pub deny_prefixes: Vec<Ipv4Network>,
 
@@ -145,33 +155,46 @@ pub struct CarbideConfig {
     /// any ASN.
     pub common_tenant_host_asn: Option<u32>,
 
+    /// VPC isolation policy enforced on tenant traffic.
+    /// Controls whether VPCs are mutually isolated or open.
     #[serde(default)]
     pub vpc_isolation_behavior: VpcIsolationBehaviorType,
 
+    /// Pinger implementation type (e.g., "OobNetBind") used
+    /// by the DPU network monitor to health-check DPU links.
     #[serde(default)]
     pub dpu_network_monitor_pinger_type: Option<String>,
 
-    /// TLS related configuration
+    /// TLS certificate and key paths for securing gRPC and
+    /// HTTP connections.
     pub tls: Option<TlsConfig>,
 
+    /// Transport mode for the gRPC API server.
+    /// Default is `Tls`.
     #[serde(default)]
     pub listen_mode: ListenMode,
 
-    /// Authentication related configuration
+    /// Authentication and authorization configuration
+    /// including Casbin policies and client certificate
+    /// trust settings.
     pub auth: Option<AuthConfig>,
 
-    // Resource pools to allocate IPs, VNIs, etc.
-    // Required.
-    // Option so that we can de-serialize partial configs (and then merge them).
+    /// Resource pools that allocate IPs, VNIs, etc.
+    /// Required, but wrapped in `Option` so partial configs
+    /// can be deserialized and merged.
     pub pools: Option<HashMap<String, ResourcePoolDef>>,
 
-    // Networks to create. Otherwise use grpcurl CreateNetworkSegment to create them later.
+    /// Networks to create at startup. Use the
+    /// `CreateNetworkSegment` gRPC to create them later
+    /// instead.
     pub networks: Option<HashMap<String, NetworkDefinition>>,
 
-    // The type of ipmitool to user (prod or fake)
+    /// IPMI tool implementation for DPU power control
+    /// (e.g., "prod" or "fake").
     pub dpu_ipmi_tool_impl: Option<String>,
 
-    // The number of retries to perform if ipmi returns an error
+    /// Number of retries when IPMI returns an error during
+    /// DPU reboot.
     pub dpu_ipmi_reboot_attempts: Option<u32>,
 
     /// Infiniband fabrics managed by the site
@@ -185,8 +208,10 @@ pub struct CarbideConfig {
     /// The alternative is to create it via `CreateDomain` grpc endpoint.
     pub initial_domain_name: Option<String>,
 
-    /// The policy we use to decide whether a specific forge-dpu-agent should be upgraded
-    /// Also settable via a `forge-admin-cli` command.
+    /// The policy we use to decide whether a specific nico-dpu-agent
+    /// should be upgraded.
+    ///
+    /// Also settable via a `nico-admin-cli` command.
     pub initial_dpu_agent_upgrade_policy: Option<AgentUpgradePolicyChoice>,
 
     /// Deprecated, use machine_updater
@@ -260,70 +285,111 @@ pub struct CarbideConfig {
     #[serde(default)]
     pub spdm_state_controller: SpdmStateControllerConfig,
 
+    /// Maps host model identifiers to firmware definitions,
+    /// used by the firmware manager to determine BMC, UEFI,
+    /// and NIC upgrade targets for each host type.
     #[serde(default)]
     pub host_models: HashMap<String, Firmware>,
 
+    /// Global firmware update settings: upload concurrency,
+    /// retry intervals, autoupdate policies, and firmware
+    /// binary storage paths.
     #[serde(default)]
     pub firmware_global: FirmwareGlobal,
 
+    /// Machine update policies: auto-reboot windows and
+    /// concurrent update limits used by the machine update
+    /// manager.
     #[serde(default)]
     pub machine_updater: MachineUpdater,
 
-    /// The maximum number of IDs allowed for find_(something)_by_ids APIs
+    /// Maximum number of IDs accepted by
+    /// `find_*_by_ids` APIs to prevent oversized queries.
+    /// Default is 100.
     #[serde(default = "default_max_find_by_ids")]
     pub max_find_by_ids: u32,
 
+    /// Network security group settings: max expanded rule
+    /// count, stateful ACL enforcement, and policy overrides
+    /// injected before user-defined rules.
     #[serde(default)]
     pub network_security_group: NetworkSecurityGroupConfig,
 
-    /// The minimum number of functioning links on a dpu for it to be considered healthy
-    /// if not present, all links must be functional.
+    /// Minimum functioning DPU links required for the DPU
+    /// to be considered healthy. If unset, all links must
+    /// be functional.
     #[serde(default)]
     pub min_dpu_functioning_links: Option<u32>,
 
+    /// Host health monitoring thresholds, used by the
+    /// machine state controller to determine hardware health
+    /// and DPU agent version compliance.
     #[serde(default)]
     pub host_health: HostHealthConfig,
 
-    // internet_l3_vni is a GNI-provided L3VNI to use for
-    // FNN VPCs to have Internet connectivity. If it's
-    // not set, VPCs in this site will not have the ability
-    // to get out to the Internet.
+    /// Network infrastructure-provided L3 VNI for FNN VPC Internet
+    /// connectivity. Combined with `datacenter_asn` to form
+    /// a route-target. If unset, VPCs cannot reach the
+    /// Internet.
+    /// Default is 100001.
     //
-    // TODO(chet): This might be interesting to be able
-    // to toggle on a per-VPC basis (e.g. if a customer
-    // wants to create a VPC that is guaranteed not to
-    // be able to access the Internet).
+    // TODO(chet): This might be interesting to toggle on
+    // a per-VPC basis (e.g. a VPC guaranteed not to access
+    // the Internet).
     #[serde(default = "default_internet_l3_vni")]
     pub internet_l3_vni: u32,
 
-    /// MeasuredBootMetricsCollector related configuration
+    /// Measured boot metrics collector configuration.
+    /// Exports TPM-based boot measurement data as
+    /// Prometheus metrics for attestation monitoring.
     #[serde(default)]
     pub measured_boot_collector: MeasuredBootMetricsCollectorConfig,
 
-    /// Machine Validation config to api server
+    /// Machine validation test configuration. Runs
+    /// hardware tests (memory latency, SSD I/O, etc.)
+    /// after ingestion to verify machine health.
     #[serde(default)]
     pub machine_validation_config: MachineValidationConfig,
 
-    /// Machine identity (SPIFFE JWT-SVID) config. Section `[machine_identity]`.
+    /// Machine identity (SPIFFE JWT-SVID) settings,
+    /// used by `SignMachineIdentity` to issue short-lived
+    /// identity tokens to tenant workloads.
+    /// Section `[machine_identity]`.
     #[serde(default)]
     pub machine_identity: MachineIdentityConfig,
 
+    /// Disables role-based access control enforcement.
+    /// Intended for testing and development only.
     #[serde(default)]
     pub bypass_rbac: bool,
 
-    /// DPU specific configs including DPU orand DPU BMC firmware
+    /// DPU-specific firmware and provisioning config,
+    /// including DPU model definitions, NIC firmware
+    /// versions, and secure boot settings.
     #[serde(default)]
     pub dpu_config: DpuConfig,
 
+    /// Fabric Nearest Neighbor (FNN) configuration for
+    /// L3 VNI-based overlay networking, including routing
+    /// profiles and route target import/export policies.
     #[serde(default)]
     pub fnn: Option<FnnConfig>,
 
+    /// Bill-of-materials (BOM) validation settings.
+    /// Ensures machines match expected SKU configurations
+    /// before being marked as Ready.
     #[serde(default)]
     pub bom_validation: BomValidationConfig,
 
+    /// BIOS profile definitions organized by vendor and
+    /// model, used by SiteExplorer to apply Redfish BIOS
+    /// settings during ingestion.
     #[serde(default)]
     pub bios_profiles: libredfish::BiosProfileVendor,
 
+    /// Default BIOS profile type (e.g., Performance,
+    /// PowerEfficiency) applied to machines when no
+    /// per-model override exists.
     #[serde(default)]
     pub selected_profile: libredfish::BiosProfileType,
 
@@ -332,35 +398,47 @@ pub struct CarbideConfig {
     #[serde(default)]
     pub dpa_config: Option<DpaConfig>,
 
-    /// DSX Exchange Event Bus configuration for publishing state change events via MQTT.
+    /// DSX Exchange Event Bus configuration. Publishes
+    /// `ManagedHostState` transitions to MQTT topics for
+    /// external consumers.
     #[serde(default)]
     pub dsx_exchange_event_bus: Option<DsxExchangeEventBusConfig>,
 
-    /// FNN depends on various route-targets that
-    /// are DC-specific.  This value is used to
-    /// build those targets for import and,
-    ///  eventually, export
+    /// Datacenter ASN used by FNN to build DC-specific
+    /// route targets for VRF import and export.
+    /// Default is 11414.
     #[serde(default = "default_datacenter_asn")]
     pub datacenter_asn: u32,
 
-    /// NvLink related configuration
+    /// NvLink partitioning configuration, used by the
+    /// NvLink monitor to manage GPU mesh partitions
+    /// via NMX-M.
     #[serde(default)]
     pub nvlink_config: Option<NvLinkConfig>,
 
+    /// Power management settings: retry intervals after
+    /// success/failure and host reboot wait time.
     #[serde(default = "default_power_options")]
     pub power_manager_options: PowerManagerOptions,
 
-    /// sitename is made visible to customers running
-    /// tenant OS via an FMDS endpoint.
+    /// Human-readable site name, exposed to customers
+    /// running tenant OS via the FMDS endpoint.
     pub sitename: Option<String>,
 
-    /// Auto machine repair plugin configuration
+    /// Auto machine repair plugin. When enabled,
+    /// automatically transitions failed machines into
+    /// repair workflows.
     #[serde(default)]
     pub auto_machine_repair_plugin: AutoMachineRepairPluginConfig,
 
-    /// configuration for using forge with a VM system
+    /// VMaaS (VM-as-a-Service) configuration for using
+    /// NICo with a VM system, including VF settings and
+    /// traffic-intercept bridging.
     pub vmaas_config: Option<VmaasConfig>,
 
+    /// Named Mellanox NIC firmware configuration profiles,
+    /// used by superNIC firmware flashing to apply
+    /// device-specific register settings.
     #[serde(
         default,
         rename = "mlx-config-profiles",
@@ -370,9 +448,9 @@ pub struct CarbideConfig {
     )]
     pub mlxconfig_profiles: Option<HashMap<String, MlxConfigProfile>>,
 
-    /// The intent of this config option is to use the forge site controller as a standalone
+    /// The intent of this config option is to use the NICo site controller as a standalone
     /// (disconnected / air-gapped) infrastructure manager for racks of GB200/GB300/VR144.
-    /// Only set this if using Forge site controller with Rack Manager to manage GB200/300/VR144.
+    /// Only set this if using NICo site controller with Rack Manager to manage GB200/300/VR144.
     /// It will change site controller behavior significantly in the following ways, etc.:
     /// 1. skip dpu management and use dpus in nic mode (optional, can set force_dpu_nic_mode=false)
     ///    a. no dpu bfb upgrade and host power cycle
@@ -410,7 +488,7 @@ pub struct CarbideConfig {
     /// trays with bluefield dpus as NICs.
     pub force_dpu_nic_mode: bool,
 
-    // rms_api_url is the URL to the Rack Manager Service API.
+    /// URL of the Rack Manager Service API for rack-level firmware upgrades and power sequencing.
     pub rms_api_url: Option<String>,
 
     /// rack_types contains the rack type definitions. When expected racks
@@ -430,7 +508,7 @@ pub struct CarbideConfig {
     )]
     pub use_onboard_nic: Arc<AtomicBool>,
 
-    // SPDM Config
+    /// SPDM (Security Protocol and Data Model) configuration for hardware attestation.
     #[serde(default)]
     pub spdm: SpdmConfig,
 
@@ -443,7 +521,7 @@ pub struct CarbideConfig {
     /// DPU to a single VRF.
     pub site_global_vpc_vni: Option<u32>,
 
-    // DPF Config
+    /// DPF (DPU Platform Framework) configuration for DPU fabric deployment as a Kubernetes service.
     #[serde(default)]
     pub dpf: DpfConfig,
 
@@ -464,7 +542,7 @@ pub struct CarbideConfig {
     /// keyed by part_number and PSID. Each profile specifies the firmware to
     /// flash and optional lifecycle flags (reset, verify_image, verify_version).
     ///
-    /// Configured in `carbide-api-config.toml`:
+    /// Configured in `nico-api-config.toml`:
     ///
     /// ```toml
     /// [supernic_firmware_profiles.900-9D3B4-00CV-TA0.MT_0000000884]
@@ -483,6 +561,9 @@ pub struct CarbideConfig {
     #[serde(default)]
     pub supernic_firmware_profiles: HashMap<String, HashMap<String, FirmwareFlasherProfile>>,
 
+    /// Component manager configuration for managing
+    /// NvLink switches and power shelves via rack
+    /// manager integration.
     #[serde(default)]
     pub component_manager: Option<component_manager::config::ComponentManagerConfig>,
 }
@@ -500,23 +581,36 @@ pub enum ComputeAllocationEnforcement {
     Always,
 }
 
+/// DPF (DPU Platform Framework) configuration for
+/// deploying DPU fabric as a Kubernetes service.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct DpfConfig {
+    /// Enables DPF deployment.
     #[serde(default)]
     pub enabled: bool,
+    /// URL to the BlueField firmware bundle (BFB) for
+    /// DPU provisioning.
     #[serde(default)]
     pub bfb_url: String,
+    /// Kubernetes deployment name for the DPF service.
     #[serde(default)]
     pub deployment_name: Option<String>,
+    /// Additional Helm services to deploy alongside
+    /// DPF.
     #[serde(default)]
     pub services: Option<Vec<DpfServiceConfig>>,
 }
 
+/// Configuration for a single Helm-based DPF service.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct DpfServiceConfig {
+    /// Name of the Helm service.
     pub name: String,
+    /// URL of the Helm chart repository.
     pub helm_repo_url: String,
+    /// Name of the Helm chart.
     pub helm_chart: String,
+    /// Version of the Helm chart.
     pub helm_version: String,
 }
 
@@ -577,31 +671,49 @@ impl From<MachineIdentityConfig> for model::tenant::IdentityConfigValidationBoun
     }
 }
 
+/// SPDM (Security Protocol and Data Model) configuration
+/// for hardware attestation of DPU components.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct SpdmConfig {
+    /// Enables SPDM-based hardware attestation.
     #[serde(default)]
     pub enabled: bool,
+    /// NRAS (Network Root of trust for Attestation
+    /// Service) configuration for secure boot
+    /// verification.
     #[serde(default)]
     pub nras_config: Option<nras::Config>,
 }
 
-/// Parameters used by the Power config.
+/// Power management configuration controlling retry
+/// intervals and reboot timing.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct PowerManagerOptions {
+    /// Master switch to enable or disable power
+    /// management.
     #[serde(default)]
     pub enabled: bool,
+    /// Interval before retrying power operations after
+    /// a successful attempt.
+    /// Default is 5 minutes.
     #[serde(
         default = "default_next_duration_success",
         deserialize_with = "deserialize_duration_chrono",
         serialize_with = "as_duration"
     )]
     pub next_try_duration_on_success: chrono::TimeDelta,
+    /// Interval before retrying power operations after
+    /// a failed attempt.
+    /// Default is 2 minutes.
     #[serde(
         default = "default_next_duration_failure",
         deserialize_with = "deserialize_duration_chrono",
         serialize_with = "as_duration"
     )]
     pub next_try_duration_on_failure: chrono::TimeDelta,
+    /// Time to wait after power-down before powering on
+    /// the host.
+    /// Default is 15 minutes.
     #[serde(
         default = "default_wait_duration_next_reboot",
         deserialize_with = "deserialize_duration_chrono",
@@ -610,29 +722,36 @@ pub struct PowerManagerOptions {
     pub wait_duration_until_host_reboot: chrono::TimeDelta,
 }
 
+/// A BGP route target used in FNN VRF import/export policies.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct RouteTargetConfig {
+    /// Autonomous System Number component of the route target.
     #[serde(default)]
     pub asn: u32,
+    /// Virtual Network Identifier component of the route target.
     #[serde(default)]
     pub vni: u32,
 }
 
+/// Fabric Nearest Neighbor (FNN) configuration for L3 VNI-based overlay networking.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct FnnConfig {
+    /// Optional FNN configuration for the admin network VPC.
     #[serde(default)]
     pub admin_vpc: Option<AdminFnnConfig>,
 
     /// We'll double-tag our internal tenant routes with this tag.
-    /// Original consumer is GNI, who will import a common
-    /// route-target for internal tenant routes, reducing
-    /// the coordination needed between forge and GNI,
-    /// but who knows what the future holds.
+    /// Original consumer is a Network Infrastructure team, who will
+    /// import a common route-target for internal tenant routes,
+    /// reducing the coordination needed between NICo and the Network
+    /// Infrastructure, but who knows what the future holds.
     #[serde(default)]
     pub common_internal_route_target: Option<RouteTargetConfig>,
+    /// Additional route targets to import on DPU VRFs beyond the per-VPC defaults.
     #[serde(default)]
     pub additional_route_target_imports: Vec<RouteTargetConfig>,
 
+    /// Named routing profiles that define per-VPC route target import/export policies.
     #[serde(default)]
     pub routing_profiles: HashMap<String, FnnRoutingProfileConfig>,
 }
@@ -653,17 +772,15 @@ pub struct FnnRoutingProfileConfig {
     pub internal: bool,
 }
 
+/// FNN configuration specific to the admin network.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct AdminFnnConfig {
-    // if FNN should be applicable on admin network as well.
+    /// Whether FNN should be applied to the admin network as well.
     pub enabled: bool,
 
+    /// VNI for the admin network VPC. When enabled, will create a VPC with this VNI
+    /// and attach it to the admin network segment. Panics if a conflicting VPC/segment exists.
     #[serde(default)]
-    // if enabled_on_admin_network is true, carbide will try to
-    //   1. Create a VPC with the given vni.
-    //   2. Attach this VPC to network_segment table with segment type `admin`.
-    // if a vpc with exiting vni exists and network_segment table has this vpc attached to admin
-    // segment, do nothing else throw a error and panic.
     pub vpc_vni: Option<u32>,
 
     /// The inline definition for the routing config to use for the admin network.
@@ -1178,36 +1295,44 @@ impl From<&StateControllerConfig> for IterationConfig {
     }
 }
 
-/// IBFabricManager related configuration
+/// InfiniBand fabric manager configuration.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct IBFabricConfig {
+    /// Maximum InfiniBand partitions per tenant (1-31).
     #[serde(
         default = "IBFabricConfig::default_max_partition_per_tenant",
         deserialize_with = "IBFabricConfig::deserialize_max_partition"
     )]
     pub max_partition_per_tenant: i32,
 
+    /// Enables InfiniBand fabric management.
     #[serde(default)]
-    /// Enable IB fabric
     pub enabled: bool,
 
-    /// Whether a fabric configuration that does not adhere to security requirements
-    /// for tenant isolation and infrastructure protection is allowed
+    /// Whether a fabric configuration that does not
+    /// adhere to security requirements for tenant
+    /// isolation and infrastructure protection is
+    /// allowed.
     #[serde(default)]
     pub allow_insecure: bool,
 
+    /// Maximum transmission unit for InfiniBand fabric
+    /// traffic.
     #[serde(
         default = "IBMtu::default",
         deserialize_with = "IBFabricConfig::deserialize_mtu"
     )]
     pub mtu: IBMtu,
 
+    /// Rate limit for InfiniBand fabric traffic.
     #[serde(
         default = "IBRateLimit::default",
         deserialize_with = "IBFabricConfig::deserialize_rate_limit"
     )]
     pub rate_limit: IBRateLimit,
 
+    /// Quality of service level for InfiniBand
+    /// packets.
     #[serde(
         default = "IBServiceLevel::default",
         deserialize_with = "IBFabricConfig::deserialize_service_level"
@@ -1287,11 +1412,11 @@ impl IBFabricConfig {
     }
 }
 
-/// NvLink related configuration
+/// NvLink related configuration.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct NvLinkConfig {
+    /// Enables NvLink partitioning.
     #[serde(default)]
-    /// Enable NvLink Partitioning
     pub enabled: bool,
 
     /// Defaults to 1 Minute if not specified.
@@ -1343,11 +1468,11 @@ impl NvLinkConfig {
     }
 }
 
-/// SiteExplorer related configuration
+/// SiteExplorer related configuration for hardware discovery and ingestion.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SiteExplorerConfig {
+    /// Whether SiteExplorer is enabled.
     #[serde(default = "default_to_true")]
-    /// Whether SiteExplorer is enabled
     pub enabled: bool,
     /// The interval at which site explorer runs.
     /// Defaults to 5 Minutes if not specified.
@@ -1380,9 +1505,8 @@ pub struct SiteExplorerConfig {
     )]
     pub create_machines: Arc<AtomicBool>,
 
+    /// How many ManagedHosts should be created in a single run. Default is 4.
     #[serde(default = "SiteExplorerConfig::default_machines_created_per_run")]
-    /// How many ManagedHosts should be created in a single run.
-    /// Default is 1.
     pub machines_created_per_run: u64,
 
     /// Whether SiteExplorer should rotate/update Switch NVOS admin credentials
@@ -1403,46 +1527,39 @@ pub struct SiteExplorerConfig {
     /// This is a debug override and should not be used in production.
     pub override_target_port: Option<u16>,
 
-    #[serde(default)]
     /// Whether to allow hosts with zero DPUs in site-explorer. This should typically be set to
     /// false in production environments where we expect all hosts to have DPUs. When false, if we
     /// encounter a host with no DPUs, site-explorer will throw an error for that host (because it
-    /// should be assumed that there's a bug in detecting the DPUs.)
+    /// should be assumed that there's a bug in detecting the DPUs).
+    #[serde(default)]
     pub allow_zero_dpu_hosts: bool,
 
+    /// The host:port to use as a proxy when making BMC calls to all hosts in NICo. This is used
+    /// for integration testing, and for local development with machine-a-tron/bmc-mock. Should not
+    /// be used in production.
     #[serde(
         default,
         deserialize_with = "deserialize_bmc_proxy",
         serialize_with = "serialize_bmc_proxy"
     )]
-    /// The host:port to use as a proxy when making BMC calls to all hosts in carbide. This is used
-    /// for integration testing, and for local development with machine-a-tron/bmc-mock. Should not
-    /// be used in production.
     pub bmc_proxy: Arc<ArcSwap<Option<HostPortPair>>>,
 
+    /// If set to `true`, the server will allow changes to the `bmc_proxy` setting at runtime.
+    /// Defaults to true if the server is launched with `bmc_proxy` set, false otherwise.
+    /// If explicitly set to true or false, that value is respected for the lifetime of the process.
     #[serde(default)]
-    /// If set to `true`, the server will allow changes to the `bmc_proxy` setting at runtime. This
-    /// will be default to true if the server is launched with bmc_proxy set:
-    /// - If the value is not set, but the server is launched with bmc_proxy, override_target_ip, or
-    ///   override_target_port set, it will be assumed true (ie. if bmc_proxy can be reconfigured if
-    ///   it was initially configured)
-    /// - If the value is not set, and the server is launched without bmc_proxy, override_target_ip,
-    ///   or override_target_port set, it will be assumed false (ie. changes to bmc_proxy will not
-    ///   be allowed if the config has not opted in)
-    /// - If the value is set to true or false, it will be respected through the lifetime of the
-    ///   process.
     pub allow_changing_bmc_proxy: Option<bool>,
 
+    /// Minimum time between consecutive force-restarts or BMC resets initiated by SiteExplorer.
+    /// Default is 1 hour.
     #[serde(
         default = "SiteExplorerConfig::default_reset_rate_limit",
         deserialize_with = "deserialize_duration_chrono",
         serialize_with = "as_duration"
     )]
-    /// Represents the minimum amount of time in between consecutive force-restarts or bmc-resets
-    /// initiated by SiteExplorer.
-    /// Default is 1 hour.
     pub reset_rate_limit: Duration,
 
+    /// When true, non-DPU hosts use the `HostInband` admin network segment type instead of `Admin`.
     #[serde(
         default = "SiteExplorerConfig::default_admin_segment_type_non_dpu",
         deserialize_with = "deserialize_arc_atomic_bool",
@@ -1475,9 +1592,9 @@ pub struct SiteExplorerConfig {
     )]
     pub explore_power_shelves_from_static_ip: Arc<AtomicBool>,
 
-    #[serde(default = "SiteExplorerConfig::default_power_shelves_created_per_run")]
     /// How many Power Shelves should be created in a single run.
     /// Default is 1.
+    #[serde(default = "SiteExplorerConfig::default_power_shelves_created_per_run")]
     pub power_shelves_created_per_run: u64,
 
     /// Whether SiteExplorer should create Switch state machine
@@ -1488,19 +1605,22 @@ pub struct SiteExplorerConfig {
     )]
     pub create_switches: Arc<AtomicBool>,
 
-    #[serde(default = "SiteExplorerConfig::default_switches_created_per_run")]
     /// How many Switches should be created in a single run.
     /// Default is 9.
+    #[serde(default = "SiteExplorerConfig::default_switches_created_per_run")]
     pub switches_created_per_run: u64,
 
+    /// Use onboard NIC for host networking instead of DPU NICs.
     #[serde(
         default = "SiteExplorerConfig::default_use_onboard_nic",
         deserialize_with = "deserialize_arc_atomic_bool",
         serialize_with = "serialize_arc_atomic_bool"
     )]
     pub use_onboard_nic: Arc<AtomicBool>,
+    /// Controls which Redfish client implementation is used
+    /// for hardware discovery (LibRedfish, NvRedfish, or
+    /// CompareResult for side-by-side validation).
     #[serde(default = "SiteExplorerConfig::default_explore_mode")]
-    /// What type of exploration to be used.
     pub explore_mode: SiteExplorerExploreMode,
 }
 
@@ -1608,12 +1728,17 @@ impl SiteExplorerConfig {
     }
 }
 
+/// Selects the Redfish client backend used by SiteExplorer
+/// for BMC discovery.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub enum SiteExplorerExploreMode {
+    /// Use the libredfish Rust client.
     #[serde(rename = "libredfish")]
     LibRedfish,
+    /// Use the NVIDIA-specific Redfish client.
     #[serde(rename = "nv-redfish")]
     NvRedfish,
+    /// Run both clients and compare results for validation.
     #[serde(rename = "compare-result")]
     CompareResult,
 }
@@ -1681,27 +1806,39 @@ where
     }
 }
 
-/// TLS related configuration
+/// TLS certificate and key configuration for securing
+/// gRPC and HTTP connections.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TlsConfig {
+    /// Path to the root CA certificate file for
+    /// validating client certificates.
     #[serde(default)]
     pub root_cafile_path: String,
 
+    /// Path to the server identity certificate PEM
+    /// file.
     #[serde(default)]
     pub identity_pemfile_path: String,
 
+    /// Path to the server identity private key file.
     #[serde(default)]
     pub identity_keyfile_path: String,
 
+    /// Path to the admin root CA certificate file for
+    /// admin client validation.
     #[serde(default)]
     pub admin_root_cafile_path: String,
 }
 
+/// The transport protocol mode for the gRPC API server.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ListenMode {
+    /// Plaintext HTTP/1.1 (no TLS).
     PlaintextHttp1,
+    /// Plaintext HTTP/2 (no TLS).
     PlaintextHttp2,
+    /// TLS-encrypted connections (default).
     #[serde(other)]
     #[default]
     Tls,
@@ -1716,7 +1853,7 @@ pub struct AuthConfig {
     /// The Casbin policy file (in CSV format).
     pub casbin_policy_file: Option<PathBuf>,
 
-    /// Additional forge-admin-cli certs allowed.  This does not include actually allowing the cert to connect, just that certs that can be verified which match these criteria can do GRPC requests.
+    /// Additional nico-admin-cli certs allowed.  This does not include actually allowing the cert to connect, just that certs that can be verified which match these criteria can do GRPC requests.
     pub cli_certs: Option<AllowedCertCriteria>,
 
     /// Configuration for the root of trust for client cert auth
@@ -1998,42 +2135,72 @@ impl Default for NetworkSecurityGroupConfig {
     }
 }
 
+/// Global firmware management settings controlling
+/// update policies, concurrency, and retry behavior.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct FirmwareGlobal {
+    /// Enables automatic host firmware updates via the
+    /// background firmware manager.
     #[serde(default)]
     pub autoupdate: bool,
+    /// Host model names to force-enable autoupdate on,
+    /// regardless of the global `autoupdate` setting.
     #[serde(default)]
     pub host_enable_autoupdate: Vec<String>,
+    /// Host model names to force-disable autoupdate on,
+    /// regardless of the global `autoupdate` setting.
     #[serde(default)]
     pub host_disable_autoupdate: Vec<String>,
+    /// Frequency at which the firmware manager checks for
+    /// and applies updates.
+    /// Default is 30 seconds.
     #[serde(
         default = "FirmwareGlobal::run_interval_default",
         deserialize_with = "deserialize_duration_chrono",
         serialize_with = "as_duration"
     )]
     pub run_interval: Duration,
+    /// Maximum concurrent firmware uploads allowed.
+    /// Default is 4.
     #[serde(default = "FirmwareGlobal::max_uploads_default")]
     pub max_uploads: usize,
+    /// Maximum concurrent firmware flashing operations
+    /// across all machines.
+    /// Default is 16.
     #[serde(default = "FirmwareGlobal::concurrency_limit_default")]
     pub concurrency_limit: usize,
+    /// Local directory where firmware binaries are stored.
+    /// Default is `/opt/carbide/firmware`.
     #[serde(default = "FirmwareGlobal::firmware_directory_default")]
     pub firmware_directory: PathBuf,
+    /// Delay before retrying a failed host firmware
+    /// upgrade.
+    /// Default is 60 minutes.
     #[serde(
         default = "FirmwareGlobal::host_firmware_upgrade_retry_interval_default",
         deserialize_with = "deserialize_duration_chrono",
         serialize_with = "as_duration"
     )]
     pub host_firmware_upgrade_retry_interval: Duration,
+    /// Requires manual tagging of instances before
+    /// firmware updates are applied.
     #[serde(default = "FirmwareGlobal::instance_updates_manual_tagging_default")]
     pub instance_updates_manual_tagging: bool,
+    /// Disables retry logic after BMC resets during
+    /// firmware operations.
     #[serde(default)]
     pub no_reset_retries: bool,
+    /// Delay after GPU reboot before the HGX BMC can be
+    /// accessed again.
+    /// Default is 30 seconds.
     #[serde(
         default = "FirmwareGlobal::hgx_bmc_gpu_reboot_delay_default",
         deserialize_with = "deserialize_duration_chrono",
         serialize_with = "as_duration"
     )]
     pub hgx_bmc_gpu_reboot_delay: Duration,
+    /// Forces all firmware upgrades to require explicit
+    /// administrator approval.
     #[serde(default)]
     pub requires_manual_upgrade: bool,
 }
@@ -2063,8 +2230,12 @@ impl FirmwareGlobal {
     }
 }
 
+/// Configuration for rolling machine updates and
+/// maintenance windows.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct MachineUpdater {
+    /// Time window during which machines may automatically
+    /// reboot for updates.
     #[serde(default)]
     pub instance_autoreboot_period: Option<TimePeriod>,
     /// The maximum number of machines that have in-progress updates running.  This prevents
@@ -2075,9 +2246,12 @@ pub struct MachineUpdater {
     pub max_concurrent_machine_updates_percent: Option<i32>,
 }
 
+/// A UTC time window defined by a start and end timestamp.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct TimePeriod {
+    /// Start of the time window (UTC).
     pub start: chrono::DateTime<chrono::Utc>,
+    /// End of the time window (UTC).
     pub end: chrono::DateTime<chrono::Utc>,
 }
 
@@ -2306,15 +2480,19 @@ pub fn default_max_network_security_group_size() -> u32 {
 }
 
 pub fn default_internet_l3_vni() -> u32 {
-    // This is a number agreed upon between GNI and Forge
-    // that they will use to tag the default route.
+    // This is a number agreed upon between the Network
+    // Infrastructure team and NICo that they will use to
+    // tag the default route.
+    //
     // It will be combined with datacenter_asn to form
     // a route-target of <DC_ASN>:<INTERNET_VNI>.
     100001
 }
 
 pub fn default_datacenter_asn() -> u32 {
-    // This is a number previously provided by GNI.
+    // This is a number previously provided by the Network
+    // Infrastructure team.
+    //
     // It represents a "global" (i.e., non-DC-specific)
     // identifier.  It's used in pre-FNN sites and in FNN
     // on DPU routes, but we'll transition away from that.
@@ -2346,17 +2524,18 @@ pub fn default_to_true() -> bool {
     true
 }
 
-/// MeasuredBootMetricsCollectorConfig related configuration
+/// Configuration for the measured boot metrics collector,
+/// which exports TPM-based boot measurement data as
+/// Prometheus metrics.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct MeasuredBootMetricsCollectorConfig {
+    /// Enables the measured boot metrics monitor. When
+    /// disabled, measured boot metrics are not exported.
     #[serde(default)]
-    /// enabled controls whether the measured boot metrics
-    /// monitor is enabled. When disabled, measured boot metrics
-    /// won't be exported.
     pub enabled: bool,
-    /// run_interval is the interval at which the monitor polls
-    /// for the latest data, in seconds.
-    /// Defaults to 60 if not specified.
+    /// Interval at which the monitor polls for the latest
+    /// measured boot data.
+    /// Default is 60 seconds.
     #[serde(
         default = "MeasuredBootMetricsCollectorConfig::default_run_interval",
         deserialize_with = "deserialize_duration",
@@ -2395,22 +2574,33 @@ pub struct IbFabricDefinition {
     pub pkeys: Vec<model::resource_pool::define::Range>,
 }
 
+/// Controls which machine validation tests are active.
 #[derive(Default, Clone, Copy, Debug, Deserialize, Serialize)]
 pub enum MachineValidationTestSelectionMode {
+    /// Only update tests in DB that are specified in the
+    /// `tests` config list.
     #[default]
-    Default, // only update tests in DB that are specified in tests config
-    EnableAll, // Enables all tests in DB, but allows config overrides specified in tests config
-    DisableAll, // Disables all tests in DB, but allows config overrides specified in tests config
+    Default,
+    /// Enable all tests in DB, but allow per-test overrides
+    /// from the `tests` config list.
+    EnableAll,
+    /// Disable all tests in DB, but allow per-test overrides
+    /// from the `tests` config list.
+    DisableAll,
 }
 
+/// Configuration for machine validation tests (memory
+/// latency, SSD I/O, etc.) run after ingestion to verify
+/// hardware health.
 #[derive(Default, Clone, Debug, Deserialize, Serialize)]
 pub struct MachineValidationConfig {
+    /// Enables machine validation testing.
     #[serde(default)]
-    /// Whether MachineValidation is enabled
     pub enabled: bool,
 
+    /// Controls whether to run all tests, no tests, or use
+    /// per-test configuration.
     #[serde(default)]
-    /// Controls whether to run all tests, no tests, or use per-test configuration
     pub test_selection_mode: MachineValidationTestSelectionMode,
 
     #[serde(
@@ -2420,20 +2610,25 @@ pub struct MachineValidationConfig {
     )]
     pub run_interval: std::time::Duration,
 
+    /// Per-test enable/disable overrides.
     #[serde(default)]
-    /// Test specific config
     pub tests: Vec<MachineValidationTestConfig>,
 }
 
-/// Test specific config.
+/// Per-test override for machine validation.
+///
 /// Example:
+/// ```toml
 /// tests = [
-///    { id = "forge_MmMemLatency", enable = true },
-///    { id = "forge_FioSSD", enable = true }
+///    { id = "MmMemLatency", enable = true },
+///    { id = "FioSSD", enable = true }
 /// ]
+/// ```
 #[derive(Default, Clone, Debug, Deserialize, Serialize)]
 pub struct MachineValidationTestConfig {
+    /// Unique test identifier (e.g., "MmMemLatency").
     pub id: String,
+    /// Whether this test is enabled.
     pub enable: bool,
 }
 
@@ -2619,22 +2814,31 @@ fn default_mqtt_broker_port() -> u16 {
     1884
 }
 
+/// MQTT authentication mode.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum MqttAuthMode {
+    /// No authentication.
     #[default]
     None,
+    /// Username/password basic authentication.
     BasicAuth,
+    /// OAuth2 token-based authentication.
     Oauth2,
 }
 
+/// OAuth2 configuration for MQTT broker authentication.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct MqttOAuth2Config {
+    /// OAuth2 token endpoint URL.
     pub token_url: String,
 
+    /// OAuth2 scopes to request when obtaining a token.
     #[serde(default)]
     pub scopes: Vec<String>,
 
+    /// HTTP timeout for token endpoint requests.
+    /// Default is 30 seconds.
     #[serde(
         default = "MqttOAuth2Config::default_http_timeout",
         deserialize_with = "deserialize_duration",
@@ -2642,6 +2846,9 @@ pub struct MqttOAuth2Config {
     )]
     pub http_timeout: std::time::Duration,
 
+    /// Username sent with the MQTT CONNECT packet when using
+    /// OAuth2.
+    /// Default is "oauth2token".
     #[serde(default = "MqttOAuth2Config::default_username")]
     pub username: String,
 }
@@ -2656,11 +2863,17 @@ impl MqttOAuth2Config {
     }
 }
 
+/// MQTT authentication configuration shared by DPA and
+/// DSX event bus.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct MqttAuthConfig {
+    /// Authentication mechanism to use for MQTT
+    /// connections.
     #[serde(default)]
     pub auth_mode: MqttAuthMode,
 
+    /// OAuth2 settings, required when `auth_mode` is
+    /// `Oauth2`.
     pub oauth2: Option<MqttOAuth2Config>,
 }
 
@@ -2681,9 +2894,12 @@ pub struct DpaConfig {
     #[serde(default = "default_mqtt_broker_port")]
     pub mqtt_broker_port: u16,
 
+    /// Base IPv4 address of the DPA/Cluster Interconnect
+    /// subnet.
     #[serde(default = "DpaConfig::default_subnet_ip")]
     pub subnet_ip: Ipv4Addr,
 
+    /// CIDR prefix length for the DPA subnet.
     #[serde(default)]
     pub subnet_mask: i32,
 


### PR DESCRIPTION
## Description

I was working on something last week, and realized that most entries in the NICo config file don't have any doc comments, which I feel like is kind of necessary now.

So, this PR adds doc comments for all config file entries, allowing `rustdoc` / `cargo doc` to generate docs for the NICo config file. This also adds a `README.md` for the module itself, so people can search/browse the config file without needing to look at the code.

Maybe the `README.md` isn't necessary, but it seems nice, and we can just use some AI agent to re-generate a `README.md` as needed.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

