### PR TITLE
feat(bmc-mock): improve GB200 NVL hardware modeling

### DIFF
--- a/crates/bmc-mock/src/hw/mod.rs
+++ b/crates/bmc-mock/src/hw/mod.rs
@@ -45,6 +45,9 @@ pub mod nvidia_dgx_h100;
 /// Common support of GB200 and GB300
 pub mod nvidia_gbx00;
 
+/// GB200 CPU/GPU
+pub mod nvidia_gb200;
+
 /// GB300 CPU/GPU
 pub mod nvidia_gb300;
 

--- a/crates/bmc-mock/src/hw/nvidia_gb200.rs
+++ b/crates/bmc-mock/src/hw/nvidia_gb200.rs
@@ -1,0 +1,265 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+use std::fmt;
+
+use rpc::PciDeviceProperties;
+use rpc::machine_discovery::{Gpu, GpuPlatformInfo, InfinibandInterface, MemoryDevice};
+
+use crate::redfish;
+
+#[derive(Clone, Copy)]
+pub enum BoardIndex {
+    Board0,
+    Board1,
+}
+
+impl fmt::Display for BoardIndex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Board0 => "0",
+            Self::Board1 => "1",
+        }
+        .fmt(f)
+    }
+}
+
+pub struct BiancaBoard<'a> {
+    pub index: BoardIndex,
+    pub cpu_serial_number: Cow<'a, str>,
+    pub gpu_serial_number: Cow<'a, str>,
+}
+
+pub struct GpuChassisIds {
+    pub chassis_id: Cow<'static, str>,
+    pub pcie_device_id: Cow<'static, str>,
+}
+
+impl BiancaBoard<'_> {
+    pub fn hgx_cpu_chassis(&self, id: Cow<'static, str>) -> redfish::chassis::SingleChassisConfig {
+        let sensors = redfish::sensor::generate_chassis_sensors(
+            &id,
+            redfish::sensor::Layout {
+                temperature: 2,
+                power: 3,
+                leak: 2, // Voltage
+                fan: 0,
+                current: 0,
+                // + 1 Energy
+                // + 72 CPU core utilzation
+                // + 1 Memory Frequency
+            },
+        );
+        redfish::chassis::SingleChassisConfig {
+            id,
+            chassis_type: "Component".into(),
+            manufacturer: Some("NVIDIA".into()),
+            part_number: Some("900-2G548-0001-000".into()),
+            model: Some("Grace A02P".into()),
+            serial_number: Some(self.cpu_serial_number.to_string().into()),
+            network_adapters: None,
+            pcie_devices: None,
+            sensors: Some(sensors),
+            assembly: None,
+            oem: None,
+        }
+    }
+
+    pub fn hgx_gpu_chassis(
+        &self,
+        ids: [GpuChassisIds; 2],
+    ) -> [redfish::chassis::SingleChassisConfig; 2] {
+        ids.map(|ids| {
+            let sensors = redfish::sensor::generate_chassis_sensors(
+                &ids.chassis_id,
+                redfish::sensor::Layout {
+                    temperature: 3,
+                    power: 2,
+                    leak: 1, // Voltage
+                    fan: 0,
+                    current: 0,
+                    // + 1 Energy
+                },
+            );
+            redfish::chassis::SingleChassisConfig {
+                chassis_type: "Component".into(),
+                manufacturer: Some("NVIDIA".into()),
+                part_number: Some("NA".into()),
+                model: Some("GB200 186GB HBM3e".into()),
+                serial_number: Some(self.gpu_serial_number.to_string().into()),
+                network_adapters: None,
+                pcie_devices: Some(vec![
+                    redfish::pcie_device::builder(&redfish::pcie_device::chassis_resource(
+                        &ids.chassis_id,
+                        &ids.pcie_device_id,
+                    ))
+                    .manufacturer("NVIDIA")
+                    .model("GB200 186GB HBM3e")
+                    .part_number("2941-892-A1")
+                    .serial_number(&self.gpu_serial_number)
+                    .build(),
+                ]),
+                id: ids.chassis_id,
+                sensors: Some(sensors),
+                assembly: None,
+                oem: None,
+            }
+        })
+    }
+
+    pub fn discovery_gpu(&self) -> [Gpu; 2] {
+        [0, 1].map(|gpun| Gpu {
+            name: "NVIDIA GB200".into(),
+            serial: self.gpu_serial_number.to_string(),
+            driver_version: "580.126.16".into(),
+            vbios_version: "97.00.B9.00.76".into(),
+            inforom_version: "G548.0201.00.06".into(),
+            total_memory: "189471 MiB".into(),
+            frequency: "2062 MHz".into(),
+            pci_bus_id: self.pcie_address(gpun).to_string(),
+            platform_info: Some(GpuPlatformInfo {
+                chassis_serial: format!("182100000000{}{gpun}", self.index),
+                slot_number: 24,
+                tray_index: 14,
+                host_id: 1,
+                module_id: self.module_id(gpun),
+                fabric_guid: format!("0xfeeeeeeeeeeeee{gpun:02x}"),
+            }),
+        })
+    }
+
+    pub fn discovery_memory(&self) -> MemoryDevice {
+        MemoryDevice {
+            size_mb: Some(491520),
+            mem_type: Some("LPDDR5".into()),
+        }
+    }
+
+    fn pcie_address(&self, gpu_index: u8) -> &'static str {
+        match (self.index, gpu_index) {
+            (BoardIndex::Board0, 0) => "00000008:01:00.0",
+            (BoardIndex::Board0, 1) => "00000009:01:00.0",
+            (BoardIndex::Board1, 0) => "00000018:01:00.0",
+            (BoardIndex::Board1, 1) => "00000019:01:00.0",
+            _ => panic!("unexpected gpu index: {gpu_index}"),
+        }
+    }
+
+    fn module_id(&self, gpu_index: u8) -> u32 {
+        match (self.index, gpu_index) {
+            (BoardIndex::Board0, 0) => 2,
+            (BoardIndex::Board0, 1) => 1,
+            (BoardIndex::Board1, 0) => 4,
+            (BoardIndex::Board1, 1) => 3,
+            _ => panic!("unexpected gpu index: {gpu_index}"),
+        }
+    }
+}
+
+pub struct IoBoard<'a> {
+    pub index: BoardIndex,
+    pub serial_number: Cow<'a, str>,
+}
+
+impl IoBoard<'_> {
+    pub fn as_chassis(&self, id: Cow<'static, str>) -> redfish::chassis::SingleChassisConfig {
+        let sensors = redfish::sensor::generate_chassis_sensors(
+            &id,
+            redfish::sensor::Layout {
+                temperature: 4,
+                ..Default::default()
+            },
+        );
+        redfish::chassis::SingleChassisConfig {
+            chassis_type: "Component".into(),
+            manufacturer: Some("Nvidia".into()),
+            part_number: Some("900-24768-0002-000".into()),
+            model: Some("2x ConnectX-7 Mezz".into()),
+            serial_number: Some(self.serial_number.to_string().into()),
+            network_adapters: Some(
+                (0..2)
+                    .map(|n| {
+                        redfish::network_adapter::builder(
+                            &redfish::network_adapter::chassis_resource(
+                                &id,
+                                &format!("{id}_CX7_{n}"),
+                            ),
+                        )
+                        .manufacturer("Nvidia")
+                        .model("2x ConnectX-7 Mezz")
+                        .part_number("900-24768-0002-000")
+                        .serial_number(&self.serial_number)
+                        .build()
+                    })
+                    .collect(),
+            ),
+            pcie_devices: Some(vec![]),
+            sensors: Some(sensors),
+            assembly: None,
+            oem: None,
+            id,
+        }
+    }
+
+    pub fn discovery_infiniband(&self) -> [InfinibandInterface; 2] {
+        [0, 1].map(|n| {
+            let numa_node = self.numa_node();
+            let domain = self.pcie_domain(n);
+            let device_name = if domain == 0 {
+                Cow::Borrowed("ibp3s0")
+            } else {
+                format!("ibP{domain}p3s0").into()
+            };
+            InfinibandInterface {
+                pci_properties: Some(PciDeviceProperties {
+                    vendor: "Mellanox Technologies".into(),
+                    device: "MT2910 Family [ConnectX-7]".into(),
+                    path: format!(
+                        "/devices/pci{domain:02x}:00\
+                             /{domain:02x}:00:00.0\
+                             /{domain:02x}:01:00.0\
+                             /{domain:02x}:02:00.0\
+                             /{domain:02x}:03:00.0\
+                             /infiniband/{device_name}"
+                    ),
+                    numa_node,
+                    description: Some("MT2910 Family [ConnectX-7]".into()),
+                    slot: format!("{domain}:03:00.0").into(),
+                }),
+                guid: format!("7c8c09000000000{n}"),
+            }
+        })
+    }
+
+    fn numa_node(&self) -> i32 {
+        match self.index {
+            BoardIndex::Board0 => 0,
+            BoardIndex::Board1 => 1,
+        }
+    }
+
+    fn pcie_domain(&self, dev_number: u8) -> u32 {
+        match (self.index, dev_number) {
+            (BoardIndex::Board0, 0) => 0x0000,
+            (BoardIndex::Board0, 1) => 0x0002,
+            (BoardIndex::Board1, 0) => 0x0010,
+            (BoardIndex::Board1, 1) => 0x0012,
+            _ => panic!("unexpected dev number: {dev_number}"),
+        }
+    }
+}

--- a/crates/bmc-mock/src/hw/nvidia_switch_nd5200_ld.rs
+++ b/crates/bmc-mock/src/hw/nvidia_switch_nd5200_ld.rs
@@ -94,7 +94,7 @@ impl NvidiaSwitchNd5200Ld<'_> {
                     manufacturer: Some("NVIDIA".into()),
                     part_number: Some("692-13809-1404-000".into()),
                     model: Some("P3809".into()),
-                    serial_number: Some(self.bmc_serial_number.to_string().into()), // 1320325107073
+                    serial_number: Some(self.bmc_serial_number.to_string().into()),
                     network_adapters: None,
                     pcie_devices: None,
                     sensors: Some(vec![]),

--- a/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
+++ b/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
@@ -18,10 +18,7 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
-use rpc::machine_discovery::{
-    BlockDevice, CpuInfo, DiscoveryInfo, DmiData, Gpu, GpuPlatformInfo, InfinibandInterface,
-    MemoryDevice, NvmeDevice, PciDeviceProperties,
-};
+use rpc::machine_discovery::{BlockDevice, CpuInfo, DiscoveryInfo, DmiData, NvmeDevice};
 use serde_json::json;
 use utils::models::arch::CpuArchitecture;
 
@@ -30,9 +27,11 @@ use crate::{PowerControl, hw, redfish};
 pub struct WiwynnGB200Nvl<'a> {
     pub system_serial_number: Cow<'a, str>,
     pub chassis_serial_number: Cow<'a, str>,
+    pub compute_board: [hw::nvidia_gb200::BiancaBoard<'a>; 2],
     pub dpu1: hw::bluefield3::Bluefield3<'a>,
     pub dpu2: hw::bluefield3::Bluefield3<'a>,
     pub topology: hw::nvidia_gbx00::Topology,
+    pub io_board: [hw::nvidia_gb200::IoBoard<'a>; 2],
 }
 
 impl WiwynnGB200Nvl<'_> {
@@ -168,53 +167,97 @@ impl WiwynnGB200Nvl<'_> {
             }
         };
         redfish::chassis::ChassisConfig {
-            chassis: vec![
-                redfish::chassis::SingleChassisConfig {
-                    id: "BMC_0".into(),
-                    chassis_type: "Module".into(),
-                    manufacturer: Some("WIWYNN".into()),
-                    part_number: Some("B81.11810.0005".into()),
-                    model: Some("GB200 NVL".into()),
-                    serial_number: None,
-                    network_adapters: None,
-                    pcie_devices: Some(vec![]),
-                    sensors: None,
-                    assembly: None,
-                    oem: None,
-                },
-                redfish::chassis::SingleChassisConfig {
-                    id: "Chassis_0".into(),
-                    chassis_type: "RackMount".into(),
-                    manufacturer: Some("NVIDIA".into()),
-                    part_number: Some("B81.11810.000D".into()),
-                    model: Some("GB200 NVL".into()),
-                    serial_number: None,
-                    network_adapters: None,
-                    pcie_devices: None,
-                    sensors: Some(redfish::sensor::generate_chassis_sensors(
-                        "Chassis_0",
-                        Self::sensor_layout(),
-                    )),
-                    assembly: Some(
-                        redfish::assembly::builder(&redfish::assembly::chassis_resource(
-                            "Chassis_0",
-                        ))
+            chassis: std::iter::once(redfish::chassis::SingleChassisConfig {
+                id: "BMC_0".into(),
+                chassis_type: "Module".into(),
+                manufacturer: Some("WIWYNN".into()),
+                part_number: Some("B81.11810.0005".into()),
+                model: Some("GB200 NVL".into()),
+                serial_number: None,
+                network_adapters: None,
+                pcie_devices: Some(vec![]),
+                sensors: None,
+                assembly: None,
+                oem: None,
+            })
+            .chain(std::iter::once(redfish::chassis::SingleChassisConfig {
+                id: "Chassis_0".into(),
+                chassis_type: "RackMount".into(),
+                manufacturer: Some("NVIDIA".into()),
+                part_number: Some("B81.11810.000D".into()),
+                model: Some("GB200 NVL".into()),
+                serial_number: None,
+                network_adapters: None,
+                pcie_devices: None,
+                sensors: Some(redfish::sensor::generate_chassis_sensors(
+                    "Chassis_0",
+                    Self::sensor_layout(),
+                )),
+                assembly: Some(
+                    redfish::assembly::builder(&redfish::assembly::chassis_resource("Chassis_0"))
                         .add_data(
                             redfish::assembly::data_builder("0".into())
                                 .serial_number(&self.chassis_serial_number)
                                 .build(),
                         )
                         .build(),
+                ),
+                oem: None,
+            }))
+            .chain((0..4).map(|index| {
+                hw::nvidia_gbx00::cbc_chassis(format!("CBC_{index}").into(), &self.topology)
+            }))
+            .chain(
+                [(0, "HGX_CPU_0"), (1, "HGX_CPU_1")]
+                    .map(|(index, id)| self.compute_board[index].hgx_cpu_chassis(id.into())),
+            )
+            .chain(
+                [
+                    (
+                        0,
+                        [
+                            hw::nvidia_gb200::GpuChassisIds {
+                                chassis_id: "HGX_GPU_0".into(),
+                                pcie_device_id: "GPU_0".into(),
+                            },
+                            hw::nvidia_gb200::GpuChassisIds {
+                                chassis_id: "HGX_GPU_1".into(),
+                                pcie_device_id: "GPU_1".into(),
+                            },
+                        ],
                     ),
-                    oem: None,
-                },
-                hw::nvidia_gbx00::cbc_chassis("CBC_0".into(), &self.topology),
-                hw::nvidia_gbx00::cbc_chassis("CBC_1".into(), &self.topology),
-                hw::nvidia_gbx00::cbc_chassis("CBC_2".into(), &self.topology),
-                hw::nvidia_gbx00::cbc_chassis("CBC_3".into(), &self.topology),
-                dpu_chassis("Riser_Slot1_BlueField_3_Card", &self.dpu1),
-                dpu_chassis("Riser_Slot2_BlueField_3_Card", &self.dpu2),
-            ],
+                    (
+                        1,
+                        [
+                            hw::nvidia_gb200::GpuChassisIds {
+                                chassis_id: "HGX_GPU_2".into(),
+                                pcie_device_id: "GPU_2".into(),
+                            },
+                            hw::nvidia_gb200::GpuChassisIds {
+                                chassis_id: "HGX_GPU_3".into(),
+                                pcie_device_id: "GPU_3".into(),
+                            },
+                        ],
+                    ),
+                ]
+                .into_iter()
+                .flat_map(|(index, ids)| self.compute_board[index].hgx_gpu_chassis(ids)),
+            )
+            .chain(
+                self.io_board
+                    .iter()
+                    .zip(["IO_Board_0", "IO_Board_1"])
+                    .map(|(board, id)| board.as_chassis(id.into())),
+            )
+            .chain(std::iter::once(dpu_chassis(
+                "Riser_Slot1_BlueField_3_Card",
+                &self.dpu1,
+            )))
+            .chain(std::iter::once(dpu_chassis(
+                "Riser_Slot2_BlueField_3_Card",
+                &self.dpu2,
+            )))
+            .collect(),
         }
     }
 
@@ -251,26 +294,10 @@ impl WiwynnGB200Nvl<'_> {
                 self.dpu1.host_nic().discovery_info(0x0603),
                 self.dpu2.host_nic().discovery_info(0x1603),
             ],
-            infiniband_interfaces: (0..4)
-                .map(|n| {
-                    let (domain, numa_node) = [(0x0000, 0), (0x0002, 0), (0x0010, 1), (0x0012, 1)][n];
-                    let device_name = if domain == 0 {
-                        Cow::Borrowed("ibp3s0")
-                    } else {
-                        format!("ibP{domain}p3s0").into()
-                    };
-                    InfinibandInterface {
-                        pci_properties: Some(PciDeviceProperties {
-                            vendor: "Mellanox Technologies".into(),
-                            device: "MT2910 Family [ConnectX-7]".into(),
-                            path: format!("/devices/pci{domain:02x}:00/{domain:02x}:00:00.0/{domain:02x}:01:00.0/{domain:02x}:02:00.0/{domain:02x}:03:00.0/infiniband/{device_name}"),
-                            numa_node,
-                            description: Some("MT2910 Family [ConnectX-7]".into()),
-                            slot: format!("{domain}:03:00.0").into(),
-                        }),
-                        guid: format!("7c8c09000000000{n}"),
-                    }
-                })
+            infiniband_interfaces: self
+                .io_board
+                .iter()
+                .flat_map(|board| board.discovery_infiniband())
                 .collect(),
             cpu_info: vec![CpuInfo {
                 model: "Neoverse-V2".into(),
@@ -308,32 +335,15 @@ impl WiwynnGB200Nvl<'_> {
                 sys_vendor: "NVIDIA".into(),
             }),
             dpu_info: None,
-            gpus: (0..4).map(|n| {
-                let module_id = [2, 1, 4, 3][n];
-                let pci_bus_id = ["00000008:01:00.0", "00000009:01:00.0", "00000018:01:00.0", "00000019:01:00.0"][n];
-                Gpu {
-                    name: "NVIDIA GB200".into(),
-                    serial: format!("165000000000{n}"),
-                    driver_version: "580.126.16".into(),
-                    vbios_version: "97.00.B9.00.76".into(),
-                    inforom_version: "G548.0201.00.06".into(),
-                    total_memory: "189471 MiB".into(),
-                    frequency: "2062 MHz".into(),
-                    pci_bus_id: pci_bus_id.into(),
-                    platform_info: Some(GpuPlatformInfo {
-                        chassis_serial: format!("182100000000{n}"),
-                        slot_number: 24,
-                        tray_index: 14,
-                        host_id: 1,
-                        module_id,
-                        fabric_guid: format!("0xfeeeeeeeeeeeee{n:02x}"),
-                    })
-                }}).collect(),
-            memory_devices: (0..2)
-                .map(|_| MemoryDevice {
-                    size_mb: Some(491520),
-                    mem_type: Some("LPDDR5".into()),
-                })
+            gpus: self
+                .compute_board
+                .iter()
+                .flat_map(|board| board.discovery_gpu())
+                .collect(),
+            memory_devices: self
+                .compute_board
+                .iter()
+                .map(|board| board.discovery_memory())
                 .collect(),
             tpm_ek_certificate: None,
             tpm_description: None,

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -316,6 +316,18 @@ impl HostMachineInfo {
         hw::wiwynn_gb200_nvl::WiwynnGB200Nvl {
             system_serial_number: Cow::Borrowed(&self.serial),
             chassis_serial_number: Cow::Borrowed(&self.serial),
+            compute_board: [
+                hw::nvidia_gb200::BiancaBoard {
+                    index: hw::nvidia_gb200::BoardIndex::Board0,
+                    cpu_serial_number: "0x000000017FFFFFFFFF00000000000001".into(),
+                    gpu_serial_number: "165300000001".into(),
+                },
+                hw::nvidia_gb200::BiancaBoard {
+                    index: hw::nvidia_gb200::BoardIndex::Board1,
+                    cpu_serial_number: "0x000000017FFFFFFFFF00000000000002".into(),
+                    gpu_serial_number: "165300000002".into(),
+                },
+            ],
             dpu1: dpus
                 .next()
                 .expect("Two DPUs must present for GB200 NVL")
@@ -324,6 +336,16 @@ impl HostMachineInfo {
                 .next()
                 .expect("Two DPUs must present for GB200 NVL")
                 .bluefield3(),
+            io_board: [
+                hw::nvidia_gb200::IoBoard {
+                    index: hw::nvidia_gb200::BoardIndex::Board0,
+                    serial_number: "MT0000000001".into(),
+                },
+                hw::nvidia_gb200::IoBoard {
+                    index: hw::nvidia_gb200::BoardIndex::Board1,
+                    serial_number: "MT0000000002".into(),
+                },
+            ],
             topology: hw::nvidia_gbx00::Topology {
                 chassis_physical_slot_number: 24,
                 compute_tray_index: 14,


### PR DESCRIPTION
## Description
Add GB200-specific compute and IO board helpers and use them to generate more realistic Redfish chassis and discovery data for the Wiwynn GB200 NVL mock.

Also remove an outdated serial-number comment from the ND5200 mock.

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

