### PR TITLE
feat(dpf): publish charts and images for dpu

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -920,6 +920,252 @@ jobs:
           ngc-path: 0837451325059433/carbide-dev
           ngc-duplicate: fail
 
+  # ============================================================================
+  # BUILD STAGE - Bluefield Images
+  # ============================================================================
+
+  build-bluefield-binaries:
+    needs:
+      - prepare
+      - build-artifacts-container-aarch64
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && contains('success,skipped', needs.build-artifacts-container-aarch64.result) }}
+    runs-on: linux-arm64-cpu8
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Login to NVCR
+        uses: ./.github/actions/docker-auth
+        with:
+          username: ${{ secrets.NVCR_USERNAME }}
+          token: ${{ secrets.NVCR_TOKEN }}
+
+      - name: Pull build container
+        run: docker pull nvcr.io/0837451325059433/carbide-dev/build-artifacts-container-aarch64:${{ needs.prepare.outputs.build_artifacts_container_aarch64_version }}
+
+      - name: Compile bluefield Rust binaries
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            -e CARGO_HOME=/workspace/cargo \
+            -e CARGO_INCREMENTAL=0 \
+            -e CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu \
+            nvcr.io/0837451325059433/carbide-dev/build-artifacts-container-aarch64:${{ needs.prepare.outputs.build_artifacts_container_aarch64_version }} \
+            bash -c "git config --global --add safe.directory /workspace && \
+              cargo make --cwd bluefield build-dpu-agent-and-dhcp-server-ci && \
+              cargo make --cwd bluefield build-fmds-ci && \
+              cargo make --cwd bluefield build-dpu-otel-agent-ci"
+
+      - name: Stage bluefield binaries for upload
+        run: |
+          mkdir -p bluefield-binaries-dir/target/aarch64-unknown-linux-gnu/release
+          cp target/aarch64-unknown-linux-gnu/release/{forge-dpu-agent,forge-dhcp-server,forge-dpu-otel-agent,carbide-fmds} \
+            bluefield-binaries-dir/target/aarch64-unknown-linux-gnu/release/
+
+      - name: Upload bluefield binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: bluefield-binaries-${{ github.run_id }}
+          path: bluefield-binaries-dir/
+
+  build-bluefield-otelcol-contrib:
+    needs:
+      - prepare
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' }}
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      dockerfile_path: bluefield/containers/otelcol-contrib/Dockerfile
+      context_path: .
+      image_name: nvcr.io/0837451325059433/carbide-dev/otelcol-contrib
+      image_tag: ${{ needs.prepare.outputs.version }}
+      platforms: linux/arm64
+      runner: linux-arm64-cpu4
+      push: ${{ !contains(github.ref, 'pull-request/') }}
+      load: false
+    secrets: inherit
+
+  build-bluefield-forge-dpu-agent:
+    needs:
+      - prepare
+      - build-bluefield-binaries
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-bluefield-binaries.result == 'success' }}
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      dockerfile_path: bluefield/containers/forge-dpu-agent/Dockerfile
+      image_name: nvcr.io/0837451325059433/carbide-dev/forge-dpu-agent
+      image_tag: ${{ needs.prepare.outputs.version }}
+      platforms: linux/arm64
+      runner: linux-arm64-cpu4
+      push: ${{ !contains(github.ref, 'pull-request/') }}
+      load: false
+      download_artifacts: true
+    secrets: inherit
+
+  build-bluefield-forge-dhcp-server:
+    needs:
+      - prepare
+      - build-bluefield-binaries
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-bluefield-binaries.result == 'success' }}
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      dockerfile_path: bluefield/containers/forge-dhcp-server/Dockerfile
+      image_name: nvcr.io/0837451325059433/carbide-dev/forge-dhcp-server
+      image_tag: ${{ needs.prepare.outputs.version }}
+      platforms: linux/arm64
+      runner: linux-arm64-cpu4
+      push: ${{ !contains(github.ref, 'pull-request/') }}
+      load: false
+      download_artifacts: true
+    secrets: inherit
+
+  build-bluefield-forge-dpu-otel-agent:
+    needs:
+      - prepare
+      - build-bluefield-binaries
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-bluefield-binaries.result == 'success' }}
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      dockerfile_path: bluefield/containers/forge-dpu-otel-agent/Dockerfile
+      image_name: nvcr.io/0837451325059433/carbide-dev/forge-dpu-otel-agent
+      image_tag: ${{ needs.prepare.outputs.version }}
+      platforms: linux/arm64
+      runner: linux-arm64-cpu4
+      push: ${{ !contains(github.ref, 'pull-request/') }}
+      load: false
+      download_artifacts: true
+    secrets: inherit
+
+  build-bluefield-carbide-fmds:
+    needs:
+      - prepare
+      - build-bluefield-binaries
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-bluefield-binaries.result == 'success' }}
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      dockerfile_path: bluefield/containers/carbide-fmds/Dockerfile
+      image_name: nvcr.io/0837451325059433/carbide-dev/carbide-fmds
+      image_tag: ${{ needs.prepare.outputs.version }}
+      platforms: linux/arm64
+      runner: linux-arm64-cpu4
+      push: ${{ !contains(github.ref, 'pull-request/') }}
+      load: false
+      download_artifacts: true
+    secrets: inherit
+
+  # ============================================================================
+  # BUILD STAGE - Bluefield Helm Charts
+  # ============================================================================
+
+  build-validate-bluefield-helm-charts:
+    needs:
+      - prepare
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' }}
+    runs-on: linux-amd64-cpu4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate carbide-otelcol chart
+        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        with:
+          chart-path: bluefield/charts/carbide-otelcol
+          lint: 'true'
+          template: 'true'
+
+      - name: Validate carbide-dpu-agent chart
+        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        with:
+          chart-path: bluefield/charts/carbide-dpu-agent
+          lint: 'true'
+          template: 'true'
+
+      - name: Validate carbide-dhcp-server chart
+        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        with:
+          chart-path: bluefield/charts/carbide-dhcp-server
+          lint: 'true'
+          template: 'true'
+
+      - name: Validate carbide-dpu-otel-agent chart
+        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        with:
+          chart-path: bluefield/charts/carbide-dpu-otel-agent
+          lint: 'true'
+          template: 'true'
+
+      - name: Validate carbide-fmds chart
+        uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
+        with:
+          chart-path: bluefield/charts/carbide-fmds
+          lint: 'true'
+          template: 'true'
+
+  build-push-bluefield-helm-charts:
+    needs:
+      - prepare
+      - build-validate-bluefield-helm-charts
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-validate-bluefield-helm-charts.result == 'success' && !contains(github.ref, 'pull-request/') }}
+    runs-on: linux-amd64-cpu4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Package and push carbide-otelcol chart
+        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@94bde998f5d7965576b0c663db7d5d709c918167
+        with:
+          chart-path: bluefield/charts/carbide-otelcol
+          chart-version: ${{ needs.prepare.outputs.helm_version }}
+          app-version: ${{ needs.prepare.outputs.version }}
+          lint: 'false'
+          ngc-key: ${{ secrets.NVCR_TOKEN }}
+          ngc-path: 0837451325059433/carbide-dev
+          ngc-duplicate: fail
+
+      - name: Package and push carbide-dpu-agent chart
+        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@94bde998f5d7965576b0c663db7d5d709c918167
+        with:
+          chart-path: bluefield/charts/carbide-dpu-agent
+          chart-version: ${{ needs.prepare.outputs.helm_version }}
+          app-version: ${{ needs.prepare.outputs.version }}
+          lint: 'false'
+          ngc-key: ${{ secrets.NVCR_TOKEN }}
+          ngc-path: 0837451325059433/carbide-dev
+          ngc-duplicate: fail
+
+      - name: Package and push carbide-dhcp-server chart
+        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@94bde998f5d7965576b0c663db7d5d709c918167
+        with:
+          chart-path: bluefield/charts/carbide-dhcp-server
+          chart-version: ${{ needs.prepare.outputs.helm_version }}
+          app-version: ${{ needs.prepare.outputs.version }}
+          lint: 'false'
+          ngc-key: ${{ secrets.NVCR_TOKEN }}
+          ngc-path: 0837451325059433/carbide-dev
+          ngc-duplicate: fail
+
+      - name: Package and push carbide-dpu-otel-agent chart
+        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@94bde998f5d7965576b0c663db7d5d709c918167
+        with:
+          chart-path: bluefield/charts/carbide-dpu-otel-agent
+          chart-version: ${{ needs.prepare.outputs.helm_version }}
+          app-version: ${{ needs.prepare.outputs.version }}
+          lint: 'false'
+          ngc-key: ${{ secrets.NVCR_TOKEN }}
+          ngc-path: 0837451325059433/carbide-dev
+          ngc-duplicate: fail
+
+      - name: Package and push carbide-fmds chart
+        uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@94bde998f5d7965576b0c663db7d5d709c918167
+        with:
+          chart-path: bluefield/charts/carbide-fmds
+          chart-version: ${{ needs.prepare.outputs.helm_version }}
+          app-version: ${{ needs.prepare.outputs.version }}
+          lint: 'false'
+          ngc-key: ${{ secrets.NVCR_TOKEN }}
+          ngc-path: 0837451325059433/carbide-dev
+          ngc-duplicate: fail
+
 
   # ============================================================================
   # BUILD SBOM
@@ -966,6 +1212,14 @@ jobs:
       - build-push-helm-chart
       - build-release-artifacts-x86-host
       - build-release-artifacts-arm-host
+      - build-bluefield-binaries
+      - build-bluefield-otelcol-contrib
+      - build-bluefield-forge-dpu-agent
+      - build-bluefield-forge-dhcp-server
+      - build-bluefield-forge-dpu-otel-agent
+      - build-bluefield-carbide-fmds
+      - build-validate-bluefield-helm-charts
+      - build-push-bluefield-helm-charts
       - lint-police
     steps:
       - name: Generate summary
@@ -1060,6 +1314,14 @@ jobs:
       - build-push-helm-chart
       - build-release-artifacts-x86-host
       - build-release-artifacts-arm-host
+      - build-bluefield-binaries
+      - build-bluefield-otelcol-contrib
+      - build-bluefield-forge-dpu-agent
+      - build-bluefield-forge-dhcp-server
+      - build-bluefield-forge-dpu-otel-agent
+      - build-bluefield-carbide-fmds
+      - build-validate-bluefield-helm-charts
+      - build-push-bluefield-helm-charts
       - build-sbom-container
       - security-secret-scan
       - security-codeql-scan

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7331,6 +7331,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "postgres-smoke-test"
+version = "0.0.0"
+dependencies = [
+ "sqlx",
+ "tokio",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/bluefield/containers/otelcol-contrib/Dockerfile
+++ b/bluefield/containers/otelcol-contrib/Dockerfile
@@ -27,18 +27,21 @@ RUN CGO_ENABLED=0 go install \
     go.opentelemetry.io/collector/cmd/builder@v${OTELCOL_VERSION} \
     && mv "$(go env GOPATH)/bin/builder" /usr/local/bin/ocb
 
-# Copy custom processors and builder config template
+# Copy custom processors, receiver, and builder config template
 COPY bluefield/otel/fileresourceprocessor /build/fileresourceprocessor
 COPY bluefield/otel/telemetrystatsprocessor /build/telemetrystatsprocessor
+COPY bluefield/otel/puntstatsreceiver /build/puntstatsreceiver
 COPY bluefield/otel/otelcol_builder_config_yaml.txt /build/
 COPY bluefield/otel/get_module_version.sh /build/
 
 # Generate the builder config with resolved versions
 RUN FILERESOURCE_VERSION=$(bash /build/get_module_version.sh /build/fileresourceprocessor) && \
     TELEMETRYSTATS_VERSION=$(bash /build/get_module_version.sh /build/telemetrystatsprocessor) && \
+    PUNTSTATS_VERSION=$(bash /build/get_module_version.sh /build/puntstatsreceiver) && \
     sed -e "s/\${VERSION}/${OTELCOL_VERSION}/g" \
         -e "s/\${FILERESOURCE_VERSION}/${FILERESOURCE_VERSION}/g" \
         -e "s/\${TELEMETRYSTATS_VERSION}/${TELEMETRYSTATS_VERSION}/g" \
+        -e "s/\${PUNTSTATS_VERSION}/${PUNTSTATS_VERSION}/g" \
         otelcol_builder_config_yaml.txt > ocb_config.yaml
 
 # Cross-compile the collector binary for arm64


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->

mirrors the existing publish pattern for the helm charts and containers needed for the dpf services on the dpu

also fixes the otelcol-contrib docker file. this was working before, but since it wasn't included in CI it got silently broken. now that it's in CI this shouldn't happen again.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

Closes FORGE-8169

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

no testing performed. purely ci update, so we need to run the ci to see if it worked.

