### PR TITLE
fix(rustfmt): update rustfmt config to edition 2024 and reformat

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -486,7 +486,7 @@ description = "Format with nightly rustfmt options for grouping and sorting impo
 category = "Formatting"
 dependencies = ["setup-nightly-rust"]
 script = [
-  "cargo +${RUST_NIGHTLY} fmt --all -- --config imports_granularity=Module,group_imports=StdExternalCrate",
+  "cargo +${RUST_NIGHTLY} fmt --all",
 ]
 
 [tasks.check-format-nightly]
@@ -495,7 +495,7 @@ description = "Check format with nightly rustfmt options for grouping and sortin
 category = "Formatting"
 dependencies = ["setup-nightly-rust"]
 script = [
-  "cargo +${RUST_NIGHTLY} fmt --all -- --config imports_granularity=Module,group_imports=StdExternalCrate --check",
+  "cargo +${RUST_NIGHTLY} fmt --all -- --check",
 ]
 
 [tasks.setup-carbide-lints]

--- a/crates/admin-cli/src/machine_interfaces/show/cmd.rs
+++ b/crates/admin-cli/src/machine_interfaces/show/cmd.rs
@@ -144,7 +144,7 @@ fn convert_machines_to_nice_table(
     table.into()
 }
 
-#[doc = r"Function to print the machine interface in Table format"]
+///Function to print the machine interface in Table format
 fn convert_machine_to_nice_format(
     machine_interface: forgerpc::MachineInterface,
     domain_list: ::rpc::protos::dns::DomainList,

--- a/crates/admin-cli/src/measurement/bundle/args.rs
+++ b/crates/admin-cli/src/measurement/bundle/args.rs
@@ -26,7 +26,7 @@
  *  - `bundle show`: Show all details about measurement bundle(s).
  *  - `bundle list all`: List high level metadata about all bundles.
  *  - `bundle list machines`: List all matchines matching a given bundle.
-*/
+ */
 
 use std::str::FromStr;
 

--- a/crates/admin-cli/src/measurement/bundle/cmds.rs
+++ b/crates/admin-cli/src/measurement/bundle/cmds.rs
@@ -17,7 +17,6 @@
 
 //!
 //! `measurement bundle` subcommand dispatcher + backing functions.
-//!
 
 use std::str::FromStr;
 

--- a/crates/admin-cli/src/measurement/bundle/mod.rs
+++ b/crates/admin-cli/src/measurement/bundle/mod.rs
@@ -18,7 +18,6 @@
 //!
 //! Measured Boot CLI-backing args & commands for the `measurement bundle`
 //! subcommand.
-//!
 
 pub mod args;
 pub mod cmds;

--- a/crates/admin-cli/src/measurement/global/cmds.rs
+++ b/crates/admin-cli/src/measurement/global/cmds.rs
@@ -18,7 +18,6 @@
 //!
 //! Global commands at the root of the CLI, as well as some helper
 //! functions used by main.
-//!
 
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 

--- a/crates/admin-cli/src/measurement/global/mod.rs
+++ b/crates/admin-cli/src/measurement/global/mod.rs
@@ -18,6 +18,5 @@
 //!
 //! Measured Boot CLI-backing global/common functions used by other
 //! CLI subcommands.
-//!
 
 pub mod cmds;

--- a/crates/admin-cli/src/measurement/journal/args.rs
+++ b/crates/admin-cli/src/measurement/journal/args.rs
@@ -23,7 +23,7 @@
  *  - `journal show`: Show all info about journal entr(ies).
  *  - `journal list`: List all journal entries.
  *  - `journal promote`: Promote the report from a journal entry into a bundle.
-*/
+ */
 
 use ::rpc::admin_cli::CarbideCliError;
 use ::rpc::protos::measured_boot::{

--- a/crates/admin-cli/src/measurement/journal/cmds.rs
+++ b/crates/admin-cli/src/measurement/journal/cmds.rs
@@ -17,7 +17,6 @@
 
 //!
 //! `measurement journal` subcommand dispatcher + backing functions.
-//!
 
 use ::rpc::admin_cli::{
     CarbideCliError, CarbideCliResult, ToTable, cli_output, just_print_summary,

--- a/crates/admin-cli/src/measurement/journal/mod.rs
+++ b/crates/admin-cli/src/measurement/journal/mod.rs
@@ -18,7 +18,6 @@
 //!
 //! Measured Boot CLI-backing args & commands for the `measurement journal`
 //! subcommand.
-//!
 
 pub mod args;
 pub mod cmds;

--- a/crates/admin-cli/src/measurement/machine/args.rs
+++ b/crates/admin-cli/src/measurement/machine/args.rs
@@ -24,7 +24,7 @@
  *  - `mock-machine attest`: Sends a measurement report for a mock machine.
  *  - `mock-machine show [id]`: Shows detailed info about mock machine(s).
  *  - `mock-machine list``: Lists all mock machines.
-*/
+ */
 
 use ::rpc::admin_cli::CarbideCliError;
 use ::rpc::protos::measured_boot::{

--- a/crates/admin-cli/src/measurement/machine/cmds.rs
+++ b/crates/admin-cli/src/measurement/machine/cmds.rs
@@ -17,7 +17,6 @@
 
 //!
 //! `measurement mock-machine` subcommand dispatcher + backing functions.
-//!
 
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, ToTable, cli_output};
 use ::rpc::protos::measured_boot::ShowCandidateMachineRequest;

--- a/crates/admin-cli/src/measurement/machine/mod.rs
+++ b/crates/admin-cli/src/measurement/machine/mod.rs
@@ -18,7 +18,6 @@
 //!
 //! Measured Boot CLI-backing args & commands for the `measurement
 //! mock-machine` subcommand.
-//!
 
 pub mod args;
 pub mod cmds;

--- a/crates/admin-cli/src/measurement/mod.rs
+++ b/crates/admin-cli/src/measurement/mod.rs
@@ -18,7 +18,6 @@
 //!
 //! `measurement` subcommand module, containing other subcommands,
 //! dispatchers, args, and backing functions.
-//!
 
 pub mod bundle;
 pub mod global;

--- a/crates/admin-cli/src/measurement/profile/args.rs
+++ b/crates/admin-cli/src/measurement/profile/args.rs
@@ -26,7 +26,7 @@
  *  - `profile list all`: List high level info about all profiles.
  *  - `profile list bundles`: List all bundles for a given profile.
  *  - `profile list machines`: List all machines for a given profile.
-*/
+ */
 
 use std::str::FromStr;
 

--- a/crates/admin-cli/src/measurement/profile/cmds.rs
+++ b/crates/admin-cli/src/measurement/profile/cmds.rs
@@ -17,7 +17,6 @@
 
 //!
 //! `measurement profile` subcommand dispatcher + backing functions.
-//!
 
 use std::str::FromStr;
 

--- a/crates/admin-cli/src/measurement/profile/mod.rs
+++ b/crates/admin-cli/src/measurement/profile/mod.rs
@@ -18,7 +18,6 @@
 //!
 //! Measured Boot CLI-backing args & commands for the `measurement prpfile`
 //! subcommand.
-//!
 
 pub mod args;
 pub mod cmds;

--- a/crates/admin-cli/src/measurement/report/args.rs
+++ b/crates/admin-cli/src/measurement/report/args.rs
@@ -29,7 +29,7 @@
  *  - `report list all`: List high level info about all reports.
  *  - `report list machine`: List all reports for a given machine.
  *  - `report match``
-*/
+ */
 
 use ::rpc::protos::measured_boot::{
     CreateMeasurementReportRequest, DeleteMeasurementReportRequest, ListMeasurementReportRequest,

--- a/crates/admin-cli/src/measurement/report/cmds.rs
+++ b/crates/admin-cli/src/measurement/report/cmds.rs
@@ -17,7 +17,6 @@
 
 //!
 //! `measurement report` subcommand dispatcher + backing functions.
-//!
 
 use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, ToTable, cli_output};
 use ::rpc::protos::measured_boot::ListMeasurementReportRequest;

--- a/crates/admin-cli/src/measurement/report/mod.rs
+++ b/crates/admin-cli/src/measurement/report/mod.rs
@@ -18,7 +18,6 @@
 //!
 //! Measured Boot CLI-backing args & commands for the `measurement report`
 //! subcommand.
-//!
 
 pub mod args;
 pub mod cmds;

--- a/crates/admin-cli/src/measurement/site/args.rs
+++ b/crates/admin-cli/src/measurement/site/args.rs
@@ -27,7 +27,7 @@
  *  - `site trusted-profile approve`: Create a trusted profile approval.
  *  - `site trusted-profile remove`: Remove a trusted profile approval.
  *  - `site trusted-profile list`: List all trusted profile approvals.
-*/
+ */
 
 use ::rpc::protos::measured_boot::{
     AddMeasurementTrustedMachineRequest, AddMeasurementTrustedProfileRequest,

--- a/crates/admin-cli/src/measurement/site/cmds.rs
+++ b/crates/admin-cli/src/measurement/site/cmds.rs
@@ -17,7 +17,6 @@
 
 //!
 //! `measurement site` subcommand dispatcher + backing functions.
-//!
 
 use std::fs::File;
 use std::io::BufReader;

--- a/crates/admin-cli/src/measurement/site/mod.rs
+++ b/crates/admin-cli/src/measurement/site/mod.rs
@@ -18,7 +18,6 @@
 //!
 //! Measured Boot CLI-backing args & commands for the `measurement site`
 //! subcommand.
-//!
 
 pub mod args;
 pub mod cmds;

--- a/crates/agent/src/nvue.rs
+++ b/crates/agent/src/nvue.rs
@@ -514,7 +514,6 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
 /// exceed predefined limits.
 ///
 /// * `rules` - A list of network security group rules
-///
 #[allow(clippy::type_complexity)]
 fn prepare_network_security_group_rules(
     rules: Vec<NetworkSecurityGroupRule>,
@@ -603,7 +602,6 @@ fn prepare_network_security_group_rules(
 /// groups will be returned.
 ///
 /// * `nsgs` - A list of references to network security groups to expand.
-///
 fn expand_network_security_group_rules(
     rules: Vec<&NetworkSecurityGroupRule>,
 ) -> Vec<TmplNetworkSecurityGroupRule> {
@@ -1180,7 +1178,6 @@ struct TmplComputeTenant {
     /// a pool of VNIs to assign as we see fit, so we carve out blocks
     /// per-site, and then manage them via the VPC_VNI (vpc-vni) resource
     /// pool.
-    ///
     // TODO(chet): Does this need to be a string?
     L3VNI: String,
 

--- a/crates/api-db/src/compute_allocation.rs
+++ b/crates/api-db/src/compute_allocation.rs
@@ -61,7 +61,6 @@ impl<'r> sqlx::FromRow<'r, PgRow> for Sum {
 ///   details about the ComputeAllocation
 /// * `count`                  - The amount of compute (# of machines) to allocate.
 /// * `instance_type_id`       - The type of machines being allocated.
-///
 pub async fn create(
     txn: &mut PgConnection,
     id: &ComputeAllocationId,
@@ -112,7 +111,6 @@ pub async fn create(
 ///   org to match against ComputeAllocation records.
 /// * `for_update`             - A boolean flag to acquire DB locks for
 ///   synchronization
-///
 pub async fn find_ids(
     txn: &mut PgConnection,
     name: Option<&str>,
@@ -247,7 +245,6 @@ pub async fn sum_allocations(
 ///   matches the record in advance.***
 /// * `updated_by`             - Optional String containing an ID to track the user who updated the
 ///   ComputeAllocation
-///
 pub async fn update(
     txn: &mut PgConnection,
     id: &ComputeAllocationId,
@@ -316,7 +313,6 @@ pub async fn update(
 ///   that owns the ComputeAllocation.  The delete will be ignored if this ID does not match that of
 ///   the requested record. ***Callers are expected to verify the relationship prior to calling this
 ///   function.***
-///
 pub async fn soft_delete(
     txn: &mut PgConnection,
     compute_allocation_id: &ComputeAllocationId,

--- a/crates/api-db/src/db_read.rs
+++ b/crates/api-db/src/db_read.rs
@@ -56,11 +56,15 @@ use sqlx::{Database, Describe, Either, Execute, PgConnection, PgExecutor, PgPool
 /// use db::db_read::DbReader;
 /// async fn two_db_calls<DB>(db: &mut DB) -> sqlx::Result<()>
 /// where
-///     for<'db> &'db mut DB: DbReader<'db>
+///     for<'db> &'db mut DB: DbReader<'db>,
 /// {
 ///     // Use `&mut *db` to avoid moving
-///     sqlx::query_scalar::<_, String>("SELECT 'test'").fetch_one(&mut *db).await?;
-///     sqlx::query_scalar::<_, String>("SELECT 'test'").fetch_one(db).await?;
+///     sqlx::query_scalar::<_, String>("SELECT 'test'")
+///         .fetch_one(&mut *db)
+///         .await?;
+///     sqlx::query_scalar::<_, String>("SELECT 'test'")
+///         .fetch_one(db)
+///         .await?;
 ///     Ok(())
 /// }
 /// ```
@@ -109,7 +113,7 @@ use sqlx::{Database, Describe, Either, Execute, PgConnection, PgExecutor, PgPool
 ///     // the downside is that you have to type out the generics and HRTB lines:
 ///     pub async fn callable_from_all_but_pgpool<DB>(db: &mut DB) -> sqlx::Result<String>
 ///     where
-///         for<'db> &'db mut DB: DbReader<'db>
+///         for<'db> &'db mut DB: DbReader<'db>,
 ///     {
 ///         sqlx::query_scalar("SELECT 'test'").fetch_one(db).await
 ///     }
@@ -118,7 +122,7 @@ use sqlx::{Database, Describe, Either, Execute, PgConnection, PgExecutor, PgPool
 ///     /// PgConnection, nor PgPoolReader.
 ///     pub async fn callable_from_pgpool_only<DB>(db: &DB) -> sqlx::Result<String>
 ///     where
-///         for<'db> &'db DB: DbReader<'db>
+///         for<'db> &'db DB: DbReader<'db>,
 ///     {
 ///         sqlx::query_scalar("SELECT 'test'").fetch_one(db).await
 ///     }

--- a/crates/api-db/src/dhcp_entry.rs
+++ b/crates/api-db/src/dhcp_entry.rs
@@ -22,7 +22,6 @@ use super::DatabaseError;
 /// A machine dhcp response is a representation of some booting interface by Mac Address or DUID
 /// (not implemented) that returns the network information for that interface on that node, and
 /// contains everything necessary to return a DHCP response
-///
 #[derive(Debug, FromRow)]
 pub struct DhcpEntry {
     pub machine_interface_id: MachineInterfaceId,

--- a/crates/api-db/src/dns/domain.rs
+++ b/crates/api-db/src/dns/domain.rs
@@ -147,8 +147,6 @@ async fn persist_inner_with_metadata(
 /// * [`ObjectColumnFilter`] - An enum that determines the query criteria
 ///
 /// # Examples
-///
-///
 pub async fn find_by<'a, C: ColumnInfo<'a, TableType = Domain>>(
     txn: impl DbReader<'_>,
     filter: ObjectColumnFilter<'a, C>,

--- a/crates/api-db/src/extension_service.rs
+++ b/crates/api-db/src/extension_service.rs
@@ -41,7 +41,6 @@ use crate::{DatabaseError, DatabaseResult};
 /// * `observability`          - Observability config for the extension service
 /// * `has_credential`         - Whether the initial extension service version has a credential
 ///   stored in the vault
-///
 #[allow(clippy::too_many_arguments)]
 pub async fn create(
     txn: &mut PgConnection,
@@ -122,7 +121,6 @@ pub async fn create(
 /// * `observability`          - Observability config for the extension service
 /// * `has_credential`         - Whether the new extension service version has a credential stored
 ///   in vault
-///
 #[allow(clippy::too_many_arguments)]
 pub async fn update(
     txn: &mut PgConnection,
@@ -267,7 +265,6 @@ pub async fn update_metadata(
 ///
 /// # Returns
 /// A vector of matching `ExtensionServiceId`s (may be empty).
-///
 pub async fn find_ids(
     txn: &mut PgConnection,
     service_type: Option<ExtensionServiceType>,
@@ -315,7 +312,6 @@ pub async fn find_ids(
 /// * `txn`        - A reference to an active DB transaction
 /// * `ids`        - A list of extension service IDs to query
 /// * `for_update` - Whether to lock the extension services for update
-///
 pub async fn find_by_ids(
     txn: &mut PgConnection,
     ids: &[ExtensionServiceId],
@@ -397,7 +393,6 @@ pub async fn find_snapshots_by_ids(
 /// * `txn`        - A reference to an active DB transaction
 /// * `service_id` - The ID of the extension service
 /// * `version`    - Optional specific version number to retrieve. If None, returns the latest version
-///
 pub async fn find_version_info(
     txn: &mut PgConnection,
     service_id: ExtensionServiceId,
@@ -462,7 +457,6 @@ pub async fn find_version_info(
 /// * `txn`        - A reference to an active DB transaction
 /// * `service_id` - The ID of the extension service
 /// * `versions`   - Optional slice of version numbers to filter by. If None, returns all version infos.
-///
 pub async fn find_versions_info(
     txn: &mut PgConnection,
     service_id: &ExtensionServiceId,
@@ -500,7 +494,6 @@ pub async fn find_versions_info(
 /// # Parameters
 /// * `txn`        - A reference to an active DB transaction
 /// * `service_id` - The ID of the extension service
-///
 pub async fn find_all_versions(
     txn: impl DbReader<'_>,
     service_id: ExtensionServiceId,
@@ -525,7 +518,6 @@ pub async fn find_all_versions(
 ///
 /// # Returns
 /// A map of extension service IDs to their active versions
-///
 pub async fn find_versions_by_service_ids(
     txn: &mut PgConnection,
     service_ids: &[ExtensionServiceId],
@@ -576,7 +568,6 @@ pub async fn find_versions_by_service_ids(
 /// * `Some(service_id)` if the service was successfully soft deleted
 /// * `None` if the service is already deleted or not found
 /// * `Err` if there is a database error other than RowNotFound
-///
 pub async fn soft_delete_service(
     txn: &mut PgConnection,
     service_id: ExtensionServiceId,
@@ -607,7 +598,6 @@ pub async fn soft_delete_service(
 /// # Returns
 /// A vector of version numbers that were successfully soft deleted (excluding ones that were
 /// already deleted or missing).
-///
 pub async fn soft_delete_versions(
     txn: &mut PgConnection,
     service_id: ExtensionServiceId,
@@ -643,7 +633,6 @@ pub async fn soft_delete_versions(
 /// * `txn`        - A reference to an active DB transaction
 /// * `service_id` - The ID of the extension service
 /// * `versions`   - Optional slice of version numbers to check if the service is in use by any instance
-///
 pub async fn is_service_in_use(
     txn: &mut PgConnection,
     service_id: ExtensionServiceId,
@@ -692,7 +681,6 @@ pub async fn is_service_in_use(
 /// * `txn`        - A reference to an active DB transaction
 /// * `service_id` - The ID of the extension service
 /// * `versions`   - Optional slice of version numbers to check if the service has credentials
-///
 pub async fn find_versions_with_credentials(
     txn: &mut PgConnection,
     service_id: ExtensionServiceId,

--- a/crates/api-db/src/ib_partition.rs
+++ b/crates/api-db/src/ib_partition.rs
@@ -96,7 +96,6 @@ pub async fn create(
 /// Retrieves the IDs of all IB partition
 ///
 /// * `txn` - A reference to a currently open database transaction
-///
 pub async fn list_segment_ids(txn: &mut PgConnection) -> Result<Vec<IBPartitionId>, DatabaseError> {
     let query = "SELECT id FROM ib_partitions";
     let mut results = Vec::new();

--- a/crates/api-db/src/lib.rs
+++ b/crates/api-db/src/lib.rs
@@ -289,7 +289,6 @@ pub trait ColumnInfo<'a>: Clone + Copy {
 
 ///
 /// Wraps a sqlx::Error and records location and query
-///
 #[derive(Debug)]
 pub struct AnnotatedSqlxError {
     file: &'static str,

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -16,7 +16,6 @@
  */
 //!
 //! Machine - represents a database-backed Machine object
-//!
 
 use std::collections::HashMap;
 use std::net::IpAddr;
@@ -83,7 +82,6 @@ lazy_static! {
 ///
 /// * `txn` - A reference to a currently open database transaction
 /// * `interface` - Network interface of the machine
-///
 pub async fn get_or_create(
     txn: &mut PgConnection,
     common_pools: Option<&CommonPools>,
@@ -185,7 +183,6 @@ pub async fn find_existing_machine(
 ///
 /// * `txn` - A reference to a currently open database transaction
 /// * `state` - A reference to a MachineState enum
-///
 // TODO: abhi, Make it private.
 pub async fn advance(
     machine: &Machine,
@@ -1820,7 +1817,6 @@ pub async fn update_failure_details_by_machine_id(
 /// Arguments
 ///
 /// * `txn` - A reference to currently open database transaction
-///
 pub async fn find_dpu_ids_and_loopback_ips(
     txn: &mut PgConnection,
 ) -> Result<Vec<DpuInfo>, DatabaseError> {

--- a/crates/api-db/src/machine_state_history.rs
+++ b/crates/api-db/src/machine_state_history.rs
@@ -54,7 +54,6 @@ impl From<DbMachineStateHistory> for model::machine::MachineStateHistory {
 /// Arguments:
 ///
 /// * `txn` - A reference to an open Transaction
-///
 pub async fn find_by_machine_ids(
     txn: &mut PgConnection,
     ids: &[MachineId],

--- a/crates/api-db/src/managed_host.rs
+++ b/crates/api-db/src/managed_host.rs
@@ -16,7 +16,6 @@
  */
 //!
 //! Database access methods for manipulating the state of a ManagedHost (Host+DPUs)
-//!
 
 use std::collections::HashMap;
 use std::ops::Deref;

--- a/crates/api-db/src/measured_boot/bundle.rs
+++ b/crates/api-db/src/measured_boot/bundle.rs
@@ -18,7 +18,7 @@
 /*!
  *  Code for working the measurement_bundles and measurement_bundles_values
  *  tables in the database, leveraging the bundle-specific record types.
-*/
+ */
 
 use std::collections::{BTreeMap, HashMap};
 

--- a/crates/api-db/src/measured_boot/interface/bundle.rs
+++ b/crates/api-db/src/measured_boot/interface/bundle.rs
@@ -18,7 +18,7 @@
 /*!
  *  Code for working the measurement_bundles and measurement_bundles_values
  *  tables in the database, leveraging the bundle-specific record types.
-*/
+ */
 
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::measured_boot::{MeasurementBundleId, MeasurementSystemProfileId};

--- a/crates/api-db/src/measured_boot/interface/common.rs
+++ b/crates/api-db/src/measured_boot/interface/common.rs
@@ -18,7 +18,7 @@
 /*!
  *  Common code for working with the database. Provides constants and generics
  *  for making boilerplate copy-pasta code handled in a common way.
-*/
+ */
 
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;

--- a/crates/api-db/src/measured_boot/interface/journal.rs
+++ b/crates/api-db/src/measured_boot/interface/journal.rs
@@ -18,7 +18,7 @@
 /*!
  *  Code for working the measuremment_journal and measurement_journal_values
  *  tables in the database, leveraging the journal-specific record types.
-*/
+ */
 
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::measured_boot::{

--- a/crates/api-db/src/measured_boot/interface/machine.rs
+++ b/crates/api-db/src/measured_boot/interface/machine.rs
@@ -18,7 +18,7 @@
 /*!
  *  Code for working the machine_topologies table in the
  *  database, leveraging the machine-specific record types.
-*/
+ */
 
 use carbide_uuid::machine::MachineId;
 use measured_boot::records::{MeasurementJournalRecord, MeasurementMachineState};

--- a/crates/api-db/src/measured_boot/interface/profile.rs
+++ b/crates/api-db/src/measured_boot/interface/profile.rs
@@ -18,7 +18,7 @@
 /*!
  *  Code for working the measurement_system_profiles and measurement_system_profiles_attrs
  *  tables in the database, leveraging the profile-specific record types.
-*/
+ */
 
 use std::collections::HashMap;
 

--- a/crates/api-db/src/measured_boot/interface/report.rs
+++ b/crates/api-db/src/measured_boot/interface/report.rs
@@ -18,7 +18,7 @@
 /*!
  *  Code for working the measuremment_reports and measurement_reports_values
  *  tables in the database, leveraging the report-specific record types.
-*/
+ */
 
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::measured_boot::MeasurementReportId;

--- a/crates/api-db/src/measured_boot/interface/site.rs
+++ b/crates/api-db/src/measured_boot/interface/site.rs
@@ -18,7 +18,7 @@
 /*!
  *  Code for working the measurement_trusted_machines and measurement_trusted_profiles
  *  tables in the database, leveraging the site-specific record types.
-*/
+ */
 
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::measured_boot::{

--- a/crates/api-db/src/measured_boot/journal.rs
+++ b/crates/api-db/src/measured_boot/journal.rs
@@ -18,7 +18,7 @@
 /*!
  *  Code for working the measuremment_journal and measurement_journal_values
  *  tables in the database, leveraging the journal-specific record types.
-*/
+ */
 
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::measured_boot::{

--- a/crates/api-db/src/measured_boot/machine.rs
+++ b/crates/api-db/src/measured_boot/machine.rs
@@ -18,7 +18,7 @@
 /*!
  *  Code for working the machine_topologies table in the
  *  database to match candidate machines to profiles and bundles.
-*/
+ */
 
 use std::collections::HashMap;
 

--- a/crates/api-db/src/measured_boot/profile.rs
+++ b/crates/api-db/src/measured_boot/profile.rs
@@ -18,7 +18,7 @@
 /*!
  *  Code for working the measurement_system_profiles and measurement_system_profiles_attrs
  *  tables in the database, leveraging the profile-specific record types.
-*/
+ */
 
 use std::collections::HashMap;
 

--- a/crates/api-db/src/measured_boot/report.rs
+++ b/crates/api-db/src/measured_boot/report.rs
@@ -18,7 +18,7 @@
 /*!
  *  Code for working the measuremment_reports and measurement_reports_values
  *  tables in the database, leveraging the report-specific record types.
-*/
+ */
 
 use std::collections::HashMap;
 

--- a/crates/api-db/src/measured_boot/site.rs
+++ b/crates/api-db/src/measured_boot/site.rs
@@ -20,7 +20,7 @@
  *  tables in the database, leveraging the site-specific record types.
  *
  * This also provides code for importing/exporting (and working with) SiteModels.
-*/
+ */
 
 use measured_boot::site::SiteModel;
 use sqlx::PgConnection;

--- a/crates/api-db/src/network_security_group.rs
+++ b/crates/api-db/src/network_security_group.rs
@@ -43,7 +43,6 @@ use crate::DatabaseError;
 /// * `stateful_egress`        - Whether egress rules are stateful.
 /// * `rules`                  - A slice of NetworkSecurityGroupRule containing the ACLs
 ///   of the NetworkSecurityGroup
-///
 pub async fn create(
     txn: &mut PgConnection,
     id: &NetworkSecurityGroupId,
@@ -94,7 +93,6 @@ pub async fn create(
 ///   org to match against NetworkSecurityGroup records.
 /// * `for_update`             - A boolean flag to acquire DB locks for
 ///   synchronization
-///
 pub async fn find_ids(
     txn: &mut PgConnection,
     name: Option<&str>,
@@ -406,7 +404,6 @@ pub async fn get_propagation_status(
 ///   in advance.***
 /// * `updated_by`             - Optional String containing an ID to track the user who updated the
 ///   NetworkSecurityGroup
-///
 #[allow(clippy::too_many_arguments)]
 pub async fn update(
     txn: &mut PgConnection,
@@ -480,7 +477,6 @@ pub async fn update(
 ///   that owns the NetworkSecurityGroup.  The delete
 ///   will be ignored if this ID does not match that of the requested record.
 ///   ***Callers are expected to verify the relationship prior to calling this function.***
-///
 pub async fn soft_delete(
     txn: &mut PgConnection,
     network_security_group_id: &NetworkSecurityGroupId,

--- a/crates/api-db/src/nvl_logical_partition.rs
+++ b/crates/api-db/src/nvl_logical_partition.rs
@@ -83,7 +83,6 @@ pub async fn create(
 /// Retrieves the IDs of all NvLink partitions
 ///
 /// * `txn` - A reference to a currently open database transaction
-///
 pub async fn for_tenant(
     txn: impl DbReader<'_>,
     tenant_organization_id: String,

--- a/crates/api-db/src/nvl_partition.rs
+++ b/crates/api-db/src/nvl_partition.rs
@@ -65,7 +65,6 @@ pub async fn create(
 /// Retrieves the IDs of all NvLink partitions
 ///
 /// * `txn` - A reference to a currently open database transaction
-///
 pub async fn for_tenant(
     txn: impl DbReader<'_>,
     tenant_organization_id: String,

--- a/crates/api-db/src/power_shelf_state_history.rs
+++ b/crates/api-db/src/power_shelf_state_history.rs
@@ -53,7 +53,6 @@ impl From<DbPowerShelfStateHistoryRecord> for PowerShelfStateHistoryRecord {
 /// Arguments:
 ///
 /// * `txn` - A reference to an open Transaction
-///
 pub async fn find_by_power_shelf_ids(
     txn: &mut PgConnection,
     ids: &[PowerShelfId],

--- a/crates/api-db/src/rack_state_history.rs
+++ b/crates/api-db/src/rack_state_history.rs
@@ -30,7 +30,6 @@ use crate::{DatabaseError, DatabaseResult};
 /// Arguments:
 ///
 /// * `txn` - A reference to an open Transaction
-///
 pub async fn find_by_rack_ids(
     txn: &mut PgConnection,
     ids: &[RackId],

--- a/crates/api-db/src/switch_state_history.rs
+++ b/crates/api-db/src/switch_state_history.rs
@@ -53,7 +53,6 @@ impl From<DbSwitchStateHistoryRecord> for SwitchStateHistoryRecord {
 /// Arguments:
 ///
 /// * `txn` - A reference to an open Transaction
-///
 pub async fn find_by_switch_ids(
     txn: &mut PgConnection,
     ids: &[SwitchId],

--- a/crates/api-model/src/dhcp_record.rs
+++ b/crates/api-model/src/dhcp_record.rs
@@ -29,7 +29,6 @@ use sqlx::FromRow;
 /// contains everything necessary to return a DHCP response.
 ///
 /// A DhcpRecord is populated by a database view (named machine_dhcp_records).
-///
 #[derive(Debug, FromRow)]
 pub struct DhcpRecord {
     pub machine_id: Option<MachineId>,

--- a/crates/api-model/src/dpa_interface/mod.rs
+++ b/crates/api-model/src/dpa_interface/mod.rs
@@ -489,7 +489,6 @@ impl From<DpaInterface> for rpc::forge::DpaInterface {
 }
 
 /// A record of a past state of a DpaInterface
-///
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct DpaInterfaceStateHistoryRecord {
     /// The UUID of the dpa interface that experienced the state change

--- a/crates/api-model/src/dpu_machine_update.rs
+++ b/crates/api-model/src/dpu_machine_update.rs
@@ -41,7 +41,6 @@ impl DpuMachineUpdate {
     /// 6. If some of the DPUs for a managed host need upgrade, put them in queue.
     ///    6.1. Make sure none of the DPU is under reprovisioning while queuing a new DPU for a
     ///    managedhost. This is done by confirming that Host is not marked for updates
-    ///
     pub fn find_available_outdated_dpus(
         limit: Option<i32>,
         dpu_nic_firmware_update_versions: &[String],

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -668,7 +668,6 @@ impl Default for MachineLastRebootRequested {
 
 ///
 /// A machine is a standalone system that performs network booting via normal DHCP processes.
-///
 #[derive(Debug, Clone)]
 pub struct Machine {
     /// The ID of the machine, this is an internal identifier in the database that's unique for

--- a/crates/api-model/src/machine_boot_override.rs
+++ b/crates/api-model/src/machine_boot_override.rs
@@ -21,7 +21,6 @@ use sqlx::{FromRow, Row};
 
 ///
 /// A custom boot response is a representation of custom data for booting machines, either with pxe or user-data
-///
 #[derive(Debug, sqlx::Encode)]
 pub struct MachineBootOverride {
     pub machine_interface_id: MachineInterfaceId,

--- a/crates/api-model/src/network_security_group/mod.rs
+++ b/crates/api-model/src/network_security_group/mod.rs
@@ -370,7 +370,6 @@ impl TryFrom<rpc::NetworkSecurityGroupRuleAction> for NetworkSecurityGroupRuleAc
 /// destination network to look for when matching
 /// network traffic. It can be either an explicit prefix
 /// or defined by an object ID.
-///
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub enum NetworkSecurityGroupRuleNet {
     Prefix(ipnetwork::IpNetwork),
@@ -470,7 +469,6 @@ impl TryFrom<NetworkSecurityGroupRuleNet>
 /// NetworkSecurityGroupRule holds the details of a
 /// single rule that will be applied on a DPU to restrict
 /// traffic.
-///
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct NetworkSecurityGroupRule {
     pub id: Option<String>,
@@ -646,7 +644,6 @@ impl TryFrom<NetworkSecurityGroupRule> for rpc::NetworkSecurityGroupRuleAttribut
 /// NetworkSecurityGroup represents a collection of L4 traffic
 /// ACLs to permit or deny network traffic based on a set of
 /// matching properties.
-///
 #[derive(Clone, Debug, PartialEq)]
 pub struct NetworkSecurityGroup {
     pub id: NetworkSecurityGroupId,
@@ -711,7 +708,6 @@ impl TryFrom<NetworkSecurityGroup> for rpc::NetworkSecurityGroup {
 
 /// NetworkSecurityGroupAttachments holds lists of objects that have
 /// the NetworkSecurityGroup attached.
-///
 #[derive(Clone, Debug, PartialEq)]
 pub struct NetworkSecurityGroupAttachments {
     pub id: NetworkSecurityGroupId,
@@ -749,7 +745,6 @@ impl From<NetworkSecurityGroupAttachments> for rpc::NetworkSecurityGroupAttachme
 /// underlying objects that do not have a more specific NSG applied.
 /// For example, for a VPC to be fully propagated, all interfaces
 /// of all instances under that VPC must be fully propagated.
-///
 #[derive(Clone, Debug, PartialEq)]
 pub struct NetworkSecurityGroupPropagationObjectStatus {
     pub id: String,

--- a/crates/api-model/src/network_segment/mod.rs
+++ b/crates/api-model/src/network_segment/mod.rs
@@ -483,7 +483,6 @@ impl<'r> FromRow<'r, PgRow> for NetworkSegment {
 /// subdomain_id - Converting from Protobuf UUID(String) to Rust UUID type can fail.
 /// Use try_from in order to return a Result where Result is an error if the conversion
 /// from String -> UUID fails
-///
 impl TryFrom<rpc::forge::NetworkSegmentCreationRequest> for NewNetworkSegment {
     type Error = RpcDataConversionError;
 
@@ -541,7 +540,6 @@ impl TryFrom<rpc::forge::NetworkSegmentCreationRequest> for NewNetworkSegment {
 /// Marshal a Data Object (NetworkSegment) into an RPC NetworkSegment
 ///
 /// subdomain_id - Rust UUID -> ProtoBuf UUID(String) cannot fail, so convert it or return None
-///
 impl TryFrom<NetworkSegment> for rpc::NetworkSegment {
     type Error = RpcDataConversionError;
     fn try_from(src: NetworkSegment) -> Result<Self, Self::Error> {

--- a/crates/api-model/src/network_segment_state_history.rs
+++ b/crates/api-model/src/network_segment_state_history.rs
@@ -22,7 +22,6 @@ use sqlx::postgres::PgRow;
 use sqlx::{FromRow, Row};
 
 /// A record of a past state of a NetworkSegment
-///
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkSegmentStateHistory {
     /// The numeric identifier of the state change. This is a global change number

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -149,7 +149,6 @@ impl<'r> FromRow<'r, PgRow> for Rack {
 ///                                                         v
 ///                                                       Ready
 /// ```
-///
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "state", rename_all = "snake_case")]
 pub enum RackState {

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -966,7 +966,6 @@ impl Forge for Api {
     /// [vlan-id]
     /// type = "integer"
     /// ranges = [{ start = "100", end = "501" }]
-    ///
     async fn admin_grow_resource_pool(
         &self,
         request: Request<rpc::GrowResourcePoolRequest>,

--- a/crates/api/src/handlers/dns.rs
+++ b/crates/api/src/handlers/dns.rs
@@ -113,7 +113,6 @@ async fn lookup_records_by_qname(
 /// 1. Queries the dns_records view for all matching records (A, AAAA, CNAME, etc.)
 /// 2. If the qname matches a domain we're authoritative for, includes the SOA record
 /// 3. Returns everything - PowerDNS decides what to include in the final packet
-///
 async fn lookup_any_record<DB>(
     txn: &mut DB,
     query_name: &str,

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -17,7 +17,6 @@
 
 //!
 //! The Carbide API server library.
-//!
 
 // It's too cumbersome for tests to adhere to these, which are less important in testing anyway.
 #![cfg_attr(test, allow(txn_held_across_await))]

--- a/crates/api/src/measured_boot/mod.rs
+++ b/crates/api/src/measured_boot/mod.rs
@@ -17,7 +17,6 @@
 
 //!
 //! Carbide API module specific to measured boot/machine attestation.
-//!
 
 pub mod metrics_collector;
 pub mod rpc;

--- a/crates/api/src/measured_boot/tests/mod.rs
+++ b/crates/api/src/measured_boot/tests/mod.rs
@@ -17,7 +17,6 @@
 
 //!
 //! Measured boot unit testing module.
-//!
 
 pub mod common;
 mod integration;

--- a/crates/api/src/measured_boot/tests/rpc.rs
+++ b/crates/api/src/measured_boot/tests/rpc.rs
@@ -17,7 +17,7 @@
 
 /*!
  *  RPC handler tests for measured boot.
-*/
+ */
 
 #[cfg(test)]
 mod tests {

--- a/crates/dhcp-server/src/cache.rs
+++ b/crates/dhcp-server/src/cache.rs
@@ -20,7 +20,6 @@
 /// We usually get about four DHCP requests from the same host in rapid succession, so this
 /// prevents us asking the API server every time. Cache is optional, and contents should
 /// be short lived.
-///
 use std::{
     net::IpAddr,
     time::{Duration, Instant},

--- a/crates/dhcp-server/src/vendor_class.rs
+++ b/crates/dhcp-server/src/vendor_class.rs
@@ -91,7 +91,6 @@ impl Display for MachineArchitecture {
 
 ///
 /// Convert a string of the form A:B:C:D... to Self
-///
 impl FromStr for VendorClass {
     type Err = VendorClassParseError;
 

--- a/crates/dhcp/src/cache.rs
+++ b/crates/dhcp/src/cache.rs
@@ -22,7 +22,6 @@
 /// be short lived.
 ///
 /// The cache is a static because we are called from Kea's hooks, potentially from multiple threads.
-///
 use std::{
     net::IpAddr,
     sync::Mutex,

--- a/crates/dhcp/src/discovery.rs
+++ b/crates/dhcp/src/discovery.rs
@@ -129,7 +129,6 @@ where
 ///
 /// This function is only safe to be called on a `ctx` which is either a null pointer
 /// or a valid `DiscoveryBuilderFFI` object.
-///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn discovery_set_client_system(
     ctx: *mut DiscoveryBuilderFFI,
@@ -149,7 +148,6 @@ pub unsafe extern "C" fn discovery_set_client_system(
 ///
 /// This function is only safe to be called on a `ctx` which is either a null pointer
 /// or a valid `DiscoveryBuilderFFI` object.
-///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn discovery_set_vendor_class(
     ctx: *mut DiscoveryBuilderFFI,
@@ -177,7 +175,6 @@ pub unsafe extern "C" fn discovery_set_vendor_class(
 ///
 /// This function is only safe to be called on a `ctx` which is either a null pointer
 /// or a valid `DiscoveryBuilderFFI` object.
-///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn discovery_set_link_select(
     ctx: *mut DiscoveryBuilderFFI,
@@ -218,7 +215,6 @@ pub unsafe extern "C" fn discovery_set_desired_address(
 ///
 /// This function is only safe to be called on a `ctx` which is either a null pointer
 /// or a valid `DiscoveryBuilderFFI` object.
-///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn discovery_set_circuit_id(
     ctx: *mut DiscoveryBuilderFFI,
@@ -246,7 +242,6 @@ pub unsafe extern "C" fn discovery_set_circuit_id(
 ///
 /// This function is only safe to be called on a `ctx` which is either a null pointer
 /// or a valid `DiscoveryBuilderFFI` object.
-///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn discovery_set_remote_id(
     ctx: *mut DiscoveryBuilderFFI,
@@ -274,7 +269,6 @@ pub unsafe extern "C" fn discovery_set_remote_id(
 ///
 /// This function is only safe to be called on a `ctx` which is either a null pointer
 /// or a valid `DiscoveryBuilderFFI` object.
-///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn discovery_set_relay(
     ctx: *mut DiscoveryBuilderFFI,
@@ -297,7 +291,6 @@ pub unsafe extern "C" fn discovery_set_relay(
 ///
 /// `raw_parts` and `size` must describe a valid memory holding 6 bytes which make
 /// up a MAC address.
-///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn discovery_set_mac_address(
     ctx: *mut DiscoveryBuilderFFI,
@@ -509,7 +502,6 @@ unsafe fn discovery_fetch_machine_at(
 ///
 /// This does not forget the memory afterwards, so the opaque pointer in the C code is now
 /// unusable.
-///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn discovery_builder_free(ctx: *mut DiscoveryBuilderFFI) {
     unsafe {

--- a/crates/dhcp/src/lib.rs
+++ b/crates/dhcp/src/lib.rs
@@ -113,7 +113,6 @@ impl CarbideDhcpContext {
 /// # Safety
 /// Function is unsafe as it dereferences a raw pointer given to it.  Caller is responsible
 /// to validate that the pointer passed to it meets the necessary conditions to be dereferenced.
-///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn carbide_set_config_api(api: *const c_char) {
     unsafe {
@@ -128,7 +127,6 @@ pub unsafe extern "C" fn carbide_set_config_api(api: *const c_char) {
 /// # Safety
 ///
 /// None, todo!()
-///
 #[unsafe(no_mangle)]
 pub extern "C" fn carbide_set_config_next_server_ipv4(next_server: u32) {
     CONFIG.write().unwrap().provisioning_server_ipv4 =
@@ -140,7 +138,6 @@ pub extern "C" fn carbide_set_config_next_server_ipv4(next_server: u32) {
 /// # Safety
 /// Function is unsafe as it dereferences a raw pointer given to it.  Caller is responsible
 /// to validate that the pointer passed to it meets the necessary conditions to be dereferenced.
-///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn carbide_set_config_name_servers(nameservers: *const c_char) {
     unsafe {
@@ -154,7 +151,6 @@ pub unsafe extern "C" fn carbide_set_config_name_servers(nameservers: *const c_c
 /// # Safety
 /// Function is unsafe as it dereferences a raw pointer given to it.  Caller is responsible
 /// to validate that the pointer passed to it meets the necessary conditions to be dereferenced.
-///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn carbide_set_config_mqtt_server(mqttserver: *const c_char) {
     unsafe {
@@ -168,7 +164,6 @@ pub unsafe extern "C" fn carbide_set_config_mqtt_server(mqttserver: *const c_cha
 /// # Safety
 /// Function is unsafe as it dereferences a raw pointer given to it.  Caller is responsible
 /// to validate that the pointer passed to it meets the necessary conditions to be dereferenced.
-///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn carbide_set_config_ntp(ntpservers: *const c_char) {
     unsafe {
@@ -182,7 +177,6 @@ pub unsafe extern "C" fn carbide_set_config_ntp(ntpservers: *const c_char) {
 /// # Safety
 /// Function is unsafe as it dereferences a raw pointer given to it.  Caller is responsible
 /// to validate that the pointer passed to it meets the necessary conditions to be dereferenced.
-///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn carbide_set_config_metrics_endpoint(endpoint: *const c_char) {
     unsafe {

--- a/crates/dhcp/src/machine.rs
+++ b/crates/dhcp/src/machine.rs
@@ -31,7 +31,6 @@ use crate::vendor_class::{MachineArchitecture, VendorClass};
 ///
 /// This just stores the protobuf DHCP record and the discovery info the client used so we can add
 /// additional constraints (options) to and from the client.
-///
 #[derive(Debug, Clone)]
 pub struct Machine {
     pub inner: rpc::DhcpRecord,
@@ -86,7 +85,6 @@ impl Machine {
 ///
 /// This function dereferences a pointer to a Machine object which is an opaque pointer
 /// consumed in C code.
-///
 #[unsafe(no_mangle)]
 pub extern "C" fn machine_get_interface_router(ctx: *mut Machine) -> u32 {
     assert!(!ctx.is_null());
@@ -131,7 +129,6 @@ pub extern "C" fn machine_get_interface_router(ctx: *mut Machine) -> u32 {
 /// # Safety
 /// This function dereferences a pointer to a Machine object which is an opaque pointer
 /// consumed in C code.
-///
 #[unsafe(no_mangle)]
 pub extern "C" fn machine_get_interface_address(ctx: *mut Machine) -> u32 {
     assert!(!ctx.is_null());
@@ -158,7 +155,6 @@ pub extern "C" fn machine_get_interface_address(ctx: *mut Machine) -> u32 {
 ///
 /// # Safety
 /// This function checks for null pointer and unboxes into a machine object
-///
 #[unsafe(no_mangle)]
 pub extern "C" fn machine_get_interface_hostname(ctx: *mut Machine) -> *mut libc::c_char {
     assert!(!ctx.is_null());
@@ -173,7 +169,6 @@ pub extern "C" fn machine_get_interface_hostname(ctx: *mut Machine) -> *mut libc
 ///
 /// # Safety
 /// This function checks for null pointer and unboxes into a machine object
-///
 #[unsafe(no_mangle)]
 pub extern "C" fn machine_get_filename(ctx: *mut Machine) -> *const libc::c_char {
     assert!(!ctx.is_null());
@@ -413,7 +408,6 @@ pub extern "C" fn machine_free_ntpservers(ntpservers: *mut libc::c_char) {
 ///
 /// This function dereferences a pointer to a Machine object which is an opaque pointer
 /// consumed in C code.
-///
 #[unsafe(no_mangle)]
 pub extern "C" fn machine_get_interface_subnet_mask(ctx: *mut Machine) -> u32 {
     assert!(!ctx.is_null());
@@ -452,7 +446,6 @@ pub extern "C" fn machine_get_interface_mtu(ctx: *mut Machine) -> u16 {
 ///
 /// This does not forget the memory afterwards, so the opaque pointer in the C code is now
 /// unusable.
-///
 #[unsafe(no_mangle)]
 pub extern "C" fn machine_free(ctx: *mut Machine) {
     if ctx.is_null() {

--- a/crates/dhcp/src/mock_api_server.rs
+++ b/crates/dhcp/src/mock_api_server.rs
@@ -20,7 +20,6 @@
 /// last byte of the MAC address sent in the DISCOVERY packet.
 ///
 /// Module only included if #cfg(test)
-///
 use std::collections::HashMap;
 use std::net::{SocketAddr, SocketAddrV4};
 use std::str::FromStr;

--- a/crates/dhcp/src/vendor_class.rs
+++ b/crates/dhcp/src/vendor_class.rs
@@ -95,7 +95,6 @@ impl Display for MachineArchitecture {
 
 ///
 /// Convert a string of the form A:B:C:D... to Self
-///
 impl FromStr for VendorClass {
     type Err = VendorClassParseError;
 

--- a/crates/dns-record/src/lib.rs
+++ b/crates/dns-record/src/lib.rs
@@ -113,7 +113,7 @@ impl Display for DnsResourceRecordType {
 /// # Example
 ///
 /// ```rust
-/// use dns_record::{SoaRecord, Seconds};
+/// use dns_record::{Seconds, SoaRecord};
 /// let soa = SoaRecord {
 ///     primary_ns: "ns1.example.com".to_string(),
 ///     contact: "hostmaster.example.com".to_string(),

--- a/crates/dns/src/pdns/request.rs
+++ b/crates/dns/src/pdns/request.rs
@@ -71,7 +71,6 @@ impl TryFrom<&PdnsRequest> for rpc::protos::dns::GetAllDomainsRequest {
 /// This conversion is used to handle DNS lookup requests from PowerDNS, typically
 /// initiated by DNS clients (e.g., `dig` or `nslookup`). The request is validated
 /// and transformed into a format that can be submitted to `carbide-api`.
-///
 impl TryFrom<&PdnsRequest> for rpc::protos::dns::DnsResourceRecordLookupRequest {
     type Error = eyre::Report;
 

--- a/crates/libnmxm/src/nmxm_model.rs
+++ b/crates/libnmxm/src/nmxm_model.rs
@@ -20,7 +20,6 @@ use serde_derive::{Deserialize, Serialize};
 /// Use Option<type> to avoid breaking serde deserialize ops on receiving json responses with
 /// some struct fields missing.
 /// only id (_id) and uuid fields are safe to keep non-optional.
-///
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AsyncResponse {

--- a/crates/measured-boot/src/bundle.rs
+++ b/crates/measured-boot/src/bundle.rs
@@ -18,7 +18,7 @@
 /*!
  *  Code for working the measurement_bundles and measurement_bundles_values
  *  tables in the database, leveraging the bundle-specific record types.
-*/
+ */
 
 use carbide_uuid::measured_boot::{MeasurementBundleId, MeasurementSystemProfileId};
 #[cfg(feature = "cli")]

--- a/crates/measured-boot/src/journal.rs
+++ b/crates/measured-boot/src/journal.rs
@@ -18,7 +18,7 @@
 /*!
  *  Code for working the measuremment_journal and measurement_journal_values
  *  tables in the database, leveraging the journal-specific record types.
-*/
+ */
 
 use std::str::FromStr;
 

--- a/crates/measured-boot/src/machine.rs
+++ b/crates/measured-boot/src/machine.rs
@@ -18,7 +18,7 @@
 /*!
  *  Code for working the machine_topologies table in the
  *  database to match candidate machines to profiles and bundles.
-*/
+ */
 
 use std::collections::HashMap;
 use std::str::FromStr;

--- a/crates/measured-boot/src/pcr.rs
+++ b/crates/measured-boot/src/pcr.rs
@@ -18,7 +18,7 @@
 /*!
  *  Common code for working with the database. Provides constants and generics
  *  for making boilerplate copy-pasta code handled in a common way.
-*/
+ */
 
 use std::collections::HashSet;
 use std::convert::{From, Into};

--- a/crates/measured-boot/src/profile.rs
+++ b/crates/measured-boot/src/profile.rs
@@ -18,7 +18,7 @@
 /*!
  *  Code for working the measurement_system_profiles and measurement_system_profiles_attrs
  *  tables in the database, leveraging the profile-specific record types.
-*/
+ */
 
 use std::convert::{Into, TryFrom};
 

--- a/crates/measured-boot/src/records.rs
+++ b/crates/measured-boot/src/records.rs
@@ -25,7 +25,7 @@
  *
  *  There are type-specific primary/foreign key IDs to make it more explicit
  *  what type of key is being passed around. A bunch of uuid::Uuid is meh.
-*/
+ */
 
 use std::convert::Into;
 use std::error::Error;

--- a/crates/measured-boot/src/report.rs
+++ b/crates/measured-boot/src/report.rs
@@ -18,7 +18,7 @@
 /*!
  *  Code for working the measuremment_reports and measurement_reports_values
  *  tables in the database, leveraging the report-specific record types.
-*/
+ */
 
 use std::str::FromStr;
 

--- a/crates/measured-boot/src/site.rs
+++ b/crates/measured-boot/src/site.rs
@@ -20,7 +20,7 @@
  *  tables in the database, leveraging the site-specific record types.
  *
  * This also provides code for importing/exporting (and working with) SiteModels.
-*/
+ */
 
 use std::convert::{From, Into};
 use std::str::FromStr;

--- a/crates/network/src/virtualization.rs
+++ b/crates/network/src/virtualization.rs
@@ -39,7 +39,6 @@ pub const DEFAULT_NETWORK_VIRTUALIZATION_TYPE: VpcVirtualizationType =
 /// and plumb the value down to the DPU agent, which gets piped into
 /// the `update_nvue` function, which is then used to drive
 /// population of the appropriate template.
-///
 // TODO(chet): Rename
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]

--- a/crates/prost-builder/src/lib.rs
+++ b/crates/prost-builder/src/lib.rs
@@ -53,7 +53,6 @@
 //!    .vendor_string("Some vendor")
 //!    .rpc()
 //! ```
-//!
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -18,7 +18,6 @@
 //!
 //! This module contains the gRPC and protocol buffer definitions to generate a client or server to
 //! interact with the API Service
-//!
 
 extern crate core;
 

--- a/crates/uuid/src/typed_uuids.rs
+++ b/crates/uuid/src/typed_uuids.rs
@@ -39,7 +39,6 @@ pub trait UuidSubtype {
 /// impl UuidSubtype for ExampleFlavor {
 ///     const TYPE_NAME: &str = "ExampleId"
 /// }
-///
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
 pub struct TypedUuid<T: UuidSubtype> {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,16 @@
+# Requires nightly rustfmt — these are unstable options.
+# CI enforces via `cargo make check-format-nightly`.
+unstable_features = true
+
+edition = "2024"
+
+# Import organization: merge use statements at the module level and group
+# into std / external / crate sections separated by blank lines.
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"
+
+# Format Rust code snippets inside doc comments.
+format_code_in_doc_comments = true
+
+# Convert #[doc = "..."] attributes to /// doc comments.
+normalize_doc_attributes = true


### PR DESCRIPTION
Set `edition = "2024"` in rustfmt.toml

The resulting `cargo fmt` pass changes mostly mechanical things: import regrouping, doc comment normalization, trailing commas in where clauses, and chain expression wrapping.

Using `rustfmt.toml` allows engineers to use `rustfmt` as the formatter within their editor environment, rather than having to run' cargo make' afterward.



