### PR TITLE
fix(dhcp): allow host DHCP for zero-DPU hosts with instances

### DIFF
--- a/crates/api/src/dhcp/discover.rs
+++ b/crates/api/src/dhcp/discover.rs
@@ -301,13 +301,17 @@ pub async fn discover_dhcp(
         .await?;
     }
 
-    if let Some(machine_id) = machine_interface.machine_id {
-        // Can't block host's DHCP handling completely to support Zero-DPU.
-        if machine_id.machine_type().is_host()
-            && let Some(instance_id) =
-                db::instance::find_id_by_machine_id(&mut txn, &machine_id).await?
-        {
-            // An instance is associated with machine id. DPU must process it.
+    if let Some(machine_id) = machine_interface.machine_id
+        && machine_id.machine_type().is_host()
+        && let Some(instance_id) =
+            db::instance::find_id_by_machine_id(&mut txn, &machine_id).await?
+    {
+        // An instance is associated with this host. If the host has DPUs,
+        // the DPUs proxy DHCP on its behalf, so we reject the host's direct
+        // DHCP request. Zero-DPU hosts have no such intermediary, so let
+        // their DHCP proceed.
+        let dpus = db::machine::find_dpus_by_host_machine_id(&mut txn, &machine_id).await?;
+        if !dpus.is_empty() {
             return Err(CarbideError::internal(format!(
                 "DHCP request received for instance: {instance_id}. Ignoring."
             )));

--- a/crates/api/src/tests/machine_dhcp.rs
+++ b/crates/api/src/tests/machine_dhcp.rs
@@ -20,10 +20,17 @@ use std::str::FromStr;
 
 use carbide_network::ip::IpAddressFamily;
 use carbide_uuid::machine::MachineInterfaceId;
+use common::api_fixtures::managed_host::ManagedHostConfig;
+use common::api_fixtures::network_segment::{
+    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY, FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY,
+    create_host_inband_network_segment,
+};
 use common::api_fixtures::{
-    FIXTURE_DHCP_RELAY_ADDRESS, TestEnv, create_managed_host, create_test_env, dpu,
+    FIXTURE_DHCP_RELAY_ADDRESS, TestEnv, TestEnvOverrides, create_managed_host,
+    create_managed_host_with_config, create_test_env, create_test_env_with_overrides, dpu,
 };
 use db::{self, ObjectColumnFilter, dhcp_entry};
+use ipnetwork::IpNetwork;
 use itertools::Itertools;
 use mac_address::MacAddress;
 use rpc::forge::ManagedHostNetworkConfigRequest;
@@ -466,6 +473,139 @@ async fn test_dhcp_record_address_family(
     );
     assert_eq!(ipv6_record.address, ipv6_addr);
     txn.rollback().await?;
+
+    Ok(())
+}
+
+/// Resolve a machine_interface + its segment gateway for the given host, so
+/// the test can drive a DHCP request with the same relay the real host would
+/// see in production.
+async fn host_interface_and_gateway(
+    env: &TestEnv,
+    host_machine_id: carbide_uuid::machine::MachineId,
+) -> Result<(MacAddress, IpAddr), Box<dyn std::error::Error>> {
+    let mut txn = env.pool.begin().await?;
+    let interfaces_by_machine =
+        db::machine_interface::find_by_machine_ids(txn.as_mut(), &[host_machine_id]).await?;
+    let interface = interfaces_by_machine
+        .get(&host_machine_id)
+        .and_then(|ifaces| ifaces.first())
+        .ok_or("host has no machine_interfaces")?;
+    let prefix = db::network_prefix::find_by(
+        txn.as_mut(),
+        ObjectColumnFilter::One(db::network_prefix::SegmentIdColumn, &interface.segment_id),
+    )
+    .await?
+    .into_iter()
+    .next()
+    .ok_or("no network_prefix for segment")?;
+    let gateway = prefix.gateway.ok_or("segment prefix has no gateway")?;
+    let mac = interface.mac_address;
+    txn.rollback().await?;
+    Ok((mac, gateway))
+}
+
+/// Insert an `instances` row directly, bypassing the allocator (which today
+/// requires DPUs + VPCs). All the DHCP branch under test reads is
+/// `instances.machine_id`, so a minimal INSERT is enough.
+async fn attach_bare_instance(
+    env: &TestEnv,
+    machine_id: carbide_uuid::machine::MachineId,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut txn = env.pool.begin().await?;
+    sqlx::query("INSERT INTO instances (machine_id) VALUES ($1)")
+        .bind(machine_id)
+        .execute(txn.as_mut())
+        .await?;
+    txn.commit().await?;
+    Ok(())
+}
+
+// A host with DPUs must have its DHCP rejected once an instance is attached:
+// the DPUs are expected to proxy the DHCP on the host's behalf. This preserves
+// the long-standing behavior that predates zero-DPU support.
+#[crate::sqlx_test]
+async fn test_dhcp_rejects_dpu_host_with_instance(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+    attach_bare_instance(&env, mh.host().id).await?;
+
+    let (host_mac, gateway) = host_interface_and_gateway(&env, mh.host().id).await?;
+
+    let result = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder(host_mac, FIXTURE_DHCP_RELAY_ADDRESS)
+                .link_address(gateway.to_string())
+                .tonic_request(),
+        )
+        .await;
+
+    let status = result.expect_err("DHCP for DPU-ful host with instance should be rejected");
+    assert!(
+        status
+            .message()
+            .contains("DHCP request received for instance"),
+        "unexpected error: {}",
+        status.message()
+    );
+
+    Ok(())
+}
+
+// A zero-DPU host with an instance attached has no DPU intermediary, so its
+// own DHCP request must be allowed through instead of being rejected on the
+// assumption that a DPU will handle it.
+#[crate::sqlx_test]
+async fn test_dhcp_allows_zero_dpu_host_with_instance(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides {
+            allow_zero_dpu_hosts: Some(true),
+            site_prefixes: Some(vec![
+                IpNetwork::new(
+                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+                IpNetwork::new(
+                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+            ]),
+            ..Default::default()
+        },
+    )
+    .await;
+    create_host_inband_network_segment(&env.api, None).await;
+
+    let mh = create_managed_host_with_config(&env, ManagedHostConfig::with_dpus(Vec::new())).await;
+    assert!(
+        mh.dpu_ids.is_empty(),
+        "zero-DPU fixture should produce no DPU machines"
+    );
+
+    attach_bare_instance(&env, mh.host().id).await?;
+
+    let (host_mac, gateway) = host_interface_and_gateway(&env, mh.host().id).await?;
+
+    let response = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder(host_mac, FIXTURE_DHCP_RELAY_ADDRESS)
+                .link_address(gateway.to_string())
+                .tonic_request(),
+        )
+        .await
+        .expect("DHCP for zero-DPU host with instance should succeed")
+        .into_inner();
+
+    assert_eq!(response.mac_address, host_mac.to_string());
 
     Ok(())
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/NVIDIA/ncx-infra-controller-core/issues/874.

`crates/api/src/dhcp/discover.rs` has always rejected any *host* DHCP request once an instance was attached to the host, on the assumption that a DPU would relay/proxy DHCP on the host's behalf. That assumption doesn't hold for zero-DPU hosts: they have no DPU intermediary, so the rejection left zero DPU hosts with no viable DHCP path the moment an instance landed on them. There was an even an old comment, "*Can't block host's DHCP handling completely to support Zero-DPU*", which called this gap out. This PR closes it!

The specific change is to narrow the rejection to only fire when the host actually has DPUs, using the existing `db::machine::find_dpus_by_host_machine_id` helper:
- If the host has DPUs, behavior is unchanged.
- If it's a zero-DPU host, DHCP proceeds normally.

Added a couple of integration tests to make sure there is no regressing for a host with DPUs, and that zero-DPU host with an instance attached now gets a DHCP response (instead of an error with "*DHCP request received for instance: ... Ignoring")

Fwiw, this doesn't "complete" zero DPU support by any means. There's still work to do. This is just a low hanging bit, and since I've been doing so much work related to DHCP and IP allocation lately, I figured this was relevant to the overall efforts there.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

