### PR TITLE
fix(pxe): add missing iPXE patches to SA aarch64 build

### DIFF
--- a/pxe/Makefile.toml
+++ b/pxe/Makefile.toml
@@ -204,7 +204,13 @@ run_task = "internal-bfb-aarch64-sa"
 [tasks.ipxe-aarch64-sa]
 category = "iPXE Kernel"
 description = "Build iPXE kernel for aarch64 (EFI) for SA builds"
-dependencies = ["ipxe-build-efi-aarch64", "ipxe-install-efi-aarch64"]
+dependencies = [
+  "ipxe-config",
+  "ipxe-patch-mlnx",
+  "ipxe-patch-grace-grace",
+  "ipxe-patch-efi-rng",
+  "ipxe-install-efi-aarch64",
+]
 
 
 [tasks.build-boot-artifacts-bfb]


### PR DESCRIPTION
The `ipxe-aarch64-sa` task skipped `ipxe-config`,
`ipxe-patch-mlnx`, `ipxe-patch-grace-grace`, and
`ipxe-patch-efi-rng`, which the dev and CI tasks both run. Without these, the SA-built `ipxe.efi` uses upstream defaults and lacks the BlueField NIC patch, causing DHCP relay failures that completely block DPU PXE boot.

Fixes #851


