### PR TITLE
fix: improvements to expected/managed rack in the admin-cli/web ui

### DIFF
--- a/crates/admin-cli/src/rack/show/cmd.rs
+++ b/crates/admin-cli/src/rack/show/cmd.rs
@@ -17,82 +17,253 @@
 
 use color_eyre::Result;
 use prettytable::{Table, row};
+use rpc::admin_cli::OutputFormat;
+use rpc::forge::Rack;
+use serde::Serialize;
 
 use super::args::Args;
 use crate::cfg::runtime::RuntimeConfig;
 use crate::rpc::ApiClient;
 
+#[derive(Serialize)]
+struct RackOutput {
+    id: String,
+    name: String,
+    state: String,
+    version: String,
+    expected_compute_tray_bmcs: Vec<String>,
+    current_compute_trays: Vec<String>,
+    expected_power_shelf_bmcs: Vec<String>,
+    current_power_shelves: Vec<String>,
+    expected_nvlink_switch_bmcs: Vec<String>,
+    current_nvlink_switches: Vec<String>,
+}
+
+impl From<&Rack> for RackOutput {
+    fn from(r: &Rack) -> Self {
+        Self {
+            id: r.id.as_ref().map(|id| id.to_string()).unwrap_or_default(),
+            name: r
+                .metadata
+                .as_ref()
+                .map(|m| m.name.clone())
+                .unwrap_or_default(),
+            state: r.rack_state.clone(),
+            version: r.version.clone(),
+            expected_compute_tray_bmcs: r.expected_compute_trays.clone(),
+            current_compute_trays: r.compute_trays.iter().map(|id| id.to_string()).collect(),
+            expected_power_shelf_bmcs: r.expected_power_shelves.clone(),
+            current_power_shelves: r.power_shelves.iter().map(|id| id.to_string()).collect(),
+            expected_nvlink_switch_bmcs: r.expected_nvlink_switches.clone(),
+            current_nvlink_switches: r.switches.iter().map(|id| id.to_string()).collect(),
+        }
+    }
+}
+
 pub async fn show_rack(api_client: &ApiClient, args: Args, config: &RuntimeConfig) -> Result<()> {
-    let racks = match args.rack {
-        Some(rack_id) => api_client.get_one_rack(rack_id).await?,
-        None => api_client.get_all_racks(config.page_size).await?,
+    let format = config.format;
+    match args.rack {
+        Some(rack_id) => {
+            let racks = api_client.get_one_rack(rack_id).await?.racks;
+            match racks.first() {
+                Some(r) => show_single(r, format)?,
+                None => println!("No rack found"),
+            }
+        }
+        None => {
+            let racks = api_client.get_all_racks(config.page_size).await?.racks;
+            if racks.is_empty() {
+                println!("No racks found");
+            } else {
+                show_list(&racks, format)?;
+            }
+        }
     }
-    .racks;
 
-    if racks.is_empty() {
-        println!("No racks found");
-        return Ok(());
+    Ok(())
+}
+
+fn show_single(r: &Rack, format: OutputFormat) -> Result<()> {
+    let output = RackOutput::from(r);
+    match format {
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&output)?),
+        OutputFormat::Yaml => println!("{}", serde_yaml::to_string(&output)?),
+        _ => show_detail(r),
     }
+    Ok(())
+}
 
+fn show_list(racks: &[Rack], format: OutputFormat) -> Result<()> {
+    let outputs: Vec<RackOutput> = racks.iter().map(RackOutput::from).collect();
+    match format {
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&outputs)?),
+        OutputFormat::Yaml => println!("{}", serde_yaml::to_string(&outputs)?),
+        OutputFormat::Csv => {
+            show_table_csv(racks);
+        }
+        _ => show_table(racks),
+    }
+    Ok(())
+}
+
+fn show_detail(r: &Rack) {
+    let id = r.id.as_ref().map(|id| id.to_string()).unwrap_or_default();
+    let name = r
+        .metadata
+        .as_ref()
+        .map(|m| m.name.as_str())
+        .unwrap_or("N/A");
+
+    let mut table = Table::new();
+    table.add_row(row!["ID", id]);
+    table.add_row(row!["Name", name]);
+    table.add_row(row!["State", r.rack_state]);
+    table.add_row(row!["Version", r.version]);
+    table.add_row(row![
+        "Expected Compute Tray BMCs",
+        if r.expected_compute_trays.is_empty() {
+            "N/A".to_string()
+        } else {
+            r.expected_compute_trays.join("\n")
+        }
+    ]);
+    table.add_row(row![
+        "Current Compute Trays",
+        if r.compute_trays.is_empty() {
+            "N/A".to_string()
+        } else {
+            r.compute_trays
+                .iter()
+                .map(|id| id.to_string())
+                .collect::<Vec<_>>()
+                .join("\n")
+        }
+    ]);
+    table.add_row(row![
+        "Expected Power Shelf BMCs",
+        if r.expected_power_shelves.is_empty() {
+            "N/A".to_string()
+        } else {
+            r.expected_power_shelves.join("\n")
+        }
+    ]);
+    table.add_row(row![
+        "Current Power Shelves",
+        if r.power_shelves.is_empty() {
+            "N/A".to_string()
+        } else {
+            r.power_shelves
+                .iter()
+                .map(|id| id.to_string())
+                .collect::<Vec<_>>()
+                .join("\n")
+        }
+    ]);
+    table.add_row(row![
+        "Expected NVLink Switch BMCs",
+        if r.expected_nvlink_switches.is_empty() {
+            "N/A".to_string()
+        } else {
+            r.expected_nvlink_switches.join("\n")
+        }
+    ]);
+    table.add_row(row![
+        "Current NVLink Switches",
+        if r.switches.is_empty() {
+            "N/A".to_string()
+        } else {
+            r.switches
+                .iter()
+                .map(|id| id.to_string())
+                .collect::<Vec<_>>()
+                .join("\n")
+        }
+    ]);
+    table.printstd();
+}
+
+fn show_table(racks: &[Rack]) {
     let mut table = Table::new();
     table.set_titles(row![
         "ID",
-        "Metadata Name",
+        "Name",
         "State",
-        "Expected Compute Trays",
-        "Expected Power Shelves",
-        "Expected NVLink Switches",
-        "Current Compute Trays",
-        "Current Power Shelves"
+        "Compute Trays",
+        "Power Shelves",
+        "Switches",
     ]);
 
     for r in racks {
-        let metadata_name = r
+        let name = r
             .metadata
             .as_ref()
             .map(|m| m.name.as_str())
             .unwrap_or("N/A");
 
         table.add_row(row![
-            r.id.map(|id| id.to_string()).unwrap_or_default(),
-            metadata_name,
+            r.id.as_ref().map(|id| id.to_string()).unwrap_or_default(),
+            name,
             r.rack_state,
-            if r.expected_compute_trays.is_empty() {
-                "N/A".to_string()
-            } else {
-                r.expected_compute_trays.join(", ")
-            },
-            if r.expected_power_shelves.is_empty() {
-                "N/A".to_string()
-            } else {
-                r.expected_power_shelves.join(", ")
-            },
-            if r.expected_nvlink_switches.is_empty() {
-                "N/A".to_string()
-            } else {
-                r.expected_nvlink_switches.join(", ")
-            },
-            if r.compute_trays.is_empty() {
-                "N/A".to_string()
-            } else {
-                r.compute_trays
-                    .iter()
-                    .map(|id| id.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            },
-            if r.power_shelves.is_empty() {
-                "N/A".to_string()
-            } else {
-                r.power_shelves
-                    .iter()
-                    .map(|id| id.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            },
+            format!(
+                "{} / {}",
+                r.compute_trays.len(),
+                r.expected_compute_trays.len()
+            ),
+            format!(
+                "{} / {}",
+                r.power_shelves.len(),
+                r.expected_power_shelves.len()
+            ),
+            format!(
+                "{} / {}",
+                r.switches.len(),
+                r.expected_nvlink_switches.len()
+            ),
         ]);
     }
 
     table.printstd();
-    Ok(())
+}
+
+fn show_table_csv(racks: &[Rack]) {
+    let mut table = Table::new();
+    table.set_titles(row![
+        "ID",
+        "Name",
+        "State",
+        "Compute Trays",
+        "Power Shelves",
+        "Switches",
+    ]);
+
+    for r in racks {
+        let name = r
+            .metadata
+            .as_ref()
+            .map(|m| m.name.as_str())
+            .unwrap_or("N/A");
+
+        table.add_row(row![
+            r.id.as_ref().map(|id| id.to_string()).unwrap_or_default(),
+            name,
+            r.rack_state,
+            format!(
+                "{} / {}",
+                r.compute_trays.len(),
+                r.expected_compute_trays.len()
+            ),
+            format!(
+                "{} / {}",
+                r.power_shelves.len(),
+                r.expected_power_shelves.len()
+            ),
+            format!(
+                "{} / {}",
+                r.switches.len(),
+                r.expected_nvlink_switches.len()
+            ),
+        ]);
+    }
+
+    table.to_csv(std::io::stdout()).ok();
 }

--- a/crates/api/src/web/filters.rs
+++ b/crates/api/src/web/filters.rs
@@ -67,21 +67,19 @@ pub fn rack_id_link(id: impl Display) -> ::askama::Result<String> {
     let mut rack_id = String::new();
     askama_escape::Html.write_escaped(&mut rack_id, &id)?;
 
-    let short_id = if rack_id.len() < 10 {
-        &rack_id
+    let formatted = if rack_id.len() < 10 {
+        format!(r#"<a href="/admin/rack/{link_path}">{rack_id}</a>"#)
     } else {
-        &rack_id[0..6] // Shorter to have space for ellipsis ("...")
-    };
-
-    // machine_id is used here since its already a defined CSS class
-    let formatted = format!(
-        r#"
+        let short_id = &rack_id[0..6];
+        format!(
+            r#"
     <a href="/admin/rack/{link_path}">
         <div class="machine_id">
             <div>{rack_id}</div><div>{short_id}</div>
         </div>
     </a>"#
-    );
+        )
+    };
 
     Ok(formatted)
 }

--- a/crates/api/src/web/rack.rs
+++ b/crates/api/src/web/rack.rs
@@ -39,21 +39,32 @@ struct Racks {
 struct RackRecord {
     id: String,
     rack_state: String,
-    expected_compute_trays: String,
-    current_compute_trays: String,
-    expected_power_shelves: String,
-    current_power_shelves: String,
+    compute_trays: String,
+    power_shelves: String,
+    switches: String,
 }
 
 #[derive(Template)]
 #[template(path = "rack_detail.html")]
 struct RackDetail {
     id: String,
-    rack: Option<rpc::forge::Rack>,
+    rack_state: String,
+    state_version: String,
+    time_in_state: String,
+    state_reason: Option<rpc::forge::ControllerStateReason>,
+    version: String,
     associated_machines: Vec<String>,
     associated_switches: Vec<String>,
     associated_power_shelves: Vec<String>,
     metadata_detail: super::MetadataDetail,
+    history: Vec<RackStateHistoryRecord>,
+}
+
+#[derive(Debug)]
+struct RackStateHistoryRecord {
+    state: String,
+    version: String,
+    time: String,
 }
 
 /// Show all racks
@@ -69,46 +80,24 @@ pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
     let racks = racks
         .racks
         .into_iter()
-        .map(|rack| {
-            let expected_compute_trays = rack.expected_compute_trays.join(", ");
-            let current_compute_trays = rack
-                .compute_trays
-                .iter()
-                .map(|m| m.to_string())
-                .collect::<Vec<String>>()
-                .join(", ");
-            let expected_power_shelves = rack.expected_power_shelves.join(", ");
-            let current_power_shelves = rack
-                .power_shelves
-                .iter()
-                .map(|ps| ps.to_string())
-                .collect::<Vec<String>>()
-                .join(", ");
-
-            RackRecord {
-                id: rack.id.map(|id| id.to_string()).unwrap_or_default(),
-                rack_state: rack.rack_state,
-                expected_compute_trays: if expected_compute_trays.is_empty() {
-                    "N/A".to_string()
-                } else {
-                    expected_compute_trays
-                },
-                current_compute_trays: if current_compute_trays.is_empty() {
-                    "N/A".to_string()
-                } else {
-                    current_compute_trays
-                },
-                expected_power_shelves: if expected_power_shelves.is_empty() {
-                    "N/A".to_string()
-                } else {
-                    expected_power_shelves
-                },
-                current_power_shelves: if current_power_shelves.is_empty() {
-                    "N/A".to_string()
-                } else {
-                    current_power_shelves
-                },
-            }
+        .map(|rack| RackRecord {
+            id: rack.id.map(|id| id.to_string()).unwrap_or_default(),
+            rack_state: rack.rack_state,
+            compute_trays: format!(
+                "{} / {}",
+                rack.compute_trays.len(),
+                rack.expected_compute_trays.len()
+            ),
+            power_shelves: format!(
+                "{} / {}",
+                rack.power_shelves.len(),
+                rack.expected_power_shelves.len()
+            ),
+            switches: format!(
+                "{} / {}",
+                rack.switches.len(),
+                rack.expected_nvlink_switches.len()
+            ),
         })
         .collect();
 
@@ -214,37 +203,67 @@ pub async fn detail(
         return (StatusCode::OK, Json(maybe_rack)).into_response();
     };
 
-    let associated_machines = match fetch_machine_ids(api, rack_id.clone()).await {
+    let associated_machines = match fetch_machine_ids(api.clone(), rack_id.clone()).await {
         Ok(m) => m,
         Err(err) => {
             tracing::error!(%err, "fetch_machine_ids");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Error loading machine IDs",
-            )
-                .into_response();
+            vec![]
         }
     };
+
+    let associated_switches = match fetch_switch_ids(&api, &rack_id).await {
+        Ok(ids) => ids,
+        Err(err) => {
+            tracing::error!(%err, "fetch_switch_ids");
+            vec![]
+        }
+    };
+
+    let associated_power_shelves = match fetch_power_shelf_ids(&api, &rack_id).await {
+        Ok(ids) => ids,
+        Err(err) => {
+            tracing::error!(%err, "fetch_power_shelf_ids");
+            vec![]
+        }
+    };
+
+    let rack_state = maybe_rack
+        .as_ref()
+        .map(|r| r.rack_state.clone())
+        .unwrap_or_default();
+
+    let version = maybe_rack
+        .as_ref()
+        .map(|r| r.version.clone())
+        .unwrap_or_default();
+
+    let time_in_state = maybe_rack
+        .as_ref()
+        .map(|r| config_version::since_state_change_humanized(&r.version))
+        .unwrap_or_default();
 
     let metadata_detail = super::MetadataDetail {
         metadata: maybe_rack
             .as_ref()
             .and_then(|r| r.metadata.clone())
             .unwrap_or_default(),
-        metadata_version: maybe_rack
-            .as_ref()
-            .map(|r| r.version.clone())
-            .unwrap_or_default(),
+        metadata_version: version.clone(),
     };
+
+    let history = fetch_rack_state_history(&api, &rack_id).await;
 
     let display = RackDetail {
         id: rack_id.to_string(),
-        rack: maybe_rack,
+        rack_state,
+        state_version: version.clone(),
+        time_in_state,
+        state_reason: None,
+        version,
         associated_machines,
-        // TODO: Add discovered switches and powershelves
-        associated_power_shelves: vec![],
-        associated_switches: vec![],
+        associated_switches,
+        associated_power_shelves,
         metadata_detail,
+        history,
     };
 
     (StatusCode::OK, Html(display.render().unwrap())).into_response()
@@ -268,4 +287,68 @@ pub async fn fetch_machine_ids(
         .into_iter()
         .map(|id| id.to_string())
         .collect())
+}
+
+async fn fetch_switch_ids(api: &Api, rack_id: &RackId) -> Result<Vec<String>, tonic::Status> {
+    let request = tonic::Request::new(rpc::forge::SwitchSearchFilter {
+        rack_id: Some(rack_id.clone()),
+        ..Default::default()
+    });
+
+    Ok(api
+        .find_switch_ids(request)
+        .await?
+        .into_inner()
+        .ids
+        .into_iter()
+        .map(|id| id.to_string())
+        .collect())
+}
+
+async fn fetch_power_shelf_ids(api: &Api, rack_id: &RackId) -> Result<Vec<String>, tonic::Status> {
+    let request = tonic::Request::new(rpc::forge::PowerShelfSearchFilter {
+        rack_id: Some(rack_id.clone()),
+        ..Default::default()
+    });
+
+    Ok(api
+        .find_power_shelf_ids(request)
+        .await?
+        .into_inner()
+        .ids
+        .into_iter()
+        .map(|id| id.to_string())
+        .collect())
+}
+
+async fn fetch_rack_state_history(api: &Api, rack_id: &RackId) -> Vec<RackStateHistoryRecord> {
+    let request = tonic::Request::new(rpc::forge::RackStateHistoriesRequest {
+        rack_ids: vec![rack_id.clone()],
+    });
+
+    match api.find_rack_state_histories(request).await {
+        Ok(response) => {
+            let mut histories = response.into_inner().histories;
+            let mut records = histories
+                .remove(&rack_id.to_string())
+                .unwrap_or_default()
+                .records;
+            records.reverse();
+            records
+                .into_iter()
+                .map(|r| RackStateHistoryRecord {
+                    state: r.state,
+                    version: r.version,
+                    time: r
+                        .time
+                        .map(|t| t.to_string())
+                        .unwrap_or_else(|| "N/A".to_string()),
+                })
+                .collect()
+        }
+        Err(err) => {
+            tracing::error!(%err, "fetch_rack_state_history");
+            vec![]
+        }
+    }
 }

--- a/crates/api/templates/rack_detail.html
+++ b/crates/api/templates/rack_detail.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ id }}{% endblock %}
+{% block title %}Rack {{ id }}{% endblock %}
 
 {% block content %}
 <div id="json">
@@ -8,26 +8,44 @@
 </div>
 <h1>Rack {{ id }}</h1>
 
-{% if let Some(rack) = rack %}
+<h2>Info</h2>
 <table class="detailsview">
-	<tr><th>State</th>
+	<tr>
+		<th>Rack ID</th>
+		<td><a href="/admin/rack/{{ id }}">{{ id }}</a></td>
+	</tr>
+	<tr>
+		<th>State</th>
 		<td>
-			{% if rack.rack_state.to_lowercase().contains("failed") %}
-				<span class="bubble error">{{ rack.rack_state }}</span>
-			{% else if rack.rack_state == "Ready" %}
-				<span class="bubble success">{{ rack.rack_state }}</span>
+			{% if rack_state == "Ready" %}
+				<span class="bubble success">{{ rack_state }}</span>
+			{% else if rack_state.to_lowercase().contains("error") || rack_state.to_lowercase().contains("failed") %}
+				<span class="bubble error">{{ rack_state }}</span>
 			{% else %}
-				<span class="bubble">{{ rack.rack_state }}</span>
+				<span class="bubble">{{ rack_state }}</span>
 			{% endif %}
 		</td>
 	</tr>
+	<tr>
+		<th>State Handler Outcome</th>
+		<td>{{ state_reason|controller_state_reason_fmt|safe }}</td>
+	</tr>
+	<tr>
+		<th>State Version</th>
+		<td>{{ state_version|config_version|safe }}</td>
+	</tr>
+	<tr>
+		<th>Time in State</th>
+		<td>{{ time_in_state }}</td>
+	</tr>
+	<tr>
+		<th>Version</th>
+		<td>{{ version }}</td>
+	</tr>
 </table>
-{% endif %}
 
 <h2>Metadata</h2>
 {{ metadata_detail|safe }}
-
-<!-- TODO: Add expected rack definition -->
 
 <h2>Managed Rack Components</h2>
 
@@ -57,7 +75,7 @@
 	<tbody>
 	{% for switch_id in associated_switches %}
 		<tr>
-			<td>{{ switch_id }}</td>
+			<td><a href="/admin/switch/{{ switch_id }}">{{ switch_id }}</a></td>
 		</tr>
 	{% endfor %}
 	</tbody>
@@ -79,11 +97,30 @@
 	</tbody>
 </table>
 
-<h3>History</h3>
-🚧
-{# Commented till implemented
-<a href="/admin/rack/{{ id }}/state-history">Open History on separate page</a>
-{{ history|safe }}
-#}
+<h2>History</h2>
+{% if !history.is_empty() %}
+<div class="table-responsive">
+	<table class="table table-striped">
+		<thead>
+		<tr>
+			<th>State</th>
+			<th>Version</th>
+			<th>Time</th>
+		</tr>
+		</thead>
+		<tbody>
+		{% for record in history %}
+		<tr>
+			<td>{{ record.state }}</td>
+			<td>{{ record.version }}</td>
+			<td>{{ record.time }}</td>
+		</tr>
+		{% endfor %}
+		</tbody>
+	</table>
+</div>
+{% else %}
+<p class="text-muted">No state history available.</p>
+{% endif %}
 
 {% endblock %}

--- a/crates/api/templates/rack_show.html
+++ b/crates/api/templates/rack_show.html
@@ -24,10 +24,9 @@
                             <tr>
                                 <th>ID</th>
                                 <th>State</th>
-                                <th>Expected Compute Trays</th>
-                                <th>Current Compute Trays</th>
-                                <th>Expected Power Shelves</th>
-                                <th>Current Power Shelves</th>
+                                <th>Compute Trays (current / expected)</th>
+                                <th>Power Shelves (current / expected)</th>
+                                <th>Switches (current / expected)</th>
                             </tr>
                             </thead>
                             <tbody>
@@ -35,10 +34,9 @@
                             <tr>
                                 <td>{{ rack.id|rack_id_link|safe }}</td>
                                 <td>{{ rack.rack_state }}</td>
-                                <td>{{ rack.expected_compute_trays }}</td>
-                                <td>{{ rack.current_compute_trays }}</td>
-                                <td>{{ rack.expected_power_shelves }}</td>
-                                <td>{{ rack.current_power_shelves }}</td>
+                                <td>{{ rack.compute_trays }}</td>
+                                <td>{{ rack.power_shelves }}</td>
+                                <td>{{ rack.switches }}</td>
                             </tr>
                             {% endfor %}
                             </tbody>


### PR DESCRIPTION
## Description

Was playing around with `ExpectedRack` and `Rack` instances on a lab rack tonight to test out the workflow, and wanted to fix some gaps in the web UI and admin CLI (mainly because we haven't really exercised them fully yet). Includes kind of a laundry list of observations, but fixing them in one shot.

- Fix issue where Rack ID was "doubled" ("a123a123").
- Improves Managed Racks list
  - Changed from listing all MACs/IDs to showing counts: "current / expected" for Compute Trays, Power Shelves, and Switches.
  - Added Switches column (was missing).
- Improves Rack detail page (`/rack/<rack-id>`)
  - Added standard Info section with: Rack ID (self-link), State (colored bubble), State Handler Outcome, State Version, Time in State, Version.
  - Added Metadata section using MetadataDetail template.
  - Fixed the Switches list — now fetches switch IDs via `FindSwitchIds` with a `rack_id` filter.
  - Fixed Power Shelves list — now fetches via `FindPowerShelfIds` with a `rack_id` filter.
  - Ensured Switch IDs in the view are linked to `/switch/<id>`.
  - State History section — now populated from `FindRackStateHistories` RPC, displayed as a table with State, Version, Time columns.
- `admin-cli rack show <id>` — now shows a vertical detail view with `prettytable` for a single rack, and a summary table for all racks.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

