### PR TITLE
feat: enhancing pxe support for AddressAllocationStrategy::StaticIp

### DIFF
--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -530,6 +530,30 @@ pub struct CarbideConfig {
     #[serde(default)]
     pub arm_pxe_boot_url_override: Option<String>,
 
+    /// Alternate API URL for external hosts that cannot resolve
+    /// https://carbide-pxe.forge. This be an IP (e.g., "https://10.0.0.1:1079"),
+    /// or an externally resolvable hostname (e.g.,
+    /// "https://carbide-stack-api.corp.example.com"). This is the URL
+    /// that gets handed back to interfaces assigned ot the static-assignments
+    /// subnet. If not set, external hosts will just get the "internal"
+    /// variant of api_url.
+    #[serde(default)]
+    pub external_api_url: Option<String>,
+
+    /// Alternate PXE URL for external hosts (e.g., "http://10.0.0.1:8080"
+    /// or "http://carbide-stack-pxe.corp.example.com"). Used for cloud-init and
+    /// root CA retrieval for interfaces on the static-assignments segment,
+    /// and follows the same rules as external_api_url above.
+    #[serde(default)]
+    pub external_pxe_url: Option<String>,
+
+    /// Alternate static PXE URL for external hosts (e.g.,
+    /// "http://10.0.0.1:8081" or "http://carbide-stack-static.corp.example.com").
+    /// Used for kernel/blob downloads on the static-assignments segment.
+    /// If not set, falls back to `external_pxe_url`.
+    #[serde(default)]
+    pub external_static_pxe_url: Option<String>,
+
     /// Controls enforcement of compute allocations when a new instance is
     /// requested.
     #[serde(default)]

--- a/crates/api/src/handlers/pxe.rs
+++ b/crates/api/src/handlers/pxe.rs
@@ -34,13 +34,44 @@ pub(crate) async fn get_pxe_instructions(
 
     let mut txn = api.txn_begin().await?;
 
-    let request = request.into_inner().try_into()?;
+    let target: model::pxe::PxeInstructionRequest = request.into_inner().try_into()?;
+    let interface_id = target.interface_id;
+    let pxe_script = PxeInstructions::get_pxe_instructions(&mut txn, target).await?;
 
-    let pxe_script = PxeInstructions::get_pxe_instructions(&mut txn, request).await?;
+    // For interfaces on the static-assignments segment, include
+    // URL overrides so external hosts can reach services via an
+    // alternate hostname or IP they can resolve and/or connect
+    // to for carbide-pxe and carbide-api.
+    let (api_url_override, pxe_url_override, static_pxe_url_override) = {
+        let iface = db::machine_interface::find_one(txn.as_pgconn(), interface_id).await?;
+        let is_external = iface.segment_id
+            == db::network_segment::static_assignments(txn.as_pgconn())
+                .await
+                .map(|s| s.id)
+                .unwrap_or_default();
+
+        if is_external {
+            (
+                api.runtime_config.external_api_url.clone(),
+                api.runtime_config.external_pxe_url.clone(),
+                api.runtime_config
+                    .external_static_pxe_url
+                    .clone()
+                    .or_else(|| api.runtime_config.external_pxe_url.clone()),
+            )
+        } else {
+            (None, None, None)
+        }
+    };
 
     txn.commit().await?;
 
-    Ok(Response::new(rpc::PxeInstructions { pxe_script }))
+    Ok(Response::new(rpc::PxeInstructions {
+        pxe_script,
+        api_url_override,
+        pxe_url_override,
+        static_pxe_url_override,
+    }))
 }
 
 pub(crate) async fn get_cloud_init_instructions(
@@ -108,6 +139,31 @@ pub(crate) async fn get_cloud_init_instructions(
                     platform,
                 });
 
+            // For interfaces on the static-assignments segment, include
+            // hostname or IP-based URL overrides so external hosts can
+            // reach carbide-api and carbide-pxe services. Just to reiterate,
+            // these can be either routable IPs, or externally resolvable
+            // hostnames to routable IPs.
+            let is_external = {
+                let mut conn = db.acquire().await.map_err(|e| {
+                    CarbideError::internal(format!("Failed to acquire database connection: {e}"))
+                })?;
+                machine_interface.segment_id
+                    == db::network_segment::static_assignments(&mut conn)
+                        .await
+                        .map(|s| s.id)
+                        .unwrap_or_default()
+            };
+
+            let (api_url_override, pxe_url_override) = if is_external {
+                (
+                    api.runtime_config.external_api_url.clone(),
+                    api.runtime_config.external_pxe_url.clone(),
+                )
+            } else {
+                (None, None)
+            };
+
             rpc::CloudInitInstructions {
                 custom_cloud_init,
                 discovery_instructions: Some(rpc::CloudInitDiscoveryInstructions {
@@ -162,6 +218,8 @@ pub(crate) async fn get_cloud_init_instructions(
                     ),
                 }),
                 metadata,
+                api_url_override,
+                pxe_url_override,
             }
         }
 
@@ -185,6 +243,8 @@ pub(crate) async fn get_cloud_init_instructions(
                     cloud_name,
                     platform,
                 }),
+                api_url_override: None,
+                pxe_url_override: None,
             }
         }
     };

--- a/crates/api/src/ipxe.rs
+++ b/crates/api/src/ipxe.rs
@@ -80,7 +80,7 @@ impl PxeInstructions {
                 if machine_type == MachineType::Host || machine_type == MachineType::PredictedHost {
                     InstructionGenerator {
                         kernel: "${base-url}/internal/aarch64/scout.efi".to_string(),
-                        command_line: format!("mac={mac_address} console=tty0 console={console},115200 pci=realloc=off iommu=off cli_cmd=auto-detect machine_id={machine_interface_id} server_uri=[api_url] "),
+                        command_line: format!("mac={mac_address} console=tty0 console={console},115200 pci=realloc=off iommu=off cli_cmd=auto-detect machine_id={machine_interface_id} server_uri=[api_url] pxe_uri=[pxe_url]"),
                         initrd: None,
                     }
                 }
@@ -88,7 +88,7 @@ impl PxeInstructions {
                      // For the DPUs, bfks => BlueField Kick Start script
                      InstructionGenerator {
                         kernel: "${base-url}/internal/aarch64/carbide.efi".to_string(),
-                        command_line: format!("console=tty0 console=ttyS0,115200 console=ttyAMA0 console=hvc0 ip=dhcp cli_cmd=auto-detect bfnet=oob_net0:dhcp bfks=${{cloudinit-url}}/user-data machine_id={machine_interface_id} server_uri=[api_url] "),
+                        command_line: format!("console=tty0 console=ttyS0,115200 console=ttyAMA0 console=hvc0 ip=dhcp cli_cmd=auto-detect bfnet=oob_net0:dhcp bfks=${{cloudinit-url}}/user-data machine_id={machine_interface_id} server_uri=[api_url] pxe_uri=[pxe_url]"),
                         initrd: Some("${base-url}/internal/aarch64/carbide.root".to_string()),
                     }
                 }
@@ -96,7 +96,7 @@ impl PxeInstructions {
             rpc::MachineArchitecture::X86 => {
                 InstructionGenerator {
                     kernel: "${base-url}/internal/x86_64/scout.efi".to_string(),
-                    command_line: format!("mac={mac_address} console=tty0 console={console},115200 pci=realloc=off iommu=off cli_cmd=auto-detect machine_id={machine_interface_id} server_uri=[api_url] "),
+                    command_line: format!("mac={mac_address} console=tty0 console={console},115200 pci=realloc=off iommu=off cli_cmd=auto-detect machine_id={machine_interface_id} server_uri=[api_url] pxe_uri=[pxe_url]"),
                     initrd: None,
                 }
             }

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -1224,6 +1224,9 @@ pub fn get_config() -> CarbideConfig {
         dpf: crate::cfg::file::DpfConfig::default(),
         x86_pxe_boot_url_override: None,
         arm_pxe_boot_url_override: None,
+        external_api_url: None,
+        external_pxe_url: None,
+        external_static_pxe_url: None,
         supernic_firmware_profiles: HashMap::default(),
         component_manager: None,
     }
@@ -1734,7 +1737,8 @@ pub async fn create_test_env_with_overrides(
 
         // Synthetic segment for operator static IPs outside Carbide-managed prefixes (expected
         // machine / switch / shelf BMC pre-allocation). Required for static-BMC integration tests.
-        create_static_assignments_segment(&api).await;
+        // Pass the domain to match production behavior (db_init passes Some(domain_id)).
+        create_static_assignments_segment(&api, Some(domain)).await;
         network_controller.run_single_iteration().await;
         network_controller.run_single_iteration().await;
 

--- a/crates/api/src/tests/common/api_fixtures/network_segment.rs
+++ b/crates/api/src/tests/common/api_fixtures/network_segment.rs
@@ -86,11 +86,14 @@ pub async fn create_underlay_network_segment(api: &Api) -> NetworkSegmentId {
     .await
 }
 
-pub async fn create_static_assignments_segment(api: &Api) -> NetworkSegmentId {
+pub async fn create_static_assignments_segment(
+    api: &Api,
+    subdomain_id: Option<carbide_uuid::domain::DomainId>,
+) -> NetworkSegmentId {
     let mut txn = db::Transaction::begin(&api.database_connection)
         .await
         .unwrap();
-    crate::db_init::ensure_static_assignments_segment(api, &mut txn, None)
+    crate::db_init::ensure_static_assignments_segment(api, &mut txn, subdomain_id)
         .await
         .unwrap();
     txn.commit().await.unwrap();

--- a/crates/api/src/tests/ipxe.rs
+++ b/crates/api/src/tests/ipxe.rs
@@ -18,7 +18,9 @@ use std::collections::HashMap;
 
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use chrono::Utc;
-use common::api_fixtures::{TestEnv, create_test_env};
+use common::api_fixtures::{
+    TestEnv, TestEnvOverrides, create_test_env, create_test_env_with_overrides, get_config,
+};
 use db::{self};
 use futures_util::FutureExt;
 use mac_address::MacAddress;
@@ -26,6 +28,7 @@ use model::machine::{DpuInitState, HostReprovisionState, MachineState, ManagedHo
 use rpc::forge::CloudInitInstructionsRequest;
 use rpc::forge::forge_server::Forge;
 
+use crate::handlers::machine_interface_address::preallocate_machine_interface;
 use crate::tests::common;
 use crate::tests::common::api_fixtures::managed_host::ManagedHostConfig;
 use crate::tests::common::api_fixtures::site_explorer::MockExploredHost;
@@ -454,4 +457,195 @@ async fn test_cloud_init_after_dpu_update(pool: sqlx::PgPool) {
         .into_inner();
 
     assert!(cloud_init_cfg.discovery_instructions.is_some());
+}
+
+/// Helper to create a test env with external URL overrides configured.
+async fn create_env_with_external_urls(pool: sqlx::PgPool) -> TestEnv {
+    let mut config = get_config();
+    config.external_api_url = Some("https://10.99.0.1:1079".to_string());
+    config.external_pxe_url = Some("http://10.99.0.1:8080".to_string());
+    config.external_static_pxe_url = Some("http://10.99.0.1:8081".to_string());
+    create_test_env_with_overrides(pool, TestEnvOverrides::with_config(config)).await
+}
+
+/// Preallocate a static interface on the static-assignments segment and
+/// return its interface ID plus the IP address used.
+async fn preallocate_external_interface(
+    env: &TestEnv,
+    mac: &str,
+    ip: &str,
+) -> (MachineInterfaceId, String) {
+    let mac_address: MacAddress = mac.parse().unwrap();
+    let ip_addr: std::net::IpAddr = ip.parse().unwrap();
+
+    let mut txn = env.pool.begin().await.unwrap();
+    preallocate_machine_interface(&mut txn, mac_address, ip_addr)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    // Look up the interface ID that was created.
+    let mut txn = env.pool.begin().await.unwrap();
+    let interfaces = db::machine_interface::find_by_mac_address(txn.as_mut(), mac_address)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    assert_eq!(
+        interfaces.len(),
+        1,
+        "expected exactly one interface for MAC {mac}"
+    );
+    (interfaces[0].id, ip.to_string())
+}
+
+#[crate::sqlx_test]
+async fn test_pxe_url_overrides_for_external_host(pool: sqlx::PgPool) {
+    let env = create_env_with_external_urls(pool).await;
+
+    // Use an IP outside any managed prefix so it lands on static-assignments.
+    let (interface_id, _ip) =
+        preallocate_external_interface(&env, "AA:BB:CC:DD:EE:01", "10.99.0.50").await;
+
+    let instructions = get_pxe_instructions(
+        &env,
+        interface_id,
+        rpc::forge::MachineArchitecture::X86,
+        None,
+    )
+    .await;
+
+    // The interface is on the static-assignments segment, so the API should
+    // return the configured external URLs as overrides.
+    assert_eq!(
+        instructions.api_url_override.as_deref(),
+        Some("https://10.99.0.1:1079"),
+        "expected api_url_override for external host"
+    );
+    assert_eq!(
+        instructions.pxe_url_override.as_deref(),
+        Some("http://10.99.0.1:8080"),
+        "expected pxe_url_override for external host"
+    );
+    assert_eq!(
+        instructions.static_pxe_url_override.as_deref(),
+        Some("http://10.99.0.1:8081"),
+        "expected static_pxe_url_override for external host"
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_cloud_init_url_overrides_for_external_host(pool: sqlx::PgPool) {
+    let env = create_env_with_external_urls(pool).await;
+
+    let (_interface_id, ip) =
+        preallocate_external_interface(&env, "AA:BB:CC:DD:EE:02", "10.99.0.51").await;
+
+    let cloud_init = env
+        .api
+        .get_cloud_init_instructions(tonic::Request::new(CloudInitInstructionsRequest { ip }))
+        .await
+        .expect("get_cloud_init_instructions returned an error")
+        .into_inner();
+
+    assert!(
+        cloud_init.discovery_instructions.is_some(),
+        "expected discovery instructions for external host"
+    );
+
+    assert_eq!(
+        cloud_init.api_url_override.as_deref(),
+        Some("https://10.99.0.1:1079"),
+        "expected api_url_override for external host cloud-init"
+    );
+    assert_eq!(
+        cloud_init.pxe_url_override.as_deref(),
+        Some("http://10.99.0.1:8080"),
+        "expected pxe_url_override for external host cloud-init"
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_pxe_url_overrides_none_for_internal_host(pool: sqlx::PgPool) {
+    let env = create_env_with_external_urls(pool).await;
+
+    // Create a normal managed host -- its interface is on the admin segment, not
+    // static-assignments.
+    let (host_id, _dpu_id) = common::api_fixtures::create_managed_host(&env).await.into();
+    let mut txn = env.pool.begin().await.unwrap();
+    let host_interface_id = db::machine_interface::find_by_machine_ids(&mut txn, &[host_id])
+        .await
+        .unwrap()[&host_id][0]
+        .id;
+    txn.commit().await.unwrap();
+
+    let instructions = get_pxe_instructions(
+        &env,
+        host_interface_id,
+        rpc::forge::MachineArchitecture::X86,
+        None,
+    )
+    .await;
+
+    // Internal hosts should NOT get URL overrides.
+    assert_eq!(
+        instructions.api_url_override, None,
+        "internal host should not get api_url_override"
+    );
+    assert_eq!(
+        instructions.pxe_url_override, None,
+        "internal host should not get pxe_url_override"
+    );
+    assert_eq!(
+        instructions.static_pxe_url_override, None,
+        "internal host should not get static_pxe_url_override"
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_cloud_init_url_overrides_none_for_internal_host(pool: sqlx::PgPool) {
+    let env = create_env_with_external_urls(pool).await;
+
+    // Discover a regular DHCP interface on a managed segment.
+    let mac_address = "AA:BB:CC:DD:EE:03".to_string();
+    // Use the admin segment gateway IP as the relay so the interface lands
+    // on the admin segment.
+    env.api
+        .discover_dhcp(DhcpDiscovery::builder(&mac_address, "192.0.2.1").tonic_request())
+        .await
+        .unwrap();
+
+    // Look up the actual allocated IP for this interface.
+    let mut txn = env.pool.begin().await.unwrap();
+    let interfaces = db::machine_interface::find_by_mac_address(
+        txn.as_mut(),
+        mac_address.parse::<MacAddress>().unwrap(),
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    assert_eq!(interfaces.len(), 1);
+    let allocated_ip = interfaces[0].addresses[0].to_string();
+
+    let cloud_init = env
+        .api
+        .get_cloud_init_instructions(tonic::Request::new(CloudInitInstructionsRequest {
+            ip: allocated_ip,
+        }))
+        .await
+        .expect("get_cloud_init_instructions returned an error")
+        .into_inner();
+
+    assert!(cloud_init.discovery_instructions.is_some());
+
+    // Internal hosts should NOT get URL overrides.
+    assert_eq!(
+        cloud_init.api_url_override, None,
+        "internal host should not get api_url_override"
+    );
+    assert_eq!(
+        cloud_init.pxe_url_override, None,
+        "internal host should not get pxe_url_override"
+    );
 }

--- a/crates/api/src/tests/static_address_management.rs
+++ b/crates/api/src/tests/static_address_management.rs
@@ -482,7 +482,7 @@ async fn test_assign_external_ip_moves_to_static_assignments(
         }))
         .await?;
 
-    // Verify the interface moved to static-assignments with None domain_id.
+    // Verify the interface moved to static-assignments with the segment's domain.
     let mut txn = env.pool.begin().await?;
     let updated = db::machine_interface::find_one(&mut *txn, interface.id).await?;
     let static_seg = db::network_segment::static_assignments(&mut txn).await?;
@@ -490,9 +490,9 @@ async fn test_assign_external_ip_moves_to_static_assignments(
         updated.segment_id, static_seg.id,
         "interface should have moved to the static-assignments segment"
     );
-    assert!(
-        updated.domain_id.is_none(),
-        "domain_id should be None on static-assignments segment"
+    assert_eq!(
+        updated.domain_id, static_seg.subdomain_id,
+        "domain_id should match the static-assignments segment's subdomain"
     );
 
     Ok(())

--- a/crates/host-support/src/agent_config.rs
+++ b/crates/host-support/src/agent_config.rs
@@ -37,7 +37,21 @@ const TELEMETRY_METRICS_SERVICE_ADDRESS: &str = "0.0.0.0:8888";
 /// This is what we WRITE to /etc/forge/config.toml
 #[derive(Debug, Clone, Serialize)]
 pub struct AgentConfigFromPxe {
+    // This is primarily used in the case of "external" overrides. If a host is
+    // being provisioned from an external location, this will ensure we correctly
+    // populate the carbide-api endpoint with CARBIDE_EXTERNAL_API_URL, and
+    // not [defaulting] to carbide-api.forge, to allow scout to work.
+    #[serde(rename = "forge-system", skip_serializing_if = "Option::is_none")]
+    pub forge_system: Option<ForgeSystemConfigFromPxe>,
     pub machine: MachineConfigFromPxe,
+}
+
+/// Optional forge-system overrides written by PXE for external hosts
+/// whose DPU agents can't resolve the default internal hostname.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ForgeSystemConfigFromPxe {
+    pub api_server: String,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/pxe/src/routes/cloud_init.rs
+++ b/crates/pxe/src/routes/cloud_init.rs
@@ -30,15 +30,26 @@ use rpc::forge;
 use rpc::forge::PxeDomain;
 
 use crate::common::{AppState, Machine};
-/// Generates the content of the /etc/forge/config.toml file
+/// Generates the content of the /etc/forge/config.toml file.
+///
+/// When `api_url_override` is provided (for external hosts on the
+/// static-assignments segment), it's written into the `[forge-system]`
+/// section so the DPU agent connects to the correct API endpoint
+/// instead of defaulting to `carbide-api.forge`.
 //
 // TODO(chet): This should take a MachineInterfaceId, but I think by doing that,
 // then agent_config (which is in host-support), would need to import forge-api,
 // which I think would then make it so scout + the agent start having a dep on
 // api/ -- I don't think it's a problem, but I'll propose it in a separate MR.
-fn generate_forge_agent_config(machine_interface_id: MachineInterfaceId) -> String {
+fn generate_forge_agent_config(
+    machine_interface_id: MachineInterfaceId,
+    api_url_override: Option<&str>,
+) -> String {
     let interface_id = uuid::Uuid::parse_str(&machine_interface_id.to_string()).unwrap();
     let config = agent_config::AgentConfigFromPxe {
+        forge_system: api_url_override.map(|url| agent_config::ForgeSystemConfigFromPxe {
+            api_server: url.to_string(),
+        }),
         machine: agent_config::MachineConfigFromPxe { interface_id },
     };
 
@@ -67,10 +78,13 @@ fn user_data_handler(
     host_intercept_bridge_port: Option<String>,
     vf_intercept_bridge_port: Option<String>,
     vf_intercept_bridge_sf: Option<String>,
+    api_url_override: Option<String>,
+    pxe_url_override: Option<String>,
     state: State<AppState>,
 ) -> (String, HashMap<String, String>) {
     let config = state.runtime_config.clone();
-    let forge_agent_config = generate_forge_agent_config(machine_interface_id);
+    let forge_agent_config =
+        generate_forge_agent_config(machine_interface_id, api_url_override.as_deref());
 
     let mut context: HashMap<String, String> = HashMap::new();
     context.insert("mac_address".to_string(), machine_interface.mac_address);
@@ -86,8 +100,16 @@ fn user_data_handler(
         }
     }
     context.insert("interface_id".to_string(), machine_interface_id.to_string());
-    context.insert("api_url".to_string(), config.client_facing_api_url);
-    context.insert("pxe_url".to_string(), config.pxe_url);
+    // Use URL overrides for external clients (static-assignments segment),
+    // falling back to global config.
+    context.insert(
+        "api_url".to_string(),
+        api_url_override.unwrap_or(config.client_facing_api_url),
+    );
+    context.insert(
+        "pxe_url".to_string(),
+        pxe_url_override.unwrap_or(config.pxe_url),
+    );
     context.insert(
         "forge_agent_config_b64".to_string(),
         base64::engine::general_purpose::STANDARD.encode(forge_agent_config),
@@ -203,6 +225,8 @@ pub async fn user_data(machine: Machine, state: State<AppState>) -> impl IntoRes
                         discovery_instructions.host_intercept_bridge_port,
                         discovery_instructions.vf_intercept_bridge_port,
                         discovery_instructions.vf_intercept_bridge_sf,
+                        machine.instructions.api_url_override,
+                        machine.instructions.pxe_url_override,
                         state.clone(),
                     ),
                     None => print_and_generate_generic_error(format!(
@@ -282,7 +306,7 @@ mod tests {
     #[test]
     fn forge_agent_config() {
         let interface_id = "91609f10-c91d-470d-a260-6293ea0c1234".parse().unwrap();
-        let config = generate_forge_agent_config(interface_id);
+        let config = generate_forge_agent_config(interface_id, None);
 
         // The intent here is to actually test what the written
         // configuration file looks like, so we can visualize to
@@ -305,6 +329,9 @@ mod tests {
             interface_id.to_string().as_str(),
         );
 
+        // No forge-system section when no override is provided.
+        assert!(data.get("forge-system").is_none());
+
         // Check to make sure is_fake_dpu gets skipped
         // from the serialized output.
         let skipped = match data.get("machine").unwrap().get("is_fake_dpu") {
@@ -312,5 +339,37 @@ mod tests {
             None => true,
         };
         assert!(skipped);
+    }
+
+    #[test]
+    fn forge_agent_config_with_external_api_url() {
+        let interface_id = "91609f10-c91d-470d-a260-6293ea0c1234".parse().unwrap();
+        let config = generate_forge_agent_config(interface_id, Some("https://10.99.0.1:1079"));
+
+        let test_config =
+            fs::read_to_string(format!("{TEST_DATA_DIR}/agent_config_external.toml")).unwrap();
+        assert_eq!(config, test_config);
+
+        let data: toml::Value = config.parse().unwrap();
+
+        assert_eq!(
+            data.get("forge-system")
+                .unwrap()
+                .get("api-server")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "https://10.99.0.1:1079",
+        );
+
+        assert_eq!(
+            data.get("machine")
+                .unwrap()
+                .get("interface-id")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            interface_id.to_string().as_str(),
+        );
     }
 }

--- a/crates/pxe/src/routes/ipxe.rs
+++ b/crates/pxe/src/routes/ipxe.rs
@@ -98,7 +98,7 @@ pub async fn boot(contents: MachineInterface, state: State<AppState>) -> impl In
                 );
             }
 
-            let instructions = RpcContext::get_pxe_instructions(
+            let pxe_response = RpcContext::get_pxe_instructions(
                 arch.into(),
                 machine_interface_id,
                 contents.product,
@@ -111,18 +111,46 @@ pub async fn boot(contents: MachineInterface, state: State<AppState>) -> impl In
                     }),
                 ),
             )
-            .await
-            .unwrap_or_else(|err| {
-                eprintln!("{err}");
-                format!(
-                    r#"
+            .await;
+
+            // Use URL overrides from the API if present (for external
+            // clients), falling back to global config.
+            let (api_url, pxe_url, static_pxe_url) = match &pxe_response {
+                Ok(resp) => (
+                    resp.api_url_override
+                        .clone()
+                        .unwrap_or_else(|| state.runtime_config.client_facing_api_url.clone()),
+                    resp.pxe_url_override
+                        .clone()
+                        .unwrap_or_else(|| state.runtime_config.pxe_url.clone()),
+                    resp.static_pxe_url_override
+                        .clone()
+                        .unwrap_or_else(|| state.runtime_config.static_pxe_url.clone()),
+                ),
+                Err(_) => (
+                    state.runtime_config.client_facing_api_url.clone(),
+                    state.runtime_config.pxe_url.clone(),
+                    state.runtime_config.static_pxe_url.clone(),
+                ),
+            };
+
+            let instructions = pxe_response
+                .map(|resp| resp.pxe_script)
+                .unwrap_or_else(|err| {
+                    eprintln!("{err}");
+                    format!(
+                        r#"
 echo Failed to fetch custom_ipxe: {err} ||
 exit 101 ||
 "#
-                )
-            })
-            .replace("[api_url]", &state.runtime_config.client_facing_api_url);
+                    )
+                })
+                .replace("[api_url]", &api_url)
+                .replace("[pxe_url]", &pxe_url);
 
+            // Override template URLs for external clients.
+            template_data.insert("pxe_url".to_string(), pxe_url);
+            template_data.insert("static_pxe_url".to_string(), static_pxe_url);
             template_data.insert("ipxe".to_string(), instructions);
 
             ("pxe", template_data)

--- a/crates/pxe/src/routes/mod.rs
+++ b/crates/pxe/src/routes/mod.rs
@@ -32,7 +32,7 @@ impl RpcContext {
         product: Option<String>,
         url: &str,
         client_config: &ForgeClientConfig,
-    ) -> Result<String, String> {
+    ) -> Result<rpc::PxeInstructions, String> {
         let api_config = ApiConfig::new(url, client_config);
         let mut client = forge_tls_client::ForgeTlsClient::retry_build(&api_config)
             .await
@@ -45,7 +45,7 @@ impl RpcContext {
         client
             .get_pxe_instructions(request)
             .await
-            .map(|response| response.into_inner().pxe_script)
+            .map(|response| response.into_inner())
             .map_err(|error| {
                 format!(
                     "Error in updating build needed flag for instance for machine {interface_id:?}; Error: {error}."

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -4221,6 +4221,13 @@ message PxeInstructionRequest {
 
 message PxeInstructions {
   string pxe_script = 1;
+  // URL overrides for external clients (e.g. on the static-assignments
+  // segment). When set, carbide-pxe uses these instead of its global
+  // env var URLs, allowing external hosts to reach services via an
+  // alternate hostname or IP that they can resolve.
+  optional string api_url_override = 2;
+  optional string pxe_url_override = 3;
+  optional string static_pxe_url_override = 4;
 }
 
 message CloudInitDiscoveryInstructions {
@@ -4257,6 +4264,12 @@ message CloudInitInstructions {
   optional string custom_cloud_init = 1;
   optional CloudInitDiscoveryInstructions discovery_instructions = 2;
   optional CloudInitMetaData metadata = 3;
+  // URL overrides for external clients (e.g. on the static-assignments
+  // segment). When set, carbide-pxe uses these instead of its global
+  // env var URLs, allowing external hosts to reach services via an
+  // alternate hostname or IP that they can resolve.
+  optional string api_url_override = 4;
+  optional string pxe_url_override = 5;
 }
 
 // Specifies whether a network interface is physical network function (PF)

--- a/pxe/common_files/check-scout-updates.sh
+++ b/pxe/common_files/check-scout-updates.sh
@@ -27,9 +27,14 @@ then
 	exit 0
 fi
 
-# Get the last updated value for the main scout image
+# Get the last updated value for the main scout image.
+# Use the PXE URL from the kernel command line if available (supports
+# external hosts that can't resolve internal hostnames), otherwise fall
+# back to the default internal hostname.
+pxe_uri=$(sed 's/ /\n/g' /proc/cmdline | grep '^pxe_uri=' | cut -d'=' -f2)
+static_pxe_base_url=${pxe_uri:-http://carbide-static-pxe.forge}
 arch=$(uname -m)
-scout_url="http://carbide-static-pxe.forge/public/blobs/internal/${arch}/scout.cpio.zst"
+scout_url="${static_pxe_base_url}/public/blobs/internal/${arch}/scout.cpio.zst"
 www_last_modified_str=$(curl -sf --head ${scout_url} 2>/dev/null | sed 's/\r//g' | grep Last-Modified)
 if (( $? != 0 ))
 then

--- a/pxe/mkosi.profiles/scout-oss-aarch64/mkosi.extra/opt/forge/forge-scout-pre.sh
+++ b/pxe/mkosi.profiles/scout-oss-aarch64/mkosi.extra/opt/forge/forge-scout-pre.sh
@@ -27,6 +27,11 @@ do
         then
                 server_uri=`echo $line|cut -d'=' -f2`
         fi
+        line=`echo $i|grep pxe_uri`
+        if [ ! -z "$line" ] ;
+        then
+                pxe_uri=`echo $line|cut -d'=' -f2`
+        fi
         line=`echo $i|grep cli_cmd`
         if [ ! -z "$line" ] ;
         then
@@ -39,7 +44,11 @@ echo server_uri=$server_uri >> "/opt/forge/forge-scout.env"
 echo machine_id=$machine_id >> "/opt/forge/forge-scout.env"
 echo cli_cmd=$cli_cmd >> "/opt/forge/forge-scout.env"
 
-curl --retry 5 --retry-all-errors -v -o /opt/forge/forge_root.pem http://carbide-pxe.forge/api/v0/tls/root_ca
+# Use the PXE URL from the kernel command line if available (supports
+# external hosts that can't resolve internal hostnames), otherwise fall
+# back to the default internal hostname.
+pxe_base_url=${pxe_uri:-http://carbide-pxe.forge}
+curl --retry 5 --retry-all-errors -v -o /opt/forge/forge_root.pem ${pxe_base_url}/api/v0/tls/root_ca
 
 mkdir -p ~/.ssh
 

--- a/pxe/mkosi.profiles/scout-oss-x86_64/mkosi.extra/opt/forge/forge-scout-pre.sh
+++ b/pxe/mkosi.profiles/scout-oss-x86_64/mkosi.extra/opt/forge/forge-scout-pre.sh
@@ -27,6 +27,11 @@ do
         then
                 server_uri=`echo $line|cut -d'=' -f2`
         fi
+        line=`echo $i|grep pxe_uri`
+        if [ ! -z "$line" ] ;
+        then
+                pxe_uri=`echo $line|cut -d'=' -f2`
+        fi
         line=`echo $i|grep cli_cmd`
         if [ ! -z "$line" ] ;
         then
@@ -39,7 +44,11 @@ echo server_uri=$server_uri >> "/opt/forge/forge-scout.env"
 echo machine_id=$machine_id >> "/opt/forge/forge-scout.env"
 echo cli_cmd=$cli_cmd >> "/opt/forge/forge-scout.env"
 
-curl --retry 5 --retry-all-errors -v -o /opt/forge/forge_root.pem http://carbide-pxe.forge/api/v0/tls/root_ca
+# Use the PXE URL from the kernel command line if available (supports
+# external hosts that can't resolve internal hostnames), otherwise fall
+# back to the default internal hostname.
+pxe_base_url=${pxe_uri:-http://carbide-pxe.forge}
+curl --retry 5 --retry-all-errors -v -o /opt/forge/forge_root.pem ${pxe_base_url}/api/v0/tls/root_ca
 
 mkdir -p ~/.ssh
 

--- a/pxe/test_data/agent_config_external.toml
+++ b/pxe/test_data/agent_config_external.toml
@@ -1,0 +1,5 @@
+[forge-system]
+api-server = "https://10.99.0.1:1079"
+
+[machine]
+interface-id = "91609f10-c91d-470d-a260-6293ea0c1234"


### PR DESCRIPTION
## Description

This is an **initial preview** adaptation of the work put in to support static IPs in NICo/Carbide (whether static "external" assignments from an outside DHCP server, or "internal" DHCP reservations from `carbide-dhcp`) to support a couple of efforts (including https://github.com/NVIDIA/ncx-infra-controller-core/issues/644 and https://github.com/NVIDIA/ncx-infra-controller-core/issues/790).

The backend plumbing to get to this point has included:
- [A new AddressSelectionStrategy(StaticIp)](https://github.com/NVIDIA/ncx-infra-controller-core/pull/808) to have baseline support.
- [A new static-assignments segment](https://github.com/NVIDIA/ncx-infra-controller-core/pull/821) for external assignments + internal reservations.
- [Support for segment-wide dynamic/static DHCP lease allocations](https://github.com/NVIDIA/ncx-infra-controller-core/pull/828).
- [Wiring up an ExpectedHostNics TODO for fixed_ip](https://github.com/NVIDIA/ncx-infra-controller-core/pull/891), which is what enables this.

With all of that plumbing in place, we can now offer an **initial preview** of support for booting + provisioning machines outside of NICo/Carbide managed networks, but with the understanding that it's very much for initial testing purposes only, not for production environments, and requires an understanding of:
1. How to configure your pre-existing, BYO (bring-your-own) DHCP server.
2. Ensuring your host IP(s) can route to your NICo/Carbide stack IPs (`carbide-pxe` and `carbide-api`).
3. Ensuring there are no ACLs blocking traffic from your host to your NICo/Carbide stack.
4. Ensuring your `EXTERNAL` variants (see below) are resolable in DNS, if using a hostname and not an IP.

This supports:
- Zero DPU machines (aka machines with "dumb" NICs as their connection to the physical underlay network).
- DPUs (but not the "machine" behind the DPU, hence the **initial preview**).

This does NOT support:
- The machine behind a DPU.
- Allocating a machine to a tenant.

This targets support of getting bare metal hosts booted into the `scout` image to allow operators/tinkerers play around with the booting + provisioning flow.

The general idea is:
1. Operator sets some new environment variables
 a. `CARBIDE_EXTERNAL_PXE_URL` -- external variant of sibling `CARBIDE_PXE_URL`.
 b. `CARBIDE_EXTERNAL_STATIC_PXE_URL` -- external variant of sibling `CARBIDE_STATIC_PXE_URL`.
 c. `CARBIDE_EXTERNAL_API_URL`) -- external variant of sibling `CARBIDE_EXTERNAL_API_URL`.

These new values instruct Carbide "*hey, if you see a client come in from an external interface, use these for `ipxe` and `cloud-init` script generation*."

2. Operator configures their `expected-machine.host-nics` with a `fixed-address`, which pre-allocates the machine interface/address plumbing based on the matching segment of the `fixed-address`. Lets assume this is a `fixed-address` OUTSIDE a Carbide-managed network, which means it gets put into the `static-assignments` segment.
3. Operator updates their self-managed DHCP server to set:
  a. `siaddr` == the external `carbide-pxe` IP address (which must be routable -- e.g. corp host -> lab stack).
  b. Option 67 to use `CARBIDE_EXTERNAL_PXE_URL` for `ipxe.efi`.

Once their target machine starts booting, it will:
1. See the `siaddr` from DHCP and connect to `carbide-pxe` (assuming it has connectivity to the IP -- routable, ACLs, etc).
2. Boot into the ipxe client, which will then fetch an ipxe script from `carbide-pxe`.
3. `carbide-pxe` will see the IP (or `machine_interface_id`) from the pxe request, and look up the network segment for the IP/interface.
4. `carbide-pxe` will see the IP is in the external "`static-assignments`" segment, and will then populate the ipxe script with values for `CARBIDE_EXTERNAL_*` instead of `CARBIDE_*`, ensuring the host will download artifacts via the external flow (and not `http://carbide-pxe.forge`, etc).
6. The machine boots into the OS, and then goes to fetch `cloud-init` data.
7. The `cloud-init` data is populated similarly: all scripts/configs are templatized, and populated with the matching `CARBIDE_EXTENRAL_*` value (e.g. instead of `https://carbide-api.forge`, it is populated with the `EXTERNAL` variant).

When `scout` goes to run, it connects to the correct `carbide-api` address, `carbide-api` already knows who it is, and the host begins provisioning.

At a high level, this change is pretty simple, in that it:
1. Introduces the new `EXTERNAL` environment variable variants.
2. Determines if the client IP/interface needs the standard or `EXTERNAL` variant injected into `ipxe` and `cloud-init`.
3. Populates templated data accordingly (we had a few places missing templated support, so that is there now).
4. Falls back to the existing flow otherwise.

Added unit and integration tests to test all of the API flows.

Update: This now also supports https://github.com/NVIDIA/infra-controller/issues/1865, which now has its own tracking issue (at the time of this PR it was more of a forward-thinking thing).

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

