### PR TITLE
fix(agent): Add additional route leaking controls

### DIFF
--- a/crates/agent/templates/nvue_startup_fnn.conf
+++ b/crates/agent/templates/nvue_startup_fnn.conf
@@ -162,6 +162,12 @@
         enable: on
       policy:
         community-list:
+          BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST:
+            rule:
+              '10':
+                action: permit
+                community:
+                  65100:02: {}
           BYOIP_LEAK_COMMUNITY_LIST:
             rule:
               '10':
@@ -306,6 +312,11 @@
         route-map:
           dpu_to_evpn:
             rule:
+              '9':
+                action:
+                  deny: {}
+                match:
+                  tag: 65102{{/* Drop prefixes requested for drop by the host */}}
               '10':
                 action:
                   deny: {}
@@ -333,6 +344,16 @@
                   permit: {}{{/* We originally did no filtering here.  An attempt to use an "allow" prefix-list and default deny route-map stripped more than expected.  It seems like a bug that we need to look into. For now, we just drop the prefixes that we wanted dropped. */}}
           leak_to_underlay:
             rule:
+              '65532':
+                action:
+                  permit: {}
+                match:
+                  tag: 65102
+                set:
+                  community:
+                    none: {}
+                  large-community:
+                    none: {}
               '65533':
                 action:
                   permit: {}
@@ -415,6 +436,19 @@
                   deny: {}
           dpu_from_instance:
             rule:
+              '9':
+                action:
+                  permit: {}{{/* We allow it in because we might need to leak to some targets and drop to others, so we tag it for later.  */}}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102{{/* tag it so we can match on the tag and use it for leaking and dropping later */}}
+                  community:
+                      none: {}{{/* Strip any communities the peer might have attached. */}}
+                  large-community:
+                    none: {}
               '10':
                 action:
                   permit: {}
@@ -479,6 +513,19 @@
           {{- end }}
           dpu_from_instance_ipv6:
             rule:
+              '9':
+                action:
+                  permit: {}{{/* We allow it in because we might need to leak to some targets and drop to others, so we tag it for later.  */}}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102{{/* tag it so we can match on the tag and use it for leaking and dropping later */}}
+                  community:
+                      none: {}{{/* Strip any communities the peer might have attached. */}}
+                  large-community:
+                    none: {}
               '10':
                 action:
                   permit: {}

--- a/crates/agent/templates/tests/full_nvue_startup_fnn_l3.yaml.expected
+++ b/crates/agent/templates/tests/full_nvue_startup_fnn_l3.yaml.expected
@@ -59,6 +59,12 @@
         enable: on
       policy:
         community-list:
+          BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST:
+            rule:
+              '10':
+                action: permit
+                community:
+                  65100:02: {}
           BYOIP_LEAK_COMMUNITY_LIST:
             rule:
               '10':
@@ -138,6 +144,11 @@
         route-map:
           dpu_to_evpn:
             rule:
+              '9':
+                action:
+                  deny: {}
+                match:
+                  tag: 65102
               '10':
                 action:
                   deny: {}
@@ -165,6 +176,16 @@
                   permit: {}
           leak_to_underlay:
             rule:
+              '65532':
+                action:
+                  permit: {}
+                match:
+                  tag: 65102
+                set:
+                  community:
+                    none: {}
+                  large-community:
+                    none: {}
               '65533':
                 action:
                   permit: {}
@@ -247,6 +268,19 @@
                   deny: {}
           dpu_from_instance:
             rule:
+              '9':
+                action:
+                  permit: {}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
               '10':
                 action:
                   permit: {}
@@ -287,6 +321,19 @@
                   deny: {}
           dpu_from_instance_ipv6:
             rule:
+              '9':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
               '10':
                 action:
                   permit: {}

--- a/crates/agent/templates/tests/nvue_build_fnn_ipv6_acls.yaml.expected
+++ b/crates/agent/templates/tests/nvue_build_fnn_ipv6_acls.yaml.expected
@@ -52,6 +52,12 @@
         enable: on
       policy:
         community-list:
+          BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST:
+            rule:
+              '10':
+                action: permit
+                community:
+                  65100:02: {}
           BYOIP_LEAK_COMMUNITY_LIST:
             rule:
               '10':
@@ -118,6 +124,11 @@
         route-map:
           dpu_to_evpn:
             rule:
+              '9':
+                action:
+                  deny: {}
+                match:
+                  tag: 65102
               '10':
                 action:
                   deny: {}
@@ -145,6 +156,16 @@
                   permit: {}
           leak_to_underlay:
             rule:
+              '65532':
+                action:
+                  permit: {}
+                match:
+                  tag: 65102
+                set:
+                  community:
+                    none: {}
+                  large-community:
+                    none: {}
               '65533':
                 action:
                   permit: {}
@@ -227,6 +248,19 @@
                   deny: {}
           dpu_from_instance:
             rule:
+              '9':
+                action:
+                  permit: {}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
               '10':
                 action:
                   permit: {}
@@ -267,6 +301,19 @@
                   deny: {}
           dpu_from_instance_ipv6:
             rule:
+              '9':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
               '10':
                 action:
                   permit: {}

--- a/crates/agent/templates/tests/nvue_build_fnn_ipv6_only_vpc.yaml.expected
+++ b/crates/agent/templates/tests/nvue_build_fnn_ipv6_only_vpc.yaml.expected
@@ -42,6 +42,12 @@
         enable: on
       policy:
         community-list:
+          BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST:
+            rule:
+              '10':
+                action: permit
+                community:
+                  65100:02: {}
           BYOIP_LEAK_COMMUNITY_LIST:
             rule:
               '10':
@@ -108,6 +114,11 @@
         route-map:
           dpu_to_evpn:
             rule:
+              '9':
+                action:
+                  deny: {}
+                match:
+                  tag: 65102
               '10':
                 action:
                   deny: {}
@@ -135,6 +146,16 @@
                   permit: {}
           leak_to_underlay:
             rule:
+              '65532':
+                action:
+                  permit: {}
+                match:
+                  tag: 65102
+                set:
+                  community:
+                    none: {}
+                  large-community:
+                    none: {}
               '65533':
                 action:
                   permit: {}
@@ -217,6 +238,19 @@
                   deny: {}
           dpu_from_instance:
             rule:
+              '9':
+                action:
+                  permit: {}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
               '10':
                 action:
                   permit: {}
@@ -257,6 +291,19 @@
                   deny: {}
           dpu_from_instance_ipv6:
             rule:
+              '9':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
               '10':
                 action:
                   permit: {}

--- a/crates/agent/templates/tests/nvue_build_fnn_multi_port_ipv6.yaml.expected
+++ b/crates/agent/templates/tests/nvue_build_fnn_multi_port_ipv6.yaml.expected
@@ -51,6 +51,12 @@
         enable: on
       policy:
         community-list:
+          BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST:
+            rule:
+              '10':
+                action: permit
+                community:
+                  65100:02: {}
           BYOIP_LEAK_COMMUNITY_LIST:
             rule:
               '10':
@@ -117,6 +123,11 @@
         route-map:
           dpu_to_evpn:
             rule:
+              '9':
+                action:
+                  deny: {}
+                match:
+                  tag: 65102
               '10':
                 action:
                   deny: {}
@@ -144,6 +155,16 @@
                   permit: {}
           leak_to_underlay:
             rule:
+              '65532':
+                action:
+                  permit: {}
+                match:
+                  tag: 65102
+                set:
+                  community:
+                    none: {}
+                  large-community:
+                    none: {}
               '65533':
                 action:
                   permit: {}
@@ -226,6 +247,19 @@
                   deny: {}
           dpu_from_instance:
             rule:
+              '9':
+                action:
+                  permit: {}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
               '10':
                 action:
                   permit: {}
@@ -266,6 +300,19 @@
                   deny: {}
           dpu_from_instance_ipv6:
             rule:
+              '9':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
               '10':
                 action:
                   permit: {}

--- a/crates/agent/templates/tests/nvue_startup_fnn_classic.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_classic.yaml.expected
@@ -90,6 +90,12 @@
         enable: on
       policy:
         community-list:
+          BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST:
+            rule:
+              '10':
+                action: permit
+                community:
+                  65100:02: {}
           BYOIP_LEAK_COMMUNITY_LIST:
             rule:
               '10':
@@ -170,6 +176,11 @@
         route-map:
           dpu_to_evpn:
             rule:
+              '9':
+                action:
+                  deny: {}
+                match:
+                  tag: 65102
               '10':
                 action:
                   deny: {}
@@ -197,6 +208,16 @@
                   permit: {}
           leak_to_underlay:
             rule:
+              '65532':
+                action:
+                  permit: {}
+                match:
+                  tag: 65102
+                set:
+                  community:
+                    none: {}
+                  large-community:
+                    none: {}
               '65533':
                 action:
                   permit: {}
@@ -279,6 +300,19 @@
                   deny: {}
           dpu_from_instance:
             rule:
+              '9':
+                action:
+                  permit: {}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
               '10':
                 action:
                   permit: {}
@@ -319,6 +353,19 @@
                   deny: {}
           dpu_from_instance_ipv6:
             rule:
+              '9':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
               '10':
                 action:
                   permit: {}

--- a/crates/agent/templates/tests/nvue_startup_fnn_classic_with_empty_nsg_default_deny.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_classic_with_empty_nsg_default_deny.yaml.expected
@@ -98,6 +98,12 @@
         enable: on
       policy:
         community-list:
+          BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST:
+            rule:
+              '10':
+                action: permit
+                community:
+                  65100:02: {}
           BYOIP_LEAK_COMMUNITY_LIST:
             rule:
               '10':
@@ -178,6 +184,11 @@
         route-map:
           dpu_to_evpn:
             rule:
+              '9':
+                action:
+                  deny: {}
+                match:
+                  tag: 65102
               '10':
                 action:
                   deny: {}
@@ -205,6 +216,16 @@
                   permit: {}
           leak_to_underlay:
             rule:
+              '65532':
+                action:
+                  permit: {}
+                match:
+                  tag: 65102
+                set:
+                  community:
+                    none: {}
+                  large-community:
+                    none: {}
               '65533':
                 action:
                   permit: {}
@@ -287,6 +308,19 @@
                   deny: {}
           dpu_from_instance:
             rule:
+              '9':
+                action:
+                  permit: {}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
               '10':
                 action:
                   permit: {}
@@ -327,6 +361,19 @@
                   deny: {}
           dpu_from_instance_ipv6:
             rule:
+              '9':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
               '10':
                 action:
                   permit: {}

--- a/crates/agent/templates/tests/nvue_startup_fnn_with_leaks.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_with_leaks.yaml.expected
@@ -90,6 +90,12 @@
         enable: on
       policy:
         community-list:
+          BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST:
+            rule:
+              '10':
+                action: permit
+                community:
+                  65100:02: {}
           BYOIP_LEAK_COMMUNITY_LIST:
             rule:
               '10':
@@ -201,6 +207,11 @@
         route-map:
           dpu_to_evpn:
             rule:
+              '9':
+                action:
+                  deny: {}
+                match:
+                  tag: 65102
               '10':
                 action:
                   deny: {}
@@ -228,6 +239,16 @@
                   permit: {}
           leak_to_underlay:
             rule:
+              '65532':
+                action:
+                  permit: {}
+                match:
+                  tag: 65102
+                set:
+                  community:
+                    none: {}
+                  large-community:
+                    none: {}
               '65533':
                 action:
                   permit: {}
@@ -310,6 +331,19 @@
                   deny: {}
           dpu_from_instance:
             rule:
+              '9':
+                action:
+                  permit: {}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
               '10':
                 action:
                   permit: {}
@@ -382,6 +416,19 @@
                   type: ipv6
           dpu_from_instance_ipv6:
             rule:
+              '9':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
               '10':
                 action:
                   permit: {}

--- a/crates/agent/templates/tests/nvue_startup_quarantined_fnn.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_quarantined_fnn.yaml.expected
@@ -110,6 +110,12 @@
         enable: on
       policy:
         community-list:
+          BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST:
+            rule:
+              '10':
+                action: permit
+                community:
+                  65100:02: {}
           BYOIP_LEAK_COMMUNITY_LIST:
             rule:
               '10':
@@ -190,6 +196,11 @@
         route-map:
           dpu_to_evpn:
             rule:
+              '9':
+                action:
+                  deny: {}
+                match:
+                  tag: 65102
               '10':
                 action:
                   deny: {}
@@ -217,6 +228,16 @@
                   permit: {}
           leak_to_underlay:
             rule:
+              '65532':
+                action:
+                  permit: {}
+                match:
+                  tag: 65102
+                set:
+                  community:
+                    none: {}
+                  large-community:
+                    none: {}
               '65533':
                 action:
                   permit: {}
@@ -299,6 +320,19 @@
                   deny: {}
           dpu_from_instance:
             rule:
+              '9':
+                action:
+                  permit: {}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
               '10':
                 action:
                   permit: {}
@@ -339,6 +373,19 @@
                   deny: {}
           dpu_from_instance_ipv6:
             rule:
+              '9':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
               '10':
                 action:
                   permit: {}


### PR DESCRIPTION
## Description
This PR adds a new community that can be used on announcements from the host to the DPU to drop announcements from the overlay and leak them only to the underlay.

HBN and cumulus linux in general, has low limits on the number of ECMP group members in in an overlay.  For users who require anycast with extremely high numbers of participating members, a work-around is to drop the announcement from the overlay and leak it to the underlay.  It's expected that this can result in asymmetric routing as inbound connections to an address would flow in from the underlay and response traffic would flow over the overlay.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

