### PR TITLE
feat(bmc-explorer,bmc-mock): initial Lenovo GB300 NVL scaffolding

### DIFF
--- a/crates/bmc-explorer/src/chassis.rs
+++ b/crates/bmc-explorer/src/chassis.rs
@@ -65,6 +65,19 @@ impl<B: Bmc> ExploredChassisCollection<B> {
             .any(|m| m.chassis.id().into_inner() == "powershelf")
     }
 
+    pub fn is_gb300(&self) -> bool {
+        self.members.iter().any(|m| {
+            m.chassis.hardware_id().manufacturer == Some(Manufacturer::new("NVIDIA"))
+                && m.chassis.hardware_id().model == Some(Model::new("NVIDIA GB300"))
+        })
+    }
+
+    pub fn is_lenovo(&self) -> bool {
+        self.members
+            .iter()
+            .any(|m| m.chassis.hardware_id().manufacturer == Some(Manufacturer::new("Lenovo")))
+    }
+
     pub fn is_bluefield2(&self) -> bool {
         self.members
             .iter()

--- a/crates/bmc-explorer/src/hw/lenovo_gb300.rs
+++ b/crates/bmc-explorer/src/hw/lenovo_gb300.rs
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::hw::BiosAttr;
+
+pub const EXPECTED_BIOS_ATTRS: [BiosAttr; 8] = [
+    BiosAttr::new_str("PCIS007", "PCIS007Enabled"), // SR-IOV Support
+    BiosAttr::new_int("LEM0001", 3),                // PXE retry count
+    BiosAttr::new_str("NWSK000", "NWSK000Enabled"), // Network Stack
+    BiosAttr::new_str("NWSK001", "NWSK001Disabled"), // IPv4 PXE Support
+    BiosAttr::new_str("NWSK006", "NWSK006Enabled"), // IPv4 HTTP Support
+    BiosAttr::new_str("NWSK002", "NWSK002Disabled"), // IPv6 PXE Support
+    BiosAttr::new_str("NWSK007", "NWSK007Disabled"), // IPv6 HTTP Support
+    BiosAttr::new_int("LEM0003", 50),               // Infinite Boot
+];

--- a/crates/bmc-explorer/src/hw/mod.rs
+++ b/crates/bmc-explorer/src/hw/mod.rs
@@ -25,6 +25,7 @@ pub mod gb200;
 pub mod hpe;
 pub mod lenovo;
 pub mod lenovo_ami;
+pub mod lenovo_gb300;
 pub mod supermicro;
 pub mod viking;
 
@@ -37,6 +38,7 @@ pub enum HwType {
     Hpe,
     Lenovo,
     LenovoAmi,
+    LenovoGb300,
     Supermicro,
     Viking,
     LiteonPowerShelf,
@@ -53,6 +55,7 @@ impl HwType {
             Self::Hpe => Some(bmc_vendor::BMCVendor::Hpe),
             Self::Lenovo => Some(bmc_vendor::BMCVendor::Lenovo),
             Self::LenovoAmi => Some(bmc_vendor::BMCVendor::LenovoAMI),
+            Self::LenovoGb300 => Some(bmc_vendor::BMCVendor::LenovoAMI),
             Self::LiteonPowerShelf => Some(bmc_vendor::BMCVendor::Liteon),
             Self::NvSwitch => Some(bmc_vendor::BMCVendor::Nvidia),
             Self::Supermicro => Some(bmc_vendor::BMCVendor::Supermicro),
@@ -69,6 +72,7 @@ impl HwType {
             Self::Hpe => None,
             Self::Lenovo => Some(BiosAttr::new_str("BootModes_InfiniteBootRetry", "Enabled")),
             Self::LenovoAmi => Some(BiosAttr::new_str("EndlessBoot", "Enabled")),
+            Self::LenovoGb300 => Some(BiosAttr::new_int("LEM0003", 50)),
             Self::LiteonPowerShelf => None,
             Self::NvSwitch => None,
             Self::Supermicro => None,

--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -89,7 +89,7 @@ pub async fn nv_generate_exploration_report_from_root<B: Bmc>(
         root = root.restrict_expand();
     }
 
-    let system = root
+    let mut systems_iter = root
         .systems()
         .await
         .map_err(Error::nv_redfish("systems"))?
@@ -97,9 +97,13 @@ pub async fn nv_generate_exploration_report_from_root<B: Bmc>(
         .members()
         .await
         .map_err(Error::nv_redfish("systems members"))?
-        .into_iter()
+        .into_iter();
+
+    let first_system = systems_iter
         .next()
         .ok_or_else(Error::bmc_not_provided("at least one computer system"))?;
+    let other_system_with_bios = systems_iter.find(|system| system.raw().bios.is_some());
+    let system = other_system_with_bios.unwrap_or(first_system);
 
     let manager = root
         .managers()
@@ -165,6 +169,10 @@ pub async fn nv_generate_exploration_report_from_root<B: Bmc>(
             ) => chassis.chassis.id().into_inner() == explored_system.system.id().into_inner(),
             // Provides only one Chassis.
             Some(hw::HwType::LenovoAmi) => true,
+            Some(hw::HwType::LenovoGb300) => {
+                let chassis_id = chassis.chassis.id().into_inner();
+                chassis_id.starts_with("HGX_GPU_")
+            }
             // No meaningful PCIeDevices.
             Some(
                 hw::HwType::Bluefield
@@ -246,6 +254,9 @@ pub(crate) fn hw_type<B: Bmc>(
         .or_else(|| (oem_id == Some("Supermicro")).then_some("Supermicro"))
         .and_then(|vendor_id| match vendor_id {
             "AMI" if system.id().into_inner() == "DGX" => Some(hw::HwType::Viking),
+            "AMI" if explored_chassis.is_gb300() && explored_chassis.is_lenovo() => {
+                Some(hw::HwType::LenovoGb300)
+            }
             "AMI" => Some(hw::HwType::Ami),
             "Dell" => Some(hw::HwType::Dell),
             "Lenovo" if oem_id == Some("Ami") => Some(hw::HwType::LenovoAmi),
@@ -705,6 +716,20 @@ fn machine_setup_status<B: Bmc>(
                     expected: expected_name.to_string(),
                     actual: actual_opt.name().to_string(),
                 });
+            }
+        }
+
+        hw::HwType::LenovoGb300 => {
+            // Check BIOS configuration:
+            diffs.extend(
+                hw::lenovo_gb300::EXPECTED_BIOS_ATTRS
+                    .iter()
+                    .flat_map(|expected| explored_system.verify_bios_attr(expected)),
+            );
+            if let Some(mac) = boot_interface_mac
+                && let Some(diff) = explored_system.check_boot_by_uefi_prefix(mac)
+            {
+                diffs.push(diff)
             }
         }
 

--- a/crates/bmc-mock/src/hw/bluefield3.rs
+++ b/crates/bmc-mock/src/hw/bluefield3.rs
@@ -36,8 +36,10 @@ pub struct Bluefield3<'a> {
 }
 
 pub enum Mode {
-    B3240ColdAisle,              // => P/N 900-9D3B6-00CN-PA0. Installed on WIWYNN GB200s.
-    SuperNIC { nic_mode: bool }, // => P/N 900-9D3B4-00CC-EA0 & 900-9D3B6-00CV-AA0
+    // P/N 900-9D3B6-00CN-PA0. Installed on WIWYNN GB200s / Lenovo GB300s.
+    B3240ColdAisle,
+    // P/N 900-9D3B4-00CC-EA0 & 900-9D3B6-00CV-AA0
+    SuperNIC { nic_mode: bool },
 }
 
 pub struct FirmwareVersions {
@@ -210,6 +212,7 @@ impl Bluefield3<'_> {
                     .interface_enabled(true)
                     .build(),
                 ]),
+                host_interfaces: None,
                 firmware_version: Some("BF-23.10-4"),
                 oem: None,
             }],

--- a/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
+++ b/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
@@ -61,6 +61,14 @@ impl DellPowerEdgeR750<'_> {
                     .interface_enabled(true)
                     .build(),
                 ]),
+                host_interfaces: Some(vec![
+                    redfish::host_interface::builder(&redfish::host_interface::manager_resource(
+                        "iDRAC.Embedded.1",
+                        "Host.1",
+                    ))
+                    .interface_enabled(false)
+                    .build(),
+                ]),
                 firmware_version: Some("6.00.30.00"),
                 oem: Some(redfish::manager::Oem::Dell),
             }],

--- a/crates/bmc-mock/src/hw/lenovo_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/lenovo_gb300_nvl.rs
@@ -1,0 +1,329 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use mac_address::MacAddress;
+use rpc::DiscoveryInfo;
+use serde_json::json;
+
+use crate::{PowerControl, hw, redfish};
+
+#[allow(dead_code)]
+pub struct LenovoGB300Nvl<'a> {
+    pub system_0_serial_number: Cow<'a, str>,
+    pub chassis_0_serial_number: Cow<'a, str>,
+    pub dpu: hw::bluefield3::Bluefield3<'a>,
+    pub embedded_1g_nic: hw::nic_intel_i210::NicIntelI210,
+    pub bmc_mac_address_eth0: MacAddress,
+    pub bmc_mac_address_eth1: MacAddress,
+    pub bmc_mac_address_usb0: MacAddress,
+    pub hgx_bmc_mac_address_usb0: MacAddress,
+    pub hgx_serial_number: Cow<'a, str>,
+    pub topology: hw::nvidia_gbx00::Topology,
+    pub cpu: [hw::nvidia_gb300::NvidiaGB300Cpu<'a>; 2],
+    pub gpu: [hw::nvidia_gb300::NvidiaGB300Gpu<'a>; 4],
+    pub io_board: [hw::nvidia_gb300::NvidiaGB300IoBoard<'a>; 2],
+}
+
+impl LenovoGB300Nvl<'_> {
+    pub fn manager_config(&self) -> redfish::manager::Config {
+        let bmc_manager_id = "BMC_0";
+        let bmc_eth_builder = |eth| {
+            redfish::ethernet_interface::builder(&redfish::ethernet_interface::manager_resource(
+                bmc_manager_id,
+                eth,
+            ))
+        };
+        redfish::manager::Config {
+            managers: vec![
+                redfish::manager::SingleConfig {
+                    id: bmc_manager_id,
+                    eth_interfaces: Some(vec![
+                        bmc_eth_builder("eth0")
+                            .mac_address(self.bmc_mac_address_eth0)
+                            .interface_enabled(true)
+                            .build(),
+                        bmc_eth_builder("eth1")
+                            .mac_address(self.bmc_mac_address_eth1)
+                            .interface_enabled(true)
+                            .build(),
+                        bmc_eth_builder("usb0")
+                            .mac_address(self.bmc_mac_address_usb0)
+                            .interface_enabled(true)
+                            .build(),
+                    ]),
+                    host_interfaces: Some(vec![
+                        redfish::host_interface::builder(
+                            &redfish::host_interface::manager_resource(bmc_manager_id, "Self"),
+                        )
+                        .interface_enabled(true)
+                        .build(),
+                    ]),
+                    firmware_version: Some("3.00.0"),
+                    oem: None,
+                },
+                redfish::manager::SingleConfig {
+                    id: "HGX_BMC_0",
+                    eth_interfaces: Some(vec![
+                        redfish::ethernet_interface::builder(
+                            &redfish::ethernet_interface::manager_resource("HGX_BMC_0", "usb0"),
+                        )
+                        .mac_address(self.hgx_bmc_mac_address_usb0)
+                        .interface_enabled(true)
+                        .build(),
+                    ]),
+                    host_interfaces: None,
+                    // GB200Nvl-25.08-B is how it is reported in
+                    // example of Redfish dump. Probably it will be
+                    // fixed in future.
+                    firmware_version: Some("GB200Nvl-25.08-B"),
+                    oem: None,
+                },
+            ],
+        }
+    }
+
+    pub fn system_config(
+        &self,
+        power_control: Arc<dyn PowerControl>,
+    ) -> redfish::computer_system::Config {
+        let system_id = "System_0";
+        // TODO: It is PXE but apparently if enable HTTP in bios HTTP
+        // (Uefi) boot options will show up here...
+        let boot_options = std::iter::once(
+            redfish::boot_option::builder(&redfish::boot_option::resource(system_id, "0002"))
+                .boot_option_reference("Boot0002")
+                .display_name("ubuntu")
+                .build(),
+        )
+        .chain(
+            [&self.embedded_1g_nic.ethernet_nic(), &self.dpu.host_nic()]
+                .into_iter()
+                .enumerate()
+                .map(|(n, nic)| {
+                    let id = format!("{:04X}", n + 3); // Starting with 0003
+                    // TODO should be taken from NIC:
+                    let pci_path = "PciRoot(0x0)/Pci(0x10,0x0)/Pci(0x0,0x0)";
+                    redfish::boot_option::builder(&redfish::boot_option::resource(system_id, &id))
+                .boot_option_reference(&format!("Boot{id}"))
+                // Real "Description": "DisplayName": "[Slot16]UEFI: PXE IPv4 Nvidia Network Adapter - 90:E3:17:95:01:DE",
+                .display_name(&format!(
+                    "[SlotFFFF]: PXE IPv4 Some Network Adapter - {}",
+                    nic.mac_address
+                ))
+                .uefi_device_path(&format!(
+                    "{pci_path}/MAC({},0x1)/IPv4(0.0.0.0,0x0,DHCP,0.0.0.0,0.0.0.0,0.0.0.0)/Uri()",
+                    nic.mac_address.to_string().replace(":", "")
+                ))
+                .build()
+                }),
+        )
+        .collect();
+
+        // Not: No DPU in EthernetInterfaces.
+        let eth_interfaces = [&self.embedded_1g_nic.ethernet_nic()]
+            .iter()
+            .enumerate()
+            .map(|(index, nic)| {
+                redfish::ethernet_interface::builder(&redfish::ethernet_interface::system_resource(
+                    system_id,
+                    &format!("EthernetInterface{index}"),
+                ))
+                .mac_address(nic.mac_address)
+                .interface_enabled(false)
+                .build()
+            })
+            .collect();
+
+        redfish::computer_system::Config {
+            // Note: Order is exactly as it reported in json.
+            systems: vec![
+                redfish::computer_system::SingleSystemConfig {
+                    base_bios: None,
+                    bios_mode: redfish::computer_system::BiosMode::Generic,
+                    boot_options: None,
+                    boot_order_mode: redfish::computer_system::BootOrderMode::Generic,
+                    chassis: vec!["HGX_Chassis_0".into()],
+                    eth_interfaces: None,
+                    id: "HGX_Baseboard_0".into(),
+                    // Note: Actually it has log services. We don't
+                    // simulate it so far.
+                    log_services: None,
+                    manufacturer: Some("NVIDIA".into()),
+                    model: Some("GB300 1CPU:2GPU Board PC".into()),
+                    oem: redfish::computer_system::Oem::Generic,
+                    power_control: None,
+                    secure_boot_available: false,
+                    serial_number: Some(self.hgx_serial_number.to_string().into()),
+                    storage: None,
+                },
+                redfish::computer_system::SingleSystemConfig {
+                    base_bios: Some(base_bios(system_id)),
+                    bios_mode: redfish::computer_system::BiosMode::Generic,
+                    boot_options: Some(boot_options),
+                    boot_order_mode: redfish::computer_system::BootOrderMode::Generic,
+                    chassis: vec!["Chassis_0".into()],
+                    eth_interfaces: Some(eth_interfaces),
+                    id: system_id.into(),
+                    // Note: Actually it has log services. We don't
+                    // simulate it so far.
+                    log_services: None,
+                    manufacturer: Some("Lenovo".into()),
+                    model: Some("HG634N_V2".into()),
+                    oem: redfish::computer_system::Oem::Generic,
+                    power_control: Some(power_control),
+                    secure_boot_available: true,
+                    serial_number: Some(self.system_0_serial_number.to_string().into()),
+                    storage: None,
+                },
+            ],
+        }
+    }
+
+    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+        let dpu_chassis = |chassis_id: &'static str, bf3: &hw::bluefield3::Bluefield3<'_>| {
+            let nic = bf3.host_nic();
+            redfish::chassis::SingleChassisConfig {
+                id: chassis_id.into(),
+                chassis_type: "Component".into(),
+                manufacturer: Some("Nvidia".into()),
+                part_number: nic.part_number.map(|v| format!("{v}           ",).into()),
+                model: Some("BlueField-3 SmartNIC Main Card".into()),
+                serial_number: nic
+                    .serial_number
+                    .map(|v| format!("{v}                 ").into()),
+                network_adapters: None,
+                pcie_devices: None,
+                sensors: Some(redfish::sensor::generate_chassis_sensors(
+                    chassis_id,
+                    redfish::sensor::Layout {
+                        temperature: 4,
+                        ..Default::default()
+                    },
+                )),
+                assembly: None,
+                oem: None,
+            }
+        };
+        redfish::chassis::ChassisConfig {
+            chassis: (0..=3)
+                .map(|n| hw::nvidia_gbx00::cbc_chassis(format!("CBC_{n}").into(), &self.topology))
+                .chain(std::iter::once(redfish::chassis::SingleChassisConfig {
+                    id: "Chassis_0".into(),
+                    chassis_type: "RackMount".into(),
+                    manufacturer: Some("Lenovo".into()),
+                    part_number: Some("SC57C26750".into()),
+                    model: Some(" ".into()),
+                    serial_number: Some(self.chassis_0_serial_number.to_string().into()),
+                    network_adapters: None,
+                    pcie_devices: None,
+                    sensors: Some(redfish::sensor::generate_chassis_sensors(
+                        "Chassis_0",
+                        redfish::sensor::Layout {
+                            temperature: 47,
+                            power: 2,
+                            leak: 12, // Leak + Voltage
+                            fan: 24,
+                            current: 0,
+                        },
+                    )),
+                    assembly: None,
+                    oem: None,
+                }))
+                .chain(self.cpu.iter().enumerate().map(|(n, cpu)| {
+                    let id = format!("HGX_CPU_{n}");
+                    cpu.as_hgx_chassis(id.into())
+                }))
+                .chain(self.gpu.iter().enumerate().map(|(n, gpu)| {
+                    let id = format!("HGX_GPU_{n}");
+                    gpu.as_hgx_chassis(id.into())
+                }))
+                .chain(self.io_board.iter().enumerate().map(|(n, ioboard)| {
+                    let id = format!("IO_board_{n}");
+                    ioboard.as_chassis(id.into())
+                }))
+                .chain(std::iter::once(dpu_chassis(
+                    "Riser_Slot1_BlueField_3_SmartNIC_Main_Card",
+                    &self.dpu,
+                )))
+                .collect(),
+        }
+    }
+
+    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+        redfish::update_service::UpdateServiceConfig {
+            firmware_inventory: vec![],
+        }
+    }
+
+    pub fn discovery_info(&self) -> DiscoveryInfo {
+        // TODO: Should be generated by scout...
+        DiscoveryInfo::default()
+    }
+}
+
+fn base_bios(system_id: &str) -> serde_json::Value {
+    // GB300 mock is intentionally in a non-compliant initial state
+    // for setup-status testing. These values are scrabbed from real
+    // hardware.
+    redfish::bios::builder(&redfish::bios::resource(system_id))
+        .attributes(json!({
+            // NOTE: No VMXEN attribute in this registry/dump.
+            // This platform appears to be Grace-based, so an Intel VMX knob
+            // is not present.
+
+            // "If system has SR-IOV capable PCIe Devices, this option Enables
+            // or Disables Single Root IO Virtualization Support."
+            "PCIS007": "PCIS007Enabled",
+
+            // "Set PXE Retry Count(0~50), Set 50 means always retry"
+            "LEM0001": 0,
+
+            // "Enable/Disable UEFI Network Stack"
+            "NWSK000": "NWSK000Enabled",
+
+            // "Enable/Disable IPv4 PXE boot support. If disabled, IPv4 PXE
+            // boot support will not be available."
+            "NWSK001": "NWSK001Enabled",
+
+            // "Enable/Disable IPv4 HTTP boot support. If disabled, IPv4 HTTP
+            // boot support will not be available."
+            "NWSK006": "NWSK006Disabled",
+
+            // "Enable/Disable IPv6 PXE boot support. If disabled, IPv6 PXE
+            // boot support will not be available."
+            "NWSK002": "NWSK002Enabled",
+
+            // "Enable/Disable IPv6 HTTP boot support. If disabled, IPv6 HTTP
+            // boot support will not be available."
+            "NWSK007": "NWSK007Disabled",
+
+            // NOTE: No FBO001 ("Boot Mode Select") attribute in this registry.
+            // Closest related attributes are boot-order entries (FBO101..,
+            // FBO201.., FBO742, FBO760..765) and SETUP006, but none is a
+            // direct UEFI/Legacy boot mode selector.
+
+            // "Set Boot Retry Counts(0~50), Set 50 means Endless Boot"
+            // NOTE: This is the closest replacement for synthetic
+            // "EndlessBoot" from lenovo_ami.rs. Value 50 means endless boot.
+            // Real dump currently reports 0.
+            "LEM0003": 0
+        }))
+        .build()
+}

--- a/crates/bmc-mock/src/hw/liteon_power_shelf.rs
+++ b/crates/bmc-mock/src/hw/liteon_power_shelf.rs
@@ -55,6 +55,7 @@ impl LiteOnPowerShelf<'_> {
                     .interface_enabled(true)
                     .build(),
                 ]),
+                host_interfaces: None,
                 firmware_version: Some("r1.3.9"),
                 oem: None,
             }],

--- a/crates/bmc-mock/src/hw/mod.rs
+++ b/crates/bmc-mock/src/hw/mod.rs
@@ -30,6 +30,9 @@ pub mod dell_poweredge_r750;
 /// Support of Wiwynn GB200 NVL servers.
 pub mod wiwynn_gb200_nvl;
 
+/// Support of Lenovo GB300 NVL servers.
+pub mod lenovo_gb300_nvl;
+
 /// Support of LiteOn Power Shelf.
 pub mod liteon_power_shelf;
 
@@ -39,11 +42,20 @@ pub mod nvidia_switch_nd5200_ld;
 /// Support of NVIDIA DGX H100.
 pub mod nvidia_dgx_h100;
 
+/// Common support of GB200 and GB300
+pub mod nvidia_gbx00;
+
+/// GB300 CPU/GPU
+pub mod nvidia_gb300;
+
 /// Intel E810 NIC.
 pub mod nic_intel_e810;
 
 /// Intel X550 NIC.
 pub mod nic_intel_x550;
+
+/// Intel I210 NIC.
+pub mod nic_intel_i210;
 
 /// NVIDIA ConnectX-7.
 pub mod nic_nvidia_cx7;

--- a/crates/bmc-mock/src/hw/nic_intel_i210.rs
+++ b/crates/bmc-mock/src/hw/nic_intel_i210.rs
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use mac_address::MacAddress;
+
+use crate::hw;
+
+// This type describes Intel® Ethernet Network Adapter I210.
+pub struct NicIntelI210 {
+    pub mac_address: MacAddress,
+}
+
+impl NicIntelI210 {
+    pub fn ethernet_nic(&self) -> hw::nic::Nic<'static> {
+        hw::nic::Nic {
+            mac_address: self.mac_address,
+            serial_number: None,
+            manufacturer: None,
+            model: None,
+            description: None,
+            part_number: None,
+            firmware_version: None,
+            is_mat_dpu: false,
+        }
+    }
+}

--- a/crates/bmc-mock/src/hw/nvidia_dgx_h100.rs
+++ b/crates/bmc-mock/src/hw/nvidia_dgx_h100.rs
@@ -64,6 +64,13 @@ impl NvidiaDgxH100<'_> {
                             .interface_enabled(true)
                             .build(),
                     ]),
+                    host_interfaces: Some(vec![
+                        redfish::host_interface::builder(
+                            &redfish::host_interface::manager_resource(bmc_manager_id, "Self"),
+                        )
+                        .interface_enabled(true)
+                        .build(),
+                    ]),
                     firmware_version: Some("25.02.12"),
                     oem: None,
                 },
@@ -77,12 +84,14 @@ impl NvidiaDgxH100<'_> {
                         .interface_enabled(true)
                         .build(),
                     ]),
+                    host_interfaces: None,
                     firmware_version: Some("HGX-22.10-1-rc67"),
                     oem: None,
                 },
                 redfish::manager::SingleConfig {
                     id: "HGX_FabricManager_0",
                     eth_interfaces: None,
+                    host_interfaces: None,
                     firmware_version: None,
                     oem: None,
                 },

--- a/crates/bmc-mock/src/hw/nvidia_gb300.rs
+++ b/crates/bmc-mock/src/hw/nvidia_gb300.rs
@@ -1,0 +1,117 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+
+use crate::redfish;
+
+pub struct NvidiaGB300Gpu<'a> {
+    pub serial_number: Cow<'a, str>,
+}
+
+impl NvidiaGB300Gpu<'_> {
+    pub fn as_hgx_chassis(&self, id: Cow<'static, str>) -> redfish::chassis::SingleChassisConfig {
+        let sensors = redfish::sensor::generate_chassis_sensors(
+            &id,
+            redfish::sensor::Layout {
+                temperature: 3,
+                power: 2,
+                leak: 1, // Leak + Voltage
+                fan: 0,
+                current: 0,
+                // + 1 Energy
+            },
+        );
+        redfish::chassis::SingleChassisConfig {
+            id,
+            chassis_type: "Component".into(),
+            manufacturer: Some("NVIDIA".into()),
+            part_number: Some("SC57C26750".into()),
+            model: Some("NVIDIA GB300".into()),
+            serial_number: Some(self.serial_number.to_string().into()),
+            network_adapters: None,
+            pcie_devices: None,
+            sensors: Some(sensors),
+            assembly: None,
+            oem: None,
+        }
+    }
+}
+
+pub struct NvidiaGB300Cpu<'a> {
+    pub serial_number: Cow<'a, str>,
+}
+
+impl NvidiaGB300Cpu<'_> {
+    pub fn as_hgx_chassis(&self, id: Cow<'static, str>) -> redfish::chassis::SingleChassisConfig {
+        let sensors = redfish::sensor::generate_chassis_sensors(
+            &id,
+            redfish::sensor::Layout {
+                temperature: 2,
+                power: 5,
+                leak: 2, // Voltage
+                fan: 0,
+                current: 0,
+                // + 1 Energy
+                // + 72 CPU core utilzation
+                // + 1 Memory Frequency
+            },
+        );
+        redfish::chassis::SingleChassisConfig {
+            id,
+            chassis_type: "Component".into(),
+            manufacturer: Some("NVIDIA".into()),
+            part_number: Some("900-2G548-0081-000".into()),
+            model: Some("Grace A02P".into()),
+            serial_number: Some(self.serial_number.to_string().into()),
+            network_adapters: None,
+            pcie_devices: None,
+            sensors: Some(sensors),
+            assembly: None,
+            oem: None,
+        }
+    }
+}
+
+pub struct NvidiaGB300IoBoard<'a> {
+    pub serial_number: Cow<'a, str>,
+}
+
+impl NvidiaGB300IoBoard<'_> {
+    pub fn as_chassis(&self, id: Cow<'static, str>) -> redfish::chassis::SingleChassisConfig {
+        let sensors = redfish::sensor::generate_chassis_sensors(
+            &id,
+            redfish::sensor::Layout {
+                temperature: 8,
+                ..Default::default()
+            },
+        );
+        redfish::chassis::SingleChassisConfig {
+            id,
+            chassis_type: "Component".into(),
+            manufacturer: Some("Nvidia".into()),
+            part_number: Some("900-9X86E-00CX-ST0           ".into()),
+            model: Some("P4768-B01".into()),
+            serial_number: Some(self.serial_number.to_string().into()),
+            network_adapters: None,
+            pcie_devices: None,
+            sensors: Some(sensors),
+            assembly: None,
+            oem: None,
+        }
+    }
+}

--- a/crates/bmc-mock/src/hw/nvidia_gbx00.rs
+++ b/crates/bmc-mock/src/hw/nvidia_gbx00.rs
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Common functions for GB200 and GB300.
+
+use std::borrow::Cow;
+
+use serde_json::json;
+
+use crate::redfish;
+
+pub struct Topology {
+    pub chassis_physical_slot_number: u32,
+    pub compute_tray_index: u32,
+    pub revision_id: u32,
+    pub topology_id: u32,
+}
+
+// CBC chassis definition.
+pub fn cbc_chassis(
+    chassis_id: Cow<'static, str>,
+    topology: &Topology,
+) -> redfish::chassis::SingleChassisConfig {
+    redfish::chassis::SingleChassisConfig {
+        id: chassis_id,
+        chassis_type: "Component".into(),
+        manufacturer: Some("Nvidia".into()),
+        part_number: Some("750-0567-002".into()),
+        model: Some("18x1RU CBL Cartridge".into()),
+        serial_number: Some("1821220000000".into()),
+        network_adapters: None,
+        pcie_devices: Some(vec![]),
+        sensors: None,
+        assembly: None,
+        oem: Some(json!({
+            "Nvidia": {
+                "@odata.type": "#NvidiaChassis.v1_4_0.NvidiaCBCChassis",
+                "ChassisPhysicalSlotNumber": topology.chassis_physical_slot_number,
+                "ComputeTrayIndex": topology.compute_tray_index,
+                "RevisionId": topology.revision_id,
+                "TopologyId": topology.topology_id,
+            }
+        })),
+    }
+}

--- a/crates/bmc-mock/src/hw/nvidia_switch_nd5200_ld.rs
+++ b/crates/bmc-mock/src/hw/nvidia_switch_nd5200_ld.rs
@@ -54,6 +54,7 @@ impl NvidiaSwitchNd5200Ld<'_> {
                         .interface_enabled(true)
                         .build(),
                 ]),
+                host_interfaces: None,
                 firmware_version: Some("88.0002.1333"),
                 oem: None,
             }],

--- a/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
+++ b/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
@@ -32,6 +32,7 @@ pub struct WiwynnGB200Nvl<'a> {
     pub chassis_serial_number: Cow<'a, str>,
     pub dpu1: hw::bluefield3::Bluefield3<'a>,
     pub dpu2: hw::bluefield3::Bluefield3<'a>,
+    pub topology: hw::nvidia_gbx00::Topology,
 }
 
 impl WiwynnGB200Nvl<'_> {
@@ -51,12 +52,20 @@ impl WiwynnGB200Nvl<'_> {
                 redfish::manager::SingleConfig {
                     id: "BMC_0",
                     eth_interfaces: Some(vec![]), // TODO: eth0 / eth1 / hmcusb0 / hostusb0
+                    host_interfaces: Some(vec![
+                        redfish::host_interface::builder(
+                            &redfish::host_interface::manager_resource("BMC_0", "hostusb0"),
+                        )
+                        .interface_enabled(true)
+                        .build(),
+                    ]),
                     firmware_version: Some("25.06-2_NV_WW_02"),
                     oem: None,
                 },
                 redfish::manager::SingleConfig {
                     id: "HGX_BMC_0",
                     eth_interfaces: Some(vec![]), // TODO: usb0
+                    host_interfaces: None,
                     firmware_version: Some("GB200Nvl-25.06-A"),
                     oem: None,
                 },
@@ -158,28 +167,6 @@ impl WiwynnGB200Nvl<'_> {
                 oem: None,
             }
         };
-        let cbc_chassis = |chassis_id: &'static str| redfish::chassis::SingleChassisConfig {
-            id: chassis_id.into(),
-            chassis_type: "Component".into(),
-            manufacturer: Some("Nvidia".into()),
-            part_number: Some("750-0567-002".into()),
-            model: Some("18x1RU CBL Cartridge".into()),
-            serial_number: Some("1821220000000".into()),
-            network_adapters: None,
-            pcie_devices: Some(vec![]),
-            sensors: None,
-            assembly: None,
-            oem: Some(json!({
-                "Nvidia": {
-                    "@odata.type": "#NvidiaChassis.v1_4_0.NvidiaCBCChassis",
-                    "ChassisPhysicalSlotNumber": 24,
-                    "ComputeTrayIndex": 14,
-                    "RevisionId": 2,
-                    "TopologyId": 128
-                }
-            })),
-        };
-
         redfish::chassis::ChassisConfig {
             chassis: vec![
                 redfish::chassis::SingleChassisConfig {
@@ -221,10 +208,10 @@ impl WiwynnGB200Nvl<'_> {
                     ),
                     oem: None,
                 },
-                cbc_chassis("CBC_0"),
-                cbc_chassis("CBC_1"),
-                cbc_chassis("CBC_2"),
-                cbc_chassis("CBC_3"),
+                hw::nvidia_gbx00::cbc_chassis("CBC_0".into(), &self.topology),
+                hw::nvidia_gbx00::cbc_chassis("CBC_1".into(), &self.topology),
+                hw::nvidia_gbx00::cbc_chassis("CBC_2".into(), &self.topology),
+                hw::nvidia_gbx00::cbc_chassis("CBC_3".into(), &self.topology),
                 dpu_chassis("Riser_Slot1_BlueField_3_Card", &self.dpu1),
                 dpu_chassis("Riser_Slot2_BlueField_3_Card", &self.dpu2),
             ],

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -51,6 +51,8 @@ pub enum HostHardwareType {
     DellPowerEdgeR750,
     #[serde(rename = "wiwynn_gb200_nvl")]
     WiwynnGB200Nvl,
+    #[serde(rename = "lenovo_gb300_nvl")]
+    LenovoGB300Nvl,
     #[serde(rename = "liteon_power_shelf")]
     LiteOnPowerShelf,
     #[serde(rename = "nvidia_switch_nd5200_ld")]
@@ -64,6 +66,7 @@ impl fmt::Display for HostHardwareType {
         match self {
             Self::DellPowerEdgeR750 => "Dell PowerEdge R750".fmt(f),
             Self::WiwynnGB200Nvl => "WIWYNN GB200 NVL".fmt(f),
+            Self::LenovoGB300Nvl => "Lenovo GB300 NVL".fmt(f),
             Self::LiteOnPowerShelf => "Lite-On Power Shelf".fmt(f),
             Self::NvidiaSwitchNd5200Ld => "NVIDIA Switch ND5200_LD".fmt(f),
             Self::NvidiaDgxH100 => "NVIDIA DGX H100".fmt(f),
@@ -79,6 +82,7 @@ impl HostHardwareType {
         match self {
             Self::DellPowerEdgeR750 => None,
             Self::WiwynnGB200Nvl => Some(2),
+            Self::LenovoGB300Nvl => Some(1),
             Self::LiteOnPowerShelf => Some(0),
             Self::NvidiaSwitchNd5200Ld => Some(0),
             Self::NvidiaDgxH100 => Some(1),

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -113,7 +113,9 @@ impl DpuMachineInfo {
                     nic_mode: self.settings.nic_mode,
                 }
             }
-            HostHardwareType::WiwynnGB200Nvl => hw::bluefield3::Mode::B3240ColdAisle,
+            HostHardwareType::WiwynnGB200Nvl | HostHardwareType::LenovoGB300Nvl => {
+                hw::bluefield3::Mode::B3240ColdAisle
+            }
             HostHardwareType::LiteOnPowerShelf | HostHardwareType::NvidiaSwitchNd5200Ld => {
                 panic!("Bluefield3 DPU is defined for {}", self.hw_type)
             }
@@ -167,6 +169,7 @@ impl HostMachineInfo {
                 redfish::oem::State::DellIdrac(redfish::oem::dell::idrac::IdracState::default())
             }
             HostHardwareType::WiwynnGB200Nvl
+            | HostHardwareType::LenovoGB300Nvl
             | HostHardwareType::LiteOnPowerShelf
             | HostHardwareType::NvidiaDgxH100
             | HostHardwareType::NvidiaSwitchNd5200Ld => redfish::oem::State::Other,
@@ -177,6 +180,7 @@ impl HostMachineInfo {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => redfish::oem::BmcVendor::Dell,
             HostHardwareType::WiwynnGB200Nvl => redfish::oem::BmcVendor::Wiwynn,
+            HostHardwareType::LenovoGB300Nvl => redfish::oem::BmcVendor::Ami,
             HostHardwareType::LiteOnPowerShelf => redfish::oem::BmcVendor::LiteOn,
             HostHardwareType::NvidiaSwitchNd5200Ld => {
                 redfish::oem::BmcVendor::Nvidia(redfish::oem::NvidiaNamestyle::Uppercase)
@@ -189,6 +193,7 @@ impl HostMachineInfo {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => None,
             HostHardwareType::WiwynnGB200Nvl => Some("GB200 NVL"),
+            HostHardwareType::LenovoGB300Nvl => Some("AMI Redfish Server"),
             HostHardwareType::LiteOnPowerShelf => None,
             HostHardwareType::NvidiaSwitchNd5200Ld => Some("P3809"),
             HostHardwareType::NvidiaDgxH100 => Some("AMI Redfish Server"),
@@ -199,6 +204,7 @@ impl HostMachineInfo {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => "1.18.0",
             HostHardwareType::WiwynnGB200Nvl => "1.17.0",
+            HostHardwareType::LenovoGB300Nvl => "1.21.1",
             HostHardwareType::LiteOnPowerShelf => "1.9.0",
             HostHardwareType::NvidiaSwitchNd5200Ld => "1.17.0",
             HostHardwareType::NvidiaDgxH100 => "1.11.0",
@@ -209,6 +215,7 @@ impl HostMachineInfo {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().manager_config(),
             HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().manager_config(),
+            HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().manager_config(),
             HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().manager_config(),
             HostHardwareType::NvidiaSwitchNd5200Ld => {
                 self.nvidia_switch_nd5200_ld().manager_config()
@@ -228,6 +235,9 @@ impl HostMachineInfo {
             HostHardwareType::WiwynnGB200Nvl => {
                 self.wiwynn_gb200_nvl().system_config(power_control)
             }
+            HostHardwareType::LenovoGB300Nvl => {
+                self.lenovo_gb300_nvl().system_config(power_control)
+            }
             HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().system_config(),
             HostHardwareType::NvidiaSwitchNd5200Ld => {
                 self.nvidia_switch_nd5200_ld().system_config()
@@ -240,6 +250,7 @@ impl HostMachineInfo {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().chassis_config(),
             HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().chassis_config(),
+            HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().chassis_config(),
             HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().chassis_config(),
             HostHardwareType::NvidiaSwitchNd5200Ld => {
                 self.nvidia_switch_nd5200_ld().chassis_config()
@@ -254,6 +265,7 @@ impl HostMachineInfo {
                 self.dell_poweredge_r750().update_service_config()
             }
             HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().update_service_config(),
+            HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().update_service_config(),
             HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().update_service_config(),
             HostHardwareType::NvidiaSwitchNd5200Ld => {
                 self.nvidia_switch_nd5200_ld().update_service_config()
@@ -266,6 +278,7 @@ impl HostMachineInfo {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().discovery_info(),
             HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().discovery_info(),
+            HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().discovery_info(),
             HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().discovery_info(),
             HostHardwareType::LiteOnPowerShelf | HostHardwareType::NvidiaSwitchNd5200Ld => {
                 panic!("discovery_info requested for {}", self.hw_type)
@@ -311,6 +324,74 @@ impl HostMachineInfo {
                 .next()
                 .expect("Two DPUs must present for GB200 NVL")
                 .bluefield3(),
+            topology: hw::nvidia_gbx00::Topology {
+                chassis_physical_slot_number: 24,
+                compute_tray_index: 14,
+                revision_id: 2,
+                topology_id: 128,
+            },
+        }
+    }
+
+    fn lenovo_gb300_nvl(&self) -> hw::lenovo_gb300_nvl::LenovoGB300Nvl<'_> {
+        let mut dpus = self.dpus.iter();
+        let cpu0_sn = "0x000000017FFFFFFFFF00000000000001";
+        let cpu1_sn = "0x000000017FFFFFFFFF00000000000002";
+        let superchip_a_sn = "165300000001";
+        let superchip_b_sn = "165300000002";
+        let io_board0_sn = "MT2524000001";
+        let io_board1_sn = "MT2524000002";
+        hw::lenovo_gb300_nvl::LenovoGB300Nvl {
+            system_0_serial_number: "012345678901234567890123".into(),
+            chassis_0_serial_number: Cow::Borrowed(&self.serial),
+            dpu: dpus
+                .next()
+                .expect("One DPU must present for GB300 NVL")
+                .bluefield3(),
+            embedded_1g_nic: hw::nic_intel_i210::NicIntelI210 {
+                mac_address: next_mac(),
+            },
+            bmc_mac_address_eth0: next_mac(),
+            bmc_mac_address_eth1: next_mac(),
+            bmc_mac_address_usb0: next_mac(),
+            hgx_bmc_mac_address_usb0: next_mac(),
+            hgx_serial_number: "012345678901234567890123".into(),
+            topology: hw::nvidia_gbx00::Topology {
+                chassis_physical_slot_number: 25,
+                compute_tray_index: 15,
+                revision_id: 2,
+                topology_id: 128,
+            },
+            cpu: [
+                hw::nvidia_gb300::NvidiaGB300Cpu {
+                    serial_number: cpu0_sn.into(),
+                },
+                hw::nvidia_gb300::NvidiaGB300Cpu {
+                    serial_number: cpu1_sn.into(),
+                },
+            ],
+            gpu: [
+                hw::nvidia_gb300::NvidiaGB300Gpu {
+                    serial_number: superchip_a_sn.into(),
+                },
+                hw::nvidia_gb300::NvidiaGB300Gpu {
+                    serial_number: superchip_a_sn.into(),
+                },
+                hw::nvidia_gb300::NvidiaGB300Gpu {
+                    serial_number: superchip_b_sn.into(),
+                },
+                hw::nvidia_gb300::NvidiaGB300Gpu {
+                    serial_number: superchip_b_sn.into(),
+                },
+            ],
+            io_board: [
+                hw::nvidia_gb300::NvidiaGB300IoBoard {
+                    serial_number: io_board0_sn.into(),
+                },
+                hw::nvidia_gb300::NvidiaGB300IoBoard {
+                    serial_number: io_board1_sn.into(),
+                },
+            ],
         }
     }
 

--- a/crates/bmc-mock/src/redfish/host_interface.rs
+++ b/crates/bmc-mock/src/redfish/host_interface.rs
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+
+use serde_json::json;
+
+use crate::json::{JsonExt, JsonPatch};
+use crate::redfish;
+use crate::redfish::Builder;
+
+pub fn manager_collection(manager_id: &str) -> redfish::Collection<'static> {
+    let odata_id = format!("/redfish/v1/Managers/{manager_id}/HostInterfaces");
+    redfish::Collection {
+        odata_id: Cow::Owned(odata_id),
+        odata_type: Cow::Borrowed("#HostInterfaceCollection.HostInterfaceCollection"),
+        name: Cow::Borrowed("HostInterface Collection"),
+    }
+}
+
+pub fn manager_resource<'a>(manager_id: &'a str, iface_id: &'a str) -> redfish::Resource<'a> {
+    let odata_id = format!("/redfish/v1/Managers/{manager_id}/HostInterfaces/{iface_id}");
+    redfish::Resource {
+        odata_id: Cow::Owned(odata_id),
+        odata_type: Cow::Borrowed("#HostInterface.v1_3_3.HostInterface"),
+        id: Cow::Borrowed(iface_id),
+        name: Cow::Borrowed("Host Interface"),
+    }
+}
+
+pub fn builder(resource: &redfish::Resource) -> HostInterfaceBuilder {
+    HostInterfaceBuilder {
+        id: Cow::Owned(resource.id.to_string()),
+        value: resource.json_patch(),
+    }
+}
+
+#[derive(Clone)]
+pub struct HostInterface {
+    pub id: Cow<'static, str>,
+    value: serde_json::Value,
+}
+
+impl HostInterface {
+    pub fn to_json(&self) -> serde_json::Value {
+        self.value.clone()
+    }
+}
+
+pub struct HostInterfaceBuilder {
+    id: Cow<'static, str>,
+    value: serde_json::Value,
+}
+
+impl Builder for HostInterfaceBuilder {
+    fn apply_patch(self, patch: serde_json::Value) -> Self {
+        Self {
+            value: self.value.patch(patch),
+            id: self.id,
+        }
+    }
+}
+
+impl HostInterfaceBuilder {
+    pub fn interface_enabled(self, v: bool) -> Self {
+        self.apply_patch(json!({ "InterfaceEnabled": v }))
+    }
+
+    pub fn build(self) -> HostInterface {
+        HostInterface {
+            id: self.id,
+            value: self.value,
+        }
+    }
+}

--- a/crates/bmc-mock/src/redfish/manager.rs
+++ b/crates/bmc-mock/src/redfish/manager.rs
@@ -80,6 +80,10 @@ impl ManagerBuilder {
         self.apply_patch(collection.nav_property("EthernetInterfaces"))
     }
 
+    pub fn host_interfaces(self, collection: &redfish::Collection<'_>) -> Self {
+        self.apply_patch(collection.nav_property("HostInterfaces"))
+    }
+
     pub fn enable_reset_action(self) -> Self {
         let patch = json!({
             "Actions": {
@@ -155,6 +159,7 @@ impl ManagerBuilder {
 pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
     const MGR_ID: &str = "{manager_id}";
     const ETH_ID: &str = "{ethernet_id}";
+    const HOST_IF_ID: &str = "{hostif_id}";
     r.route(&collection().odata_id, get(get_manager_collection))
         .route(&resource(MGR_ID).odata_id, get(get_manager))
         .route(
@@ -164,6 +169,14 @@ pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
         .route(
             &redfish::ethernet_interface::manager_resource(MGR_ID, ETH_ID).odata_id,
             get(get_ethernet_interface),
+        )
+        .route(
+            &redfish::host_interface::manager_collection(MGR_ID).odata_id,
+            get(get_host_interface_collection),
+        )
+        .route(
+            &redfish::host_interface::manager_resource(MGR_ID, HOST_IF_ID).odata_id,
+            get(get_host_interface),
         )
         .route(&reset_target(MGR_ID), post(post_reset_manager))
         .route(
@@ -195,6 +208,7 @@ pub struct Config {
 pub struct SingleConfig {
     pub id: &'static str,
     pub eth_interfaces: Option<Vec<redfish::ethernet_interface::EthernetInterface>>,
+    pub host_interfaces: Option<Vec<redfish::host_interface::HostInterface>>,
     pub firmware_version: Option<&'static str>,
     pub oem: Option<Oem>,
 }
@@ -266,6 +280,14 @@ async fn get_manager(State(state): State<BmcState>, Path(manager_id): Path<Strin
                 .as_ref()
                 .map(|_| redfish::ethernet_interface::manager_collection(&manager_id)),
         )
+        .maybe_with(
+            ManagerBuilder::host_interfaces,
+            &this
+                .config
+                .host_interfaces
+                .as_ref()
+                .map(|_| redfish::host_interface::manager_collection(&manager_id)),
+        )
         .enable_reset_action()
         .log_services(redfish::log_service::manager_collection(&manager_id))
         .status(redfish::resource::Status::Ok)
@@ -315,6 +337,45 @@ async fn get_ethernet_interface(
                 .iter()
                 .find(|eth| eth.id == eth_id)
                 .map(|eth| eth.to_json().into_ok_response())
+        })
+        .unwrap_or_else(http::not_found)
+}
+
+async fn get_host_interface_collection(
+    State(state): State<BmcState>,
+    Path(manager_id): Path<String>,
+) -> Response {
+    state
+        .manager
+        .find(&manager_id)
+        .and_then(|manager| manager.config.host_interfaces.as_ref())
+        .map(|host_interfaces| {
+            let members = host_interfaces
+                .iter()
+                .map(|iface| {
+                    redfish::host_interface::manager_resource(&manager_id, &iface.id).entity_ref()
+                })
+                .collect::<Vec<_>>();
+            redfish::host_interface::manager_collection(&manager_id)
+                .with_members(&members)
+                .into_ok_response()
+        })
+        .unwrap_or_else(http::not_found)
+}
+
+async fn get_host_interface(
+    State(state): State<BmcState>,
+    Path((manager_id, iface_id)): Path<(String, String)>,
+) -> Response {
+    state
+        .manager
+        .find(&manager_id)
+        .and_then(|manager| manager.config.host_interfaces.as_ref())
+        .and_then(|host_interfaces| {
+            host_interfaces
+                .iter()
+                .find(|iface| iface.id == iface_id)
+                .map(|iface| iface.to_json().into_ok_response())
         })
         .unwrap_or_else(http::not_found)
 }

--- a/crates/bmc-mock/src/redfish/mod.rs
+++ b/crates/bmc-mock/src/redfish/mod.rs
@@ -23,6 +23,7 @@ pub mod chassis;
 pub mod collection;
 pub mod computer_system;
 pub mod ethernet_interface;
+pub mod host_interface;
 pub mod log_service;
 pub mod manager;
 pub mod manager_network_protocol;


### PR DESCRIPTION
## Description
Add initial Lenovo GB300 NVL support in bmc-explorer and bmc-mock.

This introduces basic GB300 platform detection, setup-status handling, mock Redfish data, shared GBx00 mock helpers, and Manager HostInterfaces support needed by newer platform layouts.

This is only scaffolding for early exploration and testing, not complete GB300 support. Further work is still needed to harden detection, refine platform-specific discovery/setup behavior, improve mock fidelity, and add broader test coverage.

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

