### PR TITLE
feat: support init-container hardware enumeration for containerized agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,6 +1952,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "smbios-lib",
+ "tempfile",
  "thiserror 2.0.17",
  "tokio",
  "toml 0.8.23",

--- a/crates/agent/src/command_line.rs
+++ b/crates/agent/src/command_line.rs
@@ -362,6 +362,9 @@ pub enum AgentPlatformType {
     // inside a container with no direct access to the OS resources or any of
     // the other containers.
     Containerized,
+    // init - init-container. This mode is used to fetch hardware info as json and feed to
+    // containerized mode.
+    ContainerInitializer,
     // should "fake DPU" be modeled as a variant here?
 }
 
@@ -379,6 +382,7 @@ impl FromStr for AgentPlatformType {
         match s {
             "dpu-os" => Ok(DpuOs),
             "containerized" => Ok(Containerized),
+            "init" => Ok(ContainerInitializer),
             unknown_type => Err(eyre::eyre!("Unknown platform type \"{unknown_type}\"")),
         }
     }
@@ -391,6 +395,13 @@ pub struct HardwareOptions {
         help = "Write the hardware output (a JSON-serialized rpc::DiscoveryInfo message) to the specified file"
     )]
     pub output_file: Option<PathBuf>,
+    #[clap(
+        long,
+        default_value = "dpu-os",
+        help = "Set the platform type. Specify \"dpu-os\", \"containerized\", or \"init\".",
+        env = "AGENT_PLATFORM_TYPE"
+    )]
+    pub agent_platform_type: AgentPlatformType,
 }
 
 #[derive(Parser, Debug)]
@@ -430,5 +441,39 @@ pub struct DuppetOptions {
 impl Options {
     pub fn load() -> Self {
         Self::parse()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_platform_type_parses_all_valid_values() {
+        assert!(matches!(
+            "dpu-os".parse::<AgentPlatformType>().unwrap(),
+            AgentPlatformType::DpuOs
+        ));
+        assert!(matches!(
+            "containerized".parse::<AgentPlatformType>().unwrap(),
+            AgentPlatformType::Containerized
+        ));
+        assert!(matches!(
+            "init".parse::<AgentPlatformType>().unwrap(),
+            AgentPlatformType::ContainerInitializer
+        ));
+    }
+
+    #[test]
+    fn test_platform_type_rejects_unknown_value() {
+        let err = "banana".parse::<AgentPlatformType>().unwrap_err();
+        assert!(err.to_string().contains("banana"));
+    }
+
+    #[test]
+    fn test_is_dpu_os_only_true_for_dpu_os() {
+        assert!(AgentPlatformType::DpuOs.is_dpu_os());
+        assert!(!AgentPlatformType::Containerized.is_dpu_os());
+        assert!(!AgentPlatformType::ContainerInitializer.is_dpu_os());
     }
 }

--- a/crates/agent/src/extension_services/manager.rs
+++ b/crates/agent/src/extension_services/manager.rs
@@ -40,7 +40,7 @@ impl ExtensionServiceManager {
                         as Box<dyn ExtensionServiceHandler>,
                 );
             }
-            AgentPlatformType::Containerized => {
+            AgentPlatformType::Containerized | AgentPlatformType::ContainerInitializer => {
                 // We can't support the KubernetesPod or
                 // KubernetesPodServicesHandler handlers as currently
                 // implemented (they do a lot of raw crictl operations), so

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -23,9 +23,11 @@ use ::rpc::DiscoveryInfo;
 use ::rpc::forge_tls_client::ForgeClientConfig;
 use ::rpc::machine_discovery::DpuData;
 use carbide_host_support::agent_config::AgentConfig;
-use carbide_host_support::hardware_enumeration::enumerate_hardware;
+use carbide_host_support::hardware_enumeration::{
+    HW_CACHE_PATH, enumerate_and_save_hardware, enumerate_hardware, load_hardware_from_cache,
+};
 use carbide_host_support::registration::register_machine;
-pub use command_line::{AgentCommand, Options, RunOptions, WriteTarget};
+pub use command_line::{AgentCommand, AgentPlatformType, Options, RunOptions, WriteTarget};
 use eyre::WrapErr;
 use forge_tls::client_config::ClientCert;
 use mac_address::MacAddress;
@@ -128,12 +130,25 @@ pub async fn start(cmdline: command_line::Options) -> eyre::Result<()> {
                 tracing::warn!("Upgrades disabled. Dev only");
             }
 
+            // For Containerized mode, fall back to the hardware cache written by the init
+            // container if no explicit discovery file was provided.
+            let hw_cache_path = Path::new(HW_CACHE_PATH);
+            let discovery_info_file = match &options.agent_platform_type {
+                AgentPlatformType::Containerized => Some(
+                    options
+                        .discovery_info_file
+                        .as_deref()
+                        .unwrap_or(hw_cache_path),
+                ),
+                _ => options.discovery_info_file.as_deref(),
+            };
+
             let Registration {
                 machine_id,
                 factory_mac_address,
             } = match options.override_machine_id {
                 // Normal case
-                None => register(&agent, options.discovery_info_file.as_deref())
+                None => register(&agent, discovery_info_file)
                     .await
                     .wrap_err("registration error")?,
                 // Dev / test override
@@ -156,7 +171,14 @@ pub async fn start(cmdline: command_line::Options) -> eyre::Result<()> {
 
         // enumerate hardware and exit
         Some(AgentCommand::Hardware(options)) => {
-            let info = enumerate_hardware()?;
+            let info = match options.agent_platform_type {
+                // Init: enumerate from host and persist to the shared volume for the containerized agent
+                AgentPlatformType::ContainerInitializer => enumerate_and_save_hardware()?,
+                // Containerized: read the snapshot written by the init container
+                AgentPlatformType::Containerized => load_hardware_from_cache()?,
+                // No container mode, just plain old dpu-agent running as a service on DPU OS.
+                AgentPlatformType::DpuOs => enumerate_hardware()?,
+            };
             let string_result = serde_json::to_string_pretty(&info)?;
             match options.output_file.as_ref() {
                 Some(output_file) => tokio::fs::write(output_file.as_path(), string_result).await?,

--- a/crates/host-support/Cargo.toml
+++ b/crates/host-support/Cargo.toml
@@ -61,6 +61,9 @@ uname = { workspace = true }
 uuid = { workspace = true }
 serde_with = { workspace = true }
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [lints]
 workspace = true
 

--- a/crates/host-support/src/hardware_enumeration.rs
+++ b/crates/host-support/src/hardware_enumeration.rs
@@ -40,6 +40,9 @@ pub mod dpu;
 mod gpu;
 mod tpm;
 
+/// Path where the init container writes the hardware snapshot, and the containerized agent reads it from.
+pub const HW_CACHE_PATH: &str = "/data/hw_output.json";
+
 const PCI_SUBCLASS: &str = "ID_PCI_SUBCLASS_FROM_DATABASE";
 const PCI_DEV_PATH: &str = "DEVPATH";
 const PCI_MODEL: &str = "ID_MODEL_FROM_DATABASE";
@@ -371,6 +374,12 @@ fn get_cpu_info(
 }
 
 pub fn enumerate_hardware() -> Result<rpc_discovery::DiscoveryInfo, HardwareEnumerationError> {
+    enumerate_hardware_inner("/proc/cpuinfo")
+}
+
+fn enumerate_hardware_inner(
+    cpu_info_path: &str,
+) -> Result<rpc_discovery::DiscoveryInfo, HardwareEnumerationError> {
     let context = libudev::Context::new()?;
 
     // uname to detect type
@@ -446,7 +455,7 @@ pub fn enumerate_hardware() -> Result<rpc_discovery::DiscoveryInfo, HardwareEnum
     // cpus
     // TODO(baz): make this work with udev one day... I tried and it gave me useless information on the cpu subsystem
     let cpu_info = {
-        let file = File::open("/proc/cpuinfo")
+        let file = File::open(cpu_info_path)
             .map_err(|e| HardwareEnumerationError::GenericError(e.to_string()))?;
         let reader = BufReader::new(file);
         CpuInfo::from_read(reader)
@@ -859,4 +868,129 @@ pub fn enumerate_hardware() -> Result<rpc_discovery::DiscoveryInfo, HardwareEnum
         // TODO: Remove when there's no longer a need to handle the old topology format
         ..Default::default()
     })
+}
+
+/// Path where the host's `/proc/cpuinfo` is bind-mounted inside the init container.
+const INIT_CPU_INFO_PATH: &str = "/host-cpu-info";
+
+/// Enumerate hardware and save the result as JSON to [`HW_CACHE_PATH`].
+///
+/// Used by the init container to snapshot host hardware info so the containerized agent can
+/// read it via [`load_hardware_from_cache`] without needing direct access to host devices.
+///
+/// Reads CPU info from [`INIT_CPU_INFO_PATH`] (`/host-cpu-info`) where the init container
+/// bind-mounts the host's `/proc/cpuinfo`.
+pub fn enumerate_and_save_hardware()
+-> Result<rpc_discovery::DiscoveryInfo, HardwareEnumerationError> {
+    let info = enumerate_hardware_inner(INIT_CPU_INFO_PATH)?;
+    save_hardware_to(&info, HW_CACHE_PATH)?;
+    Ok(info)
+}
+
+/// Load the hardware snapshot from [`HW_CACHE_PATH`] written by the init container.
+///
+/// Used by the containerized agent instead of direct hardware probing.
+pub fn load_hardware_from_cache() -> Result<rpc_discovery::DiscoveryInfo, HardwareEnumerationError>
+{
+    load_hardware_from(HW_CACHE_PATH)
+}
+
+fn save_hardware_to(
+    info: &rpc_discovery::DiscoveryInfo,
+    path: &str,
+) -> Result<(), HardwareEnumerationError> {
+    let json = serde_json::to_string_pretty(info)
+        .map_err(|e| HardwareEnumerationError::GenericError(e.to_string()))?;
+    fs::write(path, json).map_err(|e| {
+        HardwareEnumerationError::GenericError(format!(
+            "Failed to write hardware cache to {path}: {e}"
+        ))
+    })
+}
+
+fn load_hardware_from(
+    path: &str,
+) -> Result<rpc_discovery::DiscoveryInfo, HardwareEnumerationError> {
+    let contents = fs::read_to_string(path).map_err(|e| {
+        HardwareEnumerationError::GenericError(format!(
+            "Failed to read hardware cache from {path}: {e}"
+        ))
+    })?;
+    serde_json::from_str(&contents).map_err(|e| {
+        HardwareEnumerationError::GenericError(format!(
+            "Failed to parse hardware cache from {path}: {e}"
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    fn minimal_discovery_info() -> rpc_discovery::DiscoveryInfo {
+        rpc_discovery::DiscoveryInfo {
+            machine_type: "aarch64".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_save_and_load_roundtrip() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_str().unwrap();
+
+        let info = minimal_discovery_info();
+        save_hardware_to(&info, path).expect("save should succeed");
+
+        let loaded = load_hardware_from(path).expect("load should succeed");
+        assert_eq!(loaded.machine_type, "aarch64");
+    }
+
+    #[test]
+    fn test_load_file_not_found() {
+        let err = load_hardware_from("/nonexistent/path/hw.json").unwrap_err();
+        assert!(
+            err.to_string().contains("/nonexistent/path/hw.json"),
+            "error should mention the path: {err}"
+        );
+    }
+
+    #[test]
+    fn test_load_invalid_json() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_str().unwrap();
+        fs::write(path, b"not valid json { {").unwrap();
+
+        let err = load_hardware_from(path).unwrap_err();
+        assert!(
+            err.to_string().contains("Failed to parse hardware cache"),
+            "error should indicate parse failure: {err}"
+        );
+    }
+
+    #[test]
+    fn test_save_roundtrip_preserves_fields() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_str().unwrap();
+
+        let info = rpc_discovery::DiscoveryInfo {
+            machine_type: "x86_64".to_string(),
+            block_devices: vec![rpc_discovery::BlockDevice {
+                model: "test-disk".to_string(),
+                serial: "SN123".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        save_hardware_to(&info, path).unwrap();
+        let loaded = load_hardware_from(path).unwrap();
+
+        assert_eq!(loaded.machine_type, "x86_64");
+        assert_eq!(loaded.block_devices.len(), 1);
+        assert_eq!(loaded.block_devices[0].model, "test-disk");
+        assert_eq!(loaded.block_devices[0].serial, "SN123");
+    }
 }


### PR DESCRIPTION
## Description
Introduce an Init platform type that runs as a k8s init container to enumerate host hardware and persist it to /data/hw_output.json (on a shared emptyDir volume). The containerized agent then reads from this cache instead of probing hardware directly.

  Key changes:
  - Add AgentPlatformType::Init with "init" CLI/env value
  - Extract enumerate_hardware_inner(cpu_info_path) so the init path reads CPU info from /host-cpu-info (the bind-mount of host /proc/cpuinfo) rather than the container's /proc/cpuinfo
  - Add enumerate_and_save_hardware() for init containers and load_hardware_from_cache() for the containerized agent
  - Hardware subcommand dispatches on platform type; Run subcommand defaults discovery_info_file to HW_CACHE_PATH when Containerized
  - ExtensionServiceManager treats Init the same as Containerized (no crictl-based handlers)

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

Not tested yet on real env.