### PR TITLE
fix: handle the chassis id changing for Liteon PMCs in between firmware versions

### DIFF
--- a/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
+++ b/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
@@ -739,10 +739,17 @@ impl EndpointExplorer for BmcEndpointExplorer {
                 // Lite-On power shelf BMCs don't expose vendor details in the
                 // service root, so we fall back to checking the Manufacturer
                 // field across all Chassis entries.
-                let vendor = self
+                let vendor = match self
                     .redfish_client
                     .probe_vendor_name_from_chassis(bmc_ip_address, username, password)
-                    .await?;
+                    .await
+                {
+                    Ok(v) => v,
+                    Err(chassis_err) => {
+                        tracing::error!(%bmc_ip_address, "Failed to probe vendor from chassis: {chassis_err}");
+                        return Err(e);
+                    }
+                };
                 if !vendor.to_lowercase().contains("lite-on") {
                     return Err(e);
                 }

--- a/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
+++ b/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
@@ -736,17 +736,12 @@ impl EndpointExplorer for BmcEndpointExplorer {
                     }
                 };
 
-                // Lite-On power shelf BMCs use "chassis" as their Chassis ID,
-                // so that's the one we'll need to collect data from (we actually
-                // look at the Manufacturer name).
-                //
-                // TODO(chet): This hack was added for Lite-On power shelves,
-                // but I'd really like to try to at least make it some generic
-                // fallback eventually (although I think Lite-On is working on
-                // a fix on their side).
+                // Lite-On power shelf BMCs don't expose vendor details in the
+                // service root, so we fall back to checking the Manufacturer
+                // field across all Chassis entries.
                 let vendor = self
                     .redfish_client
-                    .probe_vendor_name_from_chassis(bmc_ip_address, username, password, "chassis")
+                    .probe_vendor_name_from_chassis(bmc_ip_address, username, password)
                     .await?;
                 if !vendor.to_lowercase().contains("lite-on") {
                     return Err(e);

--- a/crates/api/src/site_explorer/redfish.rs
+++ b/crates/api/src/site_explorer/redfish.rs
@@ -671,23 +671,18 @@ async fn is_switch(client: &dyn Redfish) -> Result<bool, RedfishError> {
 
 async fn is_powershelf(client: &dyn Redfish) -> Result<bool, RedfishError> {
     let chassis_ids = client.get_chassis_all().await?;
-    if chassis_ids.contains(&"powershelf".to_string()) {
-        return Ok(true);
-    }
-    // Some Lite-On power shelf BMCs use "chassis" as their chassis ID,
-    // so if we failed to find "powershelf" as the chassis ID, fall
-    // back to the other "chassis" chassis ID and check the manufacturer
-    // type.
-    // TODO(chet): This should be able to go away in a later update
-    // of the lite-on firmware.
-    if chassis_ids.contains(&"chassis".to_string())
-        && let Ok(chassis) = client.get_chassis("chassis").await
-        && chassis
-            .manufacturer
-            .as_ref()
-            .is_some_and(|m| m.to_lowercase().contains("lite-on"))
-    {
-        return Ok(true);
+    for chassis_id in &chassis_ids {
+        if chassis_id == "powershelf" {
+            return Ok(true);
+        }
+        if let Ok(chassis) = client.get_chassis(chassis_id).await
+            && chassis
+                .manufacturer
+                .as_ref()
+                .is_some_and(|m| m.to_lowercase().contains("lite-on"))
+        {
+            return Ok(true);
+        }
     }
     Ok(false)
 }

--- a/crates/api/src/site_explorer/redfish.rs
+++ b/crates/api/src/site_explorer/redfish.rs
@@ -638,7 +638,6 @@ impl RedfishClient {
         bmc_ip_address: SocketAddr,
         username: String,
         password: String,
-        chassis_id: &str,
     ) -> Result<String, EndpointExplorationError> {
         let client = self
             .create_authenticated_redfish_client(
@@ -648,14 +647,14 @@ impl RedfishClient {
             .await
             .map_err(map_redfish_client_creation_error)?;
 
-        let chassis_all = client.get_chassis_all().await.map_err(map_redfish_error)?;
-        if chassis_all.contains(&chassis_id.to_string()) {
+        let chassis_ids = client.get_chassis_all().await.map_err(map_redfish_error)?;
+        for chassis_id in &chassis_ids {
             let chassis = client
                 .get_chassis(chassis_id)
                 .await
                 .map_err(map_redfish_error)?;
-            if let Some(x) = chassis.manufacturer {
-                return Ok(x);
+            if let Some(manufacturer) = chassis.manufacturer {
+                return Ok(manufacturer);
             }
         }
 


### PR DESCRIPTION
## Description

fix: handle the chassis id changing for Liteon PMCs in between firmware versions

at r1.3.7 the chassis id for a Liteon PMC is 'chassis'
at r.1.3.8 and above, the chassis id for a Liteon PMC is 'powershelf'

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

