### PR TITLE
Drop very-old VAULT_MOUNT_LOCATION env var from k8s yaml

### DIFF
--- a/deploy/carbide-base/api/deployment.yaml
+++ b/deploy/carbide-base/api/deployment.yaml
@@ -71,11 +71,6 @@ spec:
                 configMapKeyRef:
                   name: vault-cluster-info
                   key: VAULT_SERVICE
-            - name: VAULT_MOUNT_LOCATION
-              valueFrom:
-                configMapKeyRef:
-                  name: vault-cluster-info
-                  key: FORGE_VAULT_MOUNT
             - name: VAULT_KV_MOUNT_LOCATION
               valueFrom:
                 configMapKeyRef:

--- a/helm/charts/carbide-api/templates/deployment.yaml
+++ b/helm/charts/carbide-api/templates/deployment.yaml
@@ -83,11 +83,6 @@ spec:
                 configMapKeyRef:
                   name: {{ .Values.envFrom.vaultClusterInfo.configMapName }}
                   key: VAULT_SERVICE
-            - name: VAULT_MOUNT_LOCATION
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ .Values.envFrom.vaultClusterInfo.configMapName }}
-                  key: FORGE_VAULT_MOUNT
             - name: VAULT_KV_MOUNT_LOCATION
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
## Description
It has been VAULT_KV_MOUNT_LOCATION for 3 years now, the old env var was left in to not break compatibility with old versions (they both have the same value, the FORGE_VAULT_MOUNT key from the vault configMap), but it is certainly safe to remove now.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [X] This PR contains breaking changes

If you're running a version of this code from 2023 and somehow using this YAML, it'll break. :wink:

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes
