### PR TITLE
fix: increment controller_state_version in switch/rack/power_shelf

### DIFF
--- a/crates/api-db/src/power_shelf.rs
+++ b/crates/api-db/src/power_shelf.rs
@@ -175,11 +175,12 @@ pub async fn try_update_controller_state(
     expected_version: ConfigVersion,
     new_state: &PowerShelfControllerState,
 ) -> DatabaseResult<bool> {
+    let next_version = expected_version.increment();
     let query_result = sqlx::query_as::<_, PowerShelfId>(
             "UPDATE power_shelves SET controller_state = $1, controller_state_version = $2 WHERE id = $3 AND controller_state_version = $4 RETURNING id",
         )
             .bind(sqlx::types::Json(new_state))
-            .bind(expected_version)
+            .bind(next_version)
             .bind(power_shelf_id)
             .bind(expected_version)
             .fetch_optional(txn)

--- a/crates/api-db/src/rack.rs
+++ b/crates/api-db/src/rack.rs
@@ -194,11 +194,12 @@ pub async fn try_update_controller_state(
     expected_version: ConfigVersion,
     new_state: &RackState,
 ) -> DatabaseResult<bool> {
+    let next_version = expected_version.increment();
     let query_result = sqlx::query_as::<_, Rack>(
             "UPDATE racks SET controller_state = $1, controller_state_version = $2 WHERE id = $3 AND controller_state_version = $4 RETURNING *",
         )
             .bind(sqlx::types::Json(new_state))
-            .bind(expected_version)
+            .bind(next_version)
             .bind(rack_id)
             .bind(expected_version)
             .fetch_optional(txn)

--- a/crates/api-db/src/switch.rs
+++ b/crates/api-db/src/switch.rs
@@ -178,11 +178,12 @@ pub async fn try_update_controller_state(
     expected_version: ConfigVersion,
     new_state: &SwitchControllerState,
 ) -> DatabaseResult<bool> {
+    let next_version = expected_version.increment();
     let query_result = sqlx::query_as::<_, SwitchId>(
             "UPDATE switches SET controller_state = $1, controller_state_version = $2 WHERE id = $3 AND controller_state_version = $4 RETURNING id",
         )
             .bind(sqlx::types::Json(new_state))
-            .bind(expected_version)
+            .bind(next_version)
             .bind(switch_id)
             .bind(expected_version)
             .fetch_optional(txn)

--- a/crates/api/src/state_controller/power_shelf/io.rs
+++ b/crates/api/src/state_controller/power_shelf/io.rs
@@ -110,7 +110,8 @@ impl StateControllerIO for PowerShelfStateControllerIO {
         old_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<(), DatabaseError> {
-        db::power_shelf_state_history::persist(txn, object_id, new_state, old_version).await?;
+        let next_version = old_version.increment();
+        db::power_shelf_state_history::persist(txn, object_id, new_state, next_version).await?;
         Ok(())
     }
 

--- a/crates/api/src/state_controller/rack/io.rs
+++ b/crates/api/src/state_controller/rack/io.rs
@@ -103,7 +103,8 @@ impl StateControllerIO for RackStateControllerIO {
         old_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<(), DatabaseError> {
-        db::rack_state_history::persist(txn, rack_id, new_state, old_version).await?;
+        let next_version = old_version.increment();
+        db::rack_state_history::persist(txn, rack_id, new_state, next_version).await?;
         Ok(())
     }
 

--- a/crates/api/src/state_controller/switch/io.rs
+++ b/crates/api/src/state_controller/switch/io.rs
@@ -110,7 +110,8 @@ impl StateControllerIO for SwitchStateControllerIO {
         old_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<(), DatabaseError> {
-        db::switch_state_history::persist(txn, object_id, new_state, old_version).await?;
+        let next_version = old_version.increment();
+        db::switch_state_history::persist(txn, object_id, new_state, next_version).await?;
         Ok(())
     }
 

--- a/crates/api/src/tests/power_shelf.rs
+++ b/crates/api/src/tests/power_shelf.rs
@@ -348,13 +348,14 @@ async fn test_power_shelf_controller_state_transitions(
     let new_state = model::power_shelf::PowerShelfControllerState::Ready;
     let current_version = power_shelf.controller_state.version;
 
-    db_power_shelf::try_update_controller_state(
+    let updated = db_power_shelf::try_update_controller_state(
         &mut txn,
         power_shelf_id,
         current_version,
         &new_state,
     )
     .await?;
+    assert!(updated, "update with correct version should succeed");
 
     // Verify the state was updated
     let updated_power_shelves = db_power_shelf::find_by(
@@ -370,6 +371,37 @@ async fn test_power_shelf_controller_state_transitions(
         updated_power_shelf.controller_state.value,
         model::power_shelf::PowerShelfControllerState::Ready
     ));
+
+    // Version should have been incremented
+    assert_eq!(
+        updated_power_shelf.controller_state.version.version_nr(),
+        current_version.version_nr() + 1,
+        "version should be incremented after update"
+    );
+
+    // Trying to update with the old version should fail (optimistic lock)
+    let stale_update = db_power_shelf::try_update_controller_state(
+        &mut txn,
+        power_shelf_id,
+        current_version,
+        &model::power_shelf::PowerShelfControllerState::Initializing,
+    )
+    .await?;
+    assert!(
+        !stale_update,
+        "update with stale version should be rejected"
+    );
+
+    // Updating with the new version should succeed
+    let new_version = updated_power_shelf.controller_state.version;
+    let updated_again = db_power_shelf::try_update_controller_state(
+        &mut txn,
+        power_shelf_id,
+        new_version,
+        &model::power_shelf::PowerShelfControllerState::Initializing,
+    )
+    .await?;
+    assert!(updated_again, "update with current version should succeed");
 
     txn.rollback().await?;
 

--- a/crates/api/src/tests/switch.rs
+++ b/crates/api/src/tests/switch.rs
@@ -315,8 +315,10 @@ async fn test_switch_controller_state_transitions(
     let new_state = SwitchControllerState::Ready;
     let current_version = switch.controller_state.version;
 
-    db_switch::try_update_controller_state(&mut txn, switch_id, current_version, &new_state)
-        .await?;
+    let updated =
+        db_switch::try_update_controller_state(&mut txn, switch_id, current_version, &new_state)
+            .await?;
+    assert!(updated, "update with correct version should succeed");
 
     // Verify the state was updated
     let updated_switches = db_switch::find_by(
@@ -332,6 +334,37 @@ async fn test_switch_controller_state_transitions(
         updated_switch.controller_state.value,
         SwitchControllerState::Ready
     ));
+
+    // Version should have been incremented
+    assert_eq!(
+        updated_switch.controller_state.version.version_nr(),
+        current_version.version_nr() + 1,
+        "version should be incremented after update"
+    );
+
+    // Trying to update with the old version should fail (optimistic lock)
+    let stale_update = db_switch::try_update_controller_state(
+        &mut txn,
+        switch_id,
+        current_version,
+        &SwitchControllerState::Initializing,
+    )
+    .await?;
+    assert!(
+        !stale_update,
+        "update with stale version should be rejected"
+    );
+
+    // Updating with the new version should succeed
+    let new_version = updated_switch.controller_state.version;
+    let updated_again = db_switch::try_update_controller_state(
+        &mut txn,
+        switch_id,
+        new_version,
+        &SwitchControllerState::Initializing,
+    )
+    .await?;
+    assert!(updated_again, "update with current version should succeed");
 
     txn.rollback().await?;
 


### PR DESCRIPTION
## Description

Continuing to dig through the rack component state controller code (first pass was https://github.com/NVIDIA/ncx-infra-controller-core/pull/701). I noticed we weren't actually incrementing the `controller_state_version` when we'd update controller state. It was using `expected_version` as the binding for both `SET controller_state_version = $2 and WHERE controller_state_version = $4`, so we were always setting it back to the version it was.

Added tests to ensure this works as intended.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

