### PR TITLE
fix: use the bmc mac as the key when constructing and querying the bmc info lookup map in find_switches

### DIFF
--- a/crates/api/src/handlers/switch.rs
+++ b/crates/api/src/handlers/switch.rs
@@ -78,7 +78,7 @@ pub async fn find_switch(
         rows.into_iter()
             .map(|row| {
                 (
-                    row.serial_number,
+                    row.bmc_mac_address.to_string(),
                     rpc::BmcInfo {
                         ip: Some(row.ip_address.to_string()),
                         mac: Some(row.bmc_mac_address.to_string()),
@@ -98,8 +98,10 @@ pub async fn find_switch(
     let switches: Vec<rpc::Switch> = switch_list
         .into_iter()
         .map(|s| {
-            let serial = s.config.name.clone();
-            let bmc_info = bmc_info_map.get(&serial).cloned();
+            let bmc_info = s
+                .bmc_mac_address
+                .as_ref()
+                .and_then(|mac| bmc_info_map.get(&mac.to_string()).cloned());
 
             rpc::Switch::try_from(s).map(|mut rpc_switch| {
                 rpc_switch.bmc_info = bmc_info;

--- a/crates/api/src/tests/switch.rs
+++ b/crates/api/src/tests/switch.rs
@@ -568,9 +568,35 @@ async fn test_find_switch_bmc_info_no_matching_data(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env(pool).await;
-    let switch_id = new_switch(&env, Some("Switch3".to_string()), None).await?;
 
-    // bmc_info should be None when no expected_switch or machine_interface data exists
+    // Create a switch without the corresponding expected switch data
+    let switch_id = model::switch::switch_id::from_hardware_info(
+        "NO-BMC-SERIAL",
+        "NVIDIA",
+        "Switch",
+        carbide_uuid::switch::SwitchIdSource::ProductBoardChassisSerial,
+        carbide_uuid::switch::SwitchType::NvLink,
+    )
+    .unwrap();
+
+    let new_switch_record = NewSwitch {
+        id: switch_id,
+        config: SwitchConfig {
+            name: "SwitchNoBmc".to_string(),
+            enable_nmxc: false,
+            fabric_manager_config: None,
+        },
+        bmc_mac_address: None,
+        metadata: None,
+        rack_id: None,
+        slot_number: Some(0),
+        tray_index: Some(0),
+    };
+
+    let mut txn = env.pool.begin().await.unwrap();
+    db_switch::create(&mut txn, &new_switch_record).await?;
+    txn.commit().await.unwrap();
+
     let find_request = SwitchQuery {
         name: None,
         switch_id: Some(switch_id),


### PR DESCRIPTION
## Description

fix: the switch's config contains a human-readable hostname. find_switch assumed that this config contained the serial number and tried key-ing into the bmc info based on sernum. instead, use the bmc mac as the key when constructing and querying the bmc lookup map

`forge_system_carbide=# SELECT s.id, s.config->>'name' AS config_name, es.serial_number
FROM switches s
JOIN expected_switches es ON es.bmc_mac_address = s.bmc_mac_address
WHERE s.config->>'name' != es.serial_number;
                             id                              |       config_name        | serial_number 
-------------------------------------------------------------+--------------------------+---------------
 sw100nscavprarh57c382mvmau82nhpm6fgq12pmvf9076mt7kt6co89t10 | nvswitch3-nvl6-gp1-jhb01 | MT25146023L4
 sw100ns3iouqk1uqhvhp4orc1248p2qk8ftkdbaduhklgdnj22p3e51qeeg | nvswitch6-nvl6-gp1-jhb01 | MT2514600EAN
 sw100nsfujhq8068oil7b49abuet9m1pol1hpha8r0173q9n7i8m4ibodi0 | nvswitch2-nvl6-gp1-jhb01 | MT25146015VG
 sw100nscqmhku50ii8bl1tl0m8pinhba0qb2k7645votl6sc4bb1d7frl30 | nvswitch5-nvl6-gp1-jhb01 | MT2514600DZP
 sw100nsqdtuvnp2anob8t91uigv9jpbotaipof6gsl8rfhu1dmetnjjh3i0 | nvswitch4-nvl6-gp1-jhb01 | MT2514600EAQ
 sw100nsiijcoptup1vu5eu21a76kks7f725u49mc3g85m1dcaofmv76d9q0 | nvswitch9-nvl6-gp1-jhb01 | MT2514600DM2
 sw100ns1u56cb8f3eqbunb4vambspkbr2l90vckbdsfra3t8r88odk9ne1g | nvswitch7-nvl6-gp1-jhb01 | MT2514602DKY
 sw100nsdo4ro9b2hd4etgeacgtb2q51ch5mlmolbpf1967k61j7euqh448g | nvswitch1-nvl6-gp1-jhb01 | MT2514600EZY
 sw100ns0uabvoti28usqbk3vnhlg0ksh3vd8qa59o6kdhqs162hdkttf0o0 | nvswitch8-nvl6-gp1-jhb01 | MT2514600DM0
(9 rows)`

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

