### PR TITLE
fix: start to unwind legacy ETV; nvue_enabled is always true

### DIFF
--- a/crates/admin-cli/src/version/cmds.rs
+++ b/crates/admin-cli/src/version/cmds.rs
@@ -114,7 +114,6 @@ pub async fn handle_show_version(
         r!(table, config, dpu_nic_firmware_reprovision_update_enabled);
         r!(table, config, max_concurrent_machine_updates);
         r!(table, config, machine_update_runtime_interval);
-        r!(table, config, nvue_enabled);
         r!(table, config, attestation_enabled);
         r!(table, config, max_find_by_ids);
         r!(table, config, machine_validation_enabled);

--- a/crates/api-test-helper/src/api_server.rs
+++ b/crates/api-test-helper/src/api_server.rs
@@ -87,7 +87,6 @@ pub async fn start(
         initial_domain_name = "{DOMAIN_NAME}"
         initial_dpu_agent_upgrade_policy = "off"
         max_concurrent_machine_updates = 1
-        nvue_enabled = true
         attestation_enabled = false
         max_find_by_ids = 100
         internet_l3_vni = 1337

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -224,11 +224,6 @@ pub struct CarbideConfig {
     #[serde(default)]
     pub site_explorer: SiteExplorerConfig,
 
-    /// DPU agent to use NVUE instead of writing files directly.
-    /// Once we are comfortable with this and all DPUs are HBN 2+ it will become the only option.
-    #[serde(default = "default_to_true")]
-    pub nvue_enabled: bool,
-
     /// The policy to decide whether two VPCs are allowed to peer with each other based on their
     /// network virtualization type during creation
     pub vpc_peering_policy: Option<VpcPeeringPolicy>,
@@ -2679,6 +2674,7 @@ impl From<VpcIsolationBehaviorType> for rpc::forge::VpcIsolationBehaviorType {
     }
 }
 
+#[allow(deprecated)] // nvue_enabled proto field is deprecated but still set for backwards compat
 impl From<CarbideConfig> for rpc::forge::RuntimeConfig {
     fn from(value: CarbideConfig) -> Self {
         Self {
@@ -2729,7 +2725,7 @@ impl From<CarbideConfig> for rpc::forge::RuntimeConfig {
                 .max_concurrent_machine_updates_absolute
                 .unwrap_or_default(),
             machine_update_runtime_interval: value.machine_update_run_interval.unwrap_or_default(),
-            nvue_enabled: value.nvue_enabled,
+            nvue_enabled: true,
             attestation_enabled: value.attestation_enabled,
             auto_host_firmware_update: value.firmware_global.autoupdate,
             host_enable_autoupdate: value.firmware_global.host_enable_autoupdate,
@@ -3309,7 +3305,6 @@ mod tests {
         assert!(config.pools.is_none());
         assert!(config.ib_config.is_none());
         assert!(config.ib_fabrics.is_empty());
-        assert!(config.nvue_enabled);
         assert!(config.vpc_peering_policy.is_none());
         assert!(config.site_explorer.enabled);
         assert!(
@@ -3357,7 +3352,6 @@ mod tests {
         assert_eq!(config.asn, 777);
         assert_eq!(config.dhcp_servers, vec!["99.101.102.103".to_string()]);
         assert!(config.route_servers.is_empty());
-        assert!(!config.nvue_enabled);
         assert_eq!(config.vpc_peering_policy, Some(VpcPeeringPolicy::Exclusive));
         assert_eq!(config.vpc_peering_policy_on_existing, None);
         assert_eq!(
@@ -3501,7 +3495,6 @@ mod tests {
             config.dhcp_servers,
             vec!["1.2.3.4".to_string(), "5.6.7.8".to_string()]
         );
-        assert!(config.nvue_enabled);
         assert_eq!(config.vpc_peering_policy, Some(VpcPeeringPolicy::Exclusive));
         assert_eq!(
             config.vpc_peering_policy_on_existing,

--- a/crates/api/src/cfg/test_data/full_config.toml
+++ b/crates/api/src/cfg/test_data/full_config.toml
@@ -12,7 +12,6 @@ machine_update_run_interval = 60
 dpu_ipmi_tool_impl = "fake"
 dpu_ipmi_reboot_attempts = 1
 max_find_by_ids = 75
-nvue_enabled = true
 vpc_peering_policy = "exclusive"
 vpc_peering_policy_on_existing = "mixed"
 internet_l3_vni = 1337

--- a/crates/api/src/cfg/test_data/site_config.toml
+++ b/crates/api/src/cfg/test_data/site_config.toml
@@ -4,7 +4,6 @@ rapid_iterations = true
 max_database_connections = 1333
 max_find_by_ids = 50
 dpu_network_monitor_pinger_type = "OobNetBind"
-nvue_enabled = false
 vpc_peering_policy = "exclusive"
 
 

--- a/crates/api/src/ethernet_virtualization.rs
+++ b/crates/api/src/ethernet_virtualization.rs
@@ -246,7 +246,6 @@ pub async fn tenant_network(
     iface: &InstanceInterfaceConfig,
     fqdn: String,
     loopback_ip: Option<String>,
-    nvue_enabled: bool,
     network_virtualization_type: VpcVirtualizationType,
     suppress_tenant_security_groups: bool,
     network_security_group_details: Option<(i32, NetworkSecurityGroup)>,
@@ -317,17 +316,7 @@ pub async fn tenant_network(
         match policy {
             VpcPeeringPolicy::Exclusive => {
                 // Under exclusive policy, VPC only allowed to peer with VPC of same network virtualization type.
-                // If nvue_enabled, ETHERNET_VIRTUALIZER is same as ETHERNET_VIRTUALIZER_NVUE.
-                let allowed_network_virtualization_types =
-                    match (nvue_enabled, network_virtualization_type) {
-                        (true, t) if t != VpcVirtualizationType::Fnn => {
-                            vec![
-                                VpcVirtualizationType::EthernetVirtualizer,
-                                VpcVirtualizationType::EthernetVirtualizerWithNvue,
-                            ]
-                        }
-                        _ => vec![network_virtualization_type],
-                    };
+                let allowed_network_virtualization_types = vec![network_virtualization_type];
                 let vpc_peers = db::vpc_peering::get_vpc_peer_vnis(
                     txn,
                     vpc_id,

--- a/crates/api/src/handlers/dpu.rs
+++ b/crates/api/src/handlers/dpu.rs
@@ -153,11 +153,7 @@ pub(crate) async fn get_managed_host_network_config_inner(
     // prevent the host from using the DPU at all.
     let use_admin_network = dpu_snapshot.use_admin_network() || !dpu_has_tenant_interface_config;
 
-    let mut network_virtualization_type = if api.runtime_config.nvue_enabled {
-        VpcVirtualizationType::EthernetVirtualizerWithNvue
-    } else {
-        VpcVirtualizationType::EthernetVirtualizer
-    };
+    let mut network_virtualization_type = VpcVirtualizationType::EthernetVirtualizerWithNvue;
 
     let mut use_fnn_over_admin_nw = false;
 
@@ -267,23 +263,15 @@ pub(crate) async fn get_managed_host_network_config_inner(
                 None
             };
 
-            // So the network_virtualization_type historically didn't come from the VPC table,
-            // even though the value was being set there, and we're in the process of changing
-            // that. If it's Fnn*, then set it accordingly. If it is EXPLICITLY ETV w/ NVUE,
-            // then set it accordingly. If it's ETV, then check the runtime config to see if
-            // nvue_enabled is true.
+            // Use the virtualization type from the VPC, upgrading legacy ETV to ETV_NVUE,
+            // which shouldn't actually be something that happens now, but it's good to
+            // cover our bases.
             network_virtualization_type = match vpc.network_virtualization_type {
-                VpcVirtualizationType::Fnn => VpcVirtualizationType::Fnn,
-                VpcVirtualizationType::EthernetVirtualizerWithNvue => {
+                VpcVirtualizationType::EthernetVirtualizer
+                | VpcVirtualizationType::EthernetVirtualizerWithNvue => {
                     VpcVirtualizationType::EthernetVirtualizerWithNvue
                 }
-                VpcVirtualizationType::EthernetVirtualizer => {
-                    if api.runtime_config.nvue_enabled {
-                        VpcVirtualizationType::EthernetVirtualizerWithNvue
-                    } else {
-                        VpcVirtualizationType::EthernetVirtualizer
-                    }
-                }
+                VpcVirtualizationType::Fnn => VpcVirtualizationType::Fnn,
             };
 
             vpc_vni = vpc.status.as_ref().and_then(|v| v.vni.map(|x|x as u32));
@@ -440,7 +428,6 @@ pub(crate) async fn get_managed_host_network_config_inner(
                         // DPU agent reads loopback ip only from 0th interface.
                         // function build in nvue.rs
                         tenant_loopback_ip.clone(),
-                        api.runtime_config.nvue_enabled,
                         network_virtualization_type,
                         suppress_tenant_security_groups,
                         network_security_group_details.clone(),

--- a/crates/api/src/handlers/vpc_peering.rs
+++ b/crates/api/src/handlers/vpc_peering.rs
@@ -71,12 +71,11 @@ pub async fn create(
                 kind: "VPC",
                 id: peer_vpc_id.to_string(),
             })?;
-            // If nvue_enabled, then ETHERNET_VIRTUALIZER = ETHERNET_VIRTUALIZER_WITH_NVUE and
-            // only type of peering not allowed is between Fnn <-> ETV/ETV_WITH_NVUE
+            // Peering not allowed between Fnn <-> ETV/ETV_NVUE.
+            // ETV and ETV_NVUE are treated as equivalent since NVUE is always enabled.
             if vpc1.network_virtualization_type != vpc2.network_virtualization_type
-                && (!api.runtime_config.nvue_enabled
-                    || (vpc1.network_virtualization_type == VpcVirtualizationType::Fnn
-                        || vpc2.network_virtualization_type == VpcVirtualizationType::Fnn))
+                && (vpc1.network_virtualization_type == VpcVirtualizationType::Fnn
+                    || vpc2.network_virtualization_type == VpcVirtualizationType::Fnn)
             {
                 return Err(CarbideError::internal(
                             "VPC peering between VPCs of different network virtualization type not allowed.".to_string(),

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -1085,7 +1085,6 @@ pub fn get_config() -> CarbideConfig {
             allocate_secondary_vtep_ip: true,
             ..Default::default()
         },
-        nvue_enabled: true,
         vpc_peering_policy: Some(VpcPeeringPolicy::Exclusive),
         vpc_peering_policy_on_existing: None,
         attestation_enabled: false,

--- a/crates/api/src/tests/vpc.rs
+++ b/crates/api/src/tests/vpc.rs
@@ -278,8 +278,9 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
     assert!(forge_vpc.status.and_then(|s| s.vni).is_some());
     // The 'config' VNI is still None because this was an auto-allocated VNI
     assert!(forge_vpc.vni.is_none());
-    // We default to type Ethernet Virtualizer
-    assert_eq!(forge_vpc.network_virtualization_type, Some(0));
+    // We default to EthernetVirtualizerWithNvue (proto value 2).
+    // The DB stores "etv" but decodes as EthernetVirtualizerWithNvue.
+    assert_eq!(forge_vpc.network_virtualization_type, Some(2));
 
     let no_org_vpc = env
         .api
@@ -358,13 +359,10 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
     assert_eq!(updated_vpc.metadata, updated_metadata);
     assert_eq!(updated_vpc.version.version_nr(), 2);
 
-    // This only works because `EthernetVirtualizer` is the default
-    // virtualization type right now. Once we change the default type,
-    // this will fail, and we'll need to update the test. BUT, I wanted
-    // to be explicit here.
+    // DB value "etv" decodes as EthernetVirtualizerWithNvue since NVUE is always enabled.
     assert_eq!(
         updated_vpc.network_virtualization_type,
-        VpcVirtualizationType::EthernetVirtualizer
+        VpcVirtualizationType::EthernetVirtualizerWithNvue
     );
 
     // Update virtualization type.
@@ -410,7 +408,7 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
     let first = vpcs.swap_remove(0);
     assert_eq!(
         first.network_virtualization_type,
-        VpcVirtualizationType::EthernetVirtualizer
+        VpcVirtualizationType::EthernetVirtualizerWithNvue
     );
 
     // Update on outdated version

--- a/crates/api/templates/index.html
+++ b/crates/api/templates/index.html
@@ -234,10 +234,6 @@
 		</td>
 	</tr>
 	<tr>
-		<th>NVUE Enabled</th>
-		<td>{{ carbide_config.nvue_enabled }}</td>
-	</tr>
-	<tr>
 		<th>Machine Attestation Enabled</th>
 		<td>{{ carbide_config.attestation_enabled }}</td>
 	</tr>

--- a/crates/network/src/virtualization.rs
+++ b/crates/network/src/virtualization.rs
@@ -39,17 +39,93 @@ pub const DEFAULT_NETWORK_VIRTUALIZATION_TYPE: VpcVirtualizationType =
 /// and plumb the value down to the DPU agent, which gets piped into
 /// the `update_nvue` function, which is then used to drive
 /// population of the appropriate template.
-// TODO(chet): Rename
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
-#[cfg_attr(feature = "sqlx", sqlx(type_name = "network_virtualization_type_t"))]
 pub enum VpcVirtualizationType {
-    #[cfg_attr(feature = "sqlx", sqlx(rename = "etv"))]
     EthernetVirtualizer,
-    #[cfg_attr(feature = "sqlx", sqlx(rename = "etv_nvue"))]
     EthernetVirtualizerWithNvue,
-    #[cfg_attr(feature = "sqlx", sqlx(rename = "fnn"))]
     Fnn,
+}
+
+// Manual sqlx impls so that legacy DB value 'etv' decodes as EthernetVirtualizerWithNvue.
+#[cfg(feature = "sqlx")]
+const PG_TYPE_NAME: &str = "network_virtualization_type_t";
+
+#[cfg(feature = "sqlx")]
+impl sqlx::Type<sqlx::Postgres> for VpcVirtualizationType {
+    fn type_info() -> sqlx::postgres::PgTypeInfo {
+        sqlx::postgres::PgTypeInfo::with_name(PG_TYPE_NAME)
+    }
+}
+
+#[cfg(feature = "sqlx")]
+impl sqlx::Encode<'_, sqlx::Postgres> for VpcVirtualizationType {
+    fn encode_by_ref(
+        &self,
+        buf: &mut sqlx::postgres::PgArgumentBuffer,
+    ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
+        let s = match self {
+            Self::EthernetVirtualizer | Self::EthernetVirtualizerWithNvue => "etv",
+            Self::Fnn => "fnn",
+        };
+        <&str as sqlx::Encode<sqlx::Postgres>>::encode(s, buf)
+    }
+}
+
+#[cfg(feature = "sqlx")]
+impl sqlx::postgres::PgHasArrayType for VpcVirtualizationType {
+    fn array_type_info() -> sqlx::postgres::PgTypeInfo {
+        sqlx::postgres::PgTypeInfo::with_name("_network_virtualization_type_t")
+    }
+}
+
+#[cfg(feature = "sqlx")]
+impl sqlx::Decode<'_, sqlx::Postgres> for VpcVirtualizationType {
+    fn decode(value: sqlx::postgres::PgValueRef<'_>) -> Result<Self, sqlx::error::BoxDynError> {
+        let s = <&str as sqlx::Decode<sqlx::Postgres>>::decode(value)?;
+        match s {
+            // Legacy 'etv' rows are treated as EthernetVirtualizerWithNvue
+            "etv" | "etv_nvue" => Ok(Self::EthernetVirtualizerWithNvue),
+            "fnn" => Ok(Self::Fnn),
+            other => {
+                Err(format!("invalid value {:?} for enum VpcVirtualizationType", other).into())
+            }
+        }
+    }
+}
+
+#[cfg(all(test, feature = "sqlx"))]
+mod sqlx_tests {
+    use sqlx::Encode;
+    use sqlx::postgres::PgArgumentBuffer;
+
+    use super::VpcVirtualizationType;
+
+    fn encode_to_string(v: VpcVirtualizationType) -> String {
+        let mut buf = PgArgumentBuffer::default();
+        let _ = v.encode_by_ref(&mut buf).unwrap();
+        String::from_utf8(buf.to_vec()).unwrap()
+    }
+
+    #[test]
+    fn encode_etv_writes_etv() {
+        assert_eq!(
+            encode_to_string(VpcVirtualizationType::EthernetVirtualizer),
+            "etv"
+        );
+    }
+
+    #[test]
+    fn encode_etv_nvue_writes_etv() {
+        assert_eq!(
+            encode_to_string(VpcVirtualizationType::EthernetVirtualizerWithNvue),
+            "etv"
+        );
+    }
+
+    #[test]
+    fn encode_fnn_writes_fnn() {
+        assert_eq!(encode_to_string(VpcVirtualizationType::Fnn), "fnn");
+    }
 }
 
 impl VpcVirtualizationType {

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1120,7 +1120,8 @@ message RuntimeConfig {
   uint64 machine_update_runtime_interval = 23;
 
   reserved 24;
-  bool nvue_enabled = 25;
+  // Deprecated: NVUE is always enabled. This field is always set to true.
+  bool nvue_enabled = 25 [deprecated = true];
   uint32 max_database_connections = 26;
 
   bool auto_host_firmware_update = 27;


### PR DESCRIPTION
## Description

So `nvue_enabled: true` was enabled in QA over 2 years ago, began going out to production sites a month later, and was made the default for all sites December 2024 (it had already been enabled individually on each). In short, `::EthernetVirtualizerWithNvue` is running everywhere. The funny thing is, we never actually changed the value in the database. We still actually write `etv` (`::EthernetVirtualizer`), and then use `nvue_enabled` to flip it over as things work their way through the plumbing.

As part of doing IPv6 work, I ran across all of the old legacy ETV stuff, and I'd like to start unwinding it. I'll get to the agent next, but first, I want to effectively "force" `nvue_enabled: true`, get rid of the flag entirely, and cut it off at the source, by introducing `sqlx` `Encode` / `Decode` implementations that continue to always **serialize to** `etv` (so the database remains unchanged), but will always **deserialize back to** `::EthernetVirtualizerWithNvue` (effectively stopping `::EthernetVirtualizer` from coming back from the DB).

I'm NOT getting rid of `::EthernetVirtualizer` as a variant, however, because my goal, once I get to the agent side, is to just make `::EthernetVirtualizer` the name of the variant we use; "with NVUE" is implied now, and it seems silly to have a variant `WithNvue` and a corresponding `etv_nvue` value. We'll eventually be left with `::EthernetVirtualizer` and `etv`.

So I'm doing this PR first, and then the agent templates + legacy ETV code, and then the last PR is where `::EthernetVirtualizerWithNvue` -> `::EthernetVirtualizer`, and I'll unwind the `Encode` / `Decode` impls (because the value will still have stayed `etv` in the database).

Tests included.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

