### PR TITLE
fix: query machine_interface_addresses to get the IP assigned to a PMC instead of the bmc_ip_address column in expected_powershelves

### DIFF
--- a/crates/api-db/src/power_shelf.rs
+++ b/crates/api-db/src/power_shelf.rs
@@ -346,15 +346,18 @@ pub async fn find_power_shelf_endpoints_by_ids(
     db: impl crate::db_read::DbReader<'_>,
     power_shelf_ids: &[PowerShelfId],
 ) -> DatabaseResult<Vec<PowerShelfEndpointRow>> {
+    // DISTINCT ON guards against a machine_interface having multiple addresses
     let sql = r#"
-        SELECT
+        SELECT DISTINCT ON (ps.id)
             ps.id                AS power_shelf_id,
             eps.bmc_mac_address  AS pmc_mac,
-            eps.bmc_ip_address       AS pmc_ip
+            mia.address          AS pmc_ip
         FROM power_shelves ps
         JOIN expected_power_shelves eps ON eps.serial_number = ps.config->>'name'
+        JOIN machine_interfaces mi ON mi.mac_address = eps.bmc_mac_address
+        JOIN machine_interface_addresses mia ON mia.interface_id = mi.id
         WHERE ps.id = ANY($1)
-          AND eps.bmc_ip_address IS NOT NULL
+        ORDER BY ps.id
     "#;
 
     sqlx::query_as(sql)

--- a/crates/api/src/site_explorer/mod.rs
+++ b/crates/api/src/site_explorer/mod.rs
@@ -610,7 +610,7 @@ impl SiteExplorer {
         explored_power_shelves: Vec<(ExploredEndpoint, EndpointExplorationReport)>,
         expected_endpoint_index: &ExploredEndpointIndex,
     ) -> CarbideResult<()> {
-        for (endpoint, report) in explored_power_shelves {
+        for (endpoint, _report) in explored_power_shelves {
             let address = endpoint.address;
             let Some(expected_power_shelf) =
                 expected_endpoint_index.matched_expected_power_shelf(&endpoint.address)
@@ -623,12 +623,7 @@ impl SiteExplorer {
             };
 
             match self
-                .create_power_shelf(
-                    endpoint,
-                    report,
-                    expected_power_shelf,
-                    &self.database_connection,
-                )
+                .create_power_shelf(endpoint, expected_power_shelf, &self.database_connection)
                 .await
             {
                 Ok(true) => {
@@ -652,7 +647,6 @@ impl SiteExplorer {
     pub async fn create_power_shelf(
         &self,
         explored_endpoint: ExploredEndpoint,
-        report: EndpointExplorationReport,
         expected_shelf: &ExpectedPowerShelf,
         pool: &PgPool,
     ) -> CarbideResult<bool> {
@@ -732,30 +726,16 @@ impl SiteExplorer {
 
         db_power_shelf::create(&mut txn, &new_power_shelf).await?;
 
-        let mac_addresses = report.all_mac_addresses();
-        for mac_address in mac_addresses {
-            let mi = db::machine_interface::find_by_mac_address(&mut *txn, mac_address).await?;
-            if let Some(interface) = mi.first() {
-                db::machine_interface::associate_interface_with_machine(
-                    &interface.id,
-                    MachineInterfaceAssociation::PowerShelf(power_shelf_id),
-                    &mut txn,
-                )
+        let mi =
+            db::machine_interface::find_by_mac_address(&mut *txn, expected_shelf.bmc_mac_address)
                 .await?;
-            }
-        }
-
-        let mac_addresses = report.all_mac_addresses();
-        for mac_address in mac_addresses {
-            let mi = db::machine_interface::find_by_mac_address(&mut *txn, mac_address).await?;
-            if let Some(interface) = mi.first() {
-                db::machine_interface::associate_interface_with_machine(
-                    &interface.id,
-                    MachineInterfaceAssociation::PowerShelf(power_shelf_id),
-                    &mut txn,
-                )
-                .await?;
-            }
+        if let Some(interface) = mi.first() {
+            db::machine_interface::associate_interface_with_machine(
+                &interface.id,
+                MachineInterfaceAssociation::PowerShelf(power_shelf_id),
+                &mut txn,
+            )
+            .await?;
         }
 
         if let Some(ref rack_id) = expected_shelf.rack_id {

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -3727,12 +3727,7 @@ async fn test_site_explorer_creates_power_shelf(
     // Test power shelf creation
     assert!(
         explorer
-            .create_power_shelf(
-                explored_endpoint.clone(),
-                exploration_report.clone(),
-                &expected_power_shelf,
-                &env.pool,
-            )
+            .create_power_shelf(explored_endpoint.clone(), &expected_power_shelf, &env.pool,)
             .await?
     );
 
@@ -3755,12 +3750,7 @@ async fn test_site_explorer_creates_power_shelf(
     // Test that duplicate creation returns false
     assert!(
         !explorer
-            .create_power_shelf(
-                explored_endpoint,
-                exploration_report,
-                &expected_power_shelf,
-                &env.pool,
-            )
+            .create_power_shelf(explored_endpoint, &expected_power_shelf, &env.pool,)
             .await?
     );
 
@@ -3953,12 +3943,7 @@ async fn test_power_shelf_state_history(
     // Create the power shelf using site explorer
     assert!(
         explorer
-            .create_power_shelf(
-                explored_endpoint.clone(),
-                exploration_report.clone(),
-                &expected_power_shelf,
-                &env.pool,
-            )
+            .create_power_shelf(explored_endpoint.clone(), &expected_power_shelf, &env.pool,)
             .await?
     );
 
@@ -4214,7 +4199,6 @@ async fn test_power_shelf_state_history_multiple(
         explorer
             .create_power_shelf(
                 explored_endpoint1.clone(),
-                exploration_report1.clone(),
                 &expected_power_shelf1,
                 &env.pool,
             )
@@ -4225,7 +4209,6 @@ async fn test_power_shelf_state_history_multiple(
         explorer
             .create_power_shelf(
                 explored_endpoint2.clone(),
-                exploration_report2.clone(),
                 &expected_power_shelf2,
                 &env.pool,
             )
@@ -4435,12 +4418,7 @@ async fn test_power_shelf_state_history_error_handling(
     // Create the power shelf using site explorer
     assert!(
         explorer
-            .create_power_shelf(
-                explored_endpoint.clone(),
-                exploration_report.clone(),
-                &expected_power_shelf,
-                &env.pool,
-            )
+            .create_power_shelf(explored_endpoint.clone(), &expected_power_shelf, &env.pool,)
             .await?
     );
 


### PR DESCRIPTION
## Description

fix: query machine_interface_addresses to get the IP assigned to a PMC instead of the bmc_ip_address column in expected_powershelves.

This is a reliable mechanism to go from powershelf id -> bmc ip b/c the config information in the power_shelves table is filled in from the static expected_powershelf data as opposed to relying on the BMC functioning correctly at the time of ingestion.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

