### PR TITLE
feat(site-explorer): retry transient Bluefield eth interfaces 404s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,7 @@ dependencies = [
 name = "bmc-explorer"
 version = "0.1.0"
 dependencies = [
+ "axum 0.8.6",
  "bmc-mock",
  "bmc-vendor",
  "carbide-api-model",

--- a/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
+++ b/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
@@ -674,6 +674,7 @@ impl EndpointExplorer for BmcEndpointExplorer {
 
     // 1) Authenticate and set the BMC root account credentials
     // 2) Authenticate and set the BMC forge-admin account credentials (TODO)
+    #[tracing::instrument(skip_all, fields(object_id=%bmc_ip_address))]
     async fn explore_endpoint(
         &self,
         bmc_ip_address: SocketAddr,

--- a/crates/api/src/site_explorer/redfish.rs
+++ b/crates/api/src/site_explorer/redfish.rs
@@ -19,6 +19,7 @@ use std::error::Error;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use carbide_network::deserialize_input_mac_to_address;
 use forge_secrets::credentials::Credentials;
@@ -332,9 +333,12 @@ impl RedfishClient {
             .nv_redfish_client_pool
             .cached_nv_redfish_bmc(bmc_ip_address, credentials.clone())
         {
-            bmc_explorer::nv_generate_exploration_report(bmc, boot_interface_mac)
-                .await
-                .map_err(map_nv_redfish_explore_error)
+            bmc_explorer::nv_generate_exploration_report(
+                bmc,
+                &nv_bmc_explore_config(boot_interface_mac),
+            )
+            .await
+            .map_err(map_nv_redfish_explore_error)
         } else {
             let bmc = self
                 .nv_redfish_client_pool
@@ -373,9 +377,12 @@ impl RedfishClient {
             };
             self.nv_redfish_client_pool
                 .update_cache(bmc_ip_address, credentials, bmc);
-            bmc_explorer::nv_generate_exploration_report_from_root(root, boot_interface_mac)
-                .await
-                .map_err(map_nv_redfish_explore_error)
+            bmc_explorer::nv_generate_exploration_report_from_root(
+                root,
+                &nv_bmc_explore_config(boot_interface_mac),
+            )
+            .await
+            .map_err(map_nv_redfish_explore_error)
         }
     }
 
@@ -1289,6 +1296,32 @@ pub(crate) fn map_redfish_error(error: RedfishError) -> EndpointExplorationError
             response_body: None,
             response_code: None,
         },
+    }
+}
+
+fn nv_error_classifier(
+    err: &<crate::nv_redfish::NvRedfishBmc as nv_redfish::Bmc>::Error,
+) -> Option<bmc_explorer::ErrorClass> {
+    type BmcError = nv_redfish::bmc_http::reqwest::BmcError;
+    match err {
+        BmcError::InvalidResponse {
+            status: http::StatusCode::NOT_FOUND,
+            ..
+        } => Some(bmc_explorer::ErrorClass::HttpNotFound),
+        _ => None,
+    }
+}
+
+fn nv_bmc_explore_config(
+    boot_interface_mac: Option<MacAddress>,
+) -> bmc_explorer::Config<'static, crate::nv_redfish::NvRedfishBmc> {
+    bmc_explorer::Config {
+        boot_interface_mac,
+        error_classifier: &nv_error_classifier,
+        // Chosen arbitrarily: we want to wait a bit between tries,
+        // but not for too long relative to the total exploration
+        // time.
+        retry_timeout: Duration::from_millis(1000),
     }
 }
 

--- a/crates/bmc-explorer/Cargo.toml
+++ b/crates/bmc-explorer/Cargo.toml
@@ -45,9 +45,11 @@ nv-redfish = { workspace = true, features = [
 ] }
 regex = { workspace = true }
 lazy_static = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+axum = { workspace = true }
 bmc-mock = { path = "../bmc-mock" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 

--- a/crates/bmc-explorer/src/computer_system.rs
+++ b/crates/bmc-explorer/src/computer_system.rs
@@ -37,15 +37,23 @@ use nv_redfish::resource::PowerState;
 use nv_redfish::{Bmc, Resource, ResourceProvidesStatus};
 use regex::Regex;
 
-use crate::{Error, ExploredChassisCollection, compare_boot_options, hw};
+use crate::{
+    Config as ExploreConfig, Error, ErrorClass, ExploredChassisCollection, compare_boot_options, hw,
+};
 
 const UEFI_MAC_PATTERN_CAPTURE: &str = "mac";
 lazy_static::lazy_static! {
     static ref UEFI_MAC_PATTERN: Regex = Regex::new(&format!(r"MAC\((?<{UEFI_MAC_PATTERN_CAPTURE}>[[:alnum:]]+)\,")).unwrap();
 }
 
-pub struct Config {
+pub struct Config<'a, B: Bmc> {
     pub need_oem_nvidia_bluefield: bool,
+    // Temporary workaround for BlueField DPU BMCs that intermittently return
+    // HTTP 404 for the OOB interface or the full EthernetInterfaces collection.
+    // This is expected to be fixed in BMC firmware 24.10-39, which adds
+    // internal retries.
+    pub retry_404_on_eth_interfaces: bool,
+    pub explore: &'a ExploreConfig<'a, B>,
 }
 
 pub struct ExploredComputerSystem<B: Bmc> {
@@ -58,7 +66,10 @@ pub struct ExploredComputerSystem<B: Bmc> {
 }
 
 impl<B: Bmc> ExploredComputerSystem<B> {
-    pub async fn explore(system: ComputerSystem<B>, config: &Config) -> Result<Self, Error<B>> {
+    pub async fn explore(
+        system: ComputerSystem<B>,
+        config: &Config<'_, B>,
+    ) -> Result<Self, Error<B>> {
         let boot_options = if let Some(collection) = system
             .boot_options()
             .await
@@ -74,17 +85,9 @@ impl<B: Bmc> ExploredComputerSystem<B> {
 
         let bios = system.bios().await.map_err(Error::nv_redfish("bios"))?;
 
-        let ethernet_interfaces = match system.ethernet_interfaces().await {
-            Ok(Some(ifaces)) => ifaces
-                .members()
-                .await
-                .map_err(Error::nv_redfish("system ethernet interfaces members"))?,
-            Ok(None) => vec![],
-            Err(err) => Err(Error::NvRedfish {
-                context: "system ethernet interfaces",
-                err,
-            })?,
-        };
+        let ethernet_interfaces = Self::fetch_eth_interfaces(&system, config)
+            .await
+            .map_err(Error::nv_redfish("system ethernet interfaces"))?;
 
         let oem_nvidia_bluefield = if config.need_oem_nvidia_bluefield {
             system
@@ -108,6 +111,39 @@ impl<B: Bmc> ExploredComputerSystem<B> {
             oem_nvidia_bluefield,
             secure_boot,
         })
+    }
+
+    async fn fetch_eth_interfaces(
+        system: &ComputerSystem<B>,
+        config: &Config<'_, B>,
+    ) -> Result<Vec<EthernetInterface<B>>, nv_redfish::Error<B>> {
+        // Total tries: 3 (initial + 2 retries).
+        let mut retries_remaining = 2;
+        loop {
+            let result = match system.ethernet_interfaces().await {
+                Ok(Some(ifaces)) => ifaces.members().await,
+                Ok(None) => Ok(vec![]),
+                Err(err) => Err(err),
+            };
+            match result {
+                Ok(v) => break Ok(v),
+                Err(err) if config.retry_404_on_eth_interfaces && retries_remaining != 0 => {
+                    if let nv_redfish::Error::Bmc(bmc_error) = &err
+                        && (config.explore.error_classifier)(bmc_error)
+                            == Some(ErrorClass::HttpNotFound)
+                    {
+                        tracing::warn!(
+                            "received 404 on system's ethernet collection fetch. Retrying. {retries_remaining} tries left"
+                        );
+                        retries_remaining -= 1;
+                        tokio::time::sleep(config.explore.retry_timeout).await;
+                    } else {
+                        break Err(err);
+                    }
+                }
+                Err(err) => break Err(err),
+            }
+        }
     }
 
     pub fn to_model(

--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -25,6 +25,7 @@ mod network_adapter;
 use std::collections::HashMap;
 use std::convert::identity;
 use std::sync::Arc;
+use std::time::Duration;
 
 use chassis::ExploredChassisCollection;
 use computer_system::ExploredComputerSystem;
@@ -57,19 +58,32 @@ pub async fn explore_root<B: Bmc>(bmc: Arc<B>) -> Result<ServiceRoot<B>, Error<B
         .map_err(Error::nv_redfish("service_root"))
 }
 
+#[derive(PartialEq, Eq)]
+pub enum ErrorClass {
+    HttpNotFound,
+}
+
+pub type ErrorClassifier<'a, B> = &'a (dyn Fn(&<B as Bmc>::Error) -> Option<ErrorClass> + Sync);
+
+pub struct Config<'a, B: Bmc> {
+    pub boot_interface_mac: Option<MacAddress>,
+    pub error_classifier: ErrorClassifier<'a, B>,
+    pub retry_timeout: Duration,
+}
+
 pub async fn nv_generate_exploration_report<B: Bmc>(
     bmc: Arc<B>,
-    boot_interface_mac: Option<MacAddress>,
+    config: &Config<'_, B>,
 ) -> Result<EndpointExplorationReport, Error<B>> {
     let root = ServiceRoot::new(bmc)
         .await
         .map_err(Error::nv_redfish("service_root"))?;
-    nv_generate_exploration_report_from_root(root, boot_interface_mac).await
+    nv_generate_exploration_report_from_root(root, config).await
 }
 
 pub async fn nv_generate_exploration_report_from_root<B: Bmc>(
     mut root: ServiceRoot<B>,
-    boot_interface_mac: Option<MacAddress>,
+    config: &Config<'_, B>,
 ) -> Result<EndpointExplorationReport, Error<B>> {
     let chassis_explore_config = chassis::Config {
         network_adapter: network_adapter::Config {
@@ -119,6 +133,8 @@ pub async fn nv_generate_exploration_report_from_root<B: Bmc>(
 
     let system_explore_config = computer_system::Config {
         need_oem_nvidia_bluefield: system.id().into_inner() == "Bluefield",
+        retry_404_on_eth_interfaces: system.id().into_inner() == "Bluefield",
+        explore: config,
     };
     let explored_system = ExploredComputerSystem::explore(system, &system_explore_config).await?;
 
@@ -202,7 +218,7 @@ pub async fn nv_generate_exploration_report_from_root<B: Bmc>(
                 &explored_chassis,
                 &explored_system,
                 &lockdown_status,
-                boot_interface_mac,
+                config.boot_interface_mac,
             )
         })
         .unwrap_or_else(|| MachineSetupStatus {

--- a/crates/bmc-explorer/tests/bluefield3_explore.rs
+++ b/crates/bmc-explorer/tests/bluefield3_explore.rs
@@ -16,6 +16,8 @@
  */
 #![recursion_limit = "256"]
 
+mod common;
+
 use bmc_explorer::nv_generate_exploration_report;
 use bmc_mock::{DpuSettings, test_support};
 use model::site_explorer::EndpointType;
@@ -23,8 +25,10 @@ use tokio::test;
 
 #[test]
 async fn explore_bluefield3_baseline() {
-    let bmc = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default());
-    let report = nv_generate_exploration_report(bmc, None).await.unwrap();
+    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default());
+    let report = nv_generate_exploration_report(h.bmc, &common::explorer_config())
+        .await
+        .unwrap();
 
     assert_eq!(report.endpoint_type, EndpointType::Bmc);
     assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Nvidia));
@@ -52,8 +56,10 @@ async fn explore_bluefield3_without_system_eth_interfaces() {
         exposes_oob_eth: false,
         ..Default::default()
     };
-    let bmc = test_support::dell_poweredge_r750_bluefield3_bmc(settings);
-    let report = nv_generate_exploration_report(bmc, None).await.unwrap();
+    let h = test_support::dell_poweredge_r750_bluefield3_bmc(settings);
+    let report = nv_generate_exploration_report(h.bmc, &common::explorer_config())
+        .await
+        .unwrap();
     assert_eq!(report.endpoint_type, EndpointType::Bmc);
     assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Nvidia));
     assert_eq!(
@@ -62,5 +68,60 @@ async fn explore_bluefield3_without_system_eth_interfaces() {
             .first()
             .map(|v| v.ethernet_interfaces.is_empty()),
         Some(true)
+    );
+}
+
+#[test]
+async fn explore_bluefield3_retries_transient_404_on_system_eth_interfaces() {
+    let settings = DpuSettings::default();
+
+    let h = test_support::dell_poweredge_r750_bluefield3_bmc(settings.clone());
+    let baseline = nv_generate_exploration_report(h.bmc.clone(), &common::explorer_config())
+        .await
+        .unwrap();
+
+    h.state.injected_bugs.update_args(bmc_mock::bug::Args {
+        http_error: Some(bmc_mock::bug::HttpErrorRule {
+            method: Some("GET".into()),
+            path: "/redfish/v1/Systems/Bluefield/EthernetInterfaces".to_string(),
+            status: 404,
+            remaining: 1,
+        }),
+        ..Default::default()
+    });
+
+    let report = nv_generate_exploration_report(h.bmc, &common::explorer_config())
+        .await
+        .unwrap();
+
+    let baseline_count = baseline.systems.first().unwrap().ethernet_interfaces.len();
+    let actual_count = report.systems.first().unwrap().ethernet_interfaces.len();
+    assert_eq!(actual_count, baseline_count);
+}
+
+#[test]
+async fn explore_bluefield3_permanent_404_on_system_eth_interfaces_fails_without_hanging() {
+    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default());
+
+    h.state.injected_bugs.update_args(bmc_mock::bug::Args {
+        http_error: Some(bmc_mock::bug::HttpErrorRule {
+            method: Some("GET".into()),
+            path: "/redfish/v1/Systems/Bluefield/EthernetInterfaces".to_string(),
+            status: 404,
+            remaining: 10,
+        }),
+        ..Default::default()
+    });
+
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        nv_generate_exploration_report(h.bmc, &common::explorer_config()),
+    )
+    .await;
+
+    let result = result.expect("exploration should terminate and not hang in retry loop");
+    assert!(
+        result.is_err(),
+        "permanent 404 should still fail after retries are exhausted"
     );
 }

--- a/crates/bmc-explorer/tests/common.rs
+++ b/crates/bmc-explorer/tests/common.rs
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::time::Duration;
+
+use axum::http::StatusCode;
+use bmc_explorer::ErrorClass;
+use bmc_mock::test_support::TestBmc;
+use bmc_mock::test_support::axum_http_client::Error as TestBmcError;
+
+pub fn error_classifier(err: &<TestBmc as nv_redfish::Bmc>::Error) -> Option<ErrorClass> {
+    match err {
+        TestBmcError::InvalidResponse {
+            status: StatusCode::NOT_FOUND,
+            ..
+        } => Some(ErrorClass::HttpNotFound),
+        _ => None,
+    }
+}
+
+pub fn explorer_config() -> bmc_explorer::Config<'static, TestBmc> {
+    bmc_explorer::Config {
+        boot_interface_mac: None,
+        error_classifier: &error_classifier,
+        retry_timeout: Duration::from_millis(0),
+    }
+}

--- a/crates/bmc-explorer/tests/dell_poweredge_r750_explore.rs
+++ b/crates/bmc-explorer/tests/dell_poweredge_r750_explore.rs
@@ -16,6 +16,8 @@
  */
 #![recursion_limit = "256"]
 
+mod common;
+
 use bmc_explorer::nv_generate_exploration_report;
 use bmc_mock::test_support;
 use model::site_explorer::EndpointType;
@@ -23,8 +25,10 @@ use tokio::test;
 
 #[test]
 async fn explore_dell_poweredge_r750() {
-    let bmc = test_support::dell_poweredge_r750_bmc();
-    let report = nv_generate_exploration_report(bmc, None).await.unwrap();
+    let h = test_support::dell_poweredge_r750_bmc();
+    let report = nv_generate_exploration_report(h.bmc, &common::explorer_config())
+        .await
+        .unwrap();
 
     assert_eq!(report.endpoint_type, EndpointType::Bmc);
     assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Dell));

--- a/crates/bmc-explorer/tests/nvidia_switch_explore.rs
+++ b/crates/bmc-explorer/tests/nvidia_switch_explore.rs
@@ -16,6 +16,8 @@
  */
 #![recursion_limit = "256"]
 
+mod common;
+
 use bmc_explorer::nv_generate_exploration_report;
 use bmc_mock::test_support;
 use model::site_explorer::EndpointType;
@@ -23,8 +25,10 @@ use tokio::test;
 
 #[test]
 async fn explore_nvidia_switch() {
-    let bmc = test_support::nvidia_switch_nd5200_ld_bmc();
-    let report = nv_generate_exploration_report(bmc, None).await.unwrap();
+    let h = test_support::nvidia_switch_nd5200_ld_bmc();
+    let report = nv_generate_exploration_report(h.bmc, &common::explorer_config())
+        .await
+        .unwrap();
 
     assert_eq!(report.endpoint_type, EndpointType::Bmc);
     assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Nvidia));

--- a/crates/bmc-explorer/tests/powershelf_explore.rs
+++ b/crates/bmc-explorer/tests/powershelf_explore.rs
@@ -16,6 +16,8 @@
  */
 #![recursion_limit = "256"]
 
+mod common;
+
 use bmc_explorer::nv_generate_exploration_report;
 use bmc_mock::test_support;
 use model::site_explorer::EndpointType;
@@ -23,8 +25,10 @@ use tokio::test;
 
 #[test]
 async fn explore_liteon_power_shelf() {
-    let bmc = test_support::liteon_powershelf_bmc();
-    let report = nv_generate_exploration_report(bmc, None).await.unwrap();
+    let h = test_support::liteon_powershelf_bmc();
+    let report = nv_generate_exploration_report(h.bmc, &common::explorer_config())
+        .await
+        .unwrap();
 
     assert_eq!(report.endpoint_type, EndpointType::Bmc);
     assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Liteon));

--- a/crates/bmc-explorer/tests/wiwynn_gb200_explore.rs
+++ b/crates/bmc-explorer/tests/wiwynn_gb200_explore.rs
@@ -16,6 +16,8 @@
  */
 #![recursion_limit = "256"]
 
+mod common;
+
 use bmc_explorer::nv_generate_exploration_report;
 use bmc_mock::test_support;
 use model::site_explorer::EndpointType;
@@ -23,8 +25,10 @@ use tokio::test;
 
 #[test]
 async fn explore_wiwynn_gb200() {
-    let bmc = test_support::wiwynn_gb200_bmc();
-    let report = nv_generate_exploration_report(bmc, None).await.unwrap();
+    let h = test_support::wiwynn_gb200_bmc();
+    let report = nv_generate_exploration_report(h.bmc, &common::explorer_config())
+        .await
+        .unwrap();
 
     assert_eq!(report.endpoint_type, EndpointType::Bmc);
     assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Nvidia));

--- a/crates/bmc-mock/src/bug.rs
+++ b/crates/bmc-mock/src/bug.rs
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use arc_swap::ArcSwap;
+use axum::http::StatusCode;
 use duration_str::deserialize_option_duration;
 use serde::{Deserialize, Serialize};
 
@@ -29,40 +30,55 @@ use crate::redfish;
 pub struct InjectedBugs {
     all_dpu_lost_on_host: Arc<AtomicBool>,
     long_response: Arc<ArcSwap<Option<LongResponse>>>,
+    http_error: Arc<Mutex<Option<HttpErrorRule>>>,
 }
 
-#[derive(Deserialize, Serialize)]
-struct Args {
-    all_dpu_lost_on_host: Option<bool>,
-    long_response: Option<LongResponse>,
+#[derive(Deserialize, Serialize, Default)]
+pub struct Args {
+    pub all_dpu_lost_on_host: Option<bool>,
+    pub long_response: Option<LongResponse>,
+    pub http_error: Option<HttpErrorRule>,
 }
 
 #[derive(Clone, Deserialize, Serialize)]
-struct LongResponse {
-    path: Option<String>,
+pub struct LongResponse {
+    pub path: Option<String>,
     #[serde(deserialize_with = "deserialize_option_duration")]
-    timeout: Option<Duration>,
+    pub timeout: Option<Duration>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct HttpErrorRule {
+    pub path: String,
+    pub status: u16,
+    pub remaining: usize,
+    pub method: Option<String>,
 }
 
 impl InjectedBugs {
     pub fn get(&self) -> serde_json::Value {
         let long_response = self.long_response.load();
+        let http_error = self.http_error.lock().unwrap();
         serde_json::json!(Args {
             all_dpu_lost_on_host: Some(self.all_dpu_lost_on_host().is_some()),
-            long_response: long_response.as_ref().clone()
+            long_response: long_response.as_ref().clone(),
+            http_error: http_error.clone()
         })
     }
 
     pub fn update(&self, v: serde_json::Value) -> Result<(), serde_json::Error> {
         let args = serde_json::from_value::<Args>(v)?;
+        self.update_args(args);
+        Ok(())
+    }
 
+    pub fn update_args(&self, args: Args) {
         self.all_dpu_lost_on_host.store(
             args.all_dpu_lost_on_host.unwrap_or(false),
             Ordering::Relaxed,
         );
-
         self.long_response.store(args.long_response.into());
-        Ok(())
+        *self.http_error.lock().unwrap() = args.http_error;
     }
 
     pub fn all_dpu_lost_on_host(&self) -> Option<AllDpuLostOnHost> {
@@ -79,6 +95,20 @@ impl InjectedBugs {
                 None
             }
         })
+    }
+
+    pub fn http_error(&self, method: &str, path: &str) -> Option<StatusCode> {
+        let mut rule = self.http_error.lock().unwrap();
+        let rule = rule.as_mut()?;
+
+        let method_matches = rule.method.as_ref().is_none_or(|m| m == method);
+        let path_matches = rule.path == path;
+        if !method_matches || !path_matches || rule.remaining == 0 {
+            return None;
+        }
+
+        rule.remaining -= 1;
+        Some(StatusCode::from_u16(rule.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR))
     }
 }
 

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -23,7 +23,7 @@ use tokio::time::Instant;
 pub mod ipmi;
 
 mod bmc_state;
-mod bug;
+pub mod bug;
 mod combined_server;
 mod combined_service;
 mod http;

--- a/crates/bmc-mock/src/middleware_router.rs
+++ b/crates/bmc-mock/src/middleware_router.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use axum::Router;
 use axum::body::Body;
 use axum::extract::{Request, State};
-use axum::response::Response;
+use axum::response::{IntoResponse, Response};
 use axum::routing::any;
 use tracing::instrument;
 
@@ -56,6 +56,10 @@ async fn process(State(mut state): State<Middleware>, request: Request<Body>) ->
             "Error is injected waiting for {delay:?} for request",
         );
         tokio::time::sleep(delay).await;
+    }
+    if let Some(status) = state.injected_bugs.http_error(&method, &path) {
+        tracing::warn!(method, path, %status, "Injected HTTP error for request",);
+        return status.into_response();
     }
     let response = state.call_inner_router(request).await;
     if !response.status().is_success() {

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -22,8 +22,8 @@ use url::Url;
 
 use crate::machine_info::DpuSettings;
 use crate::{
-    Callbacks, DpuMachineInfo, HostHardwareType, HostMachineInfo, MachineInfo, MockPowerState,
-    SetSystemPowerError, SystemPowerControl, machine_router,
+    BmcState, Callbacks, DpuMachineInfo, HostHardwareType, HostMachineInfo, MachineInfo,
+    MockPowerState, SetSystemPowerError, SystemPowerControl, machine_router,
 };
 pub mod axum_http_client;
 
@@ -49,89 +49,83 @@ impl Callbacks for NoopCallbacks {
 
 pub type TestBmc = HttpBmc<AxumRouterHttpClient>;
 
-fn test_bmc(router: axum::Router) -> Arc<TestBmc> {
+#[derive(Clone)]
+pub struct TestBmcHandle {
+    pub bmc: Arc<TestBmc>,
+    pub state: BmcState,
+}
+
+fn test_bmc((router, state): (axum::Router, BmcState)) -> TestBmcHandle {
     let client = AxumRouterHttpClient::new(router);
     let endpoint = Url::parse("https://bmc-mock.local").expect("valid URL");
     let credentials = BmcCredentials::new("root".to_string(), "password".to_string());
-    Arc::new(HttpBmc::new(
-        client,
-        endpoint,
-        credentials,
-        CacheSettings::with_capacity(32),
+    TestBmcHandle {
+        bmc: Arc::new(HttpBmc::new(
+            client,
+            endpoint,
+            credentials,
+            CacheSettings::with_capacity(32),
+        )),
+        state,
+    }
+}
+
+pub fn wiwynn_gb200_bmc() -> TestBmcHandle {
+    test_bmc(machine_router(
+        MachineInfo::Host(HostMachineInfo::new(
+            HostHardwareType::WiwynnGB200Nvl,
+            vec![
+                DpuMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, DpuSettings::default()),
+                DpuMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, DpuSettings::default()),
+            ],
+        )),
+        Arc::new(NoopCallbacks),
+        "test-host-id".to_string(),
     ))
 }
 
-pub fn wiwynn_gb200_bmc() -> Arc<TestBmc> {
-    test_bmc(
-        machine_router(
-            MachineInfo::Host(HostMachineInfo::new(
-                HostHardwareType::WiwynnGB200Nvl,
-                vec![
-                    DpuMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, DpuSettings::default()),
-                    DpuMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, DpuSettings::default()),
-                ],
-            )),
-            Arc::new(NoopCallbacks),
-            "test-host-id".to_string(),
-        )
-        .0,
-    )
+pub fn liteon_powershelf_bmc() -> TestBmcHandle {
+    test_bmc(machine_router(
+        MachineInfo::Host(HostMachineInfo::new(
+            HostHardwareType::LiteOnPowerShelf,
+            vec![],
+        )),
+        Arc::new(NoopCallbacks),
+        "test-host-id".to_string(),
+    ))
 }
 
-pub fn liteon_powershelf_bmc() -> Arc<TestBmc> {
-    test_bmc(
-        machine_router(
-            MachineInfo::Host(HostMachineInfo::new(
-                HostHardwareType::LiteOnPowerShelf,
-                vec![],
-            )),
-            Arc::new(NoopCallbacks),
-            "test-host-id".to_string(),
-        )
-        .0,
-    )
+pub fn nvidia_switch_nd5200_ld_bmc() -> TestBmcHandle {
+    test_bmc(machine_router(
+        MachineInfo::Host(HostMachineInfo::new(
+            HostHardwareType::NvidiaSwitchNd5200Ld,
+            vec![],
+        )),
+        Arc::new(NoopCallbacks),
+        "test-host-id".to_string(),
+    ))
 }
 
-pub fn nvidia_switch_nd5200_ld_bmc() -> Arc<TestBmc> {
-    test_bmc(
-        machine_router(
-            MachineInfo::Host(HostMachineInfo::new(
-                HostHardwareType::NvidiaSwitchNd5200Ld,
-                vec![],
-            )),
-            Arc::new(NoopCallbacks),
-            "test-host-id".to_string(),
-        )
-        .0,
-    )
+pub fn dell_poweredge_r750_bmc() -> TestBmcHandle {
+    test_bmc(machine_router(
+        MachineInfo::Host(HostMachineInfo::new(
+            HostHardwareType::DellPowerEdgeR750,
+            vec![],
+        )),
+        Arc::new(NoopCallbacks),
+        "test-host-id".to_string(),
+    ))
 }
 
-pub fn dell_poweredge_r750_bmc() -> Arc<TestBmc> {
-    test_bmc(
-        machine_router(
-            MachineInfo::Host(HostMachineInfo::new(
-                HostHardwareType::DellPowerEdgeR750,
-                vec![],
-            )),
-            Arc::new(NoopCallbacks),
-            "test-host-id".to_string(),
-        )
-        .0,
-    )
-}
-
-pub fn dell_poweredge_r750_bluefield3_bmc(settings: DpuSettings) -> Arc<TestBmc> {
-    test_bmc(
-        machine_router(
-            MachineInfo::Dpu(DpuMachineInfo::new(
-                HostHardwareType::DellPowerEdgeR750,
-                settings,
-            )),
-            Arc::new(NoopCallbacks),
-            "test-dpu-id".to_string(),
-        )
-        .0,
-    )
+pub fn dell_poweredge_r750_bluefield3_bmc(settings: DpuSettings) -> TestBmcHandle {
+    test_bmc(machine_router(
+        MachineInfo::Dpu(DpuMachineInfo::new(
+            HostHardwareType::DellPowerEdgeR750,
+            settings,
+        )),
+        Arc::new(NoopCallbacks),
+        "test-dpu-id".to_string(),
+    ))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description
Add transient not-found handling for nv-redfish exploration of Bluefield system EthernetInterfaces.

- thread exploration config through bmc-explorer
- classify HTTP 404 errors for retryable nv-redfish failures
- retry Bluefield system EthernetInterfaces fetches with bounded retries
- add generic HTTP error injection support to bmc-mock middleware
- add bmc-explorer tests for:
  - successful recovery from a transient 404
  - failure without hanging on permanent 404

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

