### PR TITLE
Add paginated APIs for Rack access and fix rack deletion

### DIFF
--- a/crates/admin-cli/src/rack/list/cmd.rs
+++ b/crates/admin-cli/src/rack/list/cmd.rs
@@ -19,12 +19,12 @@ use color_eyre::Result;
 use prettytable::{Cell, Row, Table};
 use rpc::admin_cli::OutputFormat;
 
+use crate::cfg::runtime::RuntimeConfig;
 use crate::rpc::ApiClient;
 
-pub async fn list_racks(api_client: &ApiClient) -> Result<()> {
-    let query = rpc::forge::GetRackRequest { id: None };
-    let response = api_client.0.get_rack(query).await?;
-    let racks = response.rack;
+pub async fn list_racks(api_client: &ApiClient, config: &RuntimeConfig) -> Result<()> {
+    let response = api_client.get_all_racks(config.page_size).await?;
+    let racks = response.racks;
     if racks.is_empty() {
         println!("No racks found");
         return Ok(());

--- a/crates/admin-cli/src/rack/list/mod.rs
+++ b/crates/admin-cli/src/rack/list/mod.rs
@@ -26,7 +26,7 @@ use crate::cfg::runtime::RuntimeContext;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
-        cmd::list_racks(&ctx.api_client).await?;
+        cmd::list_racks(&ctx.api_client, &ctx.config).await?;
         Ok(())
     }
 }

--- a/crates/admin-cli/src/rack/show/args.rs
+++ b/crates/admin-cli/src/rack/show/args.rs
@@ -15,18 +15,11 @@
  * limitations under the License.
  */
 
+use carbide_uuid::rack::RackId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
 pub struct Args {
-    #[clap(help = "Rack ID or name to show (leave empty for all)")]
-    pub identifier: Option<String>,
-}
-
-impl From<Args> for ::rpc::forge::GetRackRequest {
-    fn from(args: Args) -> Self {
-        Self {
-            id: args.identifier,
-        }
-    }
+    #[clap(help = "Rack ID to show (leave empty for all)")]
+    pub rack: Option<RackId>,
 }

--- a/crates/admin-cli/src/rack/show/cmd.rs
+++ b/crates/admin-cli/src/rack/show/cmd.rs
@@ -18,11 +18,16 @@
 use color_eyre::Result;
 
 use super::args::Args;
+use crate::cfg::runtime::RuntimeConfig;
 use crate::rpc::ApiClient;
 
-pub async fn show_rack(api_client: &ApiClient, show_opts: Args) -> Result<()> {
-    let response = api_client.0.get_rack(show_opts).await?;
-    let racks = response.rack;
+pub async fn show_rack(api_client: &ApiClient, args: Args, config: &RuntimeConfig) -> Result<()> {
+    let racks = match args.rack {
+        Some(rack_id) => api_client.get_one_rack(rack_id).await?,
+        None => api_client.get_all_racks(config.page_size).await?,
+    }
+    .racks;
+
     if racks.is_empty() {
         println!("No racks found");
         return Ok(());

--- a/crates/admin-cli/src/rack/show/mod.rs
+++ b/crates/admin-cli/src/rack/show/mod.rs
@@ -26,7 +26,7 @@ use crate::cfg::runtime::RuntimeContext;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
-        cmd::show_rack(&ctx.api_client, self).await?;
+        cmd::show_rack(&ctx.api_client, self, &ctx.config).await?;
         Ok(())
     }
 }

--- a/crates/admin-cli/src/rack/tests.rs
+++ b/crates/admin-cli/src/rack/tests.rs
@@ -52,7 +52,7 @@ fn parse_show_no_args() {
 
     match cmd {
         Cmd::Show(args) => {
-            assert!(args.identifier.is_none());
+            assert!(args.rack.is_none());
         }
         _ => panic!("expected Show variant"),
     }
@@ -66,7 +66,7 @@ fn parse_show_with_identifier() {
 
     match cmd {
         Cmd::Show(args) => {
-            assert_eq!(args.identifier, Some("rack-123".to_string()));
+            assert_eq!(args.rack, Some("rack-123".parse().unwrap()));
         }
         _ => panic!("expected Show variant"),
     }

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -261,6 +261,30 @@ impl ApiClient {
         Ok(self.0.find_instance_ids(request).await?)
     }
 
+    pub async fn get_all_racks(&self, page_size: usize) -> CarbideCliResult<rpc::RackList> {
+        let all_ids = self.get_rack_ids().await?;
+        let mut all_list = rpc::RackList {
+            racks: Vec::with_capacity(all_ids.rack_ids.len()),
+        };
+
+        for ids in all_ids.rack_ids.chunks(page_size) {
+            let list = self.0.find_racks_by_ids(ids.to_vec()).await?;
+            all_list.racks.extend(list.racks);
+        }
+
+        Ok(all_list)
+    }
+
+    pub async fn get_one_rack(&self, rack_id: RackId) -> CarbideCliResult<rpc::RackList> {
+        let racks = self.0.find_racks_by_ids(vec![rack_id]).await?;
+
+        Ok(racks)
+    }
+
+    async fn get_rack_ids(&self) -> CarbideCliResult<rpc::RackIdList> {
+        Ok(self.0.find_rack_ids().await?)
+    }
+
     pub async fn get_all_segments(
         &self,
         tenant_org_id: Option<String>,

--- a/crates/api-db/src/rack.rs
+++ b/crates/api-db/src/rack.rs
@@ -39,17 +39,33 @@ impl ColumnInfo<'_> for IdColumn {
     }
 }
 
-pub async fn find_by<'a, C: ColumnInfo<'a, TableType = Rack>>(
-    txn: &mut PgConnection,
+pub async fn find_by<'a, C: ColumnInfo<'a, TableType = Rack>, DB>(
+    conn: &mut DB,
     filter: ObjectColumnFilter<'a, C>,
-) -> DatabaseResult<Vec<Rack>> {
+) -> DatabaseResult<Vec<Rack>>
+where
+    for<'db> &'db mut DB: DbReader<'db>,
+{
     let mut query = FilterableQueryBuilder::new("SELECT * FROM racks").filter(&filter);
 
     query
         .build_query_as()
-        .fetch_all(txn)
+        .fetch_all(&mut *conn)
         .await
         .map_err(|e| DatabaseError::new(query.sql(), e))
+}
+
+pub async fn find_ids(
+    txn: impl DbReader<'_>,
+    _filter: model::rack::RackSearchFilter,
+) -> Result<Vec<RackId>, DatabaseError> {
+    let mut builder = sqlx::QueryBuilder::new("SELECT id FROM racks WHERE TRUE "); // The TRUE will be optimized away.
+
+    let query = builder.build_query_as();
+    query
+        .fetch_all(txn)
+        .await
+        .map_err(|e| DatabaseError::new("instance::find_ids", e))
 }
 
 pub async fn list(txn: impl DbReader<'_>) -> DatabaseResult<Vec<Rack>> {
@@ -224,10 +240,10 @@ pub async fn update_controller_state_outcome(
     Ok(())
 }
 
-pub async fn mark_as_deleted(rack: &Rack, txn: &mut PgConnection) -> DatabaseResult<Rack> {
+pub async fn mark_as_deleted(rack_id: &RackId, txn: &mut PgConnection) -> DatabaseResult<Rack> {
     let query = "UPDATE racks SET updated=NOW(), deleted=NOW() WHERE id=$1 RETURNING *";
     let updated_rack = sqlx::query_as(query)
-        .bind(&rack.id)
+        .bind(rack_id)
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -88,6 +88,15 @@ impl From<Rack> for rpc::forge::Rack {
     }
 }
 
+#[derive(Clone, Debug, Default)]
+pub struct RackSearchFilter {}
+
+impl From<rpc::forge::RackSearchFilter> for RackSearchFilter {
+    fn from(_filter: rpc::forge::RackSearchFilter) -> Self {
+        RackSearchFilter {}
+    }
+}
+
 fn derive_rack_aggregate_health(overrides: &HealthReportOverrides) -> health_report::HealthReport {
     if let Some(replace) = &overrides.replace {
         return replace.clone();

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -1050,6 +1050,20 @@ impl Forge for Api {
         crate::handlers::rack::get_rack(self, request).await
     }
 
+    async fn find_rack_ids(
+        &self,
+        request: Request<rpc::RackSearchFilter>,
+    ) -> Result<Response<rpc::RackIdList>, Status> {
+        crate::handlers::rack::find_ids(self, request).await
+    }
+
+    async fn find_racks_by_ids(
+        &self,
+        request: Request<rpc::RacksByIdsRequest>,
+    ) -> Result<Response<rpc::RackList>, Status> {
+        crate::handlers::rack::find_by_ids(self, request).await
+    }
+
     async fn delete_rack(
         &self,
         request: Request<rpc::DeleteRackRequest>,

--- a/crates/api/src/auth/internal_rbac_rules.rs
+++ b/crates/api/src/auth/internal_rbac_rules.rs
@@ -669,6 +669,8 @@ impl InternalRBACRules {
             "FindSwitchStateHistories",
             vec![ForgeAdminCLI, Machineatron, Rla],
         );
+        x.perm("FindRackIds", vec![ForgeAdminCLI, SiteAgent, Rla]);
+        x.perm("FindRacksByIds", vec![ForgeAdminCLI, SiteAgent, Rla]);
         x.perm("GetRack", vec![ForgeAdminCLI, Rla]);
         x.perm("DeleteRack", vec![ForgeAdminCLI, Rla]);
         x.perm("RackManagerCall", vec![ForgeAdminCLI]);

--- a/crates/api/src/handlers/rack.rs
+++ b/crates/api/src/handlers/rack.rs
@@ -18,19 +18,21 @@ use std::str::FromStr;
 
 use ::rpc::forge::{self as rpc, HealthReportOverride};
 use carbide_uuid::rack::RackId;
-use db::{WithTransaction, rack as db_rack};
+use db::{ObjectColumnFilter, WithTransaction, rack as db_rack};
 use futures_util::FutureExt;
 use health_report::OverrideMode;
 use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
-use crate::api::Api;
+use crate::api::{Api, log_request_data};
 use crate::auth::AuthContext;
 
 pub async fn get_rack(
     api: &Api,
     request: Request<rpc::GetRackRequest>,
 ) -> Result<Response<rpc::GetRackResponse>, Status> {
+    log_request_data(&request);
+
     let req = request.into_inner();
     let rack = if let Some(id) = req.id {
         let rack_id = RackId::from_str(&id)
@@ -50,10 +52,62 @@ pub async fn get_rack(
     Ok(Response::new(rpc::GetRackResponse { rack }))
 }
 
+pub async fn find_ids(
+    api: &Api,
+    request: Request<rpc::RackSearchFilter>,
+) -> Result<Response<rpc::RackIdList>, Status> {
+    log_request_data(&request);
+
+    let filter: model::rack::RackSearchFilter = request.into_inner().into();
+
+    let rack_ids = db::rack::find_ids(&api.database_connection, filter).await?;
+
+    Ok(Response::new(rpc::RackIdList { rack_ids }))
+}
+
+pub async fn find_by_ids(
+    api: &Api,
+    request: Request<rpc::RacksByIdsRequest>,
+) -> Result<Response<rpc::RackList>, Status> {
+    log_request_data(&request);
+
+    let rack_ids = request.into_inner().rack_ids;
+
+    let max_find_by_ids = api.runtime_config.max_find_by_ids as usize;
+    if rack_ids.len() > max_find_by_ids {
+        return Err(CarbideError::InvalidArgument(format!(
+            "no more than {max_find_by_ids} IDs can be accepted"
+        ))
+        .into());
+    } else if rack_ids.is_empty() {
+        return Err(
+            CarbideError::InvalidArgument("at least one ID must be provided".to_string()).into(),
+        );
+    }
+
+    let mut txn = api.txn_begin().await?;
+
+    let racks = db::rack::find_by(
+        &mut txn,
+        ObjectColumnFilter::List(db::rack::IdColumn, &rack_ids),
+    )
+    .await?;
+
+    let _ = txn.rollback().await;
+
+    let mut result = Vec::with_capacity(racks.len());
+    for rack in racks {
+        result.push(rack.into());
+    }
+
+    Ok(Response::new(rpc::RackList { racks: result }))
+}
+
 pub async fn find_rack_state_histories(
     api: &Api,
     request: Request<rpc::RackStateHistoriesRequest>,
 ) -> Result<Response<rpc::RackStateHistories>, Status> {
+    log_request_data(&request);
     let request = request.into_inner();
     let rack_ids = request.rack_ids;
 
@@ -94,18 +148,20 @@ pub async fn delete_rack(
     api: &Api,
     request: Request<rpc::DeleteRackRequest>,
 ) -> Result<Response<()>, Status> {
+    log_request_data(&request);
+
     let req = request.into_inner();
     api.with_txn(|txn| {
         async move {
             let rack_id = RackId::from_str(&req.id)
                 .map_err(|e| CarbideError::InvalidArgument(format!("Invalid rack ID: {}", e)))?;
-            let rack =
+            let _rack =
                 db_rack::get(txn.as_mut(), &rack_id)
                     .await
                     .map_err(|e| CarbideError::Internal {
                         message: format!("Getting rack {}", e),
                     })?;
-            db_rack::mark_as_deleted(&rack, txn)
+            db_rack::mark_as_deleted(&rack_id, txn)
                 .await
                 .map_err(|e| CarbideError::Internal {
                     message: format!("Marking rack deleted {}", e),
@@ -122,6 +178,8 @@ pub async fn list_rack_health_report_overrides(
     api: &Api,
     request: Request<rpc::ListRackHealthReportOverridesRequest>,
 ) -> Result<Response<rpc::ListHealthReportOverrideResponse>, Status> {
+    log_request_data(&request);
+
     let req = request.into_inner();
     let rack_id = req
         .rack_id
@@ -147,6 +205,8 @@ pub async fn insert_rack_health_report_override(
     api: &Api,
     request: Request<rpc::InsertRackHealthReportOverrideRequest>,
 ) -> Result<Response<()>, Status> {
+    log_request_data(&request);
+
     let triggered_by = request
         .extensions()
         .get::<AuthContext>()
@@ -200,6 +260,8 @@ pub async fn remove_rack_health_report_override(
     api: &Api,
     request: Request<rpc::RemoveRackHealthReportOverrideRequest>,
 ) -> Result<Response<()>, Status> {
+    log_request_data(&request);
+
     let rpc::RemoveRackHealthReportOverrideRequest { rack_id, source } = request.into_inner();
     let rack_id = rack_id.ok_or_else(|| CarbideError::MissingArgument("rack_id"))?;
 

--- a/crates/api/src/state_controller/rack/handler.rs
+++ b/crates/api/src/state_controller/rack/handler.rs
@@ -787,9 +787,10 @@ impl StateHandler for RackStateHandler {
             }
 
             RackState::Deleting => {
-                // Rack is being deleted - no action needed for now
-                // TODO[#416]: add escape condition in case rack is recreated
-                Ok(StateHandlerOutcome::do_nothing())
+                // Rack is being deleted
+                let mut txn = ctx.services.db_pool.begin().await?;
+                db::rack::final_delete(&mut txn, id).await?;
+                Ok(StateHandlerOutcome::deleted().with_txn(txn))
             }
         }
     }

--- a/crates/api/src/state_controller/rack/io.rs
+++ b/crates/api/src/state_controller/rack/io.rs
@@ -23,7 +23,7 @@ use db::rack::IdColumn;
 use db::{DatabaseError, ObjectColumnFilter, rack as db_rack};
 use model::StateSla;
 use model::controller_outcome::PersistentStateHandlerOutcome;
-use model::rack::{Rack, RackState, RackValidationState, state_sla};
+use model::rack::{Rack, RackSearchFilter, RackState, RackValidationState, state_sla};
 use sqlx::PgConnection;
 
 use crate::state_controller::io::StateControllerIO;
@@ -51,9 +51,7 @@ impl StateControllerIO for RackStateControllerIO {
         &self,
         txn: &mut PgConnection,
     ) -> Result<Vec<Self::ObjectId>, DatabaseError> {
-        db_rack::list(txn)
-            .await
-            .map(|racks| racks.into_iter().map(|r| r.id).collect())
+        db_rack::find_ids(txn, RackSearchFilter {}).await
     }
 
     /// Loads a state snapshot from the database

--- a/crates/api/src/tests/mod.rs
+++ b/crates/api/src/tests/mod.rs
@@ -90,6 +90,7 @@ mod nvl_logical_partition;
 mod power_shelf;
 mod power_shelf_state_controller;
 mod prevent_duplicate_mac_addresses;
+mod rack_find;
 mod rack_firmware;
 mod rack_health;
 mod rack_state_controller;

--- a/crates/api/src/tests/rack_find.rs
+++ b/crates/api/src/tests/rack_find.rs
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::rack::RackId;
+use common::api_fixtures::create_test_env;
+use rpc::forge::forge_server::Forge;
+
+use crate::tests::common;
+use crate::tests::common::api_fixtures::site_explorer::TestRackDbBuilder;
+
+#[crate::sqlx_test]
+async fn test_find_rack_by_id(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+
+    let rack_id1: RackId = "Rack1".parse().unwrap();
+    let rack_id2: RackId = "Rack2".parse().unwrap();
+    let mut txn = env.pool.acquire().await.unwrap();
+    TestRackDbBuilder::new()
+        .with_rack_id(rack_id1.clone())
+        .persist(&mut txn)
+        .await
+        .unwrap();
+    TestRackDbBuilder::new()
+        .with_rack_id(rack_id2.clone())
+        .persist(&mut txn)
+        .await
+        .unwrap();
+    drop(txn);
+
+    let rack_ids = env
+        .api
+        .find_rack_ids(tonic::Request::new(rpc::forge::RackSearchFilter {}))
+        .await
+        .unwrap()
+        .into_inner()
+        .rack_ids;
+    assert_eq!(rack_ids, vec![rack_id1.clone(), rack_id2.clone()]);
+
+    let racks = env
+        .api
+        .find_racks_by_ids(tonic::Request::new(rpc::forge::RacksByIdsRequest {
+            rack_ids: vec![rack_id1.clone()],
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .racks;
+    assert_eq!(racks.len(), 1);
+    assert_eq!(racks[0].id, Some(rack_id1));
+
+    let racks = env
+        .api
+        .find_racks_by_ids(tonic::Request::new(rpc::forge::RacksByIdsRequest {
+            rack_ids: vec![rack_id2.clone()],
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .racks;
+    assert_eq!(racks.len(), 1);
+    assert_eq!(racks[0].id, Some(rack_id2));
+}

--- a/crates/api/src/tests/rack_health.rs
+++ b/crates/api/src/tests/rack_health.rs
@@ -578,7 +578,7 @@ async fn test_dsx_consumer_contract(pool: sqlx::PgPool) -> Result<(), Box<dyn st
 }
 
 #[crate::sqlx_test]
-async fn test_rack_health_visible_in_get_rack(
+async fn test_rack_health_visible_in_find_racks_by_ids(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env =
@@ -604,14 +604,14 @@ async fn test_rack_health_visible_in_get_rack(
 
     let rack_resp = env
         .api
-        .get_rack(Request::new(rpc_forge::GetRackRequest {
-            id: Some(rack_id.to_string()),
+        .find_racks_by_ids(Request::new(rpc_forge::RacksByIdsRequest {
+            rack_ids: vec![rack_id.clone()],
         }))
         .await?
         .into_inner();
 
-    assert_eq!(rack_resp.rack.len(), 1);
-    let rack = &rack_resp.rack[0];
+    assert_eq!(rack_resp.racks.len(), 1);
+    let rack = &rack_resp.racks[0];
 
     assert!(rack.health.is_some(), "Rack should have health field");
     let health: HealthReport = rack.health.clone().unwrap().try_into().unwrap();

--- a/crates/api/src/tests/rack_state_controller/fixtures/rack.rs
+++ b/crates/api/src/tests/rack_state_controller/fixtures/rack.rs
@@ -33,16 +33,3 @@ pub async fn set_rack_controller_state(
 
     Ok(())
 }
-
-/// Helper function to mark rack as deleted
-pub async fn mark_rack_as_deleted(
-    txn: &mut PgConnection,
-    rack_id: &RackId,
-) -> Result<(), sqlx::Error> {
-    sqlx::query("UPDATE racks SET deleted = NOW() WHERE id = $1")
-        .bind(rack_id)
-        .execute(txn)
-        .await?;
-
-    Ok(())
-}

--- a/crates/api/src/tests/rack_state_controller/mod.rs
+++ b/crates/api/src/tests/rack_state_controller/mod.rs
@@ -41,7 +41,7 @@ use crate::tests::common::api_fixtures::site_explorer::TestRackDbBuilder;
 
 mod fixtures;
 mod handler;
-use fixtures::rack::{mark_rack_as_deleted, set_rack_controller_state};
+use fixtures::rack::set_rack_controller_state;
 
 #[derive(Debug, Default, Clone)]
 pub struct TestRackStateHandler {
@@ -63,7 +63,7 @@ impl StateHandler for TestRackStateHandler {
         rack_id: &RackId,
         state: &mut Rack,
         controller_state: &Self::ControllerState,
-        _ctx: &mut StateHandlerContext<Self::ContextObjects>,
+        ctx: &mut StateHandlerContext<Self::ContextObjects>,
     ) -> Result<StateHandlerOutcome<Self::ControllerState>, StateHandlerError> {
         assert_eq!(state.id, *rack_id);
         self.count.fetch_add(1, Ordering::SeqCst);
@@ -107,6 +107,12 @@ impl StateHandler for TestRackStateHandler {
                 RackValidationState::Validated => RackState::Ready,
                 _ => return Ok(StateHandlerOutcome::do_nothing()),
             },
+            RackState::Deleting => {
+                // Rack is being deleted
+                let mut txn = ctx.services.db_pool.begin().await?;
+                db::rack::final_delete(&mut txn, rack_id).await?;
+                return Ok(StateHandlerOutcome::deleted().with_txn(txn));
+            }
             _ => return Ok(StateHandlerOutcome::do_nothing()),
         };
 
@@ -267,78 +273,6 @@ async fn test_rack_state_transitions(pool: sqlx::PgPool) -> Result<(), Box<dyn s
     let rack_id_str = rack_id.to_string();
     let count = guard.get(&rack_id_str).copied().unwrap_or_default();
     assert!(count > 0, "Rack ID should have been processed");
-
-    Ok(())
-}
-
-#[crate::sqlx_test]
-async fn test_rack_deletion_flow(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
-
-    // Create a rack
-    let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
-    let mut txn = pool.acquire().await?;
-    TestRackDbBuilder::new()
-        .with_rack_id(rack_id.clone())
-        .persist(&mut txn)
-        .await?;
-
-    // Verify rack exists
-    let rack = db_rack::get(&mut *txn, &rack_id).await?;
-    assert_eq!(rack.id, rack_id);
-
-    // Start the state controller to process the rack while it's active
-    let rack_handler = Arc::new(TestRackStateHandler::default());
-    const ITERATION_TIME: Duration = Duration::from_millis(50);
-
-    let handler_services = Arc::new(env.state_handler_services());
-
-    let cancel_token = CancellationToken::new();
-    let mut controller = StateController::<RackStateControllerIO>::builder()
-        .iteration_config(IterationConfig {
-            iteration_time: ITERATION_TIME,
-            processor_dispatch_interval: Duration::from_millis(10),
-            ..Default::default()
-        })
-        .database(pool.clone(), env.api.work_lock_manager_handle.clone())
-        .processor_id(uuid::Uuid::new_v4().to_string())
-        .services(handler_services.clone())
-        .state_handler(rack_handler.clone())
-        .build_for_manual_iterations(cancel_token.clone())
-        .unwrap();
-
-    controller.run_single_iteration().await;
-
-    // Verify that the handler was called while the rack was active
-    let count_before_deletion = rack_handler.count.load(Ordering::SeqCst);
-    assert!(
-        count_before_deletion > 0,
-        "State handler should have been called while rack was active"
-    );
-
-    // Mark the rack as deleted
-    mark_rack_as_deleted(pool.acquire().await?.as_mut(), &rack_id).await?;
-
-    controller.run_single_iteration().await;
-    controller.run_single_iteration().await;
-    controller.run_single_iteration().await;
-    controller.run_single_iteration().await;
-    controller.run_single_iteration().await;
-    controller.run_single_iteration().await;
-    controller.run_single_iteration().await;
-
-    // Verify that the handler count didn't increase significantly after deletion
-    // (since deleted racks should not be processed)
-    let count_after_deletion = rack_handler.count.load(Ordering::SeqCst);
-    let count_increase = count_after_deletion - count_before_deletion;
-
-    // The count might increase slightly due to timing, but should not increase significantly
-    // since deleted racks are excluded from processing
-    assert!(
-        count_increase < 5,
-        "State handler should not process deleted racks significantly. Count increase: {}",
-        count_increase
-    );
 
     Ok(())
 }
@@ -505,17 +439,10 @@ async fn test_rack_deletion_with_state_controller(
 
     controller.run_single_iteration().await;
 
-    // Verify that the handler was called while the rack was active
-    let count_before_deletion = rack_handler.count.load(Ordering::SeqCst);
-    assert!(
-        count_before_deletion > 0,
-        "State handler should have been called while rack was active"
-    );
-
     // Mark the rack as deleted
-    mark_rack_as_deleted(pool.acquire().await?.as_mut(), &rack_id).await?;
+    db::rack::mark_as_deleted(&rack_id, pool.acquire().await?.as_mut()).await?;
 
-    // Let the controller run for a bit more after marking as deleted
+    // Let the controller continue to run
     controller.run_single_iteration().await;
     controller.run_single_iteration().await;
     controller.run_single_iteration().await;
@@ -530,18 +457,16 @@ async fn test_rack_deletion_with_state_controller(
     controller.run_single_iteration().await;
     controller.run_single_iteration().await;
 
-    // Verify that the handler count didn't increase significantly after marking as deleted
-    // (since deleted racks should not be processed)
-    let count_after_deletion = rack_handler.count.load(Ordering::SeqCst);
-    let count_increase = count_after_deletion - count_before_deletion;
-
-    // The count might increase slightly due to timing, but should not increase significantly
-    // since deleted racks are excluded from processing
-    assert!(
-        count_increase <= 5, // Allow for some timing-related calls
-        "State handler should not process deleted racks significantly. Count increase: {}",
-        count_increase
-    );
+    // Verify that the DB object is gone
+    let racks = env
+        .api
+        .find_racks_by_ids(tonic::Request::new(rpc::forge::RacksByIdsRequest {
+            rack_ids: vec![rack_id],
+        }))
+        .await?
+        .into_inner()
+        .racks;
+    assert!(racks.is_empty());
 
     Ok(())
 }

--- a/crates/api/src/web/expected_rack.rs
+++ b/crates/api/src/web/expected_rack.rs
@@ -75,13 +75,10 @@ async fn fetch_expected_racks(
         }
     };
 
-    let rack_response = match api
-        .get_rack(tonic::Request::new(rpc::forge::GetRackRequest { id: None }))
-        .await
-    {
-        Ok(response) => response.into_inner(),
+    let rack_response = match super::rack::fetch_racks(api).await {
+        Ok(racks) => racks,
         Err(err) => {
-            tracing::error!(%err, "get_rack");
+            tracing::error!(%err, "fetch_racks");
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Failed to list racks".to_string(),
@@ -91,7 +88,7 @@ async fn fetch_expected_racks(
 
     // Index actual racks by their ID for quick lookup.
     let racks_by_id: std::collections::HashMap<String, &rpc::forge::Rack> = rack_response
-        .rack
+        .racks
         .iter()
         .filter_map(|r| r.id.as_ref().map(|id| (id.to_string(), r)))
         .collect();

--- a/crates/api/src/web/machine.rs
+++ b/crates/api/src/web/machine.rs
@@ -410,7 +410,7 @@ pub async fn fetch_machines(
         const PAGE_SIZE: usize = 100;
         let page_size = PAGE_SIZE.min(machine_ids.len() - offset);
         let next_ids = &machine_ids[offset..offset + page_size];
-        let next_vpcs = api
+        let next_machines = api
             .find_machines_by_ids(tonic::Request::new(forgerpc::MachinesByIdsRequest {
                 machine_ids: next_ids.to_vec(),
                 include_history,
@@ -418,7 +418,7 @@ pub async fn fetch_machines(
             .await?
             .into_inner();
 
-        machines.extend(next_vpcs.machines.into_iter());
+        machines.extend(next_machines.machines.into_iter());
         offset += page_size;
     }
 

--- a/crates/api/src/web/rack.rs
+++ b/crates/api/src/web/rack.rs
@@ -31,7 +31,7 @@ use crate::api::Api;
 
 #[derive(Template)]
 #[template(path = "rack_show.html")]
-struct Rack {
+struct Racks {
     racks: Vec<RackRecord>,
 }
 
@@ -59,39 +59,14 @@ struct RackDetail {
 pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
     let racks = match fetch_racks(&state).await {
         Ok(racks) => racks,
-        Err((code, msg)) => return (code, msg).into_response(),
-    };
-
-    let display = Rack { racks };
-    (StatusCode::OK, Html(display.render().unwrap())).into_response()
-}
-
-/// Show all racks as JSON
-pub async fn show_json(state: AxumState<Arc<Api>>) -> Response {
-    let racks = match fetch_racks(&state).await {
-        Ok(racks) => racks,
-        Err((code, msg)) => return (code, msg).into_response(),
-    };
-    (StatusCode::OK, Json(racks)).into_response()
-}
-
-async fn fetch_racks(api: &Api) -> Result<Vec<RackRecord>, (http::StatusCode, String)> {
-    let response = match api
-        .get_rack(tonic::Request::new(rpc::forge::GetRackRequest { id: None }))
-        .await
-    {
-        Ok(response) => response.into_inner(),
         Err(err) => {
-            tracing::error!(%err, "list_racks");
-            return Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to list racks".to_string(),
-            ));
+            tracing::error!(%err, "fetch_racks");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading racks").into_response();
         }
     };
 
-    let racks = response
-        .rack
+    let racks = racks
+        .racks
         .into_iter()
         .map(|rack| {
             let expected_compute_trays = rack.expected_compute_trays.join(", ");
@@ -136,34 +111,71 @@ async fn fetch_racks(api: &Api) -> Result<Vec<RackRecord>, (http::StatusCode, St
         })
         .collect();
 
-    Ok(racks)
+    let display = Racks { racks };
+    (StatusCode::OK, Html(display.render().unwrap())).into_response()
+}
+
+/// Show all racks as JSON
+pub async fn show_json(state: AxumState<Arc<Api>>) -> Response {
+    let racks = match fetch_racks(&state).await {
+        Ok(racks) => racks,
+        Err(err) => {
+            tracing::error!(%err, "fetch_racks");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading racks").into_response();
+        }
+    };
+    (StatusCode::OK, Json(racks)).into_response()
+}
+
+pub async fn fetch_racks(api: &Api) -> Result<rpc::forge::RackList, tonic::Status> {
+    let request = tonic::Request::new(rpc::forge::RackSearchFilter {});
+
+    let rack_ids = api.find_rack_ids(request).await?.into_inner().rack_ids;
+
+    let mut racks = Vec::new();
+    let mut offset = 0;
+    while offset != rack_ids.len() {
+        const PAGE_SIZE: usize = 100;
+        let page_size = PAGE_SIZE.min(rack_ids.len() - offset);
+        let next_ids = &rack_ids[offset..offset + page_size];
+        let next_racks = api
+            .find_racks_by_ids(tonic::Request::new(rpc::forge::RacksByIdsRequest {
+                rack_ids: next_ids.to_vec(),
+            }))
+            .await?
+            .into_inner();
+
+        racks.extend(next_racks.racks.into_iter());
+        offset += page_size;
+    }
+
+    Ok(rpc::forge::RackList { racks })
 }
 
 pub async fn fetch_rack(
     api: &Api,
     rack_id: &RackId,
 ) -> Result<Option<::rpc::forge::Rack>, Response> {
-    let request = tonic::Request::new(rpc::forge::GetRackRequest {
-        id: Some(rack_id.to_string()),
+    let request = tonic::Request::new(rpc::forge::RacksByIdsRequest {
+        rack_ids: vec![rack_id.clone()],
     });
 
-    // TODO: This should use FindRacksByIds
     let rack = match api
-        .get_rack(request)
+        .find_racks_by_ids(request)
         .await
         .map(|response| response.into_inner())
     {
-        Ok(r) if r.rack.is_empty() => {
+        Ok(r) if r.racks.is_empty() => {
             return Ok(None);
         }
-        Ok(r) if r.rack.len() != 1 => {
+        Ok(r) if r.racks.len() != 1 => {
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Rack list for {rack_id} returned {} racks", r.rack.len()),
+                format!("Rack list for {rack_id} returned {} racks", r.racks.len()),
             )
                 .into_response());
         }
-        Ok(mut r) => Some(r.rack.remove(0)),
+        Ok(mut r) => Some(r.racks.remove(0)),
         Err(err) if err.code() == tonic::Code::NotFound => {
             return Ok(None);
         }

--- a/crates/api/templates/rack_detail.html
+++ b/crates/api/templates/rack_detail.html
@@ -6,7 +6,7 @@
 <div id="json">
 	<a id="json-link" href="">JSON</a>
 </div>
-<h1>{{ id }}</h1>
+<h1>Rack {{ id }}</h1>
 
 {% if let Some(rack) = rack %}
 <table class="detailsview">

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -695,6 +695,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "#[derive(serde::Deserialize,serde::Serialize)]",
         )
         .type_attribute(
+            "forge.RackList",
+            "#[derive(serde::Deserialize,serde::Serialize)]",
+        )
+        .type_attribute(
             "common.Uint32List",
             "#[derive(serde::Deserialize,serde::Serialize)]",
         )

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -641,6 +641,9 @@ service Forge {
   rpc DetermineMachineIngestionState(BmcEndpointRequest) returns (MachineIngestionStateResponse);
 
   // Rack
+  rpc FindRackIds(RackSearchFilter) returns (RackIdList);
+  rpc FindRacksByIds(RacksByIdsRequest) returns (RackList);
+  // Deprecated: Use FindRackIds
   rpc GetRack(GetRackRequest) returns (GetRackResponse);
   rpc DeleteRack(DeleteRackRequest) returns (google.protobuf.Empty);
 
@@ -5992,6 +5995,21 @@ message GetRackRequest {
 
 message GetRackResponse {
   repeated Rack rack = 1;
+}
+
+message RackList {
+  repeated Rack racks = 1;
+}
+
+message RackSearchFilter {
+}
+
+message RackIdList {
+  repeated common.RackId rack_ids = 1;
+}
+
+message RacksByIdsRequest {
+  repeated common.RackId rack_ids = 1;
 }
 
 message Rack {


### PR DESCRIPTION
## Description

Adds FindRackIds and FindRacksByIds API that follow the design pattern of other gRPC APIs. GetRack API is deprecated.

Also adds a "final delete" to the rack state machine, which follows other state machines.

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

