### PR TITLE
feat: send lease expire notifications from carbide-dhcp -> carbide-api

### DIFF
--- a/crates/api-db/src/machine_interface_address.rs
+++ b/crates/api-db/src/machine_interface_address.rs
@@ -71,6 +71,21 @@ pub async fn delete(
         .map_err(|e| DatabaseError::query(query, e))
 }
 
+/// Delete the IP address allocation for the given address. Returns true if
+/// an allocation was found and deleted, false if no allocation existed.
+pub async fn delete_by_address(
+    txn: &mut PgConnection,
+    address: IpAddr,
+) -> Result<bool, DatabaseError> {
+    let query = "DELETE FROM machine_interface_addresses WHERE address = $1::inet";
+    sqlx::query(query)
+        .bind(address)
+        .execute(txn)
+        .await
+        .map(|r| r.rows_affected() > 0)
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
 #[derive(Debug, FromRow)]
 pub struct MachineInterfaceSearchResult {
     pub id: MachineInterfaceId,

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -664,6 +664,14 @@ impl Forge for Api {
         .await?)
     }
 
+    async fn expire_dhcp_lease(
+        &self,
+        request: Request<rpc::ExpireDhcpLeaseRequest>,
+    ) -> Result<Response<rpc::ExpireDhcpLeaseResponse>, Status> {
+        log_request_data(&request);
+        Ok(crate::dhcp::expire::expire_dhcp_lease(self, request).await?)
+    }
+
     async fn find_machine_ids(
         &self,
         request: Request<rpc::MachineSearchConfig>,

--- a/crates/api/src/auth/internal_rbac_rules.rs
+++ b/crates/api/src/auth/internal_rbac_rules.rs
@@ -168,6 +168,7 @@ impl InternalRBACRules {
         x.perm("CleanupMachineCompleted", vec![Machineatron, Scout]);
         x.perm("ReportForgeScoutError", vec![Scout]);
         x.perm("DiscoverDhcp", vec![Dhcp, Machineatron]);
+        x.perm("ExpireDhcpLease", vec![Dhcp, Machineatron]);
         x.perm("FindInterfaces", vec![ForgeAdminCLI, Agent, Rla]);
         x.perm("DeleteInterface", vec![ForgeAdminCLI]);
         x.perm("FindIpAddress", vec![ForgeAdminCLI]);

--- a/crates/api/src/dhcp/expire.rs
+++ b/crates/api/src/dhcp/expire.rs
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::net::IpAddr;
+
+use rpc::forge as rpc;
+use tonic::{Request, Response};
+
+use crate::api::Api;
+use crate::errors::CarbideError;
+
+pub async fn expire_dhcp_lease(
+    api: &Api,
+    request: Request<rpc::ExpireDhcpLeaseRequest>,
+) -> Result<Response<rpc::ExpireDhcpLeaseResponse>, CarbideError> {
+    let ip_address: IpAddr = request.into_inner().ip_address.parse()?;
+
+    let mut txn = api.txn_begin().await?;
+    let deleted = db::machine_interface_address::delete_by_address(&mut txn, ip_address).await?;
+    txn.commit().await?;
+
+    let status = if deleted {
+        tracing::info!(%ip_address, "Released expired DHCP lease allocation");
+        rpc::ExpireDhcpLeaseStatus::Released
+    } else {
+        tracing::debug!(%ip_address, "No allocation found for expired DHCP lease");
+        rpc::ExpireDhcpLeaseStatus::NotFound
+    };
+
+    Ok(Response::new(rpc::ExpireDhcpLeaseResponse {
+        ip_address: ip_address.to_string(),
+        status: status.into(),
+    }))
+}

--- a/crates/api/src/dhcp/mod.rs
+++ b/crates/api/src/dhcp/mod.rs
@@ -16,3 +16,4 @@
  */
 
 pub mod discover;
+pub mod expire;

--- a/crates/api/src/tests/dhcp_lease_expiration.rs
+++ b/crates/api/src/tests/dhcp_lease_expiration.rs
@@ -1,0 +1,126 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::str::FromStr;
+
+use common::api_fixtures::{FIXTURE_DHCP_RELAY_ADDRESS, create_test_env};
+use mac_address::MacAddress;
+use rpc::forge::forge_server::Forge;
+use rpc::forge::{ExpireDhcpLeaseRequest, ExpireDhcpLeaseStatus};
+use tonic::Request;
+
+use crate::tests::common;
+
+#[crate::sqlx_test]
+async fn test_expire_releases_allocation(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let relay: std::net::IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
+
+    // Create an interface with an allocated IP
+    let mut txn = env.pool.begin().await?;
+    let interface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        MacAddress::from_str("aa:bb:cc:dd:ee:01").unwrap(),
+        relay,
+        None,
+    )
+    .await?;
+    let ip = interface.addresses[0];
+    txn.commit().await?;
+
+    // Expire the lease via the RPC endpoint
+    let response = env
+        .api
+        .expire_dhcp_lease(Request::new(ExpireDhcpLeaseRequest {
+            ip_address: ip.to_string(),
+        }))
+        .await?;
+
+    let resp = response.into_inner();
+    assert_eq!(resp.ip_address, ip.to_string());
+    assert_eq!(resp.status(), ExpireDhcpLeaseStatus::Released);
+
+    // Verify the address was deleted
+    let mut txn = env.pool.begin().await?;
+    let result =
+        db::machine_interface_address::find_ipv4_for_interface(&mut txn, interface.id).await;
+    assert!(result.is_err(), "address should have been deleted");
+
+    // Verify the interface itself still exists
+    let iface = db::machine_interface::find_one(&mut *txn, interface.id).await?;
+    assert_eq!(iface.id, interface.id, "interface should still exist");
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_expire_nonexistent_address_returns_not_found(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    let response = env
+        .api
+        .expire_dhcp_lease(Request::new(ExpireDhcpLeaseRequest {
+            ip_address: "10.99.99.99".to_string(),
+        }))
+        .await?;
+
+    let resp = response.into_inner();
+    assert_eq!(resp.ip_address, "10.99.99.99");
+    assert_eq!(resp.status(), ExpireDhcpLeaseStatus::NotFound);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_expire_invalid_address_fails(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    let result = env
+        .api
+        .expire_dhcp_lease(Request::new(ExpireDhcpLeaseRequest {
+            ip_address: "not-an-ip".to_string(),
+        }))
+        .await;
+
+    assert!(result.is_err(), "invalid IP address should fail");
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_expire_ipv6_address(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    let response = env
+        .api
+        .expire_dhcp_lease(Request::new(ExpireDhcpLeaseRequest {
+            ip_address: "fd00::42".to_string(),
+        }))
+        .await?;
+
+    let resp = response.into_inner();
+    assert_eq!(resp.ip_address, "fd00::42");
+    assert_eq!(resp.status(), ExpireDhcpLeaseStatus::NotFound);
+
+    Ok(())
+}

--- a/crates/api/src/tests/mod.rs
+++ b/crates/api/src/tests/mod.rs
@@ -20,6 +20,7 @@ mod connected_device;
 mod create_domain;
 mod credential;
 mod desired_firmware_versions;
+mod dhcp_lease_expiration;
 mod dns;
 mod dpa_interfaces;
 mod dpf;

--- a/crates/dhcp/src/kea/callouts.cc
+++ b/crates/dhcp/src/kea/callouts.cc
@@ -521,4 +521,46 @@ int pkt4_send(CalloutHandle &handle) {
 
   return 0;
 }
+
+int lease4_expire(CalloutHandle &handle) {
+  Lease4Ptr lease4;
+  handle.getArgument("lease4", lease4);
+
+  if (!lease4) {
+    LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE_EXPIRE_ERROR)
+        .arg("missing lease4 argument");
+    return 0;
+  }
+
+  std::string ip_str = lease4->addr_.toText();
+  LOG_INFO(logger, isc::log::LOG_CARBIDE_LEASE_EXPIRE).arg(ip_str);
+
+  auto result = carbide_expire_lease(ip_str.c_str());
+  if (result != LeaseExpirationResult::Success) {
+    LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE_EXPIRE_ERROR).arg(ip_str);
+  }
+
+  return 0;
+}
+
+int lease6_expire(CalloutHandle &handle) {
+  Lease6Ptr lease6;
+  handle.getArgument("lease6", lease6);
+
+  if (!lease6) {
+    LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE_EXPIRE_ERROR)
+        .arg("missing lease6 argument");
+    return 0;
+  }
+
+  std::string ip_str = lease6->addr_.toText();
+  LOG_INFO(logger, isc::log::LOG_CARBIDE_LEASE_EXPIRE).arg(ip_str);
+
+  auto result = carbide_expire_lease(ip_str.c_str());
+  if (result != LeaseExpirationResult::Success) {
+    LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE_EXPIRE_ERROR).arg(ip_str);
+  }
+
+  return 0;
+}
 }

--- a/crates/dhcp/src/kea/callouts.h
+++ b/crates/dhcp/src/kea/callouts.h
@@ -89,6 +89,8 @@ int pkt4_receive(CalloutHandle &handle);
 int subnet4_select(CalloutHandle &handle);
 int lease4_select(CalloutHandle &handle);
 int pkt4_send(CalloutHandle &handle);
+int lease4_expire(CalloutHandle &handle);
+int lease6_expire(CalloutHandle &handle);
 }
 
 #endif

--- a/crates/dhcp/src/kea/carbide_logger.cc
+++ b/crates/dhcp/src/kea/carbide_logger.cc
@@ -12,6 +12,8 @@ extern const isc::log::MessageID LOG_CARBIDE_INITIALIZATION = "LOG_CARBIDE_INITI
 extern const isc::log::MessageID LOG_CARBIDE_INVALID_HANDLE = "LOG_CARBIDE_INVALID_HANDLE";
 extern const isc::log::MessageID LOG_CARBIDE_INVALID_NEXTSERVER_IPV4 = "LOG_CARBIDE_INVALID_NEXTSERVER_IPV4";
 extern const isc::log::MessageID LOG_CARBIDE_LEASE4_SELECT = "LOG_CARBIDE_LEASE4_SELECT";
+extern const isc::log::MessageID LOG_CARBIDE_LEASE_EXPIRE = "LOG_CARBIDE_LEASE_EXPIRE";
+extern const isc::log::MessageID LOG_CARBIDE_LEASE_EXPIRE_ERROR = "LOG_CARBIDE_LEASE_EXPIRE_ERROR";
 extern const isc::log::MessageID LOG_CARBIDE_PKT4_RECEIVE = "LOG_CARBIDE_PKT4_RECEIVE";
 extern const isc::log::MessageID LOG_CARBIDE_PKT4_SEND = "LOG_CARBIDE_PKT4_SEND";
 
@@ -26,6 +28,8 @@ const char* values[] = {
     "LOG_CARBIDE_INVALID_HANDLE", "Carbide hook shim_load() was called with an invalid LibraryHandle",
     "LOG_CARBIDE_INVALID_NEXTSERVER_IPV4", "Invalid provisioning server IPv4 address: %1",
     "LOG_CARBIDE_LEASE4_SELECT", "Carbide hook called for DHCPv4 lease selected from %1",
+    "LOG_CARBIDE_LEASE_EXPIRE", "Carbide releasing expired DHCP lease for %1",
+    "LOG_CARBIDE_LEASE_EXPIRE_ERROR", "Carbide failed to release expired DHCP lease for %1",
     "LOG_CARBIDE_PKT4_RECEIVE", "Carbide hook called for DHCPv4 packet receive from %1",
     "LOG_CARBIDE_PKT4_SEND", "Carbide hook called for DHCPv4 packet send from %1",
     NULL

--- a/crates/dhcp/src/kea/carbide_logger.h
+++ b/crates/dhcp/src/kea/carbide_logger.h
@@ -13,6 +13,8 @@ extern const isc::log::MessageID LOG_CARBIDE_INITIALIZATION;
 extern const isc::log::MessageID LOG_CARBIDE_INVALID_HANDLE;
 extern const isc::log::MessageID LOG_CARBIDE_INVALID_NEXTSERVER_IPV4;
 extern const isc::log::MessageID LOG_CARBIDE_LEASE4_SELECT;
+extern const isc::log::MessageID LOG_CARBIDE_LEASE_EXPIRE;
+extern const isc::log::MessageID LOG_CARBIDE_LEASE_EXPIRE_ERROR;
 extern const isc::log::MessageID LOG_CARBIDE_PKT4_RECEIVE;
 extern const isc::log::MessageID LOG_CARBIDE_PKT4_SEND;
 

--- a/crates/dhcp/src/kea/loader.cc
+++ b/crates/dhcp/src/kea/loader.cc
@@ -110,6 +110,8 @@ extern "C" {
 
 		handle->registerCallout("pkt4_receive", pkt4_receive);
 		handle->registerCallout("pkt4_send", pkt4_send);
+		handle->registerCallout("lease4_expire", lease4_expire);
+		handle->registerCallout("lease6_expire", lease6_expire);
 
 		return 0;
 	}

--- a/crates/dhcp/src/lease_expiration.rs
+++ b/crates/dhcp/src/lease_expiration.rs
@@ -1,0 +1,144 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::ffi::CStr;
+
+use ::rpc::forge as rpc;
+use ::rpc::forge_tls_client::{self, ApiConfig, ForgeClientConfig};
+use libc::c_char;
+
+use crate::{CONFIG, CarbideDhcpContext, tls};
+
+/// Result codes for the lease expiration FFI call.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum LeaseExpirationResult {
+    Success = 0,
+    InvalidAddress = 1,
+    ApiError = 2,
+}
+
+/// Called from the C++ lease4_expire / lease6_expire callouts to release
+/// an IP allocation from the carbide database when Kea expires a lease.
+///
+/// # Safety
+///
+/// `ip_address` must be a valid, null-terminated C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn carbide_expire_lease(ip_address: *const c_char) -> LeaseExpirationResult {
+    let ip_str = unsafe {
+        match CStr::from_ptr(ip_address).to_str() {
+            Ok(s) => s,
+            Err(_) => return LeaseExpirationResult::InvalidAddress,
+        }
+    };
+
+    let url = &CONFIG.read().unwrap().api_endpoint;
+    let forge_client_config = tls::build_forge_client_config();
+    expire_lease_at(ip_str, url, &forge_client_config)
+}
+
+fn expire_lease_at(
+    ip_str: &str,
+    url: &str,
+    client_config: &ForgeClientConfig,
+) -> LeaseExpirationResult {
+    let runtime = CarbideDhcpContext::get_tokio_runtime();
+
+    let result = runtime.block_on(async {
+        let api_config = ApiConfig::new(url, client_config);
+        let mut client = forge_tls_client::ForgeTlsClient::retry_build(&api_config)
+            .await
+            .map_err(|e| format!("unable to connect to Carbide API: {e:?}"))?;
+        client
+            .expire_dhcp_lease(tonic::Request::new(rpc::ExpireDhcpLeaseRequest {
+                ip_address: ip_str.to_string(),
+            }))
+            .await
+            .map_err(|e| format!("expire_dhcp_lease RPC failed: {e:?}"))
+    });
+
+    match result {
+        Ok(response) => {
+            let resp = response.into_inner();
+            let status = rpc::ExpireDhcpLeaseStatus::try_from(resp.status)
+                .unwrap_or(rpc::ExpireDhcpLeaseStatus::NotFound);
+            match status {
+                rpc::ExpireDhcpLeaseStatus::Released => {
+                    log::info!("Released expired lease for {ip_str}");
+                }
+                rpc::ExpireDhcpLeaseStatus::NotFound => {
+                    log::info!("No allocation found for expired lease {ip_str}");
+                }
+            }
+            LeaseExpirationResult::Success
+        }
+        Err(e) => {
+            log::error!("Failed to release expired lease for {ip_str}: {e}");
+            LeaseExpirationResult::ApiError
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mock_api_server;
+
+    #[test]
+    fn test_expire_lease_success() {
+        let rt = CarbideDhcpContext::get_tokio_runtime();
+        let api_server = rt.block_on(mock_api_server::MockAPIServer::start());
+        let client_config = tls::build_forge_client_config();
+
+        let result = expire_lease_at("10.0.0.1", api_server.local_http_addr(), &client_config);
+
+        assert_eq!(result, LeaseExpirationResult::Success);
+        assert_eq!(
+            api_server.calls_for(mock_api_server::ENDPOINT_EXPIRE_DHCP_LEASE),
+            1
+        );
+    }
+
+    #[test]
+    fn test_expire_lease_idempotent() {
+        let rt = CarbideDhcpContext::get_tokio_runtime();
+        let api_server = rt.block_on(mock_api_server::MockAPIServer::start());
+        let client_config = tls::build_forge_client_config();
+
+        let result1 = expire_lease_at("10.0.0.1", api_server.local_http_addr(), &client_config);
+        let result2 = expire_lease_at("10.0.0.1", api_server.local_http_addr(), &client_config);
+
+        assert_eq!(result1, LeaseExpirationResult::Success);
+        assert_eq!(result2, LeaseExpirationResult::Success);
+        assert_eq!(
+            api_server.calls_for(mock_api_server::ENDPOINT_EXPIRE_DHCP_LEASE),
+            2
+        );
+    }
+
+    #[test]
+    fn test_expire_lease_ipv6() {
+        let rt = CarbideDhcpContext::get_tokio_runtime();
+        let api_server = rt.block_on(mock_api_server::MockAPIServer::start());
+        let client_config = tls::build_forge_client_config();
+
+        let result = expire_lease_at("fd00::42", api_server.local_http_addr(), &client_config);
+
+        assert_eq!(result, LeaseExpirationResult::Success);
+    }
+}

--- a/crates/dhcp/src/lib.rs
+++ b/crates/dhcp/src/lib.rs
@@ -32,6 +32,7 @@ mod cache;
 mod discovery;
 mod kea;
 mod kea_logger;
+mod lease_expiration;
 mod machine;
 mod vendor_class;
 

--- a/crates/dhcp/src/mock_api_server.rs
+++ b/crates/dhcp/src/mock_api_server.rs
@@ -40,6 +40,7 @@ use tokio::task::JoinHandle;
 use crate::machine::Machine;
 
 pub const ENDPOINT_DISCOVER_DHCP: &str = "/forge.Forge/DiscoverDhcp";
+pub const ENDPOINT_EXPIRE_DHCP_LEASE: &str = "/forge.Forge/ExpireDhcpLease";
 
 // Contents of the response
 const DHCP_RESPONSE_FQDN: &str = "december-nitrogen.forge.local";
@@ -210,6 +211,14 @@ impl MockAPIServer {
                         MockAPIServer::discover_dhcp(req).await.into(),
                     ))
                 }
+            }
+            ENDPOINT_EXPIRE_DHCP_LEASE => {
+                let input_bytes = req.into_body().collect().await.unwrap().to_bytes();
+                let request = rpc::ExpireDhcpLeaseRequest::decode(input_bytes.slice(5..)).unwrap();
+                respond(rpc::ExpireDhcpLeaseResponse {
+                    ip_address: request.ip_address,
+                    status: rpc::ExpireDhcpLeaseStatus::Released.into(),
+                })
             }
             "/forge.Forge/Echo" => respond(rpc::EchoResponse {
                 message: "dhcp_echo".into(),

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -168,6 +168,7 @@ service Forge {
   // Invoked by forge-scout whenever a certain Machine can not be properly acted on
   rpc ReportForgeScoutError(ForgeScoutErrorReport) returns (ForgeScoutErrorReportResult);
   rpc DiscoverDhcp(DhcpDiscovery) returns (DhcpRecord);
+  rpc ExpireDhcpLease(ExpireDhcpLeaseRequest) returns (ExpireDhcpLeaseResponse);
 
   // PRIVILEGED: Find things
   rpc FindInterfaces(InterfaceSearchQuery) returns (InterfaceList);
@@ -3126,6 +3127,20 @@ message DhcpDiscovery {
   optional string circuit_id = 5;
   optional string remote_id = 6;
   optional string desired_address = 7;
+}
+
+message ExpireDhcpLeaseRequest {
+  string ip_address = 1;
+}
+
+enum ExpireDhcpLeaseStatus {
+  EXPIRE_DHCP_LEASE_STATUS_RELEASED = 0;
+  EXPIRE_DHCP_LEASE_STATUS_NOT_FOUND = 1;
+}
+
+message ExpireDhcpLeaseResponse {
+  string ip_address = 1;
+  ExpireDhcpLeaseStatus status = 2;
 }
 
 message DhcpRecord {


### PR DESCRIPTION
## Description

This is a follow up to PR https://github.com/NVIDIA/ncx-infra-controller-core/pull/668, which was attempting to address issue https://github.com/NVIDIA/ncx-infra-controller-core/issues/662, where we effectively leak IP allocations, because `carbide-api` doesn't know when leases expire in `carbide-dhcp`.

At the end of the day, the issue is that we have Kea maintaining its own DHCP leases file, and that leads to synchronization issues between `carbide-dhcp` and `carbide-api`. The previous PR attempted to fix this by looking for IPs that hadn't been renewed within their renewal window (and subsequently removing them), but that was purely speculative -- we didn't actually know if Kea had removed it from its DB.

So, THIS change implements the `lease_expire` hooks in Kea. When a lease expires (and Kea goes to clean it up from its local DB), `carbide-dhcp` will send an `ExpireDhcpLeaseRequest` call to `carbide-api`, which will in turn remove that IP allocation from the database, and respond with an `ExpireDhcpLeaseResponse` back to `carbide-dhcp`, indicating `released` or `not_found`, just so we have logs on the DHCP side too.

This is probably something we should have implemented from the beginning to keep state in sync. In the long term, we will probably want to implement our pure Rust DHCP server (that we run on the DPUs) instead of this Rust + Kea combination, but this will allow us to move forward without worrying about leaking expired leases, and give us time to plan out migrating to our pure Rust server.

Unit tests and integration tests included, including mock server e2e tests, and testing the actual DHCP -> FFI flow.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

