### PR TITLE
fix: fixing some ipv6 bugs caught during machine-a-tron integration

### DIFF
--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -972,11 +972,15 @@ pub async fn interfaces(
         let Some(iface) = network_config.admin_interface.as_ref() else {
             eyre::bail!("use_admin_network is true but admin interface is missing");
         };
+        let addresses: Vec<String> = std::iter::once(&iface.ip)
+            .chain(iface.ip6.as_ref())
+            .cloned()
+            .collect();
         interfaces.push(rpc::InstanceInterfaceStatusObservation {
             function_type: iface.function_type,
             virtual_function_id: None,
             mac_address: Some(factory_mac_address.to_string()),
-            addresses: vec![iface.ip.clone()],
+            addresses,
             prefixes: vec![iface.interface_prefix.clone()],
             gateways: vec![iface.gateway.clone()],
             network_security_group: None,
@@ -1036,11 +1040,15 @@ pub async fn interfaces(
                         version: nsg.version.clone(),
                     });
 
+            let addresses: Vec<String> = std::iter::once(&iface.ip)
+                .chain(iface.ip6.as_ref())
+                .cloned()
+                .collect();
             interfaces.push(rpc::InstanceInterfaceStatusObservation {
                 function_type: iface.function_type,
                 virtual_function_id: iface.virtual_function_id,
                 mac_address: mac,
-                addresses: vec![iface.ip.clone()],
+                addresses,
                 prefixes: vec![iface.interface_prefix.clone()],
                 gateways: vec![iface.gateway.clone()],
                 network_security_group,
@@ -1811,6 +1819,7 @@ mod tests {
     use carbide_network::virtualization::{VpcVirtualizationType, get_svi_ip};
     use eyre::WrapErr;
     use ipnetwork::IpNetwork;
+    use mac_address::MacAddress;
     use utils::models::dhcp::{DhcpConfig, HostConfig};
 
     use super::FPath;
@@ -2316,6 +2325,7 @@ mod tests {
             vpc_vni: 1002,
             gateway: "10.217.5.123/28".to_string(),
             ip: "10.217.5.123".to_string(),
+            ip6: None,
             interface_prefix: admin_interface_prefix.to_string(),
             vpc_prefixes: vec![],
             vpc_peer_prefixes: vec![],
@@ -2360,6 +2370,7 @@ mod tests {
                 vpc_vni: 1025197,
                 gateway: "10.217.5.169/29".to_string(),
                 ip: "10.217.5.170".to_string(),
+                ip6: None,
                 interface_prefix: interface_prefix_1.to_string(),
                 vpc_prefixes: vec!["10.217.5.160/30".to_string(), "10.217.5.168/29".to_string()],
                 vpc_peer_prefixes: vec!["10.217.6.176/29".to_string()],
@@ -2389,6 +2400,7 @@ mod tests {
                 vpc_vni: 1025186,
                 gateway: "10.217.5.161/30".to_string(),
                 ip: "10.217.5.162".to_string(),
+                ip6: None,
                 interface_prefix: interface_prefix_2.to_string(),
                 vpc_prefixes: vec!["10.217.5.160/30".to_string(), "10.217.5.168/29".to_string()],
                 vpc_peer_prefixes: vec!["10.217.6.176/29".to_string()],
@@ -2969,6 +2981,7 @@ mod tests {
             vpc_vni: 1002,
             gateway: "10.217.5.123".to_string(),
             ip: "10.217.5.123".to_string(),
+            ip6: None,
             interface_prefix: admin_interface_prefix.to_string(),
             vpc_prefixes: vec![],
             vpc_peer_prefixes: vec![],
@@ -3002,6 +3015,7 @@ mod tests {
                 vpc_vni: 1025197,
                 gateway: "10.217.5.169".to_string(),
                 ip: "10.217.5.170".to_string(),
+                ip6: None,
                 interface_prefix: interface_prefix_1.to_string(),
                 vpc_prefixes: vec!["10.217.5.160/30".to_string(), "10.217.5.168/29".to_string()],
                 vpc_peer_prefixes: vec!["10.217.6.176/29".to_string()],
@@ -3026,6 +3040,7 @@ mod tests {
                 vpc_vni: 1025186,
                 gateway: "10.217.5.161".to_string(),
                 ip: "10.217.5.162".to_string(),
+                ip6: None,
                 interface_prefix: interface_prefix_2.to_string(),
                 vpc_prefixes: vec!["10.217.5.160/30".to_string(), "10.217.5.168/29".to_string()],
                 vpc_peer_prefixes: vec!["10.217.6.176/29".to_string()],
@@ -3377,5 +3392,125 @@ mod tests {
 
         // Secondary dpu tenant network
         assert_eq!(needed_interface_state(false, false), InterfaceState::Up);
+    }
+
+    #[tokio::test]
+    async fn test_interfaces_admin_dual_stack() {
+        let mac: MacAddress = "00:11:22:33:44:55".parse().unwrap();
+        let network_config = rpc::ManagedHostNetworkConfigResponse {
+            use_admin_network: true,
+            admin_interface: Some(rpc::FlatInterfaceConfig {
+                function_type: rpc::InterfaceFunctionType::Physical.into(),
+                virtual_function_id: None,
+                vlan_id: 1,
+                vni: 1001,
+                vpc_vni: 0,
+                gateway: "10.0.1.1/24".to_string(),
+                ip: "10.0.1.2".to_string(),
+                ip6: Some("2001:db8::2".to_string()),
+                interface_prefix: "10.0.1.2/32".to_string(),
+                vpc_prefixes: vec![],
+                prefix: "10.0.1.0/24".to_string(),
+                fqdn: "test.local".to_string(),
+                booturl: None,
+                svi_ip: None,
+                tenant_vrf_loopback_ip: None,
+                is_l2_segment: true,
+                vpc_peer_prefixes: vec![],
+                vpc_peer_vnis: vec![],
+                network_security_group: None,
+                internal_uuid: None,
+                mtu: None,
+            }),
+            ..Default::default()
+        };
+
+        let result = super::interfaces(&network_config, mac).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].addresses,
+            vec!["10.0.1.2".to_string(), "2001:db8::2".to_string()],
+            "admin interface should report both IPv4 and IPv6 addresses"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_interfaces_tenant_dual_stack() {
+        let mac: MacAddress = "00:11:22:33:44:55".parse().unwrap();
+        let network_config = rpc::ManagedHostNetworkConfigResponse {
+            use_admin_network: false,
+            tenant_interfaces: vec![rpc::FlatInterfaceConfig {
+                function_type: rpc::InterfaceFunctionType::Physical.into(),
+                virtual_function_id: None,
+                vlan_id: 100,
+                vni: 1000,
+                vpc_vni: 2000,
+                gateway: "10.0.1.1/24".to_string(),
+                ip: "10.0.1.5".to_string(),
+                ip6: Some("2001:db8::5".to_string()),
+                interface_prefix: "10.0.1.5/32".to_string(),
+                vpc_prefixes: vec!["10.0.1.0/24".to_string()],
+                prefix: "10.0.1.0/24".to_string(),
+                fqdn: "test.local".to_string(),
+                booturl: None,
+                svi_ip: None,
+                tenant_vrf_loopback_ip: None,
+                is_l2_segment: false,
+                vpc_peer_prefixes: vec![],
+                vpc_peer_vnis: vec![],
+                network_security_group: None,
+                internal_uuid: None,
+                mtu: None,
+            }],
+            ..Default::default()
+        };
+
+        let result = super::interfaces(&network_config, mac).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].addresses,
+            vec!["10.0.1.5".to_string(), "2001:db8::5".to_string()],
+            "tenant interface should report both IPv4 and IPv6 addresses"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_interfaces_ipv4_only_no_ip6() {
+        let mac: MacAddress = "00:11:22:33:44:55".parse().unwrap();
+        let network_config = rpc::ManagedHostNetworkConfigResponse {
+            use_admin_network: true,
+            admin_interface: Some(rpc::FlatInterfaceConfig {
+                function_type: rpc::InterfaceFunctionType::Physical.into(),
+                virtual_function_id: None,
+                vlan_id: 1,
+                vni: 1001,
+                vpc_vni: 0,
+                gateway: "10.0.1.1/24".to_string(),
+                ip: "10.0.1.2".to_string(),
+                ip6: None,
+                interface_prefix: "10.0.1.2/32".to_string(),
+                vpc_prefixes: vec![],
+                prefix: "10.0.1.0/24".to_string(),
+                fqdn: "test.local".to_string(),
+                booturl: None,
+                svi_ip: None,
+                tenant_vrf_loopback_ip: None,
+                is_l2_segment: true,
+                vpc_peer_prefixes: vec![],
+                vpc_peer_vnis: vec![],
+                network_security_group: None,
+                internal_uuid: None,
+                mtu: None,
+            }),
+            ..Default::default()
+        };
+
+        let result = super::interfaces(&network_config, mac).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].addresses,
+            vec!["10.0.1.2".to_string()],
+            "IPv4-only interface should report only one address"
+        );
     }
 }

--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -473,6 +473,7 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
         vpc_vni: 10101,
         gateway: "192.168.0.0/16".to_string(),
         ip: "192.168.0.12".to_string(),
+        ip6: None,
         interface_prefix: admin_interface_prefix.to_string(),
         virtual_function_id: None,
         vpc_prefixes: vec![],
@@ -494,6 +495,10 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
 
     let tenant_interface_prefix: IpNetwork = "192.168.1.12/32".parse().unwrap();
 
+    let tenant_ip6 = match virtualization_type {
+        VpcVirtualizationType::Fnn => Some("2001:db8::12".to_string()),
+        _ => None,
+    };
     let tenant_interface = rpc::forge::FlatInterfaceConfig {
         function_type: rpc::forge::InterfaceFunctionType::Physical.into(),
         vlan_id: 10,
@@ -501,6 +506,7 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
         vpc_vni: 10101,
         gateway: "192.168.1.0/16".to_string(),
         ip: "192.168.1.12".to_string(),
+        ip6: tenant_ip6,
         interface_prefix: tenant_interface_prefix.to_string(),
         virtual_function_id: None,
         vpc_prefixes: vec![],

--- a/crates/api-db/src/instance_address.rs
+++ b/crates/api-db/src/instance_address.rs
@@ -180,7 +180,14 @@ fn validate(
     Ok(())
 }
 
-/// Counts the amount of addresses that have been allocated for a given segment
+/// Counts the amount of addresses that have been allocated for a given segment.
+///
+/// NOTE(chet): This query was simplified from a JOIN with network_prefixes to a
+/// direct query on instance_addresses. The old JOIN multiplied rows by the number
+/// of prefixes in a segment, which produced incorrect counts for dual-stack segments
+/// (e.g. returning 4 instead of 2 for a segment with IPv4 + IPv6 prefixes).
+/// The instance_addresses table has a direct segment_id column, so the JOIN was
+/// unnecessary. Tests added around this in test_dual_stack_instance_allocation.
 pub async fn count_by_segment_id(
     txn: &mut PgConnection,
     segment_id: &NetworkSegmentId,
@@ -188,8 +195,7 @@ pub async fn count_by_segment_id(
     let query = "
 SELECT count(*)
 FROM instance_addresses
-INNER JOIN network_prefixes ON network_prefixes.segment_id = instance_addresses.segment_id
-WHERE network_prefixes.segment_id = $1::uuid";
+WHERE segment_id = $1::uuid";
     let (address_count,): (i64,) = query_as(query)
         .bind(segment_id)
         .fetch_one(txn)
@@ -271,15 +277,7 @@ pub async fn allocate(
             }
         };
 
-        let valid_prefixes = segment.prefixes.clone();
-
-        if valid_prefixes.len() > 1 {
-            return Err(DatabaseError::FindOneReturnedManyResultsError(
-                segment.id.into(),
-            ));
-        }
-
-        let Some(network_prefix) = valid_prefixes.into_iter().next() else {
+        if segment.prefixes.is_empty() {
             tracing::error!(
                 segment_id = %segment.id,
                 "No prefix is attached to segment.",
@@ -287,23 +285,24 @@ pub async fn allocate(
             return Err(DatabaseError::FindOneReturnedNoResultsError(
                 segment.id.into(),
             ));
-        };
+        }
 
         // Hydrate iface with network addresses, returning the assigned addresses
         let addresses = if segment.segment_type == NetworkSegmentType::HostInband {
             // For host-inband network segments, the instance interface *is* the host interface,
             // and we simply use the hosts's address.
-            iface.assign_ips_from((machine, &network_prefix))?
+            let Some(network_prefix) = segment.prefixes.first() else {
+                return Err(DatabaseError::FindOneReturnedNoResultsError(
+                    segment.id.into(),
+                ));
+            };
+            iface.assign_ips_from((machine, network_prefix))?
         } else {
             // Use the UsedOverlayNetworkIpResolver, which specifically looks at
             // the instance addresses table in the database for finding
             // the next available IP prefix allocation (with [assumed] support for
             // allocations of varying-sized networks).
-            let busy_ips = network_prefix
-                .svi_ip
-                .iter()
-                .copied()
-                .collect::<Vec<IpAddr>>();
+            let busy_ips: Vec<IpAddr> = segment.prefixes.iter().filter_map(|p| p.svi_ip).collect();
 
             let dhcp_handler: Box<dyn UsedIpResolver<PgConnection> + Send> =
                 Box::new(UsedOverlayNetworkIpResolver {

--- a/crates/api/src/ethernet_virtualization.rs
+++ b/crates/api/src/ethernet_virtualization.rs
@@ -218,6 +218,7 @@ pub async fn admin_network(
         vpc_vni,
         gateway: prefix.gateway_cidr().unwrap_or_default(),
         ip: address.address.to_string(),
+        ip6: None,
         interface_prefix: address_prefix.to_string(),
         vpc_prefixes: if fnn_enabled_on_admin {
             vec![format!("{}/32", address.address.to_string())]
@@ -439,6 +440,14 @@ pub async fn tenant_network(
         _ => None,
     };
 
+    // Look for an IPv6 prefix and address if available.
+    let ip6 = segment
+        .prefixes
+        .iter()
+        .find(|prefix| prefix.prefix.is_ipv6())
+        .and_then(|v6_prefix| iface.ip_addrs.get(&v6_prefix.id))
+        .map(|addr| addr.to_string());
+
     Ok(rpc::FlatInterfaceConfig {
         function_type: rpc_ft.into(),
         virtual_function_id: match iface.function_id {
@@ -450,6 +459,7 @@ pub async fn tenant_network(
         vpc_vni,
         gateway: v4_prefix.gateway_cidr().unwrap_or_default(),
         ip: address.to_string(),
+        ip6,
         interface_prefix: interface_prefix.to_string(),
         vpc_prefixes,
         prefix: v4_prefix.prefix.to_string(),

--- a/crates/api/src/tests/network_segment.rs
+++ b/crates/api/src/tests/network_segment.rs
@@ -1212,6 +1212,103 @@ async fn test_create_dual_stack_tenant_segment(pool: sqlx::PgPool) -> Result<(),
     Ok(())
 }
 
+/// Verify that allocating an instance on a dual-stack segment allocates both
+/// IPv4 and IPv6 addresses, and that count_by_segment_id returns the correct
+/// count (not double-counted due to multiple prefixes).
+#[crate::sqlx_test]
+async fn test_dual_stack_instance_allocation(pool: sqlx::PgPool) -> Result<(), eyre::Report> {
+    let mut site_prefixes = TEST_SITE_PREFIXES.to_vec();
+    site_prefixes.push("2001:db8::/32".parse().unwrap());
+
+    let env = create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides {
+            site_prefixes: Some(site_prefixes),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    // Create an FNN VPC (IPv6 requires FNN)
+    let vpc = env
+        .api
+        .create_vpc(
+            VpcCreationRequest::builder("dual-stack vpc", "2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
+                .tonic_request(),
+        )
+        .await?
+        .into_inner();
+
+    // Create a dual-stack network segment
+    let segment = env
+        .api
+        .create_network_segment(Request::new(rpc::forge::NetworkSegmentCreationRequest {
+            id: None,
+            mtu: Some(1500),
+            name: "DUAL_STACK_SEGMENT".to_string(),
+            prefixes: vec![
+                rpc::forge::NetworkPrefix {
+                    id: None,
+                    prefix: "192.9.4.0/24".to_string(),
+                    gateway: Some("192.9.4.1".to_string()),
+                    reserve_first: 3,
+                    free_ip_count: 0,
+                    svi_ip: None,
+                },
+                rpc::forge::NetworkPrefix {
+                    id: None,
+                    prefix: "2001:db8:abcd::/112".to_string(),
+                    gateway: None,
+                    reserve_first: 0,
+                    free_ip_count: 0,
+                    svi_ip: None,
+                },
+            ],
+            subdomain_id: None,
+            vpc_id: vpc.id,
+            segment_type: rpc::forge::NetworkSegmentType::Tenant as i32,
+        }))
+        .await?
+        .into_inner();
+    let segment_id: NetworkSegmentId = segment.id.unwrap();
+
+    // Run the network segment controller to transition to Ready
+    env.run_network_segment_controller_iteration().await;
+    env.run_network_segment_controller_iteration().await;
+
+    // Verify count starts at 0
+    let mut txn = env.pool.begin().await?;
+    assert_eq!(
+        db::instance_address::count_by_segment_id(&mut txn, &segment_id)
+            .await
+            .unwrap(),
+        0
+    );
+    txn.commit().await?;
+
+    // Create a managed host and allocate an instance on the dual-stack segment
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+    mh.instance_builer(&env)
+        .single_interface_network_config(segment_id)
+        .build()
+        .await;
+
+    // Verify count is correct — should be 2 (one IPv4 + one IPv6), not 4
+    // (which would happen if the old JOIN-based query double-counted)
+    let mut txn = env.pool.begin().await?;
+    let count = db::instance_address::count_by_segment_id(&mut txn, &segment_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        count, 2,
+        "dual-stack segment should have exactly 2 allocated addresses (one IPv4, one IPv6)"
+    );
+    txn.commit().await?;
+
+    Ok(())
+}
+
 /// Verify that an IPv6 tenant segment prefix that is NOT contained in the site
 /// fabric prefixes is correctly rejected, just like an uncontained IPv4 prefix would be.
 #[crate::sqlx_test]
@@ -1275,6 +1372,69 @@ async fn test_ipv6_tenant_prefix_rejected_when_not_in_site_fabric(
             .message()
             .contains("not contained within the configured site fabric prefixes"),
         "Error message should mention site fabric prefix containment, got: {}",
+        status.message()
+    );
+
+    Ok(())
+}
+
+/// Verify that IPv6 network segments are rejected for non-FNN VPCs, even when the
+/// prefix IS contained in site fabric prefixes.
+#[crate::sqlx_test]
+async fn test_ipv6_segment_rejected_for_non_fnn_vpc(
+    pool: sqlx::PgPool,
+) -> Result<(), eyre::Report> {
+    let mut site_prefixes = TEST_SITE_PREFIXES.to_vec();
+    site_prefixes.push("2001:db8::/32".parse().unwrap());
+
+    let env = create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides {
+            create_network_segments: Some(false),
+            site_prefixes: Some(site_prefixes),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    // Create a non-FNN VPC (default is EthernetVirtualizer)
+    let vpc = env
+        .api
+        .create_vpc(
+            VpcCreationRequest::builder("non-fnn-vpc", "2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                .tonic_request(),
+        )
+        .await?
+        .into_inner();
+
+    // 2001:db8:1::/48 IS contained in site fabric prefixes, but the VPC is not FNN
+    let request = rpc::forge::NetworkSegmentCreationRequest {
+        id: None,
+        mtu: Some(1500),
+        name: "IPV6_ON_NON_FNN".to_string(),
+        prefixes: vec![rpc::forge::NetworkPrefix {
+            id: None,
+            prefix: "2001:db8:1::/48".to_string(),
+            gateway: None,
+            reserve_first: 0,
+            free_ip_count: 0,
+            svi_ip: None,
+        }],
+        subdomain_id: None,
+        vpc_id: vpc.id,
+        segment_type: rpc::forge::NetworkSegmentType::Tenant as i32,
+    };
+
+    let result = env.api.create_network_segment(Request::new(request)).await;
+
+    assert!(
+        result.is_err(),
+        "Expected rejection of IPv6 segment on non-FNN VPC"
+    );
+    let status = result.unwrap_err();
+    assert!(
+        status.message().contains("only supported for FNN VPCs"),
+        "Error should mention FNN requirement, got: {}",
         status.message()
     );
 

--- a/crates/api/src/tests/vpc_prefix.rs
+++ b/crates/api/src/tests/vpc_prefix.rs
@@ -22,7 +22,11 @@ use rpc::forge::{
 use sqlx::PgPool;
 use tonic::Request;
 
-use crate::tests::common::api_fixtures::{create_test_env, get_vpc_fixture_id};
+use crate::tests::common::api_fixtures::{
+    TEST_SITE_PREFIXES, TestEnvOverrides, create_test_env, create_test_env_with_overrides,
+    get_vpc_fixture_id,
+};
+use crate::tests::common::rpc_builder::VpcCreationRequest;
 
 #[crate::sqlx_test]
 async fn test_create_and_delete_vpc_prefix_deprecated_fields(
@@ -369,6 +373,104 @@ async fn test_vpc_prefix_search(pool: PgPool) -> Result<(), Box<dyn std::error::
             "We expected to find the VPC prefix id {expected_id} for prefix {expected_prefix} in the search results ({returned_vpc_prefix_ids:?}), but it was absent"
         );
     }
+
+    Ok(())
+}
+
+/// Verify that IPv6 VPC prefix creation is rejected for non-FNN VPCs.
+#[crate::sqlx_test]
+async fn test_ipv6_vpc_prefix_rejected_for_non_fnn_vpc(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut site_prefixes = TEST_SITE_PREFIXES.to_vec();
+    site_prefixes.push("2001:db8::/32".parse().unwrap());
+
+    let env = create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides {
+            site_prefixes: Some(site_prefixes),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    // Create a non-FNN VPC (default type is EthernetVirtualizer)
+    let vpc = env
+        .api
+        .create_vpc(
+            VpcCreationRequest::builder("non-fnn-vpc", "2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                .tonic_request(),
+        )
+        .await?
+        .into_inner();
+
+    let result = env
+        .api
+        .create_vpc_prefix(Request::new(VpcPrefixCreationRequest {
+            name: "ipv6-prefix".to_string(),
+            vpc_id: vpc.id,
+            prefix: "2001:db8:1::/48".to_string(),
+            ..Default::default()
+        }))
+        .await;
+
+    assert!(
+        result.is_err(),
+        "Expected rejection of IPv6 VPC prefix on non-FNN VPC"
+    );
+    let status = result.unwrap_err();
+    assert!(
+        status.message().contains("only supported for FNN VPCs"),
+        "Error should mention FNN requirement, got: {}",
+        status.message()
+    );
+
+    Ok(())
+}
+
+/// Verify that IPv6 VPC prefix creation succeeds for FNN VPCs.
+#[crate::sqlx_test]
+async fn test_ipv6_vpc_prefix_allowed_for_fnn_vpc(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut site_prefixes = TEST_SITE_PREFIXES.to_vec();
+    site_prefixes.push("2001:db8::/32".parse().unwrap());
+
+    let env = create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides {
+            site_prefixes: Some(site_prefixes),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    // Create an FNN VPC
+    let vpc = env
+        .api
+        .create_vpc(
+            VpcCreationRequest::builder("fnn-vpc", "2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
+                .tonic_request(),
+        )
+        .await?
+        .into_inner();
+
+    let result = env
+        .api
+        .create_vpc_prefix(Request::new(VpcPrefixCreationRequest {
+            name: "ipv6-prefix".to_string(),
+            vpc_id: vpc.id,
+            prefix: "2001:db8:1::/48".to_string(),
+            ..Default::default()
+        }))
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "IPv6 VPC prefix should be allowed for FNN VPC, got: {:?}",
+        result.err()
+    );
 
     Ok(())
 }

--- a/crates/network/src/virtualization.rs
+++ b/crates/network/src/virtualization.rs
@@ -147,8 +147,18 @@ impl FromStr for VpcVirtualizationType {
 /// a wider refactor + intro of Carbide IP Prefix Management.
 pub fn get_host_ip(network: &IpNetwork) -> eyre::Result<std::net::IpAddr> {
     match network.prefix() {
-        32 => Ok(network.ip()),
+        // IPv4 single-host (/32) or IPv6 single-host (/128)
+        32 | 128 => Ok(network.ip()),
+        // IPv4 point-to-point (/30): host IP is the 4th address
         30 => match network.iter().nth(3) {
+            Some(ip_addr) => Ok(ip_addr),
+            None => Err(eyre::eyre!(format!(
+                "no viable host IP found in network: {}",
+                network
+            ))),
+        },
+        // IPv6 point-to-point (/127): host IP is the 2nd address
+        127 => match network.iter().nth(1) {
             Some(ip_addr) => Ok(ip_addr),
             None => Err(eyre::eyre!(format!(
                 "no viable host IP found in network: {}",
@@ -179,4 +189,52 @@ pub fn get_svi_ip(
         return Ok(Some(IpNetwork::new(*svi_ip, prefix)?));
     }
     Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+
+    use ipnetwork::IpNetwork;
+
+    use super::*;
+
+    #[test]
+    fn test_get_host_ip_ipv4_single_host() {
+        let network: IpNetwork = "10.0.1.5/32".parse().unwrap();
+        let ip = get_host_ip(&network).unwrap();
+        assert_eq!(ip, "10.0.1.5".parse::<IpAddr>().unwrap());
+    }
+
+    #[test]
+    fn test_get_host_ip_ipv4_point_to_point() {
+        // /30 has 4 addresses: .0 (network), .1 (gateway), .2 (svi), .3 (host)
+        let network: IpNetwork = "10.0.1.0/30".parse().unwrap();
+        let ip = get_host_ip(&network).unwrap();
+        assert_eq!(ip, "10.0.1.3".parse::<IpAddr>().unwrap());
+    }
+
+    #[test]
+    fn test_get_host_ip_ipv6_single_host() {
+        let network: IpNetwork = "2001:db8::1/128".parse().unwrap();
+        let ip = get_host_ip(&network).unwrap();
+        assert_eq!(ip, "2001:db8::1".parse::<IpAddr>().unwrap());
+    }
+
+    #[test]
+    fn test_get_host_ip_ipv6_point_to_point() {
+        // /127 has 2 addresses: ::0 (first/gateway), ::1 (second/host)
+        let network: IpNetwork = "2001:db8::0/127".parse().unwrap();
+        let ip = get_host_ip(&network).unwrap();
+        assert_eq!(ip, "2001:db8::1".parse::<IpAddr>().unwrap());
+    }
+
+    #[test]
+    fn test_get_host_ip_unsupported_prefix_rejected() {
+        let network: IpNetwork = "10.0.0.0/24".parse().unwrap();
+        assert!(get_host_ip(&network).is_err());
+
+        let network: IpNetwork = "2001:db8::/64".parse().unwrap();
+        assert!(get_host_ip(&network).is_err());
+    }
 }

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -3590,6 +3590,11 @@ message FlatInterfaceConfig {
   // MTU size
   optional uint32 mtu = 18;
 
+  // IPv6 address for this interface, if dual-stack.
+  // TODO(chet): Consider formalizing this as an ip_allocations
+  // map of <address, address_family> later.
+  optional string ip6 = 19;
+
   // The details of the network security group associated with
   // either the instance or its parent VPC.
   // Currently, source would either be INSTANCE or VPC.


### PR DESCRIPTION
## Description

I went to integrate IPv6 allocation simulation into `machine-a-tron`, because that seemed like a great place to do it, and found some bugs! Fixing them here instead of in my upcoming `machine-a-tron` PR, just so the IPv6 fixes aren't hidden amist the wider `machine-a-tron` PR.

Added tests as well around all of this.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

