### PR TITLE
charts/agent: Run hardware discovery in init container

### DIFF
--- a/bluefield/charts/carbide-dpu-agent/templates/daemonset.yaml
+++ b/bluefield/charts/carbide-dpu-agent/templates/daemonset.yaml
@@ -52,7 +52,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           args:
             - hardware
-            - "--output-file=/etc/carbide/hardware/discovery_info.json"
+            - "--output-file={{ .Values.discovery.hardware_volume_path }}/discovery_info.json"
           env:
             - name: POD_IP
               valueFrom:
@@ -78,7 +78,7 @@ spec:
                   fieldPath: metadata.namespace
           volumeMounts:
             - name: agent-discovery-info
-              mountPath: /etc/carbide/hardware
+              mountPath: "{{ .Values.discovery.hardware_volume_path }}"
       containers:
         - name: forge-dpu-agent
           securityContext:
@@ -88,7 +88,7 @@ spec:
             - run
             - "--hbn-config-mode=nvue-rest"
             - "--agent-platform-type=containerized"
-            - "--discovery-info-file=/etc/carbide/hardware/discovery_info.json"
+            - "--discovery-info-file={{ .Values.discovery.hardware_volume_path }}/discovery_info.json"
             {{- if not (empty .Values.dhcp_server.interface_prepend) }}
             - "--dhcp-server-interface-prepend={{ .Values.dhcp_server.interface_prepend }}"
             {{ end }}
@@ -139,7 +139,7 @@ spec:
             - name: forge-certs
               mountPath: /opt/forge
             - name: agent-discovery-info
-              mountPath: /etc/carbide/hardware
+              mountPath: "{{ .Values.discovery.hardware_volume_path }}"
               readOnly: true
       volumes:
         - name: forge-certs

--- a/bluefield/charts/carbide-dpu-agent/templates/daemonset.yaml
+++ b/bluefield/charts/carbide-dpu-agent/templates/daemonset.yaml
@@ -47,7 +47,8 @@ spec:
       initContainers:
         - name: forge-dpu-agent-init
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            procMount: Unmasked
+            privileged: true
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           args:
             - hardware

--- a/bluefield/charts/carbide-dpu-agent/templates/daemonset.yaml
+++ b/bluefield/charts/carbide-dpu-agent/templates/daemonset.yaml
@@ -148,7 +148,7 @@ spec:
             type: DirectoryOrCreate
         - name: agent-discovery-info
           emptyDir:
-            sizeLimit: 1Gi
+            sizeLimit: 16Mi
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/bluefield/charts/carbide-dpu-agent/templates/daemonset.yaml
+++ b/bluefield/charts/carbide-dpu-agent/templates/daemonset.yaml
@@ -44,6 +44,40 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: forge-dpu-agent-init
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          args:
+            - hardware
+            - "--output-file=/etc/carbide/hardware/discovery_info.json"
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP  # always resolves to cluster-internal IP
+            - name: RUST_BACKTRACE
+              value: "full"
+            - name: RUST_LIB_BACKTRACE
+              value: "0"
+            - name: RUST_LOG
+              value: "info"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: agent-discovery-info
+              mountPath: /etc/carbide/hardware
       containers:
         - name: forge-dpu-agent
           securityContext:
@@ -53,7 +87,7 @@ spec:
             - run
             - "--hbn-config-mode=nvue-rest"
             - "--agent-platform-type=containerized"
-            - "--discovery-info-file={{ .Values.discovery.hardware_file }}"
+            - "--discovery-info-file=/etc/carbide/hardware/discovery_info.json"
             {{- if not (empty .Values.dhcp_server.interface_prepend) }}
             - "--dhcp-server-interface-prepend={{ .Values.dhcp_server.interface_prepend }}"
             {{ end }}
@@ -103,11 +137,17 @@ spec:
           volumeMounts:
             - name: forge-certs
               mountPath: /opt/forge
+            - name: agent-discovery-info
+              mountPath: /etc/carbide/hardware
+              readOnly: true
       volumes:
         - name: forge-certs
           hostPath:
             path: /opt/forge
             type: DirectoryOrCreate
+        - name: agent-discovery-info
+          emptyDir:
+            sizeLimit: 1Gi
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/bluefield/charts/carbide-dpu-agent/values.yaml
+++ b/bluefield/charts/carbide-dpu-agent/values.yaml
@@ -32,7 +32,9 @@ hbn:
   nvue_username_key: "username"
   nvue_password_key: "password"
 discovery:
-  hardware_file: "/etc/carbide/discovery_info.json"
+  # The init container will write discovery_info.json into this volume, and the
+  # main agent container will load it from there.
+  hardware_volume_path: "/etc/carbide/hardware"
 dhcp_server:
   # If interface_prepend is set to a non-empty string, it will
   # be turned into a --dhcp-server-interface-prepend argument.


### PR DESCRIPTION
## Description
Run the hardware discovery code from an init container. This will need some permissions (TBD) granted so that the init container can see the hardware details it needs.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [X] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

