### PR TITLE
chore: structured building of the composite credentials manager

### DIFF
--- a/crates/api/src/run.rs
+++ b/crates/api/src/run.rs
@@ -18,7 +18,8 @@
 use std::sync::Arc;
 
 use eyre::WrapErr;
-use forge_secrets::{CredentialConfig, create_credential_manager, create_vault_client};
+use forge_secrets::credentials::{CredentialReader, CredentialWriter};
+use forge_secrets::{CredentialConfig, create_credential_manager_from, create_vault_client};
 use tokio::sync::oneshot::Sender;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
@@ -138,8 +139,45 @@ pub async fn run(
 
     let certificate_provider =
         create_vault_client(&credential_config.vault, metrics.meter.clone())?;
-    let credential_manager =
-        create_credential_manager(&credential_config, metrics.meter.clone()).await?;
+
+    // Build credential reader chain. The idea is this chain
+    // can be flexible, to allow us to introduce an ordered
+    // list of readers, which we build on-demand based on
+    // configuration.
+    let mut readers: Vec<Box<dyn CredentialReader>> = Vec::new();
+
+    // If EnvCredentials are enabled, then add that
+    // to our chained credentials reader. It's expected
+    // that this comes first if configured.
+    if credential_config.env.enabled() {
+        readers.push(Box::new(
+            forge_secrets::local_credentials::EnvCredentials::new(credential_config.env.clone())?,
+        ));
+    }
+
+    // Next, if FileCredentials are enabled, then
+    // add those in as well. We expect these *after*
+    // EnvCredentials.
+    if credential_config.file.enabled() {
+        readers.push(Box::new(
+            forge_secrets::local_credentials::FileCredentialsWatcher::new(
+                credential_config.file.clone(),
+            )
+            .await?,
+        ));
+    }
+
+    // Last, we tack on the VaultClient to the end.
+    let vault_client = create_vault_client(&credential_config.vault, metrics.meter.clone())?;
+    readers.push(Box::new(vault_client.clone()));
+
+    // And our vault_client is also implemented as the writer.
+    let writer: Arc<dyn CredentialWriter> = vault_client;
+
+    // And now we create our new composite credential manager
+    // from the list of readers we just built, plus the Vault
+    // client.
+    let credential_manager = create_credential_manager_from(writer, readers);
 
     let redfish_pool = {
         let rf_pool = libredfish::RedfishClientPool::builder()

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -29,13 +29,15 @@ pub use crate::local_credentials::{
 };
 
 pub mod certificates;
-pub(crate) mod chained_reader;
+pub mod chained_reader;
 pub mod credentials;
 pub mod forge_vault;
 pub mod key_encryption;
-pub(crate) mod local_credentials;
+pub mod local_credentials;
 
-use credentials::{CompositeCredentialManager, CredentialManager, CredentialReader};
+use credentials::{
+    CompositeCredentialManager, CredentialManager, CredentialReader, CredentialWriter,
+};
 use local_credentials::{EnvCredentials, FileCredentialsWatcher};
 
 #[derive(Default, Debug, Clone)]
@@ -45,6 +47,7 @@ pub struct CredentialConfig {
     pub file: FileCredentialsConfig,
 }
 
+/// create_credential_manager builds the default credential chain: env -> file -> vault.
 pub async fn create_credential_manager(
     config: &CredentialConfig,
     meter: Meter,
@@ -67,6 +70,18 @@ pub async fn create_credential_manager(
     let chained = ChainedCredentialReader::from(readers);
     let composite = CompositeCredentialManager::new(chained, vault_client);
     Ok(Arc::new(composite))
+}
+
+/// create_credential_manager_from builds a
+/// credential manager from a caller-defined chain.
+/// The caller fully controls the reader order and
+/// writer selection.
+pub fn create_credential_manager_from(
+    writer: Arc<dyn CredentialWriter>,
+    readers: Vec<Box<dyn CredentialReader>>,
+) -> Arc<dyn CredentialManager> {
+    let chained = ChainedCredentialReader::from(readers);
+    Arc::new(CompositeCredentialManager::new(chained, writer))
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Description

Supports some upcoming work for https://github.com/NVIDIA/ncx-infra-controller-core/issues/353.

This introduces a `create_credential_manager_from` constructor to compliment the existing `create_credential_manager` constructor. The existing one explicitly says it exists to create the "default" chain (of `env -> file -> vault`). This is introducing one where we explicitly define a `writer` and build a `readers` chain in `run.rs`, and pass those in to create a `CompositeCredentialManager`.

This is to support some upcoming work related to https://github.com/NVIDIA/ncx-infra-controller-core/pull/939 for envelope encryption integration. Trying to do a few little things to keep PRs smaller, and this was a small, low-hanging tweak that will be involved.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

