### PR TITLE
fix: use hardcoded DPF config name and correct nvconfig wildcard for v2

### DIFF
--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -435,11 +435,15 @@ pub async fn start_api(
 
         // This is just temparary code until we make v2 only option. (just 2 weeks)
         // Soon v2 flag will be removed and will become only mode for dpf handling.
-        let v2_str = if carbide_config.dpf.v2 { "-v2" } else { "" };
         let init_config = carbide_dpf::InitDpfResourcesConfig {
             bfb_url,
             flavor_name: carbide_config.dpf.flavor_name.clone(),
-            deployment_name: format!("{}{}", carbide_config.dpf.deployment_name.clone(), v2_str),
+            deployment_name: if carbide_config.dpf.v2 {
+                // We can't keep name longer than 20 chars (DPF restriction)
+                "nico-deployment-v2".to_string()
+            } else {
+                carbide_config.dpf.deployment_name.clone()
+            },
             services: if carbide_config.dpf.v2 {
                 // Enable all the services.
                 Vec::new()

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -68,6 +68,7 @@ use crate::watcher::DpuWatcherBuilder;
 
 const SECRET_NAME: &str = "bmc-shared-password";
 const BFB_NAME_PREFIX: &str = "bf-bundle";
+const DPF_OPERATOR_CONFIG: &str = "dpfoperatorconfig";
 
 pub(crate) const RESTART_ANNOTATION: &str =
     "provisioning.dpu.nvidia.com/dpunode-external-reboot-required";
@@ -522,7 +523,8 @@ async fn create_dpu_flavor<R: DpuFlavorRepository>(
         ];
 
         flavor.spec.nvconfig = Some(vec![DpuFlavorNvconfig {
-            device: Some("mt*_pciconf0".to_string()),
+            // DPF does not allow anyother wild card. It takes only '*'
+            device: Some("*".to_string()),
             host_power_cycle_required: None,
             parameters: Some(nvue_params),
         }]);
@@ -935,7 +937,7 @@ impl<
             // Use default bf.cfg. In this case, delete bfCFGTemplateConfigMap from dpfoperatorconfig
             DpfOperatorConfigRepository::patch(
                 &*self.repo,
-                &config.deployment_name,
+                DPF_OPERATOR_CONFIG,
                 &self.namespace,
                 serde_json::json!({
                     "spec": {


### PR DESCRIPTION
## Description
These are the bug fixed found during testing over real hardware.
- Use fixed "nico-deployment-v2" deployment name to stay within DPF's 20-char limit instead of appending "-v2" suffix dynamically
- Patch dpfoperatorconfig by constant name rather than deployment name
- Fix nvconfig device wildcard from "mt*_pciconf0" to "*" (DPF only supports bare wildcards)

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

