### PR TITLE
fix: don't always disable the Machine Setup button

### DIFF
--- a/crates/api/templates/explored_endpoint_detail.html
+++ b/crates/api/templates/explored_endpoint_detail.html
@@ -174,7 +174,7 @@
 								title="Enter a valid MAC address (e.g. 00:11:22:33:44:55)"
 								required>
 							{% endif %}
-							<input type="submit" value="Machine Setup" class="disabled">
+							<input type="submit" value="Machine Setup">
 						</div>
 					</form>
 					{{ action_status::action_spinner_script("machine_setup")|safe }}


### PR DESCRIPTION
## Description
The `Machine Setup` button was hardcoded to always be disabled and a recent change by @poroh caused it be actually enforced. This PR fixes this.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

