### PR TITLE
fix: fix rack f/w upgrade in machine state handler

### DIFF
--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -6693,84 +6693,23 @@ impl HostUpgradeState {
     ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
         let machine_id = state.host_snapshot.id;
 
-        let is_current_cycle = |fw: &model::rack::RackFirmwareUpgradeStatus| -> bool {
-            match (
-                &fw.ended_at,
-                &state.host_snapshot.host_reprovision_requested,
-            ) {
-                (Some(ended), Some(req)) => ended >= &req.requested_at,
-                _ => true,
-            }
-        };
-
-        if let Some(fw) = &state.host_snapshot.rack_fw_details
-            && !fw.is_in_progress()
-            && is_current_cycle(fw)
-        {
-            match &fw.status {
-                model::rack::RackFirmwareUpgradeState::Completed => {
-                    tracing::info!(
-                        %machine_id,
-                        "Rack firmware upgrade completed, transitioning to Ready"
-                    );
-                    let outcome = StateHandlerOutcome::transition(scenario.actual_new_state(
-                        HostReprovisionState::CheckingFirmwareRepeatV2 {
-                            firmware_type: None,
-                            firmware_number: None,
-                        },
-                        state.managed_state.get_host_repro_retry_count(),
-                    ));
-                    return Ok(outcome
-                        .in_transaction(&ctx.services.db_pool, move |txn| {
-                            async move {
-                                db::host_machine_update::clear_host_reprovisioning_request(
-                                    txn,
-                                    &machine_id,
-                                )
-                                .await?;
-                                Ok::<_, DatabaseError>(())
-                            }
-                            .boxed()
-                        })
-                        .await??);
+        let outcome = StateHandlerOutcome::transition(scenario.actual_new_state(
+            HostReprovisionState::CheckingFirmwareRepeatV2 {
+                firmware_type: None,
+                firmware_number: None,
+            },
+            state.managed_state.get_host_repro_retry_count(),
+        ));
+        return Ok(outcome
+            .in_transaction(&ctx.services.db_pool, move |txn| {
+                async move {
+                    db::host_machine_update::clear_host_reprovisioning_request(txn, &machine_id)
+                        .await?;
+                    Ok::<_, DatabaseError>(())
                 }
-                model::rack::RackFirmwareUpgradeState::Failed { cause } => {
-                    tracing::warn!(
-                        %machine_id,
-                        "Rack firmware upgrade failed: {}", cause
-                    );
-                    let outcome = StateHandlerOutcome::transition(ManagedHostState::Failed {
-                        details: FailureDetails {
-                            cause: FailureCause::Reprovisioning {
-                                err: format!("Rack firmware upgrade failed: {}", cause),
-                            },
-                            failed_at: chrono::Utc::now(),
-                            source: FailureSource::StateMachine,
-                        },
-                        machine_id,
-                        retry_count: 0,
-                    });
-                    return Ok(outcome
-                        .in_transaction(&ctx.services.db_pool, move |txn| {
-                            async move {
-                                db::host_machine_update::clear_host_reprovisioning_request(
-                                    txn,
-                                    &machine_id,
-                                )
-                                .await?;
-                                Ok::<_, DatabaseError>(())
-                            }
-                            .boxed()
-                        })
-                        .await??);
-                }
-                _ => {}
-            }
-        }
-
-        Ok(StateHandlerOutcome::wait(
-            "Waiting for rack firmware upgrade to be completed".to_string(),
-        ))
+                .boxed()
+            })
+            .await??);
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/api/src/state_controller/switch/reprovisioning.rs
+++ b/crates/api/src/state_controller/switch/reprovisioning.rs
@@ -19,7 +19,6 @@
 
 use carbide_uuid::switch::SwitchId;
 use db::switch as db_switch;
-use model::rack::{RackFirmwareUpgradeState, RackFirmwareUpgradeStatus};
 use model::switch::{ReProvisioningState, Switch, SwitchControllerState};
 
 use crate::state_controller::state_handler::{
@@ -42,55 +41,9 @@ pub async fn handle_reprovisioning(
 
     match reprovisioning_state {
         ReProvisioningState::WaitingForRackFirmwareUpgrade => {
-            let is_current_cycle = |status: &RackFirmwareUpgradeStatus| -> bool {
-                match (&status.ended_at, &state.switch_reprovisioning_requested) {
-                    (Some(ended), Some(req)) => ended >= &req.requested_at,
-                    _ => true,
-                }
-            };
-
-            if let Some(status) = state.firmware_upgrade_status.as_ref()
-                && !status.is_in_progress()
-                && is_current_cycle(status)
-            {
-                match &status.status {
-                    RackFirmwareUpgradeState::Completed => {
-                        tracing::info!(
-                            "Switch {}: rack firmware upgrade completed — returning to Ready",
-                            switch_id
-                        );
-                        let mut txn = ctx.services.db_pool.begin().await?;
-                        db_switch::clear_switch_reprovisioning_requested(txn.as_mut(), *switch_id)
-                            .await?;
-                        return Ok(
-                            StateHandlerOutcome::transition(SwitchControllerState::Ready)
-                                .with_txn(txn),
-                        );
-                    }
-                    RackFirmwareUpgradeState::Failed { cause } => {
-                        tracing::warn!(
-                            "Switch {}: rack firmware upgrade failed: {}",
-                            switch_id,
-                            cause
-                        );
-                        let mut txn = ctx.services.db_pool.begin().await?;
-                        db_switch::clear_switch_reprovisioning_requested(txn.as_mut(), *switch_id)
-                            .await?;
-                        return Ok(
-                            StateHandlerOutcome::transition(SwitchControllerState::Error {
-                                cause: cause.clone(),
-                            })
-                            .with_txn(txn),
-                        );
-                    }
-                    _ => {}
-                }
-            }
-
-            Ok(StateHandlerOutcome::wait(format!(
-                "Waiting for rack firmware upgrade to be completed (firmware_upgrade_status: {:?}) switch_id: {}",
-                state.firmware_upgrade_status, switch_id
-            )))
+            let mut txn = ctx.services.db_pool.begin().await?;
+            db_switch::clear_switch_reprovisioning_requested(txn.as_mut(), *switch_id).await?;
+            Ok(StateHandlerOutcome::transition(SwitchControllerState::Ready).with_txn(txn))
         }
     }
 }


### PR DESCRIPTION
## Description
fix rack f/w upgrade in machine state handler

Machine is stuck on WaitingForRackFirmwareUpgrade. 

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

