### PR TITLE
fix(dhcp): support [re]allocating addresses to existing interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7331,6 +7331,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "postgres-smoke-test"
+version = "0.0.0"
+dependencies = [
+ "sqlx",
+ "tokio",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -577,11 +577,7 @@ async fn try_create_fast_path(
     domain_id: Option<DomainId>,
     primary_interface: bool,
 ) -> DatabaseResult<MachineInterfaceId> {
-    let mut allocated_addresses = Vec::with_capacity(segment.prefixes.len());
-    for prefix in &segment.prefixes {
-        let address = allocate_next_ip_with_retry(txn, segment, prefix).await?;
-        allocated_addresses.push(address);
-    }
+    let allocated_addresses = allocate_addresses_from_segment(txn, segment).await?;
 
     create_inner(
         txn,
@@ -592,6 +588,20 @@ async fn try_create_fast_path(
         &allocated_addresses,
     )
     .await
+}
+
+/// Allocate one IP address from each prefix in the segment.
+/// For dual-stack segments this means one IPv4 and one IPv6 address.
+async fn allocate_addresses_from_segment(
+    txn: &mut PgTransaction<'_>,
+    segment: &NetworkSegment,
+) -> DatabaseResult<Vec<IpAddr>> {
+    let mut addresses = Vec::with_capacity(segment.prefixes.len());
+    for prefix in &segment.prefixes {
+        let address = allocate_next_ip_with_retry(txn, segment, prefix).await?;
+        addresses.push(address);
+    }
+    Ok(addresses)
 }
 
 /// Create the actual machine interface once we know what addresses we want.
@@ -1075,6 +1085,28 @@ pub async fn find_by_machine_and_segment(
         .await
         .map_err(|e| DatabaseError::query(&query, e))
         .map(|interfaces| interfaces.into_iter().collect())
+}
+
+/// Allocate new IP addresses for an existing interface that
+/// has lost its addresses (e.g. after a lease expiration, because
+/// maybe it was offline for a while). Uses the same allocation
+/// logic as initial interface creation.
+#[allow(txn_held_across_await)]
+pub async fn allocate_addresses(
+    txn: &mut PgConnection,
+    interface_id: MachineInterfaceId,
+    segment: &NetworkSegment,
+) -> DatabaseResult<()> {
+    let mut fast_txn = Transaction::begin_inner(txn).await?;
+    lock_network_segment_shared(&mut fast_txn, segment).await?;
+
+    let addresses = allocate_addresses_from_segment(&mut fast_txn, segment).await?;
+    for address in &addresses {
+        insert_machine_interface_address(fast_txn.as_pgconn(), &interface_id, address).await?;
+    }
+
+    fast_txn.commit().await?;
+    Ok(())
 }
 
 /// Record that this interface just DHCPed, so it must still exist

--- a/crates/api-db/src/machine_interface_address.rs
+++ b/crates/api-db/src/machine_interface_address.rs
@@ -73,6 +73,12 @@ pub async fn delete(
 
 /// Delete the IP address allocation for the given address. Returns true if
 /// an allocation was found and deleted, false if no allocation existed.
+///
+/// Note: This intentionally does NOT delete the parent machine_interface.
+/// The interface may be associated with a machine, and deleting it would
+/// break the discovered machine linkage. We leave the interface, and let
+/// the DHCP discover flow handle re-allocating an address to any existing
+/// interface that doesn't have one (due to expiration or otherwise).
 pub async fn delete_by_address(
     txn: &mut PgConnection,
     address: IpAddr,

--- a/crates/api/src/dhcp/discover.rs
+++ b/crates/api/src/dhcp/discover.rs
@@ -268,6 +268,24 @@ pub async fn discover_dhcp(
     )
     .await?;
 
+    // If the interface exists but has no addresses (e.g., after a lease
+    // expiration cleaned up the allocation), re-allocate from the segment.
+    if machine_interface.addresses.is_empty() {
+        tracing::info!(
+            interface_id = %machine_interface.id,
+            %parsed_mac,
+            "Interface has no addresses, re-allocating from segment"
+        );
+        let segment = db::network_segment::for_relay(&mut txn, parsed_relay)
+            .await?
+            .ok_or_else(|| {
+                CarbideError::internal(format!(
+                    "No network segment defined for relay address: {parsed_relay}"
+                ))
+            })?;
+        db::machine_interface::allocate_addresses(&mut txn, machine_interface.id, &segment).await?;
+    }
+
     if let Some(machine_id) = machine_interface.machine_id {
         // Can't block host's DHCP handling completely to support Zero-DPU.
         if machine_id.machine_type().is_host()

--- a/crates/api/src/tests/dhcp_lease_expiration.rs
+++ b/crates/api/src/tests/dhcp_lease_expiration.rs
@@ -24,6 +24,7 @@ use rpc::forge::{ExpireDhcpLeaseRequest, ExpireDhcpLeaseStatus};
 use tonic::Request;
 
 use crate::tests::common;
+use crate::tests::common::rpc_builder::DhcpDiscovery;
 
 #[crate::sqlx_test]
 async fn test_expire_releases_allocation(
@@ -56,15 +57,17 @@ async fn test_expire_releases_allocation(
     assert_eq!(resp.ip_address, ip.to_string());
     assert_eq!(resp.status(), ExpireDhcpLeaseStatus::Released);
 
-    // Verify the address was deleted
+    // Verify the address was deleted but the interface preserved
     let mut txn = env.pool.begin().await?;
     let result =
         db::machine_interface_address::find_ipv4_for_interface(&mut txn, interface.id).await;
     assert!(result.is_err(), "address should have been deleted");
 
-    // Verify the interface itself still exists
     let iface = db::machine_interface::find_one(&mut *txn, interface.id).await?;
-    assert_eq!(iface.id, interface.id, "interface should still exist");
+    assert_eq!(
+        iface.id, interface.id,
+        "interface should still exist (only the address is removed)"
+    );
 
     Ok(())
 }
@@ -121,6 +124,64 @@ async fn test_expire_ipv6_address(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
     let resp = response.into_inner();
     assert_eq!(resp.ip_address, "fd00::42");
     assert_eq!(resp.status(), ExpireDhcpLeaseStatus::NotFound);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_discover_reallocates_after_expiration(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let mac_address = "aa:bb:cc:dd:ee:07";
+
+    // First, we do the initial DHCP discover, which
+    // creates an interface and allocates an IP.
+    let response1 = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder(mac_address, FIXTURE_DHCP_RELAY_ADDRESS).tonic_request(),
+        )
+        .await?
+        .into_inner();
+    let original_ip = response1.address.clone();
+    assert!(
+        !original_ip.is_empty(),
+        "should get an IP on first discover"
+    );
+
+    // Now, expire the lease by actually sending an `expire_dhcp_lease()`
+    // API call. This deletes the address, BUT keeps the interface (which
+    // now doesn't have an address).
+    let expire_response = env
+        .api
+        .expire_dhcp_lease(Request::new(ExpireDhcpLeaseRequest {
+            ip_address: original_ip.clone(),
+        }))
+        .await?
+        .into_inner();
+    assert_eq!(expire_response.status(), ExpireDhcpLeaseStatus::Released);
+
+    // And finally, DHCP discover again! This should see the interface
+    // exists, but doesn't have an IP, so it will [re]allocate an IP to
+    // that pre-existing interface
+    let response2 = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder(mac_address, FIXTURE_DHCP_RELAY_ADDRESS).tonic_request(),
+        )
+        .await?
+        .into_inner();
+    assert!(
+        !response2.address.is_empty(),
+        "should get an IP after re-allocation"
+    );
+
+    // Verify the interface is be the same one (preserved across expiration).
+    assert_eq!(
+        response1.machine_interface_id, response2.machine_interface_id,
+        "should reuse the same interface"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Description

In https://github.com/NVIDIA/ncx-infra-controller-core/pull/728, I introduced a change to pass along lease expiration notices from `carbide-dhcp` -> `carbide-api`. The reason being we were leaking IP allocations, so this gave us an opportunity to keep the `carbide-api` allocation tables in sync with the Kea lease database. We are discussing just switching to our pure-Rust `dhcp-server` component we run on DPUs now, but that's another discussion.

In any case, in one of our local development environments, we have very aggressive DHCP lease timings:
```
"renew-timer": 60,     <-- clients should start trying to renew after 60 seconds (unicast)
"rebind-timer": 300,   <-- clients should re-broadcast after 5 minutes
"valid-lifetime": 600, <-- lease expires in 10 minutes
```

..and what happened was, the engineer rebooted their machine, which takes > 10 minutes, during which `carbide-dhcp` fired off a `ExpireDhcpLeaseRequest` to `carbide-api`. Super exciting to see the new code path exercised!

...however, the problem is, which I didn't notice before (and assumed too much): we delete the `machine_interface_address` when it expires (correct), but keep the `machine_interface` (correct, we don't want to delete it, but incorrect in this case). I actually misunderstood something in thinking that when the machine re-`DHCPDISCOVER`'d again, we'd just allocate a new address. BUT.. it actually calls `find_or_create_machine_interface`, which of course finds the existing interface (because we of course leave the interface on purpose), but then the `machine_dhcp_records` view (which does an `INNER JOIN` on `machine_interface_addresses`) doesn't have an address for it, and goes ????? We expect an address to be allocated already.

So this change fixes that flow, such that when `discover_dhcp` is called, if `find_or_create_machine_interface` finds an interface (but no address), we will [re]allocate a new address for that interface. This is actually what I did a bad job in assuming already happened. Introduces a new shared `allocate_addresses_from_segment` that is used for allocating addresses.

This includes tests, as well as an integration test that fires off `api.expire_dhcp_lease(...)` to actually simulate the whole thing, and makes sure a subsequent `api.discover_dhcp(...)` for that same interface re-allocates it an IP.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

