### PR TITLE
chore: Rename proto message OperatingSystem to InstanceOperatingSystemConfig

### DIFF
--- a/crates/admin-cli/src/instance/allocate/args.rs
+++ b/crates/admin-cli/src/instance/allocate/args.rs
@@ -18,7 +18,7 @@
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::vpc::VpcPrefixId;
 use clap::{ArgGroup, Parser};
-use rpc::forge::OperatingSystemConfig;
+use rpc::forge::InstanceOperatingSystemConfig;
 
 #[derive(Parser, Debug)]
 #[clap(group(ArgGroup::new("selector").required(true).args(&["subnet", "vpc_prefix_id"])))]
@@ -59,7 +59,7 @@ pub struct Args {
     pub instance_type_id: Option<String>,
 
     #[clap(long, help = "OS definition in JSON format", value_name = "OS_JSON")]
-    pub os: Option<OperatingSystemConfig>,
+    pub os: Option<InstanceOperatingSystemConfig>,
 
     #[clap(long, help = "The subnet to assign to a VF")]
     pub vf_subnet: Vec<String>,

--- a/crates/admin-cli/src/instance/allocate/args.rs
+++ b/crates/admin-cli/src/instance/allocate/args.rs
@@ -18,7 +18,7 @@
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::vpc::VpcPrefixId;
 use clap::{ArgGroup, Parser};
-use rpc::forge::OperatingSystem;
+use rpc::forge::OperatingSystemConfig;
 
 #[derive(Parser, Debug)]
 #[clap(group(ArgGroup::new("selector").required(true).args(&["subnet", "vpc_prefix_id"])))]
@@ -59,7 +59,7 @@ pub struct Args {
     pub instance_type_id: Option<String>,
 
     #[clap(long, help = "OS definition in JSON format", value_name = "OS_JSON")]
-    pub os: Option<OperatingSystem>,
+    pub os: Option<OperatingSystemConfig>,
 
     #[clap(long, help = "The subnet to assign to a VF")]
     pub vf_subnet: Vec<String>,

--- a/crates/admin-cli/src/instance/show/cmd.rs
+++ b/crates/admin-cli/src/instance/show/cmd.rs
@@ -126,10 +126,10 @@ async fn convert_instance_to_nice_format(
             "IPXE SCRIPT",
             instance_os
                 .and_then(|os| match os.variant.as_ref() {
-                    Some(::rpc::forge::operating_system_config::Variant::Ipxe(ipxe_os)) => {
+                    Some(::rpc::forge::instance_operating_system_config::Variant::Ipxe(ipxe_os)) => {
                         Some(Cow::Borrowed(ipxe_os.ipxe_script.as_str()))
                     }
-                    Some(::rpc::forge::operating_system_config::Variant::OsImageId(image)) => {
+                    Some(::rpc::forge::instance_operating_system_config::Variant::OsImageId(image)) => {
                         Some(Cow::Owned(format!("OS Image ID: {}", image.value)))
                     }
                     None => None,

--- a/crates/admin-cli/src/instance/show/cmd.rs
+++ b/crates/admin-cli/src/instance/show/cmd.rs
@@ -126,10 +126,10 @@ async fn convert_instance_to_nice_format(
             "IPXE SCRIPT",
             instance_os
                 .and_then(|os| match os.variant.as_ref() {
-                    Some(::rpc::forge::operating_system::Variant::Ipxe(ipxe_os)) => {
+                    Some(::rpc::forge::operating_system_config::Variant::Ipxe(ipxe_os)) => {
                         Some(Cow::Borrowed(ipxe_os.ipxe_script.as_str()))
                     }
-                    Some(::rpc::forge::operating_system::Variant::OsImageId(image)) => {
+                    Some(::rpc::forge::operating_system_config::Variant::OsImageId(image)) => {
                         Some(Cow::Owned(format!("OS Image ID: {}", image.value)))
                     }
                     None => None,

--- a/crates/admin-cli/src/instance/show/cmd.rs
+++ b/crates/admin-cli/src/instance/show/cmd.rs
@@ -126,12 +126,12 @@ async fn convert_instance_to_nice_format(
             "IPXE SCRIPT",
             instance_os
                 .and_then(|os| match os.variant.as_ref() {
-                    Some(::rpc::forge::instance_operating_system_config::Variant::Ipxe(ipxe_os)) => {
-                        Some(Cow::Borrowed(ipxe_os.ipxe_script.as_str()))
-                    }
-                    Some(::rpc::forge::instance_operating_system_config::Variant::OsImageId(image)) => {
-                        Some(Cow::Owned(format!("OS Image ID: {}", image.value)))
-                    }
+                    Some(::rpc::forge::instance_operating_system_config::Variant::Ipxe(
+                        ipxe_os,
+                    )) => Some(Cow::Borrowed(ipxe_os.ipxe_script.as_str())),
+                    Some(::rpc::forge::instance_operating_system_config::Variant::OsImageId(
+                        image,
+                    )) => Some(Cow::Owned(format!("OS Image ID: {}", image.value))),
                     None => None,
                 })
                 .unwrap_or_default(),

--- a/crates/admin-cli/src/instance/update_os/args.rs
+++ b/crates/admin-cli/src/instance/update_os/args.rs
@@ -17,7 +17,7 @@
 
 use carbide_uuid::instance::InstanceId;
 use clap::Parser;
-use rpc::forge::OperatingSystemConfig;
+use rpc::forge::InstanceOperatingSystemConfig;
 
 #[derive(Parser, Debug)]
 pub struct Args {
@@ -29,5 +29,5 @@ pub struct Args {
         help = "OS definition in JSON format",
         value_name = "OS_JSON"
     )]
-    pub os: OperatingSystemConfig,
+    pub os: InstanceOperatingSystemConfig,
 }

--- a/crates/admin-cli/src/instance/update_os/args.rs
+++ b/crates/admin-cli/src/instance/update_os/args.rs
@@ -17,7 +17,7 @@
 
 use carbide_uuid::instance::InstanceId;
 use clap::Parser;
-use rpc::forge::OperatingSystem;
+use rpc::forge::OperatingSystemConfig;
 
 #[derive(Parser, Debug)]
 pub struct Args {
@@ -29,5 +29,5 @@ pub struct Args {
         help = "OS definition in JSON format",
         value_name = "OS_JSON"
     )]
-    pub os: OperatingSystem,
+    pub os: OperatingSystemConfig,
 }

--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -750,11 +750,11 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
                 hostname: None,
                 tenant_keyset_ids: vec![],
             }),
-            os: Some(rpc::forge::OperatingSystemConfig {
+            os: Some(rpc::forge::InstanceOperatingSystemConfig {
                 phone_home_enabled: false,
                 run_provisioning_instructions_on_every_boot: false,
                 user_data: Some("".to_string()),
-                variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(rpc::forge::InlineIpxe {
+                variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(rpc::forge::InlineIpxe {
                     ipxe_script: " chain http://10.217.126.4/public/blobs/internal/x86_64/qcow-imager.efi loglevel=7 console=ttyS0,115200 console=tty0 pci=realloc=off image_url=https://pbss.s8k.io/v1/AUTH_team-forge/images.qcow2/carbide-dev-environment/carbide-dev-environment-latest.qcow2".to_string(),
                     user_data: Some("".to_string()),
                 })),

--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -750,11 +750,11 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
                 hostname: None,
                 tenant_keyset_ids: vec![],
             }),
-            os: Some(rpc::forge::OperatingSystem {
+            os: Some(rpc::forge::OperatingSystemConfig {
                 phone_home_enabled: false,
                 run_provisioning_instructions_on_every_boot: false,
                 user_data: Some("".to_string()),
-                variant: Some(rpc::forge::operating_system::Variant::Ipxe(rpc::forge::InlineIpxe {
+                variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(rpc::forge::InlineIpxe {
                     ipxe_script: " chain http://10.217.126.4/public/blobs/internal/x86_64/qcow-imager.efi loglevel=7 console=ttyS0,115200 console=tty0 pci=realloc=off image_url=https://pbss.s8k.io/v1/AUTH_team-forge/images.qcow2/carbide-dev-environment/carbide-dev-environment-latest.qcow2".to_string(),
                     user_data: Some("".to_string()),
                 })),

--- a/crates/api-model/src/instance/config.rs
+++ b/crates/api-model/src/instance/config.rs
@@ -131,7 +131,7 @@ impl TryFrom<InstanceConfig> for rpc::InstanceConfig {
 
     fn try_from(config: InstanceConfig) -> Result<rpc::InstanceConfig, Self::Error> {
         let tenant = rpc::forge::TenantConfig::try_from(config.tenant)?;
-        let os = rpc::forge::OperatingSystem::try_from(config.os)?;
+        let os = rpc::forge::OperatingSystemConfig::try_from(config.os)?;
         let network = rpc::InstanceNetworkConfig::try_from(config.network)?;
         let infiniband = rpc::InstanceInfinibandConfig::try_from(config.infiniband)?;
         let infiniband = match infiniband.ib_interfaces.is_empty() {

--- a/crates/api-model/src/instance/config.rs
+++ b/crates/api-model/src/instance/config.rs
@@ -131,7 +131,7 @@ impl TryFrom<InstanceConfig> for rpc::InstanceConfig {
 
     fn try_from(config: InstanceConfig) -> Result<rpc::InstanceConfig, Self::Error> {
         let tenant = rpc::forge::TenantConfig::try_from(config.tenant)?;
-        let os = rpc::forge::OperatingSystemConfig::try_from(config.os)?;
+        let os = rpc::forge::InstanceOperatingSystemConfig::try_from(config.os)?;
         let network = rpc::InstanceNetworkConfig::try_from(config.network)?;
         let infiniband = rpc::InstanceInfinibandConfig::try_from(config.infiniband)?;
         let infiniband = match infiniband.ib_interfaces.is_empty() {

--- a/crates/api-model/src/os.rs
+++ b/crates/api-model/src/os.rs
@@ -106,7 +106,9 @@ pub struct OperatingSystem {
 impl TryFrom<rpc::forge::InstanceOperatingSystemConfig> for OperatingSystem {
     type Error = RpcDataConversionError;
 
-    fn try_from(mut config: rpc::forge::InstanceOperatingSystemConfig) -> Result<Self, Self::Error> {
+    fn try_from(
+        mut config: rpc::forge::InstanceOperatingSystemConfig,
+    ) -> Result<Self, Self::Error> {
         let variant = config
             .variant
             .take()
@@ -139,7 +141,9 @@ impl TryFrom<rpc::forge::InstanceOperatingSystemConfig> for OperatingSystem {
 impl TryFrom<OperatingSystem> for rpc::forge::InstanceOperatingSystemConfig {
     type Error = RpcDataConversionError;
 
-    fn try_from(config: OperatingSystem) -> Result<rpc::forge::InstanceOperatingSystemConfig, Self::Error> {
+    fn try_from(
+        config: OperatingSystem,
+    ) -> Result<rpc::forge::InstanceOperatingSystemConfig, Self::Error> {
         let variant = match config.variant {
             OperatingSystemVariant::Ipxe(ipxe) => {
                 let mut ipxe: rpc::forge::InlineIpxe = ipxe.try_into()?;

--- a/crates/api-model/src/os.rs
+++ b/crates/api-model/src/os.rs
@@ -103,23 +103,23 @@ pub struct OperatingSystem {
     pub run_provisioning_instructions_on_every_boot: bool,
 }
 
-impl TryFrom<rpc::forge::OperatingSystemConfig> for OperatingSystem {
+impl TryFrom<rpc::forge::InstanceOperatingSystemConfig> for OperatingSystem {
     type Error = RpcDataConversionError;
 
-    fn try_from(mut config: rpc::forge::OperatingSystemConfig) -> Result<Self, Self::Error> {
+    fn try_from(mut config: rpc::forge::InstanceOperatingSystemConfig) -> Result<Self, Self::Error> {
         let variant = config
             .variant
             .take()
             .ok_or(RpcDataConversionError::MissingArgument(
-                "OperatingSystemConfig::variant",
+                "InstanceOperatingSystemConfig::variant",
             ))?;
         let mut ipxe_user_data = None;
         let variant = match variant {
-            rpc::forge::operating_system_config::Variant::Ipxe(ipxe) => {
+            rpc::forge::instance_operating_system_config::Variant::Ipxe(ipxe) => {
                 ipxe_user_data = ipxe.user_data.clone();
                 OperatingSystemVariant::Ipxe(ipxe.try_into()?)
             }
-            rpc::forge::operating_system_config::Variant::OsImageId(id) => {
+            rpc::forge::instance_operating_system_config::Variant::OsImageId(id) => {
                 OperatingSystemVariant::OsImage(Uuid::try_from(id).map_err(|e| {
                     RpcDataConversionError::InvalidUuid("os_image_id: ", e.to_string())
                 })?)
@@ -136,18 +136,18 @@ impl TryFrom<rpc::forge::OperatingSystemConfig> for OperatingSystem {
     }
 }
 
-impl TryFrom<OperatingSystem> for rpc::forge::OperatingSystemConfig {
+impl TryFrom<OperatingSystem> for rpc::forge::InstanceOperatingSystemConfig {
     type Error = RpcDataConversionError;
 
-    fn try_from(config: OperatingSystem) -> Result<rpc::forge::OperatingSystemConfig, Self::Error> {
+    fn try_from(config: OperatingSystem) -> Result<rpc::forge::InstanceOperatingSystemConfig, Self::Error> {
         let variant = match config.variant {
             OperatingSystemVariant::Ipxe(ipxe) => {
                 let mut ipxe: rpc::forge::InlineIpxe = ipxe.try_into()?;
                 ipxe.user_data = config.user_data.clone();
-                rpc::forge::operating_system_config::Variant::Ipxe(ipxe)
+                rpc::forge::instance_operating_system_config::Variant::Ipxe(ipxe)
             }
             OperatingSystemVariant::OsImage(id) => {
-                rpc::forge::operating_system_config::Variant::OsImageId(id.into())
+                rpc::forge::instance_operating_system_config::Variant::OsImageId(id.into())
             }
         };
 

--- a/crates/api-model/src/os.rs
+++ b/crates/api-model/src/os.rs
@@ -103,23 +103,23 @@ pub struct OperatingSystem {
     pub run_provisioning_instructions_on_every_boot: bool,
 }
 
-impl TryFrom<rpc::forge::OperatingSystem> for OperatingSystem {
+impl TryFrom<rpc::forge::OperatingSystemConfig> for OperatingSystem {
     type Error = RpcDataConversionError;
 
-    fn try_from(mut config: rpc::forge::OperatingSystem) -> Result<Self, Self::Error> {
+    fn try_from(mut config: rpc::forge::OperatingSystemConfig) -> Result<Self, Self::Error> {
         let variant = config
             .variant
             .take()
             .ok_or(RpcDataConversionError::MissingArgument(
-                "OperatingSystem::variant",
+                "OperatingSystemConfig::variant",
             ))?;
         let mut ipxe_user_data = None;
         let variant = match variant {
-            rpc::forge::operating_system::Variant::Ipxe(ipxe) => {
+            rpc::forge::operating_system_config::Variant::Ipxe(ipxe) => {
                 ipxe_user_data = ipxe.user_data.clone();
                 OperatingSystemVariant::Ipxe(ipxe.try_into()?)
             }
-            rpc::forge::operating_system::Variant::OsImageId(id) => {
+            rpc::forge::operating_system_config::Variant::OsImageId(id) => {
                 OperatingSystemVariant::OsImage(Uuid::try_from(id).map_err(|e| {
                     RpcDataConversionError::InvalidUuid("os_image_id: ", e.to_string())
                 })?)
@@ -136,18 +136,18 @@ impl TryFrom<rpc::forge::OperatingSystem> for OperatingSystem {
     }
 }
 
-impl TryFrom<OperatingSystem> for rpc::forge::OperatingSystem {
+impl TryFrom<OperatingSystem> for rpc::forge::OperatingSystemConfig {
     type Error = RpcDataConversionError;
 
-    fn try_from(config: OperatingSystem) -> Result<rpc::forge::OperatingSystem, Self::Error> {
+    fn try_from(config: OperatingSystem) -> Result<rpc::forge::OperatingSystemConfig, Self::Error> {
         let variant = match config.variant {
             OperatingSystemVariant::Ipxe(ipxe) => {
                 let mut ipxe: rpc::forge::InlineIpxe = ipxe.try_into()?;
                 ipxe.user_data = config.user_data.clone();
-                rpc::forge::operating_system::Variant::Ipxe(ipxe)
+                rpc::forge::operating_system_config::Variant::Ipxe(ipxe)
             }
             OperatingSystemVariant::OsImage(id) => {
-                rpc::forge::operating_system::Variant::OsImageId(id.into())
+                rpc::forge::operating_system_config::Variant::OsImageId(id.into())
             }
         };
 

--- a/crates/api/src/tests/common/api_fixtures/instance.rs
+++ b/crates/api/src/tests/common/api_fixtures/instance.rs
@@ -271,12 +271,12 @@ pub fn single_interface_network_config_with_vpc_prefix(
     }
 }
 
-pub fn default_os_config() -> rpc::forge::OperatingSystemConfig {
-    rpc::forge::OperatingSystemConfig {
+pub fn default_os_config() -> rpc::forge::InstanceOperatingSystemConfig {
+    rpc::forge::InstanceOperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData".to_string()),
-        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
+        variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe".to_string(),
                 user_data: Some("SomeRandomData".to_string()),

--- a/crates/api/src/tests/common/api_fixtures/instance.rs
+++ b/crates/api/src/tests/common/api_fixtures/instance.rs
@@ -271,12 +271,12 @@ pub fn single_interface_network_config_with_vpc_prefix(
     }
 }
 
-pub fn default_os_config() -> rpc::forge::OperatingSystem {
-    rpc::forge::OperatingSystem {
+pub fn default_os_config() -> rpc::forge::OperatingSystemConfig {
+    rpc::forge::OperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData".to_string()),
-        variant: Some(rpc::forge::operating_system::Variant::Ipxe(
+        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe".to_string(),
                 user_data: Some("SomeRandomData".to_string()),

--- a/crates/api/src/tests/common/api_fixtures/rpc_instance.rs
+++ b/crates/api/src/tests/common/api_fixtures/rpc_instance.rs
@@ -120,7 +120,7 @@ impl<'a> RpcInstanceConfig<'a> {
         self.0.tenant.as_ref().unwrap()
     }
 
-    pub fn os(&self) -> &'a rpc::forge::OperatingSystem {
+    pub fn os(&self) -> &'a rpc::forge::OperatingSystemConfig {
         self.0.os.as_ref().unwrap()
     }
 

--- a/crates/api/src/tests/common/api_fixtures/rpc_instance.rs
+++ b/crates/api/src/tests/common/api_fixtures/rpc_instance.rs
@@ -120,7 +120,7 @@ impl<'a> RpcInstanceConfig<'a> {
         self.0.tenant.as_ref().unwrap()
     }
 
-    pub fn os(&self) -> &'a rpc::forge::OperatingSystemConfig {
+    pub fn os(&self) -> &'a rpc::forge::InstanceOperatingSystemConfig {
         self.0.os.as_ref().unwrap()
     }
 

--- a/crates/api/src/tests/common/rpc_builder.rs
+++ b/crates/api/src/tests/common/rpc_builder.rs
@@ -103,7 +103,7 @@ pub struct InstanceConfigUpdateRequest {
 #[derive(carbide_prost_builder::Builder)]
 pub struct InstanceConfig {
     pub tenant: ::core::option::Option<::rpc::forge::TenantConfig>,
-    pub os: ::core::option::Option<::rpc::forge::OperatingSystem>,
+    pub os: ::core::option::Option<::rpc::forge::OperatingSystemConfig>,
     pub network: ::core::option::Option<rpc::forge::InstanceNetworkConfig>,
     pub infiniband: ::core::option::Option<::rpc::forge::InstanceInfinibandConfig>,
     pub network_security_group_id: ::core::option::Option<::prost::alloc::string::String>,

--- a/crates/api/src/tests/common/rpc_builder.rs
+++ b/crates/api/src/tests/common/rpc_builder.rs
@@ -103,7 +103,7 @@ pub struct InstanceConfigUpdateRequest {
 #[derive(carbide_prost_builder::Builder)]
 pub struct InstanceConfig {
     pub tenant: ::core::option::Option<::rpc::forge::TenantConfig>,
-    pub os: ::core::option::Option<::rpc::forge::OperatingSystemConfig>,
+    pub os: ::core::option::Option<::rpc::forge::InstanceOperatingSystemConfig>,
     pub network: ::core::option::Option<rpc::forge::InstanceNetworkConfig>,
     pub infiniband: ::core::option::Option<::rpc::forge::InstanceInfinibandConfig>,
     pub network_security_group_id: ::core::option::Option<::prost::alloc::string::String>,

--- a/crates/api/src/tests/instance.rs
+++ b/crates/api/src/tests/instance.rs
@@ -3451,11 +3451,11 @@ async fn test_instance_cannot_allocate_requested_ip_with_network_segment(
                 .machine_id(mh.id)
                 .config(rpc::InstanceConfig {
                     tenant: Some(default_tenant_config()),
-                    os: Some(rpc::forge::OperatingSystem {
+                    os: Some(rpc::forge::OperatingSystemConfig {
                         phone_home_enabled: false,
                         run_provisioning_instructions_on_every_boot: false,
                         user_data: Some("SomeRandomData1".to_string()),
-                        variant: Some(rpc::forge::operating_system::Variant::Ipxe(
+                        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
                             rpc::forge::InlineIpxe {
                                 ipxe_script: "SomeRandomiPxe1".to_string(),
                                 user_data: Some("SomeRandomData1".to_string()),
@@ -3762,11 +3762,11 @@ async fn test_update_instance_config_vpc_prefix_network_update_delete_vf(
     let _segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host(&env).await;
 
-    let initial_os = rpc::forge::OperatingSystem {
+    let initial_os = rpc::forge::OperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system::Variant::Ipxe(
+        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -4157,11 +4157,11 @@ async fn test_update_instance_config_vpc_prefix_network_update_state_machine(
     let _segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host(&env).await;
 
-    let initial_os = rpc::forge::OperatingSystem {
+    let initial_os = rpc::forge::OperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system::Variant::Ipxe(
+        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -5117,11 +5117,11 @@ async fn test_can_not_update_instance_config_after_deletion(
     let segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host(&env).await;
 
-    let initial_os = rpc::forge::OperatingSystem {
+    let initial_os = rpc::forge::OperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system::Variant::Ipxe(
+        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -6169,11 +6169,11 @@ async fn test_allocate_instance_with_invalid_os_image(
     // Use a non-existent OS image ID
     let invalid_os_image_id = uuid::Uuid::new_v4();
 
-    let os_config = rpc::forge::OperatingSystem {
+    let os_config = rpc::forge::OperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: None,
-        variant: Some(rpc::forge::operating_system::Variant::OsImageId(
+        variant: Some(rpc::forge::operating_system_config::Variant::OsImageId(
             rpc::Uuid::from(invalid_os_image_id),
         )),
     };

--- a/crates/api/src/tests/instance.rs
+++ b/crates/api/src/tests/instance.rs
@@ -3451,11 +3451,11 @@ async fn test_instance_cannot_allocate_requested_ip_with_network_segment(
                 .machine_id(mh.id)
                 .config(rpc::InstanceConfig {
                     tenant: Some(default_tenant_config()),
-                    os: Some(rpc::forge::OperatingSystemConfig {
+                    os: Some(rpc::forge::InstanceOperatingSystemConfig {
                         phone_home_enabled: false,
                         run_provisioning_instructions_on_every_boot: false,
                         user_data: Some("SomeRandomData1".to_string()),
-                        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
+                        variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
                             rpc::forge::InlineIpxe {
                                 ipxe_script: "SomeRandomiPxe1".to_string(),
                                 user_data: Some("SomeRandomData1".to_string()),
@@ -3762,11 +3762,11 @@ async fn test_update_instance_config_vpc_prefix_network_update_delete_vf(
     let _segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host(&env).await;
 
-    let initial_os = rpc::forge::OperatingSystemConfig {
+    let initial_os = rpc::forge::InstanceOperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
+        variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -4157,11 +4157,11 @@ async fn test_update_instance_config_vpc_prefix_network_update_state_machine(
     let _segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host(&env).await;
 
-    let initial_os = rpc::forge::OperatingSystemConfig {
+    let initial_os = rpc::forge::InstanceOperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
+        variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -5117,11 +5117,11 @@ async fn test_can_not_update_instance_config_after_deletion(
     let segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host(&env).await;
 
-    let initial_os = rpc::forge::OperatingSystemConfig {
+    let initial_os = rpc::forge::InstanceOperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
+        variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -6169,11 +6169,11 @@ async fn test_allocate_instance_with_invalid_os_image(
     // Use a non-existent OS image ID
     let invalid_os_image_id = uuid::Uuid::new_v4();
 
-    let os_config = rpc::forge::OperatingSystemConfig {
+    let os_config = rpc::forge::InstanceOperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: None,
-        variant: Some(rpc::forge::operating_system_config::Variant::OsImageId(
+        variant: Some(rpc::forge::instance_operating_system_config::Variant::OsImageId(
             rpc::Uuid::from(invalid_os_image_id),
         )),
     };

--- a/crates/api/src/tests/instance.rs
+++ b/crates/api/src/tests/instance.rs
@@ -6173,9 +6173,11 @@ async fn test_allocate_instance_with_invalid_os_image(
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: None,
-        variant: Some(rpc::forge::instance_operating_system_config::Variant::OsImageId(
-            rpc::Uuid::from(invalid_os_image_id),
-        )),
+        variant: Some(
+            rpc::forge::instance_operating_system_config::Variant::OsImageId(rpc::Uuid::from(
+                invalid_os_image_id,
+            )),
+        ),
     };
 
     let result = env

--- a/crates/api/src/tests/instance_allocate.rs
+++ b/crates/api/src/tests/instance_allocate.rs
@@ -196,11 +196,11 @@ async fn test_zero_dpu_instance_allocation_explicit_network_config(
                     tenant_keyset_ids: vec![],
                 }),
                 network_security_group_id: None,
-                os: Some(forge::OperatingSystemConfig {
+                os: Some(forge::InstanceOperatingSystemConfig {
                     phone_home_enabled: false,
                     run_provisioning_instructions_on_every_boot: false,
                     user_data: None,
-                    variant: Some(forge::operating_system_config::Variant::Ipxe(
+                    variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
                         forge::InlineIpxe {
                             ipxe_script: "exit".to_string(),
                             user_data: None,
@@ -292,11 +292,11 @@ async fn test_zero_dpu_instance_allocation_no_network_config(
                     hostname: None,
                     tenant_keyset_ids: vec![],
                 }),
-                os: Some(forge::OperatingSystemConfig {
+                os: Some(forge::InstanceOperatingSystemConfig {
                     phone_home_enabled: false,
                     run_provisioning_instructions_on_every_boot: false,
                     user_data: None,
-                    variant: Some(forge::operating_system_config::Variant::Ipxe(
+                    variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
                         forge::InlineIpxe {
                             ipxe_script: "exit".to_string(),
                             user_data: None,
@@ -388,11 +388,11 @@ async fn test_zero_dpu_instance_allocation_multi_segment_no_network_config(
                     hostname: None,
                     tenant_keyset_ids: vec![],
                 }),
-                os: Some(forge::OperatingSystemConfig {
+                os: Some(forge::InstanceOperatingSystemConfig {
                     phone_home_enabled: false,
                     run_provisioning_instructions_on_every_boot: false,
                     user_data: None,
-                    variant: Some(forge::operating_system_config::Variant::Ipxe(
+                    variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
                         forge::InlineIpxe {
                             ipxe_script: "exit".to_string(),
                             user_data: None,
@@ -515,11 +515,11 @@ async fn test_reject_single_dpu_instance_allocation_no_network_config(
                     hostname: None,
                     tenant_keyset_ids: vec![],
                 }),
-                os: Some(forge::OperatingSystemConfig {
+                os: Some(forge::InstanceOperatingSystemConfig {
                     phone_home_enabled: false,
                     run_provisioning_instructions_on_every_boot: false,
                     user_data: None,
-                    variant: Some(forge::operating_system_config::Variant::Ipxe(
+                    variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
                         forge::InlineIpxe {
                             ipxe_script: "exit".to_string(),
                             user_data: None,
@@ -575,11 +575,11 @@ async fn test_reject_single_dpu_instance_allocation_host_inband_network_config(
                     hostname: None,
                     tenant_keyset_ids: vec![],
                 }),
-                os: Some(forge::OperatingSystemConfig {
+                os: Some(forge::InstanceOperatingSystemConfig {
                     phone_home_enabled: false,
                     run_provisioning_instructions_on_every_boot: false,
                     user_data: None,
-                    variant: Some(forge::operating_system_config::Variant::Ipxe(
+                    variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
                         forge::InlineIpxe {
                             ipxe_script: "exit".to_string(),
                             user_data: None,
@@ -724,11 +724,11 @@ async fn test_reject_zero_dpu_instance_allocation_multiple_vpcs(
                     hostname: None,
                     tenant_keyset_ids: vec![],
                 }),
-                os: Some(forge::OperatingSystemConfig {
+                os: Some(forge::InstanceOperatingSystemConfig {
                     phone_home_enabled: false,
                     run_provisioning_instructions_on_every_boot: false,
                     user_data: None,
-                    variant: Some(forge::operating_system_config::Variant::Ipxe(
+                    variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
                         forge::InlineIpxe {
                             ipxe_script: "exit".to_string(),
                             user_data: None,
@@ -784,11 +784,11 @@ async fn test_single_dpu_instance_allocation(
                     hostname: None,
                     tenant_keyset_ids: vec![],
                 }),
-                os: Some(forge::OperatingSystemConfig {
+                os: Some(forge::InstanceOperatingSystemConfig {
                     phone_home_enabled: false,
                     run_provisioning_instructions_on_every_boot: false,
                     user_data: None,
-                    variant: Some(forge::operating_system_config::Variant::Ipxe(
+                    variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
                         forge::InlineIpxe {
                             ipxe_script: "exit".to_string(),
                             user_data: None,

--- a/crates/api/src/tests/instance_allocate.rs
+++ b/crates/api/src/tests/instance_allocate.rs
@@ -196,14 +196,16 @@ async fn test_zero_dpu_instance_allocation_explicit_network_config(
                     tenant_keyset_ids: vec![],
                 }),
                 network_security_group_id: None,
-                os: Some(forge::OperatingSystem {
+                os: Some(forge::OperatingSystemConfig {
                     phone_home_enabled: false,
                     run_provisioning_instructions_on_every_boot: false,
                     user_data: None,
-                    variant: Some(forge::operating_system::Variant::Ipxe(forge::InlineIpxe {
-                        ipxe_script: "exit".to_string(),
-                        user_data: None,
-                    })),
+                    variant: Some(forge::operating_system_config::Variant::Ipxe(
+                        forge::InlineIpxe {
+                            ipxe_script: "exit".to_string(),
+                            user_data: None,
+                        },
+                    )),
                 }),
                 network: Some(forge::InstanceNetworkConfig {
                     interfaces: vec![forge::InstanceInterfaceConfig {
@@ -290,14 +292,16 @@ async fn test_zero_dpu_instance_allocation_no_network_config(
                     hostname: None,
                     tenant_keyset_ids: vec![],
                 }),
-                os: Some(forge::OperatingSystem {
+                os: Some(forge::OperatingSystemConfig {
                     phone_home_enabled: false,
                     run_provisioning_instructions_on_every_boot: false,
                     user_data: None,
-                    variant: Some(forge::operating_system::Variant::Ipxe(forge::InlineIpxe {
-                        ipxe_script: "exit".to_string(),
-                        user_data: None,
-                    })),
+                    variant: Some(forge::operating_system_config::Variant::Ipxe(
+                        forge::InlineIpxe {
+                            ipxe_script: "exit".to_string(),
+                            user_data: None,
+                        },
+                    )),
                 }),
                 network: None, // code under test: Network config is None
                 infiniband: None,
@@ -384,14 +388,16 @@ async fn test_zero_dpu_instance_allocation_multi_segment_no_network_config(
                     hostname: None,
                     tenant_keyset_ids: vec![],
                 }),
-                os: Some(forge::OperatingSystem {
+                os: Some(forge::OperatingSystemConfig {
                     phone_home_enabled: false,
                     run_provisioning_instructions_on_every_boot: false,
                     user_data: None,
-                    variant: Some(forge::operating_system::Variant::Ipxe(forge::InlineIpxe {
-                        ipxe_script: "exit".to_string(),
-                        user_data: None,
-                    })),
+                    variant: Some(forge::operating_system_config::Variant::Ipxe(
+                        forge::InlineIpxe {
+                            ipxe_script: "exit".to_string(),
+                            user_data: None,
+                        },
+                    )),
                 }),
                 network: None, // code under test: Network config is None
                 infiniband: None,
@@ -509,14 +515,16 @@ async fn test_reject_single_dpu_instance_allocation_no_network_config(
                     hostname: None,
                     tenant_keyset_ids: vec![],
                 }),
-                os: Some(forge::OperatingSystem {
+                os: Some(forge::OperatingSystemConfig {
                     phone_home_enabled: false,
                     run_provisioning_instructions_on_every_boot: false,
                     user_data: None,
-                    variant: Some(forge::operating_system::Variant::Ipxe(forge::InlineIpxe {
-                        ipxe_script: "exit".to_string(),
-                        user_data: None,
-                    })),
+                    variant: Some(forge::operating_system_config::Variant::Ipxe(
+                        forge::InlineIpxe {
+                            ipxe_script: "exit".to_string(),
+                            user_data: None,
+                        },
+                    )),
                 }),
                 network: None,
                 infiniband: None,
@@ -567,14 +575,16 @@ async fn test_reject_single_dpu_instance_allocation_host_inband_network_config(
                     hostname: None,
                     tenant_keyset_ids: vec![],
                 }),
-                os: Some(forge::OperatingSystem {
+                os: Some(forge::OperatingSystemConfig {
                     phone_home_enabled: false,
                     run_provisioning_instructions_on_every_boot: false,
                     user_data: None,
-                    variant: Some(forge::operating_system::Variant::Ipxe(forge::InlineIpxe {
-                        ipxe_script: "exit".to_string(),
-                        user_data: None,
-                    })),
+                    variant: Some(forge::operating_system_config::Variant::Ipxe(
+                        forge::InlineIpxe {
+                            ipxe_script: "exit".to_string(),
+                            user_data: None,
+                        },
+                    )),
                 }),
                 network: Some(forge::InstanceNetworkConfig {
                     interfaces: vec![forge::InstanceInterfaceConfig {
@@ -714,14 +724,16 @@ async fn test_reject_zero_dpu_instance_allocation_multiple_vpcs(
                     hostname: None,
                     tenant_keyset_ids: vec![],
                 }),
-                os: Some(forge::OperatingSystem {
+                os: Some(forge::OperatingSystemConfig {
                     phone_home_enabled: false,
                     run_provisioning_instructions_on_every_boot: false,
                     user_data: None,
-                    variant: Some(forge::operating_system::Variant::Ipxe(forge::InlineIpxe {
-                        ipxe_script: "exit".to_string(),
-                        user_data: None,
-                    })),
+                    variant: Some(forge::operating_system_config::Variant::Ipxe(
+                        forge::InlineIpxe {
+                            ipxe_script: "exit".to_string(),
+                            user_data: None,
+                        },
+                    )),
                 }),
                 network: None,
                 infiniband: None,
@@ -772,14 +784,16 @@ async fn test_single_dpu_instance_allocation(
                     hostname: None,
                     tenant_keyset_ids: vec![],
                 }),
-                os: Some(forge::OperatingSystem {
+                os: Some(forge::OperatingSystemConfig {
                     phone_home_enabled: false,
                     run_provisioning_instructions_on_every_boot: false,
                     user_data: None,
-                    variant: Some(forge::operating_system::Variant::Ipxe(forge::InlineIpxe {
-                        ipxe_script: "exit".to_string(),
-                        user_data: None,
-                    })),
+                    variant: Some(forge::operating_system_config::Variant::Ipxe(
+                        forge::InlineIpxe {
+                            ipxe_script: "exit".to_string(),
+                            user_data: None,
+                        },
+                    )),
                 }),
                 network: Some(forge::InstanceNetworkConfig {
                     interfaces: vec![forge::InstanceInterfaceConfig {

--- a/crates/api/src/tests/instance_config_update.rs
+++ b/crates/api/src/tests/instance_config_update.rs
@@ -75,11 +75,11 @@ async fn test_update_instance_config(_: PgPoolOptions, options: PgConnectOptions
     let segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host(&env).await;
 
-    let initial_os = rpc::forge::OperatingSystemConfig {
+    let initial_os = rpc::forge::InstanceOperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
+        variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -124,11 +124,11 @@ async fn test_update_instance_config(_: PgPoolOptions, options: PgConnectOptions
     let initial_config_version = instance.config_version();
     assert_eq!(initial_config_version.version_nr(), 1);
 
-    let updated_os_1 = rpc::forge::OperatingSystemConfig {
+    let updated_os_1 = rpc::forge::InstanceOperatingSystemConfig {
         phone_home_enabled: true,
         run_provisioning_instructions_on_every_boot: true,
         user_data: Some("SomeRandomData2".to_string()),
-        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
+        variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe2".to_string(),
                 user_data: Some("SomeRandomData2".to_string()),
@@ -226,11 +226,11 @@ async fn test_update_instance_config(_: PgPoolOptions, options: PgConnectOptions
     // And we should be ready from the tenant's perspective.
     assert_eq!(instance.status().tenant(), rpc::forge::TenantState::Ready);
 
-    let updated_os_2 = rpc::forge::OperatingSystemConfig {
+    let updated_os_2 = rpc::forge::InstanceOperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData3".to_string()),
-        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
+        variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe3".to_string(),
                 user_data: Some("SomeRandomData3".to_string()),
@@ -330,11 +330,11 @@ async fn test_reject_invalid_instance_config_updates(_: PgPoolOptions, options: 
     let segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host(&env).await;
 
-    let initial_os = rpc::forge::OperatingSystemConfig {
+    let initial_os = rpc::forge::InstanceOperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
+        variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -366,11 +366,11 @@ async fn test_reject_invalid_instance_config_updates(_: PgPoolOptions, options: 
         .await;
 
     // Try to update to an invalid OS
-    let invalid_os = rpc::forge::OperatingSystemConfig {
+    let invalid_os = rpc::forge::InstanceOperatingSystemConfig {
         phone_home_enabled: true,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData2".to_string()),
-        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
+        variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "".to_string(),
                 user_data: Some("SomeRandomData2".to_string()),
@@ -594,11 +594,11 @@ async fn test_update_instance_config_vpc_prefix_no_network_update(
     let segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host(&env).await;
 
-    let initial_os = rpc::forge::OperatingSystemConfig {
+    let initial_os = rpc::forge::InstanceOperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
+        variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -728,11 +728,11 @@ async fn test_update_instance_config_vpc_prefix_network_update(
     let _segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host(&env).await;
 
-    let initial_os = rpc::forge::OperatingSystemConfig {
+    let initial_os = rpc::forge::InstanceOperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
+        variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -926,11 +926,11 @@ async fn test_update_instance_config_vpc_prefix_network_update_post_instance_del
     let _segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host(&env).await;
 
-    let initial_os = rpc::forge::OperatingSystemConfig {
+    let initial_os = rpc::forge::InstanceOperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
+        variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -1076,11 +1076,11 @@ async fn test_update_instance_config_vpc_prefix_network_update_multidpu(
     let _segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host_multi_dpu(&env, 2).await;
 
-    let initial_os = rpc::forge::OperatingSystemConfig {
+    let initial_os = rpc::forge::InstanceOperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
+        variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -1238,11 +1238,11 @@ async fn test_update_instance_config_vpc_prefix_network_update_multidpu_differen
     let _segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host_multi_dpu(&env, 2).await;
 
-    let initial_os = rpc::forge::OperatingSystemConfig {
+    let initial_os = rpc::forge::InstanceOperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
+        variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -1427,11 +1427,11 @@ async fn test_update_instance_config_vpc_prefix_network_update_different_prefix_
     let _segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host_multi_dpu(&env, 2).await;
 
-    let initial_os = rpc::forge::OperatingSystemConfig {
+    let initial_os = rpc::forge::InstanceOperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
+        variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),

--- a/crates/api/src/tests/instance_config_update.rs
+++ b/crates/api/src/tests/instance_config_update.rs
@@ -75,11 +75,11 @@ async fn test_update_instance_config(_: PgPoolOptions, options: PgConnectOptions
     let segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host(&env).await;
 
-    let initial_os = rpc::forge::OperatingSystem {
+    let initial_os = rpc::forge::OperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system::Variant::Ipxe(
+        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -124,11 +124,11 @@ async fn test_update_instance_config(_: PgPoolOptions, options: PgConnectOptions
     let initial_config_version = instance.config_version();
     assert_eq!(initial_config_version.version_nr(), 1);
 
-    let updated_os_1 = rpc::forge::OperatingSystem {
+    let updated_os_1 = rpc::forge::OperatingSystemConfig {
         phone_home_enabled: true,
         run_provisioning_instructions_on_every_boot: true,
         user_data: Some("SomeRandomData2".to_string()),
-        variant: Some(rpc::forge::operating_system::Variant::Ipxe(
+        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe2".to_string(),
                 user_data: Some("SomeRandomData2".to_string()),
@@ -226,11 +226,11 @@ async fn test_update_instance_config(_: PgPoolOptions, options: PgConnectOptions
     // And we should be ready from the tenant's perspective.
     assert_eq!(instance.status().tenant(), rpc::forge::TenantState::Ready);
 
-    let updated_os_2 = rpc::forge::OperatingSystem {
+    let updated_os_2 = rpc::forge::OperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData3".to_string()),
-        variant: Some(rpc::forge::operating_system::Variant::Ipxe(
+        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe3".to_string(),
                 user_data: Some("SomeRandomData3".to_string()),
@@ -330,11 +330,11 @@ async fn test_reject_invalid_instance_config_updates(_: PgPoolOptions, options: 
     let segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host(&env).await;
 
-    let initial_os = rpc::forge::OperatingSystem {
+    let initial_os = rpc::forge::OperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system::Variant::Ipxe(
+        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -366,11 +366,11 @@ async fn test_reject_invalid_instance_config_updates(_: PgPoolOptions, options: 
         .await;
 
     // Try to update to an invalid OS
-    let invalid_os = rpc::forge::OperatingSystem {
+    let invalid_os = rpc::forge::OperatingSystemConfig {
         phone_home_enabled: true,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData2".to_string()),
-        variant: Some(rpc::forge::operating_system::Variant::Ipxe(
+        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "".to_string(),
                 user_data: Some("SomeRandomData2".to_string()),
@@ -594,11 +594,11 @@ async fn test_update_instance_config_vpc_prefix_no_network_update(
     let segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host(&env).await;
 
-    let initial_os = rpc::forge::OperatingSystem {
+    let initial_os = rpc::forge::OperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system::Variant::Ipxe(
+        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -728,11 +728,11 @@ async fn test_update_instance_config_vpc_prefix_network_update(
     let _segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host(&env).await;
 
-    let initial_os = rpc::forge::OperatingSystem {
+    let initial_os = rpc::forge::OperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system::Variant::Ipxe(
+        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -926,11 +926,11 @@ async fn test_update_instance_config_vpc_prefix_network_update_post_instance_del
     let _segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host(&env).await;
 
-    let initial_os = rpc::forge::OperatingSystem {
+    let initial_os = rpc::forge::OperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system::Variant::Ipxe(
+        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -1076,11 +1076,11 @@ async fn test_update_instance_config_vpc_prefix_network_update_multidpu(
     let _segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host_multi_dpu(&env, 2).await;
 
-    let initial_os = rpc::forge::OperatingSystem {
+    let initial_os = rpc::forge::OperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system::Variant::Ipxe(
+        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -1238,11 +1238,11 @@ async fn test_update_instance_config_vpc_prefix_network_update_multidpu_differen
     let _segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host_multi_dpu(&env, 2).await;
 
-    let initial_os = rpc::forge::OperatingSystem {
+    let initial_os = rpc::forge::OperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system::Variant::Ipxe(
+        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -1427,11 +1427,11 @@ async fn test_update_instance_config_vpc_prefix_network_update_different_prefix_
     let _segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host_multi_dpu(&env, 2).await;
 
-    let initial_os = rpc::forge::OperatingSystem {
+    let initial_os = rpc::forge::OperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system::Variant::Ipxe(
+        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),

--- a/crates/api/src/tests/instance_ipxe_behaviors.rs
+++ b/crates/api/src/tests/instance_ipxe_behaviors.rs
@@ -216,7 +216,7 @@ pub async fn create_instance<'a, 'b>(
     run_provisioning_instructions_on_every_boot: bool,
     segment_id: NetworkSegmentId,
 ) -> TestInstance<'a, 'b> {
-    let mut os: rpc::forge::OperatingSystemConfig = default_os_config();
+    let mut os: rpc::forge::InstanceOperatingSystemConfig = default_os_config();
     os.run_provisioning_instructions_on_every_boot = run_provisioning_instructions_on_every_boot;
 
     let config = rpc::InstanceConfig {

--- a/crates/api/src/tests/instance_ipxe_behaviors.rs
+++ b/crates/api/src/tests/instance_ipxe_behaviors.rs
@@ -216,7 +216,7 @@ pub async fn create_instance<'a, 'b>(
     run_provisioning_instructions_on_every_boot: bool,
     segment_id: NetworkSegmentId,
 ) -> TestInstance<'a, 'b> {
-    let mut os: rpc::forge::OperatingSystem = default_os_config();
+    let mut os: rpc::forge::OperatingSystemConfig = default_os_config();
     os.run_provisioning_instructions_on_every_boot = run_provisioning_instructions_on_every_boot;
 
     let config = rpc::InstanceConfig {

--- a/crates/api/src/tests/instance_os.rs
+++ b/crates/api/src/tests/instance_os.rs
@@ -30,11 +30,11 @@ async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConn
     let segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host(&env).await;
 
-    let initial_os = rpc::forge::OperatingSystem {
+    let initial_os = rpc::forge::OperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system::Variant::Ipxe(
+        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -63,11 +63,11 @@ async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConn
     let initial_config_version = instance.config_version();
     assert_eq!(initial_config_version.version_nr(), 1);
 
-    let updated_os_1 = rpc::forge::OperatingSystem {
+    let updated_os_1 = rpc::forge::OperatingSystemConfig {
         phone_home_enabled: true,
         run_provisioning_instructions_on_every_boot: true,
         user_data: Some("SomeRandomData2".to_string()),
-        variant: Some(rpc::forge::operating_system::Variant::Ipxe(
+        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe2".to_string(),
                 user_data: Some("SomeRandomData2".to_string()),
@@ -92,11 +92,11 @@ async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConn
     let updated_config_version = instance.config_version.parse::<ConfigVersion>().unwrap();
     assert_eq!(updated_config_version.version_nr(), 2);
 
-    let updated_os_2 = rpc::forge::OperatingSystem {
+    let updated_os_2 = rpc::forge::OperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData3".to_string()),
-        variant: Some(rpc::forge::operating_system::Variant::Ipxe(
+        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe3".to_string(),
                 user_data: Some("SomeRandomData3".to_string()),
@@ -169,11 +169,11 @@ async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConn
     );
 
     // Try to update to an invalid OS
-    let invalid_os = rpc::forge::OperatingSystem {
+    let invalid_os = rpc::forge::OperatingSystemConfig {
         phone_home_enabled: true,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData2".to_string()),
-        variant: Some(rpc::forge::operating_system::Variant::Ipxe(
+        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "".to_string(),
                 user_data: None,

--- a/crates/api/src/tests/instance_os.rs
+++ b/crates/api/src/tests/instance_os.rs
@@ -30,11 +30,11 @@ async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConn
     let segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host(&env).await;
 
-    let initial_os = rpc::forge::OperatingSystemConfig {
+    let initial_os = rpc::forge::InstanceOperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData1".to_string()),
-        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
+        variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
                 user_data: Some("SomeRandomData1".to_string()),
@@ -63,11 +63,11 @@ async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConn
     let initial_config_version = instance.config_version();
     assert_eq!(initial_config_version.version_nr(), 1);
 
-    let updated_os_1 = rpc::forge::OperatingSystemConfig {
+    let updated_os_1 = rpc::forge::InstanceOperatingSystemConfig {
         phone_home_enabled: true,
         run_provisioning_instructions_on_every_boot: true,
         user_data: Some("SomeRandomData2".to_string()),
-        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
+        variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe2".to_string(),
                 user_data: Some("SomeRandomData2".to_string()),
@@ -92,11 +92,11 @@ async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConn
     let updated_config_version = instance.config_version.parse::<ConfigVersion>().unwrap();
     assert_eq!(updated_config_version.version_nr(), 2);
 
-    let updated_os_2 = rpc::forge::OperatingSystemConfig {
+    let updated_os_2 = rpc::forge::InstanceOperatingSystemConfig {
         phone_home_enabled: false,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData3".to_string()),
-        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
+        variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe3".to_string(),
                 user_data: Some("SomeRandomData3".to_string()),
@@ -169,11 +169,11 @@ async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConn
     );
 
     // Try to update to an invalid OS
-    let invalid_os = rpc::forge::OperatingSystemConfig {
+    let invalid_os = rpc::forge::InstanceOperatingSystemConfig {
         phone_home_enabled: true,
         run_provisioning_instructions_on_every_boot: false,
         user_data: Some("SomeRandomData2".to_string()),
-        variant: Some(rpc::forge::operating_system_config::Variant::Ipxe(
+        variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "".to_string(),
                 user_data: None,

--- a/crates/api/src/web/instance.rs
+++ b/crates/api/src/web/instance.rs
@@ -347,7 +347,7 @@ impl From<forgerpc::Instance> for InstanceDetail {
             .and_then(|config| config.os.as_ref())
             .map(|os| match &os.variant {
                 Some(os_variant) => match os_variant {
-                    forgerpc::operating_system::Variant::Ipxe(ipxe) => InstanceOs {
+                    forgerpc::operating_system_config::Variant::Ipxe(ipxe) => InstanceOs {
                         ipxe_script: ipxe.ipxe_script.clone(),
                         userdata: os
                             .user_data
@@ -357,7 +357,7 @@ impl From<forgerpc::Instance> for InstanceDetail {
                             .run_provisioning_instructions_on_every_boot,
                         phone_home_enabled: os.phone_home_enabled,
                     },
-                    forgerpc::operating_system::Variant::OsImageId(_id) => InstanceOs {
+                    forgerpc::operating_system_config::Variant::OsImageId(_id) => InstanceOs {
                         ipxe_script: "".to_string(),
                         userdata: os.user_data.clone().unwrap_or_default(),
                         run_provisioning_instructions_on_every_boot: os

--- a/crates/api/src/web/instance.rs
+++ b/crates/api/src/web/instance.rs
@@ -357,13 +357,15 @@ impl From<forgerpc::Instance> for InstanceDetail {
                             .run_provisioning_instructions_on_every_boot,
                         phone_home_enabled: os.phone_home_enabled,
                     },
-                    forgerpc::instance_operating_system_config::Variant::OsImageId(_id) => InstanceOs {
-                        ipxe_script: "".to_string(),
-                        userdata: os.user_data.clone().unwrap_or_default(),
-                        run_provisioning_instructions_on_every_boot: os
-                            .run_provisioning_instructions_on_every_boot,
-                        phone_home_enabled: os.phone_home_enabled,
-                    },
+                    forgerpc::instance_operating_system_config::Variant::OsImageId(_id) => {
+                        InstanceOs {
+                            ipxe_script: "".to_string(),
+                            userdata: os.user_data.clone().unwrap_or_default(),
+                            run_provisioning_instructions_on_every_boot: os
+                                .run_provisioning_instructions_on_every_boot,
+                            phone_home_enabled: os.phone_home_enabled,
+                        }
+                    }
                 },
                 None => InstanceOs::default(),
             })

--- a/crates/api/src/web/instance.rs
+++ b/crates/api/src/web/instance.rs
@@ -347,7 +347,7 @@ impl From<forgerpc::Instance> for InstanceDetail {
             .and_then(|config| config.os.as_ref())
             .map(|os| match &os.variant {
                 Some(os_variant) => match os_variant {
-                    forgerpc::operating_system_config::Variant::Ipxe(ipxe) => InstanceOs {
+                    forgerpc::instance_operating_system_config::Variant::Ipxe(ipxe) => InstanceOs {
                         ipxe_script: ipxe.ipxe_script.clone(),
                         userdata: os
                             .user_data
@@ -357,7 +357,7 @@ impl From<forgerpc::Instance> for InstanceDetail {
                             .run_provisioning_instructions_on_every_boot,
                         phone_home_enabled: os.phone_home_enabled,
                     },
-                    forgerpc::operating_system_config::Variant::OsImageId(_id) => InstanceOs {
+                    forgerpc::instance_operating_system_config::Variant::OsImageId(_id) => InstanceOs {
                         ipxe_script: "".to_string(),
                         userdata: os.user_data.clone().unwrap_or_default(),
                         run_provisioning_instructions_on_every_boot: os

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -22,9 +22,9 @@ use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use mac_address::MacAddress;
 use rpc::forge::machine_cleanup_info::CleanupStepResult;
-use rpc::forge::operating_system::Variant;
+use rpc::forge::operating_system_config::Variant;
 use rpc::forge::{
-    ConfigSetting, ExpectedMachine, InlineIpxe, MachinesByIdsRequest, OperatingSystem,
+    ConfigSetting, ExpectedMachine, InlineIpxe, MachinesByIdsRequest, OperatingSystemConfig,
     PxeInstructions, SetDynamicConfigRequest,
 };
 use rpc::protos::forge_api_client::ForgeApiClient;
@@ -273,7 +273,7 @@ impl ApiClient {
 
         let instance_config = rpc::InstanceConfig {
             tenant: Some(tenant_config),
-            os: Some(OperatingSystem {
+            os: Some(OperatingSystemConfig {
                 variant: Some(Variant::Ipxe(InlineIpxe {
                     ipxe_script: "Non-existing-ipxe".to_string(),
                     user_data: None,

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -21,11 +21,11 @@ use bmc_mock::MachineInfo;
 use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use mac_address::MacAddress;
-use rpc::forge::machine_cleanup_info::CleanupStepResult;
 use rpc::forge::instance_operating_system_config::Variant;
+use rpc::forge::machine_cleanup_info::CleanupStepResult;
 use rpc::forge::{
-    ConfigSetting, ExpectedMachine, InlineIpxe, MachinesByIdsRequest, InstanceOperatingSystemConfig,
-    PxeInstructions, SetDynamicConfigRequest,
+    ConfigSetting, ExpectedMachine, InlineIpxe, InstanceOperatingSystemConfig,
+    MachinesByIdsRequest, PxeInstructions, SetDynamicConfigRequest,
 };
 use rpc::protos::forge_api_client::ForgeApiClient;
 

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -22,9 +22,9 @@ use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use mac_address::MacAddress;
 use rpc::forge::machine_cleanup_info::CleanupStepResult;
-use rpc::forge::operating_system_config::Variant;
+use rpc::forge::instance_operating_system_config::Variant;
 use rpc::forge::{
-    ConfigSetting, ExpectedMachine, InlineIpxe, MachinesByIdsRequest, OperatingSystemConfig,
+    ConfigSetting, ExpectedMachine, InlineIpxe, MachinesByIdsRequest, InstanceOperatingSystemConfig,
     PxeInstructions, SetDynamicConfigRequest,
 };
 use rpc::protos::forge_api_client::ForgeApiClient;
@@ -273,7 +273,7 @@ impl ApiClient {
 
         let instance_config = rpc::InstanceConfig {
             tenant: Some(tenant_config),
-            os: Some(OperatingSystemConfig {
+            os: Some(InstanceOperatingSystemConfig {
                 variant: Some(Variant::Ipxe(InlineIpxe {
                     ipxe_script: "Non-existing-ipxe".to_string(),
                     user_data: None,

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -270,11 +270,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .type_attribute("forge.NetworkSegmentList", "#[derive(serde::Serialize)]")
         .type_attribute(
-            "forge.OperatingSystemConfig",
+            "forge.InstanceOperatingSystemConfig",
             "#[derive(serde::Deserialize, serde::Serialize)]",
         )
         .type_attribute(
-            "forge.OperatingSystemConfig.variant",
+            "forge.InstanceOperatingSystemConfig.variant",
             "#[derive(serde::Deserialize, serde::Serialize)]",
         )
         .type_attribute("forge.InterfaceList", "#[derive(serde::Serialize)]")

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -270,11 +270,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .type_attribute("forge.NetworkSegmentList", "#[derive(serde::Serialize)]")
         .type_attribute(
-            "forge.OperatingSystem",
+            "forge.OperatingSystemConfig",
             "#[derive(serde::Deserialize, serde::Serialize)]",
         )
         .type_attribute(
-            "forge.OperatingSystem.variant",
+            "forge.OperatingSystemConfig.variant",
             "#[derive(serde::Deserialize, serde::Serialize)]",
         )
         .type_attribute("forge.InterfaceList", "#[derive(serde::Serialize)]")

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -2319,7 +2319,7 @@ message TenantConfig {
   string tenant_organization_id = 1;
 
   // These fields have been used for OS configuration in the past.
-  // They are now replaced with the OperatingSystem message.
+  // They are now replaced with the OperatingSystemConfig message.
   reserved 11, 12, 13, 14;
 
   optional string hostname = 15;

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -2329,7 +2329,7 @@ message TenantConfig {
   repeated string tenantKeysetIds = 8; // this may be empty
 }
 
-message OperatingSystem {
+message OperatingSystemConfig {
   // Contains the operating system definition based on the variant of operating system
   oneof variant {
     InlineIpxe ipxe = 1;
@@ -2381,7 +2381,7 @@ message InstanceConfig {
   TenantConfig tenant = 1;
 
   // Operating system. This is required if no operating system reference is provided
-  OperatingSystem os = 2;
+  OperatingSystemConfig os = 2;
   // Can be used to reference an OS in the OS library based on a unique ID
   // string os_reference = 3;
 
@@ -2466,7 +2466,7 @@ message InstanceOperatingSystemUpdateRequest {
   optional string if_version_match = 2;
 
   // Operating system. This is required if no operating system reference is provided
-  OperatingSystem os = 3;
+  OperatingSystemConfig os = 3;
   // Can be used to reference an OS in the OS library based on a unique ID
   // string os_reference = 4;
 }

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -2319,7 +2319,7 @@ message TenantConfig {
   string tenant_organization_id = 1;
 
   // These fields have been used for OS configuration in the past.
-  // They are now replaced with the OperatingSystemConfig message.
+  // They are now replaced with the InstanceOperatingSystemConfig message.
   reserved 11, 12, 13, 14;
 
   optional string hostname = 15;
@@ -2329,7 +2329,7 @@ message TenantConfig {
   repeated string tenantKeysetIds = 8; // this may be empty
 }
 
-message OperatingSystemConfig {
+message InstanceOperatingSystemConfig {
   // Contains the operating system definition based on the variant of operating system
   oneof variant {
     InlineIpxe ipxe = 1;
@@ -2381,7 +2381,7 @@ message InstanceConfig {
   TenantConfig tenant = 1;
 
   // Operating system. This is required if no operating system reference is provided
-  OperatingSystemConfig os = 2;
+  InstanceOperatingSystemConfig os = 2;
   // Can be used to reference an OS in the OS library based on a unique ID
   // string os_reference = 3;
 
@@ -2466,7 +2466,7 @@ message InstanceOperatingSystemUpdateRequest {
   optional string if_version_match = 2;
 
   // Operating system. This is required if no operating system reference is provided
-  OperatingSystemConfig os = 3;
+  InstanceOperatingSystemConfig os = 3;
   // Can be used to reference an OS in the OS library based on a unique ID
   // string os_reference = 4;
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -531,7 +531,7 @@ impl From<JsonDnsResourceRecord> for Value {
     }
 }
 
-impl FromStr for forge::OperatingSystemConfig {
+impl FromStr for forge::InstanceOperatingSystemConfig {
     type Err = RpcDataConversionError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -807,8 +807,8 @@ mod tests {
 
     use carbide_uuid::machine::MachineId;
 
-    use self::forge::operating_system_config::Variant;
-    use self::forge::{InlineIpxe, OperatingSystemConfig};
+    use self::forge::instance_operating_system_config::Variant;
+    use self::forge::{InlineIpxe, InstanceOperatingSystemConfig};
     use super::*;
     use crate::protos::dns::{Domain, Metadata};
 
@@ -846,7 +846,7 @@ mod tests {
 
     #[test]
     fn test_serialize_os() {
-        let os = OperatingSystemConfig {
+        let os = InstanceOperatingSystemConfig {
             phone_home_enabled: true,
             run_provisioning_instructions_on_every_boot: true,
             user_data: Some("def".to_string()),

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -531,7 +531,7 @@ impl From<JsonDnsResourceRecord> for Value {
     }
 }
 
-impl FromStr for forge::OperatingSystem {
+impl FromStr for forge::OperatingSystemConfig {
     type Err = RpcDataConversionError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -807,8 +807,8 @@ mod tests {
 
     use carbide_uuid::machine::MachineId;
 
-    use self::forge::operating_system::Variant;
-    use self::forge::{InlineIpxe, OperatingSystem};
+    use self::forge::operating_system_config::Variant;
+    use self::forge::{InlineIpxe, OperatingSystemConfig};
     use super::*;
     use crate::protos::dns::{Domain, Metadata};
 
@@ -846,7 +846,7 @@ mod tests {
 
     #[test]
     fn test_serialize_os() {
-        let os = OperatingSystem {
+        let os = OperatingSystemConfig {
             phone_home_enabled: true,
             run_provisioning_instructions_on_every_boot: true,
             user_data: Some("def".to_string()),


### PR DESCRIPTION
## Description
Rename proto message OperatingSystem to InstanceOperatingSystemConfig for consistency. All other configuration objects for InstanceConfig has a Config suffix.

## Type of Change
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes: NO

## Testing
- [X] No testing required (docs, internal refactor, etc.)
