### PR TITLE
feat(api, bmc-mock): Add HTTP IPMI transport for testing & DGX H100 test

### DIFF
--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -124,6 +124,15 @@ async fn test_integration() -> eyre::Result<()> {
         )
         .boxed(),
         test_machine_a_tron_multidpu(
+            HostHardwareType::NvidiaDgxH100,
+            &test_env,
+            &bmc_address_registry,
+            &managed_segment_id,
+            // Relay IP in admin net
+            Ipv4Addr::new(172, 20, 0, 2),
+        )
+        .boxed(),
+        test_machine_a_tron_multidpu(
             HostHardwareType::WiwynnGB200Nvl,
             &test_env,
             &bmc_address_registry,

--- a/crates/api-test-helper/src/api_server.rs
+++ b/crates/api-test-helper/src/api_server.rs
@@ -83,7 +83,7 @@ pub async fn start(
         enable_route_servers = false
         deny_prefixes = []
         site_fabric_prefixes = []
-        dpu_ipmi_tool_impl = "test"
+        dpu_ipmi_tool_impl = "bmc-mock"
         initial_domain_name = "{DOMAIN_NAME}"
         initial_dpu_agent_upgrade_policy = "off"
         max_concurrent_machine_updates = 1

--- a/crates/api/src/ipmitool.rs
+++ b/crates/api/src/ipmitool.rs
@@ -18,10 +18,12 @@
 use std::net::IpAddr;
 use std::sync::Arc;
 
+use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use carbide_uuid::machine::MachineId;
 use eyre::eyre;
 use forge_secrets::credentials::{CredentialKey, CredentialReader, Credentials};
+use utils::HostPortPair;
 use utils::cmd::{CmdError, CmdResult, TokioCmd};
 
 #[async_trait]
@@ -195,6 +197,108 @@ impl IPMITool for IPMIToolTestImpl {
     }
 }
 
+/// HTTP-based IPMI implementation for testing with bmc-mock.
+/// Sends JSON requests to bmc_proxy which routes to appropriate machine.
+pub struct IPMIToolHttpImpl {
+    bmc_proxy: Arc<ArcSwap<Option<HostPortPair>>>,
+}
+
+impl IPMIToolHttpImpl {
+    pub fn new(bmc_proxy: Arc<ArcSwap<Option<HostPortPair>>>) -> Self {
+        Self { bmc_proxy }
+    }
+
+    async fn execute_action(&self, action: &str, bmc_ip: IpAddr) -> Result<(), eyre::Report> {
+        let proxy = self.bmc_proxy.load();
+
+        // Determine the target URL and headers based on whether a proxy is configured
+        let (url, forwarded_header) = match proxy.as_ref() {
+            Some(proxy) => {
+                // Use proxy - send to proxy with Forwarded header containing BMC IP
+                let proxy_url = match proxy {
+                    HostPortPair::HostAndPort(h, p) => format!("https://{}:{}", h, p),
+                    HostPortPair::HostOnly(h) => format!("https://{}:443", h),
+                    HostPortPair::PortOnly(p) => format!("https://127.0.0.1:{}", p),
+                };
+                (
+                    format!("{}/ipmi", proxy_url),
+                    Some(format!("host={}", bmc_ip)),
+                )
+            }
+            None => {
+                // No proxy - send directly to BMC
+                (format!("https://{}/ipmi", bmc_ip), None)
+            }
+        };
+
+        let client = reqwest::Client::builder()
+            .danger_accept_invalid_certs(true)
+            .build()
+            .map_err(|e| eyre!("failed to create HTTP client: {}", e))?;
+
+        let mut request = client
+            .post(&url)
+            .json(&serde_json::json!({"action": action}));
+
+        if let Some(header) = forwarded_header {
+            request = request.header("Forwarded", header);
+        }
+
+        let resp = request
+            .send()
+            .await
+            .map_err(|e| eyre!("HTTP request to {} failed: {}", url, e))?;
+
+        if !resp.status().is_success() {
+            return Err(eyre!("HTTP error: {}", resp.status()));
+        }
+
+        #[derive(serde::Deserialize)]
+        struct IpmiHttpResponse {
+            success: bool,
+            error: Option<String>,
+        }
+
+        let body: IpmiHttpResponse = resp
+            .json()
+            .await
+            .map_err(|e| eyre!("failed to parse response: {}", e))?;
+
+        if !body.success {
+            return Err(eyre!(
+                "IPMI action failed: {}",
+                body.error.unwrap_or_else(|| "unknown error".to_string())
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl IPMITool for IPMIToolHttpImpl {
+    async fn bmc_cold_reset(
+        &self,
+        bmc_ip: IpAddr,
+        _credential_key: &CredentialKey,
+    ) -> Result<(), eyre::Report> {
+        self.execute_action("bmc_cold_reset", bmc_ip).await
+    }
+
+    async fn restart(
+        &self,
+        _machine_id: &MachineId,
+        bmc_ip: IpAddr,
+        legacy_boot: bool,
+        _credential_key: &CredentialKey,
+    ) -> Result<(), eyre::Report> {
+        if legacy_boot && self.execute_action("dpu_legacy_boot", bmc_ip).await.is_ok() {
+            return Ok(());
+        }
+        // Fall through to chassis_power_reset if legacy_boot fails or is false
+        self.execute_action("chassis_power_reset", bmc_ip).await
+    }
+}
 #[cfg(test)]
 mod test {
     use std::sync::Arc;

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -20,6 +20,7 @@ use std::net::IpAddr;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use arc_swap::ArcSwap;
 use db::machine::update_dpu_asns;
 use db::resource_pool::DefineResourcePoolError;
 use db::{Transaction, work_lock_manager};
@@ -44,6 +45,7 @@ use tokio::sync::oneshot::Sender;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing_log::AsLog as _;
+use utils::HostPortPair;
 
 use crate::api::Api;
 use crate::api::metrics::ApiMetricsEmitter;
@@ -55,7 +57,7 @@ use crate::firmware_downloader::FirmwareDownloader;
 use crate::handlers::machine_validation::apply_config_on_startup;
 use crate::ib::{self, IBFabricManager};
 use crate::ib_fabric_monitor::IbFabricMonitor;
-use crate::ipmitool::{IPMITool, IPMIToolImpl, IPMIToolTestImpl};
+use crate::ipmitool::{IPMITool, IPMIToolHttpImpl, IPMIToolImpl, IPMIToolTestImpl};
 use crate::listener::ApiListenMode;
 use crate::logging::log_limiter::LogLimiter;
 use crate::logging::service_health_metrics::{
@@ -159,22 +161,26 @@ pub fn parse_carbide_config(
 pub fn create_ipmi_tool(
     credential_reader: Arc<dyn CredentialReader>,
     carbide_config: &CarbideConfig,
+    bmc_proxy: Arc<ArcSwap<Option<HostPortPair>>>,
 ) -> Arc<dyn IPMITool> {
-    if carbide_config
-        .dpu_ipmi_tool_impl
-        .as_ref()
-        .is_some_and(|tool| tool == "test")
-    {
-        tracing::trace!("Disabling ipmitool");
-        Arc::new(IPMIToolTestImpl {})
-    } else {
-        Arc::new(IPMIToolImpl::new(
-            credential_reader,
-            &carbide_config.dpu_ipmi_reboot_attempts,
-        ))
+    match carbide_config.dpu_ipmi_tool_impl.as_deref() {
+        Some("test") => {
+            tracing::info!("Disabling ipmitool");
+            Arc::new(IPMIToolTestImpl {})
+        }
+        Some("bmc-mock") => {
+            tracing::info!("Using HTTP IPMI transport via bmc_proxy");
+            Arc::new(IPMIToolHttpImpl::new(bmc_proxy))
+        }
+        _ => {
+            tracing::info!("Using lanplus IPMI transport (/usr/bin/ipmitool)");
+            Arc::new(IPMIToolImpl::new(
+                credential_reader,
+                &carbide_config.dpu_ipmi_reboot_attempts,
+            ))
+        }
     }
 }
-
 /// Configure and create a postgres connection pool
 ///
 /// This connects to the database to verify settings
@@ -215,7 +221,11 @@ pub async fn start_api(
     cancel_token: CancellationToken,
     ready_channel: Sender<()>,
 ) -> eyre::Result<()> {
-    let ipmi_tool = create_ipmi_tool(credential_manager.clone(), &carbide_config);
+    let ipmi_tool = create_ipmi_tool(
+        credential_manager.clone(),
+        &carbide_config,
+        dynamic_settings.bmc_proxy.clone(),
+    );
 
     let db_pool = create_and_connect_postgres_pool(&carbide_config).await?;
 

--- a/crates/bmc-mock/src/bmc_state.rs
+++ b/crates/bmc-mock/src/bmc_state.rs
@@ -34,6 +34,7 @@ pub struct BmcState {
     pub chassis_state: Arc<ChassisState>,
     pub update_service_state: Arc<UpdateServiceState>,
     pub injected_bugs: Arc<InjectedBugs>,
+    pub power_control: Option<Arc<dyn crate::PowerControl>>,
 }
 
 impl BmcState {

--- a/crates/bmc-mock/src/hw/nvidia_dgx_h100.rs
+++ b/crates/bmc-mock/src/hw/nvidia_dgx_h100.rs
@@ -130,10 +130,19 @@ impl NvidiaDgxH100<'_> {
         .enumerate()
         .map(|(n, nic)| {
             let id = format!("{:04X}", n + 10); // Starting with 000A
+            // TODO should be taken from NIC:
+            let pci_path = "PciRoot(0x0)/Pci(0x10,0x0)/Pci(0x0,0x0)";
             redfish::boot_option::builder(&redfish::boot_option::resource(system_id, &id))
                 .boot_option_reference(&format!("Boot{id}"))
                 // Real DisplayName: "UEFI P0: HTTP IPv4 Nvidia Network Adapter - 94:6D:AE:00:00:00"
                 .display_name(&format!("UEFI Pn: HTTP IPv4 - {}", nic.mac_address))
+                .alias("UefiHttp")
+                .uefi_device_path(&format!(
+                    "{pci_path}/MAC({},0x1)/IPv4(0.0.0.0,0x0,DHCP,0.0.0.0,0.0.0.0,0.0.0.0)/Uri()",
+                    nic.mac_address.to_string().replace(":", "")
+                ))
+                // libredfish model requires @odata.etag field.
+                .odata_etag("MakeLibRedfishHappy")
                 .build()
         })
         .chain(std::iter::once(
@@ -315,7 +324,12 @@ impl NvidiaDgxH100<'_> {
     pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
         redfish::update_service::UpdateServiceConfig {
             firmware_inventory: [
-                ("CPLDMB_0", "0.2.1.9"), // version required carbide to pass ingestion test in site explorer.
+                // version required carbide to pass ingestion test in site explorer.
+                ("CPLDMB_0", "0.2.1.9"),
+                // This one is needed for libredfish to setup lockdown
+                ("HostBIOS_0", "01.05.03"),
+                // This one is needed for libredfish to setup lockdown
+                ("HostBMC_0", "24.09.17"),
             ]
             .iter()
             .map(|(id, version)| {

--- a/crates/bmc-mock/src/ipmi.rs
+++ b/crates/bmc-mock/src/ipmi.rs
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! IPMI-over-HTTP mock handler for testing.
+//!
+//! Receives JSON requests from `IPMIToolHttpImpl` and translates them
+//! into `BmcCommand::SetSystemPower` calls to machine-a-tron.
+
+use axum::routing::post;
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+
+use crate::SystemPowerControl;
+use crate::bmc_state::BmcState;
+
+/// Request body for IPMI mock endpoint.
+#[derive(Debug, Deserialize)]
+pub struct IpmiRequest {
+    action: String,
+}
+
+/// Response body for IPMI mock endpoint.
+#[derive(Debug, Serialize)]
+pub struct IpmiResponse {
+    success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+impl IpmiResponse {
+    fn ok() -> Self {
+        Self {
+            success: true,
+            error: None,
+        }
+    }
+
+    fn err(msg: impl Into<String>) -> Self {
+        Self {
+            success: false,
+            error: Some(msg.into()),
+        }
+    }
+}
+
+/// Add IPMI routes to the router.
+pub fn add_routes(router: Router<BmcState>) -> Router<BmcState> {
+    router.route("/ipmi", post(handle_ipmi))
+}
+
+async fn handle_ipmi(
+    axum::extract::State(state): axum::extract::State<BmcState>,
+    Json(req): Json<IpmiRequest>,
+) -> Json<IpmiResponse> {
+    tracing::debug!(action = %req.action, "IPMI mock request");
+
+    let Some(ref power_control) = state.power_control else {
+        tracing::error!("IPMI request received but power_control not configured");
+        return Json(IpmiResponse::err("power_control not configured"));
+    };
+
+    let response = match req.action.as_str() {
+        "chassis_power_reset" => {
+            tracing::info!("IPMI: chassis power reset");
+            match power_control.send_power_command(SystemPowerControl::ForceRestart) {
+                Ok(()) => IpmiResponse::ok(),
+                Err(e) => {
+                    tracing::error!(error = ?e, "chassis power reset failed");
+                    IpmiResponse::err(format!("power command failed: {:?}", e))
+                }
+            }
+        }
+        "bmc_cold_reset" => {
+            tracing::info!("IPMI: bmc cold reset (mock no-op)");
+            IpmiResponse::ok()
+        }
+        "dpu_legacy_boot" => {
+            tracing::info!("IPMI: dpu legacy boot");
+            match power_control.send_power_command(SystemPowerControl::ForceRestart) {
+                Ok(()) => IpmiResponse::ok(),
+                Err(e) => {
+                    tracing::error!(error = ?e, "dpu legacy boot failed");
+                    IpmiResponse::err(format!("power command failed: {:?}", e))
+                }
+            }
+        }
+        other => {
+            tracing::warn!(action = %other, "unknown IPMI action");
+            IpmiResponse::err(format!("unknown action: {}", other))
+        }
+    };
+
+    Json(response)
+}

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use tokio::time::Instant;
+pub mod ipmi;
 
 mod bmc_state;
 mod bug;

--- a/crates/bmc-mock/src/mock_machine_router.rs
+++ b/crates/bmc-mock/src/mock_machine_router.rs
@@ -66,7 +66,7 @@ pub fn machine_router(
     power_control: Arc<dyn PowerControl>,
     mat_host_id: String,
 ) -> Router {
-    let system_config = machine_info.system_config(power_control);
+    let system_config = machine_info.system_config(power_control.clone());
     let chassis_config = machine_info.chassis_config();
     let update_service_config = machine_info.update_service_config();
     let bmc_vendor = machine_info.bmc_vendor();
@@ -85,7 +85,8 @@ pub fn machine_router(
         .add_routes(crate::redfish::update_service::add_routes)
         .add_routes(crate::redfish::task_service::add_routes)
         .add_routes(crate::redfish::account_service::add_routes)
-        .add_routes(|routes| crate::redfish::computer_system::add_routes(routes, bmc_vendor));
+        .add_routes(|routes| crate::redfish::computer_system::add_routes(routes, bmc_vendor))
+        .add_routes(crate::ipmi::add_routes);
     let router = match &machine_info {
         MachineInfo::Dpu(_) => {
             router.add_routes(crate::redfish::oem::nvidia::bluefield::add_routes)
@@ -113,6 +114,7 @@ pub fn machine_router(
         chassis_state,
         update_service_state,
         injected_bugs: injected_bugs.clone(),
+        power_control: Some(power_control.clone()),
     });
     let router_with_expansion = redfish::expander_router::append(router);
     middleware_router::append(mat_host_id, router_with_expansion, injected_bugs)

--- a/crates/bmc-mock/src/redfish/boot_option.rs
+++ b/crates/bmc-mock/src/redfish/boot_option.rs
@@ -97,6 +97,14 @@ impl BootOptionBuilder {
         self.add_str_field("UefiDevicePath", value)
     }
 
+    pub fn alias(self, value: &str) -> Self {
+        self.add_str_field("Alias", value)
+    }
+
+    pub fn odata_etag(self, value: &str) -> Self {
+        self.add_str_field("@odata.etag", value)
+    }
+
     pub fn build(self) -> BootOption {
         BootOption {
             id: self.id,


### PR DESCRIPTION
## Description

Add IPMIToolHttpImpl that sends IPMI commands via HTTP POST to bmc-mock instead of shelling out to /usr/bin/ipmitool. This enables IPMI testing using machine-a-tron without requiring actual IPMI implementation.

Changes:
- Implement IPMIToolHttpImpl with bmc_proxy support
- Add /ipmi endpoint to bmc-mock handling chassis_power_reset, bmc_cold_reset, and dpu_legacy_boot actions
- Wire power_control into BmcState for command dispatch

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

