### PR TITLE
Fix invalid PlantUML code in switch.md

### DIFF
--- a/book/src/architecture/state_machines/switch.md
+++ b/book/src/architecture/state_machines/switch.md
@@ -39,7 +39,7 @@ Ready --> ReProvisioning : reprovision requested
 ReProvisioning --> Ready : firmware upgrade Completed
 ReProvisioning --> Error : firmware upgrade Failed
 
-Error --> Deleting/ReProvisioning : marked for deletion or enter into ReProvisioning
+Error --> Deleting : marked for deletion or wait for manual intervention
 
 Deleting --> [*] : final delete
 @enduml


### PR DESCRIPTION
## Description
The switch.md documentation contained invalid PlantUML code. Fixed the diagram and updated the message to match the [state_controller/switch/error_state.rs](https://github.com/NVIDIA/ncx-infra-controller-core/blob/903c1437f65ddb8f23466c272bbbd4ad57ff4002/crates/api/src/state_controller/switch/error_state.rs#L30) handler

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

## before
<img width="1105" height="161" alt="image" src="https://github.com/user-attachments/assets/fd667374-8ef1-42d8-8b98-00ed4e4f7d5a" />

## after 
<img width="624" height="325" alt="image" src="https://github.com/user-attachments/assets/09d48107-df77-435d-aace-ed1c4822beb6" />


