### PR TITLE
feat: wiring in RackHarwareType with rack-firmware management, as a string

### DIFF
--- a/crates/admin-cli/src/rack/capabilities/show/cmd.rs
+++ b/crates/admin-cli/src/rack/capabilities/show/cmd.rs
@@ -61,12 +61,8 @@ impl From<&GetRackCapabilitiesResponse> for CapabilitiesOutput {
                 .unwrap_or_default(),
             rack_type: r.rack_type.clone(),
             rack_hardware_type: capabilities
-                .map(|c| {
-                    rpc::forge::RackHardwareType::try_from(c.rack_hardware_type)
-                        .unwrap_or_default()
-                        .as_str_name()
-                        .to_string()
-                })
+                .and_then(|c| c.rack_hardware_type.as_ref())
+                .map(|t| t.value.clone())
                 .unwrap_or_else(|| "N/A".to_string()),
             rack_hardware_topology: capabilities
                 .map(|c| {
@@ -158,13 +154,9 @@ fn show_detail(r: &GetRackCapabilitiesResponse) {
     table.add_row(row![
         "Hardware Type",
         capabilities
-            .map(
-                |c| rpc::forge::RackHardwareType::try_from(c.rack_hardware_type)
-                    .unwrap_or_default()
-                    .as_str_name()
-                    .to_string()
-            )
-            .unwrap_or_else(|| "N/A".to_string())
+            .and_then(|c| c.rack_hardware_type.as_ref())
+            .map(|t| t.value.as_str())
+            .unwrap_or("N/A")
     ]);
     table.add_row(row![
         "Hardware Topology",

--- a/crates/admin-cli/src/rack_firmware/create/args.rs
+++ b/crates/admin-cli/src/rack_firmware/create/args.rs
@@ -22,9 +22,11 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 pub struct Args {
-    #[clap(help = "Path to JSON configuration file")]
+    #[clap(help = "Rack hardware type for this firmware configuration.")]
+    pub rack_hardware_type: String,
+    #[clap(help = "Path to JSON configuration file.")]
     pub json_file: PathBuf,
-    #[clap(help = "Artifactory token for downloading firmware files")]
+    #[clap(help = "Artifactory token for downloading firmware files.")]
     pub artifactory_token: String,
 }
 
@@ -40,11 +42,14 @@ impl TryFrom<Args> for rpc::forge::RackFirmwareCreateRequest {
             ))
         })?;
 
-        // Check that the JSON is valid
+        // Check that the JSON is valid.
         serde_json::from_str::<serde_json::Value>(&config_json)
             .map_err(|e| CarbideCliError::GenericError(format!("Invalid JSON in file: {}", e)))?;
 
         Ok(Self {
+            rack_hardware_type: Some(rpc::common::RackHardwareType {
+                value: args.rack_hardware_type,
+            }),
             config_json,
             artifactory_token: args.artifactory_token,
         })

--- a/crates/admin-cli/src/rack_firmware/create/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/create/cmd.rs
@@ -16,6 +16,7 @@
  */
 
 use ::rpc::admin_cli::{CarbideCliError, OutputFormat};
+use prettytable::{Table, row};
 
 use super::args::Args;
 use crate::rpc::ApiClient;
@@ -31,10 +32,17 @@ pub async fn create(
     if format == OutputFormat::Json {
         println!("{}", serde_json::to_string_pretty(&result)?);
     } else {
-        println!("Created Rack firmware configuration:");
-        println!("  ID: {}", result.id);
-        println!("  Available: {}", result.available);
-        println!("  Created: {}", result.created);
+        let mut table = Table::new();
+        table.add_row(row!["ID", result.id]);
+        let hw_type = result
+            .rack_hardware_type
+            .as_ref()
+            .map(|t| t.value.as_str())
+            .unwrap_or("N/A");
+        table.add_row(row!["Hardware Type", hw_type]);
+        table.add_row(row!["Available", result.available]);
+        table.add_row(row!["Created", result.created]);
+        table.printstd();
     }
 
     Ok(())

--- a/crates/admin-cli/src/rack_firmware/get/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/get/cmd.rs
@@ -16,7 +16,7 @@
  */
 
 use ::rpc::admin_cli::{CarbideCliError, OutputFormat};
-use prettytable::{Cell, Row, Table};
+use prettytable::{Cell, Row, Table, row};
 
 use super::args::Args;
 use crate::rpc::ApiClient;
@@ -42,13 +42,20 @@ pub async fn get(
     if format == OutputFormat::Json {
         println!("{}", serde_json::to_string_pretty(&result)?);
     } else {
-        println!("Rack Firmware Configuration:");
-        println!("  ID: {}", result.id);
-        println!("  Available: {}", result.available);
-        println!("  Created: {}", result.created);
-        println!("  Updated: {}", result.updated);
+        let mut table = Table::new();
+        table.add_row(row!["ID", result.id]);
+        let hw_type = result
+            .rack_hardware_type
+            .as_ref()
+            .map(|t| t.value.as_str())
+            .unwrap_or("N/A");
+        table.add_row(row!["Hardware Type", hw_type]);
+        table.add_row(row!["Available", result.available]);
+        table.add_row(row!["Created", result.created]);
+        table.add_row(row!["Updated", result.updated]);
+        table.printstd();
 
-        // Display parsed firmware components
+        // Display parsed firmware components.
         if !result.parsed_components.is_empty() && result.parsed_components != "{}" {
             if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&result.parsed_components)
                 && let Some(devices) = parsed.get("devices").and_then(|d| d.as_object())

--- a/crates/admin-cli/src/rack_firmware/history/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/history/cmd.rs
@@ -46,6 +46,7 @@ pub async fn history(
         table.set_titles(Row::new(vec![
             Cell::new("Rack ID"),
             Cell::new("Firmware ID"),
+            Cell::new("Hardware Type"),
             Cell::new("Firmware Type"),
             Cell::new("Applied At"),
             Cell::new("Available"),
@@ -53,9 +54,15 @@ pub async fn history(
 
         for (rack_id, records) in &result.histories {
             for record in &records.records {
+                let hw_type = record
+                    .rack_hardware_type
+                    .as_ref()
+                    .map(|t| t.value.as_str())
+                    .unwrap_or("N/A");
                 table.add_row(Row::new(vec![
                     Cell::new(rack_id),
                     Cell::new(&record.firmware_id),
+                    Cell::new(hw_type),
                     Cell::new(&record.firmware_type),
                     Cell::new(&record.applied_at),
                     Cell::new(&record.firmware_available.to_string()),

--- a/crates/admin-cli/src/rack_firmware/list/args.rs
+++ b/crates/admin-cli/src/rack_firmware/list/args.rs
@@ -19,14 +19,19 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 pub struct Args {
-    #[clap(long, help = "Show only available configurations")]
+    #[clap(long, help = "Show only available configurations.")]
     pub only_available: bool,
+    #[clap(help = "Filter by rack hardware type.")]
+    pub rack_hardware_type: Option<String>,
 }
 
-impl From<Args> for rpc::forge::RackFirmwareListRequest {
+impl From<Args> for rpc::forge::RackFirmwareSearchFilter {
     fn from(args: Args) -> Self {
         Self {
             only_available: args.only_available,
+            rack_hardware_type: args
+                .rack_hardware_type
+                .map(|v| rpc::common::RackHardwareType { value: v }),
         }
     }
 }

--- a/crates/admin-cli/src/rack_firmware/list/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/list/cmd.rs
@@ -36,14 +36,21 @@ pub async fn list(
         let mut table = Table::new();
         table.set_titles(Row::new(vec![
             Cell::new("ID"),
+            Cell::new("Hardware Type"),
             Cell::new("Available"),
             Cell::new("Created"),
             Cell::new("Updated"),
         ]));
 
         for config in result.configs {
+            let hw_type = config
+                .rack_hardware_type
+                .as_ref()
+                .map(|t| t.value.as_str())
+                .unwrap_or("N/A");
             table.add_row(Row::new(vec![
                 Cell::new(&config.id),
+                Cell::new(hw_type),
                 Cell::new(&config.available.to_string()),
                 Cell::new(&config.created),
                 Cell::new(&config.updated),

--- a/crates/admin-cli/src/rack_firmware/tests.rs
+++ b/crates/admin-cli/src/rack_firmware/tests.rs
@@ -71,6 +71,43 @@ fn parse_list_only_available() {
     }
 }
 
+// parse_list_with_hardware_type_filter ensures list parses with a
+// hardware type filter.
+#[test]
+fn parse_list_with_hardware_type_filter() {
+    let cmd = Cmd::try_parse_from(["rack-firmware", "list", "any"])
+        .expect("should parse list with hardware type filter");
+
+    match cmd {
+        Cmd::List(args) => {
+            assert!(!args.only_available);
+            assert_eq!(args.rack_hardware_type, Some("any".to_string()));
+        }
+        _ => panic!("expected List variant"),
+    }
+}
+
+// parse_create_with_hardware_type ensures create parses with
+// hardware type as first argument.
+#[test]
+fn parse_create_with_hardware_type() {
+    let cmd = Cmd::try_parse_from([
+        "rack-firmware",
+        "create",
+        "any",
+        "/tmp/test.json",
+        "test-token",
+    ])
+    .expect("should parse create with hardware type");
+
+    match cmd {
+        Cmd::Create(args) => {
+            assert_eq!(args.rack_hardware_type, "any");
+        }
+        _ => panic!("expected Create variant"),
+    }
+}
+
 // parse_create_missing_args_fails ensures create fails without required args.
 #[test]
 fn parse_create_missing_args_fails() {

--- a/crates/api-db/migrations/20260410163200_rack_firmware_hardware_type.sql
+++ b/crates/api-db/migrations/20260410163200_rack_firmware_hardware_type.sql
@@ -1,0 +1,7 @@
+-- Add rack_hardware_type to rack_firmware table.
+-- Defaults existing rows to 'any' (matches any rack hardware type).
+ALTER TABLE rack_firmware ADD COLUMN rack_hardware_type TEXT NOT NULL DEFAULT 'any';
+CREATE INDEX idx_rack_firmware_rack_hardware_type ON rack_firmware(rack_hardware_type);
+
+-- Add rack_hardware_type to rack_firmware_apply_history table.
+ALTER TABLE rack_firmware_apply_history ADD COLUMN rack_hardware_type TEXT NOT NULL DEFAULT 'any';

--- a/crates/api-db/src/rack_firmware.rs
+++ b/crates/api-db/src/rack_firmware.rs
@@ -17,6 +17,7 @@
 
 use chrono::{DateTime, Utc};
 use model::rack_firmware::{RackFirmware, RackFirmwareApplyHistoryRecord};
+use model::rack_type::RackHardwareType;
 use sqlx::Error::RowNotFound;
 use sqlx::postgres::PgRow;
 use sqlx::types::Json;
@@ -32,6 +33,7 @@ struct DbRackFirmwareApplyHistory {
     firmware_id: String,
     rack_id: String,
     firmware_type: String,
+    rack_hardware_type: RackHardwareType,
     applied_at: DateTime<Utc>,
 }
 
@@ -56,6 +58,7 @@ impl From<DbRackFirmwareApplyHistoryWithAvailability> for RackFirmwareApplyHisto
             firmware_id: row.history.firmware_id,
             rack_id: row.history.rack_id,
             firmware_type: row.history.firmware_type,
+            rack_hardware_type: row.history.rack_hardware_type,
             applied_at: row.history.applied_at,
             firmware_available: row.firmware_available,
         }
@@ -67,15 +70,17 @@ pub async fn record_apply_history(
     firmware_id: &str,
     rack_id: &str,
     firmware_type: &str,
+    rack_hardware_type: RackHardwareType,
 ) -> DatabaseResult<()> {
     let query = "INSERT INTO rack_firmware_apply_history \
-        (firmware_id, rack_id, firmware_type) \
-        VALUES ($1, $2, $3)";
+        (firmware_id, rack_id, firmware_type, rack_hardware_type) \
+        VALUES ($1, $2, $3, $4)";
 
     sqlx::query(query)
         .bind(firmware_id)
         .bind(rack_id)
         .bind(firmware_type)
+        .bind(rack_hardware_type)
         .execute(txn)
         .await
         .map_err(|e| DatabaseError::new(query, e))?;
@@ -128,13 +133,15 @@ pub async fn list_apply_history(
 pub async fn create(
     txn: &mut PgConnection,
     id: &str,
+    rack_hardware_type: RackHardwareType,
     config: serde_json::Value,
     parsed_components: Option<serde_json::Value>,
 ) -> DatabaseResult<RackFirmware> {
-    let query = "INSERT INTO rack_firmware (id, config, parsed_components) VALUES ($1, $2::jsonb, $3::jsonb) RETURNING *";
+    let query = "INSERT INTO rack_firmware (id, rack_hardware_type, config, parsed_components) VALUES ($1, $2, $3::jsonb, $4::jsonb) RETURNING *";
 
     sqlx::query_as(query)
         .bind(id)
+        .bind(rack_hardware_type)
         .bind(Json(config))
         .bind(parsed_components.map(Json))
         .fetch_one(txn)
@@ -156,18 +163,24 @@ pub async fn find_by_id(txn: impl DbReader<'_>, id: &str) -> DatabaseResult<Rack
 
 pub async fn list_all(
     txn: &mut PgConnection,
-    only_available: bool,
+    filter: model::rack_firmware::RackFirmwareSearchFilter,
 ) -> DatabaseResult<Vec<RackFirmware>> {
-    let query = if only_available {
-        "SELECT * FROM rack_firmware WHERE available = true ORDER BY created DESC"
-    } else {
-        "SELECT * FROM rack_firmware ORDER BY created DESC"
-    };
+    let mut qb = sqlx::QueryBuilder::new("SELECT * FROM rack_firmware WHERE TRUE");
 
-    sqlx::query_as(query)
+    if filter.only_available {
+        qb.push(" AND available = true");
+    }
+    if let Some(hw_type) = filter.rack_hardware_type {
+        qb.push(" AND rack_hardware_type = ");
+        qb.push_bind(hw_type);
+    }
+
+    qb.push(" ORDER BY created DESC");
+
+    qb.build_query_as()
         .fetch_all(txn)
         .await
-        .map_err(|e| DatabaseError::query(query, e))
+        .map_err(|e| DatabaseError::new("rack_firmware::list_all", e))
 }
 
 pub async fn update_config(
@@ -225,16 +238,28 @@ mod tests {
         let mut txn = pool.begin().await.unwrap();
 
         // Create a firmware config so we can verify the availability join
-        create(&mut txn, "fw-001", json!({"Id": "fw-001"}), None)
-            .await
-            .unwrap();
+        create(
+            &mut txn,
+            "fw-001",
+            RackHardwareType::any(),
+            json!({"Id": "fw-001"}),
+            None,
+        )
+        .await
+        .unwrap();
         set_available(&mut txn, "fw-001", true).await.unwrap();
 
         // Record two apply events for the same firmware
-        record_apply_history(&mut txn, "fw-001", "rack-a", "prod")
-            .await
-            .unwrap();
-        record_apply_history(&mut txn, "fw-001", "rack-b", "dev")
+        record_apply_history(
+            &mut txn,
+            "fw-001",
+            "rack-a",
+            "prod",
+            RackHardwareType::any(),
+        )
+        .await
+        .unwrap();
+        record_apply_history(&mut txn, "fw-001", "rack-b", "dev", RackHardwareType::any())
             .await
             .unwrap();
 
@@ -278,15 +303,27 @@ mod tests {
         let mut txn = pool.begin().await.unwrap();
 
         // Create firmware and mark available
-        create(&mut txn, "fw-002", json!({"Id": "fw-002"}), None)
-            .await
-            .unwrap();
+        create(
+            &mut txn,
+            "fw-002",
+            RackHardwareType::any(),
+            json!({"Id": "fw-002"}),
+            None,
+        )
+        .await
+        .unwrap();
         set_available(&mut txn, "fw-002", true).await.unwrap();
 
         // Record an apply
-        record_apply_history(&mut txn, "fw-002", "rack-a", "prod")
-            .await
-            .unwrap();
+        record_apply_history(
+            &mut txn,
+            "fw-002",
+            "rack-a",
+            "prod",
+            RackHardwareType::any(),
+        )
+        .await
+        .unwrap();
 
         // Verify available = true
         let before = list_apply_history(&mut txn, Some("fw-002"), &[])
@@ -311,9 +348,15 @@ mod tests {
         let mut txn = pool.begin().await.unwrap();
 
         // Record history for a firmware_id that was never created
-        record_apply_history(&mut txn, "fw-ghost", "rack-a", "prod")
-            .await
-            .unwrap();
+        record_apply_history(
+            &mut txn,
+            "fw-ghost",
+            "rack-a",
+            "prod",
+            RackHardwareType::any(),
+        )
+        .await
+        .unwrap();
 
         let history = list_apply_history(&mut txn, None, &[]).await.unwrap();
         assert_eq!(history.len(), 1);

--- a/crates/api-model/src/rack_firmware.rs
+++ b/crates/api-model/src/rack_firmware.rs
@@ -21,9 +21,12 @@ use sqlx::postgres::PgRow;
 use sqlx::types::Json;
 use sqlx::{FromRow, Row};
 
+use crate::rack_type::RackHardwareType;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RackFirmware {
     pub id: String,
+    pub rack_hardware_type: RackHardwareType,
     pub config: Json<serde_json::Value>,
     pub available: bool,
     pub parsed_components: Option<Json<serde_json::Value>>,
@@ -35,6 +38,7 @@ impl<'r> FromRow<'r, PgRow> for RackFirmware {
     fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
         Ok(RackFirmware {
             id: row.try_get("id")?,
+            rack_hardware_type: row.try_get("rack_hardware_type")?,
             config: row.try_get("config")?,
             available: row.try_get("available")?,
             parsed_components: row.try_get("parsed_components")?,
@@ -59,16 +63,39 @@ impl From<&RackFirmware> for rpc::forge::RackFirmware {
             created: db.created.format("%Y-%m-%d %H:%M:%S").to_string(),
             updated: db.updated.format("%Y-%m-%d %H:%M:%S").to_string(),
             parsed_components,
+            rack_hardware_type: Some(db.rack_hardware_type.clone().into()),
         }
     }
 }
 
-/// A record of a rack firmware apply operation
+/// Filter criteria for searching rack firmware configurations.
+#[derive(Clone, Debug, Default)]
+pub struct RackFirmwareSearchFilter {
+    pub only_available: bool,
+    pub rack_hardware_type: Option<RackHardwareType>,
+}
+
+impl From<rpc::forge::RackFirmwareSearchFilter> for RackFirmwareSearchFilter {
+    fn from(filter: rpc::forge::RackFirmwareSearchFilter) -> Self {
+        let rack_hardware_type = filter
+            .rack_hardware_type
+            .filter(|t| !t.value.is_empty())
+            .map(RackHardwareType::from);
+
+        RackFirmwareSearchFilter {
+            only_available: filter.only_available,
+            rack_hardware_type,
+        }
+    }
+}
+
+/// A record of a rack firmware apply operation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RackFirmwareApplyHistoryRecord {
     pub firmware_id: String,
     pub rack_id: String,
     pub firmware_type: String,
+    pub rack_hardware_type: RackHardwareType,
     pub applied_at: DateTime<Utc>,
     pub firmware_available: bool,
 }
@@ -81,6 +108,65 @@ impl From<RackFirmwareApplyHistoryRecord> for rpc::forge::RackFirmwareHistoryRec
             firmware_type: record.firmware_type,
             applied_at: record.applied_at.format("%Y-%m-%d %H:%M:%S").to_string(),
             firmware_available: record.firmware_available,
+            rack_hardware_type: Some(record.rack_hardware_type.into()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_search_filter_from_proto_with_hardware_type() {
+        let proto = rpc::forge::RackFirmwareSearchFilter {
+            only_available: true,
+            rack_hardware_type: Some(rpc::common::RackHardwareType {
+                value: "any".to_string(),
+            }),
+        };
+        let filter = RackFirmwareSearchFilter::from(proto);
+        assert!(filter.only_available);
+        assert_eq!(filter.rack_hardware_type, Some(RackHardwareType::any()));
+    }
+
+    #[test]
+    fn test_search_filter_from_proto_none_becomes_none() {
+        let proto = rpc::forge::RackFirmwareSearchFilter {
+            only_available: false,
+            rack_hardware_type: None,
+        };
+        let filter = RackFirmwareSearchFilter::from(proto);
+        assert!(!filter.only_available);
+        assert_eq!(filter.rack_hardware_type, None);
+    }
+
+    #[test]
+    fn test_search_filter_from_proto_empty_value_becomes_none() {
+        let proto = rpc::forge::RackFirmwareSearchFilter {
+            only_available: false,
+            rack_hardware_type: Some(rpc::common::RackHardwareType {
+                value: String::new(),
+            }),
+        };
+        let filter = RackFirmwareSearchFilter::from(proto);
+        assert!(!filter.only_available);
+        assert_eq!(filter.rack_hardware_type, None);
+    }
+
+    #[test]
+    fn test_search_filter_from_proto_specific_type() {
+        let proto = rpc::forge::RackFirmwareSearchFilter {
+            only_available: true,
+            rack_hardware_type: Some(rpc::common::RackHardwareType {
+                value: "dsx_gb200nvl_72x1".to_string(),
+            }),
+        };
+        let filter = RackFirmwareSearchFilter::from(proto);
+        assert!(filter.only_available);
+        assert_eq!(
+            filter.rack_hardware_type,
+            Some(RackHardwareType::from("dsx_gb200nvl_72x1"))
+        );
     }
 }

--- a/crates/api-model/src/rack_type.rs
+++ b/crates/api-model/src/rack_type.rs
@@ -21,29 +21,47 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 /// RackHardwareType identifies the hardware type of a rack.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
-#[sqlx(type_name = "text")]
-pub enum RackHardwareType {
-    #[serde(rename = "dsx_gb200nvl_36x1")]
-    #[sqlx(rename = "dsx_gb200nvl_36x1")]
-    DsxGb200Nvl36x1,
+/// This is a flexible string-based type to allow new hardware types
+/// without code changes. The special value "any" indicates firmware
+/// that is compatible with any rack hardware type.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(transparent)]
+#[serde(transparent)]
+pub struct RackHardwareType(pub String);
 
-    #[serde(rename = "dsx_gb200nvl_36x2")]
-    #[sqlx(rename = "dsx_gb200nvl_36x2")]
-    DsxGb200Nvl36x2,
+impl RackHardwareType {
+    /// Returns a RackHardwareType that matches any rack hardware.
+    pub fn any() -> Self {
+        Self("any".to_string())
+    }
 
-    #[serde(rename = "dsx_gb200nvl_72x1")]
-    #[sqlx(rename = "dsx_gb200nvl_72x1")]
-    DsxGb200Nvl72x1,
+    /// Returns true if this is the wildcard "any" type.
+    pub fn is_any(&self) -> bool {
+        self.0 == "any"
+    }
+}
+
+impl Default for RackHardwareType {
+    fn default() -> Self {
+        Self::any()
+    }
 }
 
 impl fmt::Display for RackHardwareType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            RackHardwareType::DsxGb200Nvl36x1 => write!(f, "dsx_gb200nvl_36x1"),
-            RackHardwareType::DsxGb200Nvl36x2 => write!(f, "dsx_gb200nvl_36x2"),
-            RackHardwareType::DsxGb200Nvl72x1 => write!(f, "dsx_gb200nvl_72x1"),
-        }
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<String> for RackHardwareType {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for RackHardwareType {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
     }
 }
 
@@ -244,30 +262,15 @@ impl RackTypeConfig {
 
 use ::rpc::errors::RpcDataConversionError;
 
-impl From<RackHardwareType> for rpc::forge::RackHardwareType {
+impl From<RackHardwareType> for rpc::common::RackHardwareType {
     fn from(value: RackHardwareType) -> Self {
-        match value {
-            RackHardwareType::DsxGb200Nvl36x1 => rpc::forge::RackHardwareType::DsxGb200nvl36x1,
-            RackHardwareType::DsxGb200Nvl36x2 => rpc::forge::RackHardwareType::DsxGb200nvl36x2,
-            RackHardwareType::DsxGb200Nvl72x1 => rpc::forge::RackHardwareType::DsxGb200nvl72x1,
-        }
+        rpc::common::RackHardwareType { value: value.0 }
     }
 }
 
-impl TryFrom<rpc::forge::RackHardwareType> for RackHardwareType {
-    type Error = RpcDataConversionError;
-
-    fn try_from(value: rpc::forge::RackHardwareType) -> Result<Self, Self::Error> {
-        match value {
-            rpc::forge::RackHardwareType::DsxGb200nvl36x1 => Ok(RackHardwareType::DsxGb200Nvl36x1),
-            rpc::forge::RackHardwareType::DsxGb200nvl36x2 => Ok(RackHardwareType::DsxGb200Nvl36x2),
-            rpc::forge::RackHardwareType::DsxGb200nvl72x1 => Ok(RackHardwareType::DsxGb200Nvl72x1),
-            rpc::forge::RackHardwareType::Unspecified => {
-                Err(RpcDataConversionError::InvalidArgument(
-                    "unspecified rack hardware type".to_string(),
-                ))
-            }
-        }
+impl From<rpc::common::RackHardwareType> for RackHardwareType {
+    fn from(value: rpc::common::RackHardwareType) -> Self {
+        RackHardwareType(value.value)
     }
 }
 
@@ -391,8 +394,8 @@ impl From<&RackCapabilitiesSet> for rpc::forge::RackCapabilitiesSet {
         rpc::forge::RackCapabilitiesSet {
             rack_hardware_type: value
                 .rack_hardware_type
-                .map(|t| rpc::forge::RackHardwareType::from(t) as i32)
-                .unwrap_or(rpc::forge::RackHardwareType::Unspecified as i32),
+                .as_ref()
+                .map(|t| rpc::common::RackHardwareType::from(t.clone())),
             rack_hardware_topology: value
                 .rack_hardware_topology
                 .map(|t| rpc::forge::RackHardwareTopology::from(t) as i32)
@@ -510,7 +513,7 @@ count = 8
 
         assert_eq!(
             nvl72.rack_hardware_type,
-            Some(RackHardwareType::DsxGb200Nvl72x1)
+            Some(RackHardwareType::from("dsx_gb200nvl_72x1"))
         );
         assert_eq!(
             nvl72.rack_hardware_topology,
@@ -539,40 +542,38 @@ count = 2
         assert_eq!(nvl36.rack_hardware_class, None);
     }
 
-    // -- RackHardwareType serde --
+    // RackHardwareType tests.
 
     #[test]
     fn test_rack_hardware_type_serde_round_trip() {
-        let cases = [
-            (RackHardwareType::DsxGb200Nvl36x1, "\"dsx_gb200nvl_36x1\""),
-            (RackHardwareType::DsxGb200Nvl36x2, "\"dsx_gb200nvl_36x2\""),
-            (RackHardwareType::DsxGb200Nvl72x1, "\"dsx_gb200nvl_72x1\""),
-        ];
-        for (variant, expected_json) in cases {
-            let json = serde_json::to_string(&variant).unwrap();
-            assert_eq!(json, expected_json, "serialize {:?}", variant);
-            let deserialized: RackHardwareType = serde_json::from_str(&json).unwrap();
-            assert_eq!(deserialized, variant, "deserialize {:?}", variant);
-        }
+        let hw_type = RackHardwareType::from("dsx_gb200nvl_72x1");
+        let json = serde_json::to_string(&hw_type).unwrap();
+        assert_eq!(json, "\"dsx_gb200nvl_72x1\"");
+        let deserialized: RackHardwareType = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, hw_type);
     }
 
     #[test]
     fn test_rack_hardware_type_display() {
+        assert_eq!(RackHardwareType::any().to_string(), "any");
         assert_eq!(
-            RackHardwareType::DsxGb200Nvl36x1.to_string(),
-            "dsx_gb200nvl_36x1"
-        );
-        assert_eq!(
-            RackHardwareType::DsxGb200Nvl36x2.to_string(),
-            "dsx_gb200nvl_36x2"
-        );
-        assert_eq!(
-            RackHardwareType::DsxGb200Nvl72x1.to_string(),
+            RackHardwareType::from("dsx_gb200nvl_72x1").to_string(),
             "dsx_gb200nvl_72x1"
         );
     }
 
-    // -- RackHardwareTopology serde --
+    #[test]
+    fn test_rack_hardware_type_is_any() {
+        assert!(RackHardwareType::any().is_any());
+        assert!(!RackHardwareType::from("dsx_gb200nvl_72x1").is_any());
+    }
+
+    #[test]
+    fn test_rack_hardware_type_default_is_any() {
+        assert_eq!(RackHardwareType::default(), RackHardwareType::any());
+    }
+
+    // RackHardwareTopology serde.
 
     #[test]
     fn test_rack_hardware_topology_serde_round_trip() {
@@ -626,7 +627,7 @@ count = 2
         );
     }
 
-    // -- RackHardwareClass serde --
+    // RackHardwareClass serde.
 
     #[test]
     fn test_rack_hardware_class_serde_round_trip() {
@@ -648,37 +649,7 @@ count = 2
         assert_eq!(RackHardwareClass::Prod.to_string(), "prod");
     }
 
-    // -- Proto conversion tests --
-
-    #[test]
-    fn test_rack_hardware_type_proto_round_trip() {
-        let cases = [
-            (
-                RackHardwareType::DsxGb200Nvl36x1,
-                rpc::forge::RackHardwareType::DsxGb200nvl36x1,
-            ),
-            (
-                RackHardwareType::DsxGb200Nvl36x2,
-                rpc::forge::RackHardwareType::DsxGb200nvl36x2,
-            ),
-            (
-                RackHardwareType::DsxGb200Nvl72x1,
-                rpc::forge::RackHardwareType::DsxGb200nvl72x1,
-            ),
-        ];
-        for (model, proto) in cases {
-            let converted: rpc::forge::RackHardwareType = model.into();
-            assert_eq!(converted, proto);
-            let back: RackHardwareType = proto.try_into().unwrap();
-            assert_eq!(back, model);
-        }
-    }
-
-    #[test]
-    fn test_rack_hardware_type_proto_unspecified_errors() {
-        let result = RackHardwareType::try_from(rpc::forge::RackHardwareType::Unspecified);
-        assert!(result.is_err());
-    }
+    // Proto conversion tests.
 
     #[test]
     fn test_rack_hardware_topology_proto_round_trip() {
@@ -745,7 +716,7 @@ count = 2
     #[test]
     fn test_rack_capabilities_set_proto_conversion() {
         let caps = RackCapabilitiesSet {
-            rack_hardware_type: Some(RackHardwareType::DsxGb200Nvl72x1),
+            rack_hardware_type: Some(RackHardwareType::from("dsx_gb200nvl_72x1")),
             rack_hardware_topology: Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology),
             rack_hardware_class: Some(RackHardwareClass::Prod),
             compute: RackCapabilityCompute {
@@ -770,10 +741,7 @@ count = 2
 
         let proto: rpc::forge::RackCapabilitiesSet = (&caps).into();
 
-        assert_eq!(
-            proto.rack_hardware_type,
-            rpc::forge::RackHardwareType::DsxGb200nvl72x1 as i32
-        );
+        assert_eq!(proto.rack_hardware_type.unwrap().value, "dsx_gb200nvl_72x1");
         assert_eq!(
             proto.rack_hardware_topology,
             rpc::forge::RackHardwareTopology::Gb200Nvl72r1C2g4 as i32
@@ -805,10 +773,7 @@ count = 2
         let caps = RackCapabilitiesSet::default();
         let proto: rpc::forge::RackCapabilitiesSet = (&caps).into();
 
-        assert_eq!(
-            proto.rack_hardware_type,
-            rpc::forge::RackHardwareType::Unspecified as i32
-        );
+        assert_eq!(proto.rack_hardware_type, None);
         assert_eq!(
             proto.rack_hardware_topology,
             rpc::forge::RackHardwareTopology::Unspecified as i32

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -1426,7 +1426,7 @@ impl Forge for Api {
 
     async fn list_rack_firmware(
         &self,
-        request: tonic::Request<rpc::RackFirmwareListRequest>,
+        request: tonic::Request<rpc::RackFirmwareSearchFilter>,
     ) -> Result<Response<rpc::RackFirmwareList>, tonic::Status> {
         crate::handlers::rack_firmware::list(self, request).await
     }

--- a/crates/api/src/handlers/rack_firmware.rs
+++ b/crates/api/src/handlers/rack_firmware.rs
@@ -25,7 +25,7 @@ use rpc::forge::{
     RackFirmwareApplyResponse, RackFirmwareCreateRequest, RackFirmwareDeleteRequest,
     RackFirmwareGetRequest, RackFirmwareHistoryRecords, RackFirmwareHistoryRequest,
     RackFirmwareHistoryResponse, RackFirmwareJobStatusRequest, RackFirmwareJobStatusResponse,
-    RackFirmwareList, RackFirmwareListRequest,
+    RackFirmwareList, RackFirmwareSearchFilter,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -334,7 +334,14 @@ pub async fn create(
         .await
         .map_err(|e| CarbideError::from(DatabaseError::new("begin create", e)))?;
 
-    let db_config = rack_firmware_db::create(&mut txn, &id, config, parsed_components).await?;
+    let rack_hardware_type: model::rack_type::RackHardwareType = req
+        .rack_hardware_type
+        .ok_or_else(|| CarbideError::MissingArgument("rack_hardware_type"))?
+        .into();
+
+    let db_config =
+        rack_firmware_db::create(&mut txn, &id, rack_hardware_type, config, parsed_components)
+            .await?;
 
     txn.commit()
         .await
@@ -379,9 +386,9 @@ pub async fn get(
 /// List all Rack firmware configurations
 pub async fn list(
     api: &Api,
-    request: Request<RackFirmwareListRequest>,
+    request: Request<RackFirmwareSearchFilter>,
 ) -> Result<Response<RackFirmwareList>, Status> {
-    let req = request.into_inner();
+    let filter: model::rack_firmware::RackFirmwareSearchFilter = request.into_inner().into();
 
     let mut txn = api
         .database_connection
@@ -389,7 +396,7 @@ pub async fn list(
         .await
         .map_err(|e| CarbideError::from(DatabaseError::new("begin list", e)))?;
 
-    let db_configs = rack_firmware_db::list_all(&mut txn, req.only_available).await?;
+    let db_configs = rack_firmware_db::list_all(&mut txn, filter).await?;
 
     txn.commit()
         .await
@@ -988,6 +995,38 @@ pub async fn apply(
             message: format!("Failed to get rack: {}", e),
         })?;
 
+    // Validate firmware hardware type and firmware_type against rack capabilities.
+    if let Some(rack_type_name) = rack.config.rack_type.as_deref()
+        && let Some(capabilities) = api.runtime_config.rack_types.get(rack_type_name)
+    {
+        // Validate firmware hardware type matches rack's hardware type.
+        if !fw_config.rack_hardware_type.is_any()
+            && let Some(rack_hw_type) = &capabilities.rack_hardware_type
+            && *rack_hw_type != fw_config.rack_hardware_type
+        {
+            return Err(CarbideError::FailedPrecondition(format!(
+                "Firmware hardware type '{}' does not match rack '{}' hardware type '{}'",
+                fw_config.rack_hardware_type, rack_id, rack_hw_type
+            ))
+            .into());
+        }
+
+        // Validate firmware_type matches rack's hardware class.
+        if let Some(rack_hw_class) = capabilities.rack_hardware_class {
+            let expected_fw_type = match rack_hw_class {
+                model::rack_type::RackHardwareClass::Dev => "dev",
+                model::rack_type::RackHardwareClass::Prod => "prod",
+            };
+            if req.firmware_type != expected_fw_type {
+                return Err(CarbideError::FailedPrecondition(format!(
+                    "Firmware type '{}' does not match rack '{}' hardware class '{}'",
+                    req.firmware_type, rack_id, rack_hw_class
+                ))
+                .into());
+            }
+        }
+    }
+
     // Convert rack to proto to get device IDs
     let rack_proto: rpc::forge::Rack = rack.into();
 
@@ -1214,6 +1253,7 @@ pub async fn apply(
         &req.firmware_id,
         &rack_id_str,
         &req.firmware_type,
+        fw_config.rack_hardware_type,
     )
     .await
     .map_err(CarbideError::from)?;

--- a/crates/api/src/tests/rack_firmware.rs
+++ b/crates/api/src/tests/rack_firmware.rs
@@ -18,7 +18,7 @@
 use common::api_fixtures::create_test_env;
 use rpc::forge::{
     RackFirmwareCreateRequest, RackFirmwareDeleteRequest, RackFirmwareGetRequest,
-    RackFirmwareListRequest,
+    RackFirmwareSearchFilter,
 };
 use rpc::protos::forge::forge_server::Forge;
 
@@ -102,6 +102,9 @@ async fn test_create_rack_firmware(pool: sqlx::PgPool) -> Result<(), Box<dyn std
     let config_json = create_valid_rack_firmware_json(firmware_id);
 
     let request = tonic::Request::new(RackFirmwareCreateRequest {
+        rack_hardware_type: Some(rpc::common::RackHardwareType {
+            value: "any".to_string(),
+        }),
         config_json: config_json.clone(),
         artifactory_token: "test-token-123".to_string(),
     });
@@ -145,6 +148,9 @@ async fn test_get_rack_firmware(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
 
     // Create firmware first
     let create_request = tonic::Request::new(RackFirmwareCreateRequest {
+        rack_hardware_type: Some(rpc::common::RackHardwareType {
+            value: "any".to_string(),
+        }),
         config_json: config_json.clone(),
         artifactory_token: "test-token".to_string(),
     });
@@ -177,8 +183,9 @@ async fn test_list_rack_firmware_empty(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env(pool).await;
 
-    let request = tonic::Request::new(RackFirmwareListRequest {
+    let request = tonic::Request::new(RackFirmwareSearchFilter {
         only_available: false,
+        rack_hardware_type: None,
     });
 
     let response = env.api.list_rack_firmware(request).await?;
@@ -201,6 +208,9 @@ async fn test_list_rack_firmware_multiple(
         let config_json = create_valid_rack_firmware_json(&firmware_id);
 
         let request = tonic::Request::new(RackFirmwareCreateRequest {
+            rack_hardware_type: Some(rpc::common::RackHardwareType {
+                value: "any".to_string(),
+            }),
             config_json,
             artifactory_token: format!("test-token-{}", i),
         });
@@ -208,8 +218,9 @@ async fn test_list_rack_firmware_multiple(
     }
 
     // List all
-    let request = tonic::Request::new(RackFirmwareListRequest {
+    let request = tonic::Request::new(RackFirmwareSearchFilter {
         only_available: false,
+        rack_hardware_type: None,
     });
 
     let response = env.api.list_rack_firmware(request).await?;
@@ -238,6 +249,9 @@ async fn test_delete_rack_firmware(pool: sqlx::PgPool) -> Result<(), Box<dyn std
 
     // Create firmware
     let create_request = tonic::Request::new(RackFirmwareCreateRequest {
+        rack_hardware_type: Some(rpc::common::RackHardwareType {
+            value: "any".to_string(),
+        }),
         config_json,
         artifactory_token: "test-token".to_string(),
     });
@@ -275,6 +289,9 @@ async fn test_rack_firmware_full_lifecycle(
 
     // 1. Create
     let create_request = tonic::Request::new(RackFirmwareCreateRequest {
+        rack_hardware_type: Some(rpc::common::RackHardwareType {
+            value: "any".to_string(),
+        }),
         config_json: config_json.clone(),
         artifactory_token: "test-token".to_string(),
     });
@@ -292,8 +309,9 @@ async fn test_rack_firmware_full_lifecycle(
     assert_eq!(retrieved_firmware.id, firmware_id);
 
     // 3. List (should contain our firmware)
-    let list_request = tonic::Request::new(RackFirmwareListRequest {
+    let list_request = tonic::Request::new(RackFirmwareSearchFilter {
         only_available: false,
+        rack_hardware_type: None,
     });
     let list_response = env.api.list_rack_firmware(list_request).await?;
     let list = list_response.into_inner();
@@ -438,6 +456,9 @@ async fn test_rack_firmware_with_multiple_components(
     .to_string();
 
     let request = tonic::Request::new(RackFirmwareCreateRequest {
+        rack_hardware_type: Some(rpc::common::RackHardwareType {
+            value: "any".to_string(),
+        }),
         config_json,
         artifactory_token: "test-token".to_string(),
     });

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -673,6 +673,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .type_attribute("forge.RackFirmwareHistoryRecord", "#[derive(serde::Serialize)]")
         .type_attribute("forge.RackFirmwareHistoryRecords", "#[derive(serde::Serialize)]")
         .type_attribute("forge.RackFirmwareHistoryResponse", "#[derive(serde::Serialize)]")
+        .type_attribute("common.RackHardwareType", "#[derive(serde::Serialize)]")
         .type_attribute("forge.RackCapabilitiesSet", "#[derive(serde::Serialize)]")
         .type_attribute("forge.RackCapabilityCompute", "#[derive(serde::Serialize)]")
         .type_attribute("forge.RackCapabilitySwitch", "#[derive(serde::Serialize)]")

--- a/crates/rpc/proto/common.proto
+++ b/crates/rpc/proto/common.proto
@@ -102,6 +102,10 @@ message IpxeTemplateId {
   string value = 1;
 }
 
+message RackHardwareType {
+  string value = 1;
+}
+
 enum SystemPowerControl {
   SYSTEM_POWER_CONTROL_UNKNOWN = 0;
   // Power on a machine

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -366,7 +366,7 @@ service Forge {
   // Get a Rack firmware configuration by ID
   rpc GetRackFirmware(RackFirmwareGetRequest) returns (RackFirmware);
   // List all Rack firmware configurations
-  rpc ListRackFirmware(RackFirmwareListRequest) returns (RackFirmwareList);
+  rpc ListRackFirmware(RackFirmwareSearchFilter) returns (RackFirmwareList);
   // Delete a Rack firmware configuration
   rpc DeleteRackFirmware(RackFirmwareDeleteRequest) returns (google.protobuf.Empty);
   // Apply firmware to all devices in a rack
@@ -6390,12 +6390,6 @@ message DeleteRackRequest {
 
 // Rack Capabilities
 
-enum RackHardwareType {
-  RACK_HARDWARE_TYPE_UNSPECIFIED = 0;
-  RACK_HARDWARE_TYPE_DSX_GB200NVL_36X1 = 1;
-  RACK_HARDWARE_TYPE_DSX_GB200NVL_36X2 = 2;
-  RACK_HARDWARE_TYPE_DSX_GB200NVL_72X1 = 3;
-}
 
 enum RackHardwareTopology {
   RACK_HARDWARE_TOPOLOGY_UNSPECIFIED = 0;
@@ -6435,7 +6429,7 @@ message RackCapabilityPowerShelf {
 }
 
 message RackCapabilitiesSet {
-  RackHardwareType rack_hardware_type = 1;
+  common.RackHardwareType rack_hardware_type = 1;
   RackHardwareTopology rack_hardware_topology = 2;
   RackHardwareClass rack_hardware_class = 3;
   RackCapabilityCompute compute = 4;
@@ -7205,6 +7199,7 @@ message RackFirmware {
   string created = 4;
   string updated = 5;
   string parsed_components = 6; // JSON string of firmware lookup table
+  common.RackHardwareType rack_hardware_type = 7;
 }
 
 message FirmwareComponentInfo {
@@ -7219,14 +7214,16 @@ message FirmwareComponentInfo {
 message RackFirmwareCreateRequest {
   string config_json = 1;
   string artifactory_token = 2;
+  common.RackHardwareType rack_hardware_type = 3;
 }
 
 message RackFirmwareGetRequest {
   string id = 1;
 }
 
-message RackFirmwareListRequest {
+message RackFirmwareSearchFilter {
   bool only_available = 1;
+  common.RackHardwareType rack_hardware_type = 2; // Optional: filter by rack hardware type. Unspecified means no filter.
 }
 
 message RackFirmwareList {
@@ -7297,6 +7294,7 @@ message RackFirmwareHistoryRecord {
   string firmware_type = 3;
   string applied_at = 4;
   bool firmware_available = 5; // Whether the firmware ID still exists and is available
+  common.RackHardwareType rack_hardware_type = 6;
 }
 
 message ModifyDPFStateRequest {


### PR DESCRIPTION
## Description

This wires in the new `RackHardwareType` and `RackHardwareClass` in with the `rack-firmware` management flows, and turns it into newtype over `String` in the process, giving us some more flexiblility as to what we set for values. It was decided we didn't want to be too restrictive with an enumerated list for now.

With the plumbing in place, the flow is now:

```
admin-cli rack-firmware create <rack-hardware-type> ...
```

...to associate a given rack firmware bundle with an expected rack type. And then, when you:

```
admin-cli rack-firmare apply <rack-id> ....
```

...the backend will now check to make sure the:
- The `RackFirmwareType` of the given `RackId` (based on its configured `RackCapabilitiesSet`) matches the configured `RackFirmwareType` for the firmware.
- The `RackHardwareClass` of the given `RackId` (based on its configured `RackCapabilitesSet`) matches the configured `firmware_type` (`<dev|prod>`) for the firmware.

I also introduced a `RackHardwareType::Any` in here, as if to say "I don't care what the hardware is, just apply the firmware", e.g.

```
admin-cli rack-firmware create any ....
```

...which will associate that firmware with `RackFirmwareType::Any`, so when you go to `rack-firmware apply`, it will apply to `::Any` hardware.

Improved the `rack-firmware list` API call as well with a filtering.

Tests included!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

