### PR TITLE
fix: create uninitialized redfish client when doing an initial probe of a redfish endpoint (with an anon client)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5657,7 +5657,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.43.6#d90e5d67011243416998214b764616f90d898a48"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.43.7#b470bef43d6ca953d067f5372dbce7ffee990d75"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.43.6" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.43.7" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.5" }
 ansi-to-html = "0.2.2"
 

--- a/crates/api/src/redfish.rs
+++ b/crates/api/src/redfish.rs
@@ -404,6 +404,17 @@ impl RedfishClientPool for RedfishClientPoolImpl {
                 .create_client_with_custom_headers(endpoint, custom_headers)
                 .await
                 .map_err(RedfishClientCreationError::RedfishError),
+            // Unknown means "no vendor" — return a standard client without
+            // making any HTTP calls (used by the anonymous probe client).
+            // This restores the behavior of the old `initialize: false` path
+            // which called create_standard_client. The full initialization
+            // path (create_client_with_vendor) makes HTTP calls to /Systems,
+            // /Managers, etc. that fail with 401 on BMCs requiring auth.
+            Some(RedfishVendor::Unknown) => self
+                .pool
+                .create_standard_client_with_custom_headers(endpoint, custom_headers)
+                .map_err(RedfishClientCreationError::RedfishError)
+                .map(|c| c as Box<dyn Redfish>),
             // Use the provided vendor directly.
             Some(vendor) => self
                 .pool


### PR DESCRIPTION
## Description
Switch exploration is currently failing on the initial redfish probe done to determine vendor :
`root@control72-cno1-cp1-jhb01:~# kubectl logs -n forge-system deploy/carbide-api -f | grep "7.243.147.152"
Found 2 pods, using pod/carbide-api-6c478d6fc5-hbfr4
level=ERROR span_id=0x3f99a996c662795 msg="Failed to probe Redfish service root endpoint: Unauthorized: HTTP 401 Unauthorized 401 at https://7.243.147.152:443/redfish/v1/Systems/" bmc_ip_address=7.243.147.152:443 location="crates/api/src/site_explorer/bmc_endpoint_explorer.rs:700"
level=INFO span_id=0x3f99a996c662795 msg="Failed to explore 7.243.147.152:443: Redfish vendor \'Unknown\' not supported" error="Redfish vendor \'Unknown\' not supported" location="crates/api/src/site_explorer/mod.rs:1532"
`

fix: if the UnknownVendor type is specified when creating a redfish client, create a client that does not make additional HTTP calls. this preserves the previous behavior when callers called create_client with initialize=false.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

