### PR TITLE
feat: drive all DPF mandatory services from per-service config with compile-time defaults

### DIFF
--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -663,7 +663,7 @@ pub struct DpfConfig {
     pub bfb_url: String,
     /// Additional Helm services to deploy alongside DPF.
     #[serde(default)]
-    pub services: Option<Vec<DpfServiceConfig>>,
+    pub services: Box<DpfMandatoryServicesConfig>,
     /// Whether to create the bf.cfg ConfigMap during initialization.
     #[serde(default = "default_to_true")]
     pub bfcfg_enabled: bool,
@@ -671,16 +671,6 @@ pub struct DpfConfig {
     /// This is just temporary flag and will be removed once v2 becomes only option.
     #[serde(default)]
     pub v2: bool,
-    /// Helm chart version for Carbide DPU services (e.g. `"1.2.3-42.gabcdef1"`).
-    /// When unset, the version baked in at compile time is used (CI builds on main).
-    /// Set this in config to test against a specific published version on PR/fork/local dev.
-    #[serde(default)]
-    pub carbide_helm_version: Option<String>,
-    /// Container image tag for Carbide DPU services (e.g. `"v1.2.3-42-gabcdef1"`).
-    /// When unset, the tag baked in at compile time is used (CI builds on main).
-    /// Set this in config to test against a specific published image on PR/fork/local dev.
-    #[serde(default)]
-    pub carbide_image_tag: Option<String>,
 }
 
 impl Default for DpfConfig {
@@ -691,11 +681,9 @@ impl Default for DpfConfig {
             flavor_name: default_dpf_flavor_name(),
             node_label_key: default_dpf_node_label_key(),
             bfb_url: String::new(),
-            services: None,
+            services: Box::default(),
             bfcfg_enabled: true,
             v2: false,
-            carbide_helm_version: None,
-            carbide_image_tag: None,
         }
     }
 }
@@ -715,6 +703,40 @@ fn default_dpf_node_label_key() -> String {
     "carbide.nvidia.com/controlled.node.v1".to_string()
 }
 
+/// Configuration for a mandatory Helm-based DPF service.
+/// Making it configurable means, a user can provide the link for his version of the service (for
+/// testing/dev purpose).
+/// There are following mandatory services:
+/// dpu-agent, fmds, dhcp-server, doca-hbn, dts and otel.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DpfMandatoryServicesConfig {
+    #[serde(default = "crate::dpf_services::default_dts_service")]
+    pub dts: DpfServiceConfig,
+    #[serde(default = "crate::dpf_services::default_doca_hbn_service")]
+    pub doca_hbn: DpfServiceConfig,
+    #[serde(default = "crate::dpf_services::default_dpu_agent_service")]
+    pub dpu_agent: DpfServiceConfig,
+    #[serde(default = "crate::dpf_services::default_dhcp_server_service")]
+    pub dhcp_server: DpfServiceConfig,
+    #[serde(default = "crate::dpf_services::default_fmds_service")]
+    pub fmds: DpfServiceConfig,
+    #[serde(default = "crate::dpf_services::default_otel_service")]
+    pub otel: DpfServiceConfig,
+}
+
+impl Default for DpfMandatoryServicesConfig {
+    fn default() -> Self {
+        Self {
+            dts: crate::dpf_services::default_dts_service(),
+            doca_hbn: crate::dpf_services::default_doca_hbn_service(),
+            dpu_agent: crate::dpf_services::default_dpu_agent_service(),
+            dhcp_server: crate::dpf_services::default_dhcp_server_service(),
+            fmds: crate::dpf_services::default_fmds_service(),
+            otel: crate::dpf_services::default_otel_service(),
+        }
+    }
+}
+
 /// Configuration for a single Helm-based DPF service.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct DpfServiceConfig {
@@ -726,6 +748,10 @@ pub struct DpfServiceConfig {
     pub helm_chart: String,
     /// Version of the Helm chart.
     pub helm_version: String,
+    /// Url for docker image
+    pub docker_repo_url: String,
+    /// Version of docker image
+    pub docker_image_tag: String,
 }
 
 /// Machine identity (SPIFFE JWT-SVID) configuration.

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -671,6 +671,16 @@ pub struct DpfConfig {
     /// This is just temporary flag and will be removed once v2 becomes only option.
     #[serde(default)]
     pub v2: bool,
+    /// Helm chart version for Carbide DPU services (e.g. `"1.2.3-42.gabcdef1"`).
+    /// When unset, the version baked in at compile time is used (CI builds on main).
+    /// Set this in config to test against a specific published version on PR/fork/local dev.
+    #[serde(default)]
+    pub carbide_helm_version: Option<String>,
+    /// Container image tag for Carbide DPU services (e.g. `"v1.2.3-42-gabcdef1"`).
+    /// When unset, the tag baked in at compile time is used (CI builds on main).
+    /// Set this in config to test against a specific published image on PR/fork/local dev.
+    #[serde(default)]
+    pub carbide_image_tag: Option<String>,
 }
 
 impl Default for DpfConfig {
@@ -684,6 +694,8 @@ impl Default for DpfConfig {
             services: None,
             bfcfg_enabled: true,
             v2: false,
+            carbide_helm_version: None,
+            carbide_image_tag: None,
         }
     }
 }

--- a/crates/api/src/dpf_services.rs
+++ b/crates/api/src/dpf_services.rs
@@ -48,18 +48,13 @@ pub const DOCA_HBN_SERVICE_NETWORK: &str = "mybrhbn";
 
 /// DHCP Service Definitions
 pub const DHCP_SERVER_SERVICE_HELM_NAME: &str = "carbide-dhcp-server";
-pub const DHCP_SERVER_SERVICE_HELM_VERSION: &str = "2.0.9";
-pub const DHCP_SERVER_SERVICE_IMAGE_NAME: &str = "forge-dhcp-server";
-pub const DHCP_SERVER_SERVICE_IMAGE_TAG: &str = "v1.9.5-arm64-distroless";
 pub const DHCP_SERVER_SERVICE_NAD_NAME: &str = "mybrsfc-dhcp";
 pub const DHCP_SERVER_SERVICE_MTU: i64 = 1500;
 
 // DPU Agent Service Definitions
 pub const DPU_AGENT_SERVICE_NAME: &str = "carbide-dpu-agent";
 pub const DPU_AGENT_SERVICE_HELM_NAME: &str = "carbide-dpu-agent";
-pub const DPU_AGENT_SERVICE_HELM_VERSION: &str = "0.9.6";
 pub const DPU_AGENT_SERVICE_IMAGE_NAME: &str = "forge-dpu-agent";
-pub const DPU_AGENT_SERVICE_IMAGE_TAG: &str = "v0.9.5-arm64-multistage";
 
 /// FMDS Agent Service Definitions
 pub const FMDS_SERVICE_HELM_NAME: &str = "carbide-fmds";
@@ -68,6 +63,18 @@ pub const FMDS_SERVICE_IMAGE_NAME: &str = "carbide-fmds";
 pub const FMDS_SERVICE_NAD_NAME: &str = "mybrsfc-fmds";
 pub const FMDS_SERVICE_IMAGE_TAG: &str = "v0.1-arm64-distroless";
 pub const FMDS_SERVICE_MTU: i64 = 1500;
+
+/// Compile-time helm version (set by CI via VERSION env var). Empty on PR/fork builds.
+const COMPILE_TIME_HELM_VERSION: &str = match option_env!("CARBIDE_BUILD_HELM_VERSION") {
+    Some(v) => v,
+    None => "",
+};
+
+/// Compile-time image tag (set by CI via VERSION env var). Empty on PR/fork builds.
+const COMPILE_TIME_IMAGE_TAG: &str = match option_env!("CARBIDE_BUILD_GIT_TAG") {
+    Some(v) => v,
+    None => "",
+};
 
 fn doca_hbn_service_interfaces() -> Vec<ServiceInterface> {
     dpu_service_interfaces(DOCA_HBN_SERVICE_NAME, DOCA_HBN_SERVICE_NETWORK)
@@ -131,6 +138,12 @@ pub struct CarbideServiceRegistryConfig {
     pub carbide_helm_registry: String,
     /// Container image registry prefix for Carbide images.
     pub carbide_image_registry: String,
+    /// Helm chart version for Carbide DPU services.
+    /// Compile-time value (from CI) takes precedence; runtime config overrides for PR/fork/local dev.
+    pub helm_version: String,
+    /// Container image tag for Carbide DPU services.
+    /// Compile-time value (from CI) takes precedence; runtime config overrides for PR/fork/local dev.
+    pub image_tag: String,
 }
 
 impl Default for CarbideServiceRegistryConfig {
@@ -140,6 +153,23 @@ impl Default for CarbideServiceRegistryConfig {
             doca_image_registry: DEFAULT_DOCA_IMAGE_REGISTRY.to_string(),
             carbide_helm_registry: DEFAULT_CARBIDE_HELM_REGISTRY.to_string(),
             carbide_image_registry: DEFAULT_CARBIDE_IMAGE_REGISTRY.to_string(),
+            helm_version: COMPILE_TIME_HELM_VERSION.to_string(),
+            image_tag: COMPILE_TIME_IMAGE_TAG.to_string(),
+        }
+    }
+}
+
+impl CarbideServiceRegistryConfig {
+    /// Build from runtime config, falling back to compile-time values when not set.
+    pub fn from_runtime(helm_version: Option<String>, image_tag: Option<String>) -> Self {
+        Self {
+            helm_version: helm_version
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| COMPILE_TIME_HELM_VERSION.to_string()),
+            image_tag: image_tag
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| COMPILE_TIME_IMAGE_TAG.to_string()),
+            ..Self::default()
         }
     }
 }
@@ -195,16 +225,15 @@ fn carbide_service(
     reg: &CarbideServiceRegistryConfig,
     name: &str,
     image_name: &str,
-    version: &str,
 ) -> ServiceDefinition {
     ServiceDefinition {
         helm_values: Some(serde_json::json!({
             "image": {
                 "repository": format!("{}/{}", reg.carbide_image_registry, image_name),
-                "tag": version
+                "tag": reg.image_tag,
             }
         })),
-        ..ServiceDefinition::new(name, &reg.carbide_helm_registry, name, version)
+        ..ServiceDefinition::new(name, &reg.carbide_helm_registry, name, &reg.helm_version)
     }
 }
 
@@ -212,7 +241,7 @@ fn carbide_service(
 #[allow(dead_code)]
 /// OpenTelemetry Collector service definition.
 pub fn otelcol_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinition {
-    let mut svc = carbide_service(reg, "carbide-otelcol", "otelcol-contrib", "0.1.0");
+    let mut svc = carbide_service(reg, "carbide-otelcol", "otelcol-contrib");
     svc.config_ports = Some(vec![ServiceConfigPort {
         name: "prometheus".to_string(),
         port: 9999,
@@ -230,7 +259,7 @@ pub fn dpu_agent_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinitio
             "image": {
                 "repository": format!("{}/{}", reg.carbide_image_registry,
                     DPU_AGENT_SERVICE_IMAGE_NAME),
-                "tag": DPU_AGENT_SERVICE_IMAGE_TAG,
+                "tag": reg.image_tag,
             },
             "hbn": {
                 "nvue_https_address": "nvue",
@@ -257,7 +286,7 @@ pub fn dpu_agent_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinitio
             DPU_AGENT_SERVICE_NAME,
             &reg.carbide_helm_registry,
             DPU_AGENT_SERVICE_HELM_NAME,
-            DPU_AGENT_SERVICE_HELM_VERSION,
+            &reg.helm_version,
         )
     }
 }
@@ -268,9 +297,8 @@ pub fn dhcp_server_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinit
     ServiceDefinition {
         helm_values: Some(serde_json::json!({
             "image": {
-                "repository": format!("{}/{}", reg.carbide_image_registry,
-                    DHCP_SERVER_SERVICE_IMAGE_NAME),
-                "tag": DHCP_SERVER_SERVICE_IMAGE_TAG,
+                "repository": format!("{}/forge-dhcp-server", reg.carbide_image_registry),
+                "tag": reg.image_tag,
             }
         })),
 
@@ -290,7 +318,7 @@ pub fn dhcp_server_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinit
             DHCP_SERVER_SERVICE_NAME,
             &reg.carbide_helm_registry,
             DHCP_SERVER_SERVICE_HELM_NAME,
-            DHCP_SERVER_SERVICE_HELM_VERSION,
+            &reg.helm_version,
         )
     }
 }
@@ -299,12 +327,7 @@ pub fn dhcp_server_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinit
 #[allow(dead_code)]
 /// Forge DPU OTel Agent service definition.
 pub fn dpu_otel_agent_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinition {
-    carbide_service(
-        reg,
-        "carbide-dpu-otel-agent",
-        "forge-dpu-otel-agent",
-        "0.1.0",
-    )
+    carbide_service(reg, "carbide-dpu-otel-agent", "forge-dpu-otel-agent")
 }
 
 /// FMDS Service

--- a/crates/api/src/dpf_services.rs
+++ b/crates/api/src/dpf_services.rs
@@ -27,17 +27,18 @@ use carbide_dpf::{
     ServiceInterface, ServiceNAD, ServiceNADResourceType,
 };
 
+use crate::cfg::file::DpfServiceConfig;
+
 /// Default DOCA helm registry (DPUServiceTemplate source.repoURL).
 pub const DEFAULT_DOCA_HELM_REGISTRY: &str = "https://helm.ngc.nvidia.com/nvidia/doca";
 
-pub const DEFAULT_CARBIDE_HELM_REGISTRY: &str =
-    "https://gitlab-master.nvidia.com/aadvani/my-helm-project/-/raw/main/charts-repo";
+pub const DEFAULT_CARBIDE_HELM_REGISTRY: &str = "https://nvcr.io/0837451325059433/carbide-dev";
 
 /// Default DOCA container image registry prefix.
 pub const DEFAULT_DOCA_IMAGE_REGISTRY: &str = "nvcr.io/nvidia/doca";
 
 /// Default Carbide container image registry prefix.
-pub const DEFAULT_CARBIDE_IMAGE_REGISTRY: &str = "gitlab-master.nvidia.com/aadvani/my-helm-project";
+pub const DEFAULT_CARBIDE_IMAGE_REGISTRY: &str = "nvcr.io/0837451325059433/carbide-dev";
 
 /// HBN service Definitions
 pub const DOCA_HBN_SERVICE_HELM_NAME: &str = "doca-hbn";
@@ -50,6 +51,12 @@ pub const DOCA_HBN_SERVICE_NETWORK: &str = "mybrhbn";
 pub const DHCP_SERVER_SERVICE_HELM_NAME: &str = "carbide-dhcp-server";
 pub const DHCP_SERVER_SERVICE_NAD_NAME: &str = "mybrsfc-dhcp";
 pub const DHCP_SERVER_SERVICE_MTU: i64 = 1500;
+pub const DHCP_SERVER_SERVICE_IMAGE_NAME: &str = "forge-dhcp-server";
+
+/// DTS service definitions
+pub const DTS_SERVICE_NAME: &str = "dts";
+pub const DTS_SERVICE_HELM_NAME: &str = "doca-telemetry";
+pub const DTS_SERVICE_HELM_VERSION: &str = "1.22.1";
 
 // DPU Agent Service Definitions
 pub const DPU_AGENT_SERVICE_NAME: &str = "carbide-dpu-agent";
@@ -58,20 +65,18 @@ pub const DPU_AGENT_SERVICE_IMAGE_NAME: &str = "forge-dpu-agent";
 
 /// FMDS Agent Service Definitions
 pub const FMDS_SERVICE_HELM_NAME: &str = "carbide-fmds";
-pub const FMDS_SERVICE_HELM_VERSION: &str = "0.2.0";
 pub const FMDS_SERVICE_IMAGE_NAME: &str = "carbide-fmds";
 pub const FMDS_SERVICE_NAD_NAME: &str = "mybrsfc-fmds";
-pub const FMDS_SERVICE_IMAGE_TAG: &str = "v0.1-arm64-distroless";
 pub const FMDS_SERVICE_MTU: i64 = 1500;
 
 /// Compile-time helm version (set by CI via VERSION env var). Empty on PR/fork builds.
-const COMPILE_TIME_HELM_VERSION: &str = match option_env!("CARBIDE_BUILD_HELM_VERSION") {
+pub(crate) const COMPILE_TIME_HELM_VERSION: &str = match option_env!("CARBIDE_BUILD_HELM_VERSION") {
     Some(v) => v,
     None => "",
 };
 
 /// Compile-time image tag (set by CI via VERSION env var). Empty on PR/fork builds.
-const COMPILE_TIME_IMAGE_TAG: &str = match option_env!("CARBIDE_BUILD_GIT_TAG") {
+pub(crate) const COMPILE_TIME_IMAGE_TAG: &str = match option_env!("CARBIDE_BUILD_GIT_TAG") {
     Some(v) => v,
     None => "",
 };
@@ -127,62 +132,75 @@ fn doca_hbn_startup_yaml(interfaces: &[ServiceInterface]) -> String {
     startup_yaml
 }
 
-/// Extended registry configuration for Carbide DPU services.
-#[derive(Debug, Clone)]
-pub struct CarbideServiceRegistryConfig {
-    /// Helm chart repository URL for DOCA services (HBN, DTS).
-    pub doca_helm_registry: String,
-    /// Helm image repository for DOCA Services
-    pub doca_image_registry: String,
-    /// Helm chart repository URL for Carbide services.
-    pub carbide_helm_registry: String,
-    /// Container image registry prefix for Carbide images.
-    pub carbide_image_registry: String,
-    /// Helm chart version for Carbide DPU services.
-    /// Compile-time value (from CI) takes precedence; runtime config overrides for PR/fork/local dev.
-    pub helm_version: String,
-    /// Container image tag for Carbide DPU services.
-    /// Compile-time value (from CI) takes precedence; runtime config overrides for PR/fork/local dev.
-    pub image_tag: String,
-}
-
-impl Default for CarbideServiceRegistryConfig {
-    fn default() -> Self {
-        Self {
-            doca_helm_registry: DEFAULT_DOCA_HELM_REGISTRY.to_string(),
-            doca_image_registry: DEFAULT_DOCA_IMAGE_REGISTRY.to_string(),
-            carbide_helm_registry: DEFAULT_CARBIDE_HELM_REGISTRY.to_string(),
-            carbide_image_registry: DEFAULT_CARBIDE_IMAGE_REGISTRY.to_string(),
-            helm_version: COMPILE_TIME_HELM_VERSION.to_string(),
-            image_tag: COMPILE_TIME_IMAGE_TAG.to_string(),
-        }
+pub(crate) fn default_dts_service() -> DpfServiceConfig {
+    DpfServiceConfig {
+        name: DTS_SERVICE_NAME.to_string(),
+        helm_repo_url: DEFAULT_DOCA_HELM_REGISTRY.to_string(),
+        helm_chart: DTS_SERVICE_HELM_NAME.to_string(),
+        helm_version: DTS_SERVICE_HELM_VERSION.to_string(),
+        docker_repo_url: String::new(),
+        docker_image_tag: String::new(),
     }
 }
 
-impl CarbideServiceRegistryConfig {
-    /// Build from runtime config, falling back to compile-time values when not set.
-    pub fn from_runtime(helm_version: Option<String>, image_tag: Option<String>) -> Self {
-        Self {
-            helm_version: helm_version
-                .filter(|s| !s.is_empty())
-                .unwrap_or_else(|| COMPILE_TIME_HELM_VERSION.to_string()),
-            image_tag: image_tag
-                .filter(|s| !s.is_empty())
-                .unwrap_or_else(|| COMPILE_TIME_IMAGE_TAG.to_string()),
-            ..Self::default()
-        }
+pub(crate) fn default_doca_hbn_service() -> DpfServiceConfig {
+    DpfServiceConfig {
+        name: DOCA_HBN_SERVICE_NAME.to_string(),
+        helm_repo_url: DEFAULT_DOCA_HELM_REGISTRY.to_string(),
+        helm_chart: DOCA_HBN_SERVICE_HELM_NAME.to_string(),
+        helm_version: DOCA_HBN_SERVICE_HELM_VERSION.to_string(),
+        docker_repo_url: format!("{DEFAULT_DOCA_IMAGE_REGISTRY}/{DOCA_HBN_SERVICE_IMAGE_NAME}"),
+        docker_image_tag: DOCA_HBN_SERVICE_IMAGE_TAG.to_string(),
     }
 }
 
-pub fn doca_hbn_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinition {
+pub(crate) fn default_dpu_agent_service() -> DpfServiceConfig {
+    DpfServiceConfig {
+        name: DPU_AGENT_SERVICE_NAME.to_string(),
+        helm_repo_url: DEFAULT_CARBIDE_HELM_REGISTRY.to_string(),
+        helm_chart: DPU_AGENT_SERVICE_HELM_NAME.to_string(),
+        helm_version: COMPILE_TIME_HELM_VERSION.to_string(),
+        docker_repo_url: format!("{DEFAULT_CARBIDE_IMAGE_REGISTRY}/{DPU_AGENT_SERVICE_IMAGE_NAME}"),
+        docker_image_tag: COMPILE_TIME_IMAGE_TAG.to_string(),
+    }
+}
+
+pub(crate) fn default_dhcp_server_service() -> DpfServiceConfig {
+    DpfServiceConfig {
+        name: DHCP_SERVER_SERVICE_NAME.to_string(),
+        helm_repo_url: DEFAULT_CARBIDE_HELM_REGISTRY.to_string(),
+        helm_chart: DHCP_SERVER_SERVICE_HELM_NAME.to_string(),
+        helm_version: COMPILE_TIME_HELM_VERSION.to_string(),
+        docker_repo_url: format!(
+            "{DEFAULT_CARBIDE_IMAGE_REGISTRY}/{DHCP_SERVER_SERVICE_IMAGE_NAME}"
+        ),
+        docker_image_tag: COMPILE_TIME_IMAGE_TAG.to_string(),
+    }
+}
+
+pub(crate) fn default_fmds_service() -> DpfServiceConfig {
+    DpfServiceConfig {
+        name: FMDS_SERVICE_NAME.to_string(),
+        helm_repo_url: DEFAULT_CARBIDE_HELM_REGISTRY.to_string(),
+        helm_chart: FMDS_SERVICE_HELM_NAME.to_string(),
+        helm_version: COMPILE_TIME_HELM_VERSION.to_string(),
+        docker_repo_url: format!("{DEFAULT_CARBIDE_IMAGE_REGISTRY}/{FMDS_SERVICE_IMAGE_NAME}"),
+        docker_image_tag: COMPILE_TIME_IMAGE_TAG.to_string(),
+    }
+}
+
+pub(crate) fn default_otel_service() -> DpfServiceConfig {
+    DpfServiceConfig::default()
+}
+
+/// DOCA HBN service definition.
+pub fn doca_hbn_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
     let interfaces = doca_hbn_service_interfaces();
-
     ServiceDefinition {
         helm_values: Some(serde_json::json!({
             "image": {
-                "repository": format!("{}/{}", reg.doca_image_registry,
-                    DOCA_HBN_SERVICE_IMAGE_NAME),
-                "tag": DOCA_HBN_SERVICE_IMAGE_TAG,
+                "repository": cfg.docker_repo_url,
+                "tag": cfg.docker_image_tag,
             },
             "resources": {
                 "memory": "6Gi",
@@ -211,55 +229,43 @@ pub fn doca_hbn_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinition
         interfaces,
 
         ..ServiceDefinition::new(
-            DOCA_HBN_SERVICE_NAME,
-            &reg.doca_helm_registry,
-            DOCA_HBN_SERVICE_HELM_NAME,
-            DOCA_HBN_SERVICE_HELM_VERSION,
+            &cfg.name,
+            &cfg.helm_repo_url,
+            &cfg.helm_chart,
+            &cfg.helm_version,
         )
     }
 }
 
-/// Build a Carbide service definition with standard image helm values.
-#[allow(dead_code)]
-fn carbide_service(
-    reg: &CarbideServiceRegistryConfig,
-    name: &str,
-    image_name: &str,
-) -> ServiceDefinition {
+/// DTS (DOCA Telemetry Service) service definition.
+pub fn dts_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
     ServiceDefinition {
         helm_values: Some(serde_json::json!({
-            "image": {
-                "repository": format!("{}/{}", reg.carbide_image_registry, image_name),
-                "tag": reg.image_tag,
-            }
+            "exposedPorts": { "ports": { "httpserverport": true } }
         })),
-        ..ServiceDefinition::new(name, &reg.carbide_helm_registry, name, &reg.helm_version)
+        config_ports: Some(vec![ServiceConfigPort {
+            name: "httpserverport".to_string(),
+            port: 9100,
+            protocol: ServiceConfigPortProtocol::Tcp,
+            node_port: None,
+        }]),
+        config_ports_service_type: Some(ConfigPortsServiceType::None),
+        ..ServiceDefinition::new(
+            &cfg.name,
+            &cfg.helm_repo_url,
+            &cfg.helm_chart,
+            &cfg.helm_version,
+        )
     }
 }
 
-// TODO: wire into setup.rs when carbide services are deployed to DPUs
-#[allow(dead_code)]
-/// OpenTelemetry Collector service definition.
-pub fn otelcol_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinition {
-    let mut svc = carbide_service(reg, "carbide-otelcol", "otelcol-contrib");
-    svc.config_ports = Some(vec![ServiceConfigPort {
-        name: "prometheus".to_string(),
-        port: 9999,
-        protocol: ServiceConfigPortProtocol::Tcp,
-        node_port: None,
-    }]);
-    svc.config_ports_service_type = Some(ConfigPortsServiceType::None);
-    svc
-}
-
 /// Forge DPU Agent service definition.
-pub fn dpu_agent_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinition {
+pub fn dpu_agent_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
     ServiceDefinition {
         helm_values: Some(serde_json::json!({
             "image": {
-                "repository": format!("{}/{}", reg.carbide_image_registry,
-                    DPU_AGENT_SERVICE_IMAGE_NAME),
-                "tag": reg.image_tag,
+                "repository": cfg.docker_repo_url,
+                "tag": cfg.docker_image_tag,
             },
             "hbn": {
                 "nvue_https_address": "nvue",
@@ -283,22 +289,21 @@ pub fn dpu_agent_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinitio
         })),
 
         ..ServiceDefinition::new(
-            DPU_AGENT_SERVICE_NAME,
-            &reg.carbide_helm_registry,
-            DPU_AGENT_SERVICE_HELM_NAME,
-            &reg.helm_version,
+            &cfg.name,
+            &cfg.helm_repo_url,
+            &cfg.helm_chart,
+            &cfg.helm_version,
         )
     }
 }
 
-// TODO: wire into setup.rs when carbide services are deployed to DPUs
 /// Forge DHCP Server service definition.
-pub fn dhcp_server_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinition {
+pub fn dhcp_server_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
     ServiceDefinition {
         helm_values: Some(serde_json::json!({
             "image": {
-                "repository": format!("{}/forge-dhcp-server", reg.carbide_image_registry),
-                "tag": reg.image_tag,
+                "repository": cfg.docker_repo_url,
+                "tag": cfg.docker_image_tag,
             }
         })),
 
@@ -315,29 +320,21 @@ pub fn dhcp_server_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinit
         }),
 
         ..ServiceDefinition::new(
-            DHCP_SERVER_SERVICE_NAME,
-            &reg.carbide_helm_registry,
-            DHCP_SERVER_SERVICE_HELM_NAME,
-            &reg.helm_version,
+            &cfg.name,
+            &cfg.helm_repo_url,
+            &cfg.helm_chart,
+            &cfg.helm_version,
         )
     }
 }
 
-// TODO: wire into setup.rs when carbide services are deployed to DPUs
-#[allow(dead_code)]
-/// Forge DPU OTel Agent service definition.
-pub fn dpu_otel_agent_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinition {
-    carbide_service(reg, "carbide-dpu-otel-agent", "forge-dpu-otel-agent")
-}
-
-/// FMDS Service
-pub fn fmds_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinition {
+/// Forge FMDS service definition.
+pub fn fmds_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
     ServiceDefinition {
         helm_values: Some(serde_json::json!({
             "image": {
-                "repository": format!("{}/{}", reg.carbide_image_registry,
-                    FMDS_SERVICE_IMAGE_NAME),
-                "tag": FMDS_SERVICE_IMAGE_TAG,
+                "repository": cfg.docker_repo_url,
+                "tag": cfg.docker_image_tag,
             }
         })),
 
@@ -354,22 +351,45 @@ pub fn fmds_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinition {
         }),
 
         ..ServiceDefinition::new(
-            FMDS_SERVICE_NAME,
-            &reg.carbide_helm_registry,
-            FMDS_SERVICE_HELM_NAME,
-            FMDS_SERVICE_HELM_VERSION,
+            &cfg.name,
+            &cfg.helm_repo_url,
+            &cfg.helm_chart,
+            &cfg.helm_version,
+        )
+    }
+}
+
+/// OTel service definition.
+#[allow(dead_code)]
+pub fn otel_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
+    ServiceDefinition {
+        helm_values: Some(serde_json::json!({
+            "image": {
+                "repository": cfg.docker_repo_url,
+                "tag": cfg.docker_image_tag,
+            }
+        })),
+        config_ports: Some(vec![ServiceConfigPort {
+            name: "prometheus".to_string(),
+            port: 9999,
+            protocol: ServiceConfigPortProtocol::Tcp,
+            node_port: None,
+        }]),
+        config_ports_service_type: Some(ConfigPortsServiceType::None),
+        ..ServiceDefinition::new(
+            &cfg.name,
+            &cfg.helm_repo_url,
+            &cfg.helm_chart,
+            &cfg.helm_version,
         )
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use carbide_dpf::build_service_interface;
     use carbide_dpf::sdk::build_dpu_interfaces_vec;
     use carbide_dpf::types::DpuServiceInterfaceTemplateType;
-    use carbide_dpf::{
-        NoLabels, build_deployment, build_service_configuration, build_service_interface,
-        build_service_nad, build_service_template,
-    };
 
     use super::*;
 
@@ -428,250 +448,6 @@ mod tests {
             );
         }
     }
-
-    // ---- doca_hbn_service ----
-
-    #[test]
-    fn test_doca_hbn_service_name_and_helm() {
-        let reg = CarbideServiceRegistryConfig::default();
-        let svc = doca_hbn_service(&reg);
-        assert_eq!(svc.name, DOCA_HBN_SERVICE_NAME);
-        assert_eq!(svc.helm_chart, DOCA_HBN_SERVICE_HELM_NAME);
-        assert_eq!(svc.helm_version, DOCA_HBN_SERVICE_HELM_VERSION);
-        assert!(svc.helm_repo_url.contains("helm.ngc.nvidia.com"));
-    }
-
-    #[test]
-    fn test_doca_hbn_service_interfaces_match_derived() {
-        let reg = CarbideServiceRegistryConfig::default();
-        let svc = doca_hbn_service(&reg);
-        let expected = dpu_service_interfaces(DOCA_HBN_SERVICE_NAME, DOCA_HBN_SERVICE_NETWORK);
-        assert_eq!(
-            svc.interfaces.len(),
-            expected.len(),
-            "HBN service interface count mismatch"
-        );
-        for (a, b) in svc.interfaces.iter().zip(expected.iter()) {
-            assert_eq!(a.name, b.name);
-            assert_eq!(a.network, b.network);
-        }
-    }
-
-    #[test]
-    fn test_doca_hbn_service_startup_yaml_contains_interfaces() {
-        let reg = CarbideServiceRegistryConfig::default();
-        let svc = doca_hbn_service(&reg);
-        let config_values = svc
-            .config_values
-            .as_ref()
-            .expect("config_values must be set");
-        let startup_yaml = config_values["configuration"]["startupYAMLJ2"]
-            .as_str()
-            .expect("startupYAMLJ2 must be a string");
-        for iface in &svc.interfaces {
-            assert!(
-                startup_yaml.contains(&iface.name),
-                "startupYAMLJ2 missing interface '{}'",
-                iface.name
-            );
-        }
-    }
-
-    #[test]
-    fn test_doca_hbn_service_image_uses_registry() {
-        let reg = CarbideServiceRegistryConfig::default();
-        let svc = doca_hbn_service(&reg);
-        let helm_values = svc.helm_values.as_ref().unwrap();
-        let repo = helm_values["image"]["repository"].as_str().unwrap();
-        assert!(
-            repo.contains(DOCA_HBN_SERVICE_IMAGE_NAME),
-            "image repository should contain image name"
-        );
-        assert!(
-            repo.starts_with(&reg.doca_image_registry),
-            "image repository should use doca_image_registry"
-        );
-    }
-
-    // ---- dhcp_server_service ----
-
-    #[test]
-    fn test_dhcp_server_service_name_and_helm() {
-        let reg = CarbideServiceRegistryConfig::default();
-        let svc = dhcp_server_service(&reg);
-        assert_eq!(svc.name, DHCP_SERVER_SERVICE_NAME);
-        assert_eq!(svc.helm_chart, DHCP_SERVER_SERVICE_HELM_NAME);
-        assert_eq!(svc.helm_version, DHCP_SERVER_SERVICE_HELM_VERSION);
-    }
-
-    #[test]
-    fn test_dhcp_server_service_interfaces_match_derived() {
-        let reg = CarbideServiceRegistryConfig::default();
-        let svc = dhcp_server_service(&reg);
-        let expected =
-            dpu_service_interfaces(DHCP_SERVER_SERVICE_NAME, DHCP_SERVER_SERVICE_NAD_NAME);
-        assert_eq!(
-            svc.interfaces.len(),
-            expected.len(),
-            "DHCP service interface count mismatch"
-        );
-        for (a, b) in svc.interfaces.iter().zip(expected.iter()) {
-            assert_eq!(a.name, b.name);
-            assert_eq!(a.network, b.network);
-        }
-    }
-
-    #[test]
-    fn test_dhcp_server_service_nad_properties() {
-        let reg = CarbideServiceRegistryConfig::default();
-        let svc = dhcp_server_service(&reg);
-        let nad = svc
-            .service_nad
-            .as_ref()
-            .expect("DHCP service must have a NAD");
-        assert_eq!(nad.name, DHCP_SERVER_SERVICE_NAD_NAME);
-        assert_eq!(nad.mtu, Some(DHCP_SERVER_SERVICE_MTU));
-        assert_eq!(nad.ipam, Some(false));
-        assert_eq!(nad.bridge.as_deref(), Some("br-sfc"));
-    }
-
-    // ---- dpu_agent_service ----
-
-    #[test]
-    fn test_dpu_agent_service_name_and_helm() {
-        let reg = CarbideServiceRegistryConfig::default();
-        let svc = dpu_agent_service(&reg);
-        assert_eq!(svc.name, DPU_AGENT_SERVICE_NAME);
-        assert_eq!(svc.helm_chart, DPU_AGENT_SERVICE_HELM_NAME);
-        assert_eq!(svc.helm_version, DPU_AGENT_SERVICE_HELM_VERSION);
-    }
-
-    #[test]
-    fn test_dpu_agent_service_image_uses_registry() {
-        let reg = CarbideServiceRegistryConfig::default();
-        let svc = dpu_agent_service(&reg);
-        let helm_values = svc.helm_values.as_ref().unwrap();
-        let repo = helm_values["image"]["repository"].as_str().unwrap();
-        assert!(repo.contains(DPU_AGENT_SERVICE_IMAGE_NAME));
-        assert!(repo.starts_with(&reg.carbide_image_registry));
-    }
-
-    // ---- build_service_template ----
-
-    #[test]
-    fn test_build_service_template_metadata() {
-        let reg = CarbideServiceRegistryConfig::default();
-        let svc = dhcp_server_service(&reg);
-        let tmpl = build_service_template(&svc, TEST_NS);
-        assert_eq!(
-            tmpl.metadata.name.as_deref(),
-            Some(DHCP_SERVER_SERVICE_NAME)
-        );
-        assert_eq!(tmpl.metadata.namespace.as_deref(), Some(TEST_NS));
-        assert_eq!(tmpl.spec.deployment_service_name, DHCP_SERVER_SERVICE_NAME);
-        assert_eq!(
-            tmpl.spec.helm_chart.source.version.as_str(),
-            DHCP_SERVER_SERVICE_HELM_VERSION
-        );
-    }
-
-    #[test]
-    fn test_build_service_template_helm_values_included() {
-        let reg = CarbideServiceRegistryConfig::default();
-        let svc = doca_hbn_service(&reg);
-        let tmpl = build_service_template(&svc, TEST_NS);
-        let values = tmpl
-            .spec
-            .helm_chart
-            .values
-            .as_ref()
-            .expect("helm values must be present");
-        assert!(
-            values.contains_key("image"),
-            "helm values must include 'image'"
-        );
-    }
-
-    // ---- build_service_configuration ----
-
-    #[test]
-    fn test_build_service_configuration_interfaces() {
-        let reg = CarbideServiceRegistryConfig::default();
-        let svc = dhcp_server_service(&reg);
-        let cfg = build_service_configuration(&svc, TEST_NS);
-        let ifaces = cfg
-            .spec
-            .interfaces
-            .as_ref()
-            .expect("interfaces must be present");
-        assert_eq!(ifaces.len(), svc.interfaces.len());
-        for (actual, expected) in ifaces.iter().zip(svc.interfaces.iter()) {
-            assert_eq!(actual.name, expected.name);
-            assert_eq!(actual.network, expected.network);
-        }
-    }
-
-    #[test]
-    fn test_build_service_configuration_config_values() {
-        let reg = CarbideServiceRegistryConfig::default();
-        let svc = doca_hbn_service(&reg);
-        let cfg = build_service_configuration(&svc, TEST_NS);
-        let svc_cfg = cfg
-            .spec
-            .service_configuration
-            .as_ref()
-            .expect("service_configuration must be present");
-        let helm = svc_cfg
-            .helm_chart
-            .as_ref()
-            .expect("helm_chart config must be present");
-        let values = helm
-            .values
-            .as_ref()
-            .expect("helm chart values must be present");
-        assert!(
-            values.contains_key("configuration"),
-            "config_values must include 'configuration'"
-        );
-    }
-
-    #[test]
-    fn test_build_service_configuration_no_interfaces_for_agents() {
-        // dpu_agent_service has no interfaces — spec.interfaces should be None
-        let reg = CarbideServiceRegistryConfig::default();
-        let svc = dpu_agent_service(&reg);
-        let cfg = build_service_configuration(&svc, TEST_NS);
-        assert!(
-            cfg.spec.interfaces.is_none(),
-            "agent service must have no interfaces in config"
-        );
-    }
-
-    // ---- build_service_nad ----
-
-    #[test]
-    fn test_build_service_nad_present_for_dhcp() {
-        let reg = CarbideServiceRegistryConfig::default();
-        let svc = dhcp_server_service(&reg);
-        let nad = build_service_nad(&svc, TEST_NS).expect("DHCP must produce a NAD");
-        assert_eq!(
-            nad.metadata.name.as_deref(),
-            Some(DHCP_SERVER_SERVICE_NAD_NAME)
-        );
-        assert_eq!(nad.metadata.namespace.as_deref(), Some(TEST_NS));
-    }
-
-    #[test]
-    fn test_build_service_nad_absent_for_hbn() {
-        let reg = CarbideServiceRegistryConfig::default();
-        let svc = doca_hbn_service(&reg);
-        assert!(
-            build_service_nad(&svc, TEST_NS).is_none(),
-            "HBN service should not produce a NAD"
-        );
-    }
-
-    // ---- build_service_interface ----
 
     #[test]
     fn test_build_service_interface_physical() {
@@ -763,65 +539,5 @@ mod tests {
                 iface.name
             );
         }
-    }
-
-    // ---- build_deployment ----
-
-    #[test]
-    fn test_build_deployment_lists_all_services() {
-        let reg = CarbideServiceRegistryConfig::default();
-        let services = vec![dhcp_server_service(&reg), doca_hbn_service(&reg)];
-        let interfaces = build_dpu_interfaces_vec();
-        let deployment = build_deployment(
-            &services,
-            "carbide-deployment",
-            "test-bfb",
-            "dpu-flavor",
-            TEST_NS,
-            &NoLabels,
-            &interfaces,
-        );
-        assert_eq!(
-            deployment.metadata.name.as_deref(),
-            Some("carbide-deployment")
-        );
-        assert_eq!(deployment.spec.dpus.bfb, "test-bfb");
-        assert_eq!(deployment.spec.dpus.flavor, "dpu-flavor");
-        assert_eq!(deployment.spec.services.len(), 2);
-        assert!(
-            deployment
-                .spec
-                .services
-                .contains_key(DHCP_SERVER_SERVICE_NAME)
-        );
-        assert!(deployment.spec.services.contains_key(DOCA_HBN_SERVICE_NAME));
-    }
-
-    #[test]
-    fn test_build_deployment_service_chain_count_matches_chained_interfaces() {
-        let reg = CarbideServiceRegistryConfig::default();
-        let services = vec![dhcp_server_service(&reg), doca_hbn_service(&reg)];
-        let interfaces = build_dpu_interfaces_vec();
-        let expected_switches = interfaces
-            .iter()
-            .filter(|i| i.chained_svc_if.is_some())
-            .count();
-        let deployment = build_deployment(
-            &services,
-            "carbide-deployment",
-            "test-bfb",
-            "dpu-flavor",
-            TEST_NS,
-            &NoLabels,
-            &interfaces,
-        );
-        let switches = deployment
-            .spec
-            .service_chains
-            .as_ref()
-            .expect("service_chains must be present")
-            .switches
-            .len();
-        assert_eq!(switches, expected_switches);
     }
 }

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -407,21 +407,15 @@ pub async fn start_api(
 
         let provider = crate::dpf::CarbideBmcPasswordProvider::new(credential_manager.clone());
 
-        let services = vec![carbide_dpf::services::dts_service(
-            &carbide_dpf::services::ServiceRegistryConfig::default(),
-        )];
-        let reg = crate::dpf_services::CarbideServiceRegistryConfig::from_runtime(
-            carbide_config.dpf.carbide_helm_version.clone(),
-            carbide_config.dpf.carbide_image_tag.clone(),
-        );
+        let mandatory_services = carbide_config.dpf.services.clone();
+        let services = vec![crate::dpf_services::dts_service(&mandatory_services.dts)];
         let v2_services = vec![
-            carbide_dpf::services::dts_service(
-                &carbide_dpf::services::ServiceRegistryConfig::default(),
-            ),
-            crate::dpf_services::dhcp_server_service(&reg),
-            crate::dpf_services::doca_hbn_service(&reg),
-            crate::dpf_services::dpu_agent_service(&reg),
-            crate::dpf_services::fmds_service(&reg),
+            crate::dpf_services::dts_service(&mandatory_services.dts),
+            crate::dpf_services::doca_hbn_service(&mandatory_services.doca_hbn),
+            crate::dpf_services::dhcp_server_service(&mandatory_services.dhcp_server),
+            crate::dpf_services::dpu_agent_service(&mandatory_services.dpu_agent),
+            crate::dpf_services::fmds_service(&mandatory_services.fmds),
+            // crate::dpf_services::otel_service(&mandatory_services.otel),
         ];
 
         let bfcfg_template = if carbide_config.dpf.bfcfg_enabled {

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -410,7 +410,10 @@ pub async fn start_api(
         let services = vec![carbide_dpf::services::dts_service(
             &carbide_dpf::services::ServiceRegistryConfig::default(),
         )];
-        let reg = crate::dpf_services::CarbideServiceRegistryConfig::default();
+        let reg = crate::dpf_services::CarbideServiceRegistryConfig::from_runtime(
+            carbide_config.dpf.carbide_helm_version.clone(),
+            carbide_config.dpf.carbide_image_tag.clone(),
+        );
         let v2_services = vec![
             carbide_dpf::services::dts_service(
                 &carbide_dpf::services::ServiceRegistryConfig::default(),

--- a/crates/api/src/tests/dpf/duplicate_events.rs
+++ b/crates/api/src/tests/dpf/duplicate_events.rs
@@ -59,7 +59,6 @@ fn dpf_config() -> crate::cfg::file::DpfConfig {
     crate::cfg::file::DpfConfig {
         enabled: true,
         bfb_url: "http://example.com/test.bfb".to_string(),
-        services: None,
         v2: true,
         ..Default::default()
     }

--- a/crates/api/src/tests/dpf/happy_path.rs
+++ b/crates/api/src/tests/dpf/happy_path.rs
@@ -51,7 +51,6 @@ async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
     config.dpf = crate::cfg::file::DpfConfig {
         enabled: true,
         bfb_url: "http://example.com/test.bfb".to_string(),
-        services: None,
         v2: true,
         ..Default::default()
     };

--- a/crates/api/src/tests/dpf/reprovisioning.rs
+++ b/crates/api/src/tests/dpf/reprovisioning.rs
@@ -64,7 +64,6 @@ fn dpf_config() -> crate::cfg::file::DpfConfig {
     crate::cfg::file::DpfConfig {
         enabled: true,
         bfb_url: "http://example.com/test.bfb".to_string(),
-        services: None,
         v2: true,
         ..Default::default()
     }

--- a/crates/api/src/tests/dpf/waiting_for_ready.rs
+++ b/crates/api/src/tests/dpf/waiting_for_ready.rs
@@ -64,7 +64,6 @@ fn dpf_config() -> crate::cfg::file::DpfConfig {
     crate::cfg::file::DpfConfig {
         enabled: true,
         bfb_url: "http://example.com/test.bfb".to_string(),
-        services: None,
         v2: true,
         ..Default::default()
     }

--- a/crates/api/src/tests/machine_admin_force_delete.rs
+++ b/crates/api/src/tests/machine_admin_force_delete.rs
@@ -766,7 +766,6 @@ async fn test_admin_force_delete_with_dpf_uses_bmc_mac(pool: sqlx::PgPool) {
     config.dpf = crate::cfg::file::DpfConfig {
         enabled: true,
         bfb_url: "http://example.com/test.bfb".to_string(),
-        services: None,
         v2: true,
         ..Default::default()
     };

--- a/crates/version/src/lib.rs
+++ b/crates/version/src/lib.rs
@@ -70,6 +70,7 @@ pub fn build() {
         // TODO: Remove after migration to new CARBIDE_ naming
         println!("cargo:rustc-env=FORGE_BUILD_GIT_TAG=");
         println!("cargo:rustc-env=CARBIDE_BUILD_GIT_HASH=");
+        println!("cargo:rustc-env=CARBIDE_BUILD_HELM_VERSION=");
         return;
     }
 
@@ -93,6 +94,17 @@ pub fn build() {
     // TODO: Remove after migration to new CARBIDE_ naming
     println!("cargo:rustc-env=FORGE_BUILD_GIT_TAG={build_version}");
     println!("cargo:rustc-env=CARBIDE_BUILD_GIT_TAG={build_version}");
+
+    // Helm version: strip leading 'v', replace last '-' with '.'
+    // e.g. "v1.2.3-42-gabcdef1" → "1.2.3-42.gabcdef1"
+    let helm_version = {
+        let s = build_version.trim_start_matches('v');
+        match s.rfind('-') {
+            Some(idx) => format!("{}.{}", &s[..idx], &s[idx + 1..]),
+            None => s.to_string(),
+        }
+    };
+    println!("cargo:rustc-env=CARBIDE_BUILD_HELM_VERSION={helm_version}");
 
     // Only re-calculate all of this when there's a new commit... but use an env var to allow
     // avoiding rebuilds when the commit hash changes. (This is good for local development iteration
@@ -200,6 +212,9 @@ macro_rules! v {
     (build_hostname) => {
         option_env!("FORGE_BUILD_HOSTNAME").unwrap_or_default()
     };
+    (helm_version) => {
+        option_env!("CARBIDE_BUILD_HELM_VERSION").unwrap_or_default()
+    };
 }
 
 /// Same a v! but expands to a literal. That allows using it in `concat!` macro.
@@ -224,6 +239,9 @@ macro_rules! literal {
     };
     (build_hostname) => {
         env!("FORGE_BUILD_HOSTNAME")
+    };
+    (helm_version) => {
+        env!("CARBIDE_BUILD_HELM_VERSION")
     };
 }
 


### PR DESCRIPTION
## Description
- Replaces the flat `CarbideServiceRegistryConfig` struct with `DpfMandatoryServicesConfig`, a typed config struct where each of the six mandatory DPF services (`dts`, `doca_hbn`, `dpu_agent`, `dhcp_server`, `fmds`, `otel`) has its own `DpfServiceConfig` carrying its helm repo/chart/version and docker repo/tag independently
- Adds `docker_repo_url` and `docker_image_tag` fields to `DpfServiceConfig` so image coordinates are first-class alongside helm coordinates
- Service builder functions (`doca_hbn_service`, `dpu_agent_service`, `dhcp_server_service`) now accept `&DpfServiceConfig` directly; new `dts_service`, `fmds_service`, and `otel_service` builders added with the same signature
- Per-service defaults live in `dpf_services.rs` next to their constants; Carbide-owned services (`dpu_agent`, `dhcp_server`) seed `helm_version` and `docker_image_tag` from compile-time CI env vars (`CARBIDE_BUILD_HELM_VERSION` / `CARBIDE_BUILD_GIT_TAG`)
- Removes the now-redundant `carbide_helm_version` and `carbide_image_tag` top-level config fields, and the `CarbideServiceRegistryConfig::from_runtime` fallback path
- `setup.rs` v1 and v2 service lists are both built entirely from `DpfMandatoryServicesConfig`, removing the last direct call to `carbide_dpf::services::dts_service`
                                                                                                                                                                                 
  On CI (main): VERSION env var → compile-time version baked in → correct                                             
  helm chart and image pulled automatically.
  On PR/fork: compile-time version is empty; set carbide_helm_version /                                               
  carbide_image_tag in config to test against a published version.   

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

