### PR TITLE
Doca hbn image name fix

### DIFF
--- a/crates/api/src/dpf_services.rs
+++ b/crates/api/src/dpf_services.rs
@@ -40,7 +40,7 @@ pub const DEFAULT_CARBIDE_IMAGE_REGISTRY: &str = "gitlab-master.nvidia.com/aadva
 pub const DOCA_HBN_SERVICE_NAME: &str = "doca-hbn";
 pub const DOCA_HBN_SERVICE_HELM_NAME: &str = "doca-hbn";
 pub const DOCA_HBN_SERVICE_HELM_VERSION: &str = "1.0.5";
-pub const DOCA_HBN_SERVICE_IMAGE_NAME: &str = "doca-hbn";
+pub const DOCA_HBN_SERVICE_IMAGE_NAME: &str = "doca_hbn";
 pub const DOCA_HBN_SERVICE_IMAGE_TAG: &str = "3.2.1-doca3.2.1";
 pub const DOCA_HBN_SERVICE_NETWORK: &str = "mybrhbn";
 

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -49,6 +49,15 @@ use crate::crds::dpuserviceconfigurations_generated::{
     DpuServiceConfigurationServiceConfigurationServiceDaemonSet, DpuServiceConfigurationSpec,
     DpuServiceConfigurationUpgradePolicy,
 };
+use crate::crds::dpuserviceinterfaces_generated::{
+    DPUServiceInterface, DpuServiceInterfaceSpec, DpuServiceInterfaceTemplate,
+    DpuServiceInterfaceTemplateSpec, DpuServiceInterfaceTemplateSpecTemplate,
+    DpuServiceInterfaceTemplateSpecTemplateMetadata, DpuServiceInterfaceTemplateSpecTemplateSpec,
+    DpuServiceInterfaceTemplateSpecTemplateSpecInterfaceType,
+    DpuServiceInterfaceTemplateSpecTemplateSpecPf,
+    DpuServiceInterfaceTemplateSpecTemplateSpecPhysical,
+    DpuServiceInterfaceTemplateSpecTemplateSpecVf,
+};
 use crate::crds::dpuservicenads_generated::{
     DPUServiceNAD, DpuServiceNadResourceType, DpuServiceNadSpec,
 };
@@ -620,6 +629,7 @@ fn build_deployment<L: ResourceLabeler>(
     flavor_name: &str,
     namespace: &str,
     labeler: &L,
+    interfaces: &[DpuServiceInterfaceTemplateDefinition],
 ) -> DPUDeployment {
     let services_map: BTreeMap<String, DpuDeploymentServices> = services
         .iter()
@@ -635,66 +645,37 @@ fn build_deployment<L: ResourceLabeler>(
         })
         .collect();
 
-    let all_switches: Vec<DpuDeploymentServiceChainsSwitches> = vec![
-        DpuDeploymentServiceChainsSwitches {
-            ports: vec![
-                DpuDeploymentServiceChainsSwitchesPorts {
-                    service_interface: Some(
-                        DpuDeploymentServiceChainsSwitchesPortsServiceInterface {
-                            match_labels: BTreeMap::from([(
-                                "interface".to_string(),
-                                "p0".to_string(),
-                            )]),
-                            ipam: None,
-                        },
-                    ),
-                    service: None,
-                },
-                DpuDeploymentServiceChainsSwitchesPorts {
-                    service_interface: None,
-                    service: Some(DpuDeploymentServiceChainsSwitchesPortsService {
-                        name: "doca-hbn".to_string(),
-                        interface: "p0_if".to_string(),
-                        ipam: None,
-                    }),
-                },
-            ],
+    let active_interfaces = &interfaces[0..2];
+    let mut all_switches = Vec::new();
+    for iface in active_interfaces {
+        let Some(chained_svc_if) = iface.chained_svc_if.as_ref() else {
+            continue;
+        };
+
+        let mut ports = vec![DpuDeploymentServiceChainsSwitchesPorts {
+            service_interface: Some(DpuDeploymentServiceChainsSwitchesPortsServiceInterface {
+                match_labels: BTreeMap::from([("interface".to_string(), iface.name.clone())]),
+                ipam: None,
+            }),
+            service: None,
+        }];
+
+        for (service_name, chain_ifname) in chained_svc_if {
+            ports.push(DpuDeploymentServiceChainsSwitchesPorts {
+                service_interface: None,
+                service: Some(DpuDeploymentServiceChainsSwitchesPortsService {
+                    name: service_name.clone(),
+                    interface: chain_ifname.clone(),
+                    ipam: None,
+                }),
+            });
+        }
+
+        all_switches.push(DpuDeploymentServiceChainsSwitches {
+            ports,
             service_mtu: None,
-        },
-        DpuDeploymentServiceChainsSwitches {
-            ports: vec![
-                DpuDeploymentServiceChainsSwitchesPorts {
-                    service_interface: Some(
-                        DpuDeploymentServiceChainsSwitchesPortsServiceInterface {
-                            match_labels: BTreeMap::from([(
-                                "interface".to_string(),
-                                "pf0hpf".to_string(),
-                            )]),
-                            ipam: None,
-                        },
-                    ),
-                    service: None,
-                },
-                DpuDeploymentServiceChainsSwitchesPorts {
-                    service_interface: None,
-                    service: Some(DpuDeploymentServiceChainsSwitchesPortsService {
-                        name: "doca-hbn".to_string(),
-                        interface: "pf0hpf_if".to_string(),
-                        ipam: None,
-                    }),
-                },
-                DpuDeploymentServiceChainsSwitchesPorts {
-                    service_interface: None,
-                    service: Some(DpuDeploymentServiceChainsSwitchesPortsService {
-                        name: "carbide-dhcp-server".to_string(),
-                        interface: "d_pf0hpf_if".to_string(),
-                        ipam: None,
-                    }),
-                },
-            ],
-            service_mtu: None,
-        },
-    ];
+        });
+    }
 
     let service_chains = if all_switches.is_empty() {
         None
@@ -752,150 +733,191 @@ fn build_deployment<L: ResourceLabeler>(
     }
 }
 
-/// Build each standard DPU service interface template and apply it to the repository in one pass.
-pub async fn apply_service_interface_templates<
-    R: crate::repository::DpuServiceInterfaceRepository,
->(
-    repo: &R,
-    namespace: &str,
-) -> Result<(), crate::error::DpfError> {
-    use kube::core::ObjectMeta;
-
-    use crate::crds::dpuserviceinterfaces_generated::{
-        DPUServiceInterface, DpuServiceInterfaceSpec, DpuServiceInterfaceTemplate,
-        DpuServiceInterfaceTemplateSpec, DpuServiceInterfaceTemplateSpecTemplate,
-        DpuServiceInterfaceTemplateSpecTemplateMetadata,
-        DpuServiceInterfaceTemplateSpecTemplateSpec,
-        DpuServiceInterfaceTemplateSpecTemplateSpecInterfaceType,
-        DpuServiceInterfaceTemplateSpecTemplateSpecPf,
-        DpuServiceInterfaceTemplateSpecTemplateSpecPhysical,
-        DpuServiceInterfaceTemplateSpecTemplateSpecVf,
-    };
-
+pub fn build_dpu_interfaces_vec() -> Vec<DpuServiceInterfaceTemplateDefinition> {
     let interfaces: Vec<DpuServiceInterfaceTemplateDefinition> = vec![
         DpuServiceInterfaceTemplateDefinition {
             name: "p0".into(),
             iface_type: DpuServiceInterfaceTemplateType::Physical,
             pf_id: 0,
             vf_id: 0,
-        },
-        DpuServiceInterfaceTemplateDefinition {
-            name: "p1".into(),
-            iface_type: DpuServiceInterfaceTemplateType::Physical,
-            pf_id: 1,
-            vf_id: 0,
+            chained_svc_if: Some(vec![("doca-hbn".into(), "p0_if".into())]),
         },
         DpuServiceInterfaceTemplateDefinition {
             name: "pf0hpf".into(),
             iface_type: DpuServiceInterfaceTemplateType::Pf,
             pf_id: 0,
             vf_id: 0,
-        },
-        DpuServiceInterfaceTemplateDefinition {
-            name: "pf1hpf".into(),
-            iface_type: DpuServiceInterfaceTemplateType::Pf,
-            pf_id: 1,
-            vf_id: 0,
+            chained_svc_if: Some(vec![
+                ("doca-hbn".into(), "pf0hpf_if".into()),
+                ("carbide-dhcp-server".into(), "d_pf0hpf_if".into()),
+            ]),
         },
         DpuServiceInterfaceTemplateDefinition {
             name: "pf0vf0".into(),
             iface_type: DpuServiceInterfaceTemplateType::Vf,
             pf_id: 0,
             vf_id: 0,
+            chained_svc_if: Some(vec![
+                ("doca-hbn".into(), "pf0vf0_if".into()),
+                ("carbide-dhcp-server".into(), "d_pf0vf0_if".into()),
+            ]),
         },
         DpuServiceInterfaceTemplateDefinition {
             name: "pf0vf1".into(),
             iface_type: DpuServiceInterfaceTemplateType::Vf,
             pf_id: 0,
             vf_id: 1,
+            chained_svc_if: Some(vec![
+                ("doca-hbn".into(), "pf0vf1_if".into()),
+                ("carbide-dhcp-server".into(), "d_pf0vf1_if".into()),
+            ]),
         },
         DpuServiceInterfaceTemplateDefinition {
             name: "pf0vf2".into(),
             iface_type: DpuServiceInterfaceTemplateType::Vf,
             pf_id: 0,
             vf_id: 2,
+            chained_svc_if: Some(vec![
+                ("doca-hbn".into(), "pf0vf2_if".into()),
+                ("carbide-dhcp-server".into(), "d_pf0vf2_if".into()),
+            ]),
         },
         DpuServiceInterfaceTemplateDefinition {
             name: "pf0vf3".into(),
             iface_type: DpuServiceInterfaceTemplateType::Vf,
             pf_id: 0,
             vf_id: 3,
+            chained_svc_if: Some(vec![
+                ("doca-hbn".into(), "pf0vf3_if".into()),
+                ("carbide-dhcp-server".into(), "d_pf0vf3_if".into()),
+            ]),
         },
         DpuServiceInterfaceTemplateDefinition {
             name: "pf0vf4".into(),
             iface_type: DpuServiceInterfaceTemplateType::Vf,
             pf_id: 0,
             vf_id: 4,
+            chained_svc_if: Some(vec![
+                ("doca-hbn".into(), "pf0vf4_if".into()),
+                ("carbide-dhcp-server".into(), "d_pf0vf4_if".into()),
+            ]),
         },
         DpuServiceInterfaceTemplateDefinition {
             name: "pf0vf5".into(),
             iface_type: DpuServiceInterfaceTemplateType::Vf,
             pf_id: 0,
             vf_id: 5,
+            chained_svc_if: Some(vec![
+                ("doca-hbn".into(), "pf0vf5_if".into()),
+                ("carbide-dhcp-server".into(), "d_pf0vf5_if".into()),
+            ]),
         },
         DpuServiceInterfaceTemplateDefinition {
             name: "pf0vf6".into(),
             iface_type: DpuServiceInterfaceTemplateType::Vf,
             pf_id: 0,
             vf_id: 6,
+            chained_svc_if: Some(vec![
+                ("doca-hbn".into(), "pf0vf6_if".into()),
+                ("carbide-dhcp-server".into(), "d_pf0vf6_if".into()),
+            ]),
         },
         DpuServiceInterfaceTemplateDefinition {
             name: "pf0vf7".into(),
             iface_type: DpuServiceInterfaceTemplateType::Vf,
             pf_id: 0,
             vf_id: 7,
+            chained_svc_if: Some(vec![
+                ("doca-hbn".into(), "pf0vf7_if".into()),
+                ("carbide-dhcp-server".into(), "d_pf0vf7_if".into()),
+            ]),
+        },
+        DpuServiceInterfaceTemplateDefinition {
+            name: "p1".into(),
+            iface_type: DpuServiceInterfaceTemplateType::Physical,
+            pf_id: 1,
+            vf_id: 0,
+            chained_svc_if: Some(vec![("doca-hbn".into(), "p1_if".into())]),
+        },
+        DpuServiceInterfaceTemplateDefinition {
+            name: "pf1hpf".into(),
+            iface_type: DpuServiceInterfaceTemplateType::Pf,
+            pf_id: 1,
+            vf_id: 0,
+            chained_svc_if: Some(vec![("doca-hbn".into(), "pf1hpf_if".into())]),
         },
         DpuServiceInterfaceTemplateDefinition {
             name: "pf1vf0".into(),
             iface_type: DpuServiceInterfaceTemplateType::Vf,
             pf_id: 1,
             vf_id: 0,
+            chained_svc_if: Some(vec![("doca-hbn".into(), "pf1vf0_if".into())]),
         },
         DpuServiceInterfaceTemplateDefinition {
             name: "pf1vf1".into(),
             iface_type: DpuServiceInterfaceTemplateType::Vf,
             pf_id: 1,
             vf_id: 1,
+            chained_svc_if: Some(vec![("doca-hbn".into(), "pf1vf1_if".into())]),
         },
         DpuServiceInterfaceTemplateDefinition {
             name: "pf1vf2".into(),
             iface_type: DpuServiceInterfaceTemplateType::Vf,
             pf_id: 1,
             vf_id: 2,
+            chained_svc_if: Some(vec![("doca-hbn".into(), "pf1vf2_if".into())]),
         },
         DpuServiceInterfaceTemplateDefinition {
             name: "pf1vf3".into(),
             iface_type: DpuServiceInterfaceTemplateType::Vf,
             pf_id: 1,
             vf_id: 3,
+            chained_svc_if: Some(vec![("doca-hbn".into(), "pf1vf3_if".into())]),
         },
         DpuServiceInterfaceTemplateDefinition {
             name: "pf1vf4".into(),
             iface_type: DpuServiceInterfaceTemplateType::Vf,
             pf_id: 1,
             vf_id: 4,
+            chained_svc_if: Some(vec![("doca-hbn".into(), "pf1vf4_if".into())]),
         },
         DpuServiceInterfaceTemplateDefinition {
             name: "pf1vf5".into(),
             iface_type: DpuServiceInterfaceTemplateType::Vf,
             pf_id: 1,
             vf_id: 5,
+            chained_svc_if: Some(vec![("doca-hbn".into(), "pf1vf5_if".into())]),
         },
         DpuServiceInterfaceTemplateDefinition {
             name: "pf1vf6".into(),
             iface_type: DpuServiceInterfaceTemplateType::Vf,
             pf_id: 1,
             vf_id: 6,
+            chained_svc_if: Some(vec![("doca-hbn".into(), "pf1vf6_if".into())]),
         },
         DpuServiceInterfaceTemplateDefinition {
             name: "pf1vf7".into(),
             iface_type: DpuServiceInterfaceTemplateType::Vf,
             pf_id: 1,
             vf_id: 7,
+            chained_svc_if: Some(vec![("doca-hbn".into(), "pf1vf7_if".into())]),
         },
     ];
 
-    let active_interfaces = &interfaces[0..4];
+    interfaces
+}
+
+/// Build each standard DPU service interface template and apply it to the repository in one pass.
+pub async fn apply_service_interface_templates<
+    R: crate::repository::DpuServiceInterfaceRepository,
+>(
+    repo: &R,
+    namespace: &str,
+    interfaces: &[DpuServiceInterfaceTemplateDefinition],
+) -> Result<(), crate::error::DpfError> {
+    use kube::core::ObjectMeta;
+
+    let active_interfaces = &interfaces[0..2];
 
     for iface in active_interfaces {
         let (interface_type, physical, pf, vf) = match iface.iface_type {
@@ -995,7 +1017,9 @@ async fn create_flavor_services_and_deployment<
 ) -> Result<(), DpfError> {
     create_dpu_flavor(repo, namespace, default_flavor_name).await?;
 
-    apply_service_interface_templates(repo, namespace).await?;
+    let interfaces = build_dpu_interfaces_vec();
+
+    apply_service_interface_templates(repo, namespace, &interfaces).await?;
 
     for svc in services {
         DpuServiceTemplateRepository::apply(repo, &build_service_template(svc, namespace)).await?;
@@ -1016,6 +1040,7 @@ async fn create_flavor_services_and_deployment<
         default_flavor_name,
         namespace,
         labeler,
+        &interfaces,
     );
     DpuDeploymentRepository::apply(repo, &deployment).await?;
     Ok(())

--- a/crates/dpf/src/test/sdk_initialization.rs
+++ b/crates/dpf/src/test/sdk_initialization.rs
@@ -39,7 +39,7 @@ use crate::repository::{
 };
 use crate::types::*;
 
-const TEST_NS: &str = "sdk-init-ns";
+const TEST_NS: &str = "dpf-operator-system";
 
 fn ns_key(ns: &str, name: &str) -> String {
     format!("{}/{}", ns, name)

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -156,6 +156,8 @@ pub struct DpuServiceInterfaceTemplateDefinition {
     pub pf_id: i64,
     /// VF Interface ID
     pub vf_id: i64,
+    /// Chained service interfaces vector
+    pub chained_svc_if: Option<Vec<(String, String)>>,
 }
 
 /// Network interface for a DPU service.


### PR DESCRIPTION
## Description
Fix the image name specified for the hbn container from "doca-hbn" to "doca_hbn"

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

