### PR TITLE
fix: actually use sccache to speed up builds w/ azure

### DIFF
--- a/.github/workflows/build-boot-artifacts.yml
+++ b/.github/workflows/build-boot-artifacts.yml
@@ -312,6 +312,18 @@ jobs:
           ENV_ARGS="$ENV_ARGS -e VERSION=${{ inputs.version }}"
           ENV_ARGS="$ENV_ARGS -e FORGE_CA=prod"
 
+          # sccache with Azure Blob Storage for persistent compilation caching.
+          # The connection string is written to a temp file and mounted into the
+          # container to avoid leaking it in the docker run command line.
+          SCCACHE_DOCKER_ARGS=""
+          if [ -n "${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}" ]; then
+            SCCACHE_CONN_FILE="$(mktemp)"
+            echo "${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}" > "${SCCACHE_CONN_FILE}"
+            SCCACHE_DOCKER_ARGS="-v ${SCCACHE_CONN_FILE}:/run/secrets/sccache_azure:ro"
+            ENV_ARGS="$ENV_ARGS -e SCCACHE_AZURE_BLOB_CONTAINER=sccache-github"
+            ENV_ARGS="$ENV_ARGS -e RUSTC_WRAPPER=sccache"
+          fi
+
           echo "============================================"
           echo "Running in container: ${{ inputs.build_container }}"
           echo "VERSION=${{ inputs.version }}"
@@ -347,10 +359,11 @@ jobs:
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
             ${EXTRA_DOCKER_ARGS} \
+            ${SCCACHE_DOCKER_ARGS} \
             -w /workspace \
             ${ENV_ARGS} \
             ${{ inputs.build_container }} \
-            bash -c "git config --global --add safe.directory /workspace && git config --global --add safe.directory /workspace/pxe/ipxe/upstream && echo 'VERSION in container: '\${VERSION} && cargo make --cwd pxe ${SA_ENABLEMENT_ARG} ${{ inputs.cargo_make_task }}"
+            bash -c "if [ -f /run/secrets/sccache_azure ]; then export SCCACHE_AZURE_CONNECTION_STRING=\$(cat /run/secrets/sccache_azure); fi && git config --global --add safe.directory /workspace && git config --global --add safe.directory /workspace/pxe/ipxe/upstream && echo 'VERSION in container: '\${VERSION} && cargo make --cwd pxe ${SA_ENABLEMENT_ARG} ${{ inputs.cargo_make_task }} && (sccache --show-stats 2>/dev/null || true)"
 
       # Run build directly on runner (for ephemeral images with mkosi)
       - name: Run cargo make task (shell mode)
@@ -363,6 +376,13 @@ jobs:
 
           # Source cargo environment
           source $HOME/.cargo/env
+
+          # sccache with Azure Blob Storage for persistent compilation caching
+          if [ -n "${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}" ]; then
+            export SCCACHE_AZURE_CONNECTION_STRING="${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}"
+            export SCCACHE_AZURE_BLOB_CONTAINER="sccache-github"
+            export RUSTC_WRAPPER=sccache
+          fi
 
           # Only set SA_ENABLEMENT when explicitly enabled
           SA_ENABLEMENT_ARG=""
@@ -380,6 +400,7 @@ jobs:
           cargo make --cwd pxe ${SA_ENABLEMENT_ARG} ${{ inputs.cargo_make_task }} 2>&1 | tee build.log
 
           echo "Build completed!"
+          if command -v sccache &> /dev/null; then sccache --show-stats; fi
 
       - name: Verify generated artifacts (informational only)
         continue-on-error: true  # Don't fail build - matches GitLab CI behavior (no verification step)

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -72,6 +72,9 @@ on:
       NVCR_TOKEN:
         description: "NVIDIA Container Registry API token"
         required: false
+      SCCACHE_AZURE_CONNECTION_STRING:
+        description: "Azure Blob Storage connection string for sccache"
+        required: false
     outputs:
       image_digest:
         description: 'Image digest'
@@ -107,11 +110,15 @@ jobs:
           pattern: '*-${{ github.run_id }}'
           merge-multiple: true
 
-      - name: Set up Docker Buildx
+      - name: Set up Docker Buildx (with custom config for push)
         if: inputs.push
         uses: docker/setup-buildx-action@v3
         with:
           buildkitd-config: /etc/buildkit/buildkitd.toml
+
+      - name: Set up Docker Buildx
+        if: ${{ !inputs.push }}
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to NVCR
         uses: ./.github/actions/docker-auth
@@ -171,6 +178,8 @@ jobs:
           load: ${{ inputs.load && !inputs.push }}
           tags: ${{ steps.tag_list.outputs.tags }}
           build-args: ${{ steps.parse-args.outputs.build_args }}
+          secrets: |
+            sccache_azure=${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
           cache-from: type=gha
           cache-to: ${{ inputs.push && 'type=gha,mode=max' || '' }}
 

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+// TODO(chet): Remove this!
+
 pub mod metrics;
 
 use std::collections::HashMap;

--- a/dev/docker/Dockerfile.release-container-aarch64
+++ b/dev/docker/Dockerfile.release-container-aarch64
@@ -31,10 +31,20 @@ RUN USER=root cargo new --bin carbide
 WORKDIR ./carbide
 COPY . ./
 
-RUN export CARGO_MAKE_SKIP_CODECOV="true" && \
+# sccache is configured to use Azure Blob Storage for persistent caching across
+# CI runs. The connection string is passed as a Docker build secret to avoid
+# leaking credentials in image layers. If the secret is not available (e.g.,
+# local builds), sccache falls back to a local directory.
+RUN --mount=type=secret,id=sccache_azure \
+  export CARGO_MAKE_SKIP_CODECOV="true" && \
   export DATABASE_URL="postgresql://%2Fvar%2Frun%2Fpostgresql" && \
-  export SCCACHE_DIR=/sccache && \
-  export RUST_WRAPPER=sccache && \
+  if [ -f /run/secrets/sccache_azure ]; then \
+    export SCCACHE_AZURE_CONNECTION_STRING="$(cat /run/secrets/sccache_azure)" && \
+    export SCCACHE_AZURE_BLOB_CONTAINER="sccache-github"; \
+  else \
+    export SCCACHE_DIR=/sccache; \
+  fi && \
+  export RUSTC_WRAPPER=sccache && \
   /etc/init.d/postgresql start && \
   sudo -u postgres psql -c "ALTER USER root WITH SUPERUSER;" && \
   createdb root && \
@@ -49,11 +59,12 @@ RUN export CARGO_MAKE_SKIP_CODECOV="true" && \
   cargo xtask check-workspace-deps && \
   echo "$(date): Finished cargo xtask check-workspace-deps\n" && \
   cargo make build-and-test-release-container-services && \
-  echo "$(date): Finished cargo make build-and-test-release-container-services\n" && \
+  echo "$(date): Finished cargo make build-and-test-release-container-services" && \
   cargo make --no-workspace check-licenses && \
   echo "$(date): Finished cargo make check-licenses\n" && \
   cargo make --no-workspace check-bans && \
   echo "$(date): Finished cargo make check-bans\n" && \
+  sccache --show-stats && \
   mkdir -p /carbide/target/bin && \
   find /carbide/target/release -maxdepth 1 -type f -exec cp -t /carbide/target/bin {} + && \
   rm -rf /carbide/target/debug && \

--- a/dev/docker/Dockerfile.release-container-sa-x86_64
+++ b/dev/docker/Dockerfile.release-container-sa-x86_64
@@ -31,10 +31,20 @@ RUN USER=root cargo new --bin carbide
 WORKDIR ./carbide
 COPY . ./
 
-RUN export CARGO_MAKE_SKIP_CODECOV="true" && \
+# sccache is configured to use Azure Blob Storage for persistent caching across
+# CI runs. The connection string is passed as a Docker build secret to avoid
+# leaking credentials in image layers. If the secret is not available (e.g.,
+# local builds), sccache falls back to a local directory.
+RUN --mount=type=secret,id=sccache_azure \
+  export CARGO_MAKE_SKIP_CODECOV="true" && \
   export DATABASE_URL="postgresql://%2Fvar%2Frun%2Fpostgresql" && \
-  export SCCACHE_DIR=/sccache && \
-  export RUST_WRAPPER=sccache && \
+  if [ -f /run/secrets/sccache_azure ]; then \
+    export SCCACHE_AZURE_CONNECTION_STRING="$(cat /run/secrets/sccache_azure)" && \
+    export SCCACHE_AZURE_BLOB_CONTAINER="sccache-github"; \
+  else \
+    export SCCACHE_DIR=/sccache; \
+  fi && \
+  export RUSTC_WRAPPER=sccache && \
   /etc/init.d/postgresql start && \
   sudo -u postgres psql -c "ALTER USER root WITH SUPERUSER;" && \
   createdb root && \
@@ -49,11 +59,12 @@ RUN export CARGO_MAKE_SKIP_CODECOV="true" && \
   cargo xtask check-workspace-deps && \
   echo "$(date): Finished cargo xtask check-workspace-deps\n" && \
   cargo make build-release && \
-  echo "$(date): Finished cargo make build-release\n" && \
+  echo "$(date): Finished cargo make build-release" && \
   cargo make --no-workspace check-licenses && \
   echo "$(date): Finished cargo make check-licenses\n" && \
   cargo make --no-workspace check-bans && \
   echo "$(date): Finished cargo make check-bans\n" && \
+  sccache --show-stats && \
   mkdir -p /carbide/target/bin && \
   find /carbide/target/release -maxdepth 1 -type f -exec cp -t /carbide/target/bin {} + && \
   rm -rf /carbide/target/debug && \

--- a/dev/docker/Dockerfile.release-container-x86_64
+++ b/dev/docker/Dockerfile.release-container-x86_64
@@ -31,10 +31,20 @@ RUN USER=root cargo new --bin carbide
 WORKDIR ./carbide
 COPY . ./
 
-RUN export CARGO_MAKE_SKIP_CODECOV="true" && \
+# sccache is configured to use Azure Blob Storage for persistent caching across
+# CI runs. The connection string is passed as a Docker build secret to avoid
+# leaking credentials in image layers. If the secret is not available (e.g.,
+# local builds), sccache falls back to a local directory.
+RUN --mount=type=secret,id=sccache_azure \
+  export CARGO_MAKE_SKIP_CODECOV="true" && \
   export DATABASE_URL="postgresql://%2Fvar%2Frun%2Fpostgresql" && \
-  export SCCACHE_DIR=/sccache && \
-  export RUST_WRAPPER=sccache && \
+  if [ -f /run/secrets/sccache_azure ]; then \
+    export SCCACHE_AZURE_CONNECTION_STRING="$(cat /run/secrets/sccache_azure)" && \
+    export SCCACHE_AZURE_BLOB_CONTAINER="sccache-github"; \
+  else \
+    export SCCACHE_DIR=/sccache; \
+  fi && \
+  export RUSTC_WRAPPER=sccache && \
   /etc/init.d/postgresql start && \
   sudo -u postgres psql -c "ALTER USER root WITH SUPERUSER;" && \
   createdb root && \
@@ -49,11 +59,12 @@ RUN export CARGO_MAKE_SKIP_CODECOV="true" && \
   cargo xtask check-workspace-deps && \
   echo "$(date): Finished cargo xtask check-workspace-deps\n" && \
   cargo make build-and-test-release-container-services && \
-  echo "$(date): Finished cargo make build-and-test-release-container-services\n" && \
+  echo "$(date): Finished cargo make build-and-test-release-container-services" && \
   cargo make --no-workspace check-licenses && \
   echo "$(date): Finished cargo make check-licenses\n" && \
   cargo make --no-workspace check-bans && \
   echo "$(date): Finished cargo make check-bans\n" && \
+  sccache --show-stats && \
   mkdir -p /carbide/target/bin && \
   find /carbide/target/release -maxdepth 1 -type f -exec cp -t /carbide/target/bin {} + && \
   rm -rf /carbide/target/debug && \

--- a/dev/docker/Dockerfile.release-forge-cli
+++ b/dev/docker/Dockerfile.release-forge-cli
@@ -13,10 +13,17 @@ RUN mkdir /carbide
 WORKDIR ./carbide
 COPY . ./
 
-RUN cd /carbide && \
-export SCCACHE_DIR=/sccache && \
-export RUST_WRAPPER=sccache && \
-cargo build --release -p carbide-admin-cli
+RUN --mount=type=secret,id=sccache_azure \
+  cd /carbide && \
+  if [ -f /run/secrets/sccache_azure ]; then \
+    export SCCACHE_AZURE_CONNECTION_STRING="$(cat /run/secrets/sccache_azure)" && \
+    export SCCACHE_AZURE_BLOB_CONTAINER="sccache-github"; \
+  else \
+    export SCCACHE_DIR=/sccache; \
+  fi && \
+  export RUSTC_WRAPPER=sccache && \
+  cargo build --release -p carbide-admin-cli && \
+  sccache --show-stats
 
 FROM debian:12-slim
 


### PR DESCRIPTION
## Description

So we have `RUSTC_WRAPPER=sccache` configured, and `/sccache` as the path, but the problem is, it's specific to the ephemeral container we use for building. It's not actually leveraging any cache for subsequent builds at all.

This change introduces an Azure-based `sccache` integration across all of our runners + containers that can benefit from `sccache`, allowing them to actually pull cached objects and speed up CICD pipelines/builds.

Behind the scenes, we set:
- `SCCACHE_AZURE_CONNECTION_STRING`, which is a new GH secret used by `sccache` to connect to Azure.
- `SCCACHE_AZURE_BLOB_CONTAINER`, which is the storage container for `sccache` to write to.

...and then wire those into the containers.

Locally I saw a 40% speedup in builds with it enabled (my local build box going to Azure), verified it was indeed writing to a test Azure container I set up, and `sccache` was reporting a 99% CHR.

My plan is to put up 2 of these PRs side by side by side so we can see what real world improvements look like (and hopefully validate it is useful), but even as this PR runs, I'm seeing cache re-use across build jobs, so even this PR might show benefits.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

