### PR TITLE
chore(web): reusable sub-templates for metadata, state display, and SLA tracking

### DIFF
--- a/crates/api/src/web/ib_partition.rs
+++ b/crates/api/src/web/ib_partition.rs
@@ -167,10 +167,8 @@ struct IbPartitionDetail {
     config_version: String,
     tenant_organization_id: String,
     metadata: rpc::forge::Metadata,
-    state: String,
-    state_sla: String,
-    time_in_state_above_sla: bool,
-    state_reason: Option<rpc::forge::ControllerStateReason>,
+    state_display: super::StateDisplay,
+    state_sla_detail: super::StateSlaDetail,
     pkey: String,
     service_level: String,
     rate_limit: String,
@@ -185,33 +183,43 @@ impl From<forgerpc::IbPartition> for IbPartitionDetail {
             config_version: partition.config_version,
             tenant_organization_id: partition.config.unwrap_or_default().tenant_organization_id,
             metadata: partition.metadata.unwrap_or_default(),
-            state: partition
-                .status
-                .as_ref()
-                .and_then(|status| forgerpc::TenantState::try_from(status.state).ok())
-                .map(|state| format!("{state:?}"))
-                .unwrap_or_default(),
-            state_sla: partition
-                .status
-                .as_ref()
-                .and_then(|status| status.state_sla.as_ref())
-                .and_then(|sla| sla.sla)
-                .map(|sla| {
-                    config_version::format_duration(
-                        chrono::TimeDelta::try_from(sla).unwrap_or(chrono::TimeDelta::MAX),
-                    )
-                })
-                .unwrap_or_default(),
-            time_in_state_above_sla: partition
-                .status
-                .as_ref()
-                .and_then(|status| status.state_sla.as_ref())
-                .map(|sla| sla.time_in_state_above_sla)
-                .unwrap_or_default(),
-            state_reason: partition
-                .status
-                .as_ref()
-                .and_then(|s| s.state_reason.clone()),
+            state_display: super::StateDisplay {
+                state: partition
+                    .status
+                    .as_ref()
+                    .and_then(|status| forgerpc::TenantState::try_from(status.state).ok())
+                    .map(|state| format!("{state:?}"))
+                    .unwrap_or_default(),
+                time_in_state_above_sla: partition
+                    .status
+                    .as_ref()
+                    .and_then(|status| status.state_sla.as_ref())
+                    .map(|sla| sla.time_in_state_above_sla)
+                    .unwrap_or_default(),
+            },
+            state_sla_detail: super::StateSlaDetail {
+                state_sla: partition
+                    .status
+                    .as_ref()
+                    .and_then(|status| status.state_sla.as_ref())
+                    .and_then(|sla| sla.sla)
+                    .map(|sla| {
+                        config_version::format_duration(
+                            chrono::TimeDelta::try_from(sla).unwrap_or(chrono::TimeDelta::MAX),
+                        )
+                    })
+                    .unwrap_or_default(),
+                time_in_state_above_sla: partition
+                    .status
+                    .as_ref()
+                    .and_then(|status| status.state_sla.as_ref())
+                    .map(|sla| sla.time_in_state_above_sla)
+                    .unwrap_or_default(),
+                state_reason: partition
+                    .status
+                    .as_ref()
+                    .and_then(|s| s.state_reason.clone()),
+            },
             pkey: partition
                 .status
                 .as_ref()

--- a/crates/api/src/web/machine.rs
+++ b/crates/api/src/web/machine.rs
@@ -431,13 +431,11 @@ struct MachineDetail<'a> {
     id: String,
     host_id: String,
     rack_id: String,
-    state: String,
     state_version: String,
     time_in_state: String,
-    state_sla: String,
-    time_in_state_above_sla: bool,
+    state_display: super::StateDisplay,
+    state_sla_detail: super::StateSlaDetail,
     last_reboot: String,
-    state_reason: Option<::rpc::forge::ControllerStateReason>,
     machine_type: String,
     is_host: bool,
     network_config: String,
@@ -459,8 +457,7 @@ struct MachineDetail<'a> {
     health_overrides: Vec<String>,
     bmc_info: Option<rpc::forge::BmcInfo>,
     discovery_info_json: String,
-    metadata: rpc::forge::Metadata,
-    version: String,
+    metadata_detail: super::MetadataDetail,
     capabilities: Vec<MachineCapability>,
     capabilities_json: String,
     validation_runs: Vec<ValidationRun>,
@@ -656,28 +653,39 @@ impl From<forgerpc::Machine> for MachineDetail<'_> {
             id: machine_id.clone(),
             rack_id: m.rack_id.map(|id| id.to_string()).unwrap_or_default(),
             time_in_state: config_version::since_state_change_humanized(&m.state_version),
-            state: m.state,
             state_version: m.state_version,
-            state_sla: m
-                .state_sla
-                .as_ref()
-                .and_then(|sla| sla.sla)
-                .map(|sla| {
-                    config_version::format_duration(
-                        chrono::TimeDelta::try_from(sla).unwrap_or(chrono::TimeDelta::MAX),
-                    )
-                })
-                .unwrap_or_default(),
-            time_in_state_above_sla: m
-                .state_sla
-                .as_ref()
-                .map(|sla| sla.time_in_state_above_sla)
-                .unwrap_or_default(),
+            state_display: super::StateDisplay {
+                state: m.state,
+                time_in_state_above_sla: m
+                    .state_sla
+                    .as_ref()
+                    .map(|sla| sla.time_in_state_above_sla)
+                    .unwrap_or_default(),
+            },
+            state_sla_detail: super::StateSlaDetail {
+                state_sla: m
+                    .state_sla
+                    .as_ref()
+                    .and_then(|sla| sla.sla)
+                    .map(|sla| {
+                        config_version::format_duration(
+                            chrono::TimeDelta::try_from(sla).unwrap_or(chrono::TimeDelta::MAX),
+                        )
+                    })
+                    .unwrap_or_default(),
+                time_in_state_above_sla: m
+                    .state_sla
+                    .as_ref()
+                    .map(|sla| sla.time_in_state_above_sla)
+                    .unwrap_or_default(),
+                state_reason: m.state_reason,
+            },
             last_reboot: to_time(m.last_reboot_time, Some(&machine_id))
                 .unwrap_or("N/A".to_string()),
-            state_reason: m.state_reason,
-            version: m.version,
-            metadata: m.metadata.unwrap_or_default(),
+            metadata_detail: super::MetadataDetail {
+                metadata: m.metadata.unwrap_or_default(),
+                metadata_version: m.version,
+            },
             machine_type: get_machine_type(&machine_id),
             is_host: m.machine_type == forgerpc::MachineType::Host as i32,
             network_config: String::new(), // filled in later

--- a/crates/api/src/web/mod.rs
+++ b/crates/api/src/web/mod.rs
@@ -59,6 +59,26 @@ pub(crate) struct MetadataDetail {
     pub metadata_version: String,
 }
 
+/// Reusable template for rendering a color-coded state bubble.
+/// Render with `{{ state_display|safe }}`.
+#[derive(Template)]
+#[template(path = "state_display.html")]
+pub(crate) struct StateDisplay {
+    pub state: String,
+    pub time_in_state_above_sla: bool,
+}
+
+/// Reusable template for rendering State SLA, time-in-state-above-SLA, and
+/// state handler outcome rows inside a `<table>`.
+/// Render with `{{ state_sla_detail|safe }}`.
+#[derive(Template)]
+#[template(path = "state_sla_details.html")]
+pub(crate) struct StateSlaDetail {
+    pub state_sla: String,
+    pub time_in_state_above_sla: bool,
+    pub state_reason: Option<rpc::forge::ControllerStateReason>,
+}
+
 mod action_status;
 mod attestation;
 mod auth;

--- a/crates/api/src/web/network_segment.rs
+++ b/crates/api/src/web/network_segment.rs
@@ -205,10 +205,8 @@ struct NetworkSegmentDetail {
     created: String,
     updated: String,
     deleted: String,
-    state: String,
-    state_sla: String,
-    time_in_state_above_sla: bool,
-    state_reason: Option<rpc::forge::ControllerStateReason>,
+    state_display: super::StateDisplay,
+    state_sla_detail: super::StateSlaDetail,
     domain_id: String,
     domain_name: String,
     segment_type: String,
@@ -263,26 +261,35 @@ impl From<forgerpc::NetworkSegment> for NetworkSegmentDetail {
                 .deleted
                 .map(|x| x.to_string())
                 .unwrap_or("Not Deleted".to_string()),
-            state: format!(
-                "{:?}",
-                forgerpc::TenantState::try_from(segment.state).unwrap_or_default()
-            ),
-            state_sla: segment
-                .state_sla
-                .as_ref()
-                .and_then(|sla| sla.sla)
-                .map(|sla| {
-                    config_version::format_duration(
-                        chrono::TimeDelta::try_from(sla).unwrap_or(chrono::TimeDelta::MAX),
-                    )
-                })
-                .unwrap_or_default(),
-            time_in_state_above_sla: segment
-                .state_sla
-                .as_ref()
-                .map(|sla| sla.time_in_state_above_sla)
-                .unwrap_or_default(),
-            state_reason: segment.state_reason,
+            state_display: super::StateDisplay {
+                state: format!(
+                    "{:?}",
+                    forgerpc::TenantState::try_from(segment.state).unwrap_or_default()
+                ),
+                time_in_state_above_sla: segment
+                    .state_sla
+                    .as_ref()
+                    .map(|sla| sla.time_in_state_above_sla)
+                    .unwrap_or_default(),
+            },
+            state_sla_detail: super::StateSlaDetail {
+                state_sla: segment
+                    .state_sla
+                    .as_ref()
+                    .and_then(|sla| sla.sla)
+                    .map(|sla| {
+                        config_version::format_duration(
+                            chrono::TimeDelta::try_from(sla).unwrap_or(chrono::TimeDelta::MAX),
+                        )
+                    })
+                    .unwrap_or_default(),
+                time_in_state_above_sla: segment
+                    .state_sla
+                    .as_ref()
+                    .map(|sla| sla.time_in_state_above_sla)
+                    .unwrap_or_default(),
+                state_reason: segment.state_reason,
+            },
             domain_id: segment.subdomain_id.unwrap_or_default().to_string(),
             domain_name: String::new(), // filled in later
             segment_type: format!(

--- a/crates/api/src/web/tenant.rs
+++ b/crates/api/src/web/tenant.rs
@@ -38,7 +38,6 @@ struct TenantDisplay {
     organization_id: String,
     routing_profile_type: String,
     metadata: rpc::forge::Metadata,
-    version: String,
 }
 
 impl From<forgerpc::Tenant> for TenantDisplay {
@@ -52,7 +51,6 @@ impl From<forgerpc::Tenant> for TenantDisplay {
             .to_string(),
             organization_id: tenant.organization_id,
             metadata: tenant.metadata.unwrap_or_default(),
-            version: tenant.version,
         }
     }
 }
@@ -123,12 +121,18 @@ async fn fetch_tenants(api: Arc<Api>) -> Result<forgerpc::TenantList, tonic::Sta
 #[template(path = "tenant_detail.html")]
 struct TenantDetail {
     tenant: TenantDisplay,
+    metadata_detail: super::MetadataDetail,
 }
 
 impl From<forgerpc::Tenant> for TenantDetail {
     fn from(tenant: forgerpc::Tenant) -> Self {
+        let metadata_detail = super::MetadataDetail {
+            metadata: tenant.metadata.clone().unwrap_or_default(),
+            metadata_version: tenant.version.clone(),
+        };
         Self {
             tenant: tenant.into(),
+            metadata_detail,
         }
     }
 }

--- a/crates/api/src/web/vpc.rs
+++ b/crates/api/src/web/vpc.rs
@@ -130,8 +130,7 @@ struct VpcDetail {
     tenant_keyset_id: String,
     network_virtualization_type: String,
     vni: String,
-    version: String,
-    metadata: rpc::forge::Metadata,
+    metadata_detail: super::MetadataDetail,
 }
 
 impl From<forgerpc::Vpc> for VpcDetail {
@@ -139,11 +138,13 @@ impl From<forgerpc::Vpc> for VpcDetail {
         Self {
             network_virtualization_type: format!("{:?}", vpc.network_virtualization_type()),
             id: vpc.id.unwrap_or_default().to_string(),
-            metadata: vpc.metadata.unwrap_or_default(),
             tenant_organization_id: vpc.tenant_organization_id,
             tenant_keyset_id: vpc.tenant_keyset_id.unwrap_or_default(),
             vni: vpc.vni.map(|vni| vni.to_string()).unwrap_or_default(),
-            version: vpc.version,
+            metadata_detail: super::MetadataDetail {
+                metadata: vpc.metadata.unwrap_or_default(),
+                metadata_version: vpc.version,
+            },
         }
     }
 }

--- a/crates/api/templates/ib_partition_detail.html
+++ b/crates/api/templates/ib_partition_detail.html
@@ -16,20 +16,8 @@
 
 <h3>Status</h3>
 <table class="detailsview">
-			<tr><th>State</th><td>
-			{% if state.to_lowercase().contains("failed") %}
-				<span class="bubble error">{{ state }}{% if time_in_state_above_sla %} ⏱️{% endif %}</span>
-			{% else if time_in_state_above_sla %}
-				<span class="bubble warning">{{ state }} ⏱️</span>
-			{% else if state == "Ready" || state == "Assigned/Ready" %}
-				<span class="bubble success">{{ state }}</span>
-			{% else %}
-				<span class="bubble">{{ state }}</span>
-			{% endif %}
-		</td></tr>
-	<tr><th>State SLA</th><td>{{ state_sla }}</td></tr>
-	<tr><th>Time in State is above SLA</th><td>{{ time_in_state_above_sla }}</td></tr>
-	<tr><th>State Handler Outcome</th><td>{{ state_reason|controller_state_reason_fmt|safe }}</td></tr>
+			<tr><th>State</th><td>{{ state_display|safe }}</td></tr>
+	{{ state_sla_detail|safe }}
 	<tr><th>Pkey</th><td>{{ pkey }}</td></tr>
 	<tr><th>Service Level</th><td>{{ service_level }}</td></tr>
 	<tr><th>Rate Limit</th><td>{{ rate_limit }}</td></tr>

--- a/crates/api/templates/machine_detail.html
+++ b/crates/api/templates/machine_detail.html
@@ -22,24 +22,12 @@
 	</tr>
 	<tr><th>Rack ID</th><td>{{ rack_id|rack_id_link|safe }}</td></tr>
 	<tr><th>State</th>
-		<td>
-			{% if state.to_lowercase().contains("failed") %}
-				<span class="bubble error">{{ state }}{% if time_in_state_above_sla %} ⏱️{% endif %}</span>
-			{% else if time_in_state_above_sla %}
-				<span class="bubble warning">{{ state }} ⏱️</span>
-			{% else if state == "Ready" || state == "Assigned/Ready" %}
-				<span class="bubble success">{{ state }}</span>
-			{% else %}
-				<span class="bubble">{{ state }}</span>
-			{% endif %}
-		</td>
+		<td>{{ state_display|safe }}</td>
 	</tr>
 	<tr><th>State Version</th><td>{{ state_version|config_version|safe }}</td></tr>
 	<tr><th>Time in state</th><td>{{ time_in_state }}</td></tr>
 	<tr><th>Last Reboot</th><td>{{ last_reboot }}</td></tr>
-	<tr><th>State SLA</th><td>{{ state_sla }}</td></tr>
-	<tr><th>Time in State is above SLA</th><td>{{ time_in_state_above_sla }}</td></tr>
-	<tr><th>State Handler Outcome</th><td>{{ state_reason|controller_state_reason_fmt|safe }}</td></tr>
+	{{ state_sla_detail|safe }}
 
 	{% if !network_config.is_empty() %}
 	<tr>
@@ -47,7 +35,6 @@
 		<td><div style="max-height: 300px; overflow: auto;"><pre><code>{{ network_config }}</code></pre></div></td>
 	</tr>
 	{% endif %}
-	<tr><th>Version</th><td>{{ version }}</td></tr>
 	{% if is_host %}
 	<tr>
 		<th>SKU</th>
@@ -75,11 +62,7 @@
 </table>
 
 <h3>Metadata</h3>
-<table class="detailsview">
-	<tr><th>Name</th><td>{{ metadata.name }}</td></tr>
-	<tr><th>Description</th><td>{{ metadata.description }}</td></tr>
-	<tr><th>Labels</th><td>{{ metadata.labels|label_list_fmt(false)|safe }}</td></tr>
-</table>
+{{ metadata_detail|safe }}
 
 <h3>Health</h3>
 <table class="detailsview">

--- a/crates/api/templates/network_segment_detail.html
+++ b/crates/api/templates/network_segment_detail.html
@@ -14,20 +14,8 @@
 	<tr><th>Created </th><td>{{ created }}</td></tr>
 	<tr><th>Updated</th><td>{{ updated }}</td></tr>
 	<tr><th>Deleted</th><td>{{ deleted }}</td></tr>
-			<tr><th>State</th><td>
-			{% if state.to_lowercase().contains("failed") %}
-				<span class="bubble error">{{ state }}{% if time_in_state_above_sla %} ⏱️{% endif %}</span>
-			{% else if time_in_state_above_sla %}
-				<span class="bubble warning">{{ state }} ⏱️</span>
-			{% else if state == "Ready" || state == "Assigned/Ready" %}
-				<span class="bubble success">{{ state }}</span>
-			{% else %}
-				<span class="bubble">{{ state }}</span>
-			{% endif %}
-		</td></tr>
-	<tr><th>State SLA</th><td>{{ state_sla }}</td></tr>
-	<tr><th>Time in State is above SLA</th><td>{{ time_in_state_above_sla }}</td></tr>
-	<tr><th>State Handler Outcome</th><td>{{ state_reason|controller_state_reason_fmt|safe }}</td></tr>
+			<tr><th>State</th><td>{{ state_display|safe }}</td></tr>
+	{{ state_sla_detail|safe }}
 	<tr><th>Domain id</th><td><a href="/admin/domain">{{ domain_id }}</a></td></tr>
 	<tr><th>Domain name</th><td>{{ domain_name }}</td></tr>
 	<tr><th>Type</th><td>{{ segment_type }}</td></tr>

--- a/crates/api/templates/state_display.html
+++ b/crates/api/templates/state_display.html
@@ -1,0 +1,9 @@
+{% if state.to_lowercase().contains("failed") %}
+	<span class="bubble error">{{ state }}{% if time_in_state_above_sla %} ⏱️{% endif %}</span>
+{% else if time_in_state_above_sla %}
+	<span class="bubble warning">{{ state }} ⏱️</span>
+{% else if state == "Ready" || state == "Assigned/Ready" %}
+	<span class="bubble success">{{ state }}</span>
+{% else %}
+	<span class="bubble">{{ state }}</span>
+{% endif %}

--- a/crates/api/templates/state_sla_details.html
+++ b/crates/api/templates/state_sla_details.html
@@ -1,0 +1,3 @@
+<tr><th>State SLA</th><td>{{ state_sla }}</td></tr>
+<tr><th>Time in State is above SLA</th><td>{{ time_in_state_above_sla }}</td></tr>
+<tr><th>State Handler Outcome</th><td>{{ state_reason|controller_state_reason_fmt|safe }}</td></tr>

--- a/crates/api/templates/tenant_detail.html
+++ b/crates/api/templates/tenant_detail.html
@@ -9,14 +9,9 @@
 <table class="detailsview">
 	<tr><th>Organization ID</th><td>{{ tenant.organization_id }}</td></tr>
 	<tr><th>Routing Profile Type</th><td>{{ tenant.routing_profile_type }}</td></tr>
-	<tr><th>Version</th><td>{{ tenant.version }}</td></tr>
 </table>
 
 <h2>Metadata</h2>
-<table class="detailsview">
-	<tr><th>Name</th><td>{{ tenant.metadata.name }}</td></tr>
-	<tr><th>Description</th><td>{{ tenant.metadata.description }}</td></tr>
-	<tr><th>Labels</th><td>{{ tenant.metadata.labels|label_list_fmt(false)|safe }}</td></tr>
-</table>
+{{ metadata_detail|safe }}
 
 {% endblock %}

--- a/crates/api/templates/vpc_detail.html
+++ b/crates/api/templates/vpc_detail.html
@@ -12,14 +12,9 @@
 	<tr><th>Keyset ID</th><td><a href="/admin/tenant_keyset/{{ tenant_organization_id }}/{{ tenant_keyset_id }}">{{ tenant_keyset_id }}</a></td></tr>
 	<tr><th>Network Virtualization</th><td>{{ network_virtualization_type }}</td></tr>
 	<tr><th>VNI</th><td>{{ vni }}</td></tr>
-	<tr><th>Version</th><td>{{ version }}</td></tr>
 </table>
 
 <h2>Metadata</h2>
-<table class="detailsview">
-	<tr><th>Name</th><td>{{ metadata.name }}</td></tr>
-	<tr><th>Description</th><td>{{ metadata.description }}</td></tr>
-	<tr><th>Labels</th><td>{{ metadata.labels|label_list_fmt(false)|safe }}</td></tr>
-</table>
+{{ metadata_detail|safe }}
 
 {% endblock %}


### PR DESCRIPTION
## Description

@Matthias247 had pointed this out to me in another PR I was doing. Figured I'd go poke at some low hanging areas to additionally implement this to move the effort along.

This gives us a few new display/detail structs:
- `StateDisplay` (and `state_display.html`) which is used for the color-coded state bubbles.
- `StateSlaDetail` (and `state_sla_details.html`) which is for the rows for State SLA, time above SLA, and the state handler outcome.

This also migrates `Machine`, `VPC`, and `Tenant` to use `MetadataDetail`.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

