### PR TITLE
feat: OnDemand Rack maintainance mode

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -22,6 +22,7 @@
 - [State Machines]()
     - [Managed Host](architecture/state_machines/managedhost.md)
     - [Switch](architecture/state_machines/switch.md)
+    - [On-Demand Rack Maintenance](architecture/state_machines/rack.md)
 
 # Manuals
 

--- a/book/src/architecture/state_machines/rack.md
+++ b/book/src/architecture/state_machines/rack.md
@@ -1,0 +1,249 @@
+# On-Demand Rack Maintenance
+
+On-demand maintenance allows an operator to trigger a maintenance cycle on a rack that is in the **Ready** or **Error** state. It supports both **full-rack** and **partial-rack** scoping — the caller can optionally specify which machines, switches, or power shelves to maintain, and which maintenance **activities** to perform.
+
+## Scope: Full Rack vs Partial Rack
+
+The maintenance request carries an optional **`MaintenanceScope`** that specifies which devices to include:
+
+| Scenario | `machine_ids` | `switch_ids` | `power_shelf_ids` | Effect |
+|----------|--------------|--------------|-------------------|--------|
+| Full rack | *(empty)* | *(empty)* | *(empty)* | All machines, switches, and power shelves in the rack are maintained. |
+| Machines only | `[id1, id2]` | *(empty)* | *(empty)* | Only the specified machines are reprovisioned and firmware-upgraded. Switches and power shelves are skipped. |
+| Mixed | `[id1]` | `[sid1]` | *(empty)* | Only the listed machines and switches are maintained; power shelves are skipped. |
+
+When no device IDs are specified (all three lists empty), the scope is treated as **full rack** — identical to the existing `reprovision_requested` behavior.
+
+## Activities
+
+The request also carries an optional list of **maintenance activities** to perform. When the list is empty, all activities are performed (the default). Available activities:
+
+| Activity | Proto `oneof` variant | Per-activity config | Description |
+|----------|----------------------|---------------------|-------------|
+| Firmware Upgrade | `FirmwareUpgradeActivity` | `firmware_version` — target firmware ID (empty = default firmware for the rack hardware type) | Reprovisioning and firmware upgrade via RMS. |
+| Configure NMX Cluster | `ConfigureNmxClusterActivity` | *(extend as needed)* | NMX cluster configuration. |
+| Power Sequence | `PowerSequenceActivity` | *(extend as needed)* | Power-on/off/reset sequencing. |
+
+Each activity is represented as a `MaintenanceActivityConfig` message with a `oneof activity` field. The `oneof` discriminant identifies the activity type, and each variant carries only the configuration fields relevant to that activity.
+
+Activities that are not in the list are skipped during the maintenance cycle. The state machine always starts at `FirmwareUpgrade(Start)` (to consume the scope), but immediately advances to the next requested activity if firmware upgrade was not requested.
+
+### Firmware Version Resolution
+
+The firmware used during the upgrade depends on how the maintenance was triggered:
+
+| Trigger | `firmware_version` | Firmware used |
+|---------|-------------------|---------------|
+| Ingestion (Discovering → Maintenance) | *(not applicable)* | Default firmware for the rack hardware type |
+| Reprovision (`reprovision_requested`) | *(not applicable)* | Default firmware for the rack hardware type |
+| On-demand CLI, no version specified | *(empty)* | Default firmware for the rack hardware type |
+| On-demand CLI, version specified | e.g. `"fw-v2.1"` | Looked up by ID via `rack_firmware` table |
+
+When a `firmware_version` is supplied through the CLI, the maintenance handler resolves it by looking up the firmware record by ID (`db_rack_firmware::find_by_id`). If the ID is not found, the rack transitions to **Error**. If the firmware exists but is not marked as available, the firmware upgrade is skipped. When no version is specified (or the maintenance was triggered through ingestion/reprovision), the default firmware for the rack's hardware type is used as before.
+
+## Flow
+
+```text
+┌────────┐       ┌──────────────┐       ┌──────────┐       ┌─────────────────┐
+│ Caller │──────▶│ gRPC Endpoint│──────▶│ Postgres │       │ Rack State      │
+│ (CLI)  │       │ OnDemandRack │       │          │       │ Handler (Ready) │
+│        │       │ Maintenance  │       │          │       │                 │
+└────────┘       └──────┬───────┘       └────┬─────┘       └────────┬────────┘
+                        │                    │                      │
+                        │ 1. Load rack       │                      │
+                        │    verify Ready    │                      │
+                        │ 2. Set config.     │                      │
+                        │    maintenance_    │                      │
+                        │    requested=scope │                      │
+                        │──────────────────▶ │                      │
+                        │                    │                      │
+                        │ 3. Return OK       │                      │
+                        │◀───────────────────│                      │
+                        │                    │                      │
+                        │                    │  4. Poll rack (Ready)│
+                        │                    │◀─────────────────────│
+                        │                    │                      │
+                        │                    │  5. Detect           │
+                        │                    │     maintenance_     │
+                        │                    │     requested        │
+                        │                    │                      │
+                        │                    │  6. Transition to    │
+                        │                    │     Maintenance      │
+                        │                    │    (FirmwareUpgrade/  │
+                        │                    │     Start)           │
+                        │                    │◀─────────────────────│
+```
+
+1. The caller invokes the `OnDemandRackMaintenance` gRPC method with a `rack_id` and optional device-ID lists.
+2. The handler validates that the rack is in `Ready` or `Error` state and no maintenance is already pending.
+3. It writes a `MaintenanceScope` to `RackConfig.maintenance_requested` and persists the config.
+4. On the next state-handler tick, `handle_ready` detects `maintenance_requested` and transitions the rack to `Maintenance(FirmwareUpgrade(Start))`.
+5. The `start_firmware_upgrade` function consumes the scope. If a `firmware_version` was specified, it resolves the firmware by ID; otherwise it uses the default firmware for the rack hardware type. It then filters device reprovisioning and firmware-upgrade operations to only the specified devices (or all devices if the scope is full-rack).
+6. After maintenance completes, the rack flows through `Validating` back to `Ready` as usual.
+
+## gRPC API
+
+**Service method** (in `Forge` service):
+
+```protobuf
+rpc OnDemandRackMaintenance(RackMaintenanceOnDemandRequest) returns (RackMaintenanceOnDemandResponse);
+```
+
+**Messages**:
+
+```protobuf
+message FirmwareUpgradeActivity {
+  string firmware_version = 1;          // empty = default firmware for rack hardware type
+}
+message ConfigureNmxClusterActivity {}  // extend as needed
+message PowerSequenceActivity {}        // extend as needed
+
+message MaintenanceActivityConfig {
+  oneof activity {
+    FirmwareUpgradeActivity firmware_upgrade = 1;
+    ConfigureNmxClusterActivity configure_nmx_cluster = 2;
+    PowerSequenceActivity power_sequence = 3;
+  }
+}
+
+message RackMaintenanceOnDemandRequest {
+  common.RackId rack_id = 1;
+  repeated string machine_ids = 2;
+  repeated string switch_ids = 3;
+  repeated string power_shelf_ids = 4;
+  repeated MaintenanceActivityConfig activities = 5;  // empty = all
+}
+
+message RackMaintenanceOnDemandResponse {}
+```
+
+## Component Manager Integration
+
+The `UpdateComponentFirmware` gRPC endpoint provides a higher-level interface for firmware updates. For **compute trays** and **switches**, it delegates to the rack state machine by internally calling `on_demand_rack_maintenance`, rather than managing firmware directly.
+
+### How it works
+
+When `update_component_firmware` receives a request targeting compute trays or switches:
+
+1. **Resolve the rack** — looks up the first device (machine or switch) in the database to find its `rack_id`.
+2. **Build a maintenance request** — constructs a `RackMaintenanceOnDemandRequest` with:
+   - The resolved `rack_id`
+   - The machine IDs and/or switch IDs from the request
+   - A `FirmwareUpgrade` activity carrying the `target_version` as `firmware_version`
+3. **Delegate** — calls `on_demand_rack_maintenance`, which writes the `MaintenanceScope` to the rack config and lets the rack state machine handle the actual firmware upgrade.
+4. **Return success** — once the maintenance is scheduled, returns a success `ComponentResult` for each device.
+
+Power shelves continue to use the component manager backend directly (they do not go through the rack state machine).
+
+```text
+┌──────────────┐      ┌──────────────────────┐      ┌──────────────────────┐
+│ Caller       │─────▶│ UpdateComponent       │─────▶│ OnDemandRack         │
+│              │      │ Firmware (gRPC)       │      │ Maintenance (gRPC)   │
+└──────────────┘      └──────────┬───────────┘      └──────────┬───────────┘
+                                  │                             │
+                      ┌───────────▼──────────┐      ┌──────────▼───────────┐
+                      │ Resolve rack_id from │      │ Write maintenance_   │
+                      │ machine/switch DB    │      │ requested to config  │
+                      └──────────────────────┘      └──────────┬───────────┘
+                                                               │
+                                                    ┌──────────▼───────────┐
+                                                    │ Rack State Machine   │
+                                                    │ Ready → Maintenance  │
+                                                    │ (FirmwareUpgrade/    │
+                                                    │  Start)              │
+                                                    └──────────────────────┘
+```
+
+| Target type | Behavior |
+|-------------|----------|
+| `ComputeTrays` | Resolves `rack_id` from first machine, delegates to `on_demand_rack_maintenance` with `machine_ids` and `firmware_version` |
+| `Switches` | Resolves `rack_id` from first switch, delegates to `on_demand_rack_maintenance` with `switch_ids` and `firmware_version` |
+| `PowerShelves` | Handled directly by the component manager power shelf backend (no state machine interaction) |
+
+### Example: CLI triggers compute tray firmware upgrade
+
+```bash
+carbide-cli component firmware update \
+  --compute-trays machine-001,machine-002 \
+  --target-version fw-v2.1
+```
+
+This results in:
+
+1. `UpdateComponentFirmware` is called with `ComputeTrays { machine_ids: [machine-001, machine-002] }` and `target_version: "fw-v2.1"`.
+2. Machine `machine-001` is looked up to discover `rack_id = rack-42`.
+3. `OnDemandRackMaintenance` is called with `rack_id = rack-42`, `machine_ids = [machine-001, machine-002]`, and `FirmwareUpgradeActivity { firmware_version: "fw-v2.1" }`.
+4. The rack state machine picks up the request, resolves firmware `fw-v2.1` from the `rack_firmware` table, and runs the firmware upgrade via RMS for the specified machines.
+
+## Preconditions
+
+The gRPC handler rejects the request with an error if:
+
+- The rack is **not in `Ready` or `Error` state** — maintenance can only be triggered from these two states.
+- A maintenance request is **already pending** (`maintenance_requested` is already set).
+- Any provided device ID is **malformed** (cannot be parsed).
+
+## RBAC
+
+The `OnDemandRackMaintenance` permission is granted to the `ForgeAdminCLI` role.
+
+## Failure Handling
+
+If the maintenance state machine transitions to `Error` (for example, a
+firmware upgrade fails, the requested rack firmware cannot be found, or RMS is
+unreachable), the handler clears `maintenance_requested` while persisting the
+`Error` transition.
+
+This is important because `handle_error` re-enters `Maintenance` whenever
+`maintenance_requested` is set; without clearing it, the rack would loop
+between `Maintenance` and `Error` on the same failing request. The user must
+issue a new `OnDemandRackMaintenance` call to retry.
+
+### Restarting a compute stuck in `FailedFirmwareUpgrade`
+
+A compute tray whose host firmware upgrade fails lands in
+`M_HostReprovision::FailedFirmwareUpgrade`. From there it normally retries
+automatically (bounded by `MAX_FIRMWARE_UPGRADE_RETRIES` and
+`host_firmware_upgrade_retry_interval`).
+
+When an on-demand maintenance call (or, equivalently, the rack maintenance
+flow) issues a fresh `trigger_host_reprovisioning_request` against such a
+machine, `host_reprovisioning_requested` is overwritten with
+`started_at = None`. The `FailedFirmwareUpgrade` arm in
+`HostUpgradeState::handle_host_reprovision` detects this fresh request
+(`started_at.is_none()`) and:
+
+- For rack-initiated requests (initiator prefixed `rack-`), transitions to
+  `M_HostReprovision::WaitingForRackFirmwareUpgrade` so the rack-level RMS
+  flow can drive the upgrade.
+- Otherwise transitions to `M_HostReprovision::CheckingFirmwareV2` with
+  `retry_count` reset to `0`, mirroring the way `ManagedHostState::Ready`
+  kicks off a Host Reprovision (including the `host-fw-update` health-report
+  alert merge).
+
+This means an on-demand maintenance call always converges a stuck compute back
+toward `M_Ready` without waiting for the auto-retry interval, which is what
+allows the rack to progress out of `R_Maintenance` into `R_Validation`.
+
+## Ready State Priority
+
+When the rack is in `Ready`, three config flags are checked in order. The first match wins:
+
+1. **`topology_changed`** → transition to `Discovering`
+2. **`reprovision_requested`** → transition to `Maintenance(FirmwareUpgrade/Start)` *(clears any pending `maintenance_requested`)*
+3. **`maintenance_requested`** → transition to `Maintenance(FirmwareUpgrade/Start)` with device scope
+
+## Implementation
+
+| Component | Location |
+|-----------|----------|
+| Scope model (`MaintenanceScope`) | `crates/api-model/src/rack.rs` |
+| Config field (`maintenance_requested`) | `RackConfig` in the same file |
+| gRPC handler | `on_demand_rack_maintenance` in `crates/api/src/handlers/rack.rs` |
+| API wiring | `crates/api/src/api.rs` |
+| RBAC rule | `crates/api/src/auth/internal_rbac_rules.rs` |
+| Ready state check | `handle_ready` in `crates/api/src/state_controller/rack/ready.rs` |
+| Firmware resolution & upgrade start | `start_firmware_upgrade` in `crates/api/src/state_controller/rack/maintenance.rs` |
+| Maintenance state dispatch | `handle_maintenance` in `crates/api/src/state_controller/rack/maintenance.rs` |
+| Component manager firmware entry point | `update_component_firmware` in `crates/api/src/handlers/component_manager.rs` |
+| Protobuf definitions | `crates/rpc/proto/forge.proto` |

--- a/book/src/architecture/state_machines/rackstatemachine.md
+++ b/book/src/architecture/state_machines/rackstatemachine.md
@@ -12,6 +12,13 @@ state "Machine (Each compute tray runs this)" as Machine {
     M_Ready --> M_Assigned : instance requested
     M_Assigned -[dotted]-> M_Ready :  Via various instance creation
     M_Ready --> M_HostReprovision : reprovision (non-NVL node only)
+    state M_HostReprovision {
+        [*] --> M_HostReprovision_CheckingFirmware
+        state "CheckingFirmware" as M_HostReprovision_CheckingFirmware
+        state "FailedFirmwareUpgrade" as M_HostReprovision_FailedFirmwareUpgrade
+        M_HostReprovision_CheckingFirmware --> M_HostReprovision_FailedFirmwareUpgrade : firmware upgrade failed
+        M_HostReprovision_FailedFirmwareUpgrade --> M_HostReprovision_CheckingFirmware : auto-retry (within MAX_FIRMWARE_UPGRADE_RETRIES)\nor new Host Reprovision request received
+    }
     M_HostReprovision --> M_Ready : Done
     M_Assigned --> M_Failed : Failure
     M_Failed --> M_ForceDeletion : Admin
@@ -185,7 +192,7 @@ The Rack state machine drives or observes the Machine (compute) state machine as
 |----------------|-------------------|
 | R_Created      | Rack checks for newly created compute machines (M_Created) that belong to this rack. |
 | R_Discovering  | Rack checks that all computes are M_Ready before moving to R_Maintenance. |
-| R_Maintenance  | Rack requests compute reprovision (drives M_HostReprovision); tracks when computes return to M_Ready. Rack can request exit from M_HostReprovision. |
+| R_Maintenance  | Rack requests compute reprovision (drives M_HostReprovision); tracks when computes return to M_Ready. Rack can request exit from M_HostReprovision. If a compute is stuck in M_HostReprovision::FailedFirmwareUpgrade, the Rack (or operator) may issue a fresh Host Reprovision request to restart the firmware upgrade flow without waiting for the auto-retry interval. |
 
 These cross-state dependencies are shown in the combined diagram above.
 
@@ -260,10 +267,34 @@ The Rack state machine coordinates with the Machine and Switch state machines as
 |----------------|--------------------|
 | R_Created      | Checks for newly created switches → S_Created; checks for newly created compute machines → M_Created. |
 | R_Discovering  | Checks for all switches ready → S_Ready; checks for all computes ready → M_Ready. |
-| R_Maintenance  | Requests switch Reprovision → S_ReProvisioning; requests compute Reprovision → M_HostReprovision. Tracks when switches and computes return to S_Ready and M_Ready. Rack can request exit from switch Reprovision (S_ReProvisioning) and from compute Reprovision (M_HostReprovision). |
+| R_Maintenance  | Requests switch Reprovision → S_ReProvisioning; requests compute Reprovision → M_HostReprovision. Tracks when switches and computes return to S_Ready and M_Ready. Rack can request exit from switch Reprovision (S_ReProvisioning) and from compute Reprovision (M_HostReprovision). A fresh Host Reprovision request issued while the compute is in M_HostReprovision::FailedFirmwareUpgrade is accepted and restarts the firmware upgrade flow (retry counter reset). |
 | R_Ready        | If a tray is replaced (external event), the rack topology changes and the rack moves back to R_Discovering to re-discover and re-validate the new tray. |
 
 These cross-state dependencies are shown in the combined diagram above.
+
+### Recovering from M_HostReprovision::FailedFirmwareUpgrade
+
+A compute machine that fails its host firmware upgrade lands in the
+`M_HostReprovision::FailedFirmwareUpgrade` substate. There are two ways out:
+
+1. **Automatic retry.** While `retry_count < MAX_FIRMWARE_UPGRADE_RETRIES` and the
+   configured `host_firmware_upgrade_retry_interval` has elapsed since the
+   failure, the machine state handler automatically transitions back to
+   `CheckingFirmwareV2` and re-attempts the upgrade.
+2. **Fresh Host Reprovision request.** The Rack state machine (or an operator
+   via `trigger_host_reprovisioning`) can issue a brand-new Host Reprovision
+   request at any time. The new request overwrites
+   `host_reprovisioning_requested` with `started_at = None`; the FailedFirmwareUpgrade
+   handler detects this fresh request and restarts the upgrade flow from
+   `CheckingFirmwareV2` with `retry_count` reset to `0`, mirroring the way
+   `ManagedHostState::Ready` kicks off a Host Reprovision (including the
+   `host-fw-update` health-report alert merge). Rack-level requests (initiator
+   prefixed with `rack-`) instead enter `WaitingForRackFirmwareUpgrade`.
+
+This guarantees the Rack can always drive a stuck compute out of
+`FailedFirmwareUpgrade` without waiting for the retry backoff, which is
+important during `R_Maintenance` where the Rack must converge all computes back
+to `M_Ready` before progressing to `R_Validation`.
 
 ### Tray Replacement (External Event)
 

--- a/crates/admin-cli/src/rack/maintenance/args.rs
+++ b/crates/admin-cli/src/rack/maintenance/args.rs
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::rack::RackId;
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+pub enum Args {
+    #[clap(about = "Start on-demand rack maintenance (full rack or partial)")]
+    Start(MaintenanceOptions),
+}
+
+#[derive(Parser, Debug)]
+pub struct MaintenanceOptions {
+    #[clap(short, long, help = "Rack ID to start maintenance on")]
+    pub rack: RackId,
+
+    #[clap(
+        long,
+        help = "Machine IDs to include (omit for full rack)",
+        num_args = 1..,
+        value_delimiter = ','
+    )]
+    pub machine_ids: Option<Vec<String>>,
+
+    #[clap(
+        long,
+        help = "Switch IDs to include (omit for full rack)",
+        num_args = 1..,
+        value_delimiter = ','
+    )]
+    pub switch_ids: Option<Vec<String>>,
+
+    #[clap(
+        long,
+        help = "Power shelf IDs to include (omit for full rack)",
+        num_args = 1..,
+        value_delimiter = ','
+    )]
+    pub power_shelf_ids: Option<Vec<String>>,
+
+    #[clap(
+        long,
+        help = "Maintenance activities to perform: firmware-upgrade, configure-nmx-cluster, power-sequence (omit for all)",
+        num_args = 1..,
+        value_delimiter = ','
+    )]
+    pub activities: Option<Vec<String>>,
+
+    #[clap(
+        long,
+        help = "Target firmware version for firmware-upgrade activity (omit for RMS default)"
+    )]
+    pub firmware_version: Option<String>,
+
+    #[clap(
+        long,
+        help = "Firmware components to update, e.g. BMC,CPLD,BIOS (omit for all components)",
+        num_args = 1..,
+        value_delimiter = ','
+    )]
+    pub components: Option<Vec<String>>,
+}

--- a/crates/admin-cli/src/rack/maintenance/cmd.rs
+++ b/crates/admin-cli/src/rack/maintenance/cmd.rs
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::CarbideCliResult;
+use ::rpc::forge as rpc;
+
+use super::args::MaintenanceOptions;
+use crate::rpc::ApiClient;
+
+pub async fn on_demand_rack_maintenance(
+    api_client: &ApiClient,
+    args: MaintenanceOptions,
+) -> CarbideCliResult<()> {
+    use rpc::maintenance_activity_config::Activity as ProtoActivity;
+
+    let firmware_version = args.firmware_version.unwrap_or_default();
+    let components = args.components.unwrap_or_default();
+
+    let activities: Vec<rpc::MaintenanceActivityConfig> = args
+         .activities
+         .unwrap_or_default()
+         .iter()
+         .map(|s| {
+             let activity = match s.as_str() {
+                 "firmware-upgrade" => Ok(ProtoActivity::FirmwareUpgrade(
+                     rpc::FirmwareUpgradeActivity {
+                         firmware_version: firmware_version.clone(),
+                         components: components.clone(),
+                     },
+                 )),
+                 "configure-nmx-cluster" => Ok(ProtoActivity::ConfigureNmxCluster(
+                     rpc::ConfigureNmxClusterActivity {},
+                 )),
+                 "power-sequence" => Ok(ProtoActivity::PowerSequence(
+                     rpc::PowerSequenceActivity {},
+                 )),
+                 other => Err(eyre::eyre!(
+                     "Unknown activity '{}'. Valid values: firmware-upgrade, configure-nmx-cluster, power-sequence",
+                     other
+                 )),
+             }?;
+            Ok::<_, eyre::Report>(rpc::MaintenanceActivityConfig {
+                activity: Some(activity),
+            })
+         })
+         .collect::<Result<Vec<_>, _>>()?;
+
+    api_client
+        .on_demand_rack_maintenance(
+            args.rack,
+            args.machine_ids.unwrap_or_default(),
+            args.switch_ids.unwrap_or_default(),
+            args.power_shelf_ids.unwrap_or_default(),
+            activities,
+        )
+        .await?;
+    println!("On-demand rack maintenance scheduled successfully.");
+    Ok(())
+}

--- a/crates/admin-cli/src/rack/maintenance/mod.rs
+++ b/crates/admin-cli/src/rack/maintenance/mod.rs
@@ -15,32 +15,19 @@
  * limitations under the License.
  */
 
-mod delete;
-mod list;
-mod maintenance;
-pub mod metadata;
-pub mod profile;
-mod show;
+pub mod args;
+pub mod cmd;
 
-#[cfg(test)]
-mod tests;
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
 
-use clap::Parser;
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
 
-use crate::cfg::dispatch::Dispatch;
-
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Show rack information")]
-    Show(show::Args),
-    #[clap(about = "List all racks")]
-    List(list::Args),
-    #[clap(about = "Delete the rack")]
-    Delete(delete::Args),
-    #[clap(subcommand, about = "Edit Metadata associated with a Rack")]
-    Metadata(metadata::Args),
-    #[clap(subcommand, about = "Rack profile")]
-    Profile(profile::Args),
-    #[clap(subcommand, about = "On-demand rack maintenance")]
-    Maintenance(maintenance::Args),
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        match self {
+            Args::Start(options) => cmd::on_demand_rack_maintenance(&ctx.api_client, options).await,
+        }
+    }
 }

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -1538,6 +1538,24 @@ impl ApiClient {
         Ok(self.0.on_demand_machine_validation(request).await?)
     }
 
+    pub async fn on_demand_rack_maintenance(
+        &self,
+        rack_id: RackId,
+        machine_ids: Vec<String>,
+        switch_ids: Vec<String>,
+        power_shelf_ids: Vec<String>,
+        activities: Vec<rpc::MaintenanceActivityConfig>,
+    ) -> CarbideCliResult<rpc::RackMaintenanceOnDemandResponse> {
+        let request = rpc::RackMaintenanceOnDemandRequest {
+            rack_id: Some(rack_id),
+            machine_ids,
+            switch_ids,
+            power_shelf_ids,
+            activities,
+        };
+        Ok(self.0.on_demand_rack_maintenance(request).await?)
+    }
+
     pub async fn list_os_image(
         &self,
         tenant_organization_id: Option<String>,

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -521,23 +521,22 @@ impl MachineRvLabels {
     }
 }
 
-// ============================================================================
-// RACK CONFIG & HISTORY
-// ============================================================================
-
 /// Individual maintenance activities that can be performed during on-demand
-/// rack maintenance. When the activities list on `MaintenanceScope` is
+/// rack maintenance. When the activities list on [`MaintenanceScope`] is
 /// empty, all activities are performed.
 ///
 /// Activity-specific configuration is carried inline on the variant
-/// (e.g. `FirmwareUpgrade` holds the optional target firmware version,
-/// `PowerControl` carries the desired power action).
+/// (e.g. `FirmwareUpgrade` holds the optional target firmware version).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MaintenanceActivity {
     FirmwareUpgrade {
         /// Target firmware version. `None` means RMS uses its default/latest.
         #[serde(default)]
         firmware_version: Option<String>,
+        /// Firmware components to update (e.g. "BMC", "CPLD", "BIOS").
+        /// Empty means all components.
+        #[serde(default)]
+        components: Vec<String>,
     },
     ConfigureNmxCluster,
     PowerSequence,
@@ -550,14 +549,14 @@ pub enum MaintenanceActivity {
 }
 
 impl MaintenanceActivity {
-    /// Returns `true` if two activities are the same kind, ignoring any
-    /// per-activity configuration (e.g. firmware version, power action).
+    /// Returns `true` if two activities are the same kind, ignoring
+    /// any per-activity configuration (e.g. firmware version).
     pub fn same_kind(&self, other: &Self) -> bool {
         std::mem::discriminant(self) == std::mem::discriminant(other)
     }
 }
 
-impl Display for MaintenanceActivity {
+impl std::fmt::Display for MaintenanceActivity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             MaintenanceActivity::FirmwareUpgrade { .. } => write!(f, "FirmwareUpgrade"),
@@ -591,8 +590,6 @@ impl MaintenanceScope {
         self.machine_ids.is_empty() && self.switch_ids.is_empty() && self.power_shelf_ids.is_empty()
     }
 
-    /// Returns `true` if the given activity should be performed. When the
-    /// activities list is empty, all activities are considered requested.
     pub fn should_run(&self, activity: &MaintenanceActivity) -> bool {
         self.activities.is_empty() || self.activities.iter().any(|a| a.same_kind(activity))
     }
@@ -684,5 +681,242 @@ pub fn state_sla(state: &RackState, state_version: &ConfigVersion) -> StateSla {
         RackState::Maintenance { .. } => StateSla::no_sla(),
         RackState::Error { .. } => StateSla::no_sla(),
         RackState::Deleting => StateSla::no_sla(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_uuid::machine::{MachineIdSource, MachineType};
+    use carbide_uuid::power_shelf::{PowerShelfIdSource, PowerShelfType};
+    use carbide_uuid::switch::{SwitchIdSource, SwitchType};
+
+    use super::*;
+
+    // ── MaintenanceScope ────────────────────────────────────────────────
+
+    #[test]
+    fn is_full_rack_when_all_lists_empty() {
+        let scope = MaintenanceScope::default();
+        assert!(scope.is_full_rack());
+    }
+
+    #[test]
+    fn is_not_full_rack_with_machines() {
+        let scope = MaintenanceScope {
+            machine_ids: vec![MachineId::new(
+                MachineIdSource::Tpm,
+                [0; 32],
+                MachineType::Host,
+            )],
+            ..Default::default()
+        };
+        assert!(!scope.is_full_rack());
+    }
+
+    #[test]
+    fn is_not_full_rack_with_switches() {
+        let scope = MaintenanceScope {
+            switch_ids: vec![SwitchId::new(
+                SwitchIdSource::Tpm,
+                [0; 32],
+                SwitchType::NvLink,
+            )],
+            ..Default::default()
+        };
+        assert!(!scope.is_full_rack());
+    }
+
+    #[test]
+    fn is_not_full_rack_with_power_shelves() {
+        let scope = MaintenanceScope {
+            power_shelf_ids: vec![PowerShelfId::new(
+                PowerShelfIdSource::Tpm,
+                [0; 32],
+                PowerShelfType::Rack,
+            )],
+            ..Default::default()
+        };
+        assert!(!scope.is_full_rack());
+    }
+
+    #[test]
+    fn should_run_all_when_activities_empty() {
+        let scope = MaintenanceScope::default();
+        assert!(scope.should_run(&MaintenanceActivity::FirmwareUpgrade {
+            firmware_version: None,
+            components: vec![],
+        }));
+        assert!(scope.should_run(&MaintenanceActivity::ConfigureNmxCluster));
+        assert!(scope.should_run(&MaintenanceActivity::PowerSequence));
+    }
+
+    #[test]
+    fn should_run_only_selected_activity() {
+        let scope = MaintenanceScope {
+            activities: vec![MaintenanceActivity::FirmwareUpgrade {
+                firmware_version: Some("v2.0".into()),
+                components: vec![],
+            }],
+            ..Default::default()
+        };
+        assert!(scope.should_run(&MaintenanceActivity::FirmwareUpgrade {
+            firmware_version: None,
+            components: vec![],
+        }));
+        assert!(!scope.should_run(&MaintenanceActivity::ConfigureNmxCluster));
+        assert!(!scope.should_run(&MaintenanceActivity::PowerSequence));
+    }
+
+    #[test]
+    fn should_run_multiple_selected_activities() {
+        let scope = MaintenanceScope {
+            activities: vec![
+                MaintenanceActivity::FirmwareUpgrade {
+                    firmware_version: None,
+                    components: vec![],
+                },
+                MaintenanceActivity::PowerSequence,
+            ],
+            ..Default::default()
+        };
+        assert!(scope.should_run(&MaintenanceActivity::FirmwareUpgrade {
+            firmware_version: Some("v1.0".into()),
+            components: vec![],
+        }));
+        assert!(!scope.should_run(&MaintenanceActivity::ConfigureNmxCluster));
+        assert!(scope.should_run(&MaintenanceActivity::PowerSequence));
+    }
+
+    // ── MaintenanceActivity ─────────────────────────────────────────────
+
+    #[test]
+    fn same_kind_matches_regardless_of_config() {
+        let a = MaintenanceActivity::FirmwareUpgrade {
+            firmware_version: Some("v1".into()),
+            components: vec!["BMC".into()],
+        };
+        let b = MaintenanceActivity::FirmwareUpgrade {
+            firmware_version: None,
+            components: vec![],
+        };
+        assert!(a.same_kind(&b));
+    }
+
+    #[test]
+    fn same_kind_does_not_match_different_variants() {
+        let a = MaintenanceActivity::FirmwareUpgrade {
+            firmware_version: None,
+            components: vec![],
+        };
+        let b = MaintenanceActivity::ConfigureNmxCluster;
+        assert!(!a.same_kind(&b));
+    }
+
+    #[test]
+    fn maintenance_activity_display() {
+        assert_eq!(
+            MaintenanceActivity::FirmwareUpgrade {
+                firmware_version: None,
+                components: vec![],
+            }
+            .to_string(),
+            "FirmwareUpgrade"
+        );
+        assert_eq!(
+            MaintenanceActivity::ConfigureNmxCluster.to_string(),
+            "ConfigureNmxCluster"
+        );
+        assert_eq!(
+            MaintenanceActivity::PowerSequence.to_string(),
+            "PowerSequence"
+        );
+    }
+
+    // ── Rack::check_accepts_maintenance ─────────────────────────────────
+
+    fn test_rack(state: RackState, maintenance_requested: Option<MaintenanceScope>) -> Rack {
+        Rack {
+            id: RackId::default(),
+            rack_profile_id: None,
+            config: RackConfig {
+                maintenance_requested,
+                ..Default::default()
+            },
+            controller_state: Versioned::new(state, ConfigVersion::initial()),
+            controller_state_outcome: None,
+            firmware_upgrade_job: None,
+            health_reports: Default::default(),
+            created: Utc::now(),
+            updated: Utc::now(),
+            deleted: None,
+            metadata: Metadata::default(),
+            version: ConfigVersion::initial(),
+        }
+    }
+
+    #[test]
+    fn accepts_maintenance_in_ready_state() {
+        let rack = test_rack(RackState::Ready, None);
+        assert!(rack.check_accepts_maintenance().is_ok());
+    }
+
+    #[test]
+    fn accepts_maintenance_in_error_state() {
+        let rack = test_rack(
+            RackState::Error {
+                cause: "something broke".into(),
+            },
+            None,
+        );
+        assert!(rack.check_accepts_maintenance().is_ok());
+    }
+
+    #[test]
+    fn rejects_maintenance_in_created_state() {
+        let rack = test_rack(RackState::Created, None);
+        let err = rack.check_accepts_maintenance().unwrap_err();
+        assert!(matches!(err, RackMaintenanceRejection::NotReadyOrError(_)));
+    }
+
+    #[test]
+    fn rejects_maintenance_in_discovering_state() {
+        let rack = test_rack(RackState::Discovering, None);
+        let err = rack.check_accepts_maintenance().unwrap_err();
+        assert!(matches!(err, RackMaintenanceRejection::NotReadyOrError(_)));
+    }
+
+    #[test]
+    fn rejects_maintenance_in_maintenance_state() {
+        let rack = test_rack(
+            RackState::Maintenance {
+                maintenance_state: RackMaintenanceState::Completed,
+            },
+            None,
+        );
+        let err = rack.check_accepts_maintenance().unwrap_err();
+        assert!(matches!(err, RackMaintenanceRejection::NotReadyOrError(_)));
+    }
+
+    #[test]
+    fn rejects_maintenance_when_already_pending() {
+        let rack = test_rack(RackState::Ready, Some(MaintenanceScope::default()));
+        let err = rack.check_accepts_maintenance().unwrap_err();
+        assert!(matches!(err, RackMaintenanceRejection::AlreadyPending));
+    }
+
+    // ── RackMaintenanceRejection display ────────────────────────────────
+
+    #[test]
+    fn rejection_not_ready_or_error_display() {
+        let rejection = RackMaintenanceRejection::NotReadyOrError(RackState::Discovering);
+        let msg = rejection.to_string();
+        assert!(msg.contains("not in Ready or Error state"));
+    }
+
+    #[test]
+    fn rejection_already_pending_display() {
+        let rejection = RackMaintenanceRejection::AlreadyPending;
+        let msg = rejection.to_string();
+        assert!(msg.contains("already has a pending maintenance request"));
     }
 }

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -2209,6 +2209,13 @@ impl Forge for Api {
         crate::handlers::machine_validation::on_demand_machine_validation(self, request).await
     }
 
+    async fn on_demand_rack_maintenance(
+        &self,
+        request: Request<rpc::RackMaintenanceOnDemandRequest>,
+    ) -> Result<Response<rpc::RackMaintenanceOnDemandResponse>, Status> {
+        crate::handlers::rack::on_demand_rack_maintenance(self, request).await
+    }
+
     async fn tpm_add_ca_cert(
         &self,
         request: Request<rpc::TpmCaCert>,

--- a/crates/api/src/auth/internal_rbac_rules.rs
+++ b/crates/api/src/auth/internal_rbac_rules.rs
@@ -456,6 +456,7 @@ impl InternalRBACRules {
         x.perm("MachineSetup", vec![ForgeAdminCLI]);
         x.perm("SetDpuFirstBootOrder", vec![ForgeAdminCLI]);
         x.perm("OnDemandMachineValidation", vec![ForgeAdminCLI]);
+        x.perm("OnDemandRackMaintenance", vec![ForgeAdminCLI]);
         x.perm("TpmAddCaCert", vec![ForgeAdminCLI, SiteAgent]);
         x.perm("TpmShowCaCerts", vec![ForgeAdminCLI, SiteAgent]);
         x.perm("TpmShowUnmatchedEkCerts", vec![ForgeAdminCLI, SiteAgent]);

--- a/crates/api/src/handlers/component_manager.rs
+++ b/crates/api/src/handlers/component_manager.rs
@@ -29,7 +29,7 @@ use component_manager::power_shelf_manager::{PowerShelfEndpoint, PowerShelfVendo
 use db::{self, WithTransaction};
 use futures_util::FutureExt;
 use mac_address::MacAddress;
-use model::component_manager::{NvSwitchComponent, PowerAction, PowerShelfComponent};
+use model::component_manager::{PowerAction, PowerShelfComponent};
 use tonic::{Request, Response, Status};
 
 use crate::api::{Api, log_request_data};
@@ -117,14 +117,27 @@ fn map_power_action(raw: i32) -> Result<PowerAction, Status> {
     }
 }
 
-fn map_nv_switch_components(raw: &[i32]) -> Result<Vec<NvSwitchComponent>, Status> {
+fn map_compute_tray_component_names(raw: &[i32]) -> Result<Vec<String>, Status> {
+    raw.iter()
+        .filter(|&&v| v != rpc::ComputeTrayComponent::Unknown as i32)
+        .map(|&v| match rpc::ComputeTrayComponent::try_from(v) {
+            Ok(rpc::ComputeTrayComponent::Bmc) => Ok("BMC".to_string()),
+            Ok(rpc::ComputeTrayComponent::Bios) => Ok("BIOS".to_string()),
+            _ => Err(Status::invalid_argument(format!(
+                "unknown compute tray component: {v}"
+            ))),
+        })
+        .collect()
+}
+
+fn map_nv_switch_component_names(raw: &[i32]) -> Result<Vec<String>, Status> {
     raw.iter()
         .filter(|&&v| v != rpc::NvSwitchComponent::Unknown as i32)
         .map(|&v| match rpc::NvSwitchComponent::try_from(v) {
-            Ok(rpc::NvSwitchComponent::Bmc) => Ok(NvSwitchComponent::Bmc),
-            Ok(rpc::NvSwitchComponent::Cpld) => Ok(NvSwitchComponent::Cpld),
-            Ok(rpc::NvSwitchComponent::Bios) => Ok(NvSwitchComponent::Bios),
-            Ok(rpc::NvSwitchComponent::Nvos) => Ok(NvSwitchComponent::Nvos),
+            Ok(rpc::NvSwitchComponent::Bmc) => Ok("BMC".to_string()),
+            Ok(rpc::NvSwitchComponent::Cpld) => Ok("CPLD".to_string()),
+            Ok(rpc::NvSwitchComponent::Bios) => Ok("BIOS".to_string()),
+            Ok(rpc::NvSwitchComponent::Nvos) => Ok("NVOS".to_string()),
             _ => Err(Status::invalid_argument(format!(
                 "unknown NV-Switch component: {v}"
             ))),
@@ -569,43 +582,70 @@ pub(crate) async fn update_component_firmware(
         .target
         .ok_or_else(|| Status::invalid_argument("target is required"))?;
 
-    let results = match target {
+    let mut rack_machine_ids: Vec<String> = Vec::new();
+    let mut rack_switch_ids: Vec<String> = Vec::new();
+    let mut rack_id: Option<carbide_uuid::rack::RackId> = None;
+    let mut power_shelf_results: Option<Vec<rpc::ComponentResult>> = None;
+    let mut component_names: Vec<String> = Vec::new();
+
+    match target {
         rpc::update_component_firmware_request::Target::Switches(t) => {
             let list = t
                 .switch_ids
                 .ok_or_else(|| Status::invalid_argument("switch_ids is required"))?;
-            let components = map_nv_switch_components(&t.components)?;
-            let endpoints = resolve_switch_endpoints(api, &list.ids).await?;
+            if list.ids.is_empty() {
+                return Err(Status::invalid_argument("switch_ids must not be empty"));
+            }
 
-            let mut results: Vec<_> = endpoints
-                .unresolved
-                .iter()
-                .map(|id| {
-                    error_result(
-                        &id.to_string(),
-                        "could not resolve endpoint for switch".into(),
-                    )
-                })
-                .collect();
+            component_names = map_nv_switch_component_names(&t.components)?;
 
-            let backend_results = cm
-                .nv_switch
-                .queue_firmware_updates(
-                    &endpoints.resolved.endpoints,
-                    &req.target_version,
-                    &components,
-                )
+            let mut txn = api
+                .database_connection
+                .begin()
                 .await
-                .map_err(component_manager_error_to_status)?;
-            results.extend(backend_results.into_iter().map(|r| {
-                let id = switch_mac_to_id_str(&r.bmc_mac, &endpoints.resolved.mac_to_id);
-                if r.success {
-                    success_result(&id)
-                } else {
-                    error_result(&id, r.error.unwrap_or_default())
-                }
-            }));
-            results
+                .map_err(|e| Status::internal(format!("failed to begin transaction: {e}")))?;
+            let switch = db::switch::find_by_id(&mut txn, &list.ids[0])
+                .await
+                .map_err(|e| Status::internal(format!("failed to look up switch: {e}")))?
+                .ok_or_else(|| Status::not_found(format!("switch {} not found", list.ids[0])))?;
+            drop(txn);
+
+            rack_id = Some(switch.rack_id.ok_or_else(|| {
+                Status::failed_precondition(format!(
+                    "switch {} is not associated with a rack",
+                    list.ids[0]
+                ))
+            })?);
+            rack_switch_ids = list.ids.iter().map(|id| id.to_string()).collect();
+        }
+        rpc::update_component_firmware_request::Target::ComputeTrays(t) => {
+            let list = t
+                .machine_ids
+                .ok_or_else(|| Status::invalid_argument("machine_ids is required"))?;
+            if list.machine_ids.is_empty() {
+                return Err(Status::invalid_argument("machine_ids must not be empty"));
+            }
+
+            component_names = map_compute_tray_component_names(&t.components)?;
+
+            let machine = db::machine::find_one(
+                api.db_reader().as_mut(),
+                &list.machine_ids[0],
+                Default::default(),
+            )
+            .await
+            .map_err(|e| Status::internal(format!("failed to look up machine: {e}")))?
+            .ok_or_else(|| {
+                Status::not_found(format!("machine {} not found", list.machine_ids[0]))
+            })?;
+
+            rack_id = Some(machine.rack_id.ok_or_else(|| {
+                Status::failed_precondition(format!(
+                    "machine {} is not associated with a rack",
+                    list.machine_ids[0]
+                ))
+            })?);
+            rack_machine_ids = list.machine_ids.iter().map(|id| id.to_string()).collect();
         }
         rpc::update_component_firmware_request::Target::PowerShelves(t) => {
             let list = t
@@ -642,14 +682,42 @@ pub(crate) async fn update_component_firmware(
                     error_result(&id, r.error.unwrap_or_default())
                 }
             }));
-            results
+            power_shelf_results = Some(results);
         }
-        rpc::update_component_firmware_request::Target::ComputeTrays(_) => {
-            return Err(Status::unimplemented(
-                "compute tray firmware updates are not yet supported",
-            ));
-        }
-    };
+    }
+
+    if let Some(results) = power_shelf_results {
+        return Ok(Response::new(rpc::UpdateComponentFirmwareResponse {
+            results,
+        }));
+    }
+
+    let rack_id = rack_id.ok_or_else(|| {
+        Status::invalid_argument("no machines or switches specified for firmware upgrade")
+    })?;
+
+    let maintenance_req = Request::new(rpc::RackMaintenanceOnDemandRequest {
+        rack_id: Some(rack_id),
+        machine_ids: rack_machine_ids.clone(),
+        switch_ids: rack_switch_ids.clone(),
+        power_shelf_ids: vec![],
+        activities: vec![rpc::MaintenanceActivityConfig {
+            activity: Some(rpc::maintenance_activity_config::Activity::FirmwareUpgrade(
+                rpc::FirmwareUpgradeActivity {
+                    firmware_version: req.target_version,
+                    components: component_names,
+                },
+            )),
+        }],
+    });
+
+    crate::handlers::rack::on_demand_rack_maintenance(api, maintenance_req).await?;
+
+    let results: Vec<_> = rack_machine_ids
+        .iter()
+        .chain(rack_switch_ids.iter())
+        .map(|id| success_result(id))
+        .collect();
 
     Ok(Response::new(rpc::UpdateComponentFirmwareResponse {
         results,

--- a/crates/api/src/handlers/rack.rs
+++ b/crates/api/src/handlers/rack.rs
@@ -14,11 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::collections::HashSet;
 use std::str::FromStr;
 
 use ::rpc::errors::RpcDataConversionError;
 use ::rpc::forge::{self as rpc, HealthReportEntry};
+use carbide_uuid::machine::MachineId;
+use carbide_uuid::power_shelf::PowerShelfId;
 use carbide_uuid::rack::RackId;
+use carbide_uuid::switch::SwitchId;
 use db::{
     ObjectColumnFilter, WithTransaction, expected_machine as db_expected_machine,
     expected_power_shelf as db_expected_power_shelf, expected_switch as db_expected_switch,
@@ -28,6 +32,7 @@ use futures_util::FutureExt;
 use health_report::HealthReportApplyMode;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::metadata::Metadata;
+use model::rack::{MaintenanceActivity, MaintenanceScope, RackState};
 use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
@@ -520,4 +525,202 @@ pub(crate) async fn update_rack_metadata(
     txn.commit().await?;
 
     Ok(tonic::Response::new(()))
+}
+
+pub(crate) async fn on_demand_rack_maintenance(
+    api: &Api,
+    request: Request<rpc::RackMaintenanceOnDemandRequest>,
+) -> Result<Response<rpc::RackMaintenanceOnDemandResponse>, Status> {
+    log_request_data(&request);
+
+    let req = request.into_inner();
+
+    let rack_id = req
+        .rack_id
+        .ok_or_else(|| CarbideError::InvalidArgument("rack_id is required".into()))?;
+
+    let rack = db_rack::find_by(
+        api.db_reader().as_mut(),
+        ObjectColumnFilter::One(db_rack::IdColumn, &rack_id),
+    )
+    .await
+    .map_err(CarbideError::from)?
+    .pop()
+    .ok_or_else(|| CarbideError::NotFoundError {
+        kind: "rack",
+        id: rack_id.to_string(),
+    })?;
+
+    if !matches!(
+        *rack.controller_state,
+        RackState::Ready | RackState::Error { .. }
+    ) {
+        return Err(CarbideError::InvalidArgument(format!(
+            "Rack {} is not in Ready or Error state (current: {:?}). Maintenance can only be requested when the rack is Ready or in Error.",
+            rack_id, *rack.controller_state
+        ))
+        .into());
+    }
+
+    if rack.config.maintenance_requested.is_some() {
+        return Err(CarbideError::InvalidArgument(format!(
+            "On-demand maintenance for rack {} is already scheduled.",
+            rack_id,
+        ))
+        .into());
+    }
+
+    use rpc::maintenance_activity_config::Activity as ProtoActivity;
+
+    let activities: Vec<MaintenanceActivity> = req
+        .activities
+        .iter()
+        .map(|entry| match &entry.activity {
+            Some(ProtoActivity::FirmwareUpgrade(fw)) => Ok(MaintenanceActivity::FirmwareUpgrade {
+                firmware_version: if fw.firmware_version.is_empty() {
+                    None
+                } else {
+                    Some(fw.firmware_version.clone())
+                },
+                components: fw.components.clone(),
+            }),
+            Some(ProtoActivity::ConfigureNmxCluster(_)) => {
+                Ok(MaintenanceActivity::ConfigureNmxCluster)
+            }
+            Some(ProtoActivity::PowerSequence(_)) => Ok(MaintenanceActivity::PowerSequence),
+            None => Err(CarbideError::InvalidArgument(
+                "Maintenance activity entry has no activity set".into(),
+            )),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let scope = MaintenanceScope {
+        machine_ids: req
+            .machine_ids
+            .iter()
+            .map(|s| MachineId::from_str(s))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| CarbideError::InvalidArgument(format!("Invalid machine_id: {e}")))?,
+        switch_ids: req
+            .switch_ids
+            .iter()
+            .map(|s| SwitchId::from_str(s))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| CarbideError::InvalidArgument(format!("Invalid switch_id: {e}")))?,
+        power_shelf_ids: req
+            .power_shelf_ids
+            .iter()
+            .map(|s| PowerShelfId::from_str(s))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| CarbideError::InvalidArgument(format!("Invalid power_shelf_id: {e}")))?,
+        activities,
+    };
+
+    if !scope.is_full_rack() {
+        let mut reader = api.db_reader();
+
+        if !scope.machine_ids.is_empty() {
+            let rack_machines: HashSet<MachineId> = db_machine::find_machine_ids(
+                reader.as_mut(),
+                MachineSearchConfig {
+                    rack_id: Some(rack_id.clone()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(CarbideError::from)?
+            .into_iter()
+            .collect();
+
+            let foreign: Vec<_> = scope
+                .machine_ids
+                .iter()
+                .filter(|id| !rack_machines.contains(id))
+                .collect();
+            if !foreign.is_empty() {
+                return Err(CarbideError::InvalidArgument(format!(
+                    "machine(s) [{}] do not belong to rack {rack_id}",
+                    foreign
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                ))
+                .into());
+            }
+        }
+
+        if !scope.switch_ids.is_empty() {
+            let rack_switches: HashSet<SwitchId> = db_switch::find_ids(
+                reader.as_mut(),
+                model::switch::SwitchSearchFilter {
+                    rack_id: Some(rack_id.clone()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(CarbideError::from)?
+            .into_iter()
+            .collect();
+
+            let foreign: Vec<_> = scope
+                .switch_ids
+                .iter()
+                .filter(|id| !rack_switches.contains(id))
+                .collect();
+            if !foreign.is_empty() {
+                return Err(CarbideError::InvalidArgument(format!(
+                    "switch(es) [{}] do not belong to rack {rack_id}",
+                    foreign
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                ))
+                .into());
+            }
+        }
+
+        if !scope.power_shelf_ids.is_empty() {
+            let rack_power_shelves: HashSet<PowerShelfId> = db_power_shelf::find_ids(
+                reader.as_mut(),
+                model::power_shelf::PowerShelfSearchFilter {
+                    rack_id: Some(rack_id.clone()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(CarbideError::from)?
+            .into_iter()
+            .collect();
+
+            let foreign: Vec<_> = scope
+                .power_shelf_ids
+                .iter()
+                .filter(|id| !rack_power_shelves.contains(id))
+                .collect();
+            if !foreign.is_empty() {
+                return Err(CarbideError::InvalidArgument(format!(
+                    "power shelf/shelves [{}] do not belong to rack {rack_id}",
+                    foreign
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                ))
+                .into());
+            }
+        }
+    }
+
+    let mut updated_config = rack.config.clone();
+    updated_config.maintenance_requested = Some(scope);
+
+    let mut txn = api.txn_begin().await?;
+    db_rack::update(&mut txn, &rack_id, &updated_config).await?;
+    txn.commit().await?;
+
+    tracing::info!("On-demand maintenance scheduled for rack {}", rack_id,);
+
+    Ok(Response::new(rpc::RackMaintenanceOnDemandResponse {}))
 }

--- a/crates/api/src/handlers/rack_firmware.rs
+++ b/crates/api/src/handlers/rack_firmware.rs
@@ -1075,7 +1075,7 @@ pub async fn apply(
         .as_ref()
         .ok_or_else(|| CarbideError::FailedPrecondition("RMS client not configured".to_string()))?;
     let batches =
-        build_firmware_update_batches(&rack_id, &fw_config, &req.firmware_type, &inventory)
+        build_firmware_update_batches(&rack_id, &fw_config, &req.firmware_type, &inventory, &[])
             .map_err(|e| CarbideError::Internal {
                 message: format!("Failed to build firmware update requests: {}", e),
             })?;

--- a/crates/api/src/rack/firmware_update.rs
+++ b/crates/api/src/rack/firmware_update.rs
@@ -180,6 +180,7 @@ pub fn build_firmware_update_batches(
     firmware: &RackFirmware,
     firmware_type: &str,
     inventory: &RackFirmwareInventory,
+    components: &[String],
 ) -> Result<Vec<FirmwareUpdateBatchRequest>> {
     let parsed_components = firmware
         .parsed_components
@@ -210,8 +211,13 @@ pub fn build_firmware_update_batches(
             continue;
         }
 
-        let firmware_targets =
-            build_firmware_targets(&parsed_components, lookup_key, firmware_type, &firmware.id)?;
+        let firmware_targets = build_firmware_targets(
+            &parsed_components,
+            lookup_key,
+            firmware_type,
+            &firmware.id,
+            components,
+        )?;
         let node_infos = devices
             .iter()
             .map(|device| build_new_node_info(rack_id, device, node_type))
@@ -309,9 +315,14 @@ fn build_firmware_targets(
     lookup_key: &str,
     firmware_type: &str,
     firmware_id: &str,
+    components: &[String],
 ) -> Result<Vec<rms::FirmwareTarget>> {
-    let mut firmware_components =
-        find_firmware_components_for_device(parsed_components, lookup_key, firmware_type)?;
+    let mut firmware_components = find_firmware_components_for_device(
+        parsed_components,
+        lookup_key,
+        firmware_type,
+        components,
+    )?;
     let flash_order = get_firmware_flash_order(lookup_key);
     firmware_components.sort_by_key(|(_, _, target)| {
         flash_order
@@ -416,6 +427,7 @@ fn find_firmware_components_for_device(
     parsed_components: &Value,
     hardware_type: &str,
     firmware_type: &str,
+    components: &[String],
 ) -> Result<Vec<(String, String, String)>> {
     let lookup_table: FirmwareLookupTable = serde_json::from_value(parsed_components.clone())
         .map_err(|err| {
@@ -427,10 +439,16 @@ fn find_firmware_components_for_device(
         })?;
 
     let wanted_type = firmware_type.to_lowercase();
+    let wanted_components: Vec<String> = components.iter().map(|c| c.to_lowercase()).collect();
     let mut results = Vec::new();
     if let Some(device_components) = lookup_table.devices.get(hardware_type) {
         for (component_key, entry) in device_components {
             if entry.firmware_type.to_lowercase() != wanted_type {
+                continue;
+            }
+            if !wanted_components.is_empty()
+                && !wanted_components.contains(&entry.component.to_lowercase())
+            {
                 continue;
             }
             results.push((

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -6687,6 +6687,34 @@ impl HostUpgradeState {
                 Ok(StateHandlerOutcome::do_nothing())
             }
             HostReprovisionState::FailedFirmwareUpgrade { report_time, .. } => {
+                // A special case in Rackfirmware upgrade to handle FailedFirmwareUpgrade
+                // Accept a freshly-issued Host Reprovision request that arrives while we are
+                // sitting in FailedFirmwareUpgrade. `trigger_host_reprovisioning_request`
+                // overwrites `host_reprovisioning_requested` with `started_at = None`, so a
+                // `None` here (after a previous failure) indicates a brand-new user request.
+                // Mirror the ManagedHostState::Ready handling: route rack-level requests to
+                // WaitingForRackFirmwareUpgrade, otherwise restart the host upgrade flow from
+                // CheckingFirmwareV2 (retry_count reset to 0) and merge the host-fw health
+                // report alert.
+                if state
+                    .host_snapshot
+                    .host_reprovision_requested
+                    .as_ref()
+                    .is_some_and(|req| req.started_at.is_none())
+                    && is_rack_level_reprovisioning(state)
+                {
+                    tracing::info!(
+                        %machine_id,
+                        "Rack-level firmware upgrade requested in FailedFirmwareUpgrade — entering WaitingForRackFirmwareUpgrade",
+                    );
+                    return Ok(StateHandlerOutcome::transition(
+                        ManagedHostState::HostReprovision {
+                            retry_count: 1,
+                            reprovision_state: HostReprovisionState::WaitingForRackFirmwareUpgrade,
+                        },
+                    ));
+                }
+
                 let can_retry = retry_count < MAX_FIRMWARE_UPGRADE_RETRIES;
                 let waited_enough = Utc::now()
                     .signed_duration_since(report_time.unwrap_or(Utc::now()))
@@ -9625,6 +9653,24 @@ async fn set_host_boot_order(
 ) -> Result<SetBootOrderOutcome, StateHandlerError> {
     match set_boot_order_info.set_boot_order_state {
         SetBootOrderState::SetBootOrder => {
+            if mh_snapshot.dpu_snapshots.is_empty() {
+                // MachineState::SetBootOrder is a NO-OP for the Zero-DPU case
+                if ctx
+                    .services
+                    .site_config
+                    .force_dpu_nic_mode
+                    .load(Ordering::Relaxed)
+                {
+                    redfish_client
+                        .boot_first(Boot::UefiHttp)
+                        .await
+                        .map_err(|e| StateHandlerError::RedfishError {
+                            operation: "boot_first",
+                            error: e,
+                        })?;
+                    return Ok(SetBootOrderOutcome::Done);
+                }
+            }
             // Resolve the boot NIC MAC the same way `CheckHostConfig` does,
             // supporting hosts with DPU(s) and zero DPUs alike.
             let boot_interface_mac = mh_snapshot.boot_interface_mac().ok_or_else(|| {

--- a/crates/api/src/state_controller/rack/error_state.rs
+++ b/crates/api/src/state_controller/rack/error_state.rs
@@ -18,14 +18,55 @@
 //! Handler for RackState::Error.
 
 use carbide_uuid::rack::RackId;
-use model::rack::RackState;
+use model::rack::{Rack, RackConfig, RackState};
 
-use crate::state_controller::state_handler::{StateHandlerError, StateHandlerOutcome};
+use crate::state_controller::rack::context::RackStateHandlerContextObjects;
+use crate::state_controller::rack::maintenance::first_maintenance_state;
+use crate::state_controller::state_handler::{
+    StateHandlerContext, StateHandlerError, StateHandlerOutcome,
+};
 
 pub async fn handle_error(
     id: &RackId,
+    _state: &mut Rack,
+    config: &RackConfig,
     cause: &str,
+    ctx: &mut StateHandlerContext<'_, RackStateHandlerContextObjects>,
 ) -> Result<StateHandlerOutcome<RackState>, StateHandlerError> {
+    if let Some(scope) = &config.maintenance_requested {
+        let activities_desc = if scope.activities.is_empty() {
+            "all".to_string()
+        } else {
+            scope
+                .activities
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        if scope.is_full_rack() {
+            tracing::info!(
+                "Rack {} on-demand maintenance requested from Error state (full rack, activities: [{}]), transitioning to Maintenance",
+                id,
+                activities_desc,
+            );
+        } else {
+            tracing::info!(
+                "Rack {} on-demand maintenance requested from Error state (partial: {} machines, {} switches, {} power shelves, activities: [{}]), transitioning to Maintenance",
+                id,
+                scope.machine_ids.len(),
+                scope.switch_ids.len(),
+                scope.power_shelf_ids.len(),
+                activities_desc,
+            );
+        }
+        let txn = ctx.services.db_pool.begin().await?;
+        return Ok(StateHandlerOutcome::transition(RackState::Maintenance {
+            maintenance_state: first_maintenance_state(scope),
+        })
+        .with_txn(txn));
+    }
+
     tracing::error!("Rack {} is in error state: {}", id, cause);
     Ok(StateHandlerOutcome::wait(format!(
         "rack in error state: {}",

--- a/crates/api/src/state_controller/rack/handler.rs
+++ b/crates/api/src/state_controller/rack/handler.rs
@@ -61,7 +61,7 @@ impl RackStateHandler {
                 handle_validating(id, state, validating_state, ctx).await
             }
             RackState::Ready => handle_ready(id, state, &config, ctx).await,
-            RackState::Error { cause } => handle_error(id, cause).await,
+            RackState::Error { cause } => handle_error(id, state, &config, cause, ctx).await,
             RackState::Deleting => handle_deleting().await,
         }
     }

--- a/crates/api/src/state_controller/rack/maintenance.rs
+++ b/crates/api/src/state_controller/rack/maintenance.rs
@@ -24,14 +24,14 @@ use db::{
     switch as db_switch,
 };
 use model::rack::{
-    FirmwareUpgradeDeviceStatus, FirmwareUpgradeState, Rack, RackFirmwareUpgradeState,
-    RackFirmwareUpgradeStatus, RackMaintenanceState, RackPowerState, RackState,
-    RackValidationState,
+    FirmwareUpgradeDeviceStatus, FirmwareUpgradeState, MaintenanceActivity, MaintenanceScope, Rack,
+    RackFirmwareUpgradeState, RackFirmwareUpgradeStatus, RackMaintenanceState, RackPowerState,
+    RackState, RackValidationState,
 };
 
 use crate::rack::firmware_update::{
-    build_firmware_update_batches, firmware_type_for_profile, load_rack_firmware_inventory,
-    submit_firmware_update_batches,
+    RackFirmwareInventory, build_firmware_update_batches, firmware_type_for_profile,
+    load_rack_firmware_inventory, submit_firmware_update_batches,
 };
 use crate::state_controller::rack::context::RackStateHandlerContextObjects;
 use crate::state_controller::rack::validating::strip_rv_labels;
@@ -108,24 +108,132 @@ async fn clear_rack_firmware_device_statuses(
 fn skip_firmware_upgrade_outcome(
     rack_id: &RackId,
     reason: impl AsRef<str>,
+    scope: &MaintenanceScope,
 ) -> StateHandlerOutcome<RackState> {
+    let next = next_state_after_firmware(scope);
     tracing::info!(
         rack_id = %rack_id,
         reason = %reason.as_ref(),
-        "Skipping rack firmware upgrade and advancing to ConfigureNmxCluster"
+        next_state = %next,
+        "Skipping rack firmware upgrade"
     );
     StateHandlerOutcome::transition(RackState::Maintenance {
-        maintenance_state: RackMaintenanceState::ConfigureNmxCluster,
+        maintenance_state: next,
     })
 }
 
-fn transition_to_rack_error(
+/// Transition the rack to `Error` from a maintenance handler failure.
+///
+/// Clears `maintenance_requested` (and persists it) so the `Error` handler
+/// does not immediately re-enter `Maintenance` and loop on the same failure.
+/// The user must explicitly request maintenance again to retry.
+async fn transition_to_rack_error(
     rack_id: &RackId,
+    state: &mut Rack,
     cause: impl Into<String>,
-) -> StateHandlerOutcome<RackState> {
+    ctx: &mut StateHandlerContext<'_, RackStateHandlerContextObjects>,
+) -> Result<StateHandlerOutcome<RackState>, StateHandlerError> {
     let cause = cause.into();
     tracing::warn!(rack_id = %rack_id, %cause, "Rack firmware upgrade failed before polling started");
-    StateHandlerOutcome::transition(RackState::Error { cause })
+    let outcome = StateHandlerOutcome::transition(RackState::Error { cause });
+    clear_maintenance_requested_on_error(rack_id, state, outcome, ctx).await
+}
+
+/// If `maintenance_requested` is set, clear it and persist the updated config
+/// using a fresh transaction attached to the outcome. Used when transitioning
+/// from `Maintenance` to `Error` to break the Error → Maintenance loop.
+async fn clear_maintenance_requested_on_error(
+    rack_id: &RackId,
+    state: &mut Rack,
+    outcome: StateHandlerOutcome<RackState>,
+    ctx: &mut StateHandlerContext<'_, RackStateHandlerContextObjects>,
+) -> Result<StateHandlerOutcome<RackState>, StateHandlerError> {
+    if state.config.maintenance_requested.is_none() {
+        return Ok(outcome);
+    }
+    state.config.maintenance_requested = None;
+    let mut txn = ctx.services.db_pool.begin().await?;
+    db_rack::update(txn.as_mut(), rack_id, &state.config).await?;
+    Ok(outcome.with_txn(txn))
+}
+
+/// Returns the next maintenance sub-state after firmware upgrade, skipping
+/// activities not requested in the scope.
+fn next_state_after_firmware(scope: &MaintenanceScope) -> RackMaintenanceState {
+    if scope.should_run(&MaintenanceActivity::ConfigureNmxCluster) {
+        RackMaintenanceState::ConfigureNmxCluster
+    } else {
+        next_state_after_configure(scope)
+    }
+}
+
+/// Returns the next maintenance sub-state after ConfigureNmxCluster, skipping
+/// activities not requested in the scope.
+fn next_state_after_configure(scope: &MaintenanceScope) -> RackMaintenanceState {
+    if scope.should_run(&MaintenanceActivity::PowerSequence) {
+        RackMaintenanceState::PowerSequence {
+            rack_power: RackPowerState::PoweringOn,
+        }
+    } else {
+        RackMaintenanceState::Completed
+    }
+}
+
+/// Returns the first maintenance sub-state to enter based on the requested
+/// activities in the scope. Called from Ready/Error when entering Maintenance.
+pub(crate) fn first_maintenance_state(scope: &MaintenanceScope) -> RackMaintenanceState {
+    if scope.should_run(&MaintenanceActivity::FirmwareUpgrade {
+        firmware_version: None,
+        components: vec![],
+    }) {
+        RackMaintenanceState::FirmwareUpgrade {
+            rack_firmware_upgrade: FirmwareUpgradeState::Start,
+        }
+    } else {
+        next_state_after_firmware(scope)
+    }
+}
+
+/// Filters a full-rack firmware inventory down to only the devices listed in
+/// the maintenance scope. When `scope.is_full_rack()` the inventory is
+/// returned unchanged.
+fn filter_inventory_by_scope(
+    mut inventory: RackFirmwareInventory,
+    scope: &MaintenanceScope,
+) -> RackFirmwareInventory {
+    if scope.is_full_rack() {
+        return inventory;
+    }
+
+    if scope.machine_ids.is_empty() {
+        inventory.machine_ids.clear();
+        inventory.machines.clear();
+    } else {
+        let allowed: std::collections::HashSet<_> = scope.machine_ids.iter().collect();
+        inventory.machine_ids.retain(|id| allowed.contains(id));
+        inventory.machines.retain(|d| {
+            match d.node_id.parse::<carbide_uuid::machine::MachineId>() {
+                Ok(ref id) => allowed.contains(id),
+                Err(_) => false,
+            }
+        });
+    }
+
+    if scope.switch_ids.is_empty() {
+        inventory.switch_ids.clear();
+        inventory.switches.clear();
+    } else {
+        let allowed: std::collections::HashSet<_> = scope.switch_ids.iter().collect();
+        inventory.switch_ids.retain(|id| allowed.contains(id));
+        inventory.switches.retain(
+            |d| match d.node_id.parse::<carbide_uuid::switch::SwitchId>() {
+                Ok(ref id) => allowed.contains(id),
+                Err(_) => false,
+            },
+        );
+    }
+
+    inventory
 }
 
 /// Submit compute and switch firmware-update batches to RMS and persist the
@@ -379,6 +487,13 @@ pub async fn handle_maintenance(
     maintenance_state: &RackMaintenanceState,
     ctx: &mut StateHandlerContext<'_, RackStateHandlerContextObjects>,
 ) -> Result<StateHandlerOutcome<RackState>, StateHandlerError> {
+    let scope = state
+        .config
+        .maintenance_requested
+        .clone()
+        .unwrap_or_default();
+    let scope = &scope;
+
     match maintenance_state {
         RackMaintenanceState::FirmwareUpgrade {
             rack_firmware_upgrade,
@@ -388,40 +503,72 @@ pub async fn handle_maintenance(
                     return Ok(skip_firmware_upgrade_outcome(
                         id,
                         "rack profile is missing or unknown",
+                        scope,
                     ));
                 };
                 let Some(rack_hardware_type) = profile.rack_hardware_type.as_ref() else {
                     return Ok(skip_firmware_upgrade_outcome(
                         id,
                         "rack capabilities do not define rack_hardware_type",
+                        scope,
                     ));
                 };
-                let default_firmware = match db_rack_firmware::find_default_by_rack_hardware_type(
-                    &ctx.services.db_pool,
-                    rack_hardware_type,
-                )
-                .await
-                {
-                    Ok(firmware) => firmware,
-                    Err(db::DatabaseError::NotFoundError { .. }) => {
-                        return Ok(skip_firmware_upgrade_outcome(
-                            id,
-                            format!(
-                                "no default rack firmware configured for hardware type '{}'",
-                                rack_hardware_type
-                            ),
-                        ));
+                let (requested_fw_version, requested_components) = scope
+                    .activities
+                    .iter()
+                    .find_map(|a| match a {
+                        MaintenanceActivity::FirmwareUpgrade {
+                            firmware_version,
+                            components,
+                        } => Some((firmware_version.as_deref(), components.as_slice())),
+                        _ => None,
+                    })
+                    .unwrap_or((None, &[]));
+
+                let firmware = if let Some(fw_version) = requested_fw_version {
+                    match db_rack_firmware::find_by_id(&ctx.services.db_pool, fw_version).await {
+                        Ok(fw) => fw,
+                        Err(db::DatabaseError::NotFoundError { .. }) => {
+                            return transition_to_rack_error(
+                                id,
+                                state,
+                                format!("requested rack firmware '{}' not found", fw_version),
+                                ctx,
+                            )
+                            .await;
+                        }
+                        Err(error) => return Err(error.into()),
                     }
-                    Err(error) => return Err(error.into()),
+                } else {
+                    match db_rack_firmware::find_default_by_rack_hardware_type(
+                        &ctx.services.db_pool,
+                        rack_hardware_type,
+                    )
+                    .await
+                    {
+                        Ok(fw) => fw,
+                        Err(db::DatabaseError::NotFoundError { .. }) => {
+                            return Ok(skip_firmware_upgrade_outcome(
+                                id,
+                                format!(
+                                    "no default rack firmware configured for hardware type '{}'",
+                                    rack_hardware_type
+                                ),
+                                scope,
+                            ));
+                        }
+                        Err(error) => return Err(error.into()),
+                    }
                 };
 
-                if !default_firmware.available {
+                if !firmware.available {
                     return Ok(skip_firmware_upgrade_outcome(
                         id,
                         format!(
-                            "default rack firmware '{}' exists but is not available",
-                            default_firmware.id
+                            "rack firmware '{}' exists but is not available",
+                            firmware.id
                         ),
+                        scope,
                     ));
                 }
 
@@ -437,38 +584,45 @@ pub async fn handle_maintenance(
                         error
                     ))
                 })?;
+                let inventory = filter_inventory_by_scope(inventory, scope);
                 let firmware_type = firmware_type_for_profile(profile);
                 let batches = match build_firmware_update_batches(
                     id,
-                    &default_firmware,
+                    &firmware,
                     firmware_type,
                     &inventory,
+                    requested_components,
                 ) {
                     Ok(batches) if batches.is_empty() => {
                         return Ok(skip_firmware_upgrade_outcome(
                             id,
                             "no compute or switch devices require rack firmware updates",
+                            scope,
                         ));
                     }
                     Ok(batches) => batches,
                     Err(error) => {
-                        return Ok(transition_to_rack_error(
+                        return transition_to_rack_error(
                             id,
+                            state,
                             format!(
-                                "failed to build firmware update requests for default firmware '{}': {}",
-                                default_firmware.id, error
+                                "failed to build firmware update requests for firmware '{}': {}",
+                                firmware.id, error
                             ),
-                        ));
+                            ctx,
+                        )
+                        .await;
                     }
                 };
                 let Some(rms_client) = ctx.services.rms_client.as_ref() else {
-                    return Ok(transition_to_rack_error(id, "RMS client not configured"));
+                    return transition_to_rack_error(id, state, "RMS client not configured", ctx)
+                        .await;
                 };
 
                 tracing::info!(
                     rack_id = %id,
                     rack_hardware_type = %rack_hardware_type,
-                    default_firmware_id = %default_firmware.id,
+                    firmware_id = %firmware.id,
                     firmware_type,
                     machine_count = inventory.machines.len(),
                     switch_count = inventory.switches.len(),
@@ -502,17 +656,16 @@ pub async fn handle_maintenance(
                 .with_txn(txn))
             }
             FirmwareUpgradeState::WaitForComplete => {
-                let current_job = match &state.firmware_upgrade_job {
-                    Some(j) => j,
-                    None => {
-                        return Ok(StateHandlerOutcome::wait(
-                            "firmware upgrade: no job recorded yet".into(),
-                        ));
-                    }
-                };
+                if state.firmware_upgrade_job.is_none() {
+                    return Ok(StateHandlerOutcome::wait(
+                        "firmware upgrade: no job recorded yet".into(),
+                    ));
+                }
                 let Some(rms_client) = ctx.services.rms_client.as_ref() else {
-                    return Ok(transition_to_rack_error(id, "RMS client not configured"));
+                    return transition_to_rack_error(id, state, "RMS client not configured", ctx)
+                        .await;
                 };
+                let current_job = state.firmware_upgrade_job.as_ref().unwrap();
                 let job = rms_get_firmware_upgrade_status(rms_client.as_ref(), current_job).await?;
 
                 let mut txn = ctx.services.db_pool.begin().await?;
@@ -621,6 +774,10 @@ pub async fn handle_maintenance(
                 if failed > 0 {
                     db_rack::update_firmware_upgrade_job(txn.as_mut(), id, Some(&job)).await?;
                     state.firmware_upgrade_job = Some(job);
+                    if state.config.maintenance_requested.is_some() {
+                        state.config.maintenance_requested = None;
+                        db_rack::update(txn.as_mut(), id, &state.config).await?;
+                    }
                     return Ok(StateHandlerOutcome::transition(RackState::Error {
                         cause: format!(
                             "firmware upgrade failed: {}/{} devices failed",
@@ -630,29 +787,31 @@ pub async fn handle_maintenance(
                     .with_txn(txn));
                 }
 
-                tracing::info!(
-                    "Rack {} firmware upgrade complete ({}/{} devices), advancing to ConfigureNmxCluster",
-                    id,
-                    completed,
-                    total
-                );
                 db_rack::update_firmware_upgrade_job(txn.as_mut(), id, None).await?;
                 state.firmware_upgrade_job = None;
+                let next = next_state_after_firmware(scope);
+                tracing::info!(
+                    rack_id = %id,
+                    completed,
+                    total,
+                    next_state = %next,
+                    "Rack firmware upgrade complete, advancing"
+                );
                 Ok(StateHandlerOutcome::transition(RackState::Maintenance {
-                    maintenance_state: RackMaintenanceState::ConfigureNmxCluster,
+                    maintenance_state: next,
                 })
                 .with_txn(txn))
             }
         },
         RackMaintenanceState::ConfigureNmxCluster => {
+            let next = next_state_after_configure(scope);
             tracing::info!(
-                "Rack {} ConfigureNmxCluster - stubbed, advancing to Completed",
-                id
+                rack_id = %id,
+                next_state = %next,
+                "ConfigureNmxCluster stubbed, advancing"
             );
             Ok(StateHandlerOutcome::transition(RackState::Maintenance {
-                maintenance_state: RackMaintenanceState::PowerSequence {
-                    rack_power: RackPowerState::PoweringOn,
-                },
+                maintenance_state: next,
             }))
         }
         RackMaintenanceState::PowerSequence { rack_power } => match rack_power {
@@ -678,13 +837,299 @@ pub async fn handle_maintenance(
         },
         RackMaintenanceState::Completed => {
             tracing::info!(
-                "Rack {} maintenance completed, clearing rv.* labels and entering Validating(Pending)",
-                id
+                rack_id = %id,
+                "Maintenance completed, clearing rv.* labels and entering Validating(Pending)"
             );
             clear_rv_labels(state, ctx).await?;
-            Ok(StateHandlerOutcome::transition(RackState::Validating {
+
+            let mut outcome = StateHandlerOutcome::transition(RackState::Validating {
                 validating_state: RackValidationState::Pending,
-            }))
+            });
+
+            if state.config.maintenance_requested.is_some() {
+                state.config.maintenance_requested = None;
+                let mut txn = ctx.services.db_pool.begin().await?;
+                db_rack::update(txn.as_mut(), id, &state.config).await?;
+                outcome = outcome.with_txn(txn);
+            }
+
+            Ok(outcome)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use model::rack::{
+        FirmwareUpgradeDeviceInfo, FirmwareUpgradeState, MaintenanceActivity, MaintenanceScope,
+        RackMaintenanceState, RackPowerState,
+    };
+
+    use super::{
+        filter_inventory_by_scope, first_maintenance_state, next_state_after_configure,
+        next_state_after_firmware,
+    };
+    use crate::rack::firmware_update::RackFirmwareInventory;
+
+    fn test_machine_id(byte: u8) -> carbide_uuid::machine::MachineId {
+        use carbide_uuid::machine::{MachineIdSource, MachineType};
+        carbide_uuid::machine::MachineId::new(MachineIdSource::Tpm, [byte; 32], MachineType::Host)
+    }
+
+    fn test_switch_id(byte: u8) -> carbide_uuid::switch::SwitchId {
+        use carbide_uuid::switch::{SwitchIdSource, SwitchType};
+        carbide_uuid::switch::SwitchId::new(SwitchIdSource::Tpm, [byte; 32], SwitchType::NvLink)
+    }
+
+    fn test_device_info(node_id: &str) -> FirmwareUpgradeDeviceInfo {
+        FirmwareUpgradeDeviceInfo {
+            node_id: node_id.to_string(),
+            mac: "AA:BB:CC:DD:EE:FF".to_string(),
+            bmc_ip: "10.0.0.1".to_string(),
+            bmc_username: "admin".to_string(),
+            bmc_password: "pass".to_string(),
+            os_mac: None,
+            os_ip: None,
+            os_username: None,
+            os_password: None,
+        }
+    }
+
+    // ── first_maintenance_state ─────────────────────────────────────────
+
+    #[test]
+    fn first_maintenance_state_all_activities() {
+        let scope = MaintenanceScope::default();
+        assert!(matches!(
+            first_maintenance_state(&scope),
+            RackMaintenanceState::FirmwareUpgrade {
+                rack_firmware_upgrade: FirmwareUpgradeState::Start,
+            }
+        ));
+    }
+
+    #[test]
+    fn first_maintenance_state_only_firmware() {
+        let scope = MaintenanceScope {
+            activities: vec![MaintenanceActivity::FirmwareUpgrade {
+                firmware_version: None,
+                components: vec![],
+            }],
+            ..Default::default()
+        };
+        assert!(matches!(
+            first_maintenance_state(&scope),
+            RackMaintenanceState::FirmwareUpgrade { .. }
+        ));
+    }
+
+    #[test]
+    fn first_maintenance_state_only_configure() {
+        let scope = MaintenanceScope {
+            activities: vec![MaintenanceActivity::ConfigureNmxCluster],
+            ..Default::default()
+        };
+        assert_eq!(
+            first_maintenance_state(&scope),
+            RackMaintenanceState::ConfigureNmxCluster,
+        );
+    }
+
+    #[test]
+    fn first_maintenance_state_only_power_sequence() {
+        let scope = MaintenanceScope {
+            activities: vec![MaintenanceActivity::PowerSequence],
+            ..Default::default()
+        };
+        assert!(matches!(
+            first_maintenance_state(&scope),
+            RackMaintenanceState::PowerSequence {
+                rack_power: RackPowerState::PoweringOn,
+            }
+        ));
+    }
+
+    #[test]
+    fn first_maintenance_state_configure_and_power() {
+        let scope = MaintenanceScope {
+            activities: vec![
+                MaintenanceActivity::ConfigureNmxCluster,
+                MaintenanceActivity::PowerSequence,
+            ],
+            ..Default::default()
+        };
+        assert_eq!(
+            first_maintenance_state(&scope),
+            RackMaintenanceState::ConfigureNmxCluster,
+        );
+    }
+
+    // ── next_state_after_firmware ───────────────────────────────────────
+
+    #[test]
+    fn after_firmware_all_activities_goes_to_configure() {
+        let scope = MaintenanceScope::default();
+        assert_eq!(
+            next_state_after_firmware(&scope),
+            RackMaintenanceState::ConfigureNmxCluster,
+        );
+    }
+
+    #[test]
+    fn after_firmware_without_configure_goes_to_power() {
+        let scope = MaintenanceScope {
+            activities: vec![
+                MaintenanceActivity::FirmwareUpgrade {
+                    firmware_version: None,
+                    components: vec![],
+                },
+                MaintenanceActivity::PowerSequence,
+            ],
+            ..Default::default()
+        };
+        assert!(matches!(
+            next_state_after_firmware(&scope),
+            RackMaintenanceState::PowerSequence { .. }
+        ));
+    }
+
+    #[test]
+    fn after_firmware_only_firmware_goes_to_completed() {
+        let scope = MaintenanceScope {
+            activities: vec![MaintenanceActivity::FirmwareUpgrade {
+                firmware_version: None,
+                components: vec![],
+            }],
+            ..Default::default()
+        };
+        assert_eq!(
+            next_state_after_firmware(&scope),
+            RackMaintenanceState::Completed,
+        );
+    }
+
+    // ── next_state_after_configure ──────────────────────────────────────
+
+    #[test]
+    fn after_configure_all_activities_goes_to_power() {
+        let scope = MaintenanceScope::default();
+        assert!(matches!(
+            next_state_after_configure(&scope),
+            RackMaintenanceState::PowerSequence {
+                rack_power: RackPowerState::PoweringOn,
+            }
+        ));
+    }
+
+    #[test]
+    fn after_configure_without_power_goes_to_completed() {
+        let scope = MaintenanceScope {
+            activities: vec![
+                MaintenanceActivity::FirmwareUpgrade {
+                    firmware_version: None,
+                    components: vec![],
+                },
+                MaintenanceActivity::ConfigureNmxCluster,
+            ],
+            ..Default::default()
+        };
+        assert_eq!(
+            next_state_after_configure(&scope),
+            RackMaintenanceState::Completed,
+        );
+    }
+
+    // ── filter_inventory_by_scope ───────────────────────────────────────
+
+    fn sample_inventory() -> RackFirmwareInventory {
+        let m1 = test_machine_id(1);
+        let m2 = test_machine_id(2);
+        let s1 = test_switch_id(1);
+        let s2 = test_switch_id(2);
+        RackFirmwareInventory {
+            machine_ids: vec![m1, m2],
+            switch_ids: vec![s1, s2],
+            machines: vec![
+                test_device_info(&m1.to_string()),
+                test_device_info(&m2.to_string()),
+            ],
+            switches: vec![
+                test_device_info(&s1.to_string()),
+                test_device_info(&s2.to_string()),
+            ],
+        }
+    }
+
+    #[test]
+    fn filter_inventory_full_rack_is_noop() {
+        let inventory = sample_inventory();
+        let scope = MaintenanceScope::default();
+        let filtered = filter_inventory_by_scope(inventory, &scope);
+        assert_eq!(filtered.machine_ids.len(), 2);
+        assert_eq!(filtered.switch_ids.len(), 2);
+        assert_eq!(filtered.machines.len(), 2);
+        assert_eq!(filtered.switches.len(), 2);
+    }
+
+    #[test]
+    fn filter_inventory_partial_machines_only() {
+        let inventory = sample_inventory();
+        let m1 = test_machine_id(1);
+        let scope = MaintenanceScope {
+            machine_ids: vec![m1],
+            ..Default::default()
+        };
+        let filtered = filter_inventory_by_scope(inventory, &scope);
+        assert_eq!(filtered.machine_ids, vec![m1]);
+        assert_eq!(filtered.machines.len(), 1);
+        assert_eq!(filtered.machines[0].node_id, m1.to_string());
+        assert!(filtered.switch_ids.is_empty());
+        assert!(filtered.switches.is_empty());
+    }
+
+    #[test]
+    fn filter_inventory_partial_switches_only() {
+        let inventory = sample_inventory();
+        let s2 = test_switch_id(2);
+        let scope = MaintenanceScope {
+            switch_ids: vec![s2],
+            ..Default::default()
+        };
+        let filtered = filter_inventory_by_scope(inventory, &scope);
+        assert!(filtered.machine_ids.is_empty());
+        assert!(filtered.machines.is_empty());
+        assert_eq!(filtered.switch_ids, vec![s2]);
+        assert_eq!(filtered.switches.len(), 1);
+        assert_eq!(filtered.switches[0].node_id, s2.to_string());
+    }
+
+    #[test]
+    fn filter_inventory_partial_both() {
+        let inventory = sample_inventory();
+        let m2 = test_machine_id(2);
+        let s1 = test_switch_id(1);
+        let scope = MaintenanceScope {
+            machine_ids: vec![m2],
+            switch_ids: vec![s1],
+            ..Default::default()
+        };
+        let filtered = filter_inventory_by_scope(inventory, &scope);
+        assert_eq!(filtered.machine_ids, vec![m2]);
+        assert_eq!(filtered.machines.len(), 1);
+        assert_eq!(filtered.switch_ids, vec![s1]);
+        assert_eq!(filtered.switches.len(), 1);
+    }
+
+    #[test]
+    fn filter_inventory_unknown_id_excluded() {
+        let inventory = sample_inventory();
+        let unknown = test_machine_id(99);
+        let scope = MaintenanceScope {
+            machine_ids: vec![unknown],
+            ..Default::default()
+        };
+        let filtered = filter_inventory_by_scope(inventory, &scope);
+        assert!(filtered.machine_ids.is_empty());
+        assert!(filtered.machines.is_empty());
     }
 }

--- a/crates/api/src/state_controller/rack/ready.rs
+++ b/crates/api/src/state_controller/rack/ready.rs
@@ -22,6 +22,7 @@ use db::rack as db_rack;
 use model::rack::{FirmwareUpgradeState, Rack, RackConfig, RackMaintenanceState, RackState};
 
 use crate::state_controller::rack::context::RackStateHandlerContextObjects;
+use crate::state_controller::rack::maintenance::first_maintenance_state;
 use crate::state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
@@ -49,6 +50,7 @@ pub async fn handle_ready(
             id
         );
         state.config.reprovision_requested = false;
+        state.config.maintenance_requested = None;
         let mut txn = ctx.services.db_pool.begin().await?;
         db_rack::update(txn.as_mut(), id, &state.config).await?;
         return Ok(StateHandlerOutcome::transition(RackState::Maintenance {
@@ -59,5 +61,43 @@ pub async fn handle_ready(
         .with_txn(txn));
     }
 
-    Ok(StateHandlerOutcome::do_nothing())
+    if let Some(scope) = &config.maintenance_requested {
+        let activities_desc = if scope.activities.is_empty() {
+            "all".to_string()
+        } else {
+            scope
+                .activities
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        if scope.is_full_rack() {
+            tracing::info!(
+                "Rack {} on-demand maintenance requested (full rack, activities: [{}]), transitioning to Maintenance",
+                id,
+                activities_desc,
+            );
+        } else {
+            tracing::info!(
+                "Rack {} on-demand maintenance requested (partial: {} machines, {} switches, {} power shelves, activities: [{}]), transitioning to Maintenance",
+                id,
+                scope.machine_ids.len(),
+                scope.switch_ids.len(),
+                scope.power_shelf_ids.len(),
+                activities_desc,
+            );
+        }
+        // Leave maintenance_requested set; the maintenance handler reads the
+        // scope to decide which activities to run and clears it on Completed.
+        let txn = ctx.services.db_pool.begin().await?;
+        return Ok(StateHandlerOutcome::transition(RackState::Maintenance {
+            maintenance_state: first_maintenance_state(scope),
+        })
+        .with_txn(txn));
+    }
+
+    Ok(StateHandlerOutcome::wait(
+        "rack is ready, no maintenance requested".into(),
+    ))
 }

--- a/crates/component-manager/src/state_controller/nv_switch.rs
+++ b/crates/component-manager/src/state_controller/nv_switch.rs
@@ -183,7 +183,10 @@ impl NvSwitchManager for StateControllerNvSwitch {
         };
         self.write_scope(
             endpoints,
-            MaintenanceActivity::FirmwareUpgrade { firmware_version },
+            MaintenanceActivity::FirmwareUpgrade {
+                firmware_version,
+                components: vec![],
+            },
         )
         .await
     }
@@ -343,7 +346,9 @@ mod tests {
             .expect("scope");
         assert_eq!(scope.switch_ids, vec![sw1]);
         match &scope.activities[0] {
-            MaintenanceActivity::FirmwareUpgrade { firmware_version } => {
+            MaintenanceActivity::FirmwareUpgrade {
+                firmware_version, ..
+            } => {
                 assert_eq!(firmware_version.as_deref(), Some("nvos-3.0"));
             }
             other => panic!("expected FirmwareUpgrade activity, got {other:?}"),

--- a/crates/component-manager/src/state_controller/power_shelf.rs
+++ b/crates/component-manager/src/state_controller/power_shelf.rs
@@ -188,7 +188,10 @@ impl PowerShelfManager for StateControllerPowerShelf {
         };
         self.write_scope(
             endpoints,
-            MaintenanceActivity::FirmwareUpgrade { firmware_version },
+            MaintenanceActivity::FirmwareUpgrade {
+                firmware_version,
+                components: vec![],
+            },
         )
         .await
     }
@@ -364,7 +367,9 @@ mod tests {
             .expect("scope");
         assert_eq!(scope.power_shelf_ids, vec![ps1]);
         match &scope.activities[0] {
-            MaintenanceActivity::FirmwareUpgrade { firmware_version } => {
+            MaintenanceActivity::FirmwareUpgrade {
+                firmware_version, ..
+            } => {
                 assert_eq!(firmware_version.as_deref(), Some("fw-2.0.0"));
             }
             other => panic!("expected FirmwareUpgrade activity, got {other:?}"),
@@ -385,7 +390,9 @@ mod tests {
             .await
             .expect("scope");
         match &scope.activities[0] {
-            MaintenanceActivity::FirmwareUpgrade { firmware_version } => {
+            MaintenanceActivity::FirmwareUpgrade {
+                firmware_version, ..
+            } => {
                 assert!(firmware_version.is_none());
             }
             other => panic!("expected FirmwareUpgrade activity, got {other:?}"),

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -629,6 +629,9 @@ service Forge {
   // On demand Machine-Validation
   rpc OnDemandMachineValidation(MachineValidationOnDemandRequest) returns (MachineValidationOnDemandResponse);
 
+  // On-demand rack maintenance (full rack or partial)
+  rpc OnDemandRackMaintenance(RackMaintenanceOnDemandRequest) returns (RackMaintenanceOnDemandResponse);
+
   // TPM CA certs Management
   //rpc TpmDeleteCaCert(TpmCaCertDetails) returns (google.protobuf.Empty);
   rpc TpmAddCaCert(TpmCaCert) returns (TpmCaAddedCaStatus);
@@ -5489,6 +5492,48 @@ message MachineValidationOnDemandRequest {
 
 message MachineValidationOnDemandResponse {
   common.UUID validation_id = 1;
+}
+
+message FirmwareUpgradeActivity {
+  // Target firmware version. When empty, RMS uses its default/latest version.
+  string firmware_version = 1;
+  // Firmware components to update (e.g. "BMC", "CPLD", "BIOS").
+  // When empty, all components are updated.
+  repeated string components = 2;
+}
+
+message ConfigureNmxClusterActivity {
+  // Per-activity configuration (extend as needed).
+}
+
+message PowerSequenceActivity {
+  // Per-activity configuration (extend as needed).
+}
+
+// A single maintenance activity with its per-activity configuration.
+// The oneof discriminant identifies the activity type.
+message MaintenanceActivityConfig {
+  oneof activity {
+    FirmwareUpgradeActivity firmware_upgrade = 1;
+    ConfigureNmxClusterActivity configure_nmx_cluster = 2;
+    PowerSequenceActivity power_sequence = 3;
+  }
+}
+
+// On-demand rack maintenance – supports full-rack or partial (subset of
+// machines, switches, power shelves).  When all device-id lists are empty
+// the full rack is maintained.
+message RackMaintenanceOnDemandRequest {
+  common.RackId rack_id = 1;
+  repeated string machine_ids = 2;
+  repeated string switch_ids = 3;
+  repeated string power_shelf_ids = 4;
+  // Which maintenance activities to run. Empty means all activities.
+  repeated MaintenanceActivityConfig activities = 5;
+}
+
+message RackMaintenanceOnDemandResponse {
+  // RackMaintenanceOnDemandResponse 
 }
 
 message AdminPowerControlRequest {


### PR DESCRIPTION
## Description

On-demand maintenance allows an operator to trigger a maintenance cycle on a rack i that is in the **Ready** or **Error** state. It supports both **full-rack** and **partial-rack** scoping — the caller can optionally specify which machines, switches, or power shelves to maintain.


## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

