### PR TITLE
feat: derive bluefield service versions from build-time git describe

### DIFF
--- a/crates/api/src/dpf_services.rs
+++ b/crates/api/src/dpf_services.rs
@@ -47,18 +47,18 @@ pub const DOCA_HBN_SERVICE_NETWORK: &str = "mybrhbn";
 /// DHCP Service Definitions
 pub const DHCP_SERVER_SERVICE_NAME: &str = "carbide-dhcp-server";
 pub const DHCP_SERVER_SERVICE_HELM_NAME: &str = "carbide-dhcp-server";
-pub const DHCP_SERVER_SERVICE_HELM_VERSION: &str = "2.0.9";
+pub const DHCP_SERVER_SERVICE_HELM_VERSION: &str = env!("CARBIDE_BUILD_HELM_VERSION");
 pub const DHCP_SERVER_SERVICE_IMAGE_NAME: &str = "forge-dhcp-server";
-pub const DHCP_SERVER_SERVICE_IMAGE_TAG: &str = "v1.9.5-arm64-distroless";
+pub const DHCP_SERVER_SERVICE_IMAGE_TAG: &str = env!("CARBIDE_BUILD_GIT_TAG");
 pub const DHCP_SERVER_SERVICE_NAD_NAME: &str = "mybrsfc-dhcp";
 pub const DHCP_SERVER_SERVICE_MTU: i64 = 1500;
 
 // DPU Agent Service Definitions
 pub const DPU_AGENT_SERVICE_NAME: &str = "carbide-dpu-agent";
 pub const DPU_AGENT_SERVICE_HELM_NAME: &str = "carbide-dpu-agent";
-pub const DPU_AGENT_SERVICE_HELM_VERSION: &str = "0.4.0";
+pub const DPU_AGENT_SERVICE_HELM_VERSION: &str = env!("CARBIDE_BUILD_HELM_VERSION");
 pub const DPU_AGENT_SERVICE_IMAGE_NAME: &str = "forge-dpu-agent";
-pub const DPU_AGENT_SERVICE_IMAGE_TAG: &str = "v0.3-arm64-multistage";
+pub const DPU_AGENT_SERVICE_IMAGE_TAG: &str = env!("CARBIDE_BUILD_GIT_TAG");
 
 /// Extended registry configuration for Carbide DPU services.
 #[derive(Debug, Clone)]
@@ -161,7 +161,12 @@ fn carbide_service(
 #[allow(dead_code)]
 /// OpenTelemetry Collector service definition.
 pub fn otelcol_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinition {
-    let mut svc = carbide_service(reg, "carbide-otelcol", "otelcol-contrib", "0.1.0");
+    let mut svc = carbide_service(
+        reg,
+        "carbide-otelcol",
+        "otelcol-contrib",
+        env!("CARBIDE_BUILD_HELM_VERSION"),
+    );
     svc.config_ports = Some(vec![ServiceConfigPort {
         name: "prometheus".to_string(),
         port: 9999,
@@ -240,6 +245,6 @@ pub fn dpu_otel_agent_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefi
         reg,
         "carbide-dpu-otel-agent",
         "forge-dpu-otel-agent",
-        "0.1.0",
+        env!("CARBIDE_BUILD_HELM_VERSION"),
     )
 }

--- a/crates/version/src/lib.rs
+++ b/crates/version/src/lib.rs
@@ -94,6 +94,19 @@ pub fn build() {
     println!("cargo:rustc-env=FORGE_BUILD_GIT_TAG={build_version}");
     println!("cargo:rustc-env=CARBIDE_BUILD_GIT_TAG={build_version}");
 
+    // Helm chart version: strip leading 'v' and replace last '-' with '.'
+    // e.g. v1.2.3-42-gabcdef1 -> 1.2.3-42.gabcdef1
+    // Matches the HELM_VERSION transformation in ci.yaml's prepare job.
+    let helm_version = build_version.strip_prefix('v').unwrap_or(&build_version);
+    let helm_version = if let Some(pos) = helm_version.rfind('-') {
+        let mut s = helm_version.to_string();
+        s.replace_range(pos..=pos, ".");
+        s
+    } else {
+        helm_version.to_string()
+    };
+    println!("cargo:rustc-env=CARBIDE_BUILD_HELM_VERSION={helm_version}");
+
     // Only re-calculate all of this when there's a new commit... but use an env var to allow
     // avoiding rebuilds when the commit hash changes. (This is good for local development iteration
     // loops when we want to avoid recompiling and when we don't really care if the generated
@@ -199,6 +212,9 @@ macro_rules! v {
     };
     (build_hostname) => {
         option_env!("FORGE_BUILD_HOSTNAME").unwrap_or_default()
+    };
+    (helm_version) => {
+        option_env!("CARBIDE_BUILD_HELM_VERSION").unwrap_or_default()
     };
 }
 


### PR DESCRIPTION
## Description
Replace hardcoded helm chart versions and image tags in dpf_services.rs with build-time constants sourced from CARBIDE_BUILD_GIT_TAG and a new CARBIDE_BUILD_HELM_VERSION env var, eliminating the manual step of updating version strings after each CI publish.                              
                                                                               
CARBIDE_BUILD_HELM_VERSION is derived in carbide_version::build() by applying the same transformation CI uses: strip leading 'v' and replace the last '-' with '.' (e.g. v1.2.3-42-gabcdef1 -> 1.2.3-42.gabcdef1).

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

