### PR TITLE
feat(bmc-mock): add boot source override and BMC lifecycle events

### DIFF
--- a/crates/bmc-mock/src/bmc_state.rs
+++ b/crates/bmc-mock/src/bmc_state.rs
@@ -37,7 +37,24 @@ pub struct BmcState {
     pub callbacks: Option<Arc<dyn crate::Callbacks>>,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub enum BmcEvent {
+    PowerOn,
+    BootCompleted,
+}
+
 impl BmcState {
+    pub fn on_event(&self, event: &BmcEvent) {
+        match event {
+            BmcEvent::PowerOn => {
+                self.complete_all_bios_jobs();
+            }
+            BmcEvent::BootCompleted => {
+                self.system_state.on_boot_completed();
+            }
+        }
+    }
+
     pub fn complete_all_bios_jobs(&self) {
         if let redfish::oem::State::DellIdrac(v) = &self.oem_state {
             v.complete_all_bios_jobs()

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -36,7 +36,7 @@ mod redfish;
 pub mod test_support;
 pub mod tls;
 
-pub use bmc_state::BmcState;
+pub use bmc_state::{BmcEvent, BmcState};
 pub use combined_server::{CombinedServer, ListenerOrAddress};
 pub use machine_info::{
     DpuFirmwareVersions, DpuMachineInfo, DpuSettings, HostMachineInfo, MachineInfo,
@@ -208,7 +208,7 @@ pub trait LogService: Send + Sync {
     fn entries(&self, collection: &redfish::Collection<'_>) -> Vec<serde_json::Value>;
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BootOptionKind {
     Disk,
     Network,

--- a/crates/bmc-mock/src/redfish/computer_system.rs
+++ b/crates/bmc-mock/src/redfish/computer_system.rs
@@ -148,9 +148,17 @@ pub struct SystemState {
     systems: Vec<SingleSystemState>,
 }
 
+#[derive(Default)]
+pub struct BootSourceOverride {
+    mode: Option<String>,
+    enabled: Option<String>,
+    target: Option<String>,
+}
+
 pub struct SingleSystemState {
     config: SingleSystemConfig,
     boot_order_override: Mutex<Option<Vec<String>>>,
+    boot_source_override: Mutex<BootSourceOverride>,
     secure_boot_enabled: Arc<AtomicBool>,
     bios_overrides: Arc<Mutex<serde_json::Value>>,
 }
@@ -199,6 +207,10 @@ impl SystemState {
             .iter()
             .find_map(|system| system.resolve_current_boot_selection())
     }
+
+    pub fn on_boot_completed(&self) {
+        self.systems.iter().for_each(|s| s.on_boot_completed())
+    }
 }
 
 impl SingleSystemState {
@@ -206,8 +218,16 @@ impl SingleSystemState {
         Self {
             config,
             boot_order_override: Mutex::new(None),
+            boot_source_override: Mutex::new(BootSourceOverride::default()),
             secure_boot_enabled: Arc::new(AtomicBool::new(false)),
             bios_overrides: Arc::new(Mutex::new(serde_json::json!({}))),
+        }
+    }
+
+    pub fn on_boot_completed(&self) {
+        let mut src = self.boot_source_override.lock().unwrap();
+        if src.enabled.as_ref().is_some_and(|v| v == "Once") {
+            src.enabled = Some("Disabled".into())
         }
     }
 
@@ -228,8 +248,28 @@ impl SingleSystemState {
     }
 
     fn resolve_current_boot_selection(&self) -> Option<BootOptionKind> {
-        self.boot_order_override()
-            .and_then(|overrides| {
+        let src = self.boot_source_override.lock().unwrap();
+        if src.enabled.as_ref().is_some_and(|v| v != "Disabled")
+            && src.mode.as_ref().is_some_and(|v| v == "UEFI")
+            && let Some(target) = src.target.as_ref()
+        {
+            match target.as_str() {
+                "Hdd" => Some(BootOptionKind::Disk),
+                "UefiHttp" | "Pxe" => Some(BootOptionKind::Network),
+                _ => None,
+            }
+            .filter(|kind| {
+                self.config
+                    .boot_options
+                    .iter()
+                    .flatten()
+                    .any(|opt| opt.kind == *kind)
+            })
+        } else {
+            None
+        }
+        .or_else(|| {
+            self.boot_order_override().and_then(|overrides| {
                 overrides.first().and_then(|optref| {
                     self.config
                         .boot_options
@@ -239,13 +279,14 @@ impl SingleSystemState {
                         .map(|opt| opt.kind)
                 })
             })
-            .or_else(|| {
-                self.config
-                    .boot_options
-                    .as_ref()?
-                    .first()
-                    .map(|opt| opt.kind)
-            })
+        })
+        .or_else(|| {
+            self.config
+                .boot_options
+                .as_ref()?
+                .first()
+                .map(|opt| opt.kind)
+        })
     }
 }
 
@@ -390,28 +431,50 @@ async fn patch_settings(
     let Some(system_state) = state.system_state.find(&system_id) else {
         return http::not_found();
     };
-    if let Some(new_boot_order) = patch_settings
-        .get("Boot")
-        .and_then(|obj| obj.get("BootOrder"))
-        .and_then(serde_json::Value::as_array)
-        .map(|arr| {
-            arr.iter()
-                .filter_map(serde_json::Value::as_str)
-                .map(ToString::to_string)
-                .collect()
-        })
-    {
-        match system_state.config.boot_order_mode {
-            BootOrderMode::ViaSettings => {
-                system_state.set_boot_order_override(new_boot_order);
-                json!({}).into_ok_response()
+    if let Some(boot) = patch_settings.get("Boot") {
+        if let Some(new_boot_order) = boot
+            .get("BootOrder")
+            .and_then(serde_json::Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(serde_json::Value::as_str)
+                    .map(ToString::to_string)
+                    .collect()
+            })
+        {
+            match system_state.config.boot_order_mode {
+                BootOrderMode::ViaSettings => {
+                    system_state.set_boot_order_override(new_boot_order);
+                }
+                _ => {
+                    return json!("Boot order setup must use ComputerSystem resource")
+                        .into_response(StatusCode::BAD_REQUEST);
+                }
             }
-            _ => json!("Boot order setup must use ComputerSystem resource")
-                .into_response(StatusCode::BAD_REQUEST),
         }
-    } else {
-        json!({}).into_ok_response()
+        boot.get("BootSourceOverrideMode").inspect(|v| {
+            if let Some(v) = v.as_str() {
+                system_state.boot_source_override.lock().unwrap().mode = Some(v.to_string())
+            } else {
+                system_state.boot_source_override.lock().unwrap().mode = None
+            }
+        });
+        boot.get("BootSourceOverrideEnabled").inspect(|v| {
+            if let Some(v) = v.as_str() {
+                system_state.boot_source_override.lock().unwrap().enabled = Some(v.to_string())
+            } else {
+                system_state.boot_source_override.lock().unwrap().enabled = None
+            }
+        });
+        boot.get("BootSourceOverrideTarget").inspect(|v| {
+            if let Some(v) = v.as_str() {
+                system_state.boot_source_override.lock().unwrap().target = Some(v.to_string())
+            } else {
+                system_state.boot_source_override.lock().unwrap().target = None
+            }
+        });
     }
+    json!({}).into_ok_response()
 }
 
 async fn patch_system(
@@ -455,8 +518,6 @@ async fn post_reset_system(
     Path(system_id): Path<String>,
     Json(mut power_request): Json<serde_json::Value>,
 ) -> Response {
-    state.complete_all_bios_jobs();
-
     let Some(system_state) = state.system_state.find(&system_id) else {
         return http::not_found();
     };

--- a/crates/machine-a-tron/src/machine_fsm.rs
+++ b/crates/machine-a-tron/src/machine_fsm.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use bmc_mock::MockPowerState;
+use bmc_mock::{BmcEvent, MockPowerState};
 
 use crate::machine_state_machine::OsImage;
 
@@ -153,7 +153,13 @@ impl MachineFsm {
 
     fn fsm_init(self, event: Event) -> (Self, Vec<Action>) {
         match event {
-            Event::TimerAlert(Timer::MachineOn) => (self, vec![Action::Dhcp(DhcpType::Machine)]),
+            Event::TimerAlert(Timer::MachineOn) => (
+                self,
+                vec![
+                    Action::BmcEvent(BmcEvent::PowerOn),
+                    Action::Dhcp(DhcpType::Machine),
+                ],
+            ),
             Event::DhcpComplete(DhcpType::Machine) => {
                 (Self::DhcpComplete, vec![Action::PxeBootRequest])
             }
@@ -183,7 +189,8 @@ impl MachineFsm {
                     OsImage::DpuAgent => OsFsm::DpuAgent(DpuAgentFsm::Discovery),
                     OsImage::Scout => OsFsm::Scout(ScoutFsm::Discovery),
                 };
-                let actions = os_fsm.init_actions();
+                let mut actions = os_fsm.init_actions();
+                actions.push(Action::BmcEvent(BmcEvent::BootCompleted));
                 (Self::MachineUp { os_fsm }, actions)
             }
             _ => (self, vec![]),
@@ -206,7 +213,10 @@ impl MachineFsm {
             Event::PowerOff => (Self::BmcOnlyMachineDown, vec![]),
             Event::PowerCycle => (
                 Self::BmcOnlyMachineDown,
-                vec![Action::SetTimer(Timer::PowerCycle)],
+                vec![
+                    Action::CleanupOnPowerOff,
+                    Action::SetTimer(Timer::PowerCycle),
+                ],
             ),
             _ => (self, vec![]),
         }
@@ -216,7 +226,10 @@ impl MachineFsm {
         match event {
             Event::PowerCycle => (
                 Self::BmcOnlyMachineDown,
-                vec![Action::SetTimer(Timer::PowerCycle)],
+                vec![
+                    Action::CleanupOnPowerOff,
+                    Action::SetTimer(Timer::PowerCycle),
+                ],
             ),
             Event::PowerOn | Event::TimerAlert(Timer::PowerCycle) => {
                 (Self::BmcOnlyMachineUp, vec![])
@@ -264,6 +277,7 @@ pub enum Action {
     AgentControlRequest(OsImage),
     DpuAgentNetworkObservation,
     CleanupOnPowerOff,
+    BmcEvent(BmcEvent),
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -411,6 +411,12 @@ impl MachineStateMachine {
                     }
                     Err(_) => return Some(self.config.run_interval_working),
                 },
+                FsmAction::BmcEvent(event) => {
+                    if let Some(bmc_state) = &self.bmc_state {
+                        bmc_state.on_event(event)
+                    }
+                    self.actions.pop_front();
+                }
                 FsmAction::InitialDiscoveryRequest(os_image) => {
                     match self.initial_discovery_request(*os_image).await {
                         Ok(None) => {


### PR DESCRIPTION
## Description

Implement BootSourceOverride (mode, enabled, target) in mock BMC with UEFI boot target resolution and automatic "Once" reset on boot.

Replace direct complete_all_bios_jobs() call with event-driven BmcEvent (PowerOff, BootCompleted) emitted by the machine FSM.

## Type of Change
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
