### PR TITLE
chore: bump libredfish to v0.43.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5774,7 +5774,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.43.9#a2f873edee9a49494a05b737e49c9c4e6378761b"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.43.10#4ac933a88a6911afb2d34fc88db3e30616911032"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.43.9" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.43.10" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.9.beta-rc2" }
 ansi-to-html = "0.2.2"
 

--- a/crates/api/src/redfish.rs
+++ b/crates/api/src/redfish.rs
@@ -824,13 +824,13 @@ pub mod test_support {
                     HashMap<libredfish::BiosProfileType, HashMap<String, serde_json::Value>>,
                 >,
             >,
-        ) -> Result<(), RedfishError> {
+        ) -> Result<Option<String>, RedfishError> {
             let mut state = self.state.lock().unwrap();
             let host_state = state.hosts.get_mut(&self._host).unwrap();
             host_state.actions.push(RedfishSimAction::MachineSetup {
                 oem_manager_profiles: oem_manager_profiles.clone(),
             });
-            Ok(())
+            Ok(None)
         }
 
         async fn machine_setup_status(

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -8973,7 +8973,8 @@ async fn call_machine_setup_and_handle_no_dpu_error(
             );
             Ok(())
         }
-        (Ok(()), _, _) => Ok(()),
+        // TODO: handle the job id returned from machine setup
+        (Ok(_), _, _) => Ok(()),
         (Err(e), _, _) => Err(e),
     }
 }

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -951,6 +951,7 @@ mod tests {
                     bmc_ip_address: None,
                     metadata: Metadata::default(),
                     rack_id: rack_id.cloned(),
+                    bmc_retain_credentials: None,
                 },
             )
             .await


### PR DESCRIPTION
## Description

chore: bump libredfish to v0.43.10 to pull in changes related to reading PSU power state while a powershelf is off

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

