### PR TITLE
doc: convergence engine

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -44,6 +44,7 @@
 
 - [SPIFFE SVID Design](design/machine-identity/spiffe-svid-sdd.md)
 - [Convergence Engine](design/convergence-engine/README.md)
+    - [Formal Model](design/convergence-engine/formal-model.md)
     - [Machine Handler](design/convergence-engine/machine.md)
     - [Rack Handler](design/convergence-engine/rack.md)
     - [Switch Handler](design/convergence-engine/switch.md)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -43,6 +43,16 @@
 # Design
 
 - [SPIFFE SVID Design](design/machine-identity/spiffe-svid-sdd.md)
+- [Convergence Engine](design/convergence-engine/README.md)
+    - [Machine Handler](design/convergence-engine/machine.md)
+    - [Rack Handler](design/convergence-engine/rack.md)
+    - [Switch Handler](design/convergence-engine/switch.md)
+    - [IB Partition Handler](design/convergence-engine/ib-partition.md)
+    - [DPA Interface Handler](design/convergence-engine/dpa-interface.md)
+    - [SPDM / Attestation Handler](design/convergence-engine/spdm.md)
+    - [Network Segment Handler](design/convergence-engine/network-segment.md)
+    - [Power Shelf Handler](design/convergence-engine/power-shelf.md)
+    - [External Policy — OPA / Rego](design/convergence-engine/rego-opa.md)
 
 # Development
 

--- a/book/src/design/convergence-engine/README.md
+++ b/book/src/design/convergence-engine/README.md
@@ -278,7 +278,7 @@ common                    (base operations: power_on, power_off, configure_bios,
 The resolved operation set for a GB300 machine would be:
 
 ```
-ops(gb300) = ops(common) ∪ ops(gbx00_base) ∪ ops(bf3_dpu) ∪ own(gb300)
+ops(gb300_resolved) = ops(common) ∪ ops(nvidia_gbx00_base) ∪ ops(nvidia_bf3_dpu) ∪ ops(nvidia_gb300)
 ```
 
 ### 3.6 Three-Predicate Scheduler
@@ -566,7 +566,7 @@ profiles/
 
 ### 5.2 State Keys and Resources as Enums
 
-State keys and resource identifiers are **enum variants** — `Copy`, zero-cost, and exhaustively matchable. A typo is a compile error. No strings involved.
+State keys and resource identifiers are **enum variants**.
 
 ```rust
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/book/src/design/convergence-engine/README.md
+++ b/book/src/design/convergence-engine/README.md
@@ -14,29 +14,25 @@ This document specifies a **declarative convergence engine** that replaces the i
 
 The specification covers:
 
-- The formal state model and delta computation.
-- The operation data model, guard algebra, and effect resolution.
-- The hardware-profile system with inheritance.
-- The three-predicate scheduler, dependency resolution, and anti-oscillation guards.
-- The convergence loop and fixpoint characterization.
-- Integration architecture with the existing `StateProcessor` / `StateControllerIO` infrastructure.
-- The Rust DSL profile system for defining operations.
-- Fleet-level coordination and external policy (OPA/Rego).
-- Migration strategy from the current imperative handlers.
+- The core concepts: state maps, delta, operations, guards, profiles, scheduling, and convergence (§3).
+- Integration architecture with the existing `StateProcessor` / `StateControllerIO` infrastructure (§4).
+- The Rust DSL profile system for defining operations (§5).
+- Fleet-level coordination and external policy (OPA/Rego) (§6).
+- Migration strategy from the current imperative handlers (§7).
 
 ### 1.2 Definitions
 
 
-| Term                       | Definition                                                                                                |
-| -------------------------- | --------------------------------------------------------------------------------------------------------- |
-| **Observed state** (`S_o`) | The ground-truth state of an object, periodically refreshed from hardware, database, or external sources. |
-| **Desired state** (`S_d`)  | The declared intent — the state the object should converge to.                                            |
-| **Delta** (`Δ`)            | The set of state keys where observed and desired disagree.                                                |
-| **Operation** (`ω`)        | An atomic, data-driven unit of work defined by guards, effects, locks, and priority.                      |
-| **Guard** (`G`)            | A boolean predicate over the observed state that must hold for an operation to fire.                      |
-| **Profile**                | A named collection of operations associated with a hardware type, supporting inheritance.                 |
-| **Tick**                   | One iteration of the convergence loop: compute delta, select operations, execute, apply effects.          |
-| **Convergence**            | The system has converged when `Δ = ∅`.                                                                    |
+| Term                 | Definition                                                                                                |
+| -------------------- | --------------------------------------------------------------------------------------------------------- |
+| **state_observed**   | The ground-truth state of an object, periodically refreshed from hardware, database, or external sources. |
+| **state_desired**    | The declared intent — the state the object should converge to.                                            |
+| **delta**            | The set of state keys where observed and desired disagree.                                                |
+| **operation**        | An atomic, data-driven unit of work defined by guards, effects, locks, and priority.                      |
+| **guard**            | A boolean predicate over the observed state that must hold for an operation to fire.                      |
+| **profile**          | A named collection of operations associated with a hardware type, supporting inheritance.                 |
+| **tick**             | One iteration of the convergence loop: compute delta, select operations, execute, apply effects.          |
+| **convergence**      | The system has converged when `delta` is empty.                                                           |
 
 
 ---
@@ -76,137 +72,55 @@ Each object type implements `StateHandler` with a `match` on its controller-stat
 
 ---
 
-## 3. Formal Model
+## 3. How the Engine Works
 
-This section provides the complete mathematical specification of the convergence engine. Each subsection defines a concept with formal notation, explains it in prose, and maps it to the corresponding Rust data structure.
+This section explains the core concepts of the convergence engine.
 
-### 3.1 State Space
+### 3.1 State: Two Maps
 
-**Definition.** Let `K` be a finite set of *state keys* — strongly-typed identifiers such as `PowerState`, `FirmwareBmcVersion`, or `BiosBootOrder`. Let `V` be a set of *state values* — a typed union of booleans, integers, semantic versions, and text. All keys, values, identifiers, and resources are strongly typed; the implementation represents `K` and `R` as enums (`StateKey`, `Resource`) and values as a typed union (`StateValue`), preventing accidental misuse at compile time.
+The engine works with two key-value maps:
 
-A **host state** is a partial function:
+- **state_observed** — what the hardware actually looks like right now: power status, firmware versions, agent heartbeats, BIOS settings hashes, etc. Refreshed every reconciliation cycle from Redfish, IPMI, databases, and agent reports.
+- **state_desired** — what the hardware *should* look like: the firmware version we want, the BIOS hash we expect, the DPU mode we need, etc. Assembled at runtime from operator intent, config templates, firmware manifests, and fleet policies.
 
-```
-S : K ⇀ V
-```
+Both maps use the same set of strongly-typed keys (the `StateKey` enum — see §5). Any key can appear in either map. Which keys appear in `state_desired` is a runtime decision, not a property of the key itself.
 
-The notation `⇀` (as opposed to `→`) indicates that `S` need not be defined on all of `K`. The **domain** of `S` is:
+In code: `HostState` is a `BTreeMap<StateKey, StateValue>`. Keys are enum variants (compile-time safe, zero-cost, impossible to misspell). Values are a typed union (`Bool`, `Int`, `Str`, `Version`) with cross-type equality.
 
-```
-dom(S) = { k ∈ K | S(k) is defined }
-```
+### 3.2 Delta: What Needs to Change
 
-At any moment in time, the system maintains two states:
+The **delta** is the set of keys where observed and desired disagree. If the desired state says `FirmwareBmcVersion = "2.4.0"` but the observed state shows `FirmwareBmcVersion = "2.3.1"`, that key is in the delta.
 
-- `S_o` — the **observed state**, populated by reading hardware (Redfish, IPMI), databases, and agent reports. This is the ground truth, refreshed periodically.
-- `S_d` — the **desired state**, assembled at runtime by the desired-state composition layer from operator intent, config templates, firmware manifests, fleet policies, and other sources.
+The engine only looks at keys that appear in the desired state. Observed keys with no desired counterpart are ignored — `state_desired` is a patch, not a complete specification. If a desired key has not been observed yet (the hardware hasn't reported it), it's treated as mismatched.
 
-**Unified key space.** Both `S_o` and `S_d` draw from the same key space `K`. There is no type-level distinction between "observed-only" and "desired" keys -- any key can appear in either or both maps. Which keys appear in `S_d` is a runtime decision made by the composition layer, not a property of the key itself.
+**The system has converged when the delta is empty** — every key the desired state cares about matches what we observe.
 
-**Domain relationship.** The desired state typically declares a subset of observed keys, but this is not a constraint:
+### 3.3 Operations: What the Engine Can Do
 
-```
-dom(S_d) ⊆ K,  dom(S_o) ⊆ K
-```
+An **operation** is an atomic unit of work, defined by six fields:
 
-`dom(S_d) \ dom(S_o)` may be non-empty when the observed state has not yet discovered a key that the desired state declares. Such keys are treated as mismatched (see §3.2).
+| Field | What it does |
+|---|---|
+| **id** | Unique name (e.g., `update_bmc_firmware`). |
+| **provides** | Which state keys this operation can change. The engine only considers an operation if it provides a key in the current delta. |
+| **guard** | A precondition that must be true before the operation can fire (e.g., "power must be on"). |
+| **locks** | Resources this operation needs exclusive access to. Two operations that lock the same resource cannot run in the same tick. |
+| **effects** | What the operation does to the state map after execution (e.g., sets `FirmwareBmcVersion` to the desired version). |
+| **priority** | Higher priority operations are scheduled first when multiple compete. |
 
-**Code mapping.** `K` is represented as a `StateKey` enum — each valid key is a variant, making it `Copy`, zero-cost, and impossible to misspell. `V` is a `StateValue` enum supporting cross-variant equality (e.g., `Bool(true)` equals the text representation `"true"`). `S` is `HostState(BTreeMap<StateKey, StateValue>)`.
+Operations are declared in Rust via the `op!` macro (see §5).
 
-### 3.2 Delta
+### 3.4 Guards: When Can an Operation Fire
 
-**Definition.** The **delta** (or *drift*) between observed and desired state is the set of keys where the two states disagree:
+Guards are boolean preconditions built from a small set of combinators:
 
-```
-Δ(S_o, S_d) = { k ∈ dom(S_d) | S_o(k) ≠ S_d(k) }
-```
+- `eq(key, value)` — key equals value
+- `neq(key, value)` — key does not equal value
+- `contains(key, substring)` — key's value contains a substring
+- `and(...)`, `or(...)`, `not(...)` — boolean combinators
+- `desired(key)` — a reference to the desired-state value for that key
 
-with the convention that if `k ∈ dom(S_d) \ dom(S_o)` — i.e., the desired state declares a key that the observed state has not yet discovered — then `S_o(k) ≠ S_d(k)` holds (the key is considered mismatched). Formally:
-
-```
-k ∈ Δ  ⟺  k ∈ dom(S_d) ∧ ( k ∉ dom(S_o) ∨ S_o(k) ≠ S_d(k) )
-```
-
-**Convergence criterion.** The system has **converged** when:
-
-```
-Δ(S_o, S_d) = ∅
-```
-
-That is, for every key the desired state cares about, the observed state agrees.
-
-**What the delta does NOT include.** Keys in `dom(S_o) \ dom(S_d)` — observed keys with no corresponding desired value — are not part of the delta. The engine does not attempt to "clean up" observed state that has no desired counterpart. This is intentional: `S_d` is a *patch*, not a complete specification.
-
-**Code mapping.** The `delta()` function iterates over `dom(S_d)` and collects keys where `observed.get(k) != Some(desired_val)`.
-
-### 3.3 Operations
-
-**Definition.** An **operation** is a tuple:
-
-```
-ω = (id, P, G, L, E, π)
-```
-
-where:
-
-
-| Component | Constraint       | Description                                                                                                                                                                         |
-| --------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`      | unique in `Ω`    | Unique identifier for this operation.                                                                                                                                               |
-| `P`       | `P ⊆ K`          | **Provides** — the set of state keys this operation can change. An operation is only considered for a delta key `k` if `k ∈ P`.                                                     |
-| `G`       | `G : S → {0, 1}` | **Guard** — a boolean predicate over the observed state (see §3.4). The operation may only fire when `G(S_o) = 1`.                                                                  |
-| `L`       | `L ⊆ R`          | **Locks** — a set of resource identifiers requiring mutual exclusion. `R` is the universe of lockable resources. Two operations with `L₁ ∩ L₂ ≠ ∅` cannot execute in the same tick. |
-| `E`       | `E : K ⇀ V`      | **Effects** — a partial function mapping state keys to their post-execution values. After execution, `S_o(k) ← E(k)` for each `k ∈ dom(E)`.                                         |
-| `π`       | `π ∈ ℕ`          | **Priority** — a non-negative integer. Higher values are scheduled first when multiple operations compete.                                                                          |
-
-
-**Note on effects and provides.** Typically `dom(E) ⊆ P`, but this is not strictly required. An operation may have effects on keys it does not "provide" (side effects), though this is discouraged as it complicates reasoning.
-
-### 3.4 Guard Algebra
-
-Guards are the precondition language of the engine. They form a small algebra closed under boolean combinators.
-
-**Grammar.** The set of guard expressions `G` is defined inductively:
-
-```
-G ::= Eq(k, v)
-    | Neq(k, v)
-    | In(k, {v₁, …, vₙ})
-    | Contains(k, s)
-    | And(G₁, …, Gₙ)
-    | Or(G₁, …, Gₙ)
-    | Not(G)
-    | True
-```
-
-**Evaluation semantics.** Given a state `S`, each guard variant evaluates as follows:
-
-
-| Guard            | `G(S) = 1` iff                            |
-| ---------------- | ----------------------------------------- |
-| `Eq(k, v)`       | `k ∈ dom(S) ∧ S(k) = resolve(v, S)`       |
-| `Neq(k, v)`      | `k ∉ dom(S) ∨ S(k) ≠ resolve(v, S)`       |
-| `In(k, V)`       | `k ∈ dom(S) ∧ S(k) ∈ V`                   |
-| `Contains(k, s)` | `k ∈ dom(S) ∧ s` is a substring of `S(k)` |
-| `And(G₁, …)`     | `∀ i : Gᵢ(S) = 1`                         |
-| `Or(G₁, …)`      | `∃ i : Gᵢ(S) = 1`                         |
-| `Not(G')`        | `G'(S) = 0`                               |
-| `True`           | always 1                                  |
-
-
-**Desired-state references.** Values `v` in guard and effect expressions may reference the desired state via `desired(k)`. The resolution function is:
-
-```
-resolve(v, S_o, S_d) =
-    if v = desired(k'):
-        return S_d(k')
-    else:
-        return v
-```
-
-This allows operations to compare observed values against desired targets (e.g., "current firmware version differs from desired") without hard-coding target values.
-
-**Example.** The guard for a firmware update operation (shown here in `op!` macro syntax — see §5):
+**Example:** a firmware update guard reads "fire only when the machine is powered on AND the current BMC firmware version differs from the desired version":
 
 ```rust
 guard: and(
@@ -215,259 +129,77 @@ guard: and(
 ),
 ```
 
-This reads: "fire only when the machine is powered on AND the current BMC firmware version differs from the desired version."
-
-**Conflict detection.** The function `conflicts_with_effect(G, k, v, S)` determines whether setting key `k` to value `v` in state `S` would cause guard `G` to transition from true to false. This is used by the anti-oscillation logic (§3.8):
-
-```
-conflicts_with_effect(G, k, v, S) = G(S) = 1  ∧  G(S[k ↦ v]) = 0
-```
-
-where `S[k ↦ v]` denotes the state `S` with key `k` overwritten to `v`.
-
-**Code mapping.** The `Guard` type implements `evaluate(S) → {0, 1}` and `conflicts_with_effect(G, k, v, S) → {0, 1}` with strongly-typed key and value parameters.
+The `desired(key)` reference lets operations compare against targets without hard-coding values. At evaluation time, `desired(FirmwareBmcVersion)` resolves to whatever version the operator declared as the target.
 
 ### 3.5 Hardware Profiles and Inheritance
 
-**Definition.** A **hardware profile** is a tuple:
+A **hardware profile** is a named collection of operations for a specific hardware type. Profiles have:
 
-```
-P = (id, M, I, Ω, α)
-```
+- A **match rule** — a guard evaluated against observed state to auto-detect hardware (e.g., `contains(HwSku, "GB300")`).
+- An **inherits** list — parent profiles whose operations are pulled in.
+- **Operations** — the operations specific to this profile.
+- An **abstract** flag — if true, the profile can only be inherited from, not directly matched.
 
-where:
+**Inheritance** works like class inheritance: a child profile gets all its parents' operations. If a child defines an operation with the same ID as a parent, the child's version wins (last-writer-wins). This lets a specific hardware profile override just the operations that differ.
 
-
-| Component | Constraint        | Description                                                                                                                              |
-| --------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`      | unique in `Π`     | Profile identifier (e.g., `nvidia_gb300`, `generic_x86`). `Π` is the set of all profiles.                                                |
-| `M`       | `M : S → {0, 1}`  | **Match rule** — a guard expression evaluated against observed state. The first non-abstract profile whose match rule holds is selected. |
-| `I`       | `I ⊆ Π`           | **Inherits** — an ordered list of parent profile identifiers.                                                                            |
-| `Ω`       | `Ω = {ω₁, …, ωₘ}` | **Operations** — the set of operations defined in this profile.                                                                          |
-| `α`       | `α ∈ {0, 1}`      | **Is abstract** — if 1, the profile cannot be directly selected but can be inherited from.                                               |
-
-
-**Inheritance resolution.** The effective operation set for a profile `P` is computed by traversing the inheritance DAG in order and merging operations:
-
-```
-ops(P) = ops(P_I₁) ∪ ops(P_I₂) ∪ … ∪ Ω_P
-```
-
-When two profiles define an operation with the same `id`, the later definition wins (**last-writer-wins**). This allows a child profile to override a parent's operation — for example, `nvidia_gb300` can override the `power_off` operation inherited from `common` to add a GPU-specific shutdown sequence.
-
-**Profile detection algorithm:**
-
-```
-function detect_profile(S_o, profiles):
-    for P in profiles sorted by specificity:
-        if P.is_abstract: continue
-        if P.match_rule(S_o) = 1:
-            return P
-    return error("no matching profile")
-```
-
-**Concrete inheritance chain example:**
+**Example chain:**
 
 ```
 common                    (base operations: power_on, power_off, configure_bios, ...)
-  └── nvidia_gbx00_base   (abstract: update_bmc_firmware with NVIDIA-specific Redfish)
-        └── nvidia_gb300   (concrete: match rule checks hw_sku contains "GB300")
+  └── nvidia_gbx00_base   (abstract: NVIDIA-specific firmware update)
+        └── nvidia_gb300   (concrete: match rule checks HwSku contains "GB300")
               inherits: [nvidia_bf3_dpu]  ← also pulls in DPU operations
-```
-
-The resolved operation set for a GB300 machine would be:
-
-```
-ops(gb300_resolved) = ops(common) ∪ ops(nvidia_gbx00_base) ∪ ops(nvidia_bf3_dpu) ∪ ops(nvidia_gb300)
 ```
 
 ### 3.6 Three-Predicate Scheduler
 
-The scheduler is the decision-making core of the engine. On each tick, it evaluates every available operation against three predicates and selects a safe, non-conflicting action set.
+The scheduler is the decision-making core. Every tick, it filters all available operations through three questions:
 
-**Predicate 1 — Relevant.** An operation is relevant if it provides at least one key in the current delta:
+1. **Relevant?** Does the operation provide a key that's in the current delta? If not, skip it — there's nothing for it to do.
+2. **Constructive?** Would the operation's effects move the state *toward* desired, not away from it? This prevents, e.g., `power_off` from firing when the desired state is "on".
+3. **Ready?** Does the operation's guard pass on the current observed state? If not, the operation is blocked and goes to dependency resolution.
 
-```
-relevant(ω)  ⟺  P_ω ∩ Δ(S_o, S_d) ≠ ∅
-```
+Operations that pass all three filters are **candidates**. The scheduler then picks a maximal non-conflicting subset using a greedy algorithm: sort by priority (highest first), and skip any operation whose locks overlap with an already-selected operation.
 
-Irrelevant operations are filtered out immediately. If the delta is empty, no operations are relevant and the system has converged.
-
-**Predicate 2 — Constructive.** A relevant operation is constructive if at least one of its effects moves the observed state *toward* the desired state (not away from it):
-
-```
-constructive(ω)  ⟺  ∃ k ∈ P_ω ∩ Δ : resolve(E_ω(k), S_o) = S_d(k)
-```
-
-where `resolve` handles `desired.*` references in effect values. This predicate prevents operations that would change a delta key but to the *wrong* value — e.g., powering off when the desired state is powered on.
-
-**Predicate 3 — Ready.** A constructive, relevant operation is ready if its guard holds on the current observed state:
-
-```
-ready(ω)  ⟺  G_ω(S_o) = 1
-```
-
-Operations that are relevant and constructive but not ready become candidates for dependency resolution (§3.7).
-
-**Candidate set.** The set of fully qualified candidates is:
-
-```
-R = { ω | relevant(ω) ∧ constructive(ω) ∧ ready(ω) }
-```
-
-**Greedy resource-conflict-free selection.** From `R`, the scheduler selects a maximal subset that respects resource locks:
-
-```
-scheduled = greedy(R, π, L)
-```
-
-**Algorithm:**
-
-```
-function schedule(R):
-    sort R by priority π descending (stable sort preserves insertion order for ties)
-    claimed_resources ← ∅
-    scheduled ← []
-
-    for ω in R:
-        if L_ω ∩ claimed_resources = ∅:
-            if not anti_oscillation_deferred(ω):
-                scheduled.append(ω)
-                claimed_resources ← claimed_resources ∪ L_ω
-
-    return scheduled
-```
-
-When two operations have equal priority, the stable sort preserves their original order (typically alphabetical by operation ID from the profile). This is deterministic but arbitrary — if tie-breaking matters, assign distinct priorities.
-
-**Formal property.** The scheduled set satisfies:
-
-```
-∀ ωᵢ, ωⱼ ∈ scheduled, i ≠ j : Lᵢ ∩ Lⱼ = ∅
-```
-
-That is, no two scheduled operations hold the same resource lock.
+Equal-priority ties are broken by stable sort order (deterministic, typically alphabetical by operation ID).
 
 ### 3.7 Dependency Resolution
 
-Some operations are relevant and constructive but not ready — their guard fails on the current observed state. The dependency resolver attempts to find **enabler** operations that can satisfy the unmet preconditions.
+When an operation is relevant and constructive but **not ready** (its guard fails), the engine tries to find an **enabler** — another operation that can satisfy the unmet precondition.
 
-**Unmet clause extraction.** For a blocked operation `ω_b` with `G(ω_b)(S_o) = 0`, the resolver decomposes the guard into its atomic `Eq` clauses and identifies which ones fail:
+**Example:** `update_bmc_firmware` needs `PowerState = "on"`, but the machine is off. The resolver finds `power_on`, whose effect sets `PowerState` to `"on"` and whose guard (`PowerState = "off"`) currently holds. It auto-schedules `power_on` as a dependency.
 
-```
-unmet(ω_b) = { (k, v) | Eq(k, v) ∈ atoms(G(ω_b))  ∧  S_o(k) ≠ resolve(v, S_o) }
-```
-
-For compound guards (`And`, `Or`), the decomposition follows the structure: for `And`, all failing clauses are unmet; for `Or`, only the first satisfiable branch is considered.
-
-**Enabler search.** For each unmet clause `(k, v)`, the resolver searches for an enabler operation:
-
-```
-∃ ω_e ∈ Ω : E_e(k) = v  ∧  G_e(S_o) = 1  ∧  L_e ∩ L_claimed = ∅
-```
-
-where `L_claimed` is the set of resources already reserved by previously scheduled operations and other enablers.
-
-**Resource pre-reservation.** When an enabler is found, its resources are immediately added to `L_claimed` *before* the main greedy pass. This prevents the greedy pass from scheduling a different operation that would conflict with the enabler.
-
-**Dependency chain depth.** The current implementation resolves dependencies to depth 1 — it finds enablers for blocked operations but does not recursively resolve enablers' own blocked dependencies. This is sufficient for common patterns (e.g., power-on enables firmware update) and avoids the complexity of recursive planning. The convergence loop naturally resolves deeper chains over multiple ticks.
-
-**Example.** Operation `update_bmc_firmware` requires `power.state = "on"`. If the machine is off:
-
-1. `update_bmc_firmware` is relevant and constructive but not ready (guard fails: `power.state = "off"`).
-2. The resolver extracts unmet clause: `(power.state, "on")`.
-3. It finds enabler `power_on` with effect `power.state → "on"`, whose guard `power.state = "off"` holds.
-4. `power_on` is auto-scheduled; its resources are reserved.
-5. After `power_on` executes, the next tick finds `update_bmc_firmware` ready.
+Dependency resolution works to **depth 1** — it finds direct enablers but doesn't recursively resolve chains. Deeper chains resolve naturally over multiple ticks (power on this tick → firmware update next tick → ...).
 
 ### 3.8 Anti-Oscillation
 
-Without safeguards, the scheduler could enter infinite cycles — for example, `power_on` and `power_off` alternating each tick because both are relevant to the same key. Two guards prevent the most common oscillation patterns.
+Without safeguards, the engine could get stuck in cycles — `power_on` and `power_off` alternating every tick. Two guards prevent this:
 
-**Guard 1 — Dominance deferral.** An operation `ω` is deferred if it would undo the effect of a dependency action scheduled in the same tick:
+1. **Dominance deferral.** If operation A is scheduled as a dependency (e.g., `power_on` for `update_firmware`), and operation B would undo A's effect (e.g., `power_off`), then B is deferred. Dependencies win.
 
-```
-ω deferred if ∃ ω_d ∈ deps, k ∈ P_ω ∩ P_d : E_ω(k) ≠ E_d(k)
-```
+2. **Competitor blocking.** If two operations share a resource lock and one would break the other's guard, the disruptive one is deferred.
 
-**Intuition.** If the scheduler found that `power_on` is needed as a dependency for `update_bmc_firmware`, and `power_off` is also relevant (because `PowerState` is in the delta), the dominance guard defers `power_off` — executing it would undo the dependency and create an oscillation.
+These guards prevent the most common 1-tick and 2-tick oscillation patterns. They are **not a formal proof of termination** — complex circular dependencies across 3+ ticks could theoretically occur. As a safety net, the engine can track visited-state fingerprints and detect recurring states.
 
-**Guard 2 — Competitor blocking deferral.** An operation `ω` is deferred if its effect would falsify the guard of another ready operation that competes for the same resource:
+In a well-configured operation set, the engine converges in roughly `|delta| × depth` ticks, where `|delta|` is the initial number of mismatched keys and `depth` is the maximum dependency chain depth.
 
-```
-ω deferred if ∃ ω_c ∈ R, L_ω ∩ L_c ≠ ∅ : conflicts_with_effect(G_c, k, E_ω(k), S_o) for some k
-```
+### 3.9 The Convergence Loop
 
-**Intuition.** If two operations share a resource lock and one would make the other's guard false, the engine defers the disruptive one, preferring the operation that preserves the conditions needed by its competitor.
+The engine runs as a **synchronous tick function**. The outer loop is the existing `PeriodicEnqueuer` → `Queue` → `StateProcessor` pipeline (see §4.2), which already handles periodic scheduling, dequeuing, and state persistence. Each tick:
 
-**What these guards do NOT guarantee.** These two guards prevent the most common 1-tick and 2-tick oscillation patterns:
+1. Compute the delta between observed and desired state.
+2. If the delta is empty → **converged**, done.
+3. Filter operations through the three predicates (relevant, constructive, ready).
+4. Resolve dependencies for blocked operations.
+5. Schedule a non-conflicting subset, respecting locks and anti-oscillation.
+6. Execute the selected operations and apply their effects to the observed state.
+7. If no operations were selected but the delta is non-empty → **deadlock or waiting for external change**.
 
-- Tick `t`: power on → Tick `t+1`: power off → Tick `t+2`: power on → ... (prevented by dominance)
-- Tick `t`: operation A blocks operation B's guard, which in turn blocks A (prevented by competitor blocking)
+The converged state is a **fixpoint** — a state where running the engine again produces no changes. The engine seeks this fixpoint iteratively, tick by tick.
 
-However, they are **not a formal proof of termination**. In the general case:
+**Long-running operations** (like firmware flashes) are handled by the outer loop, not the engine itself. The operation initiates the flash; subsequent ticks re-observe the state and detect when it completes. The engine is always a pure synchronous function — the async boundary lives outside.
 
-1. **Longer cycles** (3+ ticks) could theoretically occur if the operation graph has complex circular dependencies.
-2. **Energy function non-monotonicity.** Dependency resolution can *temporarily increase* `|Δ|` — e.g., powering on a machine adds `power.state = "on"` to observed state, which might not be the desired value if the ultimate goal is a firmware update with power-off afterward. The delta shrinks only after the full dependency chain completes.
-
-**Safety net: visited-state detection.** As a defensive measure, the engine can optionally track visited state fingerprints (hashes of `S_o`) and detect if the same observed state recurs, indicating an oscillation. Upon detection, the engine halts and reports a misconfiguration error.
-
-**Formal characterization.** Define the "energy" of the system as `|Δ(S_o, S_d)|`. In a well-configured operation set:
-
-- Each constructive operation reduces `|Δ|` by at least 1 for its primary key.
-- Dependency operations may temporarily increase `|Δ|` but are bounded in depth.
-- The anti-oscillation guards ensure that the scheduler does not undo its own progress within a single tick.
-
-Under these conditions, the convergence loop terminates in `O(|Δ₀| · d)` ticks, where `|Δ₀|` is the initial delta size and `d` is the maximum dependency chain depth.
-
-### 3.9 Convergence Loop
-
-The convergence loop is the top-level execution cycle of the engine. It repeatedly ticks until the system converges or declares a deadlock.
-
-**State evolution.** After each tick, the observed state is updated:
-
-```
-S_o(t+1) = S_o(t) ⊕ ⋃{ E_ω | ω ∈ actions(t) }
-```
-
-where `⊕` denotes state update (overwriting existing keys with new values from the effects).
-
-**Desired-state availability.** Both `S_o` and `S_d` are available to the scheduler on every tick. Guards and effects that use `desired(k)` references are resolved against `S_d` via the `resolve` function (see §3.4).
-
-**Termination conditions.** The loop terminates when:
-
-1. **Converged:** `Δ(S_o, S_d) = ∅`. All desired keys match observed values.
-2. **Idle with non-empty delta:** The scheduler returns no actions (`actions(t) = ∅`) but `Δ ≠ ∅`. This indicates either a misconfiguration (no operation provides the needed key), a deadlock (all relevant operations are blocked by guards that cannot be satisfied), or a transient condition awaiting external state changes.
-
-**Fixpoint characterization.** The converged state `S_o`* is a **fixpoint** of the convergence operator:
-
-```
-S_o* = F(S_o*, S_d)  ⟺  Δ(S_o*, S_d) = ∅
-```
-
-The engine is a fixpoint-seeking iteration: `S_o⁰, S_o¹, …, S_oⁿ = S_o*`.
-
-**Tick pseudocode:**
-
-```
-function tick(S_o, S_d, operations):
-    Δ ← delta(S_o, S_d)
-    if Δ = ∅: return CONVERGED
-
-    relevant ← { ω ∈ operations | P_ω ∩ Δ ≠ ∅ }
-    constructive ← { ω ∈ relevant | ∃ k ∈ P_ω ∩ Δ : resolve(E_ω(k), S_o, S_d) = S_d(k) }
-    ready ← { ω ∈ constructive | G_ω(S_o, S_d) = 1 }
-    blocked ← constructive \ ready
-
-    deps ← resolve_dependencies(blocked, operations, S_o, S_d)
-    actions ← schedule(ready ∪ deps, anti_oscillation_context)
-
-    for ω in actions:
-        execute(ω.steps)
-        S_o ← S_o ⊕ resolve_effects(E_ω, S_o, S_d)
-
-    return (actions, S_o)
-```
+> **Full formal specification:** For the complete mathematical definitions, set-theoretic notation, guard algebra grammar, scheduling algorithm pseudocode, and termination analysis, see [Formal Model](formal-model.md).
 ---
 
 ## 4. Architecture
@@ -507,12 +239,12 @@ flowchart LR
     Q -->|"dequeue()"| SP[StateProcessor]
     SP -->|"load_state()"| IO[StateControllerIO]
     SP -->|"handle_object_state()"| CH[ConvergenceHandler]
-    CH -->|"observe()"| OBS["Build S_o from
+    CH -->|"observe()"| OBS["Build state_observed from
         object state +
         hardware queries"]
-    CH -->|"desired()"| DES["Build S_d from
+    CH -->|"desired()"| DES["Build state_desired from
         config + policies"]
-    CH -->|"tick(S_o, S_d)"| ENG[ConvergenceEngine]
+    CH -->|"tick(state_observed, state_desired)"| ENG[ConvergenceEngine]
     ENG -->|resolve profile| PR[ProfileResolver]
     ENG -->|schedule| SCH[Scheduler]
     ENG -->|execute| EX[ActionExecutor]
@@ -539,7 +271,7 @@ flowchart LR
 
 | Component              | Responsibility                                                                                                                                         |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **ConvergenceHandler** | Implements `StateHandler`. Builds `S_o` and `S_d` from the object state, delegates to the engine, and maps `TickResult` back to `StateHandlerOutcome`. |
+| **ConvergenceHandler** | Implements `StateHandler`. Builds `state_observed` and `state_desired` from the object state, delegates to the engine, and maps `TickResult` back to `StateHandlerOutcome`. |
 | **ConvergenceEngine**  | Orchestrates one tick: resolves profile, runs scheduler, executes actions, returns result.                                                             |
 | **ProfileResolver**    | Loads hardware profiles from Rust profile modules, evaluates match rules, resolves inheritance chain, returns the effective operation set.             |
 | **Scheduler**          | Implements the three-predicate filter, dependency resolution, anti-oscillation guards, and greedy selection.                                           |
@@ -713,9 +445,9 @@ The fleet controller does not modify the engine — it controls the *desired sta
 
 ```mermaid
 flowchart TD
-    FC[Fleet Controller] -->|"set S_d for machine A"| EA[Engine A]
-    FC -->|"set S_d for machine B"| EB[Engine B]
-    FC -->|"set S_d for machine C"| EC[Engine C]
+    FC[Fleet Controller] -->|"set state_desired for machine A"| EA[Engine A]
+    FC -->|"set state_desired for machine B"| EB[Engine B]
+    FC -->|"set state_desired for machine C"| EC[Engine C]
     FC -->|"query OPA"| OPA["OPA / Rego
         Policy Engine"]
     OPA -->|"policy.* keys"| FC
@@ -752,9 +484,9 @@ The convergence engine and the current handlers produce fundamentally different 
 Before any production deployment, batch-test the engine against known-good production state snapshots:
 
 1. Take a real object's current state from the production database.
-2. Build `S_o` and `S_d` from the object's state, config, and firmware manifests.
+2. Build `state_observed` and `state_desired` from the object's state, config, and firmware manifests.
 3. Run the engine to convergence with mock action executors (no real Redfish/DB calls).
-4. Verify the final `S_o` matches the state the current handler would eventually produce.
+4. Verify the final `state_observed` matches the state the current handler would eventually produce.
 
 This validates the engine's *policy* — does it reach the same end state? — without comparing intermediate tick-by-tick decisions. A test harness runs this against hundreds of production state snapshots per profile to build statistical confidence.
 
@@ -844,23 +576,24 @@ The FSM's phase ordering (init before validation before ready) is artificial —
 | Question                     | Discussion                                                                                                                                                                                  |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Formal termination proof** | The anti-oscillation guards prevent common patterns but are not a formal proof. Should we invest in a model-checker (e.g., TLA+) to verify termination for specific profile configurations? |
-| **State persistence format** | Should `S_o` and `S_d` be persisted as flat key-value maps in the database, or reconstructed each tick from the existing model structs?                                                     |
+| **State persistence format** | Should `state_observed` and `state_desired` be persisted as flat key-value maps in the database, or reconstructed each tick from the existing model structs?                                 |
 | **Guard expressiveness**     | Is the current guard algebra sufficient, or do we need arithmetic comparisons (e.g., `firmware.version >= "2.0"`)?                                                                          |
 
 
 ---
 
-## Appendix: Per-Handler Mapping
+## Appendix: Companion Documents
 
-The following companion documents map each existing state handler to the convergence engine model:
-
-- [Machine Handler](machine.md) — 17 `ManagedHostState` variants, 10,257 lines
-- [Rack Handler](rack.md) — 7 `RackState` variants, 92 lines
-- [Switch Handler](switch.md) — 9 `SwitchControllerState` variants, 103 lines
-- [IB Partition Handler](ib-partition.md) — 4 `IBPartitionControllerState` variants, 275 lines
-- [DPA Interface Handler](dpa-interface.md) — 9 `DpaInterfaceControllerState` variants, 600 lines
-- [SPDM / Attestation Handler](spdm.md) — 6+5 `AttestationState` + `AttestationDeviceState` variants, 834 lines
-- [Network Segment Handler](network-segment.md) — 3 `NetworkSegmentControllerState` variants, 190 lines
-- [Power Shelf Handler](power-shelf.md) — 6 `PowerShelfControllerState` variants, 121 lines
+- [Formal Model](formal-model.md) — Complete mathematical specification with set-theoretic notation, guard algebra grammar, scheduling algorithm, and termination analysis.
 - [External Policy — OPA / Rego](rego-opa.md) — Cross-machine constraints and fleet coordination policies
 
+The following documents tries map each existing state handler to the convergence engine model:
+
+- [Machine Handler](machine.md) — `ManagedHostState` variants
+- [Rack Handler](rack.md) — 7 `RackState` variants
+- [Switch Handler](switch.md) — 9 `SwitchControllerState` variants
+- [IB Partition Handler](ib-partition.md) — 4 `IBPartitionControllerState` variants
+- [DPA Interface Handler](dpa-interface.md) — 9 `DpaInterfaceControllerState` variants
+- [SPDM / Attestation Handler](spdm.md) — 6+5 `AttestationState` + `AttestationDeviceState` variants
+- [Network Segment Handler](network-segment.md) — 3 `NetworkSegmentControllerState` variants
+- [Power Shelf Handler](power-shelf.md) — 6 `PowerShelfControllerState` variants

--- a/book/src/design/convergence-engine/README.md
+++ b/book/src/design/convergence-engine/README.md
@@ -468,50 +468,6 @@ function tick(S_o, S_d, operations):
 
     return (actions, S_o)
 ```
-
-### 3.10 Computational Model
-
-The convergence engine can be characterized through several well-known computational models.
-
-**Reactive production system.** The engine follows the classic **match-resolve-act** cycle of production systems (rule engines):
-
-1. **Match:** Evaluate all operation guards against current state.
-2. **Resolve:** Select which matched operations to fire (conflict resolution via priority and resource locks).
-3. **Act:** Execute the selected operations and update state.
-
-Unlike classical production systems (e.g., OPS5, CLIPS), the engine adds the *constructiveness* predicate, ensuring that only state-improving operations fire.
-
-**Dataflow / computation graph.** Each tick can be viewed as evaluating a dynamic computation graph:
-
-- **Nodes** are state keys.
-- **Edges** are operations: an operation `ω` creates edges from its guard dependencies (the keys it reads) to its effect targets (the keys it writes).
-- The graph is **regenerated each tick** because the delta changes and different operations become relevant.
-
-This makes the engine a *dynamic, self-modifying* computation graph — unlike static dataflow systems (e.g., TensorFlow graphs), the topology changes at each step.
-
-**Datalog analogy.** The convergence loop resembles bottom-up Datalog evaluation:
-
-- **Facts** are the current state key-value pairs.
-- **Rules** are the operations (guard → effect).
-- Each tick derives new facts from existing ones, like one round of stratified Datalog evaluation.
-- The process terminates at a fixpoint.
-
-The key difference is that operations have *side effects* (they mutate state rather than deriving new facts), making the engine more like a Datalog program with updates.
-
-**Terraform analogy.** The engine's tick cycle mirrors Terraform's plan/apply:
-
-- **Plan:** Compute the delta, select operations = Terraform's diff/plan.
-- **Apply:** Execute operations, update state = Terraform's apply.
-
-But the convergence engine goes further: it handles dependencies automatically (Terraform requires explicit `depends_on`), resolves them at runtime, and iterates to a fixpoint rather than executing a single plan.
-
-**Summary.** The convergence engine is a **fixpoint-seeking, priority-scheduled, resource-safe reactive production system** with dynamic rule activation and automatic dependency resolution. It combines ideas from:
-
-- Production systems (match-resolve-act)
-- Declarative state management (Terraform, Kubernetes controllers)
-- Dataflow computation (reactive graphs)
-- Fixpoint semantics (Datalog, abstract interpretation)
-
 ---
 
 ## 4. Architecture

--- a/book/src/design/convergence-engine/README.md
+++ b/book/src/design/convergence-engine/README.md
@@ -1,0 +1,910 @@
+# Convergence Engine — Design Specification
+
+**Status:** RFC  
+**Authors:** Carbide Team  
+**Last Updated:** 2026-04-02
+
+---
+
+## 1. Introduction
+
+This document specifies a **declarative convergence engine** that replaces the imperative state-handler pattern used throughout Carbide today. Rather than encoding lifecycle transitions in hand-written `match` arms, the engine defines each possible action as a data-driven **operation** — a strongly-typed Rust definition declaring what state keys the action provides, under what preconditions (guards) it may fire, what resources it locks, and what effects it produces. A three-predicate scheduler then selects, on every reconciliation tick, the maximal non-conflicting subset of operations that constructively close the gap between *observed* and *desired* state.
+
+### 1.1 Scope
+
+The specification covers:
+
+- The formal state model and delta computation.
+- The operation data model, guard algebra, and effect resolution.
+- The hardware-profile system with inheritance.
+- The three-predicate scheduler, dependency resolution, and anti-oscillation guards.
+- The convergence loop and fixpoint characterization.
+- Integration architecture with the existing `StateProcessor` / `StateControllerIO` infrastructure.
+- The Rust DSL profile system for defining operations.
+- Fleet-level coordination and external policy (OPA/Rego).
+- Migration strategy from the current imperative handlers.
+
+### 1.2 Definitions
+
+
+| Term                       | Definition                                                                                                |
+| -------------------------- | --------------------------------------------------------------------------------------------------------- |
+| **Observed state** (`S_o`) | The ground-truth state of an object, periodically refreshed from hardware, database, or external sources. |
+| **Desired state** (`S_d`)  | The declared intent — the state the object should converge to.                                            |
+| **Delta** (`Δ`)            | The set of state keys where observed and desired disagree.                                                |
+| **Operation** (`ω`)        | An atomic, data-driven unit of work defined by guards, effects, locks, and priority.                      |
+| **Guard** (`G`)            | A boolean predicate over the observed state that must hold for an operation to fire.                      |
+| **Profile**                | A named collection of operations associated with a hardware type, supporting inheritance.                 |
+| **Tick**                   | One iteration of the convergence loop: compute delta, select operations, execute, apply effects.          |
+| **Convergence**            | The system has converged when `Δ = ∅`.                                                                    |
+
+
+---
+
+## 2. Problem Statement
+
+### 2.1 Current Architecture
+
+Carbide manages the lifecycle of bare-metal objects (machines, racks, switches, DPA interfaces, IB partitions, network segments, power shelves, and SPDM attestation devices) through a common framework:
+
+1. `**StateControllerIO`** — a trait that abstracts database access for loading/persisting object state.
+2. `**StateProcessor**` — a generic reconciliation loop that dequeues objects, loads their state, invokes a handler, and persists the outcome.
+3. `**StateHandler**` — a trait whose `handle_object_state` method receives the current controller state and returns a `StateHandlerOutcome` (transition, wait, do-nothing, or deleted).
+
+Each object type implements `StateHandler` with a `match` on its controller-state enum. The machine handler alone is over 10,000 lines with 17 top-level state variants, many of which contain nested sub-state machines.
+
+### 2.2 Pain Points
+
+1. **Scale of imperative code.** The machine handler file (`handler.rs`) is 10,257 lines. Adding a new hardware variant or firmware procedure means modifying deeply nested match arms.
+2. **No separation of policy from mechanism.** The *what to do* (power on before firmware update) is interleaved with the *how to do it* (Redfish calls, retry logic). Testing a policy decision requires mocking the entire I/O layer.
+3. **Rigid state ordering.** The enum-based state machine enforces a fixed transition graph. Reordering steps (e.g., skipping BIOS configuration for a hardware type that does not need it) requires new variants or conditional branches.
+4. **Hardware-specific branching.** Different GPU/NIC/DPU platforms require different procedures, but the branching is scattered across helper functions rather than isolated in declarative profiles.
+5. **Difficulty of testing.** Unit-testing a single transition requires constructing the full `ManagedHostStateSnapshot`, all services, and the handler context. Integration tests are brittle and slow.
+6. **Cross-handler consistency.** Eight different handlers (machine, rack, switch, IB partition, DPA interface, SPDM, network segment, power shelf) each implement the same pattern independently, with inconsistent error handling and lifecycle management.
+
+### 2.3 Desired Properties
+
+
+| Property        | Description                                                                                                   |
+| --------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Declarative** | Operations are defined via a type-safe Rust DSL — compile-time checked, IDE-discoverable, refactorable.       |
+| **Extensible**  | Adding hardware support means adding a profile module with operation definitions — no changes to engine code. |
+| **Testable**    | Policy (which operations fire in which order) is testable independently of I/O.                               |
+| **Convergent**  | The engine guarantees progress toward desired state and detects deadlocks.                                    |
+| **Safe**        | Resource locks and anti-oscillation guards prevent conflicting or cyclic actions.                             |
+
+
+---
+
+## 3. Formal Model
+
+This section provides the complete mathematical specification of the convergence engine. Each subsection defines a concept with formal notation, explains it in prose, and maps it to the corresponding Rust data structure.
+
+### 3.1 State Space
+
+**Definition.** Let `K` be a finite set of *state keys* — strongly-typed identifiers such as `PowerState`, `FirmwareBmcVersion`, or `BiosBootOrder`. Let `V` be a set of *state values* — a typed union of booleans, integers, semantic versions, and text. All keys, values, identifiers, and resources are strongly typed; the implementation represents `K` and `R` as enums (`StateKey`, `Resource`) and values as a typed union (`StateValue`), preventing accidental misuse at compile time.
+
+A **host state** is a partial function:
+
+```
+S : K ⇀ V
+```
+
+The notation `⇀` (as opposed to `→`) indicates that `S` need not be defined on all of `K`. The **domain** of `S` is:
+
+```
+dom(S) = { k ∈ K | S(k) is defined }
+```
+
+At any moment in time, the system maintains two states:
+
+- `S_o` — the **observed state**, populated by reading hardware (Redfish, IPMI), databases, and agent reports. This is the ground truth, refreshed periodically.
+- `S_d` — the **desired state**, assembled at runtime by the desired-state composition layer from operator intent, config templates, firmware manifests, fleet policies, and other sources.
+
+**Unified key space.** Both `S_o` and `S_d` draw from the same key space `K`. There is no type-level distinction between "observed-only" and "desired" keys -- any key can appear in either or both maps. Which keys appear in `S_d` is a runtime decision made by the composition layer, not a property of the key itself.
+
+**Domain relationship.** The desired state typically declares a subset of observed keys, but this is not a constraint:
+
+```
+dom(S_d) ⊆ K,  dom(S_o) ⊆ K
+```
+
+`dom(S_d) \ dom(S_o)` may be non-empty when the observed state has not yet discovered a key that the desired state declares. Such keys are treated as mismatched (see §3.2).
+
+**Code mapping.** `K` is represented as a `StateKey` enum — each valid key is a variant, making it `Copy`, zero-cost, and impossible to misspell. `V` is a `StateValue` enum supporting cross-variant equality (e.g., `Bool(true)` equals the text representation `"true"`). `S` is `HostState(BTreeMap<StateKey, StateValue>)`.
+
+### 3.2 Delta
+
+**Definition.** The **delta** (or *drift*) between observed and desired state is the set of keys where the two states disagree:
+
+```
+Δ(S_o, S_d) = { k ∈ dom(S_d) | S_o(k) ≠ S_d(k) }
+```
+
+with the convention that if `k ∈ dom(S_d) \ dom(S_o)` — i.e., the desired state declares a key that the observed state has not yet discovered — then `S_o(k) ≠ S_d(k)` holds (the key is considered mismatched). Formally:
+
+```
+k ∈ Δ  ⟺  k ∈ dom(S_d) ∧ ( k ∉ dom(S_o) ∨ S_o(k) ≠ S_d(k) )
+```
+
+**Convergence criterion.** The system has **converged** when:
+
+```
+Δ(S_o, S_d) = ∅
+```
+
+That is, for every key the desired state cares about, the observed state agrees.
+
+**What the delta does NOT include.** Keys in `dom(S_o) \ dom(S_d)` — observed keys with no corresponding desired value — are not part of the delta. The engine does not attempt to "clean up" observed state that has no desired counterpart. This is intentional: `S_d` is a *patch*, not a complete specification.
+
+**Code mapping.** The `delta()` function iterates over `dom(S_d)` and collects keys where `observed.get(k) != Some(desired_val)`.
+
+### 3.3 Operations
+
+**Definition.** An **operation** is a tuple:
+
+```
+ω = (id, P, G, L, E, π)
+```
+
+where:
+
+
+| Component | Constraint       | Description                                                                                                                                                                         |
+| --------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`      | unique in `Ω`    | Unique identifier for this operation.                                                                                                                                               |
+| `P`       | `P ⊆ K`          | **Provides** — the set of state keys this operation can change. An operation is only considered for a delta key `k` if `k ∈ P`.                                                     |
+| `G`       | `G : S → {0, 1}` | **Guard** — a boolean predicate over the observed state (see §3.4). The operation may only fire when `G(S_o) = 1`.                                                                  |
+| `L`       | `L ⊆ R`          | **Locks** — a set of resource identifiers requiring mutual exclusion. `R` is the universe of lockable resources. Two operations with `L₁ ∩ L₂ ≠ ∅` cannot execute in the same tick. |
+| `E`       | `E : K ⇀ V`      | **Effects** — a partial function mapping state keys to their post-execution values. After execution, `S_o(k) ← E(k)` for each `k ∈ dom(E)`.                                         |
+| `π`       | `π ∈ ℕ`          | **Priority** — a non-negative integer. Higher values are scheduled first when multiple operations compete.                                                                          |
+
+
+**Note on effects and provides.** Typically `dom(E) ⊆ P`, but this is not strictly required. An operation may have effects on keys it does not "provide" (side effects), though this is discouraged as it complicates reasoning.
+
+### 3.4 Guard Algebra
+
+Guards are the precondition language of the engine. They form a small algebra closed under boolean combinators.
+
+**Grammar.** The set of guard expressions `G` is defined inductively:
+
+```
+G ::= Eq(k, v)
+    | Neq(k, v)
+    | In(k, {v₁, …, vₙ})
+    | Contains(k, s)
+    | And(G₁, …, Gₙ)
+    | Or(G₁, …, Gₙ)
+    | Not(G)
+    | True
+```
+
+**Evaluation semantics.** Given a state `S`, each guard variant evaluates as follows:
+
+
+| Guard            | `G(S) = 1` iff                            |
+| ---------------- | ----------------------------------------- |
+| `Eq(k, v)`       | `k ∈ dom(S) ∧ S(k) = resolve(v, S)`       |
+| `Neq(k, v)`      | `k ∉ dom(S) ∨ S(k) ≠ resolve(v, S)`       |
+| `In(k, V)`       | `k ∈ dom(S) ∧ S(k) ∈ V`                   |
+| `Contains(k, s)` | `k ∈ dom(S) ∧ s` is a substring of `S(k)` |
+| `And(G₁, …)`     | `∀ i : Gᵢ(S) = 1`                         |
+| `Or(G₁, …)`      | `∃ i : Gᵢ(S) = 1`                         |
+| `Not(G')`        | `G'(S) = 0`                               |
+| `True`           | always 1                                  |
+
+
+**Desired-state references.** Values `v` in guard and effect expressions may reference the desired state via `desired(k)`. The resolution function is:
+
+```
+resolve(v, S_o, S_d) =
+    if v = desired(k'):
+        return S_d(k')
+    else:
+        return v
+```
+
+This allows operations to compare observed values against desired targets (e.g., "current firmware version differs from desired") without hard-coding target values.
+
+**Example.** The guard for a firmware update operation (shown here in `op!` macro syntax — see §5):
+
+```rust
+guard: and(
+    eq(PowerState, "on"),
+    neq(FirmwareBmcVersion, desired(FirmwareBmcVersion)),
+),
+```
+
+This reads: "fire only when the machine is powered on AND the current BMC firmware version differs from the desired version."
+
+**Conflict detection.** The function `conflicts_with_effect(G, k, v, S)` determines whether setting key `k` to value `v` in state `S` would cause guard `G` to transition from true to false. This is used by the anti-oscillation logic (§3.8):
+
+```
+conflicts_with_effect(G, k, v, S) = G(S) = 1  ∧  G(S[k ↦ v]) = 0
+```
+
+where `S[k ↦ v]` denotes the state `S` with key `k` overwritten to `v`.
+
+**Code mapping.** The `Guard` type implements `evaluate(S) → {0, 1}` and `conflicts_with_effect(G, k, v, S) → {0, 1}` with strongly-typed key and value parameters.
+
+### 3.5 Hardware Profiles and Inheritance
+
+**Definition.** A **hardware profile** is a tuple:
+
+```
+P = (id, M, I, Ω, α)
+```
+
+where:
+
+
+| Component | Constraint        | Description                                                                                                                              |
+| --------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`      | unique in `Π`     | Profile identifier (e.g., `nvidia_gb300`, `generic_x86`). `Π` is the set of all profiles.                                                |
+| `M`       | `M : S → {0, 1}`  | **Match rule** — a guard expression evaluated against observed state. The first non-abstract profile whose match rule holds is selected. |
+| `I`       | `I ⊆ Π`           | **Inherits** — an ordered list of parent profile identifiers.                                                                            |
+| `Ω`       | `Ω = {ω₁, …, ωₘ}` | **Operations** — the set of operations defined in this profile.                                                                          |
+| `α`       | `α ∈ {0, 1}`      | **Is abstract** — if 1, the profile cannot be directly selected but can be inherited from.                                               |
+
+
+**Inheritance resolution.** The effective operation set for a profile `P` is computed by traversing the inheritance DAG in order and merging operations:
+
+```
+ops(P) = ops(P_I₁) ∪ ops(P_I₂) ∪ … ∪ Ω_P
+```
+
+When two profiles define an operation with the same `id`, the later definition wins (**last-writer-wins**). This allows a child profile to override a parent's operation — for example, `nvidia_gb300` can override the `power_off` operation inherited from `common` to add a GPU-specific shutdown sequence.
+
+**Profile detection algorithm:**
+
+```
+function detect_profile(S_o, profiles):
+    for P in profiles sorted by specificity:
+        if P.is_abstract: continue
+        if P.match_rule(S_o) = 1:
+            return P
+    return error("no matching profile")
+```
+
+**Concrete inheritance chain example:**
+
+```
+common                    (base operations: power_on, power_off, configure_bios, ...)
+  └── nvidia_gbx00_base   (abstract: update_bmc_firmware with NVIDIA-specific Redfish)
+        └── nvidia_gb300   (concrete: match rule checks hw_sku contains "GB300")
+              inherits: [nvidia_bf3_dpu]  ← also pulls in DPU operations
+```
+
+The resolved operation set for a GB300 machine would be:
+
+```
+ops(gb300) = ops(common) ∪ ops(gbx00_base) ∪ ops(bf3_dpu) ∪ own(gb300)
+```
+
+### 3.6 Three-Predicate Scheduler
+
+The scheduler is the decision-making core of the engine. On each tick, it evaluates every available operation against three predicates and selects a safe, non-conflicting action set.
+
+**Predicate 1 — Relevant.** An operation is relevant if it provides at least one key in the current delta:
+
+```
+relevant(ω)  ⟺  P_ω ∩ Δ(S_o, S_d) ≠ ∅
+```
+
+Irrelevant operations are filtered out immediately. If the delta is empty, no operations are relevant and the system has converged.
+
+**Predicate 2 — Constructive.** A relevant operation is constructive if at least one of its effects moves the observed state *toward* the desired state (not away from it):
+
+```
+constructive(ω)  ⟺  ∃ k ∈ P_ω ∩ Δ : resolve(E_ω(k), S_o) = S_d(k)
+```
+
+where `resolve` handles `desired.*` references in effect values. This predicate prevents operations that would change a delta key but to the *wrong* value — e.g., powering off when the desired state is powered on.
+
+**Predicate 3 — Ready.** A constructive, relevant operation is ready if its guard holds on the current observed state:
+
+```
+ready(ω)  ⟺  G_ω(S_o) = 1
+```
+
+Operations that are relevant and constructive but not ready become candidates for dependency resolution (§3.7).
+
+**Candidate set.** The set of fully qualified candidates is:
+
+```
+R = { ω | relevant(ω) ∧ constructive(ω) ∧ ready(ω) }
+```
+
+**Greedy resource-conflict-free selection.** From `R`, the scheduler selects a maximal subset that respects resource locks:
+
+```
+scheduled = greedy(R, π, L)
+```
+
+**Algorithm:**
+
+```
+function schedule(R):
+    sort R by priority π descending (stable sort preserves insertion order for ties)
+    claimed_resources ← ∅
+    scheduled ← []
+
+    for ω in R:
+        if L_ω ∩ claimed_resources = ∅:
+            if not anti_oscillation_deferred(ω):
+                scheduled.append(ω)
+                claimed_resources ← claimed_resources ∪ L_ω
+
+    return scheduled
+```
+
+When two operations have equal priority, the stable sort preserves their original order (typically alphabetical by operation ID from the profile). This is deterministic but arbitrary — if tie-breaking matters, assign distinct priorities.
+
+**Formal property.** The scheduled set satisfies:
+
+```
+∀ ωᵢ, ωⱼ ∈ scheduled, i ≠ j : Lᵢ ∩ Lⱼ = ∅
+```
+
+That is, no two scheduled operations hold the same resource lock.
+
+### 3.7 Dependency Resolution
+
+Some operations are relevant and constructive but not ready — their guard fails on the current observed state. The dependency resolver attempts to find **enabler** operations that can satisfy the unmet preconditions.
+
+**Unmet clause extraction.** For a blocked operation `ω_b` with `G(ω_b)(S_o) = 0`, the resolver decomposes the guard into its atomic `Eq` clauses and identifies which ones fail:
+
+```
+unmet(ω_b) = { (k, v) | Eq(k, v) ∈ atoms(G(ω_b))  ∧  S_o(k) ≠ resolve(v, S_o) }
+```
+
+For compound guards (`And`, `Or`), the decomposition follows the structure: for `And`, all failing clauses are unmet; for `Or`, only the first satisfiable branch is considered.
+
+**Enabler search.** For each unmet clause `(k, v)`, the resolver searches for an enabler operation:
+
+```
+∃ ω_e ∈ Ω : E_e(k) = v  ∧  G_e(S_o) = 1  ∧  L_e ∩ L_claimed = ∅
+```
+
+where `L_claimed` is the set of resources already reserved by previously scheduled operations and other enablers.
+
+**Resource pre-reservation.** When an enabler is found, its resources are immediately added to `L_claimed` *before* the main greedy pass. This prevents the greedy pass from scheduling a different operation that would conflict with the enabler.
+
+**Dependency chain depth.** The current implementation resolves dependencies to depth 1 — it finds enablers for blocked operations but does not recursively resolve enablers' own blocked dependencies. This is sufficient for common patterns (e.g., power-on enables firmware update) and avoids the complexity of recursive planning. The convergence loop naturally resolves deeper chains over multiple ticks.
+
+**Example.** Operation `update_bmc_firmware` requires `power.state = "on"`. If the machine is off:
+
+1. `update_bmc_firmware` is relevant and constructive but not ready (guard fails: `power.state = "off"`).
+2. The resolver extracts unmet clause: `(power.state, "on")`.
+3. It finds enabler `power_on` with effect `power.state → "on"`, whose guard `power.state = "off"` holds.
+4. `power_on` is auto-scheduled; its resources are reserved.
+5. After `power_on` executes, the next tick finds `update_bmc_firmware` ready.
+
+### 3.8 Anti-Oscillation
+
+Without safeguards, the scheduler could enter infinite cycles — for example, `power_on` and `power_off` alternating each tick because both are relevant to the same key. Two guards prevent the most common oscillation patterns.
+
+**Guard 1 — Dominance deferral.** An operation `ω` is deferred if it would undo the effect of a dependency action scheduled in the same tick:
+
+```
+ω deferred if ∃ ω_d ∈ deps, k ∈ P_ω ∩ P_d : E_ω(k) ≠ E_d(k)
+```
+
+**Intuition.** If the scheduler found that `power_on` is needed as a dependency for `update_bmc_firmware`, and `power_off` is also relevant (because `PowerState` is in the delta), the dominance guard defers `power_off` — executing it would undo the dependency and create an oscillation.
+
+**Guard 2 — Competitor blocking deferral.** An operation `ω` is deferred if its effect would falsify the guard of another ready operation that competes for the same resource:
+
+```
+ω deferred if ∃ ω_c ∈ R, L_ω ∩ L_c ≠ ∅ : conflicts_with_effect(G_c, k, E_ω(k), S_o) for some k
+```
+
+**Intuition.** If two operations share a resource lock and one would make the other's guard false, the engine defers the disruptive one, preferring the operation that preserves the conditions needed by its competitor.
+
+**What these guards do NOT guarantee.** These two guards prevent the most common 1-tick and 2-tick oscillation patterns:
+
+- Tick `t`: power on → Tick `t+1`: power off → Tick `t+2`: power on → ... (prevented by dominance)
+- Tick `t`: operation A blocks operation B's guard, which in turn blocks A (prevented by competitor blocking)
+
+However, they are **not a formal proof of termination**. In the general case:
+
+1. **Longer cycles** (3+ ticks) could theoretically occur if the operation graph has complex circular dependencies.
+2. **Energy function non-monotonicity.** Dependency resolution can *temporarily increase* `|Δ|` — e.g., powering on a machine adds `power.state = "on"` to observed state, which might not be the desired value if the ultimate goal is a firmware update with power-off afterward. The delta shrinks only after the full dependency chain completes.
+
+**Safety net: visited-state detection.** As a defensive measure, the engine can optionally track visited state fingerprints (hashes of `S_o`) and detect if the same observed state recurs, indicating an oscillation. Upon detection, the engine halts and reports a misconfiguration error.
+
+**Formal characterization.** Define the "energy" of the system as `|Δ(S_o, S_d)|`. In a well-configured operation set:
+
+- Each constructive operation reduces `|Δ|` by at least 1 for its primary key.
+- Dependency operations may temporarily increase `|Δ|` but are bounded in depth.
+- The anti-oscillation guards ensure that the scheduler does not undo its own progress within a single tick.
+
+Under these conditions, the convergence loop terminates in `O(|Δ₀| · d)` ticks, where `|Δ₀|` is the initial delta size and `d` is the maximum dependency chain depth.
+
+### 3.9 Convergence Loop
+
+The convergence loop is the top-level execution cycle of the engine. It repeatedly ticks until the system converges or declares a deadlock.
+
+**State evolution.** After each tick, the observed state is updated:
+
+```
+S_o(t+1) = S_o(t) ⊕ ⋃{ E_ω | ω ∈ actions(t) }
+```
+
+where `⊕` denotes state update (overwriting existing keys with new values from the effects).
+
+**Desired-state availability.** Both `S_o` and `S_d` are available to the scheduler on every tick. Guards and effects that use `desired(k)` references are resolved against `S_d` via the `resolve` function (see §3.4).
+
+**Termination conditions.** The loop terminates when:
+
+1. **Converged:** `Δ(S_o, S_d) = ∅`. All desired keys match observed values.
+2. **Idle with non-empty delta:** The scheduler returns no actions (`actions(t) = ∅`) but `Δ ≠ ∅`. This indicates either a misconfiguration (no operation provides the needed key), a deadlock (all relevant operations are blocked by guards that cannot be satisfied), or a transient condition awaiting external state changes.
+
+**Fixpoint characterization.** The converged state `S_o`* is a **fixpoint** of the convergence operator:
+
+```
+S_o* = F(S_o*, S_d)  ⟺  Δ(S_o*, S_d) = ∅
+```
+
+The engine is a fixpoint-seeking iteration: `S_o⁰, S_o¹, …, S_oⁿ = S_o*`.
+
+**Tick pseudocode:**
+
+```
+function tick(S_o, S_d, operations):
+    Δ ← delta(S_o, S_d)
+    if Δ = ∅: return CONVERGED
+
+    relevant ← { ω ∈ operations | P_ω ∩ Δ ≠ ∅ }
+    constructive ← { ω ∈ relevant | ∃ k ∈ P_ω ∩ Δ : resolve(E_ω(k), S_o, S_d) = S_d(k) }
+    ready ← { ω ∈ constructive | G_ω(S_o, S_d) = 1 }
+    blocked ← constructive \ ready
+
+    deps ← resolve_dependencies(blocked, operations, S_o, S_d)
+    actions ← schedule(ready ∪ deps, anti_oscillation_context)
+
+    for ω in actions:
+        execute(ω.steps)
+        S_o ← S_o ⊕ resolve_effects(E_ω, S_o, S_d)
+
+    return (actions, S_o)
+```
+
+### 3.10 Computational Model
+
+The convergence engine can be characterized through several well-known computational models.
+
+**Reactive production system.** The engine follows the classic **match-resolve-act** cycle of production systems (rule engines):
+
+1. **Match:** Evaluate all operation guards against current state.
+2. **Resolve:** Select which matched operations to fire (conflict resolution via priority and resource locks).
+3. **Act:** Execute the selected operations and update state.
+
+Unlike classical production systems (e.g., OPS5, CLIPS), the engine adds the *constructiveness* predicate, ensuring that only state-improving operations fire.
+
+**Dataflow / computation graph.** Each tick can be viewed as evaluating a dynamic computation graph:
+
+- **Nodes** are state keys.
+- **Edges** are operations: an operation `ω` creates edges from its guard dependencies (the keys it reads) to its effect targets (the keys it writes).
+- The graph is **regenerated each tick** because the delta changes and different operations become relevant.
+
+This makes the engine a *dynamic, self-modifying* computation graph — unlike static dataflow systems (e.g., TensorFlow graphs), the topology changes at each step.
+
+**Datalog analogy.** The convergence loop resembles bottom-up Datalog evaluation:
+
+- **Facts** are the current state key-value pairs.
+- **Rules** are the operations (guard → effect).
+- Each tick derives new facts from existing ones, like one round of stratified Datalog evaluation.
+- The process terminates at a fixpoint.
+
+The key difference is that operations have *side effects* (they mutate state rather than deriving new facts), making the engine more like a Datalog program with updates.
+
+**Terraform analogy.** The engine's tick cycle mirrors Terraform's plan/apply:
+
+- **Plan:** Compute the delta, select operations = Terraform's diff/plan.
+- **Apply:** Execute operations, update state = Terraform's apply.
+
+But the convergence engine goes further: it handles dependencies automatically (Terraform requires explicit `depends_on`), resolves them at runtime, and iterates to a fixpoint rather than executing a single plan.
+
+**Summary.** The convergence engine is a **fixpoint-seeking, priority-scheduled, resource-safe reactive production system** with dynamic rule activation and automatic dependency resolution. It combines ideas from:
+
+- Production systems (match-resolve-act)
+- Declarative state management (Terraform, Kubernetes controllers)
+- Dataflow computation (reactive graphs)
+- Fixpoint semantics (Datalog, abstract interpretation)
+
+---
+
+## 4. Architecture
+
+### 4.1 Current Architecture
+
+The current system uses the `StateProcessor` generic reconciliation loop with per-type `StateHandler` implementations:
+
+```mermaid
+flowchart LR
+    PE[PeriodicEnqueuer] -->|"enqueue(object_id)"| Q[Queue]
+    Q -->|"dequeue()"| SP[StateProcessor]
+    SP -->|"load_state()"| IO[StateControllerIO]
+    SP -->|"handle_object_state()"| SH[StateHandler]
+    SH -->|match state| Arms["match ManagedHostState
+        VerifyRmsMembership => ...
+        DPUInit => ...
+        HostInit => ...
+        Ready => ...
+        Assigned => ...
+        ...17 variants"]
+    SH -->|"StateHandlerOutcome"| SP
+    SP -->|"persist_outcome()"| IO
+```
+
+
+
+Each handler (`MachineStateHandler`, `RackStateHandler`, etc.) contains imperative code that directly calls Redfish, database, and other services inside `match` arms.
+
+### 4.2 Proposed Architecture
+
+The convergence engine replaces the per-type `StateHandler` implementations with a generic `ConvergenceHandler` that delegates all decision-making to the engine:
+
+```mermaid
+flowchart LR
+    PE[PeriodicEnqueuer] -->|"enqueue(object_id)"| Q[Queue]
+    Q -->|"dequeue()"| SP[StateProcessor]
+    SP -->|"load_state()"| IO[StateControllerIO]
+    SP -->|"handle_object_state()"| CH[ConvergenceHandler]
+    CH -->|"observe()"| OBS["Build S_o from
+        object state +
+        hardware queries"]
+    CH -->|"desired()"| DES["Build S_d from
+        config + policies"]
+    CH -->|"tick(S_o, S_d)"| ENG[ConvergenceEngine]
+    ENG -->|resolve profile| PR[ProfileResolver]
+    ENG -->|schedule| SCH[Scheduler]
+    ENG -->|execute| EX[ActionExecutor]
+    ENG -->|"TickResult"| CH
+    CH -->|"StateHandlerOutcome"| SP
+    SP -->|"persist_outcome()"| IO
+```
+
+
+
+**What stays the same:**
+
+- `StateProcessor`, `StateControllerIO`, the queue infrastructure, `PeriodicEnqueuer`, metrics, and state history — all unchanged.
+- The `StateHandler` trait is still implemented, but by `ConvergenceHandler` rather than per-type handlers.
+
+**What changes:**
+
+- The `match` arms disappear. Decision-making moves into profile modules evaluated by the scheduler.
+- Hardware-specific logic moves into per-profile Rust modules (one per hardware type).
+- The `observe()` and `desired()` functions replace the monolithic state snapshot with a flat key-value map.
+
+### 4.3 Component Responsibilities
+
+
+| Component              | Responsibility                                                                                                                                         |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **ConvergenceHandler** | Implements `StateHandler`. Builds `S_o` and `S_d` from the object state, delegates to the engine, and maps `TickResult` back to `StateHandlerOutcome`. |
+| **ConvergenceEngine**  | Orchestrates one tick: resolves profile, runs scheduler, executes actions, returns result.                                                             |
+| **ProfileResolver**    | Loads hardware profiles from Rust profile modules, evaluates match rules, resolves inheritance chain, returns the effective operation set.             |
+| **Scheduler**          | Implements the three-predicate filter, dependency resolution, anti-oscillation guards, and greedy selection.                                           |
+| **ActionExecutor**     | Trait for executing operation steps. Concrete implementations call Redfish, database APIs, shell commands, etc.                                        |
+
+
+---
+
+## 5. Rust DSL Profile System
+
+### 5.1 Module Layout
+
+Profiles are Rust modules — compile-time checked, IDE-discoverable, and refactorable.
+
+```
+profiles/
+├── mod.rs                     # Re-exports all profiles, provides all_profiles()
+├── common.rs                  # Base operations inherited by all profiles
+├── generic_x86.rs             # Generic x86 server profile
+├── nvidia_gbx00_base.rs       # Abstract base for NVIDIA GBx00 series
+├── nvidia_gb300.rs            # Concrete profile for GB300
+└── nvidia_bf3_dpu.rs          # Abstract DPU profile (inherited by GB300)
+```
+
+### 5.2 State Keys and Resources as Enums
+
+State keys and resource identifiers are **enum variants** — `Copy`, zero-cost, and exhaustively matchable. A typo is a compile error. No strings involved.
+
+```rust
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum StateKey {
+    // Power
+    PowerState,
+    PowerCycleCompleted,
+    // Firmware — real version strings from hardware
+    FirmwareBmcVersion,
+    FirmwareBiosVersion,
+    FirmwareHostVersion,
+    DpuFirmwareVersion,
+    // DPU — real observables, not boolean flags
+    DpuCount,                 // number of DPUs discovered (0 = not yet discovered)
+    DpuInterfaceIp,           // DPU interface IP address (empty = not configured)
+    DpuMode,                  // "dpu", "nic", "" (empty = not set)
+    DpuAgentVersion,          // DPU agent version (empty = not connected)
+    DpuNetworkConfigVersion,
+    // Host agent — real data from the agent
+    ScoutVersion,             // scout agent version (empty = not installed)
+    ScoutHeartbeat,           // "alive", "stale" — from continuous pings
+    // BIOS / Network / Security
+    BiosSettingsHash,         // hash of current BIOS attributes
+    NetworkConfigVersion,
+    LockdownEnabled,
+    // Registration
+    RmsInventoryId,           // RMS inventory ID (empty = not registered)
+    HwSku,
+    // Validation / Attestation
+    ValidationResult,         // "passed", "failed", "not_run"
+    BomValidationResult,      // "passed", "failed", "not_run"
+    AttestationStatus,
+    // Cleanup — real observable state
+    DriveEraseStatus,         // "erased", "not_erased"
+    // Instance / Lifecycle
+    InstanceAssigned,
+    LifecycleDeleted,
+    // ...
+
+    // Parameterized variants for per-device state (SPDM)
+    AttestationDeviceMetadataFetched(usize),
+    AttestationDeviceCertificateFetched(usize),
+    AttestationDeviceVerified(usize),
+    AttestationDeviceAppraised(usize),
+    AttestationDeviceStatus(usize),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Resource {
+    Power,
+    Firmware,
+    Dpu,
+    DpuDiscovery,
+    Rms,
+    Scout,
+    Validation,
+    Attestation,
+    AttestationDevice(usize),
+    Lockdown,
+    Network,
+    Bios,
+    Cleanup,
+    Lifecycle,
+    // ...
+}
+```
+
+### 5.3 Operation Macro — `op!`
+
+Operations are declared via the `op!` macro:
+
+```rust
+op!(update_bmc_firmware {
+    provides: [FirmwareBmcVersion],
+    guard: and(
+        eq(PowerState, "on"),
+        neq(FirmwareBmcVersion, desired(FirmwareBmcVersion)),
+    ),
+    locks: [Firmware, Power],
+    effects: [FirmwareBmcVersion => desired(FirmwareBmcVersion)],
+    steps: [
+        action(redfish_firmware_update, target = "bmc"),
+        action(wait_for_bmc_ready, timeout_seconds = 600),
+    ],
+    priority: 80,
+});
+```
+
+The macro expands to a function `fn update_bmc_firmware() -> Operation` with all types resolved from the enum variants. Inside the macro body:
+
+- Bare identifiers like `PowerState` resolve to `StateKey::PowerState`
+- `desired(X)` creates a desired-state reference for key `X`
+- `and(...)`, `eq(...)`, `neq(...)`, `contains(...)` map to `Guard` enum variants
+- `Firmware`, `Power` resolve to `Resource::Firmware`, `Resource::Power`
+- `effects` use `=>` syntax for key-value pairs
+
+A simple operation with a trivial guard:
+
+```rust
+op!(power_on {
+    provides: [PowerState],
+    guard: eq(PowerState, "off"),
+    locks: [Power],
+    effects: [PowerState => "on"],
+    steps: [
+        action(redfish_power_on),
+        action(wait_for_power_state, target = "on", timeout_seconds = 120),
+    ],
+    priority: 100,
+});
+```
+
+### 5.4 Profile Macro — `profile!`
+
+Profiles are declared with a similar macro:
+
+```rust
+profile!(nvidia_gb300 {
+    match_rule: contains(HwSku, "GB300"),
+    inherits: [NvidiaGbx00Base, NvidiaBf3Dpu],
+    operations: [power_off_gb300],
+});
+```
+
+### 5.5 Desired-State References
+
+The `desired(X)` syntax inside `op!` creates a reference to the corresponding desired-state value. At evaluation time, `desired(FirmwareBmcVersion)` resolves to whatever firmware version the operator has declared as the target.
+
+---
+
+## 6. Fleet Coordination
+
+The convergence engine operates at the level of a single object (one machine, one switch, etc.). Fleet-level coordination — managing rollouts across multiple objects — requires a layer above the engine.
+
+### 6.1 Fleet Controller
+
+A **Fleet Controller** sits above the per-object convergence engines and manages:
+
+- **Phased rollouts:** Update firmware on 10% of machines, validate, then proceed to the next batch.
+- **Rolling updates:** Ensure at least N machines per rack remain healthy during updates.
+- **Cross-object barriers:** All DPUs in a rack must reach firmware version X before any host proceeds to the next phase.
+
+The fleet controller does not modify the engine — it controls the *desired state* fed to each engine instance:
+
+```mermaid
+flowchart TD
+    FC[Fleet Controller] -->|"set S_d for machine A"| EA[Engine A]
+    FC -->|"set S_d for machine B"| EB[Engine B]
+    FC -->|"set S_d for machine C"| EC[Engine C]
+    FC -->|"query OPA"| OPA["OPA / Rego
+        Policy Engine"]
+    OPA -->|"policy.* keys"| FC
+    EA -->|"status: converged"| FC
+    EB -->|"status: in_progress"| FC
+    EC -->|"status: blocked"| FC
+```
+
+
+
+### 6.2 External Policy Integration
+
+Cross-machine constraints (e.g., "at most 5 machines per location may be updating firmware simultaneously") are expressed as **OPA/Rego policies**. See [External Policy — OPA / Rego](rego-opa.md) for the full specification.
+
+The integration point is simple: before each tick, the fleet controller (or a policy sidecar) queries OPA and injects the resulting decisions as `policy.`* keys into the observed state. Guards in operation definitions reference these keys naturally:
+
+```rust
+guard: and(
+    eq(PowerState, "on"),
+    eq(PolicyFirmwareUpdateAllowed, "true"),
+),
+```
+
+No engine code changes are needed — policy decisions are just `StateKey` variants like any other.
+
+---
+
+## 7. Migration Strategy
+
+The convergence engine and the current handlers produce fundamentally different outputs — the handler returns a single `StateHandlerOutcome` (transition, wait, do-nothing), while the engine returns a set of operations with state effects. Per-tick comparison is not meaningful. Migration relies on end-state validation, decision logging, and incremental cutover.
+
+### 7.1 End-State Validation
+
+Before any production deployment, batch-test the engine against known-good production state snapshots:
+
+1. Take a real object's current state from the production database.
+2. Build `S_o` and `S_d` from the object's state, config, and firmware manifests.
+3. Run the engine to convergence with mock action executors (no real Redfish/DB calls).
+4. Verify the final `S_o` matches the state the current handler would eventually produce.
+
+This validates the engine's *policy* — does it reach the same end state? — without comparing intermediate tick-by-tick decisions. A test harness runs this against hundreds of production state snapshots per profile to build statistical confidence.
+
+### 7.2 Per-Profile Cutover
+
+Route objects to the engine per-profile via feature flags, starting with the simplest:
+
+1. `**power_shelf*`* — 3 operations, linear lifecycle, placeholder logic. Ideal first candidate.
+2. `**network_segment**` — 3 operations, simple two-phase deletion.
+3. `**rack**` — 4 operations, straightforward discovery/validation.
+4. `**switch**`, `**ib_partition**` — moderate complexity.
+5. `**dpa_interface**`, `**spdm**` — higher complexity with multi-phase flows.
+6. `**machine**` — last, largest, most complex. 18+ operations, multi-profile inheritance.
+
+Each step is a real cutover for that profile — the old handler stops running for those objects, and the engine takes over. The feature flag enables instant rollback if issues arise.
+
+### 7.3 Rollback Safety
+
+Old handler code remains behind the feature flag throughout the migration:
+
+1. If the engine misbehaves for a profile, flip the flag to route objects back to the old handler.
+2. Old handlers are only removed after sustained production confidence (weeks/months per profile).
+3. The `StateHandler` trait remains — `ConvergenceHandler` becomes its sole implementation only after all profiles are validated and old code is retired.
+
+### 7.4 Design Principle: Properties, Not Phases
+
+The convergence engine's power comes from modeling **what properties an entity should have**, not **what lifecycle phases it should traverse**. This distinction is fundamental.
+
+**Anti-pattern: FSM in disguise.** A naive migration from imperative handlers wraps each FSM state transition as an operation:
+
+```
+verify_rms_membership → discover_dpus → initialize_dpu → initialize_host → validate → ...
+```
+
+This preserves the sequential pipeline of the FSM. Operations like `initialize_host` are lifecycle phases that *bundle* unrelated concerns (configure BIOS, configure network, install agent, verify reachability). The guards replicate the FSM ordering. The engine is doing extra work to arrive at the same rigid execution order the FSM already had.
+
+**Correct approach: property-oriented operations.** Each operation manages a single, independently configurable property:
+
+```
+configure_bios:         provides BiosSettingsHash,       guard: PowerState = "on"
+configure_network:      provides NetworkConfigVersion,   guard: PowerState = "on"
+install_scout:          provides ScoutVersion,           guard: PowerState = "on"
+update_bmc_firmware:    provides FirmwareBmcVersion,     guard: PowerState = "on"
+enable_lockdown:        provides LockdownEnabled,        guard: PowerState = "on"
+```
+
+There is no `initialize_host` operation — that was an FSM bucket. The engine sees that `BiosSettingsHash` differs from desired and schedules `configure_bios`; that `ScoutVersion` is empty and schedules `install_scout`. These may run in parallel or in dependency order, determined by guards, not by a hardcoded phase sequence.
+
+**Corollary: real observables, not boolean flags.** State keys should hold **real observable data**, not boolean step-completion flags. A boolean like `ScoutInstalled = "true"` is a phase marker in disguise — it records "we completed this step" rather than reflecting ground truth. Prefer:
+
+| Anti-pattern (boolean flag) | Correct (real observable) | Why |
+|---|---|---|
+| `ScoutInstalled = "true"` | `ScoutVersion = "3.2.1"` | If you can observe the version, the agent is installed. The value comes from the deployment manifest. |
+| `DpuDiscovered = "true"` | `DpuCount = "2"` | If you know how many DPUs exist, you've discovered them. |
+| `DpuModeSet = "true"` | `DpuMode = "dpu"` | The actual mode. Observable via Redfish. |
+| `DpuAgentConnected = "true"` | `DpuAgentVersion = "1.4.0"` | If the agent reports its version, it's connected. |
+| `HostReachable = "true"` | `ScoutHeartbeat = "alive"` | Continuously observed from agent pings. Reflects *current* state, not a one-time check. |
+| `RmsRegistered = "true"` | `RmsInventoryId = "rms-12345"` | The actual RMS inventory ID. If it exists, the host is registered. |
+| `BiosSettingsApplied = "true"` | `BiosSettingsHash = "a3f8c2"` | Hash of current BIOS attributes. Desired = hash from the config template. Drift is detectable. |
+
+Real observables give you **free self-healing**: if the DPU agent crashes, `DpuAgentVersion` goes empty on the next observation. The engine detects the delta and acts. With a boolean flag, `DpuAgentConnected` stays `"true"` until something explicitly clears it.
+
+Real observables also eliminate meaningless desired state. `DpuDiscovered = "true"` is a boolean flag that tells you nothing. `DpuCount = "2"` tells you the ground truth, and any key -- including `DpuCount` -- can be placed in desired state when the composition layer needs it.
+
+**Why this matters:**
+
+1. **Self-healing.** If BIOS settings drift on a machine that's been "ready" for months, the engine detects `BiosSettingsHash` has changed and runs `configure_bios` directly — without re-entering an "init" phase.
+2. **Reprovisioning disappears.** "Reprovision" in the FSM model is a phase that re-runs init steps. In the convergence model, you change the desired firmware version and the engine converges to it. There is no reprovisioning operation — just desired state changing.
+3. **Maximal parallelism.** The FSM forces `init → validation → ready`. The engine parallelizes everything whose guards are satisfied — BIOS, network, agent install, and firmware update can all run concurrently if power is on.
+4. **Hardware variance is trivial.** A profile for hardware that doesn't need BIOS configuration simply omits `configure_bios`. No conditional branches, no "skip this phase" logic.
+5. **Continuous observation.** Real observables like `ScoutHeartbeat` and `DpuAgentVersion` are refreshed every reconciliation tick. The state reflects current reality, not a historical record of completed steps.
+
+**Guards express physical constraints, not lifecycle ordering.** The only valid guard predicates are real hardware constraints:
+
+- Can't flash firmware if power is off → `guard: eq(PowerState, "on")`
+- Can't install scout if network isn't configured → `guard: eq(NetworkConfigVersion, desired(NetworkConfigVersion))`
+- Can't configure DPU network without agent → `guard: neq(DpuAgentVersion, "")`
+- Can't run two firmware flashes at once → `locks: [Firmware]`
+
+The FSM's phase ordering (init before validation before ready) is artificial — it exists because someone had to manually decide the order. The convergence engine makes that unnecessary.
+
+---
+
+## 8. Open Questions
+
+
+| Question                     | Discussion                                                                                                                                                                                  |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Formal termination proof** | The anti-oscillation guards prevent common patterns but are not a formal proof. Should we invest in a model-checker (e.g., TLA+) to verify termination for specific profile configurations? |
+| **State persistence format** | Should `S_o` and `S_d` be persisted as flat key-value maps in the database, or reconstructed each tick from the existing model structs?                                                     |
+| **Guard expressiveness**     | Is the current guard algebra sufficient, or do we need arithmetic comparisons (e.g., `firmware.version >= "2.0"`)?                                                                          |
+
+
+---
+
+## Appendix: Per-Handler Mapping
+
+The following companion documents map each existing state handler to the convergence engine model:
+
+- [Machine Handler](machine.md) — 17 `ManagedHostState` variants, 10,257 lines
+- [Rack Handler](rack.md) — 7 `RackState` variants, 92 lines
+- [Switch Handler](switch.md) — 9 `SwitchControllerState` variants, 103 lines
+- [IB Partition Handler](ib-partition.md) — 4 `IBPartitionControllerState` variants, 275 lines
+- [DPA Interface Handler](dpa-interface.md) — 9 `DpaInterfaceControllerState` variants, 600 lines
+- [SPDM / Attestation Handler](spdm.md) — 6+5 `AttestationState` + `AttestationDeviceState` variants, 834 lines
+- [Network Segment Handler](network-segment.md) — 3 `NetworkSegmentControllerState` variants, 190 lines
+- [Power Shelf Handler](power-shelf.md) — 6 `PowerShelfControllerState` variants, 121 lines
+- [External Policy — OPA / Rego](rego-opa.md) — Cross-machine constraints and fleet coordination policies
+

--- a/book/src/design/convergence-engine/README.md
+++ b/book/src/design/convergence-engine/README.md
@@ -303,7 +303,6 @@ State keys and resource identifiers are **enum variants**.
 pub enum StateKey {
     // Power
     PowerState,
-    PowerCycleCompleted,
     // Firmware — real version strings from hardware
     FirmwareBmcVersion,
     FirmwareBiosVersion,
@@ -337,10 +336,11 @@ pub enum StateKey {
     // ...
 
     // Parameterized variants for per-device state (SPDM)
-    AttestationDeviceMetadataFetched(usize),
-    AttestationDeviceCertificateFetched(usize),
-    AttestationDeviceVerified(usize),
-    AttestationDeviceAppraised(usize),
+    AttestationDeviceMetadataHash(usize),
+    AttestationDeviceCertFingerprint(usize),
+    AttestationDeviceMeasurementHash(usize),
+    AttestationDeviceVerifierResult(usize),
+    AttestationDeviceAppraisalResult(usize),
     AttestationDeviceStatus(usize),
 }
 
@@ -526,12 +526,12 @@ This preserves the sequential pipeline of the FSM. Operations like `initialize_h
 ```
 configure_bios:         provides BiosSettingsHash,       guard: PowerState = "on"
 configure_network:      provides NetworkConfigVersion,   guard: PowerState = "on"
-install_scout:          provides ScoutVersion,           guard: PowerState = "on"
+load_scout:             provides ScoutVersion,           guard: PowerState = "on"
 update_bmc_firmware:    provides FirmwareBmcVersion,     guard: PowerState = "on"
 enable_lockdown:        provides LockdownEnabled,        guard: PowerState = "on"
 ```
 
-There is no `initialize_host` operation — that was an FSM bucket. The engine sees that `BiosSettingsHash` differs from desired and schedules `configure_bios`; that `ScoutVersion` is empty and schedules `install_scout`. These may run in parallel or in dependency order, determined by guards, not by a hardcoded phase sequence.
+There is no `initialize_host` operation — that was an FSM bucket. The engine sees that `BiosSettingsHash` differs from desired and schedules `configure_bios`; that `ScoutVersion` is empty and schedules `load_scout`. These may run in parallel or in dependency order, determined by guards, not by a hardcoded phase sequence.
 
 **Corollary: real observables, not boolean flags.** State keys should hold **real observable data**, not boolean step-completion flags. A boolean like `ScoutInstalled = "true"` is a phase marker in disguise — it records "we completed this step" rather than reflecting ground truth. Prefer:
 
@@ -560,7 +560,7 @@ Real observables also eliminate meaningless desired state. `DpuDiscovered = "tru
 **Guards express physical constraints, not lifecycle ordering.** The only valid guard predicates are real hardware constraints:
 
 - Can't flash firmware if power is off → `guard: eq(PowerState, "on")`
-- Can't install scout if network isn't configured → `guard: eq(NetworkConfigVersion, desired(NetworkConfigVersion))`
+- Can't load scout if network isn't configured → `guard: eq(NetworkConfigVersion, desired(NetworkConfigVersion))`
 - Can't configure DPU network without agent → `guard: neq(DpuAgentVersion, "")`
 - Can't run two firmware flashes at once → `locks: [Firmware]`
 
@@ -587,11 +587,11 @@ The FSM's phase ordering (init before validation before ready) is artificial —
 
 The following documents tries map each existing state handler to the convergence engine model:
 
-- [Machine Handler](machine.md) — `ManagedHostState` variants
-- [Rack Handler](rack.md) — 7 `RackState` variants
-- [Switch Handler](switch.md) — 9 `SwitchControllerState` variants
-- [IB Partition Handler](ib-partition.md) — 4 `IBPartitionControllerState` variants
-- [DPA Interface Handler](dpa-interface.md) — 9 `DpaInterfaceControllerState` variants
-- [SPDM / Attestation Handler](spdm.md) — 6+5 `AttestationState` + `AttestationDeviceState` variants
-- [Network Segment Handler](network-segment.md) — 3 `NetworkSegmentControllerState` variants
-- [Power Shelf Handler](power-shelf.md) — 6 `PowerShelfControllerState` variants
+- [Machine Handler](machine.md)
+- [Rack Handler](rack.md)
+- [Switch Handler](switch.md)
+- [IB Partition Handler](ib-partition.md)
+- [DPA Interface Handler](dpa-interface.md)
+- [SPDM / Attestation Handler](spdm.md)
+- [Network Segment Handler](network-segment.md)
+- [Power Shelf Handler](power-shelf.md)

--- a/book/src/design/convergence-engine/README.md
+++ b/book/src/design/convergence-engine/README.md
@@ -85,8 +85,6 @@ The engine works with two key-value maps:
 
 Both maps use the same set of strongly-typed keys (the `StateKey` enum — see §5). Any key can appear in either map. Which keys appear in `state_desired` is a runtime decision, not a property of the key itself.
 
-In code: `HostState` is a `BTreeMap<StateKey, StateValue>`. Keys are enum variants (compile-time safe, zero-cost, impossible to misspell). Values are a typed union (`Bool`, `Int`, `Str`, `Version`) with cross-type equality.
-
 ### 3.2 Delta: What Needs to Change
 
 The **delta** is the set of keys where observed and desired disagree. If the desired state says `FirmwareBmcVersion = "2.4.0"` but the observed state shows `FirmwareBmcVersion = "2.3.1"`, that key is in the delta.

--- a/book/src/design/convergence-engine/dpa-interface.md
+++ b/book/src/design/convergence-engine/dpa-interface.md
@@ -1,0 +1,289 @@
+# DPA Interface Handler — Convergence Engine Mapping
+
+## 1. Current State
+
+**Handler file:** `crates/api/src/state_controller/dpa_interface/handler.rs` (600 lines)  
+**State enum:** `DpaInterfaceControllerState` in `crates/api-model/src/dpa_interface/mod.rs`  
+**Controller I/O:** `DpaInterfaceStateControllerIO`
+
+The DPA (Data Path Accelerator) interface handler manages the lifecycle of SuperNIC/BlueField DPA interfaces: provisioning, card lock/unlock cycles, firmware application, MlxConfig profile application, VNI (Virtual Network Identifier) assignment, and MQTT heartbeat monitoring.
+
+### 1.1 DpaInterfaceControllerState Variants
+
+| # | Variant | Description |
+|---|---------|-------------|
+| 1 | `Provisioning` | Initial state. If using admin network, stays here; otherwise transitions to `Ready`. |
+| 2 | `Ready` | Configured with zero VNI. If not admin network, transitions to `Unlocking` for tenancy prep. |
+| 3 | `Unlocking` | Waiting for the card to report `Unlocked` state via scout. |
+| 4 | `ApplyFirmware` | Sending a `FirmwareFlasherProfile` to scout for firmware update. May send `None` (noop). |
+| 5 | `ApplyProfile` | Applying an MlxConfig profile to the device. When `profile_synced`, transitions to `Locking`. |
+| 6 | `Locking` | Waiting for the card to report `Locked` state via scout. |
+| 7 | `WaitingForSetVNI` | VNI is being set on the DPA interface. |
+| 8 | `Assigned` | DPA interface is configured with a non-zero VNI and assigned to a tenant. |
+| 9 | `WaitingForResetVNI` | VNI is being reset back to zero (returning to admin network). |
+
+### 1.2 Handler Flow
+
+The handler implements a linear lifecycle with MQTT heartbeat integration:
+
+```
+Provisioning → Ready → Unlocking → ApplyFirmware → ApplyProfile → Locking → WaitingForSetVNI → Assigned
+                  ↑                                                                                    |
+                  └──────────────── WaitingForResetVNI ←──────────────────────────────────────────────────┘
+```
+
+Each state transition is driven by scout agent reports via MQTT (`card_state`, `firmware_report`, `profile_synced`).
+
+---
+
+## 2. State Keys
+
+Any key can appear in `S_o`, `S_d`, or both. Which keys appear in `S_d` is a runtime decision (see [§3.11](README.md#311-design-principle-properties-not-phases)).
+
+| Observation Source | State Key | Type | Example Values |
+|-------------------|-----------|------|----------------|
+| `mac_address` | `DpaMacAddress` | Str | `"aa:bb:cc:dd:ee:ff"` |
+| `pci_name` | `DpaPciName` | Str | `"0000:03:00.0"` |
+| `underlay_ip` | `DpaUnderlayIp` | Str | `"10.0.1.5"` or `""` |
+| `overlay_ip` | `DpaOverlayIp` | Str | `"192.168.1.10"` or `""` |
+| `card_state.lock_mode` | `DpaLockMode` | Str | `"locked"`, `"unlocked"` |
+| `card_state.firmware_report` | `DpaFirmwareVersion` | Str | `"28.40.1000"` or `""` |
+| `card_state.profile_synced` | `DpaMlxconfigHash` | Str | `"c4d2e1"` or `""` (not synced) |
+| `device_info.part_number` | `DpaPartNumber` | Str | `"MCX75310AAS-NEAT"` |
+| `device_info.psid` | `DpaPsid` | Str | `"MT_0000000884"` |
+| `network_config` | `DpaNetworkConfigVersion` | Str | `"v2"` |
+| `network_status_observation` | `DpaNetworkStatus` | Str | `"configured"`, `"pending"` |
+| `mlxconfig_profile` | `DpaMlxconfigProfile` | Str | `"bf3_default"` |
+| `last_hb_time` | `DpaHeartbeatAge` | Str | `"2s"`, `"stale"` |
+| VNI from network config | `DpaVni` | Str | `"12345"` or `"0"` (admin) |
+| `deleted` | `LifecycleDeleted` | Bool | `"true"`, `"false"` |
+
+**Typical desired-state sources.** Tenancy lifecycle (`DpaLockMode`, `DpaVni`), firmware manifests (`DpaFirmwareVersion`), operator intent (`LifecycleDeleted`).
+
+---
+
+## 3. Operations
+
+Operations are organized by setting domain — each manages a single, independently configurable property. See [§3.11](README.md#311-design-principle-properties-not-phases) for the design rationale.
+
+### `provision_dpa`
+
+**Replaces:** `DpaInterfaceControllerState::Provisioning` match arm
+
+```rust
+op!(provision_dpa {
+    provides: [DpaUnderlayIp],
+    guard: eq(DpaUnderlayIp, ""),
+    locks: [DpaInterface],
+    effects: [DpaUnderlayIp => "{assigned_ip}"],
+    steps: [
+        action(dpa_check_admin_network),
+        action(dpa_initial_config),
+    ],
+    priority: 90,
+});
+```
+
+### `unlock_dpa`
+
+**Replaces:** `DpaInterfaceControllerState::Ready` → `Unlocking` transition and `Unlocking` match arm
+
+```rust
+op!(unlock_dpa {
+    provides: [DpaLockMode],
+    guard: and(
+        neq(DpaUnderlayIp, ""),
+        eq(DpaLockMode, "locked"),
+    ),
+    locks: [DpaInterface],
+    effects: [DpaLockMode => "unlocked"],
+    steps: [
+        action(dpa_send_unlock_command),
+        action(dpa_wait_for_unlock, timeout_seconds = 120),
+    ],
+    priority: 80,
+});
+```
+
+### `apply_dpa_firmware`
+
+**Replaces:** `DpaInterfaceControllerState::ApplyFirmware` match arm
+
+```rust
+op!(apply_dpa_firmware {
+    provides: [DpaFirmwareVersion],
+    guard: and(
+        eq(DpaLockMode, "unlocked"),
+        neq(DpaFirmwareVersion, desired(DpaFirmwareVersion)),
+    ),
+    locks: [DpaInterface, DpaFirmware],
+    effects: [DpaFirmwareVersion => desired(DpaFirmwareVersion)],
+    steps: [
+        action(dpa_build_firmware_profile),
+        action(dpa_send_firmware_profile_to_scout),
+        action(dpa_wait_for_firmware_report, timeout_seconds = 600),
+    ],
+    priority: 75,
+});
+```
+
+### `apply_dpa_profile`
+
+**Replaces:** `DpaInterfaceControllerState::ApplyProfile` match arm
+
+```rust
+op!(apply_dpa_profile {
+    provides: [DpaMlxconfigHash],
+    guard: and(
+        eq(DpaFirmwareVersion, desired(DpaFirmwareVersion)),
+        eq(DpaLockMode, "unlocked"),
+        eq(DpaMlxconfigHash, ""),
+    ),
+    locks: [DpaInterface],
+    effects: [DpaMlxconfigHash => "{profile_hash}"],
+    steps: [
+        action(dpa_send_mlxconfig_profile),
+        action(dpa_wait_for_profile_sync, timeout_seconds = 300),
+    ],
+    priority: 73,
+});
+```
+
+### `lock_dpa`
+
+**Replaces:** `DpaInterfaceControllerState::Locking` match arm
+
+```rust
+op!(lock_dpa {
+    provides: [DpaLockMode],
+    guard: and(
+        neq(DpaMlxconfigHash, ""),
+        eq(DpaLockMode, "unlocked"),
+    ),
+    locks: [DpaInterface],
+    effects: [DpaLockMode => "locked"],
+    steps: [
+        action(dpa_send_lock_command),
+        action(dpa_wait_for_lock, timeout_seconds = 120),
+    ],
+    priority: 70,
+});
+```
+
+### `set_dpa_vni`
+
+**Replaces:** `DpaInterfaceControllerState::WaitingForSetVNI` match arm
+
+```rust
+op!(set_dpa_vni {
+    provides: [DpaVni],
+    guard: and(
+        eq(DpaLockMode, "locked"),
+        neq(DpaVni, desired(DpaVni)),
+    ),
+    locks: [DpaInterface, DpaNetwork],
+    effects: [DpaVni => desired(DpaVni)],
+    steps: [
+        action(dpa_send_set_vni_command),
+        action(dpa_wait_for_vni_sync),
+    ],
+    priority: 65,
+});
+```
+
+### `reset_dpa_vni`
+
+**Replaces:** `DpaInterfaceControllerState::WaitingForResetVNI` match arm
+
+```rust
+op!(reset_dpa_vni {
+    provides: [DpaVni],
+    guard: and(
+        eq(DpaLockMode, "locked"),
+        neq(DpaVni, "0"),
+    ),
+    locks: [DpaInterface, DpaNetwork],
+    effects: [DpaVni => "0"],
+    steps: [
+        action(dpa_send_reset_vni_command),
+        action(dpa_wait_for_vni_reset),
+    ],
+    priority: 65,
+});
+```
+
+### `dpa_heartbeat`
+
+**Replaces:** Heartbeat logic embedded across multiple states (`Ready`, `Assigned`)
+
+```rust
+op!(dpa_heartbeat {
+    provides: [DpaHeartbeatAge],
+    guard: eq(DpaHeartbeatAge, "stale"),
+    locks: [],
+    effects: [DpaHeartbeatAge => "{current_age}"],
+    steps: [
+        action(dpa_send_mqtt_heartbeat),
+    ],
+    priority: 50,
+});
+```
+
+### What Disappears
+
+| Old | Property-oriented view |
+|-----|------------------------|
+| `DpaInterfaceControllerState::Provisioning` | Initial property convergence only |
+| Linear lifecycle Provisioning → Ready → Unlocking → … | Parallel property convergence |
+| `Ready` as a controller state | Not a state — Δ = ∅ |
+
+---
+
+## 4. Profiles
+
+| Profile | Match Rule | Description |
+|---------|-----------|-------------|
+| `dpa_default` | `true` | Default DPA interface profile (BlueField 3+ devices) |
+
+Future profiles could distinguish between BlueField generations:
+
+| Profile | Match Rule |
+|---------|-----------|
+| `dpa_bf2` | `contains(DpaPartNumber, "BF2")` |
+| `dpa_bf3` | `contains(DpaPartNumber, "BF3")` |
+
+---
+
+## 5. Example Convergence Trace
+
+**Scenario:** A DPA interface is assigned to a tenant, requiring unlock → firmware → profile → lock → VNI.
+
+**Initial observed state:**
+```
+DpaUnderlayIp      = "10.0.1.5"
+DpaLockMode        = "locked"
+DpaFirmwareVersion = "28.39.0"
+DpaMlxconfigHash   = ""
+DpaVni             = "0"
+```
+
+**Desired state:**
+```
+DpaLockMode        = "locked"
+DpaVni             = "12345"
+DpaFirmwareVersion = "28.40.1000"
+```
+
+**Tick 1:** `unlock_dpa` is ready (underlay IP is non-empty, card is locked, needs firmware update which requires unlock). Scheduled.
+
+**Tick 2:** `DpaLockMode = "unlocked"`. `apply_dpa_firmware` is ready (unlocked, firmware version differs). Scheduled.
+
+**Tick 3:** `DpaFirmwareVersion = "28.40.1000"`. `apply_dpa_profile` is ready (firmware matches desired, unlocked, profile hash is empty). Scheduled.
+
+**Tick 4:** `DpaMlxconfigHash = "c4d2e1"`. `lock_dpa` is ready (profile hash is non-empty, card is unlocked). Scheduled.
+
+**Tick 5:** `DpaLockMode = "locked"`. `set_dpa_vni` is ready (VNI differs: `"0"` vs `"12345"`). Scheduled.
+
+**Tick 6:** `DpaVni = "12345"`. All desired keys match.
+
+**Result:** CONVERGED.

--- a/book/src/design/convergence-engine/dpa-interface.md
+++ b/book/src/design/convergence-engine/dpa-interface.md
@@ -38,8 +38,6 @@ Each state transition is driven by scout agent reports via MQTT (`card_state`, `
 
 ## 2. State Keys
 
-Any key can appear in `S_o`, `S_d`, or both. Which keys appear in `S_d` is a runtime decision (see [§3.11](README.md#311-design-principle-properties-not-phases)).
-
 | Observation Source | State Key | Type | Example Values |
 |-------------------|-----------|------|----------------|
 | `mac_address` | `DpaMacAddress` | Str | `"aa:bb:cc:dd:ee:ff"` |
@@ -64,7 +62,7 @@ Any key can appear in `S_o`, `S_d`, or both. Which keys appear in `S_d` is a run
 
 ## 3. Operations
 
-Operations are organized by setting domain — each manages a single, independently configurable property. See [§3.11](README.md#311-design-principle-properties-not-phases) for the design rationale.
+Operations are organized by setting domain — each manages a single, independently configurable property. See [§7.4](README.md#74-design-principle-properties-not-phases) for the design rationale.
 
 ### `provision_dpa`
 

--- a/book/src/design/convergence-engine/formal-model.md
+++ b/book/src/design/convergence-engine/formal-model.md
@@ -6,7 +6,7 @@ This document contains the complete mathematical specification of the convergenc
 
 ## F.1 State Space
 
-**Definition.** Let `K` be a finite set of *state keys* — strongly-typed identifiers such as `PowerState`, `FirmwareBmcVersion`, or `BiosBootOrder`. Let `V` be a set of *state values* — a typed union of booleans, integers, semantic versions, and text. All keys, values, identifiers, and resources are strongly typed; the implementation represents `K` and `R` as enums (`StateKey`, `Resource`) and values as a typed union (`StateValue`), preventing accidental misuse at compile time.
+**Definition.** Let `K` be a finite set of *state keys* — strongly-typed identifiers such as `PowerState`, `FirmwareBmcVersion`, or `BiosBootOrder`. Let `V` be a set of *state values* — a typed union of booleans, integers, semantic versions, and text.
 
 A **host state** is a partial function:
 
@@ -22,18 +22,16 @@ dom(S) = { k ∈ K | S(k) is defined }
 
 At any moment in time, the system maintains two states:
 
-- `S_o` — the **observed state**, populated by reading hardware (Redfish, IPMI), databases, and agent reports.
+- `S_o` — the **observed state**, populated by reading hardware, databases, and agent reports.
 - `S_d` — the **desired state**, assembled at runtime by the desired-state composition layer.
 
-**Unified key space.** Both `S_o` and `S_d` draw from the same key space `K`. There is no type-level distinction between "observed-only" and "desired" keys — any key can appear in either or both maps:
+**Unified key space.** Both `S_o` and `S_d` draw from the same key space `K`. Any key can appear in either or both maps:
 
 ```
 dom(S_d) ⊆ K,  dom(S_o) ⊆ K
 ```
 
 `dom(S_d) \ dom(S_o)` may be non-empty when the observed state has not yet discovered a key that the desired state declares. Such keys are treated as mismatched (see F.2).
-
-**Code mapping.** `K` is represented as a `StateKey` enum — each valid key is a variant, making it `Copy`, zero-cost, and impossible to misspell. `V` is a `StateValue` enum supporting cross-variant equality (e.g., `Bool(true)` equals the text representation `"true"`). `S` is `HostState(BTreeMap<StateKey, StateValue>)`.
 
 ---
 
@@ -45,7 +43,7 @@ dom(S_d) ⊆ K,  dom(S_o) ⊆ K
 Δ(S_o, S_d) = { k ∈ dom(S_d) | S_o(k) ≠ S_d(k) }
 ```
 
-with the convention that if `k ∈ dom(S_d) \ dom(S_o)` — i.e., the desired state declares a key that the observed state has not yet discovered — then `S_o(k) ≠ S_d(k)` holds (the key is considered mismatched). Formally:
+with the convention that if `k ∈ dom(S_d) \ dom(S_o)` — i.e., the desired state declares a key that the observed state has not yet discovered — then `S_o(k) ≠ S_d(k)` holds. Formally:
 
 ```
 k ∈ Δ  ⟺  k ∈ dom(S_d) ∧ ( k ∉ dom(S_o) ∨ S_o(k) ≠ S_d(k) )
@@ -57,9 +55,7 @@ k ∈ Δ  ⟺  k ∈ dom(S_d) ∧ ( k ∉ dom(S_o) ∨ S_o(k) ≠ S_d(k) )
 Δ(S_o, S_d) = ∅
 ```
 
-**What the delta does NOT include.** Keys in `dom(S_o) \ dom(S_d)` — observed keys with no corresponding desired value — are not part of the delta. The engine does not attempt to "clean up" observed state that has no desired counterpart. `S_d` is a *patch*, not a complete specification.
-
-**Code mapping.** The `delta()` function iterates over `dom(S_d)` and collects keys where `observed.get(k) != Some(desired_val)`.
+**What the delta does NOT include.** Keys in `dom(S_o) \ dom(S_d)` — observed keys with no corresponding desired value — are not part of the delta. `S_d` is a *patch*, not a complete specification.
 
 ---
 
@@ -126,8 +122,6 @@ resolve(v, S_o, S_d) =
         return v
 ```
 
-This allows operations to compare observed values against desired targets (e.g., "current firmware version differs from desired") without hard-coding target values.
-
 **Conflict detection.** The function `conflicts_with_effect(G, k, v, S)` determines whether setting key `k` to value `v` in state `S` would cause guard `G` to transition from true to false. Used by the anti-oscillation logic (F.8):
 
 ```
@@ -162,7 +156,7 @@ where:
 ops(P) = ops(P_I₁) ∪ ops(P_I₂) ∪ … ∪ Ω_P
 ```
 
-When two profiles define an operation with the same `id`, the later definition wins (**last-writer-wins**). This allows a child profile to override a parent's operation.
+When two profiles define an operation with the same `id`, the later definition wins (**last-writer-wins**).
 
 **Profile detection algorithm:**
 
@@ -193,8 +187,6 @@ relevant(ω)  ⟺  P_ω ∩ Δ(S_o, S_d) ≠ ∅
 constructive(ω)  ⟺  ∃ k ∈ P_ω ∩ Δ : resolve(E_ω(k), S_o) = S_d(k)
 ```
 
-where `resolve` handles `desired.*` references in effect values.
-
 **Predicate 3 — Ready.** A constructive, relevant operation is ready if its guard holds on the current observed state:
 
 ```
@@ -208,10 +200,6 @@ R = { ω | relevant(ω) ∧ constructive(ω) ∧ ready(ω) }
 ```
 
 **Greedy resource-conflict-free selection.** From `R`, the scheduler selects a maximal subset that respects resource locks:
-
-```
-scheduled = greedy(R, π, L)
-```
 
 **Algorithm:**
 
@@ -236,7 +224,7 @@ function schedule(R):
 ∀ ωᵢ, ωⱼ ∈ scheduled, i ≠ j : Lᵢ ∩ Lⱼ = ∅
 ```
 
-That is, no two scheduled operations hold the same resource lock.
+No two scheduled operations hold the same resource lock.
 
 ---
 
@@ -262,7 +250,7 @@ where `L_claimed` is the set of resources already reserved by previously schedul
 
 **Resource pre-reservation.** When an enabler is found, its resources are immediately added to `L_claimed` before the main greedy pass.
 
-**Dependency chain depth.** The current implementation resolves dependencies to depth 1. Deeper chains are naturally resolved over multiple ticks by the convergence loop.
+**Dependency chain depth.** Dependencies are resolved to depth 1. Deeper chains are naturally resolved over multiple ticks by the convergence loop.
 
 ---
 
@@ -276,22 +264,18 @@ Without safeguards, the scheduler could enter infinite cycles — for example, `
 ω deferred if ∃ ω_d ∈ deps, k ∈ P_ω ∩ P_d : E_ω(k) ≠ E_d(k)
 ```
 
-**Intuition.** If `power_on` is needed as a dependency for `update_bmc_firmware`, and `power_off` is also relevant (because `PowerState` is in the delta), the dominance guard defers `power_off` — executing it would undo the dependency.
-
 **Guard 2 — Competitor blocking deferral.** An operation `ω` is deferred if its effect would falsify the guard of another ready operation that competes for the same resource:
 
 ```
 ω deferred if ∃ ω_c ∈ R, L_ω ∩ L_c ≠ ∅ : conflicts_with_effect(G_c, k, E_ω(k), S_o) for some k
 ```
 
-**Intuition.** If two operations share a resource lock and one would make the other's guard false, the engine defers the disruptive one.
-
 **Limitations.** These guards prevent 1-tick and 2-tick oscillation patterns but are **not a formal proof of termination**:
 
 1. **Longer cycles** (3+ ticks) could theoretically occur with complex circular dependencies.
 2. **Energy function non-monotonicity.** Dependency resolution can temporarily increase `|Δ|`.
 
-**Safety net: visited-state detection.** The engine can optionally track visited state fingerprints (hashes of `S_o`) and detect if the same observed state recurs, indicating an oscillation.
+**Safety net: visited-state detection.** The engine can optionally track visited state fingerprints and detect if the same observed state recurs, indicating an oscillation.
 
 **Formal characterization.** Define the "energy" of the system as `|Δ(S_o, S_d)|`. In a well-configured operation set:
 
@@ -318,7 +302,7 @@ where `⊕` denotes state update (overwriting existing keys with new values from
 1. **Converged:** `Δ(S_o, S_d) = ∅`.
 2. **Idle with non-empty delta:** `actions(t) = ∅` but `Δ ≠ ∅`. Indicates misconfiguration, deadlock, or a transient condition awaiting external state changes.
 
-**Fixpoint characterization.** The converged state `S_o`* is a **fixpoint** of the convergence operator:
+**Fixpoint characterization.** The converged state `S_o*` is a **fixpoint** of the convergence operator:
 
 ```
 S_o* = F(S_o*, S_d)  ⟺  Δ(S_o*, S_d) = ∅

--- a/book/src/design/convergence-engine/formal-model.md
+++ b/book/src/design/convergence-engine/formal-model.md
@@ -1,0 +1,349 @@
+# Convergence Engine — Formal Model
+
+This document contains the complete mathematical specification of the convergence engine. For the approachable overview, see the [main specification](README.md).
+
+---
+
+## F.1 State Space
+
+**Definition.** Let `K` be a finite set of *state keys* — strongly-typed identifiers such as `PowerState`, `FirmwareBmcVersion`, or `BiosBootOrder`. Let `V` be a set of *state values* — a typed union of booleans, integers, semantic versions, and text. All keys, values, identifiers, and resources are strongly typed; the implementation represents `K` and `R` as enums (`StateKey`, `Resource`) and values as a typed union (`StateValue`), preventing accidental misuse at compile time.
+
+A **host state** is a partial function:
+
+```
+S : K ⇀ V
+```
+
+The notation `⇀` (as opposed to `→`) indicates that `S` need not be defined on all of `K`. The **domain** of `S` is:
+
+```
+dom(S) = { k ∈ K | S(k) is defined }
+```
+
+At any moment in time, the system maintains two states:
+
+- `S_o` — the **observed state**, populated by reading hardware (Redfish, IPMI), databases, and agent reports.
+- `S_d` — the **desired state**, assembled at runtime by the desired-state composition layer.
+
+**Unified key space.** Both `S_o` and `S_d` draw from the same key space `K`. There is no type-level distinction between "observed-only" and "desired" keys — any key can appear in either or both maps:
+
+```
+dom(S_d) ⊆ K,  dom(S_o) ⊆ K
+```
+
+`dom(S_d) \ dom(S_o)` may be non-empty when the observed state has not yet discovered a key that the desired state declares. Such keys are treated as mismatched (see F.2).
+
+**Code mapping.** `K` is represented as a `StateKey` enum — each valid key is a variant, making it `Copy`, zero-cost, and impossible to misspell. `V` is a `StateValue` enum supporting cross-variant equality (e.g., `Bool(true)` equals the text representation `"true"`). `S` is `HostState(BTreeMap<StateKey, StateValue>)`.
+
+---
+
+## F.2 Delta
+
+**Definition.** The **delta** (or *drift*) between observed and desired state is the set of keys where the two states disagree:
+
+```
+Δ(S_o, S_d) = { k ∈ dom(S_d) | S_o(k) ≠ S_d(k) }
+```
+
+with the convention that if `k ∈ dom(S_d) \ dom(S_o)` — i.e., the desired state declares a key that the observed state has not yet discovered — then `S_o(k) ≠ S_d(k)` holds (the key is considered mismatched). Formally:
+
+```
+k ∈ Δ  ⟺  k ∈ dom(S_d) ∧ ( k ∉ dom(S_o) ∨ S_o(k) ≠ S_d(k) )
+```
+
+**Convergence criterion.** The system has **converged** when:
+
+```
+Δ(S_o, S_d) = ∅
+```
+
+**What the delta does NOT include.** Keys in `dom(S_o) \ dom(S_d)` — observed keys with no corresponding desired value — are not part of the delta. The engine does not attempt to "clean up" observed state that has no desired counterpart. `S_d` is a *patch*, not a complete specification.
+
+**Code mapping.** The `delta()` function iterates over `dom(S_d)` and collects keys where `observed.get(k) != Some(desired_val)`.
+
+---
+
+## F.3 Operations
+
+**Definition.** An **operation** is a tuple:
+
+```
+ω = (id, P, G, L, E, π)
+```
+
+where:
+
+| Component | Constraint       | Description |
+| --------- | ---------------- | ----------- |
+| `id`      | unique in `Ω`    | Unique identifier for this operation. |
+| `P`       | `P ⊆ K`          | **Provides** — the set of state keys this operation can change. An operation is only considered for a delta key `k` if `k ∈ P`. |
+| `G`       | `G : S → {0, 1}` | **Guard** — a boolean predicate over the observed state (see F.4). The operation may only fire when `G(S_o) = 1`. |
+| `L`       | `L ⊆ R`          | **Locks** — a set of resource identifiers requiring mutual exclusion. `R` is the universe of lockable resources. Two operations with `L₁ ∩ L₂ ≠ ∅` cannot execute in the same tick. |
+| `E`       | `E : K ⇀ V`      | **Effects** — a partial function mapping state keys to their post-execution values. After execution, `S_o(k) ← E(k)` for each `k ∈ dom(E)`. |
+| `π`       | `π ∈ ℕ`          | **Priority** — a non-negative integer. Higher values are scheduled first when multiple operations compete. |
+
+**Note on effects and provides.** Typically `dom(E) ⊆ P`, but this is not strictly required. An operation may have effects on keys it does not "provide" (side effects), though this is discouraged as it complicates reasoning.
+
+---
+
+## F.4 Guard Algebra
+
+Guards are the precondition language of the engine. They form a small algebra closed under boolean combinators.
+
+**Grammar.** The set of guard expressions `G` is defined inductively:
+
+```
+G ::= Eq(k, v)
+    | Neq(k, v)
+    | In(k, {v₁, …, vₙ})
+    | Contains(k, s)
+    | And(G₁, …, Gₙ)
+    | Or(G₁, …, Gₙ)
+    | Not(G)
+    | True
+```
+
+**Evaluation semantics.** Given a state `S`, each guard variant evaluates as follows:
+
+| Guard            | `G(S) = 1` iff |
+| ---------------- | --------------- |
+| `Eq(k, v)`       | `k ∈ dom(S) ∧ S(k) = resolve(v, S)` |
+| `Neq(k, v)`      | `k ∉ dom(S) ∨ S(k) ≠ resolve(v, S)` |
+| `In(k, V)`       | `k ∈ dom(S) ∧ S(k) ∈ V` |
+| `Contains(k, s)` | `k ∈ dom(S) ∧ s` is a substring of `S(k)` |
+| `And(G₁, …)`     | `∀ i : Gᵢ(S) = 1` |
+| `Or(G₁, …)`      | `∃ i : Gᵢ(S) = 1` |
+| `Not(G')`        | `G'(S) = 0` |
+| `True`           | always 1 |
+
+**Desired-state references.** Values `v` in guard and effect expressions may reference the desired state via `desired(k)`. The resolution function is:
+
+```
+resolve(v, S_o, S_d) =
+    if v = desired(k'):
+        return S_d(k')
+    else:
+        return v
+```
+
+This allows operations to compare observed values against desired targets (e.g., "current firmware version differs from desired") without hard-coding target values.
+
+**Conflict detection.** The function `conflicts_with_effect(G, k, v, S)` determines whether setting key `k` to value `v` in state `S` would cause guard `G` to transition from true to false. Used by the anti-oscillation logic (F.8):
+
+```
+conflicts_with_effect(G, k, v, S) = G(S) = 1  ∧  G(S[k ↦ v]) = 0
+```
+
+where `S[k ↦ v]` denotes the state `S` with key `k` overwritten to `v`.
+
+---
+
+## F.5 Hardware Profiles and Inheritance
+
+**Definition.** A **hardware profile** is a tuple:
+
+```
+P = (id, M, I, Ω, α)
+```
+
+where:
+
+| Component | Constraint        | Description |
+| --------- | ----------------- | ----------- |
+| `id`      | unique in `Π`     | Profile identifier (e.g., `nvidia_gb300`, `generic_x86`). `Π` is the set of all profiles. |
+| `M`       | `M : S → {0, 1}`  | **Match rule** — a guard expression evaluated against observed state. The first non-abstract profile whose match rule holds is selected. |
+| `I`       | `I ⊆ Π`           | **Inherits** — an ordered list of parent profile identifiers. |
+| `Ω`       | `Ω = {ω₁, …, ωₘ}` | **Operations** — the set of operations defined in this profile. |
+| `α`       | `α ∈ {0, 1}`      | **Is abstract** — if 1, the profile cannot be directly selected but can be inherited from. |
+
+**Inheritance resolution.** The effective operation set for a profile `P` is computed by traversing the inheritance DAG in order and merging operations:
+
+```
+ops(P) = ops(P_I₁) ∪ ops(P_I₂) ∪ … ∪ Ω_P
+```
+
+When two profiles define an operation with the same `id`, the later definition wins (**last-writer-wins**). This allows a child profile to override a parent's operation.
+
+**Profile detection algorithm:**
+
+```
+function detect_profile(S_o, profiles):
+    for P in profiles sorted by specificity:
+        if P.is_abstract: continue
+        if P.match_rule(S_o) = 1:
+            return P
+    return error("no matching profile")
+```
+
+---
+
+## F.6 Three-Predicate Scheduler
+
+The scheduler is the decision-making core of the engine. On each tick, it evaluates every available operation against three predicates and selects a safe, non-conflicting action set.
+
+**Predicate 1 — Relevant.** An operation is relevant if it provides at least one key in the current delta:
+
+```
+relevant(ω)  ⟺  P_ω ∩ Δ(S_o, S_d) ≠ ∅
+```
+
+**Predicate 2 — Constructive.** A relevant operation is constructive if at least one of its effects moves the observed state *toward* the desired state:
+
+```
+constructive(ω)  ⟺  ∃ k ∈ P_ω ∩ Δ : resolve(E_ω(k), S_o) = S_d(k)
+```
+
+where `resolve` handles `desired.*` references in effect values.
+
+**Predicate 3 — Ready.** A constructive, relevant operation is ready if its guard holds on the current observed state:
+
+```
+ready(ω)  ⟺  G_ω(S_o) = 1
+```
+
+**Candidate set.** The set of fully qualified candidates is:
+
+```
+R = { ω | relevant(ω) ∧ constructive(ω) ∧ ready(ω) }
+```
+
+**Greedy resource-conflict-free selection.** From `R`, the scheduler selects a maximal subset that respects resource locks:
+
+```
+scheduled = greedy(R, π, L)
+```
+
+**Algorithm:**
+
+```
+function schedule(R):
+    sort R by priority π descending (stable sort preserves insertion order for ties)
+    claimed_resources ← ∅
+    scheduled ← []
+
+    for ω in R:
+        if L_ω ∩ claimed_resources = ∅:
+            if not anti_oscillation_deferred(ω):
+                scheduled.append(ω)
+                claimed_resources ← claimed_resources ∪ L_ω
+
+    return scheduled
+```
+
+**Formal property.** The scheduled set satisfies:
+
+```
+∀ ωᵢ, ωⱼ ∈ scheduled, i ≠ j : Lᵢ ∩ Lⱼ = ∅
+```
+
+That is, no two scheduled operations hold the same resource lock.
+
+---
+
+## F.7 Dependency Resolution
+
+Some operations are relevant and constructive but not ready — their guard fails on the current observed state. The dependency resolver attempts to find **enabler** operations that can satisfy the unmet preconditions.
+
+**Unmet clause extraction.** For a blocked operation `ω_b` with `G(ω_b)(S_o) = 0`, the resolver decomposes the guard into its atomic `Eq` clauses and identifies which ones fail:
+
+```
+unmet(ω_b) = { (k, v) | Eq(k, v) ∈ atoms(G(ω_b))  ∧  S_o(k) ≠ resolve(v, S_o) }
+```
+
+For compound guards (`And`, `Or`), the decomposition follows the structure: for `And`, all failing clauses are unmet; for `Or`, only the first satisfiable branch is considered.
+
+**Enabler search.** For each unmet clause `(k, v)`, the resolver searches for an enabler operation:
+
+```
+∃ ω_e ∈ Ω : E_e(k) = v  ∧  G_e(S_o) = 1  ∧  L_e ∩ L_claimed = ∅
+```
+
+where `L_claimed` is the set of resources already reserved by previously scheduled operations and other enablers.
+
+**Resource pre-reservation.** When an enabler is found, its resources are immediately added to `L_claimed` before the main greedy pass.
+
+**Dependency chain depth.** The current implementation resolves dependencies to depth 1. Deeper chains are naturally resolved over multiple ticks by the convergence loop.
+
+---
+
+## F.8 Anti-Oscillation Guards
+
+Without safeguards, the scheduler could enter infinite cycles — for example, `power_on` and `power_off` alternating each tick. Two guards prevent the most common oscillation patterns.
+
+**Guard 1 — Dominance deferral.** An operation `ω` is deferred if it would undo the effect of a dependency action scheduled in the same tick:
+
+```
+ω deferred if ∃ ω_d ∈ deps, k ∈ P_ω ∩ P_d : E_ω(k) ≠ E_d(k)
+```
+
+**Intuition.** If `power_on` is needed as a dependency for `update_bmc_firmware`, and `power_off` is also relevant (because `PowerState` is in the delta), the dominance guard defers `power_off` — executing it would undo the dependency.
+
+**Guard 2 — Competitor blocking deferral.** An operation `ω` is deferred if its effect would falsify the guard of another ready operation that competes for the same resource:
+
+```
+ω deferred if ∃ ω_c ∈ R, L_ω ∩ L_c ≠ ∅ : conflicts_with_effect(G_c, k, E_ω(k), S_o) for some k
+```
+
+**Intuition.** If two operations share a resource lock and one would make the other's guard false, the engine defers the disruptive one.
+
+**Limitations.** These guards prevent 1-tick and 2-tick oscillation patterns but are **not a formal proof of termination**:
+
+1. **Longer cycles** (3+ ticks) could theoretically occur with complex circular dependencies.
+2. **Energy function non-monotonicity.** Dependency resolution can temporarily increase `|Δ|`.
+
+**Safety net: visited-state detection.** The engine can optionally track visited state fingerprints (hashes of `S_o`) and detect if the same observed state recurs, indicating an oscillation.
+
+**Formal characterization.** Define the "energy" of the system as `|Δ(S_o, S_d)|`. In a well-configured operation set:
+
+- Each constructive operation reduces `|Δ|` by at least 1 for its primary key.
+- Dependency operations may temporarily increase `|Δ|` but are bounded in depth.
+- The anti-oscillation guards ensure the scheduler does not undo its own progress within a single tick.
+
+Under these conditions, the convergence loop terminates in `O(|Δ₀| · d)` ticks, where `|Δ₀|` is the initial delta size and `d` is the maximum dependency chain depth.
+
+---
+
+## F.9 Convergence Loop
+
+**State evolution.** After each tick, the observed state is updated:
+
+```
+S_o(t+1) = S_o(t) ⊕ ⋃{ E_ω | ω ∈ actions(t) }
+```
+
+where `⊕` denotes state update (overwriting existing keys with new values from the effects).
+
+**Termination conditions.** The loop terminates when:
+
+1. **Converged:** `Δ(S_o, S_d) = ∅`.
+2. **Idle with non-empty delta:** `actions(t) = ∅` but `Δ ≠ ∅`. Indicates misconfiguration, deadlock, or a transient condition awaiting external state changes.
+
+**Fixpoint characterization.** The converged state `S_o`* is a **fixpoint** of the convergence operator:
+
+```
+S_o* = F(S_o*, S_d)  ⟺  Δ(S_o*, S_d) = ∅
+```
+
+The engine is a fixpoint-seeking iteration: `S_o⁰, S_o¹, …, S_oⁿ = S_o*`.
+
+**Tick pseudocode:**
+
+```
+function tick(S_o, S_d, operations):
+    Δ ← delta(S_o, S_d)
+    if Δ = ∅: return CONVERGED
+
+    relevant ← { ω ∈ operations | P_ω ∩ Δ ≠ ∅ }
+    constructive ← { ω ∈ relevant | ∃ k ∈ P_ω ∩ Δ : resolve(E_ω(k), S_o, S_d) = S_d(k) }
+    ready ← { ω ∈ constructive | G_ω(S_o, S_d) = 1 }
+    blocked ← constructive \ ready
+
+    deps ← resolve_dependencies(blocked, operations, S_o, S_d)
+    actions ← schedule(ready ∪ deps, anti_oscillation_context)
+
+    for ω in actions:
+        execute(ω.steps)
+        S_o ← S_o ⊕ resolve_effects(E_ω, S_o, S_d)
+
+    return (actions, S_o)
+```

--- a/book/src/design/convergence-engine/formal-model.md
+++ b/book/src/design/convergence-engine/formal-model.md
@@ -1,6 +1,6 @@
 # Convergence Engine — Formal Model
 
-This document contains the complete mathematical specification of the convergence engine. For the approachable overview, see the [main specification](README.md).
+This document contains the mathematical specification of the convergence engine.
 
 ---
 

--- a/book/src/design/convergence-engine/ib-partition.md
+++ b/book/src/design/convergence-engine/ib-partition.md
@@ -30,8 +30,6 @@ The handler has notable inline logic (not delegated to sub-handlers):
 
 ## 2. State Keys
 
-Any key can appear in `S_o`, `S_d`, or both. Which keys appear in `S_d` is a runtime decision (see [§3.11](README.md#311-design-principle-properties-not-phases)).
-
 | Observation Source | State Key | Type | Example Values |
 |-------------------|-----------|------|----------------|
 | `config.name` | `PartitionName` | Str | `"gpu-partition-1"` |
@@ -52,7 +50,7 @@ Any key can appear in `S_o`, `S_d`, or both. Which keys appear in `S_d` is a run
 
 ## 3. Operations
 
-Operations are organized by setting domain — each manages a single, independently configurable property. See [§3.11](README.md#311-design-principle-properties-not-phases) for the design rationale.
+Operations are organized by setting domain — each manages a single, independently configurable property. See [§7.4](README.md#74-design-principle-properties-not-phases) for the design rationale.
 
 ### `provision_partition`
 

--- a/book/src/design/convergence-engine/ib-partition.md
+++ b/book/src/design/convergence-engine/ib-partition.md
@@ -1,0 +1,180 @@
+# IB Partition Handler — Convergence Engine Mapping
+
+## 1. Current State
+
+**Handler file:** `crates/api/src/state_controller/ib_partition/handler.rs` (275 lines)  
+**State enum:** `IBPartitionControllerState` in `crates/api-model/src/ib_partition/mod.rs`  
+**Controller I/O:** `IBPartitionStateControllerIO`
+
+The IB partition handler manages InfiniBand partition lifecycle: provisioning pkeys on the IB fabric, synchronizing partition state from the fabric manager, managing QoS settings, and cleaning up on deletion.
+
+### 1.1 IBPartitionControllerState Variants
+
+| # | Variant | Sub-state | Description |
+|---|---------|-----------|-------------|
+| 1 | `Provisioning` | — | Initial state; transitions immediately to `Ready`. |
+| 2 | `Ready` | — | Partition is active; syncs state from IB fabric on each tick. |
+| 3 | `Error` | `cause: String` | Partition is in error; may transition to `Deleting` if marked deleted. |
+| 4 | `Deleting` | — | Partition is being cleaned up and removed from fabric. |
+
+### 1.2 Handler Logic
+
+The handler has notable inline logic (not delegated to sub-handlers):
+
+- **`Provisioning`:** Transitions immediately to `Ready` (no actual provisioning step).
+- **`Ready`:** Checks for `pkey` in status, queries IB fabric for partition state, syncs QoS and membership, detects deletion requests.
+- **`Deleting`:** Validates `pkey` exists, queries fabric, handles `NotFound`, checks instance count, releases pkey, performs `final_delete`.
+- **`Error`:** Transitions to `Deleting` if `pkey` present and marked deleted; otherwise does nothing.
+
+---
+
+## 2. State Keys
+
+Any key can appear in `S_o`, `S_d`, or both. Which keys appear in `S_d` is a runtime decision (see [§3.11](README.md#311-design-principle-properties-not-phases)).
+
+| Observation Source | State Key | Type | Example Values |
+|-------------------|-----------|------|----------------|
+| `config.name` | `PartitionName` | Str | `"gpu-partition-1"` |
+| `config.pkey` | `PartitionPkey` | Str | `"0x8001"` |
+| `config.mtu` | `PartitionMtu` | Int | `"2048"` |
+| `config.rate_limit` | `PartitionRateLimit` | Str | `"100Gbps"` |
+| `config.service_level` | `PartitionServiceLevel` | Str | `"high"` |
+| `status.partition` | `PartitionFabricStatus` | Str | Status from IB fabric manager |
+| `status.pkey` | `PartitionFabricPkey` | Str | Pkey as seen by fabric |
+| IB fabric query | `PartitionFabricSyncHash` | Str | `"f4e2a1"` or `""` (not synced) |
+| IB fabric QoS query | `PartitionQosHash` | Str | `"b3c1d0"` or `""` (not synced) |
+| Instance count | `PartitionInstanceCount` | Int | `"5"` |
+| `deleted` | `LifecycleDeleted` | Bool | `"true"`, `"false"` |
+
+**Typical desired-state sources.** Operator intent (`LifecycleDeleted`). A fabric policy might also set `PartitionFabricSyncHash` or `PartitionQosHash` as desired goals to drive sync operations.
+
+---
+
+## 3. Operations
+
+Operations are organized by setting domain — each manages a single, independently configurable property. See [§3.11](README.md#311-design-principle-properties-not-phases) for the design rationale.
+
+### `provision_partition`
+
+**Replaces:** `IBPartitionControllerState::Provisioning` match arm
+
+```rust
+op!(provision_partition {
+    provides: [PartitionFabricSyncHash],
+    guard: eq(PartitionFabricSyncHash, ""),
+    locks: [IbPartition],
+    effects: [PartitionFabricSyncHash => "{computed_hash}"],
+    steps: [
+        action(ib_create_partition_on_fabric),
+        action(ib_verify_pkey_allocated),
+    ],
+    priority: 90,
+});
+```
+
+### `sync_partition`
+
+**Replaces:** Fabric sync logic in `IBPartitionControllerState::Ready` match arm
+
+```rust
+op!(sync_partition {
+    provides: [PartitionFabricSyncHash],
+    guard: eq(PartitionFabricSyncHash, "stale"),
+    locks: [IbPartition],
+    effects: [PartitionFabricSyncHash => "{computed_hash}"],
+    steps: [
+        action(ib_query_fabric_state),
+        action(ib_update_local_state),
+    ],
+    priority: 70,
+});
+```
+
+### `sync_partition_qos`
+
+**Replaces:** QoS update logic in `IBPartitionControllerState::Ready` match arm
+
+```rust
+op!(sync_partition_qos {
+    provides: [PartitionQosHash],
+    guard: and(
+        neq(PartitionFabricSyncHash, ""),
+        eq(PartitionQosHash, ""),
+    ),
+    locks: [IbPartition],
+    effects: [PartitionQosHash => "{computed_qos_hash}"],
+    steps: [
+        action(ib_update_qos_on_fabric),
+        action(ib_verify_qos_applied),
+    ],
+    priority: 65,
+});
+```
+
+### `delete_partition`
+
+**Replaces:** `IBPartitionControllerState::Deleting` match arm
+
+```rust
+op!(delete_partition {
+    provides: [LifecycleDeleted],
+    guard: and(
+        eq(LifecycleDeleted, "true"),
+        eq(PartitionInstanceCount, "0"),
+    ),
+    locks: [IbPartition, Lifecycle],
+    effects: [LifecycleDeleted => "true"],
+    steps: [
+        action(ib_release_pkey),
+        action(ib_remove_partition_from_fabric),
+        action(final_delete),
+    ],
+    priority: 110,
+});
+```
+
+### What Disappears
+
+| Old | Property-oriented view |
+|-----|------------------------|
+| `IBPartitionControllerState::Provisioning` | Initial property setting only |
+| `Error` | Observable drift; engine retries |
+
+---
+
+## 4. Profiles
+
+| Profile | Match Rule | Description |
+|---------|-----------|-------------|
+| `ib_partition_default` | `true` | Single profile — IB partition management is fabric-agnostic |
+
+---
+
+## 5. Example Convergence Trace
+
+**Scenario:** A new IB partition is created with pkey `0x8001`, needing provisioning and QoS sync.
+
+**Initial observed state:**
+```
+PartitionPkey          = "0x8001"
+PartitionFabricSyncHash = ""
+PartitionQosHash       = ""
+```
+
+No explicit desired state for sync -- the operations fire when the observed hashes are empty (meaning out of sync or not yet provisioned).
+
+**Tick 1:**
+- `provision_partition` is ready (`PartitionFabricSyncHash = ""`). Scheduled.
+- **Actions:** `provision_partition`.
+
+**Tick 2:**
+- `PartitionFabricSyncHash = "f4e2a1"`.
+- `sync_partition_qos` is now ready (sync hash is non-empty, QoS hash is empty). Scheduled.
+- **Actions:** `sync_partition_qos`.
+
+**Tick 3:**
+- `PartitionQosHash = "b3c1d0"`.
+- No further deltas.
+- **Result:** CONVERGED.
+
+**Self-healing:** If the fabric drifts (e.g., QoS settings are changed externally), the observation layer detects the hash mismatch and marks `PartitionQosHash = ""`. The engine re-runs `sync_partition_qos`.

--- a/book/src/design/convergence-engine/machine.md
+++ b/book/src/design/convergence-engine/machine.md
@@ -1,0 +1,622 @@
+# Machine Handler — Convergence Engine Mapping
+
+## 1. Current State
+
+**Handler file:** `crates/api/src/state_controller/machine/handler.rs` (10,257 lines)  
+**State enum:** `ManagedHostState` in `crates/api-model/src/machine/mod.rs`  
+**Controller I/O:** `MachineStateControllerIO` in `crates/api/src/state_controller/machine/io.rs`
+
+The machine handler is the largest and most complex state handler in Carbide. It manages the full lifecycle of a bare-metal host: from initial RMS registration, through DPU and host initialization, validation, readiness, instance assignment, cleanup, reprovisioning, firmware updates, attestation measurement, and failure recovery.
+
+### 1.1 ManagedHostState Variants
+
+| # | Variant | Sub-state | Description |
+|---|---------|-----------|-------------|
+| 1 | `VerifyRmsMembership` | — | Verify the host is registered with Rack Manager Service by checking inventory. |
+| 2 | `RegisterRmsMembership` | — | Register the host with RMS. On success, transitions to DPU discovery. |
+| 3 | `DpuDiscoveringState` | `dpu_states` | DPU discovered by site-explorer; being configured via Redfish. |
+| 4 | `DPUInit` | `dpu_states` | DPU is not yet ready; delegated to `dpu_handler`. |
+| 5 | `HostInit` | `machine_state` | DPU is ready; host initialization in progress. |
+| 6 | `Validation` | `validation_state` | Host validation for machine and DPU. |
+| 7 | `BomValidating` | `bom_validating_state` | BOM/SKU validation flow. |
+| 8 | `Measuring` | `measuring_state` | Waiting on attestation measurements or valid bundle. |
+| 9 | `Ready` | — | Host is ready for instance creation. |
+| 10 | `Assigned` | `instance_state` | Host is assigned to an instance; delegated to `instance_handler`. |
+| 11 | `PostAssignedMeasuring` | `measuring_state` | Re-measurement after instance assignment. |
+| 12 | `WaitingForCleanup` | `cleanup_state` | Cleanup in progress (BOSS secure erase, volume creation, etc.). |
+| 13 | `HostReprovision` | `reprovision_state` | Host reprovisioning in progress. |
+| 14 | `DPUReprovision` | `dpu_states` | DPU reprovisioning in progress. |
+| 15 | `Failed` | `details, retry_count` | Machine in failed state; recovery depends on cause. |
+| 16 | `ForceDeletion` | — | Admin-triggered forced deletion. |
+| 17 | `Created` | — | Dummy initial state for DPU creation. |
+
+### 1.2 Handler Dispatch Structure
+
+The handler's `attempt_state_transition` method is a single `match` on `ManagedHostState` that spans ~1,100 lines. Pre-match logic handles:
+
+- DPU network staleness detection
+- Restart verification
+- DPU reprovision restart conditions
+- Promotion to `Failed` state when `get_failed_state()` triggers
+
+Each match arm either handles the transition inline or delegates to sub-handlers:
+
+- `DPUInit` → `dpu_handler.handle_object_state()`
+- `HostInit` → `host_handler.handle_object_state()`
+- `Assigned` → `instance_handler.handle_object_state()`
+- `WaitingForCleanup` → nested `match cleanup_state` with ~15 sub-states
+- `HostReprovision` → `host_upgrade.handle_host_reprovision()`
+
+---
+
+## 2. Observed State Mapping
+
+The observed state `S_o` for a machine is built from the `Machine` struct, BMC queries (Redfish/IPMI), and agent reports.
+
+Every key holds **real observable data**, not boolean step-completion flags. If data is present, the thing exists (see [§3.11](README.md#311-design-principle-properties-not-phases)).
+
+| Source Field | State Key | Type | Example Values |
+|-------------|-----------|------|----------------|
+| Redfish power query | `PowerState` | Str | `"on"`, `"off"`, `"powering_on"`, `"powering_off"` |
+| `bmc_info.firmware_version` | `FirmwareBmcVersion` | Str | `"2.14.0"` |
+| `inventory.bios_version` | `FirmwareBiosVersion` | Str | `"1.8.3"` |
+| `inventory.host_firmware_version` | `FirmwareHostVersion` | Str | `"3.2.1"` |
+| DPU agent health report | `DpuFirmwareVersion` | Str | `"24.04.1"` or `""` (no DPU) |
+| DPU network status | `DpuNetworkConfigVersion` | Str | `"v5"` |
+| `hardware_info.manufacturer` | `HardwareManufacturer` | Str | `"NVIDIA"` |
+| `hw_sku` | `HwSku` | Str | `"NVIDIA-GB300-XYZ"` |
+| Redfish DPU discovery | `DpuCount` | Int | `"2"` (0 = not yet discovered) |
+| Redfish DPU interface query | `DpuInterfaceIp` | Str | `"10.0.1.5"` or `""` (not configured) |
+| Redfish DPU mode query | `DpuMode` | Str | `"dpu"`, `"nic"`, `""` (not set) |
+| DPU agent version query | `DpuAgentVersion` | Str | `"1.4.0"` or `""` (not connected) |
+| Scout agent version query | `ScoutVersion` | Str | `"3.2.1"` or `""` (not installed) |
+| Scout heartbeat monitoring | `ScoutHeartbeat` | Str | `"alive"`, `"stale"` |
+| Redfish BIOS attributes hash | `BiosSettingsHash` | Str | `"a3f8c2"` (hash of current attributes) |
+| `network_config` | `NetworkConfigVersion` | Str | `"v12"` |
+| `network_status_observation` | `NetworkStatus` | Str | `"configured"`, `"pending"`, `"error"` |
+| Health report aggregation | `HealthStatus` | Str | `"healthy"`, `"degraded"`, `"critical"` |
+| `dpf.enabled` | `DpfEnabled` | Bool | `"true"`, `"false"` |
+| `firmware_autoupdate` | `FirmwareAutoupdate` | Bool | `"true"`, `"false"` |
+| Lockdown status query | `LockdownEnabled` | Bool | `"true"`, `"false"` |
+| RMS inventory query | `RmsInventoryId` | Str | `"rms-12345"` or `""` (not registered) |
+| Validation runner | `ValidationResult` | Str | `"passed"`, `"failed"`, `"not_run"` |
+| BOM validation runner | `BomValidationResult` | Str | `"passed"`, `"failed"`, `"not_run"` |
+| Attestation status | `AttestationStatus` | Str | `"not_started"`, `"measuring"`, `"passed"`, `"failed"` |
+| Instance assignment | `InstanceAssigned` | Bool | `"true"`, `"false"` |
+| `deleted` | `LifecycleDeleted` | Bool | `"true"`, `"false"` |
+| Drive erase status | `DriveEraseStatus` | Str | `"erased"`, `"not_erased"` |
+
+---
+
+## 3. Operations
+
+Operations are organized by **setting domain** — each manages a single, independently configurable property. There are no "init" or "reprovision" phases. See [§3.11](README.md#311-design-principle-properties-not-phases) for the design rationale.
+
+### 3.1 Power
+
+```rust
+op!(power_on {
+    provides: [PowerState],
+    guard: eq(PowerState, "off"),
+    locks: [Power],
+    effects: [PowerState => "on"],
+    steps: [
+        action(redfish_power_on),
+        action(wait_for_power_state, target = "on", timeout_seconds = 120),
+    ],
+    priority: 100,
+});
+```
+
+```rust
+op!(power_off {
+    provides: [PowerState],
+    guard: eq(PowerState, "on"),
+    locks: [Power],
+    effects: [PowerState => "off"],
+    steps: [
+        action(redfish_power_off, reset_type = "GracefulShutdown"),
+        action(wait_for_power_state, target = "off", timeout_seconds = 120),
+    ],
+    priority: 100,
+});
+```
+
+```rust
+op!(power_cycle {
+    provides: [PowerCycleCompleted],
+    guard: eq(PowerState, "on"),
+    locks: [Power],
+    effects: [PowerCycleCompleted => "true"],
+    steps: [
+        action(redfish_power_cycle, reset_type = "ForceRestart"),
+        action(wait_for_power_state, target = "on", timeout_seconds = 180),
+    ],
+    priority: 95,
+});
+```
+
+### 3.2 Registration
+
+```rust
+op!(register_with_rms {
+    provides: [RmsInventoryId],
+    guard: eq(RmsInventoryId, ""),
+    locks: [Rms],
+    effects: [RmsInventoryId => "rms-{machine_id}"],
+    steps: [
+        action(rms_check_inventory),
+        action(rms_register_if_missing),
+    ],
+    priority: 100,
+});
+```
+
+### 3.3 DPU Discovery and Setup
+
+Each step of what the FSM called "DPU Init" is an independent property, guarded by physical constraints. Note: no operation "provides" `DpuCount` — it is **observed-only** from Redfish. The engine uses it as a prerequisite in guards.
+
+```rust
+op!(configure_dpu_interfaces {
+    provides: [DpuInterfaceIp],
+    guard: and(
+        neq(DpuCount, "0"),
+        eq(DpuInterfaceIp, ""),
+    ),
+    locks: [Dpu],
+    effects: [DpuInterfaceIp => "{configured_ip}"],
+    steps: [
+        action(redfish_configure_dpu_network_interfaces),
+    ],
+    priority: 90,
+});
+```
+
+```rust
+op!(set_dpu_mode {
+    provides: [DpuMode],
+    guard: and(
+        neq(DpuInterfaceIp, ""),
+        neq(DpuMode, desired(DpuMode)),
+    ),
+    locks: [Dpu],
+    effects: [DpuMode => desired(DpuMode)],
+    steps: [
+        action(redfish_set_dpu_mode),
+    ],
+    priority: 89,
+});
+```
+
+```rust
+op!(wait_for_dpu_agent {
+    provides: [DpuAgentVersion],
+    guard: and(
+        eq(DpuMode, desired(DpuMode)),
+        eq(DpuAgentVersion, ""),
+    ),
+    locks: [Dpu],
+    effects: [DpuAgentVersion => "{reported_version}"],
+    steps: [
+        action(dpu_wait_for_agent_ready, timeout_seconds = 120),
+        action(dpu_query_agent_version),
+    ],
+    priority: 88,
+});
+```
+
+### 3.4 Firmware
+
+Each firmware target is an independent property. All require power. The engine parallelizes BMC and BIOS updates if resource locks allow.
+
+```rust
+op!(update_bmc_firmware {
+    provides: [FirmwareBmcVersion],
+    guard: and(
+        eq(PowerState, "on"),
+        neq(FirmwareBmcVersion, desired(FirmwareBmcVersion)),
+        eq(PolicyFirmwareUpdateAllowed, "true"),
+    ),
+    locks: [Firmware, Power],
+    effects: [FirmwareBmcVersion => desired(FirmwareBmcVersion)],
+    steps: [
+        action(redfish_firmware_update, target = "bmc"),
+        action(wait_for_bmc_ready, timeout_seconds = 600),
+    ],
+    priority: 80,
+});
+```
+
+```rust
+op!(update_bios_firmware {
+    provides: [FirmwareBiosVersion],
+    guard: and(
+        eq(PowerState, "on"),
+        neq(FirmwareBiosVersion, desired(FirmwareBiosVersion)),
+    ),
+    locks: [Firmware, Power],
+    effects: [FirmwareBiosVersion => desired(FirmwareBiosVersion)],
+    steps: [
+        action(redfish_firmware_update, target = "bios"),
+        action(redfish_power_cycle),
+        action(wait_for_bios_post, timeout_seconds = 600),
+    ],
+    priority: 79,
+});
+```
+
+```rust
+op!(update_dpu_firmware {
+    provides: [DpuFirmwareVersion],
+    guard: and(
+        eq(PowerState, "on"),
+        neq(DpuAgentVersion, ""),
+        neq(DpuFirmwareVersion, desired(DpuFirmwareVersion)),
+    ),
+    locks: [Dpu, Firmware],
+    effects: [DpuFirmwareVersion => desired(DpuFirmwareVersion)],
+    steps: [
+        action(dpu_flash_firmware),
+        action(dpu_reset),
+        action(wait_for_dpu_ready, timeout_seconds = 300),
+    ],
+    priority: 78,
+});
+```
+
+### 3.5 BIOS Configuration
+
+```rust
+op!(configure_bios {
+    provides: [BiosSettingsHash],
+    guard: and(
+        eq(PowerState, "on"),
+        neq(BiosSettingsHash, desired(BiosSettingsHash)),
+    ),
+    locks: [Bios],
+    effects: [BiosSettingsHash => desired(BiosSettingsHash)],
+    steps: [
+        action(redfish_set_bios_attributes),
+        action(redfish_power_cycle),
+        action(wait_for_bios_post),
+    ],
+    priority: 82,
+});
+```
+
+### 3.6 Network
+
+```rust
+op!(configure_network {
+    provides: [NetworkConfigVersion],
+    guard: and(
+        eq(PowerState, "on"),
+        neq(NetworkConfigVersion, desired(NetworkConfigVersion)),
+    ),
+    locks: [Network],
+    effects: [NetworkConfigVersion => desired(NetworkConfigVersion)],
+    steps: [
+        action(apply_network_config),
+        action(verify_network_connectivity),
+    ],
+    priority: 83,
+});
+```
+
+```rust
+op!(configure_dpu_network {
+    provides: [DpuNetworkConfigVersion],
+    guard: and(
+        neq(DpuAgentVersion, ""),
+        neq(DpuNetworkConfigVersion, desired(DpuNetworkConfigVersion)),
+    ),
+    locks: [Dpu, Network],
+    effects: [DpuNetworkConfigVersion => desired(DpuNetworkConfigVersion)],
+    steps: [
+        action(dpu_apply_network_config),
+        action(dpu_verify_connectivity),
+    ],
+    priority: 81,
+});
+```
+
+### 3.7 Host Agent
+
+Previously buried inside the monolithic `initialize_host` FSM phase. As independent properties, each can be tested, retried, and monitored individually. Note how guards reference real data — `ScoutVersion` guards on `neq(ScoutVersion, "")`, not on a boolean flag.
+
+```rust
+op!(install_scout {
+    provides: [ScoutVersion],
+    guard: and(
+        eq(PowerState, "on"),
+        eq(NetworkConfigVersion, desired(NetworkConfigVersion)),
+        neq(ScoutVersion, desired(ScoutVersion)),
+    ),
+    locks: [Scout],
+    effects: [ScoutVersion => desired(ScoutVersion)],
+    steps: [
+        action(deploy_scout_agent, version = desired(ScoutVersion)),
+        action(verify_scout_running),
+    ],
+    priority: 84,
+});
+```
+
+`ScoutHeartbeat` is **observed-only** — it comes from continuous heartbeat monitoring, not from an operation. When the scout agent is running, the observation layer sets `ScoutHeartbeat = "alive"`. No explicit "verify reachability" operation is needed.
+
+### 3.8 Security
+
+```rust
+op!(enable_lockdown {
+    provides: [LockdownEnabled],
+    guard: and(eq(PowerState, "on"), eq(LockdownEnabled, "false")),
+    locks: [Lockdown],
+    effects: [LockdownEnabled => "true"],
+    steps: [
+        action(redfish_enable_lockdown),
+        action(set_bios_password),
+    ],
+    priority: 70,
+});
+```
+
+```rust
+op!(run_attestation {
+    provides: [AttestationStatus],
+    guard: and(
+        eq(BomValidationResult, "passed"),
+        eq(PowerState, "on"),
+    ),
+    locks: [Attestation],
+    effects: [AttestationStatus => "passed"],
+    steps: [
+        action(spdm_check_support),
+        action(spdm_fetch_targets),
+        action(spdm_collect_measurements),
+        action(spdm_verify_measurements),
+        action(spdm_apply_appraisal),
+    ],
+    priority: 75,
+});
+```
+
+### 3.9 Validation
+
+Validation is a *check*, not a lifecycle phase. Its guard expresses the real dependencies — the settings it validates must be in place. The result is a real value (`"passed"` or `"failed"`), not a boolean flag. Compare with the FSM approach where validation was gated behind an `HostInitialized` phase marker.
+
+```rust
+op!(validate_machine {
+    provides: [ValidationResult],
+    guard: and(
+        eq(PowerState, "on"),
+        eq(ScoutHeartbeat, "alive"),
+        eq(BiosSettingsHash, desired(BiosSettingsHash)),
+        eq(NetworkConfigVersion, desired(NetworkConfigVersion)),
+    ),
+    locks: [Validation],
+    effects: [ValidationResult => "passed"],
+    steps: [
+        action(run_machine_validation),
+        action(check_validation_result),
+    ],
+    priority: 70,
+});
+```
+
+```rust
+op!(validate_bom {
+    provides: [BomValidationResult],
+    guard: eq(ValidationResult, "passed"),
+    locks: [Validation],
+    effects: [BomValidationResult => "passed"],
+    steps: [
+        action(run_bom_validation),
+        action(check_bom_result),
+    ],
+    priority: 68,
+});
+```
+
+### 3.10 Cleanup
+
+What the FSM called `WaitingForCleanup` was a monolithic phase bundling four unrelated actions. In the convergence model, cleanup is just driving properties to their "empty" or "erased" values — the same mechanism as provisioning, just in the opposite direction.
+
+```rust
+op!(erase_drives {
+    provides: [DriveEraseStatus],
+    guard: and(
+        eq(InstanceAssigned, "false"),
+        neq(DriveEraseStatus, "erased"),
+    ),
+    locks: [Cleanup],
+    effects: [DriveEraseStatus => "erased"],
+    steps: [action(secure_erase_drives)],
+    priority: 60,
+});
+```
+
+```rust
+op!(remove_scout {
+    provides: [ScoutVersion],
+    guard: and(
+        eq(InstanceAssigned, "false"),
+        neq(ScoutVersion, ""),
+    ),
+    locks: [Scout],
+    effects: [ScoutVersion => ""],
+    steps: [action(remove_scout_agent)],
+    priority: 59,
+});
+```
+
+Note: `remove_scout` and `install_scout` both provide `ScoutVersion`. The scheduler selects based on which direction the delta points — if desired `ScoutVersion` is non-empty and observed is empty, `install_scout` fires; if desired is empty and observed is non-empty, `remove_scout` fires.
+
+### 3.11 Lifecycle
+
+```rust
+op!(delete_machine {
+    provides: [LifecycleDeleted],
+    guard: eq(LifecycleDeleted, "true"),
+    locks: [Lifecycle],
+    effects: [LifecycleDeleted => "true"],
+    steps: [
+        action(deregister_from_rms),
+        action(cleanup_database_records),
+        action(emit_deletion_event),
+    ],
+    priority: 110,
+});
+```
+
+### 3.12 What Disappears
+
+The following FSM concepts have no operation equivalent in the convergence model:
+
+| FSM Concept | Why It Disappears |
+|-------------|-------------------|
+| `DPUInit` | Decomposed into `configure_dpu_interfaces` (→ `DpuInterfaceIp`), `set_dpu_mode` (→ `DpuMode`), `wait_for_dpu_agent` (→ `DpuAgentVersion`) — three real observables with physical-constraint guards. |
+| `HostInit` | The "init phase" bundled BIOS, network, scout, and reachability. These are now independent operations with real observables: `configure_bios` (→ `BiosSettingsHash`), `configure_network` (→ `NetworkConfigVersion`), `install_scout` (→ `ScoutVersion`). Reachability is observed continuously (`ScoutHeartbeat`). |
+| `WaitingForCleanup` | Decomposed into `erase_drives` (→ `DriveEraseStatus`) and `remove_scout` (→ `ScoutVersion = ""`). Power-off is already its own operation. |
+| `HostReprovision` | Not an operation — it's a desired-state change. When an operator requests reprovisioning, `S_d` is updated (new firmware version, new BIOS hash, new scout version). The engine detects the deltas and converges. |
+| `DPUReprovision` | Same: update `S_d` with the new DPU firmware version, the engine runs `update_dpu_firmware`. |
+| `Ready` | Not a state — it's the absence of a delta. When `Δ = ∅`, the machine is "ready." |
+| `Assigned` | Instance assignment is an observed property (`InstanceAssigned`), not a lifecycle phase. Operations that should not run while assigned guard on `eq(InstanceAssigned, "false")`. |
+| `Failed` | Failure is observable state drift. If firmware flashing fails, `FirmwareBmcVersion` still differs from desired. The engine retries on the next tick. Persistent failures surface as "idle with non-empty delta." |
+| Boolean flags | Keys like `RmsRegistered`, `DpuDiscovered`, `ScoutInstalled`, `ValidationPassed` are replaced by real observables (`RmsInventoryId`, `DpuCount`, `ScoutVersion`, `ValidationResult`). Presence of data implies the property is satisfied. |
+
+---
+
+## 4. Profiles
+
+The machine handler maps to multiple hardware profiles, organized in an inheritance hierarchy:
+
+```
+common
+├── power_on, power_off, configure_bios, enable_lockdown
+├── register_with_rms, configure_network, install_scout, remove_scout
+├── validate_machine, validate_bom, run_attestation
+├── erase_drives, delete_machine
+│
+├── generic_x86
+│   └── update_bmc_firmware (generic Redfish firmware update)
+│
+├── nvidia_gbx00_base (abstract)
+│   └── update_bmc_firmware (NVIDIA-specific Redfish + reset sequence)
+│
+│   ├── nvidia_gb300
+│   │   ├── inherits: [nvidia_gbx00_base, nvidia_bf3_dpu]
+│   │   └── power_off (GPU-specific graceful shutdown)
+│   │
+│   └── nvidia_h100
+│       ├── inherits: [nvidia_gbx00_base]
+│       └── (uses inherited operations)
+│
+└── nvidia_bf3_dpu (abstract)
+    ├── update_dpu_firmware
+    ├── configure_dpu_network
+    ├── configure_dpu_interfaces
+    ├── set_dpu_mode
+    └── wait_for_dpu_agent
+```
+
+**Profile selection** is determined by the `HwSku` field in observed state:
+
+| Profile | Match Rule |
+|---------|-----------|
+| `nvidia_gb300` | `contains(HwSku, "GB300")` |
+| `nvidia_h100` | `contains(HwSku, "H100")` |
+| `generic_x86` | `true` (fallback) |
+
+---
+
+## 5. Example Convergence Trace
+
+**Scenario:** A new GB300 machine is ingested. The desired state contains only real goals from real sources (firmware manifests, config templates, deployment manifests, security policies). There are no boolean "done" flags — every desired key holds concrete data.
+
+**Initial observed state** (from Redfish/agent observation):
+```
+PowerState         = "off"
+RmsInventoryId     = ""
+DpuCount           = "0"
+DpuInterfaceIp     = ""
+DpuMode            = ""
+DpuAgentVersion    = ""
+FirmwareBmcVersion = "2.12.0"
+BiosSettingsHash   = "d4e1f0"
+NetworkConfigVersion = "v10"
+ScoutVersion       = ""
+ScoutHeartbeat     = "stale"
+ValidationResult   = "not_run"
+BomValidationResult = "not_run"
+AttestationStatus  = "not_started"
+LockdownEnabled    = "false"
+HwSku              = "NVIDIA-GB300-XYZ"
+```
+
+**Desired state** (from config sources):
+```
+PowerState         = "on"                  ← operator intent
+FirmwareBmcVersion = "2.14.0"              ← firmware manifest
+FirmwareBiosVersion = "1.8.3"              ← firmware manifest
+DpuFirmwareVersion = "24.04.1"             ← firmware manifest
+BiosSettingsHash   = "a3f8c2"              ← BIOS config template
+NetworkConfigVersion = "v12"               ← network config template
+DpuNetworkConfigVersion = "v5"             ← network config template
+DpuMode            = "dpu"                 ← hardware config
+ScoutVersion       = "3.2.1"              ← deployment manifest
+LockdownEnabled    = "true"                ← security policy
+AttestationStatus  = "passed"              ← security policy
+```
+
+Note: keys like `RmsInventoryId`, `DpuCount`, `DpuAgentVersion`, `ScoutHeartbeat`, `ValidationResult`, and `BomValidationResult` are **not in desired state**. They are observed-only — their values appear as prerequisites in operation guards.
+
+**Tick 1:**
+- Delta: 10 keys differ (only keys present in `S_d`).
+- `power_on` is ready (guard: `PowerState = "off"`). Scheduled.
+- `register_with_rms` is ready (guard: `RmsInventoryId = ""`). Scheduled.
+- Everything else blocked — most require `PowerState = "on"`.
+- **Actions:** `power_on`, `register_with_rms` (parallel).
+
+**Tick 2:**
+- `PowerState = "on"`, `RmsInventoryId = "rms-12345"`. Observation refreshes: `DpuCount = "2"` (Redfish discovered DPUs as part of standard observation).
+- `update_bmc_firmware` is ready (power on, version differs). Scheduled. Locks: `[Firmware, Power]`.
+- `configure_bios` is ready (power on, hash differs: `d4e1f0 ≠ a3f8c2`). Scheduled. Locks: `[Bios]`.
+- `configure_network` is ready (power on, version differs: `v10 ≠ v12`). Scheduled. Locks: `[Network]`.
+- `configure_dpu_interfaces` is ready (`DpuCount ≠ "0"`, `DpuInterfaceIp = ""`). Scheduled. Locks: `[Dpu]`.
+- No lock conflicts between these four operations.
+- **Actions:** `update_bmc_firmware`, `configure_bios`, `configure_network`, `configure_dpu_interfaces` (all parallel).
+
+**Tick 3:**
+- `FirmwareBmcVersion = "2.14.0"`, `BiosSettingsHash = "a3f8c2"`, `NetworkConfigVersion = "v12"`, `DpuInterfaceIp = "10.0.1.5"`.
+- `install_scout` is ready (power on, network matches desired, `ScoutVersion` differs). Scheduled.
+- `set_dpu_mode` is ready (`DpuInterfaceIp ≠ ""`, `DpuMode ≠ "dpu"`). Scheduled.
+- **Actions:** `install_scout`, `set_dpu_mode` (parallel).
+
+**Tick 4:**
+- `ScoutVersion = "3.2.1"`, `DpuMode = "dpu"`. Observation refreshes: `ScoutHeartbeat = "alive"` (heartbeat detected).
+- `wait_for_dpu_agent` is ready (`DpuMode` matches desired, `DpuAgentVersion = ""`). Scheduled.
+- `validate_machine` is ready (`ScoutHeartbeat = "alive"`, `BiosSettingsHash` matches, `NetworkConfigVersion` matches). Scheduled.
+- **Actions:** `wait_for_dpu_agent`, `validate_machine` (parallel).
+
+**Tick 5:**
+- `DpuAgentVersion = "1.4.0"`, `ValidationResult = "passed"`.
+- `validate_bom` is ready (`ValidationResult = "passed"`). Scheduled.
+- `configure_dpu_network` is ready (`DpuAgentVersion ≠ ""`, `DpuNetworkConfigVersion` differs). Scheduled.
+- **Actions:** `validate_bom`, `configure_dpu_network` (parallel).
+
+**Tick 6:**
+- `BomValidationResult = "passed"`, `DpuNetworkConfigVersion = "v5"`.
+- `run_attestation` is ready (`BomValidationResult = "passed"`, power on). Scheduled.
+- `enable_lockdown` is ready (power on, `LockdownEnabled = "false"`). Scheduled.
+- **Actions:** `run_attestation`, `enable_lockdown` (parallel).
+
+**Tick 7:**
+- `AttestationStatus = "passed"`, `LockdownEnabled = "true"`.
+- Delta is empty — all desired keys match observed.
+- **Result:** CONVERGED.
+
+**Comparison with boolean-flag version.** The real-observable model converges in 7 ticks vs. 8 with boolean flags. The key difference: `DpuCount` is observed data, not an operation output, so "DPU discovery" is eliminated as a step. Tick 2 runs four operations in parallel because there are no artificial phase boundaries.
+
+**Self-healing example.** Suppose after convergence, BIOS settings drift (a user resets BIOS defaults via the BMC console). On the next observation tick, `BiosSettingsHash` changes from `"a3f8c2"` to `"b7c3d1"`. The engine detects the delta against desired `"a3f8c2"` and schedules `configure_bios`. No "re-init" phase, no reprovisioning request — just delta detection and convergence. With boolean flags, `BiosSettingsApplied = "true"` would have remained true despite the actual drift, masking the problem.
+
+**DPU agent crash example.** If the DPU agent crashes, the next observation sees `DpuAgentVersion = ""`. The engine schedules `wait_for_dpu_agent`. Downstream operations that guard on `neq(DpuAgentVersion, "")` (like `configure_dpu_network`) are automatically blocked until the agent recovers. No manual intervention needed.

--- a/book/src/design/convergence-engine/machine.md
+++ b/book/src/design/convergence-engine/machine.md
@@ -53,7 +53,7 @@ Each match arm either handles the transition inline or delegates to sub-handlers
 
 The observed state `S_o` for a machine is built from the `Machine` struct, BMC queries (Redfish/IPMI), and agent reports.
 
-Every key holds **real observable data**, not boolean step-completion flags. If data is present, the thing exists (see [§3.11](README.md#311-design-principle-properties-not-phases)).
+Every key holds **real observable data**, not boolean step-completion flags. If data is present, the thing exists (see [§7.4](README.md#74-design-principle-properties-not-phases)).
 
 | Source Field | State Key | Type | Example Values |
 |-------------|-----------|------|----------------|
@@ -90,7 +90,7 @@ Every key holds **real observable data**, not boolean step-completion flags. If 
 
 ## 3. Operations
 
-Operations are organized by **setting domain** — each manages a single, independently configurable property. There are no "init" or "reprovision" phases. See [§3.11](README.md#311-design-principle-properties-not-phases) for the design rationale.
+Operations are organized by **setting domain** — each manages a single, independently configurable property. There are no "init" or "reprovision" phases. See [§7.4](README.md#74-design-principle-properties-not-phases) for the design rationale.
 
 ### 3.1 Power
 

--- a/book/src/design/convergence-engine/machine.md
+++ b/book/src/design/convergence-engine/machine.md
@@ -123,13 +123,16 @@ op!(power_off {
 ```
 
 ```rust
-op!(power_cycle {
-    provides: [PowerCycleCompleted],
-    guard: eq(PowerState, "on"),
+op!(reboot_host {
+    provides: [BootGeneration],
+    guard: and(
+        eq(PowerState, "on"),
+        neq(BootGeneration, desired(BootGeneration)),
+    ),
     locks: [Power],
-    effects: [PowerCycleCompleted => "true"],
+    effects: [BootGeneration => desired(BootGeneration)],
     steps: [
-        action(redfish_power_cycle, reset_type = "ForceRestart"),
+        action(redfish_power_cycle),
         action(wait_for_power_state, target = "on", timeout_seconds = 180),
     ],
     priority: 95,
@@ -325,7 +328,7 @@ op!(configure_dpu_network {
 Previously buried inside the monolithic `initialize_host` FSM phase. As independent properties, each can be tested, retried, and monitored individually. Note how guards reference real data — `ScoutVersion` guards on `neq(ScoutVersion, "")`, not on a boolean flag.
 
 ```rust
-op!(install_scout {
+op!(load_scout {
     provides: [ScoutVersion],
     guard: and(
         eq(PowerState, "on"),
@@ -335,7 +338,7 @@ op!(install_scout {
     locks: [Scout],
     effects: [ScoutVersion => desired(ScoutVersion)],
     steps: [
-        action(deploy_scout_agent, version = desired(ScoutVersion)),
+        action(boot_scout_via_initrd, version = desired(ScoutVersion)),
         action(verify_scout_running),
     ],
     priority: 84,
@@ -436,7 +439,7 @@ op!(erase_drives {
 ```
 
 ```rust
-op!(remove_scout {
+op!(stop_scout {
     provides: [ScoutVersion],
     guard: and(
         eq(InstanceAssigned, "false"),
@@ -444,12 +447,12 @@ op!(remove_scout {
     ),
     locks: [Scout],
     effects: [ScoutVersion => ""],
-    steps: [action(remove_scout_agent)],
+    steps: [action(stop_scout_agent)],
     priority: 59,
 });
 ```
 
-Note: `remove_scout` and `install_scout` both provide `ScoutVersion`. The scheduler selects based on which direction the delta points — if desired `ScoutVersion` is non-empty and observed is empty, `install_scout` fires; if desired is empty and observed is non-empty, `remove_scout` fires.
+Note: `stop_scout` and `load_scout` both provide `ScoutVersion`. The scheduler selects based on which direction the delta points — if desired `ScoutVersion` is non-empty and observed is empty, `load_scout` fires; if desired is empty and observed is non-empty, `stop_scout` fires.
 
 ### 3.11 Lifecycle
 
@@ -475,8 +478,8 @@ The following FSM concepts have no operation equivalent in the convergence model
 | FSM Concept | Why It Disappears |
 |-------------|-------------------|
 | `DPUInit` | Decomposed into `configure_dpu_interfaces` (→ `DpuInterfaceIp`), `set_dpu_mode` (→ `DpuMode`), `wait_for_dpu_agent` (→ `DpuAgentVersion`) — three real observables with physical-constraint guards. |
-| `HostInit` | The "init phase" bundled BIOS, network, scout, and reachability. These are now independent operations with real observables: `configure_bios` (→ `BiosSettingsHash`), `configure_network` (→ `NetworkConfigVersion`), `install_scout` (→ `ScoutVersion`). Reachability is observed continuously (`ScoutHeartbeat`). |
-| `WaitingForCleanup` | Decomposed into `erase_drives` (→ `DriveEraseStatus`) and `remove_scout` (→ `ScoutVersion = ""`). Power-off is already its own operation. |
+| `HostInit` | The "init phase" bundled BIOS, network, scout, and reachability. These are now independent operations with real observables: `configure_bios` (→ `BiosSettingsHash`), `configure_network` (→ `NetworkConfigVersion`), `load_scout` (→ `ScoutVersion`). Reachability is observed continuously (`ScoutHeartbeat`). |
+| `WaitingForCleanup` | Decomposed into `erase_drives` (→ `DriveEraseStatus`) and `stop_scout` (→ `ScoutVersion = ""`). Power-off is already its own operation. |
 | `HostReprovision` | Not an operation — it's a desired-state change. When an operator requests reprovisioning, `S_d` is updated (new firmware version, new BIOS hash, new scout version). The engine detects the deltas and converges. |
 | `DPUReprovision` | Same: update `S_d` with the new DPU firmware version, the engine runs `update_dpu_firmware`. |
 | `Ready` | Not a state — it's the absence of a delta. When `Δ = ∅`, the machine is "ready." |
@@ -493,7 +496,7 @@ The machine handler maps to multiple hardware profiles, organized in an inherita
 ```
 common
 ├── power_on, power_off, configure_bios, enable_lockdown
-├── register_with_rms, configure_network, install_scout, remove_scout
+├── register_with_rms, configure_network, load_scout, stop_scout
 ├── validate_machine, validate_bom, run_attestation
 ├── erase_drives, delete_machine
 │
@@ -588,9 +591,9 @@ Note: keys like `RmsInventoryId`, `DpuCount`, `DpuAgentVersion`, `ScoutHeartbeat
 
 **Tick 3:**
 - `FirmwareBmcVersion = "2.14.0"`, `BiosSettingsHash = "a3f8c2"`, `NetworkConfigVersion = "v12"`, `DpuInterfaceIp = "10.0.1.5"`.
-- `install_scout` is ready (power on, network matches desired, `ScoutVersion` differs). Scheduled.
+- `load_scout` is ready (power on, network matches desired, `ScoutVersion` differs). Scheduled.
 - `set_dpu_mode` is ready (`DpuInterfaceIp ≠ ""`, `DpuMode ≠ "dpu"`). Scheduled.
-- **Actions:** `install_scout`, `set_dpu_mode` (parallel).
+- **Actions:** `load_scout`, `set_dpu_mode` (parallel).
 
 **Tick 4:**
 - `ScoutVersion = "3.2.1"`, `DpuMode = "dpu"`. Observation refreshes: `ScoutHeartbeat = "alive"` (heartbeat detected).

--- a/book/src/design/convergence-engine/network-segment.md
+++ b/book/src/design/convergence-engine/network-segment.md
@@ -1,0 +1,186 @@
+# Network Segment Handler — Convergence Engine Mapping
+
+## 1. Current State
+
+**Handler file:** `crates/api/src/state_controller/network_segment/handler.rs` (190 lines)  
+**State enum:** `NetworkSegmentControllerState` in `crates/api-model/src/network_segment/mod.rs`  
+**Controller I/O:** `NetworkSegmentStateControllerIO`
+
+The network segment handler manages VLAN/VNI network segment lifecycle: provisioning, readiness, and deletion with a graceful IP drain period. The handler is relatively simple with a linear state machine and a two-phase deletion process.
+
+### 1.1 NetworkSegmentControllerState Variants
+
+| # | Variant | Sub-state | Description |
+|---|---------|-----------|-------------|
+| 1 | `Provisioning` | — | Initial state; transitions immediately to `Ready`. |
+| 2 | `Ready` | — | Segment is active; instances can be created. Watches for deletion requests. |
+| 3 | `Deleting` | `NetworkSegmentDeletionState` | Segment is being deleted through a two-phase process. |
+
+### 1.2 NetworkSegmentDeletionState
+
+| Sub-state | Description |
+|-----------|-------------|
+| `DrainAllocatedIps { delete_at }` | Waiting for all IPs to be released. A `delete_at` timestamp is set; if IPs are still in use, the timestamp is pushed forward. Deletion proceeds only when IPs are drained AND `delete_at` is reached. |
+| `DBDelete` | Final deletion: release VNI/VLAN pool allocations and delete from database. |
+
+---
+
+## 2. State Keys
+
+Any key can appear in `S_o`, `S_d`, or both. Which keys appear in `S_d` is a runtime decision (see [§3.11](README.md#311-design-principle-properties-not-phases)).
+
+| Observation Source | State Key | Type | Example Values |
+|-------------------|-----------|------|----------------|
+| `name` | `SegmentName` | Str | `"gpu-network-1"` |
+| `segment_type` | `SegmentType` | Str | `"l2"`, `"l3"` |
+| `mtu` | `SegmentMtu` | Int | `"9000"` |
+| `vlan_id` | `SegmentVlanId` | Str | `"100"` or `""` (not allocated) |
+| `vni` | `SegmentVni` | Str | `"50001"` or `""` (not allocated) |
+| `prefixes` | `SegmentPrefixCount` | Int | `"4"` |
+| `can_stretch` | `SegmentCanStretch` | Bool | `"true"`, `"false"` |
+| IP allocation query | `SegmentAllocatedIpCount` | Int | `"3"` |
+| `deleted` | `LifecycleDeleted` | Bool | `"true"`, `"false"` |
+
+**Typical desired-state sources.** Operator intent (`LifecycleDeleted`). The desired-state composition layer may also set `SegmentVni` and `SegmentVlanId` to drive initial provisioning from pool allocation.
+
+---
+
+## 3. Operations
+
+Operations are organized by setting domain — each manages a single, independently configurable property. See [§3.11](README.md#311-design-principle-properties-not-phases) for the design rationale.
+
+### `provision_segment`
+
+**Replaces:** `NetworkSegmentControllerState::Provisioning` match arm
+
+```rust
+op!(provision_segment {
+    provides: [SegmentVni, SegmentVlanId],
+    guard: and(
+        eq(SegmentVni, ""),
+        eq(SegmentVlanId, ""),
+    ),
+    locks: [NetworkSegment],
+    effects: [
+        SegmentVni => "{allocated_vni}",
+        SegmentVlanId => "{allocated_vlan}",
+    ],
+    steps: [
+        action(allocate_vni_from_pool),
+        action(allocate_vlan_from_pool),
+        action(configure_segment),
+    ],
+    priority: 90,
+});
+```
+
+### `drain_segment_ips`
+
+**Replaces:** `NetworkSegmentDeletionState::DrainAllocatedIps` logic
+
+```rust
+op!(drain_segment_ips {
+    provides: [SegmentAllocatedIpCount],
+    guard: and(
+        eq(LifecycleDeleted, "true"),
+        neq(SegmentAllocatedIpCount, "0"),
+    ),
+    locks: [NetworkSegment],
+    effects: [SegmentAllocatedIpCount => "0"],
+    steps: [
+        action(check_allocated_ip_count),
+        action(wait_for_drain_period, grace_period_seconds = 300),
+    ],
+    priority: 80,
+});
+```
+
+### `delete_segment`
+
+**Replaces:** `NetworkSegmentDeletionState::DBDelete` logic
+
+```rust
+op!(delete_segment {
+    provides: [LifecycleDeleted],
+    guard: and(
+        eq(LifecycleDeleted, "true"),
+        eq(SegmentAllocatedIpCount, "0"),
+    ),
+    locks: [NetworkSegment, Lifecycle],
+    effects: [LifecycleDeleted => "true"],
+    steps: [
+        action(release_vni_allocation),
+        action(release_vlan_allocation),
+        action(final_delete),
+    ],
+    priority: 110,
+});
+```
+
+### What Disappears
+
+| Old | Property-oriented view |
+|-----|------------------------|
+| `NetworkSegmentControllerState::Provisioning` | Initial property only |
+| `Ready` | Δ = ∅ |
+
+---
+
+## 4. Profiles
+
+| Profile | Match Rule | Description |
+|---------|-----------|-------------|
+| `network_segment_default` | `true` | Single profile — segment management is type-agnostic |
+
+---
+
+## 6. Example Convergence Trace
+
+**Scenario:** A network segment is created, becomes ready, and later is deleted with IP draining.
+
+### Phase 1: Provisioning
+
+**Initial observed state:**
+```
+SegmentVni             = ""
+SegmentVlanId          = ""
+SegmentAllocatedIpCount = "0"
+```
+
+No explicit desired state for provisioning -- the operation fires when VNI and VLAN are empty.
+
+**Tick 1:**
+- `provision_segment` is ready (VNI and VLAN are empty). Scheduled.
+- **Actions:** `provision_segment`.
+
+**Tick 2:**
+- `SegmentVni = "50001"`, `SegmentVlanId = "100"`.
+- **Result:** CONVERGED.
+
+### Phase 2: Deletion (desired state changes)
+
+**Observed state:**
+```
+SegmentVni              = "50001"
+SegmentVlanId           = "100"
+SegmentAllocatedIpCount = "3"
+LifecycleDeleted        = "false"
+```
+
+**Desired state changes to:**
+```
+LifecycleDeleted = "true"
+```
+
+**Tick 1:**
+- `drain_segment_ips` is ready (deletion requested, IP count is non-zero). Scheduled.
+- **Actions:** `drain_segment_ips` (waits for IPs to drain and grace period).
+
+**Tick 2 (after drain completes):**
+- `SegmentAllocatedIpCount = "0"`.
+- `delete_segment` is now ready (deletion requested, IPs drained). Scheduled.
+- **Actions:** `delete_segment`.
+
+**Tick 3:**
+- Object deleted from database.
+- **Result:** CONVERGED (deleted).

--- a/book/src/design/convergence-engine/network-segment.md
+++ b/book/src/design/convergence-engine/network-segment.md
@@ -27,8 +27,6 @@ The network segment handler manages VLAN/VNI network segment lifecycle: provisio
 
 ## 2. State Keys
 
-Any key can appear in `S_o`, `S_d`, or both. Which keys appear in `S_d` is a runtime decision (see [§3.11](README.md#311-design-principle-properties-not-phases)).
-
 | Observation Source | State Key | Type | Example Values |
 |-------------------|-----------|------|----------------|
 | `name` | `SegmentName` | Str | `"gpu-network-1"` |
@@ -47,7 +45,7 @@ Any key can appear in `S_o`, `S_d`, or both. Which keys appear in `S_d` is a run
 
 ## 3. Operations
 
-Operations are organized by setting domain — each manages a single, independently configurable property. See [§3.11](README.md#311-design-principle-properties-not-phases) for the design rationale.
+Operations are organized by setting domain — each manages a single, independently configurable property. See [§7.4](README.md#74-design-principle-properties-not-phases) for the design rationale.
 
 ### `provision_segment`
 

--- a/book/src/design/convergence-engine/power-shelf.md
+++ b/book/src/design/convergence-engine/power-shelf.md
@@ -36,8 +36,6 @@ Each transition is immediate — no real I/O or configuration is performed. This
 
 ## 2. State Keys
 
-Any key can appear in `S_o`, `S_d`, or both. Which keys appear in `S_d` is a runtime decision (see [§3.11](README.md#311-design-principle-properties-not-phases)).
-
 | Observation Source | State Key | Type | Example Values |
 |-------------------|-----------|------|----------------|
 | `config.name` | `ShelfName` | Str | `"power-shelf-01"` |
@@ -56,7 +54,7 @@ Any key can appear in `S_o`, `S_d`, or both. Which keys appear in `S_d` is a run
 
 ## 3. Operations
 
-Operations are organized by setting domain — each manages a single, independently configurable property. See [§3.11](README.md#311-design-principle-properties-not-phases) for the design rationale.
+Operations are organized by setting domain — each manages a single, independently configurable property. See [§7.4](README.md#74-design-principle-properties-not-phases) for the design rationale.
 
 ### `fetch_shelf_data`
 

--- a/book/src/design/convergence-engine/power-shelf.md
+++ b/book/src/design/convergence-engine/power-shelf.md
@@ -1,0 +1,172 @@
+# Power Shelf Handler — Convergence Engine Mapping
+
+## 1. Current State
+
+**Handler file:** `crates/api/src/state_controller/power_shelf/handler.rs` (121 lines)  
+**State enum:** `PowerShelfControllerState` in `crates/api-model/src/power_shelf/mod.rs`  
+**Controller I/O:** `PowerShelfStateControllerIO`
+
+The power shelf handler manages power shelf lifecycle. The current implementation is largely a placeholder with linear state transitions and minimal business logic — most states transition immediately to the next without performing real work (marked as `TODO`).
+
+### 1.1 PowerShelfControllerState Variants
+
+| # | Variant | Description |
+|---|---------|-------------|
+| 1 | `Initializing` | Initial state; transitions to `FetchingData`. |
+| 2 | `FetchingData` | Fetching power shelf data; transitions to `Configuring`. |
+| 3 | `Configuring` | Configuring power shelf; transitions to `Ready`. |
+| 4 | `Ready` | Power shelf is operational. Watches for deletion requests. |
+| 5 | `Error` | Power shelf in error. If deleted, transitions to `Deleting`; otherwise requires manual recovery. |
+| 6 | `Deleting` | Power shelf is being deleted; performs `final_delete`. |
+
+### 1.2 Handler Logic
+
+The current handler is a simple linear pipeline:
+
+```
+Initializing → FetchingData → Configuring → Ready
+                                               ↓ (if deleted)
+                                           Deleting → deleted
+Error → Deleting (if deleted) | do_nothing
+```
+
+Each transition is immediate — no real I/O or configuration is performed. This makes it an ideal candidate for early convergence engine migration.
+
+---
+
+## 2. State Keys
+
+Any key can appear in `S_o`, `S_d`, or both. Which keys appear in `S_d` is a runtime decision (see [§3.11](README.md#311-design-principle-properties-not-phases)).
+
+| Observation Source | State Key | Type | Example Values |
+|-------------------|-----------|------|----------------|
+| `config.name` | `ShelfName` | Str | `"power-shelf-01"` |
+| `config.capacity` | `ShelfCapacity` | Str | `"20kW"` |
+| `config.voltage` | `ShelfVoltage` | Str | `"48V"` |
+| `config.location` | `ShelfLocation` | Str | `"rack-1-shelf-3"` |
+| `status.shelf_name` | `ShelfReportedName` | Str | `"power-shelf-01"` or `""` |
+| `status.power` | `ShelfPowerStatus` | Str | `"on"`, `"off"`, `"unknown"` |
+| `status.health` | `ShelfHealth` | Str | `"ok"`, `"warning"`, `"critical"` |
+| `rack_id` | `ShelfRackId` | Str | `"rack-001"` |
+| `deleted` | `LifecycleDeleted` | Bool | `"true"`, `"false"` |
+
+**Typical desired-state sources.** Operator intent (`LifecycleDeleted`). The desired-state composition layer may also set `ShelfPowerStatus` or `ShelfHealth` to drive data fetching and configuration.
+
+---
+
+## 3. Operations
+
+Operations are organized by setting domain — each manages a single, independently configurable property. See [§3.11](README.md#311-design-principle-properties-not-phases) for the design rationale.
+
+### `fetch_shelf_data`
+
+**Replaces:** `PowerShelfControllerState::Initializing` → `FetchingData` transition
+
+```rust
+op!(fetch_shelf_data {
+    provides: [ShelfPowerStatus, ShelfHealth],
+    guard: and(
+        eq(ShelfPowerStatus, ""),
+        eq(ShelfHealth, ""),
+    ),
+    locks: [PowerShelf],
+    effects: [
+        ShelfPowerStatus => "{observed_power}",
+        ShelfHealth => "{observed_health}",
+    ],
+    steps: [
+        action(query_power_shelf_hardware),
+        action(store_power_shelf_status),
+    ],
+    priority: 90,
+});
+```
+
+### `configure_shelf`
+
+**Replaces:** `PowerShelfControllerState::FetchingData` → `Configuring` → `Ready` transitions
+
+```rust
+op!(configure_shelf {
+    provides: [ShelfReportedName],
+    guard: and(
+        neq(ShelfPowerStatus, ""),
+        eq(ShelfReportedName, ""),
+    ),
+    locks: [PowerShelf],
+    effects: [ShelfReportedName => "{configured_name}"],
+    steps: [
+        action(apply_power_shelf_config),
+        action(verify_power_shelf_health),
+    ],
+    priority: 80,
+});
+```
+
+### `delete_shelf`
+
+**Replaces:** `PowerShelfControllerState::Deleting` match arm
+
+```rust
+op!(delete_shelf {
+    provides: [LifecycleDeleted],
+    guard: eq(LifecycleDeleted, "true"),
+    locks: [PowerShelf, Lifecycle],
+    effects: [LifecycleDeleted => "true"],
+    steps: [
+        action(cleanup_power_shelf),
+        action(final_delete),
+    ],
+    priority: 110,
+});
+```
+
+### What Disappears
+
+| Old | Property-oriented view |
+|-----|------------------------|
+| Linear Initializing → FetchingData → Configuring → Ready | Each step is an independent property |
+| `Ready` | Δ = ∅ |
+| `Error` | Observable drift |
+
+---
+
+## 4. Profiles
+
+| Profile | Match Rule | Description |
+|---------|-----------|-------------|
+| `power_shelf_default` | `true` | Single profile — power shelf management is hardware-agnostic |
+
+---
+
+## 5. Example Convergence Trace
+
+**Scenario:** A new power shelf is created and needs initialization.
+
+**Initial observed state:**
+```
+ShelfPowerStatus  = ""
+ShelfHealth       = ""
+ShelfReportedName = ""
+```
+
+No explicit desired state for data fetching or configuration -- operations fire when observed data is empty.
+
+**Tick 1:**
+- `fetch_shelf_data` is ready (power status and health are empty). Scheduled.
+- `configure_shelf` is blocked (power status is empty).
+- **Actions:** `fetch_shelf_data`.
+
+**Tick 2:**
+- `ShelfPowerStatus = "on"`, `ShelfHealth = "ok"`.
+- `configure_shelf` is now ready (power status is non-empty, reported name is empty). Scheduled.
+- **Actions:** `configure_shelf`.
+
+**Tick 3:**
+- `ShelfReportedName = "power-shelf-01"`.
+- No further deltas.
+- **Result:** CONVERGED.
+
+### Migration Priority
+
+Due to the handler's simplicity (linear transitions, no real I/O, placeholder logic), the power shelf handler is an ideal **first candidate** for convergence engine migration. It can serve as a proof-of-concept for the migration strategy outlined in the [main specification](README.md#7-migration-strategy).

--- a/book/src/design/convergence-engine/rack.md
+++ b/book/src/design/convergence-engine/rack.md
@@ -35,8 +35,6 @@ The rack handler manages rack lifecycle: creation, switch/host discovery, valida
 
 ## 2. State Keys
 
-Any key can appear in `S_o`, `S_d`, or both. Which keys appear in `S_d` is a runtime decision (see [§3.11](README.md#311-design-principle-properties-not-phases)).
-
 | Observation Source | State Key | Type | Example Values |
 |-------------------|-----------|------|----------------|
 | `config.rack_type` | `RackType` | Str | `"standard"`, `"high-density"` |
@@ -55,7 +53,7 @@ Any key can appear in `S_o`, `S_d`, or both. Which keys appear in `S_d` is a run
 
 ## 3. Operations
 
-Operations are organized by setting domain. See §3.11 of the main specification for the design rationale.
+Operations are organized by setting domain. See §7.4 of the main specification for the design rationale.
 
 ### `discover_rack`
 

--- a/book/src/design/convergence-engine/rack.md
+++ b/book/src/design/convergence-engine/rack.md
@@ -1,0 +1,192 @@
+# Rack Handler — Convergence Engine Mapping
+
+## 1. Current State
+
+**Handler file:** `crates/api/src/state_controller/rack/handler.rs` (92 lines)  
+**State enum:** `RackState` in `crates/api-model/src/rack.rs`  
+**Controller I/O:** `RackStateControllerIO`
+
+The rack handler manages rack lifecycle: creation, switch/host discovery, validation, maintenance operations (firmware upgrades, NMX cluster configuration, power sequencing), and deletion.
+
+### 1.1 RackState Variants
+
+| # | Variant | Sub-state | Description |
+|---|---------|-----------|-------------|
+| 1 | `Created` | — | Initial state after rack is created in the database. |
+| 2 | `Discovering` | — | Discovering switches and hosts in the rack. |
+| 3 | `Validating` | `RackValidationState` | Running rack-level validation checks. |
+| 4 | `Ready` | — | Rack is operational and ready for use. |
+| 5 | `Maintenance` | `RackMaintenanceState` | Rack is undergoing maintenance (firmware upgrade, NMX config, power sequence). |
+| 6 | `Error` | `cause: String` | Rack is in an error state. |
+| 7 | `Deleting` | — | Rack is being deleted. |
+
+### 1.2 Sub-state Enums
+
+**`RackMaintenanceState`:**
+- `FirmwareUpgrade` — Coordinated firmware upgrade across rack switches/hosts.
+- `ConfigureNmxCluster` — NMX cluster configuration.
+- `PowerSequence` — Rack-level power sequencing.
+- `Completed` — Maintenance completed, returning to `Ready`.
+
+**`RackValidationState`:**
+- Validates rack topology, switch connectivity, and host reachability.
+
+---
+
+## 2. State Keys
+
+Any key can appear in `S_o`, `S_d`, or both. Which keys appear in `S_d` is a runtime decision (see [§3.11](README.md#311-design-principle-properties-not-phases)).
+
+| Observation Source | State Key | Type | Example Values |
+|-------------------|-----------|------|----------------|
+| `config.rack_type` | `RackType` | Str | `"standard"`, `"high-density"` |
+| `config.topology_changed` | `RackTopologyChanged` | Bool | `"true"`, `"false"` |
+| `config.validation_run_id` | `RackValidationRunId` | Str | `"run-2024-001"` |
+| `firmware_upgrade_job` | `RackFirmwareUpgradeStatus` | Str | `"none"`, `"in_progress"`, `"completed"` |
+| Switch discovery count | `RackSwitchCount` | Int | `"8"` (0 = not yet discovered) |
+| Host discovery count | `RackHostCount` | Int | `"32"` (0 = not yet discovered) |
+| Validation runner | `RackValidationResult` | Str | `"passed"`, `"failed"`, `"not_run"` |
+| `health_report_overrides` | `RackHealthOverride` | Str | Health override status |
+| `deleted` | `LifecycleDeleted` | Bool | `"true"`, `"false"` |
+
+**Typical desired-state sources.** Firmware manifests (`RackFirmwareUpgradeStatus`), operator intent (`LifecycleDeleted`). A fleet policy might also set `RackValidationResult = "passed"` or `RackSwitchCount` to assert rack composition.
+
+---
+
+## 3. Operations
+
+Operations are organized by setting domain. See §3.11 of the main specification for the design rationale.
+
+### `discover_rack`
+
+**Replaces:** `RackState::Created` → `Discovering` transition and `handle_discovering`
+
+`RackSwitchCount` and `RackHostCount` are **observed-only** — they come from the discovery scan. No operation explicitly "provides" them in desired state. The discovery operation runs when counts are zero and populates them with real data.
+
+```rust
+op!(discover_rack {
+    provides: [RackSwitchCount, RackHostCount],
+    guard: or(
+        eq(RackSwitchCount, "0"),
+        eq(RackHostCount, "0"),
+    ),
+    locks: [RackDiscovery],
+    effects: [
+        RackSwitchCount => "{discovered_switch_count}",
+        RackHostCount => "{discovered_host_count}",
+    ],
+    steps: [
+        action(discover_rack_switches),
+        action(discover_rack_hosts),
+        action(build_rack_topology),
+    ],
+    priority: 90,
+});
+```
+
+### `validate_rack`
+
+**Replaces:** `RackState::Validating` match arm and `handle_validating`
+
+```rust
+op!(validate_rack {
+    provides: [RackValidationResult],
+    guard: and(
+        neq(RackSwitchCount, "0"),
+        neq(RackHostCount, "0"),
+        neq(RackValidationResult, "passed"),
+    ),
+    locks: [RackValidation],
+    effects: [RackValidationResult => "passed"],
+    steps: [
+        action(validate_rack_topology),
+        action(validate_switch_connectivity),
+        action(validate_host_reachability),
+    ],
+    priority: 80,
+});
+```
+
+### `upgrade_rack_firmware`
+
+**Replaces:** `RackState::Maintenance { FirmwareUpgrade }` match arm
+
+```rust
+op!(upgrade_rack_firmware {
+    provides: [RackFirmwareUpgradeStatus],
+    guard: and(
+        eq(RackValidationResult, "passed"),
+        neq(RackFirmwareUpgradeStatus, desired(RackFirmwareUpgradeStatus)),
+    ),
+    locks: [RackMaintenance],
+    effects: [RackFirmwareUpgradeStatus => desired(RackFirmwareUpgradeStatus)],
+    steps: [
+        action(coordinate_switch_firmware_upgrade),
+        action(wait_for_all_switches_updated),
+        action(verify_rack_health),
+    ],
+    priority: 60,
+});
+```
+
+### `delete_rack`
+
+**Replaces:** `RackState::Deleting` match arm
+
+```rust
+op!(delete_rack {
+    provides: [LifecycleDeleted],
+    guard: eq(LifecycleDeleted, "true"),
+    locks: [Lifecycle],
+    effects: [LifecycleDeleted => "true"],
+    steps: [action(cleanup_rack_resources), action(final_delete)],
+    priority: 110,
+});
+```
+
+### What Disappears
+
+- **`RackState::Maintenance` phases** — Each maintenance type is an independent operation.
+- **`RackState::Error`** — Failure is observable state drift; the engine retries.
+- **`RackState::Ready`** — Not a state; just **Δ = ∅**.
+
+---
+
+## 4. Profiles
+
+Racks have a single profile since rack management is hardware-agnostic:
+
+| Profile | Match Rule | Operations |
+|---------|-----------|------------|
+| `rack_default` | `true` | All rack operations |
+
+---
+
+## 6. Example Convergence Trace
+
+**Scenario:** A new rack is created and needs discovery and validation.
+
+**Initial observed state:**
+```
+RackSwitchCount       = "0"
+RackHostCount         = "0"
+RackValidationResult  = "not_run"
+```
+
+No explicit desired state for discovery or validation — these are observed-only prerequisites. The rack converges when its firmware status (if applicable) and lifecycle keys match desired state.
+
+**Tick 1:**
+- `discover_rack` is ready (counts are `"0"`). Scheduled.
+- **Actions:** `discover_rack`.
+
+**Tick 2:**
+- `RackSwitchCount = "8"`, `RackHostCount = "32"`.
+- `validate_rack` is now ready (counts are non-zero, result is `"not_run"`). Scheduled.
+- **Actions:** `validate_rack`.
+
+**Tick 3:**
+- `RackValidationResult = "passed"`.
+- No further deltas.
+- **Result:** CONVERGED.
+
+**Self-healing:** If a switch is removed from the rack, `RackSwitchCount` changes on the next observation. `validate_rack` detects `RackValidationResult` is stale and re-runs validation.

--- a/book/src/design/convergence-engine/rego-opa.md
+++ b/book/src/design/convergence-engine/rego-opa.md
@@ -1,0 +1,532 @@
+# External Policy — OPA / Rego
+
+## 1. Motivation
+
+The convergence engine (see [main specification](README.md)) operates at the level of a single object — one machine, one switch, one rack. Its scheduler selects operations based on the delta between observed and desired state, using guards, resource locks, and priority to make safe decisions.
+
+However, many real-world constraints are **cross-object**:
+
+- **Location-scoped firmware gating.** At most N machines per location (building, row, rack) may be updating firmware simultaneously, to preserve compute capacity.
+- **Rack-level maintenance windows.** Firmware updates are only permitted during scheduled maintenance windows for a given rack.
+- **Compliance enforcement.** A machine must not receive workloads unless its attestation status is `passed`.
+- **Capacity preservation.** At least M healthy machines must remain in a rack during rolling updates.
+- **Cross-object sequencing.** All DPUs in a rack must reach firmware version X before any host proceeds to the next phase.
+
+These constraints cannot be expressed as guards within a single object's operations — they require visibility into the state of *other* objects. Rather than building a bespoke cross-object constraint system into the engine, we delegate external policy decisions to **Open Policy Agent (OPA)** using the **Rego** policy language.
+
+### Why External Policy?
+
+| Concern | Engine (internal) | Policy (external) |
+|---------|-------------------|-------------------|
+| **What** | How to converge a single object toward desired state | Whether/when an object is allowed to perform certain actions |
+| **Scope** | Single object | Fleet-wide, location-wide, rack-wide |
+| **Changed by** | Engineering (Rust code, profile modules) | Operations / SRE (Rego rules, config updates) |
+| **Testing** | Unit tests against operation definitions | Rego unit tests against policy bundles |
+
+Separating "how" (engine) from "when/whether" (policy) allows operators to modify fleet-wide constraints without redeploying the engine or changing profile modules.
+
+---
+
+## 2. Architecture
+
+### 2.1 Integration Points
+
+OPA integrates with the convergence engine at two points:
+
+```mermaid
+flowchart TD
+    subgraph perObject [Per-Object Convergence]
+        OBS["observe()"] --> INJ["Inject policy.* keys"]
+        INJ --> ENG[ConvergenceEngine]
+        ENG -->|tick| SCH[Scheduler]
+        SCH -->|guards check policy.*| OPS[Operations]
+    end
+
+    subgraph fleet [Fleet Controller]
+        FC[Fleet Controller] -->|"query: can location X proceed?"| OPA
+        OPA -->|"allow: true/false"| FC
+        FC -->|"set S_d per object"| perObject
+    end
+
+    subgraph policy [Policy Layer]
+        OPA["OPA Server"]
+        DB[(Fleet State DB)] -->|input| OPA
+        BUNDLES[Policy Bundles] -->|rules| OPA
+    end
+
+    OPA -->|"policy.* decisions"| INJ
+```
+
+**Integration Point 1 — Pre-tick policy injection.** Before each convergence tick, a policy sidecar (or the `ConvergenceHandler` itself) queries OPA with the current fleet context. OPA evaluates its Rego rules and returns a set of **policy decisions** as key-value pairs. These are mapped to `StateKey` enum variants and set in the observed state:
+
+```rust
+PolicyFirmwareUpdateAllowed  = "true"
+PolicyLocationLock           = "none"
+PolicyMaintenanceWindowActive = "false"
+PolicyCapacityHeadroom       = "3"
+```
+
+Guards in operation definitions reference these keys like any other `StateKey` variant:
+
+```rust
+and(eq(PowerState, "on"), eq(PolicyFirmwareUpdateAllowed, "true"))
+```
+
+**Integration Point 2 — Fleet controller gating.** The fleet controller (§6 of [main specification](README.md)) queries OPA before advancing rollout phases. For example:
+
+```
+Input:  { "location": "building-A", "phase": 1, "completed_count": 10, "total_count": 100 }
+Output: { "allow_next_phase": true, "batch_size": 20 }
+```
+
+### 2.2 Data Flow
+
+The full round-trip for a single convergence tick with policy:
+
+```mermaid
+sequenceDiagram
+    participant CH as ConvergenceHandler
+    participant DB as Fleet State DB
+    participant OPA as OPA Server
+    participant ENG as ConvergenceEngine
+
+    CH->>DB: Load object state + fleet context
+    CH->>OPA: POST /v1/data/carbide/policy
+    Note over OPA: Evaluate Rego rules<br/>against fleet state
+    OPA-->>CH: { firmware_update_allowed: true, ... }
+    CH->>CH: Build S_o, map OPA results to Policy* keys
+    CH->>CH: Build S_d from config + manifest
+    CH->>ENG: tick(S_o, S_d)
+    ENG-->>CH: TickResult { actions, ... }
+    CH->>DB: Persist outcome
+```
+
+---
+
+## 3. Guard Integration
+
+### 3.1 No Engine Changes Required
+
+The key insight is that policy keys are just `StateKey` enum variants. The engine does not need to know that they come from OPA rather than hardware. The guard algebra evaluates `eq(PolicyFirmwareUpdateAllowed, "true")` exactly the same way it evaluates `eq(PowerState, "on")`.
+
+This means:
+- No new guard variants are needed.
+- No engine code changes are needed.
+- Policy keys participate in delta computation, dependency resolution, and anti-oscillation just like any other key.
+
+### 3.2 Concrete Examples
+
+**Firmware update gated by policy:**
+
+```rust
+op!(update_bmc_firmware {
+    provides: [FirmwareBmcVersion],
+    guard: and(
+        eq(PowerState, "on"),
+        neq(FirmwareBmcVersion, desired(FirmwareBmcVersion)),
+        eq(PolicyFirmwareUpdateAllowed, "true"),
+        eq(PolicyMaintenanceWindowActive, "true"),
+    ),
+    locks: [Firmware, Power],
+    effects: [FirmwareBmcVersion => desired(FirmwareBmcVersion)],
+    steps: [action(redfish_firmware_update, target = "bmc")],
+    priority: 80,
+});
+```
+
+**Attestation-gated workload assignment:**
+
+```rust
+op!(assign_instance {
+    provides: [InstanceAssigned],
+    guard: and(
+        eq(AttestationStatus, "passed"),
+        eq(PolicyWorkloadAssignmentAllowed, "true"),
+    ),
+    locks: [Instance],
+    effects: [InstanceAssigned => "true"],
+    steps: [action(create_instance)],
+    priority: 50,
+});
+```
+
+**Location-scoped power operation:**
+
+```rust
+op!(power_off_for_maintenance {
+    provides: [PowerState],
+    guard: and(
+        eq(PowerState, "on"),
+        eq(PolicyLocationPowerOffAllowed, "true"),
+    ),
+    locks: [Power],
+    effects: [PowerState => "off"],
+    steps: [action(redfish_power_off)],
+    priority: 100,
+});
+```
+
+### 3.3 Policy Key Conventions
+
+| StateKey Variant | Description | Example Values |
+|-----------------|-------------|----------------|
+| `PolicyFirmwareUpdateAllowed` | Whether this object may perform firmware updates | `"true"`, `"false"` |
+| `PolicyMaintenanceWindowActive` | Whether a maintenance window is currently active | `"true"`, `"false"` |
+| `PolicyLocationLock` | Location-level lock status | `"none"`, `"firmware"`, `"power"` |
+| `PolicyCapacityHeadroom` | Number of spare healthy machines in the rack | `"0"`, `"3"`, `"10"` |
+| `PolicyWorkloadAssignmentAllowed` | Whether workload assignment is permitted | `"true"`, `"false"` |
+| `PolicyRolloutPhase` | Current rollout phase for this object | `"0"`, `"1"`, `"2"` |
+| `PolicyMaxConcurrentUpdates` | Max concurrent firmware updates at this location | `"5"`, `"10"` |
+
+---
+
+## 4. Rego Policy Examples
+
+### 4.1 Location-Scoped Firmware Gating
+
+At most 5 machines per location may be updating firmware simultaneously:
+
+```rego
+package carbide.policy
+
+import future.keywords.if
+import future.keywords.in
+
+default firmware_update_allowed := false
+
+firmware_update_allowed if {
+    # Count machines currently updating firmware in this location
+    location := input.machine.location
+    updating := [m |
+        some m in input.fleet.machines
+        m.location == location
+        m.state == "updating_firmware"
+        m.id != input.machine.id
+    ]
+    count(updating) < input.policy.max_concurrent_firmware_updates
+}
+```
+
+### 4.2 Maintenance Window Enforcement
+
+Firmware updates are only permitted during scheduled maintenance windows:
+
+```rego
+package carbide.policy
+
+import future.keywords.if
+import future.keywords.in
+
+default maintenance_window_active := false
+
+maintenance_window_active if {
+    some window in input.maintenance_windows
+    window.location == input.machine.location
+    time.now_ns() >= time.parse_rfc3339_ns(window.start)
+    time.now_ns() <= time.parse_rfc3339_ns(window.end)
+}
+```
+
+### 4.3 Attestation Compliance
+
+Block workload assignment if attestation has not passed:
+
+```rego
+package carbide.policy
+
+import future.keywords.if
+
+default workload_assignment_allowed := false
+
+workload_assignment_allowed if {
+    input.machine.attestation_status == "passed"
+    not input.machine.attestation_expired
+}
+```
+
+### 4.4 Capacity Preservation
+
+Ensure at least 3 healthy machines remain in a rack during updates:
+
+```rego
+package carbide.policy
+
+import future.keywords.if
+import future.keywords.in
+
+default firmware_update_allowed := false
+
+firmware_update_allowed if {
+    rack_id := input.machine.rack_id
+
+    healthy := [m |
+        some m in input.fleet.machines
+        m.rack_id == rack_id
+        m.health == "healthy"
+        m.state != "updating_firmware"
+    ]
+
+    count(healthy) > input.policy.min_healthy_per_rack
+}
+```
+
+### 4.5 Cross-Object Sequencing
+
+All DPUs in a rack must reach firmware version X before hosts proceed:
+
+```rego
+package carbide.policy
+
+import future.keywords.if
+import future.keywords.in
+import future.keywords.every
+
+default host_firmware_update_allowed := false
+
+host_firmware_update_allowed if {
+    rack_id := input.machine.rack_id
+    target_version := input.policy.target_dpu_firmware_version
+
+    dpus := [d |
+        some d in input.fleet.dpus
+        d.rack_id == rack_id
+    ]
+
+    every dpu in dpus {
+        dpu.firmware_version == target_version
+    }
+}
+```
+
+---
+
+## 5. OPA Deployment
+
+### 5.1 Deployment Model
+
+OPA runs as a **sidecar** alongside the Carbide API server (or as a shared service in the cluster). The deployment model:
+
+```
+┌─────────────────────────────────┐
+│         Kubernetes Pod          │
+│                                 │
+│  ┌───────────┐  ┌────────────┐  │
+│  │  Carbide  │  │    OPA     │  │
+│  │   API     │──│  Sidecar   │  │
+│  │  Server   │  │            │  │
+│  └───────────┘  └─────┬──────┘  │
+│                       │         │
+│                  ┌────┴─────┐   │
+│                  │  Policy  │   │
+│                  │  Bundle  │   │
+│                  │  Volume  │   │
+│                  └──────────┘   │
+└─────────────────────────────────┘
+```
+
+### 5.2 Bundle Distribution
+
+Policy bundles are distributed as OCI artifacts or served from an HTTP endpoint:
+
+1. Policy authors write Rego rules and unit tests.
+2. Policies are packaged into an OPA bundle (tarball of `.rego` files + `data.json`).
+3. Bundles are published to an OCI registry or S3-compatible store.
+4. OPA pulls bundles periodically (configurable interval, typically 30s–60s).
+
+### 5.3 Decision Logging
+
+OPA's built-in decision logging is enabled to provide an audit trail:
+
+- Every policy evaluation is logged with input, result, and timestamp.
+- Decision logs are shipped to a log aggregation system for analysis.
+- This enables post-hoc debugging: "why was machine X not allowed to update firmware at time T?"
+
+### 5.4 Performance Considerations
+
+| Concern | Mitigation |
+|---------|-----------|
+| **Latency** | OPA evaluates policies in-memory (microseconds). The sidecar deployment avoids network round-trips. |
+| **Fleet state freshness** | Pre-compute fleet aggregates (counts per location, healthy machine counts) and cache in OPA's data store. Update on change, not per-query. |
+| **Policy bundle size** | Keep policies modular. Only load policies relevant to the current deployment. |
+| **Evaluation frequency** | Policy is evaluated once per tick (every ~30s per object). Even with thousands of objects, the total OPA load is manageable. |
+
+---
+
+## 6. Data Flow — Detailed
+
+### 6.1 OPA Input Structure
+
+The input document sent to OPA for each policy evaluation:
+
+```json
+{
+  "machine": {
+    "id": "machine-123",
+    "location": "building-A-row-3",
+    "rack_id": "rack-42",
+    "hw_sku": "NVIDIA-GB300-XYZ",
+    "state": "ready",
+    "health": "healthy",
+    "attestation_status": "passed",
+    "firmware_version": "2.12.0",
+    "power_state": "on"
+  },
+  "fleet": {
+    "machines": [
+      { "id": "machine-124", "location": "building-A-row-3", "state": "updating_firmware", "health": "healthy", "rack_id": "rack-42" },
+      { "id": "machine-125", "location": "building-A-row-3", "state": "ready", "health": "healthy", "rack_id": "rack-42" }
+    ],
+    "dpus": [
+      { "id": "dpu-001", "rack_id": "rack-42", "firmware_version": "24.04.1" }
+    ]
+  },
+  "maintenance_windows": [
+    { "location": "building-A-row-3", "start": "2026-04-05T02:00:00Z", "end": "2026-04-05T06:00:00Z" }
+  ],
+  "policy": {
+    "max_concurrent_firmware_updates": 5,
+    "min_healthy_per_rack": 3,
+    "target_dpu_firmware_version": "24.04.1"
+  }
+}
+```
+
+### 6.2 OPA Output Structure
+
+OPA returns a flat set of policy decisions:
+
+```json
+{
+  "firmware_update_allowed": true,
+  "maintenance_window_active": false,
+  "workload_assignment_allowed": true,
+  "capacity_headroom": 2,
+  "location_lock": "none"
+}
+```
+
+These are mapped to `StateKey` variants in the observed state:
+
+```rust
+PolicyFirmwareUpdateAllowed  = "true"
+PolicyMaintenanceWindowActive = "false"
+PolicyWorkloadAssignmentAllowed = "true"
+PolicyCapacityHeadroom       = "2"
+PolicyLocationLock           = "none"
+```
+
+---
+
+## 7. Testing
+
+### 7.1 Rego Unit Tests
+
+Rego policies are unit-tested independently using OPA's built-in test framework:
+
+```rego
+package carbide.policy_test
+
+import data.carbide.policy
+
+test_firmware_allowed_under_limit {
+    policy.firmware_update_allowed with input as {
+        "machine": {"id": "m1", "location": "loc-A"},
+        "fleet": {"machines": [
+            {"id": "m2", "location": "loc-A", "state": "updating_firmware"},
+            {"id": "m3", "location": "loc-A", "state": "ready"}
+        ]},
+        "policy": {"max_concurrent_firmware_updates": 5}
+    }
+}
+
+test_firmware_blocked_at_limit {
+    not policy.firmware_update_allowed with input as {
+        "machine": {"id": "m1", "location": "loc-A"},
+        "fleet": {"machines": [
+            {"id": "m2", "location": "loc-A", "state": "updating_firmware"},
+            {"id": "m3", "location": "loc-A", "state": "updating_firmware"},
+            {"id": "m4", "location": "loc-A", "state": "updating_firmware"},
+            {"id": "m5", "location": "loc-A", "state": "updating_firmware"},
+            {"id": "m6", "location": "loc-A", "state": "updating_firmware"}
+        ]},
+        "policy": {"max_concurrent_firmware_updates": 5}
+    }
+}
+```
+
+Run with:
+
+```bash
+opa test -v policies/
+```
+
+### 7.2 Integration Testing with Mock Policy Keys
+
+For integration testing the convergence engine with policy constraints, set mock policy keys directly in the observed state:
+
+```rust
+observed.set(StateKey::PolicyFirmwareUpdateAllowed, "false");
+observed.set(StateKey::PolicyMaintenanceWindowActive, "true");
+
+let result = engine.tick(&mut observed, &desired);
+
+assert!(result.actions.iter().all(|a| a.id != Op::UpdateBmcFirmware));
+```
+
+This tests the engine's guard evaluation against policy keys without requiring a running OPA instance.
+
+### 7.3 End-to-End Testing
+
+For full end-to-end testing:
+
+1. Start OPA with test policies loaded.
+2. Seed fleet state in the test database.
+3. Run a convergence tick for a test machine.
+4. Verify that policy-gated operations are correctly allowed or blocked.
+5. Modify fleet state (e.g., bring a machine offline) and re-run.
+6. Verify that policy decisions change accordingly.
+
+---
+
+## 8. Alternatives Considered
+
+### 8.1 Hardcoded Guards
+
+**Approach:** Embed cross-machine constraints directly in operation guard expressions or engine code.
+
+**Rejected because:**
+- Guards operate on a single object's state — they cannot see other machines.
+- Changing constraints requires redeploying the engine.
+- No separation of concerns between engineering and operations.
+
+### 8.2 Common Expression Language (CEL)
+
+**Approach:** Use Google's CEL for policy evaluation.
+
+**Trade-offs:**
+- CEL is simpler than Rego — lower learning curve.
+- But CEL lacks Rego's data-oriented features: partial evaluation, incremental compilation, built-in test framework, OPA ecosystem (decision logging, bundle distribution).
+- CEL is better suited for simple validation rules, not fleet-wide constraint optimization.
+
+**Decision:** Rego/OPA is preferred for its expressiveness, ecosystem maturity, and first-class support for data-driven policy decisions over collections.
+
+### 8.3 Custom Policy DSL
+
+**Approach:** Design a Carbide-specific policy language.
+
+**Rejected because:**
+- Significant engineering investment to design, implement, and maintain a language.
+- No existing ecosystem (testing, debugging, documentation).
+- OPA/Rego is a battle-tested CNCF project used by Kubernetes, Istio, and other infrastructure systems.
+
+### 8.4 Database Queries / SQL
+
+**Approach:** Express constraints as SQL queries against the fleet state database.
+
+**Trade-offs:**
+- SQL is familiar and powerful for aggregations.
+- But SQL is not composable — complex policies become unwieldy nested queries.
+- No built-in testing framework for policy logic.
+- Tightly couples policy to database schema.
+
+**Decision:** OPA with pre-computed aggregates in its data store provides the benefits of database-backed state without coupling policy to SQL.

--- a/book/src/design/convergence-engine/spdm.md
+++ b/book/src/design/convergence-engine/spdm.md
@@ -1,0 +1,342 @@
+# SPDM / Attestation Handler — Convergence Engine Mapping
+
+## 1. Current State
+
+**Handler file:** `crates/api/src/state_controller/spdm/handler.rs` (834 lines)  
+**State enums:** `AttestationState` and `AttestationDeviceState` in `crates/api-model/src/attestation.rs`  
+**Controller I/O:** `SpdmStateControllerIO`
+
+The SPDM (Security Protocol and Data Model) handler manages hardware attestation for bare-metal machines. It operates at two levels:
+
+1. **Machine level** — orchestrates the overall attestation flow through `AttestationState`.
+2. **Device level** — manages per-device attestation through `AttestationDeviceState` (each machine may have multiple attestable devices).
+
+This two-level structure is unique among Carbide state handlers.
+
+### 1.1 AttestationState Variants (Machine Level)
+
+| # | Variant | Description |
+|---|---------|-------------|
+| 1 | `CheckIfAttestationSupported` | Query Redfish root for `ComponentIntegrity` field. If absent, attestation is not supported. |
+| 2 | `FetchAttestationTargetsAndUpdateDb` | Discover all SPDM-capable components. Delete stale targets, insert new ones. |
+| 3 | `FetchData` | Per-device: fetch measurements, certificates, and metadata. |
+| 4 | `Verification` | Per-device: submit evidence to NRAS (NVIDIA Remote Attestation Service) for verification. |
+| 5 | `ApplyEvidenceResultAppraisalPolicy` | Per-device: apply appraisal policies to verification results. |
+| 6 | `Completed` | All devices attested successfully. Do nothing. |
+
+### 1.2 AttestationDeviceState Variants (Device Level)
+
+| # | Variant | Sub-states | Description |
+|---|---------|------------|-------------|
+| 1 | `NotApplicable` | — | Device does not require attestation. |
+| 2 | `FetchData` | `FetchMetadata`, `FetchCertificate`, `Trigger`, `Poll`, `Collect`, `Collected` | Multi-step data collection from device via Redfish. |
+| 3 | `Verification` | `GetVerifierResponse`, `VerifyResponse`, `VerificationCompleted` | Submit to NRAS verifier and validate response. |
+| 4 | `ApplyEvidenceResultAppraisalPolicy` | `ApplyAppraisalPolicy`, `AppraisalPolicyValidationCompleted` | Apply compliance policies to attestation evidence. |
+| 5 | `AttestationCompleted` | `status: AttestationStatus` | Terminal state with pass/fail status. |
+
+### 1.3 Handler Structure
+
+The handler uses `SpdmMachineStateSnapshot` as its controller state, which bundles:
+- `machine_state: AttestationState` — the machine-level state
+- `devices_state` — states of all attestable devices
+- `device_state` — optional current device being processed
+
+The machine-level handler dispatches to the device-level handler for `FetchData`, `Verification`, and `ApplyEvidenceResultAppraisalPolicy` states. It advances the machine-level state only when all devices have completed their current phase.
+
+---
+
+## 2. State Keys
+
+Any key can appear in `S_o`, `S_d`, or both. Which keys appear in `S_d` is a runtime decision (see [§3.11](README.md#311-design-principle-properties-not-phases)).
+
+### Machine-Level Keys
+
+| Observation Source | State Key | Type | Example Values |
+|-------------------|-----------|------|----------------|
+| Redfish `ComponentIntegrity` | `AttestationComponentCount` | Int | `"5"` (0 = not supported) |
+| Device discovery count | `AttestationTargetCount` | Int | `"2"` (0 = not yet discovered) |
+| Overall attestation result | `AttestationStatus` | Str | `"not_started"`, `"in_progress"`, `"passed"`, `"failed"` |
+| `started_at` | `AttestationStartedAt` | Str | `"2024-01-15T10:30:00Z"` |
+| `canceled_at` | `AttestationCanceled` | Bool | `"true"`, `"false"` |
+
+### Per-Device Keys
+
+For each attestable device `d` with index `i`:
+
+| Observation Source | State Key | Type | Example Values |
+|-------------------|-----------|------|----------------|
+| Device metadata | `AttestationDeviceMetadataHash(i)` | Str | `"a1b2c3"` or `""` (not fetched) |
+| Device certificate | `AttestationDeviceCertFingerprint(i)` | Str | `"SHA256:..."` or `""` (not fetched) |
+| Measurement collection | `AttestationDeviceMeasurementHash(i)` | Str | `"d4e5f6"` or `""` (not collected) |
+| NRAS verification | `AttestationDeviceVerifierResult(i)` | Str | `"passed"`, `"failed"`, `""` |
+| Appraisal result | `AttestationDeviceAppraisalResult(i)` | Str | `"passed"`, `"failed"`, `""` |
+| Device attestation status | `AttestationDeviceStatus(i)` | Str | `"passed"`, `"failed"`, `"not_applicable"` |
+
+**Typical desired-state sources.** Security policies (`AttestationStatus`, `AttestationDeviceStatus(i)`), operator intent (`LifecycleDeleted`).
+
+---
+
+## 3. Operations
+
+Operations are organized by setting domain — each manages a single, independently configurable property. See [§3.11](README.md#311-design-principle-properties-not-phases) for the design rationale.
+
+### 3.1 Machine-Level Operations
+
+#### `check_attestation_support`
+
+**Replaces:** `AttestationState::CheckIfAttestationSupported` match arm
+
+```rust
+fn check_attestation_support() -> Operation {
+    op!(check_attestation_support {
+        provides: [AttestationComponentCount],
+        guard: eq(AttestationComponentCount, "0"),
+        locks: [Attestation],
+        effects: [AttestationComponentCount => "{discovered_count}"],
+        steps: [
+            action(redfish_query_component_integrity),
+            action(determine_attestation_support),
+        ],
+        priority: 95,
+    })
+}
+```
+
+#### `discover_attestation_targets`
+
+**Replaces:** `AttestationState::FetchAttestationTargetsAndUpdateDb` match arm
+
+```rust
+fn discover_attestation_targets() -> Operation {
+    op!(discover_attestation_targets {
+        provides: [AttestationTargetCount],
+        guard: and(
+            neq(AttestationComponentCount, "0"),
+            eq(AttestationTargetCount, "0"),
+        ),
+        locks: [Attestation],
+        effects: [AttestationTargetCount => "{discovered_target_count}"],
+        steps: [
+            action(redfish_list_spdm_components),
+            action(db_upsert_attestation_devices),
+            action(db_cleanup_stale_targets),
+        ],
+        priority: 90,
+    })
+}
+```
+
+### 3.2 Per-Device Operations
+
+#### `fetch_device_metadata`
+
+**Replaces:** `FetchDataDeviceStates::FetchMetadata`
+
+```rust
+fn fetch_device_metadata(i: usize) -> Operation {
+    op!(fetch_device_metadata_{i} {
+        provides: [AttestationDeviceMetadataHash(i)],
+        guard: and(
+            neq(AttestationTargetCount, "0"),
+            eq(AttestationDeviceMetadataHash(i), ""),
+        ),
+        locks: [AttestationDevice(i)],
+        effects: [AttestationDeviceMetadataHash(i) => "{metadata_hash}"],
+        steps: [action(redfish_fetch_device_metadata, device_index = i)],
+        priority: 85,
+    })
+}
+```
+
+#### `fetch_device_certificate`
+
+**Replaces:** `FetchDataDeviceStates::FetchCertificate`
+
+```rust
+fn fetch_device_certificate(i: usize) -> Operation {
+    op!(fetch_device_certificate_{i} {
+        provides: [AttestationDeviceCertFingerprint(i)],
+        guard: and(
+            neq(AttestationDeviceMetadataHash(i), ""),
+            eq(AttestationDeviceCertFingerprint(i), ""),
+        ),
+        locks: [AttestationDevice(i)],
+        effects: [AttestationDeviceCertFingerprint(i) => "{cert_fingerprint}"],
+        steps: [action(redfish_fetch_ca_certificate, device_index = i)],
+        priority: 84,
+    })
+}
+```
+
+#### `collect_device_measurements`
+
+**Replaces:** `FetchDataDeviceStates::Trigger`, `Poll`, `Collect`, `Collected`
+
+```rust
+fn collect_device_measurements(i: usize) -> Operation {
+    op!(collect_device_measurements_{i} {
+        provides: [AttestationDeviceMeasurementHash(i)],
+        guard: and(
+            neq(AttestationDeviceCertFingerprint(i), ""),
+            eq(AttestationDeviceMeasurementHash(i), ""),
+        ),
+        locks: [AttestationDevice(i)],
+        effects: [AttestationDeviceMeasurementHash(i) => "{measurement_hash}"],
+        steps: [
+            action(redfish_trigger_measurement_collection),
+            action(redfish_poll_measurement_status, timeout_seconds = 300),
+            action(redfish_collect_measurements),
+        ],
+        priority: 83,
+    })
+}
+```
+
+#### `verify_device_attestation`
+
+**Replaces:** `VerificationDeviceStates::GetVerifierResponse`, `VerifyResponse`
+
+```rust
+fn verify_device_attestation(i: usize) -> Operation {
+    op!(verify_device_attestation_{i} {
+        provides: [AttestationDeviceVerifierResult(i)],
+        guard: and(
+            neq(AttestationDeviceMeasurementHash(i), ""),
+            eq(AttestationDeviceVerifierResult(i), ""),
+        ),
+        locks: [AttestationDevice(i), Nras],
+        effects: [AttestationDeviceVerifierResult(i) => "passed"],
+        steps: [
+            action(nras_submit_evidence, device_index = i),
+            action(nras_verify_response),
+        ],
+        priority: 80,
+    })
+}
+```
+
+#### `appraise_device_attestation`
+
+**Replaces:** `EvidenceResultAppraisalPolicyDeviceStates::ApplyAppraisalPolicy`
+
+```rust
+fn appraise_device_attestation(i: usize) -> Operation {
+    op!(appraise_device_attestation_{i} {
+        provides: [
+            AttestationDeviceAppraisalResult(i),
+            AttestationDeviceStatus(i),
+        ],
+        guard: and(
+            eq(AttestationDeviceVerifierResult(i), "passed"),
+            eq(AttestationDeviceAppraisalResult(i), ""),
+        ),
+        locks: [AttestationDevice(i)],
+        effects: [
+            AttestationDeviceAppraisalResult(i) => "passed",
+            AttestationDeviceStatus(i) => "passed",
+        ],
+        steps: [action(apply_appraisal_policy, device_index = i)],
+        priority: 75,
+    })
+}
+```
+
+### 3.3 Aggregation Operation
+
+#### `complete_attestation`
+
+**Replaces:** Transition to `AttestationState::Completed`
+
+```rust
+fn complete_attestation(device_count: usize) -> Operation {
+    let status_guards: Vec<_> = (0..device_count)
+        .map(|i| eq(AttestationDeviceStatus(i), "passed"))
+        .collect();
+    op!(complete_attestation {
+        provides: [AttestationStatus],
+        guard: and(status_guards),
+        locks: [Attestation],
+        effects: [AttestationStatus => "passed"],
+        steps: [
+            action(aggregate_device_attestation_results),
+            action(set_attestation_status),
+        ],
+        priority: 70,
+    })
+}
+```
+
+### What Disappears
+
+| Old | Property-oriented view |
+|-----|------------------------|
+| Machine-level `AttestationState` FSM | Properties converge naturally (per-device granularity) |
+| `Completed` | Δ = ∅ |
+
+---
+
+## 4. Profiles
+
+| Profile | Match Rule | Description |
+|---------|-----------|-------------|
+| `spdm_default` | `true` | Default SPDM attestation profile |
+
+### 4.1 Nested Object Consideration
+
+The SPDM handler's two-level structure (machine + per-device) presents a design consideration. Two approaches:
+
+**Approach A — Dynamic key expansion.** The engine generates per-device state keys (`AttestationDevice*(0)`, `AttestationDevice*(1)`, etc.) dynamically based on discovered targets. Per-device operations are instantiated for each device. This fits the convergence model naturally but requires dynamic operation generation.
+
+**Approach B — Sub-engine.** Each device runs its own mini convergence loop within the machine-level engine tick. The machine-level operation `fetch_data_all_devices` delegates to a sub-engine. This isolates complexity but adds architectural weight.
+
+The recommended approach is **A** — dynamic key expansion — as it preserves the flat state model and allows the scheduler to parallelize per-device operations across different devices.
+
+---
+
+## 5. Example Convergence Trace
+
+**Scenario:** A machine with 2 attestable devices needs full attestation.
+
+**Initial observed state:**
+```
+AttestationComponentCount          = "0"
+AttestationTargetCount             = "0"
+AttestationDeviceMetadataHash(0)   = ""
+AttestationDeviceCertFingerprint(0) = ""
+AttestationDeviceMeasurementHash(0) = ""
+AttestationDeviceVerifierResult(0) = ""
+AttestationDeviceAppraisalResult(0) = ""
+AttestationDeviceStatus(0)         = "not_started"
+AttestationDeviceMetadataHash(1)   = ""
+AttestationDeviceCertFingerprint(1) = ""
+AttestationDeviceMeasurementHash(1) = ""
+AttestationDeviceVerifierResult(1) = ""
+AttestationDeviceAppraisalResult(1) = ""
+AttestationDeviceStatus(1)         = "not_started"
+AttestationStatus                  = "not_started"
+```
+
+**Desired state:**
+```
+AttestationStatus = "passed"
+AttestationDeviceStatus(0) = "passed"
+AttestationDeviceStatus(1) = "passed"
+```
+
+**Tick 1:** `check_attestation_support` -> `AttestationComponentCount = "5"`.
+
+**Tick 2:** `discover_attestation_targets` -> `AttestationTargetCount = "2"`.
+
+**Tick 3:** `fetch_device_metadata` for device 0 and device 1 (parallel). `AttestationDeviceMetadataHash(0) = "a1b2c3"`, `AttestationDeviceMetadataHash(1) = "d4e5f6"`.
+
+**Tick 4:** `fetch_device_certificate` for both devices (parallel). Cert fingerprints populated.
+
+**Tick 5:** `collect_device_measurements` for both devices (parallel). Measurement hashes populated.
+
+**Tick 6:** `verify_device_attestation` for both devices (parallel if NRAS supports concurrent requests). `AttestationDeviceVerifierResult(0) = "passed"`, `AttestationDeviceVerifierResult(1) = "passed"`.
+
+**Tick 7:** `appraise_device_attestation` for both devices. `AttestationDeviceStatus(0) = "passed"`, `AttestationDeviceStatus(1) = "passed"`.
+
+**Tick 8:** `complete_attestation` -> `AttestationStatus = "passed"`.
+
+**Result:** CONVERGED in 8 ticks. Per-device operations are parallelized across devices, and each step produces real observable data (hashes, fingerprints, results) rather than boolean flags.

--- a/book/src/design/convergence-engine/spdm.md
+++ b/book/src/design/convergence-engine/spdm.md
@@ -47,8 +47,6 @@ The machine-level handler dispatches to the device-level handler for `FetchData`
 
 ## 2. State Keys
 
-Any key can appear in `S_o`, `S_d`, or both. Which keys appear in `S_d` is a runtime decision (see [§3.11](README.md#311-design-principle-properties-not-phases)).
-
 ### Machine-Level Keys
 
 | Observation Source | State Key | Type | Example Values |
@@ -78,7 +76,7 @@ For each attestable device `d` with index `i`:
 
 ## 3. Operations
 
-Operations are organized by setting domain — each manages a single, independently configurable property. See [§3.11](README.md#311-design-principle-properties-not-phases) for the design rationale.
+Operations are organized by setting domain — each manages a single, independently configurable property. See [§7.4](README.md#74-design-principle-properties-not-phases) for the design rationale.
 
 ### 3.1 Machine-Level Operations
 

--- a/book/src/design/convergence-engine/switch.md
+++ b/book/src/design/convergence-engine/switch.md
@@ -1,0 +1,208 @@
+# Switch Handler — Convergence Engine Mapping
+
+## 1. Current State
+
+**Handler file:** `crates/api/src/state_controller/switch/handler.rs` (103 lines)  
+**State enum:** `SwitchControllerState` in `crates/api-model/src/switch/mod.rs`  
+**Controller I/O:** `SwitchStateControllerIO`
+
+The switch handler manages network switch lifecycle: initialization, configuration, validation, BOM validation, reprovisioning, and deletion. The convergence mapping below replaces sequential FSM phases with **property-oriented operations**; §1 documents the legacy controller for reference.
+
+### 1.1 SwitchControllerState Variants
+
+| # | Variant | Sub-state | Description |
+|---|---------|-----------|-------------|
+| 1 | `Created` | — | Initial state after switch creation. |
+| 2 | `Initializing` | `InitializingState` | Switch is being initialized (firmware check, basic config). |
+| 3 | `Configuring` | `ConfiguringState` | Switch is being configured with network settings. |
+| 4 | `Validating` | `ValidatingState` | Running switch-level validation checks. |
+| 5 | `BomValidating` | `BomValidatingState` | BOM/SKU validation for the switch. |
+| 6 | `Ready` | — | Switch is operational. |
+| 7 | `ReProvisioning` | `ReProvisioningState` | Switch is being reprovisioned. |
+| 8 | `Error` | `cause: String` | Switch is in an error state. |
+| 9 | `Deleting` | — | Switch is being deleted. |
+
+### 1.2 Handler Dispatch
+
+The handler's `attempt_state_transition` delegates each variant to a dedicated function (`handle_created`, `handle_initializing`, etc.). The handler ignores the passed `controller_state` parameter and instead reads `state.controller_state.value` directly.
+
+---
+
+## 2. State Keys
+
+Any key can appear in `S_o`, `S_d`, or both. Which keys appear in `S_d` is a runtime decision (see [§3.11](README.md#311-design-principle-properties-not-phases)).
+
+| Observation Source | State Key | Type | Example Values |
+|-------------------|-----------|------|----------------|
+| `config` | `SwitchConfigVersion` | Str | `"v3"` |
+| `status` | `SwitchConnectivityStatus` | Str | `"connected"`, `"disconnected"`, `"error"` |
+| `bmc_mac_address` | `SwitchBmcMac` | Str | `"aa:bb:cc:dd:ee:ff"` |
+| Firmware version query | `SwitchFirmwareVersion` | Str | `"3.10.4"` or `""` (not checked) |
+| `firmware_upgrade_status` | `SwitchFirmwareStatus` | Str | `"current"`, `"upgrading"`, `"outdated"` |
+| Basic config hash | `SwitchBasicConfigHash` | Str | `"b3c2a1"` or `""` (not applied) |
+| Validation runner | `SwitchValidationResult` | Str | `"passed"`, `"failed"`, `"not_run"` |
+| BOM validation runner | `SwitchBomValidationResult` | Str | `"passed"`, `"failed"`, `"not_run"` |
+| `rack_id` | `SwitchRackId` | Str | `"rack-001"` |
+| `deleted` | `LifecycleDeleted` | Bool | `"true"`, `"false"` |
+
+**Typical desired-state sources.** Network config templates (`SwitchConfigVersion`), firmware manifests (`SwitchFirmwareStatus`), operator intent (`LifecycleDeleted`).
+
+---
+
+## 3. Operations
+
+Operations are grouped by **setting domain**. There is no monolithic init phase or reprovision phase; guards encode dependencies. See [§3.11](README.md#311-design-principle-properties-not-phases) in the convergence README for rationale.
+
+### 3.1 Firmware and reachability
+
+```rust
+op!(check_switch_firmware {
+    provides: [SwitchFirmwareVersion],
+    guard: eq(SwitchFirmwareVersion, ""),
+    locks: [SwitchFirmware],
+    effects: [SwitchFirmwareVersion => "{detected_version}"],
+    steps: [action("switch_check_firmware")],
+    priority: 90,
+});
+```
+
+```rust
+op!(apply_switch_basic_config {
+    provides: [SwitchBasicConfigHash],
+    guard: and(
+        neq(SwitchFirmwareVersion, ""),
+        eq(SwitchBasicConfigHash, ""),
+    ),
+    locks: [SwitchBasicConfig],
+    effects: [SwitchBasicConfigHash => "{config_hash}"],
+    steps: [action("switch_basic_config")],
+    priority: 89,
+});
+```
+
+`SwitchConnectivityStatus` is **observed-only** -- it comes from the switch's health monitoring, not from an operation. Once basic config is applied, the observation layer detects connectivity.
+
+### 3.2 Configuration
+
+```rust
+op!(configure_switch {
+    provides: [SwitchConfigVersion],
+    guard: and(
+        eq(SwitchConnectivityStatus, "connected"),
+        neq(SwitchConfigVersion, desired(SwitchConfigVersion)),
+    ),
+    locks: [SwitchConfig],
+    effects: [SwitchConfigVersion => desired(SwitchConfigVersion)],
+    steps: [
+        action("switch_apply_network_config"),
+        action("switch_verify_port_status"),
+    ],
+    priority: 80,
+});
+```
+
+### 3.3 Validation
+
+```rust
+op!(validate_switch {
+    provides: [SwitchValidationResult],
+    guard: and(
+        eq(SwitchConfigVersion, desired(SwitchConfigVersion)),
+        neq(SwitchValidationResult, "passed"),
+    ),
+    locks: [SwitchValidation],
+    effects: [SwitchValidationResult => "passed"],
+    steps: [
+        action("switch_run_validation"),
+        action("switch_check_validation_result"),
+    ],
+    priority: 75,
+});
+```
+
+```rust
+op!(validate_switch_bom {
+    provides: [SwitchBomValidationResult],
+    guard: and(
+        eq(SwitchValidationResult, "passed"),
+        neq(SwitchBomValidationResult, "passed"),
+    ),
+    locks: [SwitchValidation],
+    effects: [SwitchBomValidationResult => "passed"],
+    steps: [action("switch_bom_check")],
+    priority: 73,
+});
+```
+
+### 3.4 Lifecycle
+
+```rust
+op!(delete_switch {
+    provides: [LifecycleDeleted],
+    guard: eq(LifecycleDeleted, "true"),
+    locks: [Lifecycle],
+    effects: [LifecycleDeleted => "true"],
+    steps: [action("switch_cleanup"), action("final_delete")],
+    priority: 110,
+});
+```
+
+### 3.5 What Disappears
+
+The following FSM-centric concepts have no dedicated operation in the convergence model:
+
+| FSM / legacy concept | Why it disappears |
+|---------------------|-------------------|
+| `ReProvisioning` | Reprovisioning is not an operation. When desired `SwitchConfigVersion` changes, the engine detects a delta and reconverges. |
+| Monolithic `initialize_switch` | Split into `check_switch_firmware` (provides `SwitchFirmwareVersion`), `apply_switch_basic_config` (provides `SwitchBasicConfigHash`), and passive connectivity observation (`SwitchConnectivityStatus`). |
+| Boolean flags (`SwitchConfigured`, `SwitchInitialized`, etc.) | Replaced by real observables: firmware version, config hash, validation/BOM result. |
+| `Ready` | Not a state -- delta is empty. |
+
+---
+
+## 4. Profiles
+
+| Profile | Match Rule | Description |
+|---------|-----------|-------------|
+| `switch_default` | `true` | Default switch profile for all switch types |
+| `switch_infiniband` | `eq(SwitchType, "infiniband")` | InfiniBand-specific switch operations (future) |
+
+---
+
+## 5. Example Convergence Trace
+
+**Scenario:** A new switch is created. The desired state specifies only a target config version; intermediate properties (firmware version, basic config hash, connectivity, validation results) are observed-only prerequisites.
+
+**Initial observed state:**
+```
+SwitchFirmwareVersion     = ""
+SwitchBasicConfigHash     = ""
+SwitchConnectivityStatus  = "disconnected"
+SwitchConfigVersion       = ""
+SwitchValidationResult    = "not_run"
+SwitchBomValidationResult = "not_run"
+```
+
+**Desired state:**
+```
+SwitchConfigVersion  = "v3"
+SwitchFirmwareStatus = "current"
+```
+
+**Tick 1:** `check_switch_firmware` is ready (`SwitchFirmwareVersion = ""`). Scheduled. Fleet: other switches advance concurrently.
+
+**Tick 2:** `SwitchFirmwareVersion = "3.10.4"`. `apply_switch_basic_config` is ready (firmware version is non-empty, config hash is empty). Scheduled.
+
+**Tick 3:** `SwitchBasicConfigHash = "b3c2a1"`. Observation refreshes: `SwitchConnectivityStatus = "connected"`. `configure_switch` is ready (connected, config version differs). Scheduled.
+
+**Tick 4:** `SwitchConfigVersion = "v3"`. `validate_switch` is ready (config matches desired, result is `"not_run"`). Scheduled.
+
+**Tick 5:** `SwitchValidationResult = "passed"`. `validate_switch_bom` is ready. Scheduled.
+
+**Tick 6:** `SwitchBomValidationResult = "passed"`. All desired keys match.
+
+**Result:** CONVERGED in 6 ticks.
+
+**Config-only delta:** If desired `SwitchConfigVersion` changes to `"v4"` while the switch is already converged, only `configure_switch` becomes eligible. The engine does not re-check firmware or re-apply basic config.
+
+**Self-healing:** If `SwitchConnectivityStatus` goes to `"disconnected"`, `configure_switch` is blocked until connectivity is restored. No manual intervention needed.

--- a/book/src/design/convergence-engine/switch.md
+++ b/book/src/design/convergence-engine/switch.md
@@ -30,8 +30,6 @@ The handler's `attempt_state_transition` delegates each variant to a dedicated f
 
 ## 2. State Keys
 
-Any key can appear in `S_o`, `S_d`, or both. Which keys appear in `S_d` is a runtime decision (see [§3.11](README.md#311-design-principle-properties-not-phases)).
-
 | Observation Source | State Key | Type | Example Values |
 |-------------------|-----------|------|----------------|
 | `config` | `SwitchConfigVersion` | Str | `"v3"` |
@@ -51,7 +49,7 @@ Any key can appear in `S_o`, `S_d`, or both. Which keys appear in `S_d` is a run
 
 ## 3. Operations
 
-Operations are grouped by **setting domain**. There is no monolithic init phase or reprovision phase; guards encode dependencies. See [§3.11](README.md#311-design-principle-properties-not-phases) in the convergence README for rationale.
+Operations are grouped by **setting domain**. There is no monolithic init phase or reprovision phase; guards encode dependencies. See [§7.4](README.md#74-design-principle-properties-not-phases) in the convergence README for rationale.
 
 ### 3.1 Firmware and reachability
 


### PR DESCRIPTION
This PR, adds new design for Convergence Engine. It is supposed to replace current FSM based engine in core. 

Design consistes of several docs, core one - https://github.com/yoks/bare-metal-manager-core/tree/state-rfc/book/src/design/convergence-engine

And multiple docs for each state handler (as of right now). 

Design itself is quite breaking so i think it would have heavy discussion. I think best place is under this PR. 

**I used AI to repharse/spellcheck the document, or format it.** But i after went couple times over it, it reads better than in my own words. If someone with really good English skills can improve/edit it, it can be great as well.