### PR TITLE
fix: UX/internal workflow improvements to AddressSelectionStrategy enhancements

### DIFF
--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -323,8 +323,8 @@ pub async fn validate_existing_mac_and_create(
     relay: IpAddr,
     host_nic: Option<ExpectedHostNic>,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
-    let mut existing_mac = find_by_mac_address(&mut *txn, mac_address).await?;
-    match &existing_mac.len() {
+    let mut interface_snapshot = find_by_mac_address(&mut *txn, mac_address).await?;
+    match &interface_snapshot.len() {
         0 => {
             tracing::debug!(
                 %mac_address,
@@ -387,18 +387,13 @@ pub async fn validate_existing_mac_and_create(
                 %mac_address,
                 "Mac address exists, validating the relay and returning it",
             );
-            let mac = existing_mac.remove(0);
-            // Ensure the relay segment exists before blindly giving the mac address back out
-            match crate::network_segment::for_relay(txn, relay).await? {
-                Some(ifc) if ifc.id == mac.segment_id => Ok(mac),
-                Some(ifc) => Err(DatabaseError::internal(format!(
-                    "Network segment mismatch for existing mac address: {0} expected: {1} actual from network switch: {2}",
-                    mac.mac_address, mac.segment_id, ifc.id,
-                ))),
-                None => Err(DatabaseError::internal(format!(
-                    "No network segment defined for relay address: {relay}"
-                ))),
-            }
+            // TODO(chet): I don't like that it's mut here, but this seems to be
+            // a pattern in this module in general, especially since we may or may
+            // not update the interface. Consider having reconcile_interface_segment
+            // just return the interface, which would probably look a lot better.
+            let mut existing_interface = interface_snapshot.remove(0);
+            reconcile_interface_segment(txn, &mut existing_interface, relay).await?;
+            Ok(existing_interface)
         }
         _ => {
             tracing::warn!(
@@ -1123,6 +1118,101 @@ pub async fn find_by_machine_and_segment(
         .await
         .map_err(|e| DatabaseError::query(&query, e))
         .map(|interfaces| interfaces.into_iter().collect())
+}
+
+/// Update the segment_id and domain_id for a machine interface. Used
+/// when a static address assignment or DHCP re-discovery places an
+/// interface on a different segment than it was previously on.
+pub async fn update_segment_id(
+    txn: &mut PgConnection,
+    interface_id: MachineInterfaceId,
+    segment_id: NetworkSegmentId,
+    domain_id: Option<DomainId>,
+) -> DatabaseResult<()> {
+    let query = "UPDATE machine_interfaces SET segment_id = $1, domain_id = $2 WHERE id = $3";
+    sqlx::query(query)
+        .bind(segment_id)
+        .bind(domain_id)
+        .bind(interface_id)
+        .execute(txn)
+        .await
+        .map(|_| ())
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Reconcile an existing interface's segment with the DHCP relay address.
+///
+/// - If the segments match, nothing happens.
+/// - If the interface is on the static-assignments anchor segment with
+///   no addresses (static was removed), move it to the relay's segment.
+/// - If the interface is on static-assignments with addresses, leave it
+///   alone -- the operator's static assignment takes priority over DHCP.
+/// - If the interface is on a different managed segment, error -- this
+///   is a real network mismatch (wrong VLAN/port).
+async fn reconcile_interface_segment(
+    txn: &mut PgConnection,
+    existing_interface: &mut MachineInterfaceSnapshot,
+    relay: IpAddr,
+) -> DatabaseResult<()> {
+    let relay_segment = crate::network_segment::for_relay(txn, relay)
+        .await?
+        .ok_or_else(|| {
+            DatabaseError::internal(format!(
+                "No network segment defined for DHCP relay address: {relay}"
+            ))
+        })?;
+
+    // If it's the same segment, then we're good! Nothing
+    // to do here.
+    if relay_segment.id == existing_interface.segment_id {
+        return Ok(());
+    }
+
+    let on_static_assignments = existing_interface.segment_id
+        == crate::network_segment::static_assignments(txn)
+            .await
+            .map(|s| s.id)
+            .unwrap_or_default();
+
+    // If the interface is on static-assignments with no addresses (as in
+    // the static address was removed), move it to the relay's segment
+    // so it can get a DHCP-allocated IP. The idea here being that someone
+    // removed the static allocation on purpose, and now we're waiting for
+    // the device to DHCP so we can see what segment it's coming in on.
+    if on_static_assignments && existing_interface.addresses.is_empty() {
+        tracing::info!(
+            mac_address = %existing_interface.mac_address,
+            old_segment_id = %existing_interface.segment_id,
+            new_segment_id = %relay_segment.id,
+            "Moving interface from static-assignments into DHCP-managed segment"
+        );
+        update_segment_id(
+            txn,
+            existing_interface.id,
+            relay_segment.id,
+            relay_segment.subdomain_id,
+        )
+        .await?;
+        existing_interface.segment_id = relay_segment.id;
+    } else if on_static_assignments {
+        // ...and if the interface is on static-assignments and still has
+        // an addresse, the static assignment takes priority, so we leave
+        // it as-is.
+        tracing::debug!(
+            mac_address = %existing_interface.mac_address,
+            "Interface on static-assignments with addresses, leaving as-is"
+        );
+    } else {
+        // And if it's a different managed segment, then yell. This logic
+        // existing before the static-assigmnents and DHCP "reservation"
+        // integration.
+        return Err(DatabaseError::internal(format!(
+            "Network segment mismatch for existing MAC address: {} expected: {} actual from network switch: {}",
+            existing_interface.mac_address, existing_interface.segment_id, relay_segment.id,
+        )));
+    }
+
+    Ok(())
 }
 
 /// Allocate new DHCP-based IP addresses for a specific address family

--- a/crates/api-db/src/network_segment.rs
+++ b/crates/api-db/src/network_segment.rs
@@ -564,6 +564,16 @@ pub async fn find_by_name(
         .map_err(|e| DatabaseError::query(&query, e))
 }
 
+/// Well-known name for the static assignments "anchor segment",
+/// making it extra-obvious that it's a special one.
+pub const STATIC_ASSIGNMENTS_SEGMENT_NAME: &str = "static-assignments";
+
+/// Returns the static-assignments anchor segment, used for external
+/// static IP assignments that don't fall within any managed network prefix.
+pub async fn static_assignments(txn: &mut PgConnection) -> Result<NetworkSegment, DatabaseError> {
+    find_by_name(txn, STATIC_ASSIGNMENTS_SEGMENT_NAME).await
+}
+
 /// This method returns Admin network segment.
 pub async fn admin(txn: &mut PgConnection) -> Result<NetworkSegment, DatabaseError> {
     lazy_static! {

--- a/crates/api/src/db_init.rs
+++ b/crates/api/src/db_init.rs
@@ -26,7 +26,8 @@ use model::dns::NewDomain;
 use model::firmware::AgentUpgradePolicyChoice;
 use model::machine::upgrade_policy::AgentUpgradePolicy;
 use model::metadata::Metadata;
-use model::network_segment::{NetworkDefinition, NewNetworkSegment};
+use model::network_prefix::NewNetworkPrefix;
+use model::network_segment::{NetworkDefinition, NetworkSegmentType, NewNetworkSegment};
 use model::vpc::{NewVpc, VpcStatus};
 use sqlx::{Pool, Postgres};
 
@@ -92,7 +93,50 @@ pub async fn create_initial_networks(
         crate::handlers::network_segment::save(api, &mut txn, ns, true, false).await?;
         tracing::info!("Created network segment {name}");
     }
+
+    ensure_static_assignments_segment(api, &mut txn, Some(domain_id)).await?;
+
     txn.commit().await?;
+    Ok(())
+}
+
+/// Create the static-assignments anchor segment if it doesn't exist.
+/// This segment holds external static IP assignments that don't fall
+/// within any managed network prefix. The 169.254.254.254/32 prefix is
+/// a link-local placeholder -- the allocator will never hand out IPs
+/// from it, it exists only because the schema requires a prefix.
+pub async fn ensure_static_assignments_segment(
+    api: &Api,
+    txn: &mut db::Transaction<'_>,
+    subdomain_id: Option<carbide_uuid::domain::DomainId>,
+) -> Result<(), CarbideError> {
+    let segment_name = network_segment::STATIC_ASSIGNMENTS_SEGMENT_NAME;
+    if db::network_segment::find_by_name(txn, segment_name)
+        .await
+        .is_ok()
+    {
+        return Ok(());
+    }
+
+    let ns = NewNetworkSegment {
+        id: uuid::Uuid::new_v4().into(),
+        name: segment_name.to_string(),
+        subdomain_id,
+        vpc_id: None,
+        mtu: 1500,
+        prefixes: vec![NewNetworkPrefix {
+            prefix: "169.254.254.254/32".parse().unwrap(),
+            gateway: None,
+            num_reserved: 1,
+        }],
+        vlan_id: None,
+        vni: None,
+        segment_type: NetworkSegmentType::Underlay,
+        can_stretch: Some(false),
+    };
+    crate::handlers::network_segment::save(api, txn, ns, true, false).await?;
+    tracing::info!("Created internal {segment_name} segment for holding static assignments");
+
     Ok(())
 }
 

--- a/crates/api/src/handlers/expected_power_shelf.rs
+++ b/crates/api/src/handlers/expected_power_shelf.rs
@@ -23,7 +23,9 @@ use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
 use crate::api::Api;
-use crate::handlers::machine_interface_address::preallocate_machine_interface;
+use crate::handlers::machine_interface_address::{
+    preallocate_machine_interface, update_preallocated_machine_interface,
+};
 
 pub async fn add_expected_power_shelf(
     api: &Api,
@@ -110,6 +112,11 @@ pub async fn update_expected_power_shelf(
         .map_err(|e| CarbideError::Internal {
             message: format!("Database error: {}", e),
         })?;
+
+    if let Some(bmc_ip) = power_shelf.bmc_ip_address {
+        update_preallocated_machine_interface(&mut txn, power_shelf.bmc_mac_address, bmc_ip)
+            .await?;
+    }
 
     db_expected_power_shelf::update(&mut txn, &power_shelf)
         .await

--- a/crates/api/src/handlers/expected_switch.rs
+++ b/crates/api/src/handlers/expected_switch.rs
@@ -23,7 +23,9 @@ use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
 use crate::api::Api;
-use crate::handlers::machine_interface_address::preallocate_machine_interface;
+use crate::handlers::machine_interface_address::{
+    preallocate_machine_interface, update_preallocated_machine_interface,
+};
 
 pub async fn add_expected_switch(
     api: &Api,
@@ -110,6 +112,10 @@ pub async fn update_expected_switch(
         .map_err(|e| CarbideError::Internal {
             message: format!("Database error: {}", e),
         })?;
+
+    if let Some(bmc_ip) = switch.bmc_ip_address {
+        update_preallocated_machine_interface(&mut txn, switch.bmc_mac_address, bmc_ip).await?;
+    }
 
     db_expected_switch::update(&mut txn, &switch)
         .await

--- a/crates/api/src/handlers/machine_interface_address.rs
+++ b/crates/api/src/handlers/machine_interface_address.rs
@@ -18,51 +18,61 @@
 use mac_address::MacAddress;
 use model::address_selection_strategy::AddressSelectionStrategy;
 use model::allocation_type::AllocationType;
-use model::network_segment::NetworkSegmentType;
 use rpc::forge as rpc;
 use tonic::{Request, Response, Status};
 
 use crate::api::Api;
 use crate::errors::CarbideError;
 
+/// Resolve the correct segment for a static IP. If the IP is within a
+/// managed network prefix, use that segment. Otherwise use the
+/// static-assignments anchor segment.
+async fn resolve_segment_for_static_ip(
+    txn: &mut sqlx::PgConnection,
+    ip: std::net::IpAddr,
+) -> Result<model::network_segment::NetworkSegment, CarbideError> {
+    match db::network_segment::for_relay(txn, ip).await? {
+        Some(seg) => Ok(seg),
+        None => Ok(db::network_segment::static_assignments(txn).await?),
+    }
+}
+
 /// Pre-allocate a machine_interface with a static address so
 /// site_explorer can discover the BMC at that IP.
 ///
 /// If the IP is within a managed network prefix, the interface is
-/// created on that segment. Otherwise it falls back to the first
-/// underlay segment as an anchor for external/BYO IPs.
+/// created on that segment. Otherwise it falls back to the special
+/// "static-assignments" segment where we track static assignments.
 ///
-/// Currently "assumes" a BMC, but hey maybe we can use it for
-/// other things as time goes on.
+/// This fails if a machine_interface already exists for this MAC.
+/// Use update_preallocated_machine_interface` to change the IP on
+/// an existing interface.
 pub async fn preallocate_machine_interface(
     txn: &mut sqlx::PgConnection,
     bmc_mac_address: MacAddress,
     bmc_ip: std::net::IpAddr,
 ) -> Result<(), CarbideError> {
-    let segment = match db::network_segment::for_relay(txn, bmc_ip).await? {
-        Some(seg) => seg,
-        None => {
-            let underlay_ids =
-                db::network_segment::list_segment_ids(txn, Some(NetworkSegmentType::Underlay))
-                    .await?;
-            let segment_id = underlay_ids.first().ok_or(CarbideError::NotFoundError {
-                kind: "underlay_segment",
-                id: "any".to_string(),
-            })?;
-            db::network_segment::find_by(
-                txn,
-                db::ObjectColumnFilter::One(db::network_segment::IdColumn, segment_id),
-                Default::default(),
-            )
-            .await?
-            .into_iter()
-            .next()
-            .ok_or(CarbideError::NotFoundError {
-                kind: "underlay_segment",
-                id: segment_id.to_string(),
-            })?
-        }
-    };
+    // Check if an interface already exists for this MAC.
+    let existing = db::machine_interface::find_by_mac_address(&mut *txn, bmc_mac_address).await?;
+    if !existing.is_empty() {
+        return Err(CarbideError::InvalidArgument(format!(
+            "a machine interface already exists for MAC {bmc_mac_address}; \
+             use update to change the IP address"
+        )));
+    }
+
+    // Check if the IP is already allocated to another interface.
+    if let Some(existing_addr) =
+        db::machine_interface_address::find_by_address(&mut *txn, bmc_ip).await?
+    {
+        return Err(CarbideError::InvalidArgument(format!(
+            "IP address {bmc_ip} is already allocated to interface {} \
+             on segment {}; use 'machine-interfaces assign-address' to reassign it",
+            existing_addr.id, existing_addr.name,
+        )));
+    }
+
+    let segment = resolve_segment_for_static_ip(txn, bmc_ip).await?;
 
     db::machine_interface::create(
         txn,
@@ -84,6 +94,82 @@ pub async fn preallocate_machine_interface(
     Ok(())
 }
 
+/// Update or create a machine_interface with a static address.
+///
+/// If no interface exists for this MAC, creates a new one. If an
+/// interface exists but has no addresses, assigns the static IP.
+/// If an interface exists and already has addresses, we leave it
+/// alone -- this is not an error, because expected device updates
+/// are decoupled from managed device state. The expected data is
+/// updated in the database by the caller; we only touch the
+/// machine_interface if it's safe to do so (no existing addresses).
+/// To change the IP on a live interface, operators should use
+/// 'machine-interfaces assign-address' or 'remove-address'.
+pub async fn update_preallocated_machine_interface(
+    txn: &mut sqlx::PgConnection,
+    bmc_mac_address: MacAddress,
+    bmc_ip: std::net::IpAddr,
+) -> Result<(), CarbideError> {
+    let existing = db::machine_interface::find_by_mac_address(&mut *txn, bmc_mac_address).await?;
+
+    if let Some(iface) = existing.first() {
+        if iface.addresses.is_empty() {
+            // No addresses -- safe to assign the static IP.
+            db::machine_interface_address::assign_static(txn, iface.id, bmc_ip).await?;
+
+            let segment = resolve_segment_for_static_ip(txn, bmc_ip).await?;
+            if iface.segment_id != segment.id {
+                db::machine_interface::update_segment_id(
+                    txn,
+                    iface.id,
+                    segment.id,
+                    segment.subdomain_id,
+                )
+                .await?;
+            }
+
+            tracing::info!(
+                %bmc_mac_address,
+                %bmc_ip,
+                interface_id = %iface.id,
+                "Assigned static address to existing interface without addresses"
+            );
+        } else {
+            // Interface already has address(es). We don't touch it --
+            // expected data updates are decoupled from managed state.
+            // The caller updates the expected data table; we just log.
+            tracing::info!(
+                %bmc_mac_address,
+                %bmc_ip,
+                existing_addresses = ?iface.addresses,
+                "Interface already has addresses, updated expected data only"
+            );
+        }
+    } else {
+        // No interface yet -- create a new one.
+        let segment = resolve_segment_for_static_ip(txn, bmc_ip).await?;
+
+        db::machine_interface::create(
+            txn,
+            &segment,
+            &bmc_mac_address,
+            segment.subdomain_id,
+            true,
+            AddressSelectionStrategy::StaticAddress(bmc_ip),
+        )
+        .await?;
+
+        tracing::info!(
+            %bmc_mac_address,
+            %bmc_ip,
+            segment_id = %segment.id,
+            "Pre-allocated static machine interface"
+        );
+    }
+
+    Ok(())
+}
+
 pub async fn assign_static_address(
     api: &Api,
     request: Request<rpc::AssignStaticAddressRequest>,
@@ -97,6 +183,33 @@ pub async fn assign_static_address(
     let mut txn = api.txn_begin().await?;
     let result =
         db::machine_interface_address::assign_static(&mut txn, interface_id, ip_address).await?;
+
+    // Resolve the correct segment for this IP and update the interface
+    // if needed. IPs within a managed prefix go on that prefix's segment.
+    // External IPs go on the static-assignments anchor segment.
+    let target_segment = match db::network_segment::for_relay(&mut txn, ip_address).await? {
+        Some(seg) => seg,
+        None => db::network_segment::static_assignments(&mut txn).await?,
+    };
+
+    let current_iface = db::machine_interface::find_one(txn.as_pgconn(), interface_id).await?;
+    if current_iface.segment_id != target_segment.id {
+        db::machine_interface::update_segment_id(
+            &mut txn,
+            interface_id,
+            target_segment.id,
+            target_segment.subdomain_id,
+        )
+        .await?;
+        tracing::info!(
+            %interface_id,
+            %ip_address,
+            old_segment_id = %current_iface.segment_id,
+            new_segment_id = %target_segment.id,
+            "Moved interface to correct segment for static address"
+        );
+    }
+
     txn.commit().await?;
 
     let status: rpc::AssignStaticAddressStatus = result.into();

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -134,7 +134,8 @@ use crate::tests::common::api_fixtures::managed_host::ManagedHostConfig;
 use crate::tests::common::api_fixtures::network_segment::{
     FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY, FIXTURE_TENANT_NETWORK_SEGMENT_GATEWAYS,
     FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY, create_admin_network_segment,
-    create_tenant_network_segment, create_underlay_network_segment,
+    create_static_assignments_segment, create_tenant_network_segment,
+    create_underlay_network_segment,
 };
 use crate::tests::common::rpc_builder::VpcCreationRequest;
 use crate::tests::common::test_certificates::TestCertificateProvider;
@@ -1723,6 +1724,9 @@ pub async fn create_test_env_with_overrides(
         let underlay = Some(create_underlay_network_segment(&api).await);
         network_controller.run_single_iteration().await;
         network_controller.run_single_iteration().await;
+
+        // Create static-assignments "anchor segment"
+        create_static_assignments_segment(&api).await;
 
         (admin, underlay)
     } else {

--- a/crates/api/src/tests/common/api_fixtures/network_segment.rs
+++ b/crates/api/src/tests/common/api_fixtures/network_segment.rs
@@ -86,6 +86,23 @@ pub async fn create_underlay_network_segment(api: &Api) -> NetworkSegmentId {
     .await
 }
 
+pub async fn create_static_assignments_segment(api: &Api) -> NetworkSegmentId {
+    let mut txn = db::Transaction::begin(&api.database_connection)
+        .await
+        .unwrap();
+    crate::db_init::ensure_static_assignments_segment(api, &mut txn, None)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    let mut txn = api.database_connection.begin().await.unwrap();
+    let seg = db::network_segment::static_assignments(&mut txn)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+    seg.id
+}
+
 pub async fn create_admin_network_segment(api: &Api) -> NetworkSegmentId {
     let prefix = IpNetwork::new(
         FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.network(),

--- a/crates/api/src/tests/expected_power_shelf.rs
+++ b/crates/api/src/tests/expected_power_shelf.rs
@@ -322,7 +322,7 @@ async fn test_update_expected_power_shelf(pool: sqlx::PgPool) {
             bmc_username: "ADMIN_UPDATE1".into(),
             bmc_password: "PASS_UPDATE1".into(),
             shelf_serial_number: "PS-UPD-003".into(),
-            bmc_ip_address: "192.168.2.101".into(),
+            bmc_ip_address: "192.168.2.100".into(),
             metadata: Some(rpc::forge::Metadata {
                 name: "updated-shelf".to_string(),
                 description: "Updated power shelf".to_string(),
@@ -1007,6 +1007,398 @@ async fn test_add_without_bmc_ip_creates_no_interface(
     assert!(
         interfaces.is_empty(),
         "should not create interface without bmc_ip_address"
+    );
+
+    Ok(())
+}
+
+/// Adding an expected power shelf with bmc_ip_address should fail if
+/// a machine_interface already exists for that MAC (e.g., the device
+/// already DHCP'd).
+#[crate::sqlx_test()]
+async fn test_add_with_bmc_ip_rejects_if_interface_exists(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "6A:6B:6C:6D:6E:80".parse().unwrap();
+    let relay: std::net::IpAddr = common::api_fixtures::FIXTURE_DHCP_RELAY_ADDRESS
+        .parse()
+        .unwrap();
+
+    // Create an interface via DHCP (simulating the device already being on the network).
+    let mut txn = env.pool.begin().await?;
+    db::machine_interface::validate_existing_mac_and_create(&mut txn, bmc_mac, relay, None).await?;
+    txn.commit().await?;
+
+    // Now try to add an expected power shelf with the same MAC -- should fail.
+    let result = env
+        .api
+        .add_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelf {
+            expected_power_shelf_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            shelf_serial_number: "PS-COLLISION-001".into(),
+            bmc_ip_address: "192.0.1.190".into(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+        }))
+        .await;
+
+    assert!(
+        result.is_err(),
+        "add should fail if interface already exists for this MAC"
+    );
+
+    Ok(())
+}
+
+/// Adding an expected power shelf with an external bmc_ip_address (not
+/// in any managed prefix) should create the interface on the
+/// static-assignments anchor segment.
+#[crate::sqlx_test()]
+async fn test_add_with_external_bmc_ip_uses_static_assignments(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "6A:6B:6C:6D:6E:84".parse().unwrap();
+    let external_ip = "10.50.1.150";
+
+    env.api
+        .add_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelf {
+            expected_power_shelf_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            shelf_serial_number: "PS-EXT-001".into(),
+            bmc_ip_address: external_ip.into(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+        }))
+        .await?;
+
+    // Verify interface was created on the static-assignments segment
+    let mut txn = env.pool.begin().await?;
+    let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, bmc_mac).await?;
+    assert_eq!(interfaces.len(), 1);
+
+    let iface = &interfaces[0];
+    assert!(iface.addresses.contains(&external_ip.parse().unwrap()));
+
+    let static_seg = db::network_segment::static_assignments(&mut txn).await?;
+    assert_eq!(
+        iface.segment_id, static_seg.id,
+        "external IP should be on the static-assignments segment"
+    );
+
+    Ok(())
+}
+
+/// Adding an expected power shelf with a bmc_ip_address that is already
+/// allocated to another interface should fail.
+#[crate::sqlx_test()]
+async fn test_add_with_bmc_ip_rejects_if_ip_already_allocated(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let relay: std::net::IpAddr = common::api_fixtures::FIXTURE_DHCP_RELAY_ADDRESS
+        .parse()
+        .unwrap();
+
+    // Create an interface via DHCP -- it gets an IP from the admin pool.
+    let mut txn = env.pool.begin().await?;
+    let existing = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        "6A:6B:6C:6D:6E:87".parse().unwrap(),
+        relay,
+        None,
+    )
+    .await?;
+    let taken_ip = existing.addresses[0];
+    txn.commit().await?;
+
+    // Try to add an expected power shelf with a DIFFERENT MAC but the
+    // SAME IP -- should fail.
+    let result = env
+        .api
+        .add_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelf {
+            expected_power_shelf_id: None,
+            bmc_mac_address: "6A:6B:6C:6D:6E:88".to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            shelf_serial_number: "PS-IP-COLLISION".into(),
+            bmc_ip_address: taken_ip.to_string(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+        }))
+        .await;
+
+    assert!(
+        result.is_err(),
+        "add should fail if the IP is already allocated to another interface"
+    );
+
+    Ok(())
+}
+
+/// Updating with bmc_ip_address that matches the existing address is a
+/// no-op -- the update succeeds without modifying the interface.
+#[crate::sqlx_test()]
+async fn test_update_with_matching_bmc_ip_is_noop(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "6A:6B:6C:6D:6E:81".parse().unwrap();
+    let bmc_ip = "192.0.1.191";
+
+    // Add expected power shelf with bmc_ip_address.
+    env.api
+        .add_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelf {
+            expected_power_shelf_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            shelf_serial_number: "PS-NOOP-001".into(),
+            bmc_ip_address: bmc_ip.into(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+        }))
+        .await?;
+
+    // Update with the same bmc_ip_address -- should succeed (no-op).
+    env.api
+        .update_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelf {
+            expected_power_shelf_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN-UPDATED".into(),
+            bmc_password: "PASS".into(),
+            shelf_serial_number: "PS-NOOP-001".into(),
+            bmc_ip_address: bmc_ip.into(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+        }))
+        .await?;
+
+    Ok(())
+}
+
+/// Updating with a different bmc_ip_address succeeds (updates expected
+/// data) but does not touch the interface if it already has addresses.
+/// Expected data is decoupled from managed state -- the interface IP
+/// can only be changed via assign-address / remove-address.
+#[crate::sqlx_test()]
+async fn test_update_with_different_bmc_ip_leaves_interface_alone(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "6A:6B:6C:6D:6E:82".parse().unwrap();
+    let original_ip = "192.0.1.192";
+
+    // Add expected power shelf with bmc_ip_address.
+    env.api
+        .add_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelf {
+            expected_power_shelf_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            shelf_serial_number: "PS-LEAVE-001".into(),
+            bmc_ip_address: original_ip.into(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+        }))
+        .await?;
+
+    // Update with a DIFFERENT bmc_ip_address -- should succeed but
+    // not touch the interface (it already has an address).
+    env.api
+        .update_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelf {
+            expected_power_shelf_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            shelf_serial_number: "PS-LEAVE-001".into(),
+            bmc_ip_address: "192.0.1.193".into(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+        }))
+        .await?;
+
+    // Verify the interface still has the ORIGINAL IP.
+    let mut txn = env.pool.begin().await?;
+    let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, bmc_mac).await?;
+    assert_eq!(interfaces.len(), 1);
+    assert!(
+        interfaces[0]
+            .addresses
+            .contains(&original_ip.parse().unwrap()),
+        "interface should still have the original IP, not the updated expected data IP"
+    );
+
+    Ok(())
+}
+
+/// Updating with bmc_ip_address should succeed if the interface exists
+/// but has no addresses (e.g., the address was expired/removed).
+#[crate::sqlx_test()]
+async fn test_update_with_bmc_ip_assigns_to_empty_interface(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "6A:6B:6C:6D:6E:83".parse().unwrap();
+    let relay: std::net::IpAddr = common::api_fixtures::FIXTURE_DHCP_RELAY_ADDRESS
+        .parse()
+        .unwrap();
+
+    // Create interface via DHCP, then remove its address.
+    let mut txn = env.pool.begin().await?;
+    let iface =
+        db::machine_interface::validate_existing_mac_and_create(&mut txn, bmc_mac, relay, None)
+            .await?;
+    db::machine_interface_address::delete(&mut txn, &iface.id).await?;
+    txn.commit().await?;
+
+    // Add expected power shelf WITHOUT bmc_ip_address.
+    env.api
+        .add_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelf {
+            expected_power_shelf_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            shelf_serial_number: "PS-EMPTY-001".into(),
+            bmc_ip_address: "".into(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+        }))
+        .await?;
+
+    // Update with bmc_ip_address -- should succeed since interface has no addresses.
+    env.api
+        .update_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelf {
+            expected_power_shelf_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            shelf_serial_number: "PS-EMPTY-001".into(),
+            bmc_ip_address: "192.0.1.194".into(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+        }))
+        .await?;
+
+    // Verify the interface now has the static IP.
+    let mut txn = env.pool.begin().await?;
+    let addrs = db::machine_interface_address::find_for_interface(&mut txn, iface.id).await?;
+    assert_eq!(addrs.len(), 1);
+    assert_eq!(
+        addrs[0].address,
+        "192.0.1.194".parse::<std::net::IpAddr>().unwrap()
+    );
+    assert_eq!(
+        addrs[0].allocation_type,
+        model::allocation_type::AllocationType::Static
+    );
+
+    Ok(())
+}
+
+/// Updating with bmc_ip_address when no interface exists yet (device
+/// hasn't DHCP'd) should create a new interface with the static IP.
+#[crate::sqlx_test()]
+async fn test_update_with_bmc_ip_creates_interface_if_none_exists(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "6A:6B:6C:6D:6E:85".parse().unwrap();
+    let bmc_ip = "192.0.1.195";
+
+    // Add expected power shelf without bmc_ip_address.
+    env.api
+        .add_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelf {
+            expected_power_shelf_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            shelf_serial_number: "PS-CREATE-001".into(),
+            bmc_ip_address: "".into(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+        }))
+        .await?;
+
+    // No interface should exist yet.
+    let mut txn = env.pool.begin().await?;
+    let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, bmc_mac).await?;
+    assert!(interfaces.is_empty());
+    txn.commit().await?;
+
+    // Update with bmc_ip_address -- should create a new interface.
+    env.api
+        .update_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelf {
+            expected_power_shelf_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            shelf_serial_number: "PS-CREATE-001".into(),
+            bmc_ip_address: bmc_ip.into(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+        }))
+        .await?;
+
+    // Verify interface was created with the static IP.
+    let mut txn = env.pool.begin().await?;
+    let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, bmc_mac).await?;
+    assert_eq!(interfaces.len(), 1);
+    assert!(interfaces[0].addresses.contains(&bmc_ip.parse().unwrap()));
+
+    Ok(())
+}
+
+/// Updating without bmc_ip_address should not touch any machine
+/// interface -- only the expected device record is updated.
+#[crate::sqlx_test()]
+async fn test_update_without_bmc_ip_does_not_touch_interface(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "6A:6B:6C:6D:6E:86".parse().unwrap();
+    let bmc_ip = "192.0.1.196";
+
+    // Add with bmc_ip_address -- creates an interface.
+    env.api
+        .add_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelf {
+            expected_power_shelf_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            shelf_serial_number: "PS-NOTOUCH-001".into(),
+            bmc_ip_address: bmc_ip.into(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+        }))
+        .await?;
+
+    // Update without bmc_ip_address (just changing credentials).
+    env.api
+        .update_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelf {
+            expected_power_shelf_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "NEW-ADMIN".into(),
+            bmc_password: "NEW-PASS".into(),
+            shelf_serial_number: "PS-NOTOUCH-001".into(),
+            bmc_ip_address: "".into(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+        }))
+        .await?;
+
+    // Verify the interface still has the original static IP.
+    let mut txn = env.pool.begin().await?;
+    let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, bmc_mac).await?;
+    assert_eq!(interfaces.len(), 1);
+    assert!(
+        interfaces[0].addresses.contains(&bmc_ip.parse().unwrap()),
+        "interface should still have the original IP after update without bmc_ip_address"
     );
 
     Ok(())

--- a/crates/api/src/tests/machine_dhcp.rs
+++ b/crates/api/src/tests/machine_dhcp.rs
@@ -91,7 +91,7 @@ async fn test_machine_dhcp_from_wrong_vlan_fails(
     .await;
 
     assert!(
-        matches!(output, Err(DatabaseError::Internal { message, ..}) if message.starts_with("Network segment mismatch for existing mac address"))
+        matches!(output, Err(DatabaseError::Internal { message, ..}) if message.starts_with("Network segment mismatch for existing MAC address"))
     );
 
     txn.commit().await.unwrap();

--- a/crates/api/src/tests/static_address_management.rs
+++ b/crates/api/src/tests/static_address_management.rs
@@ -34,7 +34,7 @@ async fn test_assign_static_address(pool: sqlx::PgPool) -> Result<(), Box<dyn st
     let env = create_test_env(pool).await;
     let relay: IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
 
-    // Create an interface (via DHCP discovery to get an interface_id)
+    // Create an interface (via DHCP discovery to get an interface_id).
     let mut txn = env.pool.begin().await?;
     let interface = db::machine_interface::validate_existing_mac_and_create(
         &mut txn,
@@ -43,11 +43,11 @@ async fn test_assign_static_address(pool: sqlx::PgPool) -> Result<(), Box<dyn st
         None,
     )
     .await?;
-    // Delete the DHCP address so we can assign a static one for this family
+    // Delete the DHCP address so we can assign a static one for this family.
     db::machine_interface_address::delete(&mut txn, &interface.id).await?;
     txn.commit().await?;
 
-    // Assign a static address
+    // Assign a static address.
     let resp = env
         .api
         .assign_static_address(Request::new(AssignStaticAddressRequest {
@@ -253,6 +253,54 @@ async fn test_remove_nonexistent_returns_not_found(
     Ok(())
 }
 
+/// Trying to remove a DHCP-allocated address via remove-address should
+/// return NotFound -- remove-address only operates on static allocations.
+/// DHCP allocations are managed by the lease expiration flow.
+#[crate::sqlx_test]
+async fn test_remove_dhcp_address_returns_not_found(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let relay: IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
+
+    // Create an interface with a DHCP-allocated IP.
+    let mut txn = env.pool.begin().await?;
+    let interface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        MacAddress::from_str("aa:bb:cc:dd:ee:25").unwrap(),
+        relay,
+        None,
+    )
+    .await?;
+    let dhcp_ip = interface.addresses[0];
+    txn.commit().await?;
+
+    // Try to remove it via remove-address -- should return NotFound
+    // because the address is DHCP, not static.
+    let resp = env
+        .api
+        .remove_static_address(Request::new(RemoveStaticAddressRequest {
+            interface_id: Some(interface.id),
+            ip_address: dhcp_ip.to_string(),
+        }))
+        .await?
+        .into_inner();
+
+    assert_eq!(
+        resp.status(),
+        RemoveStaticAddressStatus::NotFound,
+        "remove-address should not delete DHCP allocations"
+    );
+
+    // Verify the DHCP address is still there.
+    let mut txn = env.pool.begin().await?;
+    let addr =
+        db::machine_interface_address::find_ipv4_for_interface(&mut txn, interface.id).await?;
+    assert_eq!(addr.address, dhcp_ip, "DHCP address should still exist");
+
+    Ok(())
+}
+
 #[crate::sqlx_test]
 async fn test_find_interface_addresses_shows_types(
     pool: sqlx::PgPool,
@@ -355,6 +403,302 @@ async fn test_assign_remove_then_dhcp_reallocates(
         .into_inner();
     assert_eq!(addrs.addresses.len(), 1);
     assert_eq!(addrs.addresses[0].allocation_type, "dhcp");
+
+    Ok(())
+}
+
+/// When assigning a static IP that's within a managed segment's prefix,
+/// the interface's segment_id should be updated to that segment.
+#[crate::sqlx_test]
+async fn test_assign_moves_interface_to_correct_segment(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let relay: IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
+
+    // Create interface on the admin segment via DHCP.
+    let mut txn = env.pool.begin().await?;
+    let interface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        MacAddress::from_str("aa:bb:cc:dd:ee:20").unwrap(),
+        relay,
+        None,
+    )
+    .await?;
+    db::machine_interface_address::delete(&mut txn, &interface.id).await?;
+    txn.commit().await?;
+
+    // Interface is on the admin segment (192.0.2.0/24).
+    assert_eq!(interface.segment_id, env.admin_segment.unwrap());
+
+    // Assign a static IP in the underlay segment's range (192.0.1.0/24).
+    env.api
+        .assign_static_address(Request::new(AssignStaticAddressRequest {
+            interface_id: Some(interface.id),
+            ip_address: "192.0.1.180".to_string(),
+        }))
+        .await?;
+
+    // Verify the interface moved to the underlay segment.
+    let mut txn = env.pool.begin().await?;
+    let updated = db::machine_interface::find_one(&mut *txn, interface.id).await?;
+    assert_eq!(
+        updated.segment_id,
+        env.underlay_segment.unwrap(),
+        "interface should have moved to the underlay segment"
+    );
+
+    Ok(())
+}
+
+/// When assigning an external static IP (not in any managed prefix),
+/// the interface's segment_id should be updated to static-assignments.
+#[crate::sqlx_test]
+async fn test_assign_external_ip_moves_to_static_assignments(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let relay: IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
+
+    // Create interface on the admin segment via DHCP.
+    let mut txn = env.pool.begin().await?;
+    let interface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        MacAddress::from_str("aa:bb:cc:dd:ee:21").unwrap(),
+        relay,
+        None,
+    )
+    .await?;
+    db::machine_interface_address::delete(&mut txn, &interface.id).await?;
+    txn.commit().await?;
+
+    assert_eq!(interface.segment_id, env.admin_segment.unwrap());
+
+    // Assign an external IP (not in any managed segment).
+    env.api
+        .assign_static_address(Request::new(AssignStaticAddressRequest {
+            interface_id: Some(interface.id),
+            ip_address: "10.50.1.100".to_string(),
+        }))
+        .await?;
+
+    // Verify the interface moved to static-assignments with None domain_id.
+    let mut txn = env.pool.begin().await?;
+    let updated = db::machine_interface::find_one(&mut *txn, interface.id).await?;
+    let static_seg = db::network_segment::static_assignments(&mut txn).await?;
+    assert_eq!(
+        updated.segment_id, static_seg.id,
+        "interface should have moved to the static-assignments segment"
+    );
+    assert!(
+        updated.domain_id.is_none(),
+        "domain_id should be None on static-assignments segment"
+    );
+
+    Ok(())
+}
+
+/// When assigning a static IP within the interface's current segment,
+/// the segment_id should not change.
+#[crate::sqlx_test]
+async fn test_assign_within_same_segment_no_move(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let relay: IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
+
+    // Create interface on the admin segment via DHCP.
+    let mut txn = env.pool.begin().await?;
+    let interface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        MacAddress::from_str("aa:bb:cc:dd:ee:22").unwrap(),
+        relay,
+        None,
+    )
+    .await?;
+    db::machine_interface_address::delete(&mut txn, &interface.id).await?;
+    txn.commit().await?;
+
+    let original_segment = interface.segment_id;
+
+    // Assign a static IP within the same admin segment (192.0.2.0/24).
+    env.api
+        .assign_static_address(Request::new(AssignStaticAddressRequest {
+            interface_id: Some(interface.id),
+            ip_address: "192.0.2.220".to_string(),
+        }))
+        .await?;
+
+    // Verify the segment didn't change.
+    let mut txn = env.pool.begin().await?;
+    let updated = db::machine_interface::find_one(&mut *txn, interface.id).await?;
+    assert_eq!(
+        updated.segment_id, original_segment,
+        "interface should stay on the same segment"
+    );
+
+    Ok(())
+}
+
+/// When an interface is on static-assignments (external IP was assigned
+/// then removed), DHCP discover should move it back to the correct
+/// segment based on the relay address and allocate a new IP.
+#[crate::sqlx_test]
+async fn test_dhcp_moves_interface_back_from_static_assignments(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let mac = MacAddress::from_str("aa:bb:cc:dd:ee:23").unwrap();
+
+    // First, the initial DHCP discover, which creates an
+    // interface on the admin segment.
+    let mac_str = mac.to_string();
+    let response1 = env
+        .api
+        .discover_dhcp(
+            common::rpc_builder::DhcpDiscovery::builder(&mac_str, FIXTURE_DHCP_RELAY_ADDRESS)
+                .tonic_request(),
+        )
+        .await?
+        .into_inner();
+    let interface_id = response1.machine_interface_id.unwrap();
+
+    // Next, assign an external static IP, which moves the interface
+    // to static-assignments.
+    env.api
+        .assign_static_address(Request::new(AssignStaticAddressRequest {
+            interface_id: Some(interface_id),
+            ip_address: "10.50.1.200".to_string(),
+        }))
+        .await?;
+
+    // Verify it's on static-assignments.
+    let mut txn = env.pool.begin().await?;
+    let iface = db::machine_interface::find_one(&mut *txn, interface_id).await?;
+    let static_seg = db::network_segment::static_assignments(&mut txn).await?;
+    assert_eq!(iface.segment_id, static_seg.id);
+    txn.commit().await?;
+
+    // And then remove the static address.
+    env.api
+        .remove_static_address(Request::new(RemoveStaticAddressRequest {
+            interface_id: Some(interface_id),
+            ip_address: "10.50.1.200".to_string(),
+        }))
+        .await?;
+
+    // And now re-walk the DHCP discover path again, which should move
+    // the interace back to admin segment and allocate an IP.
+    let response2 = env
+        .api
+        .discover_dhcp(
+            common::rpc_builder::DhcpDiscovery::builder(&mac_str, FIXTURE_DHCP_RELAY_ADDRESS)
+                .tonic_request(),
+        )
+        .await?
+        .into_inner();
+
+    assert!(
+        !response2.address.is_empty(),
+        "should get a new IP after DHCP re-discover"
+    );
+    assert_eq!(
+        response2.machine_interface_id.unwrap(),
+        interface_id,
+        "should reuse the same interface"
+    );
+
+    // Verify the interface moved back to the admin segment
+    // with the correct domain_id.
+    let mut txn = env.pool.begin().await?;
+    let updated = db::machine_interface::find_one(&mut *txn, interface_id).await?;
+    assert_eq!(
+        updated.segment_id,
+        env.admin_segment.unwrap(),
+        "interface should have moved back to admin segment from static-assignments"
+    );
+    assert!(
+        updated.domain_id.is_some(),
+        "domain_id should be restored when moving back from static-assignments"
+    );
+
+    Ok(())
+}
+
+/// When an interface is on static-assignments and still has a static
+/// address, DHCP discover should NOT move it back -- the operator's
+/// static assignment takes priority over DHCP.
+#[crate::sqlx_test]
+async fn test_dhcp_does_not_move_interface_with_static_address(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let mac = MacAddress::from_str("aa:bb:cc:dd:ee:24").unwrap();
+
+    // First, the DHCP discover flow -- create an interface on
+    // the admin segment.
+    let mac_str = mac.to_string();
+    let response1 = env
+        .api
+        .discover_dhcp(
+            common::rpc_builder::DhcpDiscovery::builder(&mac_str, FIXTURE_DHCP_RELAY_ADDRESS)
+                .tonic_request(),
+        )
+        .await?
+        .into_inner();
+    let interface_id = response1.machine_interface_id.unwrap();
+
+    // And now assign external static IP -- this will move the
+    // interface to static-assignments.
+    env.api
+        .assign_static_address(Request::new(AssignStaticAddressRequest {
+            interface_id: Some(interface_id),
+            ip_address: "10.50.1.201".to_string(),
+        }))
+        .await?;
+
+    // Verify it's on static-assignments with the static IP.
+    let mut txn = env.pool.begin().await?;
+    let static_seg = db::network_segment::static_assignments(&mut txn).await?;
+    let iface = db::machine_interface::find_one(&mut *txn, interface_id).await?;
+    assert_eq!(iface.segment_id, static_seg.id);
+    assert!(
+        !iface.addresses.is_empty(),
+        "should have the static address"
+    );
+    txn.commit().await?;
+
+    // Hit the DHCP discover again -- the interface has an external static
+    // IP on static-assignments. The discover flow finds the interface but
+    // doesn't move it (static takes priority). The DHCP record view will
+    // fail because the external IP isn't within any managed prefix, which
+    // is correct -- we don't serve DHCP for external networks.
+    let result = env
+        .api
+        .discover_dhcp(
+            common::rpc_builder::DhcpDiscovery::builder(&mac_str, FIXTURE_DHCP_RELAY_ADDRESS)
+                .tonic_request(),
+        )
+        .await;
+
+    // The discover fails (external IP can't be in the DHCP records view),
+    // but the important thing is the interface was NOT moved.
+    assert!(
+        result.is_err(),
+        "DHCP discover should fail for external static IP"
+    );
+
+    // Verify the interface is still on static-assignments, untouched.
+    let mut txn = env.pool.begin().await?;
+    let updated = db::machine_interface::find_one(&mut *txn, interface_id).await?;
+    assert_eq!(
+        updated.segment_id, static_seg.id,
+        "interface should stay on static-assignments when it has a static address"
+    );
+    assert!(
+        updated.addresses.contains(&"10.50.1.201".parse().unwrap()),
+        "static address should still be intact"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Description

This follows on https://github.com/NVIDIA/ncx-infra-controller-core/pull/808, https://github.com/NVIDIA/ncx-infra-controller-core/pull/813 (which were subsequently leveraged by https://github.com/NVIDIA/ncx-infra-controller-core/pull/816 and https://github.com/NVIDIA/ncx-infra-controller-core/pull/817) as part of an effort to support https://github.com/NVIDIA/ncx-infra-controller-core/issues/644 and https://github.com/NVIDIA/ncx-infra-controller-core/issues/790.

It's worth noting these are all internal plumbing improvements, and that all existing integration tests were expected to continue to pass even with these changes.

The plumbing changes being introduced are to:
- More correctly manage underlying relational data for static "external assignment" and "internal reservation' flows.
- Have some better error handling around `machine_interfaces` and `machine_interface_addresses` conflicts.

Again, important to remind here that there are two types of static IPs:
- *External assignment* -- these are where a user wants to set an existing external address (and `site-explorer` will end up scraping this).
- *Internal reservation* -- effectively pinning a DHCP allocation to a given MAC address, making it impossible for it to get another IP. If it expires, it will get the same one when it coes back. If the site gets repaved, the interface will still come back with the same IP.

And just to re-hash the flows:
- `expected-* add --bmc-ip-address <ip-addr>`:
  - If the `--bmc-mac-address` already exists, this fails (like it always has).
  - If the `--bmc-ip-address` is already allocated to an interface, this fails.
  - If the `<ip-addr>` is within a managed segment, we make an interface in that segment and effectively do a DHCP reservation with an `AllocationType::Static` in the database.
  - If the `<ip-addr>` is outside of our managed segments, we shove it into an internal "segment" called `static-assignments` where we track these static assignments. This is a "real" segment, in that `site-explorer` finds it naturally during exploration, AND allow us to also move a managed interface naturally between static/dynamic allocation.
 
- `expected-* update --bmc-ip-address <ip-addr>`:
  - We update the expected table with the new value, and then..
  - If the MAC address doesn't have an interface IP, we'll make one and give the IP.
  - If the MAC address has an interface and an IP, we won't touch it.
  
`machine-interfaces assign-address <interface-id> <ip-addr>`: This is where an operator can say "this is your address now" for an active interface, and we will find the matching managed segment (which may fall through to the `static-assignments` segment) and update the interface accordingly.

`machine-interfaces remove-address <interface-id> <ip-addr>`: This is where the operator can say "I don't want this to have a static assignment anymore", at which point we'll remove it, and if the device is capable of hitting `carbide-dhcp`, the next time we see a `DHCPDISCOVER`, it will get an an IP again.

Now the primary adjustment being made HERE is to create an internal `static-assignments` segment during `setup.rs` where we'll store external assignments. It keeps external assignments out of the actual segments, and makes it a lot easier to find out what the current external assignments are (I added a function to query it by name). Reserved allocations in managed network segments just go where they're supposed to -- within the actual managed segment -- but external assignments get to go into their own little special happy place. This "external" segment has a garbage 169.254.254.254/32 "prefix" given to it (as if to say, we're not allocating addresses from DHCP out of this thing) -- but the /32 is meaningless, because we're not allocating (or using the `IpAllocator`) to do any sort of allocation in here.

So this all led to additional improvements, including:
- Improved segment management for external assignments (we now have an anchor move them in/out of to stop polluting a managed segment).
- Improved segment management for internal reservations (we now correctly re[assign] segment/domain IDs when IPs moved).
- Improved UX for `admin-cli machine-interfaces` flows (`assign-address` and `remove-address` flows benefit from these improvements).
- Improved UX for `admin-cli expected-* --bmc-ip-address <ip-addr>` flows (`add` and `update` flows benefit from these improvements).

Since this was primarily and internal plumbing  All existing unit and integration tests continued passing, and I also went through the various `expected-* {add, update}` and `managed-interfaces {assign-address, remove-address}` flows to make sure we've got integration tests for each flow to make sure they work as intended.

Also added more unit and integration tests around the changes.

Update: This now also supports https://github.com/NVIDIA/infra-controller/issues/1865, which now has its own tracking issue (at the time of this PR it was more of a forward-thinking thing).

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

