### PR TITLE
fix(agent): prevent NVUE config apply when no semantic change

### DIFF
--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -489,8 +489,8 @@ pub async fn update_nvue(
             };
 
             if !skip_post {
-                // Make it so
-                nvue::apply(hbn_root, &path).await?;
+                // Apply only when NVUE reports semantic diff.
+                return nvue::apply(hbn_root, &path).await;
             }
             Ok(true)
         }

--- a/crates/agent/src/nvue.rs
+++ b/crates/agent/src/nvue.rs
@@ -741,11 +741,14 @@ pub async fn hack_platform_config_for_nvue() -> eyre::Result<()> {
 }
 
 // Apply the config at `config_path`.
-pub async fn apply(hbn_root: &Path, config_path: &super::FPath) -> eyre::Result<()> {
+//
+// Returns true if we performed `nv config apply`, false when pending config matched
+// applied config and was detached without applying.
+pub async fn apply(hbn_root: &Path, config_path: &super::FPath) -> eyre::Result<bool> {
     match run_apply(hbn_root, &config_path.0).await {
-        Ok(_) => {
+        Ok(applied) => {
             config_path.del("BAK");
-            Ok(())
+            Ok(applied)
         }
         Err(err) => {
             tracing::error!("update_nvue post command failed: {err:#}");
@@ -787,7 +790,7 @@ pub async fn apply(hbn_root: &Path, config_path: &super::FPath) -> eyre::Result<
 }
 
 // Ask NVUE to use the config at `path`
-async fn run_apply(hbn_root: &Path, path: &Path) -> eyre::Result<()> {
+async fn run_apply(hbn_root: &Path, path: &Path) -> eyre::Result<bool> {
     let mut in_container_path = path
         .strip_prefix(hbn_root)
         .wrap_err("Stripping hbn_root prefix from path to make in-container path")?
@@ -813,6 +816,20 @@ async fn run_apply(hbn_root: &Path, path: &Path) -> eyre::Result<()> {
     .await?;
     if !stdout.is_empty() {
         tracing::info!("nv config replace: {stdout}");
+    }
+
+    // Compare pending to applied config at NVUE layer.
+    // This avoids no-op apply cycles when textual YAML ordering changes but
+    // semantic config does not.
+    let stdout =
+        super::hbn::run_in_container(&container_id, &["nv", "config", "diff"], true).await?;
+    if stdout.is_empty() {
+        let stdout =
+            super::hbn::run_in_container(&container_id, &["nv", "config", "detach"], true).await?;
+        if !stdout.is_empty() {
+            tracing::info!("nv config detach: {stdout}");
+        }
+        return Ok(false);
     }
 
     // Apply the pending config.
@@ -845,7 +862,7 @@ async fn run_apply(hbn_root: &Path, path: &Path) -> eyre::Result<()> {
         tracing::info!("nl2doca restart: {stdout}");
     }
 
-    Ok(())
+    Ok(true)
 }
 
 /// vni_to_svimac takes an VNI (which is a 24 bit integer whose range


### PR DESCRIPTION
## Description
An issue was observed in hfa01 where DPUs experienced network flapping due to frequent nl2doca restarts triggered after `nv config apply`. This occurs because `nv config apply` decisions was based solely on text-level changes. However in some cases, the rendered YAML can have text changes while remaining semantically identical (for example, only some ordering changes). As a result, the agent will trigger unnecessary applies.

This PR address this issue by adding `nv config diff` check after setting the pending config, so `nv config apply` will not happen when there is no semantic change between pending config and applied config.

See [this thread ](https://nvidia.slack.com/archives/C02RKLCN8BT/p1776166160043939).

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
https://requests-navigator.atlassian.net/servicedesk/customer/portal/16/FORGECS-1062?atlOrigin=eyJpIjoiNzI4MjliMjNiMzJjNDEyOTlkZmU1MmZmODBjYmFjMGUiLCJwIjoiamlyYS1zbGFjay1pbnQifQ


## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)


