### PR TITLE
fix: only query PSM for PMC firmware status

### DIFF
--- a/crates/component-manager/src/psm.rs
+++ b/crates/component-manager/src/psm.rs
@@ -289,13 +289,16 @@ impl PowerShelfManager for PsmPowerShelfBackend {
                 let mac = ep.pmc_mac.to_string();
                 vec![
                     psm::FirmwareUpdateQuery {
-                        pmc_mac_address: mac.clone(),
+                        pmc_mac_address: mac,
                         component: psm::PowershelfComponent::Pmc as i32,
                     },
+                    /*
+                    TODO: support retrieving fw status gracefully
                     psm::FirmwareUpdateQuery {
                         pmc_mac_address: mac,
                         component: psm::PowershelfComponent::Psu as i32,
                     },
+                    */
                 ]
             })
             .collect();


### PR DESCRIPTION
## Description

fix: only query PSM for PMC firmware status until PSU firmware updates are supported

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

