### PR TITLE
Wait on Dell BIOS Config job IDs

### DIFF
--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -502,7 +502,7 @@ async fn test_machine_a_tron_multidpu(
                 .await?;
 
                 machine_handle
-                    .wait_until_machine_up_with_api_state("Assigned/Ready", Duration::from_secs(60))
+                    .wait_until_machine_up_with_api_state("Assigned/Ready", Duration::from_secs(90))
                     .await?;
 
                 let instance_json = instance::get_instance_json_by_machine_id(
@@ -537,7 +537,7 @@ async fn test_machine_a_tron_multidpu(
                 instance::release(carbide_api_addrs, &machine_id, &instance_id, false).await?;
 
                 machine_handle
-                    .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(60))
+                    .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(90))
                     .await?;
                 tracing::info!("Machine {machine_id} has made it to Ready again, all done");
                 Ok::<(), eyre::Report>(())
@@ -587,7 +587,7 @@ async fn test_machine_a_tron_zerodpu(
                 .await?;
 
                 machine_handle
-                    .wait_until_machine_up_with_api_state("Assigned/Ready", Duration::from_secs(60))
+                    .wait_until_machine_up_with_api_state("Assigned/Ready", Duration::from_secs(90))
                     .await?;
                 tracing::info!(
                     "Machine {machine_id} has made it to Assigned/Ready, releasing instance"
@@ -596,7 +596,7 @@ async fn test_machine_a_tron_zerodpu(
                 instance::release(carbide_api_addrs, &machine_id, &instance_id, false).await?;
 
                 machine_handle
-                    .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(60))
+                    .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(90))
                     .await?;
                 tracing::info!("Machine {machine_id} has made it to Ready again, all done");
                 Ok::<(), eyre::Report>(())
@@ -624,7 +624,7 @@ async fn test_machine_a_tron_singledpu_nic_mode(
             let carbide_api_addrs = &test_env.carbide_api_addrs;
             async move {
                 machine_handle
-                    .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(60))
+                    .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(90))
                     .await?;
                 let machine_id = machine_handle
                     .observed_machine_id()
@@ -646,7 +646,7 @@ async fn test_machine_a_tron_singledpu_nic_mode(
                 .await?;
 
                 machine_handle
-                    .wait_until_machine_up_with_api_state("Assigned/Ready", Duration::from_secs(60))
+                    .wait_until_machine_up_with_api_state("Assigned/Ready", Duration::from_secs(90))
                     .await?;
                 tracing::info!(
                     "Machine {machine_id} has made it to Assigned/Ready, releasing instance"
@@ -655,7 +655,7 @@ async fn test_machine_a_tron_singledpu_nic_mode(
                 instance::release(carbide_api_addrs, &machine_id, &instance_id, false).await?;
 
                 machine_handle
-                    .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(60))
+                    .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(90))
                     .await?;
                 tracing::info!("Machine {machine_id} has made it to Ready again, all done");
                 Ok::<(), eyre::Report>(())
@@ -705,7 +705,7 @@ async fn test_machine_a_tron_dual_stack(
                 machine_handle
                     .wait_until_machine_up_with_api_state(
                         "Assigned/Ready",
-                        Duration::from_secs(60),
+                        Duration::from_secs(90),
                     )
                     .await?;
 
@@ -758,7 +758,7 @@ async fn test_machine_a_tron_dual_stack(
                     .await?;
 
                 machine_handle
-                    .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(60))
+                    .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(90))
                     .await?;
                 tracing::info!(
                     "Machine {machine_id} back to Ready after dual-stack release"
@@ -827,7 +827,7 @@ async fn test_machine_a_tron_dual_stack_l2(
                     .await?;
 
                 machine_handle
-                    .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(60))
+                    .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(90))
                     .await?;
                 tracing::info!(
                     "Machine {machine_id} back to Ready after dual-stack L2 release"

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1931,7 +1931,15 @@ pub enum PerformPowerOperation {
 pub enum MachineState {
     Init,
     EnableIpmiOverLan,
-    WaitingForPlatformConfiguration,
+    WaitingForPlatformConfiguration {
+        /// Retries after BIOS job failure remediation; re-run machine_setup from this state.
+        #[serde(default)]
+        retry_count: u32,
+    },
+    /// Wait for BIOS config job (Dell) to complete before PollingBiosSetup / SetBootOrder.
+    WaitingForBiosJob {
+        bios_config_info: BiosConfigInfo,
+    },
     PollingBiosSetup,
     SetBootOrder {
         set_boot_order_info: Option<SetBootOrderInfo>,
@@ -1981,6 +1989,32 @@ pub enum UefiSetupState {
     // Deprecated: no-op state, transitions directly to WaitingForLockdown::SetLockdown
     // Kept for backwards compatibility with hosts that may be in this state
     LockdownHost,
+}
+
+/// Tracks progress waiting for the Dell BIOS config job (from machine_setup PATCH) to complete
+/// before configuring boot order. Same pattern as SetBootOrderInfo / SetBootOrderState.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub struct BiosConfigInfo {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bios_job_id: Option<String>,
+    pub bios_config_state: BiosConfigState,
+    /// Full configure_host_bios retry count across HandleBiosJobFailure recovery cycles.
+    #[serde(default)]
+    pub retry_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, EnumIter)]
+#[serde(tag = "state", rename_all = "lowercase")]
+pub enum BiosConfigState {
+    WaitForBiosJobScheduled,
+    RebootHost,
+    WaitForBiosJobCompletion,
+    /// Power off → BMC reset → power on when job fails or is scheduled with errors (same as boot order).
+    HandleBiosJobFailure {
+        failure: String,
+        power_state: PowerState,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
@@ -2152,7 +2186,18 @@ pub enum HostPlatformConfigurationState {
         unlock_host_state: UnlockHostState,
     },
     CheckHostConfig,
-    ConfigureBios,
+    /// Run `machine_setup` / BIOS PATCH; on job ID, transition to [`WaitingForBiosJob`].
+    ConfigureBios {
+        /// Legacy only: persisted `Some` is migrated to `WaitingForBiosJob` on next handle. New flows use [`WaitingForBiosJob`].
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        bios_config_info: Option<BiosConfigInfo>,
+        #[serde(default)]
+        retry_count: u32,
+    },
+    /// Wait for Dell (etc.) BIOS config Redfish job to complete before `PollingBiosSetup` (mirrors HostInit `WaitingForBiosJob`).
+    WaitingForBiosJob {
+        bios_config_info: BiosConfigInfo,
+    },
     PollingBiosSetup,
     SetBootOrder {
         set_boot_order_info: SetBootOrderInfo,

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -60,9 +60,9 @@ use model::machine::LockdownMode::{self, Enable};
 use model::machine::infiniband::{IbConfigNotSyncedReason, ib_config_synced};
 use model::machine::nvlink::nvlink_config_synced;
 use model::machine::{
-    BomValidating, BomValidatingContext, CleanupState, CreateBossVolumeContext,
-    CreateBossVolumeState, DpuDiscoveringState, DpuInitNextStateResolver, DpuInitState,
-    FailureCause, FailureDetails, FailureSource, HostPlatformConfigurationState,
+    BiosConfigInfo, BiosConfigState, BomValidating, BomValidatingContext, CleanupState,
+    CreateBossVolumeContext, CreateBossVolumeState, DpuDiscoveringState, DpuInitNextStateResolver,
+    DpuInitState, FailureCause, FailureDetails, FailureSource, HostPlatformConfigurationState,
     HostReprovisionState, InitialResetPhase, InstallDpuOsState, InstanceNextStateResolver,
     InstanceState, LockdownInfo, LockdownState, Machine, MachineLastRebootRequested,
     MachineLastRebootRequestedMode, MachineNextStateResolver, MachineState, ManagedHostState,
@@ -702,7 +702,9 @@ impl MachineStateHandler {
                     );
                     Ok(StateHandlerOutcome::transition(
                         ManagedHostState::HostInit {
-                            machine_state: MachineState::WaitingForPlatformConfiguration,
+                            machine_state: MachineState::WaitingForPlatformConfiguration {
+                                retry_count: 0,
+                            },
                         },
                     ))
                 } else {
@@ -716,7 +718,9 @@ impl MachineStateHandler {
                         // skip dpu discovery and init entirely, treat it as a nic
                         return Ok(StateHandlerOutcome::transition(
                             ManagedHostState::HostInit {
-                                machine_state: MachineState::WaitingForPlatformConfiguration,
+                                machine_state: MachineState::WaitingForPlatformConfiguration {
+                                    retry_count: 0,
+                                },
                             },
                         ));
                         /*
@@ -4032,7 +4036,7 @@ impl StateHandler for DpuMachineStateHandler {
         let mut state_handler_outcome = StateHandlerOutcome::do_nothing();
         if state.host_snapshot.associated_dpu_machine_ids().is_empty() {
             let next_state = ManagedHostState::HostInit {
-                machine_state: MachineState::WaitingForPlatformConfiguration,
+                machine_state: MachineState::WaitingForPlatformConfiguration { retry_count: 0 },
             };
             Ok(StateHandlerOutcome::transition(next_state))
         } else {
@@ -4081,7 +4085,12 @@ pub struct RebootStatus {
 enum BiosConfigOutcome {
     Done,
     WaitingForReboot(String),
+    /// Dell BIOS PATCH returned a job ID; wait for it to complete before boot order.
+    WaitingForBiosJob(BiosConfigInfo),
 }
+
+/// Max configure_host_bios retry cycles through HandleBiosJobFailure recovery (matches boot-order retry budget).
+const MAX_BIOS_CONFIG_RETRIES: u32 = 3;
 
 /// Outcome of set_host_boot_order function.
 enum SetBootOrderOutcome {
@@ -4684,12 +4693,14 @@ impl StateHandler for HostMachineStateHandler {
                     }
 
                     let next_state = ManagedHostState::HostInit {
-                        machine_state: MachineState::WaitingForPlatformConfiguration,
+                        machine_state: MachineState::WaitingForPlatformConfiguration {
+                            retry_count: 0,
+                        },
                     };
 
                     Ok(StateHandlerOutcome::transition(next_state))
                 }
-                MachineState::WaitingForPlatformConfiguration => {
+                MachineState::WaitingForPlatformConfiguration { retry_count } => {
                     tracing::info!(
                         machine_id = %host_machine_id,
                         "Starting UEFI / BMC setup");
@@ -4738,18 +4749,60 @@ impl StateHandler for HostMachineStateHandler {
                         &self.host_handler_params.reachability_params,
                         redfish_client.as_ref(),
                         mh_snapshot,
+                        *retry_count,
                     )
                     .await?
                     {
-                        BiosConfigOutcome::Done => {
-                            // BIOS configuration done, move to polling
+                        BiosConfigOutcome::Done => Ok(StateHandlerOutcome::transition(
+                            ManagedHostState::HostInit {
+                                machine_state: MachineState::PollingBiosSetup,
+                            },
+                        )),
+                        BiosConfigOutcome::WaitingForBiosJob(bios_config_info) => Ok(
+                            StateHandlerOutcome::transition(ManagedHostState::HostInit {
+                                machine_state: MachineState::WaitingForBiosJob { bios_config_info },
+                            }),
+                        ),
+                        BiosConfigOutcome::WaitingForReboot(reason) => {
+                            Ok(StateHandlerOutcome::wait(reason))
+                        }
+                    }
+                }
+                MachineState::WaitingForBiosJob { bios_config_info } => {
+                    let redfish_client = ctx
+                        .services
+                        .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)
+                        .await?;
+                    match advance_bios_config_job(
+                        ctx,
+                        redfish_client.as_ref(),
+                        mh_snapshot,
+                        bios_config_info.clone(),
+                    )
+                    .await?
+                    {
+                        BiosConfigJobAdvanceOutcome::Continue(updated) => Ok(
+                            StateHandlerOutcome::transition(ManagedHostState::HostInit {
+                                machine_state: MachineState::WaitingForBiosJob {
+                                    bios_config_info: updated,
+                                },
+                            }),
+                        ),
+                        BiosConfigJobAdvanceOutcome::Done => Ok(StateHandlerOutcome::transition(
+                            ManagedHostState::HostInit {
+                                machine_state: MachineState::PollingBiosSetup,
+                            },
+                        )),
+                        BiosConfigJobAdvanceOutcome::RetryPlatformConfiguration { retry_count } => {
                             Ok(StateHandlerOutcome::transition(
                                 ManagedHostState::HostInit {
-                                    machine_state: MachineState::PollingBiosSetup,
+                                    machine_state: MachineState::WaitingForPlatformConfiguration {
+                                        retry_count,
+                                    },
                                 },
                             ))
                         }
-                        BiosConfigOutcome::WaitingForReboot(reason) => {
+                        BiosConfigJobAdvanceOutcome::Wait(reason) => {
                             Ok(StateHandlerOutcome::wait(reason))
                         }
                     }
@@ -5010,7 +5063,9 @@ impl StateHandler for HostMachineStateHandler {
                                 }
                             } else {
                                 ManagedHostState::HostInit {
-                                    machine_state: MachineState::WaitingForPlatformConfiguration,
+                                    machine_state: MachineState::WaitingForPlatformConfiguration {
+                                        retry_count: 0,
+                                    },
                                 }
                             };
 
@@ -8988,21 +9043,19 @@ fn can_restart_reprovision(dpu_snapshots: &[Machine], version: ConfigVersion) ->
     dpu_reprovision_restart_requested_after_state_transition(version, *latest_requested_at)
 }
 
-/// Call machine_setup, but ignore any RedfishError::NoDpu if we expect there
-/// to be no DPUs.
+/// Call [`Redfish::machine_setup`], but ignore any [`RedfishError::NoDpu`] if we expect there to be no DPUs.
+/// Returns `Ok(Some(job_id))` when the vendor (e.g. Dell) creates a BIOS config job that must complete
+/// before configuring boot order; `Ok(None)` when no job to wait for.
 ///
-/// So, callers can *now* plumb a "dumb" host-NIC MAC for zero-DPU hosts via
-/// boot_interface_mac(), meaning the ::NoDpu handling below is expected to
-/// fire only when `machine_setup` has DPU-specific assumptions beyond the MAC
-/// (e.g. Attribute-path checks that still require a DPU to be present). When
-/// that dependency is fully removed, this wrapper can collapse into a plain
-/// `machine_setup` call.
+/// TODO(ken): This is a temporary workaround for work-in-progress on zero-DPU support (August 2024)
+/// The way we should do this going forward is to plumb the actual non-DPU MAC address we want to
+/// boot from, instead of special-casing NoDpu errors.
 async fn call_machine_setup_and_handle_no_dpu_error(
     redfish_client: &dyn Redfish,
     boot_interface_mac: Option<&str>,
     expected_dpu_count: usize,
     site_config: &CarbideConfig,
-) -> Result<(), RedfishError> {
+) -> Result<Option<String>, RedfishError> {
     let setup_result = redfish_client
         .machine_setup(
             boot_interface_mac,
@@ -9020,10 +9073,9 @@ async fn call_machine_setup_and_handle_no_dpu_error(
             tracing::info!(
                 "redfish machine_setup failed due to there being no DPUs on the host. This is expected as the host has no DPUs, and we are configured to allow this."
             );
-            Ok(())
+            Ok(None)
         }
-        // TODO: handle the job id returned from machine setup
-        (Ok(_), _, _) => Ok(()),
+        (Ok(maybe_jid), _, _) => Ok(maybe_jid),
         (Err(e), _, _) => Err(e),
     }
 }
@@ -9430,40 +9482,92 @@ async fn handle_instance_host_platform_config(
 
             if configure_host_boot_order {
                 InstanceState::HostPlatformConfiguration {
-                    platform_config_state: HostPlatformConfigurationState::ConfigureBios,
+                    platform_config_state: HostPlatformConfigurationState::ConfigureBios {
+                        bios_config_info: None,
+                        retry_count: 0,
+                    },
                 }
             } else {
-                // Boot order is already correct (or no DPUs); skip to LockHost to
-                // re-enable BMC lockdown before proceeding.
-                InstanceState::HostPlatformConfiguration {
-                    platform_config_state: HostPlatformConfigurationState::LockHost,
-                }
+                InstanceState::WaitingForDpusToUp
             }
         }
-        HostPlatformConfigurationState::ConfigureBios => {
-            match configure_host_bios(
+        HostPlatformConfigurationState::ConfigureBios {
+            bios_config_info,
+            retry_count,
+        } => {
+            // Legacy persisted state: migrate to WaitingForBiosJob (one transition per invocation).
+            if let Some(info) = bios_config_info {
+                return Ok(StateHandlerOutcome::transition(
+                    ManagedHostState::Assigned {
+                        instance_state: InstanceState::HostPlatformConfiguration {
+                            platform_config_state:
+                                HostPlatformConfigurationState::WaitingForBiosJob {
+                                    bios_config_info: info,
+                                },
+                        },
+                    },
+                ));
+            }
+
+            let next_platform = match configure_host_bios(
                 ctx,
                 reachability_params,
                 redfish_client.as_ref(),
                 mh_snapshot,
+                retry_count,
             )
             .await?
             {
-                BiosConfigOutcome::Done => {
-                    // BIOS configuration done, move to polling
-                    return Ok(StateHandlerOutcome::transition(
-                        ManagedHostState::Assigned {
-                            instance_state: InstanceState::HostPlatformConfiguration {
-                                platform_config_state:
-                                    HostPlatformConfigurationState::PollingBiosSetup,
-                            },
-                        },
-                    ));
+                BiosConfigOutcome::Done => HostPlatformConfigurationState::PollingBiosSetup,
+                BiosConfigOutcome::WaitingForBiosJob(bios_config_info) => {
+                    HostPlatformConfigurationState::WaitingForBiosJob { bios_config_info }
                 }
                 BiosConfigOutcome::WaitingForReboot(reason) => {
                     return Ok(StateHandlerOutcome::wait(reason));
                 }
-            }
+            };
+            return Ok(StateHandlerOutcome::transition(
+                ManagedHostState::Assigned {
+                    instance_state: InstanceState::HostPlatformConfiguration {
+                        platform_config_state: next_platform,
+                    },
+                },
+            ));
+        }
+        HostPlatformConfigurationState::WaitingForBiosJob { bios_config_info } => {
+            let next_platform = match advance_bios_config_job(
+                ctx,
+                redfish_client.as_ref(),
+                mh_snapshot,
+                bios_config_info.clone(),
+            )
+            .await?
+            {
+                BiosConfigJobAdvanceOutcome::Continue(updated) => {
+                    HostPlatformConfigurationState::WaitingForBiosJob {
+                        bios_config_info: updated,
+                    }
+                }
+                BiosConfigJobAdvanceOutcome::Done => {
+                    HostPlatformConfigurationState::PollingBiosSetup
+                }
+                BiosConfigJobAdvanceOutcome::RetryPlatformConfiguration {
+                    retry_count: next_count,
+                } => HostPlatformConfigurationState::ConfigureBios {
+                    bios_config_info: None,
+                    retry_count: next_count,
+                },
+                BiosConfigJobAdvanceOutcome::Wait(reason) => {
+                    return Ok(StateHandlerOutcome::wait(reason));
+                }
+            };
+            return Ok(StateHandlerOutcome::transition(
+                ManagedHostState::Assigned {
+                    instance_state: InstanceState::HostPlatformConfiguration {
+                        platform_config_state: next_platform,
+                    },
+                },
+            ));
         }
         HostPlatformConfigurationState::PollingBiosSetup => {
             let next_instance_state = InstanceState::HostPlatformConfiguration {
@@ -9557,10 +9661,11 @@ async fn configure_host_bios(
     reachability_params: &ReachabilityParams,
     redfish_client: &dyn Redfish,
     mh_snapshot: &ManagedHostStateSnapshot,
+    retry_count: u32,
 ) -> Result<BiosConfigOutcome, StateHandlerError> {
     let boot_interface_mac = mh_snapshot.boot_interface_mac().map(|m| m.to_string());
 
-    if let Err(e) = call_machine_setup_and_handle_no_dpu_error(
+    let bios_job_id = match call_machine_setup_and_handle_no_dpu_error(
         redfish_client,
         boot_interface_mac.as_deref(),
         mh_snapshot.host_snapshot.associated_dpu_machine_ids().len(),
@@ -9568,52 +9673,296 @@ async fn configure_host_bios(
     )
     .await
     {
-        // TODO(chet): I don't know if this is still a thing, but I'm pretty sure
-        // it hasn't been fixed/addressed yet, and it appears to be logged all over
-        // the place now.
-        tracing::warn!(
-            "redfish machine_setup failed for {}, potentially due to known race condition between UEFI POST and BMC. triggering force-restart if needed. err: {}",
-            mh_snapshot.host_snapshot.id,
-            e
-        );
+        Err(e) => {
+            tracing::warn!(
+                "redfish machine_setup failed for {}, potentially due to known race condition between UEFI POST and BMC. triggering force-restart if needed. err: {}",
+                mh_snapshot.host_snapshot.id,
+                e
+            );
 
-        // if machine_setup failed, rebooted to potentially work around
-        // a known race between the DPU UEFI and the BMC, where if
-        // the BMC is not up when DPU UEFI runs, then Attributes might
-        // not come through. The fix is to force-restart the DPU to
-        // re-POST.
-        //
-        // As of July 2024, Josh Price said there's an NBU FR to fix
-        // this, but it wasn't target to a release yet.
-        let reboot_status = if mh_snapshot.host_snapshot.last_reboot_requested.is_none() {
-            handler_host_power_control(mh_snapshot, ctx, SystemPowerControl::ForceRestart).await?;
+            // if machine_setup failed, reboot to potentially work around
+            // a known race between the DPU UEFI and the BMC, where if
+            // the BMC is not up when DPU UEFI runs, then Attributes might
+            // not come through. The fix is to force-restart the DPU to
+            // re-POST.
+            //
+            // As of July 2024, Josh Price said there's an NBU FR to fix
+            // this, but it wasn't target to a release yet.
+            let reboot_status = if mh_snapshot.host_snapshot.last_reboot_requested.is_none() {
+                handler_host_power_control(mh_snapshot, ctx, SystemPowerControl::ForceRestart)
+                    .await?;
 
-            RebootStatus {
-                increase_retry_count: true,
-                status: "Restarted host".to_string(),
-            }
-        } else {
-            trigger_reboot_if_needed(
-                &mh_snapshot.host_snapshot,
-                mh_snapshot,
-                None,
-                reachability_params,
-                ctx,
-            )
-            .await?
-        };
-        // Return WaitingForReboot instead of Err to ensure the transaction is
-        // committed, and last_reboot_requested is persisted. Returning Err would
-        // cause a transaction rollback, leading to a tight reboot loop (since the
-        // reboot timestamp would be lost).
-        return Ok(BiosConfigOutcome::WaitingForReboot(format!(
-            "redfish machine_setup failed: {e}; triggered host reboot: {reboot_status:#?}"
-        )));
+                RebootStatus {
+                    increase_retry_count: true,
+                    status: "Restarted host".to_string(),
+                }
+            } else {
+                trigger_reboot_if_needed(
+                    &mh_snapshot.host_snapshot,
+                    mh_snapshot,
+                    None,
+                    reachability_params,
+                    ctx,
+                )
+                .await?
+            };
+            return Ok(BiosConfigOutcome::WaitingForReboot(format!(
+                "redfish machine_setup failed: {e}; triggered host reboot: {reboot_status:#?}"
+            )));
+        }
+        Ok(jid) => jid,
     };
 
-    // Host needs to be rebooted to pick up the changes after calling machine_setup.
+    if let Some(job_id) = &bios_job_id {
+        return Ok(BiosConfigOutcome::WaitingForBiosJob(BiosConfigInfo {
+            bios_job_id: Some(job_id.clone()),
+            bios_config_state: BiosConfigState::WaitForBiosJobScheduled,
+            retry_count,
+        }));
+    }
+
+    // No job to wait for (non-Dell or vendor that doesn't return job); reboot to apply and continue.
     handler_host_power_control(mh_snapshot, ctx, SystemPowerControl::ForceRestart).await?;
     Ok(BiosConfigOutcome::Done)
+}
+
+/// Outcome of advancing the BIOS config job state machine (Dell: wait for BIOS PATCH job before boot order).
+enum BiosConfigJobAdvanceOutcome {
+    Continue(BiosConfigInfo),
+    Done,
+    /// Same state, but wait (e.g. waiting for power down or BMC to come back).
+    Wait(String),
+    /// After successful power/BMC recovery from a failed BIOS job: re-run machine_setup (not PollingBiosSetup).
+    RetryPlatformConfiguration {
+        retry_count: u32,
+    },
+}
+
+fn bios_config_enter_handle_failure(
+    info: &BiosConfigInfo,
+    failure: String,
+    host_id: &MachineId,
+) -> Result<BiosConfigInfo, StateHandlerError> {
+    if info.retry_count >= MAX_BIOS_CONFIG_RETRIES {
+        return Err(StateHandlerError::GenericError(eyre::eyre!(
+            "BIOS config job failure remediation exceeded max retries ({MAX_BIOS_CONFIG_RETRIES}) for host {host_id}: {failure}"
+        )));
+    }
+    Ok(BiosConfigInfo {
+        bios_job_id: info.bios_job_id.clone(),
+        bios_config_state: BiosConfigState::HandleBiosJobFailure {
+            failure,
+            power_state: libredfish::PowerState::Off,
+        },
+        retry_count: info.retry_count + 1,
+    })
+}
+
+/// Advance one step of the BIOS config job wait state machine. Same pattern as set_host_boot_order.
+async fn advance_bios_config_job(
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    redfish_client: &dyn Redfish,
+    mh_snapshot: &ManagedHostStateSnapshot,
+    info: BiosConfigInfo,
+) -> Result<BiosConfigJobAdvanceOutcome, StateHandlerError> {
+    match info.bios_config_state {
+        BiosConfigState::WaitForBiosJobScheduled => {
+            if let Some(job_id) = &info.bios_job_id {
+                let job_state = redfish_client.get_job_state(job_id).await.map_err(|e| {
+                    StateHandlerError::RedfishError {
+                        operation: "get_job_state",
+                        error: e,
+                    }
+                })?;
+                if matches!(
+                    job_state,
+                    libredfish::JobState::ScheduledWithErrors
+                        | libredfish::JobState::CompletedWithErrors
+                ) {
+                    let failure = format!("BIOS job {} failed with state {job_state:#?}", job_id);
+                    tracing::warn!(
+                        "{} for {}, transitioning to HandleBiosJobFailure (power cycle + BMC reset)",
+                        failure,
+                        mh_snapshot.host_snapshot.id
+                    );
+                    return Ok(BiosConfigJobAdvanceOutcome::Continue(
+                        bios_config_enter_handle_failure(
+                            &info,
+                            failure,
+                            &mh_snapshot.host_snapshot.id,
+                        )?,
+                    ));
+                }
+                if !matches!(job_state, libredfish::JobState::Scheduled) {
+                    return Err(StateHandlerError::GenericError(eyre::eyre!(
+                        "waiting for BIOS job {:#?} to be scheduled; current state: {job_state:#?}",
+                        job_id
+                    )));
+                }
+            }
+            Ok(BiosConfigJobAdvanceOutcome::Continue(BiosConfigInfo {
+                bios_job_id: info.bios_job_id.clone(),
+                bios_config_state: BiosConfigState::RebootHost,
+                retry_count: info.retry_count,
+            }))
+        }
+        BiosConfigState::RebootHost => {
+            handler_host_power_control(mh_snapshot, ctx, SystemPowerControl::ForceRestart).await?;
+            Ok(BiosConfigJobAdvanceOutcome::Continue(BiosConfigInfo {
+                bios_job_id: info.bios_job_id.clone(),
+                bios_config_state: BiosConfigState::WaitForBiosJobCompletion,
+                retry_count: info.retry_count,
+            }))
+        }
+        BiosConfigState::WaitForBiosJobCompletion => {
+            const JOB_QUERY_WAIT_MINUTES: i64 = 5;
+            if let Some(job_id) = &info.bios_job_id {
+                let job_state = match redfish_client.get_job_state(job_id).await {
+                    Ok(s) => s,
+                    Err(e) => {
+                        let minutes_since_state_change = mh_snapshot
+                            .host_snapshot
+                            .state
+                            .version
+                            .since_state_change()
+                            .num_minutes();
+                        if minutes_since_state_change < JOB_QUERY_WAIT_MINUTES {
+                            return Err(StateHandlerError::RedfishError {
+                                operation: "get_job_state",
+                                error: e,
+                            });
+                        }
+                        let failure = format!(
+                            "BIOS config job {} lookup failed after {} min: {}",
+                            job_id, minutes_since_state_change, e
+                        );
+                        tracing::warn!(
+                            "{} for {}, transitioning to HandleBiosJobFailure (power cycle + BMC reset)",
+                            failure,
+                            mh_snapshot.host_snapshot.id
+                        );
+                        return Ok(BiosConfigJobAdvanceOutcome::Continue(
+                            bios_config_enter_handle_failure(
+                                &info,
+                                failure,
+                                &mh_snapshot.host_snapshot.id,
+                            )?,
+                        ));
+                    }
+                };
+                match job_state {
+                    libredfish::JobState::Completed => Ok(BiosConfigJobAdvanceOutcome::Done),
+                    libredfish::JobState::ScheduledWithErrors
+                    | libredfish::JobState::CompletedWithErrors => {
+                        let failure = format!(
+                            "BIOS config job {} failed with state {job_state:#?}",
+                            job_id
+                        );
+                        tracing::warn!(
+                            "{} for {}, transitioning to HandleBiosJobFailure (power cycle + BMC reset)",
+                            failure,
+                            mh_snapshot.host_snapshot.id,
+                        );
+                        Ok(BiosConfigJobAdvanceOutcome::Continue(
+                            bios_config_enter_handle_failure(
+                                &info,
+                                failure,
+                                &mh_snapshot.host_snapshot.id,
+                            )?,
+                        ))
+                    }
+                    _ => Err(StateHandlerError::GenericError(eyre::eyre!(
+                        "waiting for BIOS job {:#?} to complete; current state: {job_state:#?}",
+                        job_id
+                    ))),
+                }
+            } else {
+                Ok(BiosConfigJobAdvanceOutcome::Done)
+            }
+        }
+        BiosConfigState::HandleBiosJobFailure {
+            failure,
+            power_state,
+        } => {
+            let current_power_state = redfish_client.get_power_state().await.map_err(|e| {
+                StateHandlerError::RedfishError {
+                    operation: "get_power_state",
+                    error: e,
+                }
+            })?;
+
+            match power_state {
+                libredfish::PowerState::Off => {
+                    if current_power_state != libredfish::PowerState::Off {
+                        handler_host_power_control(mh_snapshot, ctx, SystemPowerControl::ForceOff)
+                            .await?;
+                        return Ok(BiosConfigJobAdvanceOutcome::Wait(format!(
+                            "HandleBiosJobFailure: waiting for {} to power down; current power state: {current_power_state}; failure: {}",
+                            mh_snapshot.host_snapshot.id, failure
+                        )));
+                    }
+                    tracing::info!(
+                        "HandleBiosJobFailure: Resetting BMC for {} after BIOS job failure: {}",
+                        mh_snapshot.host_snapshot.id,
+                        failure
+                    );
+                    redfish_client.bmc_reset().await.map_err(|e| {
+                        StateHandlerError::RedfishError {
+                            operation: "bmc_reset",
+                            error: e,
+                        }
+                    })?;
+                    Ok(BiosConfigJobAdvanceOutcome::Continue(BiosConfigInfo {
+                        bios_job_id: info.bios_job_id.clone(),
+                        bios_config_state: BiosConfigState::HandleBiosJobFailure {
+                            failure: failure.clone(),
+                            power_state: libredfish::PowerState::On,
+                        },
+                        retry_count: info.retry_count,
+                    }))
+                }
+                libredfish::PowerState::On => {
+                    if current_power_state != libredfish::PowerState::On {
+                        let basetime = mh_snapshot
+                            .host_snapshot
+                            .last_reboot_requested
+                            .as_ref()
+                            .map(|x| x.time)
+                            .unwrap_or(mh_snapshot.host_snapshot.state.version.timestamp());
+                        let power_down_wait = ctx
+                            .services
+                            .site_config
+                            .machine_state_controller
+                            .power_down_wait;
+                        if Utc::now().signed_duration_since(basetime) < power_down_wait {
+                            return Ok(BiosConfigJobAdvanceOutcome::Wait(format!(
+                                "HandleBiosJobFailure: waiting for BMC to come back online for {}; failure: {}",
+                                mh_snapshot.host_snapshot.id, failure
+                            )));
+                        }
+                        handler_host_power_control(mh_snapshot, ctx, SystemPowerControl::On)
+                            .await?;
+                        return Ok(BiosConfigJobAdvanceOutcome::Wait(format!(
+                            "HandleBiosJobFailure: powering on {} after BMC reset; failure: {}",
+                            mh_snapshot.host_snapshot.id, failure
+                        )));
+                    }
+                    tracing::info!(
+                        machine_id = %mh_snapshot.host_snapshot.id,
+                        retry_count = info.retry_count,
+                        "HandleBiosJobFailure: BMC reset complete; re-running platform configuration (machine_setup) — power cycle does not apply BIOS attributes",
+                    );
+                    Ok(BiosConfigJobAdvanceOutcome::RetryPlatformConfiguration {
+                        retry_count: info.retry_count,
+                    })
+                }
+                _ => Err(StateHandlerError::GenericError(eyre::eyre!(
+                    "HandleBiosJobFailure: unexpected power state {power_state:#?} for {}",
+                    mh_snapshot.host_snapshot.id
+                ))),
+            }
+        }
+    }
 }
 
 async fn set_host_boot_order(

--- a/crates/api/src/state_controller/machine/io.rs
+++ b/crates/api/src/state_controller/machine/io.rs
@@ -171,7 +171,10 @@ impl StateControllerIO for MachineStateControllerIO {
         fn machine_state_name(machine_state: &MachineState) -> &'static str {
             match machine_state {
                 MachineState::Init => "init",
-                MachineState::WaitingForPlatformConfiguration => "waitingforplatformconfiguration",
+                MachineState::WaitingForPlatformConfiguration { .. } => {
+                    "waitingforplatformconfiguration"
+                }
+                MachineState::WaitingForBiosJob { .. } => "waitingforbiosjob",
                 MachineState::PollingBiosSetup => "pollingbiossetup",
                 MachineState::SetBootOrder { .. } => "setbootorder",
                 MachineState::UefiSetup { .. } => "uefisetup",

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -407,7 +407,9 @@ impl TestEnv {
             ManagedHostState::HostInit { machine_state } => {
                 let mc = match machine_state {
                     model::machine::MachineState::Init => machine_state,
-                    model::machine::MachineState::WaitingForPlatformConfiguration => machine_state,
+                    model::machine::MachineState::WaitingForPlatformConfiguration { .. } => {
+                        machine_state
+                    }
                     model::machine::MachineState::PollingBiosSetup => machine_state,
                     model::machine::MachineState::SetBootOrder { .. } => machine_state,
                     model::machine::MachineState::UefiSetup { .. } => machine_state,
@@ -417,6 +419,7 @@ impl TestEnv {
                     model::machine::MachineState::Measuring { .. } => machine_state,
 
                     model::machine::MachineState::EnableIpmiOverLan => machine_state,
+                    model::machine::MachineState::WaitingForBiosJob { .. } => machine_state,
                 };
                 ManagedHostState::HostInit { machine_state: mc }
             }

--- a/crates/api/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/site_explorer.rs
@@ -652,7 +652,7 @@ impl<'a> MockExploredHost<'a> {
         self.test_env
             .run_machine_state_controller_iteration_until_state_matches(
                 &host_machine_id,
-                10,
+                20,
                 ManagedHostState::HostInit {
                     machine_state: MachineState::WaitingForDiscovery,
                 },
@@ -682,7 +682,7 @@ impl<'a> MockExploredHost<'a> {
             .test_env
             .run_machine_state_controller_iteration_until_state_condition(
                 &host_machine_id,
-                10,
+                15,
                 |machine| {
                     machine.current_state() == &expected_state
                         || matches!(

--- a/crates/api/src/tests/machine_history.rs
+++ b/crates/api/src/tests/machine_history.rs
@@ -48,7 +48,7 @@ async fn test_machine_state_history(pool: sqlx::PgPool) -> Result<(), Box<dyn st
         {"state": "dpuinit", "dpu_states": {"states": {&dpu_machine_id_string: {"dpustate": "pollingbiossetup"}}}},
         {"state": "dpuinit", "dpu_states": {"states": {&dpu_machine_id_string: {"dpustate": "waitingfornetworkconfig"}}}},
         {"state": "hostinit", "machine_state": {"state": "enableipmioverlan"}},
-        {"state": "hostinit", "machine_state": {"state": "waitingforplatformconfiguration"}},
+        {"state": "hostinit", "machine_state": {"state": "waitingforplatformconfiguration", "retry_count": 0}},
         {"state": "hostinit", "machine_state": {"state": "pollingbiossetup"}},
         {"state": "hostinit", "machine_state": {"state": "setbootorder", "set_boot_order_info": {"retry_count": 0, "set_boot_order_state": {"state": "setbootorder"}}}},
         {"state": "hostinit", "machine_state": {"state": "setbootorder", "set_boot_order_info": {"retry_count": 0, "set_boot_order_state": {"state": "waitforsetbootorderjobscheduled"}}}},

--- a/crates/api/src/tests/machine_states.rs
+++ b/crates/api/src/tests/machine_states.rs
@@ -1654,14 +1654,51 @@ async fn test_update_reboot_requested_time_off(pool: sqlx::PgPool) {
     }
 }
 
+/// Exercises WaitingForBiosJob state by configuring mock BMC to return a job ID from machine_setup.
+/// Verifies that host reaches "Ready" and that state machine transitioned through WaitingForBiosJob.
+#[crate::sqlx_test]
+async fn test_bios_config_job_happy_path(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+
+    env.redfish_sim
+        .set_machine_setup_bios_job_id(Some("JID_BIOS_TEST_123".to_string()));
+    env.redfish_sim.set_job_state_sequence(vec![
+        libredfish::JobState::Scheduled,
+        libredfish::JobState::Completed,
+    ]);
+
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    assert!(
+        matches!(host.current_state(), ManagedHostState::Ready),
+        "Expected host to reach Ready, but got: {:?}",
+        host.current_state()
+    );
+
+    let history = mh.host().parsed_history(None).await;
+    let went_through_bios_job = history.iter().any(|state| {
+        matches!(
+            state,
+            ManagedHostState::HostInit {
+                machine_state: MachineState::WaitingForBiosJob { .. },
+            }
+        )
+    });
+    assert!(
+        went_through_bios_job,
+        "Expected state history to include WaitingForBiosJob, but it did not. History: {:#?}",
+        history
+    );
+}
+
 #[crate::sqlx_test]
 async fn test_scout_heartbeat_timeout_alert_cleared_on_ready_transition(pool: sqlx::PgPool) {
     let env = create_test_env(pool).await;
     let mh = create_managed_host(&env).await;
     let host_machine_id = mh.host().id;
 
-    // Keep scout in timed-out state so Ready does not clear this via the normal
-    // "heartbeat recovered" path before we exercise transition-out-of-Ready logic.
     let mut txn = env.db_txn().await;
     sqlx::query(
         "UPDATE machines SET last_scout_contact_time = NOW() - INTERVAL '2 years' WHERE id = $1",
@@ -1850,14 +1887,10 @@ async fn test_tpm_logging(pool: sqlx::PgPool) {
 
     let machine_interface_id = host_discover_dhcp(&env, &host_config, &dpu_machine_id).await;
 
-    // First discovery - establishes the host with the original TPM-based ID
     host_discover_machine(&env, &host_config, machine_interface_id).await;
 
-    // Second discovery - different TPM EK cert simulates TPM replacement
-    // without force-delete, producing a different stable_machine_id
     let mut discovery_info =
         DiscoveryInfo::try_from(model::hardware_info::HardwareInfo::from(&host_config)).unwrap();
-    // Use a different valid EK cert to simulate TPM replacement
     discovery_info.tpm_ek_certificate =
         Some(BASE64_STANDARD.encode(common::api_fixtures::tpm_attestation::EK_CERT_SERIALIZED));
     discovery_info.attest_key_info = Some(AttestKeyInfo {

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::net::IpAddr;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -53,6 +53,8 @@ struct RedfishSimState {
     users: HashMap<String, String>,
     fw_version: Arc<String>,
     secure_boot: AtomicBool,
+    machine_setup_bios_job_id: Option<String>,
+    job_state_sequence: VecDeque<JobState>,
 }
 
 #[derive(Debug)]
@@ -110,6 +112,14 @@ impl RedfishSim {
                 })
                 .collect(),
         }
+    }
+
+    pub fn set_machine_setup_bios_job_id(&self, job_id: Option<String>) {
+        self.state.lock().unwrap().machine_setup_bios_job_id = job_id;
+    }
+
+    pub fn set_job_state_sequence(&self, states: Vec<JobState>) {
+        self.state.lock().unwrap().job_state_sequence = VecDeque::from(states);
     }
 }
 
@@ -224,7 +234,7 @@ impl Redfish for RedfishSimClient {
         host_state.actions.push(RedfishSimAction::MachineSetup {
             oem_manager_profiles: oem_manager_profiles.clone(),
         });
-        Ok(None)
+        Ok(state.machine_setup_bios_job_id.clone())
     }
 
     async fn machine_setup_status(
@@ -866,7 +876,11 @@ impl Redfish for RedfishSimClient {
     }
 
     async fn get_job_state(&self, _job_id: &str) -> Result<JobState, RedfishError> {
-        Ok(JobState::Unknown)
+        let mut state = self.state.lock().unwrap();
+        Ok(state
+            .job_state_sequence
+            .pop_front()
+            .unwrap_or(JobState::Unknown))
     }
 
     async fn get_collection(&self, _id: ODataId) -> Result<Collection, RedfishError> {


### PR DESCRIPTION
***Note:*** this PR is the signed-off version of [a previous PR](https://github.com/NVIDIA/ncx-infra-controller-core/pull/636)

These changes which will handle Dell BIOS config job IDs in machine setup flow:

- Parse and track job IDs from Redfish machine_setup/BIOS PATCH responses
- Add state machine for waiting on BIOS jobs (Scheduled → RebootHost → Completion)
- Handle job failures with power cycle and BMC reset (HandleBiosJobFailure)
- Integrate with HostInit and Assigned ConfigureBios/WaitingForBiosJob states
- A unit test to configure the mock BMC to return a job ID and check we reach "Ready" state through control path

Between configuring BIOS and setting the boot order in the ingestion path, the flow will look like this:
<img width="543" height="821" alt="flow_diagram" src="https://github.com/user-attachments/assets/fc4a71c3-08c4-40bd-8f34-033ec7de6675" />
