### PR TITLE
chore: Use RequestRepair tag to match what automated break-fix workflow expects

### DIFF
--- a/crates/api/templates/machine_health.html
+++ b/crates/api/templates/machine_health.html
@@ -60,7 +60,7 @@
 				<button onclick="setOverrideTextBoxToTemplate(templateMergeInternalMaintenance)">Internal Maintenance</button>
 				<button onclick="setOverrideTextBoxToTemplate(templateStopRebootForRecovery)">Prevent Reboot</button>
 				<button onclick="setOverrideTextBoxToTemplate(templateMergeOfrMaintenance)">Out for Repair</button>
-				<button onclick="setOverrideTextBoxToTemplate(templateMergeBreakfix)">Break Fix</button>
+				<button onclick="setOverrideTextBoxToTemplate(templateMergeBreakfix)">Request Repair Automation</button>
 				<button onclick="setOverrideTextBoxToTemplate(templateMergeDegradedMaintenance)">Degraded</button>
 				<button onclick="setOverrideTextBoxToTemplate(templateMergeValidationMaintenance)">Validation</button>
 				<button onclick="setOverrideTextBoxToTemplate(templateMergeSuppressExternalAlerting)">Suppress Alerts</button>


### PR DESCRIPTION
## Description
The automated break-fix workflow expects `RequestRepair` id in health-overrides, per [its document](https://requests-navigator.atlassian.net/wiki/spaces/MC/pages/1004568582/Break-Fix+YTL).

The `admin-cli` side already contains [correct id](https://github.com/NVIDIA/ncx-infra-controller-core/blob/b220b212d8748570cf4846eab34893c595f8657c/crates/admin-cli/src/machine/health_override/cmd.rs#L129), so no changes on CLI side.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

