### PR TITLE
fix: web UI + admin CLI tweaks for rack components

### DIFF
--- a/crates/admin-cli/src/managed_switch/show/cmd.rs
+++ b/crates/admin-cli/src/managed_switch/show/cmd.rs
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Write;
 
 use carbide_uuid::switch::SwitchId;
+use prettytable::{Table, row};
 use rpc::admin_cli::{CarbideCliResult, OutputFormat};
 use rpc::forge::{LinkedExpectedSwitch, MachineInterface, Switch};
 use serde::Serialize;
@@ -284,57 +284,44 @@ fn show_detail_view(m: &ManagedSwitchOutput) -> CarbideCliResult<()> {
 }
 
 fn show_table_view(outputs: &[ManagedSwitchOutput]) {
-    println!(
-        "{:<36} {:<20} {:<18} {:<18} {:<20} {:<10} {:<10} {:<15}",
-        "Switch ID", "Name", "Serial", "BMC MAC", "NVOS MAC", "Power", "Health", "State"
-    );
-    println!("{:-<160}", "");
+    let mut table = Table::new();
+    table.set_titles(row![
+        "Switch ID",
+        "Name",
+        "Serial",
+        "BMC MAC",
+        "NVOS MAC",
+        "Power",
+        "Health",
+        "State"
+    ]);
 
     for m in outputs {
-        let id = m
-            .switch_id
-            .as_ref()
-            .map(|s| Cow::Borrowed(s.as_str()))
-            .unwrap_or(Cow::Borrowed("N/A"));
-
-        let name = if m.name.len() > 18 {
-            Cow::Owned(format!("{}…", &m.name[..17]))
-        } else {
-            Cow::Borrowed(m.name.as_str())
-        };
-
-        let serial = if m.serial_number.len() > 16 {
-            Cow::Owned(format!("{}…", &m.serial_number[..15]))
-        } else if m.serial_number.is_empty() {
-            Cow::Borrowed("N/A")
-        } else {
-            Cow::Borrowed(m.serial_number.as_str())
-        };
-
-        let bmc_mac = if m.bmc_mac.is_empty() {
-            Cow::Borrowed("N/A")
-        } else {
-            Cow::Borrowed(m.bmc_mac.as_str())
-        };
-
-        let nvos_mac: Cow<str> = if m.nvos_mac_addresses.is_empty() {
-            Cow::Borrowed("N/A")
-        } else {
-            Cow::Borrowed(m.nvos_mac_addresses[0].as_str())
-        };
-
-        println!(
-            "{:<36} {:<20} {:<18} {:<18} {:<20} {:<10} {:<10} {:<15}",
-            id,
-            name,
-            serial,
-            bmc_mac,
-            nvos_mac,
+        table.add_row(row![
+            m.switch_id.as_deref().unwrap_or("N/A"),
+            m.name,
+            if m.serial_number.is_empty() {
+                "N/A"
+            } else {
+                &m.serial_number
+            },
+            if m.bmc_mac.is_empty() {
+                "N/A"
+            } else {
+                &m.bmc_mac
+            },
+            if m.nvos_mac_addresses.is_empty() {
+                "N/A".to_string()
+            } else {
+                m.nvos_mac_addresses.join(", ")
+            },
             m.power_state.as_deref().unwrap_or("N/A"),
             m.health_status.as_deref().unwrap_or("N/A"),
             m.controller_state,
-        );
+        ]);
     }
+
+    table.printstd();
 }
 
 fn show_csv(outputs: &[ManagedSwitchOutput]) {

--- a/crates/admin-cli/src/power_shelf/show/cmd.rs
+++ b/crates/admin-cli/src/power_shelf/show/cmd.rs
@@ -16,6 +16,7 @@
  */
 
 use color_eyre::Result;
+use prettytable::{Table, row};
 use rpc::admin_cli::{CarbideCliResult, OutputFormat};
 use rpc::forge::PowerShelf;
 
@@ -26,74 +27,68 @@ pub fn show_power_shelves(
     power_shelves: Vec<PowerShelf>,
     output_format: OutputFormat,
 ) -> Result<()> {
-    match output_format {
-        OutputFormat::AsciiTable => {
-            println!("Power Shelves:");
-            println!(
-                "{:<36} {:<20} {:<10} {:<10} {:<15} {:<10} {:<10} {:<10}",
-                "ID",
-                "Name",
-                "Capacity(W)",
-                "Voltage(V)",
-                "Location",
-                "Power State",
-                "Health",
-                "State"
-            );
-            println!("{:-<120}", "");
+    let build_table = |shelves: &[PowerShelf]| -> Table {
+        let mut table = Table::new();
+        table.set_titles(row![
+            "ID",
+            "Name",
+            "Capacity(W)",
+            "Voltage(V)",
+            "Location",
+            "Power State",
+            "Health",
+            "State"
+        ]);
 
-            for shelf in power_shelves {
-                let id = shelf
+        for shelf in shelves {
+            table.add_row(row![
+                shelf
                     .id
                     .as_ref()
                     .map(|id| id.to_string())
-                    .unwrap_or_else(|| "N/A".to_string());
-
-                let name = shelf
+                    .unwrap_or_else(|| "N/A".to_string()),
+                shelf
                     .config
                     .as_ref()
-                    .map(|config| config.name.as_str())
-                    .unwrap_or_else(|| "N/A");
-
-                let capacity = shelf
+                    .map(|c| c.name.as_str())
+                    .unwrap_or("N/A"),
+                shelf
                     .config
                     .as_ref()
-                    .and_then(|config| config.capacity)
+                    .and_then(|c| c.capacity)
                     .map(|c| c.to_string())
-                    .unwrap_or_else(|| "N/A".to_string());
-
-                let voltage = shelf
+                    .unwrap_or_else(|| "N/A".to_string()),
+                shelf
                     .config
                     .as_ref()
-                    .and_then(|config| config.voltage)
+                    .and_then(|c| c.voltage)
                     .map(|v| v.to_string())
-                    .unwrap_or_else(|| "N/A".to_string());
-
-                let location = shelf
+                    .unwrap_or_else(|| "N/A".to_string()),
+                shelf
                     .config
                     .as_ref()
-                    .and_then(|config| config.location.as_deref())
-                    .unwrap_or("N/A");
-
-                let power_state = shelf
+                    .and_then(|c| c.location.as_deref())
+                    .unwrap_or("N/A"),
+                shelf
                     .status
                     .as_ref()
-                    .and_then(|status| status.power_state.as_deref())
-                    .unwrap_or("N/A");
-
-                let health = shelf
+                    .and_then(|s| s.power_state.as_deref())
+                    .unwrap_or("N/A"),
+                shelf
                     .status
                     .as_ref()
-                    .and_then(|status| status.health_status.as_deref())
-                    .unwrap_or("N/A");
+                    .and_then(|s| s.health_status.as_deref())
+                    .unwrap_or("N/A"),
+                shelf.controller_state,
+            ]);
+        }
 
-                let controller_state = shelf.controller_state.as_str();
+        table
+    };
 
-                println!(
-                    "{:<36} {:<20} {:<10} {:<10} {:<15} {:<10} {:<10} {:<25}",
-                    id, name, capacity, voltage, location, power_state, health, controller_state
-                );
-            }
+    match output_format {
+        OutputFormat::AsciiTable => {
+            build_table(&power_shelves).printstd();
         }
         OutputFormat::Json => {
             println!("JSON output not supported for PowerShelf (protobuf type)");
@@ -104,59 +99,7 @@ pub fn show_power_shelves(
             println!("Use ASCII table format instead.");
         }
         OutputFormat::Csv => {
-            println!("ID,Name,Capacity(W),Voltage(V),Location,Power State,Health");
-            for shelf in &power_shelves {
-                let id = shelf
-                    .id
-                    .as_ref()
-                    .map(|id| id.to_string())
-                    .unwrap_or_else(|| "N/A".to_string());
-
-                let name = shelf
-                    .config
-                    .as_ref()
-                    .map(|config| config.name.as_str())
-                    .unwrap_or_else(|| "N/A");
-
-                let capacity = shelf
-                    .config
-                    .as_ref()
-                    .and_then(|config| config.capacity)
-                    .map(|c| c.to_string())
-                    .unwrap_or_else(|| "N/A".to_string());
-
-                let voltage = shelf
-                    .config
-                    .as_ref()
-                    .and_then(|config| config.voltage)
-                    .map(|v| v.to_string())
-                    .unwrap_or_else(|| "N/A".to_string());
-
-                let location = shelf
-                    .config
-                    .as_ref()
-                    .and_then(|config| config.location.as_deref())
-                    .unwrap_or("N/A");
-
-                let power_state = shelf
-                    .status
-                    .as_ref()
-                    .and_then(|status| status.power_state.as_deref())
-                    .unwrap_or("N/A");
-
-                let health = shelf
-                    .status
-                    .as_ref()
-                    .and_then(|status| status.health_status.as_deref())
-                    .unwrap_or("N/A");
-
-                let controller_state = shelf.controller_state.as_str();
-
-                println!(
-                    "{},{},{},{},{},{},{},{}",
-                    id, name, capacity, voltage, location, power_state, health, controller_state
-                );
-            }
+            build_table(&power_shelves).to_csv(std::io::stdout()).ok();
         }
     }
 

--- a/crates/admin-cli/src/rack/show/cmd.rs
+++ b/crates/admin-cli/src/rack/show/cmd.rs
@@ -16,6 +16,7 @@
  */
 
 use color_eyre::Result;
+use prettytable::{Table, row};
 
 use super::args::Args;
 use crate::cfg::runtime::RuntimeConfig;
@@ -33,30 +34,57 @@ pub async fn show_rack(api_client: &ApiClient, args: Args, config: &RuntimeConfi
         return Ok(());
     }
 
+    let mut table = Table::new();
+    table.set_titles(row![
+        "ID",
+        "State",
+        "Expected Compute Trays",
+        "Expected Power Shelves",
+        "Expected NVLink Switches",
+        "Current Compute Trays",
+        "Current Power Shelves"
+    ]);
+
     for r in racks {
-        println!("ID: {}", r.id.map(|id| id.to_string()).unwrap_or_default());
-        println!("State: {}", r.rack_state);
-        println!("Expected Compute Tray BMCs:");
-        for mac_address in r.expected_compute_trays {
-            println!("  {}", mac_address);
-        }
-        println!("Expected Power Shelves:");
-        for mac_address in r.expected_power_shelves {
-            println!("  {}", mac_address);
-        }
-        println!("Expected NVLink Switches:");
-        for mac_address in r.expected_nvlink_switches {
-            println!("  {}", mac_address);
-        }
-        println!("Current Compute Trays");
-        for machine_id in r.compute_trays {
-            println!("  {}", machine_id);
-        }
-        println!("Current Power Shelves");
-        for ps_id in r.power_shelves {
-            println!("  {}", ps_id);
-        }
-        println!("Current NVLink Switches");
+        table.add_row(row![
+            r.id.map(|id| id.to_string()).unwrap_or_default(),
+            r.rack_state,
+            if r.expected_compute_trays.is_empty() {
+                "N/A".to_string()
+            } else {
+                r.expected_compute_trays.join(", ")
+            },
+            if r.expected_power_shelves.is_empty() {
+                "N/A".to_string()
+            } else {
+                r.expected_power_shelves.join(", ")
+            },
+            if r.expected_nvlink_switches.is_empty() {
+                "N/A".to_string()
+            } else {
+                r.expected_nvlink_switches.join(", ")
+            },
+            if r.compute_trays.is_empty() {
+                "N/A".to_string()
+            } else {
+                r.compute_trays
+                    .iter()
+                    .map(|id| id.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            },
+            if r.power_shelves.is_empty() {
+                "N/A".to_string()
+            } else {
+                r.power_shelves
+                    .iter()
+                    .map(|id| id.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            },
+        ]);
     }
+
+    table.printstd();
     Ok(())
 }

--- a/crates/admin-cli/src/switch/show/cmd.rs
+++ b/crates/admin-cli/src/switch/show/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use std::borrow::Cow;
-
 use color_eyre::Result;
+use prettytable::{Table, row};
 use rpc::admin_cli::{CarbideCliResult, OutputFormat};
 use rpc::forge::Switch;
 
@@ -27,25 +26,28 @@ use crate::rpc::ApiClient;
 pub fn show_switches(switches: Vec<Switch>, output_format: OutputFormat) -> Result<()> {
     match output_format {
         OutputFormat::AsciiTable => {
-            println!("Switches:");
-            println!(
-                "{:<36} {:<20} {:<10} {:<10} {:<15} {:<10}",
-                "ID", "Name", "Location", "Power State", "Health", "State"
-            );
-            println!("{:-<120}", "");
+            let mut table = Table::new();
+            table.set_titles(row![
+                "ID",
+                "Name",
+                "Location",
+                "Power State",
+                "Health",
+                "State"
+            ]);
 
             for switch in &switches {
                 let id = switch
                     .id
                     .as_ref()
-                    .map(|id| Cow::Owned(id.to_string()))
-                    .unwrap_or_else(|| Cow::Borrowed("N/A"));
+                    .map(|id| id.to_string())
+                    .unwrap_or_else(|| "N/A".to_string());
 
                 let name = switch
                     .config
                     .as_ref()
                     .map(|config| config.name.as_str())
-                    .unwrap_or_else(|| "N/A");
+                    .unwrap_or("N/A");
 
                 let location = switch
                     .config
@@ -65,13 +67,17 @@ pub fn show_switches(switches: Vec<Switch>, output_format: OutputFormat) -> Resu
                     .and_then(|status| status.health_status.as_deref())
                     .unwrap_or("N/A");
 
-                let controller_state = &switch.controller_state;
-
-                println!(
-                    "{:<36} {:<20} {:<10} {:<10} {:<15} {:<10}",
-                    id, name, location, power_state, health, controller_state
-                );
+                table.add_row(row![
+                    id,
+                    name,
+                    location,
+                    power_state,
+                    health,
+                    switch.controller_state,
+                ]);
             }
+
+            table.printstd();
         }
         OutputFormat::Json => {
             println!("JSON output not supported for Switch (protobuf type)");
@@ -82,19 +88,28 @@ pub fn show_switches(switches: Vec<Switch>, output_format: OutputFormat) -> Resu
             println!("Use ASCII table format instead.");
         }
         OutputFormat::Csv => {
-            println!("ID,Name,Location,Power State,Health,State");
+            let mut table = Table::new();
+            table.set_titles(row![
+                "ID",
+                "Name",
+                "Location",
+                "Power State",
+                "Health",
+                "State"
+            ]);
+
             for switch in &switches {
                 let id = switch
                     .id
                     .as_ref()
-                    .map(|id| Cow::Owned(id.to_string()))
-                    .unwrap_or_else(|| Cow::Borrowed("N/A"));
+                    .map(|id| id.to_string())
+                    .unwrap_or_else(|| "N/A".to_string());
 
                 let name = switch
                     .config
                     .as_ref()
                     .map(|config| config.name.as_str())
-                    .unwrap_or_else(|| "N/A");
+                    .unwrap_or("N/A");
 
                 let location = switch
                     .config
@@ -114,13 +129,17 @@ pub fn show_switches(switches: Vec<Switch>, output_format: OutputFormat) -> Resu
                     .and_then(|status| status.health_status.as_deref())
                     .unwrap_or("N/A");
 
-                let controller_state = switch.controller_state.as_str();
-
-                println!(
-                    "{},{},{},{},{},{}",
-                    id, name, location, power_state, health, controller_state
-                );
+                table.add_row(row![
+                    id,
+                    name,
+                    location,
+                    power_state,
+                    health,
+                    switch.controller_state,
+                ]);
             }
+
+            table.to_csv(std::io::stdout()).ok();
         }
     }
 

--- a/crates/api-model/src/switch/mod.rs
+++ b/crates/api-model/src/switch/mod.rs
@@ -227,6 +227,7 @@ impl TryFrom<Switch> for rpc::Switch {
         } else {
             None
         };
+        let state_version = src.controller_state.version.to_string();
         let controller_state = serde_json::to_string(&src.controller_state.value).unwrap();
         Ok(rpc::Switch {
             id: Some(src.id),
@@ -235,6 +236,7 @@ impl TryFrom<Switch> for rpc::Switch {
             deleted,
             controller_state,
             bmc_info: None,
+            state_version,
         })
     }
 }

--- a/crates/api/src/web/switch.rs
+++ b/crates/api/src/web/switch.rs
@@ -121,6 +121,8 @@ fn capitalize(s: &str) -> String {
 struct SwitchDetail {
     id: String,
     controller_state: String,
+    state_version: String,
+    time_in_state: String,
     name: String,
     location: String,
     enable_nmxc: bool,
@@ -143,8 +145,8 @@ struct SwitchDetailJson {
     bmc_mac: Option<String>,
 }
 
-impl From<rpc::forge::Switch> for SwitchDetail {
-    fn from(switch: rpc::forge::Switch) -> Self {
+impl SwitchDetail {
+    fn new(switch: rpc::forge::Switch) -> Self {
         let id = switch
             .id
             .as_ref()
@@ -154,9 +156,12 @@ impl From<rpc::forge::Switch> for SwitchDetail {
         let state_reason = switch.status.as_ref().and_then(|s| s.state_reason.clone());
         let power_state = switch.status.as_ref().and_then(|s| s.power_state.clone());
         let health_status = switch.status.as_ref().and_then(|s| s.health_status.clone());
+        let time_in_state = config_version::since_state_change_humanized(&switch.state_version);
         Self {
             id,
             controller_state: parse_controller_state(&switch.controller_state),
+            state_version: switch.state_version,
+            time_in_state,
             name: config.name,
             location: config.location.unwrap_or_else(|| "N/A".to_string()),
             enable_nmxc: config.enable_nmxc,
@@ -190,7 +195,7 @@ pub async fn detail(
         Err(response) => return response,
     };
 
-    let detail = SwitchDetail::from(switch);
+    let detail = SwitchDetail::new(switch);
 
     if show_json {
         let json = SwitchDetailJson {

--- a/crates/api/templates/switch_detail.html
+++ b/crates/api/templates/switch_detail.html
@@ -15,6 +15,10 @@
 		<td>{{ id }}</td>
 	</tr>
 	<tr>
+		<th>Rack ID</th>
+		<td>TBD</td>
+	</tr>
+	<tr>
 		<th>State</th>
 		<td>
 			{% if controller_state == "Ready" %}
@@ -27,8 +31,16 @@
 		</td>
 	</tr>
 	<tr>
-		<th>State Reason</th>
+		<th>State Handler Outcome</th>
 		<td>{{ state_reason|controller_state_reason_fmt|safe }}</td>
+	</tr>
+	<tr>
+		<th>State Version</th>
+		<td>{{ state_version|config_version|safe }}</td>
+	</tr>
+	<tr>
+		<th>Time in State</th>
+		<td>{{ time_in_state }}</td>
 	</tr>
 	{% if let Some(power_state) = power_state %}
 	<tr>

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1832,6 +1832,9 @@ message Switch {
   string controller_state = 5;
 
   BmcInfo bmc_info = 6;
+
+  // Version string for the current controller state (e.g. "V3-T1774905143273055").
+  string state_version = 7;
 }
 
 message SwitchList {


### PR DESCRIPTION
## Description

This makes a few tweaks to the web UI and admin CLI for rack components, including:
- Admin UI change to tweak the Managed Switch view (added Rack ID, State Version, and Time in State -- just like we do for Machines).
- Admin CLI changes to use `prettytable` rack expected/managed components.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

