### PR TITLE
fix: increase switch nvos password length 16 -> 64; adjust rack_types configs

### DIFF
--- a/crates/api-db/migrations/20260326190000_increase_expected_switch_nvos_credential_length.sql
+++ b/crates/api-db/migrations/20260326190000_increase_expected_switch_nvos_credential_length.sql
@@ -1,0 +1,4 @@
+-- Increase nvos_username and nvos_password column sizes from VARCHAR(16) to VARCHAR(64)
+ALTER TABLE expected_switches
+    ALTER COLUMN nvos_username TYPE VARCHAR(64),
+    ALTER COLUMN nvos_password TYPE VARCHAR(64);

--- a/crates/api-model/src/rack_type.rs
+++ b/crates/api-model/src/rack_type.rs
@@ -138,7 +138,7 @@ pub struct RackCapabilitiesSet {
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RackTypeConfig {
     /// Map of rack type name to its capabilities set.
-    #[serde(default)]
+    #[serde(default, flatten)]
     pub rack_types: HashMap<String, RackCapabilitiesSet>,
 }
 
@@ -173,7 +173,7 @@ mod tests {
                 },
                 power_shelf: RackCapabilityPowerShelf {
                     name: None,
-                    count: 4,
+                    count: 8,
                     vendor: None,
                     slot_ids: None,
                 },
@@ -183,7 +183,7 @@ mod tests {
         let def = config.get("NVL72").unwrap();
         assert_eq!(def.compute.count, 18);
         assert_eq!(def.switch.count, 9);
-        assert_eq!(def.power_shelf.count, 4);
+        assert_eq!(def.power_shelf.count, 8);
 
         assert!(config.get("nonexistent").is_none());
     }
@@ -191,27 +191,27 @@ mod tests {
     #[test]
     fn test_rack_type_config_toml_deserialization() {
         let toml_str = r#"
-[rack_types.NVL72]
-[rack_types.NVL72.compute]
+[NVL72]
+[NVL72.compute]
 name = "GB200"
 count = 18
 vendor = "NVIDIA"
 
-[rack_types.NVL72.switch]
+[NVL72.switch]
 count = 9
 
-[rack_types.NVL72.power_shelf]
-count = 4
+[NVL72.power_shelf]
+count = 8
 
-[rack_types.NVL36x2]
-[rack_types.NVL36x2.compute]
+[NVL36]
+[NVL36.compute]
 count = 9
 
-[rack_types.NVL36x2.switch]
+[NVL36.switch]
 count = 9
 
-[rack_types.NVL36x2.power_shelf]
-count = 4
+[NVL36.power_shelf]
+count = 2
 "#;
         let config: RackTypeConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.rack_types.len(), 2);
@@ -220,7 +220,9 @@ count = 4
         assert_eq!(nvl72.compute.count, 18);
         assert_eq!(nvl72.compute.name.as_deref(), Some("GB200"));
 
-        let nvl36x2 = config.get("NVL36x2").unwrap();
-        assert_eq!(nvl36x2.compute.count, 9);
+        let nvl36 = config.get("NVL36").unwrap();
+        assert_eq!(nvl36.compute.count, 9);
+        assert_eq!(nvl36.switch.count, 9);
+        assert_eq!(nvl36.power_shelf.count, 2);
     }
 }

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -3771,6 +3771,18 @@ mod tests {
             MlxValueType::Integer(4)
         );
         assert!(mlxconfig_profile.get_variable("NONEXISTENT_GOO").is_none());
+
+        assert_eq!(config.rack_types.rack_types.len(), 2);
+        let nvl72 = config.rack_types.get("NVL72").unwrap();
+        assert_eq!(nvl72.compute.count, 18);
+        assert_eq!(nvl72.compute.name.as_deref(), Some("GB200"));
+        assert_eq!(nvl72.compute.vendor.as_deref(), Some("NVIDIA"));
+        assert_eq!(nvl72.switch.count, 9);
+        assert_eq!(nvl72.power_shelf.count, 8);
+        let nvl36 = config.rack_types.get("NVL36").unwrap();
+        assert_eq!(nvl36.compute.count, 9);
+        assert_eq!(nvl36.switch.count, 9);
+        assert_eq!(nvl36.power_shelf.count, 2);
     }
 
     #[test]

--- a/crates/api/src/cfg/test_data/full_config.toml
+++ b/crates/api/src/cfg/test_data/full_config.toml
@@ -194,6 +194,28 @@ OperatingModes_ChooseOperatingMode = "MaximumPerformance"
 DevicesandIOPorts_IOMMU = "Disabled"
 OperatingModes_ChooseOperatingMode = "MinimalPower"
 
+[rack_types.NVL72]
+[rack_types.NVL72.compute]
+name = "GB200"
+count = 18
+vendor = "NVIDIA"
+
+[rack_types.NVL72.switch]
+count = 9
+
+[rack_types.NVL72.power_shelf]
+count = 8
+
+[rack_types.NVL36]
+[rack_types.NVL36.compute]
+count = 9
+
+[rack_types.NVL36.switch]
+count = 9
+
+[rack_types.NVL36.power_shelf]
+count = 2
+
 [mlx-config-profiles.test-profile]
 name = "test-profile"
 registry_name = "mlx_generic"


### PR DESCRIPTION
## Description

Doing a turnup attempt in one of our sites. Ran into a couple of sillies:
- The NVOS password is 24 characters long, but we `varchar(16)`. Bumping to `varchar(64)`.
- The `rack_types` config doesn't get flattened, so it ends up as `rack_types.rack_types`.

Added tests.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

