### PR TITLE
fix: Remove verifyrmsmembership and registerrmsmembership

### DIFF
--- a/crates/api-db/migrations/20260403122011_migrate_rms_membership_states.sql
+++ b/crates/api-db/migrations/20260403122011_migrate_rms_membership_states.sql
@@ -1,0 +1,36 @@
+-- Migrate machines stuck in the removed VerifyRmsMembership or
+-- RegisterRmsMembership states to DpuDiscoveringState with all attached
+-- DPUs set to Initializing.
+--
+-- The controller_state column stores a tagged JSON enum (serde
+-- rename_all = "lowercase"), so the old values look like:
+--   {"state":"verifyrmsmembership"}
+--   {"state":"registerrmsmembership"}
+--
+-- The target state is DpuDiscoveringState whose serialised form is:
+--   {"state":"dpudiscoveringstate","dpu_states":{"states":{<id>:{"dpudiscoverystate":"initializing"}, ...}}}
+--
+-- For zero-DPU hosts the states map will be empty, which matches the
+-- code path in the state handler (it immediately skips to HostInit).
+
+UPDATE machines m
+SET    controller_state = jsonb_build_object(
+           'state', 'dpudiscoveringstate',
+           'dpu_states', jsonb_build_object(
+               'states', COALESCE(
+                   (SELECT jsonb_object_agg(
+                               mi.attached_dpu_machine_id,
+                               '{"dpudiscoverystate":"initializing"}'::jsonb
+                           )
+                    FROM   machine_interfaces mi
+                    WHERE  mi.machine_id = m.id
+                      AND  mi.attached_dpu_machine_id IS NOT NULL
+                   ),
+                   '{}'::jsonb
+               )
+           )
+       )
+WHERE  m.controller_state ->> 'state' IN (
+           'verifyrmsmembership',
+           'registerrmsmembership'
+       );

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1245,18 +1245,6 @@ pub struct DpuReprovisionStates {
 /// Only DPU machine field in DB will contain state. Host will be empty. DPU state field will be
 /// used to derive state for DPU and Host both.
 pub enum ManagedHostState {
-    /// Verifying the host is registered with RMS by checking inventory.
-    /// If no RMS client or no rack_id, skips ahead immediately.
-    /// If the node is found, skips registration and transitions forward.
-    /// If the node is not found or RMS returns NotFound, transitions to
-    /// RegisterRmsMembership. On other API errors, retries next tick.
-    VerifyRmsMembership,
-
-    /// Registering the host with Rack Manager Service.
-    /// On success, transitions forward to DpuDiscoveringState.
-    /// On failure, retries on next tick.
-    RegisterRmsMembership,
-
     /// Dpu was discovered by a site-explorer and is being configuring via redfish.
     DpuDiscoveringState {
         dpu_states: DpuDiscoveringStates,
@@ -2156,8 +2144,6 @@ impl Display for MeasuringState {
 impl Display for ManagedHostState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ManagedHostState::RegisterRmsMembership => write!(f, "RegisterRmsMembership"),
-            ManagedHostState::VerifyRmsMembership => write!(f, "VerifyRmsMembership"),
             ManagedHostState::DpuDiscoveringState { dpu_states } => {
                 // Min state indicates the least processed DPU. The state machine is blocked
                 // becasue of this.
@@ -2240,8 +2226,6 @@ impl Display for ManagedHostState {
 impl ManagedHostState {
     pub fn dpu_state_string(&self, dpu_id: &MachineId) -> String {
         match self {
-            ManagedHostState::RegisterRmsMembership => "RegisterRmsMembership".to_string(),
-            ManagedHostState::VerifyRmsMembership => "VerifyRmsMembership".to_string(),
             ManagedHostState::DpuDiscoveringState { dpu_states } => dpu_states
                 .states
                 .get(dpu_id)
@@ -2499,9 +2483,6 @@ pub fn state_sla(
         .unwrap_or(std::time::Duration::from_secs(60 * 60 * 24));
 
     match state {
-        ManagedHostState::RegisterRmsMembership | ManagedHostState::VerifyRmsMembership => {
-            StateSla::no_sla()
-        }
         ManagedHostState::DpuDiscoveringState { dpu_states } => {
             // Min state indicates the least processed DPU. The state machine is blocked
             // because of this.

--- a/crates/api/src/site_explorer/machine_creator.rs
+++ b/crates/api/src/site_explorer/machine_creator.rs
@@ -25,7 +25,9 @@ use model::expected_machine::ExpectedMachineData;
 use model::hardware_info::HardwareInfo;
 use model::machine::machine_id::host_id_from_dpu_hardware_info;
 use model::machine::machine_search_config::MachineSearchConfig;
-use model::machine::{Machine, MachineInterfaceSnapshot, ManagedHostState};
+use model::machine::{
+    DpuDiscoveringState, DpuDiscoveringStates, Machine, MachineInterfaceSnapshot, ManagedHostState,
+};
 use model::machine_interface_address::MachineInterfaceAssociation;
 use model::network_segment::NetworkSegmentType;
 use model::predicted_machine_interface::NewPredictedMachineInterface;
@@ -165,7 +167,15 @@ impl MachineCreator {
         db::machine::update_state(
             &mut txn,
             &host_machine_id,
-            &ManagedHostState::VerifyRmsMembership,
+            &ManagedHostState::DpuDiscoveringState {
+                dpu_states: DpuDiscoveringStates {
+                    states: dpu_ids
+                        .iter()
+                        .copied()
+                        .map(|id| (id, DpuDiscoveringState::Initializing))
+                        .collect(),
+                },
+            },
         )
         .await?;
 

--- a/crates/api/src/state_controller/common_services.rs
+++ b/crates/api/src/state_controller/common_services.rs
@@ -60,6 +60,7 @@ pub struct CommonStateHandlerServices {
     pub dpa_info: Option<Arc<DpaInfo>>,
 
     /// Rack Manager Service client
+    #[allow(dead_code)]
     pub rms_client: Option<Arc<dyn RmsApi>>,
 
     /// Credential manager (Vault) for fetching BMC credentials

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -41,8 +41,6 @@ use libredfish::model::oem::nvidia_dpu::HostPrivilegeLevel;
 use libredfish::model::task::TaskState;
 use libredfish::model::update_service::TransferProtocolType;
 use libredfish::{Boot, EnabledDisabled, PowerState, Redfish, RedfishError, SystemPowerControl};
-use librms::RackManagerError;
-use librms::protos::rack_manager::{NewNodeInfo, NodeType as RmsNodeType};
 use machine_validation::{handle_machine_validation_requested, handle_machine_validation_state};
 use measured_boot::records::MeasurementMachineState;
 use model::DpuModel;
@@ -62,8 +60,8 @@ use model::machine::infiniband::{IbConfigNotSyncedReason, ib_config_synced};
 use model::machine::nvlink::nvlink_config_synced;
 use model::machine::{
     BomValidating, BomValidatingContext, CleanupState, CreateBossVolumeContext,
-    CreateBossVolumeState, DpuDiscoveringState, DpuDiscoveringStates, DpuInitNextStateResolver,
-    DpuInitState, FailureCause, FailureDetails, FailureSource, HostPlatformConfigurationState,
+    CreateBossVolumeState, DpuDiscoveringState, DpuInitNextStateResolver, DpuInitState,
+    FailureCause, FailureDetails, FailureSource, HostPlatformConfigurationState,
     HostReprovisionState, InitialResetPhase, InstallDpuOsState, InstanceNextStateResolver,
     InstanceState, LockdownInfo, LockdownState, Machine, MachineLastRebootRequested,
     MachineLastRebootRequestedMode, MachineNextStateResolver, MachineState, ManagedHostState,
@@ -94,7 +92,6 @@ use crate::firmware_downloader::FirmwareDownloader;
 use crate::redfish::{
     self, host_power_control, host_power_control_with_location, set_host_uefi_password,
 };
-use crate::site_explorer::rms;
 use crate::state_controller::common_services::CommonStateHandlerServices;
 use crate::state_controller::machine::context::MachineStateHandlerContextObjects;
 use crate::state_controller::machine::{
@@ -696,204 +693,6 @@ impl MachineStateHandler {
         }
 
         match &mh_state {
-            ManagedHostState::VerifyRmsMembership => {
-                let dpu_ids = mh_snapshot.host_snapshot.associated_dpu_machine_ids();
-                let next_state = ManagedHostState::DpuDiscoveringState {
-                    dpu_states: DpuDiscoveringStates {
-                        states: dpu_ids
-                            .into_iter()
-                            .map(|id| (id, DpuDiscoveringState::Initializing))
-                            .collect(),
-                    },
-                };
-
-                let Some(rms_client) = &ctx.services.rms_client else {
-                    tracing::debug!(
-                        machine_id = %host_machine_id,
-                        "No RMS client configured, skipping RMS verification"
-                    );
-                    return Ok(StateHandlerOutcome::transition(next_state));
-                };
-
-                // If there's no rack_id, this machine isn't rack-managed,
-                // so skip RMS verification entirely.
-                let expected_machine = if let Some(bmc_mac) = mh_snapshot.host_snapshot.bmc_info.mac
-                {
-                    db::expected_machine::find_by_bmc_mac_address(
-                        &mut ctx.services.db_reader,
-                        bmc_mac,
-                    )
-                    .await?
-                } else {
-                    None
-                };
-
-                // TODO(chet): Look into copying the rack_id over to the Machine entry in
-                // site-explorer machine creation, which then allows us to skip over the
-                // ExpectedMachine lookup. Conceptually, EM == Inventory/Manifest, and the
-                // MH == what we're actually managing.
-                let rack_id = expected_machine
-                    .as_ref()
-                    .and_then(|em| em.data.rack_id.clone());
-                if rack_id.is_none() {
-                    tracing::debug!(
-                        machine_id = %host_machine_id,
-                        "No rack_id configured for machine, skipping RMS verification"
-                    );
-                    return Ok(StateHandlerOutcome::transition(next_state));
-                }
-
-                let node_id_str = host_machine_id.to_string();
-
-                match rms_client
-                    .get_all_inventory(
-                        librms::protos::rack_manager::GetAllInventoryRequest::default(),
-                    )
-                    .await
-                {
-                    Ok(response) => {
-                        let node_found = response.nodes.iter().any(|n| n.node_id == node_id_str);
-                        if node_found {
-                            tracing::info!(
-                                machine_id = %host_machine_id,
-                                "Verified machine is registered with RMS, skipping registration"
-                            );
-                            Ok(StateHandlerOutcome::transition(next_state))
-                        } else {
-                            tracing::info!(
-                                machine_id = %host_machine_id,
-                                "Machine not found in RMS inventory, registering"
-                            );
-                            Ok(StateHandlerOutcome::transition(
-                                ManagedHostState::RegisterRmsMembership,
-                            ))
-                        }
-                    }
-                    Err(e) => {
-                        // NotFound means the node definitely isn't registered —
-                        // move on to registration. Any other error (connectivity,
-                        // internal, etc.) means we should retry verification.
-                        let is_not_found = matches!(
-                            &e,
-                            RackManagerError::ApiInvocationError(status)
-                                if status.code() == tonic::Code::NotFound
-                        );
-
-                        if is_not_found {
-                            tracing::warn!(
-                                machine_id = %host_machine_id,
-                                "RMS returned NotFound during verification, registering"
-                            );
-                            Ok(StateHandlerOutcome::transition(
-                                ManagedHostState::RegisterRmsMembership,
-                            ))
-                        } else {
-                            tracing::warn!(
-                                machine_id = %host_machine_id,
-                                "Failed to verify RMS membership: {e}, will retry"
-                            );
-                            Ok(StateHandlerOutcome::wait(
-                                "Waiting to retry RMS verification".to_string(),
-                            ))
-                        }
-                    }
-                }
-            }
-
-            ManagedHostState::RegisterRmsMembership => {
-                let dpu_ids = mh_snapshot.host_snapshot.associated_dpu_machine_ids();
-                let next_state = ManagedHostState::DpuDiscoveringState {
-                    dpu_states: DpuDiscoveringStates {
-                        states: dpu_ids
-                            .into_iter()
-                            .map(|id| (id, DpuDiscoveringState::Initializing))
-                            .collect(),
-                    },
-                };
-
-                // We only reach RegisterRmsMembership via VerifyRmsMembership,
-                // which already confirmed rms_client and rack_id exist. But
-                // guard defensively in case this state is entered directly
-                // (e.g. after a restart with persisted state).
-                let Some(rms_client) = &ctx.services.rms_client else {
-                    tracing::debug!(
-                        machine_id = %host_machine_id,
-                        "No RMS client configured, skipping RMS registration"
-                    );
-                    return Ok(StateHandlerOutcome::transition(next_state));
-                };
-
-                let bmc_mac = mh_snapshot.host_snapshot.bmc_info.mac;
-                let expected_machine = if let Some(mac) = bmc_mac {
-                    db::expected_machine::find_by_bmc_mac_address(&mut ctx.services.db_reader, mac)
-                        .await?
-                } else {
-                    None
-                };
-
-                // TODO(chet): Look into copying the rack_id over to the Machine entry in
-                // site-explorer machine creation, which then allows us to skip over the
-                // ExpectedMachine lookup. Conceptually, EM == Inventory/Manifest, and the
-                // MH == what we're actually managing.
-                let rack_id = expected_machine
-                    .as_ref()
-                    .and_then(|em| em.data.rack_id.clone());
-                let Some(rack_id) = rack_id else {
-                    tracing::debug!(
-                        machine_id = %host_machine_id,
-                        "No rack_id configured for machine, skipping RMS registration"
-                    );
-                    return Ok(StateHandlerOutcome::transition(next_state));
-                };
-
-                let bmc_ip = mh_snapshot
-                    .host_snapshot
-                    .bmc_info
-                    .ip
-                    .clone()
-                    .unwrap_or_default();
-
-                // TODO(chet): If a node already exists, it returns some sense
-                // of an "already exists" error. However, the proto spec doesn't
-                // seem to define this, so once that's sorted, make sure to
-                // integrate that here.
-                let new_node_info = NewNodeInfo {
-                    rack_id: rack_id.to_string(),
-                    node_id: host_machine_id.to_string(),
-                    mac_address: bmc_mac.unwrap_or_default().to_string(),
-                    ip_address: bmc_ip,
-                    port: 443,
-                    username: None,
-                    password: None,
-                    r#type: Some(RmsNodeType::Compute.into()),
-                    vault_path: String::new(),
-                    host_ip_addresses: vec![],
-                    host_mac_addresses: vec![],
-                };
-                match rms::add_node_to_rms(rms_client.as_ref(), new_node_info).await {
-                    Ok(()) => {
-                        tracing::info!(
-                            machine_id = %host_machine_id,
-                            "Successfully registered machine with RMS"
-                        );
-                        // NOTE: We could also transition back to VerifyRmsMembership
-                        // here to confirm the registration took effect. For now, we
-                        // trust that a successful add_node means we're registered
-                        // and move forward.
-                        Ok(StateHandlerOutcome::transition(next_state))
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            machine_id = %host_machine_id,
-                            "Failed to register machine with RMS: {e}, will retry"
-                        );
-                        Ok(StateHandlerOutcome::wait(
-                            "Waiting to retry RMS registration".to_string(),
-                        ))
-                    }
-                }
-            }
-
             ManagedHostState::DpuDiscoveringState { .. } => {
                 if mh_snapshot
                     .host_snapshot

--- a/crates/api/src/state_controller/machine/io.rs
+++ b/crates/api/src/state_controller/machine/io.rs
@@ -249,8 +249,6 @@ impl StateControllerIO for MachineStateControllerIO {
             }
         }
         match state {
-            ManagedHostState::RegisterRmsMembership => ("registerrmsmembership", ""),
-            ManagedHostState::VerifyRmsMembership => ("verifyrmsmembership", ""),
             ManagedHostState::DpuDiscoveringState { dpu_states } => {
                 // Min state indicates the least processed DPU. The state machine is blocked
                 // becasue of this.

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -396,8 +396,6 @@ impl TestEnv {
     ) -> ManagedHostState {
         //This block is to fill data that is populated within statemachine
         match state.clone() {
-            ManagedHostState::RegisterRmsMembership => state.clone(),
-            ManagedHostState::VerifyRmsMembership => state.clone(),
             ManagedHostState::DpuDiscoveringState { .. } => state.clone(),
             ManagedHostState::DPUInit { .. } => state.clone(),
             ManagedHostState::HostInit { machine_state } => {

--- a/crates/api/src/tests/machine_creator.rs
+++ b/crates/api/src/tests/machine_creator.rs
@@ -248,9 +248,13 @@ async fn test_site_explorer_creates_managed_host(
     .await
     .unwrap()
     .unwrap();
-    assert_eq!(
+    assert!(
+        matches!(
+            dpu_machine.current_state(),
+            ManagedHostState::DpuDiscoveringState { .. }
+        ),
+        "expected DpuDiscoveringState, got {:?}",
         dpu_machine.current_state(),
-        &ManagedHostState::VerifyRmsMembership,
     );
     assert_eq!(
         dpu_machine.hardware_info.as_ref().unwrap().machine_type,
@@ -308,9 +312,13 @@ async fn test_site_explorer_creates_managed_host(
     let host_machine = db::machine::find_host_by_dpu_machine_id(&mut txn, &dpu_machine.id)
         .await?
         .unwrap();
-    assert_eq!(
+    assert!(
+        matches!(
+            host_machine.current_state(),
+            ManagedHostState::DpuDiscoveringState { .. }
+        ),
+        "expected DpuDiscoveringState, got {:?}",
         host_machine.current_state(),
-        &ManagedHostState::VerifyRmsMembership,
     );
     assert!(host_machine.bmc_info.ip.is_some());
 
@@ -336,8 +344,7 @@ async fn test_site_explorer_creates_managed_host(
         .build();
     env.override_machine_state_controller_handler(handler).await;
 
-    // VerifyRmsMembership -> DpuDiscovering/Initializing -> DpuDiscovering/Configuring
-    env.run_machine_state_controller_iteration().await;
+    // DpuDiscovering/Initializing -> DpuDiscovering/Configuring
     env.run_machine_state_controller_iteration().await;
 
     let dpu_machine = db::machine::find_one(
@@ -802,12 +809,23 @@ async fn test_site_explorer_creates_multi_dpu_managed_host(
         }
     );
 
-    let expected_state = ManagedHostState::VerifyRmsMembership;
-
-    assert_eq!(host_machine.unwrap().current_state(), &expected_state);
+    assert!(
+        matches!(
+            host_machine.unwrap().current_state(),
+            ManagedHostState::DpuDiscoveringState { .. }
+        ),
+        "expected DpuDiscoveringState for host",
+    );
 
     for dpu in &dpu_machines {
-        assert_eq!(dpu.current_state(), &expected_state);
+        assert!(
+            matches!(
+                dpu.current_state(),
+                ManagedHostState::DpuDiscoveringState { .. }
+            ),
+            "expected DpuDiscoveringState for DPU {:?}",
+            dpu.id,
+        );
     }
 
     let mut interfaces_map =

--- a/crates/api/src/tests/machine_history.rs
+++ b/crates/api/src/tests/machine_history.rs
@@ -31,7 +31,6 @@ async fn test_machine_state_history(pool: sqlx::PgPool) -> Result<(), Box<dyn st
 
     let expected_initial_states_json = serde_json::json!([
         {"state": "created"},
-        {"state": "verifyrmsmembership"},
         {"state": "dpudiscoveringstate", "dpu_states": {"states": {&dpu_machine_id_string: {"dpudiscoverystate": "initializing"}}}},
         {"state": "dpudiscoveringstate", "dpu_states": {"states": {&dpu_machine_id_string: {"dpudiscoverystate": "configuring"}}}},
         {"state": "dpudiscoveringstate", "dpu_states": {"states": {&dpu_machine_id_string: {"dpudiscoverystate": "enablershim"}}}},


### PR DESCRIPTION
## Description
depricating verifyrmsmembership and registerrmsmembership. As these are no longer required for latest RMS

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [x] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

