### PR TITLE
fix(api,cli,agent):  Add BGP session password support

### DIFF
--- a/crates/admin-cli/src/credential/bgp/delete_sitewide/args.rs
+++ b/crates/admin-cli/src/credential/bgp/delete_sitewide/args.rs
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use clap::Parser;
+use rpc::{CredentialType, forge as forgerpc};
+
+#[derive(Parser, Debug, Clone)]
+pub struct Args {}
+
+impl From<Args> for forgerpc::CredentialDeletionRequest {
+    fn from(_: Args) -> Self {
+        Self {
+            credential_type: CredentialType::BgpSiteWideLeafPassword.into(),
+            username: None,
+            mac_address: None,
+        }
+    }
+}

--- a/crates/admin-cli/src/credential/bgp/delete_sitewide/cmd.rs
+++ b/crates/admin-cli/src/credential/bgp/delete_sitewide/cmd.rs
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::CarbideCliResult;
+
+use super::args::Args;
+use crate::rpc::ApiClient;
+
+pub async fn delete_sitewide(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    api_client.0.delete_credential(data).await?;
+    Ok(())
+}

--- a/crates/admin-cli/src/credential/bgp/delete_sitewide/mod.rs
+++ b/crates/admin-cli/src/credential/bgp/delete_sitewide/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::delete_sitewide(self, &ctx.api_client).await
+    }
+}

--- a/crates/admin-cli/src/credential/bgp/mod.rs
+++ b/crates/admin-cli/src/credential/bgp/mod.rs
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+mod delete_sitewide;
+mod set_sitewide;
+
+use ::rpc::admin_cli::CarbideCliResult;
+use clap::Parser;
+
+use crate::cfg::dispatch::Dispatch;
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+#[derive(Parser, Debug, Clone, Dispatch)]
+#[clap(rename_all = "kebab_case")]
+pub enum Cmd {
+    #[clap(
+        name = "set-sitewide",
+        about = "Set the site-wide leaf BGP password"
+    )]
+    Set(set_sitewide::Args),
+    #[clap(
+        name = "delete-sitewide",
+        about = "Delete the site-wide leaf BGP password"
+    )]
+    Delete(delete_sitewide::Args),
+}
+
+impl Run for Cmd {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        match self {
+            Cmd::Set(args) => args.run(ctx).await,
+            Cmd::Delete(args) => args.run(ctx).await,
+        }
+    }
+}

--- a/crates/admin-cli/src/credential/bgp/set_sitewide/args.rs
+++ b/crates/admin-cli/src/credential/bgp/set_sitewide/args.rs
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use clap::Parser;
+use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+use rpc::{CredentialType, forge as forgerpc};
+
+use crate::credential::common::password_validator;
+
+#[derive(Parser, Debug, Clone)]
+pub struct Args {
+    #[clap(long, required(true), help = "Leaf BGP session password")]
+    pub password: String,
+}
+
+impl TryFrom<Args> for forgerpc::CredentialCreationRequest {
+    type Error = CarbideCliError;
+
+    fn try_from(args: Args) -> CarbideCliResult<Self> {
+        Ok(Self {
+            credential_type: CredentialType::BgpSiteWideLeafPassword.into(),
+            username: None,
+            password: password_validator(args.password)?,
+            mac_address: None,
+            vendor: None,
+        })
+    }
+}

--- a/crates/admin-cli/src/credential/bgp/set_sitewide/cmd.rs
+++ b/crates/admin-cli/src/credential/bgp/set_sitewide/cmd.rs
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::CarbideCliResult;
+use ::rpc::forge as forgerpc;
+
+use super::args::Args;
+use crate::rpc::ApiClient;
+
+pub async fn set_sitewide(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    api_client
+        .0
+        .create_credential(forgerpc::CredentialCreationRequest::try_from(data)?)
+        .await?;
+    Ok(())
+}

--- a/crates/admin-cli/src/credential/bgp/set_sitewide/mod.rs
+++ b/crates/admin-cli/src/credential/bgp/set_sitewide/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::set_sitewide(self, &ctx.api_client).await
+    }
+}

--- a/crates/admin-cli/src/credential/mod.rs
+++ b/crates/admin-cli/src/credential/mod.rs
@@ -21,6 +21,7 @@ mod add_host_factory_default;
 mod add_nmxm;
 mod add_uefi;
 mod add_ufm;
+mod bgp;
 mod common;
 mod delete_bmc;
 mod delete_nmxm;
@@ -59,4 +60,6 @@ pub enum Cmd {
     AddNmxM(add_nmxm::Args),
     #[clap(about = "Delete NmxM credentials")]
     DeleteNmxM(delete_nmxm::Args),
+    #[clap(about = "Manage leaf BGP passwords", subcommand)]
+    Bgp(bgp::Cmd),
 }

--- a/crates/agent/src/command_line.rs
+++ b/crates/agent/src/command_line.rs
@@ -214,6 +214,12 @@ pub struct NvueOptions {
         help = "Full JSON representation of a RoutingProfile (see nvue.rs)."
     )]
     pub ct_routing_profile: Option<String>,
+
+    #[clap(
+        long,
+        help = "BGP password to use with session between the DPU and the TOR"
+    )]
+    pub bgp_leaf_session_password: Option<String>,
 }
 
 #[derive(Parser, Debug)]

--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -418,6 +418,7 @@ pub async fn update_nvue(
                     .collect(),
             })
         },
+        bgp_leaf_session_password: nc.bgp_leaf_session_password.clone(),
     };
 
     // next_contents is a YAML-serialized NVUE config.
@@ -2335,6 +2336,7 @@ mod tests {
             asn: 4259912557,
             datacenter_asn: 11414,
             site_global_vpc_vni,
+            bgp_leaf_session_password: None,
             anycast_site_prefixes: vec!["5.255.255.0/24".to_string()],
             tenant_host_asn: Some(65100),
             common_internal_route_target: Some(rpc_common::RouteTarget {
@@ -2550,6 +2552,7 @@ mod tests {
         let hostname = super::hostname().wrap_err("gethostname error")?;
         let vpc_vni = 7777;
         let conf = nvue::NvueConfig {
+            bgp_leaf_session_password: None,
             is_fnn,
             vpc_virtualization_type,
             use_admin_network: true,
@@ -2808,6 +2811,7 @@ mod tests {
         };
 
         let mut network_config = rpc::ManagedHostNetworkConfigResponse {
+            bgp_leaf_session_password: None,
             site_global_vpc_vni: None,
             asn: 4259912557,
             datacenter_asn: 11414,
@@ -3023,6 +3027,7 @@ mod tests {
             quarantine_state: None,
         };
         let network_config = rpc::ManagedHostNetworkConfigResponse {
+            bgp_leaf_session_password: None,
             site_global_vpc_vni: None,
             asn: 4259912557,
             datacenter_asn: 11414,

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -396,6 +396,7 @@ pub async fn start(cmdline: command_line::Options) -> eyre::Result<()> {
                         .map(|r| serde_json::from_str::<nvue::RoutingProfile>(&r))
                         .transpose()?,
                     network_security_groups,
+                    bgp_leaf_session_password: opts.bgp_leaf_session_password,
                 };
                 let contents = nvue::build(conf)?;
                 std::fs::write(&opts.path, contents)?;

--- a/crates/agent/src/nvue.rs
+++ b/crates/agent/src/nvue.rs
@@ -409,6 +409,8 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
         split_prefixes_by_family(&conf.deny_prefixes, 1000 + deny_prefix_index_offset);
 
     let params = TmplNvue {
+        HasBgpLeafSessionPassword: conf.bgp_leaf_session_password.is_some(),
+        BgpLeafSessionPassword: conf.bgp_leaf_session_password.unwrap_or_default(),
         UseAdminNetwork: conf.use_admin_network,
         LoopbackIP: conf.loopback_ip,
         HasSiteGlobalVpcVni: conf.site_global_vpc_vni.is_some(),
@@ -874,6 +876,7 @@ pub struct NvueConfig {
     pub site_global_vpc_vni: Option<u32>,
     pub common_internal_route_target: Option<RouteTargetConfig>,
     pub additional_route_target_imports: Vec<RouteTargetConfig>,
+    pub bgp_leaf_session_password: Option<String>,
 
     pub secondary_overlay_vtep_ip: Option<String>,
     pub vf_intercept_bridge_port_name: Option<String>,
@@ -1140,6 +1143,11 @@ struct TmplNvue {
     StorageLoopback: String,  // XXX (Classic, L3)
     DPUstorageprefix: String, // XXX (Classic, L3)
     IncludeBridge: bool,
+
+    HasBgpLeafSessionPassword: bool,
+    /// A password to use for the BGP session with the
+    /// leaf TOR.
+    BgpLeafSessionPassword: String,
 }
 
 #[allow(non_snake_case)]
@@ -1462,6 +1470,7 @@ mod tests {
     /// Uses EthernetVirtualizer (ETV) by default.
     fn minimal_nvue_config() -> NvueConfig {
         NvueConfig {
+            bgp_leaf_session_password: None,
             is_fnn: false,
             vpc_virtualization_type: VpcVirtualizationType::EthernetVirtualizer,
             use_admin_network: false,

--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -819,6 +819,7 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
     };
 
     let netconf = rpc::forge::ManagedHostNetworkConfigResponse {
+        bgp_leaf_session_password: Some("this_is_not_a_real_password".to_string()),
         site_global_vpc_vni: None,
         asn: 65535,
         datacenter_asn: 11414,

--- a/crates/agent/templates/nvue_startup_fnn.conf
+++ b/crates/agent/templates/nvue_startup_fnn.conf
@@ -696,6 +696,9 @@
                 update-source: lo
               underlay:
                 remote-as: external
+                {{- if $nvueConfig.HasBgpLeafSessionPassword }}
+                password: '{{ $nvueConfig.BgpLeafSessionPassword }}'
+                {{- end }}
                 address-family:
                   ipv4-unicast:
                     policy:

--- a/crates/agent/templates/tests/full_nvue_startup_fnn_l3.yaml.expected
+++ b/crates/agent/templates/tests/full_nvue_startup_fnn_l3.yaml.expected
@@ -418,6 +418,7 @@
                 update-source: lo
               underlay:
                 remote-as: external
+                password: 'this_is_not_a_real_password'
                 address-family:
                   ipv4-unicast:
                     policy:

--- a/crates/api/src/cfg/README.md
+++ b/crates/api/src/cfg/README.md
@@ -85,6 +85,7 @@ applicable.
 | `rms_api_url` | `Option<String>` | — | Rack Manager Service API URL for rack-level firmware and power operations. |
 | `rack_types` | `RackTypeConfig` | *(default)* | Rack type definitions referenced by expected racks. |
 | `spdm` | `SpdmConfig` | *(see below)* | SPDM hardware attestation (see [SpdmConfig](#spdmconfig)). |
+| `bgp_leaf_session_password` | `Option<BgpLeafSessionPassword>` | — | Selects the credential source for leaf-facing BGP session passwords returned to agents in managed host network config. Supported value: `site_wide`. |
 | `site_global_vpc_vni` | `Option<u32>` | — | Forces all VRFs to share a single VNI (Cumulus Linux route-leaking workaround). Limits DPU to one VRF. |
 | `dpf` | `DpfConfig` | *(see below)* | DPF (DPU Platform Framework) Kubernetes deployment (see [DpfConfig](#dpfconfig)). |
 | `x86_pxe_boot_url_override` | `Option<String>` | — | Override PXE boot URL for x86 machines. |

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -563,6 +563,20 @@ pub struct CarbideConfig {
     /// manager integration.
     #[serde(default)]
     pub component_manager: Option<component_manager::config::ComponentManagerConfig>,
+
+    /// The password source to use for sites where the LEAF TOR
+    /// requires session passwords.
+    #[serde(default)]
+    pub bgp_leaf_session_password: Option<BgpLeafSessionPassword>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+pub enum BgpLeafSessionPassword {
+    /// Use a defined site-wide password.
+    /// The password should already exist in the credentials
+    /// store.
+    #[default]
+    SiteWide,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]

--- a/crates/api/src/handlers/credential.rs
+++ b/crates/api/src/handlers/credential.rs
@@ -20,8 +20,11 @@ use std::io::Write;
 
 use ::rpc::errors::RpcDataConversionError;
 use ::rpc::forge as rpc;
-use forge_secrets::credentials::{BmcCredentialType, CredentialKey, CredentialType, Credentials};
+use forge_secrets::credentials::{
+    BgpCredentialType, BmcCredentialType, CredentialKey, CredentialType, Credentials,
+};
 use mac_address::MacAddress;
+use model::ConfigValidationError;
 use model::ib::DEFAULT_IB_FABRIC_NAME;
 use tonic::{Request, Response, Status};
 
@@ -34,6 +37,12 @@ use crate::handlers::utils::convert_and_log_machine_id;
 const DEFAULT_FORGE_ADMIN_BMC_USERNAME: &str = "root";
 
 pub const DEFAULT_NMX_M_NAME: &str = "forge-nmx-m";
+
+/// The maximum size that will be accepted in the underlying BGP config
+/// on the DPU.  This was directly verified by checking the maximum accepted
+/// by FRR on the DPU.  NVUE will silently accept seemingly any length,
+/// but FRR reloads fail above this length.
+pub const MAX_BGP_PASSWORD_LENGTH: usize = 80;
 
 pub(crate) async fn create_credential(
     api: &Api,
@@ -239,6 +248,26 @@ pub(crate) async fn create_credential(
                 return Err(CarbideError::InvalidArgument("missing username".to_string()).into());
             }
         }
+        rpc::CredentialType::BgpSiteWideLeafPassword => {
+            api.credential_manager
+                .set_credentials(
+                    &CredentialKey::Bgp {
+                        credential_type: BgpCredentialType::SiteWideLeafPassword,
+                    },
+                    &Credentials::UsernamePassword {
+                        username: "".to_string(),
+                        password: if password.len() <= MAX_BGP_PASSWORD_LENGTH {
+                            password
+                        } else {
+                            return Err(CarbideError::InvalidConfiguration(ConfigValidationError::InvalidValue(format!("BGP password length exceeds {MAX_BGP_PASSWORD_LENGTH} characters"))).into())
+                        },
+                    },
+                )
+                .await
+                .map_err(|e| {
+                    CarbideError::internal(format!("Error setting BGP credential: {e:?}"))
+                })?;
+        }
     };
 
     Ok(Response::new(rpc::CredentialCreationResult {}))
@@ -311,6 +340,16 @@ pub(crate) async fn delete_credential(
         | rpc::CredentialType::BmcForgeAdminByMacAddress
         | rpc::CredentialType::NmxM => {
             // Not support delete credential for these types
+        }
+        rpc::CredentialType::BgpSiteWideLeafPassword => {
+            api.credential_manager
+                .delete_credentials(&CredentialKey::Bgp {
+                    credential_type: BgpCredentialType::SiteWideLeafPassword,
+                })
+                .await
+                .map_err(|e| {
+                    CarbideError::internal(format!("Error deleting BGP credential: {e:?}"))
+                })?;
         }
     };
 

--- a/crates/api/src/handlers/dpu.rs
+++ b/crates/api/src/handlers/dpu.rs
@@ -27,6 +27,7 @@ use db::{
     DatabaseError, ObjectColumnFilter, dpu_agent_upgrade_policy, network_security_group,
     network_segment,
 };
+use forge_secrets::credentials::{BgpCredentialType, CredentialKey, Credentials};
 use futures_util::future::join_all;
 use itertools::Itertools;
 use model::extension_service::{ExtensionService, ExtensionServiceVersionInfo};
@@ -45,7 +46,7 @@ use crate::api::{Api, log_machine_id, log_request_data};
 use crate::cfg::file::VpcIsolationBehaviorType;
 use crate::handlers::extension_service;
 use crate::handlers::utils::convert_and_log_machine_id;
-use crate::{CarbideError, ethernet_virtualization};
+use crate::{CarbideError, cfg, ethernet_virtualization};
 
 /// vxlan48 is special HBN single vxlan device. It handles networking between machines on the
 /// same subnet. It handles the encapsulation into VXLAN and VNI for cross-host comms.
@@ -719,6 +720,20 @@ pub(crate) async fn get_managed_host_network_config_inner(
             .unwrap_or_default(),
         instance: maybe_instance,
         dpu_extension_services: extension_services,
+        bgp_leaf_session_password: match api.runtime_config.bgp_leaf_session_password.as_ref() {
+            Some(p) => match p {
+                cfg::file::BgpLeafSessionPassword::SiteWide => Some(
+                    get_bgp_password(
+                        &api.credential_manager,
+                        CredentialKey::Bgp {
+                            credential_type: BgpCredentialType::SiteWideLeafPassword,
+                        },
+                    )
+                    .await?,
+                ),
+            },
+            None => None,
+        },
     };
 
     // If this all worked, we shouldn't emit a log line
@@ -1239,4 +1254,26 @@ pub(crate) async fn list_dpu_waiting_for_reprovisioning(
         .collect_vec();
 
     Ok(Response::new(rpc::DpuReprovisioningListResponse { dpus }))
+}
+
+/// Get the configured BGP password.
+pub(crate) async fn get_bgp_password(
+    credential_reader: &dyn forge_secrets::credentials::CredentialReader,
+    credential_key: forge_secrets::credentials::CredentialKey,
+) -> Result<String, CarbideError> {
+    let credential = credential_reader
+        .get_credentials(&credential_key)
+        .await
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Could not find the credential: {}", e),
+        })?;
+
+    Ok(match credential {
+        Some(Credentials::UsernamePassword { password, .. }) => password,
+        _ => {
+            return Err(CarbideError::Internal {
+                message: "Could not find BGP credential".to_string(),
+            });
+        }
+    })
 }

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -1049,6 +1049,7 @@ fn host_firmware_example() -> HashMap<String, Firmware> {
 
 pub fn get_config() -> CarbideConfig {
     CarbideConfig {
+        bgp_leaf_session_password: None,
         rack_validation_config: crate::cfg::file::RackValidationConfig {
             enabled: true,
             ..Default::default()

--- a/crates/api/src/tests/credential.rs
+++ b/crates/api/src/tests/credential.rs
@@ -15,11 +15,16 @@
  * limitations under the License.
  */
 
-use forge_secrets::credentials::{CredentialKey, CredentialReader, CredentialType, Credentials};
+use forge_secrets::credentials::{
+    BgpCredentialType, CredentialKey, CredentialReader, CredentialType, Credentials,
+};
 use rpc::forge::forge_server::Forge;
-use rpc::forge::{CredentialCreationRequest, CredentialType as RpcCredentialType};
+use rpc::forge::{
+    CredentialCreationRequest, CredentialDeletionRequest, CredentialType as RpcCredentialType,
+};
 use tonic::Code;
 
+use crate::handlers::credential::MAX_BGP_PASSWORD_LENGTH;
 use crate::tests::common::api_fixtures::create_test_env;
 
 #[crate::sqlx_test]
@@ -112,4 +117,129 @@ async fn test_create_dpu_uefi_credential_when_missing(pool: sqlx::PgPool) {
         .await;
     assert!(second.is_err());
     assert_eq!(second.unwrap_err().code(), Code::AlreadyExists);
+}
+
+#[crate::sqlx_test]
+async fn test_create_and_delete_bgp_credential(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+
+    // Create the site-wide DPU BGP credential.
+    let response = env
+        .api
+        .create_credential(tonic::Request::new(CredentialCreationRequest {
+            credential_type: RpcCredentialType::BgpSiteWideLeafPassword.into(),
+            username: None,
+            password: "test-dpu-bgp-password".to_string(),
+            vendor: None,
+            mac_address: None,
+        }))
+        .await;
+    assert!(response.is_ok());
+
+    // Verify the credential was stored in the credential manager.
+    let stored = env
+        .test_credential_manager
+        .get_credentials(&CredentialKey::Bgp {
+            credential_type: BgpCredentialType::SiteWideLeafPassword,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        stored,
+        Some(Credentials::UsernamePassword {
+            username: "".to_string(),
+            password: "test-dpu-bgp-password".to_string(),
+        })
+    );
+
+    // Delete the site-wide DPU BGP credential.
+    let delete_response = env
+        .api
+        .delete_credential(tonic::Request::new(CredentialDeletionRequest {
+            credential_type: RpcCredentialType::BgpSiteWideLeafPassword.into(),
+            username: None,
+            mac_address: None,
+        }))
+        .await;
+    assert!(delete_response.is_ok());
+
+    // Verify the credential was removed from the credential manager.
+    let deleted = env
+        .test_credential_manager
+        .get_credentials(&CredentialKey::Bgp {
+            credential_type: BgpCredentialType::SiteWideLeafPassword,
+        })
+        .await
+        .unwrap();
+    assert_eq!(deleted, None);
+}
+
+#[crate::sqlx_test]
+async fn test_create_bgp_credential_validates_max_password_length(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+
+    // Create a site-wide DPU BGP credential using the maximum supported length.
+    let max_password = "a".repeat(MAX_BGP_PASSWORD_LENGTH);
+    let ok_response = env
+        .api
+        .create_credential(tonic::Request::new(CredentialCreationRequest {
+            credential_type: RpcCredentialType::BgpSiteWideLeafPassword.into(),
+            username: None,
+            password: max_password.clone(),
+            vendor: None,
+            mac_address: None,
+        }))
+        .await;
+    assert!(ok_response.is_ok());
+
+    // Verify the credential was stored unchanged.
+    let stored = env
+        .test_credential_manager
+        .get_credentials(&CredentialKey::Bgp {
+            credential_type: BgpCredentialType::SiteWideLeafPassword,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        stored,
+        Some(Credentials::UsernamePassword {
+            username: "".to_string(),
+            password: max_password,
+        })
+    );
+
+    // Try to create a site-wide DPU BGP credential longer than the supported maximum.
+    let response = env
+        .api
+        .create_credential(tonic::Request::new(CredentialCreationRequest {
+            credential_type: RpcCredentialType::BgpSiteWideLeafPassword.into(),
+            username: None,
+            password: "a".repeat(MAX_BGP_PASSWORD_LENGTH + 1),
+            vendor: None,
+            mac_address: None,
+        }))
+        .await;
+    let err = response.expect_err("passwords longer than the max should be rejected");
+
+    // Verify the handler returns a validation error.
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(err.message().contains(&format!(
+        "BGP password length exceeds {MAX_BGP_PASSWORD_LENGTH} characters"
+    )));
+
+    // Verify the previously stored credential was left unchanged.
+    let stored = env
+        .test_credential_manager
+        .get_credentials(&CredentialKey::Bgp {
+            credential_type: BgpCredentialType::SiteWideLeafPassword,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        stored,
+        Some(Credentials::UsernamePassword {
+            username: "".to_string(),
+            password: "a".repeat(MAX_BGP_PASSWORD_LENGTH),
+        })
+    );
 }

--- a/crates/api/src/tests/machine_network.rs
+++ b/crates/api/src/tests/machine_network.rs
@@ -23,16 +23,20 @@ use ::rpc::forge::{
     ManagedHostNetworkConfigRequest, ManagedHostNetworkStatusRequest,
 };
 use common::api_fixtures::{self, create_managed_host, dpu, network_configured_with_health};
+use forge_secrets::credentials::{BgpCredentialType, CredentialKey, Credentials};
 use model::machine::network::ManagedHostQuarantineMode;
 use rpc::forge::forge_server::Forge;
 
 use crate::tests::common;
+use crate::tests::common::api_fixtures::TestEnvOverrides;
+use crate::tests::common::api_fixtures::site_explorer::MockExploredHost;
 
 #[crate::sqlx_test]
 async fn test_managed_host_network_config(pool: sqlx::PgPool) {
     let env = api_fixtures::create_test_env(pool).await;
     let host_config = env.managed_host_config();
-    let dpu_machine_id = dpu::create_dpu_machine(&env, &host_config).await;
+    let mh = dpu::create_dpu_machine_in_waiting_for_network_install(&env, &host_config).await;
+    let dpu_machine_id = mh.dpu().id;
 
     // Fetch a Machines network config
     let response = env
@@ -43,6 +47,102 @@ async fn test_managed_host_network_config(pool: sqlx::PgPool) {
         .await;
 
     assert!(response.is_ok());
+}
+
+#[crate::sqlx_test]
+async fn test_managed_host_network_config_with_sitewide_bgp_password(pool: sqlx::PgPool) {
+    // Enable site-wide DPU BGP passwords in runtime config.
+    let mut config = api_fixtures::get_config();
+    config.bgp_leaf_session_password = Some(crate::cfg::file::BgpLeafSessionPassword::SiteWide);
+
+    let env =
+        api_fixtures::create_test_env_with_overrides(pool, TestEnvOverrides::with_config(config))
+            .await;
+
+    // Seed the site-wide DPU BGP credential.
+    env.api
+        .credential_manager
+        .set_credentials(
+            &CredentialKey::Bgp {
+                credential_type: BgpCredentialType::SiteWideLeafPassword,
+            },
+            &Credentials::UsernamePassword {
+                username: "".to_string(),
+                password: "test-bgp-password".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+    // Create a DPU that can request managed host network config.
+    let host_config = env.managed_host_config();
+    let dpu_machine_id = dpu::create_dpu_machine(&env, &host_config).await;
+
+    // Verify the handler returns the configured site-wide BGP password.
+    let response = env
+        .api
+        .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
+            dpu_machine_id: Some(dpu_machine_id),
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        response.bgp_leaf_session_password,
+        Some("test-bgp-password".to_string())
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_managed_host_network_config_errors_when_sitewide_bgp_password_missing(
+    pool: sqlx::PgPool,
+) {
+    // Enable site-wide DPU BGP passwords in runtime config without creating the credential.
+    let mut config = api_fixtures::get_config();
+    config.bgp_leaf_session_password = Some(crate::cfg::file::BgpLeafSessionPassword::SiteWide);
+
+    let env =
+        api_fixtures::create_test_env_with_overrides(pool, TestEnvOverrides::with_config(config))
+            .await;
+
+    // Create a DPU without advancing to the point where the fixture fetches network config.
+    // We'll fetch config next to validate the failure case.
+    let host_config = env.managed_host_config();
+
+    let mock_explored_host = MockExploredHost::new(&env, host_config)
+        .discover_dhcp_dpu_bmc(0, |_, _| Ok(()))
+        .await
+        .unwrap()
+        .discover_dhcp_dpu_primary_iface(0)
+        .await
+        // Discover the host BMC and persist the exploration results.
+        .discover_dhcp_host_bmc(|_, _| Ok(()))
+        .await
+        .unwrap()
+        .insert_site_exploration_results()
+        .unwrap()
+        .run_site_explorer_iteration()
+        .await
+        .mark_preingestion_complete()
+        .await
+        .unwrap()
+        .run_site_explorer_iteration()
+        .await;
+
+    let dpu_machine_id = mock_explored_host.dpu_machine_ids[&0];
+
+    // Verify the handler fails when the site-wide BGP credential is missing.
+    let err = env
+        .api
+        .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
+            dpu_machine_id: Some(dpu_machine_id),
+        }))
+        .await
+        .expect_err("missing site-wide BGP password should fail");
+
+    assert_eq!(err.code(), tonic::Code::Internal);
+    assert!(err.message().contains("Could not find BGP credential"));
 }
 
 #[crate::sqlx_test]

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1113,6 +1113,7 @@ enum CredentialType {
   RootBmcByMacAddress = 8;
   BmcForgeAdminByMacAddress = 9;
   NmxM = 10;
+  BgpSiteWideLeafPassword = 11;
 }
 
 message CredentialCreationRequest {
@@ -3658,6 +3659,10 @@ message ManagedHostNetworkConfigResponse {
   // will still use the dynamically allocated VNI for deriving
   // route-targets.
   optional uint32 site_global_vpc_vni = 117;
+
+  // The password the DPU should use when configuring a
+  // BGP session with the its TOR
+  optional string bgp_leaf_session_password = 118;
 }
 
 message TrafficInterceptConfig {

--- a/crates/secrets/src/credentials.rs
+++ b/crates/secrets/src/credentials.rs
@@ -336,6 +336,12 @@ pub enum BmcCredentialType {
     BmcForgeAdmin { bmc_mac_address: MacAddress },
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum BgpCredentialType {
+    // Site Wide Credentials
+    SiteWideLeafPassword,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum MqttCredentialType {
     Dpa,
@@ -353,6 +359,9 @@ pub enum CredentialKey {
     },
     DpuRedfish {
         credential_type: CredentialType,
+    },
+    Bgp {
+        credential_type: BgpCredentialType,
     },
     HostRedfish {
         credential_type: CredentialType,
@@ -481,6 +490,9 @@ impl CredentialKey {
             CredentialKey::MachineIdentityEncryptionKey { key_id } => {
                 Cow::from(format!("machine_identity/encryption_keys/{key_id}"))
             }
+            CredentialKey::Bgp { credential_type } => match credential_type {
+                BgpCredentialType::SiteWideLeafPassword => Cow::from("bgp/leaf/site/auth"),
+            },
         }
     }
 }


### PR DESCRIPTION
## Description

Some deployments might require BGP passwords for peering with the TORs.  This adds support for configuring a site-wide leaf BGP password with room to add a per-DPU option later.


## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
Satisfies https://github.com/NVIDIA/ncx-infra-controller-core/issues/473

