### PR TITLE
feat: add bmc ip address support to nvlink switches

### DIFF
--- a/crates/admin-cli/src/expected_switch/add/args.rs
+++ b/crates/admin-cli/src/expected_switch/add/args.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use std::net::IpAddr;
+
 use carbide_uuid::rack::RackId;
 use clap::Parser;
 use mac_address::MacAddress;
@@ -73,6 +75,13 @@ pub struct Args {
         action = clap::ArgAction::Append
     )]
     pub rack_id: Option<RackId>,
+
+    #[clap(
+        long = "bmc-ip-address",
+        value_name = "BMC_IP_ADDRESS",
+        help = "BMC IP address of the expected switch"
+    )]
+    pub bmc_ip_address: Option<IpAddr>,
 }
 
 impl From<Args> for rpc::forge::ExpectedSwitch {
@@ -98,6 +107,10 @@ impl From<Args> for rpc::forge::ExpectedSwitch {
                 .collect(),
             nvos_username: value.nvos_username,
             nvos_password: value.nvos_password,
+            bmc_ip_address: value
+                .bmc_ip_address
+                .map(|ip| ip.to_string())
+                .unwrap_or_default(),
         }
     }
 }

--- a/crates/admin-cli/src/expected_switch/common.rs
+++ b/crates/admin-cli/src/expected_switch/common.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use std::net::IpAddr;
+
 use carbide_uuid::rack::RackId;
 use mac_address::MacAddress;
 use serde::{Deserialize, Serialize};
@@ -32,4 +34,5 @@ pub struct ExpectedSwitchJson {
     #[serde(default)]
     pub metadata: Option<rpc::forge::Metadata>,
     pub rack_id: Option<RackId>,
+    pub bmc_ip_address: Option<IpAddr>,
 }

--- a/crates/admin-cli/src/expected_switch/update/args.rs
+++ b/crates/admin-cli/src/expected_switch/update/args.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use std::net::IpAddr;
+
 use ::rpc::admin_cli::CarbideCliError;
 use carbide_uuid::rack::RackId;
 use clap::{ArgGroup, Parser};
@@ -103,6 +105,13 @@ pub struct Args {
         action = clap::ArgAction::Append
     )]
     pub rack_id: Option<RackId>,
+
+    #[clap(
+        long = "bmc-ip-address",
+        value_name = "BMC_IP_ADDRESS",
+        help = "BMC IP address of the expected switch"
+    )]
+    pub bmc_ip_address: Option<IpAddr>,
 }
 
 impl TryFrom<Args> for rpc::forge::ExpectedSwitch {
@@ -155,6 +164,10 @@ impl TryFrom<Args> for rpc::forge::ExpectedSwitch {
                 .iter()
                 .map(|m| m.to_string())
                 .collect(),
+            bmc_ip_address: args
+                .bmc_ip_address
+                .map(|ip| ip.to_string())
+                .unwrap_or_default(),
         })
     }
 }

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -711,6 +711,10 @@ impl ApiClient {
                         .collect(),
                     nvos_username: switch.nvos_username,
                     nvos_password: switch.nvos_password,
+                    bmc_ip_address: switch
+                        .bmc_ip_address
+                        .map(|ip| ip.to_string())
+                        .unwrap_or_default(),
                     metadata: switch.metadata,
                     rack_id: switch.rack_id,
                 })

--- a/crates/api-db/migrations/20260404154300_expected_switches_bmc_ip_address.sql
+++ b/crates/api-db/migrations/20260404154300_expected_switches_bmc_ip_address.sql
@@ -1,0 +1,3 @@
+-- Add bmc_ip_address to expected_switches (just like we do for power_shelves, etc).
+ALTER TABLE expected_switches ADD COLUMN bmc_ip_address inet;
+CREATE INDEX idx_expected_switches_bmc_ip_address ON expected_switches(bmc_ip_address);

--- a/crates/api-db/src/expected_switch.rs
+++ b/crates/api-db/src/expected_switch.rs
@@ -177,9 +177,9 @@ pub async fn create(
 ) -> DatabaseResult<ExpectedSwitch> {
     let id = switch.expected_switch_id.unwrap_or_else(Uuid::new_v4);
     let query = "INSERT INTO expected_switches
-             (expected_switch_id, bmc_mac_address, bmc_username, bmc_password, serial_number, metadata_name, metadata_description, rack_id, metadata_labels, nvos_username, nvos_password, nvos_mac_addresses)
+             (expected_switch_id, bmc_mac_address, bmc_username, bmc_password, serial_number, bmc_ip_address, metadata_name, metadata_description, rack_id, metadata_labels, nvos_username, nvos_password, nvos_mac_addresses)
              VALUES
-             ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::varchar, $7::varchar, $8::varchar, $9::jsonb, $10::varchar, $11::varchar, $12::macaddr[]) RETURNING *";
+             ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::inet, $7::varchar, $8::varchar, $9::varchar, $10::jsonb, $11::varchar, $12::varchar, $13::macaddr[]) RETURNING *";
 
     sqlx::query_as(query)
         .bind(id)
@@ -187,6 +187,7 @@ pub async fn create(
         .bind(&switch.bmc_username)
         .bind(&switch.bmc_password)
         .bind(&switch.serial_number)
+        .bind(switch.bmc_ip_address)
         .bind(&switch.metadata.name)
         .bind(&switch.metadata.description)
         .bind(&switch.rack_id)
@@ -303,18 +304,18 @@ pub async fn clear(txn: &mut PgConnection) -> Result<(), DatabaseError> {
 /// matches by ID; otherwise matches by bmc_mac_address.
 pub async fn update(txn: &mut PgConnection, switch: &ExpectedSwitch) -> DatabaseResult<()> {
     let (where_clause, target_id) = match switch.expected_switch_id {
-        Some(id) => ("expected_switch_id=$11::uuid", id.to_string()),
+        Some(id) => ("expected_switch_id=$12::uuid", id.to_string()),
         None => (
-            "bmc_mac_address=$11::macaddr",
+            "bmc_mac_address=$12::macaddr",
             switch.bmc_mac_address.to_string(),
         ),
     };
 
     let query = format!(
         "UPDATE expected_switches \
-         SET bmc_username=$1, bmc_password=$2, serial_number=$3, \
-             metadata_name=$4, metadata_description=$5, metadata_labels=$6, \
-             rack_id=$7, nvos_username=$8, nvos_password=$9, nvos_mac_addresses=$10::macaddr[] \
+         SET bmc_username=$1, bmc_password=$2, serial_number=$3, bmc_ip_address=$4, \
+             metadata_name=$5, metadata_description=$6, metadata_labels=$7, \
+             rack_id=$8, nvos_username=$9, nvos_password=$10, nvos_mac_addresses=$11::macaddr[] \
          WHERE {where_clause}"
     );
 
@@ -322,6 +323,7 @@ pub async fn update(txn: &mut PgConnection, switch: &ExpectedSwitch) -> Database
         .bind(&switch.bmc_username)
         .bind(&switch.bmc_password)
         .bind(&switch.serial_number)
+        .bind(switch.bmc_ip_address)
         .bind(&switch.metadata.name)
         .bind(&switch.metadata.description)
         .bind(sqlx::types::Json(&switch.metadata.labels))

--- a/crates/api-model/src/expected_switch.rs
+++ b/crates/api-model/src/expected_switch.rs
@@ -16,6 +16,7 @@
  */
 
 use std::collections::HashMap;
+use std::net::IpAddr;
 
 use ::rpc::errors::RpcDataConversionError;
 use carbide_uuid::rack::RackId;
@@ -41,6 +42,8 @@ pub struct ExpectedSwitch {
     pub bmc_password: String,
     pub nvos_username: Option<String>,
     pub nvos_password: Option<String>,
+    #[serde(default)]
+    pub bmc_ip_address: Option<IpAddr>,
     #[serde(default = "default_metadata_for_deserializer")]
     pub metadata: Metadata,
     pub rack_id: Option<RackId>,
@@ -67,6 +70,7 @@ impl<'r> FromRow<'r, PgRow> for ExpectedSwitch {
             bmc_password: row.try_get("bmc_password")?,
             nvos_username: row.try_get("nvos_username")?,
             nvos_password: row.try_get("nvos_password")?,
+            bmc_ip_address: row.try_get("bmc_ip_address").ok(),
             metadata,
             rack_id: row.try_get("rack_id")?,
         })
@@ -92,6 +96,10 @@ impl From<ExpectedSwitch> for rpc::forge::ExpectedSwitch {
             switch_serial_number: expected_switch.serial_number,
             nvos_username: expected_switch.nvos_username,
             nvos_password: expected_switch.nvos_password,
+            bmc_ip_address: expected_switch
+                .bmc_ip_address
+                .map(|ip| ip.to_string())
+                .unwrap_or_default(),
             metadata: Some(expected_switch.metadata.into()),
             rack_id: expected_switch.rack_id,
         }
@@ -120,6 +128,11 @@ impl TryFrom<rpc::forge::ExpectedSwitch> for ExpectedSwitch {
             })
             .transpose()?;
         let metadata = Metadata::try_from(rpc.metadata.unwrap_or_default())?;
+        let bmc_ip_address = if rpc.bmc_ip_address.is_empty() {
+            None
+        } else {
+            rpc.bmc_ip_address.parse().ok()
+        };
 
         Ok(ExpectedSwitch {
             expected_switch_id,
@@ -129,6 +142,7 @@ impl TryFrom<rpc::forge::ExpectedSwitch> for ExpectedSwitch {
             serial_number: rpc.switch_serial_number,
             nvos_username: rpc.nvos_username,
             nvos_password: rpc.nvos_password,
+            bmc_ip_address,
             metadata,
             rack_id: rpc.rack_id,
             nvos_mac_addresses,

--- a/crates/api/src/handlers/expected_switch.rs
+++ b/crates/api/src/handlers/expected_switch.rs
@@ -23,6 +23,7 @@ use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
 use crate::api::Api;
+use crate::handlers::machine_interface_address::preallocate_machine_interface;
 
 pub async fn add_expected_switch(
     api: &Api,
@@ -43,6 +44,10 @@ pub async fn add_expected_switch(
         .map_err(|e| CarbideError::Internal {
             message: format!("Database error: {}", e),
         })?;
+
+    if let Some(bmc_ip) = switch.bmc_ip_address {
+        preallocate_machine_interface(&mut txn, switch.bmc_mac_address, bmc_ip).await?;
+    }
 
     db_expected_switch::create(&mut txn, switch)
         .await

--- a/crates/api/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/site_explorer.rs
@@ -1787,6 +1787,7 @@ pub async fn create_expected_switches(
             } else {
                 None
             },
+            bmc_ip_address: None,
             metadata: Metadata {
                 name: format!("Switch{}", i + 1),
                 description: format!("Test Switch {}", i + 1),

--- a/crates/api/src/tests/expected_switch.rs
+++ b/crates/api/src/tests/expected_switch.rs
@@ -57,6 +57,7 @@ async fn test_duplicate_fail_create(pool: sqlx::PgPool) -> Result<(), Box<dyn st
             bmc_username: "ADMIN3".into(),
             bmc_password: "hmm".into(),
             serial_number: "DUPLICATE".into(),
+            bmc_ip_address: None,
             metadata: Metadata::default(),
             rack_id: None,
             nvos_username: None,
@@ -159,6 +160,7 @@ async fn test_add_expected_switch(pool: sqlx::PgPool) {
             nvos_password: None,
             metadata: None,
             rack_id: None,
+            bmc_ip_address: String::new(),
         },
         rpc::forge::ExpectedSwitch {
             expected_switch_id: None,
@@ -171,6 +173,7 @@ async fn test_add_expected_switch(pool: sqlx::PgPool) {
             nvos_password: Some("nvos_pass".into()),
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
+            bmc_ip_address: String::new(),
         },
         rpc::forge::ExpectedSwitch {
             expected_switch_id: None,
@@ -196,6 +199,7 @@ async fn test_add_expected_switch(pool: sqlx::PgPool) {
                 ],
             }),
             rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
+            bmc_ip_address: String::new(),
         },
     ] {
         env.api
@@ -294,6 +298,7 @@ async fn test_update_expected_switch(pool: sqlx::PgPool) {
             nvos_password: None,
             metadata: None,
             rack_id: None,
+            bmc_ip_address: String::new(),
         },
         rpc::forge::ExpectedSwitch {
             expected_switch_id: None,
@@ -306,6 +311,7 @@ async fn test_update_expected_switch(pool: sqlx::PgPool) {
             nvos_password: Some("nvos_upd_pass".into()),
             metadata: Some(Default::default()),
             rack_id: None,
+            bmc_ip_address: String::new(),
         },
         rpc::forge::ExpectedSwitch {
             expected_switch_id: None,
@@ -331,6 +337,7 @@ async fn test_update_expected_switch(pool: sqlx::PgPool) {
                 ],
             }),
             rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
+            bmc_ip_address: String::new(),
         },
     ] {
         env.api
@@ -382,6 +389,7 @@ async fn test_get_expected_switch_by_id(pool: sqlx::PgPool) {
         nvos_password: Some("nvos_pass".into()),
         metadata: Some(rpc::forge::Metadata::default()),
         rack_id: None,
+        bmc_ip_address: String::new(),
     };
 
     env.api
@@ -422,6 +430,7 @@ async fn test_delete_expected_switch_by_id(pool: sqlx::PgPool) {
         nvos_password: None,
         metadata: Some(rpc::forge::Metadata::default()),
         rack_id: None,
+        bmc_ip_address: String::new(),
     };
 
     env.api
@@ -474,6 +483,7 @@ async fn test_update_expected_switch_by_id(pool: sqlx::PgPool) {
         nvos_password: Some("nvos_pass".into()),
         metadata: Some(rpc::forge::Metadata::default()),
         rack_id: None,
+        bmc_ip_address: String::new(),
     };
 
     env.api
@@ -501,6 +511,7 @@ async fn test_update_expected_switch_by_id(pool: sqlx::PgPool) {
             }],
         }),
         rack_id: None,
+        bmc_ip_address: String::new(),
     };
 
     env.api
@@ -541,6 +552,7 @@ async fn test_create_expected_switch_with_explicit_id(pool: sqlx::PgPool) {
         nvos_password: None,
         metadata: Some(rpc::forge::Metadata::default()),
         rack_id: None,
+        bmc_ip_address: String::new(),
     };
 
     env.api
@@ -582,6 +594,7 @@ async fn test_create_expected_switch_auto_generates_id(pool: sqlx::PgPool) {
         nvos_password: None,
         metadata: Some(rpc::forge::Metadata::default()),
         rack_id: None,
+        bmc_ip_address: String::new(),
     };
 
     env.api
@@ -691,6 +704,7 @@ async fn test_update_expected_switch_error(pool: sqlx::PgPool) {
         nvos_password: None,
         metadata: None,
         rack_id: None,
+        bmc_ip_address: String::new(),
     };
 
     let err = env
@@ -799,6 +813,7 @@ async fn test_replace_all_expected_switches(pool: sqlx::PgPool) {
         nvos_password: Some("nvos_new_pass".into()),
         metadata: Some(rpc::Metadata::default()),
         rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
+        bmc_ip_address: String::new(),
     };
 
     let expected_switch_2 = rpc::forge::ExpectedSwitch {
@@ -812,6 +827,7 @@ async fn test_replace_all_expected_switches(pool: sqlx::PgPool) {
         nvos_password: None,
         metadata: Some(rpc::Metadata::default()),
         rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
+        bmc_ip_address: String::new(),
     };
 
     expected_switch_list
@@ -909,4 +925,93 @@ async fn test_update_persists_nvos_mac_addresses(pool: sqlx::PgPool) {
     txn.commit().await.unwrap();
 
     assert_eq!(fetched.nvos_mac_addresses, vec![new_nvos_mac]);
+}
+
+/// When an expected switch is created with a bmc_ip_address, a real
+/// machine_interface with a static address should be created in the DB.
+#[crate::sqlx_test()]
+async fn test_add_with_bmc_ip_creates_static_interface(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "6A:6B:6C:6D:6E:70".parse().unwrap();
+    let bmc_ip = "192.0.1.180";
+
+    env.api
+        .add_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
+            expected_switch_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            switch_serial_number: "SW-STATIC-001".into(),
+            nvos_mac_addresses: vec![],
+            nvos_username: None,
+            nvos_password: None,
+            bmc_ip_address: bmc_ip.into(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+        }))
+        .await?;
+
+    let mut txn = env.pool.begin().await?;
+    let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, bmc_mac).await?;
+    assert_eq!(
+        interfaces.len(),
+        1,
+        "should have one interface for the BMC MAC"
+    );
+
+    let iface = &interfaces[0];
+    assert!(
+        iface.addresses.contains(&bmc_ip.parse().unwrap()),
+        "interface should have the static BMC IP"
+    );
+
+    let addrs = db::machine_interface_address::find_for_interface(&mut txn, iface.id).await?;
+    assert_eq!(addrs.len(), 1);
+    assert_eq!(
+        addrs[0].address,
+        bmc_ip.parse::<std::net::IpAddr>().unwrap()
+    );
+    assert_eq!(
+        addrs[0].allocation_type,
+        model::allocation_type::AllocationType::Static
+    );
+
+    Ok(())
+}
+
+/// When an expected switch is created WITHOUT a bmc_ip_address,
+/// no machine_interface should be created.
+#[crate::sqlx_test()]
+async fn test_add_without_bmc_ip_creates_no_interface(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "6A:6B:6C:6D:6E:71".parse().unwrap();
+
+    env.api
+        .add_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
+            expected_switch_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            switch_serial_number: "SW-NO-IP-001".into(),
+            nvos_mac_addresses: vec![],
+            nvos_username: None,
+            nvos_password: None,
+            bmc_ip_address: String::new(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+        }))
+        .await?;
+
+    let mut txn = env.pool.begin().await?;
+    let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, bmc_mac).await?;
+    assert!(
+        interfaces.is_empty(),
+        "should not create interface without bmc_ip_address"
+    );
+
+    Ok(())
 }

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -2955,6 +2955,7 @@ async fn test_site_explorer_switch_discovery(
         bmc_password: bmc_password.clone(),
         nvos_username: None,
         nvos_password: None,
+        bmc_ip_address: None,
         metadata: Metadata {
             name: format!("Test Switch {}", serial_number),
             description: format!("A test switch with serial {}", serial_number),

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1983,6 +1983,7 @@ message ExpectedSwitch {
   // Unique identifier for the expected switch. When omitted, server generates one.
   optional common.UUID expected_switch_id = 9;
   repeated string nvos_mac_addresses = 10;
+  string bmc_ip_address = 11;
 }
 
 message ExpectedSwitchRequest {


### PR DESCRIPTION
## Description

This is similar to https://github.com/NVIDIA/ncx-infra-controller-core/pull/816, leveraging the existing plumbing from https://github.com/NVIDIA/ncx-infra-controller-core/pull/808 as part of supporting https://github.com/NVIDIA/ncx-infra-controller-core/issues/644 and https://github.com/NVIDIA/ncx-infra-controller-core/issues/790.

With all of the other plumbing in place, this integration becomes pretty straightforward.

Unit and integration tests included.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

