### PR TITLE
Allow invalid certs on BMCs. libredfish default changed to deny them by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6159,7 +6159,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.0#64c7d54eac7f33dad5ffb93ee74a5244b7c2c31b"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.2#e2e047cf1fddb4ec8861d7e7f8bdcf7ecbbdb705"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.0" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.2" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.12-rc1" }
 ansi-to-html = "0.2.2"
 

--- a/crates/admin-cli/src/redfish/cmds.rs
+++ b/crates/admin-cli/src/redfish/cmds.rs
@@ -84,6 +84,7 @@ pub async fn action(action: RedfishAction) -> color_eyre::Result<()> {
 
     use Cmd::*;
     let pool = libredfish::RedfishClientPool::builder()
+        .danger_accept_invalid_certs()
         .proxy(proxy)
         .build()?;
     let redfish: Box<dyn Redfish> = match &action.command {

--- a/crates/api/src/handlers/attestation.rs
+++ b/crates/api/src/handlers/attestation.rs
@@ -454,7 +454,7 @@ fn from_component_integrity(
     let ca_certificate_link = integrity
         .spdm
         .map(|x| x.identity_authentication)
-        .map(|x| x.component_certificate)
+        .map(|x| x.responder_authentication.component_certificate)
         .map(|x| x.odata_id);
 
     let evidence_target =

--- a/crates/api/src/run.rs
+++ b/crates/api/src/run.rs
@@ -189,6 +189,7 @@ pub async fn run(
 
     let redfish_pool = {
         let rf_pool = libredfish::RedfishClientPool::builder()
+            .danger_accept_invalid_certs()
             .build()
             .map_err(CarbideError::from)?;
 

--- a/crates/bmc-explorer-cli/src/main.rs
+++ b/crates/bmc-explorer-cli/src/main.rs
@@ -78,7 +78,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         password: args.password,
     };
 
-    let rf_pool = libredfish::RedfishClientPool::builder().build()?;
+    let rf_pool = libredfish::RedfishClientPool::builder()
+        .danger_accept_invalid_certs()
+        .build()?;
     let proxy_address = Arc::new(ArcSwap::new(None.into()));
     let credential_provider = Arc::new(TestCredentialManager::new(fallback_credentials.clone()));
 

--- a/crates/dpf/src/bin/api_harness.rs
+++ b/crates/dpf/src/bin/api_harness.rs
@@ -298,7 +298,9 @@ async fn redfish_reboot_host(
         ..Default::default()
     };
 
-    let pool = libredfish::RedfishClientPool::builder().build()?;
+    let pool = libredfish::RedfishClientPool::builder()
+        .danger_accept_invalid_certs()
+        .build()?;
     let client: Box<dyn Redfish> = pool.create_client(endpoint).await?;
 
     // Snapshot the boot progress timestamp before restarting.

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -1397,13 +1397,13 @@ impl Redfish for RedfishSimClient {
                     target_component_uri: Some("/redfish/v1/Chassis/ERoT_BMC_0".to_string()),
                     spdm: Some(libredfish::model::component_integrity::SPDMData {
                         identity_authentication:
-                            libredfish::model::component_integrity::ResponderAuthentication {
+                            libredfish::model::component_integrity::IdentityAuthentication { responder_authentication: libredfish::model::component_integrity::ResponderAuthentication {
                                 component_certificate: ODataId {
                                     odata_id:
                                         "/redfish/v1/Chassis/ERoT_BMC_0/Certificates/CertChain"
                                             .to_string(),
                                 },
-                            },
+                            } },
                         requester: ODataId {
                             odata_id: "/redfish/v1/Managers/BMC_0".to_string(),
                         },
@@ -1431,13 +1431,13 @@ impl Redfish for RedfishSimClient {
                     target_component_uri: Some("/redfish/v1/Chassis/HGX_IRoT_GPU_0".to_string()),
                     spdm: Some(libredfish::model::component_integrity::SPDMData {
                         identity_authentication:
-                            libredfish::model::component_integrity::ResponderAuthentication {
+                            libredfish::model::component_integrity::IdentityAuthentication { responder_authentication: libredfish::model::component_integrity::ResponderAuthentication {
                                 component_certificate: ODataId {
                                     odata_id:
                                         "/redfish/v1/Chassis/HGX_IRoT_GPU_0/Certificates/CertChain"
                                             .to_string(),
                                 },
-                            },
+                            } },
                         requester: ODataId {
                             odata_id: "/redfish/v1/Managers/BMC_0".to_string(),
                         },
@@ -1465,13 +1465,13 @@ impl Redfish for RedfishSimClient {
                     target_component_uri: Some("/redfish/v1/Chassis/HGX_IRoT_GPU_1".to_string()),
                     spdm: Some(libredfish::model::component_integrity::SPDMData {
                         identity_authentication:
-                            libredfish::model::component_integrity::ResponderAuthentication {
+                            libredfish::model::component_integrity::IdentityAuthentication { responder_authentication: libredfish::model::component_integrity::ResponderAuthentication {
                                 component_certificate: ODataId {
                                     odata_id:
                                         "/redfish/v1/Chassis/HGX_IRoT_GPU_1/Certificates/CertChain"
                                             .to_string(),
                                 },
-                            },
+                            } },
                         requester: ODataId {
                             odata_id: "/redfish/v1/Managers/BMC_0".to_string(),
                         },
@@ -1499,13 +1499,13 @@ impl Redfish for RedfishSimClient {
                     target_component_uri: Some("/redfish/v1/Chassis/HGX_IRoT_GPU_1".to_string()),
                     spdm: Some(libredfish::model::component_integrity::SPDMData {
                         identity_authentication:
-                            libredfish::model::component_integrity::ResponderAuthentication {
+                            libredfish::model::component_integrity::IdentityAuthentication { responder_authentication: libredfish::model::component_integrity::ResponderAuthentication {
                                 component_certificate: ODataId {
                                     odata_id:
                                         "/redfish/v1/Chassis/HGX_IRoT_GPU_1/Certificates/CertChain"
                                             .to_string(),
                                 },
-                            },
+                            } },
                         requester: ODataId {
                             odata_id: "/redfish/v1/Managers/BMC_0".to_string(),
                         },
@@ -1533,13 +1533,13 @@ impl Redfish for RedfishSimClient {
                     target_component_uri: Some("/redfish/v1/Chassis/HGX_IRoT_GPU_1".to_string()),
                     spdm: Some(libredfish::model::component_integrity::SPDMData {
                         identity_authentication:
-                            libredfish::model::component_integrity::ResponderAuthentication {
+                            libredfish::model::component_integrity::IdentityAuthentication { responder_authentication: libredfish::model::component_integrity::ResponderAuthentication {
                                 component_certificate: ODataId {
                                     odata_id:
                                         "/redfish/v1/Chassis/HGX_IRoT_GPU_1/Certificates/CertChain"
                                             .to_string(),
                                 },
-                            },
+                            } },
                         requester: ODataId {
                             odata_id: "/redfish/v1/Managers/BMC_0".to_string(),
                         },
@@ -1567,13 +1567,13 @@ impl Redfish for RedfishSimClient {
                     target_component_uri: Some("/redfish/v1/Chassis/HGX_IRoT_GPU_1".to_string()),
                     spdm: Some(libredfish::model::component_integrity::SPDMData {
                         identity_authentication:
-                            libredfish::model::component_integrity::ResponderAuthentication {
+                            libredfish::model::component_integrity::IdentityAuthentication { responder_authentication: libredfish::model::component_integrity::ResponderAuthentication {
                                 component_certificate: ODataId {
                                     odata_id:
                                         "/redfish/v1/Chassis/HGX_IRoT_GPU_1/Certificates/CertChain"
                                             .to_string(),
                                 },
-                            },
+                            } },
                         requester: ODataId {
                             odata_id: "/redfish/v1/Managers/BMC_0".to_string(),
                         },


### PR DESCRIPTION

## Description
libredfish changed to deny invalid certs by default.  this re-enables accepting invalid certs for BMCs

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
nvbug 6025251

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Requres merge of https://github.com/NVIDIA/libredfish/pull/56
