### PR TITLE
Add rack_ids to Machines

### DIFF
--- a/crates/admin-cli/src/machine/show/cmd.rs
+++ b/crates/admin-cli/src/machine/show/cmd.rs
@@ -43,6 +43,10 @@ fn convert_machine_to_nice_format(
             "ID",
             machine.id.map(|id| id.to_string()).unwrap_or_default(),
         ),
+        (
+            "RACK_ID",
+            machine.rack_id.map(|id| id.to_string()).unwrap_or_default(),
+        ),
         ("STATE", machine.state.to_uppercase()),
         ("STATE_VERSION", machine.state_version),
         ("MACHINE TYPE", get_machine_type(machine.id)),

--- a/crates/api-db/migrations/20260320120000_add_rack_id_to_machines.sql
+++ b/crates/api-db/migrations/20260320120000_add_rack_id_to_machines.sql
@@ -1,0 +1,5 @@
+-- Add a rack_id column to machines
+ALTER TABLE machines ADD COLUMN rack_id VARCHAR(64);
+
+-- Backfill it from the RackIdentifier metadata if it exists
+UPDATE machines SET rack_id=labels->>'RackIdentifier' WHERE rack_id IS NULL AND labels->>'RackIdentifier' is not NULL;

--- a/crates/api-db/src/dpa_interface.rs
+++ b/crates/api-db/src/dpa_interface.rs
@@ -573,7 +573,6 @@ mod test {
     use mac_address::MacAddress;
     use model::dpa_interface::NewDpaInterface;
     use model::machine::ManagedHostState;
-    use model::metadata::Metadata;
 
     use crate::machine;
 
@@ -584,17 +583,7 @@ mod test {
         let id =
             MachineId::from_str("fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30")?;
 
-        machine::create(
-            &mut txn,
-            None,
-            &id,
-            ManagedHostState::Ready,
-            &Metadata::default(),
-            None,
-            true,
-            2,
-        )
-        .await?;
+        machine::create(&mut txn, None, &id, ManagedHostState::Ready, None, 2).await?;
 
         let new_intf = NewDpaInterface {
             mac_address: MacAddress::from_str("00:11:22:33:44:55")?,
@@ -632,9 +621,7 @@ mod test {
             None,
             &machine_id,
             ManagedHostState::Ready,
-            &Metadata::default(),
             None,
-            true,
             2,
         )
         .await?;
@@ -689,9 +676,7 @@ mod test {
             None,
             &machine_id,
             ManagedHostState::Ready,
-            &Metadata::default(),
             None,
-            true,
             2,
         )
         .await?;

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -32,6 +32,7 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 use mac_address::MacAddress;
 use model::controller_outcome::PersistentStateHandlerOutcome;
+use model::expected_machine::ExpectedMachineData;
 use model::hardware_info::{MachineInventory, MachineNvLinkInfo};
 use model::machine::infiniband::MachineInfinibandStatusObservation;
 use model::machine::machine_search_config::MachineSearchConfig;
@@ -127,17 +128,7 @@ pub async fn get_or_create(
         // Host and DPU machines are created in same `discover_machine` call. Update same
         // state in both machines.
         let state = ManagedHostState::Created;
-        let machine = create(
-            txn,
-            common_pools,
-            stable_machine_id,
-            state,
-            &Metadata::default(),
-            None,
-            true,
-            2,
-        )
-        .await?;
+        let machine = create(txn, common_pools, stable_machine_id, state, None, 2).await?;
         crate::machine_interface::associate_interface_with_machine(
             &interface.id,
             MachineInterfaceAssociation::Machine(machine.id),
@@ -1216,23 +1207,32 @@ pub async fn clear_failure_details(
 ///
 /// If metadata.name is empty then it is initialized in
 /// stable_machine_id.to_string().
-#[allow(clippy::too_many_arguments)]
 pub async fn create(
     txn: &mut PgConnection,
     common_pools: Option<&CommonPools>,
     stable_machine_id: &MachineId,
     state: ManagedHostState,
-    metadata: &Metadata,
-    sku_id: Option<&String>,
-    dpf_enabled: bool,
+    expected_machine_data: Option<&ExpectedMachineData>,
     state_model_version: i16,
 ) -> DatabaseResult<Machine> {
     let stable_machine_id_string = stable_machine_id.to_string();
-    let metadata_name = if metadata.name.is_empty() {
-        &stable_machine_id_string
-    } else {
+
+    let default_metadata = &Metadata::default();
+    let metadata = expected_machine_data
+        .map(|data| &data.metadata)
+        .unwrap_or(default_metadata);
+    let metadata_name = if !metadata.name.is_empty() {
         &metadata.name
+    } else {
+        &stable_machine_id_string
     };
+    let rack_id = expected_machine_data.and_then(|data| data.rack_id.as_ref());
+    let sku_id = expected_machine_data.and_then(|data| data.sku_id.as_ref());
+    let dpf_enabled = match expected_machine_data {
+        Some(data) => data.dpf_enabled.unwrap_or(false), // EM entry exists
+        None => true,                                    // EM entry does not exist
+    };
+
     // Host and DPU machines are created in same `discover_machine` call. Update same
     // state in both machines.
     let state_version = ConfigVersion::initial();
@@ -1265,8 +1265,8 @@ pub async fn create(
     };
 
     let query = r#"INSERT INTO machines(
-                            id, controller_state_version, controller_state, network_config_version, network_config, machine_state_model_version, asn, version, name, description, labels, hw_sku, dpf)
-                            VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::json, $12, $13) RETURNING id"#;
+                            id, controller_state_version, controller_state, network_config_version, network_config, machine_state_model_version, asn, version, name, description, labels, rack_id, hw_sku, dpf)
+                            VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::json, $12, $13, $14) RETURNING id"#;
     let machine_id: MachineId = sqlx::query_as(query)
         .bind(&stable_machine_id_string)
         .bind(state_version)
@@ -1279,6 +1279,7 @@ pub async fn create(
         .bind(metadata_name)
         .bind(&metadata.description)
         .bind(sqlx::types::Json(&metadata.labels))
+        .bind(rack_id)
         .bind(sku_id)
         .bind(sqlx::types::Json(Dpf {
             enabled: dpf_enabled,
@@ -2319,7 +2320,6 @@ mod test {
     use carbide_uuid::machine::MachineId;
     use model::machine::ManagedHostState;
     use model::machine::machine_search_config::MachineSearchConfig;
-    use model::metadata::Metadata;
 
     #[crate::sqlx_test]
 
@@ -2329,17 +2329,7 @@ mod test {
         let mut txn: sqlx::Transaction<'_, sqlx::Postgres> = pool.begin().await.unwrap();
         let id =
             MachineId::from_str("fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30")?;
-        super::create(
-            &mut txn,
-            None,
-            &id,
-            ManagedHostState::Ready,
-            &Metadata::default(),
-            None,
-            true,
-            2,
-        )
-        .await?;
+        super::create(&mut txn, None, &id, ManagedHostState::Ready, None, 2).await?;
         super::set_firmware_autoupdate(&mut txn, &id, Some(true)).await?;
         txn.commit().await?;
         let mut txn: sqlx::Transaction<'_, sqlx::Postgres> = pool.begin().await.unwrap();

--- a/crates/api-model/src/machine/json.rs
+++ b/crates/api-model/src/machine/json.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 
 use carbide_uuid::instance_type::InstanceTypeId;
 use carbide_uuid::machine::MachineId;
+use carbide_uuid::rack::RackId;
 use chrono::{DateTime, Utc};
 use config_version::{ConfigVersion, Versioned};
 use health_report::HealthReport;
@@ -48,6 +49,7 @@ use crate::sku::SkuStatus;
 #[derive(Serialize, Deserialize)]
 pub struct MachineSnapshotPgJson {
     pub id: MachineId,
+    pub rack_id: Option<RackId>,
     pub created: DateTime<Utc>,
     pub updated: DateTime<Utc>,
     pub deployed: Option<DateTime<Utc>>,
@@ -149,6 +151,7 @@ impl TryFrom<MachineSnapshotPgJson> for Machine {
 
         Ok(Self {
             id: value.id,
+            rack_id: value.rack_id,
             state: Versioned {
                 value: value.controller_state,
                 version: value.controller_state_version.parse().map_err(|e| {

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -27,6 +27,7 @@ use carbide_uuid::instance_type::InstanceTypeId;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId, MachineType};
 use carbide_uuid::network::NetworkSegmentId;
 use carbide_uuid::power_shelf::PowerShelfId;
+use carbide_uuid::rack::RackId;
 use carbide_uuid::switch::SwitchId;
 use chrono::{DateTime, Duration, Utc};
 use config_version::{ConfigVersion, Versioned};
@@ -811,6 +812,9 @@ pub struct Machine {
     /// TEMPORARY: Used for workflow where manual upgrades are required before automatic ones
     /// TODO: Remove after upgrade-through-scout is complete
     pub manual_firmware_upgrade_completed: Option<DateTime<Utc>>,
+
+    /// The rack that this machine is associated with
+    pub rack_id: Option<RackId>,
 }
 
 // Dpf status field.
@@ -1111,6 +1115,7 @@ impl From<Machine> for rpc::forge::Machine {
 
         rpc::Machine {
             id: Some(machine.id),
+            rack_id: machine.rack_id.clone(),
             state: if machine.is_dpu() {
                 machine.state.value.dpu_state_string(&machine.id)
             } else {

--- a/crates/api/src/measured_boot/tests/common.rs
+++ b/crates/api/src/measured_boot/tests/common.rs
@@ -25,7 +25,6 @@ use carbide_uuid::machine::MachineId;
 use measured_boot::machine::CandidateMachine;
 use model::hardware_info::HardwareInfo;
 use model::machine::ManagedHostState;
-use model::metadata::Metadata;
 use sqlx::PgConnection;
 
 use crate::state_controller::machine::io::CURRENT_STATE_MODEL_VERSION;
@@ -52,9 +51,7 @@ pub async fn create_test_machine(
         None,
         &machine_id,
         ManagedHostState::Ready,
-        &Metadata::default(),
         None,
-        true,
         CURRENT_STATE_MODEL_VERSION,
     )
     .await?;

--- a/crates/api/src/measured_boot/tests/rpc.rs
+++ b/crates/api/src/measured_boot/tests/rpc.rs
@@ -28,7 +28,6 @@ mod tests {
     use measured_boot::pcr::PcrRegisterValue;
     use measured_boot::records::MeasurementApprovedMachineRecord;
     use model::machine::ManagedHostState;
-    use model::metadata::Metadata;
     use rpc::protos::measured_boot as mbrpc;
 
     use crate::measured_boot::rpc::{bundle, journal, machine, profile, report, site};
@@ -2036,9 +2035,7 @@ mod tests {
             None,
             &machine_id,
             ManagedHostState::Ready,
-            &Metadata::default(),
             None,
-            true,
             CURRENT_STATE_MODEL_VERSION,
         )
         .await

--- a/crates/api/src/site_explorer/machine_creator.rs
+++ b/crates/api/src/site_explorer/machine_creator.rs
@@ -21,13 +21,12 @@ use carbide_uuid::machine::MachineId;
 use db::{ObjectColumnFilter, Transaction};
 use librms::RmsApi;
 use model::bmc_info::BmcInfo;
-use model::expected_machine::ExpectedMachine;
+use model::expected_machine::ExpectedMachineData;
 use model::hardware_info::HardwareInfo;
 use model::machine::machine_id::host_id_from_dpu_hardware_info;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{Machine, MachineInterfaceSnapshot, ManagedHostState};
 use model::machine_interface_address::MachineInterfaceAssociation;
-use model::metadata::Metadata;
 use model::network_segment::NetworkSegmentType;
 use model::predicted_machine_interface::NewPredictedMachineInterface;
 use model::resource_pool::common::CommonPools;
@@ -76,8 +75,9 @@ impl MachineCreator {
         // for every identified ManagedHost even if we don't create any objects.
         // We can perform a single query upfront to identify which ManagedHosts don't yet have Machines
         for (host, report) in explored_managed_hosts {
-            let expected_machine =
-                expected_explored_endpoint_index.matched_expected_machine(&host.host_bmc_ip);
+            let expected_machine = expected_explored_endpoint_index
+                .matched_expected_machine(&host.host_bmc_ip)
+                .map(|em| &em.data);
 
             match self
                 .create_managed_host(host, report, expected_machine, &self.database_connection)
@@ -104,21 +104,12 @@ impl MachineCreator {
         &self,
         explored_host: &ExploredManagedHost,
         report: &mut EndpointExplorationReport,
-        expected_machine: Option<&ExpectedMachine>,
+        machine_data: Option<&ExpectedMachineData>,
         pool: &PgPool,
     ) -> CarbideResult<bool> {
         let mut managed_host = ManagedHost::init(explored_host);
 
         let mut txn = Transaction::begin(pool).await?;
-
-        let (metadata, sku_id, dpf_enabled) = match expected_machine {
-            Some(m) => (
-                Some(&m.data.metadata),
-                m.data.sku_id.as_ref(),
-                m.data.dpf_enabled.unwrap_or_default(),
-            ),
-            None => (None, None, true),
-        };
 
         // Zero-dpu case: If the explored host had no DPUs, we can create the machine now
         if managed_host.explored_host.dpus.is_empty() {
@@ -128,12 +119,7 @@ impl MachineCreator {
                 return Err(error);
             }
             if let Some(machine_id) = self
-                .create_zero_dpu_machine(
-                    &mut txn,
-                    &managed_host,
-                    report,
-                    metadata.unwrap_or(&Metadata::default()),
-                )
+                .create_zero_dpu_machine(&mut txn, &managed_host, report, machine_data)
                 .await?
             {
                 managed_host.machine_id = Some(machine_id);
@@ -152,7 +138,7 @@ impl MachineCreator {
             let dpu_machine_id = *dpu_report.machine_id_if_valid_report()?;
             dpu_ids.push(dpu_machine_id);
 
-            if !self.create_dpu(&mut txn, dpu_report, dpf_enabled).await? {
+            if !self.create_dpu(&mut txn, dpu_report).await? {
                 // Site explorer has already created a machine for this DPU previously.
                 //
                 // If the DPU's machine is not attached to its machine interface, do so here.
@@ -164,14 +150,7 @@ impl MachineCreator {
             }
 
             let host_machine_id = self
-                .attach_dpu_to_host(
-                    &mut txn,
-                    &managed_host,
-                    dpu_report,
-                    metadata.unwrap_or(&Metadata::default()),
-                    sku_id,
-                    dpf_enabled,
-                )
+                .attach_dpu_to_host(&mut txn, &managed_host, dpu_report, machine_data)
                 .await?;
             managed_host.machine_id = Some(host_machine_id)
         }
@@ -201,7 +180,7 @@ impl MachineCreator {
         txn: &mut PgConnection,
         managed_host: &ManagedHost<'_>,
         report: &mut EndpointExplorationReport,
-        metadata: &Metadata,
+        machine_data: Option<&ExpectedMachineData>,
     ) -> CarbideResult<Option<MachineId>> {
         // If there's already a machine with the same MAC address as this endpoint, return false. We
         // can't rely on matching the machine_id, as it may have migrated to a stable MachineID
@@ -269,15 +248,8 @@ impl MachineCreator {
             return Ok(None);
         }
 
-        self.create_machine_from_explored_managed_host(
-            txn,
-            managed_host,
-            machine_id,
-            metadata,
-            None,
-            true,
-        )
-        .await?;
+        self.create_machine_from_explored_managed_host(txn, managed_host, machine_id, machine_data)
+            .await?;
 
         // Create and attach a non-DPU machine_interface to the host for every MAC address we see in
         // the exploration report
@@ -336,12 +308,8 @@ impl MachineCreator {
         &self,
         txn: &mut PgConnection,
         explored_dpu: &ExploredDpu,
-        dpf_enabled: bool,
     ) -> CarbideResult<bool> {
-        if let Some(dpu_machine) = self
-            .create_dpu_machine(txn, explored_dpu, dpf_enabled)
-            .await?
-        {
+        if let Some(dpu_machine) = self.create_dpu_machine(txn, explored_dpu).await? {
             self.configure_dpu_interface(txn, explored_dpu).await?;
             self.update_dpu_network_config(txn, &dpu_machine).await?;
             let dpu_machine_id: &MachineId = explored_dpu.report.machine_id.as_ref().unwrap();
@@ -361,18 +329,14 @@ impl MachineCreator {
         txn: &mut PgConnection,
         managed_host: &ManagedHost<'_>,
         predicted_machine_id: &MachineId,
-        metadata: &Metadata,
-        sku_id: Option<&String>,
-        dpf_enabled: bool,
+        machine_data: Option<&ExpectedMachineData>,
     ) -> CarbideResult<()> {
         _ = db::machine::create(
             txn,
             Some(&self.common_pools),
             predicted_machine_id,
             ManagedHostState::Created,
-            metadata,
-            sku_id,
-            dpf_enabled,
+            machine_data,
             CURRENT_STATE_MODEL_VERSION,
         )
         .await?;
@@ -445,7 +409,6 @@ impl MachineCreator {
         &self,
         txn: &mut PgConnection,
         explored_dpu: &ExploredDpu,
-        dpf_enabled: bool,
     ) -> CarbideResult<Option<Machine>> {
         let dpu_machine_id = explored_dpu.report.machine_id.as_ref().unwrap();
         match db::machine::find_one(&mut *txn, dpu_machine_id, MachineSearchConfig::default())
@@ -458,11 +421,7 @@ impl MachineCreator {
                 Some(&self.common_pools),
                 dpu_machine_id,
                 ManagedHostState::Created,
-                &Metadata::default(),
                 None,
-                // Although this field is not used in case of DPU, but let's keep them
-                // in sync.
-                dpf_enabled,
                 CURRENT_STATE_MODEL_VERSION,
             )
             .await
@@ -484,9 +443,7 @@ impl MachineCreator {
         txn: &mut PgConnection,
         explored_host: &ManagedHost<'_>,
         explored_dpu: &ExploredDpu,
-        metadata: &Metadata,
-        sku_id: Option<&String>,
-        dpf_enabled: bool,
+        machine_data: Option<&ExpectedMachineData>,
     ) -> CarbideResult<MachineId> {
         let dpu_hw_info = explored_dpu.hardware_info()?;
         // Create Host proactively.
@@ -514,9 +471,7 @@ impl MachineCreator {
                 explored_host,
                 &host_machine_interface,
                 explored_dpu,
-                metadata,
-                sku_id,
-                dpf_enabled,
+                machine_data,
             )
             .await?;
 
@@ -613,9 +568,7 @@ impl MachineCreator {
         explored_host: &ManagedHost<'_>,
         host_machine_interface: &MachineInterfaceSnapshot,
         explored_dpu: &ExploredDpu,
-        metadata: &Metadata,
-        sku_id: Option<&String>,
-        dpf_enabled: bool,
+        machine_data: Option<&ExpectedMachineData>,
     ) -> CarbideResult<MachineId> {
         match &explored_host.machine_id {
             Some(host_machine_id) => {
@@ -638,9 +591,7 @@ impl MachineCreator {
                         txn,
                         explored_host.explored_host,
                         explored_dpu,
-                        metadata,
-                        sku_id,
-                        dpf_enabled,
+                        machine_data,
                     )
                     .await?;
 
@@ -665,9 +616,7 @@ impl MachineCreator {
         txn: &mut PgConnection,
         explored_host: &ExploredManagedHost,
         explored_dpu: &ExploredDpu,
-        metadata: &Metadata,
-        sku_id: Option<&String>,
-        dpf_enabled: bool,
+        machine_data: Option<&ExpectedMachineData>,
     ) -> CarbideResult<MachineId> {
         let dpu_hw_info = explored_dpu.hardware_info()?;
         let predicted_machine_id = host_id_from_dpu_hardware_info(&dpu_hw_info)
@@ -678,9 +627,7 @@ impl MachineCreator {
             Some(&self.common_pools),
             &predicted_machine_id,
             ManagedHostState::Created,
-            metadata,
-            sku_id,
-            dpf_enabled,
+            machine_data,
             CURRENT_STATE_MODEL_VERSION,
         )
         .await?;

--- a/crates/api/src/tests/machine_creator.rs
+++ b/crates/api/src/tests/machine_creator.rs
@@ -1241,7 +1241,7 @@ async fn test_site_explorer_creates_managed_host_with_dpf_disable(
             .create_managed_host(
                 &exploration_report,
                 &mut EndpointExplorationReport::default(),
-                Some(&expected_machine),
+                Some(&expected_machine.data),
                 &env.pool,
             )
             .await?
@@ -1260,7 +1260,13 @@ async fn test_site_explorer_creates_managed_host_with_dpf_disable(
 
     assert_eq!(machines.len(), 2);
     for machine in machines {
-        assert!(!machine.dpf.enabled);
+        if machine.is_dpu() {
+            // DPU has no expected-machine entry, so it always defaults to `true`
+            assert!(machine.dpf.enabled);
+        } else {
+            // Host has exepcted-machine entry. No `dpf_enabled` means `false`.
+            assert!(!machine.dpf.enabled);
+        }
     }
 
     Ok(())
@@ -1382,7 +1388,7 @@ async fn test_site_explorer_creates_managed_host_with_dpf_enabled(
             .create_managed_host(
                 &exploration_report,
                 &mut EndpointExplorationReport::default(),
-                Some(&expected_machine),
+                Some(&expected_machine.data),
                 &env.pool,
             )
             .await?

--- a/crates/api/src/web/machine.rs
+++ b/crates/api/src/web/machine.rs
@@ -435,6 +435,7 @@ pub async fn fetch_machines(
 struct MachineDetail<'a> {
     id: String,
     host_id: String,
+    rack_id: String,
     state: String,
     state_version: String,
     time_in_state: String,
@@ -658,6 +659,7 @@ impl From<forgerpc::Machine> for MachineDetail<'_> {
 
         MachineDetail {
             id: machine_id.clone(),
+            rack_id: m.rack_id.map(|id| id.to_string()).unwrap_or_default(),
             time_in_state: config_version::since_state_change_humanized(&m.state_version),
             state: m.state,
             state_version: m.state_version,

--- a/crates/api/templates/machine_detail.html
+++ b/crates/api/templates/machine_detail.html
@@ -20,7 +20,9 @@
 		{% endif %}
 		</td>
 	</tr>
-			<tr><th>State</th><td>
+	<tr><th>Rack ID</th><td>{{ rack_id }}</td></tr>
+	<tr><th>State</th>
+		<td>
 			{% if state.to_lowercase().contains("failed") %}
 				<span class="bubble error">{{ state }}{% if time_in_state_above_sla %} ⏱️{% endif %}</span>
 			{% else if time_in_state_above_sla %}
@@ -30,7 +32,8 @@
 			{% else %}
 				<span class="bubble">{{ state }}</span>
 			{% endif %}
-		</td></tr>
+		</td>
+	</tr>
 	<tr><th>State Version</th><td>{{ state_version|config_version|safe }}</td></tr>
 	<tr><th>Time in state</th><td>{{ time_in_state }}</td></tr>
 	<tr><th>Last Reboot</th><td>{{ last_reboot }}</td></tr>

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -2903,6 +2903,8 @@ message Machine {
   optional MachineNVLinkInfo nvlink_info = 43;
 
   optional MachineNVLinkStatusObservation nvlink_status_observation = 44;
+
+  optional common.RackId rack_id = 45;
 }
 
 message InstanceNetworkRestrictions {
@@ -6842,7 +6844,7 @@ message RackFirmwareJobStatusResponse {
 }
 
 message RackFirmwareHistoryRequest {
-  string firmware_id = 1;      // Optional: filter by firmware ID. Empty string means no filter.
+  string firmware_id = 1; // Optional: filter by firmware ID. Empty string means no filter.
   repeated string rack_ids = 2; // Optional: filter by rack IDs. Empty list returns all racks.
 }
 


### PR DESCRIPTION
## Description

Adds a rack_id field to Machine entries and backfills based it the RackIdentifier label. `rack_id` will be set based on the `rack_id` encoded in expected machines during ingestion.

The `rack_id` is visible on admin-cli and web-ui.

Also refactors Machine creation path to directly accept ExpectedMachineData as argument to reduce the amount of parameters threaded through various calls.

More tests and additional APIs will come in follow-up PRs.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

