### PR TITLE
feat(bmc-explorer): LiteOn powershelf power state via nv-redfish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6642,9 +6642,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bbabc6ec4282913f6aed55ae46cf9b381ec185de12839b714005eda7ef59b7a"
+checksum = "89af886c6d5fe2a3296b2c3a20b93fd5cedcf6d20f421550c1b42b4cdf439f0a"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -6658,9 +6658,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-bmc-http"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0417d9aab9f91c3cc38713ea839a7a1e1a7eea83e01693b2c4d2006e99e989f"
+checksum = "00fcb3fea4212eac654f9c64f39145938bc36ce9f9b41083abcfdd2db4521c83"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -6678,9 +6678,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-core"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c747366715084fc42415623d78109a3db13afdfe02eb11e595d05b5474caac"
+checksum = "7464778f7f5174af13481491d8ac2e60c1541158d7b7848f34e9d7df7eea8d45"
 dependencies = [
  "futures-core",
  "rust_decimal",
@@ -6692,9 +6692,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-csdl-compiler"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a526c4b2f23ef1766572a24bd9c88a85ab45e8610114b811d7e6a6669f0139b"
+checksum = "b05fb324cb8daa29ced5b019fa2ebd8a0374417a141331b0629df9438e31eb2c"
 dependencies = [
  "clap",
  "clap_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ tracing-appender = "0.2.4"
 tracing-opentelemetry = "0.29.0"
 
 # NV-Redfish
-nv-redfish = { version = "0.6.0", features = [
+nv-redfish = { version = "0.6.1", features = [
   "bmc-http",
   "std-redfish",
   "update-service",

--- a/crates/bmc-explorer/Cargo.toml
+++ b/crates/bmc-explorer/Cargo.toml
@@ -41,6 +41,7 @@ nv-redfish = { workspace = true, features = [
     "oem-supermicro",
     "oem-hpe",
     "oem-ami",
+    "oem-liteon",
     "bmc-http"
 ] }
 regex = { workspace = true }

--- a/crates/bmc-explorer/src/chassis.rs
+++ b/crates/bmc-explorer/src/chassis.rs
@@ -16,8 +16,10 @@
  */
 
 use std::convert::identity;
+use std::fmt;
 
-use model::site_explorer::Chassis;
+use itertools::Itertools;
+use model::site_explorer::{Chassis, PowerState as ModelPowerState};
 use nv_redfish::assembly::Model as AssemblyModel;
 use nv_redfish::chassis::Chassis as NvChassis;
 use nv_redfish::core::ODataId;
@@ -97,6 +99,14 @@ impl<B: Bmc> ExploredChassisCollection<B> {
         })
     }
 
+    pub fn liteon_power_state(&self) -> Option<LiteOnSuppliesState<'_>> {
+        self.members.iter().find_map(|m| {
+            m.oem_liteon_power_supplies
+                .as_ref()
+                .map(|v| LiteOnSuppliesState(v))
+        })
+    }
+
     pub fn is_gb300(&self) -> bool {
         self.members.iter().any(|m| {
             m.chassis.hardware_id().manufacturer == Some(Manufacturer::new("NVIDIA"))
@@ -162,6 +172,7 @@ pub struct ExploredChassis<B: Bmc> {
     pub chassis: NvChassis<B>,
     pub network_adapters: ExploredNetworkAdapterCollection<B>,
     pub assembly_sn: Option<String>,
+    pub oem_liteon_power_supplies: Option<Vec<LiteOnPowerSupply>>,
 }
 
 impl<B: Bmc> ExploredChassis<B> {
@@ -192,11 +203,36 @@ impl<B: Bmc> ExploredChassis<B> {
         } else {
             None
         };
+        // Here we rely on the fact that
+        // Chassis::oem_liteon_power_supply_links returns None
+        // immediately if chassis is not LiteOn.
+        let oem_liteon_power_supplies = if let Some(ps_links) = chassis
+            .oem_liteon_power_supply_links()
+            .await
+            .map_err(Error::nv_redfish("LiteOn power supply links"))?
+        {
+            let mut power_supplies = Vec::new();
+            for l in ps_links {
+                let ps = l
+                    .fetch()
+                    .await
+                    .map_err(Error::nv_redfish("LiteOn power supply"))?;
+                power_supplies.push(LiteOnPowerSupply {
+                    id: ps.base.id.clone(),
+                    serial_number: ps.serial_number.clone().and_then(std::convert::identity),
+                    power_state: ps.power_state,
+                });
+            }
+            Some(power_supplies)
+        } else {
+            None
+        };
 
         Ok(Self {
             chassis,
             network_adapters,
             assembly_sn,
+            oem_liteon_power_supplies,
         })
     }
 
@@ -237,6 +273,43 @@ impl<B: Bmc> ExploredChassis<B> {
                 .as_ref()
                 .and_then(|x| x.revision_id())
                 .map(|v| v.into_inner() as i32),
+        }
+    }
+}
+
+pub struct LiteOnPowerSupply {
+    pub id: String,
+    pub serial_number: Option<String>,
+    pub power_state: Option<bool>,
+}
+
+pub struct LiteOnSuppliesState<'a>(&'a [LiteOnPowerSupply]);
+
+impl fmt::Display for LiteOnSuppliesState<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0
+            .iter()
+            .map(|s| format!("{}:{:?}:{:?}", s.id, s.serial_number, s.power_state))
+            .join(", ")
+            .fmt(f)
+    }
+}
+
+impl LiteOnSuppliesState<'_> {
+    pub fn to_model(&self) -> ModelPowerState {
+        if self.0.is_empty() {
+            return ModelPowerState::Unknown;
+        }
+
+        let on = self.0.iter().all(|v| v.power_state == Some(true));
+        let off = self.0.iter().all(|v| v.power_state == Some(false));
+        if on {
+            ModelPowerState::On
+        } else if off {
+            ModelPowerState::Off
+        } else {
+            tracing::warn!("powershelf power state is unknown: {self}");
+            ModelPowerState::Unknown
         }
     }
 }

--- a/crates/bmc-explorer/src/computer_system.rs
+++ b/crates/bmc-explorer/src/computer_system.rs
@@ -209,6 +209,23 @@ impl<B: Bmc> ExploredComputerSystem<B> {
             .filter_map(|dev| pcie_device_to_model(hw_type, dev))
             .collect();
 
+        let power_state = chassis
+            .liteon_power_state()
+            .map(|v| v.to_model())
+            .unwrap_or_else(|| {
+                self.system
+                    .power_state()
+                    .and_then(|v| match v {
+                        PowerState::On => Some(ModelPowerState::On),
+                        PowerState::Off => Some(ModelPowerState::Off),
+                        PowerState::PoweringOn => Some(ModelPowerState::PoweringOn),
+                        PowerState::PoweringOff => Some(ModelPowerState::PoweringOff),
+                        PowerState::Paused => Some(ModelPowerState::Paused),
+                        PowerState::UnsupportedValue => None,
+                    })
+                    .unwrap_or_default()
+            });
+
         Ok(ModelComputerSystem {
             ethernet_interfaces,
             id: self.system.id().to_string(),
@@ -221,18 +238,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
             },
             pcie_devices,
             base_mac,
-            power_state: self
-                .system
-                .power_state()
-                .and_then(|v| match v {
-                    PowerState::On => Some(ModelPowerState::On),
-                    PowerState::Off => Some(ModelPowerState::Off),
-                    PowerState::PoweringOn => Some(ModelPowerState::PoweringOn),
-                    PowerState::PoweringOff => Some(ModelPowerState::PoweringOff),
-                    PowerState::Paused => Some(ModelPowerState::Paused),
-                    PowerState::UnsupportedValue => None,
-                })
-                .unwrap_or_default(),
+            power_state,
             sku: self.system.sku().map(|v| v.to_string()),
             boot_order,
         })


### PR DESCRIPTION
## Description

Bump nv-redfish to 0.6.1 and enable oem-liteon feature. Fetch LiteOn OEM power supply links during chassis exploration and derive overall power state from individual PSU PowerState booleans (all-on -> On, all-off -> Off, mixed/empty/None -> Unknown), matching libredfish semantics. LiteOn chassis power state takes priority over ComputerSystem.PowerState for powershelf platforms.

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
