### PR TITLE
chore: tweak trait interfaces for handling controller state/history versions

### DIFF
--- a/crates/api-db/src/dpa_interface.rs
+++ b/crates/api-db/src/dpa_interface.rs
@@ -395,13 +395,12 @@ pub async fn try_update_controller_state(
     txn: &mut PgConnection,
     id: DpaInterfaceId,
     expected_version: ConfigVersion,
+    new_version: ConfigVersion,
     new_state: &DpaInterfaceControllerState,
 ) -> Result<bool, DatabaseError> {
-    let next_version = expected_version.increment();
-
     let query = "UPDATE dpa_interfaces SET controller_state_version=$1, controller_state=$2::json where id=$3::uuid AND controller_state_version=$4 returning id";
     let result = sqlx::query_as::<_, DpaInterfaceId>(query)
-        .bind(next_version)
+        .bind(new_version)
         .bind(sqlx::types::Json(new_state))
         .bind(id)
         .bind(expected_version)

--- a/crates/api-db/src/ib_partition.rs
+++ b/crates/api-db/src/ib_partition.rs
@@ -195,13 +195,12 @@ pub async fn try_update_controller_state(
     txn: &mut PgConnection,
     partition_id: IBPartitionId,
     expected_version: ConfigVersion,
+    new_version: ConfigVersion,
     new_state: &IBPartitionControllerState,
 ) -> Result<bool, DatabaseError> {
-    let next_version = expected_version.increment();
-
     let query = "UPDATE ib_partitions SET controller_state_version=$1, controller_state=$2::json where id=$3::uuid AND controller_state_version=$4 returning id";
     let result = sqlx::query_as::<_, IBPartitionId>(query)
-        .bind(next_version)
+        .bind(new_version)
         .bind(sqlx::types::Json(new_state))
         .bind(partition_id)
         .bind(expected_version)

--- a/crates/api-db/src/network_segment.rs
+++ b/crates/api-db/src/network_segment.rs
@@ -454,13 +454,12 @@ pub async fn try_update_controller_state(
     txn: &mut PgConnection,
     segment_id: NetworkSegmentId,
     expected_version: ConfigVersion,
+    new_version: ConfigVersion,
     new_state: &NetworkSegmentControllerState,
 ) -> Result<bool, DatabaseError> {
-    let next_version = expected_version.increment();
-
     let query = "UPDATE network_segments SET controller_state_version=$1, controller_state=$2::json where id=$3::uuid AND controller_state_version=$4 returning id";
     let result = sqlx::query_as::<_, NetworkSegmentId>(query)
-        .bind(next_version)
+        .bind(new_version)
         .bind(sqlx::types::Json(new_state))
         .bind(segment_id)
         .bind(expected_version)

--- a/crates/api-db/src/power_shelf.rs
+++ b/crates/api-db/src/power_shelf.rs
@@ -173,14 +173,14 @@ pub async fn try_update_controller_state(
     txn: &mut PgConnection,
     power_shelf_id: PowerShelfId,
     expected_version: ConfigVersion,
+    new_version: ConfigVersion,
     new_state: &PowerShelfControllerState,
 ) -> DatabaseResult<bool> {
-    let next_version = expected_version.increment();
     let query_result = sqlx::query_as::<_, PowerShelfId>(
             "UPDATE power_shelves SET controller_state = $1, controller_state_version = $2 WHERE id = $3 AND controller_state_version = $4 RETURNING id",
         )
             .bind(sqlx::types::Json(new_state))
-            .bind(next_version)
+            .bind(new_version)
             .bind(power_shelf_id)
             .bind(expected_version)
             .fetch_optional(txn)

--- a/crates/api-db/src/rack.rs
+++ b/crates/api-db/src/rack.rs
@@ -192,14 +192,14 @@ pub async fn try_update_controller_state(
     txn: &mut PgConnection,
     rack_id: &RackId,
     expected_version: ConfigVersion,
+    new_version: ConfigVersion,
     new_state: &RackState,
 ) -> DatabaseResult<bool> {
-    let next_version = expected_version.increment();
     let query_result = sqlx::query_as::<_, Rack>(
             "UPDATE racks SET controller_state = $1, controller_state_version = $2 WHERE id = $3 AND controller_state_version = $4 RETURNING *",
         )
             .bind(sqlx::types::Json(new_state))
-            .bind(next_version)
+            .bind(new_version)
             .bind(rack_id)
             .bind(expected_version)
             .fetch_optional(txn)

--- a/crates/api-db/src/switch.rs
+++ b/crates/api-db/src/switch.rs
@@ -176,14 +176,14 @@ pub async fn try_update_controller_state(
     txn: &mut PgConnection,
     switch_id: SwitchId,
     expected_version: ConfigVersion,
+    new_version: ConfigVersion,
     new_state: &SwitchControllerState,
 ) -> DatabaseResult<bool> {
-    let next_version = expected_version.increment();
     let query_result = sqlx::query_as::<_, SwitchId>(
             "UPDATE switches SET controller_state = $1, controller_state_version = $2 WHERE id = $3 AND controller_state_version = $4 RETURNING id",
         )
             .bind(sqlx::types::Json(new_state))
-            .bind(next_version)
+            .bind(new_version)
             .bind(switch_id)
             .bind(expected_version)
             .fetch_optional(txn)

--- a/crates/api/src/state_controller/controller/processor.rs
+++ b/crates/api/src/state_controller/controller/processor.rs
@@ -678,11 +678,18 @@ async fn process_object<IO: StateControllerIO>(
             if *next == controller_state.value {
                 tracing::warn!(state=?next, %object_id, "Transition to current state");
             }
+            let new_version = controller_state.version.increment();
             if io
-                .persist_controller_state(&mut txn, &object_id, controller_state.version, next)
+                .persist_controller_state(
+                    &mut txn,
+                    &object_id,
+                    controller_state.version,
+                    new_version,
+                    next,
+                )
                 .await?
             {
-                io.persist_state_history(&mut txn, &object_id, controller_state.version, next)
+                io.persist_state_history(&mut txn, &object_id, new_version, next)
                     .await?;
             }
         }

--- a/crates/api/src/state_controller/dpa_interface/io.rs
+++ b/crates/api/src/state_controller/dpa_interface/io.rs
@@ -100,21 +100,27 @@ impl StateControllerIO for DpaInterfaceStateControllerIO {
         txn: &mut PgConnection,
         object_id: &Self::ObjectId,
         old_version: ConfigVersion,
+        new_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<bool, DatabaseError> {
-        db::dpa_interface::try_update_controller_state(txn, *object_id, old_version, new_state)
-            .await
+        db::dpa_interface::try_update_controller_state(
+            txn,
+            *object_id,
+            old_version,
+            new_version,
+            new_state,
+        )
+        .await
     }
 
     async fn persist_state_history(
         &self,
         txn: &mut PgConnection,
         object_id: &Self::ObjectId,
-        old_version: ConfigVersion,
+        new_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<(), DatabaseError> {
-        let next_version = old_version.increment();
-        db::dpa_interface_state_history::persist(txn, *object_id, new_state, next_version).await?;
+        db::dpa_interface_state_history::persist(txn, *object_id, new_state, new_version).await?;
         Ok(())
     }
 

--- a/crates/api/src/state_controller/ib_partition/io.rs
+++ b/crates/api/src/state_controller/ib_partition/io.rs
@@ -96,25 +96,32 @@ impl StateControllerIO for IBPartitionStateControllerIO {
         txn: &mut PgConnection,
         object_id: &Self::ObjectId,
         old_version: ConfigVersion,
+        new_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<bool, DatabaseError> {
-        db::ib_partition::try_update_controller_state(txn, *object_id, old_version, new_state).await
+        db::ib_partition::try_update_controller_state(
+            txn,
+            *object_id,
+            old_version,
+            new_version,
+            new_state,
+        )
+        .await
     }
 
     async fn persist_state_history(
         &self,
         txn: &mut PgConnection,
         object_id: &Self::ObjectId,
-        old_version: ConfigVersion,
+        new_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<(), DatabaseError> {
-        let next_version = old_version.increment();
         let query = "INSERT INTO ib_partition_state_history (partition_id, state, state_version) \
                      VALUES ($1, $2, $3)";
         sqlx::query(query)
             .bind(object_id)
             .bind(sqlx::types::Json(new_state))
-            .bind(next_version)
+            .bind(new_version)
             .execute(txn)
             .await
             .map_err(|e| DatabaseError::query(query, e))?;

--- a/crates/api/src/state_controller/io.rs
+++ b/crates/api/src/state_controller/io.rs
@@ -89,6 +89,11 @@ pub trait StateControllerIO: Send + Sync + std::fmt::Debug + 'static + Default {
 
     /// Persists the object state that is owned by the state controller.
     ///
+    /// `old_version` is the current version (used in the WHERE clause for
+    /// optimistic locking). `new_version` is the incremented version to store.
+    /// Both are computed by the processor so that implementations do not need
+    /// to call `.increment()` themselves.
+    ///
     /// Returns `true` if the state was successfully persisted, `false` if
     /// the update was skipped (e.g. optimistic lock version mismatch).
     /// The processor uses this to decide whether to persist state history.
@@ -97,6 +102,7 @@ pub trait StateControllerIO: Send + Sync + std::fmt::Debug + 'static + Default {
         txn: &mut PgConnection,
         object_id: &Self::ObjectId,
         old_version: ConfigVersion,
+        new_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<bool, DatabaseError>;
 
@@ -104,11 +110,13 @@ pub trait StateControllerIO: Send + Sync + std::fmt::Debug + 'static + Default {
     ///
     /// Called by the processor after each successful state transition
     /// (i.e. when `persist_controller_state` returns `true`).
+    /// `new_version` is the version that was just written by
+    /// `persist_controller_state`.
     async fn persist_state_history(
         &self,
         txn: &mut PgConnection,
         object_id: &Self::ObjectId,
-        old_version: ConfigVersion,
+        new_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<(), DatabaseError>;
 

--- a/crates/api/src/state_controller/machine/io.rs
+++ b/crates/api/src/state_controller/machine/io.rs
@@ -123,6 +123,7 @@ impl StateControllerIO for MachineStateControllerIO {
         txn: &mut PgConnection,
         object_id: &Self::ObjectId,
         _old_version: ConfigVersion,
+        _new_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<bool, DatabaseError> {
         db::machine::update_state(txn, object_id, new_state).await?;
@@ -137,7 +138,7 @@ impl StateControllerIO for MachineStateControllerIO {
         &self,
         _txn: &mut PgConnection,
         _object_id: &Self::ObjectId,
-        _old_version: ConfigVersion,
+        _new_version: ConfigVersion,
         _new_state: &Self::ControllerState,
     ) -> Result<(), DatabaseError> {
         Ok(())

--- a/crates/api/src/state_controller/network_segment/io.rs
+++ b/crates/api/src/state_controller/network_segment/io.rs
@@ -101,22 +101,27 @@ impl StateControllerIO for NetworkSegmentStateControllerIO {
         txn: &mut PgConnection,
         object_id: &Self::ObjectId,
         old_version: ConfigVersion,
+        new_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<bool, DatabaseError> {
-        db::network_segment::try_update_controller_state(txn, *object_id, old_version, new_state)
-            .await
+        db::network_segment::try_update_controller_state(
+            txn,
+            *object_id,
+            old_version,
+            new_version,
+            new_state,
+        )
+        .await
     }
 
     async fn persist_state_history(
         &self,
         txn: &mut PgConnection,
         object_id: &Self::ObjectId,
-        old_version: ConfigVersion,
+        new_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<(), DatabaseError> {
-        let next_version = old_version.increment();
-        db::network_segment_state_history::persist(txn, *object_id, new_state, next_version)
-            .await?;
+        db::network_segment_state_history::persist(txn, *object_id, new_state, new_version).await?;
         Ok(())
     }
 

--- a/crates/api/src/state_controller/power_shelf/io.rs
+++ b/crates/api/src/state_controller/power_shelf/io.rs
@@ -98,20 +98,27 @@ impl StateControllerIO for PowerShelfStateControllerIO {
         txn: &mut PgConnection,
         object_id: &Self::ObjectId,
         old_version: ConfigVersion,
+        new_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<bool, DatabaseError> {
-        db_power_shelf::try_update_controller_state(txn, *object_id, old_version, new_state).await
+        db_power_shelf::try_update_controller_state(
+            txn,
+            *object_id,
+            old_version,
+            new_version,
+            new_state,
+        )
+        .await
     }
 
     async fn persist_state_history(
         &self,
         txn: &mut PgConnection,
         object_id: &Self::ObjectId,
-        old_version: ConfigVersion,
+        new_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<(), DatabaseError> {
-        let next_version = old_version.increment();
-        db::power_shelf_state_history::persist(txn, object_id, new_state, next_version).await?;
+        db::power_shelf_state_history::persist(txn, object_id, new_state, new_version).await?;
         Ok(())
     }
 

--- a/crates/api/src/state_controller/rack/io.rs
+++ b/crates/api/src/state_controller/rack/io.rs
@@ -91,20 +91,21 @@ impl StateControllerIO for RackStateControllerIO {
         txn: &mut PgConnection,
         rack_id: &Self::ObjectId,
         old_version: ConfigVersion,
+        new_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<bool, DatabaseError> {
-        db_rack::try_update_controller_state(txn, rack_id, old_version, new_state).await
+        db_rack::try_update_controller_state(txn, rack_id, old_version, new_version, new_state)
+            .await
     }
 
     async fn persist_state_history(
         &self,
         txn: &mut PgConnection,
         rack_id: &Self::ObjectId,
-        old_version: ConfigVersion,
+        new_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<(), DatabaseError> {
-        let next_version = old_version.increment();
-        db::rack_state_history::persist(txn, rack_id, new_state, next_version).await?;
+        db::rack_state_history::persist(txn, rack_id, new_state, new_version).await?;
         Ok(())
     }
 

--- a/crates/api/src/state_controller/spdm/io.rs
+++ b/crates/api/src/state_controller/spdm/io.rs
@@ -88,6 +88,7 @@ impl StateControllerIO for SpdmStateControllerIO {
         txn: &mut PgConnection,
         object_id: &Self::ObjectId,
         _old_version: ConfigVersion,
+        _new_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<bool, DatabaseError> {
         db::attestation::spdm::persist_controller_state(txn, object_id, new_state).await
@@ -97,7 +98,7 @@ impl StateControllerIO for SpdmStateControllerIO {
         &self,
         txn: &mut PgConnection,
         object_id: &Self::ObjectId,
-        _old_version: ConfigVersion,
+        _new_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<(), DatabaseError> {
         db::attestation::spdm::update_history(txn, object_id, new_state).await

--- a/crates/api/src/state_controller/switch/io.rs
+++ b/crates/api/src/state_controller/switch/io.rs
@@ -98,20 +98,21 @@ impl StateControllerIO for SwitchStateControllerIO {
         txn: &mut PgConnection,
         object_id: &Self::ObjectId,
         old_version: ConfigVersion,
+        new_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<bool, DatabaseError> {
-        db_switch::try_update_controller_state(txn, *object_id, old_version, new_state).await
+        db_switch::try_update_controller_state(txn, *object_id, old_version, new_version, new_state)
+            .await
     }
 
     async fn persist_state_history(
         &self,
         txn: &mut PgConnection,
         object_id: &Self::ObjectId,
-        old_version: ConfigVersion,
+        new_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<(), DatabaseError> {
-        let next_version = old_version.increment();
-        db::switch_state_history::persist(txn, object_id, new_state, next_version).await?;
+        db::switch_state_history::persist(txn, object_id, new_state, new_version).await?;
         Ok(())
     }
 

--- a/crates/api/src/tests/network_segment.rs
+++ b/crates/api/src/tests/network_segment.rs
@@ -319,17 +319,18 @@ async fn test_network_segment_max_history_length(
         let state = NetworkSegmentControllerState::Deleting {
             deletion_state: NetworkSegmentDeletionState::DBDelete,
         };
+        let next_version = version.increment();
         assert!(
             db::network_segment::try_update_controller_state(
                 &mut txn,
                 segment_id,
                 version,
+                next_version,
                 &state,
             )
             .await
             .unwrap()
         );
-        let next_version = version.increment();
         db::network_segment_state_history::persist(&mut txn, segment_id, &state, next_version)
             .await
             .unwrap();

--- a/crates/api/src/tests/power_shelf.rs
+++ b/crates/api/src/tests/power_shelf.rs
@@ -348,10 +348,12 @@ async fn test_power_shelf_controller_state_transitions(
     let new_state = model::power_shelf::PowerShelfControllerState::Ready;
     let current_version = power_shelf.controller_state.version;
 
+    let next_version = current_version.increment();
     let updated = db_power_shelf::try_update_controller_state(
         &mut txn,
         power_shelf_id,
         current_version,
+        next_version,
         &new_state,
     )
     .await?;
@@ -384,6 +386,7 @@ async fn test_power_shelf_controller_state_transitions(
         &mut txn,
         power_shelf_id,
         current_version,
+        current_version.increment(),
         &model::power_shelf::PowerShelfControllerState::Initializing,
     )
     .await?;
@@ -398,6 +401,7 @@ async fn test_power_shelf_controller_state_transitions(
         &mut txn,
         power_shelf_id,
         new_version,
+        new_version.increment(),
         &model::power_shelf::PowerShelfControllerState::Initializing,
     )
     .await?;

--- a/crates/api/src/tests/rack_state_controller/mod.rs
+++ b/crates/api/src/tests/rack_state_controller/mod.rs
@@ -545,3 +545,68 @@ async fn test_rack_deletion_with_state_controller(
 
     Ok(())
 }
+
+#[crate::sqlx_test]
+async fn test_rack_controller_state_version_increment(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Create a rack
+    let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
+    let mut txn = pool.begin().await?;
+    db_rack::create(&mut txn, &rack_id, vec![], vec![], vec![]).await?;
+
+    // Verify initial state
+    let rack = db_rack::get(&mut *txn, &rack_id).await?;
+    assert!(matches!(rack.controller_state.value, RackState::Expected));
+    let initial_version = rack.controller_state.version;
+
+    // Update controller state with correct version
+    let new_version = initial_version.increment();
+    let updated = db_rack::try_update_controller_state(
+        &mut txn,
+        &rack_id,
+        initial_version,
+        new_version,
+        &RackState::Discovering,
+    )
+    .await?;
+    assert!(updated, "update with correct version should succeed");
+
+    // Verify version was incremented
+    let rack = db_rack::get(&mut *txn, &rack_id).await?;
+    assert_eq!(
+        rack.controller_state.version.version_nr(),
+        initial_version.version_nr() + 1,
+        "version should be incremented after update"
+    );
+
+    // Trying to update with the old version should fail (optimistic lock)
+    let stale_update = db_rack::try_update_controller_state(
+        &mut txn,
+        &rack_id,
+        initial_version,
+        initial_version.increment(),
+        &RackState::Ready,
+    )
+    .await?;
+    assert!(
+        !stale_update,
+        "update with stale version should be rejected"
+    );
+
+    // Updating with the current version should succeed
+    let current_version = rack.controller_state.version;
+    let updated_again = db_rack::try_update_controller_state(
+        &mut txn,
+        &rack_id,
+        current_version,
+        current_version.increment(),
+        &RackState::Ready,
+    )
+    .await?;
+    assert!(updated_again, "update with current version should succeed");
+
+    txn.rollback().await?;
+
+    Ok(())
+}

--- a/crates/api/src/tests/state_controller.rs
+++ b/crates/api/src/tests/state_controller.rs
@@ -564,14 +564,13 @@ impl StateControllerIO for TestStateControllerIO {
         txn: &mut PgConnection,
         object_id: &Self::ObjectId,
         old_version: ConfigVersion,
+        new_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<bool, DatabaseError> {
-        let next_version = old_version.increment();
-
         let query = "UPDATE test_objects SET controller_state_version=$1, controller_state=$2::json
             where id=$3 AND controller_state_version=$4 returning id";
         let result = sqlx::query_scalar::<_, String>(query)
-            .bind(next_version)
+            .bind(new_version)
             .bind(sqlx::types::Json(new_state))
             .bind(object_id)
             .bind(old_version)
@@ -586,7 +585,7 @@ impl StateControllerIO for TestStateControllerIO {
         &self,
         _txn: &mut PgConnection,
         _object_id: &Self::ObjectId,
-        _old_version: ConfigVersion,
+        _new_version: ConfigVersion,
         _new_state: &Self::ControllerState,
     ) -> Result<(), DatabaseError> {
         Ok(())
@@ -669,6 +668,7 @@ impl StateControllerIO for PanicInListObjectsStateControllerIO {
         _txn: &mut PgConnection,
         _object_id: &Self::ObjectId,
         _old_version: ConfigVersion,
+        _new_version: ConfigVersion,
         _new_state: &Self::ControllerState,
     ) -> Result<bool, DatabaseError> {
         unreachable!("persist_controller_state should never be called in this test")
@@ -678,7 +678,7 @@ impl StateControllerIO for PanicInListObjectsStateControllerIO {
         &self,
         _txn: &mut PgConnection,
         _object_id: &Self::ObjectId,
-        _old_version: ConfigVersion,
+        _new_version: ConfigVersion,
         _new_state: &Self::ControllerState,
     ) -> Result<(), DatabaseError> {
         unreachable!("persist_state_history should never be called in this test")

--- a/crates/api/src/tests/switch.rs
+++ b/crates/api/src/tests/switch.rs
@@ -315,9 +315,15 @@ async fn test_switch_controller_state_transitions(
     let new_state = SwitchControllerState::Ready;
     let current_version = switch.controller_state.version;
 
-    let updated =
-        db_switch::try_update_controller_state(&mut txn, switch_id, current_version, &new_state)
-            .await?;
+    let next_version = current_version.increment();
+    let updated = db_switch::try_update_controller_state(
+        &mut txn,
+        switch_id,
+        current_version,
+        next_version,
+        &new_state,
+    )
+    .await?;
     assert!(updated, "update with correct version should succeed");
 
     // Verify the state was updated
@@ -347,6 +353,7 @@ async fn test_switch_controller_state_transitions(
         &mut txn,
         switch_id,
         current_version,
+        current_version.increment(),
         &SwitchControllerState::Initializing,
     )
     .await?;
@@ -361,6 +368,7 @@ async fn test_switch_controller_state_transitions(
         &mut txn,
         switch_id,
         new_version,
+        new_version.increment(),
         &SwitchControllerState::Initializing,
     )
     .await?;


### PR DESCRIPTION
## Description

In https://github.com/NVIDIA/ncx-infra-controller-core/pull/709, I had noticed the rack-level components weren't properly incrementing their controller state version. I fixed that, but wanted to go through and try to clean up the call sites to make it harder for things like this to happen, especially when it comes to pattern matching/copypasta, etc.

With this change:
- `persist_controller_state` now takes both `old_version` and `new_version`, no hidden `.increment()`, and now there's a known "`new_version`".
- `persist_state_history` just takes `new_version` instead of `old_version` — no `.increment()`.

This is all because the processor computes `new_version` via `controller_state.version.increment()`.

Made some testing adjustments while I was in here.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

