### PR TITLE
fix: remove check when checking nvlink config sync

### DIFF
--- a/crates/api-model/src/instance/status/nvlink.rs
+++ b/crates/api-model/src/instance/status/nvlink.rs
@@ -67,10 +67,6 @@ impl InstanceNvLinkStatus {
             return Self::unsynchronized_for_config(&config);
         };
 
-        if config.gpu_configs.len() != observations.nvlink_gpus.len() {
-            return Self::unsynchronized_for_config(&config);
-        }
-
         let mut configs_synced = SyncState::Synced;
 
         let mut nvlink_gpus: Vec<InstanceNvLinkGpuStatus> =


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
Don't expect nvlink config gpus and status observation vectors to be the same length; when a tenant detaches some but not all GPUs in an instance from a partition, the gpu configs vector will be shorter than the status observation vector because we generate status observations regardless of whether the GPU is in a partition or not. This was causing an instance nvlink config to appear as Pending even when the GPUs had been added to the correct partition.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

