### PR TITLE
Drop deprecated associated_dpu_machine_id field

### DIFF
--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -75,16 +75,7 @@ impl ApiClient {
             return Err(CarbideCliError::MachineNotFound(id));
         }
 
-        let mut machine_details = machines.machines.remove(0);
-
-        // Note: The field going forward is `associated_dpu_machine_ids`, but if we're talking to
-        // an older version of the API which doesn't support it, fall back on building our own Vec
-        // out of the `associated_dpu_machine_id` field.
-        if machine_details.associated_dpu_machine_ids.is_empty()
-            && let Some(ref dpu_id) = machine_details.associated_dpu_machine_id
-        {
-            machine_details.associated_dpu_machine_ids = vec![*dpu_id];
-        }
+        let machine_details = machines.machines.remove(0);
 
         Ok(machine_details)
     }

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1109,7 +1109,6 @@ impl From<Machine> for rpc::forge::Machine {
         };
 
         let associated_dpu_machine_ids = machine.associated_dpu_machine_ids();
-        let associated_dpu_machine_id = associated_dpu_machine_ids.first().copied();
         let instance_network_restrictions = Some(machine.instance_network_restrictions());
 
         rpc::Machine {
@@ -1174,7 +1173,6 @@ impl From<Machine> for rpc::forge::Machine {
             maintenance_start_time,
             associated_host_machine_id: None, // Gets filled in the `ManagedHostStateSnapshot` conversion
             associated_dpu_machine_ids,
-            associated_dpu_machine_id,
             inventory: Some(machine.inventory.unwrap_or_default().into()),
             last_reboot_requested_time: machine
                 .last_reboot_requested

--- a/crates/api/src/tests/machine_find.rs
+++ b/crates/api/src/tests/machine_find.rs
@@ -566,15 +566,6 @@ async fn test_attached_dpu_machine_ids_multi_dpu(pool: sqlx::PgPool) {
             "host machine has an unexpected associated_dpu_machine_id {dpu_id}"
         );
     }
-
-    let deprecated_dpu_id = host_machine.associated_dpu_machine_id
-        .expect("host machine should fill in an associated_dpu_machine_id field for backwards compatibility");
-
-    let first_dpu_id = dpu_ids.into_iter().next().unwrap();
-    assert_eq!(
-        deprecated_dpu_id, first_dpu_id,
-        "deprecated DPU field should equal the first DPU ID"
-    );
 }
 
 #[crate::sqlx_test()]

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -2860,9 +2860,7 @@ message Machine {
 
   // Other machine ids associated with this machine
   optional common.MachineId associated_host_machine_id = 19;
-  // Deprecated, use associated_dpu_machine_ids. For now, this is filled in with the first DPU ID.
-  // TODO: Once all admin CLI clients have updated, drop this and stop filling it in.
-  optional common.MachineId associated_dpu_machine_id = 20;
+  reserved 20; /* previously: optional common.MachineId associated_dpu_machine_id = 20; */
 
   optional MachineInventory inventory = 21;
   optional google.protobuf.Timestamp last_reboot_requested_time = 22;


### PR DESCRIPTION
## Description
It's been replaced with associated_dpu_machine_ids since May 2024, way past time for it to finally go.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [X] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [X] This PR contains breaking changes

DPU associations in `mh show` will be broken if you're using an admin-cli from 2 years ago.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes

