### PR TITLE
fix(libnmxm): stop deriving Debug for endpoint types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5657,7 +5657,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.43.7#b470bef43d6ca953d067f5372dbce7ffee990d75"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.43.8#ec4cd0bbe6fa0a433e1da623bdc99e743dab6c77"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.43.7" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.43.8" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.5" }
 ansi-to-html = "0.2.2"
 

--- a/crates/libnmxm/src/lib.rs
+++ b/crates/libnmxm/src/lib.rs
@@ -87,7 +87,7 @@ pub enum NmxmApiError {
     InvalidArguments,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)] // WARN: Do not derive Debug: Endpoint may contain credentials and must not be logged accidentally.
 pub struct Endpoint {
     pub host: String,
     pub username: Option<String>,
@@ -147,7 +147,7 @@ impl NmxmClientPool {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct NmxmApiClient {
     endpoint: Endpoint,
     client: HttpClient,

--- a/crates/libnmxm/src/nmxm_api.rs
+++ b/crates/libnmxm/src/nmxm_api.rs
@@ -65,7 +65,7 @@ macro_rules! async_operation {
     }};
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct NmxmApi {
     pub client: NmxmApiClient,
 }


### PR DESCRIPTION
## Description
Remove `Debug` derives from `Endpoint`, `NmxmApiClient`, and `NmxmApi` to avoid accidentally logging credentials contained in endpoint data.

Also bump `libredfish` from `v0.43.7` to `v0.43.8` that has:
- Similar change for Endpoint
- Fix of escaping XML characters.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
