### PR TITLE
fix: fix find_bmc_ips_by_power_shelf_ids to retrieve the ip from machine interfaces instead of expected powershelves

### DIFF
--- a/crates/api-db/src/power_shelf.rs
+++ b/crates/api-db/src/power_shelf.rs
@@ -311,19 +311,21 @@ use std::net::IpAddr;
 
 use mac_address::MacAddress;
 
-/// Resolve PowerShelfIds to BMC/PMC IPs.
+/// Resolve PowerShelfIds to BMC/PMC IPs via the machine_interfaces path.
 pub async fn find_bmc_ips_by_power_shelf_ids(
     db: impl crate::db_read::DbReader<'_>,
     power_shelf_ids: &[PowerShelfId],
 ) -> DatabaseResult<Vec<(PowerShelfId, IpAddr)>> {
     let sql = r#"
-        SELECT
+        SELECT DISTINCT ON (ps.id)
             ps.id,
-            eps.bmc_ip_address
+            mia.address
         FROM power_shelves ps
         JOIN expected_power_shelves eps ON eps.serial_number = ps.config->>'name'
+        JOIN machine_interfaces mi ON mi.mac_address = eps.bmc_mac_address
+        JOIN machine_interface_addresses mia ON mia.interface_id = mi.id
         WHERE ps.id = ANY($1)
-          AND eps.bmc_ip_address IS NOT NULL
+        ORDER BY ps.id
     "#;
 
     sqlx::query_as(sql)


### PR DESCRIPTION
## Description

fix: fix find_bmc_ips_by_power_shelf_ids to retrieve the ip from machine interfaces instead of expected powershelves

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

