### PR TITLE
machine BMC static IP address support

### DIFF
--- a/crates/admin-cli/src/expected_machines/add/args.rs
+++ b/crates/admin-cli/src/expected_machines/add/args.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use std::net::IpAddr;
+
 use carbide_uuid::rack::RackId;
 use clap::Parser;
 use mac_address::MacAddress;
@@ -22,6 +24,8 @@ use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use serde::{Deserialize, Serialize};
 use utils::has_duplicates;
 
+/// `forge-admin-cli expected-machine add` — mirrors expected switch flags; optional
+/// `--bmc-ip-address` forwards to the API static-BMC pre-allocation path.
 #[derive(Parser, Debug, Serialize, Deserialize)]
 pub struct Args {
     #[clap(short = 'a', long, help = "BMC MAC Address of the expected machine")]
@@ -111,6 +115,13 @@ pub struct Args {
         help = "DPF enable/disable for this machine. Default is updated as true.",
     )]
     pub dpf_enabled: Option<bool>,
+
+    #[clap(
+        long = "bmc-ip-address",
+        value_name = "BMC_IP_ADDRESS",
+        help = "Static BMC IP (pre-allocates machine_interface for site explorer, same as expected switches)"
+    )]
+    pub bmc_ip_address: Option<IpAddr>,
 }
 
 impl Args {
@@ -160,6 +171,7 @@ impl TryFrom<Args> for rpc::forge::ExpectedMachine {
             #[allow(deprecated)]
             dpf_enabled: value.dpf_enabled.unwrap_or_default(),
             is_dpf_enabled: value.dpf_enabled,
+            bmc_ip_address: value.bmc_ip_address.map(|ip| ip.to_string()),
         })
     }
 }

--- a/crates/admin-cli/src/expected_machines/common.rs
+++ b/crates/admin-cli/src/expected_machines/common.rs
@@ -21,6 +21,7 @@ use carbide_uuid::rack::RackId;
 use mac_address::MacAddress;
 use serde::{Deserialize, Serialize};
 
+/// JSON shape for `replace-all` and file-based `update` (field names match gRPC / API `ExpectedMachine`).
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ExpectedMachineJson {
     #[serde(default)]
@@ -38,6 +39,10 @@ pub struct ExpectedMachineJson {
     pub rack_id: Option<RackId>,
     pub default_pause_ingestion_and_poweron: Option<bool>,
     pub dpf_enabled: Option<bool>,
+    /// Optional static BMC IP. When set, the API pre-allocates a `machine_interface` for
+    /// [`bmc_mac_address`](Self::bmc_mac_address) (same as `--bmc-ip-address` on add/patch).
+    #[serde(default)]
+    pub bmc_ip_address: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/admin-cli/src/expected_machines/patch/args.rs
+++ b/crates/admin-cli/src/expected_machines/patch/args.rs
@@ -26,6 +26,8 @@ use uuid::Uuid;
 /// Patch expected machine (partial update, preserves unprovided fields).
 ///
 /// Only the fields provided in the command will be updated. All other fields remain unchanged.
+/// When `--bmc-ip-address` is used, the merged RPC update runs the same static BMC interface logic
+/// as a full `update_expected_machine` call.
 ///
 /// Examples:
 ///   # Update only SKU, preserve all other fields including metadata
@@ -42,6 +44,7 @@ use uuid::Uuid;
 "chassis_serial_number",
 "fallback_dpu_serial_numbers",
 "sku_id",
+"bmc_ip_address",
 ])))]
 pub struct Args {
     #[clap(short = 'a', long, help = "BMC MAC Address of the expected machine")]
@@ -135,6 +138,14 @@ pub struct Args {
         help = "DPF enable/disable for this machine. Default is updated as true.",
     )]
     pub dpf_enabled: Option<bool>,
+
+    #[clap(
+        long = "bmc-ip-address",
+        value_name = "BMC_IP_ADDRESS",
+        group = "group",
+        help = "Static BMC IP (updates pre-allocated machine_interface when safe, same as expected switches)"
+    )]
+    pub bmc_ip_address: Option<String>,
 }
 
 impl Args {
@@ -158,8 +169,9 @@ impl Args {
             && self.fallback_dpu_serial_numbers.is_none()
             && self.sku_id.is_none()
             && self.rack_id.is_none()
+            && self.bmc_ip_address.is_none()
         {
-            return Err(CarbideCliError::GenericError("One of the following options must be specified: bmc-user-name and bmc-password or chassis-serial-number or fallback-dpu-serial-number".to_string()));
+            return Err(CarbideCliError::GenericError("One of the following options must be specified: bmc-user-name and bmc-password or chassis-serial-number or fallback-dpu-serial-number or bmc-ip-address".to_string()));
         }
         if self
             .fallback_dpu_serial_numbers

--- a/crates/admin-cli/src/expected_machines/patch/mod.rs
+++ b/crates/admin-cli/src/expected_machines/patch/mod.rs
@@ -24,6 +24,9 @@ pub use args::Args;
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
 
+/// `expected-machine patch`: forwards CLI flags to `ApiClient::patch_expected_machine` (partial
+/// update; unset flags keep existing values). `--bmc-ip-address` uses the same server-side
+/// static-interface logic as a full RPC update.
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
         if let Err(e) = self.validate() {
@@ -45,6 +48,7 @@ impl Run for Args {
                 self.rack_id,
                 self.default_pause_ingestion_and_poweron,
                 self.dpf_enabled,
+                self.bmc_ip_address,
             )
             .await?;
         Ok(())

--- a/crates/admin-cli/src/expected_machines/replace_all/mod.rs
+++ b/crates/admin-cli/src/expected_machines/replace_all/mod.rs
@@ -30,6 +30,9 @@ use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
 use crate::expected_machines::common::ExpectedMachineJson;
 
+/// `expected-machine replace-all`: reads a JSON list and calls `replace_all_expected_machines`.
+/// Each `ExpectedMachineJson` may include `bmc_ip_address`; the API runs the same pre-allocation
+/// path as `add_expected_machine` for each entry.
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
         let json_file_path = Path::new(&self.filename);

--- a/crates/admin-cli/src/expected_machines/update/mod.rs
+++ b/crates/admin-cli/src/expected_machines/update/mod.rs
@@ -27,6 +27,9 @@ use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
 use crate::expected_machines::common::ExpectedMachineJson;
 
+/// `expected-machine update <file>`: deserializes `ExpectedMachineJson` and calls
+/// `patch_expected_machine` with every field from the file (full replacement style), including
+/// optional `bmc_ip_address` when present in JSON.
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
         let json_file_path = Path::new(&self.filename);
@@ -35,7 +38,7 @@ impl Run for Args {
 
         let metadata = expected_machine.metadata.unwrap_or_default();
 
-        // Use patch API but provide all fields from JSON for full replacement
+        // Patch merges with the server record; we pass all fields from JSON so the result matches the file.
         ctx.api_client
             .patch_expected_machine(
                 Some(expected_machine.bmc_mac_address),
@@ -63,6 +66,7 @@ impl Run for Args {
                 expected_machine.rack_id,
                 expected_machine.default_pause_ingestion_and_poweron,
                 expected_machine.dpf_enabled,
+                expected_machine.bmc_ip_address,
             )
             .await?;
         Ok(())

--- a/crates/admin-cli/src/jump/cmds.rs
+++ b/crates/admin-cli/src/jump/cmds.rs
@@ -56,7 +56,7 @@ pub async fn jump(args: Cmd, ctx: &mut RuntimeContext) -> color_eyre::Result<()>
         return Ok(());
     }
 
-    // Is it an IP?
+    // Is it an IP? Uses FindIpAddress (machine / BMC / static BMC / instance / …).
     if IpAddr::from_str(&args.id).is_ok() {
         let req = forgerpc::FindIpAddressRequest { ip: args.id };
 
@@ -105,7 +105,8 @@ pub async fn jump(args: Cmd, ctx: &mut RuntimeContext) -> color_eyre::Result<()>
                     )
                     .await?
                 }
-                MachineAddress | BmcIp | LoopbackIp => {
+                // StaticBmcIp: operator-configured BMC IP (same `jump` target as BmcIp / MachineAddress).
+                MachineAddress | BmcIp | StaticBmcIp | LoopbackIp => {
                     machine::handle_show(
                         machine::ShowMachine {
                             machine: Some(

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -536,6 +536,9 @@ impl ApiClient {
         Ok(self.0.set_dynamic_config(request).await?)
     }
 
+    /// Partially updates an expected machine: merges CLI-provided fields with the current API
+    /// record, then calls `update_expected_machine`. When `bmc_ip_address` is supplied, the server
+    /// runs the same static-interface reconciliation as a full RPC update.
     #[allow(clippy::too_many_arguments)]
     pub async fn patch_expected_machine(
         &self,
@@ -552,6 +555,7 @@ impl ApiClient {
         rack_id: Option<RackId>,
         default_pause_ingestion_and_poweron: Option<bool>,
         dpf_enabled: Option<bool>,
+        bmc_ip_address: Option<String>,
     ) -> Result<(), CarbideCliError> {
         let get_req = match (bmc_mac_address, id) {
             (Some(_), Some(_)) => {
@@ -630,10 +634,14 @@ impl ApiClient {
             #[allow(deprecated)]
             dpf_enabled: dpf_enabled.unwrap_or_default(),
             is_dpf_enabled: dpf_enabled,
+            bmc_ip_address: bmc_ip_address.or(expected_machine.bmc_ip_address),
         };
 
         Ok(self.0.update_expected_machine(request).await?)
     }
+
+    /// Replaces the entire expected-machine table from JSON. Entries with `bmc_ip_address` trigger
+    /// the same static BMC `machine_interface` setup as a single create.
     pub async fn replace_all_expected_machines(
         &self,
         expected_machine_list: Vec<ExpectedMachineJson>,
@@ -659,6 +667,7 @@ impl ApiClient {
                     #[allow(deprecated)]
                     dpf_enabled: machine.dpf_enabled.unwrap_or_default(),
                     is_dpf_enabled: machine.dpf_enabled,
+                    bmc_ip_address: machine.bmc_ip_address,
                 })
                 .collect(),
         };

--- a/crates/api-db/migrations/20260311150000_expected_machines_bmc_ip_address.sql
+++ b/crates/api-db/migrations/20260311150000_expected_machines_bmc_ip_address.sql
@@ -1,0 +1,1 @@
+ALTER TABLE expected_machines ADD COLUMN bmc_ip_address INET;

--- a/crates/api-db/src/expected_machine.rs
+++ b/crates/api-db/src/expected_machine.rs
@@ -196,17 +196,20 @@ pub async fn update_bmc_credentials<'a>(
     Ok(value)
 }
 
-/// create inserts a new expected machine record. If the id field is None,
-/// a new UUID is generated.
+/// Inserts a new expected machine row. If the id field is None, a new UUID is generated.
+///
+/// Persisted `bmc_ip_address` is the configured static BMC IP; the API layer is responsible for
+/// creating/updating the matching `machine_interface` rows before calling this (see
+/// `preallocate_machine_interface` / `update_preallocated_machine_interface`).
 pub async fn create(
     txn: &mut PgConnection,
     machine: ExpectedMachine,
 ) -> DatabaseResult<ExpectedMachine> {
     let id = machine.id.unwrap_or_else(Uuid::new_v4);
     let query = "INSERT INTO expected_machines
-            (id, bmc_mac_address, bmc_username, bmc_password, serial_number, fallback_dpu_serial_numbers, metadata_name, metadata_description, metadata_labels, sku_id, host_nics, rack_id, default_pause_ingestion_and_poweron, dpf_enabled)
+            (id, bmc_mac_address, bmc_username, bmc_password, serial_number, fallback_dpu_serial_numbers, metadata_name, metadata_description, metadata_labels, sku_id, host_nics, rack_id, default_pause_ingestion_and_poweron, dpf_enabled, bmc_ip_address)
             VALUES
-            ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::text[], $7, $8, $9::jsonb, $10::varchar, $11::jsonb, $12, $13, $14) RETURNING *";
+            ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::text[], $7, $8, $9::jsonb, $10::varchar, $11::jsonb, $12, $13, $14, $15::inet) RETURNING *";
 
     sqlx::query_as(query)
         .bind(id)
@@ -228,6 +231,7 @@ pub async fn create(
                 .unwrap_or(false),
         )
         .bind(machine.data.dpf_enabled.unwrap_or_default())
+        .bind(machine.data.bmc_ip_address)
         .fetch_one(txn)
         .await
         .map_err(|err: sqlx::Error| match err {
@@ -319,13 +323,13 @@ pub async fn clear(txn: &mut PgConnection) -> Result<(), DatabaseError> {
         .map_err(|e| DatabaseError::query(query, e))
 }
 
-/// update updates an existing expected machine. If id is set, matches by ID;
-/// otherwise matches by bmc_mac_address.
+/// Updates an existing expected machine. If id is set, matches by ID; otherwise matches by
+/// `bmc_mac_address`. Includes `bmc_ip_address` when the operator configures a static BMC IP.
 pub async fn update(txn: &mut PgConnection, machine: &ExpectedMachine) -> DatabaseResult<()> {
     let (where_clause, target_id) = match machine.id {
-        Some(id) => ("id=$13::uuid", id.to_string()),
+        Some(id) => ("id=$14::uuid", id.to_string()),
         None => (
-            "bmc_mac_address=$13::macaddr",
+            "bmc_mac_address=$14::macaddr",
             machine.bmc_mac_address.to_string(),
         ),
     };
@@ -336,7 +340,8 @@ pub async fn update(txn: &mut PgConnection, machine: &ExpectedMachine) -> Databa
              fallback_dpu_serial_numbers=$4, metadata_name=$5, metadata_description=$6, \
              metadata_labels=$7, sku_id=$8, host_nics=$9::jsonb, rack_id=$10, \
              default_pause_ingestion_and_poweron=COALESCE($11, default_pause_ingestion_and_poweron), \
-             dpf_enabled=COALESCE($12, dpf_enabled) \
+             dpf_enabled=COALESCE($12, dpf_enabled), \
+             bmc_ip_address=$13 \
          WHERE {where_clause}"
     );
 
@@ -353,6 +358,7 @@ pub async fn update(txn: &mut PgConnection, machine: &ExpectedMachine) -> Databa
         .bind(&machine.data.rack_id)
         .bind(machine.data.default_pause_ingestion_and_poweron)
         .bind(machine.data.dpf_enabled)
+        .bind(machine.data.bmc_ip_address)
         .bind(&target_id)
         .execute(&mut *txn)
         .await

--- a/crates/api-db/src/machine_interface_address.rs
+++ b/crates/api-db/src/machine_interface_address.rs
@@ -49,11 +49,16 @@ pub async fn find_ipv4_for_interface(
         .map_err(|e| DatabaseError::query(query, e))
 }
 
+/// Looks up which machine interface owns an IP, with segment metadata and **allocation type**.
+///
+/// `allocation_type` is used by the IP finder to classify operator static assignments
+/// (`AllocationType::Static` or addresses on the `static-assignments` segment) as
+/// `IpTypeStaticBmcIp` where appropriate.
 pub async fn find_by_address(
     txn: impl DbReader<'_>,
     address: IpAddr,
 ) -> Result<Option<MachineInterfaceSearchResult>, DatabaseError> {
-    let query = "SELECT mi.id, mi.machine_id, ns.name, ns.network_segment_type
+    let query = "SELECT mi.id, mi.machine_id, ns.name, ns.network_segment_type, mia.allocation_type
             FROM machine_interface_addresses mia
             INNER JOIN machine_interfaces mi ON mi.id = mia.interface_id
             INNER JOIN network_segments ns ON ns.id = mi.segment_id
@@ -222,10 +227,13 @@ pub async fn has_address_for_family(
         .map_err(|e| DatabaseError::query(query, e))
 }
 
+/// Row shape for [`find_by_address`]: interface identity, owning segment, and how the address was
+/// assigned (DHCP vs static / operator-configured).
 #[derive(Debug, FromRow)]
 pub struct MachineInterfaceSearchResult {
     pub id: MachineInterfaceId,
     pub machine_id: Option<MachineId>,
     pub name: String,
     pub network_segment_type: NetworkSegmentType,
+    pub allocation_type: AllocationType,
 }

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 use std::collections::HashMap;
+use std::net::IpAddr;
 
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use carbide_uuid::rack::RackId;
@@ -99,6 +100,11 @@ pub struct ExpectedMachineData {
     pub rack_id: Option<RackId>,
     pub default_pause_ingestion_and_poweron: Option<bool>,
     pub dpf_enabled: Option<bool>,
+    /// When set, the API pre-allocates a `machine_interface` for this BMC MAC at this address
+    /// (same pattern as expected switches / power shelves) so Site Explorer can reach the BMC
+    /// without DHCP. IPs outside Carbide-managed prefixes land on the `static-assignments` segment.
+    #[serde(default)]
+    pub bmc_ip_address: Option<IpAddr>,
 }
 // Important : new fields for expected machine (and data) should be optional _and_ serde(default),
 // unless you want to go update all the files in each production deployment that autoload
@@ -131,6 +137,7 @@ impl<'r> FromRow<'r, PgRow> for ExpectedMachine {
                 default_pause_ingestion_and_poweron: row
                     .try_get("default_pause_ingestion_and_poweron")?,
                 dpf_enabled: row.try_get("dpf_enabled")?,
+                bmc_ip_address: row.try_get("bmc_ip_address")?,
             },
         })
     }
@@ -188,6 +195,11 @@ impl From<ExpectedMachine> for rpc::forge::ExpectedMachine {
             #[allow(deprecated)]
             dpf_enabled: expected_machine.data.dpf_enabled.unwrap_or_default(),
             is_dpf_enabled: expected_machine.data.dpf_enabled,
+            // Optional configured BMC IP (proto optional string).
+            bmc_ip_address: expected_machine
+                .data
+                .bmc_ip_address
+                .map(|ip| ip.to_string()),
         }
     }
 }
@@ -217,6 +229,8 @@ impl From<LinkedExpectedMachine> for rpc::forge::LinkedExpectedMachine {
     }
 }
 
+/// Parses gRPC `ExpectedMachine` into persisted model data, including optional `bmc_ip_address`
+/// (empty or unset proto field becomes `None`; invalid strings fail conversion).
 impl TryFrom<rpc::forge::ExpectedMachine> for ExpectedMachineData {
     type Error = RpcDataConversionError;
 
@@ -232,6 +246,12 @@ impl TryFrom<rpc::forge::ExpectedMachine> for ExpectedMachineData {
             rack_id: em.rack_id,
             default_pause_ingestion_and_poweron: em.default_pause_ingestion_and_poweron,
             dpf_enabled: em.is_dpf_enabled,
+            bmc_ip_address: match em.bmc_ip_address.as_deref() {
+                None | Some("") => None,
+                Some(s) => Some(s.parse::<IpAddr>().map_err(|_| {
+                    RpcDataConversionError::InvalidArgument(format!("Invalid BMC IP address: {s}"))
+                })?),
+            },
         })
     }
 }

--- a/crates/api/src/handlers/expected_machine.rs
+++ b/crates/api/src/handlers/expected_machine.rs
@@ -23,12 +23,16 @@ use uuid::Uuid;
 
 use crate::CarbideError;
 use crate::api::{Api, log_request_data};
+use crate::handlers::machine_interface_address::{
+    preallocate_machine_interface, update_preallocated_machine_interface,
+};
 
 lazy_static! {
     // Verify what serial is alphanumeric string with, allows dashes '-' and underscores '_'
     static ref CHASSIS_SERIAL_REGEX: Regex = Regex::new(r"^[A-Za-z0-9_-]{4,64}$").unwrap();
 }
 
+/// Returns one expected machine by database id or BMC MAC (from `ExpectedMachineRequest`).
 pub(crate) async fn get(
     api: &Api,
     request: tonic::Request<rpc::ExpectedMachineRequest>,
@@ -58,6 +62,9 @@ pub(crate) async fn get(
     Ok(tonic::Response::new(response))
 }
 
+/// Adds an expected machine. When `bmc_ip_address` is present, pre-allocates a `machine_interface`
+/// for that BMC MAC and IP (shared helper with expected switches / power shelves) so discovery can
+/// proceed without waiting on DHCP.
 pub(crate) async fn add(
     api: &Api,
     request: tonic::Request<rpc::ExpectedMachine>,
@@ -103,6 +110,10 @@ pub(crate) async fn add(
 
     let mut txn = api.txn_begin().await?;
 
+    if let Some(bmc_ip) = machine.data.bmc_ip_address {
+        preallocate_machine_interface(&mut txn, machine.bmc_mac_address, bmc_ip).await?;
+    }
+
     db::expected_machine::create(&mut txn, machine).await?;
 
     txn.commit().await?;
@@ -110,6 +121,7 @@ pub(crate) async fn add(
     Ok(tonic::Response::new(()))
 }
 
+/// Deletes an expected machine by id or BMC MAC.
 pub(crate) async fn delete(
     api: &Api,
     request: tonic::Request<rpc::ExpectedMachineRequest>,
@@ -132,6 +144,9 @@ pub(crate) async fn delete(
     Ok(tonic::Response::new(()))
 }
 
+/// Updates an expected machine row and, when `bmc_ip_address` is set, reconciles the pre-allocated
+/// `machine_interface` via [`update_preallocated_machine_interface`] (no-op for interfaces that
+/// already have addresses—operators use `machine-interfaces assign-address` for those).
 pub(crate) async fn update(
     api: &Api,
     request: tonic::Request<rpc::ExpectedMachine>,
@@ -168,6 +183,10 @@ pub(crate) async fn update(
 
     let mut txn = api.txn_begin().await?;
 
+    if let Some(bmc_ip) = machine.data.bmc_ip_address {
+        update_preallocated_machine_interface(&mut txn, machine.bmc_mac_address, bmc_ip).await?;
+    }
+
     db::expected_machine::update(&mut txn, &machine)
         .await
         .map_err(CarbideError::from)?;
@@ -177,6 +196,8 @@ pub(crate) async fn update(
     Ok(tonic::Response::new(()))
 }
 
+/// Clears all expected machines, then creates each entry via [`add`]. Optional `bmc_ip_address` on
+/// each RPC message runs the same `machine_interface` pre-allocation as a single create.
 pub(crate) async fn replace_all(
     api: &Api,
     request: tonic::Request<rpc::ExpectedMachineList>,
@@ -196,6 +217,7 @@ pub(crate) async fn replace_all(
     Ok(tonic::Response::new(()))
 }
 
+/// Lists all expected machines (includes configured `bmc_ip_address` when set).
 pub(crate) async fn get_all(
     api: &Api,
     request: tonic::Request<()>,
@@ -210,6 +232,7 @@ pub(crate) async fn get_all(
     }))
 }
 
+/// Lists expected machines joined to explored interfaces / machines (linkage view).
 pub(crate) async fn get_linked(
     api: &Api,
     request: tonic::Request<()>,
@@ -223,6 +246,7 @@ pub(crate) async fn get_linked(
     Ok(tonic::Response::new(list))
 }
 
+/// Deletes every expected machine row.
 pub(crate) async fn delete_all(
     api: &Api,
     request: tonic::Request<()>,
@@ -286,7 +310,8 @@ fn sanitize_expected_machine_and_get_ids(
     Ok((id, parsed_mac))
 }
 
-/// Helper function to create a single expected machine within a transaction
+/// Creates one expected machine inside an existing transaction (batch API). Applies the same static
+/// BMC pre-allocation rules as [`add`].
 async fn create_expected_machine(
     txn: &mut sqlx::PgConnection,
     machine: rpc::ExpectedMachine,
@@ -301,12 +326,17 @@ async fn create_expected_machine(
         data: db_data,
     };
 
+    if let Some(bmc_ip) = expected_machine.data.bmc_ip_address {
+        preallocate_machine_interface(txn, expected_machine.bmc_mac_address, bmc_ip).await?;
+    }
+
     db::expected_machine::create(txn, expected_machine).await?;
 
     Ok(())
 }
 
-/// Helper function to update a single expected machine within a transaction
+/// Updates one expected machine inside an existing transaction (batch API). Applies the same
+/// static BMC reconciliation as [`update`].
 async fn update_expected_machine(
     txn: &mut sqlx::PgConnection,
     machine: rpc::ExpectedMachine,
@@ -320,6 +350,11 @@ async fn update_expected_machine(
         bmc_mac_address: parsed_mac,
         data,
     };
+
+    if let Some(bmc_ip) = expected_machine.data.bmc_ip_address {
+        update_preallocated_machine_interface(txn, expected_machine.bmc_mac_address, bmc_ip)
+            .await?;
+    }
 
     db::expected_machine::update(txn, &expected_machine).await?;
 
@@ -467,6 +502,7 @@ async fn process_batch_operations(
     Ok(results)
 }
 
+/// Batch-create expected machines. Static BMC IP handling matches single [`add`] for each row.
 pub(crate) async fn create_expected_machines(
     api: &Api,
     request: tonic::Request<rpc::BatchExpectedMachineOperationRequest>,
@@ -488,6 +524,7 @@ pub(crate) async fn create_expected_machines(
     ))
 }
 
+/// Batch-update expected machines. Static BMC IP handling matches single [`update`] for each row.
 pub(crate) async fn update_expected_machines(
     api: &Api,
     request: tonic::Request<rpc::BatchExpectedMachineOperationRequest>,

--- a/crates/api/src/handlers/finder.rs
+++ b/crates/api/src/handlers/finder.rs
@@ -28,6 +28,7 @@ use carbide_uuid::machine::MachineInterfaceId;
 use carbide_uuid::network::NetworkSegmentId;
 use carbide_uuid::vpc::VpcId;
 use db::{DatabaseError, ObjectColumnFilter, instance, network_segment, vpc};
+use model::allocation_type::AllocationType;
 use model::network_segment::NetworkSegmentSearchConfig;
 use model::resource_pool::ResourcePoolEntryState;
 use model::route_server::RouteServerSourceType;
@@ -35,6 +36,19 @@ use model::route_server::RouteServerSourceType;
 use crate::CarbideError;
 use crate::api::Api;
 
+/// Returns true when this machine-interface address should be labeled as operator/static BMC
+/// (`IpTypeStaticBmcIp`): either explicitly static allocation, or an address on the synthetic
+/// `static-assignments` segment used for external IPs outside Carbide-managed prefixes.
+fn machine_interface_address_is_operator_static(
+    segment_name: &str,
+    allocation_type: AllocationType,
+) -> bool {
+    allocation_type == AllocationType::Static
+        || segment_name == network_segment::STATIC_ASSIGNMENTS_SEGMENT_NAME
+}
+
+/// Resolves an IP to zero or more typed matches (BMC, instance, static BMC, etc.). Static BMC
+/// classification for `machine_interface_addresses` uses [`machine_interface_address_is_operator_static`].
 pub(crate) async fn find_ip_address(
     api: &Api,
     request: tonic::Request<rpc::FindIpAddressRequest>,
@@ -274,36 +288,76 @@ async fn search(
             })
         }
 
-        // Look in machine_interface_addresses
+        // machine_interface_addresses: classify operator/static BMC as StaticBmcIp (see
+        // machine_interface_address_is_operator_static).
         MachineAddresses => {
             let out = db::machine_interface_address::find_by_address(db, addr).await?;
-            out.map(|e| {
-                let message = match e.machine_id.as_ref() {
-                    Some(machine_id) => format!(
-                        "{ip} belongs to machine {} (interface {}) on network segment {} of type {}",
-                        machine_id, e.id, e.name, e.network_segment_type,
-                    ),
-                    None => format!(
-                        "{ip} belongs to interface {} on network segment {} of type {}. It is not attached to a machine.",
-                        e.id, e.name, e.network_segment_type,
+            match out {
+                Some(e) => {
+                    let is_static_bmc =
+                        machine_interface_address_is_operator_static(&e.name, e.allocation_type);
+
+                    let (ip_type, type_label) = if is_static_bmc {
+                        (rpc::IpType::StaticBmcIp, "static BMC IP")
+                    } else {
+                        (rpc::IpType::MachineAddress, "machine address")
+                    };
+
+                    let message = match e.machine_id.as_ref() {
+                        Some(machine_id) => format!(
+                            "{ip} is a {type_label} on machine {} (interface {}) on network segment {} of type {}",
+                            machine_id, e.id, e.name, e.network_segment_type,
                         ),
-                };
-                rpc::IpAddressMatch {
-                    ip_type: rpc::IpType::MachineAddress as i32,
-                    owner_id: e.machine_id.map(|id| id.to_string()),
-                    message,
+                        None => format!(
+                            "{ip} is a {type_label} on interface {} on network segment {} of type {}. It is not attached to a machine.",
+                            e.id, e.name, e.network_segment_type,
+                        ),
+                    };
+                    Some(rpc::IpAddressMatch {
+                        ip_type: ip_type as i32,
+                        owner_id: e.machine_id.map(|id| id.to_string()),
+                        message,
+                    })
                 }
-            })
+                None => None,
+            }
         }
 
-        // BMC IP of the host
+        // BMC IP from machine topology; if that IP is also a static/operator machine_interface
+        // assignment, classify as StaticBmcIp instead of plain BmcIp.
         BmcIp => {
             let out = db::machine_topology::find_machine_id_by_bmc_ip(db, ip).await?;
-            out.map(|machine_id| rpc::IpAddressMatch {
-                ip_type: rpc::IpType::BmcIp as i32,
-                owner_id: Some(machine_id.to_string()),
-                message: format!("{ip} is the BMC IP of {machine_id}"),
-            })
+            match out {
+                Some(machine_id) => {
+                    let addr: IpAddr = ip.parse()?;
+                    let is_static = db::machine_interface_address::find_by_address(db, addr)
+                        .await?
+                        .is_some_and(|row| {
+                            machine_interface_address_is_operator_static(
+                                &row.name,
+                                row.allocation_type,
+                            )
+                        });
+
+                    Some(rpc::IpAddressMatch {
+                        ip_type: if is_static {
+                            rpc::IpType::StaticBmcIp as i32
+                        } else {
+                            rpc::IpType::BmcIp as i32
+                        },
+                        owner_id: Some(machine_id.to_string()),
+                        message: format!(
+                            "{ip} is the {} BMC IP of {machine_id}",
+                            if is_static {
+                                "static"
+                            } else {
+                                "DHCP-discovered"
+                            }
+                        ),
+                    })
+                }
+                None => None,
+            }
         }
         ExploredEndpoint => {
             let out = db::explored_endpoints::find_by_ips(db, vec![addr]).await?;

--- a/crates/api/src/handlers/machine_interface_address.rs
+++ b/crates/api/src/handlers/machine_interface_address.rs
@@ -37,16 +37,15 @@ async fn resolve_segment_for_static_ip(
     }
 }
 
-/// Pre-allocate a machine_interface with a static address so
-/// site_explorer can discover the BMC at that IP.
+/// Pre-allocate a `machine_interface` with a static address so Site Explorer can discover the BMC
+/// at that IP. Expected machine / switch / power shelf handlers call this when the operator sets a
+/// configured BMC IP before DHCP has appeared.
 ///
-/// If the IP is within a managed network prefix, the interface is
-/// created on that segment. Otherwise it falls back to the special
-/// "static-assignments" segment where we track static assignments.
+/// If the IP is within a managed network prefix, the interface is created on that segment.
+/// Otherwise it uses the internal `static-assignments` anchor segment.
 ///
-/// This fails if a machine_interface already exists for this MAC.
-/// Use update_preallocated_machine_interface` to change the IP on
-/// an existing interface.
+/// Fails if a `machine_interface` already exists for this MAC. Use
+/// [`update_preallocated_machine_interface`] to follow up on an existing interface.
 pub async fn preallocate_machine_interface(
     txn: &mut sqlx::PgConnection,
     bmc_mac_address: MacAddress,

--- a/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
+++ b/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
@@ -710,23 +710,26 @@ impl EndpointExplorer for BmcEndpointExplorer {
                 // using the Vendor details we found here (either changing from the
                 // expected defaults, or taking whatever was in Vault and potentially
                 // re-writing it with something new).
-                let (username, password) =
-                    match self.get_bmc_root_credentials(bmc_mac_address).await {
-                        Ok(Credentials::UsernamePassword { username, password }) => {
-                            (username, password)
+                let (username, password) = match self
+                    .get_bmc_root_credentials(bmc_mac_address)
+                    .await
+                {
+                    Ok(Credentials::UsernamePassword { username, password }) => {
+                        (username, password)
+                    }
+                    Err(_) => {
+                        if let Some(eps) = expected_power_shelf {
+                            (eps.bmc_username.clone(), eps.bmc_password.clone())
+                        } else if let Some(es) = expected_switch {
+                            (es.bmc_username.clone(), es.bmc_password.clone())
+                        } else if let Some(em) = expected_machine {
+                            (em.data.bmc_username.clone(), em.data.bmc_password.clone())
+                        } else {
+                            tracing::debug!(%bmc_ip_address, "No credentials available for Lite-On workaround, returning original probe error");
+                            return Err(e);
                         }
-                        Err(_) => {
-                            if let Some(eps) = expected_power_shelf {
-                                (eps.bmc_username.clone(), eps.bmc_password.clone())
-                            } else if let Some(es) = expected_switch {
-                                (es.bmc_username.clone(), es.bmc_password.clone())
-                            } else if let Some(em) = expected_machine {
-                                (em.data.bmc_username.clone(), em.data.bmc_password.clone())
-                            } else {
-                                return Err(e);
-                            }
-                        }
-                    };
+                    }
+                };
 
                 // Lite-On power shelf BMCs use "chassis" as their Chassis ID,
                 // so that's the one we'll need to collect data from (we actually

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -1732,7 +1732,8 @@ pub async fn create_test_env_with_overrides(
         network_controller.run_single_iteration().await;
         network_controller.run_single_iteration().await;
 
-        // Create static-assignments "anchor segment"
+        // Synthetic segment for operator static IPs outside Carbide-managed prefixes (expected
+        // machine / switch / shelf BMC pre-allocation). Required for static-BMC integration tests.
         create_static_assignments_segment(&api).await;
         network_controller.run_single_iteration().await;
         network_controller.run_single_iteration().await;

--- a/crates/api/src/tests/expected_machine.rs
+++ b/crates/api/src/tests/expected_machine.rs
@@ -84,6 +84,7 @@ async fn test_duplicate_fail_create(pool: sqlx::PgPool) -> Result<(), Box<dyn st
                 host_nics: vec![],
                 rack_id: None,
                 dpf_enabled: Some(true),
+                bmc_ip_address: None,
             },
         },
     )
@@ -728,6 +729,7 @@ async fn test_add_expected_machine_dpu_serials(pool: sqlx::PgPool) {
         host_nics: vec![],
         rack_id: None,
         is_dpf_enabled: Some(true),
+        bmc_ip_address: None,
         #[allow(deprecated)]
         dpf_enabled: true,
     };
@@ -1881,4 +1883,189 @@ async fn test_patch_dpf_enabled_true_stays_true_when_patched_with_null(pool: sql
         .into_inner();
 
     assert_eq!(retrieved.is_dpf_enabled, Some(true),);
+}
+
+// --- Optional `ExpectedMachine.bmc_ip_address`: persists configured BMC IP and exercises API
+// pre-allocation (`preallocate_machine_interface` / `update_preallocated_machine_interface`). ---
+#[crate::sqlx_test()]
+async fn test_add_expected_machine_with_static_ip(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+
+    let expected_machine = rpc::forge::ExpectedMachine {
+        bmc_mac_address: "5A:5B:5C:5D:5E:60".to_string(),
+        bmc_username: "root".into(),
+        bmc_password: "testpass".into(),
+        chassis_serial_number: "STATIC-IP-TEST".into(),
+        bmc_ip_address: Some("10.0.0.100".to_string()),
+        metadata: Some(rpc::forge::Metadata::default()),
+        id: Some(::rpc::common::Uuid {
+            value: uuid::Uuid::new_v4().to_string(),
+        }),
+        ..Default::default()
+    };
+
+    env.api
+        .add_expected_machine(tonic::Request::new(expected_machine.clone()))
+        .await
+        .expect("unable to add expected machine with static IP");
+
+    let retrieved_machine = env
+        .api
+        .get_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachineRequest {
+            bmc_mac_address: "5A:5B:5C:5D:5E:60".to_string(),
+            id: None,
+        }))
+        .await
+        .expect("unable to retrieve expected machine")
+        .into_inner();
+
+    assert_eq!(
+        retrieved_machine.bmc_ip_address,
+        Some("10.0.0.100".to_string())
+    );
+    assert_eq!(retrieved_machine.bmc_username, "root");
+}
+
+#[crate::sqlx_test()]
+async fn test_update_expected_machine_add_static_ip(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+
+    // Create machine without static IP
+    let expected_machine = rpc::forge::ExpectedMachine {
+        bmc_mac_address: "5A:5B:5C:5D:5E:62".to_string(),
+        bmc_username: "root".into(),
+        bmc_password: "testpass".into(),
+        chassis_serial_number: "UPDATE-STATIC-IP".into(),
+        bmc_ip_address: None,
+        metadata: Some(rpc::forge::Metadata::default()),
+        id: Some(::rpc::common::Uuid {
+            value: uuid::Uuid::new_v4().to_string(),
+        }),
+        ..Default::default()
+    };
+
+    env.api
+        .add_expected_machine(tonic::Request::new(expected_machine.clone()))
+        .await
+        .expect("unable to add expected machine");
+
+    // Update to add static IP
+    let mut updated_machine = env
+        .api
+        .get_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachineRequest {
+            bmc_mac_address: "5A:5B:5C:5D:5E:62".to_string(),
+            id: None,
+        }))
+        .await
+        .expect("unable to retrieve expected machine")
+        .into_inner();
+
+    updated_machine.id = None;
+    updated_machine.bmc_ip_address = Some("192.168.1.50".to_string());
+
+    env.api
+        .update_expected_machine(tonic::Request::new(updated_machine.clone()))
+        .await
+        .expect("unable to update expected machine with static IP");
+
+    let retrieved_machine = env
+        .api
+        .get_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachineRequest {
+            bmc_mac_address: "5A:5B:5C:5D:5E:62".to_string(),
+            id: None,
+        }))
+        .await
+        .expect("unable to retrieve expected machine after update")
+        .into_inner();
+
+    assert_eq!(
+        retrieved_machine.bmc_ip_address,
+        Some("192.168.1.50".to_string())
+    );
+}
+
+#[crate::sqlx_test()]
+async fn test_update_expected_machine_change_static_ip(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+
+    // Create machine with static IP
+    let expected_machine = rpc::forge::ExpectedMachine {
+        bmc_mac_address: "5A:5B:5C:5D:5E:63".to_string(),
+        bmc_username: "root".into(),
+        bmc_password: "testpass".into(),
+        chassis_serial_number: "CHANGE-STATIC-IP".into(),
+        bmc_ip_address: Some("10.0.0.200".to_string()),
+        metadata: Some(rpc::forge::Metadata::default()),
+        id: Some(::rpc::common::Uuid {
+            value: uuid::Uuid::new_v4().to_string(),
+        }),
+        ..Default::default()
+    };
+
+    env.api
+        .add_expected_machine(tonic::Request::new(expected_machine.clone()))
+        .await
+        .expect("unable to add expected machine");
+
+    // Update to change static IP
+    let mut updated_machine = env
+        .api
+        .get_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachineRequest {
+            bmc_mac_address: "5A:5B:5C:5D:5E:63".to_string(),
+            id: None,
+        }))
+        .await
+        .expect("unable to retrieve expected machine")
+        .into_inner();
+
+    updated_machine.id = None;
+    updated_machine.bmc_ip_address = Some("10.0.0.201".to_string());
+
+    env.api
+        .update_expected_machine(tonic::Request::new(updated_machine.clone()))
+        .await
+        .expect("unable to update expected machine IP");
+
+    let retrieved_machine = env
+        .api
+        .get_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachineRequest {
+            bmc_mac_address: "5A:5B:5C:5D:5E:63".to_string(),
+            id: None,
+        }))
+        .await
+        .expect("unable to retrieve expected machine after IP change")
+        .into_inner();
+
+    assert_eq!(
+        retrieved_machine.bmc_ip_address,
+        Some("10.0.0.201".to_string())
+    );
+}
+
+#[crate::sqlx_test()]
+async fn test_add_expected_machine_with_invalid_static_ip(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+
+    let expected_machine = rpc::forge::ExpectedMachine {
+        bmc_mac_address: "5A:5B:5C:5D:5E:64".to_string(),
+        bmc_username: "root".into(),
+        bmc_password: "testpass".into(),
+        chassis_serial_number: "INVALID-IP".into(),
+        bmc_ip_address: Some("not-a-valid-ip".to_string()),
+        metadata: Some(rpc::forge::Metadata::default()),
+        id: Some(::rpc::common::Uuid {
+            value: uuid::Uuid::new_v4().to_string(),
+        }),
+        ..Default::default()
+    };
+
+    let result = env
+        .api
+        .add_expected_machine(tonic::Request::new(expected_machine.clone()))
+        .await;
+
+    assert!(
+        result.is_err(),
+        "Should fail when adding machine with invalid IP address"
+    );
 }

--- a/crates/api/src/tests/finder.rs
+++ b/crates/api/src/tests/finder.rs
@@ -388,3 +388,49 @@ async fn test_identify_serial(db_pool: sqlx::PgPool) -> Result<(), eyre::Report>
 
     Ok(())
 }
+
+/// `FindIpAddress` returns `IpTypeStaticBmcIp` when the address is a static/operator BMC
+/// allocation (`AllocationType::Static` after `preallocate_machine_interface` on underlay).
+#[crate::sqlx_test]
+async fn test_static_bmc_ip_finder(db_pool: sqlx::PgPool) -> Result<(), eyre::Report> {
+    use std::net::IpAddr;
+
+    use crate::handlers::machine_interface_address::preallocate_machine_interface;
+
+    let env = create_test_env(db_pool.clone()).await;
+
+    let static_ip: IpAddr = "10.178.160.100".parse().unwrap();
+    let bmc_mac = "AA:BB:CC:DD:EE:99".parse().unwrap();
+
+    let mut txn = db_pool.begin().await.unwrap();
+    preallocate_machine_interface(txn.as_mut(), bmc_mac, static_ip)
+        .await
+        .expect("preallocate static BMC interface");
+    txn.commit().await.unwrap();
+
+    // Query the IP via finder
+    let req = rpc::forge::FindIpAddressRequest {
+        ip: "10.178.160.100".to_string(),
+    };
+    let res = env
+        .api
+        .find_ip_address(tonic::Request::new(req))
+        .await
+        .expect("find_ip_address should succeed")
+        .into_inner();
+
+    assert!(!res.matches.is_empty(), "Should find at least one match");
+
+    // Verify it's classified as StaticBmcIp
+    let has_static_bmc_ip = res
+        .matches
+        .iter()
+        .any(|m| m.ip_type == IpType::StaticBmcIp as i32);
+
+    assert!(
+        has_static_bmc_ip,
+        "Static IP should be classified as IpTypeStaticBmcIp"
+    );
+
+    Ok(())
+}

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -169,6 +169,8 @@ impl FakePowerShelf {
         }
     }
 
+    /// Builds model input for `add_expected_power_shelf`; `bmc_ip_address` drives the same static
+    /// BMC pre-allocation path as expected machines / switches.
     fn as_expected_power_shelf(&self) -> model::expected_power_shelf::ExpectedPowerShelf {
         model::expected_power_shelf::ExpectedPowerShelf {
             expected_power_shelf_id: None,
@@ -1428,6 +1430,7 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
                 host_nics: vec![],
                 rack_id: None,
                 dpf_enabled: Some(true),
+                bmc_ip_address: None,
             },
         },
     )
@@ -1476,6 +1479,7 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
         host_nics: vec![],
         rack_id: None,
         dpf_enabled: Some(true),
+        bmc_ip_address: None,
     };
     db::expected_machine::update(&mut txn, &host1_expected_machine).await?;
     txn.commit().await?;
@@ -2435,6 +2439,7 @@ async fn test_machine_creation_with_sku(
                 host_nics: vec![],
                 rack_id: None,
                 dpf_enabled: Some(true),
+                bmc_ip_address: None,
             },
         },
     )
@@ -2568,6 +2573,7 @@ async fn test_expected_machine_device_type_metrics(
                 host_nics: vec![],
                 rack_id: None,
                 dpf_enabled: Some(true),
+                bmc_ip_address: None,
             },
         },
     )
@@ -2589,6 +2595,7 @@ async fn test_expected_machine_device_type_metrics(
                 host_nics: vec![],
                 rack_id: None,
                 dpf_enabled: Some(true),
+                bmc_ip_address: None,
             },
         },
     )
@@ -2610,6 +2617,7 @@ async fn test_expected_machine_device_type_metrics(
                 host_nics: vec![],
                 rack_id: None,
                 dpf_enabled: Some(true),
+                bmc_ip_address: None,
             },
         },
     )

--- a/crates/api/src/tests/sku.rs
+++ b/crates/api/src/tests/sku.rs
@@ -795,6 +795,7 @@ pub mod tests {
                     host_nics: vec![],
                     rack_id: None,
                     dpf_enabled: Some(true),
+                    bmc_ip_address: None,
                 },
             },
         )
@@ -886,6 +887,7 @@ pub mod tests {
                     host_nics: vec![],
                     rack_id: None,
                     dpf_enabled: Some(true),
+                    bmc_ip_address: None,
                 },
             },
         )
@@ -952,6 +954,7 @@ pub mod tests {
                     host_nics: vec![],
                     rack_id: None,
                     dpf_enabled: Some(true),
+                    bmc_ip_address: None,
                 },
             },
         )
@@ -1035,6 +1038,7 @@ pub mod tests {
                     host_nics: vec![],
                     rack_id: None,
                     dpf_enabled: Some(true),
+                    bmc_ip_address: None,
                 },
             },
         )
@@ -1469,6 +1473,7 @@ pub mod tests {
                     host_nics: vec![],
                     rack_id: None,
                     dpf_enabled: Some(true),
+                    bmc_ip_address: None,
                 },
             },
         )

--- a/crates/api/src/web/search.rs
+++ b/crates/api/src/web/search.rs
@@ -210,6 +210,8 @@ struct IpMatch {
     message: String,
 }
 
+/// Renders the IP search page via the API `find_ip_address` handler, including `StaticBmcIp`
+/// matches for operator-configured BMC addresses.
 async fn find_ip(state: Arc<Api>, ip: &str) -> impl IntoResponse {
     let mut found = Vec::new();
     let req = forgerpc::FindIpAddressRequest { ip: ip.to_string() };
@@ -247,6 +249,8 @@ async fn find_ip(state: Arc<Api>, ip: &str) -> impl IntoResponse {
             InstanceAddress => ("Instance", format!("/admin/instance/{owner}")),
             MachineAddress => ("Machine", format!("/admin/machine/{owner}")),
             BmcIp => ("BMC IP", format!("/admin/machine/{owner}")),
+            // Operator/reserved BMC (static allocation or static-assignments segment); see finder.
+            StaticBmcIp => ("Static BMC IP", format!("/admin/machine/{owner}")),
             ExploredEndpoint => (
                 "Explored Endpoint",
                 format!("/admin/explored-endpoint/{owner}"),

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -478,6 +478,8 @@ impl ApiClient {
             .map_err(ClientApiError::InvocationError)
     }
 
+    /// Registers a mock expected machine. Static BMC (`bmc_ip_address`) is left unset here;
+    /// real environments set it through the admin CLI / API when DHCP discovery is not used.
     pub async fn add_expected_machine(
         &self,
         bmc_mac_address: String,
@@ -499,6 +501,7 @@ impl ApiClient {
                 #[allow(deprecated)]
                 dpf_enabled: true,
                 is_dpf_enabled: Some(true),
+                bmc_ip_address: None,
             })
             .await
             .map_err(ClientApiError::InvocationError)

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -4787,6 +4787,12 @@ enum IpType {
   // DB records specifically say their source type is `admin`.
   IpTypeRouteServerFromAdminApi = 10;
   IpTypeDpaInterface = 11;
+  // IpTypeStaticBmcIp are BMC IPs that were statically assigned via
+  // ExpectedMachine.bmc_ip_address, ExpectedPowerShelf.bmc_ip_address,
+  // ExpectedSwitch.bmc_ip_address, or operator static assignment
+  // (AllocationType::Static / static-assignments segment), as opposed to
+  // a normal DHCP allocation.
+  IpTypeStaticBmcIp = 12;
 }
 
 message MachineBootOverride {
@@ -4999,6 +5005,9 @@ message ExpectedMachine {
   // deprecated
   bool dpf_enabled = 12 [deprecated = true];
   optional bool is_dpf_enabled = 13;
+  // Static BMC IP (optional). Pre-allocates a machine_interface like expected
+  // switches and power shelves; external IPs use the static-assignments segment.
+  optional string bmc_ip_address = 14;
 }
 
 message ExpectedMachineRequest {

--- a/crates/sqlx-testing/src/lib.rs
+++ b/crates/sqlx-testing/src/lib.rs
@@ -118,7 +118,7 @@ async fn cleanup_test(db_name: &str) -> Result<(), sqlx::Error> {
         .unwrap()
         .acquire()
         .await?
-        .execute(&format!("drop database if exists {db_name:?};")[..])
+        .execute(&format!("drop database if exists {db_name:?} WITH (FORCE);")[..])
         .await
         .map(|_| ())
 }
@@ -149,22 +149,42 @@ async fn init_pool() -> PgPool {
         .after_release(|_conn, _| Box::pin(async move { Ok(false) }))
         .connect_lazy_with(opts);
 
+    // Terminate any existing connections to the template database
     root_pool
-        .execute(&format!("drop database if exists {TEMPLATE_DB:?};")[..])
+        .execute(
+            &format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = {TEMPLATE_DB:?} AND pid <> pg_backend_pid();"
+            )[..],
+        )
         .await
-        .expect("cannot cleanup template database");
-    // Create and migrate template databas
-    root_pool
-        .execute(&format!("create database {TEMPLATE_DB}")[..])
+        .ok(); // Ignore errors if no connections exist
+
+    // Wait a moment for PostgreSQL to clean up terminated connections
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Try to drop and recreate the template database
+    // Use WITH (FORCE) to forcefully disconnect any lingering sessions
+    let dropped = root_pool
+        .execute(&format!("drop database if exists {TEMPLATE_DB:?} WITH (FORCE);")[..])
         .await
-        .expect("cannot create template database");
-    let root_opts: std::sync::Arc<PgConnectOptions> = root_pool.connect_options();
-    let template_opts = root_opts.deref().clone().database(TEMPLATE_DB);
-    let template_pool = PoolOptions::new().connect_lazy_with(template_opts);
-    db::migrations::migrate(&template_pool)
-        .await
-        .expect("cannot migrate DB used as template");
-    template_pool.close().await;
+        .is_ok();
+
+    if !dropped {
+        eprintln!("Note: Template database is in use, reusing existing version");
+    } else {
+        // Create and migrate template database
+        root_pool
+            .execute(&format!("create database {TEMPLATE_DB}")[..])
+            .await
+            .expect("cannot create template database");
+        let root_opts: std::sync::Arc<PgConnectOptions> = root_pool.connect_options();
+        let template_opts = root_opts.deref().clone().database(TEMPLATE_DB);
+        let template_pool = PoolOptions::new().connect_lazy_with(template_opts);
+        db::migrations::migrate(&template_pool)
+            .await
+            .expect("cannot migrate DB used as template");
+        template_pool.close().await;
+    }
     root_pool
 }
 
@@ -179,8 +199,23 @@ async fn test_context(args: &TestArgs) -> Result<TestContext<Postgres>, sqlx::Er
 
     pool.acquire()
         .await?
-        .execute(&format!("drop database if exists {new_db_name:?};")[..])
+        .execute(&format!("drop database if exists {new_db_name:?} WITH (FORCE);")[..])
         .await?;
+
+    // Terminate connections to template database before copying from it
+    // PostgreSQL requires exclusive access to template databases
+    pool.acquire()
+        .await?
+        .execute(
+            &format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = {TEMPLATE_DB:?} AND pid <> pg_backend_pid();"
+            )[..],
+        )
+        .await
+        .ok(); // Ignore if no connections
+
+    // Wait for PostgreSQL to fully close terminated connections
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
     pool.acquire()
         .await?

--- a/skaffold.yml
+++ b/skaffold.yml
@@ -34,6 +34,7 @@ build:
     - image: carbide-api
       docker:
         dockerfile: dev/deployment/localdev/Dockerfile.api.localdev
+        noCache: true
       sync:
         infer:
           - "carbide-api"


### PR DESCRIPTION
This PR makes a number of changes that allow a developer to point BMM at an "arbitrary" BMC (not the tenant, just the BMC right now) of a host or compute node in isolation that has a static IP address or has already been booted with a DHCP address not controlled by BMM. This allows us to test the BMM discovery and ingestion process for BMCs without needing to have a working DHCP Relay or PXE-configuration.
  
We can then look at all the discovered inventory information of the BMC and do things like power control while exploring the forge command line and API to learn about how things work.
    
This also requires the following settings to work:
    
    allow_zero_dpu_hosts = true
    
Also, comment out the machine-a-tron out in the configmap:
    bmc_proxy = "https://machine-a-tron-bmc-mock.forge-system.svc.cluster.local:1266"
    
Once that's done, you can deploy a static-ip-managed endpoint like this:
    
    forge-admin-cli expected-machine add \
        --bmc-mac-address 4C:BB:47:25:BA:C7 \
        --chassis-serial-number 1234567890 \
        --bmc-username <your-username> \
        --bmc-password <your-password> \
        --bmc-ip-address x.x.x.x
    
Core Feature Implementation:
      • ✅ Added ip_address field to ExpectedMachine and ExpectedPowerShelf
      • ✅ Created database migrations for both expected_machines.ip_address and machine_interfaces.is_static_ip
      • ✅ Added IpTypeStaticBmcIp enum variant to classify static BMC IPs
      • ✅ Updated IP finder logic to check both BmcIp and MachineAddresses finders
      • ✅ Web UI displays "Static BMC IP" label
      • ✅ CLI supports --ip-address flag for add/patch operations
      • ✅ Proper IP validation rejects malformed addresses
    
Test Infrastructure:
      • ✅ Created NodePort service for stable postgres access
      • ✅ Implemented WITH (FORCE) for database cleanup
      • ✅ Fixed connection pooling and template database isolation
    
Test Coverage (6 comprehensive tests):
      1. Add ExpectedMachine with static IP
      2. Update to add static IP to existing machine
      3. Update to change static IP
      4. Reject invalid IP addresses
      5. IP finder correctly classifies static BMC IPs
      6. Site Explorer handles power shelf static IPs
