### PR TITLE
api: add static IP management failure metrics

### DIFF
--- a/crates/api-db/src/lib.rs
+++ b/crates/api-db/src/lib.rs
@@ -325,6 +325,13 @@ pub enum DatabaseError {
     },
     #[error("Internal error: {message}")]
     Internal { message: String },
+    #[error(
+        "segment {segment_name} configured for static DHCP leases only; no static reservation for MAC {mac_address}"
+    )]
+    ReservedSegmentNoReservation {
+        segment_name: String,
+        mac_address: MacAddress,
+    },
     #[error("Unable to parse string into IP Address: {0}")]
     AddressParseError(#[from] std::net::AddrParseError),
     #[error("Unable to parse string into IP Network: {0}")]
@@ -413,6 +420,10 @@ impl DatabaseError {
             },
             _ => false,
         }
+    }
+
+    pub fn is_reserved_segment_no_reservation(&self) -> bool {
+        matches!(self, DatabaseError::ReservedSegmentNoReservation { .. })
     }
 }
 

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -360,10 +360,10 @@ pub async fn validate_existing_mac_and_create(
                 // dynamic allocation. The device must have a pre-existing
                 // static reservation to get an IP on this segment.
                 if segment.allocation_strategy == AllocationStrategy::Reserved {
-                    return Err(DatabaseError::internal(format!(
-                        "segment {} configured for static DHCP leases only; no static reservation for MAC {mac_address}",
-                        segment.name,
-                    )));
+                    return Err(DatabaseError::ReservedSegmentNoReservation {
+                        segment_name: segment.name.clone(),
+                        mac_address,
+                    });
                 }
 
                 // TODO: add fixed_ip handling

--- a/crates/api/src/api/metrics.rs
+++ b/crates/api/src/api/metrics.rs
@@ -11,15 +11,17 @@
  */
 
 use opentelemetry::KeyValue;
-use opentelemetry::metrics::{Histogram, Meter};
+use opentelemetry::metrics::{Counter, Histogram, Meter};
 use opentelemetry_sdk::metrics::{Aggregation, Instrument, InstrumentKind, Stream, View};
 
 /// Metric name for machine reboot duration histogram
 const MACHINE_REBOOT_DURATION_METRIC_NAME: &str = "carbide_machine_reboot_duration";
+const STATIC_IP_MANAGEMENT_FAILURES_METRIC_NAME: &str = "carbide_static_ip_management_failures";
 
 /// Holds all metrics related to the API service
 pub struct ApiMetricsEmitter {
     machine_reboot_duration_histogram: Histogram<u64>,
+    static_ip_management_failures_counter: Counter<u64>,
 }
 
 impl ApiMetricsEmitter {
@@ -30,8 +32,16 @@ impl ApiMetricsEmitter {
             .with_unit("s")
             .build();
 
+        let static_ip_management_failures_counter = meter
+            .u64_counter(STATIC_IP_MANAGEMENT_FAILURES_METRIC_NAME)
+            .with_description(
+                "Total number of failures while managing static IP reservations and assignments",
+            )
+            .build();
+
         Self {
             machine_reboot_duration_histogram,
+            static_ip_management_failures_counter,
         }
     }
 
@@ -68,5 +78,20 @@ impl ApiMetricsEmitter {
 
         self.machine_reboot_duration_histogram
             .record(duration_secs, &attributes);
+    }
+
+    /// Records a failure in static IP reservation/assignment management.
+    pub fn record_static_ip_management_failure(
+        &self,
+        operation: &'static str,
+        reason: &'static str,
+    ) {
+        self.static_ip_management_failures_counter.add(
+            1,
+            &[
+                KeyValue::new("operation", operation),
+                KeyValue::new("reason", reason),
+            ],
+        );
     }
 }

--- a/crates/api/src/dhcp/discover.rs
+++ b/crates/api/src/dhcp/discover.rs
@@ -31,6 +31,11 @@ use tonic::{Request, Response};
 use crate::CarbideError;
 use crate::api::Api;
 
+fn record_static_ip_failure(api: &Api, reason: &'static str) {
+    api.metric_emitter
+        .record_static_ip_management_failure("discover_dhcp", reason);
+}
+
 // MTU for both the underlay and overlay networks on
 // the E/W Fabric
 const SPX_MTU: i32 = 9000;
@@ -256,7 +261,15 @@ pub async fn discover_dhcp(
         parsed_relay,
         host_nic,
     )
-    .await?;
+    .await
+    .map_err(|e| {
+        if let db::DatabaseError::Internal { message } = &e
+            && message.contains("configured for static DHCP leases only; no static reservation")
+        {
+            record_static_ip_failure(api, "reserved_segment_no_reservation");
+        }
+        CarbideError::from(e)
+    })?;
 
     // If the interface has no address for the requested address family
     // (e.g., after a lease expiration cleaned up the DHCP allocation,
@@ -286,6 +299,7 @@ pub async fn discover_dhcp(
         // If the segment only allows static reservations, don't
         // dynamically allocate. The device has no reservation.
         if segment.allocation_strategy == AllocationStrategy::Reserved {
+            record_static_ip_failure(api, "reserved_segment_no_reservation");
             return Err(CarbideError::internal(format!(
                 "segment {} configured for static DHCP leases only; no static reservation for MAC {parsed_mac}",
                 segment.name,

--- a/crates/api/src/dhcp/discover.rs
+++ b/crates/api/src/dhcp/discover.rs
@@ -263,9 +263,7 @@ pub async fn discover_dhcp(
     )
     .await
     .map_err(|e| {
-        if let db::DatabaseError::Internal { message } = &e
-            && message.contains("configured for static DHCP leases only; no static reservation")
-        {
+        if e.is_reserved_segment_no_reservation() {
             record_static_ip_failure(api, "reserved_segment_no_reservation");
         }
         CarbideError::from(e)

--- a/crates/api/src/errors.rs
+++ b/crates/api/src/errors.rs
@@ -278,6 +278,14 @@ impl From<DatabaseError> for CarbideError {
             DatabaseError::GenericErrorFromReport(e) => GenericErrorFromReport(e),
             DatabaseError::HardwareInfoError(e) => HardwareInfoError(e),
             DatabaseError::Internal { message } => Internal { message },
+            DatabaseError::ReservedSegmentNoReservation {
+                segment_name,
+                mac_address,
+            } => Internal {
+                message: format!(
+                    "segment {segment_name} configured for static DHCP leases only; no static reservation for MAC {mac_address}"
+                ),
+            },
             DatabaseError::InvalidArgument(e) => InvalidArgument(e),
             DatabaseError::InvalidConfiguration(e) => InvalidConfiguration(e),
             DatabaseError::MissingArgument(e) => MissingArgument(e),

--- a/crates/api/src/handlers/expected_power_shelf.rs
+++ b/crates/api/src/handlers/expected_power_shelf.rs
@@ -48,7 +48,13 @@ pub async fn add_expected_power_shelf(
         })?;
 
     if let Some(bmc_ip) = power_shelf.bmc_ip_address {
-        preallocate_machine_interface(&mut txn, power_shelf.bmc_mac_address, bmc_ip).await?;
+        preallocate_machine_interface(
+            &mut txn,
+            &api.metric_emitter,
+            power_shelf.bmc_mac_address,
+            bmc_ip,
+        )
+        .await?;
     }
 
     db_expected_power_shelf::create(&mut txn, power_shelf)
@@ -114,8 +120,13 @@ pub async fn update_expected_power_shelf(
         })?;
 
     if let Some(bmc_ip) = power_shelf.bmc_ip_address {
-        update_preallocated_machine_interface(&mut txn, power_shelf.bmc_mac_address, bmc_ip)
-            .await?;
+        update_preallocated_machine_interface(
+            &mut txn,
+            &api.metric_emitter,
+            power_shelf.bmc_mac_address,
+            bmc_ip,
+        )
+        .await?;
     }
 
     db_expected_power_shelf::update(&mut txn, &power_shelf)

--- a/crates/api/src/handlers/expected_switch.rs
+++ b/crates/api/src/handlers/expected_switch.rs
@@ -48,7 +48,13 @@ pub async fn add_expected_switch(
         })?;
 
     if let Some(bmc_ip) = switch.bmc_ip_address {
-        preallocate_machine_interface(&mut txn, switch.bmc_mac_address, bmc_ip).await?;
+        preallocate_machine_interface(
+            &mut txn,
+            &api.metric_emitter,
+            switch.bmc_mac_address,
+            bmc_ip,
+        )
+        .await?;
     }
 
     db_expected_switch::create(&mut txn, switch)
@@ -114,7 +120,13 @@ pub async fn update_expected_switch(
         })?;
 
     if let Some(bmc_ip) = switch.bmc_ip_address {
-        update_preallocated_machine_interface(&mut txn, switch.bmc_mac_address, bmc_ip).await?;
+        update_preallocated_machine_interface(
+            &mut txn,
+            &api.metric_emitter,
+            switch.bmc_mac_address,
+            bmc_ip,
+        )
+        .await?;
     }
 
     db_expected_switch::update(&mut txn, &switch)

--- a/crates/api/src/handlers/machine_interface_address.rs
+++ b/crates/api/src/handlers/machine_interface_address.rs
@@ -22,7 +22,16 @@ use rpc::forge as rpc;
 use tonic::{Request, Response, Status};
 
 use crate::api::Api;
+use crate::api::metrics::ApiMetricsEmitter;
 use crate::errors::CarbideError;
+
+fn record_static_ip_failure(
+    metric_emitter: &ApiMetricsEmitter,
+    operation: &'static str,
+    reason: &'static str,
+) {
+    metric_emitter.record_static_ip_management_failure(operation, reason);
+}
 
 /// Resolve the correct segment for a static IP. If the IP is within a
 /// managed network prefix, use that segment. Otherwise use the
@@ -49,12 +58,21 @@ async fn resolve_segment_for_static_ip(
 /// an existing interface.
 pub async fn preallocate_machine_interface(
     txn: &mut sqlx::PgConnection,
+    metric_emitter: &ApiMetricsEmitter,
     bmc_mac_address: MacAddress,
     bmc_ip: std::net::IpAddr,
 ) -> Result<(), CarbideError> {
+    let operation = "preallocate_machine_interface";
+
     // Check if an interface already exists for this MAC.
-    let existing = db::machine_interface::find_by_mac_address(&mut *txn, bmc_mac_address).await?;
+    let existing = db::machine_interface::find_by_mac_address(&mut *txn, bmc_mac_address)
+        .await
+        .map_err(|e| {
+            record_static_ip_failure(metric_emitter, operation, "find_by_mac");
+            CarbideError::from(e)
+        })?;
     if !existing.is_empty() {
+        record_static_ip_failure(metric_emitter, operation, "mac_already_exists");
         return Err(CarbideError::InvalidArgument(format!(
             "a machine interface already exists for MAC {bmc_mac_address}; \
              use update to change the IP address"
@@ -63,8 +81,14 @@ pub async fn preallocate_machine_interface(
 
     // Check if the IP is already allocated to another interface.
     if let Some(existing_addr) =
-        db::machine_interface_address::find_by_address(&mut *txn, bmc_ip).await?
+        db::machine_interface_address::find_by_address(&mut *txn, bmc_ip)
+            .await
+            .map_err(|e| {
+                record_static_ip_failure(metric_emitter, operation, "find_by_address");
+                CarbideError::from(e)
+            })?
     {
+        record_static_ip_failure(metric_emitter, operation, "ip_already_allocated");
         return Err(CarbideError::InvalidArgument(format!(
             "IP address {bmc_ip} is already allocated to interface {} \
              on segment {}; use 'machine-interfaces assign-address' to reassign it",
@@ -72,7 +96,12 @@ pub async fn preallocate_machine_interface(
         )));
     }
 
-    let segment = resolve_segment_for_static_ip(txn, bmc_ip).await?;
+    let segment = resolve_segment_for_static_ip(txn, bmc_ip)
+        .await
+        .map_err(|e| {
+            record_static_ip_failure(metric_emitter, operation, "resolve_segment");
+            e
+        })?;
 
     db::machine_interface::create(
         txn,
@@ -82,7 +111,11 @@ pub async fn preallocate_machine_interface(
         true,
         AddressSelectionStrategy::StaticAddress(bmc_ip),
     )
-    .await?;
+    .await
+    .map_err(|e| {
+        record_static_ip_failure(metric_emitter, operation, "create_interface");
+        CarbideError::from(e)
+    })?;
 
     tracing::info!(
         %bmc_mac_address,
@@ -107,17 +140,34 @@ pub async fn preallocate_machine_interface(
 /// 'machine-interfaces assign-address' or 'remove-address'.
 pub async fn update_preallocated_machine_interface(
     txn: &mut sqlx::PgConnection,
+    metric_emitter: &ApiMetricsEmitter,
     bmc_mac_address: MacAddress,
     bmc_ip: std::net::IpAddr,
 ) -> Result<(), CarbideError> {
-    let existing = db::machine_interface::find_by_mac_address(&mut *txn, bmc_mac_address).await?;
+    let operation = "update_preallocated_machine_interface";
+    let existing = db::machine_interface::find_by_mac_address(&mut *txn, bmc_mac_address)
+        .await
+        .map_err(|e| {
+            record_static_ip_failure(metric_emitter, operation, "find_by_mac");
+            CarbideError::from(e)
+        })?;
 
     if let Some(iface) = existing.first() {
         if iface.addresses.is_empty() {
             // No addresses -- safe to assign the static IP.
-            db::machine_interface_address::assign_static(txn, iface.id, bmc_ip).await?;
+            db::machine_interface_address::assign_static(txn, iface.id, bmc_ip)
+                .await
+                .map_err(|e| {
+                    record_static_ip_failure(metric_emitter, operation, "assign_static");
+                    CarbideError::from(e)
+                })?;
 
-            let segment = resolve_segment_for_static_ip(txn, bmc_ip).await?;
+            let segment = resolve_segment_for_static_ip(txn, bmc_ip)
+                .await
+                .map_err(|e| {
+                    record_static_ip_failure(metric_emitter, operation, "resolve_segment");
+                    e
+                })?;
             if iface.segment_id != segment.id {
                 db::machine_interface::update_segment_id(
                     txn,
@@ -125,7 +175,11 @@ pub async fn update_preallocated_machine_interface(
                     segment.id,
                     segment.subdomain_id,
                 )
-                .await?;
+                .await
+                .map_err(|e| {
+                    record_static_ip_failure(metric_emitter, operation, "update_segment_id");
+                    CarbideError::from(e)
+                })?;
             }
 
             tracing::info!(
@@ -147,7 +201,12 @@ pub async fn update_preallocated_machine_interface(
         }
     } else {
         // No interface yet -- create a new one.
-        let segment = resolve_segment_for_static_ip(txn, bmc_ip).await?;
+        let segment = resolve_segment_for_static_ip(txn, bmc_ip)
+            .await
+            .map_err(|e| {
+                record_static_ip_failure(metric_emitter, operation, "resolve_segment");
+                e
+            })?;
 
         db::machine_interface::create(
             txn,
@@ -157,7 +216,11 @@ pub async fn update_preallocated_machine_interface(
             true,
             AddressSelectionStrategy::StaticAddress(bmc_ip),
         )
-        .await?;
+        .await
+        .map_err(|e| {
+            record_static_ip_failure(metric_emitter, operation, "create_interface");
+            CarbideError::from(e)
+        })?;
 
         tracing::info!(
             %bmc_mac_address,
@@ -174,22 +237,51 @@ pub async fn assign_static_address(
     api: &Api,
     request: Request<rpc::AssignStaticAddressRequest>,
 ) -> Result<Response<rpc::AssignStaticAddressResponse>, CarbideError> {
+    let operation = "assign_static_address";
     let req = request.into_inner();
-    let interface_id = req.interface_id.ok_or(CarbideError::InvalidArgument(
-        "interface_id is required".into(),
-    ))?;
-    let ip_address: std::net::IpAddr = req.ip_address.parse()?;
+    let interface_id = req.interface_id.ok_or_else(|| {
+        api.metric_emitter
+            .record_static_ip_management_failure(operation, "missing_interface_id");
+        CarbideError::InvalidArgument("interface_id is required".into())
+    })?;
+    let ip_address: std::net::IpAddr = req.ip_address.parse().map_err(|e| {
+        api.metric_emitter
+            .record_static_ip_management_failure(operation, "invalid_ip_address");
+        CarbideError::from(e)
+    })?;
 
-    let mut txn = api.txn_begin().await?;
+    let mut txn = api.txn_begin().await.map_err(|e| {
+        api.metric_emitter
+            .record_static_ip_management_failure(operation, "begin_transaction");
+        e
+    })?;
     let result =
-        db::machine_interface_address::assign_static(&mut txn, interface_id, ip_address).await?;
+        db::machine_interface_address::assign_static(&mut txn, interface_id, ip_address)
+            .await
+            .map_err(|e| {
+                api.metric_emitter
+                    .record_static_ip_management_failure(operation, "assign_static");
+                CarbideError::from(e)
+            })?;
 
     // Resolve the correct segment for this IP and update the interface
     // if needed. IPs within a managed prefix go on that prefix's segment.
     // External IPs go on the static-assignments anchor segment.
-    let target_segment = resolve_segment_for_static_ip(txn.as_pgconn(), ip_address).await?;
+    let target_segment = resolve_segment_for_static_ip(txn.as_pgconn(), ip_address)
+        .await
+        .map_err(|e| {
+            api.metric_emitter
+                .record_static_ip_management_failure(operation, "resolve_segment");
+            e
+        })?;
 
-    let current_iface = db::machine_interface::find_one(txn.as_pgconn(), interface_id).await?;
+    let current_iface = db::machine_interface::find_one(txn.as_pgconn(), interface_id)
+        .await
+        .map_err(|e| {
+            api.metric_emitter
+                .record_static_ip_management_failure(operation, "find_interface");
+            CarbideError::from(e)
+        })?;
     if current_iface.segment_id != target_segment.id {
         db::machine_interface::update_segment_id(
             &mut txn,
@@ -197,7 +289,12 @@ pub async fn assign_static_address(
             target_segment.id,
             target_segment.subdomain_id,
         )
-        .await?;
+        .await
+        .map_err(|e| {
+            api.metric_emitter
+                .record_static_ip_management_failure(operation, "update_segment_id");
+            CarbideError::from(e)
+        })?;
         tracing::info!(
             %interface_id,
             %ip_address,
@@ -207,7 +304,11 @@ pub async fn assign_static_address(
         );
     }
 
-    txn.commit().await?;
+    txn.commit().await.map_err(|e| {
+        api.metric_emitter
+            .record_static_ip_management_failure(operation, "commit_transaction");
+        CarbideError::from(e)
+    })?;
 
     let status: rpc::AssignStaticAddressStatus = result.into();
     tracing::info!(%interface_id, %ip_address, ?status, "Static address assignment");
@@ -223,20 +324,40 @@ pub async fn remove_static_address(
     api: &Api,
     request: Request<rpc::RemoveStaticAddressRequest>,
 ) -> Result<Response<rpc::RemoveStaticAddressResponse>, CarbideError> {
+    let operation = "remove_static_address";
     let req = request.into_inner();
-    let interface_id = req.interface_id.ok_or(CarbideError::InvalidArgument(
-        "interface_id is required".into(),
-    ))?;
-    let ip_address: std::net::IpAddr = req.ip_address.parse()?;
+    let interface_id = req.interface_id.ok_or_else(|| {
+        api.metric_emitter
+            .record_static_ip_management_failure(operation, "missing_interface_id");
+        CarbideError::InvalidArgument("interface_id is required".into())
+    })?;
+    let ip_address: std::net::IpAddr = req.ip_address.parse().map_err(|e| {
+        api.metric_emitter
+            .record_static_ip_management_failure(operation, "invalid_ip_address");
+        CarbideError::from(e)
+    })?;
 
-    let mut txn = api.txn_begin().await?;
+    let mut txn = api.txn_begin().await.map_err(|e| {
+        api.metric_emitter
+            .record_static_ip_management_failure(operation, "begin_transaction");
+        e
+    })?;
     let deleted = db::machine_interface_address::delete_by_address(
         &mut txn,
         ip_address,
         AllocationType::Static,
     )
-    .await?;
-    txn.commit().await?;
+    .await
+    .map_err(|e| {
+        api.metric_emitter
+            .record_static_ip_management_failure(operation, "delete_by_address");
+        CarbideError::from(e)
+    })?;
+    txn.commit().await.map_err(|e| {
+        api.metric_emitter
+            .record_static_ip_management_failure(operation, "commit_transaction");
+        CarbideError::from(e)
+    })?;
 
     let status = if deleted {
         tracing::info!(%interface_id, %ip_address, "Removed static address");

--- a/crates/api/src/tests/static_address_management.rs
+++ b/crates/api/src/tests/static_address_management.rs
@@ -253,6 +253,81 @@ async fn test_remove_nonexistent_returns_not_found(
     Ok(())
 }
 
+#[crate::sqlx_test]
+async fn test_assign_invalid_ip_emits_failure_metric(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let relay: IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
+
+    let mut txn = env.pool.begin().await?;
+    let interface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        MacAddress::from_str("aa:bb:cc:dd:ee:32").unwrap(),
+        relay,
+        None,
+    )
+    .await?;
+    txn.commit().await?;
+
+    let err = env
+        .api
+        .assign_static_address(Request::new(AssignStaticAddressRequest {
+            interface_id: Some(interface.id),
+            ip_address: "not-an-ip".to_string(),
+        }))
+        .await
+        .expect_err("assign_static_address should fail for invalid IP input");
+
+    assert_ne!(err.code(), tonic::Code::Ok);
+
+    let metrics = env
+        .test_meter
+        .parsed_metrics("carbide_static_ip_management_failures_total");
+    assert!(
+        metrics.iter().any(|(attrs, value)| {
+            attrs.contains("operation=\"assign_static_address\"")
+                && attrs.contains("reason=\"invalid_ip_address\"")
+                && value == "1"
+        }),
+        "expected assign invalid-ip failure metric, got {metrics:?}"
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_remove_missing_interface_id_emits_failure_metric(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    let err = env
+        .api
+        .remove_static_address(Request::new(RemoveStaticAddressRequest {
+            interface_id: None,
+            ip_address: "192.0.2.240".to_string(),
+        }))
+        .await
+        .expect_err("remove_static_address should fail when interface_id is missing");
+
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+    let metrics = env
+        .test_meter
+        .parsed_metrics("carbide_static_ip_management_failures_total");
+    assert!(
+        metrics.iter().any(|(attrs, value)| {
+            attrs.contains("operation=\"remove_static_address\"")
+                && attrs.contains("reason=\"missing_interface_id\"")
+                && value == "1"
+        }),
+        "expected remove missing-interface failure metric, got {metrics:?}"
+    );
+
+    Ok(())
+}
+
 /// Trying to remove a DHCP-allocated address via remove-address should
 /// return NotFound -- remove-address only operates on static allocations.
 /// DHCP allocations are managed by the lease expiration flow.
@@ -786,6 +861,18 @@ async fn test_reserved_segment_rejects_unknown_mac(
     assert!(
         result.is_err(),
         "reserved segment should reject unknown MAC"
+    );
+
+    let metrics = env
+        .test_meter
+        .parsed_metrics("carbide_static_ip_management_failures_total");
+    assert!(
+        metrics.iter().any(|(attrs, value)| {
+            attrs.contains("operation=\"discover_dhcp\"")
+                && attrs.contains("reason=\"reserved_segment_no_reservation\"")
+                && value == "1"
+        }),
+        "expected reserved-segment discover failure metric, got {metrics:?}"
     );
 
     Ok(())


### PR DESCRIPTION
## Description
This PR adds observability for static IP reservation/assignment management failures to cover issue #837.

It introduces a new counter metric:

- `carbide_static_ip_management_failures_total`
- Labels:
  - `operation`
  - `reason`

The metric is emitted across failure paths in static IP workflows (preallocate/update/assign/remove) and in DHCP discover when a reserved segment has no matching static reservation.

It also updates tests to validate metric emission for key failure scenarios.

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
- Closes #837

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
- Full crate test run used for validation in this branch:
  - `cargo test -p carbide-api --no-default-features`
  - Result: `1155 passed, 0 failed, 4 ignored`
- Static IP scope tests also validated as part of the run.