### PR TITLE
chore: wire in power shelf bmc ip assignment with new plumbing

### DIFF
--- a/crates/admin-cli/src/expected_power_shelf/add/args.rs
+++ b/crates/admin-cli/src/expected_power_shelf/add/args.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use std::net::IpAddr;
+
 use carbide_uuid::rack::RackId;
 use clap::Parser;
 use mac_address::MacAddress;
@@ -76,12 +78,12 @@ pub struct Args {
     pub rack_id: Option<RackId>,
 
     #[clap(
-        long = "ip_address",
-        value_name = "IP_ADDRESS",
-        help = "IP address of the power shelf",
+        long = "bmc-ip-address",
+        value_name = "BMC_IP_ADDRESS",
+        help = "BMC IP address of the power shelf",
         action = clap::ArgAction::Append
     )]
-    pub ip_address: Option<String>,
+    pub bmc_ip_address: Option<IpAddr>,
 }
 
 impl From<Args> for rpc::forge::ExpectedPowerShelf {
@@ -98,7 +100,10 @@ impl From<Args> for rpc::forge::ExpectedPowerShelf {
             bmc_username: value.bmc_username,
             bmc_password: value.bmc_password,
             shelf_serial_number: value.shelf_serial_number,
-            ip_address: value.ip_address.unwrap_or_default(),
+            bmc_ip_address: value
+                .bmc_ip_address
+                .map(|ip| ip.to_string())
+                .unwrap_or_default(),
             rack_id: value.rack_id,
             metadata: Some(metadata),
         }

--- a/crates/admin-cli/src/expected_power_shelf/common.rs
+++ b/crates/admin-cli/src/expected_power_shelf/common.rs
@@ -29,5 +29,5 @@ pub struct ExpectedPowerShelfJson {
     pub metadata: Option<rpc::forge::Metadata>,
     pub host_name: Option<String>,
     pub rack_id: Option<RackId>,
-    pub ip_address: Option<String>,
+    pub bmc_ip_address: Option<String>,
 }

--- a/crates/admin-cli/src/expected_power_shelf/update/args.rs
+++ b/crates/admin-cli/src/expected_power_shelf/update/args.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use std::net::IpAddr;
+
 use ::rpc::admin_cli::CarbideCliError;
 use carbide_uuid::rack::RackId;
 use clap::{ArgGroup, Parser};
@@ -102,12 +104,12 @@ pub struct Args {
     pub rack_id: Option<RackId>,
 
     #[clap(
-        long = "ip_address",
-        value_name = "IP_ADDRESS",
-        help = "IP address of the power shelf",
+        long = "bmc-ip-address",
+        value_name = "BMC_IP_ADDRESS",
+        help = "BMC IP address of the power shelf",
         action = clap::ArgAction::Append
     )]
-    pub ip_address: Option<String>,
+    pub bmc_ip_address: Option<IpAddr>,
 }
 
 impl TryFrom<Args> for rpc::forge::ExpectedPowerShelf {
@@ -145,7 +147,10 @@ impl TryFrom<Args> for rpc::forge::ExpectedPowerShelf {
             bmc_username: args.bmc_username.unwrap_or_default(),
             bmc_password: args.bmc_password.unwrap_or_default(),
             shelf_serial_number: args.shelf_serial_number.unwrap_or_default(),
-            ip_address: args.ip_address.unwrap_or_default(),
+            bmc_ip_address: args
+                .bmc_ip_address
+                .map(|ip| ip.to_string())
+                .unwrap_or_default(),
             metadata: Some(rpc::forge::Metadata {
                 name: args.meta_name.unwrap_or_default(),
                 description: args.meta_description.unwrap_or_default(),

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -679,7 +679,7 @@ impl ApiClient {
                     bmc_username: power_shelf.bmc_username,
                     bmc_password: power_shelf.bmc_password,
                     shelf_serial_number: power_shelf.shelf_serial_number,
-                    ip_address: power_shelf.ip_address.unwrap_or_default(),
+                    bmc_ip_address: power_shelf.bmc_ip_address.unwrap_or_default(),
                     metadata: power_shelf.metadata,
                     rack_id: power_shelf.rack_id,
                 })

--- a/crates/api-db/migrations/20260404052100_expected_power_shelves_rename_ip_address.sql
+++ b/crates/api-db/migrations/20260404052100_expected_power_shelves_rename_ip_address.sql
@@ -1,0 +1,3 @@
+-- Rename ip_address to bmc_ip_address for naming consistency.
+ALTER TABLE expected_power_shelves RENAME COLUMN ip_address TO bmc_ip_address;
+ALTER INDEX idx_expected_power_shelves_ip_address RENAME TO idx_expected_power_shelves_bmc_ip_address;

--- a/crates/api-db/src/expected_power_shelf.rs
+++ b/crates/api-db/src/expected_power_shelf.rs
@@ -140,7 +140,7 @@ pub async fn create(
         .expected_power_shelf_id
         .unwrap_or_else(Uuid::new_v4);
     let query = "INSERT INTO expected_power_shelves
-            (expected_power_shelf_id, bmc_mac_address, bmc_username, bmc_password, serial_number, ip_address, metadata_name, metadata_description, metadata_labels, rack_id)
+            (expected_power_shelf_id, bmc_mac_address, bmc_username, bmc_password, serial_number, bmc_ip_address, metadata_name, metadata_description, metadata_labels, rack_id)
             VALUES
             ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::inet, $7, $8, $9::jsonb, $10) RETURNING *";
 
@@ -150,7 +150,7 @@ pub async fn create(
         .bind(&power_shelf.bmc_username)
         .bind(&power_shelf.bmc_password)
         .bind(&power_shelf.serial_number)
-        .bind(power_shelf.ip_address)
+        .bind(power_shelf.bmc_ip_address)
         .bind(&power_shelf.metadata.name)
         .bind(&power_shelf.metadata.description)
         .bind(sqlx::types::Json(&power_shelf.metadata.labels))
@@ -261,7 +261,7 @@ pub async fn update(
 
     let query = format!(
         "UPDATE expected_power_shelves \
-         SET bmc_username=$1, bmc_password=$2, serial_number=$3, ip_address=$4, \
+         SET bmc_username=$1, bmc_password=$2, serial_number=$3, bmc_ip_address=$4, \
              metadata_name=$5, metadata_description=$6, metadata_labels=$7, rack_id=$8 \
          WHERE {where_clause}"
     );
@@ -270,7 +270,7 @@ pub async fn update(
         .bind(&power_shelf.bmc_username)
         .bind(&power_shelf.bmc_password)
         .bind(&power_shelf.serial_number)
-        .bind(power_shelf.ip_address)
+        .bind(power_shelf.bmc_ip_address)
         .bind(&power_shelf.metadata.name)
         .bind(&power_shelf.metadata.description)
         .bind(sqlx::types::Json(&power_shelf.metadata.labels))

--- a/crates/api-db/src/power_shelf.rs
+++ b/crates/api-db/src/power_shelf.rs
@@ -319,11 +319,11 @@ pub async fn find_bmc_ips_by_power_shelf_ids(
     let sql = r#"
         SELECT
             ps.id,
-            eps.ip_address
+            eps.bmc_ip_address
         FROM power_shelves ps
         JOIN expected_power_shelves eps ON eps.serial_number = ps.config->>'name'
         WHERE ps.id = ANY($1)
-          AND eps.ip_address IS NOT NULL
+          AND eps.bmc_ip_address IS NOT NULL
     "#;
 
     sqlx::query_as(sql)
@@ -350,11 +350,11 @@ pub async fn find_power_shelf_endpoints_by_ids(
         SELECT
             ps.id                AS power_shelf_id,
             eps.bmc_mac_address  AS pmc_mac,
-            eps.ip_address       AS pmc_ip
+            eps.bmc_ip_address       AS pmc_ip
         FROM power_shelves ps
         JOIN expected_power_shelves eps ON eps.serial_number = ps.config->>'name'
         WHERE ps.id = ANY($1)
-          AND eps.ip_address IS NOT NULL
+          AND eps.bmc_ip_address IS NOT NULL
     "#;
 
     sqlx::query_as(sql)

--- a/crates/api-model/src/expected_power_shelf.rs
+++ b/crates/api-model/src/expected_power_shelf.rs
@@ -37,7 +37,7 @@ pub struct ExpectedPowerShelf {
     pub bmc_username: String,
     pub serial_number: String,
     pub bmc_password: String,
-    pub ip_address: Option<IpAddr>,
+    pub bmc_ip_address: Option<IpAddr>,
     #[serde(default = "default_metadata_for_deserializer")]
     pub metadata: Metadata,
     pub rack_id: Option<RackId>,
@@ -58,7 +58,7 @@ impl<'r> FromRow<'r, PgRow> for ExpectedPowerShelf {
             bmc_username: row.try_get("bmc_username")?,
             serial_number: row.try_get("serial_number")?,
             bmc_password: row.try_get("bmc_password")?,
-            ip_address: row.try_get("ip_address").ok(),
+            bmc_ip_address: row.try_get("bmc_ip_address").ok(),
             metadata,
             rack_id: row.try_get("rack_id").ok(),
         })
@@ -77,8 +77,8 @@ impl From<ExpectedPowerShelf> for rpc::forge::ExpectedPowerShelf {
             bmc_username: expected_power_shelf.bmc_username,
             bmc_password: expected_power_shelf.bmc_password,
             shelf_serial_number: expected_power_shelf.serial_number,
-            ip_address: expected_power_shelf
-                .ip_address
+            bmc_ip_address: expected_power_shelf
+                .bmc_ip_address
                 .map(|ip| ip.to_string())
                 .unwrap_or_default(),
             metadata: Some(expected_power_shelf.metadata.into()),
@@ -100,10 +100,10 @@ impl TryFrom<rpc::forge::ExpectedPowerShelf> for ExpectedPowerShelf {
                     .map_err(|_| RpcDataConversionError::InvalidArgument(u.value))
             })
             .transpose()?;
-        let ip_address = if rpc.ip_address.is_empty() {
+        let bmc_ip_address = if rpc.bmc_ip_address.is_empty() {
             None
         } else {
-            rpc.ip_address.parse().ok()
+            rpc.bmc_ip_address.parse().ok()
         };
         let metadata = Metadata::try_from(rpc.metadata.unwrap_or_default())?;
 
@@ -113,7 +113,7 @@ impl TryFrom<rpc::forge::ExpectedPowerShelf> for ExpectedPowerShelf {
             bmc_username: rpc.bmc_username,
             bmc_password: rpc.bmc_password,
             serial_number: rpc.shelf_serial_number,
-            ip_address,
+            bmc_ip_address,
             metadata,
             rack_id: rpc.rack_id,
         })

--- a/crates/api/src/handlers/expected_power_shelf.rs
+++ b/crates/api/src/handlers/expected_power_shelf.rs
@@ -23,6 +23,7 @@ use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
 use crate::api::Api;
+use crate::handlers::machine_interface_address::preallocate_machine_interface;
 
 pub async fn add_expected_power_shelf(
     api: &Api,
@@ -43,6 +44,10 @@ pub async fn add_expected_power_shelf(
         .map_err(|e| CarbideError::Internal {
             message: format!("Database error: {}", e),
         })?;
+
+    if let Some(bmc_ip) = power_shelf.bmc_ip_address {
+        preallocate_machine_interface(&mut txn, power_shelf.bmc_mac_address, bmc_ip).await?;
+    }
 
     db_expected_power_shelf::create(&mut txn, power_shelf)
         .await

--- a/crates/api/src/handlers/machine_interface_address.rs
+++ b/crates/api/src/handlers/machine_interface_address.rs
@@ -15,12 +15,74 @@
  * limitations under the License.
  */
 
+use mac_address::MacAddress;
+use model::address_selection_strategy::AddressSelectionStrategy;
 use model::allocation_type::AllocationType;
+use model::network_segment::NetworkSegmentType;
 use rpc::forge as rpc;
 use tonic::{Request, Response, Status};
 
 use crate::api::Api;
 use crate::errors::CarbideError;
+
+/// Pre-allocate a machine_interface with a static address so
+/// site_explorer can discover the BMC at that IP.
+///
+/// If the IP is within a managed network prefix, the interface is
+/// created on that segment. Otherwise it falls back to the first
+/// underlay segment as an anchor for external/BYO IPs.
+///
+/// Currently "assumes" a BMC, but hey maybe we can use it for
+/// other things as time goes on.
+pub async fn preallocate_machine_interface(
+    txn: &mut sqlx::PgConnection,
+    bmc_mac_address: MacAddress,
+    bmc_ip: std::net::IpAddr,
+) -> Result<(), CarbideError> {
+    let segment = match db::network_segment::for_relay(txn, bmc_ip).await? {
+        Some(seg) => seg,
+        None => {
+            let underlay_ids =
+                db::network_segment::list_segment_ids(txn, Some(NetworkSegmentType::Underlay))
+                    .await?;
+            let segment_id = underlay_ids.first().ok_or(CarbideError::NotFoundError {
+                kind: "underlay_segment",
+                id: "any".to_string(),
+            })?;
+            db::network_segment::find_by(
+                txn,
+                db::ObjectColumnFilter::One(db::network_segment::IdColumn, segment_id),
+                Default::default(),
+            )
+            .await?
+            .into_iter()
+            .next()
+            .ok_or(CarbideError::NotFoundError {
+                kind: "underlay_segment",
+                id: segment_id.to_string(),
+            })?
+        }
+    };
+
+    db::machine_interface::create(
+        txn,
+        &segment,
+        &bmc_mac_address,
+        segment.subdomain_id,
+        true,
+        AddressSelectionStrategy::StaticAddress(bmc_ip),
+    )
+    .await?;
+
+    tracing::info!(
+        %bmc_mac_address,
+        %bmc_ip,
+        segment_id = %segment.id,
+        "Pre-allocated static machine interface"
+    );
+
+    Ok(())
+}
 
 pub async fn assign_static_address(
     api: &Api,

--- a/crates/api/src/site_explorer/mod.rs
+++ b/crates/api/src/site_explorer/mod.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::fmt::Display;
 use std::io;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, SocketAddr};
 use std::panic::Location;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -27,14 +27,10 @@ use std::time::Instant;
 
 use carbide_network::sanitized_mac;
 use carbide_uuid::machine::MachineType;
-use carbide_uuid::network::NetworkSegmentId;
 use carbide_uuid::power_shelf::{PowerShelfIdSource, PowerShelfType};
 use chrono::Utc;
 use config_version::ConfigVersion;
-use db::{
-    self, DatabaseError, ObjectFilter, Transaction, machine, network_segment as db_network_segment,
-    power_shelf as db_power_shelf,
-};
+use db::{self, DatabaseError, ObjectFilter, Transaction, machine, power_shelf as db_power_shelf};
 use futures_util::stream::FuturesUnordered;
 use futures_util::{StreamExt, TryFutureExt};
 use itertools::Itertools;
@@ -1348,39 +1344,14 @@ impl SiteExplorer {
         // Note: As a side effect of this, OOB interfaces might for a short time be scanned,
         // until the machine is ingested. At that point in time this filter will remove them
         // from the to-be-scanned list.
-        let underlay_interfaces: Vec<MachineInterfaceSnapshot> = {
-            // Get all underlay interfaces from the database
-            let underlay_interfaces = interfaces.into_iter().filter(|iface| {
+        // Get all underlay interfaces from the database, which includes interfaces
+        // which have come from both DHCP and/or static assignments.
+        let underlay_interfaces: Vec<MachineInterfaceSnapshot> = interfaces
+            .into_iter()
+            .filter(|iface| {
                 underlay_segments.contains(&iface.segment_id) && iface.machine_id.is_none()
-            });
-
-            // For power shelves, currently adding a bogus static IP as an underlay interface if
-            // configured to do so.
-            if explore_power_shelves_from_static_ip {
-                let underlay_segment_id = self.get_underlay_segment_id().await?;
-                underlay_interfaces
-                    .chain(expected_power_shelves.iter().map(|expected_power_shelf| {
-                        let fake_ip = self.get_static_ip_for_power_shelf(
-                            &expected_power_shelf.bmc_mac_address,
-                            expected_power_shelf.ip_address,
-                        );
-                        // Create a fake machine interface for the power shelf
-                        let mut fake_interface = MachineInterfaceSnapshot::mock_with_mac(
-                            expected_power_shelf.bmc_mac_address,
-                        );
-                        fake_interface.hostname =
-                            format!("power-shelf-{}", expected_power_shelf.serial_number);
-                        fake_interface.segment_id = underlay_segment_id;
-                        fake_interface.addresses = vec![fake_ip];
-                        fake_interface.network_segment_type = Some(NetworkSegmentType::Underlay);
-                        fake_interface.vendors = vec!["PowerShelf".to_string()];
-                        fake_interface
-                    }))
-                    .collect()
-            } else {
-                underlay_interfaces.collect()
-            }
-        };
+            })
+            .collect();
 
         // Start an index of all underlay interfaces, expected machines, expected power shelves, and expected switches.
         let index = ExploredEndpointIndex::builder(explored_endpoints, underlay_interfaces)
@@ -1748,55 +1719,6 @@ impl SiteExplorer {
         }
 
         Ok(index)
-    }
-
-    // TODO(chet): Follow up with RMS team re: code cleanup, or
-    // just take care of it myself (import/merge feedback).
-    fn get_static_ip_for_power_shelf(
-        &self,
-        _mac_address: &MacAddress,
-        ip_address: Option<IpAddr>,
-    ) -> IpAddr {
-        // Convert MAC address to a deterministic IP address
-        // We'll use a private IP range (192.168.0.0/16) and derive the IP from MAC
-        //TODO will check this later needd better logic
-        // let mac_bytes = mac_address.bytes();
-        // let ip_bytes = [192, 168, mac_bytes[4], mac_bytes[5]];
-        // IpAddr::V4(std::net::Ipv4Addr::new(
-        //     ip_bytes[0],
-        //     ip_bytes[1],
-        //     ip_bytes[2],
-        //     ip_bytes[3],
-        // ));
-        // if ip_address.is_some() {
-        //     return ip_address.unwrap();
-        // }
-        ip_address.unwrap_or(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))
-    }
-
-    /// Get the underlay segment ID for power shelf interfaces
-    async fn get_underlay_segment_id(&self) -> CarbideResult<NetworkSegmentId> {
-        let mut txn = self
-            .database_connection
-            .begin()
-            .await
-            .map_err(|e| DatabaseError::new("begin get underlay segment id", e))?;
-
-        let underlay_segments =
-            db_network_segment::list_segment_ids(&mut txn, Some(NetworkSegmentType::Underlay))
-                .await?;
-        txn.rollback()
-            .await
-            .map_err(|e| DatabaseError::new("end get underlay segment id", e))?;
-
-        // Return the first underlay segment, or create a default one if none exist
-        underlay_segments
-            .first()
-            .copied()
-            .ok_or_else(|| CarbideError::NotFoundError {
-                kind: "underlay_segment",
-                id: "no_underlay_segments_found".to_string(),
-            })
     }
 
     pub async fn handle_redfish_error(

--- a/crates/api/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/site_explorer.rs
@@ -1855,7 +1855,7 @@ pub async fn create_expected_power_shelves(
             serial_number: format!("PS-SN-{:03}", i + 1),
             bmc_username: "ADMIN".into(),
             bmc_password: "Pwd2023x0x0x0x0x7".into(),
-            ip_address: if (3..=4).contains(&i) {
+            bmc_ip_address: if (3..=4).contains(&i) {
                 Some(format!("192.168.1.{}", 100 + i - 3).parse().unwrap())
             } else {
                 None

--- a/crates/api/src/tests/expected_power_shelf.rs
+++ b/crates/api/src/tests/expected_power_shelf.rs
@@ -59,7 +59,7 @@ async fn test_duplicate_fail_create(pool: sqlx::PgPool) -> Result<(), Box<dyn st
             bmc_username: "ADMIN3".into(),
             bmc_password: "hmm".into(),
             serial_number: "DUPLICATE".into(),
-            ip_address: None,
+            bmc_ip_address: None,
             metadata: Metadata::default(),
             rack_id: None,
         },
@@ -153,7 +153,7 @@ async fn test_add_expected_power_shelf(pool: sqlx::PgPool) {
             bmc_username: "ADMIN".into(),
             bmc_password: "PASS".into(),
             shelf_serial_number: "PS-TEST-001".into(),
-            ip_address: "".into(),
+            bmc_ip_address: "".into(),
             metadata: None,
             rack_id: None,
         },
@@ -163,7 +163,7 @@ async fn test_add_expected_power_shelf(pool: sqlx::PgPool) {
             bmc_username: "ADMIN".into(),
             bmc_password: "PASS".into(),
             shelf_serial_number: "PS-TEST-002".into(),
-            ip_address: "192.168.1.200".into(),
+            bmc_ip_address: "192.168.1.200".into(),
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
         },
@@ -173,7 +173,7 @@ async fn test_add_expected_power_shelf(pool: sqlx::PgPool) {
             bmc_username: "ADMIN".into(),
             bmc_password: "PASS".into(),
             shelf_serial_number: "PS-TEST-003".into(),
-            ip_address: "192.168.1.201".into(),
+            bmc_ip_address: "192.168.1.201".into(),
             metadata: Some(rpc::forge::Metadata {
                 name: "power-shelf-a".to_string(),
                 description: "Test power shelf".to_string(),
@@ -302,7 +302,7 @@ async fn test_update_expected_power_shelf(pool: sqlx::PgPool) {
             bmc_username: "ADMIN_UPDATE".into(),
             bmc_password: "PASS_UPDATE".into(),
             shelf_serial_number: "PS-UPD-001".into(),
-            ip_address: "".into(),
+            bmc_ip_address: "".into(),
             metadata: None,
             rack_id: None,
         },
@@ -312,7 +312,7 @@ async fn test_update_expected_power_shelf(pool: sqlx::PgPool) {
             bmc_username: "ADMIN_UPDATE".into(),
             bmc_password: "PASS_UPDATE".into(),
             shelf_serial_number: "PS-UPD-002".into(),
-            ip_address: "192.168.2.100".into(),
+            bmc_ip_address: "192.168.2.100".into(),
             metadata: Some(Default::default()),
             rack_id: None,
         },
@@ -322,7 +322,7 @@ async fn test_update_expected_power_shelf(pool: sqlx::PgPool) {
             bmc_username: "ADMIN_UPDATE1".into(),
             bmc_password: "PASS_UPDATE1".into(),
             shelf_serial_number: "PS-UPD-003".into(),
-            ip_address: "192.168.2.101".into(),
+            bmc_ip_address: "192.168.2.101".into(),
             metadata: Some(rpc::forge::Metadata {
                 name: "updated-shelf".to_string(),
                 description: "Updated power shelf".to_string(),
@@ -383,7 +383,7 @@ async fn test_update_expected_power_shelf_error(pool: sqlx::PgPool) {
         bmc_username: "ADMIN_UPDATE".into(),
         bmc_password: "PASS_UPDATE".into(),
         shelf_serial_number: "PS-UPD-001".into(),
-        ip_address: "".into(),
+        bmc_ip_address: "".into(),
         metadata: None,
         rack_id: None,
     };
@@ -463,7 +463,7 @@ async fn test_replace_all_expected_power_shelves(pool: sqlx::PgPool) {
         bmc_username: "ADMIN_NEW".into(),
         bmc_password: "PASS_NEW".into(),
         shelf_serial_number: "PS-NEW-001".into(),
-        ip_address: "192.168.100.1".into(),
+        bmc_ip_address: "192.168.100.1".into(),
         metadata: Some(rpc::Metadata::default()),
         rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
     };
@@ -474,7 +474,7 @@ async fn test_replace_all_expected_power_shelves(pool: sqlx::PgPool) {
         bmc_username: "ADMIN_NEW".into(),
         bmc_password: "PASS_NEW".into(),
         shelf_serial_number: "PS-NEW-002".into(),
-        ip_address: "192.168.100.2".into(),
+        bmc_ip_address: "192.168.100.2".into(),
         metadata: Some(rpc::Metadata::default()),
         rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
     };
@@ -568,7 +568,7 @@ async fn test_add_expected_power_shelf_with_ip(pool: sqlx::PgPool) {
         bmc_username: "ADMIN".into(),
         bmc_password: "PASS".into(),
         shelf_serial_number: "PS-IP-001".into(),
-        ip_address: "10.0.0.100".into(),
+        bmc_ip_address: "10.0.0.100".into(),
         metadata: Some(rpc::Metadata::default()),
         rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
     };
@@ -595,7 +595,7 @@ async fn test_add_expected_power_shelf_with_ip(pool: sqlx::PgPool) {
         .expected_power_shelf_id
         .clone();
     assert_eq!(retrieved_expected_power_shelf, expected_power_shelf);
-    assert_eq!(retrieved_expected_power_shelf.ip_address, "10.0.0.100");
+    assert_eq!(retrieved_expected_power_shelf.bmc_ip_address, "10.0.0.100");
 }
 
 #[crate::sqlx_test]
@@ -606,11 +606,11 @@ async fn test_with_ip_addresses(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
 
     // Shelves at indices 3 and 4 are created with IP addresses
     assert_eq!(
-        shelves[3].ip_address,
+        shelves[3].bmc_ip_address,
         Some("192.168.1.100".parse().unwrap())
     );
     assert_eq!(
-        shelves[4].ip_address,
+        shelves[4].bmc_ip_address,
         Some("192.168.1.101".parse().unwrap())
     );
 
@@ -635,7 +635,7 @@ async fn test_update_expected_power_shelf_ip_address(pool: sqlx::PgPool) {
         .expect("unable to get")
         .into_inner();
 
-    eps1.ip_address = "172.16.0.50".to_string();
+    eps1.bmc_ip_address = "172.16.0.50".to_string();
 
     env.api
         .update_expected_power_shelf(tonic::Request::new(eps1.clone()))
@@ -654,7 +654,7 @@ async fn test_update_expected_power_shelf_ip_address(pool: sqlx::PgPool) {
         .into_inner();
 
     assert_eq!(eps1, eps2);
-    assert_eq!(eps2.ip_address, "172.16.0.50");
+    assert_eq!(eps2.bmc_ip_address, "172.16.0.50");
 }
 
 #[crate::sqlx_test()]
@@ -670,7 +670,7 @@ async fn test_get_expected_power_shelf_by_id(pool: sqlx::PgPool) {
         bmc_username: "ADMIN".into(),
         bmc_password: "PASS".into(),
         shelf_serial_number: "PS-ID-001".into(),
-        ip_address: "10.0.0.50".into(),
+        bmc_ip_address: "10.0.0.50".into(),
         metadata: Some(rpc::forge::Metadata::default()),
         rack_id: None,
     };
@@ -700,7 +700,7 @@ async fn test_get_expected_power_shelf_by_id(pool: sqlx::PgPool) {
     );
     assert_eq!(retrieved.bmc_mac_address, "AA:BB:CC:DD:EE:01");
     assert_eq!(retrieved.shelf_serial_number, "PS-ID-001");
-    assert_eq!(retrieved.ip_address, "10.0.0.50");
+    assert_eq!(retrieved.bmc_ip_address, "10.0.0.50");
 }
 
 #[crate::sqlx_test()]
@@ -716,7 +716,7 @@ async fn test_delete_expected_power_shelf_by_id(pool: sqlx::PgPool) {
         bmc_username: "ADMIN".into(),
         bmc_password: "PASS".into(),
         shelf_serial_number: "PS-DEL-001".into(),
-        ip_address: "".into(),
+        bmc_ip_address: "".into(),
         metadata: Some(rpc::forge::Metadata::default()),
         rack_id: None,
     };
@@ -770,7 +770,7 @@ async fn test_update_expected_power_shelf_by_id(pool: sqlx::PgPool) {
         bmc_username: "ADMIN".into(),
         bmc_password: "PASS".into(),
         shelf_serial_number: "PS-UPD-ID-001".into(),
-        ip_address: "".into(),
+        bmc_ip_address: "".into(),
         metadata: Some(rpc::forge::Metadata::default()),
         rack_id: None,
     };
@@ -783,7 +783,7 @@ async fn test_update_expected_power_shelf_by_id(pool: sqlx::PgPool) {
     // Update by id (change username and serial number)
     expected_power_shelf.bmc_username = "ADMIN_UPDATED".into();
     expected_power_shelf.shelf_serial_number = "PS-UPD-ID-002".into();
-    expected_power_shelf.ip_address = "172.16.0.99".into();
+    expected_power_shelf.bmc_ip_address = "172.16.0.99".into();
     env.api
         .update_expected_power_shelf(tonic::Request::new(expected_power_shelf.clone()))
         .await
@@ -809,7 +809,7 @@ async fn test_update_expected_power_shelf_by_id(pool: sqlx::PgPool) {
     );
     assert_eq!(retrieved.bmc_username, "ADMIN_UPDATED");
     assert_eq!(retrieved.shelf_serial_number, "PS-UPD-ID-002");
-    assert_eq!(retrieved.ip_address, "172.16.0.99");
+    assert_eq!(retrieved.bmc_ip_address, "172.16.0.99");
 }
 
 #[crate::sqlx_test()]
@@ -825,7 +825,7 @@ async fn test_create_expected_power_shelf_with_explicit_id(pool: sqlx::PgPool) {
         bmc_username: "ADMIN".into(),
         bmc_password: "PASS".into(),
         shelf_serial_number: "PS-EXPLICIT-001".into(),
-        ip_address: "".into(),
+        bmc_ip_address: "".into(),
         metadata: Some(rpc::forge::Metadata::default()),
         rack_id: None,
     };
@@ -863,7 +863,7 @@ async fn test_create_expected_power_shelf_auto_generates_id(pool: sqlx::PgPool) 
         bmc_username: "ADMIN".into(),
         bmc_password: "PASS".into(),
         shelf_serial_number: "PS-AUTO-001".into(),
-        ip_address: "".into(),
+        bmc_ip_address: "".into(),
         metadata: Some(rpc::forge::Metadata::default()),
         rack_id: None,
     };
@@ -922,4 +922,92 @@ async fn test_get_expected_power_shelf_by_id_not_found(pool: sqlx::PgPool) {
         err.message().to_string(),
         format!("expected_power_shelf not found: {}", non_existent_id)
     );
+}
+
+/// When an expected power shelf is created with a bmc_ip_address, test to make
+/// sure a machine_interface is pre-allocated with a static address in the DB.
+/// Site explorer then just picks it up naturally from the underlay interface query.
+#[crate::sqlx_test()]
+async fn test_add_with_bmc_ip_creates_static_interface(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "4A:4B:4C:4D:4E:4F".parse().unwrap();
+    let bmc_ip = "192.0.2.180";
+
+    env.api
+        .add_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelf {
+            expected_power_shelf_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            shelf_serial_number: "PS-STATIC-001".into(),
+            bmc_ip_address: bmc_ip.into(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+        }))
+        .await?;
+
+    // Verify a machine_interface was effectiveely pre-created
+    // for the BMC MAC.
+    let mut txn = env.pool.begin().await?;
+    let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, bmc_mac).await?;
+    assert_eq!(
+        interfaces.len(),
+        1,
+        "should have one interface for the BMC MAC"
+    );
+
+    let iface = &interfaces[0];
+    assert!(
+        iface.addresses.contains(&bmc_ip.parse().unwrap()),
+        "interface should have the static BMC IP"
+    );
+
+    // Verify the address is a static allocation type.
+    let addrs = db::machine_interface_address::find_for_interface(&mut txn, iface.id).await?;
+    assert_eq!(addrs.len(), 1);
+    assert_eq!(
+        addrs[0].address,
+        bmc_ip.parse::<std::net::IpAddr>().unwrap()
+    );
+    assert_eq!(
+        addrs[0].allocation_type,
+        model::allocation_type::AllocationType::Static
+    );
+
+    Ok(())
+}
+
+/// When an expected power shelf is created WITHOUT a bmc_ip_address,
+/// no machine_interface should be created.
+#[crate::sqlx_test()]
+async fn test_add_without_bmc_ip_creates_no_interface(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "5A:5B:5C:5D:5E:5F".parse().unwrap();
+
+    env.api
+        .add_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelf {
+            expected_power_shelf_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            shelf_serial_number: "PS-NO-IP-001".into(),
+            bmc_ip_address: "".into(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+        }))
+        .await?;
+
+    // No interface should exist for this MAC.
+    let mut txn = env.pool.begin().await?;
+    let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, bmc_mac).await?;
+    assert!(
+        interfaces.is_empty(),
+        "should not create interface without bmc_ip_address"
+    );
+
+    Ok(())
 }

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -176,7 +176,7 @@ impl FakePowerShelf {
             bmc_username: self.bmc_username.clone(),
             bmc_password: self.bmc_password.clone(),
             serial_number: self.serial_number.clone(),
-            ip_address: Some(self.ip.parse().unwrap()),
+            bmc_ip_address: Some(self.ip.parse().unwrap()),
             metadata: Metadata {
                 name: format!("Test Power Shelf {}", self.serial_number),
                 description: format!("A test power shelf with serial {}", self.serial_number),
@@ -4518,7 +4518,7 @@ async fn test_site_explorer_power_shelf_discovery_with_static_ip(
 
     let power_shelf = FakePowerShelf::new(
         "B8:3F:D2:90:97:B0".parse().unwrap(),
-        "192.0.2.1".to_string(),
+        "192.0.1.180".to_string(),
         "PS123456789".to_string(),
         "admin".to_string(),
         "password".to_string(),
@@ -4531,11 +4531,13 @@ async fn test_site_explorer_power_shelf_discovery_with_static_ip(
         power_shelf.ip,
         power_shelf.bmc_mac_address,
     );
-    // Create expected power shelf entry in the database
-    let mut txn = env.pool.begin().await?;
-    let expected_power_shelf = power_shelf.as_expected_power_shelf();
-    db::expected_power_shelf::create(&mut txn, expected_power_shelf.clone()).await?;
-    txn.commit().await?;
+    // Create expected power shelf via the RPC handler, which
+    // pre-allocates a machine interface with the static IP.
+    env.api
+        .add_expected_power_shelf(tonic::Request::new(
+            power_shelf.as_expected_power_shelf().into(),
+        ))
+        .await?;
 
     let endpoint_explorer = Arc::new(MockEndpointExplorer::default());
 

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1825,7 +1825,7 @@ message ExpectedPowerShelf {
   string bmc_username = 2;
   string bmc_password = 3;
   string shelf_serial_number = 4;
-  string ip_address = 5;
+  string bmc_ip_address = 5;
   // Metadata that will automatically get associated with a newly created PowerShelf
   Metadata metadata = 6;
   optional common.RackId rack_id = 7;


### PR DESCRIPTION
## Description

There was some existing work for being able to do static/external IP assignments for power shelf BMC interfaces, but we're slowly working to revamp all of it. This adapts things to flow through the new `AddressSelectionStrategy::StaticAddress` mechanism that is in place for supporting DHCP reservations and external static assignments, which lets us clean things up considerably.

Since we're not even using this yet, I'm also changing `--ip-address` to be `--bmc-ip-address` to match all of the other `--bmc-*` prefixed flags, since this is specifically for BMC interfaces. The idea is we will do something similar for nvswitches, machines, and really anything with a BMC interface that we would potentially need to do this on.

Unit and integration tests included to for ensuring the plumbing works.

Supports https://github.com/NVIDIA/ncx-infra-controller-core/issues/644 and https://github.com/NVIDIA/ncx-infra-controller-core/issues/790.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

