### PR TITLE
feat: basic KmsProvider for envelope encryption primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,6 +1999,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "carbide-kms-provider"
+version = "0.0.1"
+dependencies = [
+ "aes-gcm",
+ "async-trait",
+ "base64 0.22.1",
+ "hex",
+ "rand 0.9.2",
+ "serde",
+ "serial_test",
+ "sha2 0.10.9",
+ "tempfile",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "vaultrs",
+ "zeroize",
+]
+
+[[package]]
 name = "carbide-libmlx"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,6 +256,7 @@ wait-timeout = "0.2.1"
 walkdir = "2.5.0"
 x509-parser = "0.17.0"
 urlencoding = "2.1"
+zeroize = { version = "1", features = ["derive"] }
 zip = "0.6"
 serde_derive = "1"
 fmt = "0.1.0"

--- a/crates/kms-provider/Cargo.toml
+++ b/crates/kms-provider/Cargo.toml
@@ -1,0 +1,47 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[package]
+name = "carbide-kms-provider"
+version = "0.0.1"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+
+[lib]
+name = "carbide_kms_provider"
+
+[dependencies]
+aes-gcm = { workspace = true }
+async-trait = { workspace = true }
+base64 = { workspace = true }
+hex = { workspace = true }
+rand = { workspace = true }
+serde = { features = ["derive"], workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+vaultrs = { workspace = true }
+zeroize = { workspace = true }
+
+[dev-dependencies]
+serial_test = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+
+[lints]
+workspace = true

--- a/crates/kms-provider/src/crypto.rs
+++ b/crates/kms-provider/src/crypto.rs
@@ -1,0 +1,156 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use aes_gcm::aead::Aead;
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+use sha2::{Digest, Sha256};
+
+use crate::KmsError;
+
+/// NONCE_LEN is the byte length of an AES-256-GCM
+/// nonce.
+const NONCE_LEN: usize = 12;
+
+/// encrypt encrypts plaintext using AES-256-GCM
+/// with a random 12-byte nonce. Returns
+/// (ciphertext, nonce) on success.
+pub fn encrypt(key: &[u8; 32], plaintext: &[u8]) -> Result<(Vec<u8>, Vec<u8>), KmsError> {
+    let cipher = Aes256Gcm::new(key.into());
+    let nonce_bytes: [u8; NONCE_LEN] = rand::random();
+    let nonce = Nonce::from_slice(&nonce_bytes);
+    let ciphertext = cipher
+        .encrypt(nonce, plaintext)
+        .map_err(|_| KmsError::EncryptionFailed("AES-256-GCM encryption failed".to_string()))?;
+    Ok((ciphertext, nonce_bytes.to_vec()))
+}
+
+/// decrypt decrypts AES-256-GCM ciphertext using
+/// the provided key and nonce.
+pub fn decrypt(key: &[u8; 32], nonce: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, KmsError> {
+    if nonce.len() != NONCE_LEN {
+        return Err(KmsError::DecryptionFailed(format!(
+            "invalid nonce length: expected {NONCE_LEN} bytes, got {}",
+            nonce.len()
+        )));
+    }
+    let cipher = Aes256Gcm::new(key.into());
+    let nonce = Nonce::from_slice(nonce);
+    cipher
+        .decrypt(nonce, ciphertext)
+        .map_err(|_| KmsError::DecryptionFailed("AES-256-GCM decryption failed".to_string()))
+}
+
+/// derive_key_id produces a deterministic identifier
+/// from key material. Returns the first 16 hex
+/// characters of the SHA-256 hash of the key.
+pub fn derive_key_id(key: &[u8; 32]) -> String {
+    let hash = Sha256::digest(key);
+    hex::encode(&hash[..8])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_key() -> [u8; 32] {
+        let mut key = [0u8; 32];
+        for (i, byte) in key.iter_mut().enumerate() {
+            *byte = i as u8;
+        }
+        key
+    }
+
+    fn other_key() -> [u8; 32] {
+        let mut key = [0u8; 32];
+        for (i, byte) in key.iter_mut().enumerate() {
+            *byte = (i as u8).wrapping_add(100);
+        }
+        key
+    }
+
+    // Verifies that encrypt then decrypt produces
+    // the original plaintext.
+    #[test]
+    fn encrypt_decrypt_round_trip() {
+        let key = test_key();
+        let plaintext = b"hello, secrets!";
+
+        let (ciphertext, nonce) = encrypt(&key, plaintext).expect("encrypt");
+        let decrypted = decrypt(&key, &nonce, &ciphertext).expect("decrypt");
+
+        assert_eq!(decrypted, plaintext);
+    }
+
+    // Verifies that decrypting with the wrong key fails.
+    #[test]
+    fn wrong_key_fails_decryption() {
+        let key = test_key();
+        let wrong_key = other_key();
+        let plaintext = b"sensitive data";
+
+        let (ciphertext, nonce) = encrypt(&key, plaintext).expect("encrypt");
+        let result = decrypt(&wrong_key, &nonce, &ciphertext);
+
+        assert!(result.is_err());
+    }
+
+    // Verifies that encrypting the same plaintext
+    // twice produces different ciphertext.
+    #[test]
+    fn different_nonces_produce_different_ciphertext() {
+        let key = test_key();
+        let plaintext = b"same plaintext";
+
+        let (ct1, nonce1) = encrypt(&key, plaintext).expect("encrypt 1");
+        let (ct2, nonce2) = encrypt(&key, plaintext).expect("encrypt 2");
+
+        assert_ne!(nonce1, nonce2);
+        assert_ne!(ct1, ct2);
+    }
+
+    // Verifies that an invalid nonce length returns
+    // an error.
+    #[test]
+    fn invalid_nonce_length_errors() {
+        let key = test_key();
+        let result = decrypt(&key, &[0u8; 11], &[]);
+        assert!(result.is_err());
+    }
+
+    // Verifies that derive_key_id is deterministic.
+    #[test]
+    fn derive_key_id_is_deterministic() {
+        let key = test_key();
+        assert_eq!(derive_key_id(&key), derive_key_id(&key));
+    }
+
+    // Verifies that different keys produce different
+    // key_ids.
+    #[test]
+    fn derive_key_id_differs_for_different_keys() {
+        assert_ne!(derive_key_id(&test_key()), derive_key_id(&other_key()));
+    }
+
+    // Verifies that derive_key_id produces 16 hex
+    // characters.
+    #[test]
+    fn derive_key_id_is_16_hex_chars() {
+        let id = derive_key_id(&test_key());
+        assert_eq!(id.len(), 16);
+        assert!(id.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/crates/kms-provider/src/lib.rs
+++ b/crates/kms-provider/src/lib.rs
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! carbide_kms_provider provides a KmsBackend trait
+//! for envelope encryption key management. Two
+//! implementations are included:
+//! - IntegratedKmsProvider: local key material.
+//! - TransitKmsProvider: Vault/OpenBao Transit.
+
+use async_trait::async_trait;
+use zeroize::Zeroizing;
+
+pub mod crypto;
+pub mod providers;
+
+pub use providers::integrated::{IntegratedKmsProvider, KeySource};
+pub use providers::multi::MultiKmsProvider;
+pub use providers::transit::{DEFAULT_TRANSIT_MOUNT, TransitKmsProvider};
+
+/// EncryptedDek holds a wrapped Data Encryption Key
+/// and the nonce used to wrap it. For Transit backends,
+/// the nonce is empty (managed internally).
+#[derive(Debug)]
+pub struct EncryptedDek {
+    /// ciphertext contains the encrypted DEK bytes.
+    pub ciphertext: Vec<u8>,
+    /// nonce contains the nonce used for wrapping
+    /// (empty for Transit backends).
+    pub nonce: Vec<u8>,
+}
+
+/// KmsError represents errors from a KMS backend.
+#[derive(Debug, thiserror::Error)]
+pub enum KmsError {
+    #[error("key not found: {0}")]
+    KeyNotFound(String),
+
+    #[error("encryption failed: {0}")]
+    EncryptionFailed(String),
+
+    #[error("decryption failed: {0}")]
+    DecryptionFailed(String),
+
+    #[error("{0}")]
+    Other(String),
+}
+
+/// KmsBackend abstracts key encryption key operations
+/// for envelope encryption. Implementations handle
+/// wrapping and unwrapping DEKs using KEKs identified
+/// by kek_id strings.
+#[async_trait]
+pub trait KmsBackend: Send + Sync {
+    /// encrypt_dek wraps a DEK using the KEK
+    /// identified by kek_id.
+    async fn encrypt_dek(&self, kek_id: &str, dek: &[u8; 32]) -> Result<EncryptedDek, KmsError>;
+
+    /// decrypt_dek unwraps an encrypted DEK using
+    /// the KEK identified by kek_id.
+    async fn decrypt_dek(
+        &self,
+        kek_id: &str,
+        encrypted: &EncryptedDek,
+    ) -> Result<Zeroizing<[u8; 32]>, KmsError>;
+
+    /// can_decrypt_kek returns whether this backend
+    /// can decrypt DEKs wrapped by the given kek_id.
+    fn can_decrypt_kek(&self, kek_id: &str) -> bool;
+
+    /// generate_and_wrap_dek generates a fresh DEK and
+    /// wraps it in a single operation. The default
+    /// generates locally and delegates to encrypt_dek.
+    /// Transit overrides this to use GenerateDataKey.
+    async fn generate_and_wrap_dek(
+        &self,
+        kek_id: &str,
+    ) -> Result<(Zeroizing<[u8; 32]>, EncryptedDek), KmsError> {
+        let dek = Zeroizing::new(rand::random::<[u8; 32]>());
+        let wrapped = self.encrypt_dek(kek_id, &dek).await?;
+        Ok((dek, wrapped))
+    }
+}

--- a/crates/kms-provider/src/providers/integrated.rs
+++ b/crates/kms-provider/src/providers/integrated.rs
@@ -1,0 +1,323 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use zeroize::{Zeroize, Zeroizing};
+
+use crate::{EncryptedDek, KmsBackend, KmsError, crypto};
+
+/// KeySource describes where to load a symmetric
+/// encryption key from.
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(untagged)]
+pub enum KeySource {
+    /// Env loads the base64-encoded key from an environment
+    /// variable.
+    Env { env: String },
+    /// File loads the base64-encoded key from a file path.
+    File { file: PathBuf },
+    /// Value contains the base64-encoded key directly.
+    Value { value: String },
+}
+
+/// IntegratedKmsProvider implements KmsBackend using
+/// local key material. Keys are configured as an
+/// explicit kek_id → key_source mapping. This is the
+/// default backend when no external KMS is configured.
+pub struct IntegratedKmsProvider {
+    keys: HashMap<String, [u8; 32]>,
+}
+
+impl Drop for IntegratedKmsProvider {
+    fn drop(&mut self) {
+        for val in self.keys.values_mut() {
+            val.zeroize();
+        }
+    }
+}
+
+/// decode_key decodes a base64-encoded 256-bit key.
+/// The intermediate buffer is zeroized.
+fn decode_key(encoded: &str) -> Result<[u8; 32], KmsError> {
+    let mut bytes = BASE64
+        .decode(encoded.trim())
+        .map_err(|e| KmsError::Other(format!("invalid base64 key: {e}")))?;
+    let len = bytes.len();
+    let result = bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| KmsError::Other(format!("invalid key length: expected 32 bytes, got {len}")));
+    bytes.zeroize();
+    result
+}
+
+/// resolve_key_source loads a key from the given source.
+fn resolve_key_source(source: &KeySource) -> Result<[u8; 32], KmsError> {
+    match source {
+        KeySource::Env { env } => {
+            let val = std::env::var(env)
+                .map_err(|_| KmsError::Other(format!("environment variable {env:?} not set")))?;
+            decode_key(&val)
+        }
+        KeySource::File { file } => {
+            let val = std::fs::read_to_string(file)
+                .map_err(|e| KmsError::Other(format!("failed to read key file {file:?}: {e}")))?;
+            decode_key(&val)
+        }
+        KeySource::Value { value } => decode_key(value),
+    }
+}
+
+impl IntegratedKmsProvider {
+    /// IntegratedKmsProvider::from_config builds a
+    /// provider from a map of kek_id to key source.
+    pub fn from_config(key_map: &HashMap<String, KeySource>) -> Result<Self, KmsError> {
+        if key_map.is_empty() {
+            return Err(KmsError::Other("no KMS keys configured".to_string()));
+        }
+
+        let mut keys = HashMap::with_capacity(key_map.len());
+        for (kek_id, source) in key_map {
+            let key = resolve_key_source(source)?;
+            tracing::info!(kek_id = %kek_id, "loaded KEK");
+            keys.insert(kek_id.clone(), key);
+        }
+
+        Ok(Self { keys })
+    }
+
+    /// IntegratedKmsProvider::new creates a provider
+    /// from pre-loaded keys (for tests).
+    pub fn new(keys: HashMap<String, [u8; 32]>) -> Self {
+        Self { keys }
+    }
+}
+
+#[async_trait]
+impl KmsBackend for IntegratedKmsProvider {
+    async fn encrypt_dek(&self, kek_id: &str, dek: &[u8; 32]) -> Result<EncryptedDek, KmsError> {
+        let kek = self
+            .keys
+            .get(kek_id)
+            .ok_or_else(|| KmsError::KeyNotFound(kek_id.to_string()))?;
+        let (ciphertext, nonce) = crypto::encrypt(kek, dek)?;
+        Ok(EncryptedDek { ciphertext, nonce })
+    }
+
+    async fn decrypt_dek(
+        &self,
+        kek_id: &str,
+        encrypted: &EncryptedDek,
+    ) -> Result<Zeroizing<[u8; 32]>, KmsError> {
+        let kek = self
+            .keys
+            .get(kek_id)
+            .ok_or_else(|| KmsError::KeyNotFound(kek_id.to_string()))?;
+        let mut plaintext = crypto::decrypt(kek, &encrypted.nonce, &encrypted.ciphertext)?;
+        let len = plaintext.len();
+        let dek: [u8; 32] = plaintext
+            .as_slice()
+            .try_into()
+            .map_err(|_| KmsError::Other(format!("DEK has wrong length: {len}")))?;
+        plaintext.zeroize();
+        Ok(Zeroizing::new(dek))
+    }
+
+    fn can_decrypt_kek(&self, kek_id: &str) -> bool {
+        self.keys.contains_key(kek_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serial_test::serial;
+
+    use super::*;
+
+    fn make_test_key(seed: u8) -> [u8; 32] {
+        let mut key = [0u8; 32];
+        for (i, byte) in key.iter_mut().enumerate() {
+            *byte = seed.wrapping_add(i as u8);
+        }
+        key
+    }
+
+    fn encode_key(key: &[u8; 32]) -> String {
+        BASE64.encode(key)
+    }
+
+    fn make_provider(kek_id: &str, key: [u8; 32]) -> IntegratedKmsProvider {
+        let mut keys = HashMap::new();
+        keys.insert(kek_id.to_string(), key);
+        IntegratedKmsProvider::new(keys)
+    }
+
+    // Verifies that encrypt_dek then decrypt_dek
+    // recovers the original DEK.
+    #[tokio::test]
+    async fn encrypt_decrypt_dek_round_trip() {
+        let kek = make_test_key(1);
+        let provider = make_provider("my-key", kek);
+
+        let dek: [u8; 32] = rand::random();
+        let encrypted = provider.encrypt_dek("my-key", &dek).await.expect("encrypt");
+        let decrypted = provider
+            .decrypt_dek("my-key", &encrypted)
+            .await
+            .expect("decrypt");
+
+        assert_eq!(*decrypted, dek);
+    }
+
+    // Verifies that decrypting a DEK with the wrong
+    // kek_id returns an error.
+    #[tokio::test]
+    async fn decrypt_dek_wrong_kek_id_errors() {
+        let provider = make_provider("my-key", make_test_key(1));
+
+        let dek: [u8; 32] = rand::random();
+        let encrypted = provider.encrypt_dek("my-key", &dek).await.expect("encrypt");
+
+        let result = provider.decrypt_dek("nonexistent", &encrypted).await;
+        assert!(result.is_err());
+    }
+
+    // Verifies that can_decrypt_kek returns true for
+    // known keys and false for unknown.
+    #[test]
+    fn can_decrypt_kek_known_and_unknown() {
+        let provider = make_provider("my-key", make_test_key(1));
+
+        assert!(provider.can_decrypt_kek("my-key"));
+        assert!(!provider.can_decrypt_kek("unknown"));
+    }
+
+    // Verifies that generate_and_wrap_dek produces
+    // a valid DEK that can be unwrapped.
+    #[tokio::test]
+    async fn generate_and_wrap_dek_round_trip() {
+        let provider = make_provider("my-key", make_test_key(1));
+
+        let (dek, wrapped) = provider
+            .generate_and_wrap_dek("my-key")
+            .await
+            .expect("generate");
+        let unwrapped = provider
+            .decrypt_dek("my-key", &wrapped)
+            .await
+            .expect("unwrap");
+
+        assert_eq!(*dek, *unwrapped);
+    }
+
+    // Verifies that from_config loads keys from
+    // env vars.
+    #[test]
+    #[serial]
+    fn from_config_env_source() {
+        let key = make_test_key(1);
+        unsafe { std::env::set_var("TEST_KMS_KEY_1", encode_key(&key)) };
+
+        let mut key_map = HashMap::new();
+        key_map.insert(
+            "my-key".to_string(),
+            KeySource::Env {
+                env: "TEST_KMS_KEY_1".to_string(),
+            },
+        );
+
+        let provider = IntegratedKmsProvider::from_config(&key_map).expect("from_config");
+        assert!(provider.can_decrypt_kek("my-key"));
+
+        unsafe { std::env::remove_var("TEST_KMS_KEY_1") };
+    }
+
+    // Verifies that from_config loads keys from files.
+    #[test]
+    fn from_config_file_source() {
+        let key = make_test_key(2);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_path = dir.path().join("test-key");
+        std::fs::write(&file_path, encode_key(&key)).expect("write");
+
+        let mut key_map = HashMap::new();
+        key_map.insert("file-key".to_string(), KeySource::File { file: file_path });
+
+        let provider = IntegratedKmsProvider::from_config(&key_map).expect("from_config");
+        assert!(provider.can_decrypt_kek("file-key"));
+    }
+
+    // Verifies that from_config loads inline base64 values.
+    #[test]
+    fn from_config_value_source() {
+        let key = make_test_key(3);
+        let mut key_map = HashMap::new();
+        key_map.insert(
+            "inline-key".to_string(),
+            KeySource::Value {
+                value: encode_key(&key),
+            },
+        );
+
+        let provider = IntegratedKmsProvider::from_config(&key_map).expect("from_config");
+        assert!(provider.can_decrypt_kek("inline-key"));
+    }
+
+    // Verifies that from_config errors when no keys
+    // are provided.
+    #[test]
+    fn from_config_empty_errors() {
+        let result = IntegratedKmsProvider::from_config(&HashMap::new());
+        assert!(result.is_err());
+    }
+
+    // Verifies that from_config errors on invalid base64.
+    #[test]
+    fn from_config_invalid_base64_errors() {
+        let mut key_map = HashMap::new();
+        key_map.insert(
+            "bad-key".to_string(),
+            KeySource::Value {
+                value: "not-valid-base64!!!".to_string(),
+            },
+        );
+
+        let result = IntegratedKmsProvider::from_config(&key_map);
+        assert!(result.is_err());
+    }
+
+    // Verifies that from_config errors when a key
+    // is not 32 bytes.
+    #[test]
+    fn from_config_wrong_key_length_errors() {
+        let mut key_map = HashMap::new();
+        key_map.insert(
+            "short-key".to_string(),
+            KeySource::Value {
+                value: BASE64.encode([0u8; 16]),
+            },
+        );
+
+        let result = IntegratedKmsProvider::from_config(&key_map);
+        assert!(result.is_err());
+    }
+}

--- a/crates/kms-provider/src/providers/mod.rs
+++ b/crates/kms-provider/src/providers/mod.rs
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod integrated;
+pub mod multi;
+pub mod transit;

--- a/crates/kms-provider/src/providers/multi.rs
+++ b/crates/kms-provider/src/providers/multi.rs
@@ -1,0 +1,225 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! MultiKmsProvider aggregates multiple KMS backends, routing
+//! writes to the active provider and decrypts to whichever provider
+//! owns the kek_id.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use zeroize::Zeroizing;
+
+use crate::{EncryptedDek, KmsBackend, KmsError};
+
+/// MultiKmsProvider routes KMS operations across
+/// multiple backends. New writes go to the active
+/// provider. Decrypts are routed to the provider
+/// that owns the kek_id (via can_decrypt_kek).
+pub struct MultiKmsProvider {
+    active: Arc<dyn KmsBackend>,
+    providers: Vec<Arc<dyn KmsBackend>>,
+}
+
+impl MultiKmsProvider {
+    /// MultiKmsProvider::new creates a multi-provider
+    /// from an active provider (for writes) and a list
+    /// of all providers (for decrypts). The active
+    /// provider should also be in the providers list.
+    pub fn new(active: Arc<dyn KmsBackend>, providers: Vec<Arc<dyn KmsBackend>>) -> Self {
+        Self { active, providers }
+    }
+
+    /// find_provider_for_kek locates the provider
+    /// that owns the given kek_id.
+    fn find_provider_for_kek(&self, kek_id: &str) -> Result<&Arc<dyn KmsBackend>, KmsError> {
+        self.providers
+            .iter()
+            .find(|p| p.can_decrypt_kek(kek_id))
+            .ok_or_else(|| {
+                KmsError::KeyNotFound(format!("no KMS provider found for kek_id {kek_id:?}"))
+            })
+    }
+}
+
+#[async_trait]
+impl KmsBackend for MultiKmsProvider {
+    async fn encrypt_dek(&self, kek_id: &str, dek: &[u8; 32]) -> Result<EncryptedDek, KmsError> {
+        self.active.encrypt_dek(kek_id, dek).await
+    }
+
+    async fn decrypt_dek(
+        &self,
+        kek_id: &str,
+        encrypted: &EncryptedDek,
+    ) -> Result<Zeroizing<[u8; 32]>, KmsError> {
+        self.find_provider_for_kek(kek_id)?
+            .decrypt_dek(kek_id, encrypted)
+            .await
+    }
+
+    fn can_decrypt_kek(&self, kek_id: &str) -> bool {
+        self.providers.iter().any(|p| p.can_decrypt_kek(kek_id))
+    }
+
+    async fn generate_and_wrap_dek(
+        &self,
+        kek_id: &str,
+    ) -> Result<(Zeroizing<[u8; 32]>, EncryptedDek), KmsError> {
+        self.active.generate_and_wrap_dek(kek_id).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::IntegratedKmsProvider;
+
+    fn make_test_key(seed: u8) -> [u8; 32] {
+        let mut key = [0u8; 32];
+        for (i, byte) in key.iter_mut().enumerate() {
+            *byte = seed.wrapping_add(i as u8);
+        }
+        key
+    }
+
+    fn make_integrated(kek_id: &str, key: [u8; 32]) -> Arc<dyn KmsBackend> {
+        let mut keys = HashMap::new();
+        keys.insert(kek_id.to_string(), key);
+        Arc::new(IntegratedKmsProvider::new(keys))
+    }
+
+    // Verifies that writes go to the active provider
+    // and can be read back.
+    #[tokio::test]
+    async fn writes_go_to_active() {
+        let provider_a = make_integrated("key-a", make_test_key(1));
+        let provider_b = make_integrated("key-b", make_test_key(2));
+
+        let multi = MultiKmsProvider::new(provider_a.clone(), vec![provider_a, provider_b]);
+
+        let dek: [u8; 32] = rand::random();
+        let encrypted = multi.encrypt_dek("key-a", &dek).await.expect("encrypt");
+        let decrypted = multi
+            .decrypt_dek("key-a", &encrypted)
+            .await
+            .expect("decrypt");
+        assert_eq!(*decrypted, dek);
+    }
+
+    // Verifies that decrypts route to the correct
+    // provider based on kek_id.
+    #[tokio::test]
+    async fn decrypt_routes_to_correct_provider() {
+        let key_a = make_test_key(1);
+        let key_b = make_test_key(2);
+        let provider_a = make_integrated("key-a", key_a);
+        let provider_b = make_integrated("key-b", key_b);
+
+        // Active is provider_a, but provider_b also participates in decrypts.
+        let multi = MultiKmsProvider::new(provider_a.clone(), vec![provider_a, provider_b.clone()]);
+
+        // Encrypt directly with provider_b.
+        let dek: [u8; 32] = rand::random();
+        let encrypted = provider_b
+            .encrypt_dek("key-b", &dek)
+            .await
+            .expect("encrypt");
+
+        // Multi should route the decrypt to provider_b based on kek_id.
+        let decrypted = multi
+            .decrypt_dek("key-b", &encrypted)
+            .await
+            .expect("decrypt");
+        assert_eq!(*decrypted, dek);
+    }
+
+    // Verifies that can_decrypt_kek returns true if
+    // any provider owns the kek_id.
+    #[test]
+    fn can_decrypt_kek_across_providers() {
+        let provider_a = make_integrated("key-a", make_test_key(1));
+        let provider_b = make_integrated("key-b", make_test_key(2));
+
+        let multi = MultiKmsProvider::new(provider_a.clone(), vec![provider_a, provider_b]);
+
+        assert!(multi.can_decrypt_kek("key-a"));
+        assert!(multi.can_decrypt_kek("key-b"));
+        assert!(!multi.can_decrypt_kek("unknown"));
+    }
+
+    // Verifies that decrypt_dek errors for an
+    // unknown kek_id.
+    #[tokio::test]
+    async fn decrypt_unknown_kek_id_errors() {
+        let provider = make_integrated("key-a", make_test_key(1));
+        let multi = MultiKmsProvider::new(provider.clone(), vec![provider]);
+
+        let dek: [u8; 32] = rand::random();
+        let encrypted = multi.encrypt_dek("key-a", &dek).await.expect("encrypt");
+
+        let result = multi.decrypt_dek("unknown-key", &encrypted).await;
+        assert!(result.is_err());
+    }
+
+    // Verifies that generate_and_wrap_dek goes
+    // through the active provider.
+    #[tokio::test]
+    async fn generate_and_wrap_uses_active() {
+        let provider_a = make_integrated("key-a", make_test_key(1));
+        let provider_b = make_integrated("key-b", make_test_key(2));
+
+        let multi = MultiKmsProvider::new(provider_a.clone(), vec![provider_a, provider_b]);
+
+        let (dek, wrapped) = multi
+            .generate_and_wrap_dek("key-a")
+            .await
+            .expect("generate");
+        let unwrapped = multi.decrypt_dek("key-a", &wrapped).await.expect("unwrap");
+        assert_eq!(*dek, *unwrapped);
+    }
+
+    // Verifies that when two providers claim the
+    // same kek_id, the first in the list wins.
+    #[tokio::test]
+    async fn duplicate_kek_id_uses_first_provider() {
+        let key_a = make_test_key(1);
+        let key_b = make_test_key(2);
+
+        // Both providers claim "shared-key" but with different key material.
+        let provider_a = make_integrated("shared-key", key_a);
+        let provider_b = make_integrated("shared-key", key_b);
+
+        let multi = MultiKmsProvider::new(provider_a.clone(), vec![provider_a.clone(), provider_b]);
+
+        // Encrypt with provider_a (via multi's active).
+        let dek: [u8; 32] = rand::random();
+        let encrypted = multi
+            .encrypt_dek("shared-key", &dek)
+            .await
+            .expect("encrypt");
+
+        // Decrypt should route to provider_a (first in list), which works.
+        let decrypted = multi
+            .decrypt_dek("shared-key", &encrypted)
+            .await
+            .expect("decrypt");
+        assert_eq!(*decrypted, dek);
+    }
+}

--- a/crates/kms-provider/src/providers/transit.rs
+++ b/crates/kms-provider/src/providers/transit.rs
@@ -1,0 +1,403 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! TransitKmsProvider implements KmsBackend using the Transit secrets
+//! engine API. Compatible with both HashiCorp Vault and OpenBao. The kek_id
+//! maps to a named Transit key, and the server handles all crypto; the
+//! key material (KEK) never leaves it.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use vaultrs::api::transit::requests::DataKeyType;
+use vaultrs::client::VaultClient;
+use vaultrs::transit;
+use zeroize::{Zeroize, Zeroizing};
+
+use crate::{EncryptedDek, KmsBackend, KmsError};
+
+/// DEFAULT_TRANSIT_MOUNT is the default Transit
+/// secrets engine mount path.
+pub const DEFAULT_TRANSIT_MOUNT: &str = "transit";
+
+/// TransitKmsProvider wraps the Transit secrets
+/// engine API to provide envelope encryption.
+/// Compatible with both HashiCorp Vault and OpenBao.
+/// Each kek_id corresponds to a named Transit key
+/// on the server.
+pub struct TransitKmsProvider {
+    client: Arc<VaultClient>,
+    transit_mount: String,
+    known_keys: Vec<String>,
+}
+
+impl TransitKmsProvider {
+    /// TransitKmsProvider::new creates a provider from
+    /// an authenticated VaultClient, mount path, and
+    /// list of known Transit key names. The known_keys
+    /// list is used by can_decrypt_kek to determine
+    /// ownership without a network call.
+    pub fn new(client: Arc<VaultClient>, transit_mount: String, known_keys: Vec<String>) -> Self {
+        tracing::info!(
+            transit_mount = %transit_mount,
+            known_keys = ?known_keys,
+            "initialized Transit KMS provider"
+        );
+        Self {
+            client,
+            transit_mount,
+            known_keys,
+        }
+    }
+
+    /// start_token_renewal spawns a background task
+    /// that periodically renews the Vault token. Right
+    /// now it's just renewing at 90% (0.9) of the lease
+    /// duration.
+    pub fn start_token_renewal(&self) -> tokio::task::JoinHandle<()> {
+        let client = self.client.clone();
+        tokio::spawn(async move {
+            // Initial lookup to get the token's TTL and renewability.
+            let info = match vaultrs::token::lookup_self(client.as_ref()).await {
+                Ok(info) => info,
+                Err(e) => {
+                    tracing::warn!("failed to look up Transit KMS token: {e}");
+                    return;
+                }
+            };
+
+            if !info.renewable {
+                tracing::info!("Transit KMS token is not renewable, skipping renewal loop");
+                return;
+            }
+
+            let mut next_renewal = Duration::from_secs((info.ttl as f64 * 0.9).max(30.0) as u64);
+            loop {
+                tracing::debug!(
+                    sleep_secs = next_renewal.as_secs(),
+                    "scheduling Transit KMS token renewal"
+                );
+                tokio::time::sleep(next_renewal).await;
+
+                match vaultrs::token::renew_self(client.as_ref(), None).await {
+                    Ok(renewed) => {
+                        next_renewal = Duration::from_secs(
+                            (renewed.lease_duration as f64 * 0.9).max(30.0) as u64,
+                        );
+                        tracing::info!(
+                            new_lease_duration = renewed.lease_duration,
+                            "renewed Transit KMS vault token"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!("failed to renew Transit KMS vault token: {e}");
+                        next_renewal = Duration::from_secs(30);
+                    }
+                }
+            }
+        })
+    }
+}
+
+#[async_trait]
+impl KmsBackend for TransitKmsProvider {
+    async fn encrypt_dek(&self, kek_id: &str, dek: &[u8; 32]) -> Result<EncryptedDek, KmsError> {
+        let plaintext_b64 = BASE64.encode(dek);
+        let response = transit::data::encrypt(
+            self.client.as_ref(),
+            &self.transit_mount,
+            kek_id,
+            &plaintext_b64,
+            None,
+        )
+        .await
+        .map_err(|e| KmsError::EncryptionFailed(format!("vault transit encrypt: {e}")))?;
+
+        // Vault Transit returns ciphertext as a string like "vault:v1:<base64>".
+        // Store the entire string as bytes, and then just 'll pass it back verbatim
+        // to decrypt.
+        Ok(EncryptedDek {
+            ciphertext: response.ciphertext.into_bytes(),
+            nonce: vec![], // Transit manages nonces internally.
+        })
+    }
+
+    async fn decrypt_dek(
+        &self,
+        kek_id: &str,
+        encrypted: &EncryptedDek,
+    ) -> Result<Zeroizing<[u8; 32]>, KmsError> {
+        let ciphertext_str = String::from_utf8(encrypted.ciphertext.clone())
+            .map_err(|_| KmsError::DecryptionFailed("invalid ciphertext encoding".to_string()))?;
+
+        let response = transit::data::decrypt(
+            self.client.as_ref(),
+            &self.transit_mount,
+            kek_id,
+            &ciphertext_str,
+            None,
+        )
+        .await
+        .map_err(|e| KmsError::DecryptionFailed(format!("vault transit decrypt: {e}")))?;
+
+        // Vault returns base64-encoded plaintext.
+        let mut decoded = BASE64
+            .decode(&response.plaintext)
+            .map_err(|e| KmsError::DecryptionFailed(format!("invalid base64 from vault: {e}")))?;
+        let len = decoded.len();
+        let dek: [u8; 32] = decoded
+            .as_slice()
+            .try_into()
+            .map_err(|_| KmsError::DecryptionFailed(format!("DEK has wrong length: {len}")))?;
+        decoded.zeroize();
+        Ok(Zeroizing::new(dek))
+    }
+
+    fn can_decrypt_kek(&self, kek_id: &str) -> bool {
+        self.known_keys.iter().any(|k| k == kek_id)
+    }
+
+    async fn generate_and_wrap_dek(
+        &self,
+        kek_id: &str,
+    ) -> Result<(Zeroizing<[u8; 32]>, EncryptedDek), KmsError> {
+        let response = transit::generate::data_key(
+            self.client.as_ref(),
+            &self.transit_mount,
+            kek_id,
+            DataKeyType::Plaintext,
+            None,
+        )
+        .await
+        .map_err(|e| KmsError::EncryptionFailed(format!("vault transit generate data key: {e}")))?;
+
+        let plaintext_b64 = response.plaintext.ok_or_else(|| {
+            KmsError::Other("vault returned no plaintext for data key".to_string())
+        })?;
+
+        let mut decoded = BASE64
+            .decode(&plaintext_b64)
+            .map_err(|e| KmsError::Other(format!("invalid base64 from vault: {e}")))?;
+        let len = decoded.len();
+        let dek: [u8; 32] = decoded
+            .as_slice()
+            .try_into()
+            .map_err(|_| KmsError::Other(format!("DEK has wrong length: {len}")))?;
+        decoded.zeroize();
+
+        let wrapped = EncryptedDek {
+            ciphertext: response.ciphertext.into_bytes(),
+            nonce: vec![], // Transit manages nonces internally.
+        };
+
+        Ok((Zeroizing::new(dek), wrapped))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::TcpListener;
+    use std::process::Stdio;
+
+    use serial_test::serial;
+    use tokio::io::AsyncBufReadExt;
+    use tokio::process;
+
+    use super::*;
+
+    /// VaultDev holds a running Vault dev server
+    /// for testing.
+    struct VaultDev {
+        _process: process::Child,
+        client: Arc<VaultClient>,
+    }
+
+    /// start_vault_dev starts a Vault dev server
+    /// with Transit enabled.
+    async fn start_vault_dev() -> Option<VaultDev> {
+        // Check if vault binary is available.
+        std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default())
+            .filter_map(|dir| {
+                let candidate = dir.join("vault");
+                candidate.is_file().then_some(candidate)
+            })
+            .next()?;
+
+        let addr = {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+            listener.local_addr().expect("local addr")
+        };
+
+        let mut proc = process::Command::new("vault")
+            .arg("server")
+            .arg("-dev")
+            .arg(format!("-dev-listen-address={addr}"))
+            .env_remove("VAULT_ADDR")
+            .env_remove("VAULT_CLIENT_KEY")
+            .env_remove("VAULT_CLIENT_CERT")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("start vault");
+
+        // Parse root token from stdout.
+        let stdout = tokio::io::BufReader::new(proc.stdout.take().unwrap());
+        let stderr = proc.stderr.take().unwrap();
+        tokio::spawn(async move {
+            let mut lines = tokio::io::BufReader::new(stderr).lines();
+            while let Some(line) = lines.next_line().await.ok().flatten() {
+                eprintln!("[vault-stderr] {line}");
+            }
+        });
+
+        let (token_tx, token_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let mut lines = stdout.lines();
+            let mut sender = Some(token_tx);
+            while let Some(line) = lines.next_line().await.ok().flatten() {
+                if let Some(rest) = line.trim().strip_prefix("Root Token:")
+                    && let Some(s) = sender.take()
+                {
+                    s.send(rest.trim().to_string()).ok();
+                }
+            }
+        });
+
+        let token = token_rx.await.expect("vault token");
+
+        // Create VaultClient.
+        let settings = vaultrs::client::VaultClientSettingsBuilder::default()
+            .token(token)
+            .address(format!("http://{addr}"))
+            .build()
+            .expect("vault settings");
+        let client = Arc::new(VaultClient::new(settings).expect("vault client"));
+
+        // Enable Transit secrets engine.
+        vaultrs::sys::mount::enable(client.as_ref(), "transit", "transit", None)
+            .await
+            .expect("enable transit");
+
+        // Create a test key.
+        transit::key::create(client.as_ref(), "transit", "test-key", None)
+            .await
+            .expect("create transit key");
+
+        Some(VaultDev {
+            _process: proc,
+            client,
+        })
+    }
+
+    // Verifies that encrypt_dek + decrypt_dek
+    // round-trips through Transit.
+    #[tokio::test]
+    #[serial]
+    async fn transit_encrypt_decrypt_round_trip() {
+        let vault = match start_vault_dev().await {
+            Some(v) => v,
+            None => {
+                eprintln!("vault not available, skipping test");
+                return;
+            }
+        };
+
+        let provider = TransitKmsProvider::new(
+            vault.client.clone(),
+            "transit".to_string(),
+            vec!["test-key".to_string()],
+        );
+
+        let dek: [u8; 32] = rand::random();
+        let encrypted = provider
+            .encrypt_dek("test-key", &dek)
+            .await
+            .expect("encrypt");
+        let decrypted = provider
+            .decrypt_dek("test-key", &encrypted)
+            .await
+            .expect("decrypt");
+
+        assert_eq!(*decrypted, dek);
+    }
+
+    // Verifies that generate_and_wrap_dek produces
+    // a DEK that can be unwrapped.
+    #[tokio::test]
+    #[serial]
+    async fn transit_generate_and_wrap_round_trip() {
+        let vault = match start_vault_dev().await {
+            Some(v) => v,
+            None => {
+                eprintln!("vault not available, skipping test");
+                return;
+            }
+        };
+
+        let provider = TransitKmsProvider::new(
+            vault.client.clone(),
+            "transit".to_string(),
+            vec!["test-key".to_string()],
+        );
+
+        let (dek, wrapped) = provider
+            .generate_and_wrap_dek("test-key")
+            .await
+            .expect("generate");
+        let unwrapped = provider
+            .decrypt_dek("test-key", &wrapped)
+            .await
+            .expect("unwrap");
+
+        assert_eq!(*dek, *unwrapped);
+    }
+
+    // Verifies that decrypting with a nonexistent
+    // key returns an error.
+    #[tokio::test]
+    #[serial]
+    async fn transit_decrypt_nonexistent_key_errors() {
+        let vault = match start_vault_dev().await {
+            Some(v) => v,
+            None => {
+                eprintln!("vault not available, skipping test");
+                return;
+            }
+        };
+
+        let provider = TransitKmsProvider::new(
+            vault.client.clone(),
+            "transit".to_string(),
+            vec!["test-key".to_string()],
+        );
+
+        let dek: [u8; 32] = rand::random();
+        let encrypted = provider
+            .encrypt_dek("test-key", &dek)
+            .await
+            .expect("encrypt");
+
+        // Try decrypting with a different key name.
+        let result = provider.decrypt_dek("nonexistent-key", &encrypted).await;
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Description

We have a few upcoming initiatives around improved secrets management (being driven by [DSX](https://nvidianews.nvidia.com/news/nvidia-releases-vera-rubin-dsx-ai-factory-reference-design-and-omniverse-dsx-digital-twin-blueprint-with-broad-industry-support)), and envelope encryption is the path forward in cases of secrets at rest (some reference [here](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/concepts.html#envelope-encryption) and [here](https://docs.cloud.google.com/kms/docs/envelope-encryption). The general idea of envelope encryption is that you have a KMS which stores "key encryption keys", or KEKs, each with its own `kek_id`, you then generate your own local "data encryption key", or DEK, *per secret*, use that to encrypt your secret, and then encrypt your DEK with a given KEK. You now have an encrypted secret that is encrypted with a key that can only be decrypted by a KMS. This is a common pattern, used by AWS (EBS, S3, RDS, etc), GCP, Azure, etc.

This introduces a basic `KmsProvider` with three [initial] trait implementations:
- `IntegratedKmsProvider` -- this lets us "use" an integrated KMS within `carbide-api` itself, primarily for local PoC/MVP/validation/initial support.
- `TransitKmsProvider` -- this lets us talk to a remote KMS that implements the [Transit secrets engine API](https://developer.hashicorp.com/vault/api-docs/secret/transit), allowing us to use any Vault or OpenBao deployment as a KMS (or anything that implements the API). In the case of DSX, `carbide-api` will use nVault. In the case of existing sites, `carbide-api` can use its existing Vault stack. NCPs will be using OpenBao. All are supported.
- `MultiKmsProvider` -- this implements a common "keyring" pattern that allows you to manage rotating between backends. The idea is there is an "active" `KmsProvider` that is used for all encryption, and then a list of `KmsProvider` "providers" used for decryption. We find which "provider" can be used for decryption, but all new encryptions use the "active" provider.

A number of unit and integration tests have been included here, including leveraging the existing Vault running for local tests to actually test the `TransitKmsProvider` against the Transit secrets engine in Vault.

We're not using this anywhere yet. More integration work to come shortly.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

