### PR TITLE
feat: add health management APIs + admin-cli management for switches

### DIFF
--- a/crates/admin-cli/src/dpu/reprovision/cmd.rs
+++ b/crates/admin-cli/src/dpu/reprovision/cmd.rs
@@ -90,7 +90,7 @@ async fn apply_health_override(
 
         if let Some(host_machine) = host_machine
             && host_machine
-                .health_overrides
+                .health_sources
                 .iter()
                 .any(|or| or.source == "host-update")
         {

--- a/crates/admin-cli/src/health_utils.rs
+++ b/crates/admin-cli/src/health_utils.rs
@@ -1,0 +1,94 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::forge::{self as forgerpc};
+use prettytable::{Table, row};
+
+use crate::machine::health_override::cmd::get_empty_template;
+use crate::machine::{HealthOverrideTemplates, get_health_report};
+
+/// Display a list of health report overrides.
+pub fn display_overrides(
+    overrides: Vec<forgerpc::HealthReportOverride>,
+    output_format: OutputFormat,
+) -> CarbideCliResult<()> {
+    let mut rows = vec![];
+    for r#override in overrides {
+        let report = r#override.report.ok_or(CarbideCliError::GenericError(
+            "missing response".to_string(),
+        ))?;
+        let mode = match forgerpc::OverrideMode::try_from(r#override.mode)
+            .map_err(|_| CarbideCliError::GenericError("invalide response".to_string()))?
+        {
+            forgerpc::OverrideMode::Merge => "Merge",
+            forgerpc::OverrideMode::Replace => "Replace",
+        };
+        rows.push((report, mode));
+    }
+    match output_format {
+        OutputFormat::Json => println!(
+            "{}",
+            serde_json::to_string_pretty(
+                &rows
+                    .into_iter()
+                    .map(|r| {
+                        serde_json::json!({
+                            "report": r.0,
+                            "mode": r.1,
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+            )?
+        ),
+        _ => {
+            let mut table = Table::new();
+            table.set_titles(row!["Report", "Mode"]);
+            for row in rows {
+                table.add_row(row![serde_json::to_string(&row.0)?, row.1]);
+            }
+            table.printstd();
+        }
+    }
+    Ok(())
+}
+
+/// Resolve a health report from either a template or raw JSON.
+pub fn resolve_health_report(
+    template: Option<HealthOverrideTemplates>,
+    health_report_json: Option<String>,
+    message: Option<String>,
+) -> CarbideCliResult<health_report::HealthReport> {
+    if let Some(template) = template {
+        Ok(get_health_report(template, message))
+    } else if let Some(json) = health_report_json {
+        serde_json::from_str::<health_report::HealthReport>(&json)
+            .map_err(CarbideCliError::JsonError)
+    } else {
+        Err(CarbideCliError::GenericError(
+            "Either health_report or template name must be provided.".to_string(),
+        ))
+    }
+}
+
+/// Print the empty health override template.
+pub fn print_empty_template() {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&get_empty_template()).unwrap()
+    );
+}

--- a/crates/admin-cli/src/host/reprovision/cmd.rs
+++ b/crates/admin-cli/src/host/reprovision/cmd.rs
@@ -40,7 +40,7 @@ pub async fn trigger_reprovisioning_set(
 
         if let Some(host_machine) = host_machine
             && host_machine
-                .health_overrides
+                .health_sources
                 .iter()
                 .any(|or| or.source == "host-update")
         {

--- a/crates/admin-cli/src/machine/health_override/cmd.rs
+++ b/crates/admin-cli/src/machine/health_override/cmd.rs
@@ -17,18 +17,18 @@
 
 use std::str::FromStr;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
-use ::rpc::forge::{self as forgerpc, RemoveHealthReportOverrideRequest};
+use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use ::rpc::forge::RemoveHealthReportOverrideRequest;
 use chrono::Utc;
 use health_report::{
     HealthAlertClassification, HealthProbeAlert, HealthProbeId, HealthProbeSuccess, HealthReport,
 };
-use prettytable::{Table, row};
 
 use super::args::{Args, HealthOverrideTemplates};
+use crate::health_utils;
 use crate::rpc::ApiClient;
 
-fn get_empty_template() -> HealthReport {
+pub fn get_empty_template() -> HealthReport {
     HealthReport {
         source: "".to_string(),
         triggered_by: None,
@@ -160,55 +160,14 @@ pub async fn handle_override(
                 .0
                 .list_health_report_overrides(machine_id)
                 .await?;
-            let mut rows = vec![];
-            for r#override in response.overrides {
-                let report = r#override.report.ok_or(CarbideCliError::GenericError(
-                    "missing response".to_string(),
-                ))?;
-                let mode = match ::rpc::forge::OverrideMode::try_from(r#override.mode)
-                    .map_err(|_| CarbideCliError::GenericError("invalide response".to_string()))?
-                {
-                    forgerpc::OverrideMode::Merge => "Merge",
-                    forgerpc::OverrideMode::Replace => "Replace",
-                };
-                rows.push((report, mode));
-            }
-            match output_format {
-                OutputFormat::Json => println!(
-                    "{}",
-                    serde_json::to_string_pretty(
-                        &rows
-                            .into_iter()
-                            .map(|r| {
-                                serde_json::json!({
-                                    "report": r.0,
-                                    "mode": r.1,
-                                })
-                            })
-                            .collect::<Vec<_>>(),
-                    )?
-                ),
-                _ => {
-                    let mut table = Table::new();
-                    table.set_titles(row!["Report", "Mode"]);
-                    for row in rows {
-                        table.add_row(row![serde_json::to_string(&row.0)?, row.1]);
-                    }
-                    table.printstd();
-                }
-            }
+            health_utils::display_overrides(response.overrides, output_format)?;
         }
         Args::Add(options) => {
-            let report = if let Some(template) = options.template {
-                get_health_report(template, options.message)
-            } else if let Some(health_report) = options.health_report {
-                serde_json::from_str::<health_report::HealthReport>(&health_report)
-                    .map_err(CarbideCliError::JsonError)?
-            } else {
-                return Err(CarbideCliError::GenericError(
-                    "Either health_report or template name must be provided.".to_string(),
-                ));
-            };
+            let report = health_utils::resolve_health_report(
+                options.template,
+                options.health_report,
+                options.message,
+            )?;
 
             if options.print_only {
                 println!("{}", serde_json::to_string_pretty(&report).unwrap());
@@ -236,10 +195,7 @@ pub async fn handle_override(
                 .await?;
         }
         Args::PrintEmptyTemplate => {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&get_empty_template()).unwrap()
-            );
+            health_utils::print_empty_template();
         }
     }
 

--- a/crates/admin-cli/src/machine/mod.rs
+++ b/crates/admin-cli/src/machine/mod.rs
@@ -48,11 +48,12 @@ pub enum Cmd {
     #[clap(subcommand, about = "Networking information")]
     Network(network::Args),
     #[clap(
-        about = "Health override related handling",
+        about = "Manage health report sources",
         subcommand,
-        visible_alias = "ho"
+        visible_alias = "hr",
+        alias = "health-override"
     )]
-    HealthOverride(health_override::Args),
+    HealthReport(health_override::Args),
     #[clap(about = "Reboot a machine")]
     Reboot(reboot::Args),
     #[clap(about = "Force delete a machine")]

--- a/crates/admin-cli/src/machine/tests.rs
+++ b/crates/admin-cli/src/machine/tests.rs
@@ -138,7 +138,7 @@ fn parse_health_override_show() {
         .expect("should parse health-override show");
 
     match cmd {
-        Cmd::HealthOverride(OverrideCommand::Show { machine_id }) => {
+        Cmd::HealthReport(OverrideCommand::Show { machine_id }) => {
             assert_eq!(machine_id.to_string(), TEST_MACHINE_ID);
         }
         _ => panic!("expected HealthOverride Show variant"),
@@ -160,7 +160,7 @@ fn parse_health_override_add_with_template() {
     .expect("should parse health-override add with template");
 
     match cmd {
-        Cmd::HealthOverride(OverrideCommand::Add(args)) => {
+        Cmd::HealthReport(OverrideCommand::Add(args)) => {
             assert!(args.template.is_some());
             assert!(args.health_report.is_none());
         }

--- a/crates/admin-cli/src/main.rs
+++ b/crates/admin-cli/src/main.rs
@@ -56,6 +56,7 @@ mod expected_switch;
 mod extension_service;
 mod firmware;
 mod generate_shell_complete;
+mod health_utils;
 mod host;
 mod ib_partition;
 mod instance;

--- a/crates/admin-cli/src/switch/health_report/add/args.rs
+++ b/crates/admin-cli/src/switch/health_report/add/args.rs
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::switch::SwitchId;
+use clap::{ArgGroup, Parser};
+
+use crate::machine::HealthOverrideTemplates;
+
+#[derive(Parser, Debug)]
+#[clap(group(ArgGroup::new("override_health").required(true).args(&["health_report", "template"])))]
+pub struct Args {
+    pub switch_id: SwitchId,
+    #[clap(long, help = "New health report as json")]
+    pub health_report: Option<String>,
+    #[clap(long, help = "Predefined Template name")]
+    pub template: Option<HealthOverrideTemplates>,
+    #[clap(long, help = "Message to be filled in template.")]
+    pub message: Option<String>,
+    #[clap(long, help = "Replace all other health reports with this override")]
+    pub replace: bool,
+    #[clap(long, help = "Print the template that is going to be send to carbide")]
+    pub print_only: bool,
+}

--- a/crates/admin-cli/src/switch/health_report/add/cmd.rs
+++ b/crates/admin-cli/src/switch/health_report/add/cmd.rs
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::CarbideCliResult;
+use ::rpc::forge::{self as rpc, InsertSwitchHealthReportRequest};
+
+use super::args::Args;
+use crate::health_utils;
+use crate::rpc::ApiClient;
+
+pub async fn add(api_client: &ApiClient, args: Args) -> CarbideCliResult<()> {
+    let report =
+        health_utils::resolve_health_report(args.template, args.health_report, args.message)?;
+
+    if args.print_only {
+        println!("{}", serde_json::to_string_pretty(&report).unwrap());
+        return Ok(());
+    }
+
+    let request = InsertSwitchHealthReportRequest {
+        switch_id: Some(args.switch_id),
+        r#override: Some(rpc::HealthReportOverride {
+            report: Some(report.into()),
+            mode: if args.replace {
+                rpc::OverrideMode::Replace
+            } else {
+                rpc::OverrideMode::Merge
+            } as i32,
+        }),
+    };
+    api_client.0.insert_switch_health_report(request).await?;
+
+    Ok(())
+}

--- a/crates/admin-cli/src/switch/health_report/add/mod.rs
+++ b/crates/admin-cli/src/switch/health_report/add/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::add(&ctx.api_client, self).await
+    }
+}

--- a/crates/admin-cli/src/switch/health_report/args.rs
+++ b/crates/admin-cli/src/switch/health_report/args.rs
@@ -15,34 +15,19 @@
  * limitations under the License.
  */
 
-mod force_delete;
-pub mod health_report;
-mod list;
-pub mod metadata;
-mod show;
-
-#[cfg(test)]
-mod tests;
-
 use clap::Parser;
 
+use super::{add, print_empty_template, remove, show};
 use crate::cfg::dispatch::Dispatch;
 
 #[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Show switch information")]
+pub enum Args {
+    #[clap(about = "List health report sources for a switch")]
     Show(show::Args),
-    #[clap(about = "List all switches")]
-    List(list::Args),
-    #[clap(about = "Force delete a switch and optionally its interfaces")]
-    ForceDelete(force_delete::Args),
-    #[clap(subcommand, about = "Manage Switch Metadata")]
-    Metadata(metadata::Args),
-    #[dispatch]
-    #[clap(
-        about = "Manage health report sources",
-        subcommand,
-        visible_alias = "hr"
-    )]
-    HealthReport(health_report::Args),
+    #[clap(about = "Insert a health report source for a switch")]
+    Add(add::Args),
+    #[clap(about = "Print an empty health report template")]
+    PrintEmptyTemplate(print_empty_template::Args),
+    #[clap(about = "Remove a health report source from a switch")]
+    Remove(remove::Args),
 }

--- a/crates/admin-cli/src/switch/health_report/mod.rs
+++ b/crates/admin-cli/src/switch/health_report/mod.rs
@@ -15,34 +15,10 @@
  * limitations under the License.
  */
 
-mod force_delete;
-pub mod health_report;
-mod list;
-pub mod metadata;
+mod add;
+pub mod args;
+mod print_empty_template;
+mod remove;
 mod show;
 
-#[cfg(test)]
-mod tests;
-
-use clap::Parser;
-
-use crate::cfg::dispatch::Dispatch;
-
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Show switch information")]
-    Show(show::Args),
-    #[clap(about = "List all switches")]
-    List(list::Args),
-    #[clap(about = "Force delete a switch and optionally its interfaces")]
-    ForceDelete(force_delete::Args),
-    #[clap(subcommand, about = "Manage Switch Metadata")]
-    Metadata(metadata::Args),
-    #[dispatch]
-    #[clap(
-        about = "Manage health report sources",
-        subcommand,
-        visible_alias = "hr"
-    )]
-    HealthReport(health_report::Args),
-}
+pub use args::Args;

--- a/crates/admin-cli/src/switch/health_report/print_empty_template/args.rs
+++ b/crates/admin-cli/src/switch/health_report/print_empty_template/args.rs
@@ -15,34 +15,7 @@
  * limitations under the License.
  */
 
-mod force_delete;
-pub mod health_report;
-mod list;
-pub mod metadata;
-mod show;
-
-#[cfg(test)]
-mod tests;
-
 use clap::Parser;
 
-use crate::cfg::dispatch::Dispatch;
-
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Show switch information")]
-    Show(show::Args),
-    #[clap(about = "List all switches")]
-    List(list::Args),
-    #[clap(about = "Force delete a switch and optionally its interfaces")]
-    ForceDelete(force_delete::Args),
-    #[clap(subcommand, about = "Manage Switch Metadata")]
-    Metadata(metadata::Args),
-    #[dispatch]
-    #[clap(
-        about = "Manage health report sources",
-        subcommand,
-        visible_alias = "hr"
-    )]
-    HealthReport(health_report::Args),
-}
+#[derive(Parser, Debug)]
+pub struct Args;

--- a/crates/admin-cli/src/switch/health_report/print_empty_template/cmd.rs
+++ b/crates/admin-cli/src/switch/health_report/print_empty_template/cmd.rs
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::health_utils;
+
+pub fn print_empty_template() {
+    health_utils::print_empty_template();
+}

--- a/crates/admin-cli/src/switch/health_report/print_empty_template/mod.rs
+++ b/crates/admin-cli/src/switch/health_report/print_empty_template/mod.rs
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, _ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::print_empty_template();
+        Ok(())
+    }
+}

--- a/crates/admin-cli/src/switch/health_report/remove/args.rs
+++ b/crates/admin-cli/src/switch/health_report/remove/args.rs
@@ -15,34 +15,11 @@
  * limitations under the License.
  */
 
-mod force_delete;
-pub mod health_report;
-mod list;
-pub mod metadata;
-mod show;
-
-#[cfg(test)]
-mod tests;
-
+use carbide_uuid::switch::SwitchId;
 use clap::Parser;
 
-use crate::cfg::dispatch::Dispatch;
-
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Show switch information")]
-    Show(show::Args),
-    #[clap(about = "List all switches")]
-    List(list::Args),
-    #[clap(about = "Force delete a switch and optionally its interfaces")]
-    ForceDelete(force_delete::Args),
-    #[clap(subcommand, about = "Manage Switch Metadata")]
-    Metadata(metadata::Args),
-    #[dispatch]
-    #[clap(
-        about = "Manage health report sources",
-        subcommand,
-        visible_alias = "hr"
-    )]
-    HealthReport(health_report::Args),
+#[derive(Parser, Debug)]
+pub struct Args {
+    pub switch_id: SwitchId,
+    pub report_source: String,
 }

--- a/crates/admin-cli/src/switch/health_report/remove/cmd.rs
+++ b/crates/admin-cli/src/switch/health_report/remove/cmd.rs
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::CarbideCliResult;
+use ::rpc::forge::RemoveSwitchHealthReportRequest;
+
+use super::args::Args;
+use crate::rpc::ApiClient;
+
+pub async fn remove(api_client: &ApiClient, args: Args) -> CarbideCliResult<()> {
+    api_client
+        .0
+        .remove_switch_health_report(RemoveSwitchHealthReportRequest {
+            switch_id: Some(args.switch_id),
+            source: args.report_source,
+        })
+        .await?;
+
+    Ok(())
+}

--- a/crates/admin-cli/src/switch/health_report/remove/mod.rs
+++ b/crates/admin-cli/src/switch/health_report/remove/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::remove(&ctx.api_client, self).await
+    }
+}

--- a/crates/admin-cli/src/switch/health_report/show/args.rs
+++ b/crates/admin-cli/src/switch/health_report/show/args.rs
@@ -15,34 +15,11 @@
  * limitations under the License.
  */
 
-mod force_delete;
-pub mod health_report;
-mod list;
-pub mod metadata;
-mod show;
-
-#[cfg(test)]
-mod tests;
-
+use carbide_uuid::switch::SwitchId;
 use clap::Parser;
 
-use crate::cfg::dispatch::Dispatch;
-
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Show switch information")]
-    Show(show::Args),
-    #[clap(about = "List all switches")]
-    List(list::Args),
-    #[clap(about = "Force delete a switch and optionally its interfaces")]
-    ForceDelete(force_delete::Args),
-    #[clap(subcommand, about = "Manage Switch Metadata")]
-    Metadata(metadata::Args),
-    #[dispatch]
-    #[clap(
-        about = "Manage health report sources",
-        subcommand,
-        visible_alias = "hr"
-    )]
-    HealthReport(health_report::Args),
+#[derive(Parser, Debug)]
+pub struct Args {
+    #[clap(help = "Switch ID to show health reports for")]
+    pub switch_id: SwitchId,
 }

--- a/crates/admin-cli/src/switch/health_report/show/cmd.rs
+++ b/crates/admin-cli/src/switch/health_report/show/cmd.rs
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+
+use super::args::Args;
+use crate::health_utils;
+use crate::rpc::ApiClient;
+
+pub async fn show(
+    api_client: &ApiClient,
+    args: Args,
+    format: OutputFormat,
+) -> CarbideCliResult<()> {
+    let response = api_client
+        .0
+        .list_switch_health_reports(args.switch_id)
+        .await?;
+    health_utils::display_overrides(response.overrides, format)?;
+    Ok(())
+}

--- a/crates/admin-cli/src/switch/health_report/show/mod.rs
+++ b/crates/admin-cli/src/switch/health_report/show/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::show(&ctx.api_client, self, ctx.config.format).await
+    }
+}

--- a/crates/api-db/migrations/20260415235755_switch_health_report_overrides.sql
+++ b/crates/api-db/migrations/20260415235755_switch_health_report_overrides.sql
@@ -1,0 +1,1 @@
+ALTER TABLE switches ADD COLUMN health_report_overrides jsonb;

--- a/crates/api-db/src/dpu_machine_update.rs
+++ b/crates/api-db/src/dpu_machine_update.rs
@@ -129,7 +129,7 @@ pub async fn get_updated_machines(
             // Skip looking at any machines that are not marked for updates
             if !managed_host
                 .host_snapshot
-                .health_report_overrides
+                .health_report_sources
                 .merges
                 .get(HOST_UPDATE_HEALTH_REPORT_SOURCE)
                 .is_some_and(|updater_report| {

--- a/crates/api-db/src/health_report.rs
+++ b/crates/api-db/src/health_report.rs
@@ -1,0 +1,98 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use health_report::{HealthReport, OverrideMode};
+use sqlx::PgConnection;
+
+use crate::DatabaseError;
+
+/// Insert a health report override into the `health_report_overrides`
+/// JSONB column of the given table (we're maintaining the "overrides" table
+/// name so we can leave machines/racks as is for now, and let switches
+/// and power shelves adopt it).
+///
+/// The `id` parameter is bound as `$2` and must match the `id`
+/// column of `table_name`.
+pub async fn insert_health_report<Id>(
+    txn: &mut PgConnection,
+    table_name: &str,
+    id: &Id,
+    mode: OverrideMode,
+    health_report: &HealthReport,
+) -> Result<(), DatabaseError>
+where
+    for<'e> Id: sqlx::Encode<'e, sqlx::Postgres> + sqlx::Type<sqlx::Postgres> + Sync,
+{
+    let column_name = "health_report_overrides";
+    let path = match mode {
+        OverrideMode::Merge => format!("merges,\"{}\"", health_report.source),
+        OverrideMode::Replace => "replace".to_string(),
+    };
+
+    let query = format!(
+        "UPDATE {table_name} SET {column_name} = jsonb_set(
+            coalesce({column_name}, '{{\"merges\": {{}}}}'::jsonb),
+            '{{{path}}}',
+            $1::jsonb
+        ) WHERE id = $2
+        RETURNING id"
+    );
+
+    sqlx::query(&query)
+        .bind(sqlx::types::Json(health_report))
+        .bind(id)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| {
+            DatabaseError::new(&format!("insert {table_name} health report override"), e)
+        })?;
+
+    Ok(())
+}
+
+/// Remove a health report override from the `health_report_overrides`
+/// JSONB column of the given table.
+pub async fn remove_health_report<Id>(
+    txn: &mut PgConnection,
+    table_name: &str,
+    id: &Id,
+    mode: OverrideMode,
+    source: &str,
+) -> Result<(), DatabaseError>
+where
+    for<'e> Id: sqlx::Encode<'e, sqlx::Postgres> + sqlx::Type<sqlx::Postgres> + Sync,
+{
+    let column_name = "health_report_overrides";
+    let path = match mode {
+        OverrideMode::Merge => format!("merges,{source}"),
+        OverrideMode::Replace => "replace".to_string(),
+    };
+    let query = format!(
+        "UPDATE {table_name} SET {column_name} = ({column_name} #- '{{{path}}}') WHERE id = $1
+            RETURNING id"
+    );
+
+    sqlx::query(&query)
+        .bind(id)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| {
+            DatabaseError::new(&format!("remove {table_name} health report override"), e)
+        })?;
+
+    Ok(())
+}

--- a/crates/api-db/src/lib.rs
+++ b/crates/api-db/src/lib.rs
@@ -41,6 +41,7 @@ pub mod explored_endpoints;
 pub mod explored_managed_host;
 pub mod extension_service;
 pub mod health_history;
+pub mod health_report;
 pub mod host_machine_update;
 pub mod ib_partition;
 pub mod instance;

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -959,14 +959,18 @@ pub async fn insert_health_report_override(
     health_report: &HealthReport,
     no_overwrite: bool,
 ) -> Result<(), DatabaseError> {
-    let column_name = "health_report_overrides";
-    let path = match mode {
-        OverrideMode::Merge => format!("merges,\"{}\"", health_report.source),
-        OverrideMode::Replace => "replace".to_string(),
-    };
+    if no_overwrite {
+        // TODO(chet): This appears to be a machine-specific thing -- skip insert
+        // if a merge with the same source already exists -- but I'm not sure what
+        // it's used for, since others seem to do a remove + insert. Do we need
+        // to support this still? Might be nice to explain it somewhere.
+        let column_name = "health_report_overrides";
+        let path = match mode {
+            OverrideMode::Merge => format!("merges,\"{}\"", health_report.source),
+            OverrideMode::Replace => "replace".to_string(),
+        };
 
-    let query = if no_overwrite {
-        format!(
+        let query = format!(
             "UPDATE machines SET {column_name} = jsonb_set(
                 coalesce({column_name}, '{{\"merges\": {{}}}}'::jsonb),
                 '{{{}}}',
@@ -975,26 +979,20 @@ pub async fn insert_health_report_override(
             AND coalesce({column_name}, '{{\"merges\": {{}}}}'::jsonb)->'merges' ? '{}' = FALSE
             RETURNING id",
             path, health_report.source
-        )
+        );
+
+        let _id: (MachineId,) = sqlx::query_as(&query)
+            .bind(sqlx::types::Json(&health_report))
+            .bind(machine_id)
+            .fetch_one(txn)
+            .await
+            .map_err(|e| DatabaseError::new("insert health report override", e))?;
+
+        Ok(())
     } else {
-        format!(
-            "UPDATE machines SET {column_name} = jsonb_set(
-                coalesce({column_name}, '{{\"merges\": {{}}}}'::jsonb),
-                '{{{path}}}',
-                $1::jsonb
-            ) WHERE id = $2
-            RETURNING id"
-        )
-    };
-
-    let _id: (MachineId,) = sqlx::query_as(&query)
-        .bind(sqlx::types::Json(&health_report))
-        .bind(machine_id)
-        .fetch_one(txn)
-        .await
-        .map_err(|e| DatabaseError::new("insert health report override", e))?;
-
-    Ok(())
+        crate::health_report::insert_health_report(txn, "machines", machine_id, mode, health_report)
+            .await
+    }
 }
 
 pub async fn remove_health_report_override(
@@ -1003,23 +1001,7 @@ pub async fn remove_health_report_override(
     mode: OverrideMode,
     source: &str,
 ) -> Result<(), DatabaseError> {
-    let column_name = "health_report_overrides";
-    let path = match mode {
-        OverrideMode::Merge => format!("merges,{source}"),
-        OverrideMode::Replace => "replace".to_string(),
-    };
-    let query = format!(
-        "UPDATE machines SET {column_name} = ({column_name} #- '{{{path}}}') WHERE id = $1
-            RETURNING id"
-    );
-
-    let _id: (MachineId,) = sqlx::query_as(&query)
-        .bind(machine_id)
-        .fetch_one(txn)
-        .await
-        .map_err(|e| DatabaseError::new("remove health report override", e))?;
-
-    Ok(())
+    crate::health_report::remove_health_report(txn, "machines", machine_id, mode, source).await
 }
 
 pub async fn update_agent_reported_inventory(

--- a/crates/api-db/src/rack.rs
+++ b/crates/api-db/src/rack.rs
@@ -200,29 +200,7 @@ pub async fn insert_health_report_override(
     mode: OverrideMode,
     health_report: &HealthReport,
 ) -> Result<(), DatabaseError> {
-    let column_name = "health_report_overrides";
-    let path = match mode {
-        OverrideMode::Merge => format!("merges,\"{}\"", health_report.source),
-        OverrideMode::Replace => "replace".to_string(),
-    };
-
-    let query = format!(
-        "UPDATE racks SET {column_name} = jsonb_set(
-            coalesce({column_name}, '{{\"merges\": {{}}}}'::jsonb),
-            '{{{path}}}',
-            $1::jsonb
-        ) WHERE id = $2
-        RETURNING id"
-    );
-
-    let _id: (RackId,) = sqlx::query_as(&query)
-        .bind(sqlx::types::Json(health_report))
-        .bind(rack_id)
-        .fetch_one(txn)
-        .await
-        .map_err(|e| DatabaseError::new("insert rack health report override", e))?;
-
-    Ok(())
+    crate::health_report::insert_health_report(txn, "racks", rack_id, mode, health_report).await
 }
 
 pub async fn remove_health_report_override(
@@ -231,23 +209,7 @@ pub async fn remove_health_report_override(
     mode: OverrideMode,
     source: &str,
 ) -> Result<(), DatabaseError> {
-    let column_name = "health_report_overrides";
-    let path = match mode {
-        OverrideMode::Merge => format!("merges,{source}"),
-        OverrideMode::Replace => "replace".to_string(),
-    };
-    let query = format!(
-        "UPDATE racks SET {column_name} = ({column_name} #- '{{{path}}}') WHERE id = $1
-            RETURNING id"
-    );
-
-    let _id: (RackId,) = sqlx::query_as(&query)
-        .bind(rack_id)
-        .fetch_one(txn)
-        .await
-        .map_err(|e| DatabaseError::new("remove rack health report override", e))?;
-
-    Ok(())
+    crate::health_report::remove_health_report(txn, "racks", rack_id, mode, source).await
 }
 
 pub async fn update_metadata(

--- a/crates/api-db/src/switch.rs
+++ b/crates/api-db/src/switch.rs
@@ -21,6 +21,7 @@ use carbide_uuid::rack::RackId;
 use carbide_uuid::switch::SwitchId;
 use chrono::prelude::*;
 use config_version::{ConfigVersion, Versioned};
+use health_report::{HealthReport, OverrideMode};
 use model::controller_outcome::PersistentStateHandlerOutcome;
 use model::metadata::Metadata;
 use model::rack::RackFirmwareUpgradeStatus;
@@ -115,6 +116,7 @@ pub async fn create(txn: &mut PgConnection, new_switch: &NewSwitch) -> DatabaseR
         rack_id: new_switch.rack_id.clone(),
         slot_number: new_switch.slot_number,
         tray_index: new_switch.tray_index,
+        health_report_sources: Default::default(),
     })
 }
 
@@ -562,4 +564,23 @@ pub async fn find_rms_identities_by_macs(
         .fetch_all(db)
         .await
         .map_err(|err| DatabaseError::new("switch::find_rms_identities_by_macs", err))
+}
+
+pub async fn insert_health_report(
+    txn: &mut PgConnection,
+    switch_id: &SwitchId,
+    mode: OverrideMode,
+    health_report: &HealthReport,
+) -> Result<(), DatabaseError> {
+    crate::health_report::insert_health_report(txn, "switches", switch_id, mode, health_report)
+        .await
+}
+
+pub async fn remove_health_report(
+    txn: &mut PgConnection,
+    switch_id: &SwitchId,
+    mode: OverrideMode,
+    source: &str,
+) -> Result<(), DatabaseError> {
+    crate::health_report::remove_health_report(txn, "switches", switch_id, mode, source).await
 }

--- a/crates/api-model/src/health.rs
+++ b/crates/api-model/src/health.rs
@@ -15,7 +15,10 @@
  * limitations under the License.
  */
 
+use std::collections::BTreeMap;
+
 use chrono::{DateTime, Utc};
+use health_report::{HealthReport, OverrideMode};
 use serde::{Deserialize, Serialize};
 
 /// History of health for a single Object
@@ -28,11 +31,135 @@ pub struct HealthHistoryRecord {
     pub time: DateTime<Utc>,
 }
 
+/// A collection of externally-managed health report sources.
+///
+/// External systems and operators can submit health reports via the API. These are
+/// stored as a set of sources, each identified by the `HealthReport::source` field.
+/// A single `replace` source can be set to completely override all other health data,
+/// while multiple `merges` sources augment the existing health data.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct HealthReportSources {
+    /// A health report that replaces all other health data when set.
+    pub replace: Option<HealthReport>,
+    /// A map from the health report source identifier to the health report.
+    pub merges: BTreeMap<String, HealthReport>,
+}
+
+impl HealthReportSources {
+    #[allow(clippy::should_implement_trait)]
+    pub fn into_iter(self) -> impl Iterator<Item = (HealthReport, OverrideMode)> {
+        self.merges
+            .into_values()
+            .map(|r| (r, OverrideMode::Merge))
+            .chain(self.replace.map(|r| (r, OverrideMode::Replace)))
+    }
+}
+
 impl From<HealthHistoryRecord> for rpc::forge::HealthHistoryRecord {
     fn from(record: HealthHistoryRecord) -> rpc::forge::HealthHistoryRecord {
         rpc::forge::HealthHistoryRecord {
             health: Some(record.health.into()),
             time: Some(record.time.into()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn health_report_sources_default_is_empty() {
+        let sources = HealthReportSources::default();
+        assert!(sources.replace.is_none());
+        assert!(sources.merges.is_empty());
+        assert_eq!(sources.into_iter().count(), 0);
+    }
+
+    #[test]
+    fn health_report_sources_into_iter_merges_only() {
+        let mut sources = HealthReportSources::default();
+        sources.merges.insert(
+            "source-a".to_string(),
+            HealthReport::empty("source-a".to_string()),
+        );
+        sources.merges.insert(
+            "source-b".to_string(),
+            HealthReport::empty("source-b".to_string()),
+        );
+
+        let items: Vec<_> = sources.into_iter().collect();
+        assert_eq!(items.len(), 2);
+        assert!(items.iter().all(|(_, mode)| *mode == OverrideMode::Merge));
+    }
+
+    #[test]
+    fn health_report_sources_into_iter_replace_only() {
+        let sources = HealthReportSources {
+            replace: Some(HealthReport::empty("admin-replace".to_string())),
+            merges: BTreeMap::new(),
+        };
+
+        let items: Vec<_> = sources.into_iter().collect();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].0.source, "admin-replace");
+        assert_eq!(items[0].1, OverrideMode::Replace);
+    }
+
+    #[test]
+    fn health_report_sources_into_iter_mixed() {
+        let mut merges = BTreeMap::new();
+        merges.insert(
+            "external-monitor".to_string(),
+            HealthReport::empty("external-monitor".to_string()),
+        );
+
+        let sources = HealthReportSources {
+            replace: Some(HealthReport::empty("sre-override".to_string())),
+            merges,
+        };
+
+        let items: Vec<_> = sources.into_iter().collect();
+        assert_eq!(items.len(), 2);
+
+        let merge_items: Vec<_> = items
+            .iter()
+            .filter(|(_, mode)| *mode == OverrideMode::Merge)
+            .collect();
+        let replace_items: Vec<_> = items
+            .iter()
+            .filter(|(_, mode)| *mode == OverrideMode::Replace)
+            .collect();
+        assert_eq!(merge_items.len(), 1);
+        assert_eq!(replace_items.len(), 1);
+        assert_eq!(merge_items[0].0.source, "external-monitor");
+        assert_eq!(replace_items[0].0.source, "sre-override");
+    }
+
+    #[test]
+    fn health_report_sources_json_round_trip() {
+        let mut merges = BTreeMap::new();
+        merges.insert(
+            "external-monitor".to_string(),
+            HealthReport::empty("external-monitor".to_string()),
+        );
+
+        let sources = HealthReportSources {
+            replace: Some(HealthReport::empty("admin-replace".to_string())),
+            merges,
+        };
+
+        let json = serde_json::to_string(&sources).unwrap();
+        let deserialized: HealthReportSources = serde_json::from_str(&json).unwrap();
+        assert_eq!(sources, deserialized);
+    }
+
+    #[test]
+    fn health_report_sources_deserialize_null_as_default() {
+        // The DB column can be NULL, which gets deserialized as default
+        let json = r#"{"merges":{}}"#;
+        let sources: HealthReportSources = serde_json::from_str(json).unwrap();
+        assert!(sources.replace.is_none());
+        assert!(sources.merges.is_empty());
     }
 }

--- a/crates/api-model/src/machine/health_override.rs
+++ b/crates/api-model/src/machine/health_override.rs
@@ -14,20 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::collections::BTreeMap;
 
-use health_report::{HealthReport, OverrideMode};
-use serde::{Deserialize, Serialize};
-
-/// All health report overrides stored as JSON in postgres.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct HealthReportOverrides {
-    /// Stores the "replace" override
-    /// The "replace" mode was called "override" in the past
-    pub replace: Option<HealthReport>,
-    /// A map from the health report source to the health report
-    pub merges: BTreeMap<String, HealthReport>,
-}
+pub use crate::health::HealthReportSources;
 
 pub const HARDWARE_HEALTH_OVERRIDE_PREFIX: &str = "hardware-health.";
 
@@ -36,18 +24,11 @@ pub struct MaintenanceOverride {
     pub maintenance_start_time: Option<rpc::Timestamp>,
 }
 
-impl HealthReportOverrides {
-    #[allow(clippy::should_implement_trait)]
-    pub fn into_iter(self) -> impl Iterator<Item = (HealthReport, OverrideMode)> {
-        self.merges
-            .into_values()
-            .map(|r| (r, OverrideMode::Merge))
-            .chain(self.replace.map(|r| (r, OverrideMode::Replace)))
-    }
-
-    /// Derive legacy Maintenance mode fields
-    /// They are determine by the value of a well-known health override, that is also set
-    /// via SetMaintenance API
+/// Machine-specific methods for HealthReportSources.
+impl HealthReportSources {
+    /// Derive legacy Maintenance mode fields.
+    /// Determined by the value of a well-known health source, that is also set
+    /// via SetMaintenance API.
     pub fn maintenance_override(&self) -> Option<MaintenanceOverride> {
         let ovr = self.merges.get("maintenance")?;
         let maintenance_alert_id = "Maintenance".parse().unwrap();

--- a/crates/api-model/src/machine/json.rs
+++ b/crates/api-model/src/machine/json.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 use crate::bmc_info::BmcInfo;
 use crate::controller_outcome::PersistentStateHandlerOutcome;
 use crate::hardware_info::{MachineInventory, MachineNvLinkInfo};
-use crate::machine::health_override::HealthReportOverrides;
+use crate::machine::health_override::HealthReportSources;
 use crate::machine::infiniband::MachineInfinibandStatusObservation;
 use crate::machine::network::{MachineNetworkStatusObservation, ManagedHostNetworkConfig};
 use crate::machine::nvlink::MachineNvLinkStatusObservation;
@@ -80,7 +80,7 @@ pub struct MachineSnapshotPgJson {
     pub machine_validation_health_report: HealthReport,
     pub site_explorer_health_report: Option<HealthReport>,
     pub firmware_autoupdate: Option<bool>,
-    pub health_report_overrides: Option<HealthReportOverrides>,
+    pub health_report_overrides: Option<HealthReportSources>,
     pub on_demand_machine_validation_id: Option<uuid::Uuid>,
     pub on_demand_machine_validation_request: Option<bool>,
     pub asn: Option<u32>,
@@ -196,7 +196,7 @@ impl TryFrom<MachineSnapshotPgJson> for Machine {
             dpu_agent_health_report: value.dpu_agent_health_report,
             machine_validation_health_report: value.machine_validation_health_report,
             site_explorer_health_report: value.site_explorer_health_report,
-            health_report_overrides: value.health_report_overrides.unwrap_or_default(),
+            health_report_sources: value.health_report_overrides.unwrap_or_default(),
             inventory: value.agent_reported_inventory,
             last_reboot_requested: value.last_reboot_requested,
             controller_state_outcome: value.controller_state_outcome,

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -36,7 +36,7 @@ use health_report::HealthReport;
 use json::MachineSnapshotPgJson;
 use libredfish::{PowerState, SystemPowerControl};
 use mac_address::MacAddress;
-use rpc::forge::HealthOverrideOrigin;
+use rpc::forge::HealthSourceOrigin;
 use rpc::forge_agent_control_response::{Action, ForgeAgentControlExtraInfo};
 use serde::{Deserialize, Serialize, Serializer};
 use sqlx::postgres::PgRow;
@@ -62,7 +62,7 @@ use crate::hardware_info::{HardwareInfo, MachineNvLinkInfo};
 use crate::instance::config::network::DeviceLocator;
 use crate::instance::snapshot::InstanceSnapshotPgJson;
 use crate::machine::capabilities::MachineCapabilitiesSet;
-use crate::machine::health_override::HealthReportOverrides;
+use crate::machine::health_override::HealthReportSources;
 use crate::machine_interface_address::InterfaceAssociationType;
 use crate::network_segment::NetworkSegmentType;
 use crate::power_manager::PowerOptions;
@@ -123,14 +123,14 @@ pub struct ManagedHostStateSnapshot {
     pub aggregate_health: health_report::HealthReport,
     /// Health overrides inherited from the rack this host belongs to (if any).
     /// Populated at read time; not stored on the machines table.
-    pub rack_health_overrides: Option<HealthReportOverrides>,
+    pub rack_health_overrides: Option<HealthReportSources>,
 }
 
 impl<'r> sqlx::FromRow<'r, sqlx::postgres::PgRow> for ManagedHostStateSnapshot {
     fn from_row(row: &'r sqlx::postgres::PgRow) -> Result<Self, sqlx::Error> {
         #[derive(Deserialize)]
         struct RackHealthOverrides {
-            json: HealthReportOverrides,
+            json: HealthReportSources,
         }
 
         let host_snapshot: sqlx::types::Json<MachineSnapshotPgJson> =
@@ -246,7 +246,7 @@ impl ManagedHostStateSnapshot {
         report: &mut HealthReport,
         hardware_health_config: HardwareHealthReportsConfig,
     ) -> bool {
-        if HealthReportOverrides::is_hardware_health_override_source(source) {
+        if HealthReportSources::is_hardware_health_override_source(source) {
             match hardware_health_config {
                 HardwareHealthReportsConfig::Disabled => {}
                 HardwareHealthReportsConfig::MonitorOnly => {
@@ -314,7 +314,7 @@ impl ManagedHostStateSnapshot {
         // If there is an [`OverrideMode::Replace`] health report override on
         // the host, then use that. A host-level Replace takes full precedence,
         // including over any rack-level overrides.
-        if let Some(mut over) = self.host_snapshot.health_report_overrides.replace.clone() {
+        if let Some(mut over) = self.host_snapshot.health_report_sources.replace.clone() {
             over.source = source;
             over.observed_at = observed_at;
             self.aggregate_health = over;
@@ -384,7 +384,7 @@ impl ManagedHostStateSnapshot {
                 output.merge(report);
             }
 
-            for (source, over) in snapshot.health_report_overrides.merges.iter_mut() {
+            for (source, over) in snapshot.health_report_sources.merges.iter_mut() {
                 let merged_hardware = Self::merge_override_report_with_hw_health(
                     &mut output,
                     source,
@@ -395,7 +395,7 @@ impl ManagedHostStateSnapshot {
             }
         }
 
-        for (source, over) in self.host_snapshot.health_report_overrides.merges.iter_mut() {
+        for (source, over) in self.host_snapshot.health_report_sources.merges.iter_mut() {
             let merged_hardware = Self::merge_override_report_with_hw_health(
                 &mut output,
                 source,
@@ -736,8 +736,8 @@ pub struct Machine {
     /// Latest health report submitted by site-explorer
     pub site_explorer_health_report: Option<HealthReport>,
 
-    /// All health report overrides
-    pub health_report_overrides: HealthReportOverrides,
+    /// All health report sources
+    pub health_report_sources: HealthReportSources,
 
     // Inventory related to a DPU machine as reported by the agent there.
     // Software and versions installed on the machine.
@@ -1091,10 +1091,10 @@ impl From<Machine> for rpc::forge::Machine {
                 if let Some(hr) = machine.site_explorer_health_report.as_ref() {
                     health.merge(hr);
                 }
-                match machine.health_report_overrides.replace.as_ref() {
+                match machine.health_report_sources.replace.as_ref() {
                     Some(over) => over.clone(),
                     None => {
-                        for over in machine.health_report_overrides.merges.values() {
+                        for over in machine.health_report_sources.merges.values() {
                             health.merge(over);
                         }
                         health
@@ -1106,7 +1106,7 @@ impl From<Machine> for rpc::forge::Machine {
 
         let (maintenance_reference, maintenance_start_time) = if !machine.is_dpu() {
             machine
-                .health_report_overrides
+                .health_report_sources
                 .maintenance_override()
                 .map(|o| (Some(o.maintenance_reference), o.maintenance_start_time))
                 .unwrap_or_default()
@@ -1188,10 +1188,10 @@ impl From<Machine> for rpc::forge::Machine {
             state_reason: machine.controller_state_outcome.map(|r| r.into()),
             health: Some(health.into()),
             firmware_autoupdate: machine.firmware_autoupdate,
-            health_overrides: machine
-                .health_report_overrides
+            health_sources: machine
+                .health_report_sources
                 .into_iter()
-                .map(|(hr, m)| HealthOverrideOrigin {
+                .map(|(hr, m)| HealthSourceOrigin {
                     mode: m as i32,
                     source: hr.source,
                 })

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -27,7 +27,7 @@ use sqlx::{FromRow, Row};
 
 use crate::StateSla;
 use crate::controller_outcome::PersistentStateHandlerOutcome;
-use crate::machine::health_override::HealthReportOverrides;
+use crate::health::HealthReportSources;
 use crate::metadata::Metadata;
 
 #[derive(Debug, Clone)]
@@ -38,7 +38,7 @@ pub struct Rack {
     pub controller_state: Versioned<RackState>,
     pub controller_state_outcome: Option<PersistentStateHandlerOutcome>,
     pub firmware_upgrade_job: Option<FirmwareUpgradeJob>,
-    pub health_report_overrides: HealthReportOverrides,
+    pub health_report_sources: HealthReportSources,
     pub created: DateTime<Utc>,
     pub updated: DateTime<Utc>,
     pub deleted: Option<DateTime<Utc>>,
@@ -152,12 +152,12 @@ pub enum RackFirmwareUpgradeState {
 
 impl From<Rack> for rpc::forge::Rack {
     fn from(value: Rack) -> Self {
-        let health = derive_rack_aggregate_health(&value.health_report_overrides);
-        let health_overrides = value
-            .health_report_overrides
+        let health = derive_rack_aggregate_health(&value.health_report_sources);
+        let health_sources = value
+            .health_report_sources
             .clone()
             .into_iter()
-            .map(|(hr, m)| rpc::forge::HealthOverrideOrigin {
+            .map(|(hr, m)| rpc::forge::HealthSourceOrigin {
                 mode: m as i32,
                 source: hr.source,
             })
@@ -176,7 +176,7 @@ impl From<Rack> for rpc::forge::Rack {
             updated: Some(Timestamp::from(value.updated)),
             deleted: value.deleted.map(Timestamp::from),
             health: Some(health.into()),
-            health_overrides,
+            health_sources,
             metadata: Some(value.metadata.into()),
             version: value.version.version_string(),
         }
@@ -192,12 +192,12 @@ impl From<rpc::forge::RackSearchFilter> for RackSearchFilter {
     }
 }
 
-fn derive_rack_aggregate_health(overrides: &HealthReportOverrides) -> health_report::HealthReport {
-    if let Some(replace) = &overrides.replace {
+fn derive_rack_aggregate_health(sources: &HealthReportSources) -> health_report::HealthReport {
+    if let Some(replace) = &sources.replace {
         return replace.clone();
     }
     let mut output = health_report::HealthReport::empty("rack-aggregate-health".to_string());
-    for report in overrides.merges.values() {
+    for report in sources.merges.values() {
         output.merge(report);
     }
     output.observed_at = Some(chrono::Utc::now());
@@ -210,8 +210,9 @@ impl<'r> FromRow<'r, PgRow> for Rack {
         let controller_state: sqlx::types::Json<RackState> = row.try_get("controller_state")?;
         let controller_state_outcome: Option<sqlx::types::Json<PersistentStateHandlerOutcome>> =
             row.try_get("controller_state_outcome").ok();
-        let health_report_overrides: HealthReportOverrides = row
-            .try_get::<sqlx::types::Json<HealthReportOverrides>, _>("health_report_overrides")
+        // DB column is still named "health_report_overrides" for backward compatibility.
+        let health_report_sources: HealthReportSources = row
+            .try_get::<sqlx::types::Json<HealthReportSources>, _>("health_report_overrides")
             .map(|j| j.0)
             .unwrap_or_default();
         let labels: sqlx::types::Json<HashMap<String, String>> = row.try_get("labels")?;
@@ -235,7 +236,7 @@ impl<'r> FromRow<'r, PgRow> for Rack {
             },
             controller_state_outcome: controller_state_outcome.map(|o| o.0),
             firmware_upgrade_job,
-            health_report_overrides,
+            health_report_sources,
             created: row.try_get("created")?,
             updated: row.try_get("updated")?,
             deleted: row.try_get("deleted")?,

--- a/crates/api-model/src/switch/mod.rs
+++ b/crates/api-model/src/switch/mod.rs
@@ -30,6 +30,7 @@ use sqlx::{FromRow, Row};
 
 use crate::StateSla;
 use crate::controller_outcome::PersistentStateHandlerOutcome;
+use crate::health::HealthReportSources;
 use crate::metadata::Metadata;
 
 pub mod slas;
@@ -147,6 +148,7 @@ pub struct Switch {
     pub version: ConfigVersion,
     pub slot_number: Option<i32>,
     pub tray_index: Option<i32>,
+    pub health_report_sources: HealthReportSources,
 }
 
 impl<'r> FromRow<'r, PgRow> for Switch {
@@ -162,6 +164,11 @@ impl<'r> FromRow<'r, PgRow> for Switch {
         let firmware_upgrade_status: Option<sqlx::types::Json<RackFirmwareUpgradeStatus>> =
             row.try_get("firmware_upgrade_status").ok();
 
+        // DB column is still named "health_report_overrides" for backward compatibility.
+        let health_report_sources: HealthReportSources = row
+            .try_get::<sqlx::types::Json<HealthReportSources>, _>("health_report_overrides")
+            .map(|j| j.0)
+            .unwrap_or_default();
         let labels: sqlx::types::Json<HashMap<String, String>> = row.try_get("labels")?;
         let metadata = Metadata {
             name: row.try_get("name")?,
@@ -186,6 +193,7 @@ impl<'r> FromRow<'r, PgRow> for Switch {
             rack_id: row.try_get("rack_id").ok().flatten(),
             slot_number: row.try_get("slot_number").ok().flatten(),
             tray_index: row.try_get("tray_index").ok().flatten(),
+            health_report_sources,
         })
     }
 }
@@ -202,6 +210,18 @@ impl TryFrom<rpc::SwitchConfig> for SwitchConfig {
             }),
         })
     }
+}
+
+fn derive_switch_aggregate_health(sources: &HealthReportSources) -> health_report::HealthReport {
+    if let Some(replace) = &sources.replace {
+        return replace.clone();
+    }
+    let mut output = health_report::HealthReport::empty("switch-aggregate-health".to_string());
+    for report in sources.merges.values() {
+        output.merge(report);
+    }
+    output.observed_at = Some(chrono::Utc::now());
+    output
 }
 
 impl TryFrom<Switch> for rpc::Switch {
@@ -246,6 +266,16 @@ impl TryFrom<Switch> for rpc::Switch {
             enable_nmxc: src.config.enable_nmxc,
         };
 
+        let health = derive_switch_aggregate_health(&src.health_report_sources);
+        let health_sources = src
+            .health_report_sources
+            .clone()
+            .into_iter()
+            .map(|(hr, m)| rpc::HealthSourceOrigin {
+                mode: m as i32,
+                source: hr.source,
+            })
+            .collect();
         let deleted = if src.deleted.is_some() {
             Some(src.deleted.unwrap().into())
         } else {
@@ -264,6 +294,8 @@ impl TryFrom<Switch> for rpc::Switch {
             version: src.version.version_string(),
             rack_id: src.rack_id,
             placement_in_rack,
+            health: Some(health.into()),
+            health_sources,
         })
     }
 }
@@ -432,6 +464,7 @@ mod tests {
             rack_id: None,
             slot_number: Some(1),
             tray_index: Some(2),
+            health_report_sources: Default::default(),
         };
 
         let rpc_switch: rpc::Switch = switch.try_into().unwrap();
@@ -472,6 +505,7 @@ mod tests {
             rack_id: None,
             slot_number: None,
             tray_index: None,
+            health_report_sources: Default::default(),
         };
 
         let rpc_switch: rpc::Switch = switch.try_into().unwrap();

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -539,6 +539,27 @@ impl Forge for Api {
         crate::handlers::rack::remove_rack_health_report_override(self, request).await
     }
 
+    async fn list_switch_health_reports(
+        &self,
+        request: Request<rpc::ListSwitchHealthReportsRequest>,
+    ) -> Result<Response<rpc::ListHealthReportOverrideResponse>, Status> {
+        crate::handlers::switch::list_switch_health_reports(self, request).await
+    }
+
+    async fn insert_switch_health_report(
+        &self,
+        request: Request<rpc::InsertSwitchHealthReportRequest>,
+    ) -> Result<Response<()>, Status> {
+        crate::handlers::switch::insert_switch_health_report(self, request).await
+    }
+
+    async fn remove_switch_health_report(
+        &self,
+        request: Request<rpc::RemoveSwitchHealthReportRequest>,
+    ) -> Result<Response<()>, Status> {
+        crate::handlers::switch::remove_switch_health_report(self, request).await
+    }
+
     async fn get_all_domain_metadata(
         &self,
         request: Request<DomainMetadataRequest>,

--- a/crates/api/src/auth/internal_rbac_rules.rs
+++ b/crates/api/src/auth/internal_rbac_rules.rs
@@ -155,6 +155,9 @@ impl InternalRBACRules {
             "RemoveRackHealthReportOverride",
             vec![ForgeAdminCLI, Health, DsxExchangeConsumer],
         );
+        x.perm("ListSwitchHealthReports", vec![ForgeAdminCLI, Health]);
+        x.perm("InsertSwitchHealthReport", vec![ForgeAdminCLI, Health]);
+        x.perm("RemoveSwitchHealthReport", vec![ForgeAdminCLI, Health]);
         x.perm("DpuAgentUpgradeCheck", vec![Scout]);
         x.perm("DpuAgentUpgradePolicyAction", vec![ForgeAdminCLI]);
         x.perm("LookupRecord", vec![Dns]);

--- a/crates/api/src/handlers/health.rs
+++ b/crates/api/src/handlers/health.rs
@@ -46,7 +46,7 @@ pub async fn list_health_report_overrides(
 
     Ok(Response::new(rpc::ListHealthReportOverrideResponse {
         overrides: host_machine
-            .health_report_overrides
+            .health_report_sources
             .clone()
             .into_iter()
             .map(|o| HealthReportOverride {
@@ -80,7 +80,7 @@ async fn remove_by_source(
 
     // Ensure this source already exists in override list
     let mode = if host_machine
-        .health_report_overrides
+        .health_report_sources
         .replace
         .as_ref()
         .map(|o| &o.source)
@@ -88,7 +88,7 @@ async fn remove_by_source(
     {
         OverrideMode::Replace
     } else if host_machine
-        .health_report_overrides
+        .health_report_sources
         .merges
         .contains_key(&source)
     {

--- a/crates/api/src/handlers/instance.rs
+++ b/crates/api/src/handlers/instance.rs
@@ -412,7 +412,7 @@ async fn handle_instance_release_from_repair_tenant(
     tenant_organization_id: &str,
 ) -> Result<(), CarbideError> {
     let has_request_repair = machine
-        .health_report_overrides
+        .health_report_sources
         .merges
         .contains_key("repair-request");
 

--- a/crates/api/src/handlers/rack.rs
+++ b/crates/api/src/handlers/rack.rs
@@ -300,7 +300,7 @@ pub async fn list_rack_health_report_overrides(
 
     Ok(Response::new(rpc::ListHealthReportOverrideResponse {
         overrides: rack
-            .health_report_overrides
+            .health_report_sources
             .into_iter()
             .map(|o| HealthReportOverride {
                 report: Some(o.0.into()),
@@ -408,14 +408,14 @@ async fn remove_rack_override_by_source(
     source: String,
 ) -> Result<(), CarbideError> {
     let mode = if rack
-        .health_report_overrides
+        .health_report_sources
         .replace
         .as_ref()
         .map(|o| &o.source)
         == Some(&source)
     {
         OverrideMode::Replace
-    } else if rack.health_report_overrides.merges.contains_key(&source) {
+    } else if rack.health_report_sources.merges.contains_key(&source) {
         OverrideMode::Merge
     } else {
         return Err(CarbideError::NotFoundError {

--- a/crates/api/src/handlers/switch.rs
+++ b/crates/api/src/handlers/switch.rs
@@ -16,13 +16,15 @@
  */
 
 use ::rpc::errors::RpcDataConversionError;
-use ::rpc::forge as rpc;
+use ::rpc::forge::{self as rpc, HealthReportOverride};
 use db::{ObjectColumnFilter, switch as db_switch};
+use health_report::OverrideMode;
 use model::metadata::Metadata;
 use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
 use crate::api::{Api, log_request_data};
+use crate::auth::AuthContext;
 
 pub async fn find_switch(
     api: &Api,
@@ -402,4 +404,154 @@ pub(crate) async fn update_switch_metadata(
     txn.commit().await?;
 
     Ok(tonic::Response::new(()))
+}
+
+pub async fn list_switch_health_reports(
+    api: &Api,
+    request: Request<rpc::ListSwitchHealthReportsRequest>,
+) -> Result<Response<rpc::ListHealthReportOverrideResponse>, Status> {
+    log_request_data(&request);
+
+    let req = request.into_inner();
+    let switch_id = req
+        .switch_id
+        .ok_or_else(|| CarbideError::MissingArgument("switch_id"))?;
+
+    let mut conn = api
+        .database_connection
+        .acquire()
+        .await
+        .map_err(|e| CarbideError::Internal {
+            message: format!("Database error: {}", e),
+        })?;
+
+    let switch = db_switch::find_by_id(&mut conn, &switch_id)
+        .await
+        .map_err(CarbideError::from)?
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "switch",
+            id: switch_id.to_string(),
+        })?;
+
+    Ok(Response::new(rpc::ListHealthReportOverrideResponse {
+        overrides: switch
+            .health_report_sources
+            .into_iter()
+            .map(|o| HealthReportOverride {
+                report: Some(o.0.into()),
+                mode: o.1 as i32,
+            })
+            .collect(),
+    }))
+}
+
+pub async fn insert_switch_health_report(
+    api: &Api,
+    request: Request<rpc::InsertSwitchHealthReportRequest>,
+) -> Result<Response<()>, Status> {
+    log_request_data(&request);
+
+    let triggered_by = request
+        .extensions()
+        .get::<AuthContext>()
+        .and_then(|ctx| ctx.get_external_user_name())
+        .map(String::from);
+
+    let rpc::InsertSwitchHealthReportRequest {
+        switch_id,
+        r#override: Some(rpc::HealthReportOverride { report, mode }),
+    } = request.into_inner()
+    else {
+        return Err(CarbideError::MissingArgument("override").into());
+    };
+    let switch_id = switch_id.ok_or_else(|| CarbideError::MissingArgument("switch_id"))?;
+
+    let Some(report) = report else {
+        return Err(CarbideError::MissingArgument("report").into());
+    };
+    let Ok(mode) = rpc::OverrideMode::try_from(mode) else {
+        return Err(CarbideError::InvalidArgument("mode".to_string()).into());
+    };
+    let mode: OverrideMode = mode.into();
+
+    let mut txn = api.txn_begin().await?;
+
+    let switch = db_switch::find_by_id(&mut txn, &switch_id)
+        .await
+        .map_err(CarbideError::from)?
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "switch",
+            id: switch_id.to_string(),
+        })?;
+
+    let mut report = health_report::HealthReport::try_from(report.clone())
+        .map_err(|e| CarbideError::internal(e.to_string()))?;
+    if report.observed_at.is_none() {
+        report.observed_at = Some(chrono::Utc::now());
+    }
+    report.triggered_by = triggered_by;
+    report.update_in_alert_since(None);
+
+    match remove_switch_health_report_by_source(&switch, &mut txn, report.source.clone()).await {
+        Ok(_) | Err(CarbideError::NotFoundError { .. }) => {}
+        Err(e) => return Err(e.into()),
+    }
+
+    db_switch::insert_health_report(&mut txn, &switch_id, mode, &report).await?;
+
+    txn.commit().await?;
+
+    Ok(Response::new(()))
+}
+
+pub async fn remove_switch_health_report(
+    api: &Api,
+    request: Request<rpc::RemoveSwitchHealthReportRequest>,
+) -> Result<Response<()>, Status> {
+    log_request_data(&request);
+
+    let rpc::RemoveSwitchHealthReportRequest { switch_id, source } = request.into_inner();
+    let switch_id = switch_id.ok_or_else(|| CarbideError::MissingArgument("switch_id"))?;
+
+    let mut txn = api.txn_begin().await?;
+
+    let switch = db_switch::find_by_id(&mut txn, &switch_id)
+        .await
+        .map_err(CarbideError::from)?
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "switch",
+            id: switch_id.to_string(),
+        })?;
+
+    remove_switch_health_report_by_source(&switch, &mut txn, source).await?;
+    txn.commit().await?;
+
+    Ok(Response::new(()))
+}
+
+async fn remove_switch_health_report_by_source(
+    switch: &model::switch::Switch,
+    txn: &mut db::Transaction<'_>,
+    source: String,
+) -> Result<(), CarbideError> {
+    let mode = if switch
+        .health_report_sources
+        .replace
+        .as_ref()
+        .map(|o| &o.source)
+        == Some(&source)
+    {
+        OverrideMode::Replace
+    } else if switch.health_report_sources.merges.contains_key(&source) {
+        OverrideMode::Merge
+    } else {
+        return Err(CarbideError::NotFoundError {
+            kind: "switch health report with source",
+            id: source,
+        });
+    };
+
+    db_switch::remove_health_report(&mut *txn, &switch.id, mode, &source).await?;
+
+    Ok(())
 }

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -518,12 +518,9 @@ impl MachineStateHandler {
             }
         }
 
-        ctx.metrics.num_merge_overrides = state.host_snapshot.health_report_overrides.merges.len();
-        ctx.metrics.replace_override_enabled = state
-            .host_snapshot
-            .health_report_overrides
-            .replace
-            .is_some();
+        ctx.metrics.num_merge_overrides = state.host_snapshot.health_report_sources.merges.len();
+        ctx.metrics.replace_override_enabled =
+            state.host_snapshot.health_report_sources.replace.is_some();
     }
 
     fn record_health_history(
@@ -1551,7 +1548,7 @@ impl MachineStateHandler {
         let timeout_threshold = self.reachability_params.scout_reporting_timeout;
         let scout_timeout_alert_exists = mh_snapshot
             .host_snapshot
-            .health_report_overrides
+            .health_report_sources
             .merges
             .contains_key("scout");
 

--- a/crates/api/src/tests/dpu_nic_firmware.rs
+++ b/crates/api/src/tests/dpu_nic_firmware.rs
@@ -308,7 +308,7 @@ async fn test_clear_completed_updates(
     assert!(
         !managed_host
             .host_snapshot
-            .health_report_overrides
+            .health_report_sources
             .merges
             .contains_key(HOST_UPDATE_HEALTH_REPORT_SOURCE)
     );

--- a/crates/api/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api/src/tests/host_bmc_firmware_test.rs
@@ -1292,9 +1292,9 @@ async fn test_instance_upgrading_actual_part_2(
     );
 
     assert!(host.host_reprovision_requested.is_some());
-    println!("{:?}", host.health_report_overrides);
+    println!("{:?}", host.health_report_sources);
     assert!(
-        host.health_report_overrides
+        host.health_report_sources
             .merges
             .contains_key(HOST_FW_UPDATE_HEALTH_REPORT_SOURCE)
     );
@@ -1748,7 +1748,7 @@ async fn test_instance_upgrading_actual_part_2(
     );
     assert!(
         !host
-            .health_report_overrides
+            .health_report_sources
             .merges
             .contains_key(HOST_FW_UPDATE_HEALTH_REPORT_SOURCE)
     );

--- a/crates/api/src/tests/instance.rs
+++ b/crates/api/src/tests/instance.rs
@@ -4585,7 +4585,7 @@ async fn test_instance_release_backward_compatibility(_: PgPoolOptions, options:
     // CRITICAL BACKWARD COMPATIBILITY VERIFICATION:
     // When using old API format (no issue, no is_repair_tenant), NO health overrides should be applied
     assert_eq!(
-        host_machine.health_report_overrides.merges.len(),
+        host_machine.health_report_sources.merges.len(),
         1, // Single HealthOverride for HardwareHealth
         "Backward compatibility test: NO health overrides should be applied when using old API format"
     );
@@ -4593,7 +4593,7 @@ async fn test_instance_release_backward_compatibility(_: PgPoolOptions, options:
     // Verify specifically that neither TenantReportedIssue nor RequestRepair overrides exist
     assert!(
         !host_machine
-            .health_report_overrides
+            .health_report_sources
             .merges
             .contains_key("tenant-reported-issue"),
         "Backward compatibility: TenantReportedIssue override should NOT be applied without issue field"
@@ -4601,7 +4601,7 @@ async fn test_instance_release_backward_compatibility(_: PgPoolOptions, options:
 
     assert!(
         !host_machine
-            .health_report_overrides
+            .health_report_sources
             .merges
             .contains_key("repair-request"),
         "Backward compatibility: RequestRepair override should NOT be applied without issue field"
@@ -4706,11 +4706,11 @@ async fn test_instance_release_repair_tenant(_: PgPoolOptions, options: PgConnec
         } else {
             // For regular tenant without issues, no health overrides should be applied
             let has_tenant_reported_override = host_machine
-                .health_report_overrides
+                .health_report_sources
                 .merges
                 .contains_key("tenant-reported-issue");
             let has_repair_request_override = host_machine
-                .health_report_overrides
+                .health_report_sources
                 .merges
                 .contains_key("repair-request");
 
@@ -4797,7 +4797,7 @@ async fn test_instance_release_combined_enhancements(_: PgPoolOptions, options: 
 
     // For repair tenant with issues (no existing RequestRepair override), should apply TenantReportedIssue
     let has_tenant_reported_override = host_machine
-        .health_report_overrides
+        .health_report_sources
         .merges
         .contains_key("tenant-reported-issue");
 
@@ -4808,7 +4808,7 @@ async fn test_instance_release_combined_enhancements(_: PgPoolOptions, options: 
 
     // Should NOT apply RequestRepair (repair tenants don't trigger auto-repair to prevent cycles)
     let has_repair_request_override = host_machine
-        .health_report_overrides
+        .health_report_sources
         .merges
         .contains_key("repair-request");
 
@@ -4886,13 +4886,13 @@ async fn test_instance_release_auto_repair_enabled(_: PgPoolOptions, options: Pg
 
     println!(
         "Auto-repair enabled test - machine health overrides: {:#?}",
-        host_machine.health_report_overrides
+        host_machine.health_report_sources
     );
 
     // CRITICAL VERIFICATIONS for auto-repair enabled scenario:
     // 1. Should have THREE health overrides (TenantReportedIssue + RequestRepair + Default HardwareHealth)
     assert_eq!(
-        host_machine.health_report_overrides.merges.len(),
+        host_machine.health_report_sources.merges.len(),
         3,
         "Auto-repair enabled should apply both TenantReportedIssue and RequestRepair overrides"
     );
@@ -4900,7 +4900,7 @@ async fn test_instance_release_auto_repair_enabled(_: PgPoolOptions, options: Pg
     // 2. Should have TenantReportedIssue override
     assert!(
         host_machine
-            .health_report_overrides
+            .health_report_sources
             .merges
             .contains_key("tenant-reported-issue"),
         "Should have TenantReportedIssue override for issue reporting"
@@ -4909,14 +4909,14 @@ async fn test_instance_release_auto_repair_enabled(_: PgPoolOptions, options: Pg
     // 3. Should have RequestRepair override
     assert!(
         host_machine
-            .health_report_overrides
+            .health_report_sources
             .merges
             .contains_key("repair-request"),
         "Should have RequestRepair override when auto-repair is enabled"
     );
 
     // 4. Verify the RequestRepair override content
-    let repair_override = &host_machine.health_report_overrides.merges["repair-request"];
+    let repair_override = &host_machine.health_report_sources.merges["repair-request"];
     let repair_report: health_report::HealthReport = repair_override.clone();
     assert_eq!(repair_report.source, "repair-request");
     assert_eq!(repair_report.alerts.len(), 1);
@@ -4991,7 +4991,7 @@ async fn test_instance_release_repair_tenant_successful_completion(
     let host_machine = mh.host().db_machine(&mut txn).await;
 
     assert_eq!(
-        host_machine.health_report_overrides.merges.len(),
+        host_machine.health_report_sources.merges.len(),
         3,
         "Should have both TenantReportedIssue and RequestRepair after regular tenant release"
     );

--- a/crates/api/src/tests/machine_health.rs
+++ b/crates/api/src/tests/machine_health.rs
@@ -22,7 +22,7 @@ use db::{self};
 use health_report::OverrideMode;
 use model::machine::health_override::HARDWARE_HEALTH_OVERRIDE_PREFIX;
 use model::machine::{HardwareHealthReportsConfig, HostHealthConfig, LoadSnapshotOptions};
-use rpc::forge::HealthOverrideOrigin;
+use rpc::forge::HealthSourceOrigin;
 use rpc::forge::forge_server::Forge;
 use tonic::Request;
 
@@ -118,7 +118,7 @@ async fn test_machine_health_reporting(
         load_snapshot(&env, &host_machine_id)
             .await?
             .host_snapshot
-            .health_report_overrides
+            .health_report_sources
             .merges
             .values()
             .next()
@@ -129,8 +129,8 @@ async fn test_machine_health_reporting(
 
     let m = find_machine(&env, &host_machine_id).await;
     assert_eq!(
-        m.health_overrides,
-        vec![HealthOverrideOrigin {
+        m.health_sources,
+        vec![HealthSourceOrigin {
             mode: OverrideMode::Merge as i32,
             source: format!("{HARDWARE_HEALTH_OVERRIDE_PREFIX}health")
         }]
@@ -193,7 +193,7 @@ async fn test_hardware_health_reporting(
         load_snapshot(&env, &host_machine_id)
             .await?
             .host_snapshot
-            .health_report_overrides
+            .health_report_sources
             .merges
             .values()
             .next()
@@ -213,7 +213,7 @@ async fn test_hardware_health_reporting(
     let stored_report = load_snapshot(&env, &host_machine_id)
         .await?
         .host_snapshot
-        .health_report_overrides
+        .health_report_sources
         .merges
         .values()
         .next()
@@ -324,13 +324,13 @@ async fn test_machine_health_aggregation(
 
     let m = find_machine(&env, &host_machine_id).await;
     assert_eq!(
-        m.health_overrides,
+        m.health_sources,
         vec![
-            HealthOverrideOrigin {
+            HealthSourceOrigin {
                 mode: OverrideMode::Merge as i32,
                 source: "add-host-failure".to_string()
             },
-            HealthOverrideOrigin {
+            HealthSourceOrigin {
                 mode: OverrideMode::Merge as i32,
                 source: "hardware-health.health".to_string()
             }
@@ -380,17 +380,17 @@ async fn test_machine_health_aggregation(
 
     let m = find_machine(&env, &host_machine_id).await;
     assert_eq!(
-        m.health_overrides,
+        m.health_sources,
         vec![
-            HealthOverrideOrigin {
+            HealthSourceOrigin {
                 mode: OverrideMode::Merge as i32,
                 source: "add-host-failure".to_string()
             },
-            HealthOverrideOrigin {
+            HealthSourceOrigin {
                 mode: OverrideMode::Merge as i32,
                 source: "hardware-health.health".to_string()
             },
-            HealthOverrideOrigin {
+            HealthSourceOrigin {
                 mode: OverrideMode::Replace as i32,
                 source: "replace-host-report".to_string()
             }
@@ -615,13 +615,13 @@ async fn test_double_insert(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error
         .unwrap();
     let m = find_machine(&env, &host_machine_id).await;
     assert_eq!(
-        m.health_overrides,
+        m.health_sources,
         vec![
-            HealthOverrideOrigin {
+            HealthSourceOrigin {
                 mode: OverrideMode::Merge as i32,
                 source: "hardware-health.health".to_string()
             },
-            HealthOverrideOrigin {
+            HealthSourceOrigin {
                 mode: OverrideMode::Merge as i32,
                 source: "over".to_string()
             }
@@ -961,9 +961,9 @@ async fn test_tenant_reported_issue_health_override_template(
     let machine = find_machine(&env, &host_machine_id).await;
 
     // Check that the override was stored
-    assert_eq!(machine.health_overrides.len(), 2);
-    assert_eq!(machine.health_overrides[1].mode, OverrideMode::Merge as i32);
-    assert_eq!(machine.health_overrides[1].source, "tenant-reported-issue");
+    assert_eq!(machine.health_sources.len(), 2);
+    assert_eq!(machine.health_sources[1].mode, OverrideMode::Merge as i32);
+    assert_eq!(machine.health_sources[1].source, "tenant-reported-issue");
 
     // Verify aggregate health includes the override
     let aggregate_health = aggregate(machine).unwrap();
@@ -1036,9 +1036,9 @@ async fn test_request_repair_health_override_template(
     let machine = find_machine(&env, &host_machine_id).await;
 
     // Check that the override was stored
-    assert_eq!(machine.health_overrides.len(), 2);
-    assert_eq!(machine.health_overrides[1].mode, OverrideMode::Merge as i32);
-    assert_eq!(machine.health_overrides[1].source, "repair-request");
+    assert_eq!(machine.health_sources.len(), 2);
+    assert_eq!(machine.health_sources[1].mode, OverrideMode::Merge as i32);
+    assert_eq!(machine.health_sources[1].source, "repair-request");
 
     // Verify aggregate health includes the override
     let aggregate_health = aggregate(machine).unwrap();
@@ -1135,9 +1135,9 @@ async fn test_tenant_reported_issue_and_request_repair_combined(
     let aggregate_health = aggregate(machine.clone()).unwrap();
 
     // Check that both overrides were stored
-    assert_eq!(machine.health_overrides.len(), 3);
+    assert_eq!(machine.health_sources.len(), 3);
     let sources: Vec<String> = machine
-        .health_overrides
+        .health_sources
         .iter()
         .map(|o| o.source.clone())
         .collect();
@@ -1145,7 +1145,7 @@ async fn test_tenant_reported_issue_and_request_repair_combined(
     assert!(sources.contains(&"repair-request".to_string()));
 
     // All should be merge mode
-    for override_entry in &machine.health_overrides {
+    for override_entry in &machine.health_sources {
         assert_eq!(override_entry.mode, OverrideMode::Merge as i32);
     }
     assert_eq!(aggregate_health.alerts.len(), 2);

--- a/crates/api/src/tests/machine_states.rs
+++ b/crates/api/src/tests/machine_states.rs
@@ -1692,7 +1692,7 @@ async fn test_scout_heartbeat_timeout_alert_cleared_on_ready_transition(pool: sq
     let mut txn = env.db_txn().await;
     let host = mh.host().db_machine(&mut txn).await;
     assert!(
-        !host.health_report_overrides.merges.contains_key("scout"),
+        !host.health_report_sources.merges.contains_key("scout"),
         "expected scout_heartbeat_timeout alert to be cleared when leaving Ready"
     );
 }
@@ -1768,7 +1768,7 @@ async fn test_scout_heartbeat_timeout_alert_cleared_on_instance_creation_transit
     let mut txn = env.db_txn().await;
     let host = mh.host().db_machine(&mut txn).await;
     assert!(
-        !host.health_report_overrides.merges.contains_key("scout"),
+        !host.health_report_sources.merges.contains_key("scout"),
         "expected scout_heartbeat_timeout alert to be cleared when leaving Ready via instance creation"
     );
 }
@@ -1830,7 +1830,7 @@ async fn test_scout_heartbeat_timeout_alert_not_cleared_when_unhealthy_allocatio
     let host = mh.host().db_machine(&mut txn).await;
     assert!(matches!(host.current_state(), ManagedHostState::Ready));
     assert!(
-        host.health_report_overrides.merges.contains_key("scout"),
+        host.health_report_sources.merges.contains_key("scout"),
         "expected scout_heartbeat_timeout alert to remain when unhealthy allocation is blocked"
     );
 }

--- a/crates/api/src/tests/machine_update_manager.rs
+++ b/crates/api/src/tests/machine_update_manager.rs
@@ -199,7 +199,7 @@ async fn test_remove_machine_update_markers(
     assert!(
         !managed_host
             .host_snapshot
-            .health_report_overrides
+            .health_report_sources
             .merges
             .contains_key(HOST_UPDATE_HEALTH_REPORT_SOURCE)
     );

--- a/crates/api/src/tests/mod.rs
+++ b/crates/api/src/tests/mod.rs
@@ -111,6 +111,7 @@ mod static_address_management;
 mod storage;
 mod switch;
 mod switch_find;
+mod switch_health;
 mod switch_metadata;
 mod switch_state_controller;
 mod tenant_keyset_find;

--- a/crates/api/src/tests/rack_health.rs
+++ b/crates/api/src/tests/rack_health.rs
@@ -463,7 +463,7 @@ async fn test_host_replace_takes_full_precedence_over_rack_replace(
     assert!(
         snapshot
             .host_snapshot
-            .health_report_overrides
+            .health_report_sources
             .replace
             .is_some(),
         "Host-level Replace override should still be present"
@@ -593,10 +593,10 @@ async fn test_rack_health_visible_in_find_racks_by_ids(
         "Rack health should contain alerts"
     );
 
-    assert_eq!(rack.health_overrides.len(), 1);
-    assert_eq!(rack.health_overrides[0].source, "dsx-exchange-consumer");
+    assert_eq!(rack.health_sources.len(), 1);
+    assert_eq!(rack.health_sources[0].source, "dsx-exchange-consumer");
     assert_eq!(
-        rack.health_overrides[0].mode,
+        rack.health_sources[0].mode,
         rpc_forge::OverrideMode::Merge as i32
     );
 

--- a/crates/api/src/tests/switch_health.rs
+++ b/crates/api/src/tests/switch_health.rs
@@ -1,0 +1,299 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use health_report::{HealthAlertClassification, HealthProbeAlert, HealthReport};
+use rpc::forge::forge_server::Forge;
+use rpc::forge::{self as rpc_forge};
+use tonic::Request;
+
+use crate::tests::common::api_fixtures::site_explorer::new_switch;
+use crate::tests::common::api_fixtures::{
+    TestEnvOverrides, create_test_env_with_overrides, get_config,
+};
+
+fn alert_report(source: &str) -> HealthReport {
+    HealthReport {
+        source: source.to_string(),
+        triggered_by: None,
+        observed_at: Some(chrono::Utc::now()),
+        successes: vec![],
+        alerts: vec![HealthProbeAlert {
+            id: "SwitchUnhealthy".parse().unwrap(),
+            target: None,
+            in_alert_since: Some(chrono::Utc::now()),
+            message: "Switch health issue detected".to_string(),
+            tenant_message: None,
+            classifications: vec![
+                HealthAlertClassification::prevent_allocations(),
+                HealthAlertClassification::hardware(),
+            ],
+        }],
+    }
+}
+
+fn empty_healthy_report(source: &str) -> HealthReport {
+    HealthReport {
+        source: source.to_string(),
+        triggered_by: None,
+        observed_at: Some(chrono::Utc::now()),
+        successes: vec![],
+        alerts: vec![],
+    }
+}
+
+#[crate::sqlx_test]
+async fn test_insert_list_remove_switch_override(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env =
+        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
+            .await;
+
+    let switch_id = new_switch(&env, None, None).await?;
+
+    let report = alert_report("external-monitor");
+
+    env.api
+        .insert_switch_health_report(Request::new(rpc_forge::InsertSwitchHealthReportRequest {
+            switch_id: Some(switch_id),
+            r#override: Some(rpc_forge::HealthReportOverride {
+                report: Some(report.clone().into()),
+                mode: rpc_forge::OverrideMode::Merge as i32,
+            }),
+        }))
+        .await?;
+
+    let list_resp = env
+        .api
+        .list_switch_health_reports(Request::new(rpc_forge::ListSwitchHealthReportsRequest {
+            switch_id: Some(switch_id),
+        }))
+        .await?
+        .into_inner();
+    assert_eq!(list_resp.overrides.len(), 1);
+    let listed_report: HealthReport = list_resp.overrides[0]
+        .report
+        .clone()
+        .unwrap()
+        .try_into()
+        .unwrap();
+    assert_eq!(listed_report.source, "external-monitor");
+    assert_eq!(listed_report.alerts.len(), 1);
+
+    env.api
+        .remove_switch_health_report(Request::new(rpc_forge::RemoveSwitchHealthReportRequest {
+            switch_id: Some(switch_id),
+            source: "external-monitor".to_string(),
+        }))
+        .await?;
+
+    let list_resp = env
+        .api
+        .list_switch_health_reports(Request::new(rpc_forge::ListSwitchHealthReportsRequest {
+            switch_id: Some(switch_id),
+        }))
+        .await?
+        .into_inner();
+    assert_eq!(list_resp.overrides.len(), 0);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_idempotent_insert(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let env =
+        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
+            .await;
+
+    let switch_id = new_switch(&env, None, None).await?;
+
+    let report = alert_report("external-monitor");
+
+    for _ in 0..3 {
+        env.api
+            .insert_switch_health_report(Request::new(rpc_forge::InsertSwitchHealthReportRequest {
+                switch_id: Some(switch_id),
+                r#override: Some(rpc_forge::HealthReportOverride {
+                    report: Some(report.clone().into()),
+                    mode: rpc_forge::OverrideMode::Merge as i32,
+                }),
+            }))
+            .await?;
+    }
+
+    let list_resp = env
+        .api
+        .list_switch_health_reports(Request::new(rpc_forge::ListSwitchHealthReportsRequest {
+            switch_id: Some(switch_id),
+        }))
+        .await?
+        .into_inner();
+    assert_eq!(list_resp.overrides.len(), 1);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_remove_nonexistent_source(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env =
+        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
+            .await;
+
+    let switch_id = new_switch(&env, None, None).await?;
+
+    let result = env
+        .api
+        .remove_switch_health_report(Request::new(rpc_forge::RemoveSwitchHealthReportRequest {
+            switch_id: Some(switch_id),
+            source: "nonexistent-source".to_string(),
+        }))
+        .await;
+
+    assert!(result.is_err());
+    let status = result.unwrap_err();
+    assert_eq!(status.code(), tonic::Code::NotFound);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_missing_switch_id(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let env =
+        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
+            .await;
+
+    let nonexistent_switch_id = carbide_uuid::switch::SwitchId::from(uuid::Uuid::new_v4());
+    let report = alert_report("external-monitor");
+
+    let result = env
+        .api
+        .insert_switch_health_report(Request::new(rpc_forge::InsertSwitchHealthReportRequest {
+            switch_id: Some(nonexistent_switch_id),
+            r#override: Some(rpc_forge::HealthReportOverride {
+                report: Some(report.into()),
+                mode: rpc_forge::OverrideMode::Merge as i32,
+            }),
+        }))
+        .await;
+
+    assert!(result.is_err(), "Expected NotFound for nonexistent switch");
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_replace_mode_override(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let env =
+        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
+            .await;
+
+    let switch_id = new_switch(&env, None, None).await?;
+
+    let replace_report = empty_healthy_report("admin-override");
+    env.api
+        .insert_switch_health_report(Request::new(rpc_forge::InsertSwitchHealthReportRequest {
+            switch_id: Some(switch_id),
+            r#override: Some(rpc_forge::HealthReportOverride {
+                report: Some(replace_report.into()),
+                mode: rpc_forge::OverrideMode::Replace as i32,
+            }),
+        }))
+        .await?;
+
+    let list_resp = env
+        .api
+        .list_switch_health_reports(Request::new(rpc_forge::ListSwitchHealthReportsRequest {
+            switch_id: Some(switch_id),
+        }))
+        .await?
+        .into_inner();
+    assert_eq!(list_resp.overrides.len(), 1);
+    assert_eq!(
+        list_resp.overrides[0].mode,
+        rpc_forge::OverrideMode::Replace as i32
+    );
+
+    env.api
+        .remove_switch_health_report(Request::new(rpc_forge::RemoveSwitchHealthReportRequest {
+            switch_id: Some(switch_id),
+            source: "admin-override".to_string(),
+        }))
+        .await?;
+
+    let list_resp = env
+        .api
+        .list_switch_health_reports(Request::new(rpc_forge::ListSwitchHealthReportsRequest {
+            switch_id: Some(switch_id),
+        }))
+        .await?
+        .into_inner();
+    assert_eq!(list_resp.overrides.len(), 0);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_switch_health_visible_in_find_switches(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env =
+        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
+            .await;
+
+    let switch_id = new_switch(&env, None, None).await?;
+
+    let report = alert_report("external-monitor");
+    env.api
+        .insert_switch_health_report(Request::new(rpc_forge::InsertSwitchHealthReportRequest {
+            switch_id: Some(switch_id),
+            r#override: Some(rpc_forge::HealthReportOverride {
+                report: Some(report.into()),
+                mode: rpc_forge::OverrideMode::Merge as i32,
+            }),
+        }))
+        .await?;
+
+    let switch_resp = env
+        .api
+        .find_switches(Request::new(rpc_forge::SwitchQuery {
+            switch_id: Some(switch_id),
+            name: None,
+        }))
+        .await?
+        .into_inner();
+
+    assert_eq!(switch_resp.switches.len(), 1);
+    let switch = &switch_resp.switches[0];
+
+    assert!(switch.health.is_some(), "Switch should have health field");
+    let health: HealthReport = switch.health.clone().unwrap().try_into().unwrap();
+    assert!(
+        !health.alerts.is_empty(),
+        "Switch health should contain alerts"
+    );
+
+    assert_eq!(switch.health_sources.len(), 1);
+    assert_eq!(switch.health_sources[0].source, "external-monitor");
+    assert_eq!(
+        switch.health_sources[0].mode,
+        rpc_forge::OverrideMode::Merge as i32
+    );
+
+    Ok(())
+}

--- a/crates/api/src/web/health.rs
+++ b/crates/api/src/web/health.rs
@@ -24,7 +24,7 @@ use axum::response::{Html, IntoResponse, Response};
 use carbide_uuid::machine::{MachineId, MachineType};
 use health_report::HealthReport;
 use hyper::http::StatusCode;
-use model::machine::health_override::HealthReportOverrides;
+use model::health::HealthReportSources;
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{
     InsertHealthReportOverrideRequest, MachinesByIdsRequest, OverrideMode,
@@ -150,7 +150,7 @@ pub async fn health(
             .as_ref()
             .map(|report| report.source.as_str())
             .unwrap_or_default();
-        if HealthReportOverrides::is_hardware_health_override_source(source) {
+        if HealthReportSources::is_hardware_health_override_source(source) {
             if let Some(report) = override_entry.report {
                 let report = health_report_from_rpc_convert_invalid(report);
                 if let Some(aggregated) = hardware_health.as_mut() {

--- a/crates/api/src/web/machine.rs
+++ b/crates/api/src/web/machine.rs
@@ -111,12 +111,12 @@ impl MachineRowDisplay {
             num_nvlink_gpus = nvlink_info.gpus.len();
         }
         let replace_count = m
-            .health_overrides
+            .health_sources
             .iter()
             .filter(|o| o.mode() == OverrideMode::Replace)
             .count();
         let merge_count = m
-            .health_overrides
+            .health_sources
             .iter()
             .filter(|o| o.mode() == OverrideMode::Merge)
             .count();
@@ -703,11 +703,7 @@ impl From<forgerpc::Machine> for MachineDetail<'_> {
                         .unwrap_or_else(health_report::HealthReport::malformed_report)
                 })
                 .unwrap_or_else(health_report::HealthReport::missing_report),
-            health_overrides: m
-                .health_overrides
-                .iter()
-                .map(|o| o.source.clone())
-                .collect(),
+            health_overrides: m.health_sources.iter().map(|o| o.source.clone()).collect(),
             discovery_info_json,
             capabilities_json: m
                 .capabilities

--- a/crates/api/src/web/managed_host.rs
+++ b/crates/api/src/web/managed_host.rs
@@ -107,7 +107,7 @@ impl From<ManagedHostStateSnapshot> for ManagedHostRowDisplay {
         } = item;
 
         let (maintenance_reference, maintenance_start_time) = host_snapshot
-            .health_report_overrides
+            .health_report_sources
             .maintenance_override()
             .map(|o| {
                 (
@@ -183,7 +183,7 @@ impl From<ManagedHostStateSnapshot> for ManagedHostRowDisplay {
                 .unwrap_or_default(),
             health_probe_alerts: aggregate_health.alerts,
             health_overrides: host_snapshot
-                .health_report_overrides
+                .health_report_sources
                 .into_iter()
                 .map(|(r, _)| r.source)
                 .collect(),

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -258,7 +258,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "#[derive(serde::Serialize)]",
         )
         .type_attribute("forge.HealthReportOverride", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.HealthOverrideOrigin", "#[derive(serde::Deserialize, serde::Serialize)]")
+        .type_attribute("forge.HealthSourceOrigin", "#[derive(serde::Deserialize, serde::Serialize)]")
         .type_attribute(
             "forge.ManagedHostNetworkConfig",
             "#[derive(serde::Serialize)]",

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -146,6 +146,12 @@ service Forge {
   rpc InsertRackHealthReportOverride(InsertRackHealthReportOverrideRequest) returns (google.protobuf.Empty);
   // Removes a health report override for a Rack
   rpc RemoveRackHealthReportOverride(RemoveRackHealthReportOverrideRequest) returns (google.protobuf.Empty);
+  // Lists all health report sources for a Switch
+  rpc ListSwitchHealthReports(ListSwitchHealthReportsRequest) returns (ListHealthReportOverrideResponse);
+  // Adds a health report source for a Switch
+  rpc InsertSwitchHealthReport(InsertSwitchHealthReportRequest) returns (google.protobuf.Empty);
+  // Removes a health report source for a Switch
+  rpc RemoveSwitchHealthReport(RemoveSwitchHealthReportRequest) returns (google.protobuf.Empty);
   rpc DpuAgentUpgradeCheck(DpuAgentUpgradeCheckRequest) returns (DpuAgentUpgradeCheckResponse);
   rpc DpuAgentUpgradePolicyAction(DpuAgentUpgradePolicyRequest) returns (DpuAgentUpgradePolicyResponse);
   // Looks up a DNS record for DNS names assigned by Forge
@@ -1979,6 +1985,8 @@ message Switch {
   // The rack that this switch is associated with
   optional common.RackId rack_id = 10;
   optional PlacementInRack placement_in_rack = 11;
+  health.HealthReport health = 12;
+  repeated HealthSourceOrigin health_sources = 13;
 }
 
 message SwitchList {
@@ -3150,9 +3158,9 @@ message Machine {
   // For DPUs, it returns the individual DPU health
   health.HealthReport health = 27;
 
-  // Informs whether any overrides (identified by a specific source name and mode) are applied
-  // to health
-  repeated HealthOverrideOrigin health_overrides = 29;
+  // Health report sources (identified by a specific source name and mode) that are applied
+  // to the aggregate health of this machine
+  repeated HealthSourceOrigin health_sources = 29;
 
   optional bool firmware_autoupdate = 28;
 
@@ -3288,8 +3296,8 @@ message MachineInventorySoftwareComponent {
   string url = 3;
 }
 
-// A health override that is applied to a Host
-message HealthOverrideOrigin {
+// Summary of a health report source: its mode and source identifier.
+message HealthSourceOrigin {
   OverrideMode mode = 1;
   string source = 2;
 }
@@ -4472,6 +4480,23 @@ message RemoveRackHealthReportOverrideRequest {
 // Request to list health report overrides for a Rack.
 message ListRackHealthReportOverridesRequest {
   optional common.RackId rack_id = 1;
+}
+
+// Request to insert a health report source for a Switch.
+message InsertSwitchHealthReportRequest {
+  common.SwitchId switch_id = 1;
+  HealthReportOverride override = 2;
+}
+
+// Request to remove a health report source for a Switch.
+message RemoveSwitchHealthReportRequest {
+  common.SwitchId switch_id = 1;
+  string source = 2;
+}
+
+// Request to list health report sources for a Switch.
+message ListSwitchHealthReportsRequest {
+  optional common.SwitchId switch_id = 1;
 }
 
 message ListHealthReportOverrideResponse {
@@ -6429,7 +6454,7 @@ message Rack {
   google.protobuf.Timestamp updated = 10;
   google.protobuf.Timestamp deleted = 11;
   health.HealthReport health = 12;
-  repeated HealthOverrideOrigin health_overrides = 13;
+  repeated HealthSourceOrigin health_sources = 13;
   Metadata metadata = 14;
   string version = 15;
 }

--- a/crates/utils/src/managed_host_display.rs
+++ b/crates/utils/src/managed_host_display.rs
@@ -186,7 +186,7 @@ impl From<Machine> for ManagedHostOutput {
             })
             .unwrap_or_else(health_report::HealthReport::missing_report);
         let health_overrides = machine
-            .health_overrides
+            .health_sources
             .into_iter()
             .map(|o| o.source)
             .collect();


### PR DESCRIPTION
## Description

This takes care of https://github.com/NVIDIA/ncx-infra-controller-core/issues/241, implementing health management APIs for switches, including:
- `InsertSwitchHealthReport`
- `RemoveSwitchHealthReport`
- `ListSwitchHealthReports`

..which comes with it's own `carbide-admin-cli` commands:

```
carbide-admin-cli switch health-report show <switch-id>
carbide-admin-cli switch health-report add <switch-id> --template mark-healthy
carbide-admin-cli switch health-report add <switch-id> --template degraded --message "fabric issue"
carbide-admin-cli switch health-report add <switch-id> --health-report '{"source": "..."}' --replace
carbide-admin-cli switch health-report remove <switch-id> <report-source>
carbide-admin-cli switch health-report print-empty-template
```

And, based on feedback from @Matthias247 to share code (and no longer call things overrides), this also:
- Renames `HealthReportOverrides` to `HealthReportSources`.
- Deduplicates `api-db` code -- we now have a `db::health_report` module with:
  - `insert_health_report_override`
  - `remove_health_report_override`
  - Both take parameters for table name and ID, and support `machine`, `rack`, and `switch`.
- Deduplicates `admin-cli` code with a `health_utils` module.

Unit and integration tests included, which test:
- The full "CRUD" lifecycle, where we insert a merge override, list it, remove it, and verify it was removed.
- Insertions are idempotent -- insert the same source a few times and make sure it results in only 1 override.
- Inserting an override for a non-existent switch returns an error as expected.
- Removing a non-existent source returns `NotFound` as expected.
- That replace mode works -- insert, verify the mode is `Replace`, remove it, and verify empty.
- That the `health` and `health_sources` fields are populated when we call `FindSwitches`.

Btw, this does *NOT* wire up switch health with the state controller (yet). We'll do that in a follow-up.

This also supports https://github.com/NVIDIA/ncx-infra-controller-core/issues/995.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

