### PR TITLE
feat: support for bmc_retain_credentials in expected components

### DIFF
--- a/crates/admin-cli/src/expected_machines/add/args.rs
+++ b/crates/admin-cli/src/expected_machines/add/args.rs
@@ -122,6 +122,13 @@ pub struct Args {
         help = "Static BMC IP (pre-allocates machine_interface for site explorer, same as expected switches)"
     )]
     pub bmc_ip_address: Option<IpAddr>,
+
+    #[clap(
+        long = "bmc-retain-credentials",
+        value_name = "BMC_RETAIN_CREDENTIALS",
+        help = "When true, site-explorer skips BMC password rotation and stores factory-default credentials in Vault as-is"
+    )]
+    pub bmc_retain_credentials: Option<bool>,
 }
 
 impl Args {
@@ -172,6 +179,7 @@ impl TryFrom<Args> for rpc::forge::ExpectedMachine {
             dpf_enabled: value.dpf_enabled.unwrap_or_default(),
             is_dpf_enabled: value.dpf_enabled,
             bmc_ip_address: value.bmc_ip_address.map(|ip| ip.to_string()),
+            bmc_retain_credentials: value.bmc_retain_credentials,
         })
     }
 }

--- a/crates/admin-cli/src/expected_machines/common.rs
+++ b/crates/admin-cli/src/expected_machines/common.rs
@@ -43,6 +43,8 @@ pub struct ExpectedMachineJson {
     /// [`bmc_mac_address`](Self::bmc_mac_address) (same as `--bmc-ip-address` on add/patch).
     #[serde(default)]
     pub bmc_ip_address: Option<String>,
+    #[serde(default)]
+    pub bmc_retain_credentials: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/admin-cli/src/expected_machines/patch/args.rs
+++ b/crates/admin-cli/src/expected_machines/patch/args.rs
@@ -146,6 +146,13 @@ pub struct Args {
         help = "Static BMC IP (updates pre-allocated machine_interface when safe, same as expected switches)"
     )]
     pub bmc_ip_address: Option<String>,
+
+    #[clap(
+        long = "bmc-retain-credentials",
+        value_name = "BMC_RETAIN_CREDENTIALS",
+        help = "When true, site-explorer skips BMC password rotation and stores factory-default credentials in Vault as-is"
+    )]
+    pub bmc_retain_credentials: Option<bool>,
 }
 
 impl Args {

--- a/crates/admin-cli/src/expected_machines/patch/mod.rs
+++ b/crates/admin-cli/src/expected_machines/patch/mod.rs
@@ -49,6 +49,7 @@ impl Run for Args {
                 self.default_pause_ingestion_and_poweron,
                 self.dpf_enabled,
                 self.bmc_ip_address,
+                self.bmc_retain_credentials,
             )
             .await?;
         Ok(())

--- a/crates/admin-cli/src/expected_machines/update/mod.rs
+++ b/crates/admin-cli/src/expected_machines/update/mod.rs
@@ -67,6 +67,7 @@ impl Run for Args {
                 expected_machine.default_pause_ingestion_and_poweron,
                 expected_machine.dpf_enabled,
                 expected_machine.bmc_ip_address,
+                expected_machine.bmc_retain_credentials,
             )
             .await?;
         Ok(())

--- a/crates/admin-cli/src/expected_power_shelf/add/args.rs
+++ b/crates/admin-cli/src/expected_power_shelf/add/args.rs
@@ -84,6 +84,13 @@ pub struct Args {
         action = clap::ArgAction::Append
     )]
     pub bmc_ip_address: Option<IpAddr>,
+
+    #[clap(
+        long = "bmc-retain-credentials",
+        value_name = "BMC_RETAIN_CREDENTIALS",
+        help = "When true, site-explorer skips BMC password rotation and stores factory-default credentials in Vault as-is"
+    )]
+    pub bmc_retain_credentials: Option<bool>,
 }
 
 impl From<Args> for rpc::forge::ExpectedPowerShelf {
@@ -106,6 +113,7 @@ impl From<Args> for rpc::forge::ExpectedPowerShelf {
                 .unwrap_or_default(),
             rack_id: value.rack_id,
             metadata: Some(metadata),
+            bmc_retain_credentials: value.bmc_retain_credentials,
         }
     }
 }

--- a/crates/admin-cli/src/expected_power_shelf/common.rs
+++ b/crates/admin-cli/src/expected_power_shelf/common.rs
@@ -32,4 +32,6 @@ pub struct ExpectedPowerShelfJson {
     pub host_name: Option<String>,
     pub rack_id: Option<RackId>,
     pub bmc_ip_address: Option<IpAddr>,
+    #[serde(default)]
+    pub bmc_retain_credentials: Option<bool>,
 }

--- a/crates/admin-cli/src/expected_power_shelf/update/args.rs
+++ b/crates/admin-cli/src/expected_power_shelf/update/args.rs
@@ -110,6 +110,13 @@ pub struct Args {
         action = clap::ArgAction::Append
     )]
     pub bmc_ip_address: Option<IpAddr>,
+
+    #[clap(
+        long = "bmc-retain-credentials",
+        value_name = "BMC_RETAIN_CREDENTIALS",
+        help = "When true, site-explorer skips BMC password rotation and stores factory-default credentials in Vault as-is"
+    )]
+    pub bmc_retain_credentials: Option<bool>,
 }
 
 impl TryFrom<Args> for rpc::forge::ExpectedPowerShelf {
@@ -157,6 +164,7 @@ impl TryFrom<Args> for rpc::forge::ExpectedPowerShelf {
                 labels: crate::metadata::parse_rpc_labels(args.labels.unwrap_or_default()),
             }),
             rack_id: args.rack_id,
+            bmc_retain_credentials: args.bmc_retain_credentials,
         })
     }
 }

--- a/crates/admin-cli/src/expected_switch/add/args.rs
+++ b/crates/admin-cli/src/expected_switch/add/args.rs
@@ -82,6 +82,13 @@ pub struct Args {
         help = "BMC IP address of the expected switch"
     )]
     pub bmc_ip_address: Option<IpAddr>,
+
+    #[clap(
+        long = "bmc-retain-credentials",
+        value_name = "BMC_RETAIN_CREDENTIALS",
+        help = "When true, site-explorer skips BMC password rotation and stores factory-default credentials in Vault as-is"
+    )]
+    pub bmc_retain_credentials: Option<bool>,
 }
 
 impl From<Args> for rpc::forge::ExpectedSwitch {
@@ -111,6 +118,7 @@ impl From<Args> for rpc::forge::ExpectedSwitch {
                 .bmc_ip_address
                 .map(|ip| ip.to_string())
                 .unwrap_or_default(),
+            bmc_retain_credentials: value.bmc_retain_credentials,
         }
     }
 }

--- a/crates/admin-cli/src/expected_switch/common.rs
+++ b/crates/admin-cli/src/expected_switch/common.rs
@@ -35,4 +35,6 @@ pub struct ExpectedSwitchJson {
     pub metadata: Option<rpc::forge::Metadata>,
     pub rack_id: Option<RackId>,
     pub bmc_ip_address: Option<IpAddr>,
+    #[serde(default)]
+    pub bmc_retain_credentials: Option<bool>,
 }

--- a/crates/admin-cli/src/expected_switch/update/args.rs
+++ b/crates/admin-cli/src/expected_switch/update/args.rs
@@ -112,6 +112,13 @@ pub struct Args {
         help = "BMC IP address of the expected switch"
     )]
     pub bmc_ip_address: Option<IpAddr>,
+
+    #[clap(
+        long = "bmc-retain-credentials",
+        value_name = "BMC_RETAIN_CREDENTIALS",
+        help = "When true, site-explorer skips BMC password rotation and stores factory-default credentials in Vault as-is"
+    )]
+    pub bmc_retain_credentials: Option<bool>,
 }
 
 impl TryFrom<Args> for rpc::forge::ExpectedSwitch {
@@ -168,6 +175,7 @@ impl TryFrom<Args> for rpc::forge::ExpectedSwitch {
                 .bmc_ip_address
                 .map(|ip| ip.to_string())
                 .unwrap_or_default(),
+            bmc_retain_credentials: args.bmc_retain_credentials,
         })
     }
 }

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -568,6 +568,7 @@ impl ApiClient {
         default_pause_ingestion_and_poweron: Option<bool>,
         dpf_enabled: Option<bool>,
         bmc_ip_address: Option<String>,
+        bmc_retain_credentials: Option<bool>,
     ) -> Result<(), CarbideCliError> {
         let get_req = match (bmc_mac_address, id) {
             (Some(_), Some(_)) => {
@@ -647,6 +648,8 @@ impl ApiClient {
             dpf_enabled: dpf_enabled.unwrap_or_default(),
             is_dpf_enabled: dpf_enabled,
             bmc_ip_address: bmc_ip_address.or(expected_machine.bmc_ip_address),
+            bmc_retain_credentials: bmc_retain_credentials
+                .or(expected_machine.bmc_retain_credentials),
         };
 
         Ok(self.0.update_expected_machine(request).await?)
@@ -680,6 +683,7 @@ impl ApiClient {
                     dpf_enabled: machine.dpf_enabled.unwrap_or_default(),
                     is_dpf_enabled: machine.dpf_enabled,
                     bmc_ip_address: machine.bmc_ip_address,
+                    bmc_retain_credentials: machine.bmc_retain_credentials,
                 })
                 .collect(),
         };
@@ -706,6 +710,7 @@ impl ApiClient {
                         .unwrap_or_default(),
                     metadata: power_shelf.metadata,
                     rack_id: power_shelf.rack_id,
+                    bmc_retain_credentials: power_shelf.bmc_retain_credentials,
                 })
                 .collect(),
         };
@@ -741,6 +746,7 @@ impl ApiClient {
                         .unwrap_or_default(),
                     metadata: switch.metadata,
                     rack_id: switch.rack_id,
+                    bmc_retain_credentials: switch.bmc_retain_credentials,
                 })
                 .collect(),
         };

--- a/crates/api-db/migrations/20260414233201_expected_bmc_retain_credentials.sql
+++ b/crates/api-db/migrations/20260414233201_expected_bmc_retain_credentials.sql
@@ -1,0 +1,3 @@
+ALTER TABLE expected_machines ADD COLUMN bmc_retain_credentials BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE expected_switches ADD COLUMN bmc_retain_credentials BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE expected_power_shelves ADD COLUMN bmc_retain_credentials BOOLEAN NOT NULL DEFAULT FALSE;

--- a/crates/api-db/src/expected_machine.rs
+++ b/crates/api-db/src/expected_machine.rs
@@ -207,9 +207,9 @@ pub async fn create(
 ) -> DatabaseResult<ExpectedMachine> {
     let id = machine.id.unwrap_or_else(Uuid::new_v4);
     let query = "INSERT INTO expected_machines
-            (id, bmc_mac_address, bmc_username, bmc_password, serial_number, fallback_dpu_serial_numbers, metadata_name, metadata_description, metadata_labels, sku_id, host_nics, rack_id, default_pause_ingestion_and_poweron, dpf_enabled, bmc_ip_address)
+            (id, bmc_mac_address, bmc_username, bmc_password, serial_number, fallback_dpu_serial_numbers, metadata_name, metadata_description, metadata_labels, sku_id, host_nics, rack_id, default_pause_ingestion_and_poweron, dpf_enabled, bmc_ip_address, bmc_retain_credentials)
             VALUES
-            ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::text[], $7, $8, $9::jsonb, $10::varchar, $11::jsonb, $12, $13, $14, $15::inet) RETURNING *";
+            ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::text[], $7, $8, $9::jsonb, $10::varchar, $11::jsonb, $12, $13, $14, $15::inet, $16) RETURNING *";
 
     sqlx::query_as(query)
         .bind(id)
@@ -232,6 +232,7 @@ pub async fn create(
         )
         .bind(machine.data.dpf_enabled.unwrap_or_default())
         .bind(machine.data.bmc_ip_address)
+        .bind(machine.data.bmc_retain_credentials.unwrap_or(false))
         .fetch_one(txn)
         .await
         .map_err(|err: sqlx::Error| match err {
@@ -327,9 +328,9 @@ pub async fn clear(txn: &mut PgConnection) -> Result<(), DatabaseError> {
 /// `bmc_mac_address`. Includes `bmc_ip_address` when the operator configures a static BMC IP.
 pub async fn update(txn: &mut PgConnection, machine: &ExpectedMachine) -> DatabaseResult<()> {
     let (where_clause, target_id) = match machine.id {
-        Some(id) => ("id=$14::uuid", id.to_string()),
+        Some(id) => ("id=$15::uuid", id.to_string()),
         None => (
-            "bmc_mac_address=$14::macaddr",
+            "bmc_mac_address=$15::macaddr",
             machine.bmc_mac_address.to_string(),
         ),
     };
@@ -341,7 +342,8 @@ pub async fn update(txn: &mut PgConnection, machine: &ExpectedMachine) -> Databa
              metadata_labels=$7, sku_id=$8, host_nics=$9::jsonb, rack_id=$10, \
              default_pause_ingestion_and_poweron=COALESCE($11, default_pause_ingestion_and_poweron), \
              dpf_enabled=COALESCE($12, dpf_enabled), \
-             bmc_ip_address=$13 \
+             bmc_ip_address=$13, \
+             bmc_retain_credentials=COALESCE($14, bmc_retain_credentials) \
          WHERE {where_clause}"
     );
 
@@ -359,6 +361,7 @@ pub async fn update(txn: &mut PgConnection, machine: &ExpectedMachine) -> Databa
         .bind(machine.data.default_pause_ingestion_and_poweron)
         .bind(machine.data.dpf_enabled)
         .bind(machine.data.bmc_ip_address)
+        .bind(machine.data.bmc_retain_credentials)
         .bind(&target_id)
         .execute(&mut *txn)
         .await

--- a/crates/api-db/src/expected_power_shelf.rs
+++ b/crates/api-db/src/expected_power_shelf.rs
@@ -140,9 +140,9 @@ pub async fn create(
         .expected_power_shelf_id
         .unwrap_or_else(Uuid::new_v4);
     let query = "INSERT INTO expected_power_shelves
-            (expected_power_shelf_id, bmc_mac_address, bmc_username, bmc_password, serial_number, bmc_ip_address, metadata_name, metadata_description, metadata_labels, rack_id)
+            (expected_power_shelf_id, bmc_mac_address, bmc_username, bmc_password, serial_number, bmc_ip_address, metadata_name, metadata_description, metadata_labels, rack_id, bmc_retain_credentials)
             VALUES
-            ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::inet, $7, $8, $9::jsonb, $10) RETURNING *";
+            ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::inet, $7, $8, $9::jsonb, $10, $11) RETURNING *";
 
     sqlx::query_as(query)
         .bind(id)
@@ -155,6 +155,7 @@ pub async fn create(
         .bind(&power_shelf.metadata.description)
         .bind(sqlx::types::Json(&power_shelf.metadata.labels))
         .bind(&power_shelf.rack_id)
+        .bind(power_shelf.bmc_retain_credentials.unwrap_or(false))
         .fetch_one(txn)
         .await
         .map_err(|err: sqlx::Error| match err {
@@ -252,9 +253,9 @@ pub async fn update(
     power_shelf: &ExpectedPowerShelf,
 ) -> DatabaseResult<()> {
     let (where_clause, target_id) = match power_shelf.expected_power_shelf_id {
-        Some(id) => ("expected_power_shelf_id=$9::uuid", id.to_string()),
+        Some(id) => ("expected_power_shelf_id=$10::uuid", id.to_string()),
         None => (
-            "bmc_mac_address=$9::macaddr",
+            "bmc_mac_address=$10::macaddr",
             power_shelf.bmc_mac_address.to_string(),
         ),
     };
@@ -262,7 +263,8 @@ pub async fn update(
     let query = format!(
         "UPDATE expected_power_shelves \
          SET bmc_username=$1, bmc_password=$2, serial_number=$3, bmc_ip_address=$4, \
-             metadata_name=$5, metadata_description=$6, metadata_labels=$7, rack_id=$8 \
+             metadata_name=$5, metadata_description=$6, metadata_labels=$7, rack_id=$8, \
+             bmc_retain_credentials=COALESCE($9, bmc_retain_credentials) \
          WHERE {where_clause}"
     );
 
@@ -275,6 +277,7 @@ pub async fn update(
         .bind(&power_shelf.metadata.description)
         .bind(sqlx::types::Json(&power_shelf.metadata.labels))
         .bind(&power_shelf.rack_id)
+        .bind(power_shelf.bmc_retain_credentials)
         .bind(&target_id)
         .execute(&mut *txn)
         .await

--- a/crates/api-db/src/expected_switch.rs
+++ b/crates/api-db/src/expected_switch.rs
@@ -177,9 +177,9 @@ pub async fn create(
 ) -> DatabaseResult<ExpectedSwitch> {
     let id = switch.expected_switch_id.unwrap_or_else(Uuid::new_v4);
     let query = "INSERT INTO expected_switches
-             (expected_switch_id, bmc_mac_address, bmc_username, bmc_password, serial_number, bmc_ip_address, metadata_name, metadata_description, rack_id, metadata_labels, nvos_username, nvos_password, nvos_mac_addresses)
+             (expected_switch_id, bmc_mac_address, bmc_username, bmc_password, serial_number, bmc_ip_address, metadata_name, metadata_description, rack_id, metadata_labels, nvos_username, nvos_password, nvos_mac_addresses, bmc_retain_credentials)
              VALUES
-             ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::inet, $7::varchar, $8::varchar, $9::varchar, $10::jsonb, $11::varchar, $12::varchar, $13::macaddr[]) RETURNING *";
+             ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::inet, $7::varchar, $8::varchar, $9::varchar, $10::jsonb, $11::varchar, $12::varchar, $13::macaddr[], $14) RETURNING *";
 
     sqlx::query_as(query)
         .bind(id)
@@ -195,6 +195,7 @@ pub async fn create(
         .bind(&switch.nvos_username)
         .bind(&switch.nvos_password)
         .bind(&switch.nvos_mac_addresses)
+        .bind(switch.bmc_retain_credentials.unwrap_or(false))
         .fetch_one(txn)
         .await
         .map_err(|err: sqlx::Error| match err {
@@ -304,9 +305,9 @@ pub async fn clear(txn: &mut PgConnection) -> Result<(), DatabaseError> {
 /// matches by ID; otherwise matches by bmc_mac_address.
 pub async fn update(txn: &mut PgConnection, switch: &ExpectedSwitch) -> DatabaseResult<()> {
     let (where_clause, target_id) = match switch.expected_switch_id {
-        Some(id) => ("expected_switch_id=$12::uuid", id.to_string()),
+        Some(id) => ("expected_switch_id=$13::uuid", id.to_string()),
         None => (
-            "bmc_mac_address=$12::macaddr",
+            "bmc_mac_address=$13::macaddr",
             switch.bmc_mac_address.to_string(),
         ),
     };
@@ -315,7 +316,8 @@ pub async fn update(txn: &mut PgConnection, switch: &ExpectedSwitch) -> Database
         "UPDATE expected_switches \
          SET bmc_username=$1, bmc_password=$2, serial_number=$3, bmc_ip_address=$4, \
              metadata_name=$5, metadata_description=$6, metadata_labels=$7, \
-             rack_id=$8, nvos_username=$9, nvos_password=$10, nvos_mac_addresses=$11::macaddr[] \
+             rack_id=$8, nvos_username=$9, nvos_password=$10, nvos_mac_addresses=$11::macaddr[], \
+             bmc_retain_credentials=COALESCE($12, bmc_retain_credentials) \
          WHERE {where_clause}"
     );
 
@@ -331,6 +333,7 @@ pub async fn update(txn: &mut PgConnection, switch: &ExpectedSwitch) -> Database
         .bind(&switch.nvos_username)
         .bind(&switch.nvos_password)
         .bind(&switch.nvos_mac_addresses)
+        .bind(switch.bmc_retain_credentials)
         .bind(&target_id)
         .execute(&mut *txn)
         .await

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -105,6 +105,10 @@ pub struct ExpectedMachineData {
     /// without DHCP. IPs outside Carbide-managed prefixes land on the `static-assignments` segment.
     #[serde(default)]
     pub bmc_ip_address: Option<IpAddr>,
+    /// When true, site-explorer skips BMC password rotation and stores the
+    /// factory-default credentials in Vault as-is.
+    #[serde(default)]
+    pub bmc_retain_credentials: Option<bool>,
 }
 // Important : new fields for expected machine (and data) should be optional _and_ serde(default),
 // unless you want to go update all the files in each production deployment that autoload
@@ -138,6 +142,7 @@ impl<'r> FromRow<'r, PgRow> for ExpectedMachine {
                     .try_get("default_pause_ingestion_and_poweron")?,
                 dpf_enabled: row.try_get("dpf_enabled")?,
                 bmc_ip_address: row.try_get("bmc_ip_address")?,
+                bmc_retain_credentials: row.try_get("bmc_retain_credentials")?,
             },
         })
     }
@@ -200,6 +205,7 @@ impl From<ExpectedMachine> for rpc::forge::ExpectedMachine {
                 .data
                 .bmc_ip_address
                 .map(|ip| ip.to_string()),
+            bmc_retain_credentials: expected_machine.data.bmc_retain_credentials.filter(|&v| v),
         }
     }
 }
@@ -252,6 +258,7 @@ impl TryFrom<rpc::forge::ExpectedMachine> for ExpectedMachineData {
                     RpcDataConversionError::InvalidArgument(format!("Invalid BMC IP address: {s}"))
                 })?),
             },
+            bmc_retain_credentials: em.bmc_retain_credentials,
         })
     }
 }

--- a/crates/api-model/src/expected_power_shelf.rs
+++ b/crates/api-model/src/expected_power_shelf.rs
@@ -41,6 +41,10 @@ pub struct ExpectedPowerShelf {
     #[serde(default = "default_metadata_for_deserializer")]
     pub metadata: Metadata,
     pub rack_id: Option<RackId>,
+    /// When true, site-explorer skips BMC password rotation and stores the
+    /// factory-default credentials in Vault as-is.
+    #[serde(default)]
+    pub bmc_retain_credentials: Option<bool>,
 }
 
 impl<'r> FromRow<'r, PgRow> for ExpectedPowerShelf {
@@ -61,6 +65,7 @@ impl<'r> FromRow<'r, PgRow> for ExpectedPowerShelf {
             bmc_ip_address: row.try_get("bmc_ip_address").ok(),
             metadata,
             rack_id: row.try_get("rack_id").ok(),
+            bmc_retain_credentials: row.try_get("bmc_retain_credentials")?,
         })
     }
 }
@@ -83,6 +88,7 @@ impl From<ExpectedPowerShelf> for rpc::forge::ExpectedPowerShelf {
                 .unwrap_or_default(),
             metadata: Some(expected_power_shelf.metadata.into()),
             rack_id: expected_power_shelf.rack_id,
+            bmc_retain_credentials: expected_power_shelf.bmc_retain_credentials.filter(|&v| v),
         }
     }
 }
@@ -116,6 +122,7 @@ impl TryFrom<rpc::forge::ExpectedPowerShelf> for ExpectedPowerShelf {
             bmc_ip_address,
             metadata,
             rack_id: rpc.rack_id,
+            bmc_retain_credentials: rpc.bmc_retain_credentials,
         })
     }
 }

--- a/crates/api-model/src/expected_switch.rs
+++ b/crates/api-model/src/expected_switch.rs
@@ -47,6 +47,10 @@ pub struct ExpectedSwitch {
     #[serde(default = "default_metadata_for_deserializer")]
     pub metadata: Metadata,
     pub rack_id: Option<RackId>,
+    /// When true, site-explorer skips BMC password rotation and stores the
+    /// factory-default credentials in Vault as-is.
+    #[serde(default)]
+    pub bmc_retain_credentials: Option<bool>,
 }
 
 impl<'r> FromRow<'r, PgRow> for ExpectedSwitch {
@@ -73,6 +77,7 @@ impl<'r> FromRow<'r, PgRow> for ExpectedSwitch {
             bmc_ip_address: row.try_get("bmc_ip_address").ok(),
             metadata,
             rack_id: row.try_get("rack_id")?,
+            bmc_retain_credentials: row.try_get("bmc_retain_credentials")?,
         })
     }
 }
@@ -102,6 +107,7 @@ impl From<ExpectedSwitch> for rpc::forge::ExpectedSwitch {
                 .unwrap_or_default(),
             metadata: Some(expected_switch.metadata.into()),
             rack_id: expected_switch.rack_id,
+            bmc_retain_credentials: expected_switch.bmc_retain_credentials.filter(|&v| v),
         }
     }
 }
@@ -146,6 +152,7 @@ impl TryFrom<rpc::forge::ExpectedSwitch> for ExpectedSwitch {
             metadata,
             rack_id: rpc.rack_id,
             nvos_mac_addresses,
+            bmc_retain_credentials: rpc.bmc_retain_credentials,
         })
     }
 }

--- a/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
+++ b/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
@@ -231,6 +231,7 @@ impl BmcEndpointExplorer {
         expected_switch: Option<&ExpectedSwitch>,
     ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
         let current_bmc_credentials;
+        let retain_credentials;
 
         tracing::info!(%bmc_ip_address, %bmc_mac_address, %vendor, "attempting to set the administrative credentials to the site password");
 
@@ -240,18 +241,28 @@ impl BmcEndpointExplorer {
                 username: expected_machine_credentials.data.bmc_username.clone(),
                 password: expected_machine_credentials.data.bmc_password.clone(),
             };
+            retain_credentials = expected_machine_credentials
+                .data
+                .bmc_retain_credentials
+                .unwrap_or(false);
         } else if let Some(expected_power_shelf_credentials) = expected_power_shelf {
             tracing::info!(%bmc_ip_address, %bmc_mac_address, "Found an expected power shelf for this BMC mac address");
             current_bmc_credentials = Credentials::UsernamePassword {
                 username: expected_power_shelf_credentials.bmc_username.clone(),
                 password: expected_power_shelf_credentials.bmc_password.clone(),
             };
+            retain_credentials = expected_power_shelf_credentials
+                .bmc_retain_credentials
+                .unwrap_or(false);
         } else if let Some(expected_switch_credentials) = expected_switch {
             tracing::info!(%bmc_ip_address, %bmc_mac_address, "Found an expected switch for this BMC mac address");
             current_bmc_credentials = Credentials::UsernamePassword {
                 username: expected_switch_credentials.bmc_username.clone(),
                 password: expected_switch_credentials.bmc_password.clone(),
             };
+            retain_credentials = expected_switch_credentials
+                .bmc_retain_credentials
+                .unwrap_or(false);
         } else {
             tracing::info!(%bmc_ip_address, %bmc_mac_address, %vendor, "No expected machine found, could be a BlueField");
             // We dont know if this machine is a DPU at this point
@@ -262,6 +273,7 @@ impl BmcEndpointExplorer {
                     // Try the DPU hardware default password to handle the DPU case
                     // This password will not work for a Viking host and we will return an error
                     current_bmc_credentials = self.get_default_hardware_dpu_bmc_root_credentials();
+                    retain_credentials = false;
                 }
                 _ => {
                     return Err(EndpointExplorationError::MissingCredentials {
@@ -274,23 +286,32 @@ impl BmcEndpointExplorer {
             }
         }
 
-        // use redfish to set the machine's BMC root password to
-        // match Forge's sitewide BMC root password (from the factory default).
-        // return an error if we cannot log into the machine's BMC using current credentials
-        let sitewide_bmc_password = self.get_sitewide_bmc_password().await?;
-        let bmc_credentials = self
-            .set_bmc_root_password(
-                bmc_ip_address,
-                vendor,
-                current_bmc_credentials,
-                sitewide_bmc_password,
-            )
-            .await?;
+        let bmc_credentials = if retain_credentials {
+            tracing::info!(
+                %bmc_ip_address, %bmc_mac_address, %vendor,
+                "bmc_retain_credentials is set; skipping BMC password rotation + storing existing credentials"
+            );
+            current_bmc_credentials
+        } else {
+            // use redfish to set the machine's BMC root password to
+            // match Forge's sitewide BMC root password (from the factory default).
+            // return an error if we cannot log into the machine's BMC using current credentials
+            let sitewide_bmc_password = self.get_sitewide_bmc_password().await?;
+            let rotated = self
+                .set_bmc_root_password(
+                    bmc_ip_address,
+                    vendor,
+                    current_bmc_credentials,
+                    sitewide_bmc_password,
+                )
+                .await?;
 
-        tracing::info!(
-            %bmc_ip_address, %bmc_mac_address, %vendor,
-            "Site explorer successfully updated the root password for {bmc_mac_address} to the Forge sitewide BMC root password"
-        );
+            tracing::info!(
+                %bmc_ip_address, %bmc_mac_address, %vendor,
+                "Site explorer successfully updated the root password for {bmc_mac_address} to the sitewide BMC root password"
+            );
+            rotated
+        };
 
         // set the BMC root credentials in vault for this machine
         self.set_bmc_root_credentials(bmc_mac_address, &bmc_credentials)

--- a/crates/api/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/site_explorer.rs
@@ -1794,6 +1794,7 @@ pub async fn create_expected_switches(
                 labels: HashMap::new(),
             },
             rack_id: None,
+            bmc_retain_credentials: None,
         };
         let result = db::expected_switch::create(txn, switch)
             .await
@@ -1863,6 +1864,7 @@ pub async fn create_expected_power_shelves(
             },
             metadata: Metadata::default(),
             rack_id: None,
+            bmc_retain_credentials: None,
         };
         let result = db::expected_power_shelf::create(txn, power_shelf)
             .await

--- a/crates/api/src/tests/expected_machine.rs
+++ b/crates/api/src/tests/expected_machine.rs
@@ -85,6 +85,7 @@ async fn test_duplicate_fail_create(pool: sqlx::PgPool) -> Result<(), Box<dyn st
                 rack_id: None,
                 dpf_enabled: Some(true),
                 bmc_ip_address: None,
+                bmc_retain_credentials: None,
             },
         },
     )
@@ -730,6 +731,7 @@ async fn test_add_expected_machine_dpu_serials(pool: sqlx::PgPool) {
         rack_id: None,
         is_dpf_enabled: Some(true),
         bmc_ip_address: None,
+        bmc_retain_credentials: None,
         #[allow(deprecated)]
         dpf_enabled: true,
     };
@@ -2170,6 +2172,104 @@ async fn test_dhcp_discover_uses_fixed_ip_from_host_nics(
     assert_eq!(
         response.address, fixed_ip,
         "DHCP should return the fixed IP from host_nics"
+    );
+
+    Ok(())
+}
+
+/// When `bmc_retain_credentials` is set to true, the value should persist through
+/// add -> get round-trip via the RPC API.
+#[crate::sqlx_test()]
+async fn test_add_expected_machine_with_bmc_retain_credentials(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "5A:5B:5C:5D:5E:70".parse().unwrap();
+
+    let expected_machine = rpc::forge::ExpectedMachine {
+        bmc_mac_address: bmc_mac.to_string(),
+        bmc_username: "ADMIN".into(),
+        bmc_password: "PASS".into(),
+        chassis_serial_number: "RETAIN-CREDS-001".into(),
+        metadata: Some(rpc::forge::Metadata::default()),
+        id: Some(::rpc::common::Uuid {
+            value: Uuid::new_v4().to_string(),
+        }),
+        bmc_retain_credentials: Some(true),
+        ..Default::default()
+    };
+
+    env.api
+        .add_expected_machine(tonic::Request::new(expected_machine.clone()))
+        .await
+        .expect("unable to add expected machine");
+
+    let retrieved = env
+        .api
+        .get_expected_machine(tonic::Request::new(ExpectedMachineRequest {
+            bmc_mac_address: bmc_mac.to_string(),
+            id: None,
+        }))
+        .await
+        .expect("unable to retrieve expected machine")
+        .into_inner();
+
+    assert_eq!(
+        retrieved.bmc_retain_credentials,
+        Some(true),
+        "bmc_retain_credentials should be true after round-trip"
+    );
+}
+
+/// Verify that updating an expected machine without specifying `bmc_retain_credentials`
+/// preserves the existing value (and making sure COALESCE works).
+#[crate::sqlx_test()]
+async fn test_update_preserves_bmc_retain_credentials(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "5A:5B:5C:5D:5E:71".parse().unwrap();
+
+    // Create with bmc_retain_credentials = true.
+    env.api
+        .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: "RETAIN-UPDATE-001".into(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            id: Some(::rpc::common::Uuid {
+                value: Uuid::new_v4().to_string(),
+            }),
+            bmc_retain_credentials: Some(true),
+            ..Default::default()
+        }))
+        .await?;
+
+    // Update without setting bmc_retain_credentials (None).
+    env.api
+        .update_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "NEW-ADMIN".into(),
+            bmc_password: "NEW-PASS".into(),
+            chassis_serial_number: "RETAIN-UPDATE-001".into(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            bmc_retain_credentials: None,
+            ..Default::default()
+        }))
+        .await?;
+
+    let retrieved = env
+        .api
+        .get_expected_machine(tonic::Request::new(ExpectedMachineRequest {
+            bmc_mac_address: bmc_mac.to_string(),
+            id: None,
+        }))
+        .await?
+        .into_inner();
+
+    assert_eq!(
+        retrieved.bmc_retain_credentials,
+        Some(true),
+        "bmc_retain_credentials should be preserved after update with None"
     );
 
     Ok(())

--- a/crates/api/src/tests/expected_power_shelf.rs
+++ b/crates/api/src/tests/expected_power_shelf.rs
@@ -62,6 +62,7 @@ async fn test_duplicate_fail_create(pool: sqlx::PgPool) -> Result<(), Box<dyn st
             bmc_ip_address: None,
             metadata: Metadata::default(),
             rack_id: None,
+            bmc_retain_credentials: None,
         },
     )
     .await;
@@ -156,6 +157,7 @@ async fn test_add_expected_power_shelf(pool: sqlx::PgPool) {
             bmc_ip_address: "".into(),
             metadata: None,
             rack_id: None,
+            bmc_retain_credentials: None,
         },
         rpc::forge::ExpectedPowerShelf {
             expected_power_shelf_id: None,
@@ -166,6 +168,7 @@ async fn test_add_expected_power_shelf(pool: sqlx::PgPool) {
             bmc_ip_address: "192.168.1.200".into(),
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
+            bmc_retain_credentials: None,
         },
         rpc::forge::ExpectedPowerShelf {
             expected_power_shelf_id: None,
@@ -189,6 +192,7 @@ async fn test_add_expected_power_shelf(pool: sqlx::PgPool) {
                 ],
             }),
             rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
+            bmc_retain_credentials: None,
         },
     ] {
         env.api
@@ -305,6 +309,7 @@ async fn test_update_expected_power_shelf(pool: sqlx::PgPool) {
             bmc_ip_address: "".into(),
             metadata: None,
             rack_id: None,
+            bmc_retain_credentials: None,
         },
         rpc::forge::ExpectedPowerShelf {
             expected_power_shelf_id: None,
@@ -315,6 +320,7 @@ async fn test_update_expected_power_shelf(pool: sqlx::PgPool) {
             bmc_ip_address: "192.168.2.100".into(),
             metadata: Some(Default::default()),
             rack_id: None,
+            bmc_retain_credentials: None,
         },
         rpc::forge::ExpectedPowerShelf {
             expected_power_shelf_id: None,
@@ -338,6 +344,7 @@ async fn test_update_expected_power_shelf(pool: sqlx::PgPool) {
                 ],
             }),
             rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
+            bmc_retain_credentials: None,
         },
     ] {
         env.api
@@ -386,6 +393,7 @@ async fn test_update_expected_power_shelf_error(pool: sqlx::PgPool) {
         bmc_ip_address: "".into(),
         metadata: None,
         rack_id: None,
+        bmc_retain_credentials: None,
     };
 
     let err = env
@@ -466,6 +474,7 @@ async fn test_replace_all_expected_power_shelves(pool: sqlx::PgPool) {
         bmc_ip_address: "192.168.100.1".into(),
         metadata: Some(rpc::Metadata::default()),
         rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
+        bmc_retain_credentials: None,
     };
 
     let expected_power_shelf_2 = rpc::forge::ExpectedPowerShelf {
@@ -477,6 +486,7 @@ async fn test_replace_all_expected_power_shelves(pool: sqlx::PgPool) {
         bmc_ip_address: "192.168.100.2".into(),
         metadata: Some(rpc::Metadata::default()),
         rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
+        bmc_retain_credentials: None,
     };
 
     expected_power_shelf_list
@@ -571,6 +581,7 @@ async fn test_add_expected_power_shelf_with_ip(pool: sqlx::PgPool) {
         bmc_ip_address: "10.0.0.100".into(),
         metadata: Some(rpc::Metadata::default()),
         rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
+        bmc_retain_credentials: None,
     };
 
     env.api
@@ -673,6 +684,7 @@ async fn test_get_expected_power_shelf_by_id(pool: sqlx::PgPool) {
         bmc_ip_address: "10.0.0.50".into(),
         metadata: Some(rpc::forge::Metadata::default()),
         rack_id: None,
+        bmc_retain_credentials: None,
     };
 
     env.api
@@ -719,6 +731,7 @@ async fn test_delete_expected_power_shelf_by_id(pool: sqlx::PgPool) {
         bmc_ip_address: "".into(),
         metadata: Some(rpc::forge::Metadata::default()),
         rack_id: None,
+        bmc_retain_credentials: None,
     };
 
     env.api
@@ -773,6 +786,7 @@ async fn test_update_expected_power_shelf_by_id(pool: sqlx::PgPool) {
         bmc_ip_address: "".into(),
         metadata: Some(rpc::forge::Metadata::default()),
         rack_id: None,
+        bmc_retain_credentials: None,
     };
 
     env.api
@@ -828,6 +842,7 @@ async fn test_create_expected_power_shelf_with_explicit_id(pool: sqlx::PgPool) {
         bmc_ip_address: "".into(),
         metadata: Some(rpc::forge::Metadata::default()),
         rack_id: None,
+        bmc_retain_credentials: None,
     };
 
     env.api
@@ -866,6 +881,7 @@ async fn test_create_expected_power_shelf_auto_generates_id(pool: sqlx::PgPool) 
         bmc_ip_address: "".into(),
         metadata: Some(rpc::forge::Metadata::default()),
         rack_id: None,
+        bmc_retain_credentials: None,
     };
 
     env.api
@@ -945,6 +961,7 @@ async fn test_add_with_bmc_ip_creates_static_interface(
             bmc_ip_address: bmc_ip.into(),
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
+            bmc_retain_credentials: None,
         }))
         .await?;
 
@@ -998,6 +1015,7 @@ async fn test_add_without_bmc_ip_creates_no_interface(
             bmc_ip_address: "".into(),
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
+            bmc_retain_credentials: None,
         }))
         .await?;
 
@@ -1042,6 +1060,7 @@ async fn test_add_with_bmc_ip_rejects_if_interface_exists(
             bmc_ip_address: "192.0.1.190".into(),
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
+            bmc_retain_credentials: None,
         }))
         .await;
 
@@ -1074,6 +1093,7 @@ async fn test_add_with_external_bmc_ip_uses_static_assignments(
             bmc_ip_address: external_ip.into(),
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
+            bmc_retain_credentials: None,
         }))
         .await?;
 
@@ -1130,6 +1150,7 @@ async fn test_add_with_bmc_ip_rejects_if_ip_already_allocated(
             bmc_ip_address: taken_ip.to_string(),
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
+            bmc_retain_credentials: None,
         }))
         .await;
 
@@ -1162,6 +1183,7 @@ async fn test_update_with_matching_bmc_ip_is_noop(
             bmc_ip_address: bmc_ip.into(),
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
+            bmc_retain_credentials: None,
         }))
         .await?;
 
@@ -1176,6 +1198,7 @@ async fn test_update_with_matching_bmc_ip_is_noop(
             bmc_ip_address: bmc_ip.into(),
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
+            bmc_retain_credentials: None,
         }))
         .await?;
 
@@ -1205,6 +1228,7 @@ async fn test_update_with_different_bmc_ip_leaves_interface_alone(
             bmc_ip_address: original_ip.into(),
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
+            bmc_retain_credentials: None,
         }))
         .await?;
 
@@ -1220,6 +1244,7 @@ async fn test_update_with_different_bmc_ip_leaves_interface_alone(
             bmc_ip_address: "192.0.1.193".into(),
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
+            bmc_retain_credentials: None,
         }))
         .await?;
 
@@ -1268,6 +1293,7 @@ async fn test_update_with_bmc_ip_assigns_to_empty_interface(
             bmc_ip_address: "".into(),
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
+            bmc_retain_credentials: None,
         }))
         .await?;
 
@@ -1282,6 +1308,7 @@ async fn test_update_with_bmc_ip_assigns_to_empty_interface(
             bmc_ip_address: "192.0.1.194".into(),
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
+            bmc_retain_credentials: None,
         }))
         .await?;
 
@@ -1322,6 +1349,7 @@ async fn test_update_with_bmc_ip_creates_interface_if_none_exists(
             bmc_ip_address: "".into(),
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
+            bmc_retain_credentials: None,
         }))
         .await?;
 
@@ -1342,6 +1370,7 @@ async fn test_update_with_bmc_ip_creates_interface_if_none_exists(
             bmc_ip_address: bmc_ip.into(),
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
+            bmc_retain_credentials: None,
         }))
         .await?;
 
@@ -1375,6 +1404,7 @@ async fn test_update_without_bmc_ip_does_not_touch_interface(
             bmc_ip_address: bmc_ip.into(),
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
+            bmc_retain_credentials: None,
         }))
         .await?;
 
@@ -1389,6 +1419,7 @@ async fn test_update_without_bmc_ip_does_not_touch_interface(
             bmc_ip_address: "".into(),
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
+            bmc_retain_credentials: None,
         }))
         .await?;
 
@@ -1399,6 +1430,104 @@ async fn test_update_without_bmc_ip_does_not_touch_interface(
     assert!(
         interfaces[0].addresses.contains(&bmc_ip.parse().unwrap()),
         "interface should still have the original IP after update without bmc_ip_address"
+    );
+
+    Ok(())
+}
+
+/// When `bmc_retain_credentials` is set to true, the value should persist through
+/// add -> get round-trip via the RPC API.
+#[crate::sqlx_test()]
+async fn test_add_expected_power_shelf_with_bmc_retain_credentials(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "7A:7B:7C:7D:7E:80".parse().unwrap();
+
+    env.api
+        .add_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelf {
+            expected_power_shelf_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            shelf_serial_number: "PS-RETAIN-001".into(),
+            bmc_ip_address: String::new(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+            bmc_retain_credentials: Some(true),
+        }))
+        .await?;
+
+    let retrieved = env
+        .api
+        .get_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelfRequest {
+            bmc_mac_address: bmc_mac.to_string(),
+            expected_power_shelf_id: None,
+        }))
+        .await?
+        .into_inner();
+
+    assert_eq!(
+        retrieved.bmc_retain_credentials,
+        Some(true),
+        "bmc_retain_credentials should be true after round-trip"
+    );
+
+    Ok(())
+}
+
+/// Verify that updating an expected power shelf without specifying `bmc_retain_credentials`
+/// preserves the existing value (and that COALESCE works).
+#[crate::sqlx_test()]
+async fn test_update_expected_power_shelf_preserves_bmc_retain_credentials(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "7A:7B:7C:7D:7E:81".parse().unwrap();
+
+    // Create with bmc_retain_credentials = true.
+    env.api
+        .add_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelf {
+            expected_power_shelf_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            shelf_serial_number: "PS-RETAIN-UPD-001".into(),
+            bmc_ip_address: String::new(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+            bmc_retain_credentials: Some(true),
+        }))
+        .await?;
+
+    // Update without setting bmc_retain_credentials (None).
+    env.api
+        .update_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelf {
+            expected_power_shelf_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "NEW-ADMIN".into(),
+            bmc_password: "NEW-PASS".into(),
+            shelf_serial_number: "PS-RETAIN-UPD-001".into(),
+            bmc_ip_address: String::new(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+            bmc_retain_credentials: None,
+        }))
+        .await?;
+
+    let retrieved = env
+        .api
+        .get_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelfRequest {
+            bmc_mac_address: bmc_mac.to_string(),
+            expected_power_shelf_id: None,
+        }))
+        .await?
+        .into_inner();
+
+    assert_eq!(
+        retrieved.bmc_retain_credentials,
+        Some(true),
+        "bmc_retain_credentials should be preserved after update with None"
     );
 
     Ok(())

--- a/crates/api/src/tests/expected_switch.rs
+++ b/crates/api/src/tests/expected_switch.rs
@@ -60,6 +60,7 @@ async fn test_duplicate_fail_create(pool: sqlx::PgPool) -> Result<(), Box<dyn st
             bmc_ip_address: None,
             metadata: Metadata::default(),
             rack_id: None,
+            bmc_retain_credentials: None,
             nvos_username: None,
             nvos_password: None,
         },
@@ -161,6 +162,7 @@ async fn test_add_expected_switch(pool: sqlx::PgPool) {
             metadata: None,
             rack_id: None,
             bmc_ip_address: String::new(),
+            bmc_retain_credentials: None,
         },
         rpc::forge::ExpectedSwitch {
             expected_switch_id: None,
@@ -174,6 +176,7 @@ async fn test_add_expected_switch(pool: sqlx::PgPool) {
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
             bmc_ip_address: String::new(),
+            bmc_retain_credentials: None,
         },
         rpc::forge::ExpectedSwitch {
             expected_switch_id: None,
@@ -200,6 +203,7 @@ async fn test_add_expected_switch(pool: sqlx::PgPool) {
             }),
             rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
             bmc_ip_address: String::new(),
+            bmc_retain_credentials: None,
         },
     ] {
         env.api
@@ -299,6 +303,7 @@ async fn test_update_expected_switch(pool: sqlx::PgPool) {
             metadata: None,
             rack_id: None,
             bmc_ip_address: String::new(),
+            bmc_retain_credentials: None,
         },
         rpc::forge::ExpectedSwitch {
             expected_switch_id: None,
@@ -312,6 +317,7 @@ async fn test_update_expected_switch(pool: sqlx::PgPool) {
             metadata: Some(Default::default()),
             rack_id: None,
             bmc_ip_address: String::new(),
+            bmc_retain_credentials: None,
         },
         rpc::forge::ExpectedSwitch {
             expected_switch_id: None,
@@ -338,6 +344,7 @@ async fn test_update_expected_switch(pool: sqlx::PgPool) {
             }),
             rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
             bmc_ip_address: String::new(),
+            bmc_retain_credentials: None,
         },
     ] {
         env.api
@@ -390,6 +397,7 @@ async fn test_get_expected_switch_by_id(pool: sqlx::PgPool) {
         metadata: Some(rpc::forge::Metadata::default()),
         rack_id: None,
         bmc_ip_address: String::new(),
+        bmc_retain_credentials: None,
     };
 
     env.api
@@ -431,6 +439,7 @@ async fn test_delete_expected_switch_by_id(pool: sqlx::PgPool) {
         metadata: Some(rpc::forge::Metadata::default()),
         rack_id: None,
         bmc_ip_address: String::new(),
+        bmc_retain_credentials: None,
     };
 
     env.api
@@ -484,6 +493,7 @@ async fn test_update_expected_switch_by_id(pool: sqlx::PgPool) {
         metadata: Some(rpc::forge::Metadata::default()),
         rack_id: None,
         bmc_ip_address: String::new(),
+        bmc_retain_credentials: None,
     };
 
     env.api
@@ -512,6 +522,7 @@ async fn test_update_expected_switch_by_id(pool: sqlx::PgPool) {
         }),
         rack_id: None,
         bmc_ip_address: String::new(),
+        bmc_retain_credentials: None,
     };
 
     env.api
@@ -553,6 +564,7 @@ async fn test_create_expected_switch_with_explicit_id(pool: sqlx::PgPool) {
         metadata: Some(rpc::forge::Metadata::default()),
         rack_id: None,
         bmc_ip_address: String::new(),
+        bmc_retain_credentials: None,
     };
 
     env.api
@@ -595,6 +607,7 @@ async fn test_create_expected_switch_auto_generates_id(pool: sqlx::PgPool) {
         metadata: Some(rpc::forge::Metadata::default()),
         rack_id: None,
         bmc_ip_address: String::new(),
+        bmc_retain_credentials: None,
     };
 
     env.api
@@ -705,6 +718,7 @@ async fn test_update_expected_switch_error(pool: sqlx::PgPool) {
         metadata: None,
         rack_id: None,
         bmc_ip_address: String::new(),
+        bmc_retain_credentials: None,
     };
 
     let err = env
@@ -814,6 +828,7 @@ async fn test_replace_all_expected_switches(pool: sqlx::PgPool) {
         metadata: Some(rpc::Metadata::default()),
         rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
         bmc_ip_address: String::new(),
+        bmc_retain_credentials: None,
     };
 
     let expected_switch_2 = rpc::forge::ExpectedSwitch {
@@ -828,6 +843,7 @@ async fn test_replace_all_expected_switches(pool: sqlx::PgPool) {
         metadata: Some(rpc::Metadata::default()),
         rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
         bmc_ip_address: String::new(),
+        bmc_retain_credentials: None,
     };
 
     expected_switch_list
@@ -950,6 +966,7 @@ async fn test_add_with_bmc_ip_creates_static_interface(
             bmc_ip_address: bmc_ip.into(),
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
+            bmc_retain_credentials: None,
         }))
         .await?;
 
@@ -1003,6 +1020,7 @@ async fn test_add_without_bmc_ip_creates_no_interface(
             bmc_ip_address: String::new(),
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
+            bmc_retain_credentials: None,
         }))
         .await?;
 
@@ -1011,6 +1029,113 @@ async fn test_add_without_bmc_ip_creates_no_interface(
     assert!(
         interfaces.is_empty(),
         "should not create interface without bmc_ip_address"
+    );
+
+    Ok(())
+}
+
+/// When `bmc_retain_credentials` is set to true, the value should persist through
+/// add -> get round-trip via the RPC API.
+#[crate::sqlx_test()]
+async fn test_add_expected_switch_with_bmc_retain_credentials(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "6A:6B:6C:6D:6E:80".parse().unwrap();
+
+    env.api
+        .add_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
+            expected_switch_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            switch_serial_number: "SW-RETAIN-001".into(),
+            nvos_mac_addresses: vec![],
+            nvos_username: None,
+            nvos_password: None,
+            bmc_ip_address: String::new(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+            bmc_retain_credentials: Some(true),
+        }))
+        .await?;
+
+    let retrieved = env
+        .api
+        .get_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitchRequest {
+            bmc_mac_address: bmc_mac.to_string(),
+            expected_switch_id: None,
+        }))
+        .await?
+        .into_inner();
+
+    assert_eq!(
+        retrieved.bmc_retain_credentials,
+        Some(true),
+        "bmc_retain_credentials should be true after round-trip"
+    );
+
+    Ok(())
+}
+
+/// Verify that updating an expected switch without specifying `bmc_retain_credentials`
+/// preserves the existing value (and that COALESCE works).
+#[crate::sqlx_test()]
+async fn test_update_expected_switch_preserves_bmc_retain_credentials(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "6A:6B:6C:6D:6E:81".parse().unwrap();
+
+    // Create with bmc_retain_credentials = true.
+    env.api
+        .add_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
+            expected_switch_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            switch_serial_number: "SW-RETAIN-UPD-001".into(),
+            nvos_mac_addresses: vec![],
+            nvos_username: None,
+            nvos_password: None,
+            bmc_ip_address: String::new(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+            bmc_retain_credentials: Some(true),
+        }))
+        .await?;
+
+    // Update without setting bmc_retain_credentials (None).
+    env.api
+        .update_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
+            expected_switch_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "NEW-ADMIN".into(),
+            bmc_password: "NEW-PASS".into(),
+            switch_serial_number: "SW-RETAIN-UPD-001".into(),
+            nvos_mac_addresses: vec![],
+            nvos_username: None,
+            nvos_password: None,
+            bmc_ip_address: String::new(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+            bmc_retain_credentials: None,
+        }))
+        .await?;
+
+    let retrieved = env
+        .api
+        .get_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitchRequest {
+            bmc_mac_address: bmc_mac.to_string(),
+            expected_switch_id: None,
+        }))
+        .await?
+        .into_inner();
+
+    assert_eq!(
+        retrieved.bmc_retain_credentials,
+        Some(true),
+        "bmc_retain_credentials should be preserved after update with None"
     );
 
     Ok(())

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -186,6 +186,7 @@ impl FakePowerShelf {
                 labels: HashMap::new(),
             },
             rack_id: None,
+            bmc_retain_credentials: None,
         }
     }
 }
@@ -1437,6 +1438,7 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
                 rack_id: None,
                 dpf_enabled: Some(true),
                 bmc_ip_address: None,
+                bmc_retain_credentials: None,
             },
         },
     )
@@ -1486,6 +1488,7 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
         rack_id: None,
         dpf_enabled: Some(true),
         bmc_ip_address: None,
+        bmc_retain_credentials: None,
     };
     db::expected_machine::update(&mut txn, &host1_expected_machine).await?;
     txn.commit().await?;
@@ -2449,6 +2452,7 @@ async fn test_machine_creation_with_sku(
                 rack_id: None,
                 dpf_enabled: Some(true),
                 bmc_ip_address: None,
+                bmc_retain_credentials: None,
             },
         },
     )
@@ -2583,6 +2587,7 @@ async fn test_expected_machine_device_type_metrics(
                 rack_id: None,
                 dpf_enabled: Some(true),
                 bmc_ip_address: None,
+                bmc_retain_credentials: None,
             },
         },
     )
@@ -2605,6 +2610,7 @@ async fn test_expected_machine_device_type_metrics(
                 rack_id: None,
                 dpf_enabled: Some(true),
                 bmc_ip_address: None,
+                bmc_retain_credentials: None,
             },
         },
     )
@@ -2627,6 +2633,7 @@ async fn test_expected_machine_device_type_metrics(
                 rack_id: None,
                 dpf_enabled: Some(true),
                 bmc_ip_address: None,
+                bmc_retain_credentials: None,
             },
         },
     )
@@ -2981,6 +2988,7 @@ async fn test_site_explorer_switch_discovery(
             labels: HashMap::new(),
         },
         rack_id: None,
+        bmc_retain_credentials: None,
     };
     db::expected_switch::create(&mut txn, expected_switch).await?;
     txn.commit().await?;

--- a/crates/api/src/tests/sku.rs
+++ b/crates/api/src/tests/sku.rs
@@ -796,6 +796,7 @@ pub mod tests {
                     rack_id: None,
                     dpf_enabled: Some(true),
                     bmc_ip_address: None,
+                    bmc_retain_credentials: None,
                 },
             },
         )
@@ -888,6 +889,7 @@ pub mod tests {
                     rack_id: None,
                     dpf_enabled: Some(true),
                     bmc_ip_address: None,
+                    bmc_retain_credentials: None,
                 },
             },
         )
@@ -955,6 +957,7 @@ pub mod tests {
                     rack_id: None,
                     dpf_enabled: Some(true),
                     bmc_ip_address: None,
+                    bmc_retain_credentials: None,
                 },
             },
         )
@@ -1039,6 +1042,7 @@ pub mod tests {
                     rack_id: None,
                     dpf_enabled: Some(true),
                     bmc_ip_address: None,
+                    bmc_retain_credentials: None,
                 },
             },
         )
@@ -1474,6 +1478,7 @@ pub mod tests {
                     rack_id: None,
                     dpf_enabled: Some(true),
                     bmc_ip_address: None,
+                    bmc_retain_credentials: None,
                 },
             },
         )

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -502,6 +502,7 @@ impl ApiClient {
                 dpf_enabled: true,
                 is_dpf_enabled: Some(true),
                 bmc_ip_address: None,
+                bmc_retain_credentials: None,
             })
             .await
             .map_err(ClientApiError::InvocationError)

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1887,6 +1887,9 @@ message ExpectedPowerShelf {
   optional common.RackId rack_id = 7;
   // Unique identifier for the expected power shelf. When omitted, server generates one.
   optional common.UUID expected_power_shelf_id = 8;
+  // When true, site-explorer skips BMC password rotation and stores the
+  // factory-default credentials in Vault as-is.
+  optional bool bmc_retain_credentials = 9;
 }
 
 message ExpectedPowerShelfRequest {
@@ -2050,6 +2053,9 @@ message ExpectedSwitch {
   optional common.UUID expected_switch_id = 9;
   repeated string nvos_mac_addresses = 10;
   string bmc_ip_address = 11;
+  // When true, site-explorer skips BMC password rotation and stores the
+  // factory-default credentials in Vault as-is.
+  optional bool bmc_retain_credentials = 12;
 }
 
 message ExpectedSwitchRequest {
@@ -5107,6 +5113,9 @@ message ExpectedMachine {
   // Static BMC IP (optional). Pre-allocates a machine_interface like expected
   // switches and power shelves; external IPs use the static-assignments segment.
   optional string bmc_ip_address = 14;
+  // When true, site-explorer skips BMC password rotation and stores the
+  // factory-default credentials in Vault as-is.
+  optional bool bmc_retain_credentials = 15;
 }
 
 message ExpectedMachineRequest {


### PR DESCRIPTION
## Description

This introduces a new `--bmc-retain-credentials` flag to `expected-*` components. By using this flag, it instructs `site-explorer` to NOT rotate the expected component's BMC credentials (and store the new ones in Vault). Instead, it will "retain" + store the default `Credentials` (comprised of the expected `bmc_username` and `bmc_password`) in Vault, allowing subsequent flows expecting Vault credentials to work as expected, and keeping the BMC credentials as-is.

**It should be noted this is NOT intended for production environments, as the expected BMC credentials are not stored securely (yet, but I'm actually working on it, even though the expected credentials are generally temporary)**.

The motivator here is we have had a number of asks from development teams using NICo if this could be a supported option; the teams have lab environments where they want their BMC credentials to remain as-is, and not have them rotated into the NICo credentials, because it breaks other testing/workflows they have with their BMCs.

Unit and integration tests added to make sure existing workflows continue to work as intended, as do the new workflows, for `add` and `update`.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

