### PR TITLE
Add an RPC endpoint to report scout firmware upgrade status

### DIFF
--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1576,6 +1576,22 @@ pub enum HostReprovisionState {
         reason: Option<String>,
     },
     WaitingForRackFirmwareUpgrade,
+    WaitingForScoutUpgrade {
+        component_type: FirmwareComponentType,
+        target_version: String,
+        started_at: DateTime<Utc>,
+        #[serde(default)]
+        result: Option<ScoutUpgradeResult>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct ScoutUpgradeResult {
+    pub success: bool,
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+    pub error: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -1145,6 +1145,14 @@ impl Forge for Api {
             .await
     }
 
+    async fn report_scout_firmware_upgrade_status(
+        &self,
+        request: Request<rpc::ScoutFirmwareUpgradeStatusRequest>,
+    ) -> Result<Response<()>, Status> {
+        crate::handlers::host_reprovisioning::report_scout_firmware_upgrade_status(self, request)
+            .await
+    }
+
     async fn list_hosts_waiting_for_reprovisioning(
         &self,
         request: Request<rpc::HostReprovisioningListRequest>,
@@ -3253,7 +3261,7 @@ pub(crate) fn log_tenant_organization_id(organization_id: &str) {
     tracing::Span::current().record("tenant.organization_id", organization_id);
 }
 
-fn truncate(mut s: String, len: usize) -> String {
+pub(crate) fn truncate(mut s: String, len: usize) -> String {
     if s.len() < len || len < 3 {
         return s;
     }

--- a/crates/api/src/auth/internal_rbac_rules.rs
+++ b/crates/api/src/auth/internal_rbac_rules.rs
@@ -168,6 +168,7 @@ impl InternalRBACRules {
         x.perm("DiscoveryCompleted", vec![Machineatron, Scout]);
         x.perm("CleanupMachineCompleted", vec![Machineatron, Scout]);
         x.perm("ReportForgeScoutError", vec![Scout]);
+        x.perm("ReportScoutFirmwareUpgradeStatus", vec![Scout]);
         x.perm("DiscoverDhcp", vec![Dhcp, Machineatron]);
         x.perm("ExpireDhcpLease", vec![Dhcp, Machineatron]);
         x.perm("AssignStaticAddress", vec![ForgeAdminCLI]);

--- a/crates/api/src/handlers/host_reprovisioning.rs
+++ b/crates/api/src/handlers/host_reprovisioning.rs
@@ -17,11 +17,13 @@
 use ::rpc::forge as rpc;
 use carbide_uuid::machine::MachineId;
 use itertools::Itertools;
-use model::machine::LoadSnapshotOptions;
+use model::machine::{
+    HostReprovisionState, LoadSnapshotOptions, ManagedHostState, ScoutUpgradeResult,
+};
 use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
-use crate::api::{Api, log_request_data};
+use crate::api::{Api, log_request_data, truncate};
 use crate::handlers::utils::convert_and_log_machine_id;
 
 pub(crate) async fn reset_host_reprovisioning(
@@ -141,6 +143,75 @@ pub async fn mark_manual_firmware_upgrade_complete(
     db::host_machine_update::set_manual_firmware_upgrade_completed(&mut txn, &machine_id).await?;
 
     txn.commit().await?;
+
+    Ok(Response::new(()))
+}
+
+pub async fn report_scout_firmware_upgrade_status(
+    api: &Api,
+    request: Request<rpc::ScoutFirmwareUpgradeStatusRequest>,
+) -> Result<Response<()>, Status> {
+    log_request_data(&request);
+
+    let req = request.into_inner();
+    let machine_id = convert_and_log_machine_id(req.machine_id.as_ref())?;
+
+    let (machine, mut txn) = api.load_machine(&machine_id, Default::default()).await?;
+
+    // Verify machine is in WaitingForScoutUpgrade state
+    let (component_type, target_version, started_at, retry_count) = match machine.current_state() {
+        ManagedHostState::HostReprovision {
+            reprovision_state:
+                HostReprovisionState::WaitingForScoutUpgrade {
+                    component_type,
+                    target_version,
+                    started_at,
+                    ..
+                },
+            retry_count,
+        } => (
+            *component_type,
+            target_version.clone(),
+            *started_at,
+            *retry_count,
+        ),
+        _ => {
+            return Err(CarbideError::FailedPrecondition(format!(
+                "Machine {machine_id} is not in WaitingForScoutUpgrade state"
+            ))
+            .into());
+        }
+    };
+
+    const MAX_STORED_OUTPUT_SIZE: usize = 1500;
+
+    let new_state = ManagedHostState::HostReprovision {
+        reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
+            component_type,
+            target_version,
+            started_at,
+            result: Some(ScoutUpgradeResult {
+                success: req.success,
+                exit_code: req.exit_code,
+                stdout: truncate(req.stdout, MAX_STORED_OUTPUT_SIZE),
+                stderr: truncate(req.stderr, MAX_STORED_OUTPUT_SIZE),
+                error: truncate(req.error, MAX_STORED_OUTPUT_SIZE),
+            }),
+        },
+        retry_count,
+    };
+
+    db::machine::advance(&machine, &mut txn, &new_state, None).await?;
+
+    txn.commit().await?;
+
+    if let Err(err) = api
+        .machine_state_handler_enqueuer
+        .enqueue_object(&machine_id)
+        .await
+    {
+        tracing::warn!(%err, %machine_id, "Failed to wake up state handler for machine");
+    }
 
     Ok(Response::new(()))
 }

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -6653,6 +6653,10 @@ impl HostUpgradeState {
                 self.host_new_firmware_reported_wait(state, ctx, details, machine_id, scenario)
                     .await
             }
+            HostReprovisionState::WaitingForScoutUpgrade { .. } => {
+                // TODO: will be implemented in a follow-up (@jrakhmonov)
+                Ok(StateHandlerOutcome::do_nothing())
+            }
             HostReprovisionState::FailedFirmwareUpgrade { report_time, .. } => {
                 let can_retry = retry_count < MAX_FIRMWARE_UPGRADE_RETRIES;
                 let waited_enough = Utc::now()

--- a/crates/api/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api/src/tests/host_bmc_firmware_test.rs
@@ -2643,3 +2643,211 @@ async fn test_manual_firmware_upgrade_workflow(pool: sqlx::PgPool) -> CarbideRes
 
     Ok(())
 }
+
+#[crate::sqlx_test]
+async fn test_report_scout_firmware_upgrade_status(pool: sqlx::PgPool) -> CarbideResult<()> {
+    let env = create_test_env(pool).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+
+    // Manually put the machine into WaitingForScoutUpgrade state
+    let mut txn = env.pool.begin().await.unwrap();
+    let host = mh.host().db_machine(&mut txn).await;
+    let waiting_state = ManagedHostState::HostReprovision {
+        reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
+            component_type: FirmwareComponentType::Bmc,
+            target_version: "1.2.3".to_string(),
+            started_at: chrono::Utc::now(),
+            result: None,
+        },
+        retry_count: 0,
+    };
+    db::machine::advance(&host, &mut txn, &waiting_state, None)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    // Call the RPC endpoint with a successful result
+    env.api
+        .report_scout_firmware_upgrade_status(Request::new(
+            rpc::forge::ScoutFirmwareUpgradeStatusRequest {
+                machine_id: Some(mh.host().id),
+                success: true,
+                exit_code: 0,
+                stdout: "upgrade complete".to_string(),
+                stderr: String::new(),
+                error: String::new(),
+            },
+        ))
+        .await
+        .unwrap();
+
+    // Verify the result was stored
+    let mut txn = env.pool.begin().await.unwrap();
+    let host = mh.host().db_machine(&mut txn).await;
+    let ManagedHostState::HostReprovision {
+        reprovision_state, ..
+    } = host.current_state()
+    else {
+        panic!("Not in HostReprovision");
+    };
+    let HostReprovisionState::WaitingForScoutUpgrade { result, .. } = reprovision_state else {
+        panic!("Not in WaitingForScoutUpgrade");
+    };
+    let result = result.as_ref().expect("result should be set");
+    assert!(result.success);
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.stdout, "upgrade complete");
+    txn.commit().await.unwrap();
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_report_scout_firmware_upgrade_status_failure(
+    pool: sqlx::PgPool,
+) -> CarbideResult<()> {
+    let env = create_test_env(pool).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+
+    // Manually put the machine into WaitingForScoutUpgrade state
+    let mut txn = env.pool.begin().await.unwrap();
+    let host = mh.host().db_machine(&mut txn).await;
+    let waiting_state = ManagedHostState::HostReprovision {
+        reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
+            component_type: FirmwareComponentType::Bmc,
+            target_version: "1.2.3".to_string(),
+            started_at: chrono::Utc::now(),
+            result: None,
+        },
+        retry_count: 0,
+    };
+    db::machine::advance(&host, &mut txn, &waiting_state, None)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    // Call the RPC endpoint with a failure result
+    env.api
+        .report_scout_firmware_upgrade_status(Request::new(
+            rpc::forge::ScoutFirmwareUpgradeStatusRequest {
+                machine_id: Some(mh.host().id),
+                success: false,
+                exit_code: 1,
+                stdout: "starting upgrade".to_string(),
+                stderr: "permission denied".to_string(),
+                error: "script failed".to_string(),
+            },
+        ))
+        .await
+        .unwrap();
+
+    // Verify the failure result was stored
+    let mut txn = env.pool.begin().await.unwrap();
+    let host = mh.host().db_machine(&mut txn).await;
+    let ManagedHostState::HostReprovision {
+        reprovision_state, ..
+    } = host.current_state()
+    else {
+        panic!("Not in HostReprovision");
+    };
+    let HostReprovisionState::WaitingForScoutUpgrade { result, .. } = reprovision_state else {
+        panic!("Not in WaitingForScoutUpgrade");
+    };
+    let result = result.as_ref().expect("result should be set");
+    assert!(!result.success);
+    assert_eq!(result.exit_code, 1);
+    assert_eq!(result.stderr, "permission denied");
+    assert_eq!(result.error, "script failed");
+    txn.commit().await.unwrap();
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_report_scout_firmware_upgrade_status_wrong_state(
+    pool: sqlx::PgPool,
+) -> CarbideResult<()> {
+    let env = create_test_env(pool).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+
+    // Machine is in its default state (not WaitingForScoutUpgrade), so the RPC should fail
+    let err = env
+        .api
+        .report_scout_firmware_upgrade_status(Request::new(
+            rpc::forge::ScoutFirmwareUpgradeStatusRequest {
+                machine_id: Some(mh.host().id),
+                success: true,
+                exit_code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+                error: String::new(),
+            },
+        ))
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_report_scout_firmware_upgrade_status_truncates_output(
+    pool: sqlx::PgPool,
+) -> CarbideResult<()> {
+    let env = create_test_env(pool).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+
+    // Manually put the machine into WaitingForScoutUpgrade state
+    let mut txn = env.pool.begin().await.unwrap();
+    let host = mh.host().db_machine(&mut txn).await;
+    let waiting_state = ManagedHostState::HostReprovision {
+        reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
+            component_type: FirmwareComponentType::Bmc,
+            target_version: "1.2.3".to_string(),
+            started_at: chrono::Utc::now(),
+            result: None,
+        },
+        retry_count: 0,
+    };
+    db::machine::advance(&host, &mut txn, &waiting_state, None)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    // Send a response with very large stdout/stderr
+    let large_output = "x".repeat(10_000);
+    env.api
+        .report_scout_firmware_upgrade_status(Request::new(
+            rpc::forge::ScoutFirmwareUpgradeStatusRequest {
+                machine_id: Some(mh.host().id),
+                success: true,
+                exit_code: 0,
+                stdout: large_output.clone(),
+                stderr: large_output.clone(),
+                error: large_output.clone(),
+            },
+        ))
+        .await
+        .unwrap();
+
+    // Verify the output was truncated
+    let mut txn = env.pool.begin().await.unwrap();
+    let host = mh.host().db_machine(&mut txn).await;
+    let ManagedHostState::HostReprovision {
+        reprovision_state, ..
+    } = host.current_state()
+    else {
+        panic!("Not in HostReprovision");
+    };
+    let HostReprovisionState::WaitingForScoutUpgrade { result, .. } = reprovision_state else {
+        panic!("Not in WaitingForScoutUpgrade");
+    };
+    let result = result.as_ref().expect("result should be set");
+    assert!(result.stdout.len() <= 1500);
+    assert!(result.stderr.len() <= 1500);
+    assert!(result.error.len() <= 1500);
+    txn.commit().await.unwrap();
+
+    Ok(())
+}

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -315,6 +315,8 @@ service Forge {
   // TODO: Remove when manual upgrade feature is removed
   // Mark host as having completed manual firmware upgrade
   rpc MarkManualFirmwareUpgradeComplete(common.MachineId) returns (google.protobuf.Empty);
+  // Report the result of a scout-based firmware upgrade
+  rpc ReportScoutFirmwareUpgradeStatus(ScoutFirmwareUpgradeStatusRequest) returns (google.protobuf.Empty);
 
   rpc GetDpuInfoList(GetDpuInfoListRequest) returns (GetDpuInfoListResponse);
 
@@ -5162,6 +5164,16 @@ message MachineRebootCompletedResponse {
 message MachineRebootCompletedRequest {
   common.MachineId machine_id = 1;
 }
+
+message ScoutFirmwareUpgradeStatusRequest {
+  common.MachineId machine_id = 1;
+  bool success = 2;
+  int32 exit_code = 3;
+  string stdout = 4;
+  string stderr = 5;
+  string error = 6;
+}
+
 // enum MachineValidationState {
 //     Started = 0;
 //     InProgress = 1;


### PR DESCRIPTION
## Description
Adding an RPC endpoint for the scout to report firmware upgrade status.

The next step will be:

1. Change scout to use this endpoint
2. Change the state machine handler to act on the new status.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

