### PR TITLE
refactor(machine-a-tron): Extract FSM logic into separate module

### DIFF
--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -386,7 +386,7 @@ impl DpuMachineHandle {
             mat_id: self.0.mat_id,
             hw_type: None,
             machine_id: guard.observed_machine_id.as_ref().map(|m| m.to_string()),
-            mat_state: guard.state_string.clone(),
+            mat_state: guard.state_string,
             api_state: guard.api_state.clone(),
             oob_ip: guard.bmc_ip.map(|ip| ip.to_string()).unwrap_or_default(),
             machine_ip: guard

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -306,6 +306,7 @@ impl HostMachine {
                 }
             }
             Some(cmd) = self.bmc_control_rx.recv() => {
+                tracing::debug!("HOST set_system_power request: {cmd:?}");
                 match cmd {
                     BmcCommand::SetSystemPower { request, reply } => {
                         let response = self.set_system_power(request);
@@ -428,7 +429,7 @@ impl HostMachine {
                 .observed_machine_id
                 .as_ref()
                 .map(|m| m.to_string()),
-            mat_state: self.state_machine.to_string(),
+            mat_state: self.state_machine.live_state.read().unwrap().state_string,
             api_state: self.api_state.clone(),
             oob_ip: live_state
                 .bmc_ip

--- a/crates/machine-a-tron/src/lib.rs
+++ b/crates/machine-a-tron/src/lib.rs
@@ -22,6 +22,7 @@ mod dhcp_wrapper;
 mod dpu_machine;
 mod host_machine;
 mod machine_a_tron;
+mod machine_fsm;
 mod machine_state_machine;
 mod machine_utils;
 mod mock_ssh_server;

--- a/crates/machine-a-tron/src/machine_fsm.rs
+++ b/crates/machine-a-tron/src/machine_fsm.rs
@@ -1,0 +1,408 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use bmc_mock::MockPowerState;
+
+use crate::machine_state_machine::OsImage;
+
+pub type FsmReturn<Fsm> = (Fsm, Vec<Action>);
+
+#[derive(Clone, Copy, Debug)]
+pub enum MachineFsm {
+    BmcInit { power_on: bool, bmc_only: bool },
+    Init,
+    MachineDown,
+    DhcpComplete,
+    MachineUp { os_fsm: OsFsm },
+    BmcOnlyMachineUp,
+    BmcOnlyMachineDown,
+}
+
+impl MachineFsm {
+    pub fn init(power_on: bool, bmc_only: bool) -> FsmReturn<Self> {
+        (
+            Self::BmcInit { power_on, bmc_only },
+            vec![Action::Dhcp(DhcpType::Bmc)],
+        )
+    }
+
+    pub fn event(self, event: Event) -> (Self, Vec<Action>) {
+        match self {
+            Self::BmcInit { power_on, bmc_only } => self.fsm_bmc_init(event, power_on, bmc_only),
+            Self::Init => self.fsm_init(event),
+            Self::MachineDown => self.fsm_machine_down(event),
+            Self::DhcpComplete => self.fsm_dhcp_complete(event),
+            Self::MachineUp { os_fsm } => self.fsm_machine_up(event, os_fsm),
+
+            Self::BmcOnlyMachineUp => self.fsm_bmc_only_machine_up(event),
+            Self::BmcOnlyMachineDown => self.fsm_bmc_only_machine_down(event),
+        }
+    }
+
+    pub fn is_up(&self) -> bool {
+        matches!(self, Self::MachineUp { .. } | Self::BmcOnlyMachineUp)
+    }
+
+    pub fn power_state(&self) -> MockPowerState {
+        match self {
+            Self::BmcInit { power_on: true, .. } => MockPowerState::On,
+            Self::BmcInit {
+                power_on: false, ..
+            } => MockPowerState::Off,
+            Self::Init => MockPowerState::On,
+            Self::MachineDown => MockPowerState::Off,
+            Self::DhcpComplete => MockPowerState::On,
+            Self::MachineUp { .. } => MockPowerState::On,
+            Self::BmcOnlyMachineUp => MockPowerState::On,
+            Self::BmcOnlyMachineDown => MockPowerState::Off,
+        }
+    }
+
+    pub fn state_string(&self) -> &'static str {
+        match self {
+            Self::BmcInit { .. } => "BmcInit",
+            Self::Init => "Init",
+            Self::MachineDown => "MachineDown",
+            Self::DhcpComplete => "DhcpComplete",
+            Self::MachineUp { .. } => "MachineUp",
+            Self::BmcOnlyMachineUp => "BmcOnly/MachineUp",
+            Self::BmcOnlyMachineDown => "BmcOnly/MachineDown",
+        }
+    }
+
+    pub fn booted_os(&self) -> Option<OsImage> {
+        match self {
+            Self::MachineUp {
+                os_fsm: OsFsm::Scout { .. },
+            } => Some(OsImage::Scout),
+            Self::MachineUp {
+                os_fsm: OsFsm::DpuAgent { .. },
+            } => Some(OsImage::DpuAgent),
+            Self::MachineUp {
+                os_fsm: OsFsm::None,
+            } => Some(OsImage::None),
+            _ => None,
+        }
+    }
+
+    fn fsm_bmc_init(self, event: Event, power_on: bool, bmc_only: bool) -> (Self, Vec<Action>) {
+        match event {
+            Event::DhcpComplete(DhcpType::Bmc) => (
+                if bmc_only {
+                    if power_on {
+                        Self::BmcOnlyMachineUp
+                    } else {
+                        Self::BmcOnlyMachineDown
+                    }
+                } else if power_on {
+                    Self::Init
+                } else {
+                    Self::MachineDown
+                },
+                vec![Action::SetupBmc],
+            ),
+            Event::PowerOn => (
+                Self::BmcInit {
+                    bmc_only,
+                    power_on: true,
+                },
+                if power_on {
+                    vec![]
+                } else {
+                    vec![Action::SetTimer(Timer::MachineOn)]
+                },
+            ),
+            Event::PowerOff => (
+                Self::BmcInit {
+                    bmc_only,
+                    power_on: false,
+                },
+                vec![],
+            ),
+            Event::PowerCycle => (
+                Self::BmcInit {
+                    bmc_only,
+                    power_on: false,
+                },
+                vec![Action::SetTimer(Timer::PowerCycle)],
+            ),
+            Event::TimerAlert(Timer::PowerCycle) => (
+                Self::BmcInit {
+                    bmc_only,
+                    power_on: true,
+                },
+                vec![],
+            ),
+            _ => (self, vec![]),
+        }
+    }
+
+    fn fsm_init(self, event: Event) -> (Self, Vec<Action>) {
+        match event {
+            Event::TimerAlert(Timer::MachineOn) => (self, vec![Action::Dhcp(DhcpType::Machine)]),
+            Event::DhcpComplete(DhcpType::Machine) => {
+                (Self::DhcpComplete, vec![Action::PxeBootRequest])
+            }
+            Event::PowerCycle => self.machine_down_on_power_cycle(),
+            Event::PowerOff => self.machine_down_on_power_off(),
+            _ => (self, vec![]),
+        }
+    }
+
+    fn fsm_machine_down(self, event: Event) -> (Self, Vec<Action>) {
+        match event {
+            Event::PowerCycle => (self, vec![Action::SetTimer(Timer::PowerCycle)]),
+            Event::PowerOn | Event::TimerAlert(Timer::PowerCycle) => {
+                (Self::Init, vec![Action::SetTimer(Timer::MachineOn)])
+            }
+            _ => (self, vec![]),
+        }
+    }
+
+    fn fsm_dhcp_complete(self, event: Event) -> (Self, Vec<Action>) {
+        match event {
+            Event::PowerCycle => self.machine_down_on_power_cycle(),
+            Event::PowerOff => self.machine_down_on_power_off(),
+            Event::PxeComplete(os_image) => {
+                let os_fsm = match os_image {
+                    OsImage::None => OsFsm::None,
+                    OsImage::DpuAgent => OsFsm::DpuAgent(DpuAgentFsm::Discovery),
+                    OsImage::Scout => OsFsm::Scout(ScoutFsm::Discovery),
+                };
+                let actions = os_fsm.init_actions();
+                (Self::MachineUp { os_fsm }, actions)
+            }
+            _ => (self, vec![]),
+        }
+    }
+
+    fn fsm_machine_up(self, event: Event, os_fsm: OsFsm) -> (Self, Vec<Action>) {
+        match event {
+            Event::PowerCycle => self.machine_down_on_power_cycle(),
+            Event::PowerOff => self.machine_down_on_power_off(),
+            _ => {
+                let (os_fsm, actions) = os_fsm.event(event);
+                (Self::MachineUp { os_fsm }, actions)
+            }
+        }
+    }
+
+    fn fsm_bmc_only_machine_up(self, event: Event) -> (Self, Vec<Action>) {
+        match event {
+            Event::PowerOff => (Self::BmcOnlyMachineDown, vec![]),
+            Event::PowerCycle => (
+                Self::BmcOnlyMachineDown,
+                vec![Action::SetTimer(Timer::PowerCycle)],
+            ),
+            _ => (self, vec![]),
+        }
+    }
+
+    fn fsm_bmc_only_machine_down(self, event: Event) -> (Self, Vec<Action>) {
+        match event {
+            Event::PowerCycle => (
+                Self::BmcOnlyMachineDown,
+                vec![Action::SetTimer(Timer::PowerCycle)],
+            ),
+            Event::PowerOn | Event::TimerAlert(Timer::PowerCycle) => {
+                (Self::BmcOnlyMachineUp, vec![])
+            }
+            _ => (self, vec![]),
+        }
+    }
+
+    fn machine_down_on_power_off(self) -> (Self, Vec<Action>) {
+        (Self::MachineDown, vec![Action::CleanupOnPowerOff])
+    }
+
+    fn machine_down_on_power_cycle(self) -> (Self, Vec<Action>) {
+        (
+            Self::MachineDown,
+            vec![
+                Action::CleanupOnPowerOff,
+                Action::SetTimer(Timer::PowerCycle),
+            ],
+        )
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum Event {
+    DhcpComplete(DhcpType),
+    PowerOn,
+    PowerOff,
+    PowerCycle,
+    TimerAlert(Timer),
+    PxeComplete(OsImage),
+    InitialDiscoveryCompleted,
+    AgentControlCompleted,
+    MachineNotFound,
+    NetworkObservationCompleted,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum Action {
+    SetupBmc,
+    SetTimer(Timer),
+    Dhcp(DhcpType),
+    PxeBootRequest,
+    InitialDiscoveryRequest(OsImage),
+    AgentControlRequest(OsImage),
+    DpuAgentNetworkObservation,
+    CleanupOnPowerOff,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum Timer {
+    PowerCycle,
+    MachineOn,
+    ScoutAgentControlPoll,
+    DpuAgentControlPoll,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum DhcpType {
+    Bmc,
+    Machine,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum OsFsm {
+    None,
+    Scout(ScoutFsm),
+    DpuAgent(DpuAgentFsm),
+}
+
+impl OsFsm {
+    pub fn init_actions(&self) -> Vec<Action> {
+        match self {
+            Self::None => vec![],
+            Self::Scout(_) => vec![Action::InitialDiscoveryRequest(OsImage::Scout)],
+            Self::DpuAgent(_) => vec![Action::InitialDiscoveryRequest(OsImage::DpuAgent)],
+        }
+    }
+
+    pub fn event(self, event: Event) -> (Self, Vec<Action>) {
+        match self {
+            Self::None => (self, vec![]),
+            Self::Scout(scout_fsm) => {
+                let (scout_fsm, actions) = scout_fsm.event(event);
+                (Self::Scout(scout_fsm), actions)
+            }
+            Self::DpuAgent(dpu_agent_fsm) => {
+                let (dpu_agent_fsm, actions) = dpu_agent_fsm.event(event);
+                (Self::DpuAgent(dpu_agent_fsm), actions)
+            }
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum ScoutFsm {
+    Discovery,
+    PollingLoop,
+    FailedAndWaitForReboot,
+}
+
+impl ScoutFsm {
+    pub fn event(self, event: Event) -> (Self, Vec<Action>) {
+        match self {
+            Self::Discovery => self.fsm_discovery(event),
+            Self::PollingLoop => self.fsm_polling_loop(event),
+            Self::FailedAndWaitForReboot => (self, vec![]),
+        }
+    }
+
+    pub fn fsm_discovery(self, event: Event) -> (Self, Vec<Action>) {
+        match event {
+            Event::InitialDiscoveryCompleted => (
+                Self::PollingLoop,
+                vec![Action::AgentControlRequest(OsImage::Scout)],
+            ),
+            Event::MachineNotFound => (Self::FailedAndWaitForReboot, vec![]),
+            _ => (self, vec![]),
+        }
+    }
+
+    pub fn fsm_polling_loop(self, event: Event) -> (Self, Vec<Action>) {
+        match event {
+            Event::AgentControlCompleted => {
+                (self, vec![Action::SetTimer(Timer::ScoutAgentControlPoll)])
+            }
+            Event::TimerAlert(Timer::ScoutAgentControlPoll) => {
+                (self, vec![Action::AgentControlRequest(OsImage::Scout)])
+            }
+            Event::MachineNotFound => (Self::FailedAndWaitForReboot, vec![]),
+            _ => (self, vec![]),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum DpuAgentFsm {
+    Discovery,
+    AgentControl,
+    NetworkObservation,
+    FailedAndWaitForReboot,
+}
+
+impl DpuAgentFsm {
+    pub fn event(self, event: Event) -> (Self, Vec<Action>) {
+        match self {
+            Self::Discovery => self.fsm_discovery(event),
+            Self::AgentControl => self.fsm_agent_control(event),
+            Self::NetworkObservation => self.fsm_network_observation(event),
+            Self::FailedAndWaitForReboot => (self, vec![]),
+        }
+    }
+
+    pub fn fsm_discovery(self, event: Event) -> (Self, Vec<Action>) {
+        match event {
+            Event::InitialDiscoveryCompleted => (
+                Self::AgentControl,
+                vec![Action::AgentControlRequest(OsImage::DpuAgent)],
+            ),
+            Event::MachineNotFound => (Self::FailedAndWaitForReboot, vec![]),
+            _ => (self, vec![]),
+        }
+    }
+
+    pub fn fsm_agent_control(self, event: Event) -> (Self, Vec<Action>) {
+        match event {
+            Event::TimerAlert(Timer::DpuAgentControlPoll) => {
+                (self, vec![Action::AgentControlRequest(OsImage::DpuAgent)])
+            }
+            Event::AgentControlCompleted => (
+                Self::NetworkObservation,
+                vec![Action::DpuAgentNetworkObservation],
+            ),
+            Event::MachineNotFound => (Self::FailedAndWaitForReboot, vec![]),
+            _ => (self, vec![]),
+        }
+    }
+
+    pub fn fsm_network_observation(self, event: Event) -> (Self, Vec<Action>) {
+        match event {
+            Event::NetworkObservationCompleted => (
+                Self::AgentControl,
+                vec![Action::SetTimer(Timer::DpuAgentControlPoll)],
+            ),
+            Event::MachineNotFound => (Self::FailedAndWaitForReboot, vec![]),
+            _ => (self, vec![]),
+        }
+    }
+}

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 use std::borrow::Cow;
+use std::collections::VecDeque;
+use std::convert::identity;
 use std::fmt::{Display, Formatter};
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::{Arc, RwLock};
@@ -25,7 +27,6 @@ use bmc_mock::{
     PowerControl, SetSystemPowerError, SetSystemPowerResult, SystemPowerControl,
 };
 use carbide_uuid::machine::MachineId;
-use rand::Rng;
 use rpc::forge::{MachineArchitecture, MachineDiscoveryResult, ManagedHostNetworkConfigResponse};
 use rpc::forge_agent_control_response::Action;
 use serde::{Deserialize, Serialize};
@@ -36,13 +37,18 @@ use uuid::Uuid;
 use crate::api_client::{ClientApiError, DpuNetworkStatusArgs, MockDiscoveryData};
 use crate::bmc_mock_wrapper::{BmcMockRegistry, BmcMockWrapper, BmcMockWrapperHandle};
 use crate::config::{MachineATronContext, MachineConfig};
-use crate::dhcp_wrapper::{DhcpRelayError, DhcpRequestInfo, DhcpResponseInfo, DpuDhcpRelay};
+use crate::dhcp_wrapper::{
+    DhcpRelayError, DhcpRelayResult, DhcpRequestInfo, DhcpResponseInfo, DpuDhcpRelay,
+};
+use crate::machine_fsm::{Action as FsmAction, DhcpType, Event, MachineFsm, Timer};
 use crate::machine_state_machine::MachineStateError::MissingMachineId;
 use crate::machine_utils::{
     PxeError, PxeResponse, forge_agent_control, get_fac_action, get_validation_id,
     send_pxe_boot_request,
 };
 use crate::{PersistedDpuMachine, PersistedHostMachine, dhcp_wrapper};
+
+pub type DpuDhcpRelayHandle = oneshot::Sender<()>;
 
 /// MachineStateMachine (yo dawg) models the state machine of a machine endpoint
 ///
@@ -51,17 +57,27 @@ use crate::{PersistedDpuMachine, PersistedHostMachine, dhcp_wrapper};
 #[derive(Debug)]
 pub struct MachineStateMachine {
     pub live_state: Arc<RwLock<LiveState>>,
-    pub initial_os_image: OsImage,
     pub machine_dhcp_id: Uuid,
     pub bmc_dhcp_id: Uuid,
     pub mat_host_id: Uuid,
+    pub installed_os: OsImage,
 
-    state: MachineState,
+    fsm: MachineFsm,
+    bmc_mock: Option<Arc<BmcMockWrapperHandle>>,
+    power_cycle_deadline: Option<Instant>,
+    machine_on_deadline: Option<Instant>,
+    agent_polling_deadline: Option<(Instant, Timer)>,
+    bmc_dhcp_info: Option<DhcpResponseInfo>,
+    machine_dhcp_info: Option<DhcpResponseInfo>,
+    machine_discovery_result: Option<MachineDiscoveryResult>,
+
+    actions: VecDeque<FsmAction>,
     machine_info: MachineInfo,
     bmc_command_channel: mpsc::UnboundedSender<BmcCommand>,
     config: Arc<MachineConfig>,
     app_context: Arc<MachineATronContext>,
     dpu_dhcp_relay: Option<DpuDhcpRelay>,
+    dpu_dhcp_relay_handle: Option<DpuDhcpRelayHandle>,
 }
 
 #[derive(Debug, Clone)]
@@ -126,7 +142,7 @@ pub struct LiveState {
     pub bmc_ip: Option<Ipv4Addr>,
     pub booted_os: MaybeOsImage,
     pub installed_os: OsImage,
-    pub state_string: String,
+    pub state_string: Option<&'static str>,
     pub api_state: String,
     pub tpm_ek_certificate: Option<Vec<u8>>,
     pub ssh_host_key: Option<String>,
@@ -143,7 +159,7 @@ impl Default for LiveState {
             bmc_ip: None,
             booted_os: Default::default(),
             installed_os: Default::default(),
-            state_string: MachineState::BmcInit.to_string(),
+            state_string: None,
             api_state: "Unknown".to_string(),
             tpm_ek_certificate: None,
             ssh_host_key: None,
@@ -166,22 +182,6 @@ pub enum BmcRegistrationMode {
     /// carbide to be able to reach these aliases, so it is only /// suitable for local use where
     /// carbide and machine-a-tron are on the same host.
     None(u16),
-}
-
-#[derive(Debug)]
-enum MachineState {
-    BmcInit,
-    BmcOnly(BmcInitializedState),
-    MachineDown(MachineDownState),
-    Init(InitState),
-    DhcpComplete(DhcpCompleteState),
-    MachineUp(Box<MachineUpState>), // avoid large enum variants
-}
-
-enum NextState {
-    Advance(MachineState),
-    SleepFor(Duration),
-    AdvanceAndSleepFor(MachineState, Duration),
 }
 
 pub enum PersistedMachine {
@@ -221,10 +221,18 @@ impl MachineStateMachine {
                     MachineInfo::Dpu(d.into()),
                 ),
             };
-
+        let (fsm, actions) = MachineFsm::init(true, Self::is_bmc_only(&machine_info, &config));
         MachineStateMachine {
-            state: MachineState::BmcInit,
-            initial_os_image,
+            fsm,
+            actions: actions.into_iter().collect(),
+            bmc_mock: None,
+            power_cycle_deadline: None,
+            machine_on_deadline: None,
+            agent_polling_deadline: None,
+            bmc_dhcp_info: None,
+            machine_dhcp_info: None,
+            machine_discovery_result: None,
+            installed_os: initial_os_image,
             live_state: Arc::new(RwLock::new(LiveState {
                 power_state: MockPowerState::On,
                 tpm_ek_certificate,
@@ -237,6 +245,7 @@ impl MachineStateMachine {
             config,
             app_context,
             dpu_dhcp_relay,
+            dpu_dhcp_relay_handle: None,
             mat_host_id,
         }
     }
@@ -250,310 +259,406 @@ impl MachineStateMachine {
         dpu_dhcp_relay: Option<DpuDhcpRelay>,
         mat_host_id: Uuid,
     ) -> MachineStateMachine {
+        let (fsm, actions) = MachineFsm::init(false, Self::is_bmc_only(&machine_info, &config));
         MachineStateMachine {
             live_state: Arc::new(RwLock::new(LiveState {
                 power_state: MockPowerState::Off,
                 tpm_ek_certificate,
                 ..Default::default()
             })),
-            state: MachineState::BmcInit,
+            fsm,
+            actions: actions.into_iter().collect(),
+            bmc_dhcp_info: None,
+            bmc_mock: None,
+            machine_dhcp_info: None,
+            machine_discovery_result: None,
+            machine_on_deadline: None,
+            agent_polling_deadline: None,
+            power_cycle_deadline: None,
             bmc_dhcp_id: Uuid::new_v4(),
-            initial_os_image: OsImage::default(),
+            installed_os: OsImage::default(),
             machine_info,
             bmc_command_channel,
             machine_dhcp_id: Uuid::new_v4(),
             config,
             app_context,
             dpu_dhcp_relay,
+            dpu_dhcp_relay_handle: None,
             mat_host_id,
         }
     }
 
     pub async fn advance(&mut self) -> Duration {
-        if let MockPowerState::PowerCycling { since } = self.live_state.read().unwrap().power_state
-        {
-            let elapsed = since.elapsed();
-            if elapsed > POWER_CYCLE_DELAY {
-                self.live_state.write().unwrap().power_state = MockPowerState::On;
-            } else {
-                tracing::info!("Simulating 5-second power cycle");
-                return POWER_CYCLE_DELAY - elapsed;
-            }
-        }
-
-        let next_state = self.next_state().await;
-        let duration = match next_state {
-            Ok(NextState::Advance(next_state)) => {
-                self.state = next_state;
-                self.config.run_interval_working
-            }
-            Ok(NextState::SleepFor(duration)) => duration,
-            Ok(NextState::AdvanceAndSleepFor(next_state, duration)) => {
-                self.state = next_state;
-                duration
-            }
-            Err(e) => {
-                // TODO:
-                // For now, any unhandled errors will just retry in the same state after sleeping
-                // for a random interval (in this case, between 5 and 15 seconds.) Going forward we
-                // should strive to emulate real machinese in these cases: For instance, failing to
-                // get DHCP may mean we just boot to the host OS (ie. PXE boot failure), the correct
-                // state for which depends on whether we've installed forge-agent or not, etc.
-                tracing::error!(
-                    error = %e,
-                    "Error running state machine, will retry",
-                );
-                let jitter_ms = rand::rng().random::<u64>() % 10_000;
-                Duration::from_millis(jitter_ms + 5_000)
-            }
-        };
-
-        // Update self.live_state with new values after every state transition
-        {
-            let mut live_state = self.live_state.write().unwrap();
-            live_state.is_up = matches!(
-                &self.state,
-                MachineState::MachineUp(_) | MachineState::BmcOnly(_)
-            );
-            live_state.machine_ip = self.machine_ip();
-            live_state.bmc_ip = self.bmc_ip();
-            live_state.installed_os = self.installed_os();
-            if let Some(machine_id) = self.machine_id()
-                && live_state.observed_machine_id.as_ref() != Some(machine_id)
+        if let Some(duration) = self.process_actions().await {
+            duration
+        } else {
+            let now = Instant::now();
+            if let Some(power_cycle_deadline) = self.power_cycle_deadline
+                && now > power_cycle_deadline
             {
-                live_state.observed_machine_id = Some(*machine_id)
+                self.power_cycle_deadline = None;
+                self.fsm_event(Event::TimerAlert(Timer::PowerCycle));
             }
-            live_state.state_string = self.state.to_string();
-            live_state.booted_os = self.booted_os();
-        }
+            if let Some(machine_on_deadline) = self.machine_on_deadline
+                && now > machine_on_deadline
+            {
+                self.machine_on_deadline = None;
+                self.fsm_event(Event::TimerAlert(Timer::MachineOn));
+            }
+            if let Some((agent_polling_deadline, timer)) = self.agent_polling_deadline
+                && now > agent_polling_deadline
+            {
+                self.agent_polling_deadline = None;
+                self.fsm_event(Event::TimerAlert(timer));
+            }
 
-        duration
+            if let Some(duration) = self.process_actions().await {
+                duration
+            } else {
+                [
+                    self.machine_on_deadline,
+                    self.power_cycle_deadline,
+                    self.agent_polling_deadline.map(|v| v.0),
+                ]
+                .iter()
+                .flatten()
+                .min()
+                .map(|nearest| nearest.saturating_duration_since(now))
+                .unwrap_or(self.config.run_interval_idle)
+            }
+        }
     }
 
-    async fn next_state(&self) -> Result<NextState, MachineStateError> {
-        match &self.state {
-            MachineState::BmcInit => {
-                tracing::trace!(
-                    "Sending BMC DHCP Request for {}",
-                    self.machine_info.bmc_mac_address(),
-                );
-
-                let start = Instant::now();
-                let dhcp_info = dhcp_wrapper::request_ip(
-                    self.app_context.api_client(),
-                    DhcpRequestInfo {
-                        mac_address: self.machine_info.bmc_mac_address(),
-                        relay_address: self.config.oob_dhcp_relay_address,
-                        template_dir: self.config.template_dir.clone(),
-                    },
-                )
-                .await?;
-
-                tracing::trace!(
-                    "BMC DHCP Request for {} took {}ms",
-                    self.machine_info.bmc_mac_address(),
-                    start.elapsed().as_millis()
-                );
-
-                let maybe_bmc_mock_handle = self.run_bmc_mock(dhcp_info.ip_address).await?;
-
-                if self.is_nic_mode_dpu() {
-                    tracing::info!("DPU Running in NicMode, will only run BMC and not PXE boot");
-                    Ok(NextState::Advance(MachineState::BmcOnly(
-                        BmcInitializedState {
-                            _bmc_mock_handle: maybe_bmc_mock_handle,
-                            bmc_dhcp_info: dhcp_info,
-                        },
-                    )))
-                } else {
-                    let bmc_state = BmcInitializedState {
-                        _bmc_mock_handle: maybe_bmc_mock_handle,
-                        bmc_dhcp_info: dhcp_info,
+    pub async fn process_actions(&mut self) -> Option<Duration> {
+        while let Some(action) = self.actions.front() {
+            self.update_live_state();
+            match action {
+                FsmAction::SetupBmc => match self.setup_bmc().await {
+                    Ok(bmc_mock) => {
+                        self.bmc_mock = bmc_mock;
+                        self.actions.pop_front();
+                    }
+                    Err(_) => return Some(self.config.run_interval_working),
+                },
+                FsmAction::SetTimer(Timer::PowerCycle) => {
+                    self.power_cycle_deadline = Some(Instant::now() + POWER_CYCLE_DELAY);
+                    self.actions.pop_front();
+                }
+                FsmAction::SetTimer(Timer::MachineOn) => {
+                    let delay = match self.machine_info {
+                        MachineInfo::Dpu(_) => self.config.dpu_reboot_delay,
+                        MachineInfo::Host(_) => self.config.host_reboot_delay,
                     };
-                    Ok(NextState::Advance(
-                        match self.live_state.read().unwrap().power_state {
-                            MockPowerState::On => MachineState::Init(InitState {
-                                bmc_state,
-                                installed_os: self.initial_os_image,
-                            }),
-                            MockPowerState::Off | MockPowerState::PowerCycling { .. } => {
-                                MachineState::MachineDown(MachineDownState {
-                                    since: start,
-                                    bmc_state,
-                                    installed_os: self.initial_os_image,
-                                    bmc_only: false,
-                                })
+                    self.machine_on_deadline = Some(Instant::now() + Duration::from_secs(delay));
+                    self.actions.pop_front();
+                }
+                FsmAction::SetTimer(Timer::ScoutAgentControlPoll) => {
+                    self.agent_polling_deadline = Some((
+                        Instant::now() + self.config.scout_run_interval,
+                        Timer::ScoutAgentControlPoll,
+                    ));
+                    self.actions.pop_front();
+                }
+                FsmAction::SetTimer(Timer::DpuAgentControlPoll) => {
+                    self.agent_polling_deadline = Some((
+                        Instant::now() + self.config.network_status_run_interval,
+                        Timer::DpuAgentControlPoll,
+                    ));
+                    self.actions.pop_front();
+                }
+                FsmAction::Dhcp(DhcpType::Bmc) => match self.bmc_dhcp_discovery().await {
+                    Ok(bmc_dhcp_info) => {
+                        self.bmc_dhcp_info = Some(bmc_dhcp_info);
+                        self.actions.pop_front();
+                        self.fsm_event(Event::DhcpComplete(DhcpType::Bmc))
+                    }
+                    Err(_) => return Some(self.config.run_interval_working),
+                },
+                FsmAction::Dhcp(DhcpType::Machine) => match self.machine_dhcp_discovery().await {
+                    Ok(machine_dhcp_info) => {
+                        self.machine_dhcp_info = Some(machine_dhcp_info);
+                        self.actions.pop_front();
+                        self.fsm_event(Event::DhcpComplete(DhcpType::Machine))
+                    }
+                    Err(_) => return Some(self.config.run_interval_working),
+                },
+                FsmAction::PxeBootRequest => match self.pxe_boot_request().await {
+                    Ok(os_image) => {
+                        self.actions.pop_front();
+                        self.fsm_event(Event::PxeComplete(os_image))
+                    }
+                    Err(_) => return Some(self.config.run_interval_working),
+                },
+                FsmAction::InitialDiscoveryRequest(os_image) => {
+                    match self.initial_discovery_request(*os_image).await {
+                        Ok(None) => {
+                            self.actions.pop_front();
+                            self.fsm_event(Event::MachineNotFound)
+                        }
+                        Ok(Some(machine_discovery_result)) => {
+                            self.installed_os = *os_image;
+                            self.machine_discovery_result = Some(machine_discovery_result);
+                            self.actions.pop_front();
+                            self.fsm_event(Event::InitialDiscoveryCompleted)
+                        }
+                        Err(_) => return Some(self.config.run_interval_working),
+                    }
+                }
+                FsmAction::AgentControlRequest(os_image) => {
+                    match self.agent_control_request(*os_image).await {
+                        Ok(_) => {
+                            self.actions.pop_front();
+                            self.fsm_event(Event::AgentControlCompleted)
+                        }
+                        Err(MachineStateError::MachineNotFound(machine_id)) => {
+                            tracing::warn!(%machine_id, "Machine not found during agent control, likely force deleted");
+                            self.actions.pop_front();
+                            self.fsm_event(Event::MachineNotFound)
+                        }
+                        Err(_) => return Some(self.config.run_interval_working),
+                    }
+                }
+                FsmAction::DpuAgentNetworkObservation => {
+                    match self.dpu_agent_network_observation().await {
+                        Ok(maybe_dhcp_relay_handle) => {
+                            if let Some(dhcp_relay_handle) = maybe_dhcp_relay_handle {
+                                self.dpu_dhcp_relay_handle = Some(dhcp_relay_handle);
                             }
-                        },
-                    ))
+                            self.actions.pop_front();
+                            self.fsm_event(Event::NetworkObservationCompleted)
+                        }
+                        Err(MachineStateError::MachineNotFound(machine_id)) => {
+                            tracing::warn!(%machine_id, "Machine not found during network observation, likely force deleted");
+                            self.actions.pop_front();
+                            self.fsm_event(Event::MachineNotFound)
+                        }
+                        Err(_) => return Some(self.config.run_interval_working),
+                    }
+                }
+                FsmAction::CleanupOnPowerOff => {
+                    self.actions.pop_front();
+                    self.machine_discovery_result = None;
+                    self.dpu_dhcp_relay_handle = None;
                 }
             }
-            MachineState::BmcOnly(_) => Ok(NextState::SleepFor(Duration::MAX)),
-            MachineState::MachineDown(inner_state) => {
-                match self.live_state.read().unwrap().power_state {
-                    MockPowerState::Off => {
-                        tracing::info!("Power is off, will wait for power signal");
-                        return Ok(NextState::SleepFor(Duration::MAX));
-                    }
-                    MockPowerState::PowerCycling { since } => {
-                        // Technically this should never be hit, since `advance()` will never call
-                        // next_state until the delay is over and the power is back on.
-                        tracing::info!("Power is cycling, will wait for a delay");
-                        return Ok(NextState::SleepFor(POWER_CYCLE_DELAY - since.elapsed()));
-                    }
-                    _ => {}
-                }
-                let reboot_delay_secs = match self.machine_info {
-                    MachineInfo::Dpu(_) => self.config.dpu_reboot_delay,
-                    MachineInfo::Host(_) => self.config.host_reboot_delay,
-                };
-                let elapsed = inner_state.since.elapsed();
-                let delay = Duration::from_secs(reboot_delay_secs);
-                if elapsed >= delay {
-                    Ok(NextState::Advance(inner_state.power_on()))
-                } else {
-                    Ok(NextState::SleepFor(delay - elapsed))
-                }
-            }
-            MachineState::Init(inner_state) => {
-                let Some(primary_mac) = self.machine_info.dhcp_mac_addresses().first().copied()
-                else {
-                    return Err(MachineStateError::NoMachineMacAddress);
-                };
-                tracing::debug!("Sending Admin DHCP Request for {}", primary_mac);
+        }
+        self.update_live_state();
+        None
+    }
 
-                let start = Instant::now();
+    fn fsm_event(&mut self, event: Event) {
+        let old_state = self.fsm;
+        let (new_state, actions) = self.fsm.event(event);
+        tracing::info!(?old_state, ?event, ?new_state, ?actions, "machine FSM step");
+        actions
+            .into_iter()
+            .for_each(|action| self.actions.push_back(action));
+        self.fsm = new_state;
+    }
 
-                let machine_dhcp_info =
-                    if let Some(DpuDhcpRelay::HostEnd(relay_tx)) = &self.dpu_dhcp_relay {
-                        let (reply_tx, reply_rx) = oneshot::channel();
-                        relay_tx.send(reply_tx).map_err(|_| {
-                            DhcpRelayError::DpuRelayError(
-                                "Error sending request, channel closed".to_string(),
-                            )
-                        })?;
-                        reply_rx.await.map_err(|_| {
-                            DhcpRelayError::DpuRelayError(
-                                "Error reading reply, channel closed".to_string(),
-                            )
-                        })??
-                    } else {
-                        dhcp_wrapper::request_ip(
-                            self.app_context.api_client(),
-                            DhcpRequestInfo {
-                                mac_address: primary_mac,
-                                relay_address: self.config.admin_dhcp_relay_address,
-                                template_dir: self.config.template_dir.clone(),
-                            },
+    async fn setup_bmc(&self) -> Result<Option<Arc<BmcMockWrapperHandle>>, MachineStateError> {
+        let Some(dhcp_info) = &self.bmc_dhcp_info else {
+            return Err(MachineStateError::NoBmcDhcpInfo);
+        };
+        self.run_bmc_mock(dhcp_info.ip_address).await
+    }
+
+    async fn bmc_dhcp_discovery(&self) -> DhcpRelayResult<DhcpResponseInfo> {
+        let start = Instant::now();
+        dhcp_wrapper::request_ip(
+            self.app_context.api_client(),
+            DhcpRequestInfo {
+                mac_address: self.machine_info.bmc_mac_address(),
+                relay_address: self.config.oob_dhcp_relay_address,
+                template_dir: self.config.template_dir.clone(),
+            },
+        )
+        .await
+        .inspect(|_| {
+            tracing::debug!(
+                "BMC DHCP Request for {} took {}ms",
+                self.machine_info.bmc_mac_address(),
+                start.elapsed().as_millis()
+            );
+        })
+        .inspect_err(|err| {
+            tracing::warn!(
+                "BMC DHCP Request failed after {}ms: {err}",
+                start.elapsed().as_millis()
+            );
+        })
+    }
+
+    async fn machine_dhcp_discovery(&self) -> Result<DhcpResponseInfo, MachineStateError> {
+        let Some(primary_mac) = self.machine_info.dhcp_mac_addresses().first().copied() else {
+            return Err(MachineStateError::NoMachineMacAddress);
+        };
+
+        tracing::debug!("Sending Admin DHCP Request for {}", primary_mac);
+        let start = Instant::now();
+        let machine_dhcp_info_result = if let Some(DpuDhcpRelay::HostEnd(relay_tx)) =
+            &self.dpu_dhcp_relay
+        {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            match relay_tx.send(reply_tx).map_err(|_| {
+                DhcpRelayError::DpuRelayError("Error sending request, channel closed".to_string())
+            }) {
+                Ok(_) => reply_rx
+                    .await
+                    .map_err(|_| {
+                        DhcpRelayError::DpuRelayError(
+                            "Error reading reply, channel closed".to_string(),
                         )
-                        .await?
-                    };
+                    })
+                    .and_then(identity),
+                Err(err) => Err(err),
+            }
+        } else {
+            dhcp_wrapper::request_ip(
+                self.app_context.api_client(),
+                DhcpRequestInfo {
+                    mac_address: primary_mac,
+                    relay_address: self.config.admin_dhcp_relay_address,
+                    template_dir: self.config.template_dir.clone(),
+                },
+            )
+            .await
+        };
+        machine_dhcp_info_result
+            .inspect(|_| {
                 tracing::debug!(
                     "Admin DHCP Request for {} took {}ms",
                     primary_mac,
                     start.elapsed().as_millis()
                 );
+            })
+            .map_err(|err| {
+                tracing::debug!(
+                    "Admin DHCP Request for {} failed after {}ms: {err}",
+                    primary_mac,
+                    start.elapsed().as_millis()
+                );
+                err.into()
+            })
+    }
 
-                Ok(NextState::Advance(
-                    inner_state.dhcp_complete(machine_dhcp_info),
-                ))
-            }
-            MachineState::DhcpComplete(inner_state) => {
-                let Some(machine_interface_id) = inner_state.machine_dhcp_info.interface_id else {
-                    return Err(MachineStateError::MissingInterfaceId);
-                };
+    async fn pxe_boot_request(&self) -> Result<OsImage, MachineStateError> {
+        let Some(machine_interface_id) = self
+            .machine_dhcp_info
+            .as_ref()
+            .and_then(|info| info.interface_id.as_ref())
+        else {
+            return Err(MachineStateError::MissingInterfaceId);
+        };
 
-                let (architecture, product) = match self.machine_info {
-                    MachineInfo::Dpu(_) => (
-                        MachineArchitecture::Arm,
-                        "Machine-A-Tron Bluefield".to_string(),
-                    ),
-                    MachineInfo::Host(_) => (
-                        MachineArchitecture::X86,
-                        "Machine-A-Tron X86 Host".to_string(),
-                    ),
-                };
+        let (architecture, product) = match self.machine_info {
+            MachineInfo::Dpu(_) => (
+                MachineArchitecture::Arm,
+                "Machine-A-Tron Bluefield".to_string(),
+            ),
+            MachineInfo::Host(_) => (
+                MachineArchitecture::X86,
+                "Machine-A-Tron X86 Host".to_string(),
+            ),
+        };
 
-                let pxe_response = send_pxe_boot_request(
-                    &self.app_context,
-                    architecture,
-                    machine_interface_id,
-                    Some(product),
-                    Some(inner_state.machine_dhcp_info.ip_address.to_string()),
-                )
-                .await?;
+        let pxe_response = send_pxe_boot_request(
+            &self.app_context,
+            architecture,
+            *machine_interface_id,
+            Some(product),
+            self.machine_dhcp_info
+                .as_ref()
+                .map(|info| info.ip_address.to_string()),
+        )
+        .await?;
 
-                let booted_os = match pxe_response {
-                    PxeResponse::Exit => inner_state.installed_os,
-                    PxeResponse::Scout => OsImage::Scout,
-                    PxeResponse::DpuAgent => OsImage::DpuAgent,
-                };
-
-                Ok(NextState::Advance(inner_state.machine_up(booted_os)))
-            }
-            MachineState::MachineUp(inner_state) => match inner_state.booted_os {
-                OsImage::DpuAgent => self.run_dpu_agent_iteration(inner_state).await,
-                OsImage::Scout => self.run_scout_iteration(inner_state).await,
-                // Now we install bfb via redfish, so this is expected.
-                OsImage::None if matches!(self.machine_info, MachineInfo::Dpu(_)) => {
-                    self.run_scout_iteration(inner_state).await
+        let os = match pxe_response {
+            PxeResponse::Exit => self.installed_os,
+            PxeResponse::Scout => OsImage::Scout,
+            PxeResponse::DpuAgent => OsImage::DpuAgent,
+        };
+        match os {
+            OsImage::None => Ok(os),
+            OsImage::DpuAgent => {
+                if matches!(self.machine_info, MachineInfo::Host(_)) {
+                    Err(MachineStateError::WrongOsForMachine(
+                        "ERROR: Running DpuAgent OS on a host machine, this should not happen."
+                            .to_string(),
+                    ))
+                } else {
+                    Ok(os)
                 }
-                OsImage::None => {
-                    tracing::debug!("Host booted to tenant OS");
-                    Ok(NextState::SleepFor(Duration::MAX))
+            }
+            OsImage::Scout => {
+                if matches!(self.machine_info, MachineInfo::Dpu(_)) {
+                    tracing::warn!(
+                        "ERROR: Running Scout OS on a DPU machine, this should not happen."
+                    );
+                    Err(MachineStateError::WrongOsForMachine(
+                        "ERROR: Running Scout OS on a DPU machine, this should not happen."
+                            .to_string(),
+                    ))
+                } else {
+                    Ok(os)
                 }
-            },
+            }
         }
     }
 
-    /// Pretend we're the Dpu Agent image (carbide.efi), performing discovery and sending network health checks
-    async fn run_dpu_agent_iteration(
+    async fn initial_discovery_request(
         &self,
-        machine_up_state: &MachineUpState,
-    ) -> Result<NextState, MachineStateError> {
-        if matches!(self.machine_info, MachineInfo::Host(_)) {
-            return Err(MachineStateError::WrongOsForMachine(
-                "ERROR: Running DpuAgent OS on a host machine, this should not happen.".to_string(),
-            ));
-        }
-
-        // Run discovery once to get the machine ID
-        let Some(machine_discovery_result) = machine_up_state.machine_discovery_result.as_ref()
-        else {
-            // No machine_discovery_result means we just booted. Run discovery now.
-            let machine_discovery_result = match self
-                .run_machine_discovery(&machine_up_state.machine_dhcp_info)
-                .await
-            {
-                Ok(result) => result,
-                Err(MachineStateError::ClientApi(ClientApiError::InvocationError(status))) => {
-                    return match status.code() {
-                        tonic::Code::InvalidArgument => {
-                            tracing::error!(error=%status, "Invalid argument running dpu agent iteration, likely not ingested yet. Will sleep until we are rebooted");
-                            Ok(NextState::SleepFor(Duration::MAX))
-                        }
-                        _ => Err(MachineStateError::ClientApi(
-                            ClientApiError::InvocationError(status),
-                        )),
-                    };
-                }
-                Err(e) => return Err(e),
-            };
-            // Put the DpuAgent image as the installed_os so that we can boot to it when PXE tells us to local.
-            return Ok(NextState::Advance(
-                machine_up_state
-                    .install_os_with_discovery_result(OsImage::DpuAgent, machine_discovery_result),
-            ));
+        os_image: OsImage,
+    ) -> Result<Option<MachineDiscoveryResult>, MachineStateError> {
+        let Some(machine_dhcp_info) = self.machine_dhcp_info.as_ref() else {
+            return Err(MachineStateError::NoMachineDhcpInfo);
         };
+        // No machine_discovery_result means we just booted. Run discovery now.
+        tracing::trace!("Running initial discovery after boot");
+        match self.run_machine_discovery(machine_dhcp_info).await {
+            Ok(result) => {
+                if os_image == OsImage::Scout {
+                    let machine_id = result.machine_id.as_ref().ok_or(MissingMachineId)?;
+                    // Inform the API that we have finished our reboot (ie. scout is now running)
+                    self.app_context
+                        .forge_api_client
+                        .reboot_completed(*machine_id)
+                        .await?;
+                }
+                Ok(Some(result))
+            }
+            Err(MachineStateError::ClientApi(ClientApiError::InvocationError(status))) => {
+                match status.code() {
+                    tonic::Code::InvalidArgument => {
+                        tracing::error!(error=%status, "Invalid argument return by discovery, likely not ingested yet.");
+                        Ok(None)
+                    }
+                    tonic::Code::NotFound => {
+                        tracing::warn!(error=%status, "Machine not found in discovery, likely force deleted.");
+                        Ok(None)
+                    }
+                    _ => Err(MachineStateError::ClientApi(
+                        ClientApiError::InvocationError(status),
+                    )),
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
 
-        let machine_id = machine_discovery_result
-            .machine_id
+    async fn agent_control_request(&self, os_image: OsImage) -> Result<(), MachineStateError> {
+        let machine_id = self
+            .machine_discovery_result
             .as_ref()
+            .and_then(|result| result.machine_id)
             .ok_or(MissingMachineId)?;
 
         // Ask the API server what to do next
         let start = Instant::now();
-        let control_response = forge_agent_control(&self.app_context, *machine_id).await;
+        let Some(control_response) = forge_agent_control(&self.app_context, machine_id).await
+        else {
+            return Err(MachineStateError::MachineNotFound(machine_id));
+        };
         let action = get_fac_action(&control_response);
         tracing::trace!(
             "get action took {}ms; action={:?}",
@@ -562,21 +667,55 @@ impl MachineStateMachine {
         );
 
         match action {
-            Action::Discovery => self.send_discovery_complete(machine_id).await?,
+            Action::Discovery => self.send_discovery_complete(&machine_id).await?,
+            Action::MachineValidation if os_image == OsImage::Scout => {
+                if let Some(validation_id) = get_validation_id(&control_response) {
+                    self.app_context
+                        .api_client()
+                        .machine_validation_complete(&machine_id, validation_id)
+                        .await?;
+                }
+            }
+            Action::Reset if os_image == OsImage::Scout => {
+                tracing::debug!("Got Reset action in scout image, sending cleanup_complete");
+                // Wait a bit before confirming the cleanup in order to mimic real
+                // cleanup and give the tests a higher chance to observe teh cleanup state
+                tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                self.app_context
+                    .api_client()
+                    .cleanup_complete(&machine_id)
+                    .await?;
+            }
             Action::Noop => {}
             _ => {
                 tracing::warn!(
-                    "Dpu agent got unknown action from forge_agent_control: {:?}",
-                    action
+                    "Unknown action from forge_agent_control: {action:?} for OS image {os_image}"
                 );
             }
         }
+        Ok(())
+    }
+    pub async fn dpu_agent_network_observation(
+        &self,
+    ) -> Result<Option<DpuDhcpRelayHandle>, MachineStateError> {
+        let machine_id = self
+            .machine_discovery_result
+            .as_ref()
+            .and_then(|result| result.machine_id)
+            .ok_or(MissingMachineId)?;
 
-        let network_config = self
+        let network_config = match self
             .app_context
             .forge_api_client
-            .get_managed_host_network_config(*machine_id)
-            .await?;
+            .get_managed_host_network_config(machine_id)
+            .await
+        {
+            Ok(config) => config,
+            Err(status) if status.code() == tonic::Code::NotFound => {
+                return Err(MachineStateError::MachineNotFound(machine_id));
+            }
+            Err(status) => return Err(status.into()),
+        };
 
         // DPUs send network status periodically
         self.send_network_status_observation(machine_id.to_owned(), &network_config)
@@ -585,116 +724,28 @@ impl MachineStateMachine {
         // Launch a DHCP server for the HostMachine to call, if it's not already running.
         if let (Some(DpuDhcpRelay::DpuEnd(dhcp_relay)), true) = (
             self.dpu_dhcp_relay.clone(),
-            machine_up_state.dpu_dhcp_relay_handle.is_none(),
+            self.dpu_dhcp_relay_handle.is_none(),
         ) {
-            // The relay will stop when this is dropped (ie. when we move out of `MachineUp`)
-            let relay_handle = dhcp_relay.spawn(network_config.clone());
-            Ok(NextState::AdvanceAndSleepFor(
-                MachineState::MachineUp(
-                    machine_up_state
-                        .with_dpu_dhcp_relay_handle(relay_handle)
-                        .into(),
-                ),
-                self.config.network_status_run_interval,
-            ))
+            Ok(Some(dhcp_relay.spawn(network_config.clone())))
         } else {
-            Ok(NextState::SleepFor(self.config.network_status_run_interval))
+            Ok(None)
         }
     }
 
-    /// Pretend we're the Scout image (which hosts can PXE boot too but don't install), which performs discovery and periodically runs actions via ForgeAgentControl.
-    async fn run_scout_iteration(
-        &self,
-        machine_up_state: &MachineUpState,
-    ) -> Result<NextState, MachineStateError> {
-        if matches!(self.machine_info, MachineInfo::Dpu(_)) {
-            tracing::warn!("ERROR: Running Scout OS on a DPU machine, this should not happen.");
-            return Ok(NextState::Advance(MachineState::MachineDown(
-                MachineDownState {
-                    since: Instant::now(),
-                    bmc_state: machine_up_state.bmc_state.clone(),
-                    installed_os: machine_up_state.installed_os,
-                    bmc_only: false,
-                },
-            )));
+    pub fn update_live_state(&self) {
+        let mut live_state = self.live_state.write().unwrap();
+        live_state.is_up = self.fsm.is_up();
+        live_state.machine_ip = self.machine_ip();
+        live_state.bmc_ip = self.bmc_ip();
+        live_state.installed_os = self.installed_os;
+        if let Some(machine_id) = self.machine_id()
+            && live_state.observed_machine_id != Some(machine_id)
+        {
+            live_state.observed_machine_id = Some(machine_id)
         }
-
-        let Some(machine_discovery_result) = machine_up_state.machine_discovery_result.as_ref()
-        else {
-            // No machine_discovery_result means scout has not yet run this boot. Run discovery now.
-            tracing::trace!("Running initial discovery after boot");
-            let machine_discovery_result = match self
-                .run_machine_discovery(&machine_up_state.machine_dhcp_info)
-                .await
-            {
-                Ok(r) => r,
-                Err(e) => {
-                    tracing::error!(error=%e, "Error running discovery after booting scout image. Will sleep until we are rebooted");
-                    return Ok(NextState::SleepFor(Duration::MAX));
-                }
-            };
-            let machine_id = machine_discovery_result
-                .machine_id
-                .as_ref()
-                .ok_or(MissingMachineId)?;
-
-            // Inform the API that we have finished our reboot (ie. scout is now running)
-            self.app_context
-                .forge_api_client
-                .reboot_completed(*machine_id)
-                .await?;
-
-            return Ok(NextState::Advance(
-                machine_up_state
-                    .install_os_with_discovery_result(OsImage::None, machine_discovery_result),
-            ));
-        };
-
-        let machine_id = machine_discovery_result
-            .machine_id
-            .as_ref()
-            .ok_or(MissingMachineId)?;
-
-        // Ask the API server what to do next
-        let start = Instant::now();
-        let control_response = forge_agent_control(&self.app_context, *machine_id).await;
-        let action = get_fac_action(&control_response);
-        tracing::trace!(
-            "get action took {}ms; action={:?}",
-            start.elapsed().as_millis(),
-            action,
-        );
-
-        match action {
-            Action::Discovery => self.send_discovery_complete(machine_id).await?,
-            Action::MachineValidation => {
-                if let Some(validation_id) = get_validation_id(&control_response) {
-                    self.app_context
-                        .api_client()
-                        .machine_validation_complete(machine_id, validation_id)
-                        .await?;
-                }
-            }
-            Action::Reset => {
-                tracing::debug!("Got Reset action in scout image, sending cleanup_complete");
-                // Wait a bit before confirming the cleanup in order to mimic real
-                // cleanup and give the tests a higher chance to observe teh cleanup state
-                tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-                self.app_context
-                    .api_client()
-                    .cleanup_complete(machine_id)
-                    .await?;
-            }
-            Action::Noop => {}
-            _ => {
-                tracing::warn!(
-                    "Scout image got unknown action from forge_agent_control: {:?}",
-                    action
-                );
-            }
-        }
-
-        Ok(NextState::SleepFor(self.config.scout_run_interval))
+        live_state.state_string = Some(self.fsm.state_string());
+        live_state.power_state = self.fsm.power_state();
+        live_state.booted_os = self.booted_os();
     }
 
     async fn run_machine_discovery(
@@ -787,143 +838,37 @@ impl MachineStateMachine {
     }
 
     pub fn set_system_power(&mut self, request: SystemPowerControl) -> SetSystemPowerResult {
-        let bmc_only = self.is_nic_mode_dpu();
         use SystemPowerControl::*;
-        let (new_machine_state, new_power_state) = match (
-            request,
-            self.live_state.read().unwrap().power_state,
-        ) {
-            // If we're off and we get an on or power-cycle signal, turn on.
-            // Ditto if we're on and get a power-cycle or restart signal.
-            (On | ForceOn | PushPowerButton | PowerCycle, power_state @ MockPowerState::Off)
-            | (PowerCycle | GracefulRestart | ForceRestart, power_state @ MockPowerState::On) => {
-                if matches!(power_state, MockPowerState::Off) {
-                    tracing::debug!("Powering on machine");
-                } else {
-                    tracing::debug!("Power cycling machine");
-                }
-
-                let new_power_state = match request {
-                    PowerCycle => MockPowerState::PowerCycling {
-                        since: Instant::now(),
-                    },
-                    _ => MockPowerState::On,
-                };
-
-                // If we haven't initialized the BMC yet, no-op, as we haven't booted yet either.
-                let maybe_machine_state = self.bmc_state().map(|bmc_state| {
-                    // Set the time the machine has been down since to now, so that reboot_delay is respected.
-                    MachineState::MachineDown(MachineDownState {
-                        since: Instant::now(),
-                        bmc_state: bmc_state.clone(),
-                        installed_os: self.installed_os(),
-                        bmc_only,
-                    })
-                });
-
-                (maybe_machine_state, new_power_state)
-            }
-            (GracefulShutdown | ForceOff | PushPowerButton, MockPowerState::On) => {
-                tracing::debug!("Powering off machine");
-                let maybe_machine_state = self.bmc_state().map(|bmc_state| {
-                    MachineState::MachineDown(MachineDownState {
-                        since: Instant::now(),
-                        bmc_state: bmc_state.clone(),
-                        installed_os: self.installed_os(),
-                        bmc_only,
-                    })
-                });
-                (maybe_machine_state, MockPowerState::Off)
-            }
-            (GracefulShutdown | ForceOff | GracefulRestart | ForceRestart, MockPowerState::Off) => {
-                let msg =
-                    "Machine-a-tron mock: cannot power off machine, it is already off".to_string();
-                tracing::warn!("{msg}");
-                return Err(SetSystemPowerError::BadRequest(msg));
-            }
-            (On | ForceOn, MockPowerState::On) => {
-                let msg =
-                    "Machine-a-tron mock: cannot power on machine, it is already on".to_string();
-                tracing::warn!("{msg}");
-                return Err(SetSystemPowerError::BadRequest(msg));
-            }
-            (Nmi | Suspend | Pause | Resume, _) => {
+        match request {
+            On | ForceOn => self.fsm_event(Event::PowerOn),
+            GracefulRestart | ForceRestart | PowerCycle => self.fsm_event(Event::PowerCycle),
+            GracefulShutdown | ForceOff => self.fsm_event(Event::PowerOff),
+            PushPowerButton | Nmi | Suspend | Pause | Resume => {
                 let msg = format!("Machine-a-tron mock: unsupported power request {request:?}",);
                 tracing::warn!("{msg}");
                 return Err(SetSystemPowerError::BadRequest(msg));
             }
-            (request, MockPowerState::PowerCycling { .. }) => {
-                let msg = format!(
-                    "Machine-a-tron mock: Got power request while in the middle of power cycling {request:?}"
-                );
-                tracing::warn!("{msg}");
-                return Err(SetSystemPowerError::BadRequest(msg));
-            }
         };
-
-        self.live_state.write().unwrap().power_state = new_power_state;
-        if let Some(new_machine_state) = new_machine_state {
-            self.state = new_machine_state;
-        }
-
+        self.update_live_state();
         Ok(())
     }
 
-    pub fn machine_id(&self) -> Option<&MachineId> {
-        match &self.state {
-            MachineState::BmcInit | MachineState::BmcOnly(_) => None,
-            MachineState::MachineDown(_) => None,
-            MachineState::Init(_) => None,
-            MachineState::DhcpComplete(_) => None,
-            MachineState::MachineUp(s) => s
-                .machine_discovery_result
-                .as_ref()
-                .and_then(|m| m.machine_id.as_ref()),
-        }
+    pub fn machine_id(&self) -> Option<MachineId> {
+        self.machine_discovery_result
+            .as_ref()
+            .and_then(|result| result.machine_id)
     }
 
     pub fn machine_ip(&self) -> Option<Ipv4Addr> {
-        match &self.state {
-            MachineState::BmcInit | MachineState::BmcOnly(_) => None,
-            MachineState::MachineDown(_) => None,
-            MachineState::Init(_) => None,
-            MachineState::DhcpComplete(s) => Some(s.machine_dhcp_info.ip_address),
-            MachineState::MachineUp(s) => Some(s.machine_dhcp_info.ip_address),
-        }
+        self.machine_dhcp_info.as_ref().map(|v| v.ip_address)
     }
 
     pub fn bmc_ip(&self) -> Option<Ipv4Addr> {
-        self.bmc_state().map(|b| b.bmc_dhcp_info.ip_address)
+        self.bmc_dhcp_info.as_ref().map(|v| v.ip_address)
     }
 
     pub fn booted_os(&self) -> MaybeOsImage {
-        if let MachineState::MachineUp(machine_up_state) = &self.state {
-            MaybeOsImage(Some(machine_up_state.booted_os))
-        } else {
-            MaybeOsImage(None)
-        }
-    }
-
-    fn bmc_state(&self) -> Option<&BmcInitializedState> {
-        let bmc_state = match &self.state {
-            MachineState::BmcInit => return None,
-            MachineState::BmcOnly(s) => s,
-            MachineState::MachineDown(s) => &s.bmc_state,
-            MachineState::Init(s) => &s.bmc_state,
-            MachineState::DhcpComplete(s) => &s.bmc_state,
-            MachineState::MachineUp(s) => &s.bmc_state,
-        };
-        Some(bmc_state)
-    }
-
-    pub fn installed_os(&self) -> OsImage {
-        match &self.state {
-            MachineState::BmcInit | MachineState::BmcOnly(_) => self.initial_os_image,
-            MachineState::MachineDown(s) => s.installed_os,
-            MachineState::Init(s) => s.installed_os,
-            MachineState::DhcpComplete(s) => s.installed_os,
-            MachineState::MachineUp(s) => s.installed_os,
-        }
+        MaybeOsImage(self.fsm.booted_os())
     }
 
     async fn run_bmc_mock(
@@ -974,143 +919,19 @@ impl MachineStateMachine {
         Ok(())
     }
 
-    fn is_nic_mode_dpu(&self) -> bool {
-        matches!(self.machine_info, MachineInfo::Dpu(_)) && self.config.dpus_in_nic_mode
-    }
-}
-
-// MARK: - Associated state definitions
-#[derive(Debug, Clone)]
-struct BmcInitializedState {
-    bmc_dhcp_info: DhcpResponseInfo,
-    _bmc_mock_handle: Option<Arc<BmcMockWrapperHandle>>,
-}
-
-#[derive(Debug, Clone)]
-struct MachineDownState {
-    since: Instant,
-    bmc_state: BmcInitializedState,
-    installed_os: OsImage,
-    bmc_only: bool,
-}
-
-impl MachineDownState {
-    fn power_on(&self) -> MachineState {
-        if self.bmc_only {
-            MachineState::BmcOnly(self.bmc_state.clone())
-        } else {
-            MachineState::Init(InitState {
-                bmc_state: self.bmc_state.clone(),
-                installed_os: self.installed_os,
-            })
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-struct InitState {
-    bmc_state: BmcInitializedState,
-    installed_os: OsImage,
-}
-
-impl InitState {
-    fn dhcp_complete(&self, machine_dhcp_info: DhcpResponseInfo) -> MachineState {
-        MachineState::DhcpComplete(DhcpCompleteState {
-            machine_dhcp_info,
-            bmc_state: self.bmc_state.clone(),
-            installed_os: self.installed_os,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
-struct DhcpCompleteState {
-    machine_dhcp_info: DhcpResponseInfo,
-    bmc_state: BmcInitializedState,
-    installed_os: OsImage,
-}
-
-impl DhcpCompleteState {
-    fn machine_up(&self, os: OsImage) -> MachineState {
-        MachineState::MachineUp(
-            MachineUpState {
-                machine_dhcp_info: self.machine_dhcp_info.clone(),
-                bmc_state: self.bmc_state.clone(),
-                machine_discovery_result: None,
-                booted_os: os,
-                installed_os: self.installed_os,
-                dpu_dhcp_relay_handle: None,
-            }
-            .into(),
-        )
-    }
-}
-
-#[derive(Debug)]
-struct MachineUpState {
-    machine_dhcp_info: DhcpResponseInfo,
-    bmc_state: BmcInitializedState,
-    machine_discovery_result: Option<MachineDiscoveryResult>,
-    booted_os: OsImage,
-    installed_os: OsImage,
-    dpu_dhcp_relay_handle: Option<oneshot::Sender<()>>,
-}
-
-impl MachineUpState {
-    fn with_dpu_dhcp_relay_handle(&self, handle: oneshot::Sender<()>) -> Self {
-        Self {
-            machine_dhcp_info: self.machine_dhcp_info.clone(),
-            bmc_state: self.bmc_state.clone(),
-            machine_discovery_result: self.machine_discovery_result.clone(),
-            booted_os: self.booted_os,
-            installed_os: self.installed_os,
-            dpu_dhcp_relay_handle: Some(handle),
-        }
-    }
-}
-
-impl MachineUpState {
-    fn install_os_with_discovery_result(
-        &self,
-        installed_os: OsImage,
-        machine_discovery_result: MachineDiscoveryResult,
-    ) -> MachineState {
-        MachineState::MachineUp(
-            MachineUpState {
-                machine_dhcp_info: self.machine_dhcp_info.clone(),
-                bmc_state: self.bmc_state.clone(),
-                booted_os: self.booted_os,
-                installed_os,
-                machine_discovery_result: Some(machine_discovery_result),
-                dpu_dhcp_relay_handle: None,
-            }
-            .into(),
-        )
-    }
-}
-
-impl Display for MachineState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let str_repr = match self {
-            Self::BmcInit => "BmcInit",
-            Self::BmcOnly(_) => "BmcOnly",
-            Self::MachineDown(_) => "MachineDown",
-            Self::Init(_) => "Init",
-            Self::DhcpComplete(_) => "DhcpComplete",
-            Self::MachineUp(_) => "MachineUp",
-        };
-        write!(f, "{str_repr}")
+    fn is_bmc_only(info: &MachineInfo, config: &MachineConfig) -> bool {
+        matches!(info, MachineInfo::Dpu(_)) && config.dpus_in_nic_mode
     }
 }
 
 impl Display for MachineStateMachine {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        self.state.fmt(f)
+        self.fsm.state_string().fmt(f)
     }
 }
 
 /// Represents the image that can be booted to via PXE or installed on-device
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum OsImage {
     /// Default installed OS, will sleep forever when booted to.
@@ -1156,6 +977,10 @@ pub enum MachineStateError {
     MissingMachineId,
     #[error("No mac addresses specified for machine")]
     NoMachineMacAddress,
+    #[error("No DHCP info for BMC. This is bug.")]
+    NoBmcDhcpInfo,
+    #[error("No DHCP info for machine. This is bug.")]
+    NoMachineDhcpInfo,
     #[error("Error configuring listening address: {0}")]
     ListenAddressConfigError(#[from] AddressConfigError),
     #[error("Could not find certificates at {0}")]
@@ -1172,6 +997,8 @@ pub enum MachineStateError {
     MockSshServer(String),
     #[error("{0}")]
     WrongOsForMachine(String),
+    #[error("Machine not found: {0}")]
+    MachineNotFound(MachineId),
 }
 impl From<tonic::Status> for MachineStateError {
     fn from(err: tonic::Status) -> Self {

--- a/crates/machine-a-tron/src/machine_utils.rs
+++ b/crates/machine-a-tron/src/machine_utils.rs
@@ -58,18 +58,24 @@ pub enum PxeError {
 pub async fn forge_agent_control(
     app_context: &MachineATronContext,
     machine_id: MachineId,
-) -> ForgeAgentControlResponse {
-    app_context
+) -> Option<ForgeAgentControlResponse> {
+    match app_context
         .forge_api_client
         .forge_agent_control(machine_id)
         .await
-        .unwrap_or_else(|e| {
+    {
+        Ok(response) => Some(response),
+        Err(e) => {
+            if e.code() == tonic::Code::NotFound {
+                return None;
+            }
             tracing::warn!("Error getting control action: {e}");
-            ForgeAgentControlResponse {
+            Some(ForgeAgentControlResponse {
                 action: Action::Noop as i32,
                 data: None,
-            }
-        })
+            })
+        }
+    }
 }
 
 pub fn get_fac_action(

--- a/crates/machine-a-tron/src/tui.rs
+++ b/crates/machine-a-tron/src/tui.rs
@@ -94,7 +94,7 @@ pub struct HostDetails {
     pub machine_id: Option<String>,
     pub hw_type: Option<HostHardwareType>,
     pub power_state: MockPowerState,
-    pub mat_state: String,
+    pub mat_state: Option<&'static str>,
     pub api_state: String,
     pub oob_ip: String,
     pub machine_ip: String,
@@ -109,7 +109,7 @@ impl HostDetails {
             self.machine_id
                 .clone()
                 .unwrap_or_else(|| self.mat_id.to_string()),
-            self.mat_state,
+            self.mat_state.unwrap_or("Unknown"),
             self.api_state
         )
     }
@@ -130,7 +130,7 @@ impl HostDetails {
             &format!("BMC IP: {}\n", self.oob_ip),
             &format!("Power State: {}\n", self.power_state),
             &format!("Booted OS: {}\n", self.booted_os),
-            &format!("MAT State: {}\n", self.mat_state),
+            &format!("MAT State: {}\n", self.mat_state.unwrap_or("Unknown")),
             &format!("API State: {}\n", self.api_state),
         ]
         .into_iter()


### PR DESCRIPTION
## Description

Refactor MachineStateMachine to use an explicit, pure FSM design by extracting state machine logic into a new machine_fsm.rs module.

Key changes:
- Replace nested state structs with clean enum-based FSM (MachineFsm, OsFsm, ScoutFsm, DpuAgentFsm)
- Use action queue pattern for side effects instead of inline execution
- Add explicit timer handling with deadlines (PowerCycle, MachineOn, AgentControlPoll)
- Handle MachineNotFound errors gracefully for force-deleted machines
- Remove random jitter from retry logic

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

