### PR TITLE
refactor(health): simplify cleanup of inactive collectors

### DIFF
--- a/crates/health/src/discovery/cleanup.rs
+++ b/crates/health/src/discovery/cleanup.rs
@@ -15,44 +15,30 @@
  * limitations under the License.
  */
 
-use std::borrow::Cow;
 use std::collections::HashSet;
 
 use super::context::{CollectorKind, DiscoveryLoopContext};
 
-fn stop_collectors_for_keys(
-    ctx: &mut DiscoveryLoopContext,
-    kind: CollectorKind,
-    removed_keys: &HashSet<Cow<'static, str>>,
-) {
-    let collectors = ctx.collectors.map_mut_for_kind(kind);
-    for key in removed_keys {
-        if let Some(collector) = collectors.remove(key) {
-            tracing::info!(
-                endpoint_key = %key,
-                remaining_collectors = collectors.len(),
-                "{}",
-                kind.stop_message()
-            );
-            tokio::spawn(async move {
-                collector.stop().await;
-            });
-        }
-    }
-}
-
 pub(super) fn stop_removed_bmc_collectors(
     ctx: &mut DiscoveryLoopContext,
-    active_endpoints: &HashSet<Cow<'static, str>>,
+    active_endpoints: &HashSet<&str>,
 ) {
-    let removed_keys = ctx.collectors.removed_keys(active_endpoints);
-    for kind in CollectorKind::ALL {
-        stop_collectors_for_keys(ctx, kind, &removed_keys);
+    let removed_collectors = ctx.collectors.remove_inactive_collectors(active_endpoints);
+    let removed_count = removed_collectors.len();
+    for (kind, key, collector) in removed_collectors {
+        tracing::info!(
+            endpoint_key = %key,
+            "{}",
+            kind.stop_message()
+        );
+        tokio::spawn(async move {
+            collector.stop().await;
+        });
     }
 
-    if !removed_keys.is_empty() {
+    if removed_count != 0 {
         tracing::info!(
-            removed_count = removed_keys.len(),
+            removed_count,
             remaining_sensors = ctx.collectors.len(CollectorKind::Sensor),
             remaining_collectors = ctx.collectors.len(CollectorKind::Logs),
             remaining_firmware_collectors = ctx.collectors.len(CollectorKind::Firmware),

--- a/crates/health/src/discovery/context.rs
+++ b/crates/health/src/discovery/context.rs
@@ -47,14 +47,6 @@ pub(super) enum CollectorKind {
 }
 
 impl CollectorKind {
-    pub(super) const ALL: [CollectorKind; 5] = [
-        CollectorKind::Sensor,
-        CollectorKind::Logs,
-        CollectorKind::Firmware,
-        CollectorKind::Nmxt,
-        CollectorKind::NvueRest,
-    ];
-
     pub(super) fn stop_message(self) -> &'static str {
         match self {
             CollectorKind::Sensor => "Stopping sensor collector for removed BMC endpoint",
@@ -122,26 +114,24 @@ impl CollectorState {
         self.map(kind).len()
     }
 
-    pub(super) fn map_mut_for_kind(
+    pub(super) fn remove_inactive_collectors(
         &mut self,
-        kind: CollectorKind,
-    ) -> &mut HashMap<Cow<'static, str>, Collector> {
-        self.map_mut(kind)
-    }
-
-    pub(super) fn removed_keys(
-        &self,
-        active_keys: &HashSet<Cow<'static, str>>,
-    ) -> HashSet<Cow<'static, str>> {
-        self.sensors
-            .keys()
-            .chain(self.logs.keys())
-            .chain(self.firmware.keys())
-            .chain(self.nmxt.keys())
-            .chain(self.nvue_rest.keys())
-            .filter(|key| !active_keys.contains(*key))
-            .cloned()
-            .collect()
+        active_keys: &HashSet<&str>,
+    ) -> Vec<(CollectorKind, Cow<'static, str>, Collector)> {
+        [
+            (&mut self.sensors, CollectorKind::Sensor),
+            (&mut self.logs, CollectorKind::Logs),
+            (&mut self.firmware, CollectorKind::Firmware),
+            (&mut self.nmxt, CollectorKind::Nmxt),
+            (&mut self.nvue_rest, CollectorKind::NvueRest),
+        ]
+        .into_iter()
+        .flat_map(|(collectors, kind)| {
+            collectors
+                .extract_if(|key, _| !active_keys.contains(key.as_ref()))
+                .map(move |(k, v)| (kind, k, v))
+        })
+        .collect()
     }
 }
 

--- a/crates/health/src/discovery/iteration.rs
+++ b/crates/health/src/discovery/iteration.rs
@@ -16,7 +16,6 @@
  */
 
 use std::borrow::Cow;
-use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -29,11 +28,8 @@ use crate::endpoint::{BmcEndpoint, EndpointSource};
 use crate::sharding::ShardManager;
 use crate::sink::DataSink;
 
-fn active_keys(sharded_endpoints: &[Arc<BmcEndpoint>]) -> HashSet<Cow<'static, str>> {
-    sharded_endpoints
-        .iter()
-        .map(|e| e.identity().into_owned().into())
-        .collect()
+fn active_keys<'a>(sharded_endpoints: &'a [Arc<BmcEndpoint>]) -> Vec<Cow<'a, str>> {
+    sharded_endpoints.iter().map(|e| e.identity()).collect()
 }
 
 pub async fn run_discovery_iteration(
@@ -78,7 +74,7 @@ pub async fn run_discovery_iteration(
     }
 
     let active_endpoints = active_keys(&sharded_endpoints);
-    stop_removed_bmc_collectors(ctx, &active_endpoints);
+    stop_removed_bmc_collectors(ctx, &active_endpoints.iter().map(Cow::as_ref).collect());
 
     let iteration_duration = iteration_start.elapsed();
     ctx.discovery_iteration_histogram
@@ -128,14 +124,9 @@ mod tests {
         let ep1 = endpoint(MacAddress::from_str("42:9e:b1:bd:9d:dd").unwrap(), false);
         let ep2 = endpoint(MacAddress::from_str("11:22:33:44:55:66").unwrap(), true);
 
-        let keys = active_keys(&[ep1.clone(), ep2.clone()]);
-
         assert_eq!(
-            keys,
-            HashSet::from([
-                Cow::Owned(ep1.identity().into_owned()),
-                Cow::Owned(ep2.identity().into_owned()),
-            ])
+            active_keys(&[ep1.clone(), ep2.clone()]),
+            vec![ep1.identity(), ep2.identity()]
         );
     }
 }


### PR DESCRIPTION
## Description

Simplify cleanup of inactive health collectors by removing them directly from collector state in one pass.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

