### PR TITLE
fix(helm): init container examples with `bootArtifactContainers`

### DIFF
--- a/helm/charts/carbide-api/templates/deployment.yaml
+++ b/helm/charts/carbide-api/templates/deployment.yaml
@@ -27,9 +27,28 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.initContainers }}
+      {{- if or .Values.initContainers .Values.bootArtifactContainers }}
       initContainers:
+        {{- range .Values.bootArtifactContainers }}
+        - name: {{ .name }}
+          image: {{ .image }}
+          {{- with .command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .imagePullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
+          volumeMounts:
+            - name: boot-artifacts
+              mountPath: /boot-artifacts/blobs/internal
+            {{- with .volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- end }}
+        {{- with .Values.initContainers }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: carbide-api
@@ -147,6 +166,11 @@ spec:
             - name: firmware
               mountPath: "/opt/carbide/firmware"
               readOnly: true
+            {{- if .Values.bootArtifactContainers }}
+            - name: boot-artifacts
+              mountPath: /boot-artifacts/blobs/internal
+              readOnly: true
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -166,3 +190,7 @@ spec:
             secretName: forge-roots
         - name: firmware
           emptyDir: {}
+        {{- if .Values.bootArtifactContainers }}
+        - name: boot-artifacts
+          emptyDir: {}
+        {{- end }}

--- a/helm/charts/carbide-api/tests/boot_artifacts_test.yaml
+++ b/helm/charts/carbide-api/tests/boot_artifacts_test.yaml
@@ -1,0 +1,117 @@
+suite: boot artifact init containers
+templates:
+  - deployment.yaml
+tests:
+  - it: should not render init containers or boot-artifacts volume when bootArtifactContainers is empty
+    asserts:
+      - isKind:
+          of: Deployment
+      - notExists:
+          path: spec.template.spec.initContainers
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: boot-artifacts
+            emptyDir: {}
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: boot-artifacts
+            mountPath: /boot-artifacts/blobs/internal
+            readOnly: true
+
+  - it: should render boot artifact init containers with auto-injected volume mount
+    set:
+      bootArtifactContainers:
+        - name: boot-artifacts-x86-64
+          image: registry.example.com/boot-artifacts-x86_64:latest
+          command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+        - name: boot-artifacts-aarch64
+          image: registry.example.com/boot-artifacts-aarch64:latest
+          command: ["sh", "-c", "cp -r /aarch64 /apt /firmware /boot-artifacts/blobs/internal"]
+    asserts:
+      - exists:
+          path: spec.template.spec.initContainers
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 2
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: boot-artifacts-x86-64
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: registry.example.com/boot-artifacts-x86_64:latest
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: boot-artifacts
+            mountPath: /boot-artifacts/blobs/internal
+      - contains:
+          path: spec.template.spec.initContainers[1].volumeMounts
+          content:
+            name: boot-artifacts
+            mountPath: /boot-artifacts/blobs/internal
+
+  - it: should add boot-artifacts volume and mount on main container
+    set:
+      bootArtifactContainers:
+        - name: boot-artifacts-x86-64
+          image: registry.example.com/boot-artifacts-x86_64:latest
+          command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: boot-artifacts
+            emptyDir: {}
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: boot-artifacts
+            mountPath: /boot-artifacts/blobs/internal
+            readOnly: true
+
+  - it: should merge bootArtifactContainers and initContainers
+    set:
+      bootArtifactContainers:
+        - name: boot-artifacts-x86-64
+          image: registry.example.com/boot-artifacts-x86_64:latest
+          command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+      initContainers:
+        - name: custom-init
+          image: busybox:latest
+          command: ["sh", "-c", "echo hello"]
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 2
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: boot-artifacts-x86-64
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: custom-init
+
+  - it: should preserve extra volumeMounts on boot artifact containers
+    set:
+      bootArtifactContainers:
+        - name: boot-artifacts-x86-64
+          image: registry.example.com/boot-artifacts-x86_64:latest
+          command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+          volumeMounts:
+            - name: extra-volume
+              mountPath: /extra
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          count: 2
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: boot-artifacts
+            mountPath: /boot-artifacts/blobs/internal
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: extra-volume
+            mountPath: /extra

--- a/helm/charts/carbide-api/values.yaml
+++ b/helm/charts/carbide-api/values.yaml
@@ -46,15 +46,23 @@ resources:
     cpu: 1500m
     memory: 8Gi
 
-## Optional init containers (e.g. boot-artifacts)
+## Optional init containers (general-purpose pass-through)
 initContainers: []
-# initContainers:
-#   - name: boot-artifacts-x86
+
+## Boot-artifact init containers
+## Each entry is rendered as a Kubernetes init container with the boot-artifacts
+## volume automatically mounted at /boot-artifacts/blobs/internal.
+bootArtifactContainers: []
+# bootArtifactContainers:
+#   - name: boot-artifacts-x86-64
 #     image: <your-registry>/boot-artifacts-x86_64:latest
-#     command: ["cp", "-r", "/artifacts/.", "/opt/carbide/firmware/"]
-#     volumeMounts:
-#       - name: firmware
-#         mountPath: /opt/carbide/firmware
+#     command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+#   - name: boot-artifacts-aarch64
+#     image: <your-registry>/boot-artifacts-aarch64:latest
+#     command: ["sh", "-c", "cp -r /aarch64 /apt /firmware /boot-artifacts/blobs/internal"]
+#   - name: machine-validation-config
+#     image: <your-registry>/machine-validation-config:latest
+#     command: ["sh", "-c", "cp -r /machine-validation /boot-artifacts/blobs/internal"]
 
 service:
   grpc:

--- a/helm/charts/carbide-pxe/templates/deployment.yaml
+++ b/helm/charts/carbide-pxe/templates/deployment.yaml
@@ -26,9 +26,28 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.initContainers }}
+      {{- if or .Values.initContainers .Values.bootArtifactContainers }}
       initContainers:
+        {{- range .Values.bootArtifactContainers }}
+        - name: {{ .name }}
+          image: {{ .image }}
+          {{- with .command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .imagePullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
+          volumeMounts:
+            - name: boot-artifacts
+              mountPath: /boot-artifacts/blobs/internal
+            {{- with .volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- end }}
+        {{- with .Values.initContainers }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: carbide-pxe
@@ -37,7 +56,7 @@ spec:
             - /opt/carbide/carbide
           args:
             - -s
-            - /forge-boot-artifacts
+            - {{ .Values.bootArtifacts.servePath }}
           env:
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
@@ -63,7 +82,16 @@ spec:
             - name: spiffe
               mountPath: /var/run/secrets/spiffe.io
               readOnly: true
+            {{- if .Values.bootArtifactContainers }}
+            - name: boot-artifacts
+              mountPath: /boot-artifacts/blobs/internal
+              readOnly: true
+            {{- end }}
       volumes:
         - name: spiffe
           secret:
             secretName: carbide-pxe-certificate
+        {{- if .Values.bootArtifactContainers }}
+        - name: boot-artifacts
+          emptyDir: {}
+        {{- end }}

--- a/helm/charts/carbide-pxe/tests/boot_artifacts_test.yaml
+++ b/helm/charts/carbide-pxe/tests/boot_artifacts_test.yaml
@@ -1,0 +1,109 @@
+suite: boot artifact init containers
+templates:
+  - deployment.yaml
+tests:
+  - it: should not render init containers or boot-artifacts volume when bootArtifactContainers is empty
+    asserts:
+      - isKind:
+          of: Deployment
+      - notExists:
+          path: spec.template.spec.initContainers
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: boot-artifacts
+            emptyDir: {}
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: boot-artifacts
+            mountPath: /boot-artifacts/blobs/internal
+            readOnly: true
+
+  - it: should render boot artifact init containers with auto-injected volume mount
+    set:
+      bootArtifactContainers:
+        - name: boot-artifacts-x86-64
+          image: registry.example.com/boot-artifacts-x86_64:latest
+          command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+        - name: boot-artifacts-aarch64
+          image: registry.example.com/boot-artifacts-aarch64:latest
+          command: ["sh", "-c", "cp -r /aarch64 /apt /firmware /boot-artifacts/blobs/internal"]
+    asserts:
+      - exists:
+          path: spec.template.spec.initContainers
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 2
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: boot-artifacts-x86-64
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: boot-artifacts
+            mountPath: /boot-artifacts/blobs/internal
+      - contains:
+          path: spec.template.spec.initContainers[1].volumeMounts
+          content:
+            name: boot-artifacts
+            mountPath: /boot-artifacts/blobs/internal
+
+  - it: should add boot-artifacts volume and mount on main container
+    set:
+      bootArtifactContainers:
+        - name: boot-artifacts-x86-64
+          image: registry.example.com/boot-artifacts-x86_64:latest
+          command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: boot-artifacts
+            emptyDir: {}
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: boot-artifacts
+            mountPath: /boot-artifacts/blobs/internal
+            readOnly: true
+
+  - it: should use configurable serve path
+    set:
+      bootArtifacts:
+        servePath: /custom-boot-path
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - -s
+            - /custom-boot-path
+
+  - it: should default serve path to /boot-artifacts
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - -s
+            - /boot-artifacts
+
+  - it: should merge bootArtifactContainers and initContainers
+    set:
+      bootArtifactContainers:
+        - name: boot-artifacts-x86-64
+          image: registry.example.com/boot-artifacts-x86_64:latest
+          command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+      initContainers:
+        - name: custom-init
+          image: busybox:latest
+          command: ["sh", "-c", "echo hello"]
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 2
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: boot-artifacts-x86-64
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: custom-init

--- a/helm/charts/carbide-pxe/values.yaml
+++ b/helm/charts/carbide-pxe/values.yaml
@@ -27,8 +27,27 @@ namespaceOverride: ""
 
 replicas: 1
 
-## Optional init containers (e.g. boot-artifacts)
+## Optional init containers (general-purpose pass-through)
 initContainers: []
+
+## Boot-artifact init containers
+## Each entry is rendered as a Kubernetes init container with the boot-artifacts
+## volume automatically mounted at /boot-artifacts/blobs/internal.
+bootArtifactContainers: []
+# bootArtifactContainers:
+#   - name: boot-artifacts-x86-64
+#     image: <your-registry>/boot-artifacts-x86_64:latest
+#     command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+#   - name: boot-artifacts-aarch64
+#     image: <your-registry>/boot-artifacts-aarch64:latest
+#     command: ["sh", "-c", "cp -r /aarch64 /apt /firmware /boot-artifacts/blobs/internal"]
+#   - name: machine-validation-config
+#     image: <your-registry>/machine-validation-config:latest
+#     command: ["sh", "-c", "cp -r /machine-validation /boot-artifacts/blobs/internal"]
+
+## Boot artifact serving configuration
+bootArtifacts:
+  servePath: /boot-artifacts
 
 annotations:
   configmap.reloader.stakater.com/reload: "carbide-pxe-env-config"

--- a/helm/examples/values-full.yaml
+++ b/helm/examples/values-full.yaml
@@ -55,14 +55,18 @@ carbide-api:
       cpu: 1500m
       memory: 8Gi
 
-  ## Optional init containers for boot artifacts
-  initContainers:
-    - name: boot-artifacts-x86
+  ## Boot-artifact init containers — volume mount at /boot-artifacts/blobs/internal
+  ## is auto-injected by the template.
+  bootArtifactContainers:
+    - name: boot-artifacts-x86-64
       image: "your-registry.example.com/boot-artifacts-x86_64:latest"
-      command: ["cp", "-r", "/artifacts/.", "/opt/carbide/firmware/"]
-      volumeMounts:
-        - name: firmware
-          mountPath: /opt/carbide/firmware
+      command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+    - name: boot-artifacts-aarch64
+      image: "your-registry.example.com/boot-artifacts-aarch64:latest"
+      command: ["sh", "-c", "cp -r /aarch64 /apt /firmware /boot-artifacts/blobs/internal"]
+    - name: machine-validation-config
+      image: "your-registry.example.com/machine-validation-config:latest"
+      command: ["sh", "-c", "cp -r /machine-validation /boot-artifacts/blobs/internal"]
 
   env:
     VAULT_PKI_ROLE_NAME: "forge-cluster"
@@ -226,6 +230,20 @@ carbide-hardware-health:
 carbide-pxe:
   enabled: true
   replicas: 1
+
+  bootArtifacts:
+    servePath: /boot-artifacts
+
+  bootArtifactContainers:
+    - name: boot-artifacts-x86-64
+      image: "your-registry.example.com/boot-artifacts-x86_64:latest"
+      command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+    - name: boot-artifacts-aarch64
+      image: "your-registry.example.com/boot-artifacts-aarch64:latest"
+      command: ["sh", "-c", "cp -r /aarch64 /apt /firmware /boot-artifacts/blobs/internal"]
+    - name: machine-validation-config
+      image: "your-registry.example.com/machine-validation-config:latest"
+      command: ["sh", "-c", "cp -r /machine-validation /boot-artifacts/blobs/internal"]
 
   externalService:
     enabled: true


### PR DESCRIPTION
The commented examples and `values-full.yaml` referenced `/artifacts/` as the source path for boot-artifacts init containers, but no image actually places content there. The open-source Dockerfiles copy to `/` (yielding `/x86_64/`, `/aarch64/`, etc.) and the machine-validation image uses `/machine-validation/`.

This PR introduces a dedicated `bootArtifactContainers` values field that the deployment templates render as Kubernetes init containers with the `boot-artifacts` emptyDir volume mount auto-injected at `/boot-artifacts/blobs/internal`. This separates boot-artifact concerns from the general-purpose `initContainers` pass-through.

Other changes:
- carbide-pxe serve path is now configurable via `bootArtifacts.servePath` (default `/boot-artifacts`), replacing the hardcoded `/forge-boot-artifacts`.
- helm-unittest test suites added for both charts covering init container rendering, volume injection, serve path override, and the empty-default case.

Closes NVIDIA/ncx-infra-controller-core#772