### PR TITLE
feat: extend AddressSelectionStrategy to support StaticAddress

### DIFF
--- a/crates/api-db/migrations/20260403072500_machine_interface_addresses_allocation_type.sql
+++ b/crates/api-db/migrations/20260403072500_machine_interface_addresses_allocation_type.sql
@@ -1,0 +1,5 @@
+-- Add allocation_type to distinguish DHCP-allocated addresses from
+-- statically assigned ones. This allows for coexistence and cooperation
+-- between DHCP-managed and static allocations.
+ALTER TABLE machine_interface_addresses
+    ADD COLUMN allocation_type TEXT NOT NULL DEFAULT 'dhcp';

--- a/crates/api-db/src/ip_allocator.rs
+++ b/crates/api-db/src/ip_allocator.rs
@@ -217,6 +217,18 @@ impl Iterator for IpAllocator {
                 }
             }
             AddressSelectionStrategy::NextAvailablePrefix(len) => len,
+            AddressSelectionStrategy::StaticAddress(_) => {
+                // Static addresses don't use the allocator at all, and should
+                // have gone through create_static_path. If it makes it through
+                // into here, yell. Fwiw, this is a benefit to AddressSelectionStrategy
+                // in general, we can catch potential bugs like this.
+                return Some((
+                    segment_prefix.id,
+                    Err(DatabaseError::internal(
+                        "StaticAddress cannot be allocated by the DHCP allocator".to_string(),
+                    )),
+                ));
+            }
         };
 
         // And now get the next available network prefix of prefix_length

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -18,6 +18,7 @@
 use std::net::IpAddr;
 use std::str::FromStr;
 
+use carbide_network::ip::IdentifyAddressFamily;
 use carbide_uuid::domain::DomainId;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use carbide_uuid::network::{NetworkPrefixId, NetworkSegmentId};
@@ -28,6 +29,7 @@ use ipnetwork::IpNetwork;
 use lazy_static::lazy_static;
 use mac_address::MacAddress;
 use model::address_selection_strategy::AddressSelectionStrategy;
+use model::allocation_type::AllocationType;
 use model::expected_machine::ExpectedHostNic;
 use model::hardware_info::HardwareInfo;
 use model::machine::MachineInterfaceSnapshot;
@@ -419,21 +421,24 @@ pub async fn create(
     primary_interface: bool,
     address_strategy: AddressSelectionStrategy,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
-    if matches!(
-        address_strategy,
-        AddressSelectionStrategy::NextAvailableIp | AddressSelectionStrategy::Automatic
-    ) {
-        create_fast_path(txn, segment, macaddr, domain_id, primary_interface).await
-    } else {
-        create_slow_path(
-            txn,
-            segment,
-            macaddr,
-            domain_id,
-            primary_interface,
-            address_strategy,
-        )
-        .await
+    match address_strategy {
+        AddressSelectionStrategy::NextAvailableIp | AddressSelectionStrategy::Automatic => {
+            create_fast_path(txn, segment, macaddr, domain_id, primary_interface).await
+        }
+        AddressSelectionStrategy::StaticAddress(addr) => {
+            create_static_path(txn, segment, macaddr, domain_id, primary_interface, addr).await
+        }
+        AddressSelectionStrategy::NextAvailablePrefix(_) => {
+            create_slow_path(
+                txn,
+                segment,
+                macaddr,
+                domain_id,
+                primary_interface,
+                address_strategy,
+            )
+            .await
+        }
     }
 }
 
@@ -492,6 +497,34 @@ async fn create_fast_path(
         "unable to create machine interface in fast path for segment {} after {} retries",
         segment.id, FAST_PATH_MAX_RETRIES
     )))
+}
+
+/// Create a machine interface with a specific static IP address.
+/// A perfect compliment to create_fast_path and create_slow_path.
+async fn create_static_path(
+    txn: &mut PgConnection,
+    segment: &NetworkSegment,
+    macaddr: &MacAddress,
+    domain_id: Option<DomainId>,
+    primary_interface: bool,
+    address: IpAddr,
+) -> DatabaseResult<MachineInterfaceSnapshot> {
+    let interface_id = create_inner(
+        txn,
+        segment,
+        macaddr,
+        domain_id,
+        primary_interface,
+        &[address],
+        AllocationType::Static,
+    )
+    .await?;
+
+    Ok(
+        find_by(txn, ObjectColumnFilter::One(IdColumn, &interface_id))
+            .await?
+            .remove(0),
+    )
 }
 
 /// Create a machine interface and allocate IP addresses, slow path for whole-prefix allocation.
@@ -554,6 +587,7 @@ pub async fn create_slow_path(
         domain_id,
         primary_interface,
         &allocated_addresses,
+        AllocationType::Dhcp,
     )
     .await?;
     inner_txn.commit().await?;
@@ -586,6 +620,7 @@ async fn try_create_fast_path(
         domain_id,
         primary_interface,
         &allocated_addresses,
+        AllocationType::Dhcp,
     )
     .await
 }
@@ -612,6 +647,7 @@ async fn create_inner(
     domain_id: Option<DomainId>,
     primary_interface: bool,
     allocated_addresses: &[IpAddr],
+    allocation_type: AllocationType,
 ) -> DatabaseResult<MachineInterfaceId> {
     // Prefer IPv4 for hostname (more human-readable), fall back to
     // an IPv6-derived hostname otherwise.
@@ -643,7 +679,7 @@ async fn create_inner(
     .await?;
 
     for address in allocated_addresses {
-        insert_machine_interface_address(txn, &interface_id, address).await?;
+        insert_machine_interface_address(txn, &interface_id, address, allocation_type).await?;
     }
 
     Ok(interface_id)
@@ -865,11 +901,13 @@ async fn insert_machine_interface_address(
     txn: &mut PgConnection,
     interface_id: &MachineInterfaceId,
     address: &IpAddr,
+    allocation_type: model::allocation_type::AllocationType,
 ) -> DatabaseResult<()> {
-    let query = "INSERT INTO machine_interface_addresses (interface_id, address) VALUES ($1::uuid, $2::inet)";
+    let query = "INSERT INTO machine_interface_addresses (interface_id, address, allocation_type) VALUES ($1::uuid, $2::inet, $3)";
     sqlx::query(query)
         .bind(interface_id)
         .bind(address)
+        .bind(allocation_type)
         .execute(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -1087,22 +1125,37 @@ pub async fn find_by_machine_and_segment(
         .map(|interfaces| interfaces.into_iter().collect())
 }
 
-/// Allocate new IP addresses for an existing interface that
-/// has lost its addresses (e.g. after a lease expiration, because
-/// maybe it was offline for a while). Uses the same allocation
-/// logic as initial interface creation.
+/// Allocate new DHCP-based IP addresses for a specific address family
+/// on an existing interface that has lost its addresses (e.g. after a
+/// lease expiration, because maybe it was offline for a while, etc --
+/// basically anything that caused a lease expiration to be cleaned up,
+/// probably from ExpireDhcpLease being called). This uses the same
+/// allocation logic that we use for allocating initial addresses, and
+/// only allocates from prefixes matching the requested family (IPv4
+/// or IPv6).
 #[allow(txn_held_across_await)]
-pub async fn allocate_addresses(
+pub async fn allocate_address_for_family(
     txn: &mut PgConnection,
     interface_id: MachineInterfaceId,
     segment: &NetworkSegment,
+    family: carbide_network::ip::IpAddressFamily,
 ) -> DatabaseResult<()> {
     let mut fast_txn = Transaction::begin_inner(txn).await?;
     lock_network_segment_shared(&mut fast_txn, segment).await?;
 
-    let addresses = allocate_addresses_from_segment(&mut fast_txn, segment).await?;
-    for address in &addresses {
-        insert_machine_interface_address(fast_txn.as_pgconn(), &interface_id, address).await?;
+    for prefix in segment
+        .prefixes
+        .iter()
+        .filter(|p| p.prefix.is_address_family(family))
+    {
+        let address = allocate_next_ip_with_retry(&mut fast_txn, segment, prefix).await?;
+        insert_machine_interface_address(
+            fast_txn.as_pgconn(),
+            &interface_id,
+            &address,
+            AllocationType::Dhcp,
+        )
+        .await?;
     }
 
     fast_txn.commit().await?;

--- a/crates/api-db/src/machine_interface_address.rs
+++ b/crates/api-db/src/machine_interface_address.rs
@@ -16,6 +16,7 @@
  */
 use std::net::IpAddr;
 
+use carbide_network::ip::IpAddressFamily;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use model::network_segment::NetworkSegmentType;
 use sqlx::{FromRow, PgConnection};
@@ -71,24 +72,42 @@ pub async fn delete(
         .map_err(|e| DatabaseError::query(query, e))
 }
 
-/// Delete the IP address allocation for the given address. Returns true if
-/// an allocation was found and deleted, false if no allocation existed.
-///
-/// Note: This intentionally does NOT delete the parent machine_interface.
-/// The interface may be associated with a machine, and deleting it would
-/// break the discovered machine linkage. We leave the interface, and let
-/// the DHCP discover flow handle re-allocating an address to any existing
-/// interface that doesn't have one (due to expiration or otherwise).
+/// Delete an address allocation of the given type. Returns true if a
+/// matching allocation was found and deleted, false otherwise.
 pub async fn delete_by_address(
     txn: &mut PgConnection,
     address: IpAddr,
+    allocation_type: model::allocation_type::AllocationType,
 ) -> Result<bool, DatabaseError> {
-    let query = "DELETE FROM machine_interface_addresses WHERE address = $1::inet";
+    let query =
+        "DELETE FROM machine_interface_addresses WHERE address = $1::inet AND allocation_type = $2";
     sqlx::query(query)
         .bind(address)
+        .bind(allocation_type)
         .execute(txn)
         .await
         .map(|r| r.rows_affected() > 0)
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Check whether an interface has any address assigned for the
+/// given address family.
+///
+/// This is used by the DHCPDISCOVER flow to decide whether to
+/// re-allocate after a lease expiration. If the interface still
+/// has an address for the family (static or DHCP), no re-allocation
+// is needed.
+pub async fn has_address_for_family(
+    txn: &mut PgConnection,
+    interface_id: MachineInterfaceId,
+    family: IpAddressFamily,
+) -> Result<bool, DatabaseError> {
+    let query = "SELECT EXISTS(SELECT 1 FROM machine_interface_addresses WHERE interface_id = $1 AND family(address) = $2)";
+    sqlx::query_scalar(query)
+        .bind(interface_id)
+        .bind(family.pg_family())
+        .fetch_one(txn)
+        .await
         .map_err(|e| DatabaseError::query(query, e))
 }
 

--- a/crates/api-model/src/address_selection_strategy.rs
+++ b/crates/api-model/src/address_selection_strategy.rs
@@ -28,4 +28,14 @@ pub enum AddressSelectionStrategy {
     /// For example, `NextAvailablePrefix(30)` allocates a /30 block
     /// (used by FNN to allocate a 4-address subnet per DPU).
     NextAvailablePrefix(u8),
+
+    /// Assign a specific IP address to the interface.
+    ///
+    /// This IP address can either be a "reservation" within an
+    /// existing carbide-dhcp managed network (and allows you
+    /// to pin your device to an IP within a managed network),
+    /// or it can be outside of the Carbide-managed networks
+    /// entirely, allowing you to effectively BYO DHCP for
+    /// underlay interfaces.
+    StaticAddress(std::net::IpAddr),
 }

--- a/crates/api-model/src/allocation_type.rs
+++ b/crates/api-model/src/allocation_type.rs
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use serde::{Deserialize, Serialize};
+
+use crate::address_selection_strategy::AddressSelectionStrategy;
+
+/// Distinguishes how an IP address was allocated to a machine interface,
+/// and are generally derived from the AddressSelectionStrategy used.
+///
+/// - `Dhcp`: These addresses allocated and managed by carbide-dhcp,
+///   or a DHCP service that integrates directly with carbide-api.
+/// - `Static`: These addresses are assigned and managed explicitly by
+///   an operator or operator-provided configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, sqlx::Type, Serialize, Deserialize)]
+#[sqlx(type_name = "text", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum AllocationType {
+    Dhcp,
+    Static,
+}
+
+impl From<AddressSelectionStrategy> for AllocationType {
+    fn from(strategy: AddressSelectionStrategy) -> Self {
+        match strategy {
+            AddressSelectionStrategy::NextAvailableIp => AllocationType::Dhcp,
+            AddressSelectionStrategy::Automatic => AllocationType::Dhcp,
+            AddressSelectionStrategy::NextAvailablePrefix(_) => AllocationType::Dhcp,
+            AddressSelectionStrategy::StaticAddress(_) => AllocationType::Static,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use super::*;
+
+    #[test]
+    fn next_available_ip_is_dhcp() {
+        assert_eq!(
+            AllocationType::from(AddressSelectionStrategy::NextAvailableIp),
+            AllocationType::Dhcp,
+        );
+    }
+
+    #[test]
+    fn automatic_is_dhcp() {
+        assert_eq!(
+            AllocationType::from(AddressSelectionStrategy::Automatic),
+            AllocationType::Dhcp,
+        );
+    }
+
+    #[test]
+    fn next_available_prefix_is_dhcp() {
+        assert_eq!(
+            AllocationType::from(AddressSelectionStrategy::NextAvailablePrefix(30)),
+            AllocationType::Dhcp,
+        );
+    }
+
+    #[test]
+    fn static_address_is_static() {
+        assert_eq!(
+            AllocationType::from(AddressSelectionStrategy::StaticAddress(
+                Ipv4Addr::new(10, 0, 0, 1).into()
+            )),
+            AllocationType::Static,
+        );
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let dhcp: AllocationType = serde_json::from_str(r#""dhcp""#).unwrap();
+        assert_eq!(dhcp, AllocationType::Dhcp);
+
+        let static_: AllocationType = serde_json::from_str(r#""static""#).unwrap();
+        assert_eq!(static_, AllocationType::Static);
+
+        assert_eq!(
+            serde_json::to_string(&AllocationType::Dhcp).unwrap(),
+            r#""dhcp""#
+        );
+        assert_eq!(
+            serde_json::to_string(&AllocationType::Static).unwrap(),
+            r#""static""#
+        );
+    }
+}

--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -34,6 +34,7 @@ use mac_address::MacAddress;
 use serde::{Deserialize, Serialize};
 
 pub mod address_selection_strategy;
+pub mod allocation_type;
 pub mod attestation;
 pub mod bmc_info;
 pub mod compute_allocation;

--- a/crates/api/src/dhcp/discover.rs
+++ b/crates/api/src/dhcp/discover.rs
@@ -257,13 +257,22 @@ pub async fn discover_dhcp(
     )
     .await?;
 
-    // If the interface exists but has no addresses (e.g., after a lease
-    // expiration cleaned up the allocation), re-allocate from the segment.
-    if machine_interface.addresses.is_empty() {
+    // If the interface has no address for the requested address family
+    // (e.g., after a lease expiration cleaned up the DHCP allocation,
+    // or this is a new address family for a dual-stack interface),
+    // re-allocate from the segment.
+    if !db::machine_interface_address::has_address_for_family(
+        &mut txn,
+        machine_interface.id,
+        address_family,
+    )
+    .await?
+    {
         tracing::info!(
             interface_id = %machine_interface.id,
             %parsed_mac,
-            "Interface has no addresses, re-allocating from segment"
+            ?address_family,
+            "Interface missing address for family, re-allocating from segment"
         );
         let segment = db::network_segment::for_relay(&mut txn, parsed_relay)
             .await?
@@ -272,7 +281,13 @@ pub async fn discover_dhcp(
                     "No network segment defined for relay address: {parsed_relay}"
                 ))
             })?;
-        db::machine_interface::allocate_addresses(&mut txn, machine_interface.id, &segment).await?;
+        db::machine_interface::allocate_address_for_family(
+            &mut txn,
+            machine_interface.id,
+            &segment,
+            address_family,
+        )
+        .await?;
     }
 
     if let Some(machine_id) = machine_interface.machine_id {

--- a/crates/api/src/dhcp/expire.rs
+++ b/crates/api/src/dhcp/expire.rs
@@ -30,7 +30,12 @@ pub async fn expire_dhcp_lease(
     let ip_address: IpAddr = request.into_inner().ip_address.parse()?;
 
     let mut txn = api.txn_begin().await?;
-    let deleted = db::machine_interface_address::delete_by_address(&mut txn, ip_address).await?;
+    let deleted = db::machine_interface_address::delete_by_address(
+        &mut txn,
+        ip_address,
+        model::allocation_type::AllocationType::Dhcp,
+    )
+    .await?;
     txn.commit().await?;
 
     let status = if deleted {

--- a/crates/api/src/tests/dhcp_lease_expiration.rs
+++ b/crates/api/src/tests/dhcp_lease_expiration.rs
@@ -15,10 +15,12 @@
  * limitations under the License.
  */
 
+use std::net::IpAddr;
 use std::str::FromStr;
 
 use common::api_fixtures::{FIXTURE_DHCP_RELAY_ADDRESS, create_test_env};
 use mac_address::MacAddress;
+use model::address_selection_strategy::AddressSelectionStrategy;
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{ExpireDhcpLeaseRequest, ExpireDhcpLeaseStatus};
 use tonic::Request;
@@ -180,6 +182,113 @@ async fn test_discover_reallocates_after_expiration(
     // Verify the interface is be the same one (preserved across expiration).
     assert_eq!(
         response1.machine_interface_id, response2.machine_interface_id,
+        "should reuse the same interface"
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_expire_does_not_delete_static_allocation(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let static_ip: IpAddr = "192.0.2.200".parse().unwrap();
+
+    // Create an interface with a static IP via the proper create path.
+    let mut txn = env.pool.begin().await?;
+    let segment = db::network_segment::admin(&mut txn).await?;
+    let interface = db::machine_interface::create(
+        &mut txn,
+        &segment,
+        &MacAddress::from_str("aa:bb:cc:dd:ee:08").unwrap(),
+        segment.subdomain_id,
+        true,
+        AddressSelectionStrategy::StaticAddress(static_ip),
+    )
+    .await?;
+    txn.commit().await?;
+
+    assert_eq!(interface.addresses[0], static_ip);
+
+    // Try to expire it -- should NOT delete because it's static.
+    let response = env
+        .api
+        .expire_dhcp_lease(Request::new(ExpireDhcpLeaseRequest {
+            ip_address: static_ip.to_string(),
+        }))
+        .await?
+        .into_inner();
+    assert_eq!(
+        response.status(),
+        ExpireDhcpLeaseStatus::NotFound,
+        "static allocation should not be expired"
+    );
+
+    // Verify the address still exists.
+    let mut txn = env.pool.begin().await?;
+    let addr =
+        db::machine_interface_address::find_ipv4_for_interface(&mut txn, interface.id).await?;
+    assert_eq!(addr.address, static_ip, "static address should still exist");
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_static_address_survives_expiration_and_rediscover(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let mac = MacAddress::from_str("aa:bb:cc:dd:ee:09").unwrap();
+    let static_ip: IpAddr = "192.0.2.201".parse().unwrap();
+
+    // Create an interface with a static IP via the proper create path.
+    let mut txn = env.pool.begin().await?;
+    let segment = db::network_segment::admin(&mut txn).await?;
+    let interface = db::machine_interface::create(
+        &mut txn,
+        &segment,
+        &mac,
+        segment.subdomain_id,
+        true,
+        AddressSelectionStrategy::StaticAddress(static_ip),
+    )
+    .await?;
+    txn.commit().await?;
+
+    assert_eq!(interface.addresses[0], static_ip);
+
+    // Device goes offline, Kea expires the lease.
+    let expire_response = env
+        .api
+        .expire_dhcp_lease(Request::new(ExpireDhcpLeaseRequest {
+            ip_address: static_ip.to_string(),
+        }))
+        .await?
+        .into_inner();
+    assert_eq!(
+        expire_response.status(),
+        ExpireDhcpLeaseStatus::NotFound,
+        "static address should not be expired"
+    );
+
+    // Device comes back online, sends DHCP discover.
+    let mac_str = mac.to_string();
+    let discover_response = env
+        .api
+        .discover_dhcp(DhcpDiscovery::builder(&mac_str, FIXTURE_DHCP_RELAY_ADDRESS).tonic_request())
+        .await?
+        .into_inner();
+
+    // Should get the same static IP back, on the same interface.
+    assert_eq!(
+        discover_response.address,
+        static_ip.to_string(),
+        "should get the same static IP back"
+    );
+    assert_eq!(
+        discover_response.machine_interface_id.unwrap(),
+        interface.id,
         "should reuse the same interface"
     );
 


### PR DESCRIPTION
## Description

There is a bunch of discussion going on right now about needing Carbide to support static IPs for various reasons (including https://github.com/NVIDIA/ncx-infra-controller-core/issues/644 and https://github.com/NVIDIA/ncx-infra-controller-core/issues/790). Most of that discussion is for lab/testing environments. We have internal and external customers who want to be able to test pieces of provisioning and management with Carbide, but their host BMCs are connected and configured in a way that it's very, very difficult to get them to get addresses allocated by `carbide-dhcp`. The thought is, "*why can't I just point `site-explorer` at my existing component's IP?*"

I do understand the desire. I'm sure if I was a new customer trying it out, I'd have my devices connected to my network, and I'd go, "sooo how do I tell Carbide to provision this stuff?" ...and then I'd come to the realization I'd need to do a bunch of network tweaks (config + potentially recabling work) to get my devices to hit `carbide-dhcp`.

So, I'm introducing support for generic static address allocation in the backend plumbing. **I have a follow-up PR that's ready that includes `admin-cli` -> API calls for doing `admin-cli machine-interface-address <assign, delete, show>` support, but I want to make sure the backend plumbing is done independently of that first.** The goal is to get this dialed in, to give other people something very primitive to build on that ties into our existing allocation/management flows.

The idea is, we already have `AddressSelectionStrategy` as how we determine how to `create(..., strategy)` a new IP address mapping for an interface, so at the ground level, we now have `AddressSelectionStrategy::StaticAddress(addr)`, which allows us to continue to leverage `create(..., strategy)` without changing the interface at all.

From there, within `create(..)`, we introduce a new `create_static_path` that accompanies the existing `create_fast_path` and `create_slow_path` amongst the match arms. It fits in nicely!

And then, when we go to create over any "path", the underlying `machine_interface_addresses` entry now includes a new `AllocationType` enum, which has a `From` implementation off of its parent `AddressSelectionStrategy`, allowing us to annotate the `machine_interface_addresses` entry as either `AllocationType::Dhcp` or `AllocationType::Static` -- this gives us some primitive information to allow both address types to coexist. For example, for a given `machine_interface`, we can actually have a static IPv4 assignment AND a DHCP-based IPv6 assignment. Would we? Who knows. But it supports it just fine.

What's also nice is, this supports a couple of things:
- Static assignments *OUTSIDE* of Carbide-managed networks -- i.e. BYO DHCP.
- Static reservations *INSIDE* of Carbide-managed networks -- i.e. you are using `carbide-dhcp` but want to statically allocate an address (and it plays nicely with the existing `IpAllocator`).

From there, we have `delete(..)`, which doesn't change much -- we just now check to make sure the `AllocationType` you expect is the `AllocationType` that's configured. This allows it so `ExpireDhcpLease` calls can't accidentally delete a static allocation.

That part was all pretty easy. The "hard" part, tbh, is making sure DHCP vs. static allocations can all cooperate with eachother, so this makes sure:

- DHCP lease expirations skip static allocations (the thing I mentioned above re: `delete(...)`.
- Re-allocation after expiration is family-aware: when a DHCP address expires and the device re-DHCPs, the discover flow checks a new `has_address_for_family(interface_id, address_family)`, where:
  - It only looks at DHCP allocations -- if the interface has a static IPv4 and a DHCP IPv6, it only looks at v6 and renews that one.
  - If the interface has a static IPv4 and an IPv4 DHCP request comes in, it sees "already has IPv4" and returns the static allocation (this allows static reservations with managed networks to be a thing).
- Re-allocation only allocates for the missing family. where `allocate_address_for_family` filters prefixes by address family, so it won't try to insert an IPv4 when one already exists (which would violate DB constraints anyway).
- The allocator "naturally" excludes static IPs already. The DHCP-specific "fast-path" allocator finds free IPs by querying `machine_interface_addresses` and skipping IPs that already exist. Once a static IP is in that table, no future DHCP allocation will hand it out — also just works for free.

Added a mix of unit and integration tests for a number of things, including:
- Static IPs can't accidentally be "expired".
- Duplicate IPs can't happen (whether 2x static IPs, or accidental allocation of a DHCP address that has a static reservation already).
- Ensuring static "reservations" within managed networks work as expected (including surviving lease expirations)

Update: This now also supports https://github.com/NVIDIA/infra-controller/issues/1865, which now has its own tracking issue (at the time of this PR it was more of a forward-thinking thing).

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

