### PR TITLE
chore: bump libredfish to v0.43.9 to pull in changes to accurately query a powershelf's power state via the PMC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5658,7 +5658,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.43.8#ec4cd0bbe6fa0a433e1da623bdc99e743dab6c77"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.43.9#a2f873edee9a49494a05b737e49c9c4e6378761b"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.43.8" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.43.9" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.5" }
 ansi-to-html = "0.2.2"
 

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -1344,6 +1344,7 @@ impl From<PowerState> for rpc::site_explorer::PowerState {
             PowerState::PoweringOff => rpc::site_explorer::PowerState::PoweringOff,
             PowerState::PoweringOn => rpc::site_explorer::PowerState::PoweringOn,
             PowerState::Paused => rpc::site_explorer::PowerState::Paused,
+            PowerState::Unknown => rpc::site_explorer::PowerState::Unknown,
         }
     }
 }
@@ -1356,6 +1357,7 @@ pub enum PowerState {
     PoweringOff,
     PoweringOn,
     Paused,
+    Unknown,
 }
 
 /// `Manager` definition. Matches redfish definition
@@ -1745,6 +1747,7 @@ impl From<libredfish::PowerState> for PowerState {
             libredfish::PowerState::PoweringOn => PowerState::PoweringOn,
             libredfish::PowerState::Paused => PowerState::Paused,
             libredfish::PowerState::Reset => PowerState::PoweringOn,
+            libredfish::PowerState::Unknown => PowerState::Unknown,
         }
     }
 }

--- a/crates/api/src/state_controller/machine/handler/power.rs
+++ b/crates/api/src/state_controller/machine/handler/power.rs
@@ -227,7 +227,7 @@ async fn get_power_state(
         libredfish::PowerState::On | libredfish::PowerState::PoweringOn => {
             UsablePowerState::Usable(PowerState::On)
         }
-        libredfish::PowerState::Paused | libredfish::PowerState::Reset => {
+        libredfish::PowerState::Paused | libredfish::PowerState::Reset | libredfish::PowerState::Unknown => {
             UsablePowerState::NotUsable(power_state)
         }
     })

--- a/crates/api/src/state_controller/machine/handler/power.rs
+++ b/crates/api/src/state_controller/machine/handler/power.rs
@@ -227,8 +227,8 @@ async fn get_power_state(
         libredfish::PowerState::On | libredfish::PowerState::PoweringOn => {
             UsablePowerState::Usable(PowerState::On)
         }
-        libredfish::PowerState::Paused | libredfish::PowerState::Reset | libredfish::PowerState::Unknown => {
-            UsablePowerState::NotUsable(power_state)
-        }
+        libredfish::PowerState::Paused
+        | libredfish::PowerState::Reset
+        | libredfish::PowerState::Unknown => UsablePowerState::NotUsable(power_state),
     })
 }

--- a/crates/rpc/proto/site_explorer.proto
+++ b/crates/rpc/proto/site_explorer.proto
@@ -155,6 +155,7 @@ enum PowerState {
   PoweringOff = 2;
   PoweringOn = 3;
   Paused = 4;
+  Unknown = 5;
 }
 
 // `Manager` definition. Matches redfish definition


### PR DESCRIPTION
## Description

chore: bump libredfish to v0.43.9 to pull in changes to accurately query a powershelf's power state via the PMC

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

