### PR TITLE
bmc-mock: power supply mock support and chassis config cleanup

### DIFF
--- a/crates/bmc-mock/src/hw/bluefield3.rs
+++ b/crates/bmc-mock/src/hw/bluefield3.rs
@@ -72,22 +72,14 @@ impl Bluefield3<'_> {
                     part_number: Some(Cow::Borrowed(self.part_number())),
                     pcie_devices: Some(vec![]),
                     serial_number: Some(self.product_serial_number.to_string().into()),
-                    sensors: None,
-                    assembly: None,
-                    oem: None,
+                    ..redfish::chassis::SingleChassisConfig::defaults()
                 },
                 redfish::chassis::SingleChassisConfig {
                     id: "Bluefield_ERoT".into(),
                     chassis_type: "Component".into(),
                     manufacturer: Some(Cow::Borrowed("NVIDIA")),
-                    model: None,
-                    network_adapters: None,
-                    part_number: None,
-                    pcie_devices: None,
                     serial_number: Some("".into()),
-                    sensors: None,
-                    assembly: None,
-                    oem: None,
+                    ..redfish::chassis::SingleChassisConfig::defaults()
                 },
                 redfish::chassis::SingleChassisConfig {
                     id: "CPU_0".into(),
@@ -98,9 +90,7 @@ impl Bluefield3<'_> {
                     part_number: Some(format!("OPN: {}", self.opn()).into()),
                     serial_number: Some("Unspecified Serial Number".into()),
                     pcie_devices: Some(vec![]),
-                    sensors: None,
-                    assembly: None,
-                    oem: None,
+                    ..redfish::chassis::SingleChassisConfig::defaults()
                 },
                 redfish::chassis::SingleChassisConfig {
                     id: "Card1".into(),
@@ -115,8 +105,7 @@ impl Bluefield3<'_> {
                         "Card1",
                         Self::sensor_layout(),
                     )),
-                    assembly: None,
-                    oem: None,
+                    ..redfish::chassis::SingleChassisConfig::defaults()
                 },
             ],
         }

--- a/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
+++ b/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
@@ -247,8 +247,7 @@ impl DellPowerEdgeR750<'_> {
                     chassis_id,
                     Self::sensor_layout(),
                 )),
-                assembly: None,
-                oem: None,
+                ..redfish::chassis::SingleChassisConfig::defaults()
             }],
         }
     }

--- a/crates/bmc-mock/src/hw/lenovo_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/lenovo_gb300_nvl.rs
@@ -212,8 +212,6 @@ impl LenovoGB300Nvl<'_> {
                 serial_number: nic
                     .serial_number
                     .map(|v| format!("{v}                 ").into()),
-                network_adapters: None,
-                pcie_devices: None,
                 sensors: Some(redfish::sensor::generate_chassis_sensors(
                     chassis_id,
                     redfish::sensor::Layout {
@@ -221,8 +219,7 @@ impl LenovoGB300Nvl<'_> {
                         ..Default::default()
                     },
                 )),
-                assembly: None,
-                oem: None,
+                ..redfish::chassis::SingleChassisConfig::defaults()
             }
         };
         redfish::chassis::ChassisConfig {
@@ -235,8 +232,6 @@ impl LenovoGB300Nvl<'_> {
                     part_number: Some("SC57C26750".into()),
                     model: Some(" ".into()),
                     serial_number: Some(self.chassis_0_serial_number.to_string().into()),
-                    network_adapters: None,
-                    pcie_devices: None,
                     sensors: Some(redfish::sensor::generate_chassis_sensors(
                         "Chassis_0",
                         redfish::sensor::Layout {
@@ -247,8 +242,7 @@ impl LenovoGB300Nvl<'_> {
                             current: 0,
                         },
                     )),
-                    assembly: None,
-                    oem: None,
+                    ..redfish::chassis::SingleChassisConfig::defaults()
                 }))
                 .chain(self.cpu.iter().enumerate().map(|(n, cpu)| {
                     let id = format!("HGX_CPU_{n}");

--- a/crates/bmc-mock/src/hw/liteon_power_shelf.rs
+++ b/crates/bmc-mock/src/hw/liteon_power_shelf.rs
@@ -90,6 +90,7 @@ impl LiteOnPowerShelf<'_> {
 
     pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         let chassis_id = "powershelf";
+
         redfish::chassis::ChassisConfig {
             chassis: vec![redfish::chassis::SingleChassisConfig {
                 id: chassis_id.into(),
@@ -98,14 +99,26 @@ impl LiteOnPowerShelf<'_> {
                 part_number: Some("PF-1333-7R".into()),
                 model: Some("PF-1333-7R".into()),
                 serial_number: Some(self.product_serial_number.to_string().into()),
-                network_adapters: None,
-                pcie_devices: None,
                 sensors: Some(redfish::sensor::generate_chassis_sensors(
                     chassis_id,
                     Self::sensor_layout(),
                 )),
-                assembly: None,
-                oem: None,
+                power_supplies: Some(
+                    (0..=5)
+                        .map(|idx| {
+                            redfish::power_supply::builder(&redfish::power_supply::resource(
+                                chassis_id,
+                                &idx.to_string(),
+                            ))
+                            .oem_liteon_power_state(true)
+                            // libredfish requires status to be
+                            // here...
+                            .status(redfish::resource::Status::Ok)
+                            .build()
+                        })
+                        .collect(),
+                ),
+                ..redfish::chassis::SingleChassisConfig::defaults()
             }],
         }
     }

--- a/crates/bmc-mock/src/hw/nvidia_dgx_h100.rs
+++ b/crates/bmc-mock/src/hw/nvidia_dgx_h100.rs
@@ -275,7 +275,6 @@ impl NvidiaDgxH100<'_> {
                     model: Some("DGXH100".into()),
                     serial_number: Some(self.dgx_system_serial_number.to_string().into()),
                     network_adapters: Some(vec![]),
-                    pcie_devices: None,
                     sensors: Some(redfish::sensor::generate_chassis_sensors(
                         "CPUBaseboard",
                         redfish::sensor::Layout {
@@ -283,8 +282,7 @@ impl NvidiaDgxH100<'_> {
                             ..Default::default()
                         },
                     )),
-                    assembly: None,
-                    oem: None,
+                    ..redfish::chassis::SingleChassisConfig::defaults()
                 },
                 redfish::chassis::SingleChassisConfig {
                     id: dgx_chassis_id.into(),
@@ -326,8 +324,7 @@ impl NvidiaDgxH100<'_> {
                                                   //     WATCHDOG2
                         },
                     )),
-                    assembly: None,
-                    oem: None,
+                    ..redfish::chassis::SingleChassisConfig::defaults()
                 },
             ]
             .into_iter()
@@ -554,7 +551,6 @@ fn hgx_gpu_sxm_chassis(index: usize, serial: &str) -> redfish::chassis::SingleCh
         part_number: Some("2330-885-A1".into()),
         model: Some("H100 80GB HBM3".into()),
         serial_number: Some(serial.to_string().into()),
-        network_adapters: None,
         pcie_devices: Some(vec![
             redfish::pcie_device::builder(&redfish::pcie_device::chassis_resource(
                 &id,
@@ -576,7 +572,6 @@ fn hgx_gpu_sxm_chassis(index: usize, serial: &str) -> redfish::chassis::SingleCh
             },
         )),
         id: id.into(),
-        assembly: None,
-        oem: None,
+        ..redfish::chassis::SingleChassisConfig::defaults()
     }
 }

--- a/crates/bmc-mock/src/hw/nvidia_gb200.rs
+++ b/crates/bmc-mock/src/hw/nvidia_gb200.rs
@@ -72,11 +72,8 @@ impl BiancaBoard<'_> {
             part_number: Some("900-2G548-0001-000".into()),
             model: Some("Grace A02P".into()),
             serial_number: Some(self.cpu_serial_number.to_string().into()),
-            network_adapters: None,
-            pcie_devices: None,
             sensors: Some(sensors),
-            assembly: None,
-            oem: None,
+            ..redfish::chassis::SingleChassisConfig::defaults()
         }
     }
 
@@ -102,7 +99,6 @@ impl BiancaBoard<'_> {
                 part_number: Some("NA".into()),
                 model: Some("GB200 186GB HBM3e".into()),
                 serial_number: Some(self.gpu_serial_number.to_string().into()),
-                network_adapters: None,
                 pcie_devices: Some(vec![
                     redfish::pcie_device::builder(&redfish::pcie_device::chassis_resource(
                         &ids.chassis_id,
@@ -116,8 +112,7 @@ impl BiancaBoard<'_> {
                 ]),
                 id: ids.chassis_id,
                 sensors: Some(sensors),
-                assembly: None,
-                oem: None,
+                ..redfish::chassis::SingleChassisConfig::defaults()
             }
         })
     }
@@ -210,9 +205,8 @@ impl IoBoard<'_> {
             ),
             pcie_devices: Some(vec![]),
             sensors: Some(sensors),
-            assembly: None,
-            oem: None,
             id,
+            ..redfish::chassis::SingleChassisConfig::defaults()
         }
     }
 

--- a/crates/bmc-mock/src/hw/nvidia_gb300.rs
+++ b/crates/bmc-mock/src/hw/nvidia_gb300.rs
@@ -43,11 +43,8 @@ impl NvidiaGB300Gpu<'_> {
             part_number: Some("SC57C26750".into()),
             model: Some("NVIDIA GB300".into()),
             serial_number: Some(self.serial_number.to_string().into()),
-            network_adapters: None,
-            pcie_devices: None,
             sensors: Some(sensors),
-            assembly: None,
-            oem: None,
+            ..redfish::chassis::SingleChassisConfig::defaults()
         }
     }
 }
@@ -78,11 +75,8 @@ impl NvidiaGB300Cpu<'_> {
             part_number: Some("900-2G548-0081-000".into()),
             model: Some("Grace A02P".into()),
             serial_number: Some(self.serial_number.to_string().into()),
-            network_adapters: None,
-            pcie_devices: None,
             sensors: Some(sensors),
-            assembly: None,
-            oem: None,
+            ..redfish::chassis::SingleChassisConfig::defaults()
         }
     }
 }
@@ -107,11 +101,8 @@ impl NvidiaGB300IoBoard<'_> {
             part_number: Some("900-9X86E-00CX-ST0           ".into()),
             model: Some("P4768-B01".into()),
             serial_number: Some(self.serial_number.to_string().into()),
-            network_adapters: None,
-            pcie_devices: None,
             sensors: Some(sensors),
-            assembly: None,
-            oem: None,
+            ..redfish::chassis::SingleChassisConfig::defaults()
         }
     }
 }

--- a/crates/bmc-mock/src/hw/nvidia_gbx00.rs
+++ b/crates/bmc-mock/src/hw/nvidia_gbx00.rs
@@ -42,10 +42,7 @@ pub fn cbc_chassis(
         part_number: Some("750-0567-002".into()),
         model: Some("18x1RU CBL Cartridge".into()),
         serial_number: Some("1821220000000".into()),
-        network_adapters: None,
         pcie_devices: Some(vec![]),
-        sensors: None,
-        assembly: None,
         oem: Some(json!({
             "Nvidia": {
                 "@odata.type": "#NvidiaChassis.v1_4_0.NvidiaCBCChassis",
@@ -55,5 +52,6 @@ pub fn cbc_chassis(
                 "TopologyId": topology.topology_id,
             }
         })),
+        ..redfish::chassis::SingleChassisConfig::defaults()
     }
 }

--- a/crates/bmc-mock/src/hw/nvidia_switch_nd5200_ld.rs
+++ b/crates/bmc-mock/src/hw/nvidia_switch_nd5200_ld.rs
@@ -95,11 +95,8 @@ impl NvidiaSwitchNd5200Ld<'_> {
                     part_number: Some("692-13809-1404-000".into()),
                     model: Some("P3809".into()),
                     serial_number: Some(self.bmc_serial_number.to_string().into()),
-                    network_adapters: None,
-                    pcie_devices: None,
                     sensors: Some(vec![]),
-                    assembly: None,
-                    oem: None,
+                    ..redfish::chassis::SingleChassisConfig::defaults()
                 },
                 redfish::chassis::SingleChassisConfig {
                     id: "CPLD_0".into(),
@@ -108,11 +105,9 @@ impl NvidiaSwitchNd5200Ld<'_> {
                     part_number: Some("".into()),
                     model: Some("LCMXO3D-9400HC-5BG256C".into()),
                     serial_number: Some("CPLDSerialNumber".into()),
-                    network_adapters: None,
                     pcie_devices: Some(vec![]),
                     sensors: Some(vec![]),
-                    assembly: None,
-                    oem: None,
+                    ..redfish::chassis::SingleChassisConfig::defaults()
                 },
                 redfish::chassis::SingleChassisConfig {
                     id: "MGX_BMC_0".into(),
@@ -121,7 +116,6 @@ impl NvidiaSwitchNd5200Ld<'_> {
                     part_number: Some("692-13809-1404-000".into()),
                     model: Some("P3809".into()),
                     serial_number: Some(self.bmc_serial_number.to_string().into()),
-                    network_adapters: None,
                     pcie_devices: Some(vec![]),
                     sensors: Some(redfish::sensor::generate_chassis_sensors(
                         "MGX_BMC_0",
@@ -130,8 +124,7 @@ impl NvidiaSwitchNd5200Ld<'_> {
                             ..Default::default()
                         },
                     )),
-                    assembly: None,
-                    oem: None,
+                    ..redfish::chassis::SingleChassisConfig::defaults()
                 },
             ]
             .into_iter()
@@ -150,14 +143,8 @@ impl NvidiaSwitchNd5200Ld<'_> {
                         id: erot_chassis_id.into(),
                         chassis_type: "Component".into(),
                         manufacturer: Some("NVIDIA".into()),
-                        part_number: None,
-                        model: None,
                         serial_number: Some(format!("0xFEEEEEEE{n:04X}").into()),
-                        network_adapters: None,
-                        pcie_devices: None,
-                        sensors: None,
-                        assembly: None,
-                        oem: None,
+                        ..redfish::chassis::SingleChassisConfig::defaults()
                     }
                 }),
             )
@@ -180,8 +167,8 @@ impl NvidiaSwitchNd5200Ld<'_> {
                         },
                     )),
                     assembly: None,
-                    oem: None,
                     id: chassis_id.into(),
+                    ..redfish::chassis::SingleChassisConfig::defaults()
                 }
             }))
             .collect(),

--- a/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
+++ b/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
@@ -158,12 +158,9 @@ impl WiwynnGB200Nvl<'_> {
                 manufacturer: nic.manufacturer,
                 part_number: nic.part_number,
                 model: Some("GB200 NVL".into()),
-                serial_number: None,
                 network_adapters,
                 pcie_devices: Some(vec![]),
-                sensors: None,
-                assembly: None,
-                oem: None,
+                ..redfish::chassis::SingleChassisConfig::defaults()
             }
         };
         redfish::chassis::ChassisConfig {
@@ -173,12 +170,8 @@ impl WiwynnGB200Nvl<'_> {
                 manufacturer: Some("WIWYNN".into()),
                 part_number: Some("B81.11810.0005".into()),
                 model: Some("GB200 NVL".into()),
-                serial_number: None,
-                network_adapters: None,
                 pcie_devices: Some(vec![]),
-                sensors: None,
-                assembly: None,
-                oem: None,
+                ..redfish::chassis::SingleChassisConfig::defaults()
             })
             .chain(std::iter::once(redfish::chassis::SingleChassisConfig {
                 id: "Chassis_0".into(),
@@ -186,9 +179,6 @@ impl WiwynnGB200Nvl<'_> {
                 manufacturer: Some("NVIDIA".into()),
                 part_number: Some("B81.11810.000D".into()),
                 model: Some("GB200 NVL".into()),
-                serial_number: None,
-                network_adapters: None,
-                pcie_devices: None,
                 sensors: Some(redfish::sensor::generate_chassis_sensors(
                     "Chassis_0",
                     Self::sensor_layout(),
@@ -202,7 +192,7 @@ impl WiwynnGB200Nvl<'_> {
                         )
                         .build(),
                 ),
-                oem: None,
+                ..redfish::chassis::SingleChassisConfig::defaults()
             }))
             .chain((0..4).map(|index| {
                 hw::nvidia_gbx00::cbc_chassis(format!("CBC_{index}").into(), &self.topology)

--- a/crates/bmc-mock/src/redfish/chassis.rs
+++ b/crates/bmc-mock/src/redfish/chassis.rs
@@ -59,6 +59,7 @@ pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
     const NET_FUNC_ID: &str = "{function_id}";
     const PCIE_DEVICE_ID: &str = "{pcie_device_id}";
     const SENSOR_ID: &str = "{sensor_id}";
+    const POWER_SUPPLY_ID: &str = "{power_supply_id}";
     r.route(&collection().odata_id, get(get_chassis_collection))
         .route(&resource(CHASSIS_ID).odata_id, get(get_chassis))
         .route(
@@ -103,6 +104,18 @@ pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
             &redfish::assembly::chassis_resource(CHASSIS_ID).odata_id,
             get(get_chassis_assembly),
         )
+        .route(
+            &redfish::power_subsystem::resource(CHASSIS_ID).odata_id,
+            get(get_chassis_power_subsystem),
+        )
+        .route(
+            &redfish::power_supply::collection(CHASSIS_ID).odata_id,
+            get(get_chassis_power_supply_collection),
+        )
+        .route(
+            &redfish::power_supply::resource(CHASSIS_ID, POWER_SUPPLY_ID).odata_id,
+            get(get_chassis_power_supply),
+        )
 }
 
 pub struct SingleChassisConfig {
@@ -116,7 +129,29 @@ pub struct SingleChassisConfig {
     pub sensors: Option<Vec<redfish::sensor::Sensor>>,
     pub chassis_type: Cow<'static, str>,
     pub assembly: Option<serde_json::Value>,
+    pub power_supplies: Option<Vec<redfish::power_supply::PowerSupply>>,
     pub oem: Option<serde_json::Value>,
+}
+
+impl SingleChassisConfig {
+    // To use with ..SingleChassisConfig::defaults() to fill config
+    // with defaults.
+    pub fn defaults() -> SingleChassisConfig {
+        Self {
+            id: "".into(),
+            chassis_type: "".into(),
+            serial_number: None,
+            manufacturer: None,
+            model: None,
+            part_number: None,
+            network_adapters: None,
+            pcie_devices: None,
+            sensors: None,
+            assembly: None,
+            power_supplies: None,
+            oem: None,
+        }
+    }
 }
 
 pub struct ChassisConfig {
@@ -182,6 +217,13 @@ impl SingleChassisState {
             .as_ref()
             .and_then(|sensors| sensors.iter().find(|sensor| sensor.id.as_ref() == id))
     }
+
+    fn find_power_supply(&self, id: &str) -> Option<&redfish::power_supply::PowerSupply> {
+        self.config
+            .power_supplies
+            .as_ref()
+            .and_then(|v| v.iter().find(|v| v.id == id))
+    }
 }
 
 async fn get_chassis_collection(State(state): State<BmcState>) -> Response {
@@ -219,6 +261,11 @@ async fn get_chassis(State(state): State<BmcState>, Path(chassis_id): Path<Strin
         .is_some()
         .then_some(redfish::assembly::chassis_resource(&chassis_id));
 
+    let power_subsystem = config
+        .power_supplies
+        .is_some()
+        .then_some(redfish::power_subsystem::resource(&chassis_id));
+
     let mut b = builder(&resource(&chassis_id))
         .chassis_type(&config.chassis_type)
         .maybe_with(ChassisBuilder::assembly, &assembly)
@@ -228,6 +275,7 @@ async fn get_chassis(State(state): State<BmcState>, Path(chassis_id): Path<Strin
         .maybe_with(ChassisBuilder::serial_number, &config.serial_number)
         .maybe_with(ChassisBuilder::manufacturer, &config.manufacturer)
         .maybe_with(ChassisBuilder::part_number, &config.part_number)
+        .maybe_with(ChassisBuilder::power_subsystem, &power_subsystem)
         .maybe_with(ChassisBuilder::model, &config.model);
 
     if let Some(oem) = &config.oem {
@@ -408,6 +456,59 @@ async fn get_chassis_assembly(
         .unwrap_or_else(http::not_found)
 }
 
+async fn get_chassis_power_subsystem(
+    State(state): State<BmcState>,
+    Path(chassis_id): Path<String>,
+) -> Response {
+    state
+        .chassis_state
+        .find(&chassis_id)
+        .and_then(|chassis_state| {
+            chassis_state.config.power_supplies.as_ref().map(|_| {
+                redfish::power_subsystem::builder(&redfish::power_subsystem::resource(&chassis_id))
+                    .power_supplies(redfish::power_supply::collection(&chassis_id))
+                    .build()
+            })
+        })
+        .map(|power_subsystem| power_subsystem.into_ok_response())
+        .unwrap_or_else(http::not_found)
+}
+
+async fn get_chassis_power_supply_collection(
+    State(state): State<BmcState>,
+    Path(chassis_id): Path<String>,
+) -> Response {
+    state
+        .chassis_state
+        .find(&chassis_id)
+        .and_then(|chassis_state| chassis_state.config.power_supplies.as_ref())
+        .map(|power_supplies| {
+            power_supplies
+                .iter()
+                .map(|ps| redfish::power_supply::resource(&chassis_id, &ps.id).entity_ref())
+                .collect::<Vec<_>>()
+        })
+        .map(|members| {
+            redfish::power_supply::collection(&chassis_id)
+                .with_members(&members)
+                .into_ok_response()
+        })
+        .unwrap_or_else(http::not_found)
+}
+
+async fn get_chassis_power_supply(
+    State(state): State<BmcState>,
+    Path((chassis_id, power_supply_id)): Path<(String, String)>,
+) -> Response {
+    let Some(chassis_state) = state.chassis_state.find(&chassis_id) else {
+        return http::not_found();
+    };
+    chassis_state
+        .find_power_supply(&power_supply_id)
+        .map(|v| v.to_json().into_ok_response())
+        .unwrap_or_else(http::not_found)
+}
+
 pub struct ChassisBuilder {
     value: serde_json::Value,
 }
@@ -455,6 +556,10 @@ impl ChassisBuilder {
 
     pub fn sensors(self, v: &redfish::Collection<'_>) -> Self {
         self.apply_patch(v.nav_property("Sensors"))
+    }
+
+    pub fn power_subsystem(self, v: &redfish::Resource<'_>) -> Self {
+        self.apply_patch(v.nav_property("PowerSubsystem"))
     }
 
     pub fn oem(self, v: &serde_json::Value) -> Self {

--- a/crates/bmc-mock/src/redfish/mod.rs
+++ b/crates/bmc-mock/src/redfish/mod.rs
@@ -31,6 +31,8 @@ pub mod network_adapter;
 pub mod network_device_function;
 pub mod oem;
 pub mod pcie_device;
+pub mod power_subsystem;
+pub mod power_supply;
 pub mod resource;
 pub mod secure_boot;
 pub mod sensor;

--- a/crates/bmc-mock/src/redfish/power_subsystem.rs
+++ b/crates/bmc-mock/src/redfish/power_subsystem.rs
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+
+use crate::json::{JsonExt, JsonPatch};
+use crate::redfish;
+use crate::redfish::Builder;
+
+pub fn resource(chassis_id: &str) -> redfish::Resource<'static> {
+    let odata_id = format!(
+        "{}/PowerSubsystem",
+        redfish::chassis::resource(chassis_id).odata_id
+    );
+    redfish::Resource {
+        odata_id: Cow::Owned(odata_id),
+        odata_type: Cow::Borrowed("#PowerSubsystem.v1_1_3.PowerSubsystem"),
+        id: Cow::Borrowed("PowerSubsystem"),
+        name: Cow::Borrowed("Power Subsystem"),
+    }
+}
+
+pub fn builder(resource: &redfish::Resource) -> PowerSubsystemBuilder {
+    PowerSubsystemBuilder {
+        value: resource.json_patch(),
+    }
+}
+
+pub struct PowerSubsystemBuilder {
+    value: serde_json::Value,
+}
+
+impl Builder for PowerSubsystemBuilder {
+    fn apply_patch(self, patch: serde_json::Value) -> Self {
+        Self {
+            value: self.value.patch(patch),
+        }
+    }
+}
+
+impl PowerSubsystemBuilder {
+    pub fn power_supplies(self, v: redfish::Collection) -> Self {
+        self.apply_patch(v.nav_property("PowerSupplies"))
+    }
+
+    pub fn build(self) -> serde_json::Value {
+        self.value
+    }
+}

--- a/crates/bmc-mock/src/redfish/power_supply.rs
+++ b/crates/bmc-mock/src/redfish/power_supply.rs
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+
+use serde_json::json;
+
+use crate::json::{JsonExt, JsonPatch};
+use crate::redfish;
+use crate::redfish::Builder;
+
+pub fn resource<'a>(chassis_id: &str, supply_id: &'a str) -> redfish::Resource<'a> {
+    let odata_id = format!(
+        "{}/PowerSubsystem/PowerSupplies/{supply_id}",
+        redfish::chassis::resource(chassis_id).odata_id
+    );
+    redfish::Resource {
+        odata_id: Cow::Owned(odata_id),
+        odata_type: Cow::Borrowed("#PowerSupply.v1_5_0.PowerSupply"),
+        id: Cow::Borrowed(supply_id),
+        name: Cow::Borrowed("Power Supply"),
+    }
+}
+
+pub fn collection(chassis_id: &str) -> redfish::Collection<'static> {
+    let odata_id = format!(
+        "{}/PowerSubsystem/PowerSupplies",
+        redfish::chassis::resource(chassis_id).odata_id
+    );
+    redfish::Collection {
+        odata_id: Cow::Owned(odata_id),
+        odata_type: Cow::Borrowed("#PowerSupplyCollection.PowerSupplyCollection"),
+        name: Cow::Borrowed("Power Supply"),
+    }
+}
+
+pub struct PowerSupply {
+    pub id: Cow<'static, str>,
+    value: serde_json::Value,
+}
+
+impl PowerSupply {
+    pub fn to_json(&self) -> serde_json::Value {
+        self.value.clone()
+    }
+}
+
+pub fn builder(resource: &redfish::Resource) -> PowerSupplyBuilder {
+    PowerSupplyBuilder {
+        id: Cow::Owned(resource.id.to_string()),
+        value: resource.json_patch(),
+    }
+}
+
+pub struct PowerSupplyBuilder {
+    id: Cow<'static, str>,
+    value: serde_json::Value,
+}
+
+impl Builder for PowerSupplyBuilder {
+    fn apply_patch(self, patch: serde_json::Value) -> Self {
+        Self {
+            value: self.value.patch(patch),
+            id: self.id,
+        }
+    }
+}
+
+impl PowerSupplyBuilder {
+    pub fn oem_liteon_power_state(self, v: bool) -> Self {
+        self.apply_patch(json!({"PowerState": v}))
+    }
+
+    pub fn status(self, status: redfish::resource::Status) -> Self {
+        self.apply_patch(json!({
+            "Status": status.into_json()
+        }))
+    }
+
+    pub fn build(self) -> PowerSupply {
+        PowerSupply {
+            id: self.id,
+            value: self.value,
+        }
+    }
+}


### PR DESCRIPTION
## Description

Add PowerSubsystem and PowerSupply mock builders with routing, used by LiteOn powershelf (6 PSUs with OEM PowerState field).

Introduce SingleChassisConfig::defaults() and replace explicit None assignments across all hardware configs with struct update syntax.

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes


