### PR TITLE
Helm Chart Source and Dockerfile Fixes for DPU Carbide DHCP Server an…

### DIFF
--- a/bluefield/charts/carbide-dhcp-server/templates/_helpers.tpl
+++ b/bluefield/charts/carbide-dhcp-server/templates/_helpers.tpl
@@ -47,3 +47,10 @@ Selector labels
 app.kubernetes.io/name: {{ include "carbide-dhcp-server.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Server Port
+*/}}
+{{- define "carbide-dhcp-server.serverPort" -}}
+{{- default 10079 .Values.serverPort -}}
+{{- end -}}

--- a/bluefield/charts/carbide-dhcp-server/templates/daemonset.yaml
+++ b/bluefield/charts/carbide-dhcp-server/templates/daemonset.yaml
@@ -31,8 +31,7 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
+      dnsPolicy: ClusterFirst
       {{- if not (empty .Values.serviceDaemonSet.nodeSelector) }}
       affinity:
         nodeAffinity:
@@ -50,6 +49,8 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          args:
+            - "--grpc-listen-addr=$(POD_IP):10079"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with toYaml .Values.serviceDaemonSet.resources }}
           resources:
@@ -59,6 +60,10 @@ spec:
               {{- . | nindent 14 }}
           {{- end }}
           env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP  # Always resolves to cluster-internal IP
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
@@ -71,11 +76,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: RUST_BACKTRACE
+              value: "full"
           volumeMounts:
             - name: dhcp-conf
-              mountPath: /var/lib/hbn/var/support/forge-dhcp/conf
+              mountPath: /var/support/forge-dhcp/conf
             - name: dhcp-logs
-              mountPath: /var/lib/hbn/var/support/forge-dhcp/logs
+              mountPath: /var/support/forge-dhcp/logs
       volumes:
         - name: dhcp-conf
           hostPath:

--- a/bluefield/charts/carbide-dhcp-server/templates/service.yaml
+++ b/bluefield/charts/carbide-dhcp-server/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "carbide-dhcp-server.fullname" . }}
+  labels:
+    {{- include "carbide-dhcp-server.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "carbide-dhcp-server.selectorLabels" . | nindent 4 }}
+    {{- with .Values.serviceDaemonSet.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  ports:
+    - protocol: TCP
+      port: {{ include "carbide-dhcp-server.serverPort" . | int }}
+      targetPort: {{ include "carbide-dhcp-server.serverPort" . | int }}

--- a/bluefield/charts/carbide-dpu-agent/templates/_helpers.tpl
+++ b/bluefield/charts/carbide-dpu-agent/templates/_helpers.tpl
@@ -47,3 +47,10 @@ Selector labels
 app.kubernetes.io/name: {{ include "carbide-dpu-agent.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Server Port
+*/}}
+{{- define "carbide-dpu-agent.serverPort" -}}
+{{- default 8888 .Values.serverPort -}}
+{{- end -}}

--- a/bluefield/charts/carbide-dpu-agent/templates/daemonset.yaml
+++ b/bluefield/charts/carbide-dpu-agent/templates/daemonset.yaml
@@ -31,8 +31,7 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
+      dnsPolicy: ClusterFirst
       {{- if not (empty .Values.serviceDaemonSet.nodeSelector) }}
       affinity:
         nodeAffinity:
@@ -50,8 +49,8 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          args: ["run"]
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: ["run", "--enable-metadata-service"]
           {{- with toYaml .Values.serviceDaemonSet.resources }}
           resources:
             limits:
@@ -60,6 +59,10 @@ spec:
               {{- . | nindent 14 }}
           {{- end }}
           env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP  # always resolves to cluster-internal IP
             - name: RUST_BACKTRACE
               value: "full"
             - name: RUST_LIB_BACKTRACE

--- a/bluefield/charts/carbide-dpu-agent/templates/service.yaml
+++ b/bluefield/charts/carbide-dpu-agent/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "carbide-dpu-agent.fullname" . }}
+  labels:
+    {{- include "carbide-dpu-agent.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "carbide-dpu-agent.selectorLabels" . | nindent 4 }}
+    {{- with .Values.serviceDaemonSet.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  ports:
+    - protocol: TCP
+      port: {{ include "carbide-dpu-agent.serverPort" . | int }}
+      targetPort: {{ include "carbide-dpu-agent.serverPort" . | int }}

--- a/bluefield/containers/forge-dhcp-server/Dockerfile
+++ b/bluefield/containers/forge-dhcp-server/Dockerfile
@@ -13,6 +13,6 @@ ARG DISTROLESS_DEBUG_TAG=${DEBUG_DISTROLESS:+"dev"} # 'dev' provides a busybox s
 # NVIDIA Distroless Container
 FROM --platform=linux/arm64 ${IMG}:${TAG}-${DISTROLESS_DEBUG_TAG}
 
-COPY target/aarch64-unknown-linux-gnu/release/forge-dhcp-server /usr/bin/forge-dhcp-server
+COPY target/aarch64-unknown-linux-gnu/release/forge-dhcp-server /var/support/forge-dhcp/bin/forge-dhcp-server
 
-ENTRYPOINT ["/usr/bin/forge-dhcp-server"]
+ENTRYPOINT ["/var/support/forge-dhcp/bin/forge-dhcp-server"]

--- a/bluefield/containers/forge-dpu-agent/Dockerfile
+++ b/bluefield/containers/forge-dpu-agent/Dockerfile
@@ -11,9 +11,18 @@ ARG DEBUG_DISTROLESS=true
 ARG DISTROLESS_DEBUG_TAG=${DEBUG_DISTROLESS:+"dev"} # 'dev' provides a busybox shell
 
 # NVIDIA Distroless Container
+
+# Stage 1
+
+# Get libudev1 for arm64
+FROM --platform=linux/arm64 debian:bookworm-slim AS builder
+RUN apt-get update && apt-get install -y libudev1
+
+# Stage 2
 FROM --platform=linux/arm64 ${IMG}:${TAG}-${DISTROLESS_DEBUG_TAG}
 
+# Copy the library from builder and forge-dpu-agent
+COPY --from=builder /lib/aarch64-linux-gnu/libudev.so.1 /lib/aarch64-linux-gnu/libudev.so.1
 COPY target/aarch64-unknown-linux-gnu/release/forge-dpu-agent /usr/bin/forge-dpu-agent
 
 ENTRYPOINT ["/usr/bin/forge-dpu-agent"]
-CMD ["run", "--enable-metadata-service"]


### PR DESCRIPTION
…d Carbide DPU Agent

## Description
- Updates the Helm Chart and Docker files for DPU Dhcp server and DPU agent

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
1. Volume mounts for forge-dhcp had to be fixed as this is where conf files / logs are stored
2. Added service files for dhcp and dpu to setup a cluster IP for these containers. Server port for dpu was just picked from a hat, needs to be corrected
3. Removed FMDS enablement for DPU agent
4. Removed --platform=linux/arm64 from Dockerfiles as this was generating a warning while building. This might be an internal artifact of the way I am building, so we may need to revert based on review.
5. Testing was based on the bringup of these containers on the DPU via DPF.
