### PR TITLE
fix: gracefully handle invalid BaseMac in stored exploration reports

### DIFF
--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -32,7 +32,7 @@ use libredfish::RedfishError;
 pub use libredfish::model::oem::nvidia_dpu::NicMode;
 use mac_address::MacAddress;
 use regex::Regex;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use utils::models::arch::CpuArchitecture;
 
 use super::DpuModel;
@@ -1281,12 +1281,21 @@ pub struct ComputerSystem {
     pub attributes: ComputerSystemAttributes,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub pcie_devices: Vec<PCIeDevice>,
+    #[serde(default, deserialize_with = "base_mac_deserialize")]
     pub base_mac: Option<BaseMac>,
     #[serde(default)]
     pub power_state: PowerState,
     pub sku: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub boot_order: Option<BootOrder>,
+}
+
+pub fn base_mac_deserialize<'a, D>(deserializer: D) -> Result<Option<BaseMac>, D::Error>
+where
+    D: Deserializer<'a>,
+{
+    let optional_value: Option<String> = Option::deserialize(deserializer)?;
+    Ok(optional_value.and_then(|v| v.parse().ok()))
 }
 
 impl ComputerSystem {
@@ -2393,5 +2402,80 @@ mod tests {
             ..Default::default()
         };
         assert!(!report.is_power_shelf());
+    }
+
+    #[test]
+    fn test_computer_system_with_invalid_base_mac_deserializes_as_none() {
+        let json = serde_json::json!({
+            "EthernetInterfaces": [],
+            "Id": "Bluefield",
+            "Manufacturer": "Nvidia",
+            "Model": "Bluefield-3 DPU",
+            "SerialNumber": "ABC1234",
+            "Attributes": {},
+            "PcieDevices": [],
+            "BaseMac": "pe:",
+            "PowerState": "On"
+        });
+
+        let system: ComputerSystem =
+            serde_json::from_value(json).expect("should deserialize despite invalid BaseMac");
+        assert_eq!(system.base_mac, None);
+    }
+
+    #[test]
+    fn test_computer_system_with_valid_base_mac_deserializes_correctly() {
+        let json = serde_json::json!({
+            "EthernetInterfaces": [],
+            "Id": "Bluefield",
+            "Manufacturer": "Nvidia",
+            "Model": "Bluefield-3 DPU",
+            "SerialNumber": "ABC1234",
+            "Attributes": {},
+            "PcieDevices": [],
+            "BaseMac": "A088C208804C",
+            "PowerState": "On"
+        });
+
+        let system: ComputerSystem =
+            serde_json::from_value(json).expect("should deserialize valid BaseMac");
+        assert_eq!(system.base_mac, Some("A088C208804C".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_computer_system_with_null_base_mac_deserializes_as_none() {
+        let json = serde_json::json!({
+            "EthernetInterfaces": [],
+            "Id": "Bluefield",
+            "Manufacturer": "Nvidia",
+            "Model": "Bluefield-3 DPU",
+            "SerialNumber": "ABC1234",
+            "Attributes": {},
+            "PcieDevices": [],
+            "BaseMac": null,
+            "PowerState": "On"
+        });
+
+        let system: ComputerSystem =
+            serde_json::from_value(json).expect("should deserialize null BaseMac");
+        assert_eq!(system.base_mac, None);
+    }
+
+    #[test]
+    fn test_computer_system_with_missing_base_mac_deserializes_as_none() {
+        let json = serde_json::json!({
+            "EthernetInterfaces": [],
+            "Id": "Bluefield",
+            "Manufacturer": "Nvidia",
+            "Model": "Bluefield-3 DPU",
+            "SerialNumber": "ABC1234",
+            "Attributes": {},
+            "PcieDevices": [],
+            "PowerState": "On"
+        });
+
+        let system: ComputerSystem =
+            serde_json::from_value(json).expect("should deserialize missing BaseMac");
+        assert_eq!(system.base_mac, None);
     }
 }


### PR DESCRIPTION
## Description
Exploration reports stored in the database may contain malformed BaseMac values (e.g. "pe:") originating from BMC Redfish responses. Previously, loading such reports would fail because BaseMac's Deserialize impl rejects invalid MAC strings.

Add a custom serde deserializer for the base_mac field that maps unparseable values to None instead of failing, allowing existing reports with garbage BaseMac data to be loaded successfully.

Add tests for invalid, valid, null, and missing BaseMac deserialization.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Introduced by #511 
