### PR TITLE
fix(ci): clean helm package directory before packaging charts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1122,6 +1122,10 @@ jobs:
           ngc-path: 0837451325059433/carbide-dev
           ngc-duplicate: fail
 
+      # helm-package-push expects exactly one .tgz in package/, so we have to clean the previously built chart
+      - name: Clean helm package directory
+        run: rm -rf package/
+
       - name: Package and push carbide-dpu-agent chart
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@94bde998f5d7965576b0c663db7d5d709c918167
         with:
@@ -1132,6 +1136,10 @@ jobs:
           ngc-key: ${{ secrets.NVCR_TOKEN }}
           ngc-path: 0837451325059433/carbide-dev
           ngc-duplicate: fail
+
+      # helm-package-push expects exactly one .tgz in package/, so we have to clean the previously built chart
+      - name: Clean helm package directory
+        run: rm -rf package/
 
       - name: Package and push carbide-dhcp-server chart
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@94bde998f5d7965576b0c663db7d5d709c918167
@@ -1144,6 +1152,10 @@ jobs:
           ngc-path: 0837451325059433/carbide-dev
           ngc-duplicate: fail
 
+      # helm-package-push expects exactly one .tgz in package/, so we have to clean the previously built chart
+      - name: Clean helm package directory
+        run: rm -rf package/
+
       - name: Package and push carbide-dpu-otel-agent chart
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@94bde998f5d7965576b0c663db7d5d709c918167
         with:
@@ -1154,6 +1166,10 @@ jobs:
           ngc-key: ${{ secrets.NVCR_TOKEN }}
           ngc-path: 0837451325059433/carbide-dev
           ngc-duplicate: fail
+
+      # helm-package-push expects exactly one .tgz in package/, so we have to clean the previously built chart
+      - name: Clean helm package directory
+        run: rm -rf package/
 
       - name: Package and push carbide-fmds chart
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@94bde998f5d7965576b0c663db7d5d709c918167


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->

there are chart tgz files left over between steps and the helm package push action is expecting a clean dir

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

since the actions only run on main, we have to merge it to see if it actually worked.