### PR TITLE
feat: fix managed switch cli

### DIFF
--- a/crates/admin-cli/src/managed_switch/show/cmd.rs
+++ b/crates/admin-cli/src/managed_switch/show/cmd.rs
@@ -81,6 +81,10 @@ fn build_managed_switch_outputs(
             .as_ref()
             .and_then(|id| switch_map.get(&id.to_string()));
 
+        if switch.is_none() {
+            continue;
+        }
+
         let switch_id_str = linked_switch.switch_id.as_ref().map(|id| id.to_string());
 
         if let Some(ref id) = switch_id_str {


### PR DESCRIPTION
`ms show` was showing always first fetched switch. After the fix it will show queried switch

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

