### PR TITLE
chore: break out lint checks into lint-police, remove from release containers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,7 @@ jobs:
       runtime_container_aarch64_version: ${{ steps.base-container-gate.outputs.runtime_container_aarch64_version }}
       powerdns_container_run: ${{ steps.base-container-gate.outputs.powerdns_container_run }}
       proto_files_changed: ${{ steps.base-container-gate.outputs.proto_files_changed }}
+      source_files_changed: ${{ steps.base-container-gate.outputs.source_files_changed }}
       release_build_args: ${{ steps.release-metadata.outputs.build_args }}
       release_build_args_aarch64: ${{ steps.release-metadata.outputs.build_args_aarch64 }}
       sbom_container_run: ${{ steps.base-container-gate.outputs.sbom_container_run }}
@@ -91,6 +92,12 @@ jobs:
               - 'dev/docker/Dockerfile-powerdns'
             proto_files:
               - '**/*.proto'
+            source_files:
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'Makefile.toml'
+              - 'rust-toolchain.toml'
             sbom_container:
               - 'dev/docker/sbom-tools/Dockerfile'
       - name: Calculate version
@@ -164,6 +171,7 @@ jobs:
           BUILD_ARTIFACTS_AARCH64_DOCKERFILE_CHANGED: ${{ steps.build-container-changes.outputs.build_artifacts_aarch64 }}
           POWERDNS_DOCKERFILE_CHANGED: ${{ steps.build-container-changes.outputs.powerdns_container }}
           PROTO_FILES_CHANGED: ${{ steps.build-container-changes.outputs.proto_files }}
+          SOURCE_FILES_CHANGED: ${{ steps.build-container-changes.outputs.source_files }}
         run: |
           build_container_x86_64_run=false
           runtime_container_x86_64_run=false
@@ -173,6 +181,7 @@ jobs:
           build_artifacts_container_aarch64_run=false
           powerdns_container_run=false
           proto_files_changed=false
+          source_files_changed=false
 
           if [[ "${COMMIT_MESSAGE}" =~ ci-rebuild-base-containers ]]; then
             build_container_x86_64_run=true
@@ -195,6 +204,10 @@ jobs:
 
           if [[ "${PROTO_FILES_CHANGED}" == "true" ]]; then
              proto_files_changed=true
+          fi
+
+          if [[ "${SOURCE_FILES_CHANGED}" == "true" ]]; then
+             source_files_changed=true
           fi
 
           if [[ "${RUNTIME_CONTAINER_X86_64_DOCKERFILE_CHANGED}" == "true" ]]; then
@@ -229,6 +242,7 @@ jobs:
           echo "build_artifacts_container_aarch64_run=${build_artifacts_container_aarch64_run}" >> "$GITHUB_OUTPUT"
           echo "powerdns_container_run=${powerdns_container_run}" >> "$GITHUB_OUTPUT"
           echo "proto_files_changed=${proto_files_changed}" >> "$GITHUB_OUTPUT"
+          echo "source_files_changed=${source_files_changed}" >> "$GITHUB_OUTPUT"
           echo "sbom_container_run=${sbom_container_run}" >> "$GITHUB_OUTPUT"
 
           if [[ "$build_container_x86_64_run" == "true" ]]; then
@@ -819,6 +833,52 @@ jobs:
       - name: Run Protolint
         run: protolint lint -config_path=.protolint.yaml crates/rpc/proto/
 
+  lint-police:
+    needs:
+      - prepare
+      - build-container-x86_64
+    if: ${{ !failure() && !cancelled() && needs.prepare.outputs.source_files_changed == 'true' && contains(github.ref, 'pull-request/') }}
+    runs-on: linux-amd64-cpu16
+    container:
+      image: nvcr.io/0837451325059433/carbide-dev/build-container-x86_64:${{ needs.prepare.outputs.build_container_x86_64_version }}
+      credentials:
+        username: ${{ secrets.NVCR_USERNAME }}
+        password: ${{ secrets.NVCR_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # PostgreSQL is required because sqlx proc macros (sqlx::query!) connect to
+      # a local database at compile time to validate SQL queries and return types.
+      - name: Start PostgreSQL
+        run: |
+          /etc/init.d/postgresql start
+          sudo -u postgres psql -c "ALTER USER root WITH SUPERUSER;"
+          createdb root
+
+      - name: Run clippy
+        env:
+          DATABASE_URL: "postgresql://%2Fvar%2Frun%2Fpostgresql"
+        run: cargo make --no-workspace clippy-flow
+
+      - name: Run carbide lints
+        run: cargo make carbide-lints
+
+      - name: Check TOML formatting
+        run: taplo fmt --check || echo "Please format toml files"
+
+      - name: Check Rust formatting
+        run: cargo make --no-workspace check-format-nightly
+
+      - name: Check workspace deps
+        run: cargo xtask check-workspace-deps
+
+      - name: Check licenses
+        run: cargo make --no-workspace check-licenses
+
+      - name: Check bans
+        run: cargo make --no-workspace check-bans
+
   # ============================================================================
   # BUILD STAGE - Helm Chart
   # ============================================================================
@@ -906,6 +966,7 @@ jobs:
       - build-push-helm-chart
       - build-release-artifacts-x86-host
       - build-release-artifacts-arm-host
+      - lint-police
     steps:
       - name: Generate summary
         run: |

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -356,7 +356,7 @@ workspace = false
 description = "Tasks that run on workspace level (not crate level) in pre-commit-verify"
 category = "CI"
 # clippy-flow, check-format-flow are default targets provided by cargo-make.
-# NOTE: If you add something here, and you also want it to be checked by CI, make sure to call it from dev/docker/Dockerfile.release-container-x86_64 too.
+# NOTE: If you add something here, and you also want it to be checked by CI, make sure to add it to the lint-police job in .github/workflows/ci.yaml too.
 dependencies = [
   "clippy-flow",
   "carbide-lints",

--- a/dev/docker/Dockerfile.release-container-aarch64
+++ b/dev/docker/Dockerfile.release-container-aarch64
@@ -38,22 +38,8 @@ RUN export CARGO_MAKE_SKIP_CODECOV="true" && \
   /etc/init.d/postgresql start && \
   sudo -u postgres psql -c "ALTER USER root WITH SUPERUSER;" && \
   createdb root && \
-  cargo make --no-workspace clippy-flow && \
-  echo "$(date): Finished cargo make clippy-flow\n" && \
-  cargo make carbide-lints && \
-  echo "$(date): Finished cargo make carbide-lints\n" && \
-  (taplo fmt --check || echo "Please format toml files") && \
-  echo "$(date): Finished taplo fmt \n" && \
-  cargo make --no-workspace check-format-nightly && \
-  echo "$(date): Finished cargo make check-format-nightly\n" && \
-  cargo xtask check-workspace-deps && \
-  echo "$(date): Finished cargo xtask check-workspace-deps\n" && \
   cargo make build-and-test-release-container-services && \
   echo "$(date): Finished cargo make build-and-test-release-container-services\n" && \
-  cargo make --no-workspace check-licenses && \
-  echo "$(date): Finished cargo make check-licenses\n" && \
-  cargo make --no-workspace check-bans && \
-  echo "$(date): Finished cargo make check-bans\n" && \
   mkdir -p /carbide/target/bin && \
   find /carbide/target/release -maxdepth 1 -type f -exec cp -t /carbide/target/bin {} + && \
   rm -rf /carbide/target/debug && \

--- a/dev/docker/Dockerfile.release-container-x86_64
+++ b/dev/docker/Dockerfile.release-container-x86_64
@@ -38,22 +38,8 @@ RUN export CARGO_MAKE_SKIP_CODECOV="true" && \
   /etc/init.d/postgresql start && \
   sudo -u postgres psql -c "ALTER USER root WITH SUPERUSER;" && \
   createdb root && \
-  cargo make --no-workspace clippy-flow && \
-  echo "$(date): Finished cargo make clippy-flow\n" && \
-  cargo make carbide-lints && \
-  echo "$(date): Finished cargo make carbide-lints\n" && \
-  (taplo fmt --check || echo "Please format toml files") && \
-  echo "$(date): Finished taplo fmt \n" && \
-  cargo make --no-workspace check-format-nightly && \
-  echo "$(date): Finished cargo make check-format-nightly\n" && \
-  cargo xtask check-workspace-deps && \
-  echo "$(date): Finished cargo xtask check-workspace-deps\n" && \
   cargo make build-and-test-release-container-services && \
   echo "$(date): Finished cargo make build-and-test-release-container-services\n" && \
-  cargo make --no-workspace check-licenses && \
-  echo "$(date): Finished cargo make check-licenses\n" && \
-  cargo make --no-workspace check-bans && \
-  echo "$(date): Finished cargo make check-bans\n" && \
   mkdir -p /carbide/target/bin && \
   find /carbide/target/release -maxdepth 1 -type f -exec cp -t /carbide/target/bin {} + && \
   rm -rf /carbide/target/debug && \


### PR DESCRIPTION
## Description

Trying to figure out ways to shave off some CICD time. Right now, lint checks take ~10 minutes in each release container. The release containers do run in parallel, BUT, I figure if we split the lint checking out into its own `lint-police` job (running parallel to `proto-police`, etc), then we could at least shave 10 minutes off the total build time (10 minutes from each release container).

I figure if we can find enough ~10 minute improvements, it might add up!

The only thing here is `lint-police` runs on x86_64, so if we have some lint that is aarch64 specific due to `#[cfg(target_arch = "aarch64")]`, we'd miss it, but I'm not sure if we care? We could probably have two `lint-police-x86_64` and `lint-police-aarch64` jobs that run in parallel also, and it'd still shave some time off.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

