### PR TITLE
chore: drop EthernetVirtualizerWithNvue override from carbide-api -> dpu-agent

### DIFF
--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -1046,7 +1046,7 @@ fn effective_virtualization_type(
     // table for the VPC this DPU is in).
     //
     // This may be unset, which means to just use
-    // EthernetVirtualizerWithNvue.
+    // EthernetVirtualizer.
     let virtualization_type_from_remote = conf
         .network_virtualization_type
         .map(rpc::VpcVirtualizationType::try_from)
@@ -1055,7 +1055,7 @@ fn effective_virtualization_type(
 
     // And now see if the remote virtualization type should be overwritten
     // by runtime options. If it's not, and the remote value was also unset,
-    // then just use EthernetVirtualizerWithNvue.
+    // then just use EthernetVirtualizer.
     let virtualization_type = options
         .override_network_virtualization_type // dev
         .or(virtualization_type_from_remote)

--- a/crates/agent/src/nvue.rs
+++ b/crates/agent/src/nvue.rs
@@ -36,9 +36,6 @@ const TMPL_ETV_WITH_NVUE: &str = include_str!("../templates/nvue_startup_etv.con
 const TMPL_FNN: &str = include_str!("../templates/nvue_startup_fnn.conf");
 
 /// Returns the NVUE template for the given virtualization type.
-/// EthernetVirtualizerWithNvue is hanging around for a bit longer in here
-/// just for an extra sense of security and compatibilty; it all goes
-/// to EthernetVirtualizer.
 pub fn template_for(vtype: VpcVirtualizationType) -> eyre::Result<&'static str> {
     match vtype {
         VpcVirtualizationType::EthernetVirtualizer
@@ -1508,7 +1505,9 @@ mod tests {
 
     #[test]
     fn test_template_for_etv_with_nvue() {
-        // EthernetVirtualizerWithNvue is kept for wire compat with older API servers
+        // EthernetVirtualizerWithNvue is the same as EthernetVirtualizer
+        // now, and while we shouldn't see it coming through anymore, lets
+        // still make sure we support it.
         assert!(template_for(VpcVirtualizationType::EthernetVirtualizerWithNvue).is_ok());
     }
 

--- a/crates/api/src/handlers/dpu.rs
+++ b/crates/api/src/handlers/dpu.rs
@@ -636,17 +636,9 @@ pub(crate) async fn get_managed_host_network_config_inner(
                 .version_string()
         },
         remote_id: dpu_machine_id.remote_id(),
-        // TODO(chet): Once all agents are upgraded past the ETV cleanup PRs, this can
-        // use rpc::VpcVirtualizationType::from(network_virtualization_type).into() instead.
-        // For now, force ETV to proto value 2 (ETHERNET_VIRTUALIZER_WITH_NVUE) so that
-        // older agents that reject proto value 0 (ETHERNET_VIRTUALIZER) continue to work.
-        network_virtualization_type: Some(match network_virtualization_type {
-            VpcVirtualizationType::EthernetVirtualizer
-            | VpcVirtualizationType::EthernetVirtualizerWithNvue => {
-                rpc::VpcVirtualizationType::EthernetVirtualizerWithNvue.into()
-            }
-            VpcVirtualizationType::Fnn => rpc::VpcVirtualizationType::Fnn.into(),
-        }),
+        network_virtualization_type: Some(
+            rpc::VpcVirtualizationType::from(network_virtualization_type).into(),
+        ),
         vpc_vni,
         // Deprecated: this field is always true now.
         // This should be removed in future version.


### PR DESCRIPTION
## Description

And now we can drop this. There was somewhat of a backwards compatibility concern in between releases, because if `carbide-api` got bumped and started passing down `EthernetVirtualizer`, and `carbide-dpu-agent` hand't been updated yet, it would reject config updates for <= 10 minutes while we waited for the next "update `carbide-dpu-agent` cron job" to fire off. The plan was to wait on this for the next release, but since the release schedule got modified due to a shortened QA cycle, I can actually do this now.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

