### PR TITLE
fix(bmc-explorer): work around BlueField-3 DPU ERoT chassis timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6558,9 +6558,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66689536dc565b539a8636894449215b1b694784628c2928d0609e53cbf5fbc"
+checksum = "6bbabc6ec4282913f6aed55ae46cf9b381ec185de12839b714005eda7ef59b7a"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -6574,9 +6574,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-bmc-http"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6510d7a2155ff4d7054c89afa7700972fb27e32f1138ea988c2025f3c8756edc"
+checksum = "e0417d9aab9f91c3cc38713ea839a7a1e1a7eea83e01693b2c4d2006e99e989f"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -6594,9 +6594,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-core"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37bfa3c6ab939e8be20ebd5feeb51b01cf475f67faf07d31db1d28951ffd34cb"
+checksum = "36c747366715084fc42415623d78109a3db13afdfe02eb11e595d05b5474caac"
 dependencies = [
  "futures-core",
  "rust_decimal",
@@ -6608,9 +6608,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-csdl-compiler"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ab80d9109120adcd29beac75c0162333c85fca5054730271c05028bd62b52f"
+checksum = "3a526c4b2f23ef1766572a24bd9c88a85ab45e8610114b811d7e6a6669f0139b"
 dependencies = [
  "clap",
  "clap_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ tracing-appender = "0.2.4"
 tracing-opentelemetry = "0.29.0"
 
 # NV-Redfish
-nv-redfish = { version = "0.5.0", features = [
+nv-redfish = { version = "0.6.0", features = [
   "bmc-http",
   "std-redfish",
   "update-service",

--- a/crates/bmc-explorer/src/chassis.rs
+++ b/crates/bmc-explorer/src/chassis.rs
@@ -20,6 +20,7 @@ use std::convert::identity;
 use model::site_explorer::Chassis;
 use nv_redfish::assembly::Model as AssemblyModel;
 use nv_redfish::chassis::Chassis as NvChassis;
+use nv_redfish::core::ODataId;
 use nv_redfish::hardware_id::{Manufacturer, Model};
 use nv_redfish::pcie_device::PcieDevice;
 use nv_redfish::resource::ResourceIdRef;
@@ -32,6 +33,7 @@ type AssemblyModelFilterFn = fn(Option<AssemblyModel<&str>>) -> bool;
 pub struct Config {
     pub network_adapter: network_adapter::Config,
     pub need_assembly_sn: fn(ResourceIdRef) -> Option<AssemblyModelFilterFn>,
+    pub lazy_fetch: Option<fn(&ODataId) -> bool>,
 }
 
 pub struct ExploredChassisCollection<B: Bmc> {
@@ -40,19 +42,43 @@ pub struct ExploredChassisCollection<B: Bmc> {
 
 impl<B: Bmc> ExploredChassisCollection<B> {
     pub async fn explore(root: &ServiceRoot<B>, config: &Config) -> Result<Self, Error<B>> {
-        let nv_members = root
-            .chassis()
-            .await
-            .map_err(Error::nv_redfish("chassis collection"))?
-            .ok_or_else(Error::bmc_not_provided("chassis collection"))?
-            .members()
-            .await
-            .map_err(Error::nv_redfish("chassis collection members"))?;
         let mut members = Vec::new();
-        for m in nv_members {
+        for m in Self::fetch_members(root, config).await? {
             members.push(ExploredChassis::explore(m, config).await?);
         }
         Ok(Self { members })
+    }
+
+    async fn fetch_members(
+        root: &ServiceRoot<B>,
+        config: &Config,
+    ) -> Result<Vec<NvChassis<B>>, Error<B>> {
+        if let Some(filter) = config.lazy_fetch {
+            let links = root
+                .chassis_links()
+                .await
+                .map_err(Error::nv_redfish("chassis collection"))?
+                .ok_or_else(Error::bmc_not_provided("chassis collection"))?;
+            let mut result = Vec::with_capacity(links.len());
+            for l in links {
+                if filter(l.odata_id()) {
+                    result.push(
+                        l.upgrade()
+                            .await
+                            .map_err(Error::nv_redfish("chassis collection member"))?,
+                    )
+                }
+            }
+            Ok(result)
+        } else {
+            root.chassis()
+                .await
+                .map_err(Error::nv_redfish("chassis collection"))?
+                .ok_or_else(Error::bmc_not_provided("chassis collection"))?
+                .members()
+                .await
+                .map_err(Error::nv_redfish("chassis collection members"))
+        }
     }
 
     pub fn to_model(&self) -> Vec<Chassis> {

--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -15,6 +15,10 @@
  * limitations under the License.
  */
 
+// Needed for nv-redfish that requires deep recursion for Redfish
+// object type tree.
+#![recursion_limit = "256"]
+
 mod chassis;
 mod computer_system;
 mod error;
@@ -94,6 +98,13 @@ pub async fn nv_generate_exploration_report_from_root<B: Bmc>(
             (*id.inner() == "Chassis_0")
                 .then_some(|model| model == Some(AssemblyModel::new("GB200 NVL")))
         },
+        // BlueField-3 DPU (Tested on BF-25.10-9 firmware) has issue
+        // with ERoT chassis. It stucks sometimes until next request
+        // of BlueField_ERoT. Because carbide doesn't need
+        // BlueField_ERoT we just skip it.
+        lazy_fetch: (root.vendor() == Some(Vendor::new("Nvidia"))
+            && root.product() == Some(Product::new("BlueField-3 DPU")))
+        .then_some(|odata_id| odata_id.last_segment() != Some("Bluefield_ERoT")),
     };
     let explored_chassis =
         ExploredChassisCollection::explore(&root, &chassis_explore_config).await?;

--- a/crates/bmc-explorer/tests/bluefield3_explore.rs
+++ b/crates/bmc-explorer/tests/bluefield3_explore.rs
@@ -125,3 +125,78 @@ async fn explore_bluefield3_permanent_404_on_system_eth_interfaces_fails_without
         "permanent 404 should still fail after retries are exhausted"
     );
 }
+
+#[test]
+async fn explore_bluefield3_skips_erot_chassis() {
+    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default());
+    let report = nv_generate_exploration_report(h.bmc, &common::explorer_config())
+        .await
+        .unwrap();
+
+    let chassis_ids: Vec<&str> = report.chassis.iter().map(|c| c.id.as_str()).collect();
+    assert!(
+        !chassis_ids.contains(&"Bluefield_ERoT"),
+        "Bluefield_ERoT chassis should be skipped, but found chassis: {chassis_ids:?}"
+    );
+    assert_eq!(
+        report.chassis.len(),
+        3,
+        "expected 3 chassis (Bluefield_BMC, CPU_0, Card1), got: {chassis_ids:?}"
+    );
+}
+
+#[test]
+async fn explore_bluefield3_succeeds_when_erot_hangs() {
+    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default());
+
+    h.state.injected_bugs.update_args(bmc_mock::bug::Args {
+        long_response: Some(bmc_mock::bug::LongResponse {
+            path: Some("/redfish/v1/Chassis/Bluefield_ERoT".to_string()),
+            timeout: Some(std::time::Duration::from_secs(30)),
+        }),
+        ..Default::default()
+    });
+
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        nv_generate_exploration_report(h.bmc, &common::explorer_config()),
+    )
+    .await;
+
+    let report = result
+        .expect("exploration must not hang on ERoT timeout")
+        .expect("exploration must succeed");
+
+    let chassis_ids: Vec<&str> = report.chassis.iter().map(|c| c.id.as_str()).collect();
+    assert!(
+        !chassis_ids.contains(&"Bluefield_ERoT"),
+        "Bluefield_ERoT should be skipped even when it would hang"
+    );
+    assert_eq!(report.chassis.len(), 3);
+}
+
+#[test]
+async fn explore_bluefield3_succeeds_when_erot_returns_error() {
+    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default());
+
+    h.state.injected_bugs.update_args(bmc_mock::bug::Args {
+        http_error: Some(bmc_mock::bug::HttpErrorRule {
+            method: Some("GET".into()),
+            path: "/redfish/v1/Chassis/Bluefield_ERoT".to_string(),
+            status: 500,
+            remaining: 100,
+        }),
+        ..Default::default()
+    });
+
+    let report = nv_generate_exploration_report(h.bmc, &common::explorer_config())
+        .await
+        .expect("exploration must succeed even when ERoT returns 500");
+
+    let chassis_ids: Vec<&str> = report.chassis.iter().map(|c| c.id.as_str()).collect();
+    assert!(
+        !chassis_ids.contains(&"Bluefield_ERoT"),
+        "Bluefield_ERoT should be skipped even when it returns errors"
+    );
+    assert_eq!(report.chassis.len(), 3);
+}

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -517,7 +517,7 @@ impl MachineInfo {
     pub fn bmc_product(&self) -> Option<&'static str> {
         match self {
             MachineInfo::Host(h) => h.bmc_product(),
-            MachineInfo::Dpu(_) => None,
+            MachineInfo::Dpu(_) => Some("BlueField-3 DPU"),
         }
     }
 

--- a/crates/health/src/collectors/sensors.rs
+++ b/crates/health/src/collectors/sensors.rs
@@ -26,7 +26,7 @@ use futures::{StreamExt, stream};
 use nv_redfish::chassis::{Chassis, PowerSupply};
 use nv_redfish::computer_system::{ComputerSystem, Drive, Memory, Processor, Storage};
 use nv_redfish::core::{Bmc, EntityTypeRef, ToSnakeCase};
-use nv_redfish::sensor::SensorRef;
+use nv_redfish::sensor::SensorLink;
 use nv_redfish::{Resource, ServiceRoot};
 
 use crate::HealthError;
@@ -89,35 +89,35 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for SensorCollector<B> {
 enum MonitoredEntity<B: Bmc> {
     Processor {
         entity: Arc<Processor<B>>,
-        sensor: SensorRef<B>,
+        sensor: SensorLink<B>,
         system: Arc<ComputerSystem<B>>,
     },
     Memory {
         entity: Arc<Memory<B>>,
-        sensor: SensorRef<B>,
+        sensor: SensorLink<B>,
         system: Arc<ComputerSystem<B>>,
     },
     Drive {
         entity: Arc<Drive<B>>,
-        sensor: SensorRef<B>,
+        sensor: SensorLink<B>,
         system: Arc<ComputerSystem<B>>,
         storage: Arc<Storage<B>>,
     },
     PowerSupply {
         entity: Arc<PowerSupply<B>>,
-        sensor: SensorRef<B>,
+        sensor: SensorLink<B>,
         chassis: Arc<Chassis<B>>,
     },
     Chassis {
         entity: Arc<Chassis<B>>,
-        sensor: SensorRef<B>,
+        sensor: SensorLink<B>,
     },
 }
 
 /// Trait for entities that can record sensor metrics
 trait SensorRecordable<B: Bmc> {
     fn metric_prefix(&self) -> &'static str;
-    fn sensor(&self) -> &SensorRef<B>;
+    fn sensor(&self) -> &SensorLink<B>;
     fn base_attributes(&self) -> Vec<MetricLabel>;
     fn entity_specific_attributes(&self) -> Vec<MetricLabel>;
     fn entity_metrics(&self, attributes: &[MetricLabel]) -> Vec<SensorHealthData>;
@@ -128,7 +128,7 @@ impl<B: Bmc> SensorRecordable<B> for MonitoredEntity<B> {
         "hw_sensor"
     }
 
-    fn sensor(&self) -> &SensorRef<B> {
+    fn sensor(&self) -> &SensorLink<B> {
         match self {
             MonitoredEntity::Processor { sensor, .. }
             | MonitoredEntity::Memory { sensor, .. }
@@ -368,7 +368,7 @@ impl<B: Bmc + 'static> SensorCollector<B> {
             .then(|processor| async move {
                 let processor = Arc::new(processor);
                 let env_sensors = processor
-                    .environment_sensors()
+                    .environment_sensor_links()
                     .await
                     .log_and_ok(
                         "Failed to get processors enviroment sensors",
@@ -377,7 +377,7 @@ impl<B: Bmc + 'static> SensorCollector<B> {
                     )
                     .unwrap_or_default();
                 let metric_sensors = processor
-                    .metrics_sensors()
+                    .metrics_sensor_links()
                     .await
                     .log_and_ok(
                         "Failed to get processors metric sensors",
@@ -419,7 +419,7 @@ impl<B: Bmc + 'static> SensorCollector<B> {
             .then(|memory| async move {
                 let memory = Arc::new(memory);
                 let env_sensors = memory
-                    .environment_sensors()
+                    .environment_sensor_links()
                     .await
                     .log_and_ok(
                         "Failed to get memory enviroment sensors",
@@ -472,7 +472,7 @@ impl<B: Bmc + 'static> SensorCollector<B> {
                     async move {
                         let drive = Arc::new(drive);
                         let env_sensors = drive
-                            .environment_sensors()
+                            .environment_sensor_links()
                             .await
                             .log_and_ok(
                                 "Failed to get drives enviroment sensors",
@@ -515,7 +515,7 @@ impl<B: Bmc + 'static> SensorCollector<B> {
             .then(|ps| async move {
                 let ps = Arc::new(ps);
                 let metric_sensors = ps
-                    .metrics_sensors()
+                    .metrics_sensor_links()
                     .await
                     .log_and_ok(
                         "Failed to get power supplies metrics sensors",
@@ -542,7 +542,7 @@ impl<B: Bmc + 'static> SensorCollector<B> {
         chassis: Arc<Chassis<B>>,
         fetch_failures: &AtomicUsize,
     ) -> Vec<MonitoredEntity<B>> {
-        match chassis.sensors().await {
+        match chassis.sensor_links().await {
             Ok(Some(sensors)) => sensors
                 .into_iter()
                 .map(move |sensor| MonitoredEntity::Chassis {


### PR DESCRIPTION
## Description
BlueField-3 DPU (tested on BF-25.10-9 firmware) intermittently stalls when fetching Bluefield_ERoT chassis, blocking exploration until the next unrelated request. Since carbide does not need ERoT chassis data, skip it entirely.

Use nv-redfish 0.6.0 chassis_links() to lazily enumerate chassis members and selectively upgrade only the ones we need, avoiding the problematic ERoT endpoint on BlueField-3 DPUs.

Other changes driven by nv-redfish 0.6.0 API:
- SensorRef -> SensorLink
- environment_sensors() -> environment_sensor_links()
- metrics_sensors() -> metrics_sensor_links()
- sensors() -> sensor_links()
- Add recursion_limit = "256" for nv-redfish deep schema types

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

