### PR TITLE
fix: properly fetch boot order in libredfish site-explorer mode

### DIFF
--- a/crates/api/src/site_explorer/redfish.rs
+++ b/crates/api/src/site_explorer/redfish.rs
@@ -1064,20 +1064,25 @@ async fn fetch_boot_order(
                 url: system.odata.odata_id.to_string(),
             })?;
 
-    let all_boot_options: Vec<BootOption> = client
+    let all_boot_options: Vec<libredfish::model::BootOption> = client
         .get_collection(boot_options_id)
         .await
         .and_then(|t1| t1.try_get::<libredfish::model::BootOption>())
         .into_iter()
         .flat_map(|x1| x1.members)
-        .map(Into::into)
         .collect();
 
     let boot_order: Vec<BootOption> = system
         .boot
         .boot_order
         .iter()
-        .filter_map(|id| all_boot_options.iter().find(|opt| opt.id == *id).cloned())
+        .filter_map(|ref_id| {
+            all_boot_options
+                .iter()
+                .find(|opt| opt.boot_option_reference == *ref_id)
+                .cloned()
+                .map(Into::into)
+        })
         .collect();
 
     Ok(BootOrder { boot_order })


### PR DESCRIPTION
## Description
The `BootOrder` array in Redfish uses `BootOptionReference` values (e.g., `"Boot0005"`), but `fetch_boot_order` was matching them against `BootOption.Id` (e.g., `"0005"` on Vikings). Since they never matched, the boot order displayed as empty. Fixed by matching against `boot_option_reference` instead of `id`, consistent with how bmc-explorer already handles it.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
NVBug 6074809

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

