### PR TITLE
fix(api,agent): Add routing-profile option to restrict tenant route l…

### DIFF
--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -399,6 +399,7 @@ pub async fn update_nvue(
             nc.routing_profile.as_ref().map(|rp| nvue::RoutingProfile {
                 leak_default_route_from_underlay: rp.leak_default_route_from_underlay,
                 leak_tenant_host_routes_to_underlay: rp.leak_tenant_host_routes_to_underlay,
+                tenant_leak_communities_accepted: rp.tenant_leak_communities_accepted,
                 route_target_imports: rp
                     .route_target_imports
                     .iter()
@@ -2347,6 +2348,7 @@ mod tests {
             routing_profile: Some(rpc::RoutingProfile {
                 leak_default_route_from_underlay: include_network_host_route_and_default_leaking,
                 leak_tenant_host_routes_to_underlay: include_network_host_route_and_default_leaking,
+                tenant_leak_communities_accepted: include_network_host_route_and_default_leaking,
                 route_target_imports: vec![rpc_common::RouteTarget {
                     asn: 44444,
                     vni: 55555,
@@ -2593,6 +2595,7 @@ mod tests {
                 ip: "10.217.4.70".to_string(),
             }],
             ct_routing_profile: Some(nvue::RoutingProfile {
+                tenant_leak_communities_accepted: false,
                 leak_default_route_from_underlay: false,
                 leak_tenant_host_routes_to_underlay: false,
                 route_target_imports: vec![nvue::RouteTargetConfig {
@@ -2820,6 +2823,7 @@ mod tests {
             anycast_site_prefixes: vec!["5.255.255.0/24".to_string()],
             tenant_host_asn: Some(65100),
             routing_profile: Some(rpc::RoutingProfile {
+                tenant_leak_communities_accepted: false,
                 leak_default_route_from_underlay: false,
                 leak_tenant_host_routes_to_underlay: false,
                 route_target_imports: vec![rpc_common::RouteTarget {

--- a/crates/agent/src/nvue.rs
+++ b/crates/agent/src/nvue.rs
@@ -126,6 +126,7 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
         .ct_routing_profile
         .as_ref()
         .map(|rt| TmplRoutingProfile {
+            TenantLeakCommunitiesAccepted: rt.tenant_leak_communities_accepted,
             LeakDefaultRouteFromUnderlay: rt.leak_default_route_from_underlay,
             LeakTenantHostRoutesToUnderlay: rt.leak_tenant_host_routes_to_underlay,
             RouteTargetImports: rt
@@ -922,6 +923,7 @@ pub struct RoutingProfile {
     pub leak_tenant_host_routes_to_underlay: bool,
     pub route_target_imports: Vec<RouteTargetConfig>,
     pub route_targets_on_exports: Vec<RouteTargetConfig>,
+    pub tenant_leak_communities_accepted: bool,
 }
 
 #[derive(Clone, Deserialize, Debug)]
@@ -1179,6 +1181,7 @@ struct TmplRoutingProfile {
     LeakDefaultRouteFromUnderlay: bool,
     RouteTargetImports: Vec<TmplRouteTargetConfig>,
     RouteTargetsOnExports: Vec<TmplRouteTargetConfig>,
+    TenantLeakCommunitiesAccepted: bool,
 }
 
 #[allow(non_snake_case)]
@@ -1576,6 +1579,7 @@ mod tests {
         conf.deny_prefixes = vec!["192.0.2.0/24".into(), "2001:db8:bad::/48".into()];
         conf.site_fabric_prefixes = vec!["10.0.0.0/16".into(), "fd00:abcd::/32".into()];
         conf.ct_routing_profile = Some(RoutingProfile {
+            tenant_leak_communities_accepted: false,
             leak_default_route_from_underlay: false,
             leak_tenant_host_routes_to_underlay: false,
             route_target_imports: vec![],
@@ -1650,6 +1654,7 @@ mod tests {
         conf.deny_prefixes = vec!["192.0.2.0/24".into()];
         conf.site_fabric_prefixes = vec!["10.0.0.0/16".into(), "fd00::/48".into()];
         conf.ct_routing_profile = Some(RoutingProfile {
+            tenant_leak_communities_accepted: false,
             leak_default_route_from_underlay: false,
             leak_tenant_host_routes_to_underlay: false,
 
@@ -1729,6 +1734,7 @@ mod tests {
         conf.use_vpc_isolation = true;
         conf.site_fabric_prefixes = vec!["10.0.0.0/16".into(), "fd00::/32".into()];
         conf.ct_routing_profile = Some(RoutingProfile {
+            tenant_leak_communities_accepted: false,
             leak_default_route_from_underlay: false,
             leak_tenant_host_routes_to_underlay: false,
             route_target_imports: vec![],

--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -831,6 +831,7 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
             vni: 22222,
         }],
         routing_profile: Some(rpc::forge::RoutingProfile {
+            tenant_leak_communities_accepted: false,
             leak_default_route_from_underlay: false,
             leak_tenant_host_routes_to_underlay: false,
             route_target_imports: vec![rpc_common::RouteTarget {

--- a/crates/agent/templates/nvue_startup_fnn.conf
+++ b/crates/agent/templates/nvue_startup_fnn.conf
@@ -434,8 +434,10 @@
               '65535':
                 action:
                   deny: {}
-          dpu_from_instance:
+          {{- range $vpc := $tenant.Vpcs }}   
+          dpu_from_instance_{{ $vpc.VrfName }}:
             rule:
+              {{- if $vpc.RoutingProfile.TenantLeakCommunitiesAccepted }}
               '9':
                 action:
                   permit: {}{{/* We allow it in because we might need to leak to some targets and drop to others, so we tag it for later.  */}}
@@ -462,6 +464,7 @@
                       none: {}{{/* Strip any communities the peer might have attached. */}}
                   large-community:
                     none: {}
+              {{- end }}
               '11':
                 action:
                   permit: {}
@@ -477,6 +480,52 @@
               '65535':
                 action:
                   deny: {}
+          dpu_from_instance_ipv6_{{ $vpc.VrfName }}:
+            rule:
+              {{- if $vpc.RoutingProfile.TenantLeakCommunitiesAccepted }}
+              '9':
+                action:
+                  permit: {}{{/* We allow it in because we might need to leak to some targets and drop to others, so we tag it for later.  */}}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102{{/* tag it so we can match on the tag and use it for leaking and dropping later */}}
+                  community:
+                      none: {}{{/* Strip any communities the peer might have attached. */}}
+                  large-community:
+                    none: {}
+              '10':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
+                  community-list: BYOIP_LEAK_COMMUNITY_LIST
+                set:
+                  tag: 65100
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              {{- end }}
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}
+          {{- end }}
           dpu_to_instance:
             rule:
               '10':
@@ -511,49 +560,6 @@
                   type: ipv6
             {{- end }}
           {{- end }}
-          dpu_from_instance_ipv6:
-            rule:
-              '9':
-                action:
-                  permit: {}{{/* We allow it in because we might need to leak to some targets and drop to others, so we tag it for later.  */}}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
-                set:
-                  tag: 65102{{/* tag it so we can match on the tag and use it for leaking and dropping later */}}
-                  community:
-                      none: {}{{/* Strip any communities the peer might have attached. */}}
-                  large-community:
-                    none: {}
-              '10':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                  community-list: BYOIP_LEAK_COMMUNITY_LIST
-                set:
-                  tag: 65100
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '11':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                set:
-                  tag: 65101
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '65535':
-                action:
-                  deny: {}
           dpu_from_traffic_intercept_gw_peer_ipv6:
             rule:
               '10':
@@ -808,14 +814,14 @@
                   ipv4-unicast:
                     policy:
                       inbound:
-                        route-map: dpu_from_instance
+                        route-map: dpu_from_instance_{{ $vpc.VrfName }}
                       outbound:
                         route-map: dpu_to_instance
                   ipv6-unicast:
                     enable: on
                     policy:
                       inbound:
-                        route-map: dpu_from_instance_ipv6
+                        route-map: dpu_from_instance_ipv6_{{ $vpc.VrfName }}
                       outbound:
                         route-map: dpu_to_instance
                 nexthop-connected-check: off

--- a/crates/agent/templates/tests/full_nvue_startup_fnn_l3.yaml.expected
+++ b/crates/agent/templates/tests/full_nvue_startup_fnn_l3.yaml.expected
@@ -265,41 +265,32 @@
                     none: {}
               '65535':
                 action:
-                  deny: {}
-          dpu_from_instance:
+                  deny: {}   
+          dpu_from_instance_vpc_10101:
             rule:
-              '9':
-                action:
-                  permit: {}
-                match:
-                  type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
-                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
-                set:
-                  tag: 65102
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '10':
-                action:
-                  permit: {}
-                match:
-                  type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
-                  community-list: BYOIP_LEAK_COMMUNITY_LIST
-                set:
-                  tag: 65100
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv4
                   ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}
+          dpu_from_instance_ipv6_vpc_10101:
+            rule:
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
                 set:
                   tag: 65101
                   community:
@@ -317,49 +308,6 @@
           dpu_to_traffic_intercept_gw_peer:
             rule:
               '10':
-                action:
-                  deny: {}
-          dpu_from_instance_ipv6:
-            rule:
-              '9':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
-                set:
-                  tag: 65102
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '10':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                  community-list: BYOIP_LEAK_COMMUNITY_LIST
-                set:
-                  tag: 65100
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '11':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                set:
-                  tag: 65101
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '65535':
                 action:
                   deny: {}
           dpu_from_traffic_intercept_gw_peer_ipv6:
@@ -564,14 +512,14 @@
                   ipv4-unicast:
                     policy:
                       inbound:
-                        route-map: dpu_from_instance
+                        route-map: dpu_from_instance_vpc_10101
                       outbound:
                         route-map: dpu_to_instance
                   ipv6-unicast:
                     enable: on
                     policy:
                       inbound:
-                        route-map: dpu_from_instance_ipv6
+                        route-map: dpu_from_instance_ipv6_vpc_10101
                       outbound:
                         route-map: dpu_to_instance
                 nexthop-connected-check: off

--- a/crates/agent/templates/tests/nvue_build_fnn_ipv6_acls.yaml.expected
+++ b/crates/agent/templates/tests/nvue_build_fnn_ipv6_acls.yaml.expected
@@ -245,41 +245,32 @@
                     none: {}
               '65535':
                 action:
-                  deny: {}
-          dpu_from_instance:
+                  deny: {}   
+          dpu_from_instance_vpc_100:
             rule:
-              '9':
-                action:
-                  permit: {}
-                match:
-                  type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
-                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
-                set:
-                  tag: 65102
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '10':
-                action:
-                  permit: {}
-                match:
-                  type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
-                  community-list: BYOIP_LEAK_COMMUNITY_LIST
-                set:
-                  tag: 65100
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv4
                   ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}
+          dpu_from_instance_ipv6_vpc_100:
+            rule:
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
                 set:
                   tag: 65101
                   community:
@@ -297,49 +288,6 @@
           dpu_to_traffic_intercept_gw_peer:
             rule:
               '10':
-                action:
-                  deny: {}
-          dpu_from_instance_ipv6:
-            rule:
-              '9':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
-                set:
-                  tag: 65102
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '10':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                  community-list: BYOIP_LEAK_COMMUNITY_LIST
-                set:
-                  tag: 65100
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '11':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                set:
-                  tag: 65101
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '65535':
                 action:
                   deny: {}
           dpu_from_traffic_intercept_gw_peer_ipv6:
@@ -518,14 +466,14 @@
                   ipv4-unicast:
                     policy:
                       inbound:
-                        route-map: dpu_from_instance
+                        route-map: dpu_from_instance_vpc_100
                       outbound:
                         route-map: dpu_to_instance
                   ipv6-unicast:
                     enable: on
                     policy:
                       inbound:
-                        route-map: dpu_from_instance_ipv6
+                        route-map: dpu_from_instance_ipv6_vpc_100
                       outbound:
                         route-map: dpu_to_instance
                 nexthop-connected-check: off

--- a/crates/agent/templates/tests/nvue_build_fnn_ipv6_only_vpc.yaml.expected
+++ b/crates/agent/templates/tests/nvue_build_fnn_ipv6_only_vpc.yaml.expected
@@ -235,41 +235,32 @@
                     none: {}
               '65535':
                 action:
-                  deny: {}
-          dpu_from_instance:
+                  deny: {}   
+          dpu_from_instance_vpc_100:
             rule:
-              '9':
-                action:
-                  permit: {}
-                match:
-                  type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
-                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
-                set:
-                  tag: 65102
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '10':
-                action:
-                  permit: {}
-                match:
-                  type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
-                  community-list: BYOIP_LEAK_COMMUNITY_LIST
-                set:
-                  tag: 65100
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv4
                   ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}
+          dpu_from_instance_ipv6_vpc_100:
+            rule:
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
                 set:
                   tag: 65101
                   community:
@@ -287,49 +278,6 @@
           dpu_to_traffic_intercept_gw_peer:
             rule:
               '10':
-                action:
-                  deny: {}
-          dpu_from_instance_ipv6:
-            rule:
-              '9':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
-                set:
-                  tag: 65102
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '10':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                  community-list: BYOIP_LEAK_COMMUNITY_LIST
-                set:
-                  tag: 65100
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '11':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                set:
-                  tag: 65101
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '65535':
                 action:
                   deny: {}
           dpu_from_traffic_intercept_gw_peer_ipv6:
@@ -508,14 +456,14 @@
                   ipv4-unicast:
                     policy:
                       inbound:
-                        route-map: dpu_from_instance
+                        route-map: dpu_from_instance_vpc_100
                       outbound:
                         route-map: dpu_to_instance
                   ipv6-unicast:
                     enable: on
                     policy:
                       inbound:
-                        route-map: dpu_from_instance_ipv6
+                        route-map: dpu_from_instance_ipv6_vpc_100
                       outbound:
                         route-map: dpu_to_instance
                 nexthop-connected-check: off

--- a/crates/agent/templates/tests/nvue_build_fnn_multi_port_ipv6.yaml.expected
+++ b/crates/agent/templates/tests/nvue_build_fnn_multi_port_ipv6.yaml.expected
@@ -244,41 +244,32 @@
                     none: {}
               '65535':
                 action:
-                  deny: {}
-          dpu_from_instance:
+                  deny: {}   
+          dpu_from_instance_vpc_200:
             rule:
-              '9':
-                action:
-                  permit: {}
-                match:
-                  type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
-                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
-                set:
-                  tag: 65102
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '10':
-                action:
-                  permit: {}
-                match:
-                  type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
-                  community-list: BYOIP_LEAK_COMMUNITY_LIST
-                set:
-                  tag: 65100
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv4
                   ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}
+          dpu_from_instance_ipv6_vpc_200:
+            rule:
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
                 set:
                   tag: 65101
                   community:
@@ -296,49 +287,6 @@
           dpu_to_traffic_intercept_gw_peer:
             rule:
               '10':
-                action:
-                  deny: {}
-          dpu_from_instance_ipv6:
-            rule:
-              '9':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
-                set:
-                  tag: 65102
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '10':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                  community-list: BYOIP_LEAK_COMMUNITY_LIST
-                set:
-                  tag: 65100
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '11':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                set:
-                  tag: 65101
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '65535':
                 action:
                   deny: {}
           dpu_from_traffic_intercept_gw_peer_ipv6:
@@ -521,14 +469,14 @@
                   ipv4-unicast:
                     policy:
                       inbound:
-                        route-map: dpu_from_instance
+                        route-map: dpu_from_instance_vpc_200
                       outbound:
                         route-map: dpu_to_instance
                   ipv6-unicast:
                     enable: on
                     policy:
                       inbound:
-                        route-map: dpu_from_instance_ipv6
+                        route-map: dpu_from_instance_ipv6_vpc_200
                       outbound:
                         route-map: dpu_to_instance
                 nexthop-connected-check: off

--- a/crates/agent/templates/tests/nvue_startup_fnn_classic.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_classic.yaml.expected
@@ -297,41 +297,66 @@
                     none: {}
               '65535':
                 action:
-                  deny: {}
-          dpu_from_instance:
+                  deny: {}   
+          dpu_from_instance_vpc_1025186:
             rule:
-              '9':
-                action:
-                  permit: {}
-                match:
-                  type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
-                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
-                set:
-                  tag: 65102
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '10':
-                action:
-                  permit: {}
-                match:
-                  type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
-                  community-list: BYOIP_LEAK_COMMUNITY_LIST
-                set:
-                  tag: 65100
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv4
                   ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}
+          dpu_from_instance_ipv6_vpc_1025186:
+            rule:
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}   
+          dpu_from_instance_vpc_1025197:
+            rule:
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}
+          dpu_from_instance_ipv6_vpc_1025197:
+            rule:
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
                 set:
                   tag: 65101
                   community:
@@ -349,49 +374,6 @@
           dpu_to_traffic_intercept_gw_peer:
             rule:
               '10':
-                action:
-                  deny: {}
-          dpu_from_instance_ipv6:
-            rule:
-              '9':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
-                set:
-                  tag: 65102
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '10':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                  community-list: BYOIP_LEAK_COMMUNITY_LIST
-                set:
-                  tag: 65100
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '11':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                set:
-                  tag: 65101
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '65535':
                 action:
                   deny: {}
           dpu_from_traffic_intercept_gw_peer_ipv6:
@@ -592,14 +574,14 @@
                   ipv4-unicast:
                     policy:
                       inbound:
-                        route-map: dpu_from_instance
+                        route-map: dpu_from_instance_vpc_1025186
                       outbound:
                         route-map: dpu_to_instance
                   ipv6-unicast:
                     enable: on
                     policy:
                       inbound:
-                        route-map: dpu_from_instance_ipv6
+                        route-map: dpu_from_instance_ipv6_vpc_1025186
                       outbound:
                         route-map: dpu_to_instance
                 nexthop-connected-check: off
@@ -695,14 +677,14 @@
                   ipv4-unicast:
                     policy:
                       inbound:
-                        route-map: dpu_from_instance
+                        route-map: dpu_from_instance_vpc_1025197
                       outbound:
                         route-map: dpu_to_instance
                   ipv6-unicast:
                     enable: on
                     policy:
                       inbound:
-                        route-map: dpu_from_instance_ipv6
+                        route-map: dpu_from_instance_ipv6_vpc_1025197
                       outbound:
                         route-map: dpu_to_instance
                 nexthop-connected-check: off

--- a/crates/agent/templates/tests/nvue_startup_fnn_classic_with_empty_nsg_default_deny.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_classic_with_empty_nsg_default_deny.yaml.expected
@@ -305,41 +305,66 @@
                     none: {}
               '65535':
                 action:
-                  deny: {}
-          dpu_from_instance:
+                  deny: {}   
+          dpu_from_instance_vpc_1025186:
             rule:
-              '9':
-                action:
-                  permit: {}
-                match:
-                  type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
-                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
-                set:
-                  tag: 65102
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '10':
-                action:
-                  permit: {}
-                match:
-                  type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
-                  community-list: BYOIP_LEAK_COMMUNITY_LIST
-                set:
-                  tag: 65100
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv4
                   ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}
+          dpu_from_instance_ipv6_vpc_1025186:
+            rule:
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}   
+          dpu_from_instance_vpc_1025197:
+            rule:
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}
+          dpu_from_instance_ipv6_vpc_1025197:
+            rule:
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
                 set:
                   tag: 65101
                   community:
@@ -357,49 +382,6 @@
           dpu_to_traffic_intercept_gw_peer:
             rule:
               '10':
-                action:
-                  deny: {}
-          dpu_from_instance_ipv6:
-            rule:
-              '9':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
-                set:
-                  tag: 65102
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '10':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                  community-list: BYOIP_LEAK_COMMUNITY_LIST
-                set:
-                  tag: 65100
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '11':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                set:
-                  tag: 65101
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '65535':
                 action:
                   deny: {}
           dpu_from_traffic_intercept_gw_peer_ipv6:
@@ -603,14 +585,14 @@
                   ipv4-unicast:
                     policy:
                       inbound:
-                        route-map: dpu_from_instance
+                        route-map: dpu_from_instance_vpc_1025186
                       outbound:
                         route-map: dpu_to_instance
                   ipv6-unicast:
                     enable: on
                     policy:
                       inbound:
-                        route-map: dpu_from_instance_ipv6
+                        route-map: dpu_from_instance_ipv6_vpc_1025186
                       outbound:
                         route-map: dpu_to_instance
                 nexthop-connected-check: off
@@ -706,14 +688,14 @@
                   ipv4-unicast:
                     policy:
                       inbound:
-                        route-map: dpu_from_instance
+                        route-map: dpu_from_instance_vpc_1025197
                       outbound:
                         route-map: dpu_to_instance
                   ipv6-unicast:
                     enable: on
                     policy:
                       inbound:
-                        route-map: dpu_from_instance_ipv6
+                        route-map: dpu_from_instance_ipv6_vpc_1025197
                       outbound:
                         route-map: dpu_to_instance
                 nexthop-connected-check: off

--- a/crates/agent/templates/tests/nvue_startup_fnn_with_leaks.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_with_leaks.yaml.expected
@@ -328,8 +328,8 @@
                     none: {}
               '65535':
                 action:
-                  deny: {}
-          dpu_from_instance:
+                  deny: {}   
+          dpu_from_instance_vpc_1025186:
             rule:
               '9':
                 action:
@@ -363,6 +363,135 @@
                 match:
                   type: ipv4
                   ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}
+          dpu_from_instance_ipv6_vpc_1025186:
+            rule:
+              '9':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '10':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
+                  community-list: BYOIP_LEAK_COMMUNITY_LIST
+                set:
+                  tag: 65100
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}   
+          dpu_from_instance_vpc_1025197:
+            rule:
+              '9':
+                action:
+                  permit: {}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '10':
+                action:
+                  permit: {}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                  community-list: BYOIP_LEAK_COMMUNITY_LIST
+                set:
+                  tag: 65100
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}
+          dpu_from_instance_ipv6_vpc_1025197:
+            rule:
+              '9':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '10':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
+                  community-list: BYOIP_LEAK_COMMUNITY_LIST
+                set:
+                  tag: 65100
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
                 set:
                   tag: 65101
                   community:
@@ -414,49 +543,6 @@
                 match:
                   ip-prefix-list: FROM_DEFAULT_VRF_TO_vpc_1025197_PREFIX_LIST_IPV6
                   type: ipv6
-          dpu_from_instance_ipv6:
-            rule:
-              '9':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
-                set:
-                  tag: 65102
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '10':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                  community-list: BYOIP_LEAK_COMMUNITY_LIST
-                set:
-                  tag: 65100
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '11':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                set:
-                  tag: 65101
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '65535':
-                action:
-                  deny: {}
           dpu_from_traffic_intercept_gw_peer_ipv6:
             rule:
               '10':
@@ -661,14 +747,14 @@
                   ipv4-unicast:
                     policy:
                       inbound:
-                        route-map: dpu_from_instance
+                        route-map: dpu_from_instance_vpc_1025186
                       outbound:
                         route-map: dpu_to_instance
                   ipv6-unicast:
                     enable: on
                     policy:
                       inbound:
-                        route-map: dpu_from_instance_ipv6
+                        route-map: dpu_from_instance_ipv6_vpc_1025186
                       outbound:
                         route-map: dpu_to_instance
                 nexthop-connected-check: off
@@ -770,14 +856,14 @@
                   ipv4-unicast:
                     policy:
                       inbound:
-                        route-map: dpu_from_instance
+                        route-map: dpu_from_instance_vpc_1025197
                       outbound:
                         route-map: dpu_to_instance
                   ipv6-unicast:
                     enable: on
                     policy:
                       inbound:
-                        route-map: dpu_from_instance_ipv6
+                        route-map: dpu_from_instance_ipv6_vpc_1025197
                       outbound:
                         route-map: dpu_to_instance
                 nexthop-connected-check: off

--- a/crates/agent/templates/tests/nvue_startup_quarantined_fnn.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_quarantined_fnn.yaml.expected
@@ -317,41 +317,66 @@
                     none: {}
               '65535':
                 action:
-                  deny: {}
-          dpu_from_instance:
+                  deny: {}   
+          dpu_from_instance_vpc_1025186:
             rule:
-              '9':
-                action:
-                  permit: {}
-                match:
-                  type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
-                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
-                set:
-                  tag: 65102
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '10':
-                action:
-                  permit: {}
-                match:
-                  type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
-                  community-list: BYOIP_LEAK_COMMUNITY_LIST
-                set:
-                  tag: 65100
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv4
                   ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}
+          dpu_from_instance_ipv6_vpc_1025186:
+            rule:
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}   
+          dpu_from_instance_vpc_1025197:
+            rule:
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}
+          dpu_from_instance_ipv6_vpc_1025197:
+            rule:
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
                 set:
                   tag: 65101
                   community:
@@ -369,49 +394,6 @@
           dpu_to_traffic_intercept_gw_peer:
             rule:
               '10':
-                action:
-                  deny: {}
-          dpu_from_instance_ipv6:
-            rule:
-              '9':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
-                set:
-                  tag: 65102
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '10':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                  community-list: BYOIP_LEAK_COMMUNITY_LIST
-                set:
-                  tag: 65100
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '11':
-                action:
-                  permit: {}
-                match:
-                  type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6
-                set:
-                  tag: 65101
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '65535':
                 action:
                   deny: {}
           dpu_from_traffic_intercept_gw_peer_ipv6:
@@ -615,14 +597,14 @@
                   ipv4-unicast:
                     policy:
                       inbound:
-                        route-map: dpu_from_instance
+                        route-map: dpu_from_instance_vpc_1025186
                       outbound:
                         route-map: dpu_to_instance
                   ipv6-unicast:
                     enable: on
                     policy:
                       inbound:
-                        route-map: dpu_from_instance_ipv6
+                        route-map: dpu_from_instance_ipv6_vpc_1025186
                       outbound:
                         route-map: dpu_to_instance
                 nexthop-connected-check: off
@@ -718,14 +700,14 @@
                   ipv4-unicast:
                     policy:
                       inbound:
-                        route-map: dpu_from_instance
+                        route-map: dpu_from_instance_vpc_1025197
                       outbound:
                         route-map: dpu_to_instance
                   ipv6-unicast:
                     enable: on
                     policy:
                       inbound:
-                        route-map: dpu_from_instance_ipv6
+                        route-map: dpu_from_instance_ipv6_vpc_1025197
                       outbound:
                         route-map: dpu_to_instance
                 nexthop-connected-check: off

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -818,6 +818,11 @@ pub struct FnnRoutingProfileConfig {
     /// into the underlay?
     #[serde(default)]
     pub leak_tenant_host_routes_to_underlay: bool,
+
+    /// Are route-leak communities sent by the host OS honored by the DPU for allowing
+    /// routes advertised by the host OS to be leaked into the underlay?
+    #[serde(default)]
+    pub tenant_leak_communities_accepted: bool,
 }
 
 /// FNN configuration specific to the admin network.

--- a/crates/api/src/handlers/dpu.rs
+++ b/crates/api/src/handlers/dpu.rs
@@ -665,6 +665,7 @@ pub(crate) async fn get_managed_host_network_config_inner(
                 })
         }),
         routing_profile: routing_profile.map(|p| rpc::RoutingProfile {
+            tenant_leak_communities_accepted: p.tenant_leak_communities_accepted,
             leak_default_route_from_underlay: p.leak_default_route_from_underlay,
             leak_tenant_host_routes_to_underlay: p.leak_tenant_host_routes_to_underlay,
             route_target_imports: p

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -286,6 +286,7 @@ impl TestEnvOverrides {
                             route_targets_on_exports: vec![],
                             leak_default_route_from_underlay: false,
                             leak_tenant_host_routes_to_underlay: false,
+                            tenant_leak_communities_accepted: false,
                         },
                     ),
                     (
@@ -296,6 +297,7 @@ impl TestEnvOverrides {
                             route_targets_on_exports: vec![],
                             leak_default_route_from_underlay: false,
                             leak_tenant_host_routes_to_underlay: false,
+                            tenant_leak_communities_accepted: false,
                         },
                     ),
                 ]),

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -6923,6 +6923,11 @@ message RoutingProfile {
   repeated common.RouteTarget route_targets_on_exports = 2;
   bool leak_default_route_from_underlay                = 3;
   bool leak_tenant_host_routes_to_underlay             = 4;
+  
+  // Are route-leak communities sent by the host OS honored by the DPU for allowing
+  // routes advertised by the host OS to be leaked into the underlay?
+  bool tenant_leak_communities_accepted                = 5;
+
 }
 
 // ============================================================================


### PR DESCRIPTION
Tenants have the option of tagging their routes with communities to trigger the routes to leak to the underlay, and optionally drop from the overlay.  Because this shifts control of some of the networking over to tenants, the default behavior should be to ignore the communities unless a deployment is specifically configured to allow it.  The option is being place on route-profiles to make it possible to restrict with a little granularity. E.g., allow the leak community for internal tenants, but ignore it for external.

There aren't any expected users of this feature yet, but it's _technically_ a breaking change because any deployment allowing the leaking currently would stop unless configs are updated, so I'm marking this as a breaking change just for awareness.

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [x] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

