### PR TITLE
feat: wire up a long-lived TODO for ExpectedHostNic DHCP fixed-address support

### DIFF
--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -366,23 +366,28 @@ pub async fn validate_existing_mac_and_create(
                     )));
                 }
 
-                // TODO: add fixed_ip handling
-                if let Some(expected_nic) = host_nic.clone()
-                    && let Some(ipaddr) = expected_nic.fixed_ip
+                // If a fixed IP is specified for this NIC, use static
+                // allocation instead of the pool allocator.
+                let strategy = if let Some(ref expected_nic) = host_nic
+                    && let Some(ref ipaddr) = expected_nic.fixed_ip
                 {
-                    return Err(DatabaseError::internal(format!(
-                        "IP reservation per MAC address not implemented yet for {ipaddr}, {mac_address}"
-                    )));
-                }
+                    let fixed_addr: IpAddr = ipaddr.parse().map_err(|_| {
+                        DatabaseError::internal(format!(
+                            "invalid fixed_ip '{ipaddr}' for MAC {mac_address}"
+                        ))
+                    })?;
+                    AddressSelectionStrategy::StaticAddress(fixed_addr)
+                } else {
+                    AddressSelectionStrategy::NextAvailableIp
+                };
 
-                // actually create the interface
                 let v = create(
                     txn,
                     &segment,
                     &mac_address,
                     segment.subdomain_id,
                     true,
-                    AddressSelectionStrategy::NextAvailableIp,
+                    strategy,
                 )
                 .await?;
                 Ok(v)

--- a/crates/api/src/handlers/expected_machine.rs
+++ b/crates/api/src/handlers/expected_machine.rs
@@ -110,8 +110,19 @@ pub(crate) async fn add(
 
     let mut txn = api.txn_begin().await?;
 
+    // Pre-allocate BMC interface if bmc_ip_address is set.
     if let Some(bmc_ip) = machine.data.bmc_ip_address {
         preallocate_machine_interface(&mut txn, machine.bmc_mac_address, bmc_ip).await?;
+    }
+
+    // Pre-allocate machine interfaces for host NICs with fixed IPs.
+    for nic in &machine.data.host_nics {
+        if let Some(ref ip_str) = nic.fixed_ip {
+            let ip: std::net::IpAddr = ip_str.parse().map_err(|_| {
+                CarbideError::InvalidArgument(format!("invalid fixed_ip: {ip_str}"))
+            })?;
+            preallocate_machine_interface(&mut txn, nic.mac_address, ip).await?;
+        }
     }
 
     db::expected_machine::create(&mut txn, machine).await?;
@@ -183,8 +194,19 @@ pub(crate) async fn update(
 
     let mut txn = api.txn_begin().await?;
 
+    // Update BMC interface if bmc_ip_address is set.
     if let Some(bmc_ip) = machine.data.bmc_ip_address {
         update_preallocated_machine_interface(&mut txn, machine.bmc_mac_address, bmc_ip).await?;
+    }
+
+    // Update/create machine interfaces for host NICs with fixed IPs.
+    for nic in &machine.data.host_nics {
+        if let Some(ref ip_str) = nic.fixed_ip {
+            let ip: std::net::IpAddr = ip_str.parse().map_err(|_| {
+                CarbideError::InvalidArgument(format!("invalid fixed_ip: {ip_str}"))
+            })?;
+            update_preallocated_machine_interface(&mut txn, nic.mac_address, ip).await?;
+        }
     }
 
     db::expected_machine::update(&mut txn, &machine)

--- a/crates/api/src/tests/expected_machine.rs
+++ b/crates/api/src/tests/expected_machine.rs
@@ -2069,3 +2069,108 @@ async fn test_add_expected_machine_with_invalid_static_ip(pool: sqlx::PgPool) {
         "Should fail when adding machine with invalid IP address"
     );
 }
+
+/// Adding an expected machine with host_nics[].fixed_ip should
+/// pre-allocate a machine_interface with a static address.
+#[crate::sqlx_test]
+async fn test_add_with_host_nic_fixed_ip_creates_interface(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "7A:7B:7C:7D:7E:01".parse().unwrap();
+    let nic_mac: MacAddress = "7A:7B:7C:7D:7E:02".parse().unwrap();
+    let fixed_ip = "192.0.2.230";
+
+    env.api
+        .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+            id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: "EM-FIXEDIP-001".into(),
+            host_nics: vec![rpc::forge::ExpectedHostNic {
+                mac_address: nic_mac.to_string(),
+                nic_type: Some("onboard".into()),
+                fixed_ip: Some(fixed_ip.into()),
+                fixed_mask: None,
+                fixed_gateway: None,
+            }],
+            ..Default::default()
+        }))
+        .await?;
+
+    // Verify a machine_interface was created for the host NIC MAC.
+    let mut txn = env.pool.begin().await?;
+    let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, nic_mac).await?;
+    assert_eq!(
+        interfaces.len(),
+        1,
+        "should have one interface for the host NIC MAC"
+    );
+    assert!(
+        interfaces[0].addresses.contains(&fixed_ip.parse().unwrap()),
+        "interface should have the fixed IP"
+    );
+
+    let addrs =
+        db::machine_interface_address::find_for_interface(&mut txn, interfaces[0].id).await?;
+    assert_eq!(addrs.len(), 1);
+    assert_eq!(
+        addrs[0].allocation_type,
+        model::allocation_type::AllocationType::Static
+    );
+
+    Ok(())
+}
+
+/// When a device DHCPs with a MAC that has a fixed_ip in the expected
+/// machine's host_nics, it should get the fixed IP (not a pool allocation).
+#[crate::sqlx_test]
+async fn test_dhcp_discover_uses_fixed_ip_from_host_nics(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "7A:7B:7C:7D:7E:03".parse().unwrap();
+    let nic_mac: MacAddress = "7A:7B:7C:7D:7E:04".parse().unwrap();
+    let fixed_ip = "192.0.2.231";
+
+    // Register expected machine with host NIC fixed_ip.
+    env.api
+        .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+            id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: "EM-DHCP-001".into(),
+            host_nics: vec![rpc::forge::ExpectedHostNic {
+                mac_address: nic_mac.to_string(),
+                nic_type: Some("onboard".into()),
+                fixed_ip: Some(fixed_ip.into()),
+                fixed_mask: None,
+                fixed_gateway: None,
+            }],
+            ..Default::default()
+        }))
+        .await?;
+
+    // DHCP discover with the host NIC MAC -- should get the fixed IP.
+    let nic_mac_str = nic_mac.to_string();
+    let response = env
+        .api
+        .discover_dhcp(
+            common::rpc_builder::DhcpDiscovery::builder(
+                &nic_mac_str,
+                common::api_fixtures::FIXTURE_DHCP_RELAY_ADDRESS,
+            )
+            .tonic_request(),
+        )
+        .await?
+        .into_inner();
+
+    assert_eq!(
+        response.address, fixed_ip,
+        "DHCP should return the fixed IP from host_nics"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

This is kind of a funny one. I went to start working on `fixed-address` support for *host* NICs (not BMCs) for both static DHCP reservations and external assignments, and I came across `ExpectedHostNic`, and how it has `fixed_ip`, `fixed_gateway`, and `fixed_mask` parameters, with a `TODO` to implement things from a loooong ago.

So, this actually leverages that: this will pre-allocate static DHCP reservations for host NICs, so when a machine goes to `carbide-dhcp` the first time, it will get the "expected" IP we've allocated.

While I'm in here, I'm also ripping out `fixed_gateway` and `fixed_mask`. None of it was used, BUT, now that I'm using something in there, the other two parts might just be confusing. Maybe we can re-add later if we have a use case, but for now, scope it just to the use case.

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

