### PR TITLE
fix: bump nv-redfish from 0.4.3 to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6509,9 +6509,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c9cc7e5fc69e068dbea45368f18494ee6dbba0f324a741622cf84d02957c03"
+checksum = "b66689536dc565b539a8636894449215b1b694784628c2928d0609e53cbf5fbc"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -6525,9 +6525,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-bmc-http"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1d599f8b7c1d913a62ef51183255a0f42e24b4770901bd853f5cad5d043e62"
+checksum = "6510d7a2155ff4d7054c89afa7700972fb27e32f1138ea988c2025f3c8756edc"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -6545,9 +6545,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-core"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3f28ca2cfecf4e0a6cf5865d84feb22e8ff3fcbc0f021a98486baa1f0fc542f"
+checksum = "37bfa3c6ab939e8be20ebd5feeb51b01cf475f67faf07d31db1d28951ffd34cb"
 dependencies = [
  "futures-core",
  "rust_decimal",
@@ -6559,9 +6559,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-csdl-compiler"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511b072f3cc1b419b294fc1e40e6a36c889f94bf2c52967d03aebe3c3483bcdf"
+checksum = "45ab80d9109120adcd29beac75c0162333c85fca5054730271c05028bd62b52f"
 dependencies = [
  "clap",
  "clap_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ tracing-appender = "0.2.4"
 tracing-opentelemetry = "0.29.0"
 
 # NV-Redfish
-nv-redfish = { version = "0.4.3", features = [
+nv-redfish = { version = "0.5.0", features = [
   "bmc-http",
   "std-redfish",
   "update-service",

--- a/crates/bmc-explorer/src/computer_system.rs
+++ b/crates/bmc-explorer/src/computer_system.rs
@@ -188,12 +188,13 @@ impl<B: Bmc> ExploredComputerSystem<B> {
             power_state: self
                 .system
                 .power_state()
-                .map(|v| match v {
-                    PowerState::On => ModelPowerState::On,
-                    PowerState::Off => ModelPowerState::Off,
-                    PowerState::PoweringOn => ModelPowerState::PoweringOn,
-                    PowerState::PoweringOff => ModelPowerState::PoweringOff,
-                    PowerState::Paused => ModelPowerState::Paused,
+                .and_then(|v| match v {
+                    PowerState::On => Some(ModelPowerState::On),
+                    PowerState::Off => Some(ModelPowerState::Off),
+                    PowerState::PoweringOn => Some(ModelPowerState::PoweringOn),
+                    PowerState::PoweringOff => Some(ModelPowerState::PoweringOff),
+                    PowerState::Paused => Some(ModelPowerState::Paused),
+                    PowerState::UnsupportedValue => None,
                 })
                 .unwrap_or_default(),
             sku: self.system.sku().map(|v| v.to_string()),
@@ -388,9 +389,10 @@ impl<B: Bmc> ExploredComputerSystem<B> {
                     | Some("BlueField-3 SmartNIC Main Card")
                     | Some("Bluefield 3 SmartNIC Main Card") => {
                         use nv_redfish::oem::nvidia::bluefield::nvidia_computer_system::Mode;
-                        bf_ncs.mode().map(|v| match v {
-                            Mode::DpuMode => NicMode::Dpu,
-                            Mode::NicMode => NicMode::Nic,
+                        bf_ncs.mode().and_then(|v| match v {
+                            Mode::DpuMode => Some(NicMode::Dpu),
+                            Mode::NicMode => Some(NicMode::Nic),
+                            Mode::UnsupportedValue => None,
                         })
                     }
                     Some("Bluefield 2 SmartNIC Main Card") | Some("Bluefield SoC") => {
@@ -516,22 +518,24 @@ fn pcie_device_to_model<B: Bmc>(
         }),
         // TODO: Should not be converted to string....
         status: status.map(|status| model::site_explorer::SystemStatus {
-            health: status.health.map(|v| {
-                match v {
-                    nv_redfish::resource::Health::Ok => "OK",
-                    nv_redfish::resource::Health::Warning => "Warning",
-                    nv_redfish::resource::Health::Critical => "Critical",
-                }
-                .into()
-            }),
-            health_rollup: status.health_rollup.map(|v| {
-                match v {
-                    nv_redfish::resource::Health::Ok => "OK",
-                    nv_redfish::resource::Health::Warning => "Warning",
-                    nv_redfish::resource::Health::Critical => "Critical",
-                }
-                .into()
-            }),
+            health: status
+                .health
+                .and_then(|v| match v {
+                    nv_redfish::resource::Health::Ok => Some("OK"),
+                    nv_redfish::resource::Health::Warning => Some("Warning"),
+                    nv_redfish::resource::Health::Critical => Some("Critical"),
+                    nv_redfish::resource::Health::UnsupportedValue => None,
+                })
+                .map(ToString::to_string),
+            health_rollup: status
+                .health_rollup
+                .and_then(|v| match v {
+                    nv_redfish::resource::Health::Ok => Some("OK"),
+                    nv_redfish::resource::Health::Warning => Some("Warning"),
+                    nv_redfish::resource::Health::Critical => Some("Critical"),
+                    nv_redfish::resource::Health::UnsupportedValue => None,
+                })
+                .map(ToString::to_string),
             // Not enabled devices are filtered by code above.
             state: status
                 .state


### PR DESCRIPTION
## Description

Redifsh specification states that client should be able to receive enum variants that are not supported by current schema (for standard future extension). However, many BMC implementations wrongly invents their own values like "Unknown" empty values etc and this cause issue that even with support most recent published standard nv-redfish was not able to parse these values.

nv-redfish 0.5.0 implements requirements of support future values AND quirks of number of BMC implementation that invents their own values in enum fields.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

