### PR TITLE
Fix DPU Flavor and HBN image name

### DIFF
--- a/crates/api/src/dpf_services.rs
+++ b/crates/api/src/dpf_services.rs
@@ -40,7 +40,7 @@ pub const DEFAULT_CARBIDE_IMAGE_REGISTRY: &str = "gitlab-master.nvidia.com/aadva
 pub const DOCA_HBN_SERVICE_NAME: &str = "doca-hbn";
 pub const DOCA_HBN_SERVICE_HELM_NAME: &str = "doca-hbn";
 pub const DOCA_HBN_SERVICE_HELM_VERSION: &str = "1.0.5";
-pub const DOCA_HBN_SERVICE_IMAGE_NAME: &str = "doca-hbn";
+pub const DOCA_HBN_SERVICE_IMAGE_NAME: &str = "doca_hbn";
 pub const DOCA_HBN_SERVICE_IMAGE_TAG: &str = "3.2.1-doca3.2.1";
 pub const DOCA_HBN_SERVICE_NETWORK: &str = "mybrhbn";
 

--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -54,8 +54,6 @@ fn get_default_ovs_defaults() -> String {
 /// Build the default DPUFlavor CR.
 pub fn default_flavor(namespace: &str, name: &str) -> DPUFlavor {
     let bfcfg_parameters = vec![
-        "ENABLE_BR_HBN=yes".to_string(),
-        "ENABLE_BR_SFC=yes".to_string(),
         "UPDATE_ATF_UEFI=yes".to_string(),
         "UPDATE_DPU_OS=yes".to_string(),
         "WITH_NIC_FW_UPDATE=yes".to_string(),


### PR DESCRIPTION
## Description
- Fix the DPU flavor to default one
- Fix the HBN image name from "doca-hbn" to "doca_hbn"

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

