### PR TITLE
feat: admin-cli and API address interface within managed-interfaces

### DIFF
--- a/crates/admin-cli/src/cfg/cli_options.rs
+++ b/crates/admin-cli/src/cfg/cli_options.rs
@@ -195,7 +195,7 @@ pub enum CliCommand {
     #[clap(about = "Site explorer functions", subcommand)]
     SiteExplorer(site_explorer::Cmd),
     #[clap(
-        about = "List of all Machine interfaces",
+        about = "Machine interfaces and address management",
         subcommand,
         visible_alias = "mi"
     )]

--- a/crates/admin-cli/src/machine_interfaces/assign_address/args.rs
+++ b/crates/admin-cli/src/machine_interfaces/assign_address/args.rs
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::net::IpAddr;
+
+use carbide_uuid::machine::MachineInterfaceId;
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+pub struct Args {
+    #[clap(help = "The machine interface ID to assign the address to")]
+    pub interface_id: MachineInterfaceId,
+
+    #[clap(help = "The IP address to assign (IPv4 or IPv6)")]
+    pub ip_address: IpAddr,
+}

--- a/crates/admin-cli/src/machine_interfaces/assign_address/cmd.rs
+++ b/crates/admin-cli/src/machine_interfaces/assign_address/cmd.rs
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::CarbideCliResult;
+use ::rpc::forge as forgerpc;
+
+use super::args::Args;
+use crate::rpc::ApiClient;
+
+pub async fn handle_assign_address(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let resp = api_client
+        .0
+        .assign_static_address(forgerpc::AssignStaticAddressRequest {
+            interface_id: Some(args.interface_id),
+            ip_address: args.ip_address.to_string(),
+        })
+        .await?;
+
+    match resp.status() {
+        forgerpc::AssignStaticAddressStatus::Assigned => {
+            println!(
+                "Assigned static address {} to interface {}",
+                resp.ip_address, args.interface_id
+            );
+        }
+        forgerpc::AssignStaticAddressStatus::ReplacedStatic => {
+            println!(
+                "Replaced existing static address with {} on interface {}",
+                resp.ip_address, args.interface_id
+            );
+        }
+        forgerpc::AssignStaticAddressStatus::ReplacedDhcp => {
+            println!(
+                "Replaced DHCP allocation with static address {} on interface {}",
+                resp.ip_address, args.interface_id
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/crates/admin-cli/src/machine_interfaces/assign_address/mod.rs
+++ b/crates/admin-cli/src/machine_interfaces/assign_address/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::handle_assign_address(self, &ctx.api_client).await
+    }
+}

--- a/crates/admin-cli/src/machine_interfaces/mod.rs
+++ b/crates/admin-cli/src/machine_interfaces/mod.rs
@@ -15,8 +15,11 @@
  * limitations under the License.
  */
 
+mod assign_address;
 mod delete;
+mod remove_address;
 mod show;
+mod show_addresses;
 
 // Cross-module re-exports for jump module
 pub use show::args::Args as ShowMachineInterfaces;
@@ -35,4 +38,10 @@ pub enum Cmd {
     Show(show::Args),
     #[clap(about = "Delete Machine interface.")]
     Delete(delete::Args),
+    #[clap(about = "Show addresses for a machine interface")]
+    ShowAddresses(show_addresses::Args),
+    #[clap(about = "Assign a static address to a machine interface")]
+    AssignAddress(assign_address::Args),
+    #[clap(about = "Remove a static address from a machine interface")]
+    RemoveAddress(remove_address::Args),
 }

--- a/crates/admin-cli/src/machine_interfaces/remove_address/args.rs
+++ b/crates/admin-cli/src/machine_interfaces/remove_address/args.rs
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::net::IpAddr;
+
+use carbide_uuid::machine::MachineInterfaceId;
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+pub struct Args {
+    #[clap(help = "The machine interface ID to remove the address from")]
+    pub interface_id: MachineInterfaceId,
+
+    #[clap(help = "The IP address to remove")]
+    pub ip_address: IpAddr,
+}

--- a/crates/admin-cli/src/machine_interfaces/remove_address/cmd.rs
+++ b/crates/admin-cli/src/machine_interfaces/remove_address/cmd.rs
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::CarbideCliResult;
+use ::rpc::forge as forgerpc;
+
+use super::args::Args;
+use crate::rpc::ApiClient;
+
+pub async fn handle_remove_address(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let resp = api_client
+        .0
+        .remove_static_address(forgerpc::RemoveStaticAddressRequest {
+            interface_id: Some(args.interface_id),
+            ip_address: args.ip_address.to_string(),
+        })
+        .await?;
+
+    match resp.status() {
+        forgerpc::RemoveStaticAddressStatus::Removed => {
+            println!(
+                "Removed static address {} from interface {}",
+                resp.ip_address, args.interface_id
+            );
+        }
+        forgerpc::RemoveStaticAddressStatus::NotFound => {
+            println!(
+                "No static address {} found on interface {}",
+                resp.ip_address, args.interface_id
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/crates/admin-cli/src/machine_interfaces/remove_address/mod.rs
+++ b/crates/admin-cli/src/machine_interfaces/remove_address/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::handle_remove_address(self, &ctx.api_client).await
+    }
+}

--- a/crates/admin-cli/src/machine_interfaces/show_addresses/args.rs
+++ b/crates/admin-cli/src/machine_interfaces/show_addresses/args.rs
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::machine::MachineInterfaceId;
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+pub struct Args {
+    #[clap(help = "The machine interface ID to show addresses for")]
+    pub interface_id: MachineInterfaceId,
+}

--- a/crates/admin-cli/src/machine_interfaces/show_addresses/cmd.rs
+++ b/crates/admin-cli/src/machine_interfaces/show_addresses/cmd.rs
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use ::rpc::forge as forgerpc;
+use prettytable::{Cell, Row, Table};
+use serde::Serialize;
+
+use super::args::Args;
+use crate::rpc::ApiClient;
+
+#[derive(Serialize)]
+struct AddressRow {
+    address: String,
+    family: String,
+    allocation_type: String,
+}
+
+pub async fn handle_show_addresses(
+    args: Args,
+    output_format: OutputFormat,
+    api_client: &ApiClient,
+) -> CarbideCliResult<()> {
+    let resp = api_client
+        .0
+        .find_interface_addresses(forgerpc::FindInterfaceAddressesRequest {
+            interface_id: Some(args.interface_id),
+        })
+        .await?;
+
+    let rows: Vec<AddressRow> = resp
+        .addresses
+        .iter()
+        .map(|a| AddressRow {
+            address: a.address.clone(),
+            family: if a.address.contains(':') {
+                "IPv6".into()
+            } else {
+                "IPv4".into()
+            },
+            allocation_type: a.allocation_type.clone(),
+        })
+        .collect();
+
+    match output_format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&rows)?);
+        }
+        _ => {
+            if rows.is_empty() {
+                println!("No addresses found for interface {}", args.interface_id);
+            } else {
+                let mut table = Table::new();
+                table.set_titles(Row::new(vec![
+                    Cell::new("Address"),
+                    Cell::new("Family"),
+                    Cell::new("Type"),
+                ]));
+
+                for row in &rows {
+                    table.add_row(Row::new(vec![
+                        Cell::new(&row.address),
+                        Cell::new(&row.family),
+                        Cell::new(&row.allocation_type),
+                    ]));
+                }
+
+                table.printstd();
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/admin-cli/src/machine_interfaces/show_addresses/mod.rs
+++ b/crates/admin-cli/src/machine_interfaces/show_addresses/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::handle_show_addresses(self, ctx.config.format, &ctx.api_client).await
+    }
+}

--- a/crates/api-db/src/machine_interface_address.rs
+++ b/crates/api-db/src/machine_interface_address.rs
@@ -18,6 +18,7 @@ use std::net::IpAddr;
 
 use carbide_network::ip::IpAddressFamily;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
+use model::allocation_type::{AllocationType, AssignStaticResult};
 use model::network_segment::NetworkSegmentType;
 use sqlx::{FromRow, PgConnection};
 
@@ -27,6 +28,12 @@ use crate::db_read::DbReader;
 #[derive(Debug, FromRow, Clone)]
 pub struct MachineInterfaceAddress {
     pub address: IpAddr,
+}
+
+#[derive(Debug, FromRow, Clone)]
+pub struct MachineInterfaceAddressWithType {
+    pub address: IpAddr,
+    pub allocation_type: AllocationType,
 }
 
 pub async fn find_ipv4_for_interface(
@@ -70,6 +77,114 @@ pub async fn delete(
         .await
         .map(|_| ())
         .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Find all addresses for an interface, including their allocation type.
+pub async fn find_for_interface(
+    txn: &mut PgConnection,
+    interface_id: MachineInterfaceId,
+) -> Result<Vec<MachineInterfaceAddressWithType>, DatabaseError> {
+    let query =
+        "SELECT address, allocation_type FROM machine_interface_addresses WHERE interface_id = $1";
+    sqlx::query_as(query)
+        .bind(interface_id)
+        .fetch_all(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Find the allocation type of the existing address for a given
+/// interface and address family, if one exists.
+pub async fn find_allocation_type_for_family(
+    txn: &mut PgConnection,
+    interface_id: MachineInterfaceId,
+    family: IpAddressFamily,
+) -> Result<Option<AllocationType>, DatabaseError> {
+    let query = "SELECT allocation_type FROM machine_interface_addresses WHERE interface_id = $1 AND family(address) = $2";
+    let result: Option<(AllocationType,)> = sqlx::query_as(query)
+        .bind(interface_id)
+        .bind(family.pg_family())
+        .fetch_optional(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+    Ok(result.map(|(t,)| t))
+}
+
+/// Delete the address for a given interface, address family, and
+/// allocation type. Returns true if a row was deleted.
+pub async fn delete_by_interface_family(
+    txn: &mut PgConnection,
+    interface_id: MachineInterfaceId,
+    family: IpAddressFamily,
+    allocation_type: AllocationType,
+) -> Result<bool, DatabaseError> {
+    let query = "DELETE FROM machine_interface_addresses WHERE interface_id = $1 AND family(address) = $2 AND allocation_type = $3";
+    sqlx::query(query)
+        .bind(interface_id)
+        .bind(family.pg_family())
+        .bind(allocation_type)
+        .execute(txn)
+        .await
+        .map(|r| r.rows_affected() > 0)
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Insert a new address for an interface with the given allocation type.
+pub async fn insert(
+    txn: &mut PgConnection,
+    interface_id: MachineInterfaceId,
+    address: IpAddr,
+    allocation_type: AllocationType,
+) -> Result<(), DatabaseError> {
+    let query = "INSERT INTO machine_interface_addresses (interface_id, address, allocation_type) VALUES ($1::uuid, $2::inet, $3)";
+    sqlx::query(query)
+        .bind(interface_id)
+        .bind(address)
+        .bind(allocation_type)
+        .execute(txn)
+        .await
+        .map(|_| ())
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Assign a static address to an interface. If the interface already
+/// has an address for the same family, the behavior depends on its
+/// allocation type:
+///
+/// - `Static`: the old static address is replaced.
+/// - `Dhcp`: the DHCP allocation is removed and replaced with the
+///   static assignment.
+#[allow(txn_held_across_await)]
+pub async fn assign_static(
+    txn: &mut PgConnection,
+    interface_id: MachineInterfaceId,
+    address: IpAddr,
+) -> Result<AssignStaticResult, DatabaseError> {
+    let family = if address.is_ipv4() {
+        IpAddressFamily::Ipv4
+    } else {
+        IpAddressFamily::Ipv6
+    };
+
+    let existing = find_allocation_type_for_family(&mut *txn, interface_id, family).await?;
+
+    let result = match existing {
+        Some(AllocationType::Dhcp) => {
+            delete_by_interface_family(&mut *txn, interface_id, family, AllocationType::Dhcp)
+                .await?;
+            AssignStaticResult::ReplacedDhcp
+        }
+        Some(AllocationType::Static) => {
+            delete_by_interface_family(&mut *txn, interface_id, family, AllocationType::Static)
+                .await?;
+            AssignStaticResult::ReplacedStatic
+        }
+        None => AssignStaticResult::Assigned,
+    };
+
+    insert(txn, interface_id, address, AllocationType::Static).await?;
+
+    Ok(result)
 }
 
 /// Delete an address allocation of the given type. Returns true if a

--- a/crates/api-model/src/allocation_type.rs
+++ b/crates/api-model/src/allocation_type.rs
@@ -34,6 +34,59 @@ pub enum AllocationType {
     Static,
 }
 
+/// The result of assigning a static address, indicating what
+/// previously existed for that address family on the interface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AssignStaticResult {
+    /// No prior address existed for this family.
+    Assigned,
+    /// An existing static address was replaced.
+    ReplacedStatic,
+    /// An existing DHCP allocation was replaced.
+    ///
+    /// If you "replace" a DHCP allocation with the same address
+    /// (effectively making a static DHCP  reservation), then it's
+    /// basically a no-op.
+    ///
+    /// If you replace a DHCP allocation with a static address that
+    /// is within a Carbide-managed network, then the next time the
+    /// machine renews its lease, carbide-dhcp -> carbide-api will
+    /// flow, and carbide-api will see the new IP and naturally
+    /// return it. MOST DHCP clients will accept this new IP and
+    /// reconfigure. SOME DHCP clients will see this is NOT their
+    /// original offer, and re-DHCPDISCOVER, at which point the
+    /// carbide-dhcp -> carbide-api flow will naturally return
+    /// the static reservation anyway. It will be a small hiccup
+    /// in a sense, but the client will never lose it's address,
+    /// and will just re-discover to the same address.
+    ///
+    /// If you replace a DHCP allocation with a static address that
+    /// is OUTSIDE a Carbide-managed network, then we will now assume
+    /// that device is where you say it is. But it's important to
+    /// understand a bit of a nuance, as soon as that previous DHCP
+    /// allocation is deleted, it is eligible for re-assignment,
+    /// meaning if your device is still holding onto that IP (before
+    /// it's next renewal), there will potentially be a period of time
+    /// where there are duplicate IP conflicts. We can definitely
+    /// do some work to make sure these things are mitigated, but
+    /// I also think replacing DHCP -> static reservations comes
+    /// with some "use at your own risk" in general. We can improve
+    /// on it if needed.
+    ReplacedDhcp,
+}
+
+impl From<AssignStaticResult> for rpc::forge::AssignStaticAddressStatus {
+    fn from(result: AssignStaticResult) -> Self {
+        match result {
+            AssignStaticResult::Assigned => rpc::forge::AssignStaticAddressStatus::Assigned,
+            AssignStaticResult::ReplacedStatic => {
+                rpc::forge::AssignStaticAddressStatus::ReplacedStatic
+            }
+            AssignStaticResult::ReplacedDhcp => rpc::forge::AssignStaticAddressStatus::ReplacedDhcp,
+        }
+    }
+}
+
 impl From<AddressSelectionStrategy> for AllocationType {
     fn from(strategy: AddressSelectionStrategy) -> Self {
         match strategy {

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -757,6 +757,36 @@ impl Forge for Api {
         crate::handlers::machine::find_machine_health_histories(self, request).await
     }
 
+    async fn assign_static_address(
+        &self,
+        request: Request<rpc::AssignStaticAddressRequest>,
+    ) -> Result<Response<rpc::AssignStaticAddressResponse>, Status> {
+        log_request_data(&request);
+        Ok(
+            crate::handlers::machine_interface_address::assign_static_address(self, request)
+                .await?,
+        )
+    }
+
+    async fn remove_static_address(
+        &self,
+        request: Request<rpc::RemoveStaticAddressRequest>,
+    ) -> Result<Response<rpc::RemoveStaticAddressResponse>, Status> {
+        log_request_data(&request);
+        Ok(
+            crate::handlers::machine_interface_address::remove_static_address(self, request)
+                .await?,
+        )
+    }
+
+    async fn find_interface_addresses(
+        &self,
+        request: Request<rpc::FindInterfaceAddressesRequest>,
+    ) -> Result<Response<rpc::FindInterfaceAddressesResponse>, Status> {
+        log_request_data(&request);
+        crate::handlers::machine_interface_address::find_interface_addresses(self, request).await
+    }
+
     async fn find_interfaces(
         &self,
         request: Request<rpc::InterfaceSearchQuery>,

--- a/crates/api/src/auth/internal_rbac_rules.rs
+++ b/crates/api/src/auth/internal_rbac_rules.rs
@@ -170,6 +170,9 @@ impl InternalRBACRules {
         x.perm("ReportForgeScoutError", vec![Scout]);
         x.perm("DiscoverDhcp", vec![Dhcp, Machineatron]);
         x.perm("ExpireDhcpLease", vec![Dhcp, Machineatron]);
+        x.perm("AssignStaticAddress", vec![ForgeAdminCLI]);
+        x.perm("RemoveStaticAddress", vec![ForgeAdminCLI]);
+        x.perm("FindInterfaceAddresses", vec![ForgeAdminCLI]);
         x.perm("FindInterfaces", vec![ForgeAdminCLI, Agent, Rla]);
         x.perm("DeleteInterface", vec![ForgeAdminCLI]);
         x.perm("FindIpAddress", vec![ForgeAdminCLI]);

--- a/crates/api/src/handlers/machine_interface_address.rs
+++ b/crates/api/src/handlers/machine_interface_address.rs
@@ -1,0 +1,113 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use model::allocation_type::AllocationType;
+use rpc::forge as rpc;
+use tonic::{Request, Response, Status};
+
+use crate::api::Api;
+use crate::errors::CarbideError;
+
+pub async fn assign_static_address(
+    api: &Api,
+    request: Request<rpc::AssignStaticAddressRequest>,
+) -> Result<Response<rpc::AssignStaticAddressResponse>, CarbideError> {
+    let req = request.into_inner();
+    let interface_id = req.interface_id.ok_or(CarbideError::InvalidArgument(
+        "interface_id is required".into(),
+    ))?;
+    let ip_address: std::net::IpAddr = req.ip_address.parse()?;
+
+    let mut txn = api.txn_begin().await?;
+    let result =
+        db::machine_interface_address::assign_static(&mut txn, interface_id, ip_address).await?;
+    txn.commit().await?;
+
+    let status: rpc::AssignStaticAddressStatus = result.into();
+    tracing::info!(%interface_id, %ip_address, ?status, "Static address assignment");
+
+    Ok(Response::new(rpc::AssignStaticAddressResponse {
+        interface_id: Some(interface_id),
+        ip_address: ip_address.to_string(),
+        status: status.into(),
+    }))
+}
+
+pub async fn remove_static_address(
+    api: &Api,
+    request: Request<rpc::RemoveStaticAddressRequest>,
+) -> Result<Response<rpc::RemoveStaticAddressResponse>, CarbideError> {
+    let req = request.into_inner();
+    let interface_id = req.interface_id.ok_or(CarbideError::InvalidArgument(
+        "interface_id is required".into(),
+    ))?;
+    let ip_address: std::net::IpAddr = req.ip_address.parse()?;
+
+    let mut txn = api.txn_begin().await?;
+    let deleted = db::machine_interface_address::delete_by_address(
+        &mut txn,
+        ip_address,
+        AllocationType::Static,
+    )
+    .await?;
+    txn.commit().await?;
+
+    let status = if deleted {
+        tracing::info!(%interface_id, %ip_address, "Removed static address");
+        rpc::RemoveStaticAddressStatus::Removed
+    } else {
+        tracing::info!(%interface_id, %ip_address, "Static address not found");
+        rpc::RemoveStaticAddressStatus::NotFound
+    };
+
+    Ok(Response::new(rpc::RemoveStaticAddressResponse {
+        interface_id: Some(interface_id),
+        ip_address: ip_address.to_string(),
+        status: status.into(),
+    }))
+}
+
+pub async fn find_interface_addresses(
+    api: &Api,
+    request: Request<rpc::FindInterfaceAddressesRequest>,
+) -> Result<Response<rpc::FindInterfaceAddressesResponse>, Status> {
+    let req = request.into_inner();
+    let interface_id = req.interface_id.ok_or(CarbideError::InvalidArgument(
+        "interface_id is required".into(),
+    ))?;
+
+    let mut txn = api.txn_begin().await?;
+    let addresses =
+        db::machine_interface_address::find_for_interface(&mut txn, interface_id).await?;
+    txn.commit().await?;
+
+    let proto_addresses = addresses
+        .into_iter()
+        .map(|a| rpc::InterfaceAddress {
+            address: a.address.to_string(),
+            allocation_type: match a.allocation_type {
+                AllocationType::Dhcp => "dhcp".to_string(),
+                AllocationType::Static => "static".to_string(),
+            },
+        })
+        .collect();
+
+    Ok(Response::new(rpc::FindInterfaceAddressesResponse {
+        interface_id: Some(interface_id),
+        addresses: proto_addresses,
+    }))
+}

--- a/crates/api/src/handlers/mod.rs
+++ b/crates/api/src/handlers/mod.rs
@@ -50,6 +50,7 @@ pub mod machine_discovery;
 pub mod machine_hardware_info;
 pub mod machine_identity;
 pub mod machine_interface;
+pub mod machine_interface_address;
 pub mod machine_quarantine;
 pub mod machine_scout;
 pub mod machine_validation;

--- a/crates/api/src/tests/mod.rs
+++ b/crates/api/src/tests/mod.rs
@@ -106,6 +106,7 @@ mod site_explorer;
 mod sku;
 mod spdm;
 mod state_controller;
+mod static_address_management;
 mod storage;
 mod switch;
 mod switch_find;

--- a/crates/api/src/tests/static_address_management.rs
+++ b/crates/api/src/tests/static_address_management.rs
@@ -1,0 +1,360 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::net::IpAddr;
+use std::str::FromStr;
+
+use common::api_fixtures::{FIXTURE_DHCP_RELAY_ADDRESS, create_test_env};
+use mac_address::MacAddress;
+use rpc::forge::forge_server::Forge;
+use rpc::forge::{
+    AssignStaticAddressRequest, AssignStaticAddressStatus, FindInterfaceAddressesRequest,
+    RemoveStaticAddressRequest, RemoveStaticAddressStatus,
+};
+use tonic::Request;
+
+use crate::tests::common;
+
+#[crate::sqlx_test]
+async fn test_assign_static_address(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let relay: IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
+
+    // Create an interface (via DHCP discovery to get an interface_id)
+    let mut txn = env.pool.begin().await?;
+    let interface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        MacAddress::from_str("aa:bb:cc:dd:ee:10").unwrap(),
+        relay,
+        None,
+    )
+    .await?;
+    // Delete the DHCP address so we can assign a static one for this family
+    db::machine_interface_address::delete(&mut txn, &interface.id).await?;
+    txn.commit().await?;
+
+    // Assign a static address
+    let resp = env
+        .api
+        .assign_static_address(Request::new(AssignStaticAddressRequest {
+            interface_id: Some(interface.id),
+            ip_address: "192.0.2.210".to_string(),
+        }))
+        .await?
+        .into_inner();
+
+    assert_eq!(resp.status(), AssignStaticAddressStatus::Assigned);
+    assert_eq!(resp.ip_address, "192.0.2.210");
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_assign_replaces_existing_static(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let relay: IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
+
+    let mut txn = env.pool.begin().await?;
+    let interface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        MacAddress::from_str("aa:bb:cc:dd:ee:11").unwrap(),
+        relay,
+        None,
+    )
+    .await?;
+    db::machine_interface_address::delete(&mut txn, &interface.id).await?;
+    txn.commit().await?;
+
+    // Assign first static address.
+    env.api
+        .assign_static_address(Request::new(AssignStaticAddressRequest {
+            interface_id: Some(interface.id),
+            ip_address: "192.0.2.211".to_string(),
+        }))
+        .await?;
+
+    // Assign a different static address for the same family,
+    // which should replace.
+    let resp = env
+        .api
+        .assign_static_address(Request::new(AssignStaticAddressRequest {
+            interface_id: Some(interface.id),
+            ip_address: "192.0.2.212".to_string(),
+        }))
+        .await?
+        .into_inner();
+
+    assert_eq!(resp.status(), AssignStaticAddressStatus::ReplacedStatic);
+    assert_eq!(resp.ip_address, "192.0.2.212");
+
+    // Verify only the new address exists.
+    let addrs = env
+        .api
+        .find_interface_addresses(Request::new(FindInterfaceAddressesRequest {
+            interface_id: Some(interface.id),
+        }))
+        .await?
+        .into_inner();
+
+    assert_eq!(addrs.addresses.len(), 1);
+    assert_eq!(addrs.addresses[0].address, "192.0.2.212");
+    assert_eq!(addrs.addresses[0].allocation_type, "static");
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_assign_takes_over_dhcp_allocation(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let relay: IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
+
+    // Create interface with DHCP-allocated IPv4.
+    let mut txn = env.pool.begin().await?;
+    let interface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        MacAddress::from_str("aa:bb:cc:dd:ee:12").unwrap(),
+        relay,
+        None,
+    )
+    .await?;
+    let dhcp_ip = interface.addresses[0];
+    txn.commit().await?;
+
+    // And now assign a static IPv4 over the DHCP allocation,
+    // which should take over.
+    let resp = env
+        .api
+        .assign_static_address(Request::new(AssignStaticAddressRequest {
+            interface_id: Some(interface.id),
+            ip_address: "192.0.2.213".to_string(),
+        }))
+        .await?
+        .into_inner();
+
+    assert_eq!(resp.status(), AssignStaticAddressStatus::ReplacedDhcp);
+    assert_eq!(resp.ip_address, "192.0.2.213");
+
+    // Verify the old DHCP address is gone and the static one is there.
+    let addrs = env
+        .api
+        .find_interface_addresses(Request::new(FindInterfaceAddressesRequest {
+            interface_id: Some(interface.id),
+        }))
+        .await?
+        .into_inner();
+
+    assert_eq!(addrs.addresses.len(), 1);
+    assert_eq!(addrs.addresses[0].address, "192.0.2.213");
+    assert_eq!(addrs.addresses[0].allocation_type, "static");
+    assert_ne!(
+        addrs.addresses[0].address,
+        dhcp_ip.to_string(),
+        "old DHCP address should be gone"
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_remove_static_address(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let relay: IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
+
+    let mut txn = env.pool.begin().await?;
+    let interface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        MacAddress::from_str("aa:bb:cc:dd:ee:13").unwrap(),
+        relay,
+        None,
+    )
+    .await?;
+    db::machine_interface_address::delete(&mut txn, &interface.id).await?;
+    txn.commit().await?;
+
+    // Assign then remove.
+    env.api
+        .assign_static_address(Request::new(AssignStaticAddressRequest {
+            interface_id: Some(interface.id),
+            ip_address: "192.0.2.214".to_string(),
+        }))
+        .await?;
+
+    let resp = env
+        .api
+        .remove_static_address(Request::new(RemoveStaticAddressRequest {
+            interface_id: Some(interface.id),
+            ip_address: "192.0.2.214".to_string(),
+        }))
+        .await?
+        .into_inner();
+
+    assert_eq!(resp.status(), RemoveStaticAddressStatus::Removed);
+
+    // Verify no addresses remain.
+    let addrs = env
+        .api
+        .find_interface_addresses(Request::new(FindInterfaceAddressesRequest {
+            interface_id: Some(interface.id),
+        }))
+        .await?
+        .into_inner();
+
+    assert!(addrs.addresses.is_empty());
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_remove_nonexistent_returns_not_found(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let relay: IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
+
+    let mut txn = env.pool.begin().await?;
+    let interface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        MacAddress::from_str("aa:bb:cc:dd:ee:14").unwrap(),
+        relay,
+        None,
+    )
+    .await?;
+    txn.commit().await?;
+
+    let resp = env
+        .api
+        .remove_static_address(Request::new(RemoveStaticAddressRequest {
+            interface_id: Some(interface.id),
+            ip_address: "10.99.99.99".to_string(),
+        }))
+        .await?
+        .into_inner();
+
+    assert_eq!(resp.status(), RemoveStaticAddressStatus::NotFound);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_find_interface_addresses_shows_types(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let relay: IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
+
+    // Create interface with DHCP address.
+    let mut txn = env.pool.begin().await?;
+    let interface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        MacAddress::from_str("aa:bb:cc:dd:ee:15").unwrap(),
+        relay,
+        None,
+    )
+    .await?;
+    txn.commit().await?;
+
+    let addrs = env
+        .api
+        .find_interface_addresses(Request::new(FindInterfaceAddressesRequest {
+            interface_id: Some(interface.id),
+        }))
+        .await?
+        .into_inner();
+
+    assert_eq!(addrs.addresses.len(), 1);
+    assert_eq!(addrs.addresses[0].allocation_type, "dhcp");
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_assign_remove_then_dhcp_reallocates(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let relay: IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
+    let mac = MacAddress::from_str("aa:bb:cc:dd:ee:16").unwrap();
+    let static_ip = "192.0.2.216";
+
+    // First, create the interface, clear its DHCP address, and
+    // a assign static one.
+    let mut txn = env.pool.begin().await?;
+    let interface =
+        db::machine_interface::validate_existing_mac_and_create(&mut txn, mac, relay, None).await?;
+    db::machine_interface_address::delete(&mut txn, &interface.id).await?;
+    txn.commit().await?;
+
+    env.api
+        .assign_static_address(Request::new(AssignStaticAddressRequest {
+            interface_id: Some(interface.id),
+            ip_address: static_ip.to_string(),
+        }))
+        .await?;
+
+    // Now, remove the static address.
+    let remove_resp = env
+        .api
+        .remove_static_address(Request::new(RemoveStaticAddressRequest {
+            interface_id: Some(interface.id),
+            ip_address: static_ip.to_string(),
+        }))
+        .await?
+        .into_inner();
+    assert_eq!(remove_resp.status(), RemoveStaticAddressStatus::Removed);
+
+    // And then fire off a DHCPDISCOVER -- the interface has no addresses,
+    // should it should re-allocate a new one that is DHCP-managed.
+    let mac_str = mac.to_string();
+    let discover_resp = env
+        .api
+        .discover_dhcp(
+            crate::tests::common::rpc_builder::DhcpDiscovery::builder(
+                &mac_str,
+                FIXTURE_DHCP_RELAY_ADDRESS,
+            )
+            .tonic_request(),
+        )
+        .await?
+        .into_inner();
+
+    assert!(
+        !discover_resp.address.is_empty(),
+        "should get a DHCP address after static was removed"
+    );
+    assert_eq!(
+        discover_resp.machine_interface_id.unwrap(),
+        interface.id,
+        "should reuse the same interface"
+    );
+
+    // Moment of truth.. verify it's a DHCP allocation.
+    let addrs = env
+        .api
+        .find_interface_addresses(Request::new(FindInterfaceAddressesRequest {
+            interface_id: Some(interface.id),
+        }))
+        .await?
+        .into_inner();
+    assert_eq!(addrs.addresses.len(), 1);
+    assert_eq!(addrs.addresses[0].allocation_type, "dhcp");
+
+    Ok(())
+}

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -176,6 +176,10 @@ service Forge {
   rpc DiscoverDhcp(DhcpDiscovery) returns (DhcpRecord);
   rpc ExpireDhcpLease(ExpireDhcpLeaseRequest) returns (ExpireDhcpLeaseResponse);
 
+  rpc AssignStaticAddress(AssignStaticAddressRequest) returns (AssignStaticAddressResponse);
+  rpc RemoveStaticAddress(RemoveStaticAddressRequest) returns (RemoveStaticAddressResponse);
+  rpc FindInterfaceAddresses(FindInterfaceAddressesRequest) returns (FindInterfaceAddressesResponse);
+
   // PRIVILEGED: Find things
   rpc FindInterfaces(InterfaceSearchQuery) returns (InterfaceList);
   rpc DeleteInterface(InterfaceDeleteQuery) returns (google.protobuf.Empty);
@@ -2886,6 +2890,53 @@ message InterfaceDeleteQuery {
 message InterfaceSearchQuery {
   optional common.MachineInterfaceId id = 1;
   optional string ip = 2;
+}
+
+message AssignStaticAddressRequest {
+  common.MachineInterfaceId interface_id = 1;
+  string ip_address = 2;
+}
+
+enum AssignStaticAddressStatus {
+  ASSIGN_STATIC_ADDRESS_STATUS_ASSIGNED = 0;
+  ASSIGN_STATIC_ADDRESS_STATUS_REPLACED_STATIC = 1;
+  ASSIGN_STATIC_ADDRESS_STATUS_REPLACED_DHCP = 2;
+}
+
+message AssignStaticAddressResponse {
+  common.MachineInterfaceId interface_id = 1;
+  string ip_address = 2;
+  AssignStaticAddressStatus status = 3;
+}
+
+message RemoveStaticAddressRequest {
+  common.MachineInterfaceId interface_id = 1;
+  string ip_address = 2;
+}
+
+enum RemoveStaticAddressStatus {
+  REMOVE_STATIC_ADDRESS_STATUS_REMOVED = 0;
+  REMOVE_STATIC_ADDRESS_STATUS_NOT_FOUND = 1;
+}
+
+message RemoveStaticAddressResponse {
+  common.MachineInterfaceId interface_id = 1;
+  string ip_address = 2;
+  RemoveStaticAddressStatus status = 3;
+}
+
+message FindInterfaceAddressesRequest {
+  common.MachineInterfaceId interface_id = 1;
+}
+
+message InterfaceAddress {
+  string address = 1;
+  string allocation_type = 2;
+}
+
+message FindInterfaceAddressesResponse {
+  common.MachineInterfaceId interface_id = 1;
+  repeated InterfaceAddress addresses = 2;
 }
 
 enum MachineType {


### PR DESCRIPTION
## Description

With the work that was done in https://github.com/NVIDIA/ncx-infra-controller-core/pull/808 to extend `AddressSelectionStrategy` to support `StaticAddress` (as part of https://github.com/NVIDIA/ncx-infra-controller-core/issues/790 and https://github.com/NVIDIA/ncx-infra-controller-core/issues/644), I'm adding additional `admin-cli` -> `carbide-api` plumbing for doing basic things related to address management. Once you know your interface from `carbide-admin-cli machine-interfaces show`, you can now:

```
carbide-admin-cli machine-interfaces show-addresses <interface-id>
carbide-admin-cli machine-interfaces assign-address <interface-id> <ip>
carbide-admin-cli machine-interfaces remove-address <interface-id> <ip>
```

The general idea is that for devices with static reservations (ones that used `AddressSelectionStrategy::StaticAddress`), we may want to do things like:
- Change that static reservation by `assign`-ing a new one.
- `remove` that static reservation (and allow `carbide-dhcp` to go back to dynamic allocation).
- `show` what addresses are currently associated (which you can get from `mi show` also, but this lets you target the one interface, which is useful if dual-stacked).

Address `assign`-ment is meant both as a way to update an existing static allocation to a new one, AND to generally assign an address. For example:
- You have a DHCP allocation you want to turn into a static reservation, you can `assign` it, and it becomes `AllocationType::Static`.
- You want to override your DHCP allocation to a new `AllocationType::Static`, you `assign` it.

And if you want to go to DHCP-based allocation, you simply `remove` the assignment, and `carbide-dhcp` will wait for a `DHCPDISCOVER` and allocate it a dynamic one.

Similar to "Expected" BMC passwords, once a machine is discovered, we change the actual Managed BMC password, but the Expected BMC password in config stays the same. The same goes for this. An operator may configure an Expected static assigment (which becomes the Managed static assignment), but can use this administrative interface to update the Managed assignment to something other than the original Expected one. It is up to the operator to sync their Expected configs (if needed).

Unit and integration tests included for various interactions, including the static removal + DHCP-reallocation flow.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

