### PR TITLE
fix: Grant SiteAgent access to expected switches and power shelves RBAC rules

### DIFF
--- a/crates/api/src/auth/internal_rbac_rules.rs
+++ b/crates/api/src/auth/internal_rbac_rules.rs
@@ -643,7 +643,7 @@ impl InternalRBACRules {
         );
         x.perm(
             "GetAllExpectedPowerShelves",
-            vec![ForgeAdminCLI, Machineatron, Rla],
+            vec![ForgeAdminCLI, Machineatron, SiteAgent, Rla],
         );
         x.perm(
             "ReplaceAllExpectedPowerShelves",
@@ -655,7 +655,7 @@ impl InternalRBACRules {
         );
         x.perm(
             "GetAllExpectedPowerShelvesLinked",
-            vec![ForgeAdminCLI, Machineatron, Rla],
+            vec![ForgeAdminCLI, Machineatron, SiteAgent, Rla],
         );
         x.perm(
             "FindPowerShelfStateHistories",
@@ -681,7 +681,7 @@ impl InternalRBACRules {
         x.perm("GetExpectedSwitch", vec![ForgeAdminCLI, Machineatron, Rla]);
         x.perm(
             "GetAllExpectedSwitches",
-            vec![ForgeAdminCLI, Machineatron, Rla],
+            vec![ForgeAdminCLI, Machineatron, SiteAgent, Rla],
         );
         x.perm(
             "ReplaceAllExpectedSwitches",
@@ -693,7 +693,7 @@ impl InternalRBACRules {
         );
         x.perm(
             "GetAllExpectedSwitchesLinked",
-            vec![ForgeAdminCLI, Machineatron, Rla],
+            vec![ForgeAdminCLI, Machineatron, SiteAgent, Rla],
         );
         x.perm(
             "AddExpectedRack",
@@ -1022,6 +1022,23 @@ mod rbac_rule_tests {
                 "carbide-maintenance-jobs".to_string()
             )]
         ));
+
+        for method in [
+            "GetAllExpectedSwitches",
+            "GetAllExpectedSwitchesLinked",
+            "GetAllExpectedPowerShelves",
+            "GetAllExpectedPowerShelvesLinked",
+        ] {
+            assert!(
+                InternalRBACRules::allowed_from_static(
+                    method,
+                    &[Principal::SpiffeServiceIdentifier(
+                        "elektra-site-agent".to_string()
+                    )]
+                ),
+                "{method} should allow SiteAgent"
+            );
+        }
 
         assert!(InternalRBACRules::allowed_from_static(
             "SetMaintenance",


### PR DESCRIPTION
 
## Description
- Add `SiteAgent` to the RBAC principal list for `GetAllExpectedSwitches`, `GetAllExpectedSwitchesLinked`, `GetAllExpectedPowerShelves`, and `GetAllExpectedPowerShelvesLinked`
- This aligns with the existing pattern where `GetAllExpectedMachines` and `GetAllExpectedMachinesLinked` already include `SiteAgent`
- Added test assertions to verify SiteAgent access for all four methods

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

