### PR TITLE
fix(api): support vault -> expected credential fallback for scraping Chassis

### DIFF
--- a/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
+++ b/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
@@ -137,18 +137,15 @@ impl BmcEndpointExplorer {
         vendor: RedfishVendor,
         current_bmc_credentials: Credentials,
         new_password: String,
-        skip_password_change: bool,
     ) -> Result<Credentials, EndpointExplorationError> {
-        if !skip_password_change {
-            self.redfish_client
-                .set_bmc_root_password(
-                    bmc_ip_address,
-                    vendor,
-                    current_bmc_credentials.clone(),
-                    new_password.clone(),
-                )
-                .await?;
-        }
+        self.redfish_client
+            .set_bmc_root_password(
+                bmc_ip_address,
+                vendor,
+                current_bmc_credentials.clone(),
+                new_password.clone(),
+            )
+            .await?;
 
         let (user, _) = match current_bmc_credentials {
             Credentials::UsernamePassword { username, password } => (username, password),
@@ -231,10 +228,8 @@ impl BmcEndpointExplorer {
         expected_switch: Option<&ExpectedSwitch>,
     ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
         let current_bmc_credentials;
-        let mut skip_password_change = false;
 
         tracing::info!(%bmc_ip_address, %bmc_mac_address, %vendor, "attempting to set the administrative credentials to the site password");
-        let mut sitewide_bmc_password = self.get_sitewide_bmc_password().await?;
 
         if let Some(expected_machine_credentials) = expected_machine {
             tracing::info!(%bmc_ip_address, %bmc_mac_address, "Found an expected machine for this BMC mac address");
@@ -244,10 +239,6 @@ impl BmcEndpointExplorer {
             };
         } else if let Some(expected_power_shelf_credentials) = expected_power_shelf {
             tracing::info!(%bmc_ip_address, %bmc_mac_address, "Found an expected power shelf for this BMC mac address");
-            sitewide_bmc_password = expected_power_shelf_credentials.bmc_password.clone();
-            // Lite-On power shelf BMCs do not support the Redfish service root endpoint
-            // so we skip the password change
-            skip_password_change = true;
             current_bmc_credentials = Credentials::UsernamePassword {
                 username: expected_power_shelf_credentials.bmc_username.clone(),
                 password: expected_power_shelf_credentials.bmc_password.clone(),
@@ -283,13 +274,13 @@ impl BmcEndpointExplorer {
         // use redfish to set the machine's BMC root password to
         // match Forge's sitewide BMC root password (from the factory default).
         // return an error if we cannot log into the machine's BMC using current credentials
+        let sitewide_bmc_password = self.get_sitewide_bmc_password().await?;
         let bmc_credentials = self
             .set_bmc_root_password(
                 bmc_ip_address,
                 vendor,
                 current_bmc_credentials,
                 sitewide_bmc_password,
-                skip_password_change,
             )
             .await?;
 
@@ -703,12 +694,39 @@ impl EndpointExplorer for BmcEndpointExplorer {
             Ok(vendor) => vendor,
             Err(e) => {
                 tracing::error!(%bmc_ip_address, "Failed to probe Redfish service root endpoint: {e}");
-                //This is workaround for Lite-On power shelf BMCs
-                // that do not support the Redfish service root endpoint
-                let credentials = self.get_bmc_root_credentials(bmc_mac_address).await?;
-                let (username, password) = match credentials.clone() {
-                    Credentials::UsernamePassword { username, password } => (username, password),
-                };
+                // This used to be part of a workaround for Lite-On power shelf BMCs,
+                // because they don't expose Vendor details in the service root, so
+                // we needed to make a subsequent call to get Vendor details from the
+                // Chassis endpoint (Vendor details are needed so we can know how to
+                // rotate/update the BMC password into Vault). I tried to make this
+                // more generic, since it seemed useful -- this will attempt to get
+                // the BMC root credentials from Vault (for devices that have already
+                // already their credentials rotated -- like maybe we force-deleted
+                // and are re-ingesting), and if those aren't found, then we'll assume
+                // it's still the default from the Expected-* configuration, and fall
+                // back to the expected BMC username/password.
+                //
+                // We will then continue on to doing a set_sitewide_bmc_root_password
+                // using the Vendor details we found here (either changing from the
+                // expected defaults, or taking whatever was in Vault and potentially
+                // re-writing it with something new).
+                let (username, password) =
+                    match self.get_bmc_root_credentials(bmc_mac_address).await {
+                        Ok(Credentials::UsernamePassword { username, password }) => {
+                            (username, password)
+                        }
+                        Err(_) => {
+                            if let Some(eps) = expected_power_shelf {
+                                (eps.bmc_username.clone(), eps.bmc_password.clone())
+                            } else if let Some(es) = expected_switch {
+                                (es.bmc_username.clone(), es.bmc_password.clone())
+                            } else if let Some(em) = expected_machine {
+                                (em.data.bmc_username.clone(), em.data.bmc_password.clone())
+                            } else {
+                                return Err(e);
+                            }
+                        }
+                    };
 
                 let vendor = self
                     .redfish_client


### PR DESCRIPTION
## Description

Tried a power shelf ingestion, and ran into an interesting situation!

Right now the general flow for all components is:
- Scrape the Redfish root to detect vendor information (`probe_redfish_endpoint(bmc_ip_address)`).
- Do a `match vendor` to determine how to update/rotate the password, and store in Vault.

Power shelves (LITE-ON, specifically) don't expose any usable vendor details in the Redfish service root (which we leverage for all OTHER components), so we need to make a subsequent "fallback" call to get `Chassis` details to parse the vendor. There's some fallback code in place for this already. Nice.

HOWEVER, the "fallback" code (which makes a `probe_vendor_name_from_chassis(...)` call, is *authenticated*, so it queries Vault for the component credentials. The idea behind this is, for OTHER components, they always give us vendor details in the serice root, so if the call fails, it's because we've set non-default credentials on them (in Vault), and need to now make an authenticated call.

The PROBLEM is, for power shelves, we haven't set credentials yet! This is the first run.

So, I've tried to make a tweak that is as generic as possible (and left code comments).

The idea is:

> Try to get credentials from Vault, and if we don't find any, use the expected credentials.

..and then the flow will continue, thus allowing power shelves to then `set_sitewide_bmc_root_password(...)` as expected (which is what the default/expected BMC creds are used for). This keeps the default fallback behavior we've had, while allowing for a subsequent "fallback" to just use expected credentials if needed.

Confirmed that I can indeed update the power shelf BMC passwords, so I'm getting rid of the `skip_password_change` variable while I'm in here. That was the only thing using it.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

