### PR TITLE
chore: record machine serial and who issued the command in machine force deletion

### DIFF
--- a/crates/api/src/handlers/machine.rs
+++ b/crates/api/src/handlers/machine.rs
@@ -296,13 +296,7 @@ pub(crate) async fn admin_force_delete_machine(
 ) -> Result<Response<rpc::AdminForceDeleteMachineResponse>, Status> {
     log_request_data(&request);
 
-    let issued_by = request
-        .extensions()
-        .get::<AuthContext>()
-        .and_then(|ctx| ctx.get_external_user_name())
-        .map(String::from);
-
-    let request = request.into_inner();
+    let (_metadata, extensions, request) = request.into_parts();
     let query = request.host_query;
 
     let mut response = rpc::AdminForceDeleteMachineResponse {
@@ -327,12 +321,17 @@ pub(crate) async fn admin_force_delete_machine(
     };
     log_machine_id(&machine.id);
 
+    let issued_by = extensions
+        .get::<AuthContext>()
+        .and_then(|ctx| ctx.get_external_user_name());
+
     let serial = machine
         .hardware_info
         .as_ref()
         .and_then(|hw| hw.dmi_data.as_ref())
         .map(|dmi| dmi.product_serial.as_str())
         .unwrap_or("unknown");
+
     tracing::info!(
         "admin_force_delete_machine query='{query}' machine_id={} serial='{serial}' issued_by={issued_by:?}",
         machine.id


### PR DESCRIPTION
## Description
In machine force deletion RPC, record who issued the command and also the machine's serial. This is a small quality of life change to make it easier to discover what machine was affected. The machine ID is not also recorded, but may not enough since machine hardware could change in between resulting in a different ID.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

