### PR TITLE
feat(dpf): v2 provisioning path — operator config patching and skip discovery gating

### DIFF
--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -597,6 +597,10 @@ pub struct DpfConfig {
     /// Whether to create the bf.cfg ConfigMap during initialization.
     #[serde(default = "default_to_true")]
     pub bfcfg_enabled: bool,
+    /// Are we testing v2 version??
+    /// This is just temporary flag and will be removed once v2 becomes only option.
+    #[serde(default)]
+    pub v2: bool,
 }
 
 impl Default for DpfConfig {
@@ -609,6 +613,7 @@ impl Default for DpfConfig {
             bfb_url: String::new(),
             services: None,
             bfcfg_enabled: true,
+            v2: false,
         }
     }
 }

--- a/crates/api/src/dpf.rs
+++ b/crates/api/src/dpf.rs
@@ -21,6 +21,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use carbide_dpf::types::{DpuFlavorBridgeDefinition, DpuFlavorDefinition};
 use carbide_dpf::{
     BmcPasswordProvider, DpfError, DpfSdk, DpuDeviceInfo, DpuNodeInfo, DpuPhase, DpuWatcher,
     KubeRepository, ResourceLabeler, node_id_from_dpu_node_cr_name,
@@ -417,6 +418,44 @@ impl DpfOperations for DpfSdkOps {
 
     async fn verify_node_labels(&self, node_name: &str) -> Result<bool, DpfError> {
         self.sdk.verify_node_labels(node_name).await
+    }
+}
+
+impl From<CarbideConfig> for DpuFlavorDefinition {
+    fn from(config: CarbideConfig) -> Self {
+        let mut definition = Self {
+            carbide_hbn_reps: None,
+            carbide_hbn_sfs: None,
+            bridge_def: None,
+        };
+        if let Some(vmaas) = config.vmaas_config.as_ref() {
+            if let Some(hbn_reps) = vmaas.hbn_reps.as_ref() {
+                definition.carbide_hbn_reps = Some(hbn_reps.clone());
+            }
+            if let Some(hbn_sfs) = vmaas.hbn_sfs.as_ref() {
+                definition.carbide_hbn_sfs = Some(hbn_sfs.clone());
+            }
+
+            if let Some(bridge) = vmaas.bridging.as_ref() {
+                let vf_intercept_bridge_name = bridge.vf_intercept_bridge_name.clone();
+                let vf_intercept_bridge_port = bridge.vf_intercept_bridge_port.clone();
+                let host_intercept_bridge_name = bridge.host_intercept_bridge_name.clone();
+                let host_intercept_bridge_port = bridge.host_intercept_bridge_port.clone();
+                let vf_intercept_bridge_sf = bridge.vf_intercept_bridge_sf.clone();
+
+                let bridge = DpuFlavorBridgeDefinition {
+                    vf_intercept_bridge_name,
+                    vf_intercept_bridge_port,
+                    host_intercept_bridge_name,
+                    host_intercept_bridge_port,
+                    vf_intercept_bridge_sf,
+                };
+
+                definition.bridge_def = Some(bridge);
+            }
+        }
+
+        definition
     }
 }
 

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -397,23 +397,49 @@ pub async fn start_api(
             None
         };
 
-        let bfb_url = if carbide_config.dpf.bfb_url.is_empty() {
+        let bfb_url = if carbide_config.dpf.v2 && carbide_config.dpf.bfb_url.is_empty() {
+            // This should move to cfg/file as a default value once v2 is the only mode.
+            "https://content.mellanox.com/BlueField/BFBs/Ubuntu22.04/bf-bundle-3.2.0-113_25.10_ubuntu-22.04_prod.bfb".to_string()
+        } else if carbide_config.dpf.bfb_url.is_empty() {
             crate::dpf::resolve_bfb_url().await?
         } else {
             carbide_config.dpf.bfb_url.clone()
         };
 
+        // This is just temparary code until we make v2 only option. (just 2 weeks)
+        // Soon v2 flag will be removed and will become only mode for dpf handling.
+        let v2_str = if carbide_config.dpf.v2 { "-v2" } else { "" };
         let init_config = carbide_dpf::InitDpfResourcesConfig {
             bfb_url,
-            deployment_name: carbide_config.dpf.deployment_name.clone(),
             flavor_name: carbide_config.dpf.flavor_name.clone(),
-            services,
-            bfcfg_template,
+            deployment_name: format!("{}{}", carbide_config.dpf.deployment_name.clone(), v2_str),
+            services: if carbide_config.dpf.v2 {
+                // Enable all the services.
+                Vec::new()
+            } else {
+                services
+            },
+            bfcfg_template: if carbide_config.dpf.v2 {
+                // We use default bf.cfg.
+                None
+            } else {
+                bfcfg_template
+            },
+            dpu_flavor: if carbide_config.dpf.v2 {
+                Some((*carbide_config).clone().into())
+            } else {
+                None
+            },
         };
 
         let sdk = carbide_dpf::DpfSdkBuilder::new(repo, carbide_dpf::NAMESPACE, provider)
             .with_labeler(crate::dpf::CarbideDPFLabeler::new(
-                carbide_config.dpf.node_label_key.clone(),
+                if carbide_config.dpf.v2 {
+                    // This will be removed and moved to config file when v1 code is deleted.
+                    "carbide.nvidia.com/controlled.node.v2".to_string()
+                } else {
+                    carbide_config.dpf.node_label_key.clone()
+                },
             ))
             .with_bmc_password_refresh_interval(std::time::Duration::from_secs(60))
             .with_join_set(join_set)

--- a/crates/api/src/state_controller/machine/handler/dpf.rs
+++ b/crates/api/src/state_controller/machine/handler/dpf.rs
@@ -222,10 +222,14 @@ async fn handle_dpf_reboot(
     // Custom BFB: wait for all DPU agents to complete discovery before rebooting
     // the host. This indicates cloud-init has completed on every DPU.
     // Remove when switching to a vanilla BFB.
-    if let Some(pending) = state
-        .dpu_snapshots
-        .iter()
-        .find(|d| d.last_discovery_time.is_none())
+
+    // BUG ALERT: This is a bug. This might work fine for M1 for initial ingestion, but will fail for reprovisioning.
+    // Quickest fix might be clearing discovery_time on reprovisioning.
+    if !ctx.services.site_config.dpf.v2
+        && let Some(pending) = state
+            .dpu_snapshots
+            .iter()
+            .find(|d| d.last_discovery_time.is_none())
     {
         return update_phase_detail_or_wait(
             state,
@@ -329,7 +333,7 @@ async fn handle_dpf_waiting_for_ready(
         );
     }
     // also wait for dpu scout discovery to complete
-    if dpu_snapshot.last_discovery_time.is_none() {
+    if !ctx.services.site_config.dpf.v2 && dpu_snapshot.last_discovery_time.is_none() {
         return update_phase_detail_or_wait(
             state,
             &dpu_snapshot.id,

--- a/crates/api/src/tests/dpf/duplicate_events.rs
+++ b/crates/api/src/tests/dpf/duplicate_events.rs
@@ -48,6 +48,8 @@ fn dpf_config() -> crate::cfg::file::DpfConfig {
     crate::cfg::file::DpfConfig {
         enabled: true,
         bfb_url: "http://example.com/test.bfb".to_string(),
+        services: None,
+        v2: true,
         ..Default::default()
     }
 }

--- a/crates/api/src/tests/dpf/happy_path.rs
+++ b/crates/api/src/tests/dpf/happy_path.rs
@@ -51,6 +51,8 @@ async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
     config.dpf = crate::cfg::file::DpfConfig {
         enabled: true,
         bfb_url: "http://example.com/test.bfb".to_string(),
+        services: None,
+        v2: true,
         ..Default::default()
     };
 

--- a/crates/api/src/tests/dpf/reprovisioning.rs
+++ b/crates/api/src/tests/dpf/reprovisioning.rs
@@ -64,6 +64,8 @@ fn dpf_config() -> crate::cfg::file::DpfConfig {
     crate::cfg::file::DpfConfig {
         enabled: true,
         bfb_url: "http://example.com/test.bfb".to_string(),
+        services: None,
+        v2: true,
         ..Default::default()
     }
 }

--- a/crates/api/src/tests/dpf/waiting_for_ready.rs
+++ b/crates/api/src/tests/dpf/waiting_for_ready.rs
@@ -52,6 +52,8 @@ fn dpf_config() -> crate::cfg::file::DpfConfig {
     crate::cfg::file::DpfConfig {
         enabled: true,
         bfb_url: "http://example.com/test.bfb".to_string(),
+        services: None,
+        v2: true,
         ..Default::default()
     }
 }
@@ -502,6 +504,7 @@ async fn test_waiting_for_ready_reboot_blocked_without_discovery(pool: sqlx::PgP
     let dpf_sdk: Arc<dyn crate::dpf::DpfOperations> = Arc::new(mock);
     let mut config = get_config();
     config.dpf = dpf_config();
+    config.dpf.v2 = false;
 
     let env = create_test_env_with_overrides(
         pool.clone(),
@@ -578,6 +581,7 @@ async fn test_waiting_for_ready_reboot_proceeds_after_discovery(pool: sqlx::PgPo
     let dpf_sdk: Arc<dyn crate::dpf::DpfOperations> = Arc::new(mock);
     let mut config = get_config();
     config.dpf = dpf_config();
+    config.dpf.v2 = false;
 
     let env = create_test_env_with_overrides(
         pool.clone(),
@@ -732,6 +736,7 @@ async fn test_waiting_for_ready_reboot_blocked_until_all_dpus_discover(pool: sql
     let dpf_sdk: Arc<dyn crate::dpf::DpfOperations> = Arc::new(mock);
     let mut config = get_config();
     config.dpf = dpf_config();
+    config.dpf.v2 = false;
 
     let env = create_test_env_with_overrides(
         pool.clone(),

--- a/crates/api/src/tests/machine_admin_force_delete.rs
+++ b/crates/api/src/tests/machine_admin_force_delete.rs
@@ -758,6 +758,8 @@ async fn test_admin_force_delete_with_dpf_uses_bmc_mac(pool: sqlx::PgPool) {
     config.dpf = crate::cfg::file::DpfConfig {
         enabled: true,
         bfb_url: "http://example.com/test.bfb".to_string(),
+        services: None,
+        v2: true,
         ..Default::default()
     };
 

--- a/crates/dpf/src/bin/api_harness.rs
+++ b/crates/dpf/src/bin/api_harness.rs
@@ -709,6 +709,8 @@ async fn run_provisioning_flow(
     let init_config = InitDpfResourcesConfig {
         bfb_url: bfb_url.to_string(),
         services: services.to_vec(),
+        bfcfg_template: None,
+        dpu_flavor: None,
         ..Default::default()
     };
     sdk.create_initialization_objects(&init_config).await?;

--- a/crates/dpf/src/repository/kube.rs
+++ b/crates/dpf/src/repository/kube.rs
@@ -567,6 +567,22 @@ impl K8sConfigRepository for KubeRepository {
     }
 }
 
+#[async_trait]
+impl DpfOperatorConfigRepository for KubeRepository {
+    async fn patch(
+        &self,
+        name: &str,
+        namespace: &str,
+        patch: serde_json::Value,
+    ) -> Result<(), DpfError> {
+        use crate::crds::dpfoperatorconfigs_generated::DPFOperatorConfig;
+        let api: Api<DPFOperatorConfig> = Api::namespaced(self.client.clone(), namespace);
+        api.patch(name, &PatchParams::default(), &Patch::Merge(&patch))
+            .await?;
+        Ok(())
+    }
+}
+
 // Implement the meta trait
 impl DpfRepository for KubeRepository {}
 

--- a/crates/dpf/src/repository/traits.rs
+++ b/crates/dpf/src/repository/traits.rs
@@ -239,6 +239,17 @@ pub trait K8sConfigRepository: Send + Sync {
     ) -> Result<(), DpfError>;
 }
 
+/// Repository for DPFOperatorConfig resources.
+#[async_trait]
+pub trait DpfOperatorConfigRepository: Send + Sync {
+    async fn patch(
+        &self,
+        name: &str,
+        namespace: &str,
+        patch: serde_json::Value,
+    ) -> Result<(), DpfError>;
+}
+
 /// Combined trait for all DPF repository operations.
 ///
 /// Implementors of this trait provide access to all DPF CRD operations,
@@ -259,6 +270,7 @@ pub trait DpfRepository:
     + DpuServiceChainRepository
     + DpuServiceInterfaceRepository
     + K8sConfigRepository
+    + DpfOperatorConfigRepository
     + Send
     + Sync
 {

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -35,6 +35,7 @@ use crate::crds::dpudeployments_generated::{
     DpuDeploymentServiceChainsUpgradePolicy, DpuDeploymentServices, DpuDeploymentSpec,
 };
 use crate::crds::dpudevices_generated::{DPUDevice, DpuDeviceSpec};
+use crate::crds::dpuflavors_generated::{DPUFlavor, DpuFlavorNvconfig};
 use crate::crds::dpunodes_generated::{
     DPUNode, DpuNodeDpus, DpuNodeNodeRebootMethod, DpuNodeNodeRebootMethodExternal, DpuNodeSpec,
 };
@@ -55,13 +56,13 @@ use crate::crds::dpuservicetemplates_generated::{
 };
 use crate::error::DpfError;
 use crate::repository::{
-    BfbRepository, DpuDeploymentRepository, DpuDeviceRepository, DpuFlavorRepository,
-    DpuNodeMaintenanceRepository, DpuNodeRepository, DpuRepository,
+    BfbRepository, DpfOperatorConfigRepository, DpuDeploymentRepository, DpuDeviceRepository,
+    DpuFlavorRepository, DpuNodeMaintenanceRepository, DpuNodeRepository, DpuRepository,
     DpuServiceConfigurationRepository, DpuServiceTemplateRepository, K8sConfigRepository,
 };
 use crate::types::{
-    BmcPasswordProvider, ConfigPortsServiceType, DpuDeviceInfo, DpuNodeInfo, DpuPhase,
-    InitDpfResourcesConfig, ServiceConfigPortProtocol, ServiceDefinition,
+    BmcPasswordProvider, ConfigPortsServiceType, DpuDeviceInfo, DpuFlavorDefinition, DpuNodeInfo,
+    DpuPhase, InitDpfResourcesConfig, ServiceConfigPortProtocol, ServiceDefinition,
 };
 use crate::watcher::DpuWatcherBuilder;
 
@@ -238,6 +239,7 @@ where
         + DpuServiceTemplateRepository
         + DpuServiceConfigurationRepository
         + K8sConfigRepository
+        + DpfOperatorConfigRepository
         + 'static,
     P: BmcPasswordProvider + 'static,
     L: ResourceLabeler,
@@ -418,184 +420,328 @@ async fn create_bfb<R: BfbRepository>(
     }
 }
 
+// Right now there are only couple of parameters which needs to be compared for the mismatch.
+// Here we are not comparing each parameter.
+fn is_new_flavor_needed(
+    old_flavor: &DPUFlavor,
+    new_bfcfg: &[String],
+    ovs_commands: &[String],
+) -> bool {
+    let old_bfcfg_parameters = old_flavor.spec.bfcfg_parameters.clone().unwrap_or_default();
+
+    if !new_bfcfg.iter().all(|x| old_bfcfg_parameters.contains(x)) {
+        return false;
+    }
+
+    let old_ovs_commands = old_flavor
+        .spec
+        .ovs
+        .clone()
+        .and_then(|x| x.raw_config_script)
+        .unwrap_or_default();
+
+    old_ovs_commands == ovs_commands.join("\n")
+}
+
 async fn create_dpu_flavor<R: DpuFlavorRepository>(
     repo: &R,
     namespace: &str,
-    flavor_name: &str,
-) -> Result<(), DpfError> {
-    let flavor = crate::flavor::default_flavor(namespace, flavor_name);
+    dpu_flavor_def: &Option<DpuFlavorDefinition>,
+    existing_flavor_name: Option<String>,
+    default_flavor_name: &str,
+) -> Result<String, DpfError> {
+    let mut flavor = crate::flavor::default_flavor(namespace, default_flavor_name);
+
+    let mut bfcfg_parameters = vec![
+        "ENABLE_BR_HBN=yes".to_string(),
+        "ENABLE_BR_SFC=yes".to_string(),
+    ];
+
+    // These parameters are taken from CarbdieConfig which can be changed at runtime.
+    // If these parameters are changed, we need to create a new DPUFlavor since DPUFlavor specs are
+    // immutable.
+    let (should_try_create_dpu_flavor, name) = if let Some(definition) = dpu_flavor_def {
+        if let Some(carbide_hbn_reps) = &definition.carbide_hbn_reps {
+            bfcfg_parameters.push(format!("BR_HBN_REPS={carbide_hbn_reps}"));
+        }
+
+        if let Some(carbide_hbn_sfs) = &definition.carbide_hbn_sfs {
+            bfcfg_parameters.push(format!("BR_HBN_SFS={carbide_hbn_sfs}"));
+        }
+
+        let mut ovs_commands = vec![];
+        if let Some(bridge) = &definition.bridge_def {
+            let vf_intercept_bridge_name = bridge.vf_intercept_bridge_name.clone();
+            let vf_intercept_bridge_port = bridge.vf_intercept_bridge_port.clone();
+            let host_intercept_bridge_name = bridge.host_intercept_bridge_name.clone();
+            let host_intercept_bridge_port = bridge.host_intercept_bridge_port.clone();
+            let vf_intercept_bridge_sf = bridge.vf_intercept_bridge_sf.clone();
+            let vf_intercept_hbn_port = format!("patch-hbn-{vf_intercept_bridge_port}");
+            let host_intercept_hbn_port = format!("patch-hbn-{host_intercept_bridge_port}");
+            let vf_intercept_bridge_sf_representor = format!("{vf_intercept_bridge_sf}_r");
+            let vf_intercept_bridge_sf_hbn_bridge_representor =
+                format!("{vf_intercept_bridge_sf}_if_r");
+
+            ovs_commands.push(format!("_ovs-vsctl --may-exist add-br {vf_intercept_bridge_name} -- set bridge {vf_intercept_bridge_name} datapath_type=netdev -- set interface {vf_intercept_bridge_name} mtu_request=9216"));
+            ovs_commands.push("next_br_hbn_ofport_index=$(($(_ovs-vsctl get bridge br-hbn external_ids | grep -o '[0-9]*')+1))".to_string());
+            ovs_commands.push(
+                "_ovs-vsctl set bridge br-hbn external_ids:ofport_index=${next_br_hbn_ofport_index}"
+                    .to_string(),
+            );
+            ovs_commands.push(format!("_ovs-vsctl --may-exist add-port br-hbn {vf_intercept_hbn_port} -- set interface {vf_intercept_hbn_port} type=patch options:peer={vf_intercept_bridge_port} ofport_request=\"${{next_br_hbn_ofport_index}}\""));
+            ovs_commands.push(format!("_ovs-vsctl --may-exist add-port {vf_intercept_bridge_name} {vf_intercept_bridge_port} -- set interface {vf_intercept_bridge_port} type=patch options:peer={vf_intercept_hbn_port}"));
+            ovs_commands.push(format!("sed -i 's/br-hbn~{vf_intercept_bridge_sf_representor}~{vf_intercept_bridge_sf_hbn_bridge_representor}/br-hbn~{vf_intercept_hbn_port}~{vf_intercept_bridge_sf_hbn_bridge_representor}/' /etc/mellanox/sfc.conf"));
+            ovs_commands.push(format!("_ovs-vsctl set interface {vf_intercept_bridge_port} ofport_request=$(_ovs-vsctl get interface {vf_intercept_bridge_port} ofport)"));
+            ovs_commands.push(format!("sed -i ':a;N;$!ba;s/{vf_intercept_bridge_sf_representor}:{vf_intercept_bridge_sf_hbn_bridge_representor}\\n*//' /etc/mellanox/sfc.conf"));
+            ovs_commands.push(format!(
+                "_ovs-vsctl --if-exists del-port {vf_intercept_bridge_sf_representor}"
+            ));
+
+            ovs_commands.push(format!("_ovs-vsctl --may-exist add-br {host_intercept_bridge_name} -- set bridge {host_intercept_bridge_name} datapath_type=netdev"));
+            ovs_commands.push("next_br_hbn_ofport_index=$(($(_ovs-vsctl get bridge br-hbn external_ids | grep -o '[0-9]*')+1))".to_string());
+            ovs_commands.push("_ovs-vsctl set bridge br-hbn external_ids:ofport_index=${next_br_hbn_ofport_index}".to_string());
+            ovs_commands.push(format!("_ovs-vsctl --may-exist add-port br-hbn {host_intercept_hbn_port} -- set interface {host_intercept_hbn_port} type=patch options:peer={host_intercept_bridge_port} ofport_request=\"${{next_br_hbn_ofport_index}}\" external_ids='{{dependencies=pf0hpf_if_r, hbn_netdev=pf0hpf_if, hbn_rep_ofport=pf0hpf_if_r}}'"));
+            ovs_commands.push(format!("_ovs-vsctl --may-exist add-port {host_intercept_bridge_name} {host_intercept_bridge_port} -- set interface {host_intercept_bridge_port} type=patch options:peer={host_intercept_hbn_port}"));
+            ovs_commands.push(format!("_ovs-vsctl set interface {host_intercept_bridge_port} ofport_request=$(_ovs-vsctl get interface {host_intercept_bridge_port} ofport)"));
+            ovs_commands.push(format!("sed -i 's/br-hbn~pf0hpf~pf0hpf_if_r~pf0hpf_if~pf0hpf_if_r/br-hbn~{host_intercept_hbn_port}~pf0hpf_if_r~pf0hpf_if~pf0hpf_if_r/' /etc/mellanox/sfc.conf"));
+            ovs_commands.push(format!("_ovs-vsctl --if-exists del-port pf0hpf -- --may-exist add-port {host_intercept_bridge_name} pf0hpf -- set interface pf0hpf type=dpdk mtu_request=9216 external_ids='{{}}'"));
+            ovs_commands.push("_ovs-vsctl set interface pf0hpf ofport_request=$(_ovs-vsctl get interface pf0hpf ofport)".to_string());
+
+            flavor.spec.ovs = Some(crate::crds::dpuflavors_generated::DpuFlavorOvs {
+                raw_config_script: Some(ovs_commands.join("\n")),
+            });
+        }
+
+        let nvue_params = vec![
+            "SRIOV_EN=True".to_string(),
+            "NUM_OF_VFS=16".to_string(),
+            "HIDE_PORT2_PF=True".to_string(),
+            "NUM_OF_PF=1".to_string(),
+            "LINK_TYPE_P1=2".to_string(),
+            "LINK_TYPE_P2=2".to_string(),
+        ];
+
+        flavor.spec.nvconfig = Some(vec![DpuFlavorNvconfig {
+            device: Some("mt*_pciconf0".to_string()),
+            host_power_cycle_required: None,
+            parameters: Some(nvue_params),
+        }]);
+
+        if let Some(name) = existing_flavor_name {
+            let existing_flavor = DpuFlavorRepository::get(repo, &name, namespace).await?;
+            if let Some(flavor) = &existing_flavor {
+                // Flavor exists. Check if we have to create new or not.
+                let is_flavor_needed =
+                    is_new_flavor_needed(flavor, &bfcfg_parameters, &ovs_commands);
+
+                match is_flavor_needed {
+                    true => {
+                        let name = format!("{}-{}", default_flavor_name, uuid::Uuid::new_v4());
+                        (true, name)
+                    }
+                    // no need to create a new flavor. It is already exists with same parameter.
+                    false => (false, name.to_string()),
+                }
+            } else {
+                // No flavor exists with given name.
+                // It should not happen.
+                tracing::error!(
+                    "No DPUFlavor exists with name {name}. Will try again to create DPUFlavor."
+                );
+                (true, name.to_string())
+            }
+        } else {
+            (true, default_flavor_name.to_string())
+        }
+    } else {
+        (true, default_flavor_name.to_string())
+    };
+
+    if !should_try_create_dpu_flavor {
+        return Ok(name);
+    }
+
+    flavor.spec.bfcfg_parameters = Some(bfcfg_parameters);
+
+    // Update name as we decided in last stage.
+    flavor.metadata.name = Some(name.clone());
+
     match DpuFlavorRepository::create(repo, &flavor).await {
-        Ok(_) => Ok(()),
+        Ok(_) => Ok(name),
         Err(DpfError::KubeError(kube::Error::Api(ref err)))
             if err.is_already_exists() || err.is_conflict() =>
         {
-            let existing = DpuFlavorRepository::get(repo, flavor_name, namespace).await?;
+            let existing = DpuFlavorRepository::get(repo, &name, namespace).await?;
             if existing
                 .as_ref()
                 .is_some_and(|f| f.metadata.deletion_timestamp.is_some())
             {
                 return Err(DpfError::InvalidState(format!(
-                    "DPUFlavor {flavor_name} is being deleted (has deletionTimestamp); \
+                    "DPUFlavor {name} is being deleted (has deletionTimestamp); \
                      cannot re-create until the old resource is fully removed",
                 )));
             }
             tracing::debug!("DPU flavor already exists");
-            Ok(())
+            Ok(name)
         }
         Err(e) => Err(e),
     }
 }
 
-async fn create_services_and_deployment<
-    R: DpuServiceTemplateRepository + DpuServiceConfigurationRepository + DpuDeploymentRepository,
-    L: ResourceLabeler,
->(
-    repo: &R,
+fn build_service_template(svc: &ServiceDefinition, namespace: &str) -> DPUServiceTemplate {
+    let helm_values: Option<BTreeMap<String, serde_json::Value>> =
+        svc.helm_values.as_ref().and_then(|v| {
+            v.as_object()
+                .map(|obj| obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+        });
+
+    DPUServiceTemplate {
+        metadata: ObjectMeta {
+            name: Some(svc.name.clone()),
+            namespace: Some(namespace.to_string()),
+            ..Default::default()
+        },
+        spec: DpuServiceTemplateSpec {
+            deployment_service_name: svc.name.clone(),
+            helm_chart: DpuServiceTemplateHelmChart {
+                source: DpuServiceTemplateHelmChartSource {
+                    chart: Some(svc.helm_chart.clone()),
+                    path: None,
+                    release_name: None,
+                    repo_url: svc.helm_repo_url.clone(),
+                    version: svc.helm_version.clone(),
+                },
+                values: helm_values,
+            },
+            resource_requirements: None,
+        },
+        status: None,
+    }
+}
+
+fn build_service_configuration(
+    svc: &ServiceDefinition,
     namespace: &str,
-    labeler: &L,
+) -> DPUServiceConfiguration {
+    let interfaces: Vec<DpuServiceConfigurationInterfaces> = svc
+        .interfaces
+        .iter()
+        .map(|i| DpuServiceConfigurationInterfaces {
+            name: i.name.clone(),
+            network: i.network.clone(),
+            virtual_network: None,
+        })
+        .collect();
+
+    let config_ports_crd = svc.config_ports.as_ref().and_then(|ports| {
+        svc.config_ports_service_type.map(|st| {
+            DpuServiceConfigurationServiceConfigurationConfigPorts {
+                ports: ports
+                    .iter()
+                    .map(|p| DpuServiceConfigurationServiceConfigurationConfigPortsPorts {
+                        name: p.name.clone(),
+                        node_port: p.node_port,
+                        port: p.port,
+                        protocol: match p.protocol {
+                            ServiceConfigPortProtocol::Tcp => {
+                                DpuServiceConfigurationServiceConfigurationConfigPortsPortsProtocol::Tcp
+                            }
+                            ServiceConfigPortProtocol::Udp => {
+                                DpuServiceConfigurationServiceConfigurationConfigPortsPortsProtocol::Udp
+                            }
+                        },
+                    })
+                    .collect(),
+                service_type: match st {
+                    ConfigPortsServiceType::NodePort => {
+                        DpuServiceConfigurationServiceConfigurationConfigPortsServiceType::NodePort
+                    }
+                    ConfigPortsServiceType::ClusterIp => {
+                        DpuServiceConfigurationServiceConfigurationConfigPortsServiceType::ClusterIp
+                    }
+                    ConfigPortsServiceType::None => {
+                        DpuServiceConfigurationServiceConfigurationConfigPortsServiceType::None
+                    }
+                },
+            }
+        })
+    });
+
+    let helm_chart_config = svc.config_values.as_ref().and_then(|v| {
+        v.as_object().map(|obj| {
+            let values: BTreeMap<String, serde_json::Value> =
+                obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+            DpuServiceConfigurationServiceConfigurationHelmChart {
+                values: Some(values),
+            }
+        })
+    });
+
+    let service_daemon_set = svc.service_daemon_set_annotations.as_ref().map(|annos| {
+        DpuServiceConfigurationServiceConfigurationServiceDaemonSet {
+            annotations: Some(annos.clone()),
+            labels: None,
+            resources: None,
+            update_strategy: None,
+        }
+    });
+
+    let service_configuration = if config_ports_crd.is_some()
+        || helm_chart_config.is_some()
+        || service_daemon_set.is_some()
+    {
+        Some(DpuServiceConfigurationServiceConfiguration {
+            config_ports: config_ports_crd,
+            deploy_in_cluster: None,
+            helm_chart: helm_chart_config,
+            service_daemon_set,
+        })
+    } else {
+        None
+    };
+
+    DPUServiceConfiguration {
+        metadata: ObjectMeta {
+            name: Some(svc.name.clone()),
+            namespace: Some(namespace.to_string()),
+            ..Default::default()
+        },
+        spec: DpuServiceConfigurationSpec {
+            deployment_service_name: svc.name.clone(),
+            interfaces: if interfaces.is_empty() {
+                None
+            } else {
+                Some(interfaces)
+            },
+            service_configuration,
+            upgrade_policy: DpuServiceConfigurationUpgradePolicy {
+                apply_node_effect: Some(false),
+            },
+        },
+    }
+}
+
+fn build_deployment<L: ResourceLabeler>(
     services: &[ServiceDefinition],
     deployment_name: &str,
-    flavor_name: &str,
     bfb_name: &str,
-) -> Result<(), DpfError> {
-    for svc in services {
-        let helm_values: Option<BTreeMap<String, serde_json::Value>> =
-            svc.helm_values.as_ref().and_then(|v| {
-                v.as_object()
-                    .map(|obj| obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
-            });
-
-        let template = DPUServiceTemplate {
-            metadata: ObjectMeta {
-                name: Some(svc.name.clone()),
-                namespace: Some(namespace.to_string()),
-                ..Default::default()
-            },
-            spec: DpuServiceTemplateSpec {
-                deployment_service_name: svc.name.clone(),
-                helm_chart: DpuServiceTemplateHelmChart {
-                    source: DpuServiceTemplateHelmChartSource {
-                        chart: Some(svc.helm_chart.clone()),
-                        path: None,
-                        release_name: None,
-                        repo_url: svc.helm_repo_url.clone(),
-                        version: svc.helm_version.clone(),
-                    },
-                    values: helm_values,
+    flavor_name: String,
+    namespace: &str,
+    labeler: &L,
+) -> DPUDeployment {
+    let services_map: BTreeMap<String, DpuDeploymentServices> = services
+        .iter()
+        .map(|svc| {
+            (
+                svc.name.clone(),
+                DpuDeploymentServices {
+                    depends_on: None,
+                    service_configuration: Some(svc.name.clone()),
+                    service_template: Some(svc.name.clone()),
                 },
-                resource_requirements: None,
-            },
-            status: None,
-        };
-        DpuServiceTemplateRepository::apply(repo, &template).await?;
-
-        let interfaces: Vec<DpuServiceConfigurationInterfaces> = svc
-            .interfaces
-            .iter()
-            .map(|i| DpuServiceConfigurationInterfaces {
-                name: i.name.clone(),
-                network: i.network.clone(),
-                virtual_network: None,
-            })
-            .collect();
-
-        let config_ports_crd = svc.config_ports.as_ref().and_then(|ports| {
-            svc.config_ports_service_type.map(|st| {
-                DpuServiceConfigurationServiceConfigurationConfigPorts {
-                    ports: ports
-                        .iter()
-                        .map(|p| DpuServiceConfigurationServiceConfigurationConfigPortsPorts {
-                            name: p.name.clone(),
-                            node_port: p.node_port,
-                            port: p.port,
-                            protocol: match p.protocol {
-                                ServiceConfigPortProtocol::Tcp => {
-                                    DpuServiceConfigurationServiceConfigurationConfigPortsPortsProtocol::Tcp
-                                }
-                                ServiceConfigPortProtocol::Udp => {
-                                    DpuServiceConfigurationServiceConfigurationConfigPortsPortsProtocol::Udp
-                                }
-                            },
-                        })
-                        .collect(),
-                    service_type: match st {
-                        ConfigPortsServiceType::NodePort => {
-                            DpuServiceConfigurationServiceConfigurationConfigPortsServiceType::NodePort
-                        }
-                        ConfigPortsServiceType::ClusterIp => {
-                            DpuServiceConfigurationServiceConfigurationConfigPortsServiceType::ClusterIp
-                        }
-                        ConfigPortsServiceType::None => {
-                            DpuServiceConfigurationServiceConfigurationConfigPortsServiceType::None
-                        }
-                    },
-                }
-            })
-        });
-        let helm_chart_config = svc.config_values.as_ref().and_then(|v| {
-            v.as_object().map(|obj| {
-                let values: BTreeMap<String, serde_json::Value> =
-                    obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-                DpuServiceConfigurationServiceConfigurationHelmChart {
-                    values: Some(values),
-                }
-            })
-        });
-        let service_daemon_set = svc.service_daemon_set_annotations.as_ref().map(|annos| {
-            DpuServiceConfigurationServiceConfigurationServiceDaemonSet {
-                annotations: Some(annos.clone()),
-                labels: None,
-                resources: None,
-                update_strategy: None,
-            }
-        });
-        let service_configuration = if config_ports_crd.is_some()
-            || helm_chart_config.is_some()
-            || service_daemon_set.is_some()
-        {
-            Some(DpuServiceConfigurationServiceConfiguration {
-                config_ports: config_ports_crd,
-                deploy_in_cluster: None,
-                helm_chart: helm_chart_config,
-                service_daemon_set,
-            })
-        } else {
-            None
-        };
-
-        let config_crd = DPUServiceConfiguration {
-            metadata: ObjectMeta {
-                name: Some(svc.name.clone()),
-                namespace: Some(namespace.to_string()),
-                ..Default::default()
-            },
-            spec: DpuServiceConfigurationSpec {
-                deployment_service_name: svc.name.clone(),
-                interfaces: if interfaces.is_empty() {
-                    None
-                } else {
-                    Some(interfaces)
-                },
-                service_configuration,
-                upgrade_policy: DpuServiceConfigurationUpgradePolicy {
-                    apply_node_effect: Some(false),
-                },
-            },
-        };
-        DpuServiceConfigurationRepository::apply(repo, &config_crd).await?;
-    }
-
-    let mut services_map = BTreeMap::new();
-    for svc in services {
-        services_map.insert(
-            svc.name.clone(),
-            DpuDeploymentServices {
-                depends_on: None,
-                service_configuration: Some(svc.name.clone()),
-                service_template: Some(svc.name.clone()),
-            },
-        );
-    }
+            )
+        })
+        .collect();
 
     let all_switches: Vec<DpuDeploymentServiceChainsSwitches> = services
         .iter()
@@ -641,7 +787,15 @@ async fn create_services_and_deployment<
         })
     };
 
-    let deployment = DPUDeployment {
+    let mut node_labels = BTreeMap::from([(
+        "feature.node.kubernetes.io/dpu-enabled".to_string(),
+        "true".to_string(),
+    )]);
+    for (k, v) in labeler.node_labels() {
+        node_labels.insert(k, v);
+    }
+
+    DPUDeployment {
         metadata: ObjectMeta {
             name: Some(deployment_name.to_string()),
             namespace: Some(namespace.to_string()),
@@ -654,21 +808,12 @@ async fn create_services_and_deployment<
                     dpu_annotations: None,
                     dpu_selector: None,
                     name_suffix: "default".to_string(),
-                    node_selector: {
-                        let mut labels = BTreeMap::from([(
-                            "feature.node.kubernetes.io/dpu-enabled".to_string(),
-                            "true".to_string(),
-                        )]);
-                        for (k, v) in labeler.node_labels() {
-                            labels.insert(k, v);
-                        }
-                        Some(DpuDeploymentDpusDpuSetsNodeSelector {
-                            match_expressions: None,
-                            match_labels: Some(labels),
-                        })
-                    },
+                    node_selector: Some(DpuDeploymentDpusDpuSetsNodeSelector {
+                        match_expressions: None,
+                        match_labels: Some(node_labels),
+                    }),
                 }]),
-                flavor: flavor_name.to_string(),
+                flavor: flavor_name,
                 node_effect: Some(DpuDeploymentDpusNodeEffect {
                     custom_action: None,
                     custom_label: None,
@@ -684,8 +829,55 @@ async fn create_services_and_deployment<
             services: services_map,
         },
         status: None,
-    };
+    }
+}
 
+#[allow(clippy::too_many_arguments)]
+async fn create_flavor_services_and_deployment<
+    R: DpuServiceTemplateRepository
+        + DpuServiceConfigurationRepository
+        + DpuDeploymentRepository
+        + DpuFlavorRepository,
+    L: ResourceLabeler,
+>(
+    repo: &R,
+    namespace: &str,
+    labeler: &L,
+    services: &[ServiceDefinition],
+    deployment_name: &str,
+    bfb_name: &str,
+    dpu_flavor_def: &Option<DpuFlavorDefinition>,
+    default_flavor_name: &str,
+) -> Result<(), DpfError> {
+    let existing_deployment =
+        DpuDeploymentRepository::get(repo, deployment_name, namespace).await?;
+
+    let flavor_name = create_dpu_flavor(
+        repo,
+        namespace,
+        dpu_flavor_def,
+        existing_deployment.map(|x| x.spec.dpus.flavor),
+        default_flavor_name,
+    )
+    .await?;
+
+    for svc in services {
+        DpuServiceTemplateRepository::apply(repo, &build_service_template(svc, namespace)).await?;
+        DpuServiceConfigurationRepository::apply(
+            repo,
+            &build_service_configuration(svc, namespace),
+        )
+        .await?;
+    }
+
+    let deployment = build_deployment(
+        services,
+        deployment_name,
+        bfb_name,
+        flavor_name,
+        namespace,
+        labeler,
+    );
     DpuDeploymentRepository::apply(repo, &deployment).await?;
     Ok(())
 }
@@ -696,7 +888,8 @@ impl<
         + DpuDeploymentRepository
         + DpuServiceTemplateRepository
         + DpuServiceConfigurationRepository
-        + K8sConfigRepository,
+        + K8sConfigRepository
+        + DpfOperatorConfigRepository,
     L: ResourceLabeler,
 > DpfSdk<R, L>
 {
@@ -712,22 +905,23 @@ impl<
         config: &InitDpfResourcesConfig,
     ) -> Result<(), DpfError> {
         let bfb_name = create_bfb(&*self.repo, &self.namespace, &config.bfb_url).await?;
-        create_dpu_flavor(&*self.repo, &self.namespace, &config.flavor_name).await?;
         let services = if config.services.is_empty() {
             crate::services::default_services(&crate::services::ServiceRegistryConfig::default())
         } else {
             config.services.clone()
         };
-        create_services_and_deployment(
+        create_flavor_services_and_deployment(
             &*self.repo,
             &self.namespace,
             &self.labeler,
             &services,
             &config.deployment_name,
-            &config.flavor_name,
             &bfb_name,
+            &config.dpu_flavor,
+            &config.flavor_name,
         )
         .await?;
+
         if let Some(ref bfcfg) = config.bfcfg_template {
             let data = BTreeMap::from([("BF_CFG_TEMPLATE".to_string(), bfcfg.clone())]);
             K8sConfigRepository::apply_configmap(
@@ -735,6 +929,21 @@ impl<
                 "dpf-bf-cfg-template",
                 &self.namespace,
                 data,
+            )
+            .await?;
+        } else {
+            // Use default bf.cfg. In this case, delete bfCFGTemplateConfigMap from dpfoperatorconfig
+            DpfOperatorConfigRepository::patch(
+                &*self.repo,
+                &config.deployment_name,
+                &self.namespace,
+                serde_json::json!({
+                    "spec": {
+                        "provisioningController": {
+                            "bfCFGTemplateConfigMap": null
+                        }
+                    }
+                }),
             )
             .await?;
         }
@@ -1418,6 +1627,13 @@ mod tests {
     }
 
     #[async_trait]
+    impl crate::repository::DpfOperatorConfigRepository for SdkMock {
+        async fn patch(&self, _: &str, _: &str, _: serde_json::Value) -> Result<(), DpfError> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
     impl DpuFlavorRepository for SdkMock {
         async fn get(&self, name: &str, ns: &str) -> Result<Option<DPUFlavor>, DpfError> {
             Ok(self
@@ -1913,6 +2129,13 @@ mod tests {
         }
     }
 
+    #[async_trait]
+    impl crate::repository::DpfOperatorConfigRepository for SecretTrackingMock {
+        async fn patch(&self, _: &str, _: &str, _: serde_json::Value) -> Result<(), DpfError> {
+            Ok(())
+        }
+    }
+
     #[tokio::test]
     async fn test_refresh_writes_secret_when_password_changes() {
         let mock = SecretTrackingMock::default();
@@ -1973,6 +2196,7 @@ mod tests {
             flavor_name: "my-flavor".to_string(),
             services: vec![],
             bfcfg_template: None,
+            dpu_flavor: None,
         };
 
         assert_eq!(config.bfb_url, "http://example.com/test.bfb");
@@ -2162,9 +2386,15 @@ mod tests {
             .unwrap()
             .insert(SdkMock::key(&terminating_flavor), terminating_flavor);
 
-        let err = create_dpu_flavor(&mock, TEST_NAMESPACE, crate::flavor::DEFAULT_FLAVOR_NAME)
-            .await
-            .unwrap_err();
+        let err = create_dpu_flavor(
+            &mock,
+            TEST_NAMESPACE,
+            &None,
+            None,
+            crate::flavor::DEFAULT_FLAVOR_NAME,
+        )
+        .await
+        .unwrap_err();
         assert!(
             matches!(err, DpfError::InvalidState(_)),
             "expected InvalidState, got: {err:?}"
@@ -2181,9 +2411,15 @@ mod tests {
             .unwrap()
             .insert(SdkMock::key(&flavor), flavor);
 
-        create_dpu_flavor(&mock, TEST_NAMESPACE, crate::flavor::DEFAULT_FLAVOR_NAME)
-            .await
-            .unwrap();
+        create_dpu_flavor(
+            &mock,
+            TEST_NAMESPACE,
+            &None,
+            None,
+            crate::flavor::DEFAULT_FLAVOR_NAME,
+        )
+        .await
+        .unwrap();
     }
 
     #[derive(Clone, Default)]

--- a/crates/dpf/src/test/helpers.rs
+++ b/crates/dpf/src/test/helpers.rs
@@ -32,7 +32,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::crds::dpus_generated::*;
 use crate::error::DpfError;
-use crate::repository::{DpuRepository, K8sConfigRepository};
+use crate::repository::{DpfOperatorConfigRepository, DpuRepository, K8sConfigRepository};
 
 pub(crate) struct Collector<T> {
     pub items: Mutex<Vec<T>>,
@@ -288,6 +288,13 @@ impl K8sConfigRepository for ConfigMock {
         _: &str,
         _: BTreeMap<String, Vec<u8>>,
     ) -> Result<(), DpfError> {
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl DpfOperatorConfigRepository for ConfigMock {
+    async fn patch(&self, _: &str, _: &str, _: serde_json::Value) -> Result<(), DpfError> {
         Ok(())
     }
 }

--- a/crates/dpf/src/test/maintenance_flow.rs
+++ b/crates/dpf/src/test/maintenance_flow.rs
@@ -36,7 +36,8 @@ use crate::crds::dpunodes_generated::*;
 use crate::crds::dpus_generated::*;
 use crate::error::DpfError;
 use crate::repository::{
-    DpuNodeMaintenanceRepository, DpuNodeRepository, DpuRepository, K8sConfigRepository,
+    DpfOperatorConfigRepository, DpuNodeMaintenanceRepository, DpuNodeRepository, DpuRepository,
+    K8sConfigRepository,
 };
 use crate::sdk::{DpfSdkBuilder, HOLD_ANNOTATION, RESTART_ANNOTATION};
 use crate::types::*;
@@ -239,6 +240,13 @@ impl K8sConfigRepository for MaintenanceFlowMock {
         _: &str,
         _: BTreeMap<String, Vec<u8>>,
     ) -> Result<(), DpfError> {
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl DpfOperatorConfigRepository for MaintenanceFlowMock {
+    async fn patch(&self, _: &str, _: &str, _: serde_json::Value) -> Result<(), DpfError> {
         Ok(())
     }
 }

--- a/crates/dpf/src/test/sdk_device_registration.rs
+++ b/crates/dpf/src/test/sdk_device_registration.rs
@@ -29,7 +29,8 @@ use crate::crds::dpunodes_generated::*;
 use crate::crds::dpus_generated::*;
 use crate::error::DpfError;
 use crate::repository::{
-    DpuDeviceRepository, DpuNodeRepository, DpuRepository, K8sConfigRepository,
+    DpfOperatorConfigRepository, DpuDeviceRepository, DpuNodeRepository, DpuRepository,
+    K8sConfigRepository,
 };
 use crate::sdk::DpfSdkBuilder;
 use crate::types::*;
@@ -171,6 +172,13 @@ impl K8sConfigRepository for DeviceRegistrationMock {
         _: &str,
         _: BTreeMap<String, Vec<u8>>,
     ) -> Result<(), DpfError> {
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl DpfOperatorConfigRepository for DeviceRegistrationMock {
+    async fn patch(&self, _: &str, _: &str, _: serde_json::Value) -> Result<(), DpfError> {
         Ok(())
     }
 }

--- a/crates/dpf/src/test/sdk_initialization.rs
+++ b/crates/dpf/src/test/sdk_initialization.rs
@@ -31,8 +31,8 @@ use crate::crds::dpuserviceconfigurations_generated::DPUServiceConfiguration;
 use crate::crds::dpuservicetemplates_generated::DPUServiceTemplate;
 use crate::error::DpfError;
 use crate::repository::{
-    BfbRepository, DpuDeploymentRepository, DpuFlavorRepository, DpuServiceConfigurationRepository,
-    DpuServiceTemplateRepository, K8sConfigRepository,
+    BfbRepository, DpfOperatorConfigRepository, DpuDeploymentRepository, DpuFlavorRepository,
+    DpuServiceConfigurationRepository, DpuServiceTemplateRepository, K8sConfigRepository,
 };
 use crate::types::*;
 
@@ -217,6 +217,13 @@ impl K8sConfigRepository for InitializationMock {
         data: BTreeMap<String, Vec<u8>>,
     ) -> Result<(), DpfError> {
         self.secrets.insert(ns_key(ns, name), data);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl DpfOperatorConfigRepository for InitializationMock {
+    async fn patch(&self, _: &str, _: &str, _: serde_json::Value) -> Result<(), DpfError> {
         Ok(())
     }
 }

--- a/crates/dpf/src/test/sdk_maintenance_hold.rs
+++ b/crates/dpf/src/test/sdk_maintenance_hold.rs
@@ -25,7 +25,9 @@ use kube::core::ObjectMeta;
 
 use crate::crds::dpunodemaintenances_generated::*;
 use crate::error::DpfError;
-use crate::repository::{DpuNodeMaintenanceRepository, K8sConfigRepository};
+use crate::repository::{
+    DpfOperatorConfigRepository, DpuNodeMaintenanceRepository, K8sConfigRepository,
+};
 use crate::sdk::{DpfSdkBuilder, HOLD_ANNOTATION};
 
 const TEST_NS: &str = "sdk-maintenance-ns";
@@ -106,6 +108,13 @@ impl K8sConfigRepository for MaintenanceHoldMock {
         _: &str,
         _: BTreeMap<String, Vec<u8>>,
     ) -> Result<(), DpfError> {
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl DpfOperatorConfigRepository for MaintenanceHoldMock {
+    async fn patch(&self, _: &str, _: &str, _: serde_json::Value) -> Result<(), DpfError> {
         Ok(())
     }
 }

--- a/crates/dpf/src/test/sdk_provisioning_flow.rs
+++ b/crates/dpf/src/test/sdk_provisioning_flow.rs
@@ -33,7 +33,9 @@ use super::helpers::{Collector, make_dpu, make_dpu_reboot};
 use crate::crds::dpunodes_generated::*;
 use crate::crds::dpus_generated::*;
 use crate::error::DpfError;
-use crate::repository::{DpuNodeRepository, DpuRepository, K8sConfigRepository};
+use crate::repository::{
+    DpfOperatorConfigRepository, DpuNodeRepository, DpuRepository, K8sConfigRepository,
+};
 use crate::sdk::{DpfSdkBuilder, RESTART_ANNOTATION};
 use crate::types::*;
 
@@ -199,6 +201,13 @@ impl K8sConfigRepository for ProvisioningFlowMock {
         _: &str,
         _: BTreeMap<String, Vec<u8>>,
     ) -> Result<(), DpfError> {
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl DpfOperatorConfigRepository for ProvisioningFlowMock {
+    async fn patch(&self, _: &str, _: &str, _: serde_json::Value) -> Result<(), DpfError> {
         Ok(())
     }
 }

--- a/crates/dpf/src/test/sdk_reboot_annotation.rs
+++ b/crates/dpf/src/test/sdk_reboot_annotation.rs
@@ -25,7 +25,7 @@ use kube::Resource;
 
 use crate::crds::dpunodes_generated::*;
 use crate::error::DpfError;
-use crate::repository::{DpuNodeRepository, K8sConfigRepository};
+use crate::repository::{DpfOperatorConfigRepository, DpuNodeRepository, K8sConfigRepository};
 use crate::sdk::{DpfSdkBuilder, RESTART_ANNOTATION};
 use crate::types::*;
 
@@ -123,6 +123,13 @@ impl K8sConfigRepository for RebootAnnotationMock {
         _: &str,
         _: BTreeMap<String, Vec<u8>>,
     ) -> Result<(), DpfError> {
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl DpfOperatorConfigRepository for RebootAnnotationMock {
+    async fn patch(&self, _: &str, _: &str, _: serde_json::Value) -> Result<(), DpfError> {
         Ok(())
     }
 }

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -50,6 +50,8 @@ pub struct InitDpfResourcesConfig {
     /// Rendered bf.cfg template content for the DPU configuration ConfigMap.
     /// When set, a ConfigMap is created during initialization.
     pub bfcfg_template: Option<String>,
+    /// Custom fields for DPUFlavor
+    pub dpu_flavor: Option<DpuFlavorDefinition>,
 }
 
 impl Default for InitDpfResourcesConfig {
@@ -60,6 +62,7 @@ impl Default for InitDpfResourcesConfig {
             flavor_name: crate::flavor::DEFAULT_FLAVOR_NAME.to_string(),
             services: Vec::new(),
             bfcfg_template: None,
+            dpu_flavor: None,
         }
     }
 }
@@ -151,6 +154,23 @@ impl ServiceDefinition {
             ..Default::default()
         }
     }
+}
+
+/// Definition of a DPUFlavor. This struct contains only customizable fields.
+#[derive(Debug, Clone, Default)]
+pub struct DpuFlavorDefinition {
+    pub carbide_hbn_reps: Option<String>,
+    pub carbide_hbn_sfs: Option<String>,
+    pub bridge_def: Option<DpuFlavorBridgeDefinition>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DpuFlavorBridgeDefinition {
+    pub vf_intercept_bridge_name: String,
+    pub vf_intercept_bridge_port: String,
+    pub host_intercept_bridge_name: String,
+    pub host_intercept_bridge_port: String,
+    pub vf_intercept_bridge_sf: String,
 }
 
 /// Information about a DPU device (DPUDevice CR).


### PR DESCRIPTION
## Description
Skip DPU scout discovery checks when dpf.v2=true in handle_dpf_reboot and handle_dpf_waiting_for_ready; v2 uses a self-contained BFB that does not require scout agent signaling.

Implement DpfOperatorConfigRepository with a patch method on KubeRepository (JSON merge patch) and wire it into DpfSdk. Use it to null out bfCFGTemplateConfigMap in DPFOperatorConfig when no custom bf.cfg template is provided (v2 path), replacing the unimplemented stub.

Add BUG ALERT comment on the v1 discovery check in handle_dpf_reboot: it will fail on reprovisioning because discovery_time is never cleared; quickest fix is to clear it at reprovision time.

Made upstream BFB default for the `v2` mode.

With these changes, if v2 flag is enabled in carbide-config.toml, DPF will:
1. try to install all services (dpu-agent/fmds/dhcp-server/hbn/dts/otel) and will fail as most services are not ready yet. (Changes are going on and will be added one by one)
2. Use default BFB and bf.cfg. No carbide plumbing.
3. No dependency on discovery-completed message.

`forged` changes are in the queue to allow dev to use v2 in dev-env.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

