### PR TITLE
feat: carbide-dpu-agent support for writing to the NVUE API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,6 +1325,7 @@ dependencies = [
  "tower 0.5.2",
  "tower-http",
  "tracing",
+ "urlencoding",
  "uuid",
  "uzers",
  "version-compare 0.2.1",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -94,6 +94,10 @@ opentelemetry_sdk = { workspace = true, features = [
 prometheus = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
+reqwest = { default-features = false, features = [
+  "rustls-tls",
+  "json",
+], workspace = true }
 resolv-conf = { workspace = true }
 rtnetlink = { workspace = true }
 rustls = { workspace = true }
@@ -111,6 +115,7 @@ prost = { workspace = true }
 tower = { workspace = true }
 tower-http = { features = ["trace"], workspace = true }
 tracing = { workspace = true }
+urlencoding = { workspace = true }
 uuid = { features = ["v4", "serde"], workspace = true }
 uzers = { workspace = true }
 version-compare = { workspace = true }
@@ -123,10 +128,6 @@ tonic-prost-build = { workspace = true }
 [dev-dependencies]
 ctor = { workspace = true }
 prost = { workspace = true }
-reqwest = { default-features = false, features = [
-  "rustls-tls",
-  "stream",
-], workspace = true }
 rustls-pemfile = { workspace = true }
 rustls-pki-types = { workspace = true }
 

--- a/crates/agent/src/command_line.rs
+++ b/crates/agent/src/command_line.rs
@@ -304,6 +304,31 @@ pub struct RunOptions {
                 When set, the agent sends config updates via gRPC instead of running embedded FMDS."
     )]
     pub fmds_grpc_server: Option<String>,
+    #[clap(
+        long,
+        help = "Address of the NVUE REST API (e.g. https://localhost:8765). \
+                When set, the agent applies NVUE config via the REST API instead of \
+                exec'ing into the HBN container."
+    )]
+    pub nvue_api_address: Option<String>,
+    #[clap(
+        long,
+        help = "Username for NVUE REST API basic auth. \
+                Format: env:<VAR>, file:<path>, or value:<literal> (plain string treated as value)."
+    )]
+    pub nvue_api_user: Option<String>,
+    #[clap(
+        long,
+        help = "Password for NVUE REST API basic auth. \
+                Format: env:<VAR>, file:<path>, or value:<literal> (plain string treated as value)."
+    )]
+    pub nvue_api_passwd: Option<String>,
+    #[clap(
+        long,
+        default_value = "false",
+        help = "Skip TLS certificate verification for the NVUE REST API."
+    )]
+    pub nvue_api_insecure: bool,
 }
 
 #[derive(Parser, Debug)]

--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -48,7 +48,7 @@ use crate::{
 const MAX_EXPECTED_SIZE: u64 = 1048576; // 1 MiB
 
 /// ACL to prevent access to nvued's API
-const NVUED_BLOCK_RULE: &str = r"
+pub(crate) const NVUED_BLOCK_RULE: &str = r"
 [iptables]
 # Block access to nvued API
 -A INPUT -p tcp --dport 8765 -j DROP
@@ -122,7 +122,7 @@ impl InterfaceState {
     }
 }
 
-struct EthernetVirtualizerPaths {
+pub(crate) struct EthernetVirtualizerPaths {
     interfaces: FPath,
     frr: FPath,
     daemons: FPath,
@@ -164,7 +164,7 @@ struct PostAction {
     path: FPath,
 }
 
-fn paths(hbn_root: &Path) -> EthernetVirtualizerPaths {
+pub(crate) fn paths(hbn_root: &Path) -> EthernetVirtualizerPaths {
     let ps = EthernetVirtualizerPaths {
         interfaces: FPath(hbn_root.join(interfaces::PATH)),
         frr: FPath(hbn_root.join(frr::PATH)),
@@ -177,13 +177,12 @@ fn paths(hbn_root: &Path) -> EthernetVirtualizerPaths {
 
 // Update network config using nvue (`nv`). Return Ok(true) if the config change, Ok(false) if not.
 pub async fn update_nvue(
+    nvue_applier: &dyn crate::nvue_applier::NvueApplier,
     vpc_virtualization_type: VpcVirtualizationType,
-    hbn_root: &Path,
     nc: &rpc::ManagedHostNetworkConfigResponse,
-    // if true don't run the `nv` commands after writing the file
-    skip_post: bool,
     hbn_device_names: HBNDeviceNames,
 ) -> eyre::Result<bool> {
+    let hbn_root = nvue_applier.hbn_root();
     let hbn_version = hbn::read_version().await?;
 
     let l_ip_str = match &nc.managed_host_config {
@@ -437,6 +436,10 @@ pub async fn update_nvue(
         },
     };
 
+    // Static file housekeeping that applies regardless of applier type.
+    // These files live on the HBN container filesystem and are not part of the
+    // NVUE config that gets applied via `nv config replace` or the REST API.
+
     // Cleanup any left over non-NVUE temp files
     let _ = paths(hbn_root);
 
@@ -451,7 +454,7 @@ pub async fn update_nvue(
     rules.push_str(acl_rules::ARP_SUPPRESSION_RULE);
     match write(rules, &path_acl, "NVUE ACL", false) {
         Ok(true) => {
-            if !skip_post {
+            if !nvue_applier.skip_reload() {
                 let cmd = acl_rules::RELOAD_CMD;
                 if let Err(err) = hbn::run_in_container_shell(cmd).await {
                     tracing::error!("running nvue extra acl post '{}': {err:#}", cmd);
@@ -465,44 +468,15 @@ pub async fn update_nvue(
         Err(err) => tracing::error!("write nvue extra ACL: {err:#}"),
     }
 
-    // nvue can save a copy of the config here. If that exists nvue uses it on boot.
-    // We always want to use the most recent `nv config apply`, so ensure this doesn't exist.
-    let saved_config = hbn_root.join(nvue::SAVE_PATH);
-    if saved_config.exists()
-        && let Err(err) = fs::remove_file(&saved_config)
-    {
-        tracing::warn!(
-            "Failed removing old startup.yaml at {}: {err:#}",
-            saved_config.display()
-        );
+    // If switching to the admin network, force the write even if the config
+    // appears unchanged or exceeds MAX_EXPECTED_SIZE. Workaround for a past
+    // incident where an oversized tenant config blocked the admin transition.
+    if nc.use_admin_network {
+        nvue_applier.set_force_next_write(true);
     }
 
-    // Write the config we're going to apply
     let next_contents = nvue::build(conf)?;
-    let path = FPath(hbn_root.join(nvue::PATH));
-    path.cleanup();
-    // If switching to the admin network, we want to just force the write.
-    // We've seen a past incident where a tenant managed to create a config
-    // that exceeded MAX_EXPECTED_SIZE.  Because of the diff check failing, it
-    // also prevented a successful termination because the NVUE config couldn't
-    // be switched to the admin network.
-    if !write(
-        next_contents,
-        &path,
-        "NVUE",
-        nc.use_admin_network && path.0.exists() && path.0.metadata()?.len() > MAX_EXPECTED_SIZE,
-    )
-    .wrap_err(format!("NVUE config at {path}"))?
-    {
-        // config didn't change OR we are switching to the admin network.
-        return Ok(false);
-    };
-
-    if !skip_post {
-        // Make it so
-        nvue::apply(hbn_root, &path).await?;
-    }
-    Ok(true)
+    nvue_applier.apply(next_contents).await
 }
 
 // Update internal bridge configuration for traffic-intercept routing and bridging.
@@ -1491,7 +1465,7 @@ fn instance_interface_acls_by_name(
 
 // Update configuration file
 // Returns true if the file has changes, false otherwise.
-fn write(
+pub(crate) fn write(
     // What to write into the file
     next_contents: String,
     // The file to write to
@@ -1752,7 +1726,7 @@ impl fmt::Display for FPath {
 
 /// Delete the non-NVUE ACL rules so that they don't interfere with NVUE.
 /// Also delete the very old VPC migration ACL rules, which used a non-standard naming convention
-fn cleanup_old_acls(hbn_root: &Path) {
+pub(crate) fn cleanup_old_acls(hbn_root: &Path) {
     let old_acls = hbn_root.join(acl_rules::PATH);
 
     let mut old_acls_test = old_acls.clone();
@@ -1910,11 +1884,13 @@ mod tests {
         fs::create_dir_all(hbn_root.join("var/support"))?;
         fs::create_dir_all(hbn_root.join("etc/cumulus/acl/policy.d"))?;
 
+        let skip_reload = true;
+        let applier =
+            crate::nvue_applier::ContainerApplier::new(hbn_root.to_path_buf(), skip_reload);
         let has_changes = super::update_nvue(
+            &applier,
             virtualization_type,
-            hbn_root,
             &network_config,
-            true,
             HBNDeviceNames::hbn_23(),
         )
         .await?;
@@ -1946,11 +1922,13 @@ mod tests {
         fs::create_dir_all(hbn_root.join("var/support"))?;
         fs::create_dir_all(hbn_root.join("etc/cumulus/acl/policy.d"))?;
 
+        let skip_reload = true;
+        let applier =
+            crate::nvue_applier::ContainerApplier::new(hbn_root.to_path_buf(), skip_reload);
         let has_changes = super::update_nvue(
+            &applier,
             virtualization_type,
-            hbn_root,
             &network_config,
-            true,
             HBNDeviceNames::hbn_23(),
         )
         .await?;
@@ -1993,11 +1971,13 @@ mod tests {
         fs::create_dir_all(hbn_root.join("var/support"))?;
         fs::create_dir_all(hbn_root.join("etc/cumulus/acl/policy.d"))?;
 
+        let skip_reload = true;
+        let applier =
+            crate::nvue_applier::ContainerApplier::new(hbn_root.to_path_buf(), skip_reload);
         let has_changes = super::update_nvue(
+            &applier,
             virtualization_type,
-            hbn_root,
             &network_config,
-            true,
             HBNDeviceNames::hbn_23(),
         )
         .await?;
@@ -2040,11 +2020,13 @@ mod tests {
         fs::create_dir_all(hbn_root.join("var/support"))?;
         fs::create_dir_all(hbn_root.join("etc/cumulus/acl/policy.d"))?;
 
+        let skip_reload = true;
+        let applier =
+            crate::nvue_applier::ContainerApplier::new(hbn_root.to_path_buf(), skip_reload);
         let has_changes = super::update_nvue(
+            &applier,
             virtualization_type,
-            hbn_root,
             &network_config,
-            true,
             HBNDeviceNames::hbn_23(),
         )
         .await?;
@@ -2077,11 +2059,13 @@ mod tests {
         fs::create_dir_all(hbn_root.join("var/support"))?;
         fs::create_dir_all(hbn_root.join("etc/cumulus/acl/policy.d"))?;
 
+        let skip_reload = true;
+        let applier =
+            crate::nvue_applier::ContainerApplier::new(hbn_root.to_path_buf(), skip_reload);
         let has_changes = super::update_nvue(
+            &applier,
             virtualization_type,
-            hbn_root,
             &network_config,
-            true,
             HBNDeviceNames::hbn_23(),
         )
         .await?;
@@ -2120,11 +2104,13 @@ mod tests {
         fs::create_dir_all(hbn_root.join("var/support"))?;
         fs::create_dir_all(hbn_root.join("etc/cumulus/acl/policy.d"))?;
 
+        let skip_reload = true;
+        let applier =
+            crate::nvue_applier::ContainerApplier::new(hbn_root.to_path_buf(), skip_reload);
         let has_changes = super::update_nvue(
+            &applier,
             virtualization_type,
-            hbn_root,
             &network_config,
-            true,
             HBNDeviceNames::hbn_23(),
         )
         .await?;
@@ -2166,11 +2152,13 @@ mod tests {
         fs::create_dir_all(hbn_root.join("var/support"))?;
         fs::create_dir_all(hbn_root.join("etc/cumulus/acl/policy.d"))?;
 
+        let skip_reload = true;
+        let applier =
+            crate::nvue_applier::ContainerApplier::new(hbn_root.to_path_buf(), skip_reload);
         let has_changes = super::update_nvue(
+            &applier,
             virtualization_type,
-            hbn_root,
             &network_config,
-            true,
             HBNDeviceNames::hbn_23(),
         )
         .await?;
@@ -2220,11 +2208,13 @@ mod tests {
         fs::create_dir_all(hbn_root.join("var/support"))?;
         fs::create_dir_all(hbn_root.join("etc/cumulus/acl/policy.d"))?;
 
+        let skip_reload = true;
+        let applier =
+            crate::nvue_applier::ContainerApplier::new(hbn_root.to_path_buf(), skip_reload);
         let has_changes = super::update_nvue(
+            &applier,
             virtualization_type,
-            hbn_root,
             &network_config,
-            true,
             HBNDeviceNames::hbn_23(),
         )
         .await?;
@@ -2265,11 +2255,13 @@ mod tests {
         fs::create_dir_all(hbn_root.join("var/support"))?;
         fs::create_dir_all(hbn_root.join("etc/cumulus/acl/policy.d"))?;
 
+        let skip_reload = true;
+        let applier =
+            crate::nvue_applier::ContainerApplier::new(hbn_root.to_path_buf(), skip_reload);
         let has_changes = super::update_nvue(
+            &applier,
             virtualization_type,
-            hbn_root,
             &network_config,
-            true,
             HBNDeviceNames::hbn_23(),
         )
         .await?;

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -70,6 +70,7 @@ mod mtu;
 pub mod netlink;
 pub mod network_monitor;
 pub mod nvue; // pub so that integration tests can read nvue::PATH
+pub mod nvue_applier;
 mod ovs;
 mod periodic_config_fetcher;
 mod sysfs;

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -331,6 +331,30 @@ pub async fn setup_and_run(
     // used in the event that hbn crashes and can no longer read the actual version of hbn
     let hbn_device_names = HBNDeviceNames::hbn_23();
 
+    let nvue_applier: Box<dyn crate::nvue_applier::NvueApplier> =
+        if let Some(ref addr) = options.nvue_api_address {
+            tracing::info!(
+                nvue_api_address = addr,
+                "Using NVUE REST API for config application"
+            );
+            Box::new(
+                crate::nvue_applier::ApiApplier::new(
+                    addr,
+                    options.nvue_api_user.as_deref(),
+                    options.nvue_api_passwd.as_deref(),
+                    options.nvue_api_insecure,
+                    agent_config.hbn.root_dir.clone(),
+                    agent_config.hbn.skip_reload,
+                )
+                .wrap_err("Failed to create NVUE API client")?,
+            )
+        } else {
+            Box::new(crate::nvue_applier::ContainerApplier::new(
+                agent_config.hbn.root_dir.clone(),
+                agent_config.hbn.skip_reload,
+            ))
+        };
+
     let mut main_loop = MainLoop {
         forge_client_config,
         build_version,
@@ -355,6 +379,7 @@ pub async fn setup_and_run(
         factory_mac_address,
         service_addrs,
         close_sender,
+        nvue_applier,
         network_monitor_handle,
         extension_service_manager: extension_services::ExtensionServiceManager::default(),
     };
@@ -385,6 +410,7 @@ struct MainLoop {
     fmds_minimum_hbn_version: Version<'static>,
     nvue_minimum_hbn_version: Version<'static>,
     service_addrs: ServiceAddresses,
+    nvue_applier: Box<dyn crate::nvue_applier::NvueApplier>,
     network_monitor_handle: Option<JoinHandle<()>>,
     close_sender: watch::Sender<bool>,
     extension_service_manager: extension_services::ExtensionServiceManager,
@@ -643,10 +669,9 @@ impl MainLoop {
 
                             if bridging_result.is_ok() {
                                 ethernet_virtualization::update_nvue(
+                                    self.nvue_applier.as_ref(),
                                     virtualization_type,
-                                    &self.agent_config.hbn.root_dir,
                                     &conf,
-                                    self.agent_config.hbn.skip_reload,
                                     self.hbn_device_names.clone(),
                                 )
                                 .await

--- a/crates/agent/src/nvue.rs
+++ b/crates/agent/src/nvue.rs
@@ -16,7 +16,6 @@
  */
 
 use std::collections::HashMap;
-use std::fs;
 use std::path::Path;
 
 use ::rpc::forge as rpc;
@@ -739,54 +738,8 @@ pub async fn hack_platform_config_for_nvue() -> eyre::Result<()> {
     Ok(())
 }
 
-// Apply the config at `config_path`.
-pub async fn apply(hbn_root: &Path, config_path: &super::FPath) -> eyre::Result<()> {
-    match run_apply(hbn_root, &config_path.0).await {
-        Ok(_) => {
-            config_path.del("BAK");
-            Ok(())
-        }
-        Err(err) => {
-            tracing::error!("update_nvue post command failed: {err:#}");
-
-            // If the config apply failed, we won't be using it, so move it out
-            // of the way to an .error file for others to enjoy (while attempting
-            // to remove any previous .error file in the process).
-            let path_error = config_path.with_ext("error");
-            if path_error.exists()
-                && let Err(e) = fs::remove_file(path_error.clone())
-            {
-                tracing::warn!(
-                    "Failed to remove previous error file ({}): {e}",
-                    path_error.display()
-                );
-            }
-
-            if let Err(err) = fs::rename(config_path, &path_error) {
-                eyre::bail!(
-                    "rename {config_path} to {} on error: {err:#}",
-                    path_error.display()
-                );
-            }
-            // .. and copy the old one back.
-            // This also ensures that we retry writing the config on subsequent runs.
-            let path_bak = config_path.backup();
-            if path_bak.exists()
-                && let Err(err) = fs::rename(&path_bak, config_path)
-            {
-                eyre::bail!(
-                    "rename {} to {config_path}, reverting on error: {err:#}",
-                    path_bak.display(),
-                );
-            }
-
-            Err(err)
-        }
-    }
-}
-
-// Ask NVUE to use the config at `path`
-async fn run_apply(hbn_root: &Path, path: &Path) -> eyre::Result<()> {
+// Ask NVUE to use the config at `path` by exec'ing into the HBN container.
+pub(crate) async fn run_apply(hbn_root: &Path, path: &Path) -> eyre::Result<()> {
     let mut in_container_path = path
         .strip_prefix(hbn_root)
         .wrap_err("Stripping hbn_root prefix from path to make in-container path")?

--- a/crates/agent/src/nvue_applier/api.rs
+++ b/crates/agent/src/nvue_applier/api.rs
@@ -1,0 +1,441 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use async_trait::async_trait;
+use eyre::WrapErr;
+use reqwest::Client;
+
+use super::NvueApplier;
+
+/// Apply NVUE config via the NVUE REST API over HTTP. No files are written
+/// to the HBN filesystem except for the static ones that don't have an
+/// API equivalent (yet).
+#[derive(Debug)]
+pub struct ApiApplier {
+    client: Client,
+    base_url: String,
+    credentials: Option<(String, String)>,
+    hbn_root: std::path::PathBuf,
+    skip_reload: bool,
+    /// Hash of the last successfully applied config, used for diff detection.
+    /// Behind a Mutex because `apply()` takes `&self` (required by the async trait)
+    /// but needs to update this value. In practice this is only called sequentially
+    /// from the main loop — the lock is never contended.
+    last_applied_hash: std::sync::Mutex<Option<blake3::Hash>>,
+}
+
+/// Resolve a credential string with format: `env:<VAR>`, `file:<path>`, `value:<literal>`,
+/// or a bare string (treated as a literal value).
+fn resolve_credential(raw: &str) -> eyre::Result<String> {
+    if let Some(var) = raw.strip_prefix("env:") {
+        std::env::var(var)
+            .wrap_err_with(|| format!("reading env var {var} for NVUE API credential"))
+    } else if let Some(path) = raw.strip_prefix("file:") {
+        std::fs::read_to_string(path)
+            .map(|s| s.trim().to_string())
+            .wrap_err_with(|| format!("reading file {path} for NVUE API credential"))
+    } else if let Some(val) = raw.strip_prefix("value:") {
+        Ok(val.to_string())
+    } else {
+        Ok(raw.to_string())
+    }
+}
+
+impl ApiApplier {
+    pub fn new(
+        address: &str,
+        user: Option<&str>,
+        passwd: Option<&str>,
+        insecure: bool,
+        hbn_root: std::path::PathBuf,
+        skip_reload: bool,
+    ) -> eyre::Result<Self> {
+        let credentials = match (user, passwd) {
+            (Some(u), Some(p)) => {
+                let user = resolve_credential(u)?;
+                let passwd = resolve_credential(p)?;
+                Some((user, passwd))
+            }
+            (None, None) => None,
+            _ => eyre::bail!(
+                "--nvue-api-user and --nvue-api-passwd must both be set, or both be unset"
+            ),
+        };
+
+        let client = Client::builder()
+            .danger_accept_invalid_certs(insecure)
+            .build()
+            .wrap_err("building NVUE API HTTP client")?;
+
+        let base_url = address.trim_end_matches('/').to_string();
+
+        Ok(Self {
+            client,
+            base_url,
+            credentials,
+            hbn_root,
+            skip_reload,
+            last_applied_hash: std::sync::Mutex::new(None),
+        })
+    }
+
+    /// Create a new NVUE revision. All config changes are staged against a revision
+    /// before being applied. Returns the revision ID.
+    async fn create_revision(&self) -> eyre::Result<String> {
+        let url = format!("{}/nvue_v1/revision", self.base_url);
+        let resp = self
+            .request(reqwest::Method::POST, &url)
+            .send()
+            .await
+            .wrap_err("POST /nvue_v1/revision")?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            eyre::bail!("POST /nvue_v1/revision returned {status}: {body}");
+        }
+
+        // Response is a JSON object like {"changeset/cumulus/2026-03-23_...": {"state": "pending", ...}}
+        // The key is the revision ID.
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .wrap_err("parsing revision response JSON")?;
+        let revision_id = body
+            .as_object()
+            .and_then(|obj| obj.keys().next())
+            .ok_or_else(|| eyre::eyre!("unexpected revision response format: {body}"))?
+            .clone();
+
+        Ok(revision_id)
+    }
+
+    /// Delete all config in the revision, giving us a clean slate. This is
+    /// necessary for full-replacement semantics matching `nv config replace`.
+    /// Without this, the subsequent PATCH would merge with existing config,
+    /// potentially leaving stale entries from previous applies.
+    async fn delete_config(&self, revision_id: &str) -> eyre::Result<()> {
+        let url = format!(
+            "{}/nvue_v1/?rev={}",
+            self.base_url,
+            urlencoding::encode(revision_id)
+        );
+        let resp = self
+            .request(reqwest::Method::DELETE, &url)
+            .send()
+            .await
+            .wrap_err("DELETE /nvue_v1/")?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            eyre::bail!("DELETE /nvue_v1/ returned {status}: {body}");
+        }
+        Ok(())
+    }
+
+    /// Write the full config JSON into the revision. This is a root-level PATCH
+    /// that sets the entire NVUE configuration tree.
+    async fn patch_config(
+        &self,
+        revision_id: &str,
+        config: &serde_json::Value,
+    ) -> eyre::Result<()> {
+        let url = format!(
+            "{}/nvue_v1/?rev={}",
+            self.base_url,
+            urlencoding::encode(revision_id)
+        );
+        let resp = self
+            .request(reqwest::Method::PATCH, &url)
+            .header("Content-Type", "application/json")
+            .json(config)
+            .send()
+            .await
+            .wrap_err("PATCH /nvue_v1/")?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            eyre::bail!("PATCH /nvue_v1/ returned {status}: {body}");
+        }
+        Ok(())
+    }
+
+    /// Apply the revision, transitioning it from "pending" to "applied". This
+    /// is the equivalent of `nv config apply -y` and makes the config take effect.
+    async fn apply_revision(&self, revision_id: &str) -> eyre::Result<()> {
+        let url = format!(
+            "{}/nvue_v1/revision/{}",
+            self.base_url,
+            urlencoding::encode(revision_id)
+        );
+        let body = serde_json::json!({
+            "state": "apply",
+            "auto-prompt": {
+                "ays": "ays_yes"
+            }
+        });
+        let resp = self
+            .request(reqwest::Method::PATCH, &url)
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .wrap_err("PATCH /nvue_v1/revision (apply)")?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            eyre::bail!("PATCH /nvue_v1/revision/{revision_id} (apply) returned {status}: {body}");
+        }
+        Ok(())
+    }
+
+    fn request(&self, method: reqwest::Method, url: &str) -> reqwest::RequestBuilder {
+        let mut req = self.client.request(method, url);
+        if let Some((ref user, ref passwd)) = self.credentials {
+            req = req.basic_auth(user, Some(passwd));
+        }
+        req
+    }
+}
+
+#[async_trait]
+impl NvueApplier for ApiApplier {
+    fn hbn_root(&self) -> &std::path::Path {
+        &self.hbn_root
+    }
+
+    fn skip_reload(&self) -> bool {
+        self.skip_reload
+    }
+
+    async fn apply(&self, yaml_content: String) -> eyre::Result<bool> {
+        let content_hash = blake3::hash(yaml_content.as_bytes());
+        let last_hash = self
+            .last_applied_hash
+            .lock()
+            .map_err(|e| eyre::eyre!("last_applied_hash lock poisoned: {e}"))?
+            .as_ref()
+            .copied();
+        if last_hash == Some(content_hash) {
+            return Ok(false);
+        }
+
+        let yaml_value: serde_yaml::Value =
+            serde_yaml::from_str(&yaml_content).wrap_err("parsing NVUE YAML config")?;
+        let json_value: serde_json::Value = serde_json::to_value(yaml_to_json(yaml_value))
+            .wrap_err("converting NVUE YAML to JSON")?;
+
+        // First, we create a new revision.
+        let revision_id = self.create_revision().await?;
+        tracing::info!(revision_id, "created NVUE API revision");
+
+        // Then, we DELETE existing config in the revision. This gives us
+        // full-replacement semantics matching `nv config replace`. Without
+        // this, PATCH does a merge, which could leave stale config entries,
+        // from previous applies. A metaphor here would be applying updated
+        // mlxconfig parameters without first doing a reset, and then laying
+        // our config over it.
+        self.delete_config(&revision_id).await?;
+
+        // And now we PATCH the new config into the revision.
+        self.patch_config(&revision_id, &json_value).await?;
+
+        // Finally, apply the revision.
+        self.apply_revision(&revision_id).await?;
+        tracing::info!(revision_id, "applied NVUE API revision");
+
+        *self
+            .last_applied_hash
+            .lock()
+            .map_err(|e| eyre::eyre!("last_applied_hash lock poisoned: {e}"))? = Some(content_hash);
+
+        Ok(true)
+    }
+}
+
+/// Convert a serde_yaml::Value to a serde_json::Value.
+/// serde_yaml uses different key types (particularly mapping keys can be non-string),
+/// so we walk the tree to ensure clean JSON output.
+fn yaml_to_json(yaml: serde_yaml::Value) -> serde_json::Value {
+    match yaml {
+        serde_yaml::Value::Null => serde_json::Value::Null,
+        serde_yaml::Value::Bool(b) => serde_json::Value::Bool(b),
+        serde_yaml::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                serde_json::Value::Number(i.into())
+            } else if let Some(u) = n.as_u64() {
+                serde_json::Value::Number(u.into())
+            } else if let Some(f) = n.as_f64() {
+                serde_json::Number::from_f64(f)
+                    .map(serde_json::Value::Number)
+                    .unwrap_or(serde_json::Value::Null)
+            } else {
+                serde_json::Value::Null
+            }
+        }
+        serde_yaml::Value::String(s) => serde_json::Value::String(s),
+        serde_yaml::Value::Sequence(seq) => {
+            serde_json::Value::Array(seq.into_iter().map(yaml_to_json).collect())
+        }
+        serde_yaml::Value::Mapping(map) => {
+            let obj = map
+                .into_iter()
+                .map(|(k, v)| {
+                    let key = match k {
+                        serde_yaml::Value::String(s) => s,
+                        other => serde_yaml::to_string(&other)
+                            .unwrap_or_default()
+                            .trim()
+                            .to_string(),
+                    };
+                    (key, yaml_to_json(v))
+                })
+                .collect();
+            serde_json::Value::Object(obj)
+        }
+        serde_yaml::Value::Tagged(tagged) => yaml_to_json(tagged.value),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_credential_bare_value() {
+        assert_eq!(resolve_credential("myuser").unwrap(), "myuser");
+    }
+
+    #[test]
+    fn test_resolve_credential_value_prefix() {
+        assert_eq!(resolve_credential("value:myuser").unwrap(), "myuser");
+    }
+
+    #[test]
+    fn test_resolve_credential_env_prefix() {
+        // SAFETY: This test is not run in parallel with other tests that use this env var.
+        unsafe { std::env::set_var("TEST_NVUE_CRED", "from_env") };
+        assert_eq!(
+            resolve_credential("env:TEST_NVUE_CRED").unwrap(),
+            "from_env"
+        );
+        unsafe { std::env::remove_var("TEST_NVUE_CRED") };
+    }
+
+    #[test]
+    fn test_resolve_credential_env_missing() {
+        assert!(resolve_credential("env:NONEXISTENT_NVUE_VAR_12345").is_err());
+    }
+
+    #[test]
+    fn test_resolve_credential_file_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cred.txt");
+        std::fs::write(&path, "from_file\n").unwrap();
+        assert_eq!(
+            resolve_credential(&format!("file:{}", path.display())).unwrap(),
+            "from_file"
+        );
+    }
+
+    #[test]
+    fn test_resolve_credential_file_missing() {
+        assert!(resolve_credential("file:/nonexistent/path/cred.txt").is_err());
+    }
+
+    #[test]
+    fn test_yaml_to_json_conversion() {
+        let yaml = r#"
+system:
+  hostname: my-dpu
+interface:
+  lo:
+    ip:
+      address:
+        10.0.0.1/32: {}
+  swp1:
+    type: swp
+router:
+  bgp:
+    autonomous-system: 65001
+    enable: on
+"#;
+        let yaml_val: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+        let json_val = yaml_to_json(yaml_val);
+
+        assert_eq!(
+            json_val["system"]["hostname"],
+            serde_json::Value::String("my-dpu".to_string())
+        );
+        assert_eq!(
+            json_val["router"]["bgp"]["autonomous-system"],
+            serde_json::json!(65001)
+        );
+        assert_eq!(
+            json_val["interface"]["lo"]["ip"]["address"]["10.0.0.1/32"],
+            serde_json::json!({})
+        );
+    }
+
+    #[test]
+    fn test_new_requires_both_credentials() {
+        let result = ApiApplier::new(
+            "https://localhost:8765",
+            Some("user"),
+            None,
+            false,
+            "/tmp".into(),
+            false,
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("must both be set"));
+    }
+
+    #[test]
+    fn test_new_no_credentials() {
+        let client = ApiApplier::new(
+            "https://localhost:8765",
+            None,
+            None,
+            false,
+            "/tmp".into(),
+            false,
+        )
+        .unwrap();
+        assert!(client.credentials.is_none());
+    }
+
+    #[test]
+    fn test_new_with_credentials() {
+        let client = ApiApplier::new(
+            "https://localhost:8765",
+            Some("nvidia"),
+            Some("nvidia"),
+            false,
+            "/tmp".into(),
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            client.credentials,
+            Some(("nvidia".to_string(), "nvidia".to_string()))
+        );
+    }
+}

--- a/crates/agent/src/nvue_applier/container.rs
+++ b/crates/agent/src/nvue_applier/container.rs
@@ -1,0 +1,136 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use async_trait::async_trait;
+use eyre::WrapErr;
+
+use super::NvueApplier;
+use crate::ethernet_virtualization::FPath;
+
+/// Apply config by writing it to the HBN container's filesystem and exec'ing
+/// `nv config replace` + `nv config apply` inside the container.
+pub struct ContainerApplier {
+    hbn_root: PathBuf,
+    skip_reload: bool,
+    /// When true, force the next write even if it exceeds MAX_EXPECTED_SIZE.
+    /// Set via the trait's `set_force_next_write` when switching to admin network.
+    /// AtomicBool instead of Cell<bool> because the NvueApplier trait requires Sync
+    /// (imposed by async_trait + &self). In practice this is only accessed
+    /// sequentially from the main loop.
+    force_next_write: AtomicBool,
+}
+
+impl ContainerApplier {
+    pub fn new(hbn_root: PathBuf, skip_reload: bool) -> Self {
+        Self {
+            hbn_root,
+            skip_reload,
+            force_next_write: AtomicBool::new(false),
+        }
+    }
+
+    /// Exec `nv config replace` + `nv config apply` in the HBN container,
+    /// with backup/error file recovery on failure.
+    async fn exec_apply(&self, config_path: &FPath) -> eyre::Result<()> {
+        match crate::nvue::run_apply(&self.hbn_root, &config_path.0).await {
+            Ok(()) => {
+                config_path.del("BAK");
+                Ok(())
+            }
+            Err(err) => {
+                tracing::error!("update_nvue post command failed: {err:#}");
+
+                // Move the failed config to .error for inspection.
+                let path_error = config_path.with_ext("error");
+                if path_error.exists()
+                    && let Err(e) = std::fs::remove_file(path_error.clone())
+                {
+                    tracing::warn!(
+                        "Failed to remove previous error file ({}): {e}",
+                        path_error.display()
+                    );
+                }
+
+                if let Err(rename_err) = std::fs::rename(config_path, &path_error) {
+                    eyre::bail!(
+                        "rename {config_path} to {} on error: {rename_err:#}",
+                        path_error.display()
+                    );
+                }
+                // Restore the backup so the next run will retry with the previous config.
+                let path_bak = config_path.backup();
+                if path_bak.exists()
+                    && let Err(rename_err) = std::fs::rename(&path_bak, config_path)
+                {
+                    eyre::bail!(
+                        "rename {} to {config_path}, reverting on error: {rename_err:#}",
+                        path_bak.display(),
+                    );
+                }
+
+                Err(err)
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl NvueApplier for ContainerApplier {
+    fn hbn_root(&self) -> &std::path::Path {
+        &self.hbn_root
+    }
+
+    async fn apply(&self, yaml_content: String) -> eyre::Result<bool> {
+        // nvue can save a copy of the config here. If that exists nvue uses it on boot.
+        // We always want to use the most recent `nv config apply`, so ensure this doesn't exist.
+        let saved_config = self.hbn_root.join(crate::nvue::SAVE_PATH);
+        if saved_config.exists()
+            && let Err(err) = std::fs::remove_file(&saved_config)
+        {
+            tracing::warn!(
+                "Failed removing old startup.yaml at {}: {err:#}",
+                saved_config.display()
+            );
+        }
+
+        let path = FPath(self.hbn_root.join(crate::nvue::PATH));
+        path.cleanup();
+
+        let force = self.force_next_write.swap(false, Ordering::Relaxed);
+        if !crate::ethernet_virtualization::write(yaml_content, &path, "NVUE", force)
+            .wrap_err(format!("NVUE config at {path}"))?
+        {
+            return Ok(false);
+        }
+
+        if !self.skip_reload {
+            self.exec_apply(&path).await?;
+        }
+        Ok(true)
+    }
+
+    fn skip_reload(&self) -> bool {
+        self.skip_reload
+    }
+
+    fn set_force_next_write(&self, force: bool) {
+        self.force_next_write.store(force, Ordering::Relaxed);
+    }
+}

--- a/crates/agent/src/nvue_applier/mod.rs
+++ b/crates/agent/src/nvue_applier/mod.rs
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+mod api;
+mod container;
+
+use std::path::Path;
+
+pub use api::ApiApplier;
+use async_trait::async_trait;
+pub use container::ContainerApplier;
+
+/// Trait for applying NVUE configuration to HBN.
+#[async_trait]
+pub trait NvueApplier: Send + Sync {
+    /// Apply the given NVUE YAML config. Returns `Ok(true)` if the config
+    /// changed and was applied, `Ok(false)` if it was unchanged.
+    async fn apply(&self, yaml_content: String) -> eyre::Result<bool>;
+
+    /// The root directory of the HBN container filesystem.
+    fn hbn_root(&self) -> &Path;
+
+    /// Whether post-write commands (container exec, etc.) should be skipped.
+    /// Used in dev/test mode via `agent_config.hbn.skip_reload`.
+    fn skip_reload(&self) -> bool;
+
+    /// Hint that the next `apply()` should force-write even if the config
+    /// appears unchanged or oversized. Used when switching to the admin network
+    /// to ensure a bloated tenant config doesn't block the transition.
+    /// Default is a no-op; only `ContainerApplier` acts on this.
+    fn set_force_next_write(&self, _force: bool) {}
+}

--- a/crates/agent/src/tests/common/mod.rs
+++ b/crates/agent/src/tests/common/mod.rs
@@ -115,6 +115,10 @@ pub fn setup_agent_run_env(
             skip_upgrade_check: false,
             dhcp_grpc_server: None,
             fmds_grpc_server: None,
+            nvue_api_address: None,
+            nvue_api_user: None,
+            nvue_api_passwd: None,
+            nvue_api_insecure: false,
         }))),
     };
 

--- a/crates/api/src/state_controller/rack/handler.rs
+++ b/crates/api/src/state_controller/rack/handler.rs
@@ -687,7 +687,7 @@ impl StateHandler for RackStateHandler {
                         );
                         state.config.validation_run_id = Some(run_id);
                         let mut txn = ctx.services.db_pool.begin().await?;
-                        db_rack::update(&mut txn, *id, &state.config).await?;
+                        db_rack::update(&mut txn, id, &state.config).await?;
                         Ok(StateHandlerOutcome::transition(RackState::Validation {
                             rack_validation: RackValidationState::Pending,
                         })


### PR DESCRIPTION
**_Note that this is a draft of sorts mainly for discussion about the effort. Wanted to get written down what I was thinking._**

## Description

This adds support to `carbide-dpu-agent` for writing our NVUE config to the NVUE REST API, instead of writing out a config file and exec'ing into the HBN container. It is controlled by runtime flags, disabled by default, and will continue to run as it does today unless enabled.

The four new runtime flags are being introduced here:
```
--nvue-api-address (Option<String>) — NVUE REST API address (e.g. https://localhost:8765)
--nvue-api-user (Option<String>) — basic auth username, format: env:<VAR>, file:<path>, value:<literal>, or bare string
--nvue-api-passwd (Option<String>) — basic auth password, same format
--nvue-api-insecure (bool, default false) — skip TLS certificate verification
```

Again, all of these are disabled by default, and when disabled, the `carbide-dpu-agent` will continue to work as it does today.

By setting `--nvue-api-address`, you imply you're switching from the file-based approach to the API-based approach. Since the REST API only supports basic auth, this also has flags for controlling the enablement of basic auth (and how/where you want to set the values provided). Additionally, if the API is HTTPS, you must explicitly set `--nvue-api-insecure` if the client does not trust the signing CA. This is on purpose as a callout that maybe we want to trust it.

Additionally, to make this cleaner, there is a new `NvueApplier` trait that we use to construct either an `ApiApplier` or `ContainerApplier` in `main_loop.rs`, then pass along, giving us a cleaner interface in `ethernet_virtualization.rs`.

Tests added for all of this.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

