### PR TITLE
fix: Fix rack component deletion by removing deleted filter deleted filter from queries

### DIFF
--- a/crates/api-db/src/power_shelf.rs
+++ b/crates/api-db/src/power_shelf.rs
@@ -18,7 +18,6 @@
 use carbide_uuid::power_shelf::PowerShelfId;
 use chrono::prelude::*;
 use config_version::{ConfigVersion, Versioned};
-use futures::StreamExt;
 use model::controller_outcome::PersistentStateHandlerOutcome;
 use model::metadata::Metadata;
 use model::power_shelf::{NewPowerShelf, PowerShelf, PowerShelfControllerState};
@@ -157,20 +156,6 @@ pub async fn find_by_id(
             ),
         ))
     }
-}
-
-pub async fn list_segment_ids(txn: &mut PgConnection) -> DatabaseResult<Vec<PowerShelfId>> {
-    let query =
-        sqlx::query_as::<_, PowerShelfId>("SELECT id FROM power_shelves WHERE deleted IS NULL");
-
-    let mut rows = query.fetch(txn);
-    let mut ids = Vec::new();
-
-    while let Some(row) = rows.next().await {
-        ids.push(row.map_err(|e| DatabaseError::new("list_segment_ids power_shelf", e))?);
-    }
-
-    Ok(ids)
 }
 
 pub async fn find_ids(

--- a/crates/api-db/src/rack.rs
+++ b/crates/api-db/src/rack.rs
@@ -68,27 +68,6 @@ pub async fn find_ids(
         .map_err(|e| DatabaseError::new("instance::find_ids", e))
 }
 
-pub async fn list(txn: impl DbReader<'_>) -> DatabaseResult<Vec<Rack>> {
-    let query = "SELECT * from racks where deleted IS NULL".to_string();
-    sqlx::query_as(&query)
-        .fetch_all(txn)
-        .await
-        .map_err(|e| DatabaseError::new("racks get", e))
-}
-
-pub async fn get(txn: impl DbReader<'_>, rack_id: &RackId) -> DatabaseResult<Rack> {
-    let query = "SELECT * from racks l WHERE l.id=$1".to_string();
-    sqlx::query_as(&query)
-        .bind(rack_id)
-        .fetch_optional(txn)
-        .await
-        .map_err(|e| DatabaseError::new("racks get", e))?
-        .ok_or_else(|| DatabaseError::NotFoundError {
-            kind: "rack",
-            id: rack_id.to_string(),
-        })
-}
-
 pub async fn create(
     txn: &mut PgConnection,
     rack_id: &RackId,

--- a/crates/api-db/src/switch.rs
+++ b/crates/api-db/src/switch.rs
@@ -20,7 +20,6 @@ use std::net::IpAddr;
 use carbide_uuid::switch::SwitchId;
 use chrono::prelude::*;
 use config_version::{ConfigVersion, Versioned};
-use futures::StreamExt;
 use model::controller_outcome::PersistentStateHandlerOutcome;
 use model::metadata::Metadata;
 use model::rack::RackFirmwareUpgradeStatus;
@@ -150,19 +149,6 @@ pub async fn find_by_id(txn: &mut PgConnection, id: &SwitchId) -> DatabaseResult
             ),
         ))
     }
-}
-
-pub async fn find_all(txn: &mut PgConnection) -> DatabaseResult<Vec<SwitchId>> {
-    let query = sqlx::query_as::<_, SwitchId>("SELECT id FROM switches WHERE deleted IS NULL");
-
-    let mut rows = query.fetch(txn);
-    let mut ids = Vec::new();
-
-    while let Some(row) = rows.next().await {
-        ids.push(row.map_err(|e| DatabaseError::new("find_all switch", e))?);
-    }
-
-    Ok(ids)
 }
 
 pub async fn find_ids(

--- a/crates/api/src/handlers/rack.rs
+++ b/crates/api/src/handlers/rack.rs
@@ -41,24 +41,31 @@ pub async fn get_rack(
     log_request_data(&request);
 
     let req = request.into_inner();
+
+    let mut reader = api.db_reader();
+
     let racks = if let Some(id) = req.id {
         let rack_id = RackId::from_str(&id)
             .map_err(|e| CarbideError::InvalidArgument(format!("Invalid rack ID: {}", e)))?;
-        let r = db_rack::get(&api.database_connection, &rack_id)
-            .await
-            .map_err(CarbideError::from)?;
-        vec![r]
+        db_rack::find_by(
+            reader.as_mut(),
+            ObjectColumnFilter::One(db_rack::IdColumn, &rack_id),
+        )
+        .await
+        .map_err(CarbideError::from)?
     } else {
-        db_rack::list(&api.database_connection)
-            .await
-            .map_err(CarbideError::from)?
+        db_rack::find_by(
+            reader.as_mut(),
+            ObjectColumnFilter::All::<db_rack::IdColumn>,
+        )
+        .await
+        .map_err(CarbideError::from)?
     };
 
-    let mut txn = api.txn_begin().await?;
     let mut result = Vec::with_capacity(racks.len());
     for r in racks {
         let machine_ids = db_machine::find_machine_ids(
-            &mut txn,
+            reader.as_mut(),
             MachineSearchConfig {
                 rack_id: Some(r.id.clone()),
                 ..Default::default()
@@ -66,7 +73,7 @@ pub async fn get_rack(
         )
         .await?;
         let switch_ids = db_switch::find_ids(
-            &mut txn,
+            reader.as_mut(),
             model::switch::SwitchSearchFilter {
                 rack_id: Some(r.id.clone()),
                 ..Default::default()
@@ -74,7 +81,7 @@ pub async fn get_rack(
         )
         .await?;
         let power_shelf_ids = db_power_shelf::find_ids(
-            &mut txn,
+            reader.as_mut(),
             model::power_shelf::PowerShelfSearchFilter {
                 rack_id: Some(r.id.clone()),
                 ..Default::default()
@@ -88,7 +95,6 @@ pub async fn get_rack(
         rpc_rack.power_shelves = power_shelf_ids;
         result.push(rpc_rack);
     }
-    let _ = txn.rollback().await;
 
     Ok(Response::new(rpc::GetRackResponse { rack: result }))
 }
@@ -244,12 +250,18 @@ pub async fn delete_rack(
         async move {
             let rack_id = RackId::from_str(&req.id)
                 .map_err(|e| CarbideError::InvalidArgument(format!("Invalid rack ID: {}", e)))?;
-            let _rack =
-                db_rack::get(txn.as_mut(), &rack_id)
-                    .await
-                    .map_err(|e| CarbideError::Internal {
-                        message: format!("Getting rack {}", e),
-                    })?;
+            let _rack = db_rack::find_by(
+                txn.as_mut(),
+                ObjectColumnFilter::One(db_rack::IdColumn, &rack_id),
+            )
+            .await
+            .map_err(CarbideError::from)?
+            .pop()
+            .ok_or_else(|| CarbideError::NotFoundError {
+                kind: "rack",
+                id: rack_id.to_string(),
+            })?;
+
             db_rack::mark_as_deleted(&rack_id, txn)
                 .await
                 .map_err(|e| CarbideError::Internal {
@@ -274,9 +286,17 @@ pub async fn list_rack_health_report_overrides(
         .rack_id
         .ok_or_else(|| CarbideError::MissingArgument("rack_id"))?;
 
-    let rack = db_rack::get(&api.database_connection, &rack_id)
-        .await
-        .map_err(CarbideError::from)?;
+    let rack = db_rack::find_by(
+        api.db_reader().as_mut(),
+        ObjectColumnFilter::One(db_rack::IdColumn, &rack_id),
+    )
+    .await
+    .map_err(CarbideError::from)?
+    .pop()
+    .ok_or_else(|| CarbideError::NotFoundError {
+        kind: "rack",
+        id: rack_id.to_string(),
+    })?;
 
     Ok(Response::new(rpc::ListHealthReportOverrideResponse {
         overrides: rack
@@ -321,9 +341,17 @@ pub async fn insert_rack_health_report_override(
 
     let mut txn = api.txn_begin().await?;
 
-    let rack = db_rack::get(&mut txn, &rack_id)
-        .await
-        .map_err(CarbideError::from)?;
+    let rack = db_rack::find_by(
+        &mut txn,
+        ObjectColumnFilter::One(db_rack::IdColumn, &rack_id),
+    )
+    .await
+    .map_err(CarbideError::from)?
+    .pop()
+    .ok_or_else(|| CarbideError::NotFoundError {
+        kind: "rack",
+        id: rack_id.to_string(),
+    })?;
 
     let mut report = health_report::HealthReport::try_from(report.clone())
         .map_err(|e| CarbideError::internal(e.to_string()))?;
@@ -356,9 +384,17 @@ pub async fn remove_rack_health_report_override(
 
     let mut txn = api.txn_begin().await?;
 
-    let rack = db_rack::get(&mut txn, &rack_id)
-        .await
-        .map_err(CarbideError::from)?;
+    let rack = db_rack::find_by(
+        &mut txn,
+        ObjectColumnFilter::One(db_rack::IdColumn, &rack_id),
+    )
+    .await
+    .map_err(CarbideError::from)?
+    .pop()
+    .ok_or_else(|| CarbideError::NotFoundError {
+        kind: "rack",
+        id: rack_id.to_string(),
+    })?;
 
     remove_rack_override_by_source(&rack, &mut txn, source).await?;
     txn.commit().await?;
@@ -404,9 +440,17 @@ pub async fn get_rack_capabilities(
         .rack_id
         .ok_or_else(|| CarbideError::MissingArgument("rack_id"))?;
 
-    let rack = db_rack::get(&api.database_connection, &rack_id)
-        .await
-        .map_err(CarbideError::from)?;
+    let rack = db_rack::find_by(
+        api.db_reader().as_mut(),
+        ObjectColumnFilter::One(db_rack::IdColumn, &rack_id),
+    )
+    .await
+    .map_err(CarbideError::from)?
+    .pop()
+    .ok_or_else(|| CarbideError::NotFoundError {
+        kind: "rack",
+        id: rack_id.to_string(),
+    })?;
 
     let rack_type_name = rack.config.rack_type.as_deref().unwrap_or_default();
     if rack_type_name.is_empty() {
@@ -457,9 +501,17 @@ pub(crate) async fn update_rack_metadata(
 
     let mut txn = api.txn_begin().await?;
 
-    let rack = db_rack::get(&mut txn, &rack_id)
-        .await
-        .map_err(CarbideError::from)?;
+    let rack = db_rack::find_by(
+        &mut txn,
+        ObjectColumnFilter::One(db_rack::IdColumn, &rack_id),
+    )
+    .await
+    .map_err(CarbideError::from)?
+    .pop()
+    .ok_or_else(|| CarbideError::NotFoundError {
+        kind: "rack",
+        id: rack_id.to_string(),
+    })?;
 
     let expected_version: config_version::ConfigVersion = match request.if_version_match {
         Some(version) => version.parse().map_err(CarbideError::from)?,

--- a/crates/api/src/handlers/rack_firmware.rs
+++ b/crates/api/src/handlers/rack_firmware.rs
@@ -18,7 +18,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use db::{DatabaseError, rack_firmware as rack_firmware_db};
+use db::{DatabaseError, ObjectColumnFilter, rack_firmware as rack_firmware_db};
 use forge_secrets::credentials::{CredentialKey, CredentialReader, Credentials};
 use rpc::forge::{
     DeviceUpdateResult, NodeJobInfo, RackFirmware, RackFirmwareApplyRequest,
@@ -1004,11 +1004,17 @@ pub async fn apply(
             serde_json::json!({})
         });
 
-    let rack = db::rack::get(&api.database_connection, &rack_id)
-        .await
-        .map_err(|e| CarbideError::Internal {
-            message: format!("Failed to get rack: {}", e),
-        })?;
+    let rack = db::rack::find_by(
+        api.db_reader().as_mut(),
+        ObjectColumnFilter::One(db::rack::IdColumn, &rack_id),
+    )
+    .await
+    .map_err(CarbideError::from)?
+    .pop()
+    .ok_or_else(|| CarbideError::NotFoundError {
+        kind: "rack",
+        id: rack_id.to_string(),
+    })?;
 
     // Validate firmware hardware type and firmware_type against rack capabilities.
     if let Some(rack_type_name) = rack.config.rack_type.as_deref()

--- a/crates/api/src/site_explorer/mod.rs
+++ b/crates/api/src/site_explorer/mod.rs
@@ -96,9 +96,9 @@ pub(crate) async fn ensure_rack_exists(
     txn: &mut sqlx::PgConnection,
     rack_id: &RackId,
 ) -> CarbideResult<Option<Rack>> {
-    match db::rack::get(&mut *txn, rack_id).await {
-        Ok(rack) => Ok(Some(rack)),
-        Err(DatabaseError::NotFoundError { .. }) => {
+    match db::rack::find_by(txn, ObjectColumnFilter::One(db::rack::IdColumn, rack_id)).await {
+        Ok(mut racks) if !racks.is_empty() => Ok(racks.pop()),
+        Ok(_) | Err(DatabaseError::NotFoundError { .. }) => {
             let expected = db::expected_rack::find_by_rack_id(&mut *txn, rack_id)
                 .await
                 .map_err(CarbideError::from)?;

--- a/crates/api/src/state_controller/power_shelf/io.rs
+++ b/crates/api/src/state_controller/power_shelf/io.rs
@@ -20,9 +20,11 @@
 use carbide_uuid::power_shelf::PowerShelfId;
 use config_version::{ConfigVersion, Versioned};
 use db::{DatabaseError, ObjectColumnFilter, power_shelf as db_power_shelf};
-use model::StateSla;
 use model::controller_outcome::PersistentStateHandlerOutcome;
-use model::power_shelf::{PowerShelf, PowerShelfControllerState, state_sla};
+use model::power_shelf::{
+    PowerShelf, PowerShelfControllerState, PowerShelfSearchFilter, state_sla,
+};
+use model::{DeletedFilter, StateSla};
 use sqlx::PgConnection;
 
 use crate::state_controller::io::StateControllerIO;
@@ -50,7 +52,16 @@ impl StateControllerIO for PowerShelfStateControllerIO {
         &self,
         txn: &mut PgConnection,
     ) -> Result<Vec<Self::ObjectId>, DatabaseError> {
-        db_power_shelf::list_segment_ids(txn).await
+        db_power_shelf::find_ids(
+            txn,
+            PowerShelfSearchFilter {
+                rack_id: None,
+                deleted: DeletedFilter::Include,
+                controller_state: None,
+                bmc_mac: None,
+            },
+        )
+        .await
     }
 
     /// Loads a state snapshot from the database

--- a/crates/api/src/state_controller/rack/io.rs
+++ b/crates/api/src/state_controller/rack/io.rs
@@ -53,7 +53,7 @@ impl StateControllerIO for RackStateControllerIO {
         &self,
         txn: &mut PgConnection,
     ) -> Result<Vec<Self::ObjectId>, DatabaseError> {
-        db_rack::find_ids(txn, RackSearchFilter::default()).await
+        db_rack::find_ids(txn, RackSearchFilter {}).await
     }
 
     /// Loads a state snapshot from the database

--- a/crates/api/src/state_controller/switch/io.rs
+++ b/crates/api/src/state_controller/switch/io.rs
@@ -22,7 +22,7 @@ use config_version::{ConfigVersion, Versioned};
 use db::{DatabaseError, ObjectColumnFilter, switch as db_switch};
 use model::StateSla;
 use model::controller_outcome::PersistentStateHandlerOutcome;
-use model::switch::{Switch, SwitchControllerState, state_sla};
+use model::switch::{Switch, SwitchControllerState, SwitchSearchFilter, state_sla};
 use sqlx::PgConnection;
 
 use crate::state_controller::io::StateControllerIO;
@@ -50,7 +50,16 @@ impl StateControllerIO for SwitchStateControllerIO {
         &self,
         txn: &mut PgConnection,
     ) -> Result<Vec<Self::ObjectId>, DatabaseError> {
-        db_switch::find_all(txn).await
+        db_switch::find_ids(
+            txn,
+            SwitchSearchFilter {
+                rack_id: None,
+                deleted: model::DeletedFilter::Include,
+                controller_state: None,
+                bmc_mac: None,
+            },
+        )
+        .await
     }
 
     /// Loads a state snapshot from the database

--- a/crates/api/src/tests/power_shelf.rs
+++ b/crates/api/src/tests/power_shelf.rs
@@ -17,7 +17,10 @@
 
 use carbide_uuid::power_shelf::PowerShelfId;
 use db::power_shelf as db_power_shelf;
-use model::power_shelf::{NewPowerShelf, PowerShelfConfig, PowerShelfStatus};
+use model::DeletedFilter;
+use model::power_shelf::{
+    NewPowerShelf, PowerShelfConfig, PowerShelfSearchFilter, PowerShelfStatus,
+};
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{AdminForceDeletePowerShelfRequest, PowerShelfDeletionRequest, PowerShelfQuery};
 use tonic::Code;
@@ -501,7 +504,16 @@ async fn test_power_shelf_list_segment_ids(
     }
 
     // Test listing all power shelf IDs
-    let listed_ids = db_power_shelf::list_segment_ids(&mut txn).await?;
+    let listed_ids = db_power_shelf::find_ids(
+        txn.as_mut(),
+        PowerShelfSearchFilter {
+            rack_id: None,
+            deleted: DeletedFilter::Include,
+            controller_state: None,
+            bmc_mac: None,
+        },
+    )
+    .await?;
 
     // Verify all created IDs are in the list
     for created_id in &created_ids {

--- a/crates/api/src/tests/power_shelf_state_controller/mod.rs
+++ b/crates/api/src/tests/power_shelf_state_controller/mod.rs
@@ -15,25 +15,18 @@
  * limitations under the License.
  */
 
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
-use carbide_uuid::power_shelf::PowerShelfId;
 use db::power_shelf as db_power_shelf;
-use model::power_shelf::{PowerShelf, PowerShelfControllerState};
+use model::power_shelf::PowerShelfControllerState;
 use rpc::forge::forge_server::Forge;
-use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
 use crate::state_controller::config::IterationConfig;
 use crate::state_controller::controller::StateController;
-use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
+use crate::state_controller::power_shelf::handler::PowerShelfStateHandler;
 use crate::state_controller::power_shelf::io::PowerShelfStateControllerIO;
-use crate::state_controller::state_handler::{
-    StateHandler, StateHandlerContext, StateHandlerError, StateHandlerOutcome,
-};
 use crate::tests::common;
 use crate::tests::common::api_fixtures::create_test_env;
 mod fixtures;
@@ -41,297 +34,6 @@ use fixtures::power_shelf::{mark_power_shelf_as_deleted, set_power_shelf_control
 use forge_secrets::credentials::TestCredentialManager;
 
 use crate::state_controller::common_services::CommonStateHandlerServices;
-
-#[derive(Debug, Default, Clone)]
-pub struct TestPowerShelfStateHandler {
-    /// The total count for the handler
-    pub count: Arc<AtomicUsize>,
-    /// We count for every power shelf ID how often the handler was called
-    pub counts_per_id: Arc<Mutex<HashMap<String, usize>>>,
-}
-
-#[async_trait::async_trait]
-impl StateHandler for TestPowerShelfStateHandler {
-    type State = PowerShelf;
-    type ControllerState = PowerShelfControllerState;
-    type ObjectId = PowerShelfId;
-    type ContextObjects = PowerShelfStateHandlerContextObjects;
-
-    async fn handle_object_state(
-        &self,
-        power_shelf_id: &PowerShelfId,
-        state: &mut PowerShelf,
-        _controller_state: &Self::ControllerState,
-        _ctx: &mut StateHandlerContext<Self::ContextObjects>,
-    ) -> Result<StateHandlerOutcome<Self::ControllerState>, StateHandlerError> {
-        assert_eq!(state.id, *power_shelf_id);
-        self.count.fetch_add(1, Ordering::SeqCst);
-        {
-            let mut guard = self.counts_per_id.lock().unwrap();
-            *guard.entry(power_shelf_id.to_string()).or_default() += 1;
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        Ok(StateHandlerOutcome::do_nothing())
-    }
-}
-
-#[crate::sqlx_test]
-async fn test_power_shelf_state_transitions(
-    pool: sqlx::PgPool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
-
-    // Create a power shelf
-    let power_shelf_id = common::api_fixtures::site_explorer::new_power_shelf(
-        &env,
-        Some("State Transition Test Power Shelf".to_string()),
-        Some(5000),
-        Some(240),
-        Some("Data Center A, Rack 1".to_string()),
-    )
-    .await?;
-
-    // Verify initial state is Initializing
-    let mut txn = pool.acquire().await?;
-    let power_shelf = db_power_shelf::find_by_id(&mut txn, &power_shelf_id).await?;
-    assert!(power_shelf.is_some());
-    let power_shelf = power_shelf.unwrap();
-    assert!(matches!(
-        power_shelf.controller_state.value,
-        PowerShelfControllerState::Initializing
-    ));
-
-    // Start the state controller
-    let power_shelf_handler = Arc::new(TestPowerShelfStateHandler::default());
-    const ITERATION_TIME: Duration = Duration::from_millis(50);
-    const TEST_TIME: Duration = Duration::from_secs(5);
-
-    let handler_services = Arc::new(CommonStateHandlerServices {
-        db_pool: pool.clone(),
-        db_reader: pool.clone().into(),
-        redfish_client_pool: env.redfish_sim.clone(),
-        ib_fabric_manager: env.ib_fabric_manager.clone(),
-        ib_pools: env.common_pools.infiniband.clone(),
-        ipmi_tool: env.ipmi_tool.clone(),
-        site_config: env.config.clone(),
-        dpa_info: None,
-        rms_client: None,
-        credential_manager: Arc::new(TestCredentialManager::default()),
-    });
-
-    let mut join_set = JoinSet::new();
-    let cancel_token = CancellationToken::new();
-    StateController::<PowerShelfStateControllerIO>::builder()
-        .iteration_config(IterationConfig {
-            iteration_time: ITERATION_TIME,
-            processor_dispatch_interval: Duration::from_millis(10),
-            ..Default::default()
-        })
-        .database(pool.clone(), env.api.work_lock_manager_handle.clone())
-        .processor_id(uuid::Uuid::new_v4().to_string())
-        .services(handler_services.clone())
-        .state_handler(power_shelf_handler.clone())
-        .build_and_spawn(&mut join_set, cancel_token.clone())
-        .unwrap();
-
-    tokio::time::sleep(TEST_TIME).await;
-    cancel_token.cancel();
-    join_set.join_all().await;
-
-    // Verify that the handler was called
-    let count = power_shelf_handler.count.load(Ordering::SeqCst);
-    assert!(
-        count > 0,
-        "State handler should have been called at least once"
-    );
-
-    // Verify that the power shelf ID was processed
-    let guard = power_shelf_handler.counts_per_id.lock().unwrap();
-    let count = guard
-        .get(&power_shelf_id.to_string())
-        .copied()
-        .unwrap_or_default();
-    assert!(count > 0, "Power shelf ID should have been processed");
-
-    Ok(())
-}
-
-#[crate::sqlx_test]
-async fn test_power_shelf_deletion_flow(
-    pool: sqlx::PgPool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
-
-    // Create a power shelf
-    let power_shelf_id = common::api_fixtures::site_explorer::new_power_shelf(
-        &env,
-        Some("Deletion Test Power Shelf".to_string()),
-        Some(5000),
-        Some(240),
-        Some("Data Center A, Rack 1".to_string()),
-    )
-    .await?;
-
-    // Verify power shelf exists
-    let mut txn = pool.acquire().await?;
-    let power_shelf = db_power_shelf::find_by_id(&mut txn, &power_shelf_id).await?;
-    assert!(power_shelf.is_some());
-
-    // Start the state controller to process the power shelf while it's active
-    let power_shelf_handler = Arc::new(TestPowerShelfStateHandler::default());
-    const ITERATION_TIME: Duration = Duration::from_millis(50);
-    const TEST_TIME: Duration = Duration::from_secs(2);
-
-    let handler_services = Arc::new(CommonStateHandlerServices {
-        db_pool: pool.clone(),
-        db_reader: pool.clone().into(),
-        redfish_client_pool: env.redfish_sim.clone(),
-        ib_fabric_manager: env.ib_fabric_manager.clone(),
-        ib_pools: env.common_pools.infiniband.clone(),
-        ipmi_tool: env.ipmi_tool.clone(),
-        site_config: env.config.clone(),
-        dpa_info: None,
-        rms_client: None,
-        credential_manager: Arc::new(TestCredentialManager::default()),
-    });
-
-    let mut join_set = JoinSet::new();
-    let cancel_token = CancellationToken::new();
-    StateController::<PowerShelfStateControllerIO>::builder()
-        .iteration_config(IterationConfig {
-            iteration_time: ITERATION_TIME,
-            processor_dispatch_interval: Duration::from_millis(10),
-            ..Default::default()
-        })
-        .database(pool.clone(), env.api.work_lock_manager_handle.clone())
-        .processor_id(uuid::Uuid::new_v4().to_string())
-        .services(handler_services.clone())
-        .state_handler(power_shelf_handler.clone())
-        .build_and_spawn(&mut join_set, cancel_token.clone())
-        .unwrap();
-
-    // Let the controller process the active power shelf
-    tokio::time::sleep(TEST_TIME).await;
-
-    // Verify that the handler was called while the power shelf was active
-    let count_before_deletion = power_shelf_handler.count.load(Ordering::SeqCst);
-    assert!(
-        count_before_deletion > 0,
-        "State handler should have been called while power shelf was active"
-    );
-
-    // Delete the power shelf
-    let delete_request = rpc::forge::PowerShelfDeletionRequest {
-        id: Some(power_shelf_id),
-    };
-
-    env.api
-        .delete_power_shelf(tonic::Request::new(delete_request))
-        .await?;
-
-    // Let the controller run for a bit more after deletion
-    tokio::time::sleep(TEST_TIME).await;
-    cancel_token.cancel();
-    join_set.join_all().await;
-
-    // Verify that the handler count didn't increase significantly after deletion
-    // (since deleted power shelves should not be processed)
-    let count_after_deletion = power_shelf_handler.count.load(Ordering::SeqCst);
-    let count_increase = count_after_deletion - count_before_deletion;
-
-    // The count might increase slightly due to timing, but should not increase significantly
-    // since deleted power shelves are excluded from processing
-    assert!(
-        count_increase <= 5, // Allow for some timing-related calls
-        "State handler should not process deleted power shelves significantly. Count increase: {}",
-        count_increase
-    );
-
-    Ok(())
-}
-
-#[crate::sqlx_test]
-async fn test_power_shelf_error_state_handling(
-    pool: sqlx::PgPool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
-
-    // Create a power shelf
-    let power_shelf_id = common::api_fixtures::site_explorer::new_power_shelf(
-        &env,
-        Some("Error State Test Power Shelf".to_string()),
-        Some(5000),
-        Some(240),
-        Some("Data Center A, Rack 1".to_string()),
-    )
-    .await?;
-
-    // Manually set the power shelf to error state for testing
-    let error_state = PowerShelfControllerState::Error {
-        cause: "Test error state".to_string(),
-    };
-
-    // Update the controller state directly in the database
-    set_power_shelf_controller_state(pool.acquire().await?.as_mut(), &power_shelf_id, error_state)
-        .await?;
-
-    // Start the state controller
-    let power_shelf_handler = Arc::new(TestPowerShelfStateHandler::default());
-    const ITERATION_TIME: Duration = Duration::from_millis(50);
-    const TEST_TIME: Duration = Duration::from_secs(5);
-
-    let handler_services = Arc::new(CommonStateHandlerServices {
-        db_pool: pool.clone(),
-        db_reader: pool.clone().into(),
-        redfish_client_pool: env.redfish_sim.clone(),
-        ib_fabric_manager: env.ib_fabric_manager.clone(),
-        ib_pools: env.common_pools.infiniband.clone(),
-        ipmi_tool: env.ipmi_tool.clone(),
-        site_config: env.config.clone(),
-        dpa_info: None,
-        rms_client: None,
-        credential_manager: Arc::new(TestCredentialManager::default()),
-    });
-
-    let mut join_set = JoinSet::new();
-    let cancel_token = CancellationToken::new();
-    StateController::<PowerShelfStateControllerIO>::builder()
-        .iteration_config(IterationConfig {
-            iteration_time: ITERATION_TIME,
-            processor_dispatch_interval: Duration::from_millis(10),
-            ..Default::default()
-        })
-        .database(pool.clone(), env.api.work_lock_manager_handle.clone())
-        .processor_id(uuid::Uuid::new_v4().to_string())
-        .services(handler_services.clone())
-        .state_handler(power_shelf_handler.clone())
-        .build_and_spawn(&mut join_set, cancel_token.clone())
-        .unwrap();
-
-    tokio::time::sleep(TEST_TIME).await;
-    cancel_token.cancel();
-    join_set.join_all().await;
-
-    // Verify that the handler was called even in error state
-    let count = power_shelf_handler.count.load(Ordering::SeqCst);
-    assert!(
-        count > 0,
-        "State handler should have been called in error state"
-    );
-
-    // Verify that the power shelf ID was processed
-    let guard = power_shelf_handler.counts_per_id.lock().unwrap();
-    let count = guard
-        .get(&power_shelf_id.to_string())
-        .copied()
-        .unwrap_or_default();
-    assert!(
-        count > 0,
-        "Power shelf ID should have been processed in error state"
-    );
-
-    Ok(())
-}
 
 #[crate::sqlx_test]
 async fn test_power_shelf_state_transition_validation(
@@ -407,9 +109,8 @@ async fn test_power_shelf_deletion_with_state_controller(
     .await?;
 
     // Start the state controller
-    let power_shelf_handler = Arc::new(TestPowerShelfStateHandler::default());
+    let power_shelf_handler = Arc::new(PowerShelfStateHandler::default());
     const ITERATION_TIME: Duration = Duration::from_millis(50);
-    const TEST_TIME: Duration = Duration::from_secs(2);
 
     let handler_services = Arc::new(CommonStateHandlerServices {
         db_pool: pool.clone(),
@@ -424,9 +125,8 @@ async fn test_power_shelf_deletion_with_state_controller(
         credential_manager: Arc::new(TestCredentialManager::default()),
     });
 
-    let mut join_set = JoinSet::new();
     let cancel_token = CancellationToken::new();
-    StateController::<PowerShelfStateControllerIO>::builder()
+    let mut controller = StateController::<PowerShelfStateControllerIO>::builder()
         .iteration_config(IterationConfig {
             iteration_time: ITERATION_TIME,
             processor_dispatch_interval: Duration::from_millis(10),
@@ -436,40 +136,46 @@ async fn test_power_shelf_deletion_with_state_controller(
         .processor_id(uuid::Uuid::new_v4().to_string())
         .services(handler_services.clone())
         .state_handler(power_shelf_handler.clone())
-        .build_and_spawn(&mut join_set, cancel_token.clone())
+        .build_for_manual_iterations(cancel_token.clone())
         .unwrap();
 
-    // Let the controller run for a bit to process the active power shelf
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    // Walk through state machine
+    for _ in 0..20 {
+        controller.run_single_iteration().await;
+    }
 
-    // Verify that the handler was called while the power shelf was active
-    let count_before_deletion = power_shelf_handler.count.load(Ordering::SeqCst);
-    assert!(
-        count_before_deletion > 0,
-        "State handler should have been called while power shelf was active"
+    let power_shelf = env
+        .api
+        .find_power_shelves_by_ids(tonic::Request::new(rpc::forge::PowerShelvesByIdsRequest {
+            power_shelf_ids: vec![power_shelf_id],
+        }))
+        .await?
+        .into_inner()
+        .power_shelves
+        .remove(0);
+    assert_eq!(
+        power_shelf.controller_state,
+        "{\"state\":\"ready\"}".to_string()
     );
 
     // Mark the power shelf as deleted
     mark_power_shelf_as_deleted(pool.acquire().await?.as_mut(), &power_shelf_id).await?;
 
-    // Let the controller run for a bit more after marking as deleted
-    tokio::time::sleep(TEST_TIME).await;
-    cancel_token.cancel();
-    join_set.join_all().await;
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    // Walk through state machine
+    for _ in 0..20 {
+        controller.run_single_iteration().await;
+    }
 
-    // Verify that the handler count didn't increase significantly after marking as deleted
-    // (since deleted power shelves should not be processed)
-    let count_after_deletion = power_shelf_handler.count.load(Ordering::SeqCst);
-    let count_increase = count_after_deletion - count_before_deletion;
-
-    // The count might increase slightly due to timing, but should not increase significantly
-    // since deleted power shelves are excluded from processing
-    assert!(
-        count_increase <= 5, // Allow for some timing-related calls
-        "State handler should not process deleted power shelves significantly. Count increase: {}",
-        count_increase
-    );
+    // Verify that the DB object is gone
+    let power_shelves = env
+        .api
+        .find_power_shelves_by_ids(tonic::Request::new(rpc::forge::PowerShelvesByIdsRequest {
+            power_shelf_ids: vec![power_shelf_id],
+        }))
+        .await?
+        .into_inner()
+        .power_shelves;
+    assert!(power_shelves.is_empty());
 
     Ok(())
 }

--- a/crates/api/src/tests/rack_metadata.rs
+++ b/crates/api/src/tests/rack_metadata.rs
@@ -16,7 +16,7 @@
  */
 
 use carbide_uuid::rack::RackId;
-use db::{DatabaseError, rack as db_rack};
+use db::{DatabaseError, ObjectColumnFilter, rack as db_rack};
 use model::metadata::Metadata;
 use model::rack::RackConfig;
 
@@ -110,7 +110,14 @@ async fn test_rack_metadata_update(pool: sqlx::PgPool) -> Result<(), Box<dyn std
 
     db_rack::update_metadata(&mut txn, &rack_id, version1, new_metadata.clone()).await?;
 
-    let updated_rack = db_rack::get(&mut *txn, &rack_id).await?;
+    let updated_rack = db_rack::find_by(
+        txn.as_mut(),
+        ObjectColumnFilter::One(db_rack::IdColumn, &rack_id),
+    )
+    .await
+    .unwrap()
+    .pop()
+    .unwrap();
     assert_eq!(updated_rack.metadata.name, "Updated Rack");
     assert_eq!(updated_rack.metadata.description, "Updated description");
     assert_eq!(

--- a/crates/api/src/tests/rack_state_controller/handler.rs
+++ b/crates/api/src/tests/rack_state_controller/handler.rs
@@ -17,10 +17,11 @@
 
 use carbide_uuid::machine::{MachineId, MachineIdSource, MachineType};
 use carbide_uuid::rack::RackId;
-use db::{expected_rack as db_expected_rack, rack as db_rack};
+use db::db_read::DbReader;
+use db::{ObjectColumnFilter, expected_rack as db_expected_rack, rack as db_rack};
 use model::expected_rack::ExpectedRack;
 use model::rack::{
-    FirmwareUpgradeState, RackConfig, RackMaintenanceState, RackPowerState, RackState,
+    FirmwareUpgradeState, Rack, RackConfig, RackMaintenanceState, RackPowerState, RackState,
     RackValidationState,
 };
 use model::rack_type::{
@@ -179,7 +180,7 @@ async fn test_expected_no_definition_stays_parked(
     )
     .await?;
 
-    let mut rack = db_rack::get(&pool, &rack_id).await?;
+    let mut rack = get_db_rack(txn.as_mut(), &rack_id).await;
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -294,7 +295,7 @@ async fn test_expected_counts_match_but_not_linked_stays(
 
     create_expected_rack(&pool, &rack_id, "NVL72").await;
 
-    let mut rack = db_rack::get(&pool, &rack_id).await?;
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -367,7 +368,7 @@ async fn test_expected_zero_topology_transitions_to_discovering(
 
     create_expected_rack(&pool, &rack_id, "Empty").await;
 
-    let mut rack = db_rack::get(&pool, &rack_id).await?;
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -446,7 +447,7 @@ async fn test_expected_more_discovered_than_expected_transitions(
     )
     .await?;
 
-    let mut rack = db_rack::get(&pool, &rack_id).await?;
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -572,7 +573,7 @@ async fn test_discovering_empty_rack_transitions_to_maintenance(
     };
     db_rack::update(&mut txn, &rack_id, &cfg).await?;
 
-    let mut rack = db_rack::get(&pool, &rack_id).await?;
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -625,7 +626,7 @@ async fn test_error_state_does_nothing(
     )
     .await?;
 
-    let mut rack = db_rack::get(&pool, &rack_id).await?;
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -673,7 +674,7 @@ async fn test_maintenance_completed_transitions_to_validation(
     )
     .await?;
 
-    let mut rack = db_rack::get(&pool, &rack_id).await?;
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -735,7 +736,7 @@ async fn test_ready_with_no_labels_stays_ready(
     )
     .await?;
 
-    let mut rack = db_rack::get(&pool, &rack_id).await?;
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -785,7 +786,7 @@ async fn test_firmware_upgrade_start_transitions_to_wait_for_complete(
     )
     .await?;
 
-    let mut rack = db_rack::get(&pool, &rack_id).await?;
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler_instance = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -851,7 +852,7 @@ async fn test_configure_nmx_cluster_transitions_to_completed(
     )
     .await?;
 
-    let mut rack = db_rack::get(&pool, &rack_id).await?;
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler_instance = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -921,7 +922,7 @@ async fn test_ready_topology_changed_transitions_to_discovering(
     };
     db_rack::update(&mut txn, &rack_id, &cfg).await?;
 
-    let mut rack = db_rack::get(&pool, &rack_id).await?;
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler_instance = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -981,7 +982,7 @@ async fn test_ready_reprovision_requested_transitions_to_maintenance(
     };
     db_rack::update(&mut txn, &rack_id, &cfg).await?;
 
-    let mut rack = db_rack::get(&pool, &rack_id).await?;
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler_instance = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -1035,7 +1036,7 @@ async fn test_validation_failed_transitions_to_error(
     )
     .await?;
 
-    let mut rack = db_rack::get(&pool, &rack_id).await?;
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler_instance = RackStateHandler::default();
     let mut services = env.state_handler_services();
@@ -1063,4 +1064,15 @@ async fn test_validation_failed_transitions_to_error(
     );
 
     Ok(())
+}
+
+async fn get_db_rack<DB>(conn: &mut DB, rack_id: &RackId) -> Rack
+where
+    for<'db> &'db mut DB: DbReader<'db>,
+{
+    db_rack::find_by(conn, ObjectColumnFilter::One(db_rack::IdColumn, rack_id))
+        .await
+        .unwrap()
+        .pop()
+        .unwrap()
 }

--- a/crates/api/src/tests/rack_state_controller/mod.rs
+++ b/crates/api/src/tests/rack_state_controller/mod.rs
@@ -21,7 +21,8 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use carbide_uuid::rack::RackId;
-use db::{self, machine as db_machine, rack as db_rack};
+use db::db_read::DbReader;
+use db::{self, ObjectColumnFilter, machine as db_machine, rack as db_rack};
 use model::expected_machine::ExpectedMachineData;
 use model::machine::ManagedHostState;
 use model::machine::machine_search_config::MachineSearchConfig;
@@ -219,7 +220,7 @@ async fn test_can_retrieve_rack_state_history_with_real_handler(
     // power shelves, so Created transitions immediately.
     controller.run_single_iteration().await;
 
-    let rack = db_rack::get(&pool, &rack_id).await?;
+    let rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
     assert!(
         matches!(rack.controller_state.value, RackState::Discovering),
         "Expected rack to be in Discovering, got: {:?}",
@@ -232,7 +233,7 @@ async fn test_can_retrieve_rack_state_history_with_real_handler(
     // Both machines are already Ready (created above).
     controller.run_single_iteration().await;
 
-    let rack = db_rack::get(&pool, &rack_id).await?;
+    let rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
     assert!(
         matches!(
             rack.controller_state.value,
@@ -258,7 +259,7 @@ async fn test_can_retrieve_rack_state_history_with_real_handler(
     controller.run_single_iteration().await; // ConfigureNmxCluster -> PowerSequence(PoweringOn)
     controller.run_single_iteration().await; // PowerSequence(PoweringOn) -> Completed
 
-    let rack = db_rack::get(&pool, &rack_id).await?;
+    let rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
     assert!(
         matches!(
             rack.controller_state.value,
@@ -274,7 +275,7 @@ async fn test_can_retrieve_rack_state_history_with_real_handler(
     // The handler clears rv.* labels (none present yet) and transitions.
     controller.run_single_iteration().await;
 
-    let rack = db_rack::get(&pool, &rack_id).await?;
+    let rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
     assert!(
         matches!(
             rack.controller_state.value,
@@ -322,7 +323,7 @@ async fn test_can_retrieve_rack_state_history_with_real_handler(
     // The handler finds rv.run-id on a machine and promotes to InProgress.
     controller.run_single_iteration().await;
 
-    let rack = db_rack::get(&pool, &rack_id).await?;
+    let rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
     assert!(
         matches!(
             rack.controller_state.value,
@@ -340,7 +341,7 @@ async fn test_can_retrieve_rack_state_history_with_real_handler(
     // Partition p0 has validated > 0 (both nodes pass), so InProgress -> Partial.
     controller.run_single_iteration().await;
 
-    let rack = db_rack::get(&pool, &rack_id).await?;
+    let rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
     assert!(
         matches!(
             rack.controller_state.value,
@@ -358,7 +359,7 @@ async fn test_can_retrieve_rack_state_history_with_real_handler(
     // validated(1) == total_partitions(1) -> Validated.
     controller.run_single_iteration().await;
 
-    let rack = db_rack::get(&pool, &rack_id).await?;
+    let rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
     assert!(
         matches!(
             rack.controller_state.value,
@@ -375,7 +376,7 @@ async fn test_can_retrieve_rack_state_history_with_real_handler(
     // Iteration 11: Validating(Validated) -> Ready.
     controller.run_single_iteration().await;
 
-    let rack = db_rack::get(&pool, &rack_id).await?;
+    let rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
     assert!(
         matches!(rack.controller_state.value, RackState::Ready),
         "Expected Ready, got: {:?}",
@@ -457,7 +458,7 @@ async fn test_error_state_does_nothing_with_controller(
 
     controller.run_single_iteration().await;
 
-    let rack = db_rack::get(&pool, &rack_id).await?;
+    let rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
     assert!(
         matches!(rack.controller_state.value, RackState::Error { .. }),
         "Error state should not transition"
@@ -553,7 +554,7 @@ async fn test_rack_controller_state_version_increment(
     .await?;
 
     // Verify initial state
-    let rack = db_rack::get(&mut *txn, &rack_id).await?;
+    let rack = get_db_rack(txn.as_mut(), &rack_id).await;
     assert!(matches!(rack.controller_state.value, RackState::Created));
     let initial_version = rack.controller_state.version;
 
@@ -570,7 +571,7 @@ async fn test_rack_controller_state_version_increment(
     assert!(updated, "update with correct version should succeed");
 
     // Verify version was incremented
-    let rack = db_rack::get(&mut *txn, &rack_id).await?;
+    let rack = get_db_rack(txn.as_mut(), &rack_id).await;
     assert_eq!(
         rack.controller_state.version.version_nr(),
         initial_version.version_nr() + 1,
@@ -606,4 +607,15 @@ async fn test_rack_controller_state_version_increment(
     txn.rollback().await?;
 
     Ok(())
+}
+
+async fn get_db_rack<DB>(conn: &mut DB, rack_id: &RackId) -> Rack
+where
+    for<'db> &'db mut DB: DbReader<'db>,
+{
+    db_rack::find_by(conn, ObjectColumnFilter::One(db_rack::IdColumn, rack_id))
+        .await
+        .unwrap()
+        .pop()
+        .unwrap()
 }

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -39,6 +39,7 @@ use model::site_explorer::{
     Chassis, ComputerSystem, EndpointExplorationError, EndpointExplorationReport, EndpointType,
     ExploredDpu, ExploredEndpoint, ExploredManagedHost, PreingestionState, UefiDevicePath,
 };
+use model::switch::SwitchSearchFilter;
 use rpc::forge::GetSiteExplorationRequest;
 use rpc::forge::forge_server::Forge;
 use rpc::site_explorer::{
@@ -3080,7 +3081,7 @@ async fn test_site_explorer_switch_discovery(
     );
 
     let mut txn = env.pool.begin().await?;
-    let switches = db::switch::find_all(txn.as_mut()).await?;
+    let switches = db::switch::find_ids(txn.as_mut(), SwitchSearchFilter::default()).await?;
     println!("switches: {:?}", switches);
     txn.commit().await?;
     assert_eq!(switches.len(), 1, "Expected one switch to be created");

--- a/crates/api/src/tests/switch.rs
+++ b/crates/api/src/tests/switch.rs
@@ -16,7 +16,9 @@
  */
 use carbide_uuid::switch::SwitchId;
 use db::switch as db_switch;
-use model::switch::{NewSwitch, SwitchConfig, SwitchControllerState, SwitchStatus};
+use model::switch::{
+    NewSwitch, SwitchConfig, SwitchControllerState, SwitchSearchFilter, SwitchStatus,
+};
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{AdminForceDeleteSwitchRequest, SwitchDeletionRequest, SwitchQuery};
 use tonic::Code;
@@ -467,7 +469,7 @@ async fn test_switch_find_all(pool: sqlx::PgPool) -> Result<(), Box<dyn std::err
     }
 
     // Test listing all switch IDs
-    let listed_ids = db_switch::find_all(&mut txn).await?;
+    let listed_ids = db_switch::find_ids(txn.as_mut(), SwitchSearchFilter::default()).await?;
 
     // Verify all created IDs are in the list
     for created_id in &created_ids {

--- a/crates/api/src/tests/switch_state_controller/mod.rs
+++ b/crates/api/src/tests/switch_state_controller/mod.rs
@@ -15,26 +15,18 @@
  * limitations under the License.
  */
 
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
-use carbide_uuid::switch::SwitchId;
 use db::switch as db_switch;
 use forge_secrets::credentials::TestCredentialManager;
-use model::switch::{ConfiguringState, Switch, SwitchControllerState};
+use model::switch::{ConfiguringState, SwitchControllerState};
 use rpc::forge::forge_server::Forge;
-use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
 use crate::state_controller::common_services::CommonStateHandlerServices;
 use crate::state_controller::config::IterationConfig;
 use crate::state_controller::controller::StateController;
-use crate::state_controller::state_handler::{
-    StateHandler, StateHandlerContext, StateHandlerError, StateHandlerOutcome,
-};
-use crate::state_controller::switch::context::SwitchStateHandlerContextObjects;
 use crate::state_controller::switch::handler::SwitchStateHandler;
 use crate::state_controller::switch::io::SwitchStateControllerIO;
 use crate::tests::common;
@@ -42,287 +34,6 @@ use crate::tests::common::api_fixtures::create_test_env;
 
 mod fixtures;
 use fixtures::switch::{mark_switch_as_deleted, set_switch_controller_state};
-
-#[derive(Debug, Default, Clone)]
-pub struct TestSwitchStateHandler {
-    /// The total count for the handler
-    pub count: Arc<AtomicUsize>,
-    /// We count for every switch ID how often the handler was called
-    pub counts_per_id: Arc<Mutex<HashMap<String, usize>>>,
-}
-
-#[async_trait::async_trait]
-impl StateHandler for TestSwitchStateHandler {
-    type State = Switch;
-    type ControllerState = SwitchControllerState;
-    type ObjectId = SwitchId;
-    type ContextObjects = SwitchStateHandlerContextObjects;
-
-    async fn handle_object_state(
-        &self,
-        switch_id: &SwitchId,
-        state: &mut Switch,
-        _controller_state: &Self::ControllerState,
-        _ctx: &mut StateHandlerContext<Self::ContextObjects>,
-    ) -> Result<StateHandlerOutcome<Self::ControllerState>, StateHandlerError> {
-        assert_eq!(state.id, *switch_id);
-        self.count.fetch_add(1, Ordering::SeqCst);
-        {
-            let mut guard = self.counts_per_id.lock().unwrap();
-            *guard.entry(switch_id.to_string()).or_default() += 1;
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        Ok(StateHandlerOutcome::do_nothing())
-    }
-}
-
-#[crate::sqlx_test]
-async fn test_switch_state_transitions(
-    pool: sqlx::PgPool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
-
-    // Create a switch
-    let switch_id = common::api_fixtures::site_explorer::new_switch(
-        &env,
-        Some("Switch1".to_string()),
-        Some("Data Center A, Rack 1".to_string()),
-    )
-    .await?;
-
-    // Verify initial state is Initializing
-    let mut txn = pool.acquire().await?;
-    let switch = db_switch::find_by_id(&mut txn, &switch_id).await?;
-    assert!(switch.is_some());
-    let switch = switch.unwrap();
-    assert!(matches!(
-        switch.controller_state.value,
-        SwitchControllerState::Created
-    ));
-
-    // Start the state controller
-    let switch_handler = Arc::new(TestSwitchStateHandler::default());
-    const ITERATION_TIME: Duration = Duration::from_millis(50);
-    const TEST_TIME: Duration = Duration::from_secs(5);
-
-    let handler_services = Arc::new(CommonStateHandlerServices {
-        db_pool: pool.clone(),
-        db_reader: pool.clone().into(),
-        redfish_client_pool: env.redfish_sim.clone(),
-        ib_fabric_manager: env.ib_fabric_manager.clone(),
-        ib_pools: env.common_pools.infiniband.clone(),
-        ipmi_tool: env.ipmi_tool.clone(),
-        site_config: env.config.clone(),
-        dpa_info: None,
-        rms_client: None,
-        credential_manager: Arc::new(TestCredentialManager::default()),
-    });
-
-    let cancel_token = CancellationToken::new();
-    let mut join_set = JoinSet::new();
-    StateController::<SwitchStateControllerIO>::builder()
-        .iteration_config(IterationConfig {
-            iteration_time: ITERATION_TIME,
-            processor_dispatch_interval: Duration::from_millis(10),
-            ..Default::default()
-        })
-        .database(pool.clone(), env.api.work_lock_manager_handle.clone())
-        .processor_id(uuid::Uuid::new_v4().to_string())
-        .services(handler_services.clone())
-        .state_handler(switch_handler.clone())
-        .build_and_spawn(&mut join_set, cancel_token.clone())
-        .unwrap();
-
-    tokio::time::sleep(TEST_TIME).await;
-    cancel_token.cancel();
-    join_set.join_all().await;
-
-    // Verify that the handler was called
-    let count = switch_handler.count.load(Ordering::SeqCst);
-    assert!(
-        count > 0,
-        "State handler should have been called at least once"
-    );
-
-    // Verify that the switch ID was processed
-    let guard = switch_handler.counts_per_id.lock().unwrap();
-    let count = guard
-        .get(&switch_id.to_string())
-        .copied()
-        .unwrap_or_default();
-    assert!(count > 0, "Switch ID should have been processed");
-
-    Ok(())
-}
-
-#[crate::sqlx_test]
-async fn test_switch_deletion_flow(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
-
-    // Create a switch
-    let switch_id = common::api_fixtures::site_explorer::new_switch(
-        &env,
-        Some("Switch1".to_string()),
-        Some("Data Center A, Rack 1".to_string()),
-    )
-    .await?;
-
-    // Verify switch exists
-    let mut txn = pool.acquire().await?;
-    let switch = db_switch::find_by_id(&mut txn, &switch_id).await?;
-    assert!(switch.is_some());
-
-    // Start the state controller to process the switch while it's active
-    let switch_handler = Arc::new(TestSwitchStateHandler::default());
-    const ITERATION_TIME: Duration = Duration::from_millis(50);
-    const TEST_TIME: Duration = Duration::from_secs(2);
-
-    let handler_services = Arc::new(CommonStateHandlerServices {
-        db_pool: pool.clone(),
-        db_reader: pool.clone().into(),
-        redfish_client_pool: env.redfish_sim.clone(),
-        ib_fabric_manager: env.ib_fabric_manager.clone(),
-        ib_pools: env.common_pools.infiniband.clone(),
-        ipmi_tool: env.ipmi_tool.clone(),
-        site_config: env.config.clone(),
-        dpa_info: None,
-        rms_client: None,
-        credential_manager: Arc::new(TestCredentialManager::default()),
-    });
-
-    let cancel_token = CancellationToken::new();
-    let mut join_set = JoinSet::new();
-    StateController::<SwitchStateControllerIO>::builder()
-        .iteration_config(IterationConfig {
-            iteration_time: ITERATION_TIME,
-            processor_dispatch_interval: Duration::from_millis(10),
-            ..Default::default()
-        })
-        .database(pool.clone(), env.api.work_lock_manager_handle.clone())
-        .processor_id(uuid::Uuid::new_v4().to_string())
-        .services(handler_services.clone())
-        .state_handler(switch_handler.clone())
-        .build_and_spawn(&mut join_set, cancel_token.clone())
-        .unwrap();
-
-    // Let the controller process the active switch
-    tokio::time::sleep(TEST_TIME).await;
-
-    // Verify that the handler was called while the switch was active
-    let count_before_deletion = switch_handler.count.load(Ordering::SeqCst);
-    assert!(
-        count_before_deletion > 0,
-        "State handler should have been called while switch was active"
-    );
-
-    // Delete the switch
-    let delete_request = rpc::forge::SwitchDeletionRequest {
-        id: Some(switch_id),
-    };
-
-    env.api
-        .delete_switch(tonic::Request::new(delete_request))
-        .await?;
-
-    tokio::time::sleep(TEST_TIME).await;
-    cancel_token.cancel();
-    join_set.join_all().await;
-
-    // Verify that the handler count didn't increase significantly after deletion
-    // (since deleted switches should not be processed)
-    let count_after_deletion = switch_handler.count.load(Ordering::SeqCst);
-    let count_increase = count_after_deletion - count_before_deletion;
-
-    // The count might increase slightly due to timing, but should not increase significantly
-    // since deleted switches are excluded from processing
-    assert!(
-        count_increase <= 5, // Allow for some timing-related calls
-        "State handler should not process deleted switches significantly. Count increase: {}",
-        count_increase
-    );
-
-    Ok(())
-}
-
-#[crate::sqlx_test]
-async fn test_switch_error_state_handling(
-    pool: sqlx::PgPool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
-
-    // Create a switch
-    let switch_id = common::api_fixtures::site_explorer::new_switch(
-        &env,
-        Some("Switch1".to_string()),
-        Some("Data Center A, Rack 1".to_string()),
-    )
-    .await?;
-
-    // Manually set the switch to error state for testing
-    let error_state = SwitchControllerState::Error {
-        cause: "Test error state".to_string(),
-    };
-
-    // Update the controller state directly in the database
-    set_switch_controller_state(pool.acquire().await?.as_mut(), &switch_id, error_state).await?;
-
-    // Start the state controller
-    let switch_handler = Arc::new(TestSwitchStateHandler::default());
-    const ITERATION_TIME: Duration = Duration::from_millis(50);
-    const TEST_TIME: Duration = Duration::from_secs(5);
-
-    let handler_services = Arc::new(CommonStateHandlerServices {
-        db_pool: pool.clone(),
-        db_reader: pool.clone().into(),
-        redfish_client_pool: env.redfish_sim.clone(),
-        ib_fabric_manager: env.ib_fabric_manager.clone(),
-        ib_pools: env.common_pools.infiniband.clone(),
-        ipmi_tool: env.ipmi_tool.clone(),
-        site_config: env.config.clone(),
-        dpa_info: None,
-        rms_client: None,
-        credential_manager: Arc::new(TestCredentialManager::default()),
-    });
-
-    let cancel_token = CancellationToken::new();
-    let mut join_set = JoinSet::new();
-    StateController::<SwitchStateControllerIO>::builder()
-        .iteration_config(IterationConfig {
-            iteration_time: ITERATION_TIME,
-            processor_dispatch_interval: Duration::from_millis(10),
-            ..Default::default()
-        })
-        .database(pool.clone(), env.api.work_lock_manager_handle.clone())
-        .processor_id(uuid::Uuid::new_v4().to_string())
-        .services(handler_services.clone())
-        .state_handler(switch_handler.clone())
-        .build_and_spawn(&mut join_set, cancel_token.clone())
-        .unwrap();
-
-    tokio::time::sleep(TEST_TIME).await;
-    cancel_token.cancel();
-    join_set.join_all().await;
-
-    // Verify that the handler was called even in error state
-    let count = switch_handler.count.load(Ordering::SeqCst);
-    assert!(
-        count > 0,
-        "State handler should have been called in error state"
-    );
-
-    // Verify that the switch ID was processed
-    let guard = switch_handler.counts_per_id.lock().unwrap();
-    let count = guard
-        .get(&switch_id.to_string())
-        .copied()
-        .unwrap_or_default();
-    assert!(
-        count > 0,
-        "Switch ID should have been processed in error state"
-    );
-
-    Ok(())
-}
 
 #[crate::sqlx_test]
 async fn test_switch_state_transition_validation(
@@ -391,9 +102,8 @@ async fn test_switch_deletion_with_state_controller(
     .await?;
 
     // Start the state controller
-    let switch_handler = Arc::new(TestSwitchStateHandler::default());
+    let switch_handler = Arc::new(SwitchStateHandler::default());
     const ITERATION_TIME: Duration = Duration::from_millis(50);
-    const TEST_TIME: Duration = Duration::from_secs(2);
 
     let handler_services = Arc::new(CommonStateHandlerServices {
         db_pool: pool.clone(),
@@ -409,8 +119,7 @@ async fn test_switch_deletion_with_state_controller(
     });
 
     let cancel_token = CancellationToken::new();
-    let mut join_set = JoinSet::new();
-    StateController::<SwitchStateControllerIO>::builder()
+    let mut controller = StateController::<SwitchStateControllerIO>::builder()
         .iteration_config(IterationConfig {
             iteration_time: ITERATION_TIME,
             processor_dispatch_interval: Duration::from_millis(10),
@@ -420,39 +129,43 @@ async fn test_switch_deletion_with_state_controller(
         .processor_id(uuid::Uuid::new_v4().to_string())
         .services(handler_services.clone())
         .state_handler(switch_handler.clone())
-        .build_and_spawn(&mut join_set, cancel_token.clone())
+        .build_for_manual_iterations(cancel_token.clone())
         .unwrap();
 
-    // Let the controller run for a bit to process the active switch
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    // Walk through state machine
+    for _ in 0..20 {
+        controller.run_single_iteration().await;
+    }
 
-    // Verify that the handler was called while the switch was active
-    let count_before_deletion = switch_handler.count.load(Ordering::SeqCst);
-    assert!(
-        count_before_deletion > 0,
-        "State handler should have been called while switch was active"
-    );
+    let switch = env
+        .api
+        .find_switches_by_ids(tonic::Request::new(rpc::forge::SwitchesByIdsRequest {
+            switch_ids: vec![switch_id],
+        }))
+        .await?
+        .into_inner()
+        .switches
+        .remove(0);
+    assert_eq!(switch.controller_state, "{\"state\":\"ready\"}".to_string());
 
     // Mark the switch as deleted
     mark_switch_as_deleted(pool.acquire().await?.as_mut(), &switch_id).await?;
 
-    // Let the controller run for a bit more after marking as deleted
-    tokio::time::sleep(TEST_TIME).await;
-    cancel_token.cancel();
-    join_set.join_all().await;
+    // Walk through state machine
+    for _ in 0..20 {
+        controller.run_single_iteration().await;
+    }
 
-    // Verify that the handler count didn't increase significantly after marking as deleted
-    // (since deleted switches should not be processed)
-    let count_after_deletion = switch_handler.count.load(Ordering::SeqCst);
-    let count_increase = count_after_deletion - count_before_deletion;
-
-    // The count might increase slightly due to timing, but should not increase significantly
-    // since deleted switches are excluded from processing
-    assert!(
-        count_increase <= 5, // Allow for some timing-related calls
-        "State handler should not process deleted switches significantly. Count increase: {}",
-        count_increase
-    );
+    // Verify that the DB object is gone
+    let switches = env
+        .api
+        .find_switches_by_ids(tonic::Request::new(rpc::forge::SwitchesByIdsRequest {
+            switch_ids: vec![switch_id],
+        }))
+        .await?
+        .into_inner()
+        .switches;
+    assert!(switches.is_empty());
 
     Ok(())
 }


### PR DESCRIPTION
## Description

Its not ok to exclude objects that are marked as deleted from certain queries, because this means the state handler would no longer run on them. Therefore the objects would also never flow from the READY state into the actual DELETING states, and would never get fully removed from the database.

Due to that the objects would stay forever invisible in the database, and new objects with the same name also could not get created.

This change removes the DELETED filters and migrates code from the more specialized find functions (e.g. `find_all`) to the standardized `find_ids` and `find_by` functions.

It also fixes the unit-tests referencing the wrong behavior and deletes some unit-test that were just duplications of the base stand-handler unit-tests.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

