### PR TITLE
feat: support for default rack firmware identifier

### DIFF
--- a/crates/admin-cli/src/rack_firmware/create/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/create/cmd.rs
@@ -40,6 +40,7 @@ pub async fn create(
             .map(|t| t.value.as_str())
             .unwrap_or("N/A");
         table.add_row(row!["Hardware Type", hw_type]);
+        table.add_row(row!["Default", result.is_default]);
         table.add_row(row!["Available", result.available]);
         table.add_row(row!["Created", result.created]);
         table.printstd();

--- a/crates/admin-cli/src/rack_firmware/get/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/get/cmd.rs
@@ -50,6 +50,7 @@ pub async fn get(
             .map(|t| t.value.as_str())
             .unwrap_or("N/A");
         table.add_row(row!["Hardware Type", hw_type]);
+        table.add_row(row!["Default", result.is_default]);
         table.add_row(row!["Available", result.available]);
         table.add_row(row!["Created", result.created]);
         table.add_row(row!["Updated", result.updated]);

--- a/crates/admin-cli/src/rack_firmware/list/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/list/cmd.rs
@@ -37,6 +37,7 @@ pub async fn list(
         table.set_titles(Row::new(vec![
             Cell::new("ID"),
             Cell::new("Hardware Type"),
+            Cell::new("Default"),
             Cell::new("Available"),
             Cell::new("Created"),
             Cell::new("Updated"),
@@ -48,9 +49,11 @@ pub async fn list(
                 .as_ref()
                 .map(|t| t.value.as_str())
                 .unwrap_or("N/A");
+            let default_marker = if config.is_default { "*" } else { "" };
             table.add_row(Row::new(vec![
                 Cell::new(&config.id),
                 Cell::new(hw_type),
+                Cell::new(default_marker),
                 Cell::new(&config.available.to_string()),
                 Cell::new(&config.created),
                 Cell::new(&config.updated),

--- a/crates/admin-cli/src/rack_firmware/mod.rs
+++ b/crates/admin-cli/src/rack_firmware/mod.rs
@@ -21,6 +21,7 @@ mod delete;
 mod get;
 mod history;
 mod list;
+mod set_default;
 mod status;
 
 #[cfg(test)]
@@ -52,4 +53,7 @@ pub enum Cmd {
 
     #[clap(about = "Show history of rack firmware apply operations")]
     History(history::Args),
+
+    #[clap(about = "Set a firmware configuration as the default for its hardware type")]
+    SetDefault(set_default::Args),
 }

--- a/crates/admin-cli/src/rack_firmware/set_default/args.rs
+++ b/crates/admin-cli/src/rack_firmware/set_default/args.rs
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+pub struct Args {
+    #[clap(help = "Firmware configuration ID to set as default.")]
+    pub firmware_id: String,
+}
+
+impl From<Args> for rpc::forge::RackFirmwareSetDefaultRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            firmware_id: args.firmware_id,
+        }
+    }
+}

--- a/crates/admin-cli/src/rack_firmware/set_default/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/set_default/cmd.rs
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::CarbideCliError;
+
+use super::args::Args;
+use crate::rpc::ApiClient;
+
+pub async fn set_default(opts: Args, api_client: &ApiClient) -> Result<(), CarbideCliError> {
+    let firmware_id = opts.firmware_id.clone();
+    api_client.0.rack_firmware_set_default(opts).await?;
+    println!("Set firmware '{}' as default.", firmware_id);
+    Ok(())
+}

--- a/crates/admin-cli/src/rack_firmware/set_default/mod.rs
+++ b/crates/admin-cli/src/rack_firmware/set_default/mod.rs
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::set_default(self, &ctx.api_client).await?;
+        Ok(())
+    }
+}

--- a/crates/admin-cli/src/rack_firmware/tests.rs
+++ b/crates/admin-cli/src/rack_firmware/tests.rs
@@ -128,3 +128,24 @@ fn parse_delete_missing_id_fails() {
     let result = Cmd::try_parse_from(["rack-firmware", "delete"]);
     assert!(result.is_err(), "should fail without id");
 }
+
+// parse_set_default ensures set-default parses with firmware ID.
+#[test]
+fn parse_set_default() {
+    let cmd = Cmd::try_parse_from(["rack-firmware", "set-default", "fw-001"])
+        .expect("should parse set-default");
+
+    match cmd {
+        Cmd::SetDefault(args) => {
+            assert_eq!(args.firmware_id, "fw-001");
+        }
+        _ => panic!("expected SetDefault variant"),
+    }
+}
+
+// parse_set_default_missing_id_fails ensures set-default fails without ID.
+#[test]
+fn parse_set_default_missing_id_fails() {
+    let result = Cmd::try_parse_from(["rack-firmware", "set-default"]);
+    assert!(result.is_err(), "should fail without firmware_id");
+}

--- a/crates/api-db/migrations/20260414062505_rack_firmware_is_default.sql
+++ b/crates/api-db/migrations/20260414062505_rack_firmware_is_default.sql
@@ -1,0 +1,7 @@
+-- Add is_default flag to rack_firmware table.
+-- Defaults to false for existing rows.
+ALTER TABLE rack_firmware ADD COLUMN is_default BOOLEAN NOT NULL DEFAULT false;
+
+-- Enforce at most one default per rack_hardware_type.
+CREATE UNIQUE INDEX idx_rack_firmware_one_default_per_type
+    ON rack_firmware (rack_hardware_type) WHERE is_default = true;

--- a/crates/api-db/src/rack_firmware.rs
+++ b/crates/api-db/src/rack_firmware.rs
@@ -215,6 +215,44 @@ pub async fn set_available(
         .map_err(|e| DatabaseError::new(query, e))
 }
 
+/// Returns true if there is already a default firmware for the given rack_hardware_type.
+pub async fn has_default(
+    txn: &mut PgConnection,
+    rack_hardware_type: &RackHardwareType,
+) -> DatabaseResult<bool> {
+    let query = "SELECT EXISTS(SELECT 1 FROM rack_firmware WHERE rack_hardware_type = $1 AND is_default = true)";
+    let (exists,) = sqlx::query_as(query)
+        .bind(rack_hardware_type)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::new(query, e))?;
+    Ok(exists)
+}
+
+/// Sets the given firmware as the default for its rack_hardware_type.
+/// Clears any previous default for the same rack_hardware_type.
+pub async fn set_default(txn: &mut PgConnection, id: &str) -> DatabaseResult<RackFirmware> {
+    // First, get the firmware to learn its rack_hardware_type.
+    let fw = find_by_id(&mut *txn, id).await?;
+
+    // Clear previous default for this rack_hardware_type.
+    let clear_query = "UPDATE rack_firmware SET is_default = false WHERE rack_hardware_type = $1";
+    sqlx::query(clear_query)
+        .bind(&fw.rack_hardware_type)
+        .execute(&mut *txn)
+        .await
+        .map_err(|e| DatabaseError::new(clear_query, e))?;
+
+    // Set this one as default.
+    let set_query =
+        "UPDATE rack_firmware SET is_default = true, updated = NOW() WHERE id = $1 RETURNING *";
+    sqlx::query_as(set_query)
+        .bind(id)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::new(set_query, e))
+}
+
 pub async fn delete(txn: &mut PgConnection, id: &str) -> DatabaseResult<()> {
     let query = "DELETE FROM rack_firmware WHERE id = $1 RETURNING id";
 
@@ -362,5 +400,144 @@ mod tests {
         assert_eq!(history.len(), 1);
         assert_eq!(history[0].firmware_id, "fw-ghost");
         assert!(!history[0].firmware_available);
+    }
+
+    #[crate::sqlx_test]
+    async fn test_create_firmware_defaults_to_not_default(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+
+        let fw = create(
+            &mut txn,
+            "fw-010",
+            RackHardwareType::any(),
+            json!({"Id": "fw-010"}),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(!fw.is_default);
+    }
+
+    #[crate::sqlx_test]
+    async fn test_has_default_returns_false_when_none_set(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+
+        create(
+            &mut txn,
+            "fw-011",
+            RackHardwareType::any(),
+            json!({"Id": "fw-011"}),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            !has_default(&mut txn, &RackHardwareType::any())
+                .await
+                .unwrap()
+        );
+    }
+
+    #[crate::sqlx_test]
+    async fn test_set_default_and_has_default(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+
+        create(
+            &mut txn,
+            "fw-012",
+            RackHardwareType::any(),
+            json!({"Id": "fw-012"}),
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Set as default.
+        let fw = set_default(&mut txn, "fw-012").await.unwrap();
+        assert!(fw.is_default);
+
+        // has_default should now return true.
+        assert!(
+            has_default(&mut txn, &RackHardwareType::any())
+                .await
+                .unwrap()
+        );
+    }
+
+    #[crate::sqlx_test]
+    async fn test_set_default_clears_previous_default(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+
+        let hw_type = RackHardwareType::from("test-type");
+
+        create(
+            &mut txn,
+            "fw-a",
+            hw_type.clone(),
+            json!({"Id": "fw-a"}),
+            None,
+        )
+        .await
+        .unwrap();
+        create(
+            &mut txn,
+            "fw-b",
+            hw_type.clone(),
+            json!({"Id": "fw-b"}),
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Set fw-a as default.
+        set_default(&mut txn, "fw-a").await.unwrap();
+        let a = find_by_id(&mut *txn, "fw-a").await.unwrap();
+        assert!(a.is_default);
+
+        // Set fw-b as default — fw-a should lose default.
+        set_default(&mut txn, "fw-b").await.unwrap();
+        let a = find_by_id(&mut *txn, "fw-a").await.unwrap();
+        let b = find_by_id(&mut *txn, "fw-b").await.unwrap();
+        assert!(!a.is_default);
+        assert!(b.is_default);
+    }
+
+    #[crate::sqlx_test]
+    async fn test_set_default_does_not_affect_other_hardware_types(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+
+        let type_a = RackHardwareType::from("type-a");
+        let type_b = RackHardwareType::from("type-b");
+
+        create(
+            &mut txn,
+            "fw-x",
+            type_a.clone(),
+            json!({"Id": "fw-x"}),
+            None,
+        )
+        .await
+        .unwrap();
+        create(
+            &mut txn,
+            "fw-y",
+            type_b.clone(),
+            json!({"Id": "fw-y"}),
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Set both as default for their respective types.
+        set_default(&mut txn, "fw-x").await.unwrap();
+        set_default(&mut txn, "fw-y").await.unwrap();
+
+        // Both should be default (different hardware types).
+        let x = find_by_id(&mut *txn, "fw-x").await.unwrap();
+        let y = find_by_id(&mut *txn, "fw-y").await.unwrap();
+        assert!(x.is_default);
+        assert!(y.is_default);
     }
 }

--- a/crates/api-model/src/rack_firmware.rs
+++ b/crates/api-model/src/rack_firmware.rs
@@ -29,6 +29,7 @@ pub struct RackFirmware {
     pub rack_hardware_type: RackHardwareType,
     pub config: Json<serde_json::Value>,
     pub available: bool,
+    pub is_default: bool,
     pub parsed_components: Option<Json<serde_json::Value>>,
     pub created: DateTime<Utc>,
     pub updated: DateTime<Utc>,
@@ -41,6 +42,7 @@ impl<'r> FromRow<'r, PgRow> for RackFirmware {
             rack_hardware_type: row.try_get("rack_hardware_type")?,
             config: row.try_get("config")?,
             available: row.try_get("available")?,
+            is_default: row.try_get("is_default")?,
             parsed_components: row.try_get("parsed_components")?,
             created: row.try_get("created")?,
             updated: row.try_get("updated")?,
@@ -64,6 +66,7 @@ impl From<&RackFirmware> for rpc::forge::RackFirmware {
             updated: db.updated.format("%Y-%m-%d %H:%M:%S").to_string(),
             parsed_components,
             rack_hardware_type: Some(db.rack_hardware_type.clone().into()),
+            is_default: db.is_default,
         }
     }
 }

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -1459,6 +1459,13 @@ impl Forge for Api {
         crate::handlers::rack_firmware::get_history(self, request).await
     }
 
+    async fn rack_firmware_set_default(
+        &self,
+        request: tonic::Request<rpc::RackFirmwareSetDefaultRequest>,
+    ) -> Result<Response<()>, tonic::Status> {
+        crate::handlers::rack_firmware::set_default(self, request).await
+    }
+
     async fn get_expected_power_shelf(
         &self,
         request: Request<rpc::ExpectedPowerShelfRequest>,

--- a/crates/api/src/auth/internal_rbac_rules.rs
+++ b/crates/api/src/auth/internal_rbac_rules.rs
@@ -418,6 +418,7 @@ impl InternalRBACRules {
         x.perm("ApplyRackFirmware", vec![ForgeAdminCLI]);
         x.perm("GetRackFirmwareJobStatus", vec![ForgeAdminCLI]);
         x.perm("GetRackFirmwareHistory", vec![ForgeAdminCLI]);
+        x.perm("RackFirmwareSetDefault", vec![ForgeAdminCLI]);
         x.perm("RebootCompleted", vec![Machineatron, Scout]);
         x.perm("PersistValidationResult", vec![Scout]);
         x.perm("GetMachineValidationResults", vec![ForgeAdminCLI, Scout]);

--- a/crates/api/src/handlers/rack_firmware.rs
+++ b/crates/api/src/handlers/rack_firmware.rs
@@ -25,7 +25,7 @@ use rpc::forge::{
     RackFirmwareApplyResponse, RackFirmwareCreateRequest, RackFirmwareDeleteRequest,
     RackFirmwareGetRequest, RackFirmwareHistoryRecords, RackFirmwareHistoryRequest,
     RackFirmwareHistoryResponse, RackFirmwareJobStatusRequest, RackFirmwareJobStatusResponse,
-    RackFirmwareList, RackFirmwareSearchFilter,
+    RackFirmwareList, RackFirmwareSearchFilter, RackFirmwareSetDefaultRequest,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -339,9 +339,24 @@ pub async fn create(
         .ok_or_else(|| CarbideError::MissingArgument("rack_hardware_type"))?
         .into();
 
-    let db_config =
-        rack_firmware_db::create(&mut txn, &id, rack_hardware_type, config, parsed_components)
-            .await?;
+    let mut db_config = rack_firmware_db::create(
+        &mut txn,
+        &id,
+        rack_hardware_type.clone(),
+        config,
+        parsed_components,
+    )
+    .await?;
+
+    // Auto-set as default if no default exists for this rack_hardware_type.
+    if !rack_firmware_db::has_default(&mut txn, &rack_hardware_type).await? {
+        db_config = rack_firmware_db::set_default(&mut txn, &id).await?;
+        tracing::info!(
+            firmware_id = %id,
+            rack_hardware_type = %rack_hardware_type,
+            "Auto-set as default firmware (first for this rack hardware type)."
+        );
+    }
 
     txn.commit()
         .await
@@ -1441,4 +1456,30 @@ pub async fn get_history(
         .collect();
 
     Ok(Response::new(RackFirmwareHistoryResponse { histories }))
+}
+
+/// Set a rack firmware configuration as the default for its rack hardware type.
+pub async fn set_default(
+    api: &Api,
+    request: Request<RackFirmwareSetDefaultRequest>,
+) -> Result<Response<()>, Status> {
+    let req = request.into_inner();
+
+    if req.firmware_id.is_empty() {
+        return Err(CarbideError::InvalidArgument("firmware_id is required".to_string()).into());
+    }
+
+    let mut txn = api
+        .database_connection
+        .begin()
+        .await
+        .map_err(|e| CarbideError::from(DatabaseError::new("begin set_default", e)))?;
+
+    rack_firmware_db::set_default(&mut txn, &req.firmware_id).await?;
+
+    txn.commit()
+        .await
+        .map_err(|e| CarbideError::from(DatabaseError::new("commit set_default", e)))?;
+
+    Ok(Response::new(()))
 }

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -375,6 +375,7 @@ service Forge {
   rpc GetRackFirmwareJobStatus(RackFirmwareJobStatusRequest) returns (RackFirmwareJobStatusResponse);
   // Get the history of rack firmware apply operations
   rpc GetRackFirmwareHistory(RackFirmwareHistoryRequest) returns (RackFirmwareHistoryResponse);
+  rpc RackFirmwareSetDefault(RackFirmwareSetDefaultRequest) returns (google.protobuf.Empty);
 
   // Replace all expected machines in site
   rpc ReplaceAllExpectedMachines(ExpectedMachineList) returns (google.protobuf.Empty);
@@ -7203,6 +7204,11 @@ message RackFirmware {
   string updated = 5;
   string parsed_components = 6; // JSON string of firmware lookup table
   common.RackHardwareType rack_hardware_type = 7;
+  bool is_default = 8;
+}
+
+message RackFirmwareSetDefaultRequest {
+  string firmware_id = 1;
 }
 
 message FirmwareComponentInfo {


### PR DESCRIPTION
## Description

This introduces a new `is_default` identifier for rack firmware.

Now, when you `rack-firmware create` for a given `RackHardwareType`, if it's the first instance of firmware for that hardware type (or there's no default firmware yet), it will set `is_default = true` for that firmware. You can then `rack-firmware set-default <firmware-id>` to set new default firmware. Since firmware is specific to a `RackHardwareType`, there's no need to specify anything other than the `<firmware-id>` you want to make default.

A unique index is put in place to ensure that a given `rack_hardware_type` can only have 1 default firmware.

Tests included to ensure:
- New firmware starts with `is_default = false`.
- `has_default()` returns false when no default exists.
- Setting a default works, and `has_default()` reflects it accordingly.
- Setting a new default for the same hardware type clears the old one.
- Defaults for different hardware types are independent (as in, the constraint works).

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

