### PR TITLE
fix: mac-local-dev/run-carbide-api.sh script

### DIFF
--- a/dev/mac-local-dev/run-carbide-api.sh
+++ b/dev/mac-local-dev/run-carbide-api.sh
@@ -136,9 +136,12 @@ fi
 # -----------------------------------------------------------------------------
 # Environment
 # -----------------------------------------------------------------------------
-export CARBIDE_WEB_AUTH_TYPE="${CARBIDE_WEB_AUTH_TYPE:-basic}"
+export CARBIDE_WEB_AUTH_TYPE="${CARBIDE_WEB_AUTH_TYPE:-none}"
 export DATABASE_URL="postgresql://postgres:admin@localhost"
 export VAULT_ADDR="$VAULT_ADDR"
+# Vault runs without TLS in local dev (HTTP). The code requires VAULT_CACERT to
+# point to an existing file; for HTTP connections the cert is never actually used.
+export VAULT_CACERT="$REPO_ROOT/dev/certs/localhost/ca.crt"
 export VAULT_KV_MOUNT_LOCATION="secrets"
 export VAULT_PKI_MOUNT_LOCATION="certs"
 export VAULT_PKI_ROLE_NAME="role"


### PR DESCRIPTION
## Description
Fix the `mac-local-dev/run-carbide-api.sh` script to enable running carbide-api natively on macOS.

### Problem 1
Error message:
```
level=ERROR msg="Vault root CA not found at /var/run/secrets/forge-roots/ca.crt. Refusing to connect without TLS verification."
location="crates/secrets/src/forge_vault.rs:90"
```

Reason: https://github.com/NVIDIA/ncx-infra-controller-core/pull/652 enforces TLS verification even when http is used in the VAULT_ADDR environment variable.

fix(workaround): Pass any existing certificate in the local dev setup to satisfy the initial check.

### Problem 2

Error message:
```
Error: CARBIDE_WEB_AUTH_TYPE=basic is not supported. Use "none" (default; secure the UI with network controls or an auth proxy) or "oauth2" (SSO via Entra).

Location:
    crates/api/src/web/mod.rs:240:24
```

fix: Starting from https://github.com/NVIDIA/ncx-infra-controller-core/pull/761, use "none" instead of "basic".

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

