### PR TITLE
Add FMDS container and support for using nvcr.io helm repo

### DIFF
--- a/bluefield/charts/carbide-dpu-agent/templates/_helpers.tpl
+++ b/bluefield/charts/carbide-dpu-agent/templates/_helpers.tpl
@@ -54,3 +54,14 @@ Server Port
 {{- define "carbide-dpu-agent.serverPort" -}}
 {{- default 8888 .Values.serverPort -}}
 {{- end -}}
+
+{{/*
+NVUE credentials secret name: use explicit value if set, otherwise the chart-generated name.
+*/}}
+{{- define "carbide-dpu-agent.nvueSecretName" -}}
+{{- if .Values.hbn.nvue_credentials_secret_name -}}
+{{- .Values.hbn.nvue_credentials_secret_name -}}
+{{- else -}}
+{{- include "carbide-dpu-agent.fullname" . -}}-nvue-creds
+{{- end -}}
+{{- end -}}

--- a/bluefield/charts/carbide-dpu-agent/templates/daemonset.yaml
+++ b/bluefield/charts/carbide-dpu-agent/templates/daemonset.yaml
@@ -93,12 +93,12 @@ spec:
             - name: NVUE_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.hbn.nvue_credentials_secret_name }}
+                  name: {{ include "carbide-dpu-agent.nvueSecretName" . }}
                   key: {{ .Values.hbn.nvue_username_key }}
             - name: NVUE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.hbn.nvue_credentials_secret_name }}
+                  name: {{ include "carbide-dpu-agent.nvueSecretName" . }}
                   key: {{ .Values.hbn.nvue_password_key }}
           volumeMounts:
             - name: forge-certs

--- a/bluefield/charts/carbide-dpu-agent/templates/nvue-credentials-secret.yaml
+++ b/bluefield/charts/carbide-dpu-agent/templates/nvue-credentials-secret.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.hbn.nvue_credentials_secret_name }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "carbide-dpu-agent.fullname" . }}-nvue-creds
+  labels:
+    {{- include "carbide-dpu-agent.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ .Values.hbn.nvue_username_key }}: {{ .Values.hbn.nvue_username | b64enc }}
+  {{ .Values.hbn.nvue_password_key }}: {{ .Values.hbn.nvue_password | b64enc }}
+{{- end }}

--- a/bluefield/charts/carbide-dpu-agent/values.yaml
+++ b/bluefield/charts/carbide-dpu-agent/values.yaml
@@ -31,6 +31,8 @@ hbn:
   nvue_credentials_secret_name: ""
   nvue_username_key: "username"
   nvue_password_key: "password"
+  nvue_username: "cumulus"
+  nvue_password: "CumuluS!"
 discovery:
   hardware_file: "/etc/carbide/discovery_info.json"
 dhcp_server:

--- a/bluefield/charts/carbide-fmds/templates/_helpers.tpl
+++ b/bluefield/charts/carbide-fmds/templates/_helpers.tpl
@@ -47,3 +47,10 @@ Selector labels
 app.kubernetes.io/name: {{ include "carbide-fmds.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Server Port
+*/}}
+{{- define "carbide-fmds.serverPort" -}}
+{{- default 50052 .Values.serverPort -}}
+{{- end -}}

--- a/bluefield/charts/carbide-fmds/templates/daemonset.yaml
+++ b/bluefield/charts/carbide-fmds/templates/daemonset.yaml
@@ -31,8 +31,7 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
+      dnsPolicy: ClusterFirst
       {{- if not (empty .Values.serviceDaemonSet.nodeSelector) }}
       affinity:
         nodeAffinity:
@@ -48,6 +47,8 @@ spec:
       initContainers:
         - name: wait-for-certs
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          args:
+            - "--grpc-address=$(POD_IP):50052"
           command:
             - /bin/sh
             - -c
@@ -81,6 +82,10 @@ spec:
               value: "0"
             - name: RUST_LOG
               value: "info"
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: NODE_NAME
               valueFrom:
                 fieldRef:

--- a/bluefield/charts/carbide-fmds/templates/service.yaml
+++ b/bluefield/charts/carbide-fmds/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "carbide-fmds.fullname" . }}
+  labels:
+    {{- include "carbide-fmds.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "carbide-fmds.selectorLabels" . | nindent 4 }}
+    {{- with .Values.serviceDaemonSet.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  ports:
+    - protocol: TCP
+      port: {{ include "carbide-fmds.serverPort" . | int }}
+      targetPort: {{ include "carbide-fmds.serverPort" . | int }}

--- a/crates/api/src/dpf_services.rs
+++ b/crates/api/src/dpf_services.rs
@@ -28,13 +28,13 @@ use carbide_dpf::{
 pub const DEFAULT_DOCA_HELM_REGISTRY: &str = "https://helm.ngc.nvidia.com/nvidia/doca";
 
 pub const DEFAULT_CARBIDE_HELM_REGISTRY: &str =
-    "https://gitlab-master.nvidia.com/aadvani/my-helm-project/-/raw/main/charts-repo";
+    "https://helm.ngc.nvidia.com/0837451325059433/carbide-dev";
 
 /// Default DOCA container image registry prefix.
 pub const DEFAULT_DOCA_IMAGE_REGISTRY: &str = "nvcr.io/nvidia/doca";
 
 /// Default Carbide container image registry prefix.
-pub const DEFAULT_CARBIDE_IMAGE_REGISTRY: &str = "gitlab-master.nvidia.com/aadvani/my-helm-project";
+pub const DEFAULT_CARBIDE_IMAGE_REGISTRY: &str = "nvcr.io/0837451325059433/carbide-dev";
 
 /// HBN service Definitions
 pub const DOCA_HBN_SERVICE_NAME: &str = "doca-hbn";
@@ -44,21 +44,27 @@ pub const DOCA_HBN_SERVICE_IMAGE_NAME: &str = "doca-hbn";
 pub const DOCA_HBN_SERVICE_IMAGE_TAG: &str = "3.2.1-doca3.2.1";
 pub const DOCA_HBN_SERVICE_NETWORK: &str = "mybrhbn";
 
+/// Common DPU Service Helm Version and Tags
+pub const DPU_COMMON_SERVICE_HELM_VERSION: &str = "0.8.0-pr-27.g44dd729b";
+pub const DPU_COMMON_SERVICE_IMAGE_TAG: &str = "v0.8.0-pr-27-g44dd729b";
+pub const DPU_COMMON_SERVICE_MTU: i64 = 1500;
+
 /// DHCP Service Definitions
 pub const DHCP_SERVER_SERVICE_NAME: &str = "carbide-dhcp-server";
 pub const DHCP_SERVER_SERVICE_HELM_NAME: &str = "carbide-dhcp-server";
-pub const DHCP_SERVER_SERVICE_HELM_VERSION: &str = "2.0.9";
 pub const DHCP_SERVER_SERVICE_IMAGE_NAME: &str = "forge-dhcp-server";
-pub const DHCP_SERVER_SERVICE_IMAGE_TAG: &str = "v1.9.5-arm64-distroless";
 pub const DHCP_SERVER_SERVICE_NAD_NAME: &str = "mybrsfc-dhcp";
-pub const DHCP_SERVER_SERVICE_MTU: i64 = 1500;
 
-// DPU Agent Service Definitions
+/// DPU Agent Service Definitions
 pub const DPU_AGENT_SERVICE_NAME: &str = "carbide-dpu-agent";
 pub const DPU_AGENT_SERVICE_HELM_NAME: &str = "carbide-dpu-agent";
-pub const DPU_AGENT_SERVICE_HELM_VERSION: &str = "0.4.0";
 pub const DPU_AGENT_SERVICE_IMAGE_NAME: &str = "forge-dpu-agent";
-pub const DPU_AGENT_SERVICE_IMAGE_TAG: &str = "v0.3-arm64-multistage";
+
+/// FMDS Agent Service Definitions
+pub const FMDS_SERVICE_NAME: &str = "carbide-fmds";
+pub const FMDS_SERVICE_HELM_NAME: &str = "carbide-fmds";
+pub const FMDS_SERVICE_IMAGE_NAME: &str = "carbide-fmds";
+pub const FMDS_SERVICE_NAD_NAME: &str = "mybrsfc-fmds";
 
 /// Extended registry configuration for Carbide DPU services.
 #[derive(Debug, Clone)]
@@ -181,7 +187,7 @@ pub fn dpu_agent_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinitio
             "image": {
                 "repository": format!("{}/{}", reg.carbide_image_registry,
                     DPU_AGENT_SERVICE_IMAGE_NAME),
-                "tag": DPU_AGENT_SERVICE_IMAGE_TAG,
+                "tag": DPU_COMMON_SERVICE_IMAGE_TAG,
             }
         })),
 
@@ -191,7 +197,7 @@ pub fn dpu_agent_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinitio
             DPU_AGENT_SERVICE_NAME,
             &reg.carbide_helm_registry,
             DPU_AGENT_SERVICE_HELM_NAME,
-            DPU_AGENT_SERVICE_HELM_VERSION,
+            DPU_COMMON_SERVICE_HELM_VERSION,
         )
     }
 }
@@ -204,7 +210,7 @@ pub fn dhcp_server_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinit
             "image": {
                 "repository": format!("{}/{}", reg.carbide_image_registry,
                     DHCP_SERVER_SERVICE_IMAGE_NAME),
-                "tag": DHCP_SERVER_SERVICE_IMAGE_TAG,
+                "tag": DPU_COMMON_SERVICE_IMAGE_TAG,
             }
         })),
 
@@ -220,14 +226,14 @@ pub fn dhcp_server_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinit
             bridge: Some("br-sfc".to_string()),
             resource_type: ServiceNADResourceType::Sf,
             ipam: Some(false),
-            mtu: Some(DHCP_SERVER_SERVICE_MTU),
+            mtu: Some(DPU_COMMON_SERVICE_MTU),
         }),
 
         ..ServiceDefinition::new(
             DHCP_SERVER_SERVICE_NAME,
             &reg.carbide_helm_registry,
             DHCP_SERVER_SERVICE_HELM_NAME,
-            DHCP_SERVER_SERVICE_HELM_VERSION,
+            DPU_COMMON_SERVICE_HELM_VERSION,
         )
     }
 }
@@ -242,4 +248,42 @@ pub fn dpu_otel_agent_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefi
         "forge-dpu-otel-agent",
         "0.1.0",
     )
+}
+
+/// FMDS Service
+pub fn fmds_service (reg: &CarbideServiceRegistryConfig) -> ServiceDefinition
+{
+    ServiceDefinition {
+        helm_values:  Some(serde_json::json!({
+            "image": {
+                "repository": format!("{}/{}", reg.carbide_image_registry,
+                    FMDS_SERVICE_IMAGE_NAME),
+                "tag": DPU_COMMON_SERVICE_IMAGE_TAG,
+            }
+        })),
+
+        interfaces: vec![ServiceInterface {
+            name: "f_pf0hpf_if".to_string(),
+            network: FMDS_SERVICE_NAD_NAME.to_string(),
+        }],
+
+        service_daemon_set_annotations: Some(BTreeMap::new()),
+
+        service_nad: Some(ServiceNAD {
+            name: FMDS_SERVICE_NAD_NAME.to_string(),
+            bridge: Some("br-sfc".to_string()),
+            resource_type: ServiceNADResourceType::Sf,
+            ipam: Some(false),
+            mtu: Some(DPU_COMMON_SERVICE_MTU),
+        }),
+
+        ..ServiceDefinition::new(
+            FMDS_SERVICE_NAME,
+            &reg.carbide_helm_registry,
+            FMDS_SERVICE_HELM_NAME,
+            DPU_COMMON_SERVICE_HELM_VERSION,
+        )
+
+    }
+
 }

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -425,6 +425,7 @@ pub async fn start_api(
             crate::dpf_services::dhcp_server_service(&reg),
             crate::dpf_services::doca_hbn_service(&reg),
             crate::dpf_services::dpu_agent_service(&reg),
+            crate::dpf_services::fmds_service(&reg),
         ];
 
         let bfcfg_template = if carbide_config.dpf.bfcfg_enabled {


### PR DESCRIPTION
## Description
This PR adds FMDS container and also support for using nvcr.io helm repository instead of the private gitlab repo

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

- The PR changes were tested by ensuring that the FMDS service and other custom services are created
- The helm chart changes can only be tested after they are published, but the dpu-agent chart change was needed because it was broken in that it provided an empty nvue credential which was causing the service to not come up
- The helm chart for the fmds adds a Cluster IP Service and adds args to use that IP as the grpc-address
