### PR TITLE
bug: hardcoded web admin credential

### DIFF
--- a/crates/api/src/tests/web/machine_health.rs
+++ b/crates/api/src/tests/web/machine_health.rs
@@ -23,7 +23,7 @@ use rpc::forge::forge_server::Forge;
 use tower::ServiceExt;
 
 use crate::tests::common::api_fixtures::{create_managed_host, create_test_env};
-use crate::tests::web::{authenticated_request_builder, make_test_app};
+use crate::tests::web::{make_test_app, web_request_builder};
 
 #[crate::sqlx_test]
 async fn test_health_of_nonexisting_machine(pool: sqlx::PgPool) {
@@ -34,7 +34,7 @@ async fn test_health_of_nonexisting_machine(pool: sqlx::PgPool) {
         let response = app
             .clone()
             .oneshot(
-                authenticated_request_builder()
+                web_request_builder()
                     .uri(format!("/admin/machine/{machine_id}/health"))
                     .body(Body::empty())
                     .unwrap(),

--- a/crates/api/src/tests/web/managed_host.rs
+++ b/crates/api/src/tests/web/managed_host.rs
@@ -28,7 +28,7 @@ use crate::tests::common::api_fixtures::managed_host::ManagedHostConfig;
 use crate::tests::common::api_fixtures::{
     create_managed_host_multi_dpu, create_test_env, site_explorer,
 };
-use crate::tests::web::{authenticated_request_builder, make_test_app};
+use crate::tests::web::{make_test_app, web_request_builder};
 use crate::web::managed_host::ManagedHostRowDisplay;
 
 #[crate::sqlx_test]
@@ -39,7 +39,7 @@ async fn test_ok(pool: sqlx::PgPool) {
 
     let response = app
         .oneshot(
-            authenticated_request_builder()
+            web_request_builder()
                 .uri("/admin/managed-host.json")
                 .body(Body::empty())
                 .unwrap(),
@@ -77,7 +77,7 @@ async fn test_multi_dpu(pool: sqlx::PgPool) {
 
     let response = app
         .oneshot(
-            authenticated_request_builder()
+            web_request_builder()
                 .uri("/admin/managed-host.json")
                 .body(Body::empty())
                 .unwrap(),

--- a/crates/api/src/tests/web/mod.rs
+++ b/crates/api/src/tests/web/mod.rs
@@ -29,9 +29,7 @@ fn make_test_app(env: &TestEnv) -> Router {
     Router::new().nest_service("/admin", r)
 }
 
-fn authenticated_request_builder() -> Builder {
-    // admin:Welcome123
-    Request::builder()
-        .header("Host", "with.the.most")
-        .header("Authorization", "Basic YWRtaW46V2VsY29tZTEyMw==")
+/// Builder for admin UI requests (in-process auth defaults to none in tests).
+fn web_request_builder() -> Builder {
+    Request::builder().header("Host", "with.the.most")
 }

--- a/crates/api/src/web/mod.rs
+++ b/crates/api/src/web/mod.rs
@@ -29,8 +29,7 @@ use axum::response::{Html, IntoResponse, Redirect, Response};
 use axum::routing::{Router, get, post};
 use axum_extra::extract::Host;
 use axum_extra::extract::cookie::{Cookie, Key, PrivateCookieJar};
-use base64::prelude::*;
-use http::header::{CONTENT_TYPE, WWW_AUTHENTICATE};
+use http::header::CONTENT_TYPE;
 use http::{HeaderMap, Request, StatusCode, Uri};
 use itertools::Itertools;
 use oauth2::basic::{
@@ -97,8 +96,6 @@ mod tenant_keyset;
 mod ufm_browser;
 mod vpc;
 
-const WEB_AUTH: &str = "admin:Welcome123";
-
 const AUTH_TYPE_ENV: &str = "CARBIDE_WEB_AUTH_TYPE";
 const AUTH_CALLBACK_ROOT: &str = "auth-callback";
 
@@ -148,17 +145,12 @@ pub(crate) struct Oauth2Layer {
 
 /// All the URLs in the admin interface. Nested under /admin in api.rs.
 pub fn routes(api: Arc<Api>) -> eyre::Result<NormalizePath<Router>> {
-    // Just something to let us transition more easily.
-    // By default, everything will be the original basic-auth,
-    // so we can deploy this all over and flip on azure auth with
-    // some env-vars.  When everything is switched over, we can
-    // clean this up this up, maybe directly send the struct without the option wrapper,
-    // and only ever use oauth2 if we want.
-    let oauth_extension_layer = match env::var(AUTH_TYPE_ENV)
-        .unwrap_or("basic".to_string())
-        .to_lowercase()
-        .as_str()
-    {
+    // `CARBIDE_WEB_AUTH_TYPE`: `none` (default) = no in-process auth — protect the admin UI with
+    // network policy, or a reverse proxy (OAuth2 Proxy, etc.). `oauth2` = Entra / OIDC via env.
+    let auth_type = env::var(AUTH_TYPE_ENV)
+        .unwrap_or_else(|_| "none".to_string())
+        .to_lowercase();
+    let oauth_extension_layer = match auth_type.as_str() {
         "oauth2" => {
             // Get our cookiejar key so we can add it as an extension.
             let private_cookiejar_key = Key::try_from(
@@ -228,7 +220,23 @@ pub fn routes(api: Arc<Api>) -> eyre::Result<NormalizePath<Router>> {
                 http_client,
             })
         }
-        _ => None,
+        "none" | "" => {
+            tracing::warn!(
+                "{}: admin web UI has no in-process authentication; restrict access with network policy, a private network, or an authenticating reverse proxy (for example OAuth2 Proxy)",
+                AUTH_TYPE_ENV
+            );
+            None
+        }
+        "basic" => {
+            return Err(eyre::eyre!(
+                "{AUTH_TYPE_ENV}=basic is not supported. Use \"none\" (default; secure the UI with network controls or an auth proxy) or \"oauth2\" (SSO via Entra)."
+            ));
+        }
+        other => {
+            return Err(eyre::eyre!(
+                "unknown {AUTH_TYPE_ENV}={other:?}: expected \"none\" or \"oauth2\""
+            ));
+        }
     };
 
     Ok(NormalizePath::trim_trailing_slash(
@@ -568,7 +576,7 @@ pub async fn auth_oauth2(
         }
         Some(o) => match o {
             None => {
-                return auth_basic(req, next).await;
+                return Ok(next.run(req).await);
             }
             Some(oa) => oa.to_owned(),
         },
@@ -675,58 +683,6 @@ pub async fn auth_oauth2(
         Redirect::to(auth_url.as_ref()),
     )
         .into_response())
-}
-
-pub async fn auth_basic(req: Request<AxumBody>, next: Next) -> Result<Response, StatusCode> {
-    let must_auth = (
-        StatusCode::UNAUTHORIZED,
-        [(WWW_AUTHENTICATE, "Basic realm=Carbide")],
-    );
-    match req.headers().get("Authorization") {
-        None => {
-            return Ok(must_auth.into_response());
-        }
-        Some(auth_val) => {
-            let Ok(auth_val) = auth_val.to_str() else {
-                tracing::error!("Invalid auth header");
-                return Err(StatusCode::BAD_REQUEST);
-            };
-            if !is_valid_auth(auth_val) {
-                return Ok(must_auth.into_response());
-            }
-        }
-    };
-
-    let mut peer = String::new();
-    if let Some(conn) = req
-        .extensions()
-        .get::<Arc<crate::listener::ConnectionAttributes>>()
-    {
-        peer = conn.peer_address().ip().to_string();
-    }
-    let path = req.uri().path();
-    let at = format!("{:?}", chrono::Utc::now());
-    tracing::info!(client_ip=%peer, path=%path, at=%at, "carbide-web_authorized_request");
-
-    Ok(next.run(req).await)
-}
-
-fn is_valid_auth(auth_str: &str) -> bool {
-    let parts: Vec<&str> = auth_str.split(' ').collect();
-    if parts.len() != 2 || parts[0] != "Basic" {
-        tracing::trace!(auth_str, "Auth must match 'Basic <str>'");
-        return false;
-    }
-    let Ok(plain) = BASE64_STANDARD.decode(parts[1]) else {
-        tracing::trace!(auth_str, "Auth should be base64");
-        return false;
-    };
-    let plain = String::from_utf8_lossy(&plain);
-    if plain != WEB_AUTH {
-        tracing::trace!(auth_str, "Wrong username or password");
-        return false;
-    }
-    true
 }
 
 #[derive(Template)]

--- a/deploy/carbide-base/api/deployment.yaml
+++ b/deploy/carbide-base/api/deployment.yaml
@@ -127,6 +127,8 @@ spec:
             #     configMapKeyRef:
             #       name: carbide-web-api-hostname
             #       key: hostname
+            # Admin UI: omit or CARBIDE_WEB_AUTH_TYPE=none (no in-process auth; use network/proxy).
+            # For Entra SSO: CARBIDE_WEB_AUTH_TYPE=oauth2 plus OAuth env vars below.
             # - name: CARBIDE_WEB_AUTH_TYPE
             #   value: oauth2
             - name: BITNAMI_DEBUG

--- a/dev/webdev-env/run-env.sh
+++ b/dev/webdev-env/run-env.sh
@@ -80,7 +80,7 @@ export DISABLE_TLS_ENFORCEMENT=1
 export VAULT_KV_MOUNT_LOCATION="secrets"
 export VAULT_PKI_MOUNT_LOCATION="certs"
 export VAULT_PKI_ROLE_NAME="role"
-export CARBIDE_WEB_AUTH_TYPE="basic"
+export CARBIDE_WEB_AUTH_TYPE="none"
 
 # Run SQL migrations
 echo "Running database migrations..."
@@ -92,7 +92,8 @@ menu() {
 
   ┌─────────────────────────────────────────┐
   │  http://localhost:1079/admin/           │
-  │  Login: admin / Welcome123              │
+  │  No in-process auth                     │
+  │  (recommended to set oauth2)            │
   │                                         │
   │  Templates: crates/api/templates/       │
   │                                         │


### PR DESCRIPTION
## Description
The admin web UI uses a hardcoded HTTP Basic Auth credential compiled into the binary. 

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [x] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
bug/5996597

## Breaking Changes
- [x] This PR contains breaking changes
Previously, if SSO was not configured, the WebUI would default to basic authentication with a hardcoded credential. In the upcoming release, this fallback will be removed.

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

