### PR TITLE
feat(bmc-mock): expose next boot kind in MAT

### DIFF
--- a/crates/bmc-mock/src/bmc_state.rs
+++ b/crates/bmc-mock/src/bmc_state.rs
@@ -34,7 +34,7 @@ pub struct BmcState {
     pub chassis_state: Arc<ChassisState>,
     pub update_service_state: Arc<UpdateServiceState>,
     pub injected_bugs: Arc<InjectedBugs>,
-    pub power_control: Option<Arc<dyn crate::PowerControl>>,
+    pub callbacks: Option<Arc<dyn crate::Callbacks>>,
 }
 
 impl BmcState {

--- a/crates/bmc-mock/src/hw/bluefield3.rs
+++ b/crates/bmc-mock/src/hw/bluefield3.rs
@@ -24,7 +24,7 @@ use rpc::{NetworkInterface, PciDeviceProperties};
 use serde_json::json;
 use utils::models::arch::CpuArchitecture;
 
-use crate::{LogService, LogServices, PowerControl, hw, redfish};
+use crate::{BootOptionKind, Callbacks, LogService, LogServices, hw, redfish};
 
 pub struct Bluefield3<'a> {
     pub product_serial_number: Cow<'a, str>,
@@ -122,10 +122,10 @@ impl Bluefield3<'_> {
         }
     }
 
-    pub fn system_config(&self, pc: Arc<dyn PowerControl>) -> redfish::computer_system::Config {
+    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
         let system_id = "Bluefield";
-        let boot_opt_builder = |id: &str| {
-            redfish::boot_option::builder(&redfish::boot_option::resource(system_id, id))
+        let boot_opt_builder = |id: &str, kind| {
+            redfish::boot_option::builder(&redfish::boot_option::resource(system_id, id), kind)
                 .boot_option_reference(id)
         };
         let nic_mode = if let hw::bluefield3::Mode::SuperNIC { nic_mode: true } = self.mode {
@@ -146,7 +146,7 @@ impl Bluefield3<'_> {
                 })
                 .collect();
         let boot_options = [
-            boot_opt_builder("Boot0040")
+            boot_opt_builder("Boot0040", BootOptionKind::Disk)
                 .display_name("ubuntu0")
                 .uefi_device_path("HD(1,GPT,2FAFB38D-05F6-DF41-AE01-F9991E2CC0F0,0x800,0x19000)/\\EFI\\ubuntu\\shimaa64.efi")
                 .build()
@@ -156,7 +156,7 @@ impl Bluefield3<'_> {
                 .replace(':', "")
                 .to_ascii_uppercase();
             vec![
-                boot_opt_builder("Boot0000")
+                boot_opt_builder("Boot0000", BootOptionKind::Network)
                     .display_name("NET-OOB-IPV4-HTTP")
                     .uefi_device_path(&format!("MAC({mocked_mac_no_colons},0x1)/IPv4(0.0.0.0,0x0,DHCP,0.0.0.0,0.0.0.0,0.0.0.0)/Uri()"))
                     .build(),
@@ -171,8 +171,8 @@ impl Bluefield3<'_> {
                 eth_interfaces: Some(eth_interfaces),
                 chassis: vec!["Bluefield_BMC".into()],
                 serial_number: Some(self.product_serial_number.to_string().into()),
-                boot_order_mode: redfish::computer_system::BootOrderMode::Generic,
-                power_control: Some(pc),
+                boot_order_mode: redfish::computer_system::BootOrderMode::ViaSettings,
+                callbacks: Some(callbacks),
                 boot_options: Some(boot_options),
                 bios_mode: redfish::computer_system::BiosMode::Generic,
                 oem: redfish::computer_system::Oem::NvidiaBluefield,

--- a/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
+++ b/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
@@ -24,7 +24,7 @@ use rpc::machine_discovery::{BlockDevice, CpuInfo, DiscoveryInfo, DmiData, Memor
 use serde_json::json;
 use utils::models::arch::CpuArchitecture;
 
-use crate::{PowerControl, hw, redfish};
+use crate::{BootOptionKind, Callbacks, hw, redfish};
 
 pub struct DellPowerEdgeR750<'a> {
     pub bmc_mac_address: MacAddress,
@@ -75,8 +75,8 @@ impl DellPowerEdgeR750<'_> {
         }
     }
 
-    pub fn system_config(&self, pc: Arc<dyn PowerControl>) -> redfish::computer_system::Config {
-        let power_control = Some(pc);
+    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
+        let callbacks = Some(callbacks);
         let serial_number = Some(self.product_serial_number.to_string().into());
         let system_id = "System.Embedded.1";
 
@@ -105,20 +105,26 @@ impl DellPowerEdgeR750<'_> {
         }))
         .collect();
 
-        let boot_opt_builder = |id: &str| {
-            redfish::boot_option::builder(&redfish::boot_option::resource(system_id, id))
+        let boot_opt_builder = |id: &str, kind| {
+            redfish::boot_option::builder(&redfish::boot_option::resource(system_id, id), kind)
                 .boot_option_reference(id)
         };
         let boot_options = self
             .nics
             .iter()
-            .map(|(slot_number, _)| format!("HTTP Device 1: NIC in Slot {slot_number} Port 1"))
-            .chain(std::iter::once(
+            .map(|(slot_number, _)| {
+                (
+                    format!("HTTP Device 1: NIC in Slot {slot_number} Port 1"),
+                    BootOptionKind::Network,
+                )
+            })
+            .chain(std::iter::once((
                 "PCIe SSD in Slot 2 in Bay 1: EFI Fixed Disk Boot Device 1".to_string(),
-            ))
+                BootOptionKind::Disk,
+            )))
             .enumerate()
-            .map(|(index, display_name)| {
-                boot_opt_builder(&format!("Boot{index:04X}"))
+            .map(|(index, (display_name, kind))| {
+                boot_opt_builder(&format!("Boot{index:04X}"), kind)
                     .display_name(&display_name)
                     .build()
             })
@@ -132,7 +138,7 @@ impl DellPowerEdgeR750<'_> {
                 eth_interfaces: Some(eth_interfaces),
                 serial_number,
                 boot_order_mode: redfish::computer_system::BootOrderMode::DellOem,
-                power_control,
+                callbacks,
                 chassis: vec!["System.Embedded.1".into()],
                 boot_options: Some(boot_options),
                 bios_mode: redfish::computer_system::BiosMode::DellOem,

--- a/crates/bmc-mock/src/hw/lenovo_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/lenovo_gb300_nvl.rs
@@ -22,7 +22,7 @@ use mac_address::MacAddress;
 use rpc::DiscoveryInfo;
 use serde_json::json;
 
-use crate::{PowerControl, hw, redfish};
+use crate::{BootOptionKind, Callbacks, hw, redfish};
 
 #[allow(dead_code)]
 pub struct LenovoGB300Nvl<'a> {
@@ -99,18 +99,18 @@ impl LenovoGB300Nvl<'_> {
         }
     }
 
-    pub fn system_config(
-        &self,
-        power_control: Arc<dyn PowerControl>,
-    ) -> redfish::computer_system::Config {
+    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
         let system_id = "System_0";
         // TODO: It is PXE but apparently if enable HTTP in bios HTTP
         // (Uefi) boot options will show up here...
         let boot_options = std::iter::once(
-            redfish::boot_option::builder(&redfish::boot_option::resource(system_id, "0002"))
-                .boot_option_reference("Boot0002")
-                .display_name("ubuntu")
-                .build(),
+            redfish::boot_option::builder(
+                &redfish::boot_option::resource(system_id, "0002"),
+                BootOptionKind::Disk,
+            )
+            .boot_option_reference("Boot0002")
+            .display_name("ubuntu")
+            .build(),
         )
         .chain(
             [&self.embedded_1g_nic.ethernet_nic(), &self.dpu.host_nic()]
@@ -120,18 +120,22 @@ impl LenovoGB300Nvl<'_> {
                     let id = format!("{:04X}", n + 3); // Starting with 0003
                     // TODO should be taken from NIC:
                     let pci_path = "PciRoot(0x0)/Pci(0x10,0x0)/Pci(0x0,0x0)";
-                    redfish::boot_option::builder(&redfish::boot_option::resource(system_id, &id))
-                .boot_option_reference(&format!("Boot{id}"))
-                // Real "Description": "DisplayName": "[Slot16]UEFI: PXE IPv4 Nvidia Network Adapter - 90:E3:17:95:01:DE",
-                .display_name(&format!(
-                    "[SlotFFFF]: PXE IPv4 Some Network Adapter - {}",
-                    nic.mac_address
-                ))
-                .uefi_device_path(&format!(
-                    "{pci_path}/MAC({},0x1)/IPv4(0.0.0.0,0x0,DHCP,0.0.0.0,0.0.0.0,0.0.0.0)/Uri()",
-                    nic.mac_address.to_string().replace(":", "")
-                ))
-                .build()
+                    redfish::boot_option::builder(
+                        &redfish::boot_option::resource(system_id, &id),
+                        BootOptionKind::Network,
+                    )
+                    .boot_option_reference(&format!("Boot{id}"))
+                    // Real "Description": "DisplayName": "[Slot16]UEFI: PXE IPv4 Nvidia Network Adapter - 90:E3:17:95:01:DE",
+                    .display_name(&format!(
+                        "[SlotFFFF]: PXE IPv4 Some Network Adapter - {}",
+                        nic.mac_address
+                    ))
+                    .uefi_device_path(&format!(
+                        "{pci_path}/MAC({},0x1)\
+                             /IPv4(0.0.0.0,0x0,DHCP,0.0.0.0,0.0.0.0,0.0.0.0)/Uri()",
+                        nic.mac_address.to_string().replace(":", "")
+                    ))
+                    .build()
                 }),
         )
         .collect();
@@ -168,7 +172,7 @@ impl LenovoGB300Nvl<'_> {
                     manufacturer: Some("NVIDIA".into()),
                     model: Some("GB300 1CPU:2GPU Board PC".into()),
                     oem: redfish::computer_system::Oem::Generic,
-                    power_control: None,
+                    callbacks: None,
                     secure_boot_available: false,
                     serial_number: Some(self.hgx_serial_number.to_string().into()),
                     storage: None,
@@ -187,7 +191,7 @@ impl LenovoGB300Nvl<'_> {
                     manufacturer: Some("Lenovo".into()),
                     model: Some("HG634N_V2".into()),
                     oem: redfish::computer_system::Oem::Generic,
-                    power_control: Some(power_control),
+                    callbacks: Some(callbacks),
                     secure_boot_available: true,
                     serial_number: Some(self.system_0_serial_number.to_string().into()),
                     storage: None,

--- a/crates/bmc-mock/src/hw/liteon_power_shelf.rs
+++ b/crates/bmc-mock/src/hw/liteon_power_shelf.rs
@@ -73,7 +73,7 @@ impl LiteOnPowerShelf<'_> {
                 eth_interfaces: None,
                 serial_number: None,
                 boot_order_mode: redfish::computer_system::BootOrderMode::Generic,
-                power_control: None,
+                callbacks: None,
                 chassis: vec!["powershelf".into()],
                 boot_options: None,
                 bios_mode: redfish::computer_system::BiosMode::Generic,

--- a/crates/bmc-mock/src/hw/nvidia_dgx_h100.rs
+++ b/crates/bmc-mock/src/hw/nvidia_dgx_h100.rs
@@ -25,7 +25,7 @@ use serde_json::json;
 use utils::models::arch::CpuArchitecture;
 
 use crate::json::JsonExt;
-use crate::{PowerControl, hw, redfish};
+use crate::{BootOptionKind, Callbacks, hw, redfish};
 
 pub struct NvidiaDgxH100<'a> {
     pub dgx_system_serial_number: Cow<'a, str>,
@@ -99,9 +99,9 @@ impl NvidiaDgxH100<'_> {
         }
     }
 
-    pub fn system_config(&self, pc: Arc<dyn PowerControl>) -> redfish::computer_system::Config {
+    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
         let system_id = "DGX";
-        let power_control = Some(pc);
+        let callbacks = Some(callbacks);
         let storage_nic0_ports = self.storage_nic0.ethernet_nics();
         let storage_nic1_ports = self.storage_nic1.ethernet_nics();
 
@@ -141,24 +141,30 @@ impl NvidiaDgxH100<'_> {
             let id = format!("{:04X}", n + 10); // Starting with 000A
             // TODO should be taken from NIC:
             let pci_path = "PciRoot(0x0)/Pci(0x10,0x0)/Pci(0x0,0x0)";
-            redfish::boot_option::builder(&redfish::boot_option::resource(system_id, &id))
-                .boot_option_reference(&format!("Boot{id}"))
-                // Real DisplayName: "UEFI P0: HTTP IPv4 Nvidia Network Adapter - 94:6D:AE:00:00:00"
-                .display_name(&format!("UEFI Pn: HTTP IPv4 - {}", nic.mac_address))
-                .alias("UefiHttp")
-                .uefi_device_path(&format!(
-                    "{pci_path}/MAC({},0x1)/IPv4(0.0.0.0,0x0,DHCP,0.0.0.0,0.0.0.0,0.0.0.0)/Uri()",
-                    nic.mac_address.to_string().replace(":", "")
-                ))
-                // libredfish model requires @odata.etag field.
-                .odata_etag("MakeLibRedfishHappy")
-                .build()
+            redfish::boot_option::builder(
+                &redfish::boot_option::resource(system_id, &id),
+                BootOptionKind::Network,
+            )
+            .boot_option_reference(&format!("Boot{id}"))
+            // Real DisplayName: "UEFI P0: HTTP IPv4 Nvidia Network Adapter - 94:6D:AE:00:00:00"
+            .display_name(&format!("UEFI Pn: HTTP IPv4 - {}", nic.mac_address))
+            .alias("UefiHttp")
+            .uefi_device_path(&format!(
+                "{pci_path}/MAC({},0x1)/IPv4(0.0.0.0,0x0,DHCP,0.0.0.0,0.0.0.0,0.0.0.0)/Uri()",
+                nic.mac_address.to_string().replace(":", "")
+            ))
+            // libredfish model requires @odata.etag field.
+            .odata_etag("MakeLibRedfishHappy")
+            .build()
         })
         .chain(std::iter::once(
-            redfish::boot_option::builder(&redfish::boot_option::resource(system_id, "0030"))
-                .boot_option_reference("Boot0030")
-                .display_name("UEFI OS")
-                .build(),
+            redfish::boot_option::builder(
+                &redfish::boot_option::resource(system_id, "0030"),
+                BootOptionKind::Disk,
+            )
+            .boot_option_reference("Boot0030")
+            .display_name("UEFI OS")
+            .build(),
         ))
         .collect();
 
@@ -171,7 +177,7 @@ impl NvidiaDgxH100<'_> {
                     eth_interfaces,
                     serial_number: Some(self.dgx_system_serial_number.to_string().into()),
                     boot_order_mode: redfish::computer_system::BootOrderMode::ViaSettings,
-                    power_control,
+                    callbacks,
                     chassis: vec!["BMC".into()],
                     boot_options: Some(boot_options),
                     bios_mode: redfish::computer_system::BiosMode::Generic,
@@ -187,7 +193,7 @@ impl NvidiaDgxH100<'_> {
                     model: None,
                     chassis: vec!["HGX_BMC_0".into()],
                     eth_interfaces: None,
-                    power_control: None,
+                    callbacks: None,
                     boot_options: None,
                     serial_number: None,
                     boot_order_mode: redfish::computer_system::BootOrderMode::Generic,

--- a/crates/bmc-mock/src/hw/nvidia_switch_nd5200_ld.rs
+++ b/crates/bmc-mock/src/hw/nvidia_switch_nd5200_ld.rs
@@ -72,7 +72,7 @@ impl NvidiaSwitchNd5200Ld<'_> {
                 eth_interfaces: None,
                 serial_number: None,
                 boot_order_mode: redfish::computer_system::BootOrderMode::Generic,
-                power_control: None,
+                callbacks: None,
                 chassis: vec!["BMC_eeprom".into()],
                 boot_options: None,
                 bios_mode: redfish::computer_system::BiosMode::Generic,

--- a/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
+++ b/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
@@ -22,7 +22,7 @@ use rpc::machine_discovery::{BlockDevice, CpuInfo, DiscoveryInfo, DmiData, NvmeD
 use serde_json::json;
 use utils::models::arch::CpuArchitecture;
 
-use crate::{PowerControl, hw, redfish};
+use crate::{BootOptionKind, Callbacks, hw, redfish};
 
 pub struct WiwynnGB200Nvl<'a> {
     pub system_serial_number: Cow<'a, str>,
@@ -72,23 +72,23 @@ impl WiwynnGB200Nvl<'_> {
         }
     }
 
-    pub fn system_config(&self, pc: Arc<dyn PowerControl>) -> redfish::computer_system::Config {
+    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
         let system_id = "System_0";
-        let power_control = Some(pc);
+        let callbacks = Some(callbacks);
         let serial_number = Some(self.system_serial_number.to_string().into());
-        let boot_opt_builder = |id: &str| {
-            redfish::boot_option::builder(&redfish::boot_option::resource(system_id, id))
+        let boot_opt_builder = |id: &str, kind| {
+            redfish::boot_option::builder(&redfish::boot_option::resource(system_id, id), kind)
                 .boot_option_reference(id)
         };
         let boot_options = [
-            boot_opt_builder("Boot0020")
+            boot_opt_builder("Boot0020", BootOptionKind::Disk)
                 .display_name("Ubuntu")
                 .uefi_device_path("HD(1,GPT,C07AA982-7D30-4663-9538-776771BBED85,0x800,0x219800)/\\EFI\\ubuntu\\shimaa64.efi")
                 .build()
         ].into_iter().chain([&self.dpu1, &self.dpu2].into_iter().enumerate().map(|(index, dpu)| {
             let mac = dpu.host_mac_address.to_string().replace(":", "").to_uppercase();
             let display_name = format!("UEFI HTTPv4 (MAC:{mac})");
-            boot_opt_builder(&format!("Boot{index:04X}"))
+            boot_opt_builder(&format!("Boot{index:04X}"), BootOptionKind::Network)
                 .display_name(&display_name)
                 .uefi_device_path(&format!("MAC({mac},0x1)/IPv4(0.0.0.0,0x0,DHCP,0.0.0.0,0.0.0.0,0.0.0.0)/Uri()"))
                 .build()
@@ -103,7 +103,7 @@ impl WiwynnGB200Nvl<'_> {
                     eth_interfaces: None,
                     serial_number,
                     boot_order_mode: redfish::computer_system::BootOrderMode::ViaSettings,
-                    power_control,
+                    callbacks,
                     chassis: vec!["BMC_0".into()],
                     boot_options: Some(boot_options),
                     bios_mode: redfish::computer_system::BiosMode::Generic,
@@ -125,7 +125,7 @@ impl WiwynnGB200Nvl<'_> {
                     model: Some("GB200 NVL".into()),
                     chassis: vec!["HGX_Chassis_0".into()],
                     eth_interfaces: None,
-                    power_control: None,
+                    callbacks: None,
                     boot_options: None,
                     serial_number: None,
                     boot_order_mode: redfish::computer_system::BootOrderMode::Generic,

--- a/crates/bmc-mock/src/ipmi.rs
+++ b/crates/bmc-mock/src/ipmi.rs
@@ -68,15 +68,15 @@ async fn handle_ipmi(
 ) -> Json<IpmiResponse> {
     tracing::debug!(action = %req.action, "IPMI mock request");
 
-    let Some(ref power_control) = state.power_control else {
-        tracing::error!("IPMI request received but power_control not configured");
-        return Json(IpmiResponse::err("power_control not configured"));
+    let Some(ref callbacks) = state.callbacks else {
+        tracing::error!("IPMI request received but IPMI handler is not configured");
+        return Json(IpmiResponse::err("IPMI handler is not configured"));
     };
 
     let response = match req.action.as_str() {
         "chassis_power_reset" => {
             tracing::info!("IPMI: chassis power reset");
-            match power_control.send_power_command(SystemPowerControl::ForceRestart) {
+            match callbacks.send_power_command(SystemPowerControl::ForceRestart) {
                 Ok(()) => IpmiResponse::ok(),
                 Err(e) => {
                     tracing::error!(error = ?e, "chassis power reset failed");
@@ -90,7 +90,7 @@ async fn handle_ipmi(
         }
         "dpu_legacy_boot" => {
             tracing::info!("IPMI: dpu legacy boot");
-            match power_control.send_power_command(SystemPowerControl::ForceRestart) {
+            match callbacks.send_power_command(SystemPowerControl::ForceRestart) {
                 Ok(()) => IpmiResponse::ok(),
                 Err(e) => {
                     tracing::error!(error = ?e, "dpu legacy boot failed");

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -36,6 +36,7 @@ mod redfish;
 pub mod test_support;
 pub mod tls;
 
+pub use bmc_state::BmcState;
 pub use combined_server::{CombinedServer, ListenerOrAddress};
 pub use machine_info::{
     DpuFirmwareVersions, DpuMachineInfo, DpuSettings, HostMachineInfo, MachineInfo,
@@ -113,7 +114,7 @@ impl fmt::Display for MockPowerState {
 // Simulate a 5-second power cycle
 pub const POWER_CYCLE_DELAY: Duration = Duration::from_secs(5);
 
-pub trait PowerControl: std::fmt::Debug + Send + Sync {
+pub trait Callbacks: std::fmt::Debug + Send + Sync {
     fn get_power_state(&self) -> MockPowerState;
     fn send_power_command(&self, reset_type: SystemPowerControl)
     -> Result<(), SetSystemPowerError>;
@@ -139,6 +140,8 @@ pub trait PowerControl: std::fmt::Debug + Send + Sync {
         }?;
         self.send_power_command(reset_type)
     }
+
+    fn state_refresh_indication(&self);
 }
 
 pub trait HostnameQuerying: std::fmt::Debug + Send + Sync {
@@ -203,4 +206,10 @@ pub trait LogService: Send + Sync {
     fn id(&self) -> &str;
 
     fn entries(&self, collection: &redfish::Collection<'_>) -> Vec<serde_json::Value>;
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum BootOptionKind {
+    Disk,
+    Network,
 }

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -226,23 +226,19 @@ impl HostMachineInfo {
 
     pub fn system_config(
         &self,
-        power_control: Arc<dyn crate::PowerControl>,
+        callbacks: Arc<dyn crate::Callbacks>,
     ) -> redfish::computer_system::Config {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => {
-                self.dell_poweredge_r750().system_config(power_control)
+                self.dell_poweredge_r750().system_config(callbacks)
             }
-            HostHardwareType::WiwynnGB200Nvl => {
-                self.wiwynn_gb200_nvl().system_config(power_control)
-            }
-            HostHardwareType::LenovoGB300Nvl => {
-                self.lenovo_gb300_nvl().system_config(power_control)
-            }
+            HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().system_config(callbacks),
+            HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().system_config(callbacks),
             HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().system_config(),
             HostHardwareType::NvidiaSwitchNd5200Ld => {
                 self.nvidia_switch_nd5200_ld().system_config()
             }
-            HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().system_config(power_control),
+            HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().system_config(callbacks),
         }
     }
 
@@ -527,11 +523,11 @@ impl MachineInfo {
 
     pub fn system_config(
         &self,
-        power_control: Arc<dyn crate::PowerControl>,
+        callbacks: Arc<dyn crate::Callbacks>,
     ) -> redfish::computer_system::Config {
         match self {
-            MachineInfo::Host(host) => host.system_config(power_control),
-            MachineInfo::Dpu(dpu) => dpu.bluefield3().system_config(power_control),
+            MachineInfo::Host(host) => host.system_config(callbacks),
+            MachineInfo::Dpu(dpu) => dpu.bluefield3().system_config(callbacks),
         }
     }
 

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -25,8 +25,8 @@ use std::sync::Arc;
 
 use axum::Router;
 use bmc_mock::{
-    BmcCommand, DpuMachineInfo, HostHardwareType, HostMachineInfo, ListenerOrAddress, MachineInfo,
-    MockPowerState, PowerControl, SetSystemPowerError, SystemPowerControl,
+    BmcCommand, Callbacks, DpuMachineInfo, HostHardwareType, HostMachineInfo, ListenerOrAddress,
+    MachineInfo, MockPowerState, SetSystemPowerError, SystemPowerControl,
 };
 use tar_router::TarGzOption;
 use tokio::sync::{RwLock, mpsc};
@@ -114,6 +114,7 @@ fn spawn_qemu_reboot_handler() -> mpsc::UnboundedSender<BmcCommand> {
             match command {
                 // Assume SetSystemPower is just a reboot
                 BmcCommand::SetSystemPower { .. } => {}
+                BmcCommand::StateRefreshIndication => continue,
             }
             let reboot_output = match Command::new("virsh")
                 .arg("reboot")
@@ -153,29 +154,30 @@ fn spawn_qemu_reboot_handler() -> mpsc::UnboundedSender<BmcCommand> {
 
 fn default_host_mock() -> Router {
     let command_channel = spawn_qemu_reboot_handler();
-    let power_control = Arc::new(ChannelPowerControl::new(command_channel));
+    let callbacks = Arc::new(ChannelCallbacks::new(command_channel));
     bmc_mock::machine_router(
         MachineInfo::Host(HostMachineInfo::new(
             HostHardwareType::WiwynnGB200Nvl,
             vec![DpuMachineInfo::default(), DpuMachineInfo::default()],
         )),
-        power_control,
+        callbacks,
         String::default(),
     )
+    .0
 }
 
 #[derive(Debug)]
-struct ChannelPowerControl {
+struct ChannelCallbacks {
     command_channel: mpsc::UnboundedSender<BmcCommand>,
 }
 
-impl ChannelPowerControl {
+impl ChannelCallbacks {
     fn new(command_channel: mpsc::UnboundedSender<BmcCommand>) -> Self {
         Self { command_channel }
     }
 }
 
-impl PowerControl for ChannelPowerControl {
+impl Callbacks for ChannelCallbacks {
     fn get_power_state(&self) -> MockPowerState {
         MockPowerState::On
     }
@@ -190,5 +192,11 @@ impl PowerControl for ChannelPowerControl {
                 reply: None,
             })
             .map_err(|err| SetSystemPowerError::CommandSendError(err.to_string()))
+    }
+
+    fn state_refresh_indication(&self) {
+        let _ = self
+            .command_channel
+            .send(BmcCommand::StateRefreshIndication);
     }
 }

--- a/crates/bmc-mock/src/middleware_router.rs
+++ b/crates/bmc-mock/src/middleware_router.rs
@@ -24,21 +24,29 @@ use axum::response::Response;
 use axum::routing::any;
 use tracing::instrument;
 
+use crate::Callbacks;
 use crate::bug::InjectedBugs;
 use crate::http::call_router_with_new_request;
 
-pub fn append(mat_host_id: String, router: Router, injected_bugs: Arc<InjectedBugs>) -> Router {
+pub fn append(
+    mat_host_id: String,
+    router: Router,
+    injected_bugs: Arc<InjectedBugs>,
+    callbacks: Arc<dyn Callbacks>,
+) -> Router {
     Router::new()
         .route("/{*all}", any(process))
         .with_state(Middleware {
             mat_host_id,
             inner: router,
             injected_bugs,
+            callbacks,
         })
 }
 
 #[instrument(skip_all, fields(mat_host_id = %state.mat_host_id))]
 async fn process(State(mut state): State<Middleware>, request: Request<Body>) -> Response {
+    let is_safe = request.method().is_safe();
     let method = request.method().to_string();
     let path = request.uri().path().to_string();
     if let Some(delay) = state.injected_bugs.long_response(&path) {
@@ -53,6 +61,9 @@ async fn process(State(mut state): State<Middleware>, request: Request<Body>) ->
     if !response.status().is_success() {
         tracing::warn!(method, path, status = response.status().to_string());
     }
+    if !is_safe && response.status().is_success() {
+        state.callbacks.state_refresh_indication();
+    }
     response
 }
 
@@ -61,6 +72,7 @@ struct Middleware {
     mat_host_id: String,
     inner: Router,
     injected_bugs: Arc<InjectedBugs>,
+    callbacks: Arc<dyn Callbacks>,
 }
 
 impl Middleware {

--- a/crates/bmc-mock/src/mock_machine_router.rs
+++ b/crates/bmc-mock/src/mock_machine_router.rs
@@ -27,7 +27,7 @@ use crate::bmc_state::BmcState;
 use crate::bug::InjectedBugs;
 use crate::json::JsonExt;
 use crate::redfish::manager::ManagerState;
-use crate::{MachineInfo, PowerControl, SystemPowerControl, middleware_router, redfish};
+use crate::{Callbacks, MachineInfo, SystemPowerControl, middleware_router, redfish};
 
 #[derive(Debug)]
 pub enum BmcCommand {
@@ -35,6 +35,7 @@ pub enum BmcCommand {
         request: SystemPowerControl,
         reply: Option<oneshot::Sender<SetSystemPowerResult>>,
     },
+    StateRefreshIndication,
 }
 
 pub type SetSystemPowerResult = Result<(), SetSystemPowerError>;
@@ -63,10 +64,10 @@ impl AddRoutes for Router<BmcState> {
 /// the provided MachineInfo.
 pub fn machine_router(
     machine_info: MachineInfo,
-    power_control: Arc<dyn PowerControl>,
+    callbacks: Arc<dyn Callbacks>,
     mat_host_id: String,
-) -> Router {
-    let system_config = machine_info.system_config(power_control.clone());
+) -> (Router, BmcState) {
+    let system_config = machine_info.system_config(callbacks.clone());
     let chassis_config = machine_info.chassis_config();
     let update_service_config = machine_info.update_service_config();
     let bmc_vendor = machine_info.bmc_vendor();
@@ -104,7 +105,7 @@ pub fn machine_router(
         crate::redfish::update_service::UpdateServiceState::from_config(update_service_config),
     );
     let injected_bugs = Arc::new(InjectedBugs::default());
-    let router = router.with_state(BmcState {
+    let state = BmcState {
         bmc_vendor,
         bmc_product,
         bmc_redfish_version,
@@ -114,10 +115,14 @@ pub fn machine_router(
         chassis_state,
         update_service_state,
         injected_bugs: injected_bugs.clone(),
-        power_control: Some(power_control.clone()),
-    });
+        callbacks: Some(callbacks.clone()),
+    };
+    let router = router.with_state(state.clone());
     let router_with_expansion = redfish::expander_router::append(router);
-    middleware_router::append(mat_host_id, router_with_expansion, injected_bugs)
+    (
+        middleware_router::append(mat_host_id, router_with_expansion, injected_bugs, callbacks),
+        state,
+    )
 }
 
 async fn get_injected_bugs(State(state): State<BmcState>) -> Response {

--- a/crates/bmc-mock/src/redfish/boot_option.rs
+++ b/crates/bmc-mock/src/redfish/boot_option.rs
@@ -18,8 +18,8 @@
 use std::borrow::Cow;
 
 use crate::json::{JsonExt, JsonPatch};
-use crate::redfish;
 use crate::redfish::Builder;
+use crate::{BootOptionKind, redfish};
 
 pub fn collection(system_id: &str) -> redfish::Collection<'static> {
     let odata_id = format!(
@@ -43,17 +43,19 @@ pub fn resource<'a>(system_id: &str, boot_option_id: &'a str) -> redfish::Resour
     }
 }
 
-pub fn builder(resource: &redfish::Resource) -> BootOptionBuilder {
+pub fn builder(resource: &redfish::Resource, kind: BootOptionKind) -> BootOptionBuilder {
     BootOptionBuilder {
         id: Cow::Owned(resource.id.to_string()),
         value: resource.json_patch(),
         reference: None,
+        kind,
     }
 }
 
 pub struct BootOption {
     pub id: Cow<'static, str>,
     pub reference: Option<String>,
+    pub kind: BootOptionKind,
     value: serde_json::Value,
 }
 
@@ -70,6 +72,7 @@ pub struct BootOptionBuilder {
     id: Cow<'static, str>,
     reference: Option<String>,
     value: serde_json::Value,
+    kind: BootOptionKind,
 }
 
 impl Builder for BootOptionBuilder {
@@ -78,6 +81,7 @@ impl Builder for BootOptionBuilder {
             value: self.value.patch(patch),
             id: self.id,
             reference: self.reference,
+            kind: self.kind,
         }
     }
 }
@@ -110,6 +114,7 @@ impl BootOptionBuilder {
             id: self.id,
             reference: self.reference,
             value: self.value,
+            kind: self.kind,
         }
     }
 }

--- a/crates/bmc-mock/src/redfish/computer_system.rs
+++ b/crates/bmc-mock/src/redfish/computer_system.rs
@@ -30,8 +30,8 @@ use crate::bmc_state::BmcState;
 use crate::json::{JsonExt, JsonPatch, json_patch};
 use crate::redfish::Builder;
 use crate::{
-    LogServices, MockPowerState, POWER_CYCLE_DELAY, PowerControl, SetSystemPowerError, http,
-    redfish,
+    BootOptionKind, Callbacks, LogServices, MockPowerState, POWER_CYCLE_DELAY, SetSystemPowerError,
+    http, redfish,
 };
 
 pub fn collection() -> redfish::Collection<'static> {
@@ -129,7 +129,7 @@ pub struct SingleSystemConfig {
     pub manufacturer: Option<Cow<'static, str>>,
     pub model: Option<Cow<'static, str>>,
     pub boot_order_mode: BootOrderMode,
-    pub power_control: Option<Arc<dyn PowerControl>>,
+    pub callbacks: Option<Arc<dyn Callbacks>>,
     pub chassis: Vec<Cow<'static, str>>,
     pub boot_options: Option<Vec<redfish::boot_option::BootOption>>,
     pub bios_mode: BiosMode,
@@ -193,6 +193,12 @@ impl SystemState {
         let systems = configs.into_iter().map(SingleSystemState::new).collect();
         Self { systems }
     }
+
+    pub fn resolve_current_boot_selection(&self) -> Option<BootOptionKind> {
+        self.systems
+            .iter()
+            .find_map(|system| system.resolve_current_boot_selection())
+    }
 }
 
 impl SingleSystemState {
@@ -220,6 +226,27 @@ impl SingleSystemState {
     fn boot_order_override(&self) -> Option<Vec<String>> {
         self.boot_order_override.lock().unwrap().clone()
     }
+
+    fn resolve_current_boot_selection(&self) -> Option<BootOptionKind> {
+        self.boot_order_override()
+            .and_then(|overrides| {
+                overrides.first().and_then(|optref| {
+                    self.config
+                        .boot_options
+                        .iter()
+                        .flatten()
+                        .find(|v| v.boot_reference() == optref)
+                        .map(|opt| opt.kind)
+                })
+            })
+            .or_else(|| {
+                self.config
+                    .boot_options
+                    .as_ref()?
+                    .first()
+                    .map(|opt| opt.kind)
+            })
+    }
 }
 
 async fn get_system_collection(State(state): State<BmcState>) -> Response {
@@ -242,9 +269,9 @@ async fn get_system(State(state): State<BmcState>, Path(system_id): Path<String>
     let config = &system_state.config;
 
     if let Some(state) = config
-        .power_control
+        .callbacks
         .as_ref()
-        .map(|control| control.get_power_state())
+        .map(|callbacks| callbacks.get_power_state())
     {
         b = b.power_state(state)
     }
@@ -433,7 +460,7 @@ async fn post_reset_system(
     let Some(system_state) = state.system_state.find(&system_id) else {
         return http::not_found();
     };
-    let Some(power_control) = system_state.config.power_control.as_ref() else {
+    let Some(callbacks) = system_state.config.callbacks.as_ref() else {
         return http::not_found();
     };
     let Some(reset_type) = power_request
@@ -451,7 +478,7 @@ async fn post_reset_system(
     // introduce a deadlock if the API server holds a lock on the row for this machine
     // while issuing a redfish call, and MachineStateMachine is blocked waiting for the row lock
     // to be released.
-    match power_control.set_power_state(reset_type) {
+    match callbacks.set_power_state(reset_type) {
         Ok(_) => json!({}).into_ok_response(),
         Err(SetSystemPowerError::BadRequest(_)) => StatusCode::BAD_REQUEST.into_response(),
         Err(SetSystemPowerError::CommandSendError(_)) => {

--- a/crates/bmc-mock/src/redfish/expander_router.rs
+++ b/crates/bmc-mock/src/redfish/expander_router.rs
@@ -242,27 +242,29 @@ mod tests {
     use crate::*;
 
     #[derive(Debug)]
-    struct TestPowerControl {}
+    struct TestCallbacks {}
 
-    impl PowerControl for TestPowerControl {
+    impl Callbacks for TestCallbacks {
         fn get_power_state(&self) -> MockPowerState {
             MockPowerState::On
         }
         fn send_power_command(&self, _: SystemPowerControl) -> Result<(), SetSystemPowerError> {
             Ok(())
         }
+        fn state_refresh_indication(&self) {}
     }
 
     fn test_host_mock() -> Router {
-        let power_control = Arc::new(TestPowerControl {});
+        let callbacks = Arc::new(TestCallbacks {});
         crate::machine_router(
             MachineInfo::Host(HostMachineInfo::new(
                 HostHardwareType::DellPowerEdgeR750,
                 vec![DpuMachineInfo::default()],
             )),
-            power_control,
+            callbacks,
             String::default(),
         )
+        .0
     }
 
     #[tokio::test]

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -22,7 +22,7 @@ use url::Url;
 
 use crate::machine_info::DpuSettings;
 use crate::{
-    DpuMachineInfo, HostHardwareType, HostMachineInfo, MachineInfo, MockPowerState, PowerControl,
+    Callbacks, DpuMachineInfo, HostHardwareType, HostMachineInfo, MachineInfo, MockPowerState,
     SetSystemPowerError, SystemPowerControl, machine_router,
 };
 pub mod axum_http_client;
@@ -30,9 +30,9 @@ pub mod axum_http_client;
 use axum_http_client::AxumRouterHttpClient;
 
 #[derive(Debug)]
-struct NoopPowerControl;
+struct NoopCallbacks;
 
-impl PowerControl for NoopPowerControl {
+impl Callbacks for NoopCallbacks {
     fn get_power_state(&self) -> MockPowerState {
         MockPowerState::On
     }
@@ -43,6 +43,8 @@ impl PowerControl for NoopPowerControl {
     ) -> Result<(), SetSystemPowerError> {
         Ok(())
     }
+
+    fn state_refresh_indication(&self) {}
 }
 
 pub type TestBmc = HttpBmc<AxumRouterHttpClient>;
@@ -60,61 +62,76 @@ fn test_bmc(router: axum::Router) -> Arc<TestBmc> {
 }
 
 pub fn wiwynn_gb200_bmc() -> Arc<TestBmc> {
-    test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::WiwynnGB200Nvl,
-            vec![
-                DpuMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, DpuSettings::default()),
-                DpuMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, DpuSettings::default()),
-            ],
-        )),
-        Arc::new(NoopPowerControl),
-        "test-host-id".to_string(),
-    ))
+    test_bmc(
+        machine_router(
+            MachineInfo::Host(HostMachineInfo::new(
+                HostHardwareType::WiwynnGB200Nvl,
+                vec![
+                    DpuMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, DpuSettings::default()),
+                    DpuMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, DpuSettings::default()),
+                ],
+            )),
+            Arc::new(NoopCallbacks),
+            "test-host-id".to_string(),
+        )
+        .0,
+    )
 }
 
 pub fn liteon_powershelf_bmc() -> Arc<TestBmc> {
-    test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::LiteOnPowerShelf,
-            vec![],
-        )),
-        Arc::new(NoopPowerControl),
-        "test-host-id".to_string(),
-    ))
+    test_bmc(
+        machine_router(
+            MachineInfo::Host(HostMachineInfo::new(
+                HostHardwareType::LiteOnPowerShelf,
+                vec![],
+            )),
+            Arc::new(NoopCallbacks),
+            "test-host-id".to_string(),
+        )
+        .0,
+    )
 }
 
 pub fn nvidia_switch_nd5200_ld_bmc() -> Arc<TestBmc> {
-    test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::NvidiaSwitchNd5200Ld,
-            vec![],
-        )),
-        Arc::new(NoopPowerControl),
-        "test-host-id".to_string(),
-    ))
+    test_bmc(
+        machine_router(
+            MachineInfo::Host(HostMachineInfo::new(
+                HostHardwareType::NvidiaSwitchNd5200Ld,
+                vec![],
+            )),
+            Arc::new(NoopCallbacks),
+            "test-host-id".to_string(),
+        )
+        .0,
+    )
 }
 
 pub fn dell_poweredge_r750_bmc() -> Arc<TestBmc> {
-    test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::DellPowerEdgeR750,
-            vec![],
-        )),
-        Arc::new(NoopPowerControl),
-        "test-host-id".to_string(),
-    ))
+    test_bmc(
+        machine_router(
+            MachineInfo::Host(HostMachineInfo::new(
+                HostHardwareType::DellPowerEdgeR750,
+                vec![],
+            )),
+            Arc::new(NoopCallbacks),
+            "test-host-id".to_string(),
+        )
+        .0,
+    )
 }
 
 pub fn dell_poweredge_r750_bluefield3_bmc(settings: DpuSettings) -> Arc<TestBmc> {
-    test_bmc(machine_router(
-        MachineInfo::Dpu(DpuMachineInfo::new(
-            HostHardwareType::DellPowerEdgeR750,
-            settings,
-        )),
-        Arc::new(NoopPowerControl),
-        "test-dpu-id".to_string(),
-    ))
+    test_bmc(
+        machine_router(
+            MachineInfo::Dpu(DpuMachineInfo::new(
+                HostHardwareType::DellPowerEdgeR750,
+                settings,
+            )),
+            Arc::new(NoopCallbacks),
+            "test-dpu-id".to_string(),
+        )
+        .0,
+    )
 }
 
 #[cfg(test)]
@@ -129,14 +146,17 @@ mod test {
 
     #[tokio::test]
     async fn transport_supports_expand_query_through_mock_expander() {
-        let client = AxumRouterHttpClient::new(machine_router(
-            MachineInfo::Host(HostMachineInfo::new(
-                HostHardwareType::DellPowerEdgeR750,
-                vec![],
-            )),
-            Arc::new(NoopPowerControl),
-            "test-host-id".to_string(),
-        ));
+        let client = AxumRouterHttpClient::new(
+            machine_router(
+                MachineInfo::Host(HostMachineInfo::new(
+                    HostHardwareType::DellPowerEdgeR750,
+                    vec![],
+                )),
+                Arc::new(NoopCallbacks),
+                "test-host-id".to_string(),
+            )
+            .0,
+        );
         let url =
             Url::parse("https://bmc-mock.local/redfish/v1/Chassis?$expand=.($levels=1)").unwrap();
 

--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -20,7 +20,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use axum::Router;
-use bmc_mock::{CombinedServer, HostnameQuerying, ListenerOrAddress, MachineInfo, PowerControl};
+use bmc_mock::{
+    BmcState, Callbacks, CombinedServer, HostnameQuerying, ListenerOrAddress, MachineInfo,
+};
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
@@ -33,11 +35,11 @@ use crate::mock_ssh_server::{MockSshServerHandle, PromptBehavior};
 /// BmcMockWrapper launches a single instance of bmc-mock, configured to mock a single BMC for
 /// either a DPU or a Host. It will rewrite certain responses to customize them for the machines
 /// machine-a-tron is mocking.
-#[derive(Debug)]
 pub struct BmcMockWrapper {
     machine_info: MachineInfo,
     app_context: Arc<MachineATronContext>,
     bmc_mock_router: Router,
+    bmc_mock_state: BmcState,
     hostname: Arc<dyn HostnameQuerying>,
 }
 
@@ -45,17 +47,18 @@ impl BmcMockWrapper {
     pub fn new(
         machine_info: MachineInfo,
         app_context: Arc<MachineATronContext>,
-        power_control: Arc<dyn PowerControl>,
+        callbacks: Arc<dyn Callbacks>,
         hostname: Arc<dyn HostnameQuerying>,
         host_id: Uuid,
     ) -> Self {
-        let bmc_mock_router =
-            bmc_mock::machine_router(machine_info.clone(), power_control, host_id.to_string());
+        let (bmc_mock_router, bmc_mock_state) =
+            bmc_mock::machine_router(machine_info.clone(), callbacks, host_id.to_string());
 
         BmcMockWrapper {
             machine_info,
             app_context,
             bmc_mock_router,
+            bmc_mock_state,
             hostname,
         }
     }
@@ -155,6 +158,10 @@ impl BmcMockWrapper {
 
     pub fn router(&self) -> &Router {
         &self.bmc_mock_router
+    }
+
+    pub fn state(&self) -> &BmcState {
+        &self.bmc_mock_state
     }
 }
 

--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -36,7 +36,6 @@ use crate::machine_state_machine::{LiveState, MachineStateMachine, OsImage, Pers
 use crate::tui::HostDetails;
 use crate::{MachineConfig, saturating_add_duration_to_instant};
 
-#[derive(Debug)]
 pub struct DpuMachine {
     mat_id: Uuid,
     // The mat_id of the host that owns this DPU
@@ -242,6 +241,9 @@ impl DpuMachine {
                             _ = reply.send(response)
                         }
                     }
+                    BmcCommand::StateRefreshIndication => {
+                        self.state_machine.update_live_state();
+                    }
                 }
             }
             result = actor_message_rx.recv() => {
@@ -395,6 +397,7 @@ impl DpuMachineHandle {
                 .unwrap_or_default(),
             dpus: Vec::default(),
             booted_os: guard.booted_os.to_string(),
+            next_boot_kind: guard.ui_next_boot_kind().into(),
             power_state: guard.power_state,
         }
     }

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -39,7 +39,6 @@ use crate::machine_utils::create_random_self_signed_cert;
 use crate::saturating_add_duration_to_instant;
 use crate::tui::{HostDetails, UiUpdate};
 
-#[derive(Debug)]
 pub struct HostMachine {
     mat_id: Uuid,
     machine_config_section: String,
@@ -314,6 +313,9 @@ impl HostMachine {
                             _ = reply.send(response);
                         }
                     }
+                    BmcCommand::StateRefreshIndication => {
+                        self.state_machine.update_live_state();
+                    }
                 }
                 // continue to process_state
             }
@@ -422,14 +424,11 @@ impl HostMachine {
         HostDetails {
             mat_id: self.mat_id,
             hw_type: Some(self.host_info.hw_type),
-            machine_id: self
-                .live_state
-                .read()
-                .unwrap()
+            machine_id: live_state
                 .observed_machine_id
                 .as_ref()
                 .map(|m| m.to_string()),
-            mat_state: self.state_machine.live_state.read().unwrap().state_string,
+            mat_state: live_state.state_string,
             api_state: self.api_state.clone(),
             oob_ip: live_state
                 .bmc_ip
@@ -443,6 +442,7 @@ impl HostMachine {
                 .unwrap_or_default(),
             dpus: dpu_details,
             booted_os: live_state.booted_os.to_string(),
+            next_boot_kind: live_state.ui_next_boot_kind().into(),
             power_state: live_state.power_state,
         }
     }

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -23,8 +23,9 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use bmc_mock::{
-    BmcCommand, HostMachineInfo, HostnameQuerying, MachineInfo, MockPowerState, POWER_CYCLE_DELAY,
-    PowerControl, SetSystemPowerError, SetSystemPowerResult, SystemPowerControl,
+    BmcCommand, BmcState, BootOptionKind, Callbacks, HostMachineInfo, HostnameQuerying,
+    MachineInfo, MockPowerState, POWER_CYCLE_DELAY, SetSystemPowerError, SetSystemPowerResult,
+    SystemPowerControl,
 };
 use carbide_uuid::machine::MachineId;
 use rpc::forge::{MachineArchitecture, MachineDiscoveryResult, ManagedHostNetworkConfigResponse};
@@ -54,7 +55,6 @@ pub type DpuDhcpRelayHandle = oneshot::Sender<()>;
 ///
 /// This code is in common between DPUs and Hosts.(ie. anything that has a BMC, boots via DHCP, can
 /// receive PXE instructions, etc.)
-#[derive(Debug)]
 pub struct MachineStateMachine {
     pub live_state: Arc<RwLock<LiveState>>,
     pub machine_dhcp_id: Uuid,
@@ -64,6 +64,7 @@ pub struct MachineStateMachine {
 
     fsm: MachineFsm,
     bmc_mock: Option<Arc<BmcMockWrapperHandle>>,
+    bmc_state: Option<BmcState>,
     power_cycle_deadline: Option<Instant>,
     machine_on_deadline: Option<Instant>,
     agent_polling_deadline: Option<(Instant, Timer)>,
@@ -81,12 +82,12 @@ pub struct MachineStateMachine {
 }
 
 #[derive(Debug, Clone)]
-pub struct LiveStatePowerControl {
+pub struct LiveStateCallbacks {
     state: Arc<RwLock<LiveState>>,
     command_channel: mpsc::UnboundedSender<BmcCommand>,
 }
 
-impl LiveStatePowerControl {
+impl LiveStateCallbacks {
     pub fn new(
         state: Arc<RwLock<LiveState>>,
         command_channel: mpsc::UnboundedSender<BmcCommand>,
@@ -98,7 +99,7 @@ impl LiveStatePowerControl {
     }
 }
 
-impl PowerControl for LiveStatePowerControl {
+impl Callbacks for LiveStateCallbacks {
     fn get_power_state(&self) -> MockPowerState {
         self.state.read().unwrap().power_state
     }
@@ -113,6 +114,12 @@ impl PowerControl for LiveStatePowerControl {
                 reply: None,
             })
             .map_err(|err| SetSystemPowerError::CommandSendError(err.to_string()))
+    }
+
+    fn state_refresh_indication(&self) {
+        let _ = self
+            .command_channel
+            .send(BmcCommand::StateRefreshIndication);
     }
 }
 
@@ -141,6 +148,7 @@ pub struct LiveState {
     pub machine_ip: Option<Ipv4Addr>,
     pub bmc_ip: Option<Ipv4Addr>,
     pub booted_os: MaybeOsImage,
+    pub next_boot_kind: Option<BootOptionKind>,
     pub installed_os: OsImage,
     pub state_string: Option<&'static str>,
     pub api_state: String,
@@ -158,11 +166,22 @@ impl Default for LiveState {
             machine_ip: None,
             bmc_ip: None,
             booted_os: Default::default(),
+            next_boot_kind: None,
             installed_os: Default::default(),
             state_string: None,
             api_state: "Unknown".to_string(),
             tpm_ek_certificate: None,
             ssh_host_key: None,
+        }
+    }
+}
+
+impl LiveState {
+    pub fn ui_next_boot_kind(&self) -> &'static str {
+        match self.next_boot_kind {
+            Some(BootOptionKind::Disk) => "Disk",
+            Some(BootOptionKind::Network) => "Network",
+            None => "Unknown",
         }
     }
 }
@@ -226,6 +245,7 @@ impl MachineStateMachine {
             fsm,
             actions: actions.into_iter().collect(),
             bmc_mock: None,
+            bmc_state: None,
             power_cycle_deadline: None,
             machine_on_deadline: None,
             agent_polling_deadline: None,
@@ -270,6 +290,7 @@ impl MachineStateMachine {
             actions: actions.into_iter().collect(),
             bmc_dhcp_info: None,
             bmc_mock: None,
+            bmc_state: None,
             machine_dhcp_info: None,
             machine_discovery_result: None,
             machine_on_deadline: None,
@@ -334,8 +355,9 @@ impl MachineStateMachine {
             self.update_live_state();
             match action {
                 FsmAction::SetupBmc => match self.setup_bmc().await {
-                    Ok(bmc_mock) => {
+                    Ok((bmc_mock, bmc_state)) => {
                         self.bmc_mock = bmc_mock;
+                        self.bmc_state = Some(bmc_state);
                         self.actions.pop_front();
                     }
                     Err(_) => return Some(self.config.run_interval_working),
@@ -456,7 +478,9 @@ impl MachineStateMachine {
         self.fsm = new_state;
     }
 
-    async fn setup_bmc(&self) -> Result<Option<Arc<BmcMockWrapperHandle>>, MachineStateError> {
+    async fn setup_bmc(
+        &self,
+    ) -> Result<(Option<Arc<BmcMockWrapperHandle>>, BmcState), MachineStateError> {
         let Some(dhcp_info) = &self.bmc_dhcp_info else {
             return Err(MachineStateError::NoBmcDhcpInfo);
         };
@@ -746,6 +770,10 @@ impl MachineStateMachine {
         live_state.state_string = Some(self.fsm.state_string());
         live_state.power_state = self.fsm.power_state();
         live_state.booted_os = self.booted_os();
+        live_state.next_boot_kind = self
+            .bmc_state
+            .as_ref()
+            .and_then(|state| state.system_state.resolve_current_boot_selection());
     }
 
     async fn run_machine_discovery(
@@ -874,11 +902,11 @@ impl MachineStateMachine {
     async fn run_bmc_mock(
         &self,
         ip_address: Ipv4Addr,
-    ) -> Result<Option<Arc<BmcMockWrapperHandle>>, MachineStateError> {
+    ) -> Result<(Option<Arc<BmcMockWrapperHandle>>, BmcState), MachineStateError> {
         let mut bmc_mock = BmcMockWrapper::new(
             self.machine_info.clone(),
             self.app_context.clone(),
-            Arc::new(LiveStatePowerControl::new(
+            Arc::new(LiveStateCallbacks::new(
                 self.live_state.clone(),
                 self.bmc_command_channel.clone(),
             )),
@@ -905,7 +933,7 @@ impl MachineStateMachine {
                 None
             }
         };
-        Ok(maybe_bmc_mock_handle)
+        Ok((maybe_bmc_mock_handle, bmc_mock.state().clone()))
     }
 
     async fn send_discovery_complete(&self, machine_id: &MachineId) -> Result<(), ClientApiError> {

--- a/crates/machine-a-tron/src/tui.rs
+++ b/crates/machine-a-tron/src/tui.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::error::Error;
 use std::time::Duration;
@@ -100,6 +101,7 @@ pub struct HostDetails {
     pub machine_ip: String,
     pub dpus: Vec<HostDetails>,
     pub booted_os: String,
+    pub next_boot_kind: Cow<'static, str>,
 }
 
 impl HostDetails {
@@ -130,6 +132,7 @@ impl HostDetails {
             &format!("BMC IP: {}\n", self.oob_ip),
             &format!("Power State: {}\n", self.power_state),
             &format!("Booted OS: {}\n", self.booted_os),
+            &format!("Next boot: {}\n", self.next_boot_kind),
             &format!("MAT State: {}\n", self.mat_state.unwrap_or("Unknown")),
             &format!("API State: {}\n", self.api_state),
         ]


### PR DESCRIPTION
## Description

Rename PowerControl to Callbacks and extend the interface with
state_refresh_indication() so bmc-mock can notify machine-a-tron when
successful mutating Redfish/IPMI operations should refresh derived live
state.

Add BootOptionKind to boot options and annotate mocked hardware boot
entries as Disk or Network. Use this in computer_system state resolution
to infer the current selected boot target from boot order overrides (or
the default first option), and surface that in machine-a-tron live state
and TUI as “Next boot”.

Also:
- return BmcState from machine_router() so MAT can inspect mock state
  directly
- wire StateRefreshIndication through BmcCommand handlers
- update middleware to refresh state only after successful non-safe
  requests
- clean up naming from power_control to callbacks

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
