### PR TITLE
feat: support for segment-wide dynamic/static DHCP lease allocations

### DIFF
--- a/crates/api-db/migrations/20260406194600_network_segments_allocation_strategy.sql
+++ b/crates/api-db/migrations/20260406194600_network_segments_allocation_strategy.sql
@@ -1,0 +1,5 @@
+-- Add allocation_strategy to network segments.
+-- "dynamic" (default): DHCP allocator hands out IPs from the pool.
+-- "reserved": Only pre-existing static/fixed-address reservations are served.
+ALTER TABLE network_segments
+    ADD COLUMN allocation_strategy TEXT NOT NULL DEFAULT 'dynamic';

--- a/crates/api-db/src/instance_address.rs
+++ b/crates/api-db/src/instance_address.rs
@@ -629,6 +629,7 @@ mod tests {
                     vni: None,
                     segment_type: NetworkSegmentType::Tenant,
                     can_stretch: None,
+                    allocation_strategy: Default::default(),
                 }
             })
             .collect_vec();

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -35,7 +35,7 @@ use model::hardware_info::HardwareInfo;
 use model::machine::MachineInterfaceSnapshot;
 use model::machine_interface_address::MachineInterfaceAssociation;
 use model::network_prefix::NetworkPrefix;
-use model::network_segment::{NetworkSegment, NetworkSegmentType};
+use model::network_segment::{AllocationStrategy, NetworkSegment, NetworkSegmentType};
 use model::predicted_machine_interface::PredictedMachineInterface;
 use sqlx::{FromRow, PgConnection, PgTransaction};
 
@@ -356,6 +356,16 @@ pub async fn validate_existing_mac_and_create(
             };
 
             if let Some(segment) = network_segment {
+                // If the segment only allows static reservations, reject
+                // dynamic allocation. The device must have a pre-existing
+                // static reservation to get an IP on this segment.
+                if segment.allocation_strategy == AllocationStrategy::Reserved {
+                    return Err(DatabaseError::internal(format!(
+                        "segment {} configured for static DHCP leases only; no static reservation for MAC {mac_address}",
+                        segment.name,
+                    )));
+                }
+
                 // TODO: add fixed_ip handling
                 if let Some(expected_nic) = host_nic.clone()
                     && let Some(ipaddr) = expected_nic.fixed_ip

--- a/crates/api-db/src/network_segment.rs
+++ b/crates/api-db/src/network_segment.rs
@@ -115,8 +115,9 @@ pub async fn persist(
                 vlan_id,
                 vni_id,
                 network_segment_type,
-                can_stretch)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+                can_stretch,
+                allocation_strategy)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
             RETURNING id";
     let segment_id: NetworkSegmentId = sqlx::query_as(query)
         .bind(value.id)
@@ -131,6 +132,7 @@ pub async fn persist(
         .bind(value.vni)
         .bind(value.segment_type)
         .bind(value.can_stretch)
+        .bind(value.allocation_strategy)
         .fetch_one(&mut *txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;

--- a/crates/api-model/src/network_segment/mod.rs
+++ b/crates/api-model/src/network_segment/mod.rs
@@ -95,6 +95,14 @@ pub struct NetworkDefinition {
     pub mtu: i32,
     /// How many addresses to skip before allocating
     pub reserve_first: i32,
+    /// Controls whether DHCP allocates IPs dynamically from the pool
+    /// for this specific network (with the ability to have per-IP static
+    /// reservations), or ONLY serves pre-configured static reservations.
+    ///
+    /// Defaults to dynamic if not specified, which is the traditional
+    /// behavior of Carbide + carbide-dhcp.
+    #[serde(default)]
+    pub allocation_strategy: AllocationStrategy,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
@@ -342,6 +350,8 @@ pub struct NetworkSegment {
     pub segment_type: NetworkSegmentType,
 
     pub can_stretch: Option<bool>,
+
+    pub allocation_strategy: AllocationStrategy,
 }
 
 impl NetworkSegment {
@@ -371,6 +381,25 @@ impl NetworkSegmentType {
     }
 }
 
+/// Controls how IP addresses are assigned via DHCP on a network segment,
+/// giving us support for segment-wide dynamic DHCP allocations or static
+/// DHCP leases/reservations. It is worth noting that even if the entire
+/// network segment is configured as `Dynamic`, an operator can still
+/// do per-IP static reservation overrides within that segment.
+///
+/// - `Dynamic`: The DHCP allocator hands out IPs from the pool (default).
+/// - `Reserved`: Only pre-existing static reservations are served.
+///
+/// Devices without a reservation get no DHCP response.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, sqlx::Type, Serialize, Deserialize)]
+#[sqlx(type_name = "text", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum AllocationStrategy {
+    #[default]
+    Dynamic,
+    Reserved,
+}
+
 #[derive(Debug)]
 pub struct NewNetworkSegment {
     pub id: NetworkSegmentId,
@@ -383,6 +412,7 @@ pub struct NewNetworkSegment {
     pub vni: Option<i32>,
     pub segment_type: NetworkSegmentType,
     pub can_stretch: Option<bool>,
+    pub allocation_strategy: AllocationStrategy,
 }
 
 impl TryFrom<i32> for NetworkSegmentType {
@@ -474,6 +504,7 @@ impl<'r> FromRow<'r, PgRow> for NetworkSegment {
             vni: row.try_get("vni_id").unwrap_or_default(),
             segment_type: row.try_get("network_segment_type")?,
             can_stretch: row.try_get("can_stretch")?,
+            allocation_strategy: row.try_get("allocation_strategy").unwrap_or_default(),
         })
     }
 }
@@ -532,6 +563,7 @@ impl TryFrom<rpc::forge::NetworkSegmentCreationRequest> for NewNetworkSegment {
             vni: None,
             segment_type,
             can_stretch,
+            allocation_strategy: AllocationStrategy::Dynamic,
         })
     }
 }
@@ -645,6 +677,7 @@ impl NewNetworkSegment {
                 NetworkDefinitionSegmentType::Underlay => NetworkSegmentType::Underlay,
             },
             can_stretch: None,
+            allocation_strategy: value.allocation_strategy,
         })
     }
 }

--- a/crates/api/src/db_init.rs
+++ b/crates/api/src/db_init.rs
@@ -133,6 +133,7 @@ pub async fn ensure_static_assignments_segment(
         vni: None,
         segment_type: NetworkSegmentType::Underlay,
         can_stretch: Some(false),
+        allocation_strategy: model::network_segment::AllocationStrategy::Reserved,
     };
     crate::handlers::network_segment::save(api, txn, ns, true, false).await?;
     tracing::info!("Created internal {segment_name} segment for holding static assignments");

--- a/crates/api/src/dhcp/discover.rs
+++ b/crates/api/src/dhcp/discover.rs
@@ -24,6 +24,7 @@ use db::{self, expected_machine, machine_interface};
 use mac_address::MacAddress;
 use model::dpa_interface::DpaInterface;
 use model::expected_machine::ExpectedHostNic;
+use model::network_segment::AllocationStrategy;
 use sqlx::PgConnection;
 use tonic::{Request, Response};
 
@@ -281,6 +282,16 @@ pub async fn discover_dhcp(
                     "No network segment defined for relay address: {parsed_relay}"
                 ))
             })?;
+
+        // If the segment only allows static reservations, don't
+        // dynamically allocate. The device has no reservation.
+        if segment.allocation_strategy == AllocationStrategy::Reserved {
+            return Err(CarbideError::internal(format!(
+                "segment {} configured for static DHCP leases only; no static reservation for MAC {parsed_mac}",
+                segment.name,
+            )));
+        }
+
         db::machine_interface::allocate_address_for_family(
             &mut txn,
             machine_interface.id,

--- a/crates/api/src/network_segment/allocate.rs
+++ b/crates/api/src/network_segment/allocate.rs
@@ -22,7 +22,7 @@ use carbide_uuid::vpc::{VpcId, VpcPrefixId};
 use ipnetwork::IpNetwork;
 use itertools::Itertools;
 use model::network_prefix::NewNetworkPrefix;
-use model::network_segment::NewNetworkSegment;
+use model::network_segment::{AllocationStrategy, NewNetworkSegment};
 use sqlx::PgConnection;
 
 use crate::{CarbideError, CarbideResult};
@@ -188,6 +188,7 @@ impl PrefixAllocator {
             vni: None,
             segment_type: model::network_segment::NetworkSegmentType::Tenant,
             can_stretch: Some(false), // All segments allocated here are FNN linknets.
+            allocation_strategy: AllocationStrategy::Dynamic,
         };
 
         let mut segment = db::network_segment::persist(

--- a/crates/api/src/tests/machine_interface_addresses.rs
+++ b/crates/api/src/tests/machine_interface_addresses.rs
@@ -54,6 +54,7 @@ async fn find_by_address_bmc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::erro
         segment_type: NetworkSegmentType::Underlay,
         id: uuid::uuid!("f9860f19-37d5-44f6-b637-84de4648cd39").into(),
         can_stretch: None,
+        allocation_strategy: Default::default(),
     };
     let network_segment =
         db::network_segment::persist(new_ns, &mut txn, NetworkSegmentControllerState::Ready)

--- a/crates/api/src/tests/network_segment.rs
+++ b/crates/api/src/tests/network_segment.rs
@@ -99,6 +99,7 @@ async fn test_advance_network_prefix_state(
             vlan_id: None,
             vni: None,
             can_stretch: None,
+            allocation_strategy: Default::default(),
         },
         &mut txn,
         NetworkSegmentControllerState::Provisioning,
@@ -485,6 +486,7 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
                 gateway: "172.20.0.1".to_string(),
                 mtu: 9000,
                 reserve_first: 5,
+                allocation_strategy: Default::default(),
             },
         ),
         (
@@ -495,6 +497,7 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
                 gateway: "172.99.0.1".to_string(),
                 mtu: 1500,
                 reserve_first: 5,
+                allocation_strategy: Default::default(),
             },
         ),
     ]);

--- a/crates/api/src/tests/static_address_management.rs
+++ b/crates/api/src/tests/static_address_management.rs
@@ -702,3 +702,91 @@ async fn test_dhcp_does_not_move_interface_with_static_address(
 
     Ok(())
 }
+
+/// On a reserved segment, a device with a static reservation gets
+/// its reserved IP via DHCP.
+#[crate::sqlx_test]
+async fn test_reserved_segment_serves_static_reservation(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac = MacAddress::from_str("aa:bb:cc:dd:ee:30").unwrap();
+    let reserved_ip: IpAddr = "192.0.2.230".parse().unwrap();
+
+    // Set the admin segment to reserved allocation strategy.
+    let mut txn = env.pool.begin().await?;
+    sqlx::query("UPDATE network_segments SET allocation_strategy = 'reserved' WHERE id = $1")
+        .bind(env.admin_segment.unwrap())
+        .execute(&mut *txn)
+        .await?;
+    txn.commit().await?;
+
+    // Create a static reservation for this MAC on the admin segment.
+    let mut txn = env.pool.begin().await?;
+    let admin_seg = db::network_segment::admin(&mut txn).await?;
+    db::machine_interface::create(
+        &mut txn,
+        &admin_seg,
+        &bmc_mac,
+        admin_seg.subdomain_id,
+        true,
+        model::address_selection_strategy::AddressSelectionStrategy::StaticAddress(reserved_ip),
+    )
+    .await?;
+    txn.commit().await?;
+
+    // DHCP discover -- should get the reserved IP.
+    let mac_str = bmc_mac.to_string();
+    let response = env
+        .api
+        .discover_dhcp(
+            common::rpc_builder::DhcpDiscovery::builder(&mac_str, FIXTURE_DHCP_RELAY_ADDRESS)
+                .tonic_request(),
+        )
+        .await?
+        .into_inner();
+
+    assert_eq!(
+        response.address,
+        reserved_ip.to_string(),
+        "should get the reserved IP"
+    );
+
+    Ok(())
+}
+
+/// On a reserved segment, a device without a static reservation
+/// gets no DHCP response (the discover fails).
+#[crate::sqlx_test]
+async fn test_reserved_segment_rejects_unknown_mac(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    // Set the admin segment to reserved allocation strategy.
+    let mut txn = env.pool.begin().await?;
+    sqlx::query("UPDATE network_segments SET allocation_strategy = 'reserved' WHERE id = $1")
+        .bind(env.admin_segment.unwrap())
+        .execute(&mut *txn)
+        .await?;
+    txn.commit().await?;
+
+    // DHCP discover with an unknown MAC -- should fail.
+    let result = env
+        .api
+        .discover_dhcp(
+            common::rpc_builder::DhcpDiscovery::builder(
+                "aa:bb:cc:dd:ee:31",
+                FIXTURE_DHCP_RELAY_ADDRESS,
+            )
+            .tonic_request(),
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "reserved segment should reject unknown MAC"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

This is additional feature work for enhancing  already-completed work for https://github.com/NVIDIA/ncx-infra-controller-core/issues/790 and https://github.com/NVIDIA/ncx-infra-controller-core/issues/644 (the original support coming in as part of https://github.com/NVIDIA/ncx-infra-controller-core/pull/808).

This adds first-class support to configure the _default_ behavior of an _entire_ managed network for _dynamic_ allocation from the address pool, or _static_ DHCP leases only (aka DHCP reservations or host reservations or `fixed-address` or whatever term you'd like to use).

We do this by adding a new `AllocationStrategy` type, with options for `::Dynamic` (DHCP allocates IPs) or `::Reserved` (static DHCP leases only).

The default behavior remains `::Dynamic` (which is the traditional behavior of Carbide), with `carbide-dhcp` using `carbide-api` to allocate IPs from the in-scope network segment via our IP allocator (with the new ability to do per-IP static DHCP lease overrides).

The new behavior is `::Reserved`, which makes it so `carbide-dhcp` will only hand back IPs for MACs which are pre-configured with `fixed-address` IP reservations in the segment, which is primarily driven by `--bmc-ip-address` assignments during expected machine/power-shelf/switch configuration. Site operators can use this to ensure BMCs maintain a static allocation within a Carbide-managed network segment for their lifetime. If there is no matching static DHCP lease in the target segment, `carbide-dhcp` will receive the error from `carbide-api` and we will silently drop the packet, which is the RFC (client asks for an IP and purposely don't reply).

A config example would be something like:
```
  [networks.bmc-interfaces-segment]
  type = "underlay"
  prefix = "10.2.3.4/24"
  gateway = "10.2.3.5"
  mtu = 1500
  reserve_first = 5
  allocation_strategy = "reserved"
```

Integration tests added to confirm the new behavior works as expected. Existing integration tests, which all continue to default to `::Dynamic`, continue to work as expected.

Update: This now also supports https://github.com/NVIDIA/infra-controller/issues/1865, which now has its own tracking issue (at the time of this PR it was more of a forward-thinking thing).

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

