### PR TITLE
Devspace build: Cache CARGO_HOME for faster rebuilds

### DIFF
--- a/dev/deployment/devspace/Dockerfile.api
+++ b/dev/deployment/devspace/Dockerfile.api
@@ -2,6 +2,7 @@
 
 FROM build-container-localdev AS builder
 
+ENV CARGO_HOME=/cargo-home
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 ENV CARGO_TARGET_DIR=/cargo-target
 
@@ -9,9 +10,8 @@ WORKDIR /workspace
 
 COPY . .
 
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-  --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-  --mount=type=cache,target=/cargo-target,sharing=locked \
+RUN --mount=type=cache,id=nico-devspace-cargo-home,target=/cargo-home,sharing=locked \
+  --mount=type=cache,id=nico-devspace-cargo-target,target=/cargo-target,sharing=locked \
   cargo build -p carbide-api --bin carbide-api --locked && \
   mkdir -p /artifacts && \
   cp /cargo-target/debug/carbide-api /artifacts/carbide-api

--- a/dev/deployment/devspace/Dockerfile.machine-a-tron
+++ b/dev/deployment/devspace/Dockerfile.machine-a-tron
@@ -2,6 +2,7 @@
 
 FROM build-container-localdev AS builder
 
+ENV CARGO_HOME=/cargo-home
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 ENV CARGO_TARGET_DIR=/cargo-target
 
@@ -9,9 +10,8 @@ WORKDIR /workspace
 
 COPY . .
 
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-  --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-  --mount=type=cache,target=/cargo-target,sharing=locked \
+RUN --mount=type=cache,id=nico-devspace-cargo-home,target=/cargo-home,sharing=locked \
+  --mount=type=cache,id=nico-devspace-cargo-target,target=/cargo-target,sharing=locked \
   cargo build -p carbide-machine-a-tron --bin machine-a-tron --locked && \
   mkdir -p /artifacts && \
   cp /cargo-target/debug/machine-a-tron /artifacts/machine-a-tron


### PR DESCRIPTION
## Description

Prior to this we were caching the registry and git folders, as well as cargo's target dir, but cargo still seemed to want to re-download dependencies every time you touch the code and rebuild. Caching CARGO_HOME instead of the registry/git folders is simpler and seems to work a lot better.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

