### PR TITLE
Create a metric for enqueued object times for state controllers

### DIFF
--- a/crates/api/src/state_controller/controller/builder.rs
+++ b/crates/api/src/state_controller/controller/builder.rs
@@ -179,9 +179,13 @@ impl<IO: StateControllerIO> Builder<IO> {
             StateControllerBuildError::MissingArgument("work_lock_manager_handle"),
         )?;
 
-        let period_enqueuer_metric_emitter = meter
-            .clone()
-            .map(|meter| EnqueuerMetricsEmitter::new(&controller_name, &meter));
+        let period_enqueuer_metric_emitter = meter.clone().map(|meter| {
+            EnqueuerMetricsEmitter::new(
+                &controller_name,
+                &meter,
+                self.iteration_config.metric_hold_time,
+            )
+        });
 
         let enqueuer = PeriodicEnqueuer::<IO> {
             pool: database.clone(),

--- a/crates/api/src/state_controller/controller/db.rs
+++ b/crates/api/src/state_controller/controller/db.rs
@@ -17,11 +17,13 @@
 
 //! Database access methods used in the StateController framework
 
+use db::db_read::DbReader;
 use db::work_lock_manager::{AcquireLockError, WorkLockManagerHandle};
 use db::{BIND_LIMIT, DatabaseError};
 use sqlx::{PgConnection, PgPool};
 
 use crate::api::TransactionVending;
+use crate::state_controller::controller::periodic_enqueuer::QueueWaitMetricsSnapshot;
 use crate::state_controller::controller::{
     ControllerIteration, ControllerIterationId, LockedControllerIteration, QueuedObject,
 };
@@ -160,6 +162,48 @@ pub async fn queue_objects(
     }
 
     Ok(num_enqueued)
+}
+
+/// Calculates wait-time snapshot metrics for queued objects that have not started processing yet.
+pub async fn fetch_queue_wait_metrics(
+    db: impl DbReader<'_>,
+    table_id: &'static str,
+) -> Result<QueueWaitMetricsSnapshot, DatabaseError> {
+    #[derive(sqlx::FromRow)]
+    struct QueueWaitMetricsRow {
+        num_waiting_objects: i64,
+        oldest_wait_seconds: f64,
+        mean_wait_seconds: f64,
+        p50_wait_seconds: f64,
+        p95_wait_seconds: f64,
+        p99_wait_seconds: f64,
+    }
+
+    let query = format!(
+        "SELECT
+            COUNT(*) AS num_waiting_objects,
+            COALESCE(EXTRACT(EPOCH FROM MAX(now() - processing_started_at)), 0)::double precision AS oldest_wait_seconds,
+            COALESCE(EXTRACT(EPOCH FROM AVG(now() - processing_started_at)), 0)::double precision AS mean_wait_seconds,
+            COALESCE(percentile_cont(0.50) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM now() - processing_started_at)), 0)::double precision AS p50_wait_seconds,
+            COALESCE(percentile_cont(0.95) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM now() - processing_started_at)), 0)::double precision AS p95_wait_seconds,
+            COALESCE(percentile_cont(0.99) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM now() - processing_started_at)), 0)::double precision AS p99_wait_seconds
+        FROM {table_id}
+        WHERE processed_by IS NULL"
+    );
+
+    let result = sqlx::query_as::<_, QueueWaitMetricsRow>(&query)
+        .fetch_one(db)
+        .await
+        .map_err(|e| DatabaseError::new("StateController::fetch_queue_wait_metrics", e))?;
+
+    Ok(QueueWaitMetricsSnapshot {
+        num_waiting_objects: result.num_waiting_objects.max(0) as u64,
+        oldest_wait_seconds: result.oldest_wait_seconds,
+        mean_wait_seconds: result.mean_wait_seconds,
+        p50_wait_seconds: result.p50_wait_seconds,
+        p95_wait_seconds: result.p95_wait_seconds,
+        p99_wait_seconds: result.p99_wait_seconds,
+    })
 }
 
 /// Fetches all objects which have been queued for execution

--- a/crates/api/src/state_controller/controller/periodic_enqueuer.rs
+++ b/crates/api/src/state_controller/controller/periodic_enqueuer.rs
@@ -19,10 +19,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ::db::work_lock_manager::WorkLockManagerHandle;
+use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Counter, Histogram, Meter};
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 
+use crate::logging::metrics_utils::SharedMetricsHolder;
 use crate::periodic_timer::PeriodicTimer;
 use crate::state_controller::config::IterationConfig;
 use crate::state_controller::controller::{
@@ -218,9 +220,12 @@ impl<IO: StateControllerIO> PeriodicEnqueuer<IO> {
         // The transactions for listing and enqueuing are decoupled to avoid
         // any locking side-effects
         let mut txn = self.pool.begin().await?;
+        // Get wait time before inserting: We should expect the typical "number of objects waiting"
+        // to be zero in the common case.
+        iteration_metrics.queue_wait_metrics =
+            db::fetch_queue_wait_metrics(txn.as_mut(), IO::DB_QUEUED_OBJECTS_TABLE_NAME).await?;
         iteration_metrics.num_enqueued_objects =
             db::queue_objects(&mut txn, IO::DB_QUEUED_OBJECTS_TABLE_NAME, &queued_objects).await?;
-
         txn.commit().await?;
 
         Ok(())
@@ -238,6 +243,8 @@ pub(super) struct PeriodicEnqueuerMetrics {
     pub iteration_id: Option<ControllerIterationId>,
     /// The amount of objects which have been enqueued in this run
     pub num_enqueued_objects: usize,
+    /// Snapshot metrics for queued objects that are still waiting to be processed
+    pub queue_wait_metrics: QueueWaitMetricsSnapshot,
 }
 
 impl Default for PeriodicEnqueuerMetrics {
@@ -247,18 +254,76 @@ impl Default for PeriodicEnqueuerMetrics {
             recording_finished_at: std::time::Instant::now(),
             iteration_id: None,
             num_enqueued_objects: 0,
+            queue_wait_metrics: QueueWaitMetricsSnapshot::default(),
         }
     }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct QueueWaitMetricsSnapshot {
+    pub num_waiting_objects: u64,
+    pub oldest_wait_seconds: f64,
+    pub mean_wait_seconds: f64,
+    pub p50_wait_seconds: f64,
+    pub p95_wait_seconds: f64,
+    pub p99_wait_seconds: f64,
 }
 
 #[derive(Debug)]
 pub(super) struct EnqueuerMetricsEmitter {
     enqueuer_iteration_latency: Histogram<f64>,
     num_enqueued_objects_counter: Counter<u64>,
+    queue_wait_metrics: SharedMetricsHolder<QueueWaitMetricsSnapshot>,
 }
 
 impl EnqueuerMetricsEmitter {
-    pub(super) fn new(object_type: &str, meter: &Meter) -> Self {
+    pub(super) fn new(object_type: &str, meter: &Meter, metric_hold_time: Duration) -> Self {
+        let fresh_period = metric_hold_time.saturating_add(Duration::from_secs(60));
+        let queue_wait_metrics =
+            SharedMetricsHolder::<QueueWaitMetricsSnapshot>::with_fresh_period(fresh_period);
+
+        {
+            let metrics = queue_wait_metrics.clone();
+            meter
+                .u64_observable_gauge(format!("{object_type}_queued_objects_waiting"))
+                .with_description(format!(
+                    "The number of {object_type} objects currently waiting in the queued-objects table"
+                ))
+                .with_callback(move |observer| {
+                    metrics.if_available(|metrics, attrs| {
+                        observer.observe(metrics.num_waiting_objects, attrs);
+                    });
+                })
+                .build();
+        }
+
+        {
+            let metrics = queue_wait_metrics.clone();
+            meter
+                .f64_observable_gauge(format!("{object_type}_queued_object_wait_time"))
+                .with_description(format!(
+                    "Snapshot statistics for how long queued {object_type} objects have been waiting to start processing"
+                ))
+                .with_unit("s")
+                .with_callback(move |observer| {
+                    metrics.if_available(|metrics, attrs| {
+                        for (stat, value) in [
+                            ("oldest", metrics.oldest_wait_seconds),
+                            ("mean", metrics.mean_wait_seconds),
+                            ("p50", metrics.p50_wait_seconds),
+                            ("p95", metrics.p95_wait_seconds),
+                            ("p99", metrics.p99_wait_seconds),
+                        ] {
+                            observer.observe(
+                                value,
+                                &[attrs, &[KeyValue::new("stat", stat)]].concat(),
+                            );
+                        }
+                    });
+                })
+                .build();
+        }
+
         let enqueuer_iteration_latency = meter
             .f64_histogram(format!("{object_type}_enqueuer_iteration_latency"))
             .with_description(format!(
@@ -277,6 +342,7 @@ impl EnqueuerMetricsEmitter {
         Self {
             enqueuer_iteration_latency,
             num_enqueued_objects_counter,
+            queue_wait_metrics,
         }
     }
 
@@ -292,6 +358,8 @@ impl EnqueuerMetricsEmitter {
 
         self.num_enqueued_objects_counter
             .add(iteration_metrics.num_enqueued_objects as u64, &[]);
+        self.queue_wait_metrics
+            .update(iteration_metrics.queue_wait_metrics.clone());
     }
 
     /// Emits the metrics that had been collected during a state controller iteration
@@ -314,5 +382,62 @@ impl EnqueuerMetricsEmitter {
         if let Some(iteration_id) = iteration_metrics.iteration_id.as_ref() {
             span.record("iteration_id", iteration_id.0);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+    use crate::tests::common::test_meter::TestMeter;
+
+    #[test]
+    fn test_enqueuer_queue_wait_metrics_are_exported() {
+        let test_meter = TestMeter::default();
+        let emitter =
+            EnqueuerMetricsEmitter::new("test_objects", &test_meter.meter(), Duration::MAX);
+
+        let mut iteration_metrics = PeriodicEnqueuerMetrics::default();
+        iteration_metrics.queue_wait_metrics = QueueWaitMetricsSnapshot {
+            num_waiting_objects: 4,
+            oldest_wait_seconds: 42.0,
+            mean_wait_seconds: 21.0,
+            p50_wait_seconds: 20.0,
+            p95_wait_seconds: 39.0,
+            p99_wait_seconds: 41.0,
+        };
+
+        emitter.emit_iteration_counters_and_histograms(&iteration_metrics);
+
+        assert_eq!(
+            test_meter.formatted_metric("test_objects_queued_objects_waiting{fresh=\"true\"}"),
+            Some("4".to_string())
+        );
+        assert_eq!(
+            test_meter.parsed_metrics("test_objects_queued_object_wait_time_seconds"),
+            vec![
+                (
+                    "{fresh=\"true\",stat=\"mean\"}".to_string(),
+                    "21".to_string()
+                ),
+                (
+                    "{fresh=\"true\",stat=\"oldest\"}".to_string(),
+                    "42".to_string()
+                ),
+                (
+                    "{fresh=\"true\",stat=\"p50\"}".to_string(),
+                    "20".to_string()
+                ),
+                (
+                    "{fresh=\"true\",stat=\"p95\"}".to_string(),
+                    "39".to_string()
+                ),
+                (
+                    "{fresh=\"true\",stat=\"p99\"}".to_string(),
+                    "41".to_string()
+                ),
+            ]
+        );
     }
 }

--- a/crates/api/src/tests/state_controller.rs
+++ b/crates/api/src/tests/state_controller.rs
@@ -393,6 +393,40 @@ async fn test_queue_objects(pool: sqlx::PgPool) -> sqlx::Result<()> {
     Ok(())
 }
 
+#[crate::sqlx_test]
+async fn test_fetch_queue_wait_metrics(pool: sqlx::PgPool) -> eyre::Result<()> {
+    create_test_state_controller_tables(&pool).await;
+
+    let mut txn = pool.begin().await?;
+    sqlx::query(
+        "INSERT INTO test_state_controller_queued_objects(object_id, processed_by, processing_started_at)
+         VALUES
+            ('waiting-1', NULL, now() - interval '10 seconds'),
+            ('waiting-2', NULL, now() - interval '20 seconds'),
+            ('waiting-3', NULL, now() - interval '30 seconds'),
+            ('running-1', 'processor-a', now() - interval '300 seconds')",
+    )
+    .execute(&mut *txn)
+    .await?;
+
+    let metrics = controller::db::fetch_queue_wait_metrics(
+        txn.as_mut(),
+        TestStateControllerIO::DB_QUEUED_OBJECTS_TABLE_NAME,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(metrics.num_waiting_objects, 3);
+    assert!((metrics.oldest_wait_seconds - 30.0).abs() < 2.0);
+    assert!((metrics.mean_wait_seconds - 20.0).abs() < 2.0);
+    assert!((metrics.p50_wait_seconds - 20.0).abs() < 2.0);
+    assert!((metrics.p95_wait_seconds - 29.0).abs() < 2.0);
+    assert!((metrics.p99_wait_seconds - 29.8).abs() < 2.0);
+    txn.commit().await?;
+
+    Ok(())
+}
+
 #[derive(Debug, Default)]
 struct TestStateControllerIO {}
 


### PR DESCRIPTION
## Description

This creates a metric that samples how long state controller objects (e.g. machines) are currently waiting to be processed after being enqueued. It is gathered immediately before enqueuing metrics, as part of periodic_enqueuer.

This builds the duration stats manually rather than using a native prometheus histogram, because the queue age is essentially "state", not an event. We could instead emit an event for how long an object was waiting every time we enqueue it (and let prometheus make a histogram over those events), but that would only affect the metric once an object actually gets picked up... we want metrics to show a long delay if for some reason the objects are stuck and not processing at all.

## Type of Change
- [X] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
Closes #625 

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [X] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

