### PR TITLE
fix: iterative improvements to switch ingestion workflow

### DIFF
--- a/crates/api-db/src/expected_switch.rs
+++ b/crates/api-db/src/expected_switch.rs
@@ -137,7 +137,7 @@ pub async fn find_all_linked(txn: &mut PgConnection) -> DatabaseResult<Vec<Linke
   host(ee.address) AS address,
   es.rack_id
  FROM expected_switches es
-  LEFT JOIN switches s ON es.serial_number = s.config->>'name'
+  LEFT JOIN switches s ON es.bmc_mac_address = s.bmc_mac_address
   LEFT JOIN machine_interfaces mi ON es.bmc_mac_address = mi.mac_address
   LEFT JOIN machine_interface_addresses mia ON mi.id = mia.interface_id
   LEFT JOIN explored_endpoints ee ON mia.address = ee.address
@@ -159,7 +159,7 @@ pub async fn find_one_linked(
   s.id AS switch_id,
   es.expected_switch_id
  FROM expected_switches es
-  LEFT JOIN switches s ON es.serial_number = s.config->>'name'
+  LEFT JOIN switches s ON es.bmc_mac_address = s.bmc_mac_address
   ORDER BY es.bmc_mac_address
  LIMIT 1
  "#;
@@ -303,9 +303,9 @@ pub async fn clear(txn: &mut PgConnection) -> Result<(), DatabaseError> {
 /// matches by ID; otherwise matches by bmc_mac_address.
 pub async fn update(txn: &mut PgConnection, switch: &ExpectedSwitch) -> DatabaseResult<()> {
     let (where_clause, target_id) = match switch.expected_switch_id {
-        Some(id) => ("expected_switch_id=$10::uuid", id.to_string()),
+        Some(id) => ("expected_switch_id=$11::uuid", id.to_string()),
         None => (
-            "bmc_mac_address=$10::macaddr",
+            "bmc_mac_address=$11::macaddr",
             switch.bmc_mac_address.to_string(),
         ),
     };
@@ -314,7 +314,7 @@ pub async fn update(txn: &mut PgConnection, switch: &ExpectedSwitch) -> Database
         "UPDATE expected_switches \
          SET bmc_username=$1, bmc_password=$2, serial_number=$3, \
              metadata_name=$4, metadata_description=$5, metadata_labels=$6, \
-             rack_id=$7, nvos_username=$8, nvos_password=$9 \
+             rack_id=$7, nvos_username=$8, nvos_password=$9, nvos_mac_addresses=$10::macaddr[] \
          WHERE {where_clause}"
     );
 
@@ -328,6 +328,7 @@ pub async fn update(txn: &mut PgConnection, switch: &ExpectedSwitch) -> Database
         .bind(&switch.rack_id)
         .bind(&switch.nvos_username)
         .bind(&switch.nvos_password)
+        .bind(&switch.nvos_mac_addresses)
         .bind(&target_id)
         .execute(&mut *txn)
         .await

--- a/crates/api-model/src/switch/mod.rs
+++ b/crates/api-model/src/switch/mod.rs
@@ -190,15 +190,23 @@ impl TryFrom<Switch> for rpc::Switch {
     type Error = RpcDataConversionError;
 
     fn try_from(src: Switch) -> Result<Self, Self::Error> {
-        let status = src.status.map(|s| rpc::SwitchStatus {
-            state_reason: None, // TODO: implement state_reason
-            state_sla: Some(rpc::StateSla {
-                sla: None,
-                time_in_state_above_sla: false,
-            }),
-            switch_name: Some(s.switch_name),
-            power_state: Some(s.power_state),
-            health_status: Some(s.health_status),
+        let state_reason = src.controller_state_outcome.map(|r| r.into());
+        let sla = state_sla(&src.controller_state.value, &src.controller_state.version).into();
+        let status = Some(match src.status {
+            Some(s) => rpc::SwitchStatus {
+                state_reason,
+                state_sla: Some(sla),
+                switch_name: Some(s.switch_name),
+                power_state: Some(s.power_state),
+                health_status: Some(s.health_status),
+            },
+            None => rpc::SwitchStatus {
+                state_reason,
+                state_sla: Some(sla),
+                switch_name: None,
+                power_state: None,
+                health_status: None,
+            },
         });
 
         let config = rpc::SwitchConfig {
@@ -364,6 +372,83 @@ impl Switch {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::controller_outcome::PersistentStateHandlerOutcome;
+
+    #[test]
+    fn try_from_switch_populates_state_reason() {
+        let switch = Switch {
+            id: SwitchId::from(uuid::Uuid::new_v4()),
+            config: SwitchConfig {
+                name: "test-switch".to_string(),
+                enable_nmxc: false,
+                fabric_manager_config: None,
+                location: Some("test-location".to_string()),
+            },
+            status: Some(SwitchStatus {
+                switch_name: "test-switch".to_string(),
+                power_state: "on".to_string(),
+                health_status: "ok".to_string(),
+            }),
+            deleted: None,
+            bmc_mac_address: None,
+            controller_state: Versioned::new(
+                SwitchControllerState::Ready,
+                config_version::ConfigVersion::initial(),
+            ),
+            controller_state_outcome: Some(PersistentStateHandlerOutcome::Transition {
+                source_ref: None,
+            }),
+            switch_reprovisioning_requested: None,
+            firmware_upgrade_status: None,
+        };
+
+        let rpc_switch: rpc::Switch = switch.try_into().unwrap();
+        let status = rpc_switch.status.expect("status should be Some");
+        assert!(
+            status.state_reason.is_some(),
+            "state_reason should be populated from controller_state_outcome"
+        );
+        assert!(status.state_sla.is_some(), "state_sla should be populated");
+        assert_eq!(status.power_state, Some("on".to_string()));
+        assert_eq!(status.health_status, Some("ok".to_string()));
+    }
+
+    #[test]
+    fn try_from_switch_without_status_still_has_state_reason() {
+        let switch = Switch {
+            id: SwitchId::from(uuid::Uuid::new_v4()),
+            config: SwitchConfig {
+                name: "test-switch".to_string(),
+                enable_nmxc: false,
+                fabric_manager_config: None,
+                location: None,
+            },
+            status: None,
+            deleted: None,
+            bmc_mac_address: None,
+            controller_state: Versioned::new(
+                SwitchControllerState::Created,
+                config_version::ConfigVersion::initial(),
+            ),
+            controller_state_outcome: Some(PersistentStateHandlerOutcome::Wait {
+                reason: "waiting for something".to_string(),
+                source_ref: None,
+            }),
+            switch_reprovisioning_requested: None,
+            firmware_upgrade_status: None,
+        };
+
+        let rpc_switch: rpc::Switch = switch.try_into().unwrap();
+        let status = rpc_switch
+            .status
+            .expect("status should be Some even when switch.status is None");
+        assert!(
+            status.state_reason.is_some(),
+            "state_reason should be populated even without switch status"
+        );
+        assert_eq!(status.power_state, None);
+        assert_eq!(status.health_status, None);
+    }
 
     #[test]
     fn serialize_controller_state() {

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -710,11 +710,9 @@ impl Forge for Api {
 
     async fn find_switch_state_histories(
         &self,
-        _request: Request<rpc::SwitchStateHistoriesRequest>,
+        request: Request<rpc::SwitchStateHistoriesRequest>,
     ) -> Result<Response<rpc::SwitchStateHistories>, Status> {
-        Err(Status::unimplemented(
-            "not implemented yet -- under construction",
-        ))
+        crate::handlers::switch::find_switch_state_histories(self, request).await
     }
 
     async fn find_machine_health_histories(

--- a/crates/api/src/handlers/switch.rs
+++ b/crates/api/src/handlers/switch.rs
@@ -20,7 +20,7 @@ use db::switch as db_switch;
 use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
-use crate::api::Api;
+use crate::api::{Api, log_request_data};
 
 pub async fn find_switch(
     api: &Api,
@@ -114,6 +114,47 @@ pub async fn find_switch(
         })?;
 
     Ok(Response::new(rpc::SwitchList { switches }))
+}
+
+pub async fn find_switch_state_histories(
+    api: &Api,
+    request: Request<rpc::SwitchStateHistoriesRequest>,
+) -> Result<Response<rpc::SwitchStateHistories>, Status> {
+    log_request_data(&request);
+    let request = request.into_inner();
+    let switch_ids = request.switch_ids;
+
+    let max_find_by_ids = api.runtime_config.max_find_by_ids as usize;
+    if switch_ids.len() > max_find_by_ids {
+        return Err(CarbideError::InvalidArgument(format!(
+            "no more than {max_find_by_ids} IDs can be accepted"
+        ))
+        .into());
+    } else if switch_ids.is_empty() {
+        return Err(
+            CarbideError::InvalidArgument("at least one ID must be provided".to_string()).into(),
+        );
+    }
+
+    let mut txn = api.txn_begin().await?;
+
+    let results = db::switch_state_history::find_by_switch_ids(&mut txn, &switch_ids)
+        .await
+        .map_err(CarbideError::from)?;
+
+    let mut response = rpc::SwitchStateHistories::default();
+    for (switch_id, records) in results {
+        response.histories.insert(
+            switch_id.to_string(),
+            ::rpc::forge::SwitchStateHistoryRecords {
+                records: records.into_iter().map(Into::into).collect(),
+            },
+        );
+    }
+
+    txn.commit().await?;
+
+    Ok(tonic::Response::new(response))
 }
 
 // TODO: block if switch is in use (firmware update, etc.)

--- a/crates/api/src/tests/expected_switch.rs
+++ b/crates/api/src/tests/expected_switch.rs
@@ -848,3 +848,65 @@ async fn test_replace_all_expected_switches(pool: sqlx::PgPool) {
             .any(|s| s.switch_serial_number == expected_switch_2.switch_serial_number)
     );
 }
+
+/// Verify that find_all_linked joins on bmc_mac_address (not serial_number = config.name).
+#[crate::sqlx_test]
+async fn test_find_all_linked_joins_on_bmc_mac(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+
+    // new_switch creates expected switches and a managed switch linked by bmc_mac_address.
+    // The managed switch config.name is the expected switch's metadata name, NOT the serial number.
+    let switch_id = common::api_fixtures::site_explorer::new_switch(&env, None, None)
+        .await
+        .unwrap();
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let linked = db::expected_switch::find_all_linked(&mut txn)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    // At least one expected switch should be linked to the managed switch.
+    let linked_switch = linked.iter().find(|l| l.switch_id.is_some());
+    assert!(
+        linked_switch.is_some(),
+        "expected at least one linked switch, but all were unlinked"
+    );
+    assert_eq!(
+        linked_switch.unwrap().switch_id.unwrap().to_string(),
+        switch_id.to_string(),
+    );
+}
+
+/// Verify that update persists nvos_mac_addresses.
+#[crate::sqlx_test]
+async fn test_update_persists_nvos_mac_addresses(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let switches = create_expected_switches(&mut txn).await;
+    txn.commit().await.unwrap();
+
+    let original = &switches[0];
+    let new_nvos_mac: MacAddress = "AA:BB:CC:DD:EE:FF".parse().unwrap();
+
+    // Update with new nvos_mac_addresses.
+    let mut updated = original.clone();
+    updated.nvos_mac_addresses = vec![new_nvos_mac];
+
+    let mut txn = env.pool.begin().await.unwrap();
+    db::expected_switch::update(&mut txn, &updated)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    // Read back and verify.
+    let mut txn = env.pool.begin().await.unwrap();
+    let fetched = db::expected_switch::find_by_bmc_mac_address(&mut txn, original.bmc_mac_address)
+        .await
+        .unwrap()
+        .expect("expected switch should exist");
+    txn.commit().await.unwrap();
+
+    assert_eq!(fetched.nvos_mac_addresses, vec![new_nvos_mac]);
+}

--- a/crates/api/src/web/mod.rs
+++ b/crates/api/src/web/mod.rs
@@ -405,6 +405,7 @@ pub fn routes(api: Arc<Api>) -> eyre::Result<NormalizePath<Router>> {
             .route("/rack/{rack_id}", get(rack::detail))
             .route("/switch", get(switch::show_html))
             .route("/switch.json", get(switch::show_json))
+            .route("/switch/{switch_id}", get(switch::detail))
             .route(
                 "/switch/{switch_id}/state-history",
                 get(switch_state_history::show_state_history),

--- a/crates/api/src/web/switch.rs
+++ b/crates/api/src/web/switch.rs
@@ -15,15 +15,18 @@
  * limitations under the License.
  */
 
+use std::str::FromStr;
 use std::sync::Arc;
 
 use askama::Template;
 use axum::Json;
-use axum::extract::State as AxumState;
+use axum::extract::{Path as AxumPath, State as AxumState};
 use axum::response::{Html, IntoResponse, Response};
+use carbide_uuid::switch::SwitchId;
 use hyper::http::StatusCode;
 use rpc::forge::forge_server::Forge;
 
+use super::filters;
 use crate::api::Api;
 
 #[derive(Template)]
@@ -109,4 +112,122 @@ async fn fetch_switches(api: &Api) -> Result<Vec<SwitchRecord>, (http::StatusCod
         .collect();
 
     Ok(switches)
+}
+
+#[derive(Template)]
+#[template(path = "switch_detail.html")]
+struct SwitchDetail {
+    id: String,
+    controller_state: String,
+    name: String,
+    location: String,
+    enable_nmxc: bool,
+    state_reason: Option<rpc::forge::ControllerStateReason>,
+    power_state: Option<String>,
+    health_status: Option<String>,
+    bmc_info: Option<rpc::forge::BmcInfo>,
+}
+
+#[derive(serde::Serialize)]
+struct SwitchDetailJson {
+    id: String,
+    controller_state: String,
+    name: String,
+    location: String,
+    enable_nmxc: bool,
+    power_state: Option<String>,
+    health_status: Option<String>,
+    bmc_ip: Option<String>,
+    bmc_mac: Option<String>,
+}
+
+impl From<rpc::forge::Switch> for SwitchDetail {
+    fn from(switch: rpc::forge::Switch) -> Self {
+        let id = switch
+            .id
+            .as_ref()
+            .map(|id| id.to_string())
+            .unwrap_or_default();
+        let config = switch.config.unwrap_or_default();
+        let state_reason = switch.status.as_ref().and_then(|s| s.state_reason.clone());
+        let power_state = switch.status.as_ref().and_then(|s| s.power_state.clone());
+        let health_status = switch.status.as_ref().and_then(|s| s.health_status.clone());
+        Self {
+            id,
+            controller_state: switch.controller_state,
+            name: config.name,
+            location: config.location.unwrap_or_else(|| "N/A".to_string()),
+            enable_nmxc: config.enable_nmxc,
+            state_reason,
+            power_state,
+            health_status,
+            bmc_info: switch.bmc_info,
+        }
+    }
+}
+
+/// View details about a Switch.
+pub async fn detail(
+    AxumState(api): AxumState<Arc<Api>>,
+    AxumPath(switch_id): AxumPath<String>,
+) -> Response {
+    let (show_json, switch_id) = match switch_id.strip_suffix(".json") {
+        Some(id) => (true, id.to_string()),
+        None => (false, switch_id),
+    };
+
+    let switch = match fetch_switch(&api, &switch_id).await {
+        Ok(Some(switch)) => switch,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                format!("Switch {switch_id} not found"),
+            )
+                .into_response();
+        }
+        Err(response) => return response,
+    };
+
+    let detail = SwitchDetail::from(switch);
+
+    if show_json {
+        let json = SwitchDetailJson {
+            id: detail.id.clone(),
+            controller_state: detail.controller_state.clone(),
+            name: detail.name.clone(),
+            location: detail.location.clone(),
+            enable_nmxc: detail.enable_nmxc,
+            power_state: detail.power_state.clone(),
+            health_status: detail.health_status.clone(),
+            bmc_ip: detail.bmc_info.as_ref().and_then(|b| b.ip.clone()),
+            bmc_mac: detail.bmc_info.as_ref().and_then(|b| b.mac.clone()),
+        };
+        return (StatusCode::OK, Json(json)).into_response();
+    }
+
+    (StatusCode::OK, Html(detail.render().unwrap())).into_response()
+}
+
+async fn fetch_switch(api: &Api, switch_id: &str) -> Result<Option<rpc::forge::Switch>, Response> {
+    let switch_id_parsed = match SwitchId::from_str(switch_id) {
+        Ok(id) => id,
+        Err(_) => return Err((StatusCode::BAD_REQUEST, "Invalid switch ID").into_response()),
+    };
+
+    let response = match api
+        .find_switches(tonic::Request::new(rpc::forge::SwitchQuery {
+            name: None,
+            switch_id: Some(switch_id_parsed),
+        }))
+        .await
+    {
+        Ok(response) => response.into_inner(),
+        Err(err) if err.code() == tonic::Code::NotFound => return Ok(None),
+        Err(err) => {
+            tracing::error!(%err, %switch_id, "fetch_switch");
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response());
+        }
+    };
+
+    Ok(response.switches.into_iter().next())
 }

--- a/crates/api/templates/switch.html
+++ b/crates/api/templates/switch.html
@@ -32,7 +32,7 @@
                             <tbody>
                             {% for switch in switches %}
                             <tr>
-                                <td>{{ switch.id }}</td>
+                                <td><a href="/admin/switch/{{ switch.id }}">{{ switch.id }}</a></td>
                                 <td>{{ switch.name }}</td>
                                 <td>{{ switch.state }}</td>
                                 <td>{{ switch.location }}</td>

--- a/crates/api/templates/switch_detail.html
+++ b/crates/api/templates/switch_detail.html
@@ -1,0 +1,137 @@
+{% extends "base.html" %}
+
+{% block title %}Switch {{ id }}{% endblock %}
+
+{% block content %}
+<div id="json">
+	<a id="json-link" href="">JSON</a>
+</div>
+<h1>Switch {{ id }}</h1>
+
+<h2>Info</h2>
+<table class="detailsview">
+	<tr>
+		<th>ID</th>
+		<td>{{ id }}</td>
+	</tr>
+	<tr>
+		<th>State</th>
+		<td>
+			{% if controller_state.to_lowercase().contains("failed") %}
+				<span class="bubble error">{{ controller_state }}</span>
+			{% else if controller_state == "Ready" %}
+				<span class="bubble success">{{ controller_state }}</span>
+			{% else %}
+				<span class="bubble">{{ controller_state }}</span>
+			{% endif %}
+		</td>
+	</tr>
+	<tr>
+		<th>State Reason</th>
+		<td>{{ state_reason|controller_state_reason_fmt|safe }}</td>
+	</tr>
+	{% if let Some(power_state) = power_state %}
+	<tr>
+		<th>Power State</th>
+		<td>{{ power_state }}</td>
+	</tr>
+	{% endif %}
+	{% if let Some(health_status) = health_status %}
+	<tr>
+		<th>Health Status</th>
+		<td>
+			{% if health_status == "ok" || health_status == "OK" %}
+				<span class="bubble success">{{ health_status }}</span>
+			{% else if health_status == "critical" || health_status == "Critical" %}
+				<span class="bubble error">{{ health_status }}</span>
+			{% else %}
+				<span class="bubble warning">{{ health_status }}</span>
+			{% endif %}
+		</td>
+	</tr>
+	{% endif %}
+</table>
+
+<h2>Metadata</h2>
+<table class="detailsview">
+	<tr>
+		<th>Name</th>
+		<td>{{ name }}</td>
+	</tr>
+	<tr>
+		<th>Location</th>
+		<td>{{ location }}</td>
+	</tr>
+	<tr>
+		<th>Enable NMXC</th>
+		<td>{{ enable_nmxc }}</td>
+	</tr>
+</table>
+
+<h2>Health</h2>
+<table class="detailsview">
+	{% if let Some(health_status) = health_status %}
+	<tr>
+		<th>Health Status</th>
+		<td>{{ health_status }}</td>
+	</tr>
+	{% else %}
+	<tr>
+		<td colspan="2" class="text-muted">No health data available.</td>
+	</tr>
+	{% endif %}
+</table>
+
+<h2>Maintenance and Quarantine</h2>
+<p>TBD</p>
+
+<h2>BMC</h2>
+<table class="detailsview">
+	{% if let Some(bmc_info) = bmc_info %}
+	{% if let Some(ip) = bmc_info.ip %}
+	<tr>
+		<th>BMC IP</th>
+		<td>{{ ip }}</td>
+	</tr>
+	{% endif %}
+	{% if let Some(port) = bmc_info.port %}
+	<tr>
+		<th>BMC Port</th>
+		<td>{{ port }}</td>
+	</tr>
+	{% endif %}
+	{% if let Some(mac) = bmc_info.mac %}
+	<tr>
+		<th>BMC MAC</th>
+		<td>{{ mac }}</td>
+	</tr>
+	{% endif %}
+	{% if let Some(version) = bmc_info.version %}
+	<tr>
+		<th>BMC Version</th>
+		<td>{{ version }}</td>
+	</tr>
+	{% endif %}
+	{% if let Some(firmware_version) = bmc_info.firmware_version %}
+	<tr>
+		<th>BMC Firmware Version</th>
+		<td>{{ firmware_version }}</td>
+	</tr>
+	{% endif %}
+	{% else %}
+	<tr>
+		<td colspan="2" class="text-muted">No BMC info available.</td>
+	</tr>
+	{% endif %}
+</table>
+
+<h2>Discovery Info</h2>
+<p>TBD</p>
+
+<h2>Interfaces</h2>
+<p>TBD</p>
+
+<h2>History</h2>
+<a href="/admin/switch/{{ id }}/state-history">Open State History</a>
+
+{% endblock %}


### PR DESCRIPTION
## Description

Ran through an exercise pulling in a switch this evening. Found a few things along the way. Ultimately was `Ready` when it was done.

This includes:
- Fixing the `find_all_linked` query to join on `bmc_mac_address` (component linking wasn't working)
- Implementing `find_switch_state_histories`; it was a `TODO`, and we have the history, so lets implement it.
- Fixing the `expected-machine update` flow to pass through the `nvos_mac_address` when provided (and making it so it works in the web UI).
- Wired up `state_reason` in the web UI so it doesn't always show "Unknown" for state.
- Creating a Switch detail page (`/switch/<switch-id>`) with proper linkage.

In addition to fixing plumbing for display in the web UI, this also fixes similar plumbing in `managed-switch show`.

Added tests.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

