### PR TITLE
chore: add an is_zero_dpu() helper on ManagedHostStateSnapshot

### DIFF
--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -239,6 +239,22 @@ impl From<ManagedHostStateSnapshotError> for sqlx::Error {
 }
 
 impl ManagedHostStateSnapshot {
+    /// Returns `true` if this managed host has no DPU snapshots attached.
+    ///
+    /// Most call sites in the state controller use this to follow a "zero-DPU"
+    /// branch -- skip DPU-specific work, use the host's primary interface MAC
+    /// directly, reject DPU-only operations, etc.
+    ///
+    /// Note: Currently, a handful of call sites combine this with
+    /// `host_snapshot.associated_dpu_machine_ids().is_empty()` to distinguish
+    /// "truly zero-DPU" from "DPU expected per topology but the snapshot
+    /// failed to load". Those sites intentionally inspect both fields and
+    /// should NOT be rewritten to use this helper alone. Maybe we can enhance
+    /// that later, but for now this keeps it simple.
+    pub fn is_zero_dpu(&self) -> bool {
+        self.dpu_snapshots.is_empty()
+    }
+
     /// Returns `true` if override report is hw_health, `false` otherwise
     fn merge_override_report_with_hw_health(
         output: &mut HealthReport,
@@ -549,7 +565,7 @@ impl ManagedHostStateSnapshot {
                 let snapshot = self.dpu_snapshots.remove(index);
                 self.dpu_snapshots.insert(0, snapshot);
             }
-        } else if !self.dpu_snapshots.is_empty() {
+        } else if !self.is_zero_dpu() {
             // If it is not Zero-DPU case, return failure.
             return Err(ManagedHostStateSnapshotError::AttachedDpuIdMissing(
                 self.host_snapshot.id,

--- a/crates/api/src/handlers/dpu.rs
+++ b/crates/api/src/handlers/dpu.rs
@@ -1176,7 +1176,7 @@ pub(crate) async fn trigger_dpu_reprovisioning(
                 return Err(CarbideError::InvalidArgument("A restart has to be triggered for all DPUs together. Only host_id is accepted for restart operation.".to_string()).into());
             }
 
-            if snapshot.dpu_snapshots.is_empty() {
+            if snapshot.is_zero_dpu() {
                 return Err(CarbideError::InvalidArgument(
                     "Machine has no DPUs, cannot trigger DPU reprovisioning.".to_string(),
                 )

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -4750,7 +4750,7 @@ impl StateHandler for HostMachineStateHandler {
                         .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)
                         .await?;
 
-                    let boot_interface_mac = if !mh_snapshot.dpu_snapshots.is_empty() {
+                    let boot_interface_mac = if !mh_snapshot.is_zero_dpu() {
                         let primary_interface = mh_snapshot
                             .host_snapshot
                             .interfaces
@@ -9327,7 +9327,7 @@ async fn handle_instance_host_platform_config(
             }
         }
         HostPlatformConfigurationState::CheckHostConfig => {
-            let configure_host_boot_order = if !mh_snapshot.dpu_snapshots.is_empty() {
+            let configure_host_boot_order = if !mh_snapshot.is_zero_dpu() {
                 // Given that we are checking the boot order of a server immediately after a power cycle, we
                 // should do some waiting to ensure that the host is not reporting stale redfish information from
                 // before Carbide powered it off.
@@ -9434,7 +9434,7 @@ async fn handle_instance_host_platform_config(
                 },
             };
 
-            let boot_interface_mac = if !mh_snapshot.dpu_snapshots.is_empty() {
+            let boot_interface_mac = if !mh_snapshot.is_zero_dpu() {
                 let primary_interface = mh_snapshot
                     .host_snapshot
                     .interfaces
@@ -9531,7 +9531,7 @@ async fn configure_host_bios(
     redfish_client: &dyn Redfish,
     mh_snapshot: &ManagedHostStateSnapshot,
 ) -> Result<BiosConfigOutcome, StateHandlerError> {
-    let boot_interface_mac = if !mh_snapshot.dpu_snapshots.is_empty() {
+    let boot_interface_mac = if !mh_snapshot.is_zero_dpu() {
         let primary_interface = mh_snapshot
             .host_snapshot
             .interfaces
@@ -9610,7 +9610,7 @@ async fn set_host_boot_order(
 ) -> Result<SetBootOrderOutcome, StateHandlerError> {
     match set_boot_order_info.set_boot_order_state {
         SetBootOrderState::SetBootOrder => {
-            if mh_snapshot.dpu_snapshots.is_empty() {
+            if mh_snapshot.is_zero_dpu() {
                 // MachineState::SetBootOrder is a NO-OP for the Zero-DPU case
                 Ok(SetBootOrderOutcome::Done)
             } else {


### PR DESCRIPTION
## Description

"Zero-DPU" awareness was previously inferred at various call sites by different `.is_empty()` patterns on either `dpu_snapshots` or `associated_dpu_machine_ids()`. This PR introduces a single named helper/predicate, `ManagedHostStateSnapshot::is_zero_dpu()`, and swaps the call sites that are asking the semantic question of "is this a zero-DPU host?" to use it.

It's very basic, but will be the groundwork for some other things to build on, will read a little better, and give us some flexibility later on if we want to change what defines `is_zero_dpu()`.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

