### PR TITLE
fix: support Chassis variants for lite-on power shelves

### DIFF
--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -817,11 +817,21 @@ impl EndpointExplorationReport {
         self.identify_dpu().is_some()
     }
 
-    /// Return `true` if the explored endpoint is a PowerShelf
+    /// Return `true` if the explored endpoint is a PowerShelf.
+    /// This checks if the chassis ID is /Chassis/powershelf, or,
+    /// if that fails, checks to see if /Chassis/chassis has
+    /// a manufacturer containing "lite-on".
+    ///
+    /// TODO(chet): These are obviously workarounds for now while
+    /// we work with vendors to update their BMC firmware.
     pub fn is_power_shelf(&self) -> bool {
-        self.chassis
-            .iter()
-            .any(|c| c.id.to_lowercase().contains("powershelf"))
+        self.chassis.iter().any(|c| {
+            c.id.to_lowercase().contains("powershelf")
+                || (c.id == "chassis"
+                    && c.manufacturer
+                        .as_ref()
+                        .is_some_and(|m| m.to_lowercase().contains("lite-on")))
+        })
     }
 
     /// Return `true` if the explored endpoint is a Switch
@@ -2331,5 +2341,57 @@ mod tests {
         assert_eq!(report.compute_tray_index, None);
         assert_eq!(report.topology_id, None);
         assert_eq!(report.revision_id, None);
+    }
+
+    #[test]
+    fn is_power_shelf_with_powershelf_chassis_id() {
+        let report = EndpointExplorationReport {
+            chassis: vec![Chassis {
+                id: "powershelf".to_string(),
+                manufacturer: Some("lite-on technology corp.".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        assert!(report.is_power_shelf());
+    }
+
+    #[test]
+    fn is_power_shelf_with_chassis_id_and_liteon_manufacturer() {
+        let report = EndpointExplorationReport {
+            chassis: vec![Chassis {
+                id: "chassis".to_string(),
+                manufacturer: Some("LITE-ON TECHNOLOGY CORP.".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        assert!(report.is_power_shelf());
+    }
+
+    #[test]
+    fn is_power_shelf_with_generic_chassis_id_not_liteon() {
+        let report = EndpointExplorationReport {
+            chassis: vec![Chassis {
+                id: "chassis".to_string(),
+                manufacturer: Some("Dell Inc.".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        assert!(!report.is_power_shelf());
+    }
+
+    #[test]
+    fn is_power_shelf_with_no_manufacturer() {
+        let report = EndpointExplorationReport {
+            chassis: vec![Chassis {
+                id: "chassis".to_string(),
+                manufacturer: None,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        assert!(!report.is_power_shelf());
     }
 }

--- a/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
+++ b/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
@@ -728,11 +728,19 @@ impl EndpointExplorer for BmcEndpointExplorer {
                         }
                     };
 
+                // Lite-On power shelf BMCs use "chassis" as their Chassis ID,
+                // so that's the one we'll need to collect data from (we actually
+                // look at the Manufacturer name).
+                //
+                // TODO(chet): This hack was added for Lite-On power shelves,
+                // but I'd really like to try to at least make it some generic
+                // fallback eventually (although I think Lite-On is working on
+                // a fix on their side).
                 let vendor = self
                     .redfish_client
-                    .probe_vendor_name_from_chassis(bmc_ip_address, username, password)
+                    .probe_vendor_name_from_chassis(bmc_ip_address, username, password, "chassis")
                     .await?;
-                if !vendor.to_lowercase().contains("lite-on technology corp") {
+                if !vendor.to_lowercase().contains("lite-on") {
                     return Err(e);
                 }
                 RedfishVendor::LiteOnPowerShelf

--- a/crates/api/src/site_explorer/redfish.rs
+++ b/crates/api/src/site_explorer/redfish.rs
@@ -615,6 +615,7 @@ impl RedfishClient {
         bmc_ip_address: SocketAddr,
         username: String,
         password: String,
+        chassis_id: &str,
     ) -> Result<String, EndpointExplorationError> {
         let client = self
             .create_authenticated_redfish_client(
@@ -625,9 +626,9 @@ impl RedfishClient {
             .map_err(map_redfish_client_creation_error)?;
 
         let chassis_all = client.get_chassis_all().await.map_err(map_redfish_error)?;
-        if chassis_all.contains(&"powershelf".to_string()) {
+        if chassis_all.contains(&chassis_id.to_string()) {
             let chassis = client
-                .get_chassis("powershelf")
+                .get_chassis(chassis_id)
                 .await
                 .map_err(map_redfish_error)?;
             if let Some(x) = chassis.manufacturer {
@@ -647,8 +648,26 @@ async fn is_switch(client: &dyn Redfish) -> Result<bool, RedfishError> {
 }
 
 async fn is_powershelf(client: &dyn Redfish) -> Result<bool, RedfishError> {
-    let chassis = client.get_chassis_all().await?;
-    Ok(chassis.contains(&"powershelf".to_string()))
+    let chassis_ids = client.get_chassis_all().await?;
+    if chassis_ids.contains(&"powershelf".to_string()) {
+        return Ok(true);
+    }
+    // Some Lite-On power shelf BMCs use "chassis" as their chassis ID,
+    // so if we failed to find "powershelf" as the chassis ID, fall
+    // back to the other "chassis" chassis ID and check the manufacturer
+    // type.
+    // TODO(chet): This should be able to go away in a later update
+    // of the lite-on firmware.
+    if chassis_ids.contains(&"chassis".to_string())
+        && let Ok(chassis) = client.get_chassis("chassis").await
+        && chassis
+            .manufacturer
+            .as_ref()
+            .is_some_and(|m| m.to_lowercase().contains("lite-on"))
+    {
+        return Ok(true);
+    }
+    Ok(false)
 }
 
 async fn fetch_manager(client: &dyn Redfish) -> Result<Manager, RedfishError> {

--- a/crates/bmc-explorer/src/chassis.rs
+++ b/crates/bmc-explorer/src/chassis.rs
@@ -60,9 +60,15 @@ impl<B: Bmc> ExploredChassisCollection<B> {
     }
 
     pub fn is_liteon_powershelf(&self) -> bool {
-        self.members
-            .iter()
-            .any(|m| m.chassis.id().into_inner() == "powershelf")
+        self.members.iter().any(|m| {
+            m.chassis.id().into_inner() == "powershelf"
+                || (m.chassis.id().into_inner() == "chassis"
+                    && m.chassis
+                        .hardware_id()
+                        .manufacturer
+                        .as_ref()
+                        .is_some_and(|mfg| mfg.as_ref().to_lowercase().contains("lite-on")))
+        })
     }
 
     pub fn is_gb300(&self) -> bool {


### PR DESCRIPTION
## Description

It turns out that Lite-On power shelves support `/Chassis/chassis` AND `/Chassis/powershelf`. In older firmware, only `/Chassis/chassis` is what is exposed in the Chassis Collection registry, meaning the code we have (which checks for `"powershelf"` in the registry, fails.

I'm updating "*is power shelf*" checks to [continue to] look for `"powershelf"`, and if that's not found, then to look for `"chassis"` where the manufacturer contains `"lite-on`". The real fixes are:
- Making sure the power shelf vendors give us vendor information in the service root.
- Enumerating the `/Chassis/powershelf` in the Chassis Collection (which is already fixed in newer FW).

Confirmed on actual hardware, and also added some unit tests.

On the plus side, our credentials fallback logic from https://github.com/NVIDIA/ncx-infra-controller-core/pull/842 is working. This is just the next bit (we did the fall back, collected the vendor details, and the vendor details failed, because we were looking for `"powershelf"`).

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

