### PR TITLE
feat: RMS-backed power shelf component implementation + MockRmsApi client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,6 +1598,7 @@ dependencies = [
 name = "carbide-api-test-helper"
 version = "0.0.0"
 dependencies = [
+ "async-trait",
  "bmc-mock",
  "carbide-api",
  "carbide-machine-a-tron",
@@ -1613,6 +1614,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "lazy_static",
+ "librms",
  "metrics-endpoint",
  "rand 0.9.2",
  "serde",
@@ -1624,6 +1626,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tokio-util",
+ "tonic 0.14.5",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -2945,17 +2948,25 @@ name = "component-manager"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "carbide-api-db",
+ "carbide-api-model",
+ "carbide-api-test-helper",
+ "carbide-macros",
+ "carbide-sqlx-testing",
  "carbide-uuid",
+ "librms",
  "mac_address",
  "prost 0.14.1",
  "prost-types 0.14.1",
  "serde",
+ "sqlx",
  "thiserror 2.0.17",
  "tokio",
  "tonic 0.14.5",
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/api-db/migrations/20260415043310_add_bmc_mac_address_to_power_shelves.sql
+++ b/crates/api-db/migrations/20260415043310_add_bmc_mac_address_to_power_shelves.sql
@@ -1,0 +1,13 @@
+-- Add bmc_mac_address to power_shelves, matching the pattern already used by
+-- the switches table.  This gives a direct FK link from power_shelves to
+-- expected_power_shelves and removes the need to join via config->>'name'.
+ALTER TABLE power_shelves
+ADD COLUMN bmc_mac_address macaddr REFERENCES expected_power_shelves(bmc_mac_address);
+
+-- Backfill existing rows from expected_power_shelves via the legacy
+-- serial_number / config->>'name' join.
+UPDATE power_shelves ps
+SET    bmc_mac_address = eps.bmc_mac_address
+FROM   expected_power_shelves eps
+WHERE  ps.config ->> 'name' = eps.serial_number
+  AND  ps.bmc_mac_address IS NULL;

--- a/crates/api-test-helper/Cargo.toml
+++ b/crates/api-test-helper/Cargo.toml
@@ -28,6 +28,7 @@ name = "api_test_helper"
 [dependencies]
 
 # [local-dependencies]
+async-trait = { workspace = true }
 bmc-mock = { path = "../bmc-mock" }
 carbide-api = { path = "../api", default-features = false }
 carbide-version = { path = "../version" }
@@ -57,6 +58,7 @@ sqlx = { workspace = true, features = [
 ] }
 tempfile = { workspace = true }
 tokio.workspace = true
+tonic = { workspace = true }
 tokio-util.workspace = true
 tracing = { workspace = true }
 tracing-subscriber = { features = [
@@ -64,6 +66,7 @@ tracing-subscriber = { features = [
   "local-time",
 ], workspace = true }
 futures = { workspace = true }
+librms = { workspace = true }
 itertools = { workspace = true }
 ctor = { workspace = true }
 temp-dir = { workspace = true }

--- a/crates/api-test-helper/src/lib.rs
+++ b/crates/api-test-helper/src/lib.rs
@@ -22,6 +22,7 @@ pub mod instance;
 pub mod machine;
 pub mod machine_a_tron;
 pub mod metrics;
+pub mod mock_rms;
 pub mod subnet;
 pub mod tenant;
 pub mod utils;

--- a/crates/api-test-helper/src/mock_rms.rs
+++ b/crates/api-test-helper/src/mock_rms.rs
@@ -1,0 +1,848 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! MockRmsApi is a configurable mock implementation of librms::RmsApi.
+//!
+//! The idea is tests queue up responses for each method they care about
+//! and want to test, then hand an `Arc<MockRmsApi>` to the code under test.
+//! As methods are called, queued responses are popped off and returned in
+//! order. Recorded requests can be inspected after the call to verify the
+//! correct arguments were sent.
+//!
+//! # Example
+//!
+//! ```ignore
+//! let mock = MockRmsApi::new();
+//! mock.enqueue_power_state(Ok(MockRmsApi::power_ok())).await;
+//!
+//! let backend = RmsPowerShelfBackend::new(Arc::new(mock));
+//! let results = backend.power_control(&endpoints, PowerAction::On).await.unwrap();
+//!
+//! assert!(results[0].success);
+//! let calls = mock.power_state_calls().await;
+//! assert_eq!(calls[0].node_id, "ps-001");
+//! ```
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+use librms::protos::rack_manager as rms;
+use librms::{RackManagerError, RmsApi};
+use tokio::sync::Mutex;
+
+/// A configurable mock `RmsApi` client that lets tests queue responses
+/// per method and inspect what requests were sent.
+///
+/// Every `RmsApi` method has a corresponding:
+/// - `enqueue_*()` — push a response to be returned on the next call
+/// - `*_calls()` — retrieve all recorded requests for that method
+///
+/// If no response is queued when a method is called, it returns a
+/// clear "no response queued" error so tests fail explicitly.
+pub struct MockRmsApi {
+    // Power control calls.
+    set_power_state_responses:
+        Mutex<VecDeque<Result<rms::SetPowerStateResponse, RackManagerError>>>,
+    set_power_state_calls: Mutex<Vec<rms::SetPowerStateRequest>>,
+
+    get_power_state_responses:
+        Mutex<VecDeque<Result<rms::GetPowerStateResponse, RackManagerError>>>,
+    get_power_state_calls: Mutex<Vec<rms::GetPowerStateRequest>>,
+
+    sequence_rack_power_responses:
+        Mutex<VecDeque<Result<rms::SequenceRackPowerResponse, RackManagerError>>>,
+    sequence_rack_power_calls: Mutex<Vec<rms::SequenceRackPowerRequest>>,
+
+    // Inventory calls.
+    get_all_inventory_responses:
+        Mutex<VecDeque<Result<rms::GetAllInventoryResponse, RackManagerError>>>,
+    get_all_inventory_calls: Mutex<Vec<rms::GetAllInventoryRequest>>,
+
+    add_node_responses: Mutex<VecDeque<Result<rms::AddNodeResponse, RackManagerError>>>,
+    add_node_calls: Mutex<Vec<rms::AddNodeRequest>>,
+
+    update_node_responses: Mutex<VecDeque<Result<rms::UpdateNodeResponse, RackManagerError>>>,
+    update_node_calls: Mutex<Vec<rms::UpdateNodeRequest>>,
+
+    remove_node_responses: Mutex<VecDeque<Result<rms::RemoveNodeResponse, RackManagerError>>>,
+    remove_node_calls: Mutex<Vec<rms::RemoveNodeRequest>>,
+
+    list_racks_responses: Mutex<VecDeque<Result<rms::ListRacksResponse, RackManagerError>>>,
+    list_racks_calls: Mutex<Vec<rms::ListRacksRequest>>,
+
+    // Device info calls.
+    get_node_device_info_responses:
+        Mutex<VecDeque<Result<rms::GetNodeDeviceInfoResponse, RackManagerError>>>,
+    get_node_device_info_calls: Mutex<Vec<rms::GetNodeDeviceInfoRequest>>,
+
+    get_device_info_by_node_type_responses:
+        Mutex<VecDeque<Result<rms::GetDeviceInfoByNodeTypeResponse, RackManagerError>>>,
+    get_device_info_by_node_type_calls: Mutex<Vec<rms::GetDeviceInfoByNodeTypeRequest>>,
+
+    get_device_info_by_device_list_responses:
+        Mutex<VecDeque<Result<rms::GetDeviceInfoByDeviceListResponse, RackManagerError>>>,
+    get_device_info_by_device_list_calls: Mutex<Vec<rms::GetDeviceInfoByDeviceListRequest>>,
+
+    // Power-on sequence calls.
+    get_rack_power_on_sequence_responses:
+        Mutex<VecDeque<Result<rms::GetRackPowerOnSequenceResponse, RackManagerError>>>,
+    get_rack_power_on_sequence_calls: Mutex<Vec<rms::GetRackPowerOnSequenceRequest>>,
+
+    set_rack_power_on_sequence_responses:
+        Mutex<VecDeque<Result<rms::SetRackPowerOnSequenceResponse, RackManagerError>>>,
+    set_rack_power_on_sequence_calls: Mutex<Vec<rms::SetRackPowerOnSequenceRequest>>,
+
+    // Node firmware calls.
+    get_node_firmware_inventory_responses:
+        Mutex<VecDeque<Result<rms::GetNodeFirmwareInventoryResponse, RackManagerError>>>,
+    get_node_firmware_inventory_calls: Mutex<Vec<rms::GetNodeFirmwareInventoryRequest>>,
+
+    get_rack_firmware_inventory_responses:
+        Mutex<VecDeque<Result<rms::GetRackFirmwareInventoryResponse, RackManagerError>>>,
+    get_rack_firmware_inventory_calls: Mutex<Vec<rms::GetRackFirmwareInventoryRequest>>,
+
+    update_node_firmware_async_responses:
+        Mutex<VecDeque<Result<rms::UpdateNodeFirmwareResponse, RackManagerError>>>,
+    update_node_firmware_async_calls: Mutex<Vec<rms::UpdateNodeFirmwareRequest>>,
+
+    update_firmware_by_node_type_async_responses:
+        Mutex<VecDeque<Result<rms::UpdateFirmwareByNodeTypeAsyncResponse, RackManagerError>>>,
+    update_firmware_by_node_type_async_calls: Mutex<Vec<rms::UpdateFirmwareByNodeTypeRequest>>,
+
+    update_firmware_by_device_list_responses:
+        Mutex<VecDeque<Result<rms::UpdateFirmwareByDeviceListResponse, RackManagerError>>>,
+    update_firmware_by_device_list_calls: Mutex<Vec<rms::UpdateFirmwareByDeviceListRequest>>,
+
+    get_firmware_job_status_responses:
+        Mutex<VecDeque<Result<rms::GetFirmwareJobStatusResponse, RackManagerError>>>,
+    get_firmware_job_status_calls: Mutex<Vec<rms::GetFirmwareJobStatusRequest>>,
+
+    // Switch firmware calls.
+    list_firmware_on_switch_responses:
+        Mutex<VecDeque<Result<rms::ListFirmwareOnSwitchResponse, RackManagerError>>>,
+    list_firmware_on_switch_calls: Mutex<Vec<rms::ListFirmwareOnSwitchCommand>>,
+
+    push_firmware_to_switch_responses:
+        Mutex<VecDeque<Result<rms::PushFirmwareToSwitchResponse, RackManagerError>>>,
+    push_firmware_to_switch_calls: Mutex<Vec<rms::PushFirmwareToSwitchCommand>>,
+
+    upgrade_firmware_on_switch_responses:
+        Mutex<VecDeque<Result<rms::UpgradeFirmwareOnSwitchResponse, RackManagerError>>>,
+    upgrade_firmware_on_switch_calls: Mutex<Vec<rms::UpgradeFirmwareOnSwitchCommand>>,
+
+    // Switch system images calls.
+    fetch_switch_system_image_responses:
+        Mutex<VecDeque<Result<rms::FetchSwitchSystemImageResponse, RackManagerError>>>,
+    fetch_switch_system_image_calls: Mutex<Vec<rms::FetchSwitchSystemImageRequest>>,
+
+    install_switch_system_image_responses:
+        Mutex<VecDeque<Result<rms::InstallSwitchSystemImageResponse, RackManagerError>>>,
+    install_switch_system_image_calls: Mutex<Vec<rms::InstallSwitchSystemImageRequest>>,
+
+    list_switch_system_images_responses:
+        Mutex<VecDeque<Result<rms::ListSwitchSystemImagesResponse, RackManagerError>>>,
+    list_switch_system_images_calls: Mutex<Vec<rms::ListSwitchSystemImagesRequest>>,
+
+    poll_job_status_responses:
+        Mutex<VecDeque<Result<rms::PollJobStatusResponse, RackManagerError>>>,
+    poll_job_status_calls: Mutex<Vec<rms::PollJobStatusCommand>>,
+
+    // Scale-up fabric calls.
+    configure_scale_up_fabric_manager_responses:
+        Mutex<VecDeque<Result<rms::ConfigureScaleUpFabricManagerResponse, RackManagerError>>>,
+    configure_scale_up_fabric_manager_calls: Mutex<Vec<rms::ConfigureScaleUpFabricManagerRequest>>,
+
+    enable_scale_up_fabric_telemetry_interface_responses: Mutex<
+        VecDeque<Result<rms::EnableScaleUpFabricTelemetryInterfaceResponse, RackManagerError>>,
+    >,
+    enable_scale_up_fabric_telemetry_interface_calls:
+        Mutex<Vec<rms::EnableScaleUpFabricTelemetryInterfaceRequest>>,
+
+    // Version (no request type).
+    version_responses: Mutex<VecDeque<Result<(), RackManagerError>>>,
+    version_call_count: Mutex<u32>,
+}
+
+/// Generate enqueue + inspect methods for a request/response pair.
+macro_rules! impl_enqueue_inspect {
+    ($enqueue:ident, $inspect:ident, $responses:ident, $calls:ident, $req:ty, $resp:ty) => {
+        pub async fn $enqueue(&self, resp: Result<$resp, RackManagerError>) {
+            self.$responses.lock().await.push_back(resp);
+        }
+
+        pub async fn $inspect(&self) -> Vec<$req> {
+            self.$calls.lock().await.clone()
+        }
+    };
+}
+
+impl MockRmsApi {
+    pub fn new() -> Self {
+        Self {
+            set_power_state_responses: Default::default(),
+            set_power_state_calls: Default::default(),
+            get_power_state_responses: Default::default(),
+            get_power_state_calls: Default::default(),
+            sequence_rack_power_responses: Default::default(),
+            sequence_rack_power_calls: Default::default(),
+            get_all_inventory_responses: Default::default(),
+            get_all_inventory_calls: Default::default(),
+            add_node_responses: Default::default(),
+            add_node_calls: Default::default(),
+            update_node_responses: Default::default(),
+            update_node_calls: Default::default(),
+            remove_node_responses: Default::default(),
+            remove_node_calls: Default::default(),
+            list_racks_responses: Default::default(),
+            list_racks_calls: Default::default(),
+            get_node_device_info_responses: Default::default(),
+            get_node_device_info_calls: Default::default(),
+            get_device_info_by_node_type_responses: Default::default(),
+            get_device_info_by_node_type_calls: Default::default(),
+            get_device_info_by_device_list_responses: Default::default(),
+            get_device_info_by_device_list_calls: Default::default(),
+            get_rack_power_on_sequence_responses: Default::default(),
+            get_rack_power_on_sequence_calls: Default::default(),
+            set_rack_power_on_sequence_responses: Default::default(),
+            set_rack_power_on_sequence_calls: Default::default(),
+            get_node_firmware_inventory_responses: Default::default(),
+            get_node_firmware_inventory_calls: Default::default(),
+            get_rack_firmware_inventory_responses: Default::default(),
+            get_rack_firmware_inventory_calls: Default::default(),
+            update_node_firmware_async_responses: Default::default(),
+            update_node_firmware_async_calls: Default::default(),
+            update_firmware_by_node_type_async_responses: Default::default(),
+            update_firmware_by_node_type_async_calls: Default::default(),
+            update_firmware_by_device_list_responses: Default::default(),
+            update_firmware_by_device_list_calls: Default::default(),
+            get_firmware_job_status_responses: Default::default(),
+            get_firmware_job_status_calls: Default::default(),
+            list_firmware_on_switch_responses: Default::default(),
+            list_firmware_on_switch_calls: Default::default(),
+            push_firmware_to_switch_responses: Default::default(),
+            push_firmware_to_switch_calls: Default::default(),
+            upgrade_firmware_on_switch_responses: Default::default(),
+            upgrade_firmware_on_switch_calls: Default::default(),
+            fetch_switch_system_image_responses: Default::default(),
+            fetch_switch_system_image_calls: Default::default(),
+            install_switch_system_image_responses: Default::default(),
+            install_switch_system_image_calls: Default::default(),
+            list_switch_system_images_responses: Default::default(),
+            list_switch_system_images_calls: Default::default(),
+            poll_job_status_responses: Default::default(),
+            poll_job_status_calls: Default::default(),
+            configure_scale_up_fabric_manager_responses: Default::default(),
+            configure_scale_up_fabric_manager_calls: Default::default(),
+            enable_scale_up_fabric_telemetry_interface_responses: Default::default(),
+            enable_scale_up_fabric_telemetry_interface_calls: Default::default(),
+            version_responses: Default::default(),
+            version_call_count: Default::default(),
+        }
+    }
+
+    /// Wrap in `Arc` for passing to code that expects `Arc<dyn RmsApi>`.
+    pub fn into_arc(self) -> Arc<dyn RmsApi> {
+        Arc::new(self)
+    }
+
+    // Power control
+    impl_enqueue_inspect!(
+        enqueue_set_power_state,
+        set_power_state_calls,
+        set_power_state_responses,
+        set_power_state_calls,
+        rms::SetPowerStateRequest,
+        rms::SetPowerStateResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_get_power_state,
+        get_power_state_calls,
+        get_power_state_responses,
+        get_power_state_calls,
+        rms::GetPowerStateRequest,
+        rms::GetPowerStateResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_sequence_rack_power,
+        sequence_rack_power_calls,
+        sequence_rack_power_responses,
+        sequence_rack_power_calls,
+        rms::SequenceRackPowerRequest,
+        rms::SequenceRackPowerResponse
+    );
+
+    // Inventory
+    impl_enqueue_inspect!(
+        enqueue_get_all_inventory,
+        get_all_inventory_calls,
+        get_all_inventory_responses,
+        get_all_inventory_calls,
+        rms::GetAllInventoryRequest,
+        rms::GetAllInventoryResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_add_node,
+        add_node_calls,
+        add_node_responses,
+        add_node_calls,
+        rms::AddNodeRequest,
+        rms::AddNodeResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_update_node,
+        update_node_calls,
+        update_node_responses,
+        update_node_calls,
+        rms::UpdateNodeRequest,
+        rms::UpdateNodeResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_remove_node,
+        remove_node_calls,
+        remove_node_responses,
+        remove_node_calls,
+        rms::RemoveNodeRequest,
+        rms::RemoveNodeResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_list_racks,
+        list_racks_calls,
+        list_racks_responses,
+        list_racks_calls,
+        rms::ListRacksRequest,
+        rms::ListRacksResponse
+    );
+
+    // Device info
+    impl_enqueue_inspect!(
+        enqueue_get_node_device_info,
+        get_node_device_info_calls,
+        get_node_device_info_responses,
+        get_node_device_info_calls,
+        rms::GetNodeDeviceInfoRequest,
+        rms::GetNodeDeviceInfoResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_get_device_info_by_node_type,
+        get_device_info_by_node_type_calls,
+        get_device_info_by_node_type_responses,
+        get_device_info_by_node_type_calls,
+        rms::GetDeviceInfoByNodeTypeRequest,
+        rms::GetDeviceInfoByNodeTypeResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_get_device_info_by_device_list,
+        get_device_info_by_device_list_calls,
+        get_device_info_by_device_list_responses,
+        get_device_info_by_device_list_calls,
+        rms::GetDeviceInfoByDeviceListRequest,
+        rms::GetDeviceInfoByDeviceListResponse
+    );
+
+    // Power-on sequence
+    impl_enqueue_inspect!(
+        enqueue_get_rack_power_on_sequence,
+        get_rack_power_on_sequence_calls,
+        get_rack_power_on_sequence_responses,
+        get_rack_power_on_sequence_calls,
+        rms::GetRackPowerOnSequenceRequest,
+        rms::GetRackPowerOnSequenceResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_set_rack_power_on_sequence,
+        set_rack_power_on_sequence_calls,
+        set_rack_power_on_sequence_responses,
+        set_rack_power_on_sequence_calls,
+        rms::SetRackPowerOnSequenceRequest,
+        rms::SetRackPowerOnSequenceResponse
+    );
+
+    // Node firmware
+    impl_enqueue_inspect!(
+        enqueue_get_node_firmware_inventory,
+        get_node_firmware_inventory_calls,
+        get_node_firmware_inventory_responses,
+        get_node_firmware_inventory_calls,
+        rms::GetNodeFirmwareInventoryRequest,
+        rms::GetNodeFirmwareInventoryResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_get_rack_firmware_inventory,
+        get_rack_firmware_inventory_calls,
+        get_rack_firmware_inventory_responses,
+        get_rack_firmware_inventory_calls,
+        rms::GetRackFirmwareInventoryRequest,
+        rms::GetRackFirmwareInventoryResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_update_node_firmware_async,
+        update_node_firmware_async_calls,
+        update_node_firmware_async_responses,
+        update_node_firmware_async_calls,
+        rms::UpdateNodeFirmwareRequest,
+        rms::UpdateNodeFirmwareResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_update_firmware_by_node_type_async,
+        update_firmware_by_node_type_async_calls,
+        update_firmware_by_node_type_async_responses,
+        update_firmware_by_node_type_async_calls,
+        rms::UpdateFirmwareByNodeTypeRequest,
+        rms::UpdateFirmwareByNodeTypeAsyncResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_update_firmware_by_device_list,
+        update_firmware_by_device_list_calls,
+        update_firmware_by_device_list_responses,
+        update_firmware_by_device_list_calls,
+        rms::UpdateFirmwareByDeviceListRequest,
+        rms::UpdateFirmwareByDeviceListResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_get_firmware_job_status,
+        get_firmware_job_status_calls,
+        get_firmware_job_status_responses,
+        get_firmware_job_status_calls,
+        rms::GetFirmwareJobStatusRequest,
+        rms::GetFirmwareJobStatusResponse
+    );
+
+    // Switch firmware
+    impl_enqueue_inspect!(
+        enqueue_list_firmware_on_switch,
+        list_firmware_on_switch_calls,
+        list_firmware_on_switch_responses,
+        list_firmware_on_switch_calls,
+        rms::ListFirmwareOnSwitchCommand,
+        rms::ListFirmwareOnSwitchResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_push_firmware_to_switch,
+        push_firmware_to_switch_calls,
+        push_firmware_to_switch_responses,
+        push_firmware_to_switch_calls,
+        rms::PushFirmwareToSwitchCommand,
+        rms::PushFirmwareToSwitchResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_upgrade_firmware_on_switch,
+        upgrade_firmware_on_switch_calls,
+        upgrade_firmware_on_switch_responses,
+        upgrade_firmware_on_switch_calls,
+        rms::UpgradeFirmwareOnSwitchCommand,
+        rms::UpgradeFirmwareOnSwitchResponse
+    );
+
+    // Switch system images
+    impl_enqueue_inspect!(
+        enqueue_fetch_switch_system_image,
+        fetch_switch_system_image_calls,
+        fetch_switch_system_image_responses,
+        fetch_switch_system_image_calls,
+        rms::FetchSwitchSystemImageRequest,
+        rms::FetchSwitchSystemImageResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_install_switch_system_image,
+        install_switch_system_image_calls,
+        install_switch_system_image_responses,
+        install_switch_system_image_calls,
+        rms::InstallSwitchSystemImageRequest,
+        rms::InstallSwitchSystemImageResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_list_switch_system_images,
+        list_switch_system_images_calls,
+        list_switch_system_images_responses,
+        list_switch_system_images_calls,
+        rms::ListSwitchSystemImagesRequest,
+        rms::ListSwitchSystemImagesResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_poll_job_status,
+        poll_job_status_calls,
+        poll_job_status_responses,
+        poll_job_status_calls,
+        rms::PollJobStatusCommand,
+        rms::PollJobStatusResponse
+    );
+
+    // Scale-up fabric
+    impl_enqueue_inspect!(
+        enqueue_configure_scale_up_fabric_manager,
+        configure_scale_up_fabric_manager_calls,
+        configure_scale_up_fabric_manager_responses,
+        configure_scale_up_fabric_manager_calls,
+        rms::ConfigureScaleUpFabricManagerRequest,
+        rms::ConfigureScaleUpFabricManagerResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_enable_scale_up_fabric_telemetry_interface,
+        enable_scale_up_fabric_telemetry_interface_calls,
+        enable_scale_up_fabric_telemetry_interface_responses,
+        enable_scale_up_fabric_telemetry_interface_calls,
+        rms::EnableScaleUpFabricTelemetryInterfaceRequest,
+        rms::EnableScaleUpFabricTelemetryInterfaceResponse
+    );
+
+    // Version (special — no request type)
+    pub async fn enqueue_version(&self, resp: Result<(), RackManagerError>) {
+        self.version_responses.lock().await.push_back(resp);
+    }
+
+    pub async fn version_call_count(&self) -> u32 {
+        *self.version_call_count.lock().await
+    }
+
+    // ...and put a few response builders/helpers in here.
+
+    /// Success response for `set_power_state`.
+    pub fn power_ok() -> rms::SetPowerStateResponse {
+        rms::SetPowerStateResponse {
+            status: rms::ReturnCode::Success as i32,
+            ..Default::default()
+        }
+    }
+
+    /// Failure response for `set_power_state`.
+    pub fn power_fail() -> rms::SetPowerStateResponse {
+        rms::SetPowerStateResponse {
+            status: rms::ReturnCode::Failure as i32,
+            ..Default::default()
+        }
+    }
+
+    /// Success response for `update_node_firmware_async` with a job ID.
+    pub fn firmware_update_ok(job_id: &str) -> rms::UpdateNodeFirmwareResponse {
+        rms::UpdateNodeFirmwareResponse {
+            status: rms::ReturnCode::Success as i32,
+            job_id: job_id.to_owned(),
+            ..Default::default()
+        }
+    }
+
+    /// Failure response for `update_node_firmware_async`.
+    pub fn firmware_update_fail(msg: &str) -> rms::UpdateNodeFirmwareResponse {
+        rms::UpdateNodeFirmwareResponse {
+            status: rms::ReturnCode::Failure as i32,
+            message: msg.to_owned(),
+            ..Default::default()
+        }
+    }
+
+    /// Success response for `get_firmware_job_status`.
+    pub fn firmware_job_status_ok(
+        state: rms::FirmwareJobState,
+    ) -> rms::GetFirmwareJobStatusResponse {
+        rms::GetFirmwareJobStatusResponse {
+            status: rms::ReturnCode::Success as i32,
+            job_state: state as i32,
+            ..Default::default()
+        }
+    }
+
+    /// Success response for `get_node_firmware_inventory`.
+    pub fn firmware_inventory_ok(
+        versions: &[(&str, &str)],
+    ) -> rms::GetNodeFirmwareInventoryResponse {
+        rms::GetNodeFirmwareInventoryResponse {
+            status: rms::ReturnCode::Success as i32,
+            firmware_list: versions
+                .iter()
+                .map(|(name, ver)| rms::FirmwareInventoryInfo {
+                    name: name.to_string(),
+                    version: ver.to_string(),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    /// Build an RMS API error (useful for simulating transport failures).
+    pub fn unavailable(msg: &str) -> RackManagerError {
+        RackManagerError::ApiInvocationError(tonic::Status::unavailable(msg))
+    }
+}
+
+impl Default for MockRmsApi {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Error returned when a test forgets to enqueue a response.
+fn no_response_queued() -> RackManagerError {
+    RackManagerError::ApiInvocationError(tonic::Status::internal("mock: no response queued"))
+}
+
+/// Pop the next queued response, or return a clear error if none was enqueued.
+fn pop_or_err<T>(
+    q: &mut tokio::sync::MutexGuard<'_, VecDeque<Result<T, RackManagerError>>>,
+) -> Result<T, RackManagerError> {
+    q.pop_front().unwrap_or(Err(no_response_queued()))
+}
+
+#[async_trait::async_trait]
+impl RmsApi for MockRmsApi {
+    async fn set_power_state(
+        &self,
+        cmd: rms::SetPowerStateRequest,
+    ) -> Result<rms::SetPowerStateResponse, RackManagerError> {
+        self.set_power_state_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.set_power_state_responses.lock().await)
+    }
+    async fn get_power_state(
+        &self,
+        cmd: rms::GetPowerStateRequest,
+    ) -> Result<rms::GetPowerStateResponse, RackManagerError> {
+        self.get_power_state_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.get_power_state_responses.lock().await)
+    }
+    async fn sequence_rack_power(
+        &self,
+        cmd: rms::SequenceRackPowerRequest,
+    ) -> Result<rms::SequenceRackPowerResponse, RackManagerError> {
+        self.sequence_rack_power_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.sequence_rack_power_responses.lock().await)
+    }
+    async fn get_all_inventory(
+        &self,
+        cmd: rms::GetAllInventoryRequest,
+    ) -> Result<rms::GetAllInventoryResponse, RackManagerError> {
+        self.get_all_inventory_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.get_all_inventory_responses.lock().await)
+    }
+    async fn add_node(
+        &self,
+        cmd: rms::AddNodeRequest,
+    ) -> Result<rms::AddNodeResponse, RackManagerError> {
+        self.add_node_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.add_node_responses.lock().await)
+    }
+    async fn update_node(
+        &self,
+        cmd: rms::UpdateNodeRequest,
+    ) -> Result<rms::UpdateNodeResponse, RackManagerError> {
+        self.update_node_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.update_node_responses.lock().await)
+    }
+    async fn remove_node(
+        &self,
+        cmd: rms::RemoveNodeRequest,
+    ) -> Result<rms::RemoveNodeResponse, RackManagerError> {
+        self.remove_node_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.remove_node_responses.lock().await)
+    }
+    async fn list_racks(
+        &self,
+        cmd: rms::ListRacksRequest,
+    ) -> Result<rms::ListRacksResponse, RackManagerError> {
+        self.list_racks_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.list_racks_responses.lock().await)
+    }
+    async fn get_node_device_info(
+        &self,
+        cmd: rms::GetNodeDeviceInfoRequest,
+    ) -> Result<rms::GetNodeDeviceInfoResponse, RackManagerError> {
+        self.get_node_device_info_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.get_node_device_info_responses.lock().await)
+    }
+    async fn get_device_info_by_node_type(
+        &self,
+        cmd: rms::GetDeviceInfoByNodeTypeRequest,
+    ) -> Result<rms::GetDeviceInfoByNodeTypeResponse, RackManagerError> {
+        self.get_device_info_by_node_type_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(&mut self.get_device_info_by_node_type_responses.lock().await)
+    }
+    async fn get_device_info_by_device_list(
+        &self,
+        cmd: rms::GetDeviceInfoByDeviceListRequest,
+    ) -> Result<rms::GetDeviceInfoByDeviceListResponse, RackManagerError> {
+        self.get_device_info_by_device_list_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(&mut self.get_device_info_by_device_list_responses.lock().await)
+    }
+    async fn get_rack_power_on_sequence(
+        &self,
+        cmd: rms::GetRackPowerOnSequenceRequest,
+    ) -> Result<rms::GetRackPowerOnSequenceResponse, RackManagerError> {
+        self.get_rack_power_on_sequence_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.get_rack_power_on_sequence_responses.lock().await)
+    }
+    async fn set_rack_power_on_sequence(
+        &self,
+        cmd: rms::SetRackPowerOnSequenceRequest,
+    ) -> Result<rms::SetRackPowerOnSequenceResponse, RackManagerError> {
+        self.set_rack_power_on_sequence_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.set_rack_power_on_sequence_responses.lock().await)
+    }
+    async fn get_node_firmware_inventory(
+        &self,
+        cmd: rms::GetNodeFirmwareInventoryRequest,
+    ) -> Result<rms::GetNodeFirmwareInventoryResponse, RackManagerError> {
+        self.get_node_firmware_inventory_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(&mut self.get_node_firmware_inventory_responses.lock().await)
+    }
+    async fn get_rack_firmware_inventory(
+        &self,
+        cmd: rms::GetRackFirmwareInventoryRequest,
+    ) -> Result<rms::GetRackFirmwareInventoryResponse, RackManagerError> {
+        self.get_rack_firmware_inventory_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(&mut self.get_rack_firmware_inventory_responses.lock().await)
+    }
+    async fn update_node_firmware_async(
+        &self,
+        cmd: rms::UpdateNodeFirmwareRequest,
+    ) -> Result<rms::UpdateNodeFirmwareResponse, RackManagerError> {
+        self.update_node_firmware_async_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.update_node_firmware_async_responses.lock().await)
+    }
+    async fn update_firmware_by_node_type_async(
+        &self,
+        cmd: rms::UpdateFirmwareByNodeTypeRequest,
+    ) -> Result<rms::UpdateFirmwareByNodeTypeAsyncResponse, RackManagerError> {
+        self.update_firmware_by_node_type_async_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(
+            &mut self
+                .update_firmware_by_node_type_async_responses
+                .lock()
+                .await,
+        )
+    }
+    async fn update_firmware_by_device_list(
+        &self,
+        cmd: rms::UpdateFirmwareByDeviceListRequest,
+    ) -> Result<rms::UpdateFirmwareByDeviceListResponse, RackManagerError> {
+        self.update_firmware_by_device_list_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(&mut self.update_firmware_by_device_list_responses.lock().await)
+    }
+    async fn get_firmware_job_status(
+        &self,
+        cmd: rms::GetFirmwareJobStatusRequest,
+    ) -> Result<rms::GetFirmwareJobStatusResponse, RackManagerError> {
+        self.get_firmware_job_status_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.get_firmware_job_status_responses.lock().await)
+    }
+    async fn list_firmware_on_switch(
+        &self,
+        cmd: rms::ListFirmwareOnSwitchCommand,
+    ) -> Result<rms::ListFirmwareOnSwitchResponse, RackManagerError> {
+        self.list_firmware_on_switch_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.list_firmware_on_switch_responses.lock().await)
+    }
+    async fn push_firmware_to_switch(
+        &self,
+        cmd: rms::PushFirmwareToSwitchCommand,
+    ) -> Result<rms::PushFirmwareToSwitchResponse, RackManagerError> {
+        self.push_firmware_to_switch_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.push_firmware_to_switch_responses.lock().await)
+    }
+    async fn upgrade_firmware_on_switch(
+        &self,
+        cmd: rms::UpgradeFirmwareOnSwitchCommand,
+    ) -> Result<rms::UpgradeFirmwareOnSwitchResponse, RackManagerError> {
+        self.upgrade_firmware_on_switch_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.upgrade_firmware_on_switch_responses.lock().await)
+    }
+    async fn fetch_switch_system_image(
+        &self,
+        cmd: rms::FetchSwitchSystemImageRequest,
+    ) -> Result<rms::FetchSwitchSystemImageResponse, RackManagerError> {
+        self.fetch_switch_system_image_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.fetch_switch_system_image_responses.lock().await)
+    }
+    async fn install_switch_system_image(
+        &self,
+        cmd: rms::InstallSwitchSystemImageRequest,
+    ) -> Result<rms::InstallSwitchSystemImageResponse, RackManagerError> {
+        self.install_switch_system_image_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(&mut self.install_switch_system_image_responses.lock().await)
+    }
+    async fn list_switch_system_images(
+        &self,
+        cmd: rms::ListSwitchSystemImagesRequest,
+    ) -> Result<rms::ListSwitchSystemImagesResponse, RackManagerError> {
+        self.list_switch_system_images_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.list_switch_system_images_responses.lock().await)
+    }
+    async fn poll_job_status(
+        &self,
+        cmd: rms::PollJobStatusCommand,
+    ) -> Result<rms::PollJobStatusResponse, RackManagerError> {
+        self.poll_job_status_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.poll_job_status_responses.lock().await)
+    }
+    async fn configure_scale_up_fabric_manager(
+        &self,
+        cmd: rms::ConfigureScaleUpFabricManagerRequest,
+    ) -> Result<rms::ConfigureScaleUpFabricManagerResponse, RackManagerError> {
+        self.configure_scale_up_fabric_manager_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(
+            &mut self
+                .configure_scale_up_fabric_manager_responses
+                .lock()
+                .await,
+        )
+    }
+    async fn enable_scale_up_fabric_telemetry_interface(
+        &self,
+        cmd: rms::EnableScaleUpFabricTelemetryInterfaceRequest,
+    ) -> Result<rms::EnableScaleUpFabricTelemetryInterfaceResponse, RackManagerError> {
+        self.enable_scale_up_fabric_telemetry_interface_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(
+            &mut self
+                .enable_scale_up_fabric_telemetry_interface_responses
+                .lock()
+                .await,
+        )
+    }
+    async fn version(&self) -> Result<(), RackManagerError> {
+        *self.version_call_count.lock().await += 1;
+        self.version_responses
+            .lock()
+            .await
+            .pop_front()
+            .unwrap_or(Ok(()))
+    }
+}

--- a/crates/api/src/handlers/component_manager.rs
+++ b/crates/api/src/handlers/component_manager.rs
@@ -48,6 +48,7 @@ fn component_manager_error_to_status(err: ComponentManagerError) -> Status {
         ComponentManagerError::Internal(msg) => Status::internal(msg),
         ComponentManagerError::Transport(e) => Status::unavailable(format!("transport error: {e}")),
         ComponentManagerError::Status(s) => s,
+        ComponentManagerError::Rms(msg) => Status::internal(format!("RMS error: {msg}")),
     }
 }
 

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -494,7 +494,13 @@ pub async fn start_api(
     };
 
     let component_manager = if let Some(cd_config) = &carbide_config.component_manager {
-        match component_manager::component_manager::build_component_manager(cd_config).await {
+        match component_manager::component_manager::build_component_manager(
+            cd_config,
+            rms_client.clone(),
+            Some(db_pool.clone()),
+        )
+        .await
+        {
             Ok(cm) => {
                 tracing::info!(
                     "Component manager configured (nv_switch={}, power_shelf={})",

--- a/crates/component-manager/Cargo.toml
+++ b/crates/component-manager/Cargo.toml
@@ -23,8 +23,11 @@ authors.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
+carbide-api-db = { path = "../api-db", default-features = false }
 carbide-uuid = { path = "../uuid" }
+librms = { workspace = true }
 mac_address = { workspace = true }
+sqlx = { workspace = true, features = ["postgres"] }
 prost = { workspace = true }
 prost-types = { workspace = true }
 thiserror = { workspace = true }
@@ -33,6 +36,13 @@ tonic = { workspace = true }
 tonic-prost = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tracing = { workspace = true }
+
+[dev-dependencies]
+carbide-api-test-helper = { path = "../api-test-helper" }
+carbide-macros = { path = "../macros" }
+carbide-sqlx-testing = { path = "../sqlx-testing" }
+carbide-api-model = { path = "../api-model" }
+uuid = { workspace = true }
 
 [build-dependencies]
 tonic-prost-build = { workspace = true }

--- a/crates/component-manager/src/component_manager.rs
+++ b/crates/component-manager/src/component_manager.rs
@@ -3,6 +3,9 @@
 
 use std::sync::Arc;
 
+use librms::RmsApi;
+use sqlx::PgPool;
+
 use crate::config::ComponentManagerConfig;
 use crate::error::ComponentManagerError;
 use crate::nv_switch_manager::NvSwitchManager;
@@ -34,6 +37,8 @@ impl ComponentManager {
 /// return an error.
 pub async fn build_component_manager(
     config: &ComponentManagerConfig,
+    rms_client: Option<Arc<dyn RmsApi>>,
+    db: Option<PgPool>,
 ) -> Result<ComponentManager, ComponentManagerError> {
     let nv_switch: Arc<dyn NvSwitchManager> = match config.nv_switch_backend.as_str() {
         "nsm" => {
@@ -68,6 +73,19 @@ pub async fn build_component_manager(
                     .await?,
             )
         }
+        "rms" => {
+            let client = rms_client.clone().ok_or_else(|| {
+                ComponentManagerError::InvalidArgument(
+                    "power_shelf_backend is 'rms' but RMS client is not configured".into(),
+                )
+            })?;
+            let db = db.clone().ok_or_else(|| {
+                ComponentManagerError::InvalidArgument(
+                    "power_shelf_backend is 'rms' but database pool is not configured".into(),
+                )
+            })?;
+            Arc::new(crate::rms::RmsBackend::new(client, db))
+        }
         "mock" => Arc::new(crate::mock::MockPowerShelfManager),
         other => {
             return Err(ComponentManagerError::InvalidArgument(format!(
@@ -92,7 +110,7 @@ mod tests {
             nsm: None,
             psm: None,
         };
-        let cm = build_component_manager(&config).await.unwrap();
+        let cm = build_component_manager(&config, None, None).await.unwrap();
         assert_eq!(cm.nv_switch.name(), "mock-nsm");
         assert_eq!(cm.power_shelf.name(), "mock-psm");
     }
@@ -105,7 +123,9 @@ mod tests {
             nsm: None,
             psm: None,
         };
-        let err = build_component_manager(&config).await.unwrap_err();
+        let err = build_component_manager(&config, None, None)
+            .await
+            .unwrap_err();
         assert!(
             matches!(err, ComponentManagerError::InvalidArgument(msg) if msg.contains("bogus"))
         );
@@ -119,7 +139,9 @@ mod tests {
             nsm: None,
             psm: None,
         };
-        let err = build_component_manager(&config).await.unwrap_err();
+        let err = build_component_manager(&config, None, None)
+            .await
+            .unwrap_err();
         assert!(
             matches!(err, ComponentManagerError::InvalidArgument(msg) if msg.contains("bogus"))
         );
@@ -133,7 +155,9 @@ mod tests {
             nsm: None,
             psm: None,
         };
-        let err = build_component_manager(&config).await.unwrap_err();
+        let err = build_component_manager(&config, None, None)
+            .await
+            .unwrap_err();
         assert!(matches!(err, ComponentManagerError::InvalidArgument(_)));
     }
 
@@ -145,7 +169,9 @@ mod tests {
             nsm: None,
             psm: None,
         };
-        let err = build_component_manager(&config).await.unwrap_err();
+        let err = build_component_manager(&config, None, None)
+            .await
+            .unwrap_err();
         assert!(matches!(err, ComponentManagerError::InvalidArgument(_)));
     }
 }

--- a/crates/component-manager/src/error.rs
+++ b/crates/component-manager/src/error.rs
@@ -20,4 +20,20 @@ pub enum ComponentManagerError {
 
     #[error("gRPC status error: {0}")]
     Status(#[from] tonic::Status),
+
+    #[error("RMS error: {0}")]
+    Rms(String),
+}
+
+impl From<librms::RackManagerError> for ComponentManagerError {
+    fn from(err: librms::RackManagerError) -> Self {
+        match err {
+            librms::RackManagerError::ApiInvocationError(status) => {
+                ComponentManagerError::Status(status)
+            }
+            librms::RackManagerError::TlsError(e) => {
+                ComponentManagerError::Unavailable(e.to_string())
+            }
+        }
+    }
 }

--- a/crates/component-manager/src/lib.rs
+++ b/crates/component-manager/src/lib.rs
@@ -9,6 +9,7 @@ pub mod nsm;
 pub mod nv_switch_manager;
 pub mod power_shelf_manager;
 pub mod psm;
+pub mod rms;
 pub mod tls;
 pub mod types;
 

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -1,0 +1,1042 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use carbide_uuid::power_shelf::PowerShelfId;
+use carbide_uuid::rack::RackId;
+use librms::RmsApi;
+use librms::protos::rack_manager as rms;
+use mac_address::MacAddress;
+use sqlx::PgPool;
+use tracing::instrument;
+
+use crate::error::ComponentManagerError;
+use crate::power_shelf_manager::{
+    PowerShelfComponentResult, PowerShelfEndpoint, PowerShelfFirmwareUpdateStatus,
+    PowerShelfFirmwareVersions, PowerShelfManager,
+};
+use crate::types::{FirmwareState, PowerAction, PowerShelfComponent};
+
+/// RMS identity for a power shelf: the node_id and rack_id that RMS
+/// needs to address a device.
+#[derive(Clone)]
+struct RmsIdentity {
+    node_id: String,
+    rack_id: String,
+}
+
+pub struct RmsBackend {
+    client: Arc<dyn RmsApi>,
+    db: PgPool,
+    /// Tracks firmware update job IDs keyed by PMC MAC address.
+    firmware_jobs: Mutex<HashMap<MacAddress, String>>,
+    /// Pre-set identity overrides for testing (bypasses DB lookup).
+    #[cfg(test)]
+    identity_overrides: Option<HashMap<MacAddress, RmsIdentity>>,
+}
+
+impl std::fmt::Debug for RmsBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RmsBackend")
+            .field("client", &"<RmsApi>")
+            .finish()
+    }
+}
+
+impl RmsBackend {
+    pub fn new(client: Arc<dyn RmsApi>, db: PgPool) -> Self {
+        Self {
+            client,
+            db,
+            firmware_jobs: Mutex::new(HashMap::new()),
+            #[cfg(test)]
+            identity_overrides: None,
+        }
+    }
+
+    /// Resolve identities from the override map (test) or the database (prod).
+    async fn resolve_identities(
+        &self,
+        endpoints: &[PowerShelfEndpoint],
+    ) -> Result<HashMap<MacAddress, RmsIdentity>, ComponentManagerError> {
+        #[cfg(test)]
+        if let Some(overrides) = &self.identity_overrides {
+            return Ok(overrides.clone());
+        }
+        resolve_rms_identities(&self.db, endpoints).await
+    }
+}
+
+/// Resolve PMC MAC addresses to RMS identities (node_id, rack_id) via the
+/// database. Uses the `bmc_mac_address` column on `power_shelves`, which was
+/// a complete oversight on my part not adding like we had for `switches`,
+/// sorry!
+async fn resolve_rms_identities(
+    db: &PgPool,
+    endpoints: &[PowerShelfEndpoint],
+) -> Result<HashMap<MacAddress, RmsIdentity>, ComponentManagerError> {
+    let macs: Vec<MacAddress> = endpoints.iter().map(|ep| ep.pmc_mac).collect();
+
+    let rows: Vec<(PowerShelfId, MacAddress, Option<RackId>)> = sqlx::query_as(
+        r#"
+        SELECT ps.id, ps.bmc_mac_address, ps.rack_id
+        FROM power_shelves ps
+        WHERE ps.bmc_mac_address = ANY($1)
+        "#,
+    )
+    .bind(&macs)
+    .fetch_all(db)
+    .await
+    .map_err(|e| {
+        ComponentManagerError::Internal(format!("failed to resolve RMS identities: {e}"))
+    })?;
+
+    let mut map = HashMap::with_capacity(rows.len());
+    for (ps_id, mac, rack_id) in rows {
+        let Some(rack_id) = rack_id else {
+            tracing::warn!(pmc_mac = %mac, "power shelf has no rack_id, skipping");
+            continue;
+        };
+        map.insert(
+            mac,
+            RmsIdentity {
+                node_id: ps_id.to_string(),
+                rack_id: rack_id.to_string(),
+            },
+        );
+    }
+    Ok(map)
+}
+
+fn to_rms_power_operation(action: PowerAction) -> i32 {
+    match action {
+        PowerAction::On => rms::PowerOperation::PowerOn as i32,
+        PowerAction::GracefulShutdown | PowerAction::ForceOff => {
+            rms::PowerOperation::PowerOff as i32
+        }
+        PowerAction::GracefulRestart | PowerAction::ForceRestart | PowerAction::AcPowercycle => {
+            rms::PowerOperation::PowerReset as i32
+        }
+    }
+}
+
+fn map_rms_firmware_job_state(state: i32) -> FirmwareState {
+    match rms::FirmwareJobState::try_from(state) {
+        Ok(rms::FirmwareJobState::FwJobQueued) => FirmwareState::Queued,
+        Ok(rms::FirmwareJobState::FwJobRunning) => FirmwareState::InProgress,
+        Ok(rms::FirmwareJobState::FwJobCompleted) => FirmwareState::Completed,
+        Ok(rms::FirmwareJobState::FwJobFailed) => FirmwareState::Failed,
+        _ => FirmwareState::Unknown,
+    }
+}
+
+/// Map PowerShelfComponent to a firmware target name used by RMS.
+fn component_target_name(c: &PowerShelfComponent) -> &'static str {
+    match c {
+        PowerShelfComponent::Pmc => "pmc",
+        PowerShelfComponent::Psu => "psu",
+    }
+}
+
+#[async_trait::async_trait]
+impl PowerShelfManager for RmsBackend {
+    fn name(&self) -> &str {
+        "rms"
+    }
+
+    #[instrument(skip(self), fields(backend = "rms"))]
+    async fn power_control(
+        &self,
+        endpoints: &[PowerShelfEndpoint],
+        action: PowerAction,
+    ) -> Result<Vec<PowerShelfComponentResult>, ComponentManagerError> {
+        let ids = self.resolve_identities(endpoints).await?;
+        let operation = to_rms_power_operation(action);
+        let mut results = Vec::with_capacity(endpoints.len());
+
+        for ep in endpoints {
+            let Some(identity) = ids.get(&ep.pmc_mac) else {
+                results.push(PowerShelfComponentResult {
+                    pmc_mac: ep.pmc_mac,
+                    success: false,
+                    error: Some("could not resolve RMS identity from database".into()),
+                });
+                continue;
+            };
+
+            let request = rms::SetPowerStateRequest {
+                node_id: identity.node_id.clone(),
+                rack_id: identity.rack_id.clone(),
+                operation,
+                ..Default::default()
+            };
+
+            match self.client.set_power_state(request).await {
+                Ok(response) => {
+                    let success = response.status == rms::ReturnCode::Success as i32;
+                    results.push(PowerShelfComponentResult {
+                        pmc_mac: ep.pmc_mac,
+                        success,
+                        error: if success {
+                            None
+                        } else {
+                            Some("RMS power control failed".into())
+                        },
+                    });
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        pmc_mac = %ep.pmc_mac,
+                        error = %e,
+                        "RMS power control failed for power shelf"
+                    );
+                    results.push(PowerShelfComponentResult {
+                        pmc_mac: ep.pmc_mac,
+                        success: false,
+                        error: Some(e.to_string()),
+                    });
+                }
+            }
+        }
+
+        Ok(results)
+    }
+
+    #[instrument(skip(self), fields(backend = "rms"))]
+    async fn update_firmware(
+        &self,
+        endpoints: &[PowerShelfEndpoint],
+        target_version: &str,
+        components: &[PowerShelfComponent],
+    ) -> Result<Vec<PowerShelfComponentResult>, ComponentManagerError> {
+        let ids = self.resolve_identities(endpoints).await?;
+        let firmware_targets: Vec<rms::FirmwareTarget> = components
+            .iter()
+            .map(|c| rms::FirmwareTarget {
+                target: component_target_name(c).to_owned(),
+                filename: target_version.to_owned(),
+            })
+            .collect();
+
+        let mut results = Vec::with_capacity(endpoints.len());
+
+        for ep in endpoints {
+            let Some(identity) = ids.get(&ep.pmc_mac) else {
+                results.push(PowerShelfComponentResult {
+                    pmc_mac: ep.pmc_mac,
+                    success: false,
+                    error: Some("could not resolve RMS identity from database".into()),
+                });
+                continue;
+            };
+
+            let request = rms::UpdateNodeFirmwareRequest {
+                node_id: identity.node_id.clone(),
+                rack_id: identity.rack_id.clone(),
+                firmware_targets: firmware_targets.clone(),
+                ..Default::default()
+            };
+
+            match self.client.update_node_firmware_async(request).await {
+                Ok(response) => {
+                    let success = response.status == rms::ReturnCode::Success as i32;
+
+                    if !response.job_id.is_empty() {
+                        self.firmware_jobs
+                            .lock()
+                            .unwrap()
+                            .insert(ep.pmc_mac, response.job_id.clone());
+                    }
+
+                    results.push(PowerShelfComponentResult {
+                        pmc_mac: ep.pmc_mac,
+                        success,
+                        error: if success {
+                            None
+                        } else {
+                            Some(if response.message.is_empty() {
+                                "RMS firmware update failed".to_owned()
+                            } else {
+                                response.message
+                            })
+                        },
+                    });
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        pmc_mac = %ep.pmc_mac,
+                        error = %e,
+                        "RMS firmware update failed for power shelf"
+                    );
+                    results.push(PowerShelfComponentResult {
+                        pmc_mac: ep.pmc_mac,
+                        success: false,
+                        error: Some(e.to_string()),
+                    });
+                }
+            }
+        }
+
+        Ok(results)
+    }
+
+    #[instrument(skip(self), fields(backend = "rms"))]
+    async fn get_firmware_status(
+        &self,
+        endpoints: &[PowerShelfEndpoint],
+    ) -> Result<Vec<PowerShelfFirmwareUpdateStatus>, ComponentManagerError> {
+        // Snapshot job IDs under the lock, then release it before making
+        // async RMS calls (avoids holding a std::sync::Mutex across await).
+        let endpoint_jobs: Vec<(MacAddress, Option<String>)> = {
+            let jobs = self.firmware_jobs.lock().unwrap();
+            endpoints
+                .iter()
+                .map(|ep| (ep.pmc_mac, jobs.get(&ep.pmc_mac).cloned()))
+                .collect()
+        };
+
+        let mut statuses = Vec::with_capacity(endpoints.len());
+
+        for (pmc_mac, job_id) in &endpoint_jobs {
+            let Some(job_id) = job_id else {
+                statuses.push(PowerShelfFirmwareUpdateStatus {
+                    pmc_mac: *pmc_mac,
+                    state: FirmwareState::Unknown,
+                    target_version: String::new(),
+                    error: Some("no firmware job tracked for this power shelf".into()),
+                });
+                continue;
+            };
+
+            let request = rms::GetFirmwareJobStatusRequest {
+                job_id: job_id.clone(),
+                ..Default::default()
+            };
+
+            match self.client.get_firmware_job_status(request).await {
+                Ok(response) => {
+                    let state = if response.status == rms::ReturnCode::Success as i32 {
+                        map_rms_firmware_job_state(response.job_state)
+                    } else {
+                        FirmwareState::Unknown
+                    };
+                    statuses.push(PowerShelfFirmwareUpdateStatus {
+                        pmc_mac: *pmc_mac,
+                        state,
+                        target_version: String::new(),
+                        error: if response.error_message.is_empty() {
+                            None
+                        } else {
+                            Some(response.error_message)
+                        },
+                    });
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        pmc_mac = %pmc_mac,
+                        job_id = %job_id,
+                        error = %e,
+                        "RMS firmware job status query failed"
+                    );
+                    statuses.push(PowerShelfFirmwareUpdateStatus {
+                        pmc_mac: *pmc_mac,
+                        state: FirmwareState::Unknown,
+                        target_version: String::new(),
+                        error: Some(e.to_string()),
+                    });
+                }
+            }
+        }
+
+        Ok(statuses)
+    }
+
+    #[instrument(skip(self), fields(backend = "rms"))]
+    async fn list_firmware(
+        &self,
+        endpoints: &[PowerShelfEndpoint],
+    ) -> Result<Vec<PowerShelfFirmwareVersions>, ComponentManagerError> {
+        let ids = self.resolve_identities(endpoints).await?;
+        let mut results = Vec::with_capacity(endpoints.len());
+
+        for ep in endpoints {
+            let Some(identity) = ids.get(&ep.pmc_mac) else {
+                results.push(PowerShelfFirmwareVersions {
+                    pmc_mac: ep.pmc_mac,
+                    versions: vec![],
+                    error: Some("could not resolve RMS identity from database".into()),
+                });
+                continue;
+            };
+
+            let request = rms::GetNodeFirmwareInventoryRequest {
+                node_id: identity.node_id.clone(),
+                rack_id: identity.rack_id.clone(),
+                ..Default::default()
+            };
+
+            match self.client.get_node_firmware_inventory(request).await {
+                Ok(response) => {
+                    if response.status != rms::ReturnCode::Success as i32 {
+                        results.push(PowerShelfFirmwareVersions {
+                            pmc_mac: ep.pmc_mac,
+                            versions: vec![],
+                            error: Some("RMS firmware inventory query failed".into()),
+                        });
+                        continue;
+                    }
+
+                    let versions = response
+                        .firmware_list
+                        .into_iter()
+                        .map(|fi| fi.version)
+                        .collect();
+
+                    results.push(PowerShelfFirmwareVersions {
+                        pmc_mac: ep.pmc_mac,
+                        versions,
+                        error: None,
+                    });
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        pmc_mac = %ep.pmc_mac,
+                        error = %e,
+                        "RMS firmware inventory query failed for power shelf"
+                    );
+                    results.push(PowerShelfFirmwareVersions {
+                        pmc_mac: ep.pmc_mac,
+                        versions: vec![],
+                        error: Some(e.to_string()),
+                    });
+                }
+            }
+        }
+
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use api_test_helper::mock_rms::MockRmsApi;
+
+    use super::*;
+    use crate::power_shelf_manager::PowerShelfVendor;
+
+    #[test]
+    fn power_action_on_maps_to_power_on() {
+        assert_eq!(
+            to_rms_power_operation(PowerAction::On),
+            rms::PowerOperation::PowerOn as i32,
+        );
+    }
+
+    #[test]
+    fn power_action_shutdown_maps_to_power_off() {
+        assert_eq!(
+            to_rms_power_operation(PowerAction::GracefulShutdown),
+            rms::PowerOperation::PowerOff as i32,
+        );
+    }
+
+    #[test]
+    fn power_action_force_off_maps_to_power_off() {
+        assert_eq!(
+            to_rms_power_operation(PowerAction::ForceOff),
+            rms::PowerOperation::PowerOff as i32,
+        );
+    }
+
+    #[test]
+    fn power_action_restart_maps_to_power_reset() {
+        for action in [
+            PowerAction::GracefulRestart,
+            PowerAction::ForceRestart,
+            PowerAction::AcPowercycle,
+        ] {
+            assert_eq!(
+                to_rms_power_operation(action),
+                rms::PowerOperation::PowerReset as i32,
+                "expected PowerReset for {action:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn firmware_job_state_queued() {
+        assert_eq!(
+            map_rms_firmware_job_state(rms::FirmwareJobState::FwJobQueued as i32),
+            FirmwareState::Queued,
+        );
+    }
+
+    #[test]
+    fn firmware_job_state_running() {
+        assert_eq!(
+            map_rms_firmware_job_state(rms::FirmwareJobState::FwJobRunning as i32),
+            FirmwareState::InProgress,
+        );
+    }
+
+    #[test]
+    fn firmware_job_state_completed() {
+        assert_eq!(
+            map_rms_firmware_job_state(rms::FirmwareJobState::FwJobCompleted as i32),
+            FirmwareState::Completed,
+        );
+    }
+
+    #[test]
+    fn firmware_job_state_failed() {
+        assert_eq!(
+            map_rms_firmware_job_state(rms::FirmwareJobState::FwJobFailed as i32),
+            FirmwareState::Failed,
+        );
+    }
+
+    #[test]
+    fn firmware_job_state_unknown_for_unrecognized_value() {
+        assert_eq!(map_rms_firmware_job_state(9999), FirmwareState::Unknown);
+    }
+
+    #[test]
+    fn component_target_names() {
+        assert_eq!(component_target_name(&PowerShelfComponent::Pmc), "pmc");
+        assert_eq!(component_target_name(&PowerShelfComponent::Psu), "psu");
+    }
+
+    // ---- Test helpers ----
+
+    fn make_endpoint(mac: &str) -> PowerShelfEndpoint {
+        PowerShelfEndpoint {
+            pmc_ip: "10.0.0.1".parse().unwrap(),
+            pmc_mac: mac.parse().unwrap(),
+            pmc_vendor: PowerShelfVendor::Liteon,
+        }
+    }
+
+    fn make_endpoints() -> Vec<PowerShelfEndpoint> {
+        vec![
+            make_endpoint("AA:BB:CC:DD:EE:01"),
+            make_endpoint("AA:BB:CC:DD:EE:02"),
+        ]
+    }
+
+    /// Build identity overrides that map our test MACs to known RMS IDs.
+    fn test_identities() -> HashMap<MacAddress, RmsIdentity> {
+        let mut map = HashMap::new();
+        map.insert(
+            "AA:BB:CC:DD:EE:01".parse().unwrap(),
+            RmsIdentity {
+                node_id: "ps-001".into(),
+                rack_id: "rack-001".into(),
+            },
+        );
+        map.insert(
+            "AA:BB:CC:DD:EE:02".parse().unwrap(),
+            RmsIdentity {
+                node_id: "ps-002".into(),
+                rack_id: "rack-001".into(),
+            },
+        );
+        map
+    }
+
+    /// Create a backend backed by the shared mock with pre-set identity
+    /// overrides (no real database needed).
+    fn make_backend() -> (Arc<MockRmsApi>, RmsBackend) {
+        let mock = Arc::new(MockRmsApi::new());
+        // connect_lazy doesn't actually connect — the identity overrides
+        // bypass the DB so this pool is never used.
+        let db = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://test@localhost/fake")
+            .unwrap();
+        let mut backend = RmsBackend::new(mock.clone(), db);
+        backend.identity_overrides = Some(test_identities());
+        (mock, backend)
+    }
+
+    #[tokio::test]
+    async fn power_control_success() {
+        let (mock, backend) = make_backend();
+        mock.enqueue_set_power_state(Ok(MockRmsApi::power_ok()))
+            .await;
+        mock.enqueue_set_power_state(Ok(MockRmsApi::power_ok()))
+            .await;
+
+        let eps = make_endpoints();
+        let results = backend.power_control(&eps, PowerAction::On).await.unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert!(results[0].success);
+        assert!(results[1].success);
+        assert!(results[0].error.is_none());
+
+        // Verify correct requests were sent
+        let calls = mock.set_power_state_calls().await;
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].node_id, "ps-001");
+        assert_eq!(calls[0].rack_id, "rack-001");
+        assert_eq!(calls[0].operation, rms::PowerOperation::PowerOn as i32);
+        assert_eq!(calls[1].node_id, "ps-002");
+    }
+
+    #[tokio::test]
+    async fn power_control_partial_failure() {
+        let (mock, backend) = make_backend();
+        mock.enqueue_set_power_state(Ok(MockRmsApi::power_ok()))
+            .await;
+        mock.enqueue_set_power_state(Ok(MockRmsApi::power_fail()))
+            .await;
+
+        let eps = make_endpoints();
+        let results = backend.power_control(&eps, PowerAction::On).await.unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert!(results[0].success);
+        assert!(!results[1].success);
+        assert!(results[1].error.is_some());
+    }
+
+    #[tokio::test]
+    async fn power_control_rms_transport_error() {
+        let (mock, backend) = make_backend();
+        mock.enqueue_set_power_state(Ok(MockRmsApi::power_ok()))
+            .await;
+        mock.enqueue_set_power_state(Err(librms::RackManagerError::ApiInvocationError(
+            tonic::Status::unavailable("connection refused"),
+        )))
+        .await;
+
+        let eps = make_endpoints();
+        let results = backend.power_control(&eps, PowerAction::On).await.unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert!(results[0].success);
+        assert!(!results[1].success);
+        assert!(
+            results[1]
+                .error
+                .as_ref()
+                .unwrap()
+                .contains("connection refused")
+        );
+    }
+
+    #[tokio::test]
+    async fn power_control_unknown_mac_skips_endpoint() {
+        let (mock, backend) = make_backend();
+        mock.enqueue_set_power_state(Ok(MockRmsApi::power_ok()))
+            .await;
+
+        let eps = vec![
+            make_endpoint("FF:FF:FF:FF:FF:FF"), // not in identity overrides
+            make_endpoint("AA:BB:CC:DD:EE:02"),
+        ];
+        let results = backend
+            .power_control(&eps, PowerAction::GracefulShutdown)
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert!(!results[0].success); // skipped — not found in DB
+        assert!(results[1].success); // called RMS
+
+        let calls = mock.set_power_state_calls().await;
+        assert_eq!(calls.len(), 1); // only one RMS call made
+        assert_eq!(calls[0].operation, rms::PowerOperation::PowerOff as i32);
+    }
+
+    #[tokio::test]
+    async fn update_firmware_success_stores_job_ids() {
+        let (mock, backend) = make_backend();
+        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("job-aaa")))
+            .await;
+        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("job-bbb")))
+            .await;
+
+        let eps = make_endpoints();
+        let results = backend
+            .update_firmware(&eps, "fw-1.0.0", &[PowerShelfComponent::Pmc])
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert!(results[0].success);
+        assert!(results[1].success);
+
+        // Verify firmware targets were built correctly
+        let calls = mock.update_node_firmware_async_calls().await;
+        assert_eq!(calls[0].firmware_targets.len(), 1);
+        assert_eq!(calls[0].firmware_targets[0].target, "pmc");
+        assert_eq!(calls[0].firmware_targets[0].filename, "fw-1.0.0");
+        assert_eq!(calls[0].node_id, "ps-001");
+        assert_eq!(calls[0].rack_id, "rack-001");
+
+        // Verify job IDs were stored for later status queries
+        let jobs = backend.firmware_jobs.lock().unwrap();
+        assert_eq!(
+            jobs.get(&"AA:BB:CC:DD:EE:01".parse::<MacAddress>().unwrap()),
+            Some(&"job-aaa".to_string()),
+        );
+        assert_eq!(
+            jobs.get(&"AA:BB:CC:DD:EE:02".parse::<MacAddress>().unwrap()),
+            Some(&"job-bbb".to_string()),
+        );
+    }
+
+    #[tokio::test]
+    async fn update_firmware_multiple_components() {
+        let (mock, backend) = make_backend();
+        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("job-1")))
+            .await;
+
+        let eps = vec![make_endpoint("AA:BB:CC:DD:EE:01")];
+        let results = backend
+            .update_firmware(
+                &eps,
+                "fw-2.0.0",
+                &[PowerShelfComponent::Pmc, PowerShelfComponent::Psu],
+            )
+            .await
+            .unwrap();
+
+        assert!(results[0].success);
+
+        let calls = mock.update_node_firmware_async_calls().await;
+        assert_eq!(calls[0].firmware_targets.len(), 2);
+        assert_eq!(calls[0].firmware_targets[0].target, "pmc");
+        assert_eq!(calls[0].firmware_targets[1].target, "psu");
+    }
+
+    #[tokio::test]
+    async fn update_firmware_failure_reports_message() {
+        let (mock, backend) = make_backend();
+        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_fail(
+            "bad firmware file",
+        )))
+        .await;
+
+        let eps = vec![make_endpoint("AA:BB:CC:DD:EE:01")];
+        let results = backend
+            .update_firmware(&eps, "fw-bad", &[PowerShelfComponent::Pmc])
+            .await
+            .unwrap();
+
+        assert!(!results[0].success);
+        assert_eq!(results[0].error.as_deref(), Some("bad firmware file"));
+    }
+
+    #[tokio::test]
+    async fn get_firmware_status_returns_job_state() {
+        let (mock, backend) = make_backend();
+
+        // First, do a firmware update to populate job tracking
+        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("job-xyz")))
+            .await;
+        let eps = vec![make_endpoint("AA:BB:CC:DD:EE:01")];
+        backend
+            .update_firmware(&eps, "fw-1.0.0", &[PowerShelfComponent::Pmc])
+            .await
+            .unwrap();
+
+        // Now query status
+        mock.enqueue_get_firmware_job_status(Ok(MockRmsApi::firmware_job_status_ok(
+            rms::FirmwareJobState::FwJobRunning,
+        )))
+        .await;
+
+        let statuses = backend.get_firmware_status(&eps).await.unwrap();
+
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(statuses[0].state, FirmwareState::InProgress);
+        assert!(statuses[0].error.is_none());
+
+        // Verify the correct job_id was sent
+        let calls = mock.get_firmware_job_status_calls().await;
+        assert_eq!(calls[0].job_id, "job-xyz");
+    }
+
+    #[tokio::test]
+    async fn get_firmware_status_no_tracked_job() {
+        let (_mock, backend) = make_backend();
+
+        let eps = vec![make_endpoint("AA:BB:CC:DD:EE:01")];
+        let statuses = backend.get_firmware_status(&eps).await.unwrap();
+
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(statuses[0].state, FirmwareState::Unknown);
+        assert!(
+            statuses[0]
+                .error
+                .as_ref()
+                .unwrap()
+                .contains("no firmware job")
+        );
+    }
+
+    #[tokio::test]
+    async fn get_firmware_status_completed() {
+        let (mock, backend) = make_backend();
+
+        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("job-done")))
+            .await;
+        let eps = vec![make_endpoint("AA:BB:CC:DD:EE:01")];
+        backend
+            .update_firmware(&eps, "fw-1.0.0", &[PowerShelfComponent::Pmc])
+            .await
+            .unwrap();
+
+        mock.enqueue_get_firmware_job_status(Ok(MockRmsApi::firmware_job_status_ok(
+            rms::FirmwareJobState::FwJobCompleted,
+        )))
+        .await;
+
+        let statuses = backend.get_firmware_status(&eps).await.unwrap();
+        assert_eq!(statuses[0].state, FirmwareState::Completed);
+    }
+
+    #[tokio::test]
+    async fn get_firmware_status_failed_with_error_message() {
+        let (mock, backend) = make_backend();
+
+        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("job-fail")))
+            .await;
+        let eps = vec![make_endpoint("AA:BB:CC:DD:EE:01")];
+        backend
+            .update_firmware(&eps, "fw-1.0.0", &[PowerShelfComponent::Pmc])
+            .await
+            .unwrap();
+
+        mock.enqueue_get_firmware_job_status(Ok(rms::GetFirmwareJobStatusResponse {
+            status: rms::ReturnCode::Success as i32,
+            job_state: rms::FirmwareJobState::FwJobFailed as i32,
+            error_message: "checksum mismatch".into(),
+            ..Default::default()
+        }))
+        .await;
+
+        let statuses = backend.get_firmware_status(&eps).await.unwrap();
+        assert_eq!(statuses[0].state, FirmwareState::Failed);
+        assert_eq!(statuses[0].error.as_deref(), Some("checksum mismatch"));
+    }
+
+    #[tokio::test]
+    async fn list_firmware_returns_versions() {
+        let (mock, backend) = make_backend();
+        mock.enqueue_get_node_firmware_inventory(Ok(MockRmsApi::firmware_inventory_ok(&[
+            ("PMC", "1.2.3"),
+            ("PSU", "4.5.6"),
+        ])))
+        .await;
+
+        let eps = vec![make_endpoint("AA:BB:CC:DD:EE:01")];
+        let results = backend.list_firmware(&eps).await.unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].versions, vec!["1.2.3", "4.5.6"]);
+        assert!(results[0].error.is_none());
+
+        let calls = mock.get_node_firmware_inventory_calls().await;
+        assert_eq!(calls[0].node_id, "ps-001");
+        assert_eq!(calls[0].rack_id, "rack-001");
+    }
+
+    #[tokio::test]
+    async fn list_firmware_rms_failure() {
+        let (mock, backend) = make_backend();
+        mock.enqueue_get_node_firmware_inventory(Ok(rms::GetNodeFirmwareInventoryResponse {
+            status: rms::ReturnCode::Failure as i32,
+            ..Default::default()
+        }))
+        .await;
+
+        let eps = vec![make_endpoint("AA:BB:CC:DD:EE:01")];
+        let results = backend.list_firmware(&eps).await.unwrap();
+
+        assert!(results[0].versions.is_empty());
+        assert!(results[0].error.is_some());
+    }
+
+    #[tokio::test]
+    async fn list_firmware_transport_error() {
+        let (mock, backend) = make_backend();
+        mock.enqueue_get_node_firmware_inventory(Err(
+            librms::RackManagerError::ApiInvocationError(tonic::Status::unavailable("down")),
+        ))
+        .await;
+
+        let eps = vec![make_endpoint("AA:BB:CC:DD:EE:01")];
+        let results = backend.list_firmware(&eps).await.unwrap();
+
+        assert!(results[0].versions.is_empty());
+        assert!(results[0].error.as_ref().unwrap().contains("down"));
+    }
+
+    #[tokio::test]
+    async fn list_firmware_unknown_mac() {
+        let (_mock, backend) = make_backend();
+
+        let eps = vec![make_endpoint("FF:FF:FF:FF:FF:FF")];
+        let results = backend.list_firmware(&eps).await.unwrap();
+
+        assert!(results[0].versions.is_empty());
+        assert!(results[0].error.is_some());
+    }
+
+    // ---- DB-backed integration tests ----
+    //
+    // These use a real PostgreSQL database to verify the SQL join in
+    // `resolve_rms_identities` works end-to-end.
+
+    mod db_tests {
+        use carbide_uuid::power_shelf::{PowerShelfIdSource, PowerShelfType};
+        use carbide_uuid::rack::RackId;
+        use model::expected_power_shelf::ExpectedPowerShelf;
+        use model::metadata::Metadata;
+        use model::power_shelf::{NewPowerShelf, PowerShelfConfig};
+        use model::rack::RackConfig;
+
+        use super::*;
+
+        /// Create a deterministic PowerShelfId from a label string.
+        fn test_power_shelf_id(label: &str) -> PowerShelfId {
+            let mut hash = [0u8; 32];
+            let bytes = label.as_bytes();
+            hash[..bytes.len().min(32)].copy_from_slice(&bytes[..bytes.len().min(32)]);
+            PowerShelfId::new(
+                PowerShelfIdSource::ProductBoardChassisSerial,
+                hash,
+                PowerShelfType::Rack,
+            )
+        }
+
+        /// Insert a power shelf with bmc_mac_address set. Also creates the
+        /// expected_power_shelf row (required by FK constraint).
+        async fn seed_power_shelf(
+            txn: &mut sqlx::PgConnection,
+            mac: &str,
+            label: &str,
+            rack_id: Option<&RackId>,
+        ) -> PowerShelfId {
+            let ps_id = test_power_shelf_id(label);
+            let mac: MacAddress = mac.parse().unwrap();
+
+            // expected_power_shelf must exist first (FK on bmc_mac_address)
+            db::expected_power_shelf::create(
+                &mut *txn,
+                ExpectedPowerShelf {
+                    expected_power_shelf_id: None,
+                    bmc_mac_address: mac,
+                    serial_number: label.to_owned(),
+                    bmc_username: "admin".into(),
+                    bmc_password: "pass".into(),
+                    bmc_ip_address: None,
+                    metadata: Metadata::default(),
+                    rack_id: rack_id.cloned(),
+                },
+            )
+            .await
+            .expect("failed to create expected power shelf");
+
+            let new_ps = NewPowerShelf {
+                id: ps_id,
+                config: PowerShelfConfig {
+                    name: label.to_owned(),
+                    capacity: None,
+                    voltage: None,
+                },
+                metadata: Some(Metadata::default()),
+                rack_id: rack_id.cloned(),
+            };
+            db::power_shelf::create(&mut *txn, &new_ps)
+                .await
+                .expect("failed to create power shelf");
+
+            sqlx::query("UPDATE power_shelves SET bmc_mac_address = $1 WHERE id = $2")
+                .bind(mac)
+                .bind(ps_id)
+                .execute(&mut *txn)
+                .await
+                .expect("failed to set bmc_mac_address");
+
+            ps_id
+        }
+
+        #[carbide_macros::sqlx_test]
+        async fn resolve_identities_from_database(pool: sqlx::PgPool) {
+            let mut txn = pool.begin().await.unwrap();
+
+            let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
+            db::rack::create(&mut txn, &rack_id, &RackConfig::default(), None)
+                .await
+                .expect("failed to create rack");
+
+            let mac = "AA:BB:CC:DD:EE:01";
+            let ps_id = seed_power_shelf(&mut txn, mac, "PS-SERIAL-001", Some(&rack_id)).await;
+
+            txn.commit().await.unwrap();
+
+            // Build backend with real DB pool (no identity overrides)
+            let mock = Arc::new(MockRmsApi::new());
+            let backend = RmsBackend::new(mock.clone(), pool.clone());
+
+            mock.enqueue_get_node_firmware_inventory(Ok(MockRmsApi::firmware_inventory_ok(&[(
+                "PMC", "1.0.0",
+            )])))
+            .await;
+
+            let eps = vec![make_endpoint(mac)];
+            let results = backend.list_firmware(&eps).await.unwrap();
+
+            // Verify the firmware call succeeded (identity was resolved)
+            assert_eq!(results.len(), 1);
+            assert!(results[0].error.is_none());
+            assert_eq!(results[0].versions, vec!["1.0.0"]);
+
+            // Verify the correct node_id and rack_id were sent to RMS
+            let calls = mock.get_node_firmware_inventory_calls().await;
+            assert_eq!(calls.len(), 1);
+            assert_eq!(calls[0].node_id, ps_id.to_string());
+            assert_eq!(calls[0].rack_id, rack_id.to_string());
+        }
+
+        #[carbide_macros::sqlx_test]
+        async fn resolve_identities_missing_rack_id_skips_endpoint(pool: sqlx::PgPool) {
+            let mut txn = pool.begin().await.unwrap();
+
+            let mac = "AA:BB:CC:DD:EE:02";
+            seed_power_shelf(&mut txn, mac, "PS-NO-RACK", None).await;
+
+            txn.commit().await.unwrap();
+
+            let mock = Arc::new(MockRmsApi::new());
+            let backend = RmsBackend::new(mock, pool.clone());
+
+            let eps = vec![make_endpoint(mac)];
+            let results = backend.list_firmware(&eps).await.unwrap();
+
+            // Endpoint should be skipped — power shelf has no rack_id
+            assert_eq!(results.len(), 1);
+            assert!(results[0].error.is_some());
+            assert!(results[0].versions.is_empty());
+        }
+    }
+}


### PR DESCRIPTION
## Description

This introduces `RmsBackend`, which is an RMS-backed `PowerShelfManager` component implementation (will add the switch trait implementation next) for the `ComponentManager` API, implementing:
- `name()`, which simply returns `"rms"`.
- `power_control(endpoints, action)`, which calls RMS `set_power_state` per device, mapping `PowerAction` to RMS's `PowerOperation` (`::On`, `::Off`, `::Reset`).
- `update_firmware(endpoints, target_version, components)`, which calls RMS `update_node_firmware_async` with a `FirmwareTarget` entry built from the component list, storing the returned `job_id` in a map keyed by MAC.
- `get_firmware_status(endpoints)`, which uses the `job_id` from the above map, and calls RMS `get_firmware_job_status`, mapping `FirmwareJobState` to the shared `FirmwareState` enum.
- `list_firmware(endpoints)`, which calls RMS `get_node_firmware_inventory`, extracting the version string from the returned firmware component list.

This also introduces a `MockRmsApi` client, which has per-endpoint queues that allow us to push "expected" responses (happy path or errors), and then each real call to that endpoint pops off the next response. It also records each request, allowing tests to inspect what was actually passed to RMS.

The `MockRmsApi` client is then used for integration testing here, with a number of different flows being tested to verify:
- **Power control** -- success for multiple endpoints, partial failure (one succeeds + one fails), RMS transport errors (e.g. "*connection refused*"), and graceful skipping when an endpoint is missing `node_id` / `rack_id`.
- **Firmware update** -- successful updates that stores a `job_id` for later polling, multi-component updates, and failures w/ error message propagation.
- **Firmware status** -- polling a tracked job and verifying state mapping (`Running` -> `InProgress`, `Completed`, `Failed` w/ error message), and the "*no tracked job*" case when no prior update was done.
- **Firmware inventory** -- listing versions from a device, RMS returning a failure status, handling transport errors, and missing endpoint IDs.

To enable, just set:
```
[component_manager]
power_shelf_backend = "rms"
```

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

