### PR TITLE
feat: Add API filter to find machines by Rack ID

### DIFF
--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -1723,6 +1723,11 @@ pub async fn find_machine_ids(
         qb.push_bind(id);
     }
 
+    if let Some(rack_id) = search_config.rack_id {
+        qb.push(" AND rack_id = ");
+        qb.push_bind(rack_id);
+    }
+
     if search_config.for_update {
         qb.push(" FOR UPDATE");
     }

--- a/crates/api-model/src/machine/machine_search_config.rs
+++ b/crates/api-model/src/machine/machine_search_config.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 use carbide_uuid::instance_type::InstanceTypeId;
+use carbide_uuid::rack::RackId;
 use rpc::errors::RpcDataConversionError;
 
 /// MachineSearchConfig: Search parameters
@@ -28,6 +29,7 @@ pub struct MachineSearchConfig {
     /// Only include quarantined machines
     pub only_quarantine: bool,
     pub exclude_hosts: bool,
+    /// Returns machines only if they are assigned the given instance type
     pub instance_type_id: Option<InstanceTypeId>,
 
     /// Whether the query results will be later
@@ -39,10 +41,12 @@ pub struct MachineSearchConfig {
     /// and any joined tables.  The value is *not*
     /// propagated to any additional underlying queries.
     pub for_update: bool,
-    // Only include NVLink capable machines (GB200/GB300 etc)
+    /// Only include NVLink capable machines (GB200/GB300 etc)
     pub mnnvl_only: bool,
     pub only_with_power_state: Option<String>,
     pub only_with_health_alert: Option<String>,
+    /// Returns machines only if they are part of the given rack
+    pub rack_id: Option<RackId>,
 }
 
 impl TryFrom<rpc::forge::MachineSearchConfig> for MachineSearchConfig {
@@ -67,6 +71,7 @@ impl TryFrom<rpc::forge::MachineSearchConfig> for MachineSearchConfig {
             mnnvl_only: value.mnnvl_only,
             only_with_power_state: value.only_with_power_state,
             only_with_health_alert: value.only_with_health_alert,
+            rack_id: value.rack_id,
         })
     }
 }

--- a/crates/api/src/tests/common/api_fixtures/managed_host.rs
+++ b/crates/api/src/tests/common/api_fixtures/managed_host.rs
@@ -22,6 +22,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use itertools::Itertools;
 use libredfish::{OData, PCIeDevice};
 use mac_address::MacAddress;
+use model::expected_machine::ExpectedMachineData;
 use model::hardware_info::{HardwareInfo, NetworkInterface, PciDeviceProperties, TpmEkCertificate};
 use model::machine::ManagedHostState;
 use model::site_explorer::{
@@ -58,6 +59,11 @@ pub struct ManagedHostConfig {
     /// Default: true (maintains backward compatibility)
     pub auto_assign_sku_in_fixture: bool,
     pub hardware_info_template: HardwareInfoTemplate,
+    /// The contents of this will be used as ExpectedMachine entry
+    /// However not all fields need to be filled
+    /// - bmc username/password are not required
+    /// - serial number is copied from ManagedHostConfig
+    pub expected_machine_data: Option<ExpectedMachineData>,
 }
 
 impl ManagedHostConfig {
@@ -85,6 +91,13 @@ impl ManagedHostConfig {
     pub fn with_hardware_info_template(hardware_info_template: HardwareInfoTemplate) -> Self {
         Self {
             hardware_info_template,
+            ..Default::default()
+        }
+    }
+
+    pub fn with_expected_machine_data(expected_machine_data: ExpectedMachineData) -> Self {
+        Self {
+            expected_machine_data: Some(expected_machine_data),
             ..Default::default()
         }
     }
@@ -126,6 +139,7 @@ impl Default for ManagedHostConfig {
                 .collect(),
             auto_assign_sku_in_fixture: true,
             hardware_info_template: HardwareInfoTemplate::Default,
+            expected_machine_data: None,
         }
     }
 }

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -2288,14 +2288,7 @@ pub async fn forge_agent_control(
 
 /// Create a managed host with 1 DPU (default config)
 pub async fn create_managed_host(env: &TestEnv) -> TestManagedHost {
-    let mh = site_explorer::new_host(env, ManagedHostConfig::default())
-        .await
-        .expect("Failed to create a new host");
-    TestManagedHost {
-        id: mh.host_snapshot.id,
-        dpu_ids: mh.dpu_snapshots.iter().map(|dpu| dpu.id).collect(),
-        api: env.api.clone(),
-    }
+    create_managed_host_with_config(env, ManagedHostConfig::default()).await
 }
 
 /// Create a managed host with 1 DPU (default config)
@@ -2341,13 +2334,7 @@ pub async fn create_managed_host_multi_dpu(env: &TestEnv, dpu_count: usize) -> T
     assert!(dpu_count >= 1, "need to specify at least 1 dpu");
     let config =
         ManagedHostConfig::with_dpus((0..dpu_count).map(|_| DpuConfig::default()).collect());
-    let mh = site_explorer::new_host(env, config).await.unwrap();
-
-    TestManagedHost {
-        id: mh.host_snapshot.id,
-        dpu_ids: mh.dpu_snapshots.iter().map(|dpu| dpu.id).collect(),
-        api: env.api.clone(),
-    }
+    create_managed_host_with_config(env, config).await
 }
 
 /// Create a managed host with full config control
@@ -2355,27 +2342,18 @@ pub async fn create_managed_host_with_config(
     env: &TestEnv,
     config: ManagedHostConfig,
 ) -> TestManagedHost {
-    let dpu_count = config.dpus.len();
     let mh = site_explorer::new_host(env, config)
         .await
         .expect("Failed to create a new host");
 
-    let host_machine_id = mh.host_snapshot.id;
+    let dpu_ids = mh
+        .dpu_snapshots
+        .iter()
+        .map(|snapshot| snapshot.id)
+        .collect();
 
-    let (id, dpu_ids) = match dpu_count {
-        0 => (host_machine_id, vec![]),
-        1 => (host_machine_id, vec![mh.dpu_snapshots[0].id]),
-        _ => {
-            let dpu_ids = mh
-                .dpu_snapshots
-                .iter()
-                .map(|snapshot| snapshot.id)
-                .collect();
-            (host_machine_id, dpu_ids)
-        }
-    };
     TestManagedHost {
-        id,
+        id: mh.host_snapshot.id,
         dpu_ids,
         api: env.api.clone(),
     }
@@ -2401,12 +2379,7 @@ pub async fn create_managed_host_with_hardware_info_template(
     hardware_info_template: managed_host::HardwareInfoTemplate,
 ) -> TestManagedHost {
     let config = ManagedHostConfig::with_hardware_info_template(hardware_info_template);
-    let mh = site_explorer::new_host(env, config).await.unwrap();
-    TestManagedHost {
-        id: mh.host_snapshot.id,
-        dpu_ids: mh.dpu_snapshots.into_iter().map(|s| s.id).collect(),
-        api: env.api.clone(),
-    }
+    create_managed_host_with_config(env, config).await
 }
 
 pub async fn update_time_params(

--- a/crates/api/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/site_explorer.rs
@@ -29,6 +29,7 @@ use forge_secrets::credentials::{BmcCredentialType, CredentialKey, Credentials};
 use futures_util::FutureExt;
 use health_report::HealthReport;
 use mac_address::MacAddress;
+use model::expected_machine::ExpectedMachine;
 use model::hardware_info::HardwareInfo;
 use model::machine::health_override::HARDWARE_HEALTH_OVERRIDE_PREFIX;
 use model::machine::{
@@ -1166,6 +1167,36 @@ impl<'a> MockExploredHost<'a> {
     }
 }
 
+pub async fn register_expected_machine(env: &'_ TestEnv, config: &ManagedHostConfig) {
+    let Some(data) = config.expected_machine_data.as_ref() else {
+        return;
+    };
+
+    let mut data = data.clone();
+    // Fill data from ManagedHostConfig
+    // TODO: Disambiguate chassis and product serial number
+    // We seem to set the product serial number here
+    data.serial_number = config.serial.clone();
+
+    let em = ExpectedMachine {
+        id: Some(uuid::Uuid::new_v4()),
+        bmc_mac_address: config.bmc_mac_address,
+        data,
+    };
+
+    env.api
+        .create_expected_machines(tonic::Request::new(
+            rpc::forge::BatchExpectedMachineOperationRequest {
+                expected_machines: Some(rpc::forge::ExpectedMachineList {
+                    expected_machines: vec![em.into()],
+                }),
+                accept_partial_results: false,
+            },
+        ))
+        .await
+        .expect("Expect expected machine to get registered");
+}
+
 /// Use this function to make a new managed host with a given number of DPUs, using site-explorer
 /// to ingest it into the database. Returns a MockExploredHost that you can call more methods on
 /// before finishing.
@@ -1178,6 +1209,9 @@ pub async fn new_mock_host(
     for ib_guid in config.ib_guids.iter() {
         mock_ib_fabric.register_port(ib_guid.clone());
     }
+
+    // Create an expected-machine record for the new machine
+    register_expected_machine(env, &config).await;
 
     // Set BMC credentials in vault
     for bmc_mac_address in vec![config.bmc_mac_address]
@@ -1653,6 +1687,9 @@ pub async fn new_mock_host_with_dpf(
     for ib_guid in config.ib_guids.iter() {
         mock_ib_fabric.register_port(ib_guid.clone());
     }
+
+    // Create an expected-machine record for the new machine
+    register_expected_machine(env, &config).await;
 
     // Set BMC credentials in vault
     for bmc_mac_address in vec![config.bmc_mac_address]

--- a/crates/api/src/tests/machine_find.rs
+++ b/crates/api/src/tests/machine_find.rs
@@ -17,6 +17,7 @@
 use std::net::IpAddr;
 
 use carbide_uuid::machine::{MACHINE_ID_PREFIX_LENGTH, MachineId, MachineType};
+use carbide_uuid::rack::RackId;
 use common::api_fixtures::dpu::create_dpu_machine;
 use common::api_fixtures::managed_host::ManagedHostConfig;
 use common::api_fixtures::{create_managed_host, create_test_env, site_explorer};
@@ -25,6 +26,7 @@ use data_encoding::BASE32_DNSSEC;
 use db::ObjectFilter;
 use itertools::Itertools;
 use mac_address::MacAddress;
+use model::expected_machine::ExpectedMachineData;
 use model::hardware_info::HardwareInfo;
 use model::machine::machine_id::host_id_from_dpu_hardware_info;
 use model::machine::machine_search_config::MachineSearchConfig;
@@ -36,7 +38,9 @@ use sha2::{Digest, Sha256};
 use tonic::Request;
 
 use crate::tests::common;
-use crate::tests::common::api_fixtures::create_managed_host_multi_dpu;
+use crate::tests::common::api_fixtures::{
+    create_managed_host_multi_dpu, create_managed_host_with_config,
+};
 use crate::tests::sku::tests::FULL_SKU_DATA;
 
 #[crate::sqlx_test]
@@ -157,23 +161,73 @@ async fn test_find_machine_without_sku(pool: sqlx::PgPool) {
 #[crate::sqlx_test]
 async fn test_find_machine_with_sku(pool: sqlx::PgPool) {
     let env = create_test_env(pool).await;
-    let mh = create_managed_host(&env).await;
     let sku = serde_json::de::from_str::<rpc::forge::Sku>(FULL_SKU_DATA)
         .unwrap()
         .into();
 
     let mut txn = env.pool.begin().await.unwrap();
     db::sku::create(&mut txn, &sku).await.unwrap();
-    db::machine::assign_sku(&mut txn, &mh.id, "sku id")
-        .await
-        .unwrap();
-
     txn.commit().await.unwrap();
-    let mut txn = env.pool.begin().await.unwrap();
 
-    let machine = mh.host().db_machine(&mut txn).await;
+    let sku_id = "sku id".to_string();
+    let host_config = ManagedHostConfig::with_expected_machine_data(ExpectedMachineData {
+        sku_id: Some(sku_id.clone()),
+        ..Default::default()
+    });
+    let mh = create_managed_host_with_config(&env, host_config).await;
 
-    assert_eq!(machine.hw_sku, Some("sku id".to_string()));
+    let machine = mh.host().rpc_machine().await;
+    assert_eq!(machine.hw_sku.as_ref(), Some(&sku_id));
+}
+
+#[crate::sqlx_test]
+async fn test_find_machine_without_rack_id(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+
+    let machine = mh.host().rpc_machine().await;
+    assert!(machine.rack_id.is_none());
+
+    let machines = env
+        .api
+        .find_machine_ids(tonic::Request::new(rpc::forge::MachineSearchConfig {
+            rack_id: Some("rack1".to_string().into()),
+            ..Default::default()
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .machine_ids;
+    assert!(machines.is_empty());
+}
+
+#[crate::sqlx_test]
+async fn test_find_machine_by_rack_id(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let rack_id: RackId = "Rack1".parse().unwrap();
+    let host_config = ManagedHostConfig::with_expected_machine_data(ExpectedMachineData {
+        rack_id: rack_id.clone().into(),
+        ..Default::default()
+    });
+    let mh = create_managed_host_with_config(&env, host_config).await;
+
+    let machine = mh.host().rpc_machine().await;
+    let machine_id = mh.id;
+    assert_eq!(machine.rack_id.as_ref(), Some(&rack_id));
+
+    let machine_ids = env
+        .api
+        .find_machine_ids(tonic::Request::new(rpc::forge::MachineSearchConfig {
+            rack_id: Some(rack_id),
+            ..Default::default()
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .machine_ids;
+
+    assert_eq!(machine_ids.len(), 1);
+    assert_eq!(machine_ids[0], machine_id);
 }
 
 #[crate::sqlx_test]

--- a/crates/api/src/web/expected_power_shelf.rs
+++ b/crates/api/src/web/expected_power_shelf.rs
@@ -24,6 +24,7 @@ use axum::response::{Html, IntoResponse, Response};
 use hyper::http::StatusCode;
 use rpc::forge::forge_server::Forge;
 
+use super::filters;
 use crate::api::Api;
 
 #[derive(Template)]

--- a/crates/api/src/web/expected_rack.rs
+++ b/crates/api/src/web/expected_rack.rs
@@ -24,6 +24,7 @@ use axum::response::{Html, IntoResponse, Response};
 use hyper::http::StatusCode;
 use rpc::forge::forge_server::Forge;
 
+use super::filters;
 use crate::api::Api;
 
 #[derive(Template)]

--- a/crates/api/src/web/filters.rs
+++ b/crates/api/src/web/filters.rs
@@ -35,6 +35,8 @@ pub fn machine_id_link(id: impl Display) -> ::askama::Result<String> {
 /// Generates a formatted link for Machine IDs to a predefined path
 fn machine_link(id: impl Display, path: impl Display) -> ::askama::Result<String> {
     let id = id.to_string();
+    let link_path: String = url::form_urlencoded::byte_serialize(id.as_bytes()).collect();
+
     let short_id = if MachineId::from_str(&id).is_err() {
         // Not a Machine ID. Escape HTML to make it safe for post processing with safe filter
         let mut output = String::new();
@@ -47,9 +49,34 @@ fn machine_link(id: impl Display, path: impl Display) -> ::askama::Result<String
 
     let formatted = format!(
         r#"
-    <a href="/admin/{path}/{id}">
+    <a href="/admin/{path}/{link_path}">
         <div class="machine_id">
             <div>{id}</div><div>{short_id}</div>
+        </div>
+    </a>"#
+    );
+
+    Ok(formatted)
+}
+
+pub fn rack_id_link(id: impl Display) -> ::askama::Result<String> {
+    // Sanitize rack ID for HTML content and links (it can contain arbitrary content)
+    let mut rack_id = String::new();
+    let link_path: String = url::form_urlencoded::byte_serialize(rack_id.as_bytes()).collect();
+    askama_escape::Html.write_escaped(&mut rack_id, &id.to_string())?;
+
+    let short_id = if rack_id.len() < 10 {
+        &rack_id
+    } else {
+        &rack_id[0..6] // Shorter to have space for ellipsis ("...")
+    };
+
+    // machine_id is used here since its already a defined CSS class
+    let formatted = format!(
+        r#"
+    <a href="/admin/rack/{link_path}">
+        <div class="machine_id">
+            <div>{rack_id}</div><div>{short_id}</div>
         </div>
     </a>"#
     );

--- a/crates/api/src/web/machine.rs
+++ b/crates/api/src/web/machine.rs
@@ -394,15 +394,8 @@ pub async fn fetch_machines(
 ) -> Result<forgerpc::MachineList, tonic::Status> {
     let request = tonic::Request::new(forgerpc::MachineSearchConfig {
         include_dpus,
-        include_history: false,
         include_predicted_host: true,
-        only_maintenance: false,
-        exclude_hosts: false,
-        only_quarantine: false,
-        instance_type_id: None,
-        mnnvl_only: false,
-        only_with_power_state: None,
-        only_with_health_alert: None,
+        ..Default::default()
     });
 
     let machine_ids = api

--- a/crates/api/src/web/managed_host.rs
+++ b/crates/api/src/web/managed_host.rs
@@ -653,15 +653,8 @@ async fn fetch_managed_hosts_with_metadata(
     let machine_ids = api
         .find_machine_ids(tonic::Request::new(forgerpc::MachineSearchConfig {
             include_dpus: true,
-            include_history: false,
             include_predicted_host: true,
-            only_maintenance: false,
-            exclude_hosts: false,
-            only_quarantine: false,
-            instance_type_id: None,
-            mnnvl_only: false,
-            only_with_health_alert: None,
-            only_with_power_state: None,
+            ..Default::default()
         }))
         .await?
         .into_inner()

--- a/crates/api/src/web/mod.rs
+++ b/crates/api/src/web/mod.rs
@@ -402,6 +402,7 @@ pub fn routes(api: Arc<Api>) -> eyre::Result<NormalizePath<Router>> {
             )
             .route("/rack", get(rack::show_html))
             .route("/rack.json", get(rack::show_json))
+            .route("/rack/{rack_id}", get(rack::detail))
             .route("/switch", get(switch::show_html))
             .route("/switch.json", get(switch::show_json))
             .route(

--- a/crates/api/src/web/nvlink.rs
+++ b/crates/api/src/web/nvlink.rs
@@ -294,16 +294,9 @@ async fn fetch_logical_partitions(
 
         if detail {
             let request = tonic::Request::new(forgerpc::MachineSearchConfig {
-                include_dpus: false,
-                include_history: false,
-                include_predicted_host: false,
-                only_maintenance: false,
-                exclude_hosts: false,
-                only_quarantine: false,
-                instance_type_id: None,
                 mnnvl_only: true,
-                only_with_health_alert: None,
-                only_with_power_state: None,
+                include_predicted_host: true,
+                ..Default::default()
             });
 
             let machine_ids = api

--- a/crates/api/src/web/rack.rs
+++ b/crates/api/src/web/rack.rs
@@ -15,19 +15,22 @@
  * limitations under the License.
  */
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use askama::Template;
 use axum::Json;
-use axum::extract::State as AxumState;
+use axum::extract::{Path as AxumPath, Query, State as AxumState};
 use axum::response::{Html, IntoResponse, Response};
+use carbide_uuid::rack::RackId;
 use hyper::http::StatusCode;
 use rpc::forge::forge_server::Forge;
 
+use super::filters;
 use crate::api::Api;
 
 #[derive(Template)]
-#[template(path = "rack.html")]
+#[template(path = "rack_show.html")]
 struct Rack {
     racks: Vec<RackRecord>,
 }
@@ -40,6 +43,16 @@ struct RackRecord {
     current_compute_trays: String,
     expected_power_shelves: String,
     current_power_shelves: String,
+}
+
+#[derive(Template)]
+#[template(path = "rack_detail.html")]
+struct RackDetail {
+    id: String,
+    rack: Option<rpc::forge::Rack>,
+    associated_machines: Vec<String>,
+    associated_switches: Vec<String>,
+    associated_power_shelves: Vec<String>,
 }
 
 /// Show all racks
@@ -124,4 +137,110 @@ async fn fetch_racks(api: &Api) -> Result<Vec<RackRecord>, (http::StatusCode, St
         .collect();
 
     Ok(racks)
+}
+
+pub async fn fetch_rack(
+    api: &Api,
+    rack_id: &RackId,
+) -> Result<Option<::rpc::forge::Rack>, Response> {
+    let request = tonic::Request::new(rpc::forge::GetRackRequest {
+        id: Some(rack_id.to_string()),
+    });
+
+    // TODO: This should use FindRacksByIds
+    let rack = match api
+        .get_rack(request)
+        .await
+        .map(|response| response.into_inner())
+    {
+        Ok(r) if r.rack.is_empty() => {
+            return Ok(None);
+        }
+        Ok(r) if r.rack.len() != 1 => {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Rack list for {rack_id} returned {} racks", r.rack.len()),
+            )
+                .into_response());
+        }
+        Ok(mut r) => Some(r.rack.remove(0)),
+        Err(err) if err.code() == tonic::Code::NotFound => {
+            return Ok(None);
+        }
+        Err(err) => {
+            tracing::error!(%err, %rack_id, "find_racks_by_ids");
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
+        }
+    };
+
+    Ok(rack)
+}
+
+/// View details about a Rack
+pub async fn detail(
+    AxumState(api): AxumState<Arc<Api>>,
+    AxumPath(rack_id): AxumPath<String>,
+    Query(_params): Query<HashMap<String, String>>,
+) -> Response {
+    let (show_json, rack_id) = match rack_id.strip_suffix(".json") {
+        Some(rack_id) => (true, rack_id.to_string()),
+        None => (false, rack_id),
+    };
+
+    let rack_id = match rack_id.parse::<RackId>() {
+        Ok(rack_id) => rack_id,
+        Err(e) => return (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
+    };
+
+    let maybe_rack = match fetch_rack(&api, &rack_id).await {
+        Ok(maybe_rack) => maybe_rack,
+        Err(response) => return response,
+    };
+
+    if show_json {
+        return (StatusCode::OK, Json(maybe_rack)).into_response();
+    };
+
+    let associated_machines = match fetch_machine_ids(api, rack_id.clone()).await {
+        Ok(m) => m,
+        Err(err) => {
+            tracing::error!(%err, "fetch_machine_ids");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Error loading machine IDs",
+            )
+                .into_response();
+        }
+    };
+
+    let display = RackDetail {
+        id: rack_id.to_string(),
+        rack: maybe_rack,
+        associated_machines,
+        // TODO: Add discovered switches and powershelves
+        associated_power_shelves: vec![],
+        associated_switches: vec![],
+    };
+
+    (StatusCode::OK, Html(display.render().unwrap())).into_response()
+}
+
+pub async fn fetch_machine_ids(
+    api: Arc<Api>,
+    rack_id: RackId,
+) -> Result<Vec<String>, tonic::Status> {
+    let request = tonic::Request::new(rpc::forge::MachineSearchConfig {
+        include_predicted_host: true,
+        rack_id: Some(rack_id.clone()),
+        ..Default::default()
+    });
+
+    Ok(api
+        .find_machine_ids(request)
+        .await?
+        .into_inner()
+        .machine_ids
+        .into_iter()
+        .map(|id| id.to_string())
+        .collect())
 }

--- a/crates/api/templates/expected_power_shelf.html
+++ b/crates/api/templates/expected_power_shelf.html
@@ -35,7 +35,7 @@
                                 <td>{{ shelf.serial_number }}</td>
                                 <td>{{ shelf.bmc_mac_address }}</td>
                                 <td>{{ shelf.explored_bmc_ip }}</td>
-                                <td>{{ shelf.rack_id }}</td>
+                                <td>{{ shelf.rack_id|rack_id_link|safe }}</td>
                                 <td>{{ shelf.power_shelf_id }}</td>
                             </tr>
                             {% endfor %}

--- a/crates/api/templates/expected_rack.html
+++ b/crates/api/templates/expected_rack.html
@@ -32,7 +32,7 @@
                             <tbody>
                             {% for rack in racks %}
                             <tr>
-                                <td>{{ rack.rack_id }}</td>
+                                <td>{{ rack.rack_id|rack_id_link|safe }}</td>
                                 <td>{{ rack.rack_type }}</td>
                                 <td>{{ rack.compute_trays }}</td>
                                 <td>{{ rack.switches }}</td>

--- a/crates/api/templates/machine_detail.html
+++ b/crates/api/templates/machine_detail.html
@@ -20,7 +20,7 @@
 		{% endif %}
 		</td>
 	</tr>
-	<tr><th>Rack ID</th><td>{{ rack_id }}</td></tr>
+	<tr><th>Rack ID</th><td>{{ rack_id|rack_id_link|safe }}</td></tr>
 	<tr><th>State</th>
 		<td>
 			{% if state.to_lowercase().contains("failed") %}

--- a/crates/api/templates/rack_detail.html
+++ b/crates/api/templates/rack_detail.html
@@ -1,0 +1,86 @@
+{% extends "base.html" %}
+
+{% block title %}{{ id }}{% endblock %}
+
+{% block content %}
+<div id="json">
+	<a id="json-link" href="">JSON</a>
+</div>
+<h1>{{ id }}</h1>
+
+{% if let Some(rack) = rack %}
+<table class="detailsview">
+	<tr><th>State</th>
+		<td>
+			{% if rack.rack_state.to_lowercase().contains("failed") %}
+				<span class="bubble error">{{ rack.rack_state }}</span>
+			{% else if rack.rack_state == "Ready" %}
+				<span class="bubble success">{{ rack.rack_state }}</span>
+			{% else %}
+				<span class="bubble">{{ rack.rack_state }}</span>
+			{% endif %}
+		</td>
+	</tr>
+</table>
+{% endif %}
+
+<!-- TODO: Add expected rack definition -->
+
+<h2>Managed Rack Components</h2>
+
+<h3>Compute Trays (Host machines)</h3>
+<table class="detailsview">
+	<thead>
+		<tr>
+			<th>ID</th>
+		</tr>
+	</thead>
+	<tbody>
+	{% for machine_id in associated_machines %}
+		<tr>
+			<td>{{ machine_id|machine_id_link|safe }}</td>
+		</tr>
+	{% endfor %}
+	</tbody>
+</table>
+
+<h3>Switches</h3>
+<table class="detailsview">
+	<thead>
+		<tr>
+			<th>ID</th>
+		</tr>
+	</thead>
+	<tbody>
+	{% for switch_id in associated_switches %}
+		<tr>
+			<td>{{ switch_id }}</td>
+		</tr>
+	{% endfor %}
+	</tbody>
+</table>
+
+<h3>Power Shelves</h3>
+<table class="detailsview">
+	<thead>
+		<tr>
+			<th>ID</th>
+		</tr>
+	</thead>
+	<tbody>
+	{% for ps_id in associated_power_shelves %}
+		<tr>
+			<td>{{ ps_id }}</td>
+		</tr>
+	{% endfor %}
+	</tbody>
+</table>
+
+<h3>History</h3>
+🚧
+{# Commented till implemented
+<a href="/admin/rack/{{ id }}/state-history">Open History on separate page</a>
+{{ history|safe }}
+#}
+
+{% endblock %}

--- a/crates/api/templates/rack_show.html
+++ b/crates/api/templates/rack_show.html
@@ -33,7 +33,7 @@
                             <tbody>
                             {% for rack in racks %}
                             <tr>
-                                <td>{{ rack.id }}</td>
+                                <td>{{ rack.id|rack_id_link|safe }}</td>
                                 <td>{{ rack.rack_state }}</td>
                                 <td>{{ rack.expected_compute_trays }}</td>
                                 <td>{{ rack.current_compute_trays }}</td>

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -2710,12 +2710,15 @@ message MachineSearchConfig {
   reserved 5; // Was: bool include_associated_machine_id = 5; Now always included
   bool exclude_hosts = 6;
   bool only_quarantine = 7;
+  // Returns machines only if they are assigned the given instance type
   optional string instance_type_id = 8;
   bool mnnvl_only = 9;
   // PowerState would mirror host_power_state_t, basically 'on' and 'off'
   optional string only_with_power_state = 10;
   // For example, to search for leak alerts, set the below to "hardware-health.tray-leak-detection"
   optional string only_with_health_alert = 11;
+  // Returns machines only if they are part of the given rack
+  optional common.RackId rack_id = 12;
 }
 
 message MachineStateHistoriesRequest {


### PR DESCRIPTION
## Description

- Also add extensions to unit-test workflows that make it possible to ingest machines with a matching ExpectedMachine record. This did not exist, and any machines ingested in tests so far did not use ExpectedMachines.
- Add a Rack details page on web ui, which shows rack components. This one uses the new API to find Machines by Rack ID.

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

