### PR TITLE
feat: enhancing RackCapabilitiesSet with type, topology, class + API endpoint

### DIFF
--- a/crates/admin-cli/src/rack/capabilities/args.rs
+++ b/crates/admin-cli/src/rack/capabilities/args.rs
@@ -15,29 +15,12 @@
  * limitations under the License.
  */
 
-pub mod capabilities;
-mod delete;
-mod list;
-pub mod metadata;
-mod show;
-
-#[cfg(test)]
-mod tests;
-
 use clap::Parser;
 
-use crate::cfg::dispatch::Dispatch;
+use super::show;
 
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Show rack information")]
+#[derive(Parser, Debug, Clone)]
+pub enum Args {
+    #[clap(about = "Show rack capabilities for a given rack")]
     Show(show::Args),
-    #[clap(about = "List all racks")]
-    List(list::Args),
-    #[clap(about = "Delete the rack")]
-    Delete(delete::Args),
-    #[clap(subcommand, about = "Edit Metadata associated with a Rack")]
-    Metadata(metadata::Args),
-    #[clap(subcommand, about = "Rack capabilities")]
-    Capabilities(capabilities::Args),
 }

--- a/crates/admin-cli/src/rack/capabilities/mod.rs
+++ b/crates/admin-cli/src/rack/capabilities/mod.rs
@@ -15,29 +15,22 @@
  * limitations under the License.
  */
 
-pub mod capabilities;
-mod delete;
-mod list;
-pub mod metadata;
+pub mod args;
 mod show;
 
-#[cfg(test)]
-mod tests;
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
 
-use clap::Parser;
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
 
-use crate::cfg::dispatch::Dispatch;
-
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Show rack information")]
-    Show(show::Args),
-    #[clap(about = "List all racks")]
-    List(list::Args),
-    #[clap(about = "Delete the rack")]
-    Delete(delete::Args),
-    #[clap(subcommand, about = "Edit Metadata associated with a Rack")]
-    Metadata(metadata::Args),
-    #[clap(subcommand, about = "Rack capabilities")]
-    Capabilities(capabilities::Args),
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        match self {
+            Args::Show(args) => {
+                show::cmd::show_capabilities(&ctx.api_client, args, &ctx.config).await?;
+            }
+        }
+        Ok(())
+    }
 }

--- a/crates/admin-cli/src/rack/capabilities/show/args.rs
+++ b/crates/admin-cli/src/rack/capabilities/show/args.rs
@@ -15,29 +15,11 @@
  * limitations under the License.
  */
 
-pub mod capabilities;
-mod delete;
-mod list;
-pub mod metadata;
-mod show;
-
-#[cfg(test)]
-mod tests;
-
+use carbide_uuid::rack::RackId;
 use clap::Parser;
 
-use crate::cfg::dispatch::Dispatch;
-
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Show rack information")]
-    Show(show::Args),
-    #[clap(about = "List all racks")]
-    List(list::Args),
-    #[clap(about = "Delete the rack")]
-    Delete(delete::Args),
-    #[clap(subcommand, about = "Edit Metadata associated with a Rack")]
-    Metadata(metadata::Args),
-    #[clap(subcommand, about = "Rack capabilities")]
-    Capabilities(capabilities::Args),
+#[derive(Parser, Debug, Clone)]
+pub struct Args {
+    #[clap(help = "Rack ID to get capabilities for")]
+    pub rack_id: RackId,
 }

--- a/crates/admin-cli/src/rack/capabilities/show/cmd.rs
+++ b/crates/admin-cli/src/rack/capabilities/show/cmd.rs
@@ -1,0 +1,245 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use color_eyre::Result;
+use prettytable::{Table, row};
+use rpc::admin_cli::OutputFormat;
+use rpc::forge::GetRackCapabilitiesResponse;
+use serde::Serialize;
+
+use super::args::Args;
+use crate::cfg::runtime::RuntimeConfig;
+use crate::rpc::ApiClient;
+
+#[derive(Serialize)]
+struct CapabilitiesOutput {
+    rack_id: String,
+    rack_type: String,
+    rack_hardware_type: String,
+    rack_hardware_topology: String,
+    rack_hardware_class: String,
+    compute_name: String,
+    compute_count: u32,
+    compute_vendor: String,
+    compute_slot_ids: Vec<u32>,
+    switch_name: String,
+    switch_count: u32,
+    switch_vendor: String,
+    switch_slot_ids: Vec<u32>,
+    power_shelf_name: String,
+    power_shelf_count: u32,
+    power_shelf_vendor: String,
+    power_shelf_slot_ids: Vec<u32>,
+}
+
+impl From<&GetRackCapabilitiesResponse> for CapabilitiesOutput {
+    fn from(r: &GetRackCapabilitiesResponse) -> Self {
+        let capabilities = r.capabilities.as_ref();
+        let compute = capabilities.and_then(|c| c.compute.as_ref());
+        let switch = capabilities.and_then(|c| c.switch.as_ref());
+        let power_shelf = capabilities.and_then(|c| c.power_shelf.as_ref());
+
+        Self {
+            rack_id: r
+                .rack_id
+                .as_ref()
+                .map(|id| id.to_string())
+                .unwrap_or_default(),
+            rack_type: r.rack_type.clone(),
+            rack_hardware_type: capabilities
+                .map(|c| {
+                    rpc::forge::RackHardwareType::try_from(c.rack_hardware_type)
+                        .unwrap_or_default()
+                        .as_str_name()
+                        .to_string()
+                })
+                .unwrap_or_else(|| "N/A".to_string()),
+            rack_hardware_topology: capabilities
+                .map(|c| {
+                    rpc::forge::RackHardwareTopology::try_from(c.rack_hardware_topology)
+                        .unwrap_or_default()
+                        .as_str_name()
+                        .to_string()
+                })
+                .unwrap_or_else(|| "N/A".to_string()),
+            rack_hardware_class: capabilities
+                .map(|c| {
+                    rpc::forge::RackHardwareClass::try_from(c.rack_hardware_class)
+                        .unwrap_or_default()
+                        .as_str_name()
+                        .to_string()
+                })
+                .unwrap_or_else(|| "N/A".to_string()),
+            compute_name: compute
+                .and_then(|c| c.name.clone())
+                .unwrap_or_else(|| "N/A".to_string()),
+            compute_count: compute.map(|c| c.count).unwrap_or(0),
+            compute_vendor: compute
+                .and_then(|c| c.vendor.clone())
+                .unwrap_or_else(|| "N/A".to_string()),
+            compute_slot_ids: compute.map(|c| c.slot_ids.clone()).unwrap_or_default(),
+            switch_name: switch
+                .and_then(|s| s.name.clone())
+                .unwrap_or_else(|| "N/A".to_string()),
+            switch_count: switch.map(|s| s.count).unwrap_or(0),
+            switch_vendor: switch
+                .and_then(|s| s.vendor.clone())
+                .unwrap_or_else(|| "N/A".to_string()),
+            switch_slot_ids: switch.map(|s| s.slot_ids.clone()).unwrap_or_default(),
+            power_shelf_name: power_shelf
+                .and_then(|p| p.name.clone())
+                .unwrap_or_else(|| "N/A".to_string()),
+            power_shelf_count: power_shelf.map(|p| p.count).unwrap_or(0),
+            power_shelf_vendor: power_shelf
+                .and_then(|p| p.vendor.clone())
+                .unwrap_or_else(|| "N/A".to_string()),
+            power_shelf_slot_ids: power_shelf.map(|p| p.slot_ids.clone()).unwrap_or_default(),
+        }
+    }
+}
+
+pub async fn show_capabilities(
+    api_client: &ApiClient,
+    args: Args,
+    config: &RuntimeConfig,
+) -> Result<()> {
+    let response = api_client.get_rack_capabilities(args.rack_id).await?;
+
+    let output = CapabilitiesOutput::from(&response);
+    match config.format {
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&output)?),
+        OutputFormat::Yaml => println!("{}", serde_yaml::to_string(&output)?),
+        _ => show_detail(&response),
+    }
+
+    Ok(())
+}
+
+fn slot_ids_display(ids: &[u32]) -> String {
+    if ids.is_empty() {
+        "N/A".to_string()
+    } else {
+        ids.iter()
+            .map(|id| id.to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+fn show_detail(r: &GetRackCapabilitiesResponse) {
+    let capabilities = r.capabilities.as_ref();
+    let compute = capabilities.and_then(|c| c.compute.as_ref());
+    let switch = capabilities.and_then(|c| c.switch.as_ref());
+    let power_shelf = capabilities.and_then(|c| c.power_shelf.as_ref());
+
+    let mut table = Table::new();
+    table.add_row(row![
+        "Rack ID",
+        r.rack_id
+            .as_ref()
+            .map(|id| id.to_string())
+            .unwrap_or_default()
+    ]);
+    table.add_row(row!["Rack Type", r.rack_type]);
+    table.add_row(row![
+        "Hardware Type",
+        capabilities
+            .map(
+                |c| rpc::forge::RackHardwareType::try_from(c.rack_hardware_type)
+                    .unwrap_or_default()
+                    .as_str_name()
+                    .to_string()
+            )
+            .unwrap_or_else(|| "N/A".to_string())
+    ]);
+    table.add_row(row![
+        "Hardware Topology",
+        capabilities
+            .map(
+                |c| rpc::forge::RackHardwareTopology::try_from(c.rack_hardware_topology)
+                    .unwrap_or_default()
+                    .as_str_name()
+                    .to_string()
+            )
+            .unwrap_or_else(|| "N/A".to_string())
+    ]);
+    table.add_row(row![
+        "Hardware Class",
+        capabilities
+            .map(
+                |c| rpc::forge::RackHardwareClass::try_from(c.rack_hardware_class)
+                    .unwrap_or_default()
+                    .as_str_name()
+                    .to_string()
+            )
+            .unwrap_or_else(|| "N/A".to_string())
+    ]);
+    table.add_row(row!["", ""]);
+    table.add_row(row![
+        "Compute Name",
+        compute.and_then(|c| c.name.as_deref()).unwrap_or("N/A")
+    ]);
+    table.add_row(row!["Compute Count", compute.map(|c| c.count).unwrap_or(0)]);
+    table.add_row(row![
+        "Compute Vendor",
+        compute.and_then(|c| c.vendor.as_deref()).unwrap_or("N/A")
+    ]);
+    table.add_row(row![
+        "Compute Slot IDs",
+        compute
+            .map(|c| slot_ids_display(&c.slot_ids))
+            .unwrap_or_else(|| "N/A".to_string())
+    ]);
+    table.add_row(row!["", ""]);
+    table.add_row(row![
+        "Switch Name",
+        switch.and_then(|s| s.name.as_deref()).unwrap_or("N/A")
+    ]);
+    table.add_row(row!["Switch Count", switch.map(|s| s.count).unwrap_or(0)]);
+    table.add_row(row![
+        "Switch Vendor",
+        switch.and_then(|s| s.vendor.as_deref()).unwrap_or("N/A")
+    ]);
+    table.add_row(row![
+        "Switch Slot IDs",
+        switch
+            .map(|s| slot_ids_display(&s.slot_ids))
+            .unwrap_or_else(|| "N/A".to_string())
+    ]);
+    table.add_row(row!["", ""]);
+    table.add_row(row![
+        "Power Shelf Name",
+        power_shelf.and_then(|p| p.name.as_deref()).unwrap_or("N/A")
+    ]);
+    table.add_row(row![
+        "Power Shelf Count",
+        power_shelf.map(|p| p.count).unwrap_or(0)
+    ]);
+    table.add_row(row![
+        "Power Shelf Vendor",
+        power_shelf
+            .and_then(|p| p.vendor.as_deref())
+            .unwrap_or("N/A")
+    ]);
+    table.add_row(row![
+        "Power Shelf Slot IDs",
+        power_shelf
+            .map(|p| slot_ids_display(&p.slot_ids))
+            .unwrap_or_else(|| "N/A".to_string())
+    ]);
+    table.printstd();
+}

--- a/crates/admin-cli/src/rack/capabilities/show/mod.rs
+++ b/crates/admin-cli/src/rack/capabilities/show/mod.rs
@@ -15,29 +15,7 @@
  * limitations under the License.
  */
 
-pub mod capabilities;
-mod delete;
-mod list;
-pub mod metadata;
-mod show;
+pub mod args;
+pub mod cmd;
 
-#[cfg(test)]
-mod tests;
-
-use clap::Parser;
-
-use crate::cfg::dispatch::Dispatch;
-
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Show rack information")]
-    Show(show::Args),
-    #[clap(about = "List all racks")]
-    List(list::Args),
-    #[clap(about = "Delete the rack")]
-    Delete(delete::Args),
-    #[clap(subcommand, about = "Edit Metadata associated with a Rack")]
-    Metadata(metadata::Args),
-    #[clap(subcommand, about = "Rack capabilities")]
-    Capabilities(capabilities::Args),
-}
+pub use args::Args;

--- a/crates/admin-cli/src/rack/tests.rs
+++ b/crates/admin-cli/src/rack/tests.rs
@@ -100,3 +100,25 @@ fn parse_delete_missing_identifier_fails() {
     let result = Cmd::try_parse_from(["rack", "delete"]);
     assert!(result.is_err(), "should fail without identifier");
 }
+
+// parse_capabilities_show ensures capabilities show parses with rack ID.
+#[test]
+fn parse_capabilities_show() {
+    let cmd = Cmd::try_parse_from(["rack", "capabilities", "show", "rack-123"])
+        .expect("should parse capabilities show");
+
+    match cmd {
+        Cmd::Capabilities(capabilities::Args::Show(args)) => {
+            assert_eq!(args.rack_id, "rack-123".parse().unwrap());
+        }
+        _ => panic!("expected Capabilities(Show) variant"),
+    }
+}
+
+// parse_capabilities_show_missing_rack_id_fails ensures capabilities
+// show fails without rack ID.
+#[test]
+fn parse_capabilities_show_missing_rack_id_fails() {
+    let result = Cmd::try_parse_from(["rack", "capabilities", "show"]);
+    assert!(result.is_err(), "should fail without rack_id");
+}

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -274,6 +274,18 @@ impl ApiClient {
         Ok(racks)
     }
 
+    pub async fn get_rack_capabilities(
+        &self,
+        rack_id: RackId,
+    ) -> CarbideCliResult<rpc::GetRackCapabilitiesResponse> {
+        Ok(self
+            .0
+            .get_rack_capabilities(rpc::GetRackCapabilitiesRequest {
+                rack_id: Some(rack_id),
+            })
+            .await?)
+    }
+
     async fn get_rack_ids(&self) -> CarbideCliResult<rpc::RackIdList> {
         Ok(self.0.find_rack_ids().await?)
     }

--- a/crates/api-model/src/rack_type.rs
+++ b/crates/api-model/src/rack_type.rs
@@ -20,6 +20,90 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
+/// RackHardwareType identifies the hardware type of a rack.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "text")]
+pub enum RackHardwareType {
+    #[serde(rename = "dsx_gb200nvl_36x1")]
+    #[sqlx(rename = "dsx_gb200nvl_36x1")]
+    DsxGb200Nvl36x1,
+
+    #[serde(rename = "dsx_gb200nvl_36x2")]
+    #[sqlx(rename = "dsx_gb200nvl_36x2")]
+    DsxGb200Nvl36x2,
+
+    #[serde(rename = "dsx_gb200nvl_72x1")]
+    #[sqlx(rename = "dsx_gb200nvl_72x1")]
+    DsxGb200Nvl72x1,
+}
+
+impl fmt::Display for RackHardwareType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RackHardwareType::DsxGb200Nvl36x1 => write!(f, "dsx_gb200nvl_36x1"),
+            RackHardwareType::DsxGb200Nvl36x2 => write!(f, "dsx_gb200nvl_36x2"),
+            RackHardwareType::DsxGb200Nvl72x1 => write!(f, "dsx_gb200nvl_72x1"),
+        }
+    }
+}
+
+/// RackHardwareTopology describes the hardware topology of a rack.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "text", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+#[allow(clippy::enum_variant_names)] // Topology suffix is part of the canonical config names
+pub enum RackHardwareTopology {
+    Gb200Nvl36r1C2g4Topology,
+    Gb300Nvl36r1C2g4Topology,
+    Gb200Nvl72r1C2g4Topology,
+    Gb300Nvl72r1C2g4Topology,
+    VrNvl8r1C2g4RtfTopology,
+    VrNvl72r1C2g4Topology,
+}
+
+impl fmt::Display for RackHardwareTopology {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RackHardwareTopology::Gb200Nvl36r1C2g4Topology => {
+                write!(f, "gb200_nvl36r1_c2g4_topology")
+            }
+            RackHardwareTopology::Gb300Nvl36r1C2g4Topology => {
+                write!(f, "gb300_nvl36r1_c2g4_topology")
+            }
+            RackHardwareTopology::Gb200Nvl72r1C2g4Topology => {
+                write!(f, "gb200_nvl72r1_c2g4_topology")
+            }
+            RackHardwareTopology::Gb300Nvl72r1C2g4Topology => {
+                write!(f, "gb300_nvl72r1_c2g4_topology")
+            }
+            RackHardwareTopology::VrNvl8r1C2g4RtfTopology => {
+                write!(f, "vr_nvl8r1_c2g4_rtf_topology")
+            }
+            RackHardwareTopology::VrNvl72r1C2g4Topology => {
+                write!(f, "vr_nvl72r1_c2g4_topology")
+            }
+        }
+    }
+}
+
+/// RackHardwareClass indicates whether a rack is a dev or production rack.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "text", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum RackHardwareClass {
+    Dev,
+    Prod,
+}
+
+impl fmt::Display for RackHardwareClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RackHardwareClass::Dev => write!(f, "dev"),
+            RackHardwareClass::Prod => write!(f, "prod"),
+        }
+    }
+}
+
 /* ********************************** */
 /*        RackCapabilityType          */
 /* ********************************** */
@@ -123,6 +207,15 @@ pub struct RackCapabilityPowerShelf {
 /// compute trays, switches, and power shelves.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RackCapabilitiesSet {
+    #[serde(default)]
+    pub rack_hardware_type: Option<RackHardwareType>,
+
+    #[serde(default)]
+    pub rack_hardware_topology: Option<RackHardwareTopology>,
+
+    #[serde(default)]
+    pub rack_hardware_class: Option<RackHardwareClass>,
+
     pub compute: RackCapabilityCompute,
     pub switch: RackCapabilitySwitch,
     pub power_shelf: RackCapabilityPowerShelf,
@@ -146,6 +239,172 @@ impl RackTypeConfig {
     /// get looks up a rack capabilities set by name.
     pub fn get(&self, name: &str) -> Option<&RackCapabilitiesSet> {
         self.rack_types.get(name)
+    }
+}
+
+use ::rpc::errors::RpcDataConversionError;
+
+impl From<RackHardwareType> for rpc::forge::RackHardwareType {
+    fn from(value: RackHardwareType) -> Self {
+        match value {
+            RackHardwareType::DsxGb200Nvl36x1 => rpc::forge::RackHardwareType::DsxGb200nvl36x1,
+            RackHardwareType::DsxGb200Nvl36x2 => rpc::forge::RackHardwareType::DsxGb200nvl36x2,
+            RackHardwareType::DsxGb200Nvl72x1 => rpc::forge::RackHardwareType::DsxGb200nvl72x1,
+        }
+    }
+}
+
+impl TryFrom<rpc::forge::RackHardwareType> for RackHardwareType {
+    type Error = RpcDataConversionError;
+
+    fn try_from(value: rpc::forge::RackHardwareType) -> Result<Self, Self::Error> {
+        match value {
+            rpc::forge::RackHardwareType::DsxGb200nvl36x1 => Ok(RackHardwareType::DsxGb200Nvl36x1),
+            rpc::forge::RackHardwareType::DsxGb200nvl36x2 => Ok(RackHardwareType::DsxGb200Nvl36x2),
+            rpc::forge::RackHardwareType::DsxGb200nvl72x1 => Ok(RackHardwareType::DsxGb200Nvl72x1),
+            rpc::forge::RackHardwareType::Unspecified => {
+                Err(RpcDataConversionError::InvalidArgument(
+                    "unspecified rack hardware type".to_string(),
+                ))
+            }
+        }
+    }
+}
+
+impl From<RackHardwareTopology> for rpc::forge::RackHardwareTopology {
+    fn from(value: RackHardwareTopology) -> Self {
+        match value {
+            RackHardwareTopology::Gb200Nvl36r1C2g4Topology => {
+                rpc::forge::RackHardwareTopology::Gb200Nvl36r1C2g4
+            }
+            RackHardwareTopology::Gb300Nvl36r1C2g4Topology => {
+                rpc::forge::RackHardwareTopology::Gb300Nvl36r1C2g4
+            }
+            RackHardwareTopology::Gb200Nvl72r1C2g4Topology => {
+                rpc::forge::RackHardwareTopology::Gb200Nvl72r1C2g4
+            }
+            RackHardwareTopology::Gb300Nvl72r1C2g4Topology => {
+                rpc::forge::RackHardwareTopology::Gb300Nvl72r1C2g4
+            }
+            RackHardwareTopology::VrNvl8r1C2g4RtfTopology => {
+                rpc::forge::RackHardwareTopology::VrNvl8r1C2g4Rtf
+            }
+            RackHardwareTopology::VrNvl72r1C2g4Topology => {
+                rpc::forge::RackHardwareTopology::VrNvl72r1C2g4
+            }
+        }
+    }
+}
+
+impl TryFrom<rpc::forge::RackHardwareTopology> for RackHardwareTopology {
+    type Error = RpcDataConversionError;
+
+    fn try_from(value: rpc::forge::RackHardwareTopology) -> Result<Self, Self::Error> {
+        match value {
+            rpc::forge::RackHardwareTopology::Gb200Nvl36r1C2g4 => {
+                Ok(RackHardwareTopology::Gb200Nvl36r1C2g4Topology)
+            }
+            rpc::forge::RackHardwareTopology::Gb300Nvl36r1C2g4 => {
+                Ok(RackHardwareTopology::Gb300Nvl36r1C2g4Topology)
+            }
+            rpc::forge::RackHardwareTopology::Gb200Nvl72r1C2g4 => {
+                Ok(RackHardwareTopology::Gb200Nvl72r1C2g4Topology)
+            }
+            rpc::forge::RackHardwareTopology::Gb300Nvl72r1C2g4 => {
+                Ok(RackHardwareTopology::Gb300Nvl72r1C2g4Topology)
+            }
+            rpc::forge::RackHardwareTopology::VrNvl8r1C2g4Rtf => {
+                Ok(RackHardwareTopology::VrNvl8r1C2g4RtfTopology)
+            }
+            rpc::forge::RackHardwareTopology::VrNvl72r1C2g4 => {
+                Ok(RackHardwareTopology::VrNvl72r1C2g4Topology)
+            }
+            rpc::forge::RackHardwareTopology::Unspecified => {
+                Err(RpcDataConversionError::InvalidArgument(
+                    "unspecified rack hardware topology".to_string(),
+                ))
+            }
+        }
+    }
+}
+
+impl From<RackHardwareClass> for rpc::forge::RackHardwareClass {
+    fn from(value: RackHardwareClass) -> Self {
+        match value {
+            RackHardwareClass::Dev => rpc::forge::RackHardwareClass::Dev,
+            RackHardwareClass::Prod => rpc::forge::RackHardwareClass::Prod,
+        }
+    }
+}
+
+impl TryFrom<rpc::forge::RackHardwareClass> for RackHardwareClass {
+    type Error = RpcDataConversionError;
+
+    fn try_from(value: rpc::forge::RackHardwareClass) -> Result<Self, Self::Error> {
+        match value {
+            rpc::forge::RackHardwareClass::Dev => Ok(RackHardwareClass::Dev),
+            rpc::forge::RackHardwareClass::Prod => Ok(RackHardwareClass::Prod),
+            rpc::forge::RackHardwareClass::Unspecified => {
+                Err(RpcDataConversionError::InvalidArgument(
+                    "unspecified rack hardware class".to_string(),
+                ))
+            }
+        }
+    }
+}
+
+impl From<&RackCapabilityCompute> for rpc::forge::RackCapabilityCompute {
+    fn from(value: &RackCapabilityCompute) -> Self {
+        rpc::forge::RackCapabilityCompute {
+            name: value.name.clone(),
+            count: value.count,
+            vendor: value.vendor.clone(),
+            slot_ids: value.slot_ids.clone().unwrap_or_default(),
+        }
+    }
+}
+
+impl From<&RackCapabilitySwitch> for rpc::forge::RackCapabilitySwitch {
+    fn from(value: &RackCapabilitySwitch) -> Self {
+        rpc::forge::RackCapabilitySwitch {
+            name: value.name.clone(),
+            count: value.count,
+            vendor: value.vendor.clone(),
+            slot_ids: value.slot_ids.clone().unwrap_or_default(),
+        }
+    }
+}
+
+impl From<&RackCapabilityPowerShelf> for rpc::forge::RackCapabilityPowerShelf {
+    fn from(value: &RackCapabilityPowerShelf) -> Self {
+        rpc::forge::RackCapabilityPowerShelf {
+            name: value.name.clone(),
+            count: value.count,
+            vendor: value.vendor.clone(),
+            slot_ids: value.slot_ids.clone().unwrap_or_default(),
+        }
+    }
+}
+
+impl From<&RackCapabilitiesSet> for rpc::forge::RackCapabilitiesSet {
+    fn from(value: &RackCapabilitiesSet) -> Self {
+        rpc::forge::RackCapabilitiesSet {
+            rack_hardware_type: value
+                .rack_hardware_type
+                .map(|t| rpc::forge::RackHardwareType::from(t) as i32)
+                .unwrap_or(rpc::forge::RackHardwareType::Unspecified as i32),
+            rack_hardware_topology: value
+                .rack_hardware_topology
+                .map(|t| rpc::forge::RackHardwareTopology::from(t) as i32)
+                .unwrap_or(rpc::forge::RackHardwareTopology::Unspecified as i32),
+            rack_hardware_class: value
+                .rack_hardware_class
+                .map(|c| rpc::forge::RackHardwareClass::from(c) as i32)
+                .unwrap_or(rpc::forge::RackHardwareClass::Unspecified as i32),
+            compute: Some((&value.compute).into()),
+            switch: Some((&value.switch).into()),
+            power_shelf: Some((&value.power_shelf).into()),
+        }
     }
 }
 
@@ -177,6 +436,7 @@ mod tests {
                     vendor: None,
                     slot_ids: None,
                 },
+                ..Default::default()
             },
         );
 
@@ -224,5 +484,338 @@ count = 2
         assert_eq!(nvl36.compute.count, 9);
         assert_eq!(nvl36.switch.count, 9);
         assert_eq!(nvl36.power_shelf.count, 2);
+    }
+
+    #[test]
+    fn test_rack_type_config_toml_with_hardware_fields() {
+        let toml_str = r#"
+[NVL72]
+rack_hardware_type = "dsx_gb200nvl_72x1"
+rack_hardware_topology = "gb200_nvl72r1_c2g4_topology"
+rack_hardware_class = "prod"
+
+[NVL72.compute]
+name = "GB200"
+count = 18
+vendor = "NVIDIA"
+
+[NVL72.switch]
+count = 9
+
+[NVL72.power_shelf]
+count = 8
+"#;
+        let config: RackTypeConfig = toml::from_str(toml_str).unwrap();
+        let nvl72 = config.get("NVL72").unwrap();
+
+        assert_eq!(
+            nvl72.rack_hardware_type,
+            Some(RackHardwareType::DsxGb200Nvl72x1)
+        );
+        assert_eq!(
+            nvl72.rack_hardware_topology,
+            Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology)
+        );
+        assert_eq!(nvl72.rack_hardware_class, Some(RackHardwareClass::Prod));
+        assert_eq!(nvl72.compute.count, 18);
+    }
+
+    #[test]
+    fn test_rack_type_config_toml_without_hardware_fields_defaults_to_none() {
+        let toml_str = r#"
+[NVL36]
+[NVL36.compute]
+count = 9
+[NVL36.switch]
+count = 9
+[NVL36.power_shelf]
+count = 2
+"#;
+        let config: RackTypeConfig = toml::from_str(toml_str).unwrap();
+        let nvl36 = config.get("NVL36").unwrap();
+
+        assert_eq!(nvl36.rack_hardware_type, None);
+        assert_eq!(nvl36.rack_hardware_topology, None);
+        assert_eq!(nvl36.rack_hardware_class, None);
+    }
+
+    // -- RackHardwareType serde --
+
+    #[test]
+    fn test_rack_hardware_type_serde_round_trip() {
+        let cases = [
+            (RackHardwareType::DsxGb200Nvl36x1, "\"dsx_gb200nvl_36x1\""),
+            (RackHardwareType::DsxGb200Nvl36x2, "\"dsx_gb200nvl_36x2\""),
+            (RackHardwareType::DsxGb200Nvl72x1, "\"dsx_gb200nvl_72x1\""),
+        ];
+        for (variant, expected_json) in cases {
+            let json = serde_json::to_string(&variant).unwrap();
+            assert_eq!(json, expected_json, "serialize {:?}", variant);
+            let deserialized: RackHardwareType = serde_json::from_str(&json).unwrap();
+            assert_eq!(deserialized, variant, "deserialize {:?}", variant);
+        }
+    }
+
+    #[test]
+    fn test_rack_hardware_type_display() {
+        assert_eq!(
+            RackHardwareType::DsxGb200Nvl36x1.to_string(),
+            "dsx_gb200nvl_36x1"
+        );
+        assert_eq!(
+            RackHardwareType::DsxGb200Nvl36x2.to_string(),
+            "dsx_gb200nvl_36x2"
+        );
+        assert_eq!(
+            RackHardwareType::DsxGb200Nvl72x1.to_string(),
+            "dsx_gb200nvl_72x1"
+        );
+    }
+
+    // -- RackHardwareTopology serde --
+
+    #[test]
+    fn test_rack_hardware_topology_serde_round_trip() {
+        let cases = [
+            (
+                RackHardwareTopology::Gb200Nvl36r1C2g4Topology,
+                "\"gb200_nvl36r1_c2g4_topology\"",
+            ),
+            (
+                RackHardwareTopology::Gb300Nvl36r1C2g4Topology,
+                "\"gb300_nvl36r1_c2g4_topology\"",
+            ),
+            (
+                RackHardwareTopology::Gb200Nvl72r1C2g4Topology,
+                "\"gb200_nvl72r1_c2g4_topology\"",
+            ),
+            (
+                RackHardwareTopology::Gb300Nvl72r1C2g4Topology,
+                "\"gb300_nvl72r1_c2g4_topology\"",
+            ),
+            (
+                RackHardwareTopology::VrNvl8r1C2g4RtfTopology,
+                "\"vr_nvl8r1_c2g4_rtf_topology\"",
+            ),
+            (
+                RackHardwareTopology::VrNvl72r1C2g4Topology,
+                "\"vr_nvl72r1_c2g4_topology\"",
+            ),
+        ];
+        for (variant, expected_json) in cases {
+            let json = serde_json::to_string(&variant).unwrap();
+            assert_eq!(json, expected_json, "serialize {:?}", variant);
+            let deserialized: RackHardwareTopology = serde_json::from_str(&json).unwrap();
+            assert_eq!(deserialized, variant, "deserialize {:?}", variant);
+        }
+    }
+
+    #[test]
+    fn test_rack_hardware_topology_display() {
+        assert_eq!(
+            RackHardwareTopology::Gb200Nvl36r1C2g4Topology.to_string(),
+            "gb200_nvl36r1_c2g4_topology"
+        );
+        assert_eq!(
+            RackHardwareTopology::VrNvl8r1C2g4RtfTopology.to_string(),
+            "vr_nvl8r1_c2g4_rtf_topology"
+        );
+        assert_eq!(
+            RackHardwareTopology::VrNvl72r1C2g4Topology.to_string(),
+            "vr_nvl72r1_c2g4_topology"
+        );
+    }
+
+    // -- RackHardwareClass serde --
+
+    #[test]
+    fn test_rack_hardware_class_serde_round_trip() {
+        let cases = [
+            (RackHardwareClass::Dev, "\"dev\""),
+            (RackHardwareClass::Prod, "\"prod\""),
+        ];
+        for (variant, expected_json) in cases {
+            let json = serde_json::to_string(&variant).unwrap();
+            assert_eq!(json, expected_json, "serialize {:?}", variant);
+            let deserialized: RackHardwareClass = serde_json::from_str(&json).unwrap();
+            assert_eq!(deserialized, variant, "deserialize {:?}", variant);
+        }
+    }
+
+    #[test]
+    fn test_rack_hardware_class_display() {
+        assert_eq!(RackHardwareClass::Dev.to_string(), "dev");
+        assert_eq!(RackHardwareClass::Prod.to_string(), "prod");
+    }
+
+    // -- Proto conversion tests --
+
+    #[test]
+    fn test_rack_hardware_type_proto_round_trip() {
+        let cases = [
+            (
+                RackHardwareType::DsxGb200Nvl36x1,
+                rpc::forge::RackHardwareType::DsxGb200nvl36x1,
+            ),
+            (
+                RackHardwareType::DsxGb200Nvl36x2,
+                rpc::forge::RackHardwareType::DsxGb200nvl36x2,
+            ),
+            (
+                RackHardwareType::DsxGb200Nvl72x1,
+                rpc::forge::RackHardwareType::DsxGb200nvl72x1,
+            ),
+        ];
+        for (model, proto) in cases {
+            let converted: rpc::forge::RackHardwareType = model.into();
+            assert_eq!(converted, proto);
+            let back: RackHardwareType = proto.try_into().unwrap();
+            assert_eq!(back, model);
+        }
+    }
+
+    #[test]
+    fn test_rack_hardware_type_proto_unspecified_errors() {
+        let result = RackHardwareType::try_from(rpc::forge::RackHardwareType::Unspecified);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_rack_hardware_topology_proto_round_trip() {
+        let cases = [
+            (
+                RackHardwareTopology::Gb200Nvl36r1C2g4Topology,
+                rpc::forge::RackHardwareTopology::Gb200Nvl36r1C2g4,
+            ),
+            (
+                RackHardwareTopology::Gb300Nvl36r1C2g4Topology,
+                rpc::forge::RackHardwareTopology::Gb300Nvl36r1C2g4,
+            ),
+            (
+                RackHardwareTopology::Gb200Nvl72r1C2g4Topology,
+                rpc::forge::RackHardwareTopology::Gb200Nvl72r1C2g4,
+            ),
+            (
+                RackHardwareTopology::Gb300Nvl72r1C2g4Topology,
+                rpc::forge::RackHardwareTopology::Gb300Nvl72r1C2g4,
+            ),
+            (
+                RackHardwareTopology::VrNvl8r1C2g4RtfTopology,
+                rpc::forge::RackHardwareTopology::VrNvl8r1C2g4Rtf,
+            ),
+            (
+                RackHardwareTopology::VrNvl72r1C2g4Topology,
+                rpc::forge::RackHardwareTopology::VrNvl72r1C2g4,
+            ),
+        ];
+        for (model, proto) in cases {
+            let converted: rpc::forge::RackHardwareTopology = model.into();
+            assert_eq!(converted, proto);
+            let back: RackHardwareTopology = proto.try_into().unwrap();
+            assert_eq!(back, model);
+        }
+    }
+
+    #[test]
+    fn test_rack_hardware_topology_proto_unspecified_errors() {
+        let result = RackHardwareTopology::try_from(rpc::forge::RackHardwareTopology::Unspecified);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_rack_hardware_class_proto_round_trip() {
+        let cases = [
+            (RackHardwareClass::Dev, rpc::forge::RackHardwareClass::Dev),
+            (RackHardwareClass::Prod, rpc::forge::RackHardwareClass::Prod),
+        ];
+        for (model, proto) in cases {
+            let converted: rpc::forge::RackHardwareClass = model.into();
+            assert_eq!(converted, proto);
+            let back: RackHardwareClass = proto.try_into().unwrap();
+            assert_eq!(back, model);
+        }
+    }
+
+    #[test]
+    fn test_rack_hardware_class_proto_unspecified_errors() {
+        let result = RackHardwareClass::try_from(rpc::forge::RackHardwareClass::Unspecified);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_rack_capabilities_set_proto_conversion() {
+        let caps = RackCapabilitiesSet {
+            rack_hardware_type: Some(RackHardwareType::DsxGb200Nvl72x1),
+            rack_hardware_topology: Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology),
+            rack_hardware_class: Some(RackHardwareClass::Prod),
+            compute: RackCapabilityCompute {
+                name: Some("GB200".to_string()),
+                count: 18,
+                vendor: Some("NVIDIA".to_string()),
+                slot_ids: Some(vec![1, 2, 3]),
+            },
+            switch: RackCapabilitySwitch {
+                name: None,
+                count: 9,
+                vendor: None,
+                slot_ids: None,
+            },
+            power_shelf: RackCapabilityPowerShelf {
+                name: Some("PSU".to_string()),
+                count: 8,
+                vendor: Some("Delta".to_string()),
+                slot_ids: None,
+            },
+        };
+
+        let proto: rpc::forge::RackCapabilitiesSet = (&caps).into();
+
+        assert_eq!(
+            proto.rack_hardware_type,
+            rpc::forge::RackHardwareType::DsxGb200nvl72x1 as i32
+        );
+        assert_eq!(
+            proto.rack_hardware_topology,
+            rpc::forge::RackHardwareTopology::Gb200Nvl72r1C2g4 as i32
+        );
+        assert_eq!(
+            proto.rack_hardware_class,
+            rpc::forge::RackHardwareClass::Prod as i32
+        );
+
+        let compute = proto.compute.unwrap();
+        assert_eq!(compute.name, Some("GB200".to_string()));
+        assert_eq!(compute.count, 18);
+        assert_eq!(compute.vendor, Some("NVIDIA".to_string()));
+        assert_eq!(compute.slot_ids, vec![1, 2, 3]);
+
+        let switch = proto.switch.unwrap();
+        assert_eq!(switch.name, None);
+        assert_eq!(switch.count, 9);
+
+        let power_shelf = proto.power_shelf.unwrap();
+        assert_eq!(power_shelf.name, Some("PSU".to_string()));
+        assert_eq!(power_shelf.count, 8);
+        assert_eq!(power_shelf.vendor, Some("Delta".to_string()));
+        assert_eq!(power_shelf.slot_ids, Vec::<u32>::new());
+    }
+
+    #[test]
+    fn test_rack_capabilities_set_proto_conversion_with_none_fields() {
+        let caps = RackCapabilitiesSet::default();
+        let proto: rpc::forge::RackCapabilitiesSet = (&caps).into();
+
+        assert_eq!(
+            proto.rack_hardware_type,
+            rpc::forge::RackHardwareType::Unspecified as i32
+        );
+        assert_eq!(
+            proto.rack_hardware_topology,
+            rpc::forge::RackHardwareTopology::Unspecified as i32
+        );
+        assert_eq!(
+            proto.rack_hardware_class,
+            rpc::forge::RackHardwareClass::Unspecified as i32
+        );
     }
 }

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -1108,6 +1108,13 @@ impl Forge for Api {
         crate::handlers::rack::delete_rack(self, request).await
     }
 
+    async fn get_rack_capabilities(
+        &self,
+        request: Request<rpc::GetRackCapabilitiesRequest>,
+    ) -> Result<Response<rpc::GetRackCapabilitiesResponse>, Status> {
+        crate::handlers::rack::get_rack_capabilities(self, request).await
+    }
+
     /// Trigger DPU reprovisioning
     async fn trigger_dpu_reprovisioning(
         &self,

--- a/crates/api/src/auth/internal_rbac_rules.rs
+++ b/crates/api/src/auth/internal_rbac_rules.rs
@@ -707,6 +707,7 @@ impl InternalRBACRules {
         x.perm("FindRacksByIds", vec![ForgeAdminCLI, SiteAgent, Rla]);
         x.perm("GetRack", vec![ForgeAdminCLI, Rla]);
         x.perm("DeleteRack", vec![ForgeAdminCLI, Rla]);
+        x.perm("GetRackCapabilities", vec![ForgeAdminCLI]);
         x.perm("RackManagerCall", vec![ForgeAdminCLI]);
         x.perm("ScoutStream", vec![Scout]);
         x.perm("ScoutStreamShowConnections", vec![ForgeAdminCLI]);

--- a/crates/api/src/handlers/rack.rs
+++ b/crates/api/src/handlers/rack.rs
@@ -393,6 +393,48 @@ async fn remove_rack_override_by_source(
     Ok(())
 }
 
+pub async fn get_rack_capabilities(
+    api: &Api,
+    request: Request<rpc::GetRackCapabilitiesRequest>,
+) -> Result<Response<rpc::GetRackCapabilitiesResponse>, Status> {
+    log_request_data(&request);
+
+    let req = request.into_inner();
+    let rack_id = req
+        .rack_id
+        .ok_or_else(|| CarbideError::MissingArgument("rack_id"))?;
+
+    let rack = db_rack::get(&api.database_connection, &rack_id)
+        .await
+        .map_err(CarbideError::from)?;
+
+    let rack_type_name = rack.config.rack_type.as_deref().unwrap_or_default();
+    if rack_type_name.is_empty() {
+        return Err(CarbideError::NotFoundError {
+            kind: "rack_type for rack",
+            id: rack_id.to_string(),
+        }
+        .into());
+    }
+
+    let capabilities = api
+        .runtime_config
+        .rack_types
+        .get(rack_type_name)
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "rack capabilities for rack_type",
+            id: rack_type_name.to_string(),
+        })?;
+
+    let rpc_capabilities: rpc::RackCapabilitiesSet = capabilities.into();
+
+    Ok(Response::new(rpc::GetRackCapabilitiesResponse {
+        rack_id: Some(rack_id),
+        rack_type: rack_type_name.to_string(),
+        capabilities: Some(rpc_capabilities),
+    }))
+}
+
 pub(crate) async fn update_rack_metadata(
     api: &Api,
     request: Request<rpc::RackMetadataUpdateRequest>,

--- a/crates/api/src/tests/expected_rack.rs
+++ b/crates/api/src/tests/expected_rack.rs
@@ -52,6 +52,7 @@ fn config_with_rack_types() -> crate::cfg::file::CarbideConfig {
                         vendor: None,
                         slot_ids: None,
                     },
+                    ..Default::default()
                 },
             ),
             (
@@ -75,6 +76,7 @@ fn config_with_rack_types() -> crate::cfg::file::CarbideConfig {
                         vendor: None,
                         slot_ids: None,
                     },
+                    ..Default::default()
                 },
             ),
         ]

--- a/crates/api/src/tests/rack_state_controller/handler.rs
+++ b/crates/api/src/tests/rack_state_controller/handler.rs
@@ -58,6 +58,7 @@ fn test_capabilities() -> RackCapabilitiesSet {
             vendor: None,
             slot_ids: None,
         },
+        ..Default::default()
     }
 }
 
@@ -81,6 +82,7 @@ fn simple_capabilities() -> RackCapabilitiesSet {
             vendor: None,
             slot_ids: None,
         },
+        ..Default::default()
     }
 }
 
@@ -104,6 +106,7 @@ fn single_capabilities() -> RackCapabilitiesSet {
             vendor: None,
             slot_ids: None,
         },
+        ..Default::default()
     }
 }
 

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -643,6 +643,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .type_attribute("forge.RackFirmwareHistoryRecord", "#[derive(serde::Serialize)]")
         .type_attribute("forge.RackFirmwareHistoryRecords", "#[derive(serde::Serialize)]")
         .type_attribute("forge.RackFirmwareHistoryResponse", "#[derive(serde::Serialize)]")
+        .type_attribute("forge.RackCapabilitiesSet", "#[derive(serde::Serialize)]")
+        .type_attribute("forge.RackCapabilityCompute", "#[derive(serde::Serialize)]")
+        .type_attribute("forge.RackCapabilitySwitch", "#[derive(serde::Serialize)]")
+        .type_attribute("forge.RackCapabilityPowerShelf", "#[derive(serde::Serialize)]")
+        .type_attribute("forge.GetRackCapabilitiesResponse", "#[derive(serde::Serialize)]")
         .type_attribute(
             "forge.MachineHardwareInfoGpu",
             "#[derive(serde::Deserialize, serde::Serialize)]",

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -670,6 +670,7 @@ service Forge {
   // Deprecated: Use FindRackIds
   rpc GetRack(GetRackRequest) returns (GetRackResponse);
   rpc DeleteRack(DeleteRackRequest) returns (google.protobuf.Empty);
+  rpc GetRackCapabilities(GetRackCapabilitiesRequest) returns (GetRackCapabilitiesResponse);
 
   //
   // Compute Allocations
@@ -6319,6 +6320,71 @@ message RackStateHistoryRecords {
 
 message DeleteRackRequest {
   string id = 1;
+}
+
+// Rack Capabilities
+
+enum RackHardwareType {
+  RACK_HARDWARE_TYPE_UNSPECIFIED = 0;
+  RACK_HARDWARE_TYPE_DSX_GB200NVL_36X1 = 1;
+  RACK_HARDWARE_TYPE_DSX_GB200NVL_36X2 = 2;
+  RACK_HARDWARE_TYPE_DSX_GB200NVL_72X1 = 3;
+}
+
+enum RackHardwareTopology {
+  RACK_HARDWARE_TOPOLOGY_UNSPECIFIED = 0;
+  RACK_HARDWARE_TOPOLOGY_GB200_NVL36R1_C2G4 = 1;
+  RACK_HARDWARE_TOPOLOGY_GB300_NVL36R1_C2G4 = 2;
+  RACK_HARDWARE_TOPOLOGY_GB200_NVL72R1_C2G4 = 3;
+  RACK_HARDWARE_TOPOLOGY_GB300_NVL72R1_C2G4 = 4;
+  RACK_HARDWARE_TOPOLOGY_VR_NVL8R1_C2G4_RTF = 5;
+  RACK_HARDWARE_TOPOLOGY_VR_NVL72R1_C2G4 = 6;
+}
+
+enum RackHardwareClass {
+  RACK_HARDWARE_CLASS_UNSPECIFIED = 0;
+  RACK_HARDWARE_CLASS_DEV = 1;
+  RACK_HARDWARE_CLASS_PROD = 2;
+}
+
+message RackCapabilityCompute {
+  optional string name = 1;
+  uint32 count = 2;
+  optional string vendor = 3;
+  repeated uint32 slot_ids = 4;
+}
+
+message RackCapabilitySwitch {
+  optional string name = 1;
+  uint32 count = 2;
+  optional string vendor = 3;
+  repeated uint32 slot_ids = 4;
+}
+
+message RackCapabilityPowerShelf {
+  optional string name = 1;
+  uint32 count = 2;
+  optional string vendor = 3;
+  repeated uint32 slot_ids = 4;
+}
+
+message RackCapabilitiesSet {
+  RackHardwareType rack_hardware_type = 1;
+  RackHardwareTopology rack_hardware_topology = 2;
+  RackHardwareClass rack_hardware_class = 3;
+  RackCapabilityCompute compute = 4;
+  RackCapabilitySwitch switch = 5;
+  RackCapabilityPowerShelf power_shelf = 6;
+}
+
+message GetRackCapabilitiesRequest {
+  common.RackId rack_id = 1;
+}
+
+message GetRackCapabilitiesResponse {
+  common.RackId rack_id = 1;
+  string rack_type = 2;
+  RackCapabilitiesSet capabilities = 3;
 }
 
 // put some sample rack manager commands in for now


### PR DESCRIPTION
## Description

This enhances `RackCapabilitiesSet` with three new parameters:
- `rack_hardware_type` -- e.g. `Gb200Nvl72x1`
- `rack_hardware_topology` -- e.g. `gb200_nvl72r1_c2g4_topology`
- `rack_hardware_class` -- e.g. `< dev | prod >`

Where:
- `rack_hardware_type` is used for mapping a given firmware SOT to a given hardware type. Right now an SOT does *not* contain the hardware type in the JSON manifest, so we will maintain our own mapping of type -> SOT. This will include subsequent updates to require a `RackHardwareType` when defining a new SOT, which we will use to set default firmware for a given rack type, see what is available per rack type, etc.
- `rack_hardware_class` is also related to firmware/SOT. Right now an SOT is split into different groupings (`dev` or `prod`), and even if an SOT is one or the other, you need to know where to look. This also allows us to be more flexible in our own `name -> RackCapabilitesSet` mappings, letting us have a mix of dev and prod racks with different configurations.
- `rack_hardware_topology` is used for configuration of the GFM/fabric on the rack.

This also introduces a new `GetRackCapabilitesSet` API endpoint (with a first-class `message RackCapabilitiesSet` + supporting messages), allowing an operator to `carbide-admin-cli rack capabilities show <rack-id>` and get back the current `RackCapabilitiesSet` driving the given `<rack-id>`.

**TODOs**:
- A follow up PR to integrate with `admin-cli rack-firmware` calls.
- A follow up PR to build out `admin-cli rack capabilities` more.

...but I wanted to keep this PR more focused, if we're ok with that.

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

