### PR TITLE
fix(dsx-exchange): update to use current name of nico

### DIFF
--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -2963,7 +2963,7 @@ pub struct DpaConfig {
 /// DSX Exchange Event Bus configuration for publishing state change events via MQTT 3.1.1.
 ///
 /// When configured, Carbide will publish `ManagedHostState` transitions to the
-/// topic `carbide/v1/machine/{machineId}/state` as defined in `carbide.yaml`.
+/// topic `nico/v1/machine/{machineId}/state` as defined in `carbide.yaml`.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct DsxExchangeEventBusConfig {
     /// Enable/disable the DSX Exchange Event Bus.

--- a/crates/api/src/mqtt_state_change_hook/hook.rs
+++ b/crates/api/src/mqtt_state_change_hook/hook.rs
@@ -35,7 +35,7 @@ use crate::mqtt_state_change_hook::metrics::MqttHookMetrics;
 use crate::state_controller::state_change_emitter::{StateChangeEvent, StateChangeHook};
 
 /// Topic prefix for state change messages.
-const TOPIC_PREFIX: &str = "carbide/v1/machine";
+const TOPIC_PREFIX: &str = "nico/v1/machine";
 
 /// Internal queue item containing pre-serialized MQTT message with deadline.
 struct QueuedMessage {
@@ -69,7 +69,7 @@ impl<T: MqttPublisher> MqttPublisher for Arc<T> {
 /// MQTT hook that publishes `ManagedHostState` changes to the MQTT broker.
 ///
 /// Implements the AsyncAPI specification in `carbide.yaml`, publishing to
-/// `carbide/v1/machine/{machineId}/state`.
+/// `nico/v1/machine/{machineId}/state`.
 ///
 /// This hook maintains an internal queue and processes events in a background task.
 /// If the queue is full, events are dropped and a warning is logged.
@@ -260,7 +260,7 @@ mod tests {
         // Wait for publish to complete
         let (topic, payload) = receiver.recv().await.expect("should receive message");
 
-        assert!(topic.starts_with("carbide/v1/machine/"));
+        assert!(topic.starts_with("nico/v1/machine/"));
         assert!(topic.ends_with("/state"));
 
         let parsed: serde_json::Value = serde_json::from_slice(&payload).unwrap();

--- a/crates/api/src/mqtt_state_change_hook/mod.rs
+++ b/crates/api/src/mqtt_state_change_hook/mod.rs
@@ -18,7 +18,7 @@
 //! MQTT state change hook for publishing ManagedHostState transitions.
 //!
 //! This module implements the AsyncAPI specification defined in `carbide.yaml`,
-//! publishing state changes to `carbide/v1/machine/{machineId}/state` over MQTT 3.1.1.
+//! publishing state changes to `nico/v1/machine/{machineId}/state` over MQTT 3.1.1.
 
 pub mod hook;
 pub mod message;


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->

called nico, not carbide anymore. asyncapi spec has already been updated.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

spec was not yet released, so no breaking change