### PR TITLE
feat: add synchronous Redfish POST/PATCH proxy for the Carbide-DPS agent

### DIFF
--- a/crates/api/casbin-policy.csv
+++ b/crates/api/casbin-policy.csv
@@ -33,11 +33,9 @@ p, carbide-dns, forge/LookupRecord
 # FIXME: This should be removed once we have more fine-grained rule coverage.
 p, trusted-certificate, forge/*
 
-# Allow the DPS service to call Redfish proxy methods.
-g, spiffe-service-id/carbide-dps-agent, carbide-dps-agent
-p, carbide-dps-agent, forge/RedfishBrowse
-p, carbide-dps-agent, forge/RedfishPost
-p, carbide-dps-agent, forge/RedfishPatch
+# Allow the power-provisioning-agent to call the Redfish proxy.
+g, spiffe-service-id/power-provisioning-agent, power-provisioning-agent
+p, power-provisioning-agent, forge/RedfishProxy
 
 # Anonymous access to endpoints that don't modify state or expose any customer
 # or site data should be fine.

--- a/crates/api/casbin-policy.csv
+++ b/crates/api/casbin-policy.csv
@@ -34,10 +34,10 @@ p, carbide-dns, forge/LookupRecord
 p, trusted-certificate, forge/*
 
 # Allow the DPS service to call Redfish proxy methods.
-g, spiffe-service-id/carbide-dps, carbide-dps
-p, carbide-dps, forge/RedfishBrowse
-p, carbide-dps, forge/RedfishPost
-p, carbide-dps, forge/RedfishPatch
+g, spiffe-service-id/carbide-dps-agent, carbide-dps-agent
+p, carbide-dps-agent, forge/RedfishBrowse
+p, carbide-dps-agent, forge/RedfishPost
+p, carbide-dps-agent, forge/RedfishPatch
 
 # Anonymous access to endpoints that don't modify state or expose any customer
 # or site data should be fine.

--- a/crates/api/casbin-policy.csv
+++ b/crates/api/casbin-policy.csv
@@ -33,6 +33,12 @@ p, carbide-dns, forge/LookupRecord
 # FIXME: This should be removed once we have more fine-grained rule coverage.
 p, trusted-certificate, forge/*
 
+# Allow the DPS service to call Redfish proxy methods.
+g, spiffe-service-id/carbide-dps, carbide-dps
+p, carbide-dps, forge/RedfishBrowse
+p, carbide-dps, forge/RedfishPost
+p, carbide-dps, forge/RedfishPatch
+
 # Anonymous access to endpoints that don't modify state or expose any customer
 # or site data should be fine.
 p, anonymous, forge/Version

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -2252,18 +2252,11 @@ impl Forge for Api {
         crate::handlers::redfish::redfish_cancel_action(self, request).await
     }
 
-    async fn redfish_post(
+    async fn redfish_proxy(
         &self,
-        request: Request<rpc::RedfishPostRequest>,
-    ) -> Result<Response<rpc::RedfishPostResponse>, Status> {
-        crate::handlers::redfish::redfish_post(self, request).await
-    }
-
-    async fn redfish_patch(
-        &self,
-        request: Request<rpc::RedfishPatchRequest>,
-    ) -> Result<Response<rpc::RedfishPatchResponse>, Status> {
-        crate::handlers::redfish::redfish_patch(self, request).await
+        request: Request<rpc::RedfishProxyRequest>,
+    ) -> Result<Response<rpc::RedfishProxyResponse>, Status> {
+        crate::handlers::redfish::redfish_proxy(self, request).await
     }
 
     async fn ufm_browse(

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -2252,6 +2252,20 @@ impl Forge for Api {
         crate::handlers::redfish::redfish_cancel_action(self, request).await
     }
 
+    async fn redfish_post(
+        &self,
+        request: Request<rpc::RedfishPostRequest>,
+    ) -> Result<Response<rpc::RedfishPostResponse>, Status> {
+        crate::handlers::redfish::redfish_post(self, request).await
+    }
+
+    async fn redfish_patch(
+        &self,
+        request: Request<rpc::RedfishPatchRequest>,
+    ) -> Result<Response<rpc::RedfishPatchResponse>, Status> {
+        crate::handlers::redfish::redfish_patch(self, request).await
+    }
+
     async fn ufm_browse(
         &self,
         request: Request<rpc::UfmBrowseRequest>,

--- a/crates/api/src/auth/internal_rbac_rules.rs
+++ b/crates/api/src/auth/internal_rbac_rules.rs
@@ -44,10 +44,11 @@ enum RulePrincipal {
     Rla,
     MaintenanceJobs,
     DsxExchangeConsumer,
+    Dps,
     Anonymous, // Permitted for everything
 }
 use self::RulePrincipal::{
-    Agent, Anonymous, Dhcp, Dns, DsxExchangeConsumer, ForgeAdminCLI, Health, Machineatron,
+    Agent, Anonymous, Dhcp, Dns, Dps, DsxExchangeConsumer, ForgeAdminCLI, Health, Machineatron,
     MaintenanceJobs, Pxe, Rla, Scout, SiteAgent, Ssh, SshRs,
 };
 
@@ -481,7 +482,9 @@ impl InternalRBACRules {
             "RemoveMachineInstanceTypeAssociation",
             vec![ForgeAdminCLI, SiteAgent],
         );
-        x.perm("RedfishBrowse", vec![ForgeAdminCLI]);
+        x.perm("RedfishBrowse", vec![ForgeAdminCLI, Dps]);
+        x.perm("RedfishPost", vec![ForgeAdminCLI, Dps]);
+        x.perm("RedfishPatch", vec![ForgeAdminCLI, Dps]);
         x.perm("UfmBrowse", vec![ForgeAdminCLI]);
         x.perm("NmxmBrowse", vec![ForgeAdminCLI]);
         x.perm("UpdateMachineMetadata", vec![ForgeAdminCLI, SiteAgent]);
@@ -860,6 +863,9 @@ impl RuleInfo {
                     RulePrincipal::DsxExchangeConsumer => Principal::SpiffeServiceIdentifier(
                         "carbide-dsx-exchange-consumer".to_string(),
                     ),
+                    RulePrincipal::Dps => {
+                        Principal::SpiffeServiceIdentifier("carbide-dps".to_string())
+                    }
                     RulePrincipal::Anonymous => Principal::Anonymous,
                 })
                 .collect(),

--- a/crates/api/src/auth/internal_rbac_rules.rs
+++ b/crates/api/src/auth/internal_rbac_rules.rs
@@ -44,11 +44,11 @@ enum RulePrincipal {
     Rla,
     MaintenanceJobs,
     DsxExchangeConsumer,
-    Dps,
+    CarbideDpsAgent,
     Anonymous, // Permitted for everything
 }
 use self::RulePrincipal::{
-    Agent, Anonymous, Dhcp, Dns, Dps, DsxExchangeConsumer, ForgeAdminCLI, Health, Machineatron,
+    Agent, Anonymous, CarbideDpsAgent, Dhcp, Dns, DsxExchangeConsumer, ForgeAdminCLI, Health, Machineatron,
     MaintenanceJobs, Pxe, Rla, Scout, SiteAgent, Ssh, SshRs,
 };
 
@@ -482,9 +482,9 @@ impl InternalRBACRules {
             "RemoveMachineInstanceTypeAssociation",
             vec![ForgeAdminCLI, SiteAgent],
         );
-        x.perm("RedfishBrowse", vec![ForgeAdminCLI, Dps]);
-        x.perm("RedfishPost", vec![ForgeAdminCLI, Dps]);
-        x.perm("RedfishPatch", vec![ForgeAdminCLI, Dps]);
+        x.perm("RedfishBrowse", vec![ForgeAdminCLI, CarbideDpsAgent]);
+        x.perm("RedfishPost", vec![ForgeAdminCLI, CarbideDpsAgent]);
+        x.perm("RedfishPatch", vec![ForgeAdminCLI, CarbideDpsAgent]);
         x.perm("UfmBrowse", vec![ForgeAdminCLI]);
         x.perm("NmxmBrowse", vec![ForgeAdminCLI]);
         x.perm("UpdateMachineMetadata", vec![ForgeAdminCLI, SiteAgent]);
@@ -863,8 +863,8 @@ impl RuleInfo {
                     RulePrincipal::DsxExchangeConsumer => Principal::SpiffeServiceIdentifier(
                         "carbide-dsx-exchange-consumer".to_string(),
                     ),
-                    RulePrincipal::Dps => {
-                        Principal::SpiffeServiceIdentifier("carbide-dps".to_string())
+                    RulePrincipal::CarbideDpsAgent => {
+                        Principal::SpiffeServiceIdentifier("carbide-dps-agent".to_string())
                     }
                     RulePrincipal::Anonymous => Principal::Anonymous,
                 })

--- a/crates/api/src/auth/internal_rbac_rules.rs
+++ b/crates/api/src/auth/internal_rbac_rules.rs
@@ -863,9 +863,7 @@ impl RuleInfo {
                         "carbide-dsx-exchange-consumer".to_string(),
                     ),
                     RulePrincipal::PowerProvisioningAgent => {
-                        Principal::SpiffeServiceIdentifier(
-                            "power-provisioning-agent".to_string(),
-                        )
+                        Principal::SpiffeServiceIdentifier("power-provisioning-agent".to_string())
                     }
                     RulePrincipal::Anonymous => Principal::Anonymous,
                 })

--- a/crates/api/src/auth/internal_rbac_rules.rs
+++ b/crates/api/src/auth/internal_rbac_rules.rs
@@ -44,12 +44,12 @@ enum RulePrincipal {
     Rla,
     MaintenanceJobs,
     DsxExchangeConsumer,
-    CarbideDpsAgent,
+    PowerProvisioningAgent,
     Anonymous, // Permitted for everything
 }
 use self::RulePrincipal::{
-    Agent, Anonymous, CarbideDpsAgent, Dhcp, Dns, DsxExchangeConsumer, ForgeAdminCLI, Health, Machineatron,
-    MaintenanceJobs, Pxe, Rla, Scout, SiteAgent, Ssh, SshRs,
+    Agent, Anonymous, Dhcp, Dns, DsxExchangeConsumer, ForgeAdminCLI, Health, Machineatron,
+    MaintenanceJobs, PowerProvisioningAgent, Pxe, Rla, Scout, SiteAgent, Ssh, SshRs,
 };
 
 impl InternalRBACRules {
@@ -482,9 +482,8 @@ impl InternalRBACRules {
             "RemoveMachineInstanceTypeAssociation",
             vec![ForgeAdminCLI, SiteAgent],
         );
-        x.perm("RedfishBrowse", vec![ForgeAdminCLI, CarbideDpsAgent]);
-        x.perm("RedfishPost", vec![ForgeAdminCLI, CarbideDpsAgent]);
-        x.perm("RedfishPatch", vec![ForgeAdminCLI, CarbideDpsAgent]);
+        x.perm("RedfishBrowse", vec![ForgeAdminCLI]);
+        x.perm("RedfishProxy", vec![ForgeAdminCLI, PowerProvisioningAgent]);
         x.perm("UfmBrowse", vec![ForgeAdminCLI]);
         x.perm("NmxmBrowse", vec![ForgeAdminCLI]);
         x.perm("UpdateMachineMetadata", vec![ForgeAdminCLI, SiteAgent]);
@@ -863,8 +862,10 @@ impl RuleInfo {
                     RulePrincipal::DsxExchangeConsumer => Principal::SpiffeServiceIdentifier(
                         "carbide-dsx-exchange-consumer".to_string(),
                     ),
-                    RulePrincipal::CarbideDpsAgent => {
-                        Principal::SpiffeServiceIdentifier("carbide-dps-agent".to_string())
+                    RulePrincipal::PowerProvisioningAgent => {
+                        Principal::SpiffeServiceIdentifier(
+                            "power-provisioning-agent".to_string(),
+                        )
                     }
                     RulePrincipal::Anonymous => Principal::Anonymous,
                 })

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -563,6 +563,24 @@ pub struct CarbideConfig {
     /// manager integration.
     #[serde(default)]
     pub component_manager: Option<component_manager::config::ComponentManagerConfig>,
+
+    /// Per-principal URI allowlists for the RedfishPost
+    /// and RedfishPatch synchronous proxy RPCs.
+    /// Keyed by SPIFFE service identifier name (e.g. "carbide-dps").
+    /// Section `[redfish_proxy.<principal>]`.
+    #[serde(default)]
+    pub redfish_proxy: HashMap<String, RedfishProxyPrincipalConfig>,
+}
+
+/// Per-principal configuration for the Redfish POST/PATCH
+/// synchronous proxy. Controls which URI patterns a given
+/// principal is allowed to target. Use `"*"` to allow all URIs.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct RedfishProxyPrincipalConfig {
+    #[serde(default)]
+    pub allowed_post_uris: Vec<String>,
+    #[serde(default)]
+    pub allowed_patch_uris: Vec<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -564,17 +564,18 @@ pub struct CarbideConfig {
     #[serde(default)]
     pub component_manager: Option<component_manager::config::ComponentManagerConfig>,
 
-    /// Per-principal URI allowlists for the RedfishPost
-    /// and RedfishPatch synchronous proxy RPCs.
-    /// Keyed by SPIFFE service identifier name (e.g. "carbide-dps").
+    /// Per-principal URI allowlists for the RedfishProxy RPC
+    /// (POST and PATCH methods; GET is unrestricted).
+    /// Keyed by SPIFFE service identifier name (e.g. "power-provisioning-agent").
     /// Section `[redfish_proxy.<principal>]`.
     #[serde(default)]
     pub redfish_proxy: HashMap<String, RedfishProxyPrincipalConfig>,
 }
 
-/// Per-principal configuration for the Redfish POST/PATCH
-/// synchronous proxy. Controls which URI patterns a given
-/// principal is allowed to target. Use `"*"` to allow all URIs.
+/// Per-principal configuration for the RedfishProxy RPC
+/// (GET/POST/PATCH). Controls which POST and PATCH URI patterns
+/// a given principal is allowed to target. GET is unrestricted.
+/// Use `"*"` to allow all URIs for a method.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct RedfishProxyPrincipalConfig {
     #[serde(default)]

--- a/crates/api/src/handlers/redfish.rs
+++ b/crates/api/src/handlers/redfish.rs
@@ -210,44 +210,62 @@ async fn redfish_proxy_mutate(
     Ok((text, response_headers, status))
 }
 
-pub async fn redfish_post(
+async fn redfish_proxy_get(
     api: &crate::api::Api,
-    request: tonic::Request<::rpc::forge::RedfishPostRequest>,
-) -> Result<tonic::Response<::rpc::forge::RedfishPostResponse>, tonic::Status> {
-    log_request_data(&request);
+    uri: http::Uri,
+) -> Result<(String, HashMap<String, String>, String), tonic::Status> {
+    let (metadata, new_uri, headers, http_client) = create_client(
+        uri,
+        &api.database_connection,
+        api.credential_manager.as_ref(),
+        &api.dynamic_settings.bmc_proxy,
+    )
+    .await?;
 
-    let uri: http::Uri = request
-        .get_ref()
-        .uri
-        .parse()
-        .map_err(|err| CarbideError::internal(format!("Parsing uri failed: {err}")))?;
-    let uri_path = uri.path().to_owned();
+    let response = http_client
+        .request(http::Method::GET, new_uri.to_string())
+        .basic_auth(metadata.user.clone(), Some(metadata.password.clone()))
+        .headers(headers)
+        .send()
+        .await
+        .map_err(|e| CarbideError::internal(format!("Http request failed: {e:?}")))?;
 
-    check_redfish_proxy_allowlist(
-        &api.runtime_config.redfish_proxy,
-        &request,
-        &uri_path,
-        &http::Method::POST,
-    )?;
+    let response_headers = response
+        .headers()
+        .iter()
+        .map(|(x, y)| {
+            (
+                x.to_string(),
+                String::from_utf8_lossy(y.as_bytes()).to_string(),
+            )
+        })
+        .collect::<HashMap<String, String>>();
 
-    tracing::info!(method = "POST", uri = %uri, "redfish proxy request");
+    let status = response.status().to_string();
+    let text = response.text().await.map_err(|e| {
+        CarbideError::internal(format!("Error reading response body: {e}, Status: {status}"))
+    })?;
 
-    let body = request.into_inner().body;
-    let (text, headers, status) =
-        redfish_proxy_mutate(api, uri, body, http::Method::POST).await?;
-
-    Ok(tonic::Response::new(::rpc::forge::RedfishPostResponse {
-        text,
-        headers,
-        status,
-    }))
+    Ok((text, response_headers, status))
 }
 
-pub async fn redfish_patch(
+pub async fn redfish_proxy(
     api: &crate::api::Api,
-    request: tonic::Request<::rpc::forge::RedfishPatchRequest>,
-) -> Result<tonic::Response<::rpc::forge::RedfishPatchResponse>, tonic::Status> {
+    request: tonic::Request<::rpc::forge::RedfishProxyRequest>,
+) -> Result<tonic::Response<::rpc::forge::RedfishProxyResponse>, tonic::Status> {
     log_request_data(&request);
+
+    let method = match request.get_ref().method.to_uppercase().as_str() {
+        "GET" => http::Method::GET,
+        "POST" => http::Method::POST,
+        "PATCH" => http::Method::PATCH,
+        other => {
+            return Err(CarbideError::InvalidArgument(format!(
+                "unsupported redfish proxy method: {other} (must be GET, POST, or PATCH)"
+            ))
+            .into())
+        }
+    };
 
     let uri: http::Uri = request
         .get_ref()
@@ -256,24 +274,35 @@ pub async fn redfish_patch(
         .map_err(|err| CarbideError::internal(format!("Parsing uri failed: {err}")))?;
     let uri_path = uri.path().to_owned();
 
-    check_redfish_proxy_allowlist(
-        &api.runtime_config.redfish_proxy,
-        &request,
-        &uri_path,
-        &http::Method::PATCH,
-    )?;
+    // URI allowlist only applies to POST and PATCH; GET is unrestricted.
+    if method != http::Method::GET {
+        check_redfish_proxy_allowlist(
+            &api.runtime_config.redfish_proxy,
+            &request,
+            &uri_path,
+            &method,
+        )?;
+    }
 
-    tracing::info!(method = "PATCH", uri = %uri, "redfish proxy request");
+    tracing::info!(method = %method, uri = %uri, "redfish proxy request");
 
     let body = request.into_inner().body;
-    let (text, headers, status) =
-        redfish_proxy_mutate(api, uri, body, http::Method::PATCH).await?;
 
-    Ok(tonic::Response::new(::rpc::forge::RedfishPatchResponse {
-        text,
-        headers,
-        status,
-    }))
+    if method == http::Method::GET {
+        let (text, headers, status) = redfish_proxy_get(api, uri).await?;
+        Ok(tonic::Response::new(::rpc::forge::RedfishProxyResponse {
+            text,
+            headers,
+            status,
+        }))
+    } else {
+        let (text, headers, status) = redfish_proxy_mutate(api, uri, body, method).await?;
+        Ok(tonic::Response::new(::rpc::forge::RedfishProxyResponse {
+            text,
+            headers,
+            status,
+        }))
+    }
 }
 
 pub async fn redfish_list_actions(
@@ -852,7 +881,7 @@ mod tests {
     ) -> HashMap<String, RedfishProxyPrincipalConfig> {
         let mut m = HashMap::new();
         m.insert(
-            "carbide-dps-agent".to_string(),
+            "power-provisioning-agent".to_string(),
             RedfishProxyPrincipalConfig {
                 allowed_post_uris: post_uris.into_iter().map(String::from).collect(),
                 allowed_patch_uris: patch_uris.into_iter().map(String::from).collect(),
@@ -902,7 +931,7 @@ mod tests {
             vec!["/redfish/v1/Managers/BMC/NodeManager/Domains"],
             vec![],
         );
-        let req = spiffe_request("carbide-dps-agent", ());
+        let req = spiffe_request("power-provisioning-agent", ());
         assert!(check_redfish_proxy_allowlist(
             &config,
             &req,
@@ -918,7 +947,7 @@ mod tests {
             vec!["/redfish/v1/Managers/BMC/NodeManager/Domains"],
             vec![],
         );
-        let req = spiffe_request("carbide-dps-agent", ());
+        let req = spiffe_request("power-provisioning-agent", ());
         let result = check_redfish_proxy_allowlist(
             &config,
             &req,
@@ -935,7 +964,7 @@ mod tests {
             vec![],
             vec!["/redfish/v1/Managers/BMC/NodeManager/Domains/{id}"],
         );
-        let req = spiffe_request("carbide-dps-agent", ());
+        let req = spiffe_request("power-provisioning-agent", ());
         assert!(check_redfish_proxy_allowlist(
             &config,
             &req,
@@ -951,7 +980,7 @@ mod tests {
             vec!["/redfish/v1/Managers/BMC/NodeManager/Domains"],
             vec![],
         );
-        let req = spiffe_request("carbide-dps-agent", ());
+        let req = spiffe_request("power-provisioning-agent", ());
         let result = check_redfish_proxy_allowlist(
             &config,
             &req,
@@ -996,7 +1025,7 @@ mod tests {
     #[test]
     fn allowlist_star_pattern_grants_full_access() {
         let config = make_config(vec!["*"], vec!["*"]);
-        let req = spiffe_request("carbide-dps-agent", ());
+        let req = spiffe_request("power-provisioning-agent", ());
         assert!(check_redfish_proxy_allowlist(
             &config,
             &req,
@@ -1004,7 +1033,7 @@ mod tests {
             &http::Method::POST,
         )
         .is_ok());
-        let req2 = spiffe_request("carbide-dps-agent", ());
+        let req2 = spiffe_request("power-provisioning-agent", ());
         assert!(check_redfish_proxy_allowlist(
             &config,
             &req2,

--- a/crates/api/src/handlers/redfish.rs
+++ b/crates/api/src/handlers/redfish.rs
@@ -852,7 +852,7 @@ mod tests {
     ) -> HashMap<String, RedfishProxyPrincipalConfig> {
         let mut m = HashMap::new();
         m.insert(
-            "carbide-dps".to_string(),
+            "carbide-dps-agent".to_string(),
             RedfishProxyPrincipalConfig {
                 allowed_post_uris: post_uris.into_iter().map(String::from).collect(),
                 allowed_patch_uris: patch_uris.into_iter().map(String::from).collect(),
@@ -876,7 +876,7 @@ mod tests {
         ctx.principals
             .push(Principal::ExternalUser(ExternalUserInfo {
                 org: None,
-                group: "admin".to_string(),
+                group: "admins".to_string(),
                 user: Some("testuser".to_string()),
             }));
         req.extensions_mut().insert(ctx);
@@ -902,7 +902,7 @@ mod tests {
             vec!["/redfish/v1/Managers/BMC/NodeManager/Domains"],
             vec![],
         );
-        let req = spiffe_request("carbide-dps", ());
+        let req = spiffe_request("carbide-dps-agent", ());
         assert!(check_redfish_proxy_allowlist(
             &config,
             &req,
@@ -918,7 +918,7 @@ mod tests {
             vec!["/redfish/v1/Managers/BMC/NodeManager/Domains"],
             vec![],
         );
-        let req = spiffe_request("carbide-dps", ());
+        let req = spiffe_request("carbide-dps-agent", ());
         let result = check_redfish_proxy_allowlist(
             &config,
             &req,
@@ -935,7 +935,7 @@ mod tests {
             vec![],
             vec!["/redfish/v1/Managers/BMC/NodeManager/Domains/{id}"],
         );
-        let req = spiffe_request("carbide-dps", ());
+        let req = spiffe_request("carbide-dps-agent", ());
         assert!(check_redfish_proxy_allowlist(
             &config,
             &req,
@@ -951,7 +951,7 @@ mod tests {
             vec!["/redfish/v1/Managers/BMC/NodeManager/Domains"],
             vec![],
         );
-        let req = spiffe_request("carbide-dps", ());
+        let req = spiffe_request("carbide-dps-agent", ());
         let result = check_redfish_proxy_allowlist(
             &config,
             &req,
@@ -996,7 +996,7 @@ mod tests {
     #[test]
     fn allowlist_star_pattern_grants_full_access() {
         let config = make_config(vec!["*"], vec!["*"]);
-        let req = spiffe_request("carbide-dps", ());
+        let req = spiffe_request("carbide-dps-agent", ());
         assert!(check_redfish_proxy_allowlist(
             &config,
             &req,
@@ -1004,7 +1004,7 @@ mod tests {
             &http::Method::POST,
         )
         .is_ok());
-        let req2 = spiffe_request("carbide-dps", ());
+        let req2 = spiffe_request("carbide-dps-agent", ());
         assert!(check_redfish_proxy_allowlist(
             &config,
             &req2,

--- a/crates/api/src/handlers/redfish.rs
+++ b/crates/api/src/handlers/redfish.rs
@@ -46,52 +46,13 @@ pub async fn redfish_browse(
 ) -> Result<tonic::Response<::rpc::forge::RedfishBrowseResponse>, tonic::Status> {
     log_request_data(&request);
 
-    let request = request.into_inner();
-    let uri: http::Uri = match request.uri.clone().parse() {
-        Ok(uri) => uri,
-        Err(err) => {
-            return Err(CarbideError::internal(format!("Parsing uri failed: {err}")).into());
-        }
-    };
+    let uri: http::Uri = request
+        .into_inner()
+        .uri
+        .parse()
+        .map_err(|err| CarbideError::internal(format!("Parsing uri failed: {err}")))?;
 
-    let (metadata, new_uri, headers, http_client) = create_client(
-        uri,
-        &api.database_connection,
-        api.credential_manager.as_ref(),
-        &api.dynamic_settings.bmc_proxy,
-    )
-    .await?;
-
-    let response = match http_client
-        .request(http::Method::GET, new_uri.to_string())
-        .basic_auth(metadata.user.clone(), Some(metadata.password.clone()))
-        .headers(headers)
-        .send()
-        .await
-    {
-        Ok(response) => response,
-        Err(e) => {
-            return Err(CarbideError::internal(format!("Http request failed: {e:?}")).into());
-        }
-    };
-
-    let headers = response
-        .headers()
-        .iter()
-        .map(|(x, y)| {
-            (
-                x.to_string(),
-                String::from_utf8_lossy(y.as_bytes()).to_string(),
-            )
-        })
-        .collect::<HashMap<String, String>>();
-
-    let status = response.status();
-    let text = response.text().await.map_err(|e| {
-        CarbideError::internal(format!(
-            "Error reading response body: {e}, Status: {status}"
-        ))
-    })?;
+    let (text, headers, _status) = redfish_proxy_get(api, uri).await?;
 
     Ok(tonic::Response::new(::rpc::forge::RedfishBrowseResponse {
         text,
@@ -204,7 +165,9 @@ async fn redfish_proxy_mutate(
 
     let status = response.status().to_string();
     let text = response.text().await.map_err(|e| {
-        CarbideError::internal(format!("Error reading response body: {e}, Status: {status}"))
+        CarbideError::internal(format!(
+            "Error reading response body: {e}, Status: {status}"
+        ))
     })?;
 
     Ok((text, response_headers, status))
@@ -243,10 +206,137 @@ async fn redfish_proxy_get(
 
     let status = response.status().to_string();
     let text = response.text().await.map_err(|e| {
-        CarbideError::internal(format!("Error reading response body: {e}, Status: {status}"))
+        CarbideError::internal(format!(
+            "Error reading response body: {e}, Status: {status}"
+        ))
     })?;
 
     Ok((text, response_headers, status))
+}
+
+/// Resolves a `RedfishProxyEndpoint` enum value and optional component id
+/// into a concrete (URI path, HTTP method) pair. Returns an error for
+/// unrecognized or unspecified endpoints.
+fn resolve_proxy_endpoint(
+    endpoint: i32,
+    component_id: Option<u32>,
+) -> Result<(String, http::Method), CarbideError> {
+    use ::rpc::forge::RedfishProxyEndpoint;
+
+    let ep = RedfishProxyEndpoint::try_from(endpoint).map_err(|_| {
+        CarbideError::InvalidArgument(format!("unknown RedfishProxyEndpoint value: {endpoint}"))
+    })?;
+
+    let id = component_id.map(|i| i.to_string());
+    let require_id = |label: &str| -> Result<String, CarbideError> {
+        id.clone().ok_or_else(|| {
+            CarbideError::InvalidArgument(format!("component_id is required for {label}"))
+        })
+    };
+
+    let (path, method) = match ep {
+        RedfishProxyEndpoint::Unspecified => {
+            return Err(CarbideError::InvalidArgument(
+                "RedfishProxyEndpoint must not be UNSPECIFIED".to_owned(),
+            ));
+        }
+
+        RedfishProxyEndpoint::GetBmcFirmwareVersion => (
+            "/redfish/v1/UpdateService/FirmwareInventory/FW_BMC_0".to_owned(),
+            http::Method::GET,
+        ),
+
+        RedfishProxyEndpoint::GetGpuProcessor => (
+            format!(
+                "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_{}",
+                require_id("GET_GPU_PROCESSOR")?
+            ),
+            http::Method::GET,
+        ),
+        RedfishProxyEndpoint::GetGpuEnvironmentMetrics => (
+            format!(
+                "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_{}/EnvironmentMetrics",
+                require_id("GET_GPU_ENVIRONMENT_METRICS")?
+            ),
+            http::Method::GET,
+        ),
+        RedfishProxyEndpoint::SetGpuPowerLimit => (
+            format!(
+                "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_{}/EnvironmentMetrics",
+                require_id("SET_GPU_POWER_LIMIT")?
+            ),
+            http::Method::PATCH,
+        ),
+
+        RedfishProxyEndpoint::GetCpuProcessor => (
+            format!(
+                "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_{}",
+                require_id("GET_CPU_PROCESSOR")?
+            ),
+            http::Method::GET,
+        ),
+        RedfishProxyEndpoint::GetCpuEnvironmentMetrics => (
+            format!(
+                "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_{}/EnvironmentMetrics",
+                require_id("GET_CPU_ENVIRONMENT_METRICS")?
+            ),
+            http::Method::GET,
+        ),
+        RedfishProxyEndpoint::SetCpuPowerLimit => (
+            format!(
+                "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_{}/EnvironmentMetrics",
+                require_id("SET_CPU_POWER_LIMIT")?
+            ),
+            http::Method::PATCH,
+        ),
+
+        RedfishProxyEndpoint::GetChassis => (
+            "/redfish/v1/Chassis/Chassis_0".to_owned(),
+            http::Method::GET,
+        ),
+        RedfishProxyEndpoint::GetChassisEnvironmentMetrics => (
+            "/redfish/v1/Chassis/Chassis_0/EnvironmentMetrics".to_owned(),
+            http::Method::GET,
+        ),
+
+        RedfishProxyEndpoint::GetHgxChassis => (
+            "/redfish/v1/Chassis/HGX_Chassis_0".to_owned(),
+            http::Method::GET,
+        ),
+        RedfishProxyEndpoint::GetHgxChassisEnvironmentMetrics => (
+            "/redfish/v1/Chassis/HGX_Chassis_0/EnvironmentMetrics".to_owned(),
+            http::Method::GET,
+        ),
+
+        RedfishProxyEndpoint::GetProcessorModuleEnvironmentMetrics => (
+            format!(
+                "/redfish/v1/Chassis/HGX_ProcessorModule_{}/EnvironmentMetrics",
+                require_id("GET_PROCESSOR_MODULE_ENVIRONMENT_METRICS")?
+            ),
+            http::Method::GET,
+        ),
+        RedfishProxyEndpoint::SetProcessorModulePowerLimit => (
+            format!(
+                "/redfish/v1/Chassis/HGX_ProcessorModule_{}/EnvironmentMetrics",
+                require_id("SET_PROCESSOR_MODULE_POWER_LIMIT")?
+            ),
+            http::Method::PATCH,
+        ),
+        RedfishProxyEndpoint::GetProcessorModuleAssembly => (
+            format!(
+                "/redfish/v1/Chassis/HGX_ProcessorModule_{}/Assembly",
+                require_id("GET_PROCESSOR_MODULE_ASSEMBLY")?
+            ),
+            http::Method::GET,
+        ),
+
+        RedfishProxyEndpoint::GetHgxBmcManager => (
+            "/redfish/v1/Managers/HGX_BMC_0".to_owned(),
+            http::Method::GET,
+        ),
+    };
+
+    Ok((path, method))
 }
 
 pub async fn redfish_proxy(
@@ -255,23 +345,45 @@ pub async fn redfish_proxy(
 ) -> Result<tonic::Response<::rpc::forge::RedfishProxyResponse>, tonic::Status> {
     log_request_data(&request);
 
-    let method = match request.get_ref().method.to_uppercase().as_str() {
-        "GET" => http::Method::GET,
-        "POST" => http::Method::POST,
-        "PATCH" => http::Method::PATCH,
-        other => {
-            return Err(CarbideError::InvalidArgument(format!(
-                "unsupported redfish proxy method: {other} (must be GET, POST, or PATCH)"
-            ))
-            .into())
+    let inner = request.get_ref();
+
+    // New enum-based path: prefer `endpoint` if set to a non-default value.
+    let (uri, method) = if inner.endpoint != 0 {
+        let (path, method) = resolve_proxy_endpoint(inner.endpoint, inner.component_id)?;
+        let bmc_ip = &inner.bmc_ip;
+        if bmc_ip.is_empty() {
+            return Err(CarbideError::InvalidArgument(
+                "bmc_ip is required when using the endpoint field".to_owned(),
+            )
+            .into());
         }
+        let uri: http::Uri = http::Uri::builder()
+            .scheme("https")
+            .authority(bmc_ip.as_str())
+            .path_and_query(path.as_str())
+            .build()
+            .map_err(|e| CarbideError::internal(format!("building proxy URI: {e}")))?;
+        (uri, method)
+    } else {
+        // Legacy path: raw uri + method strings (deprecated, kept for backward compat).
+        let method = match inner.method.to_uppercase().as_str() {
+            "GET" => http::Method::GET,
+            "POST" => http::Method::POST,
+            "PATCH" => http::Method::PATCH,
+            other => {
+                return Err(CarbideError::InvalidArgument(format!(
+                    "unsupported redfish proxy method: {other} (must be GET, POST, or PATCH)"
+                ))
+                .into());
+            }
+        };
+        let uri: http::Uri = inner
+            .uri
+            .parse()
+            .map_err(|err| CarbideError::internal(format!("Parsing uri failed: {err}")))?;
+        (uri, method)
     };
 
-    let uri: http::Uri = request
-        .get_ref()
-        .uri
-        .parse()
-        .map_err(|err| CarbideError::internal(format!("Parsing uri failed: {err}")))?;
     let uri_path = uri.path().to_owned();
 
     // URI allowlist only applies to POST and PATCH; GET is unrestricted.
@@ -816,8 +928,7 @@ mod tests {
 
     #[test]
     fn uri_allowlist_id_placeholder_matches_any_segment() {
-        let patterns =
-            vec!["/redfish/v1/Managers/BMC/NodeManager/Domains/{id}".to_string()];
+        let patterns = vec!["/redfish/v1/Managers/BMC/NodeManager/Domains/{id}".to_string()];
         assert!(uri_matches_allowlist(
             "/redfish/v1/Managers/BMC/NodeManager/Domains/42",
             &patterns,
@@ -845,8 +956,7 @@ mod tests {
 
     #[test]
     fn uri_allowlist_segment_count_mismatch_rejects() {
-        let patterns =
-            vec!["/redfish/v1/Managers/BMC/NodeManager/Domains/{id}".to_string()];
+        let patterns = vec!["/redfish/v1/Managers/BMC/NodeManager/Domains/{id}".to_string()];
         assert!(!uri_matches_allowlist(
             "/redfish/v1/Managers/BMC/NodeManager/Domains",
             &patterns,
@@ -865,10 +975,7 @@ mod tests {
 
     #[test]
     fn uri_allowlist_multiple_patterns_any_match_suffices() {
-        let patterns = vec![
-            "/redfish/v1/A".to_string(),
-            "/redfish/v1/B".to_string(),
-        ];
+        let patterns = vec!["/redfish/v1/A".to_string(), "/redfish/v1/B".to_string()];
         assert!(uri_matches_allowlist("/redfish/v1/B", &patterns));
         assert!(!uri_matches_allowlist("/redfish/v1/C", &patterns));
     }
@@ -916,37 +1023,29 @@ mod tests {
     fn allowlist_external_user_always_passes() {
         let config = HashMap::new();
         let req = external_user_request(());
-        assert!(check_redfish_proxy_allowlist(
-            &config,
-            &req,
-            "/any/uri",
-            &http::Method::POST,
-        )
-        .is_ok());
+        assert!(
+            check_redfish_proxy_allowlist(&config, &req, "/any/uri", &http::Method::POST,).is_ok()
+        );
     }
 
     #[test]
     fn allowlist_spiffe_allowed_post_uri() {
-        let config = make_config(
-            vec!["/redfish/v1/Managers/BMC/NodeManager/Domains"],
-            vec![],
-        );
+        let config = make_config(vec!["/redfish/v1/Managers/BMC/NodeManager/Domains"], vec![]);
         let req = spiffe_request("power-provisioning-agent", ());
-        assert!(check_redfish_proxy_allowlist(
-            &config,
-            &req,
-            "/redfish/v1/Managers/BMC/NodeManager/Domains",
-            &http::Method::POST,
-        )
-        .is_ok());
+        assert!(
+            check_redfish_proxy_allowlist(
+                &config,
+                &req,
+                "/redfish/v1/Managers/BMC/NodeManager/Domains",
+                &http::Method::POST,
+            )
+            .is_ok()
+        );
     }
 
     #[test]
     fn allowlist_spiffe_denied_post_uri() {
-        let config = make_config(
-            vec!["/redfish/v1/Managers/BMC/NodeManager/Domains"],
-            vec![],
-        );
+        let config = make_config(vec!["/redfish/v1/Managers/BMC/NodeManager/Domains"], vec![]);
         let req = spiffe_request("power-provisioning-agent", ());
         let result = check_redfish_proxy_allowlist(
             &config,
@@ -965,21 +1064,20 @@ mod tests {
             vec!["/redfish/v1/Managers/BMC/NodeManager/Domains/{id}"],
         );
         let req = spiffe_request("power-provisioning-agent", ());
-        assert!(check_redfish_proxy_allowlist(
-            &config,
-            &req,
-            "/redfish/v1/Managers/BMC/NodeManager/Domains/42",
-            &http::Method::PATCH,
-        )
-        .is_ok());
+        assert!(
+            check_redfish_proxy_allowlist(
+                &config,
+                &req,
+                "/redfish/v1/Managers/BMC/NodeManager/Domains/42",
+                &http::Method::PATCH,
+            )
+            .is_ok()
+        );
     }
 
     #[test]
     fn allowlist_post_patterns_not_checked_for_patch() {
-        let config = make_config(
-            vec!["/redfish/v1/Managers/BMC/NodeManager/Domains"],
-            vec![],
-        );
+        let config = make_config(vec!["/redfish/v1/Managers/BMC/NodeManager/Domains"], vec![]);
         let req = spiffe_request("power-provisioning-agent", ());
         let result = check_redfish_proxy_allowlist(
             &config,
@@ -1026,20 +1124,201 @@ mod tests {
     fn allowlist_star_pattern_grants_full_access() {
         let config = make_config(vec!["*"], vec!["*"]);
         let req = spiffe_request("power-provisioning-agent", ());
-        assert!(check_redfish_proxy_allowlist(
-            &config,
-            &req,
-            "/literally/any/path",
-            &http::Method::POST,
-        )
-        .is_ok());
+        assert!(
+            check_redfish_proxy_allowlist(
+                &config,
+                &req,
+                "/literally/any/path",
+                &http::Method::POST,
+            )
+            .is_ok()
+        );
         let req2 = spiffe_request("power-provisioning-agent", ());
-        assert!(check_redfish_proxy_allowlist(
-            &config,
-            &req2,
-            "/literally/any/other/path",
-            &http::Method::PATCH,
+        assert!(
+            check_redfish_proxy_allowlist(
+                &config,
+                &req2,
+                "/literally/any/other/path",
+                &http::Method::PATCH,
+            )
+            .is_ok()
+        );
+    }
+
+    // ── resolve_proxy_endpoint ─────────────────────────────────────────
+
+    use ::rpc::forge::RedfishProxyEndpoint;
+
+    #[test]
+    fn resolve_unspecified_endpoint_is_error() {
+        let result = resolve_proxy_endpoint(RedfishProxyEndpoint::Unspecified as i32, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_unknown_endpoint_value_is_error() {
+        let result = resolve_proxy_endpoint(9999, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_get_bmc_firmware_version() {
+        let (path, method) =
+            resolve_proxy_endpoint(RedfishProxyEndpoint::GetBmcFirmwareVersion as i32, None)
+                .unwrap();
+        assert_eq!(
+            path,
+            "/redfish/v1/UpdateService/FirmwareInventory/FW_BMC_0"
+        );
+        assert_eq!(method, http::Method::GET);
+    }
+
+    #[test]
+    fn resolve_get_gpu_processor_requires_id() {
+        let result =
+            resolve_proxy_endpoint(RedfishProxyEndpoint::GetGpuProcessor as i32, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_get_gpu_processor_with_id() {
+        let (path, method) =
+            resolve_proxy_endpoint(RedfishProxyEndpoint::GetGpuProcessor as i32, Some(3))
+                .unwrap();
+        assert_eq!(
+            path,
+            "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_3"
+        );
+        assert_eq!(method, http::Method::GET);
+    }
+
+    #[test]
+    fn resolve_set_gpu_power_limit_is_patch() {
+        let (path, method) =
+            resolve_proxy_endpoint(RedfishProxyEndpoint::SetGpuPowerLimit as i32, Some(0))
+                .unwrap();
+        assert_eq!(
+            path,
+            "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/EnvironmentMetrics"
+        );
+        assert_eq!(method, http::Method::PATCH);
+    }
+
+    #[test]
+    fn resolve_get_cpu_processor_with_id() {
+        let (path, method) =
+            resolve_proxy_endpoint(RedfishProxyEndpoint::GetCpuProcessor as i32, Some(1))
+                .unwrap();
+        assert_eq!(
+            path,
+            "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_1"
+        );
+        assert_eq!(method, http::Method::GET);
+    }
+
+    #[test]
+    fn resolve_set_cpu_power_limit_is_patch() {
+        let (path, method) =
+            resolve_proxy_endpoint(RedfishProxyEndpoint::SetCpuPowerLimit as i32, Some(0))
+                .unwrap();
+        assert_eq!(
+            path,
+            "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_0/EnvironmentMetrics"
+        );
+        assert_eq!(method, http::Method::PATCH);
+    }
+
+    #[test]
+    fn resolve_get_chassis() {
+        let (path, method) =
+            resolve_proxy_endpoint(RedfishProxyEndpoint::GetChassis as i32, None).unwrap();
+        assert_eq!(path, "/redfish/v1/Chassis/Chassis_0");
+        assert_eq!(method, http::Method::GET);
+    }
+
+    #[test]
+    fn resolve_get_chassis_environment_metrics() {
+        let (path, method) = resolve_proxy_endpoint(
+            RedfishProxyEndpoint::GetChassisEnvironmentMetrics as i32,
+            None,
         )
-        .is_ok());
+        .unwrap();
+        assert_eq!(path, "/redfish/v1/Chassis/Chassis_0/EnvironmentMetrics");
+        assert_eq!(method, http::Method::GET);
+    }
+
+    #[test]
+    fn resolve_get_hgx_chassis() {
+        let (path, method) =
+            resolve_proxy_endpoint(RedfishProxyEndpoint::GetHgxChassis as i32, None).unwrap();
+        assert_eq!(path, "/redfish/v1/Chassis/HGX_Chassis_0");
+        assert_eq!(method, http::Method::GET);
+    }
+
+    #[test]
+    fn resolve_get_hgx_chassis_environment_metrics() {
+        let (path, method) = resolve_proxy_endpoint(
+            RedfishProxyEndpoint::GetHgxChassisEnvironmentMetrics as i32,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            path,
+            "/redfish/v1/Chassis/HGX_Chassis_0/EnvironmentMetrics"
+        );
+        assert_eq!(method, http::Method::GET);
+    }
+
+    #[test]
+    fn resolve_get_processor_module_env_metrics_requires_id() {
+        let result = resolve_proxy_endpoint(
+            RedfishProxyEndpoint::GetProcessorModuleEnvironmentMetrics as i32,
+            None,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_set_processor_module_power_limit() {
+        let (path, method) = resolve_proxy_endpoint(
+            RedfishProxyEndpoint::SetProcessorModulePowerLimit as i32,
+            Some(1),
+        )
+        .unwrap();
+        assert_eq!(
+            path,
+            "/redfish/v1/Chassis/HGX_ProcessorModule_1/EnvironmentMetrics"
+        );
+        assert_eq!(method, http::Method::PATCH);
+    }
+
+    #[test]
+    fn resolve_get_processor_module_assembly() {
+        let (path, method) = resolve_proxy_endpoint(
+            RedfishProxyEndpoint::GetProcessorModuleAssembly as i32,
+            Some(0),
+        )
+        .unwrap();
+        assert_eq!(
+            path,
+            "/redfish/v1/Chassis/HGX_ProcessorModule_0/Assembly"
+        );
+        assert_eq!(method, http::Method::GET);
+    }
+
+    #[test]
+    fn resolve_get_hgx_bmc_manager() {
+        let (path, method) =
+            resolve_proxy_endpoint(RedfishProxyEndpoint::GetHgxBmcManager as i32, None)
+                .unwrap();
+        assert_eq!(path, "/redfish/v1/Managers/HGX_BMC_0");
+        assert_eq!(method, http::Method::GET);
+    }
+
+    #[test]
+    fn resolve_ignores_component_id_for_fixed_endpoints() {
+        let (path, _) =
+            resolve_proxy_endpoint(RedfishProxyEndpoint::GetChassis as i32, Some(42)).unwrap();
+        assert_eq!(path, "/redfish/v1/Chassis/Chassis_0");
     }
 }

--- a/crates/api/src/handlers/redfish.rs
+++ b/crates/api/src/handlers/redfish.rs
@@ -219,28 +219,94 @@ use ::rpc::forge::RedfishProxyEndpoint;
 /// Endpoint-to-URI lookup table. To add a new endpoint, add a proto enum
 /// variant and append one entry here.
 const REDFISH_PROXY_ENDPOINT_TO_URI: &[(RedfishProxyEndpoint, &str)] = &[
-    (RedfishProxyEndpoint::BmcFirmwareVersion,               "/redfish/v1/UpdateService/FirmwareInventory/FW_BMC_0"),
-    (RedfishProxyEndpoint::Gpu0Processor,                    "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0"),
-    (RedfishProxyEndpoint::Gpu1Processor,                    "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_1"),
-    (RedfishProxyEndpoint::Gpu2Processor,                    "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_2"),
-    (RedfishProxyEndpoint::Gpu3Processor,                    "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_3"),
-    (RedfishProxyEndpoint::Gpu0EnvironmentMetrics,           "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/EnvironmentMetrics"),
-    (RedfishProxyEndpoint::Gpu1EnvironmentMetrics,           "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_1/EnvironmentMetrics"),
-    (RedfishProxyEndpoint::Gpu2EnvironmentMetrics,           "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_2/EnvironmentMetrics"),
-    (RedfishProxyEndpoint::Gpu3EnvironmentMetrics,           "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_3/EnvironmentMetrics"),
-    (RedfishProxyEndpoint::Cpu0Processor,                    "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_0"),
-    (RedfishProxyEndpoint::Cpu1Processor,                    "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_1"),
-    (RedfishProxyEndpoint::Cpu0EnvironmentMetrics,           "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_0/EnvironmentMetrics"),
-    (RedfishProxyEndpoint::Cpu1EnvironmentMetrics,           "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_1/EnvironmentMetrics"),
-    (RedfishProxyEndpoint::Chassis,                          "/redfish/v1/Chassis/Chassis_0"),
-    (RedfishProxyEndpoint::ChassisEnvironmentMetrics,        "/redfish/v1/Chassis/Chassis_0/EnvironmentMetrics"),
-    (RedfishProxyEndpoint::HgxChassis,                       "/redfish/v1/Chassis/HGX_Chassis_0"),
-    (RedfishProxyEndpoint::HgxChassisEnvironmentMetrics,     "/redfish/v1/Chassis/HGX_Chassis_0/EnvironmentMetrics"),
-    (RedfishProxyEndpoint::ProcessorModule0EnvironmentMetrics, "/redfish/v1/Chassis/HGX_ProcessorModule_0/EnvironmentMetrics"),
-    (RedfishProxyEndpoint::ProcessorModule1EnvironmentMetrics, "/redfish/v1/Chassis/HGX_ProcessorModule_1/EnvironmentMetrics"),
-    (RedfishProxyEndpoint::ProcessorModule0Assembly,         "/redfish/v1/Chassis/HGX_ProcessorModule_0/Assembly"),
-    (RedfishProxyEndpoint::ProcessorModule1Assembly,         "/redfish/v1/Chassis/HGX_ProcessorModule_1/Assembly"),
-    (RedfishProxyEndpoint::HgxBmcManager,                    "/redfish/v1/Managers/HGX_BMC_0"),
+    (
+        RedfishProxyEndpoint::BmcFirmwareVersion,
+        "/redfish/v1/UpdateService/FirmwareInventory/FW_BMC_0",
+    ),
+    (
+        RedfishProxyEndpoint::Gpu0Processor,
+        "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0",
+    ),
+    (
+        RedfishProxyEndpoint::Gpu1Processor,
+        "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_1",
+    ),
+    (
+        RedfishProxyEndpoint::Gpu2Processor,
+        "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_2",
+    ),
+    (
+        RedfishProxyEndpoint::Gpu3Processor,
+        "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_3",
+    ),
+    (
+        RedfishProxyEndpoint::Gpu0EnvironmentMetrics,
+        "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/EnvironmentMetrics",
+    ),
+    (
+        RedfishProxyEndpoint::Gpu1EnvironmentMetrics,
+        "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_1/EnvironmentMetrics",
+    ),
+    (
+        RedfishProxyEndpoint::Gpu2EnvironmentMetrics,
+        "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_2/EnvironmentMetrics",
+    ),
+    (
+        RedfishProxyEndpoint::Gpu3EnvironmentMetrics,
+        "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_3/EnvironmentMetrics",
+    ),
+    (
+        RedfishProxyEndpoint::Cpu0Processor,
+        "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_0",
+    ),
+    (
+        RedfishProxyEndpoint::Cpu1Processor,
+        "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_1",
+    ),
+    (
+        RedfishProxyEndpoint::Cpu0EnvironmentMetrics,
+        "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_0/EnvironmentMetrics",
+    ),
+    (
+        RedfishProxyEndpoint::Cpu1EnvironmentMetrics,
+        "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_1/EnvironmentMetrics",
+    ),
+    (
+        RedfishProxyEndpoint::Chassis,
+        "/redfish/v1/Chassis/Chassis_0",
+    ),
+    (
+        RedfishProxyEndpoint::ChassisEnvironmentMetrics,
+        "/redfish/v1/Chassis/Chassis_0/EnvironmentMetrics",
+    ),
+    (
+        RedfishProxyEndpoint::HgxChassis,
+        "/redfish/v1/Chassis/HGX_Chassis_0",
+    ),
+    (
+        RedfishProxyEndpoint::HgxChassisEnvironmentMetrics,
+        "/redfish/v1/Chassis/HGX_Chassis_0/EnvironmentMetrics",
+    ),
+    (
+        RedfishProxyEndpoint::ProcessorModule0EnvironmentMetrics,
+        "/redfish/v1/Chassis/HGX_ProcessorModule_0/EnvironmentMetrics",
+    ),
+    (
+        RedfishProxyEndpoint::ProcessorModule1EnvironmentMetrics,
+        "/redfish/v1/Chassis/HGX_ProcessorModule_1/EnvironmentMetrics",
+    ),
+    (
+        RedfishProxyEndpoint::ProcessorModule0Assembly,
+        "/redfish/v1/Chassis/HGX_ProcessorModule_0/Assembly",
+    ),
+    (
+        RedfishProxyEndpoint::ProcessorModule1Assembly,
+        "/redfish/v1/Chassis/HGX_ProcessorModule_1/Assembly",
+    ),
+    (
+        RedfishProxyEndpoint::HgxBmcManager,
+        "/redfish/v1/Managers/HGX_BMC_0",
+    ),
 ];
 
 /// Resolves a `RedfishProxyEndpoint` enum value to a Redfish URI path.
@@ -259,9 +325,7 @@ fn resolve_proxy_endpoint(endpoint: i32) -> Result<&'static str, CarbideError> {
         .iter()
         .find(|(e, _)| *e == ep)
         .map(|(_, path)| *path)
-        .ok_or_else(|| {
-            CarbideError::InvalidArgument(format!("no URI mapping for endpoint {ep:?}"))
-        })
+        .ok_or_else(|| CarbideError::InvalidArgument(format!("no URI mapping for endpoint {ep:?}")))
 }
 
 /// Resolves a `RedfishProxyMethod` enum value to an `http::Method`.
@@ -295,9 +359,7 @@ pub async fn redfish_proxy(
 
     let bmc_ip = &inner.bmc_ip;
     if bmc_ip.is_empty() {
-        return Err(
-            CarbideError::InvalidArgument("bmc_ip is required".to_owned()).into(),
-        );
+        return Err(CarbideError::InvalidArgument("bmc_ip is required".to_owned()).into());
     }
     let uri: http::Uri = http::Uri::builder()
         .scheme("https")
@@ -1083,31 +1145,7 @@ mod tests {
 
     #[test]
     fn resolve_all_endpoints() {
-        let cases: &[(RedfishProxyEndpoint, &str)] = &[
-            (RedfishProxyEndpoint::BmcFirmwareVersion, "/redfish/v1/UpdateService/FirmwareInventory/FW_BMC_0"),
-            (RedfishProxyEndpoint::Gpu0Processor, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0"),
-            (RedfishProxyEndpoint::Gpu1Processor, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_1"),
-            (RedfishProxyEndpoint::Gpu2Processor, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_2"),
-            (RedfishProxyEndpoint::Gpu3Processor, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_3"),
-            (RedfishProxyEndpoint::Gpu0EnvironmentMetrics, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/EnvironmentMetrics"),
-            (RedfishProxyEndpoint::Gpu1EnvironmentMetrics, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_1/EnvironmentMetrics"),
-            (RedfishProxyEndpoint::Gpu2EnvironmentMetrics, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_2/EnvironmentMetrics"),
-            (RedfishProxyEndpoint::Gpu3EnvironmentMetrics, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_3/EnvironmentMetrics"),
-            (RedfishProxyEndpoint::Cpu0Processor, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_0"),
-            (RedfishProxyEndpoint::Cpu1Processor, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_1"),
-            (RedfishProxyEndpoint::Cpu0EnvironmentMetrics, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_0/EnvironmentMetrics"),
-            (RedfishProxyEndpoint::Cpu1EnvironmentMetrics, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_1/EnvironmentMetrics"),
-            (RedfishProxyEndpoint::Chassis, "/redfish/v1/Chassis/Chassis_0"),
-            (RedfishProxyEndpoint::ChassisEnvironmentMetrics, "/redfish/v1/Chassis/Chassis_0/EnvironmentMetrics"),
-            (RedfishProxyEndpoint::HgxChassis, "/redfish/v1/Chassis/HGX_Chassis_0"),
-            (RedfishProxyEndpoint::HgxChassisEnvironmentMetrics, "/redfish/v1/Chassis/HGX_Chassis_0/EnvironmentMetrics"),
-            (RedfishProxyEndpoint::ProcessorModule0EnvironmentMetrics, "/redfish/v1/Chassis/HGX_ProcessorModule_0/EnvironmentMetrics"),
-            (RedfishProxyEndpoint::ProcessorModule1EnvironmentMetrics, "/redfish/v1/Chassis/HGX_ProcessorModule_1/EnvironmentMetrics"),
-            (RedfishProxyEndpoint::ProcessorModule0Assembly, "/redfish/v1/Chassis/HGX_ProcessorModule_0/Assembly"),
-            (RedfishProxyEndpoint::ProcessorModule1Assembly, "/redfish/v1/Chassis/HGX_ProcessorModule_1/Assembly"),
-            (RedfishProxyEndpoint::HgxBmcManager, "/redfish/v1/Managers/HGX_BMC_0"),
-        ];
-        for &(ep, expected_path) in cases {
+        for &(ep, expected_path) in REDFISH_PROXY_ENDPOINT_TO_URI {
             let path = resolve_proxy_endpoint(ep as i32).unwrap();
             assert_eq!(path, expected_path, "mismatch for {ep:?}");
         }

--- a/crates/api/src/handlers/redfish.rs
+++ b/crates/api/src/handlers/redfish.rs
@@ -35,7 +35,7 @@ use uuid::Uuid;
 
 use crate::CarbideError;
 use crate::api::log_request_data;
-use crate::auth::external_user_info;
+use crate::auth::{AuthContext, Principal, external_user_info};
 
 // TODO: put this in carbide config?
 pub const NUM_REQUIRED_APPROVALS: usize = 2;
@@ -98,6 +98,184 @@ pub async fn redfish_browse(
         headers,
     }))
 }
+
+fn uri_matches_allowlist(uri_path: &str, patterns: &[String]) -> bool {
+    patterns.iter().any(|pattern| {
+        if pattern == "*" {
+            return true;
+        }
+        let pattern_segments: Vec<&str> = pattern.split('/').collect();
+        let uri_segments: Vec<&str> = uri_path.split('/').collect();
+        if pattern_segments.len() != uri_segments.len() {
+            return false;
+        }
+        pattern_segments
+            .iter()
+            .zip(uri_segments.iter())
+            .all(|(p, u)| p.contains("{id}") || *p == *u)
+    })
+}
+
+fn check_redfish_proxy_allowlist<T>(
+    redfish_proxy_config: &HashMap<String, crate::cfg::file::RedfishProxyPrincipalConfig>,
+    request: &tonic::Request<T>,
+    uri_path: &str,
+    method: &http::Method,
+) -> Result<(), tonic::Status> {
+    let auth_context = request.extensions().get::<AuthContext>();
+    let principals = auth_context
+        .map(|ctx| ctx.principals.as_slice())
+        .unwrap_or_default();
+
+    let is_external_user = principals
+        .iter()
+        .any(|p| matches!(p, Principal::ExternalUser(_)));
+    if is_external_user {
+        return Ok(());
+    }
+
+    let spiffe_name = principals.iter().find_map(|p| match p {
+        Principal::SpiffeServiceIdentifier(name) => Some(name.as_str()),
+        _ => None,
+    });
+
+    let Some(name) = spiffe_name else {
+        return Err(tonic::Status::permission_denied(
+            "no SPIFFE service identity found for redfish proxy allowlist check",
+        ));
+    };
+
+    let Some(principal_config) = redfish_proxy_config.get(name) else {
+        return Err(tonic::Status::permission_denied(format!(
+            "no redfish_proxy config for principal {name}"
+        )));
+    };
+
+    let patterns = if method == http::Method::POST {
+        &principal_config.allowed_post_uris
+    } else {
+        &principal_config.allowed_patch_uris
+    };
+
+    if uri_matches_allowlist(uri_path, patterns) {
+        Ok(())
+    } else {
+        Err(tonic::Status::permission_denied(format!(
+            "URI {uri_path} not in allowed {method} URIs for principal {name}"
+        )))
+    }
+}
+
+async fn redfish_proxy_mutate(
+    api: &crate::api::Api,
+    uri: http::Uri,
+    body: String,
+    method: http::Method,
+) -> Result<(String, HashMap<String, String>, String), tonic::Status> {
+    let (metadata, new_uri, mut headers, http_client) = create_client(
+        uri,
+        &api.database_connection,
+        api.credential_manager.as_ref(),
+        &api.dynamic_settings.bmc_proxy,
+    )
+    .await?;
+
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+    let response = http_client
+        .request(method, new_uri.to_string())
+        .basic_auth(metadata.user.clone(), Some(metadata.password.clone()))
+        .body(body)
+        .headers(headers)
+        .send()
+        .await
+        .map_err(|e| CarbideError::internal(format!("Http request failed: {e:?}")))?;
+
+    let response_headers = response
+        .headers()
+        .iter()
+        .map(|(x, y)| {
+            (
+                x.to_string(),
+                String::from_utf8_lossy(y.as_bytes()).to_string(),
+            )
+        })
+        .collect::<HashMap<String, String>>();
+
+    let status = response.status().to_string();
+    let text = response.text().await.map_err(|e| {
+        CarbideError::internal(format!("Error reading response body: {e}, Status: {status}"))
+    })?;
+
+    Ok((text, response_headers, status))
+}
+
+pub async fn redfish_post(
+    api: &crate::api::Api,
+    request: tonic::Request<::rpc::forge::RedfishPostRequest>,
+) -> Result<tonic::Response<::rpc::forge::RedfishPostResponse>, tonic::Status> {
+    log_request_data(&request);
+
+    let uri: http::Uri = request
+        .get_ref()
+        .uri
+        .parse()
+        .map_err(|err| CarbideError::internal(format!("Parsing uri failed: {err}")))?;
+    let uri_path = uri.path().to_owned();
+
+    check_redfish_proxy_allowlist(
+        &api.runtime_config.redfish_proxy,
+        &request,
+        &uri_path,
+        &http::Method::POST,
+    )?;
+
+    tracing::info!(method = "POST", uri = %uri, "redfish proxy request");
+
+    let body = request.into_inner().body;
+    let (text, headers, status) =
+        redfish_proxy_mutate(api, uri, body, http::Method::POST).await?;
+
+    Ok(tonic::Response::new(::rpc::forge::RedfishPostResponse {
+        text,
+        headers,
+        status,
+    }))
+}
+
+pub async fn redfish_patch(
+    api: &crate::api::Api,
+    request: tonic::Request<::rpc::forge::RedfishPatchRequest>,
+) -> Result<tonic::Response<::rpc::forge::RedfishPatchResponse>, tonic::Status> {
+    log_request_data(&request);
+
+    let uri: http::Uri = request
+        .get_ref()
+        .uri
+        .parse()
+        .map_err(|err| CarbideError::internal(format!("Parsing uri failed: {err}")))?;
+    let uri_path = uri.path().to_owned();
+
+    check_redfish_proxy_allowlist(
+        &api.runtime_config.redfish_proxy,
+        &request,
+        &uri_path,
+        &http::Method::PATCH,
+    )?;
+
+    tracing::info!(method = "PATCH", uri = %uri, "redfish proxy request");
+
+    let body = request.into_inner().body;
+    let (text, headers, status) =
+        redfish_proxy_mutate(api, uri, body, http::Method::PATCH).await?;
+
+    Ok(tonic::Response::new(::rpc::forge::RedfishPatchResponse {
+        text,
+        headers,
+        status,
+    }))
+}
+
 pub async fn redfish_list_actions(
     api: &crate::api::Api,
     request: tonic::Request<::rpc::forge::RedfishListActionsRequest>,
@@ -571,5 +749,268 @@ impl From<reqwest::Error> for RequestErrorInfo {
             status_code: e.status(),
             description: e.to_string(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::{AuthContext, ExternalUserInfo, Principal};
+    use crate::cfg::file::RedfishProxyPrincipalConfig;
+
+    // ── uri_matches_allowlist ──────────────────────────────────────────
+
+    #[test]
+    fn uri_allowlist_exact_match() {
+        let patterns = vec!["/redfish/v1/Managers/BMC/NodeManager/Domains".to_string()];
+        assert!(uri_matches_allowlist(
+            "/redfish/v1/Managers/BMC/NodeManager/Domains",
+            &patterns,
+        ));
+    }
+
+    #[test]
+    fn uri_allowlist_exact_mismatch() {
+        let patterns = vec!["/redfish/v1/Managers/BMC/NodeManager/Domains".to_string()];
+        assert!(!uri_matches_allowlist(
+            "/redfish/v1/Managers/BMC/NodeManager/Other",
+            &patterns,
+        ));
+    }
+
+    #[test]
+    fn uri_allowlist_wildcard_star_matches_anything() {
+        let patterns = vec!["*".to_string()];
+        assert!(uri_matches_allowlist("/any/path/at/all", &patterns));
+        assert!(uri_matches_allowlist("/", &patterns));
+    }
+
+    #[test]
+    fn uri_allowlist_id_placeholder_matches_any_segment() {
+        let patterns =
+            vec!["/redfish/v1/Managers/BMC/NodeManager/Domains/{id}".to_string()];
+        assert!(uri_matches_allowlist(
+            "/redfish/v1/Managers/BMC/NodeManager/Domains/42",
+            &patterns,
+        ));
+        assert!(uri_matches_allowlist(
+            "/redfish/v1/Managers/BMC/NodeManager/Domains/abc-def",
+            &patterns,
+        ));
+    }
+
+    #[test]
+    fn uri_allowlist_id_placeholder_in_middle() {
+        let patterns = vec![
+            "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_{id}/Oem/Nvidia/WorkloadPowerProfile/Actions/NvidiaWorkloadPower.EnableProfiles".to_string(),
+        ];
+        assert!(uri_matches_allowlist(
+            "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Oem/Nvidia/WorkloadPowerProfile/Actions/NvidiaWorkloadPower.EnableProfiles",
+            &patterns,
+        ));
+        assert!(uri_matches_allowlist(
+            "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_7/Oem/Nvidia/WorkloadPowerProfile/Actions/NvidiaWorkloadPower.EnableProfiles",
+            &patterns,
+        ));
+    }
+
+    #[test]
+    fn uri_allowlist_segment_count_mismatch_rejects() {
+        let patterns =
+            vec!["/redfish/v1/Managers/BMC/NodeManager/Domains/{id}".to_string()];
+        assert!(!uri_matches_allowlist(
+            "/redfish/v1/Managers/BMC/NodeManager/Domains",
+            &patterns,
+        ));
+        assert!(!uri_matches_allowlist(
+            "/redfish/v1/Managers/BMC/NodeManager/Domains/42/extra",
+            &patterns,
+        ));
+    }
+
+    #[test]
+    fn uri_allowlist_empty_patterns_rejects_all() {
+        let patterns: Vec<String> = vec![];
+        assert!(!uri_matches_allowlist("/redfish/v1/anything", &patterns));
+    }
+
+    #[test]
+    fn uri_allowlist_multiple_patterns_any_match_suffices() {
+        let patterns = vec![
+            "/redfish/v1/A".to_string(),
+            "/redfish/v1/B".to_string(),
+        ];
+        assert!(uri_matches_allowlist("/redfish/v1/B", &patterns));
+        assert!(!uri_matches_allowlist("/redfish/v1/C", &patterns));
+    }
+
+    // ── check_redfish_proxy_allowlist ──────────────────────────────────
+
+    fn make_config(
+        post_uris: Vec<&str>,
+        patch_uris: Vec<&str>,
+    ) -> HashMap<String, RedfishProxyPrincipalConfig> {
+        let mut m = HashMap::new();
+        m.insert(
+            "carbide-dps".to_string(),
+            RedfishProxyPrincipalConfig {
+                allowed_post_uris: post_uris.into_iter().map(String::from).collect(),
+                allowed_patch_uris: patch_uris.into_iter().map(String::from).collect(),
+            },
+        );
+        m
+    }
+
+    fn spiffe_request<T>(name: &str, body: T) -> tonic::Request<T> {
+        let mut req = tonic::Request::new(body);
+        let mut ctx = AuthContext::default();
+        ctx.principals
+            .push(Principal::SpiffeServiceIdentifier(name.to_string()));
+        req.extensions_mut().insert(ctx);
+        req
+    }
+
+    fn external_user_request<T>(body: T) -> tonic::Request<T> {
+        let mut req = tonic::Request::new(body);
+        let mut ctx = AuthContext::default();
+        ctx.principals
+            .push(Principal::ExternalUser(ExternalUserInfo {
+                org: None,
+                group: "admin".to_string(),
+                user: Some("testuser".to_string()),
+            }));
+        req.extensions_mut().insert(ctx);
+        req
+    }
+
+    #[test]
+    fn allowlist_external_user_always_passes() {
+        let config = HashMap::new();
+        let req = external_user_request(());
+        assert!(check_redfish_proxy_allowlist(
+            &config,
+            &req,
+            "/any/uri",
+            &http::Method::POST,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn allowlist_spiffe_allowed_post_uri() {
+        let config = make_config(
+            vec!["/redfish/v1/Managers/BMC/NodeManager/Domains"],
+            vec![],
+        );
+        let req = spiffe_request("carbide-dps", ());
+        assert!(check_redfish_proxy_allowlist(
+            &config,
+            &req,
+            "/redfish/v1/Managers/BMC/NodeManager/Domains",
+            &http::Method::POST,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn allowlist_spiffe_denied_post_uri() {
+        let config = make_config(
+            vec!["/redfish/v1/Managers/BMC/NodeManager/Domains"],
+            vec![],
+        );
+        let req = spiffe_request("carbide-dps", ());
+        let result = check_redfish_proxy_allowlist(
+            &config,
+            &req,
+            "/redfish/v1/Some/Other/Path",
+            &http::Method::POST,
+        );
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code(), tonic::Code::PermissionDenied);
+    }
+
+    #[test]
+    fn allowlist_spiffe_allowed_patch_uri_with_id() {
+        let config = make_config(
+            vec![],
+            vec!["/redfish/v1/Managers/BMC/NodeManager/Domains/{id}"],
+        );
+        let req = spiffe_request("carbide-dps", ());
+        assert!(check_redfish_proxy_allowlist(
+            &config,
+            &req,
+            "/redfish/v1/Managers/BMC/NodeManager/Domains/42",
+            &http::Method::PATCH,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn allowlist_post_patterns_not_checked_for_patch() {
+        let config = make_config(
+            vec!["/redfish/v1/Managers/BMC/NodeManager/Domains"],
+            vec![],
+        );
+        let req = spiffe_request("carbide-dps", ());
+        let result = check_redfish_proxy_allowlist(
+            &config,
+            &req,
+            "/redfish/v1/Managers/BMC/NodeManager/Domains",
+            &http::Method::PATCH,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn allowlist_missing_principal_config_denied() {
+        let config = HashMap::new();
+        let req = spiffe_request("unknown-service", ());
+        let result = check_redfish_proxy_allowlist(
+            &config,
+            &req,
+            "/redfish/v1/anything",
+            &http::Method::POST,
+        );
+        assert!(result.is_err());
+        let status = result.unwrap_err();
+        assert_eq!(status.code(), tonic::Code::PermissionDenied);
+        assert!(status.message().contains("no redfish_proxy config"));
+    }
+
+    #[test]
+    fn allowlist_no_auth_context_denied() {
+        let config = HashMap::new();
+        let req = tonic::Request::new(());
+        let result = check_redfish_proxy_allowlist(
+            &config,
+            &req,
+            "/redfish/v1/anything",
+            &http::Method::POST,
+        );
+        assert!(result.is_err());
+        let status = result.unwrap_err();
+        assert_eq!(status.code(), tonic::Code::PermissionDenied);
+        assert!(status.message().contains("no SPIFFE service identity"));
+    }
+
+    #[test]
+    fn allowlist_star_pattern_grants_full_access() {
+        let config = make_config(vec!["*"], vec!["*"]);
+        let req = spiffe_request("carbide-dps", ());
+        assert!(check_redfish_proxy_allowlist(
+            &config,
+            &req,
+            "/literally/any/path",
+            &http::Method::POST,
+        )
+        .is_ok());
+        let req2 = spiffe_request("carbide-dps", ());
+        assert!(check_redfish_proxy_allowlist(
+            &config,
+            &req2,
+            "/literally/any/other/path",
+            &http::Method::PATCH,
+        )
+        .is_ok());
     }
 }

--- a/crates/api/src/handlers/redfish.rs
+++ b/crates/api/src/handlers/redfish.rs
@@ -214,129 +214,72 @@ async fn redfish_proxy_get(
     Ok((text, response_headers, status))
 }
 
-/// Resolves a `RedfishProxyEndpoint` enum value and optional component id
-/// into a concrete (URI path, HTTP method) pair. Returns an error for
-/// unrecognized or unspecified endpoints.
-fn resolve_proxy_endpoint(
-    endpoint: i32,
-    component_id: Option<u32>,
-) -> Result<(String, http::Method), CarbideError> {
-    use ::rpc::forge::RedfishProxyEndpoint;
+use ::rpc::forge::RedfishProxyEndpoint;
 
+/// Endpoint-to-URI lookup table. To add a new endpoint, add a proto enum
+/// variant and append one entry here.
+const REDFISH_PROXY_ENDPOINT_TO_URI: &[(RedfishProxyEndpoint, &str)] = &[
+    (RedfishProxyEndpoint::BmcFirmwareVersion,               "/redfish/v1/UpdateService/FirmwareInventory/FW_BMC_0"),
+    (RedfishProxyEndpoint::Gpu0Processor,                    "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0"),
+    (RedfishProxyEndpoint::Gpu1Processor,                    "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_1"),
+    (RedfishProxyEndpoint::Gpu2Processor,                    "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_2"),
+    (RedfishProxyEndpoint::Gpu3Processor,                    "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_3"),
+    (RedfishProxyEndpoint::Gpu0EnvironmentMetrics,           "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/EnvironmentMetrics"),
+    (RedfishProxyEndpoint::Gpu1EnvironmentMetrics,           "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_1/EnvironmentMetrics"),
+    (RedfishProxyEndpoint::Gpu2EnvironmentMetrics,           "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_2/EnvironmentMetrics"),
+    (RedfishProxyEndpoint::Gpu3EnvironmentMetrics,           "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_3/EnvironmentMetrics"),
+    (RedfishProxyEndpoint::Cpu0Processor,                    "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_0"),
+    (RedfishProxyEndpoint::Cpu1Processor,                    "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_1"),
+    (RedfishProxyEndpoint::Cpu0EnvironmentMetrics,           "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_0/EnvironmentMetrics"),
+    (RedfishProxyEndpoint::Cpu1EnvironmentMetrics,           "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_1/EnvironmentMetrics"),
+    (RedfishProxyEndpoint::Chassis,                          "/redfish/v1/Chassis/Chassis_0"),
+    (RedfishProxyEndpoint::ChassisEnvironmentMetrics,        "/redfish/v1/Chassis/Chassis_0/EnvironmentMetrics"),
+    (RedfishProxyEndpoint::HgxChassis,                       "/redfish/v1/Chassis/HGX_Chassis_0"),
+    (RedfishProxyEndpoint::HgxChassisEnvironmentMetrics,     "/redfish/v1/Chassis/HGX_Chassis_0/EnvironmentMetrics"),
+    (RedfishProxyEndpoint::ProcessorModule0EnvironmentMetrics, "/redfish/v1/Chassis/HGX_ProcessorModule_0/EnvironmentMetrics"),
+    (RedfishProxyEndpoint::ProcessorModule1EnvironmentMetrics, "/redfish/v1/Chassis/HGX_ProcessorModule_1/EnvironmentMetrics"),
+    (RedfishProxyEndpoint::ProcessorModule0Assembly,         "/redfish/v1/Chassis/HGX_ProcessorModule_0/Assembly"),
+    (RedfishProxyEndpoint::ProcessorModule1Assembly,         "/redfish/v1/Chassis/HGX_ProcessorModule_1/Assembly"),
+    (RedfishProxyEndpoint::HgxBmcManager,                    "/redfish/v1/Managers/HGX_BMC_0"),
+];
+
+/// Resolves a `RedfishProxyEndpoint` enum value to a Redfish URI path.
+fn resolve_proxy_endpoint(endpoint: i32) -> Result<&'static str, CarbideError> {
     let ep = RedfishProxyEndpoint::try_from(endpoint).map_err(|_| {
         CarbideError::InvalidArgument(format!("unknown RedfishProxyEndpoint value: {endpoint}"))
     })?;
 
-    let id = component_id.map(|i| i.to_string());
-    let require_id = |label: &str| -> Result<String, CarbideError> {
-        id.clone().ok_or_else(|| {
-            CarbideError::InvalidArgument(format!("component_id is required for {label}"))
+    if ep == RedfishProxyEndpoint::Unspecified {
+        return Err(CarbideError::InvalidArgument(
+            "RedfishProxyEndpoint must not be UNSPECIFIED".to_owned(),
+        ));
+    }
+
+    REDFISH_PROXY_ENDPOINT_TO_URI
+        .iter()
+        .find(|(e, _)| *e == ep)
+        .map(|(_, path)| *path)
+        .ok_or_else(|| {
+            CarbideError::InvalidArgument(format!("no URI mapping for endpoint {ep:?}"))
         })
-    };
+}
 
-    let (path, method) = match ep {
-        RedfishProxyEndpoint::Unspecified => {
-            return Err(CarbideError::InvalidArgument(
-                "RedfishProxyEndpoint must not be UNSPECIFIED".to_owned(),
-            ));
-        }
+/// Resolves a `RedfishProxyMethod` enum value to an `http::Method`.
+fn resolve_proxy_method(method: i32) -> Result<http::Method, CarbideError> {
+    use ::rpc::forge::RedfishProxyMethod;
 
-        RedfishProxyEndpoint::GetBmcFirmwareVersion => (
-            "/redfish/v1/UpdateService/FirmwareInventory/FW_BMC_0".to_owned(),
-            http::Method::GET,
-        ),
+    let m = RedfishProxyMethod::try_from(method).map_err(|_| {
+        CarbideError::InvalidArgument(format!("unknown RedfishProxyMethod value: {method}"))
+    })?;
 
-        RedfishProxyEndpoint::GetGpuProcessor => (
-            format!(
-                "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_{}",
-                require_id("GET_GPU_PROCESSOR")?
-            ),
-            http::Method::GET,
-        ),
-        RedfishProxyEndpoint::GetGpuEnvironmentMetrics => (
-            format!(
-                "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_{}/EnvironmentMetrics",
-                require_id("GET_GPU_ENVIRONMENT_METRICS")?
-            ),
-            http::Method::GET,
-        ),
-        RedfishProxyEndpoint::SetGpuPowerLimit => (
-            format!(
-                "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_{}/EnvironmentMetrics",
-                require_id("SET_GPU_POWER_LIMIT")?
-            ),
-            http::Method::PATCH,
-        ),
-
-        RedfishProxyEndpoint::GetCpuProcessor => (
-            format!(
-                "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_{}",
-                require_id("GET_CPU_PROCESSOR")?
-            ),
-            http::Method::GET,
-        ),
-        RedfishProxyEndpoint::GetCpuEnvironmentMetrics => (
-            format!(
-                "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_{}/EnvironmentMetrics",
-                require_id("GET_CPU_ENVIRONMENT_METRICS")?
-            ),
-            http::Method::GET,
-        ),
-        RedfishProxyEndpoint::SetCpuPowerLimit => (
-            format!(
-                "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_{}/EnvironmentMetrics",
-                require_id("SET_CPU_POWER_LIMIT")?
-            ),
-            http::Method::PATCH,
-        ),
-
-        RedfishProxyEndpoint::GetChassis => (
-            "/redfish/v1/Chassis/Chassis_0".to_owned(),
-            http::Method::GET,
-        ),
-        RedfishProxyEndpoint::GetChassisEnvironmentMetrics => (
-            "/redfish/v1/Chassis/Chassis_0/EnvironmentMetrics".to_owned(),
-            http::Method::GET,
-        ),
-
-        RedfishProxyEndpoint::GetHgxChassis => (
-            "/redfish/v1/Chassis/HGX_Chassis_0".to_owned(),
-            http::Method::GET,
-        ),
-        RedfishProxyEndpoint::GetHgxChassisEnvironmentMetrics => (
-            "/redfish/v1/Chassis/HGX_Chassis_0/EnvironmentMetrics".to_owned(),
-            http::Method::GET,
-        ),
-
-        RedfishProxyEndpoint::GetProcessorModuleEnvironmentMetrics => (
-            format!(
-                "/redfish/v1/Chassis/HGX_ProcessorModule_{}/EnvironmentMetrics",
-                require_id("GET_PROCESSOR_MODULE_ENVIRONMENT_METRICS")?
-            ),
-            http::Method::GET,
-        ),
-        RedfishProxyEndpoint::SetProcessorModulePowerLimit => (
-            format!(
-                "/redfish/v1/Chassis/HGX_ProcessorModule_{}/EnvironmentMetrics",
-                require_id("SET_PROCESSOR_MODULE_POWER_LIMIT")?
-            ),
-            http::Method::PATCH,
-        ),
-        RedfishProxyEndpoint::GetProcessorModuleAssembly => (
-            format!(
-                "/redfish/v1/Chassis/HGX_ProcessorModule_{}/Assembly",
-                require_id("GET_PROCESSOR_MODULE_ASSEMBLY")?
-            ),
-            http::Method::GET,
-        ),
-
-        RedfishProxyEndpoint::GetHgxBmcManager => (
-            "/redfish/v1/Managers/HGX_BMC_0".to_owned(),
-            http::Method::GET,
-        ),
-    };
-
-    Ok((path, method))
+    match m {
+        RedfishProxyMethod::Unspecified => Err(CarbideError::InvalidArgument(
+            "RedfishProxyMethod must not be UNSPECIFIED".to_owned(),
+        )),
+        RedfishProxyMethod::Get => Ok(http::Method::GET),
+        RedfishProxyMethod::Post => Ok(http::Method::POST),
+        RedfishProxyMethod::Patch => Ok(http::Method::PATCH),
+    }
 }
 
 pub async fn redfish_proxy(
@@ -347,42 +290,21 @@ pub async fn redfish_proxy(
 
     let inner = request.get_ref();
 
-    // New enum-based path: prefer `endpoint` if set to a non-default value.
-    let (uri, method) = if inner.endpoint != 0 {
-        let (path, method) = resolve_proxy_endpoint(inner.endpoint, inner.component_id)?;
-        let bmc_ip = &inner.bmc_ip;
-        if bmc_ip.is_empty() {
-            return Err(CarbideError::InvalidArgument(
-                "bmc_ip is required when using the endpoint field".to_owned(),
-            )
-            .into());
-        }
-        let uri: http::Uri = http::Uri::builder()
-            .scheme("https")
-            .authority(bmc_ip.as_str())
-            .path_and_query(path.as_str())
-            .build()
-            .map_err(|e| CarbideError::internal(format!("building proxy URI: {e}")))?;
-        (uri, method)
-    } else {
-        // Legacy path: raw uri + method strings (deprecated, kept for backward compat).
-        let method = match inner.method.to_uppercase().as_str() {
-            "GET" => http::Method::GET,
-            "POST" => http::Method::POST,
-            "PATCH" => http::Method::PATCH,
-            other => {
-                return Err(CarbideError::InvalidArgument(format!(
-                    "unsupported redfish proxy method: {other} (must be GET, POST, or PATCH)"
-                ))
-                .into());
-            }
-        };
-        let uri: http::Uri = inner
-            .uri
-            .parse()
-            .map_err(|err| CarbideError::internal(format!("Parsing uri failed: {err}")))?;
-        (uri, method)
-    };
+    let path = resolve_proxy_endpoint(inner.endpoint)?;
+    let method = resolve_proxy_method(inner.method)?;
+
+    let bmc_ip = &inner.bmc_ip;
+    if bmc_ip.is_empty() {
+        return Err(
+            CarbideError::InvalidArgument("bmc_ip is required".to_owned()).into(),
+        );
+    }
+    let uri: http::Uri = http::Uri::builder()
+        .scheme("https")
+        .authority(bmc_ip.as_str())
+        .path_and_query(path)
+        .build()
+        .map_err(|e| CarbideError::internal(format!("building proxy URI: {e}")))?;
 
     let uri_path = uri.path().to_owned();
 
@@ -1147,178 +1069,83 @@ mod tests {
 
     // ── resolve_proxy_endpoint ─────────────────────────────────────────
 
-    use ::rpc::forge::RedfishProxyEndpoint;
+    use ::rpc::forge::RedfishProxyMethod;
 
     #[test]
     fn resolve_unspecified_endpoint_is_error() {
-        let result = resolve_proxy_endpoint(RedfishProxyEndpoint::Unspecified as i32, None);
-        assert!(result.is_err());
+        assert!(resolve_proxy_endpoint(RedfishProxyEndpoint::Unspecified as i32).is_err());
     }
 
     #[test]
     fn resolve_unknown_endpoint_value_is_error() {
-        let result = resolve_proxy_endpoint(9999, None);
-        assert!(result.is_err());
+        assert!(resolve_proxy_endpoint(9999).is_err());
     }
 
     #[test]
-    fn resolve_get_bmc_firmware_version() {
-        let (path, method) =
-            resolve_proxy_endpoint(RedfishProxyEndpoint::GetBmcFirmwareVersion as i32, None)
-                .unwrap();
+    fn resolve_all_endpoints() {
+        let cases: &[(RedfishProxyEndpoint, &str)] = &[
+            (RedfishProxyEndpoint::BmcFirmwareVersion, "/redfish/v1/UpdateService/FirmwareInventory/FW_BMC_0"),
+            (RedfishProxyEndpoint::Gpu0Processor, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0"),
+            (RedfishProxyEndpoint::Gpu1Processor, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_1"),
+            (RedfishProxyEndpoint::Gpu2Processor, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_2"),
+            (RedfishProxyEndpoint::Gpu3Processor, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_3"),
+            (RedfishProxyEndpoint::Gpu0EnvironmentMetrics, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/EnvironmentMetrics"),
+            (RedfishProxyEndpoint::Gpu1EnvironmentMetrics, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_1/EnvironmentMetrics"),
+            (RedfishProxyEndpoint::Gpu2EnvironmentMetrics, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_2/EnvironmentMetrics"),
+            (RedfishProxyEndpoint::Gpu3EnvironmentMetrics, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_3/EnvironmentMetrics"),
+            (RedfishProxyEndpoint::Cpu0Processor, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_0"),
+            (RedfishProxyEndpoint::Cpu1Processor, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_1"),
+            (RedfishProxyEndpoint::Cpu0EnvironmentMetrics, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_0/EnvironmentMetrics"),
+            (RedfishProxyEndpoint::Cpu1EnvironmentMetrics, "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_1/EnvironmentMetrics"),
+            (RedfishProxyEndpoint::Chassis, "/redfish/v1/Chassis/Chassis_0"),
+            (RedfishProxyEndpoint::ChassisEnvironmentMetrics, "/redfish/v1/Chassis/Chassis_0/EnvironmentMetrics"),
+            (RedfishProxyEndpoint::HgxChassis, "/redfish/v1/Chassis/HGX_Chassis_0"),
+            (RedfishProxyEndpoint::HgxChassisEnvironmentMetrics, "/redfish/v1/Chassis/HGX_Chassis_0/EnvironmentMetrics"),
+            (RedfishProxyEndpoint::ProcessorModule0EnvironmentMetrics, "/redfish/v1/Chassis/HGX_ProcessorModule_0/EnvironmentMetrics"),
+            (RedfishProxyEndpoint::ProcessorModule1EnvironmentMetrics, "/redfish/v1/Chassis/HGX_ProcessorModule_1/EnvironmentMetrics"),
+            (RedfishProxyEndpoint::ProcessorModule0Assembly, "/redfish/v1/Chassis/HGX_ProcessorModule_0/Assembly"),
+            (RedfishProxyEndpoint::ProcessorModule1Assembly, "/redfish/v1/Chassis/HGX_ProcessorModule_1/Assembly"),
+            (RedfishProxyEndpoint::HgxBmcManager, "/redfish/v1/Managers/HGX_BMC_0"),
+        ];
+        for &(ep, expected_path) in cases {
+            let path = resolve_proxy_endpoint(ep as i32).unwrap();
+            assert_eq!(path, expected_path, "mismatch for {ep:?}");
+        }
+    }
+
+    // ── resolve_proxy_method ────────────────────────────────────────────
+
+    #[test]
+    fn resolve_unspecified_method_is_error() {
+        assert!(resolve_proxy_method(RedfishProxyMethod::Unspecified as i32).is_err());
+    }
+
+    #[test]
+    fn resolve_unknown_method_value_is_error() {
+        assert!(resolve_proxy_method(9999).is_err());
+    }
+
+    #[test]
+    fn resolve_get_method() {
         assert_eq!(
-            path,
-            "/redfish/v1/UpdateService/FirmwareInventory/FW_BMC_0"
+            resolve_proxy_method(RedfishProxyMethod::Get as i32).unwrap(),
+            http::Method::GET,
         );
-        assert_eq!(method, http::Method::GET);
     }
 
     #[test]
-    fn resolve_get_gpu_processor_requires_id() {
-        let result =
-            resolve_proxy_endpoint(RedfishProxyEndpoint::GetGpuProcessor as i32, None);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn resolve_get_gpu_processor_with_id() {
-        let (path, method) =
-            resolve_proxy_endpoint(RedfishProxyEndpoint::GetGpuProcessor as i32, Some(3))
-                .unwrap();
+    fn resolve_post_method() {
         assert_eq!(
-            path,
-            "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_3"
+            resolve_proxy_method(RedfishProxyMethod::Post as i32).unwrap(),
+            http::Method::POST,
         );
-        assert_eq!(method, http::Method::GET);
     }
 
     #[test]
-    fn resolve_set_gpu_power_limit_is_patch() {
-        let (path, method) =
-            resolve_proxy_endpoint(RedfishProxyEndpoint::SetGpuPowerLimit as i32, Some(0))
-                .unwrap();
+    fn resolve_patch_method() {
         assert_eq!(
-            path,
-            "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/EnvironmentMetrics"
+            resolve_proxy_method(RedfishProxyMethod::Patch as i32).unwrap(),
+            http::Method::PATCH,
         );
-        assert_eq!(method, http::Method::PATCH);
-    }
-
-    #[test]
-    fn resolve_get_cpu_processor_with_id() {
-        let (path, method) =
-            resolve_proxy_endpoint(RedfishProxyEndpoint::GetCpuProcessor as i32, Some(1))
-                .unwrap();
-        assert_eq!(
-            path,
-            "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_1"
-        );
-        assert_eq!(method, http::Method::GET);
-    }
-
-    #[test]
-    fn resolve_set_cpu_power_limit_is_patch() {
-        let (path, method) =
-            resolve_proxy_endpoint(RedfishProxyEndpoint::SetCpuPowerLimit as i32, Some(0))
-                .unwrap();
-        assert_eq!(
-            path,
-            "/redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_0/EnvironmentMetrics"
-        );
-        assert_eq!(method, http::Method::PATCH);
-    }
-
-    #[test]
-    fn resolve_get_chassis() {
-        let (path, method) =
-            resolve_proxy_endpoint(RedfishProxyEndpoint::GetChassis as i32, None).unwrap();
-        assert_eq!(path, "/redfish/v1/Chassis/Chassis_0");
-        assert_eq!(method, http::Method::GET);
-    }
-
-    #[test]
-    fn resolve_get_chassis_environment_metrics() {
-        let (path, method) = resolve_proxy_endpoint(
-            RedfishProxyEndpoint::GetChassisEnvironmentMetrics as i32,
-            None,
-        )
-        .unwrap();
-        assert_eq!(path, "/redfish/v1/Chassis/Chassis_0/EnvironmentMetrics");
-        assert_eq!(method, http::Method::GET);
-    }
-
-    #[test]
-    fn resolve_get_hgx_chassis() {
-        let (path, method) =
-            resolve_proxy_endpoint(RedfishProxyEndpoint::GetHgxChassis as i32, None).unwrap();
-        assert_eq!(path, "/redfish/v1/Chassis/HGX_Chassis_0");
-        assert_eq!(method, http::Method::GET);
-    }
-
-    #[test]
-    fn resolve_get_hgx_chassis_environment_metrics() {
-        let (path, method) = resolve_proxy_endpoint(
-            RedfishProxyEndpoint::GetHgxChassisEnvironmentMetrics as i32,
-            None,
-        )
-        .unwrap();
-        assert_eq!(
-            path,
-            "/redfish/v1/Chassis/HGX_Chassis_0/EnvironmentMetrics"
-        );
-        assert_eq!(method, http::Method::GET);
-    }
-
-    #[test]
-    fn resolve_get_processor_module_env_metrics_requires_id() {
-        let result = resolve_proxy_endpoint(
-            RedfishProxyEndpoint::GetProcessorModuleEnvironmentMetrics as i32,
-            None,
-        );
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn resolve_set_processor_module_power_limit() {
-        let (path, method) = resolve_proxy_endpoint(
-            RedfishProxyEndpoint::SetProcessorModulePowerLimit as i32,
-            Some(1),
-        )
-        .unwrap();
-        assert_eq!(
-            path,
-            "/redfish/v1/Chassis/HGX_ProcessorModule_1/EnvironmentMetrics"
-        );
-        assert_eq!(method, http::Method::PATCH);
-    }
-
-    #[test]
-    fn resolve_get_processor_module_assembly() {
-        let (path, method) = resolve_proxy_endpoint(
-            RedfishProxyEndpoint::GetProcessorModuleAssembly as i32,
-            Some(0),
-        )
-        .unwrap();
-        assert_eq!(
-            path,
-            "/redfish/v1/Chassis/HGX_ProcessorModule_0/Assembly"
-        );
-        assert_eq!(method, http::Method::GET);
-    }
-
-    #[test]
-    fn resolve_get_hgx_bmc_manager() {
-        let (path, method) =
-            resolve_proxy_endpoint(RedfishProxyEndpoint::GetHgxBmcManager as i32, None)
-                .unwrap();
-        assert_eq!(path, "/redfish/v1/Managers/HGX_BMC_0");
-        assert_eq!(method, http::Method::GET);
-    }
-
-    #[test]
-    fn resolve_ignores_component_id_for_fixed_endpoints() {
-        let (path, _) =
-            resolve_proxy_endpoint(RedfishProxyEndpoint::GetChassis as i32, Some(42)).unwrap();
-        assert_eq!(path, "/redfish/v1/Chassis/Chassis_0");
     }
 }

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -1225,6 +1225,7 @@ pub fn get_config() -> CarbideConfig {
         arm_pxe_boot_url_override: None,
         supernic_firmware_profiles: HashMap::default(),
         component_manager: None,
+        redfish_proxy: HashMap::default(),
     }
 }
 

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -617,8 +617,7 @@ service Forge {
   rpc RedfishApproveAction(RedfishActionID) returns (RedfishApproveActionResponse);
   rpc RedfishApplyAction(RedfishActionID) returns (RedfishApplyActionResponse);
   rpc RedfishCancelAction(RedfishActionID) returns (RedfishCancelActionResponse);
-  rpc RedfishPost(RedfishPostRequest) returns (RedfishPostResponse);
-  rpc RedfishPatch(RedfishPatchRequest) returns (RedfishPatchResponse);
+  rpc RedfishProxy(RedfishProxyRequest) returns (RedfishProxyResponse);
 
   rpc UfmBrowse(UfmBrowseRequest) returns (UfmBrowseResponse);
 
@@ -5648,23 +5647,13 @@ message RedfishApplyActionResponse {
 message RedfishCancelActionResponse {
 }
 
-message RedfishPostRequest {
+message RedfishProxyRequest {
   string uri = 1;
   string body = 2;
+  string method = 3;  // "GET", "POST", or "PATCH"
 }
 
-message RedfishPostResponse {
-  string text = 1;
-  map<string, string> headers = 2;
-  string status = 3;
-}
-
-message RedfishPatchRequest {
-  string uri = 1;
-  string body = 2;
-}
-
-message RedfishPatchResponse {
+message RedfishProxyResponse {
   string text = 1;
   map<string, string> headers = 2;
   string status = 3;

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -617,6 +617,8 @@ service Forge {
   rpc RedfishApproveAction(RedfishActionID) returns (RedfishApproveActionResponse);
   rpc RedfishApplyAction(RedfishActionID) returns (RedfishApplyActionResponse);
   rpc RedfishCancelAction(RedfishActionID) returns (RedfishCancelActionResponse);
+  rpc RedfishPost(RedfishPostRequest) returns (RedfishPostResponse);
+  rpc RedfishPatch(RedfishPatchRequest) returns (RedfishPatchResponse);
 
   rpc UfmBrowse(UfmBrowseRequest) returns (UfmBrowseResponse);
 
@@ -5644,6 +5646,28 @@ message RedfishApplyActionResponse {
 }
 
 message RedfishCancelActionResponse {
+}
+
+message RedfishPostRequest {
+  string uri = 1;
+  string body = 2;
+}
+
+message RedfishPostResponse {
+  string text = 1;
+  map<string, string> headers = 2;
+  string status = 3;
+}
+
+message RedfishPatchRequest {
+  string uri = 1;
+  string body = 2;
+}
+
+message RedfishPatchResponse {
+  string text = 1;
+  map<string, string> headers = 2;
+  string status = 3;
 }
 
 message UfmBrowseRequest {

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -5647,72 +5647,99 @@ message RedfishApplyActionResponse {
 message RedfishCancelActionResponse {
 }
 
-// Typed endpoint enum for the RedfishProxy RPC. Each variant maps to a
-// fixed Redfish URI pattern (with optional component index) and an implicit
-// HTTP method, so callers never construct raw URIs.
+// Typed endpoint enum for the RedfishProxy RPC. Each variant identifies a
+// specific Redfish URI path. The HTTP method is specified separately in the
+// request message.
+//
+// GB200 topology: 4 GPUs (0-3), 2 CPUs (0-1), 2 processor modules (0-1).
 enum RedfishProxyEndpoint {
   REDFISH_PROXY_ENDPOINT_UNSPECIFIED = 0;
 
-  // GET /redfish/v1/UpdateService/FirmwareInventory/FW_BMC_0
-  GET_BMC_FIRMWARE_VERSION = 1;
+  // /redfish/v1/UpdateService/FirmwareInventory/FW_BMC_0
+  BMC_FIRMWARE_VERSION = 1;
 
-  // GET /redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_{id}
-  GET_GPU_PROCESSOR = 2;
-  // GET /redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_{id}/EnvironmentMetrics
-  GET_GPU_ENVIRONMENT_METRICS = 3;
-  // PATCH /redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_{id}/EnvironmentMetrics
-  SET_GPU_POWER_LIMIT = 4;
+  // --- GPU processors (0-3) ---
 
-  // GET /redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_{id}
-  GET_CPU_PROCESSOR = 5;
-  // GET /redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_{id}/EnvironmentMetrics
-  GET_CPU_ENVIRONMENT_METRICS = 6;
-  // PATCH /redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_{id}/EnvironmentMetrics
-  SET_CPU_POWER_LIMIT = 7;
+  // /redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0
+  GPU_0_PROCESSOR = 2;
+  // /redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_1
+  GPU_1_PROCESSOR = 3;
+  // /redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_2
+  GPU_2_PROCESSOR = 4;
+  // /redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_3
+  GPU_3_PROCESSOR = 5;
 
-  // GET /redfish/v1/Chassis/Chassis_0
-  GET_CHASSIS = 8;
-  // GET /redfish/v1/Chassis/Chassis_0/EnvironmentMetrics
-  GET_CHASSIS_ENVIRONMENT_METRICS = 9;
+  // /redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/EnvironmentMetrics
+  GPU_0_ENVIRONMENT_METRICS = 6;
+  // /redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_1/EnvironmentMetrics
+  GPU_1_ENVIRONMENT_METRICS = 7;
+  // /redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_2/EnvironmentMetrics
+  GPU_2_ENVIRONMENT_METRICS = 8;
+  // /redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_3/EnvironmentMetrics
+  GPU_3_ENVIRONMENT_METRICS = 9;
 
-  // GET /redfish/v1/Chassis/HGX_Chassis_0
-  GET_HGX_CHASSIS = 10;
-  // GET /redfish/v1/Chassis/HGX_Chassis_0/EnvironmentMetrics
-  GET_HGX_CHASSIS_ENVIRONMENT_METRICS = 11;
+  // --- CPU processors (0-1) ---
 
-  // GET /redfish/v1/Chassis/HGX_ProcessorModule_{id}/EnvironmentMetrics
-  GET_PROCESSOR_MODULE_ENVIRONMENT_METRICS = 12;
-  // PATCH /redfish/v1/Chassis/HGX_ProcessorModule_{id}/EnvironmentMetrics
-  SET_PROCESSOR_MODULE_POWER_LIMIT = 13;
-  // GET /redfish/v1/Chassis/HGX_ProcessorModule_{id}/Assembly
-  GET_PROCESSOR_MODULE_ASSEMBLY = 14;
+  // /redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_0
+  CPU_0_PROCESSOR = 10;
+  // /redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_1
+  CPU_1_PROCESSOR = 11;
 
-  // GET /redfish/v1/Managers/HGX_BMC_0
-  GET_HGX_BMC_MANAGER = 15;
+  // /redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_0/EnvironmentMetrics
+  CPU_0_ENVIRONMENT_METRICS = 12;
+  // /redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_1/EnvironmentMetrics
+  CPU_1_ENVIRONMENT_METRICS = 13;
+
+  // --- Chassis ---
+
+  // /redfish/v1/Chassis/Chassis_0
+  CHASSIS = 14;
+  // /redfish/v1/Chassis/Chassis_0/EnvironmentMetrics
+  CHASSIS_ENVIRONMENT_METRICS = 15;
+
+  // /redfish/v1/Chassis/HGX_Chassis_0
+  HGX_CHASSIS = 16;
+  // /redfish/v1/Chassis/HGX_Chassis_0/EnvironmentMetrics
+  HGX_CHASSIS_ENVIRONMENT_METRICS = 17;
+
+  // --- Processor modules (0-1) ---
+
+  // /redfish/v1/Chassis/HGX_ProcessorModule_0/EnvironmentMetrics
+  PROCESSOR_MODULE_0_ENVIRONMENT_METRICS = 18;
+  // /redfish/v1/Chassis/HGX_ProcessorModule_1/EnvironmentMetrics
+  PROCESSOR_MODULE_1_ENVIRONMENT_METRICS = 19;
+
+  // /redfish/v1/Chassis/HGX_ProcessorModule_0/Assembly
+  PROCESSOR_MODULE_0_ASSEMBLY = 20;
+  // /redfish/v1/Chassis/HGX_ProcessorModule_1/Assembly
+  PROCESSOR_MODULE_1_ASSEMBLY = 21;
+
+  // --- Managers ---
+
+  // /redfish/v1/Managers/HGX_BMC_0
+  HGX_BMC_MANAGER = 22;
+}
+
+// HTTP method for the RedfishProxy RPC.
+enum RedfishProxyMethod {
+  REDFISH_PROXY_METHOD_UNSPECIFIED = 0;
+  GET = 1;
+  POST = 2;
+  PATCH = 3;
 }
 
 message RedfishProxyRequest {
-  // Which Redfish endpoint to target.
-  RedfishProxyEndpoint endpoint = 4;
+  // Which Redfish endpoint (URI path) to target.
+  RedfishProxyEndpoint endpoint = 1;
 
-  // Component index for endpoints that include {id} in the URI pattern
-  // (e.g. GPU_0, CPU_1, HGX_ProcessorModule_0). Ignored for endpoints
-  // without an {id} segment.
-  optional uint32 component_id = 5;
+  // HTTP method to use against the endpoint.
+  RedfishProxyMethod method = 2;
 
-  // BMC IP address to target. Required when using the `endpoint` field.
-  // In the legacy flow, the BMC IP was embedded as the host component
-  // of the `uri` field.
-  string bmc_ip = 6;
+  // BMC IP address to target.
+  string bmc_ip = 3;
 
-  // JSON body for PATCH requests. Ignored for GET endpoints.
-  string body = 2;
-
-  // Deprecated: raw URI and method strings. Callers should migrate to the
-  // `endpoint` + `bmc_ip` fields. These are retained for backward
-  // compatibility during the transition period.
-  string uri = 1 [deprecated = true];
-  string method = 3 [deprecated = true];
+  // JSON body for POST/PATCH requests. Ignored for GET.
+  string body = 4;
 }
 
 message RedfishProxyResponse {

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -5647,10 +5647,72 @@ message RedfishApplyActionResponse {
 message RedfishCancelActionResponse {
 }
 
+// Typed endpoint enum for the RedfishProxy RPC. Each variant maps to a
+// fixed Redfish URI pattern (with optional component index) and an implicit
+// HTTP method, so callers never construct raw URIs.
+enum RedfishProxyEndpoint {
+  REDFISH_PROXY_ENDPOINT_UNSPECIFIED = 0;
+
+  // GET /redfish/v1/UpdateService/FirmwareInventory/FW_BMC_0
+  GET_BMC_FIRMWARE_VERSION = 1;
+
+  // GET /redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_{id}
+  GET_GPU_PROCESSOR = 2;
+  // GET /redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_{id}/EnvironmentMetrics
+  GET_GPU_ENVIRONMENT_METRICS = 3;
+  // PATCH /redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_{id}/EnvironmentMetrics
+  SET_GPU_POWER_LIMIT = 4;
+
+  // GET /redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_{id}
+  GET_CPU_PROCESSOR = 5;
+  // GET /redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_{id}/EnvironmentMetrics
+  GET_CPU_ENVIRONMENT_METRICS = 6;
+  // PATCH /redfish/v1/Systems/HGX_Baseboard_0/Processors/CPU_{id}/EnvironmentMetrics
+  SET_CPU_POWER_LIMIT = 7;
+
+  // GET /redfish/v1/Chassis/Chassis_0
+  GET_CHASSIS = 8;
+  // GET /redfish/v1/Chassis/Chassis_0/EnvironmentMetrics
+  GET_CHASSIS_ENVIRONMENT_METRICS = 9;
+
+  // GET /redfish/v1/Chassis/HGX_Chassis_0
+  GET_HGX_CHASSIS = 10;
+  // GET /redfish/v1/Chassis/HGX_Chassis_0/EnvironmentMetrics
+  GET_HGX_CHASSIS_ENVIRONMENT_METRICS = 11;
+
+  // GET /redfish/v1/Chassis/HGX_ProcessorModule_{id}/EnvironmentMetrics
+  GET_PROCESSOR_MODULE_ENVIRONMENT_METRICS = 12;
+  // PATCH /redfish/v1/Chassis/HGX_ProcessorModule_{id}/EnvironmentMetrics
+  SET_PROCESSOR_MODULE_POWER_LIMIT = 13;
+  // GET /redfish/v1/Chassis/HGX_ProcessorModule_{id}/Assembly
+  GET_PROCESSOR_MODULE_ASSEMBLY = 14;
+
+  // GET /redfish/v1/Managers/HGX_BMC_0
+  GET_HGX_BMC_MANAGER = 15;
+}
+
 message RedfishProxyRequest {
-  string uri = 1;
+  // Which Redfish endpoint to target.
+  RedfishProxyEndpoint endpoint = 4;
+
+  // Component index for endpoints that include {id} in the URI pattern
+  // (e.g. GPU_0, CPU_1, HGX_ProcessorModule_0). Ignored for endpoints
+  // without an {id} segment.
+  optional uint32 component_id = 5;
+
+  // BMC IP address to target. Required when using the `endpoint` field.
+  // In the legacy flow, the BMC IP was embedded as the host component
+  // of the `uri` field.
+  string bmc_ip = 6;
+
+  // JSON body for PATCH requests. Ignored for GET endpoints.
   string body = 2;
-  string method = 3;  // "GET", "POST", or "PATCH"
+
+  // Deprecated: raw URI and method strings. Callers should migrate to the
+  // `endpoint` + `bmc_ip` fields. These are retained for backward
+  // compatibility during the transition period.
+  string uri = 1 [deprecated = true];
+  string method = 3 [deprecated = true];
 }
 
 message RedfishProxyResponse {


### PR DESCRIPTION
## Description

The Carbide-DPS agent must authenticate via mTLS using a SPIFFE X.509 certificate with the service identity `carbide-dps-agent`. Carbide authorizes this identity through both internal RBAC rules and Casbin policy to call RedfishBrowse, RedfishPost, and RedfishPatch.

Allow the Carbide-DPS agent to perform Redfish GET, POST, and PATCH operations on BMCs through Carbide's gRPC API.

POST and PATCH requests are subject to per-principal URI allowlists configured in `carbide-api-config.toml`, restricting which Redfish endpoints a given service principal can target. External (certificate-based) users bypass the allowlist since the RBAC layer already gates their access.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

