### PR TITLE
chore: attempt fixing flaky tests::resource_pool::test_parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7331,6 +7331,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "postgres-smoke-test"
+version = "0.0.0"
+dependencies = [
+ "sqlx",
+ "tokio",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/api/src/tests/resource_pool.rs
+++ b/crates/api/src/tests/resource_pool.rs
@@ -557,11 +557,23 @@ async fn test_list(db_pool: sqlx::PgPool) -> Result<(), eyre::Report> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 50)]
 async fn test_parallel() -> Result<(), eyre::Report> {
-    // We have to do [crate::sqlx_test] 's work manually here so that we can use a multi-threaded executor
-    let db_url = std::env::var("DATABASE_URL")? + "/test_parallel";
+    // sqlx tests expect this, so we're taking advantage
+    // of knowing this is going to be set. The reason we
+    // don't just use an sqlx_test here is so we can use
+    // a multi-threaded executor.
+    let base_url = std::env::var("DATABASE_URL")?;
+    let db_url = format!("{base_url}/test_parallel");
+
+    // We also also a dedicated "admin" pool (connected to
+    // the default database) to query pg_stat_activity and
+    // wait for lingering backends to drain before dropping
+    // the test_parallel database.
+    let admin = sqlx::Pool::<sqlx::postgres::Postgres>::connect(&base_url).await?;
+
     if sqlx::Postgres::database_exists(&db_url).await? {
         sqlx::Postgres::drop_database(&db_url).await?;
     }
+
     sqlx::Postgres::create_database(&db_url).await?;
     let db_pool = sqlx::Pool::<sqlx::postgres::Postgres>::connect(&db_url).await?;
     tests::MIGRATOR.run(&db_pool).await?;
@@ -571,6 +583,7 @@ async fn test_parallel() -> Result<(), eyre::Report> {
         "test_parallel".to_string(),
         ValueType::Integer,
     ));
+
     db::resource_pool::populate(
         &pool,
         &mut txn,
@@ -614,7 +627,48 @@ async fn test_parallel() -> Result<(), eyre::Report> {
     // Every value we got was unique, so the HashSet had no duplicates
     assert_eq!(all_values.lock().await.len(), 5_000);
 
+    // Wait up to 60 seconds for Postgres to fully release all
+    // backends before dropping. If there are still active
+    // connections left, just let it fail. It should really only
+    // be momentarily.
+    //
+    // The problem we were observing in CICD (but not really ever
+    // on local workstations), is that this will go to do the final
+    // drop_database(..) call down below, but would very occasionally
+    // fail, because the database was "being accessed by other users".
+    //
+    // The theory is that, while we do `db_pool.close().await`, that's
+    // only part of the story; we closed connections on our side, but
+    // Postgres may still be cleaning up backends, especially on our
+    // Github runners, which tend to be kind of busy.
+    //
+    // Another approach would be to `DROP DATABASSE WITH FORCE`, but
+    // it seemed nicer to actually take an approach of detecting if
+    // thre are still active connections for the database, logging if
+    // we detect, and then waiting.
+    //
+    // I haven't been able to get this to "trigger" on my desktop,
+    // and it always passes successfully, but hopefully we see the
+    // flaky test go away at this point
+    //
+    // Btw, the log output here will only show if you run the test
+    // with --nocapture, OR if the test fails, so if this actually
+    // does its job, you should never really see it log, which is
+    // kind of sad.
+    for attempt in 1..=60 {
+        let remaining: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM pg_stat_activity WHERE datname = 'test_parallel'",
+        )
+        .fetch_one(&admin)
+        .await?;
+        if remaining == 0 {
+            break;
+        }
+        println!("test_parallel: {remaining} connection(s) still open (attempt {attempt}/60)");
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
     sqlx::Postgres::drop_database(&db_url).await?;
+    admin.close().await;
     Ok(())
 }
 


### PR DESCRIPTION
## Description

This has been going on for a while, and some trip over it more than others. I had been looking into it thinking it had something to do with `join_all`, which it didn't, but kept me down a similar path. I left a bunch of comments in the fix so people understand why it's there, but my running theory is that we `db_pool.close()` and immediately `drop_database()`, and Postgres isn't done cleaning up all of the backends yet, so it comes back saying other users are still accessing the database.

I could have changed it to a `DROP DATABASE WITH FORCE`, but figured it might be nicer to actually be gentle and check for active connections, and log while we wait.

Two things here are:
- If this does happen, it will be as intermittent as the flaky test is; it really shouldn't happen much.
- If this does happen, we won't see the logging unless we have `--nocapture` set.

I've never been able to get it to trip on my workstation, BUT, if we never see it flake again after this, then we know it was the fix. If the issue persists, then I'll rip it out.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

