### PR TITLE
chore: internal cleanup around network interface/segment management

### DIFF
--- a/crates/api-db/src/machine_interface_address.rs
+++ b/crates/api-db/src/machine_interface_address.rs
@@ -16,7 +16,7 @@
  */
 use std::net::IpAddr;
 
-use carbide_network::ip::IpAddressFamily;
+use carbide_network::ip::{IdentifyAddressFamily, IpAddressFamily};
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use model::allocation_type::{AllocationType, AssignStaticResult};
 use model::network_segment::NetworkSegmentType;
@@ -160,11 +160,7 @@ pub async fn assign_static(
     interface_id: MachineInterfaceId,
     address: IpAddr,
 ) -> Result<AssignStaticResult, DatabaseError> {
-    let family = if address.is_ipv4() {
-        IpAddressFamily::Ipv4
-    } else {
-        IpAddressFamily::Ipv6
-    };
+    let family = address.address_family();
 
     let existing = find_allocation_type_for_family(&mut *txn, interface_id, family).await?;
 
@@ -192,7 +188,7 @@ pub async fn assign_static(
 pub async fn delete_by_address(
     txn: &mut PgConnection,
     address: IpAddr,
-    allocation_type: model::allocation_type::AllocationType,
+    allocation_type: AllocationType,
 ) -> Result<bool, DatabaseError> {
     let query =
         "DELETE FROM machine_interface_addresses WHERE address = $1::inet AND allocation_type = $2";

--- a/crates/api/src/handlers/machine_interface_address.rs
+++ b/crates/api/src/handlers/machine_interface_address.rs
@@ -187,10 +187,7 @@ pub async fn assign_static_address(
     // Resolve the correct segment for this IP and update the interface
     // if needed. IPs within a managed prefix go on that prefix's segment.
     // External IPs go on the static-assignments anchor segment.
-    let target_segment = match db::network_segment::for_relay(&mut txn, ip_address).await? {
-        Some(seg) => seg,
-        None => db::network_segment::static_assignments(&mut txn).await?,
-    };
+    let target_segment = resolve_segment_for_static_ip(txn.as_pgconn(), ip_address).await?;
 
     let current_iface = db::machine_interface::find_one(txn.as_pgconn(), interface_id).await?;
     if current_iface.segment_id != target_segment.id {

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -1727,6 +1727,8 @@ pub async fn create_test_env_with_overrides(
 
         // Create static-assignments "anchor segment"
         create_static_assignments_segment(&api).await;
+        network_controller.run_single_iteration().await;
+        network_controller.run_single_iteration().await;
 
         (admin, underlay)
     } else {

--- a/crates/api/src/tests/dpf/happy_path.rs
+++ b/crates/api/src/tests/dpf/happy_path.rs
@@ -76,6 +76,6 @@ async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
 
     assert!(carbide_machines_per_state.contains(&(
         "{fresh=\"true\",state=\"ready\",substate=\"\"}".to_string(),
-        "2".to_string()
+        "3".to_string()
     )));
 }

--- a/crates/api/src/tests/machine_states.rs
+++ b/crates/api/src/tests/machine_states.rs
@@ -86,7 +86,7 @@ async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
 
     assert!(carbide_machines_per_state.contains(&(
         "{fresh=\"true\",state=\"ready\",substate=\"\"}".to_string(),
-        "2".to_string()
+        "3".to_string()
     )));
 
     let expected_states_entered = &[


### PR DESCRIPTION
## Description

I was looking through code after it went in, and realized I could have done a better job in a few places. Also tweaks the network segment testing to correctly bump the iterator like we do for the other network segment additions (since we have 3 segments now, it should be 3).

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

