### PR TITLE
chore: bump nv-redfish to 0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6506,9 +6506,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f385e8c65f5b20e39ce7dc4097068d2fc1f29768b8f0feff4c7cbaa607f19a03"
+checksum = "26c9cc7e5fc69e068dbea45368f18494ee6dbba0f324a741622cf84d02957c03"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -6522,9 +6522,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-bmc-http"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3cad61bfbf44c2d9636adbaf40be728f06b57d430fe982ad32a1f7787bc5245"
+checksum = "3a1d599f8b7c1d913a62ef51183255a0f42e24b4770901bd853f5cad5d043e62"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -6542,9 +6542,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-core"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c045d4e9c9cb32a85d4e325aaf55f70bba7d8954ae29e7d5109bfb1f4c00a2"
+checksum = "d3f28ca2cfecf4e0a6cf5865d84feb22e8ff3fcbc0f021a98486baa1f0fc542f"
 dependencies = [
  "futures-core",
  "rust_decimal",
@@ -6556,9 +6556,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-csdl-compiler"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2cfc5dda9526b849ddbab9bee999ed951afb505a16cebe8c27ac991a9cf3d3b"
+checksum = "511b072f3cc1b419b294fc1e40e6a36c889f94bf2c52967d03aebe3c3483bcdf"
 dependencies = [
  "clap",
  "clap_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ tracing-appender = "0.2.4"
 tracing-opentelemetry = "0.29.0"
 
 # NV-Redfish
-nv-redfish = { version = "0.4.2", features = [
+nv-redfish = { version = "0.4.3", features = [
   "bmc-http",
   "std-redfish",
   "update-service",


### PR DESCRIPTION
## Description
This PR bumps nv-redfish to `0.4.3`.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

