### PR TITLE
fix(helm): promote database ConfigMap to pre-install hook

### DIFF
--- a/helm/charts/carbide-api/templates/configmap.yaml
+++ b/helm/charts/carbide-api/templates/configmap.yaml
@@ -55,6 +55,10 @@ metadata:
   namespace: {{ include "carbide-api.namespace" . }}
   annotations:
     argocd.argoproj.io/sync-wave: "-10"
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/resource-policy: keep
   labels:
     {{- include "carbide-api.labels" . | nindent 4 }}
 data:

--- a/helm/charts/carbide-api/tests/migration_job_test.yaml
+++ b/helm/charts/carbide-api/tests/migration_job_test.yaml
@@ -1,0 +1,51 @@
+suite: database migration hook ordering
+templates:
+  - configmap.yaml
+  - migration-job.yaml
+tests:
+  - it: should create database ConfigMap as a pre-install hook with lower weight than migration job
+    template: configmap.yaml
+    set:
+      databaseConfig:
+        DB_HOST: "postgres.example.com"
+        DB_PORT: "5432"
+        DB_NAME: "carbide"
+    documentIndex: 2
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: forge-system-carbide-database-config
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-10"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: migration job hook weight should be higher than database ConfigMap
+    template: migration-job.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-5"
+
+  - it: should not create database ConfigMap when databaseConfig is empty
+    template: configmap.yaml
+    documentIndex: 2
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: carbide-web-api-hostname


### PR DESCRIPTION
The `carbide-api-migrate` Job is a `pre-install,pre-upgrade` hook at weight `-5`. It references `forge-system-carbide-database-config` for DB connection details, but that ConfigMap was a regular Helm-managed resource — not a hook. Helm creates hooks before non-hook resources, so the ConfigMap didn't exist when the migration pod started, causing pod errors on every fresh
`helm install`.

Add Helm hook annotations to the database ConfigMap:

- `helm.sh/hook: pre-install,pre-upgrade` — create the ConfigMap during hook phase alongside the migration job
- `helm.sh/hook-weight: "-10"` — Create the ConfigMap before the migration job at `-5`
- `helm.sh/hook-delete-policy: before-hook-creation` — recreate the ConfigMap on each install/upgrade
- `helm.sh/resource-policy: keep` — Do not delete the ConfigMap after hook phase so the main deployment can still reference it

Closes NVIDIA/ncx-infra-controller-core#773
