### PR TITLE
refactor(site-explorer): unify expected entities into ExpectedEntity

### DIFF
--- a/book/src/manuals/metrics/core_metrics.md
+++ b/book/src/manuals/metrics/core_metrics.md
@@ -40,6 +40,8 @@ This file contains a list of metrics exported by NCX Infra Controller (NICo). Th
 <tr><td>carbide_hosts_health_overrides_count</td><td>gauge</td><td>The amount of health overrides that are configured in the site</td></tr>
 <tr><td>carbide_hosts_health_status_count</td><td>gauge</td><td>The total number of Managed Hosts in the system that have reported any a healthy nor not healthy status - based on the presence of health probe alerts</td></tr>
 <tr><td>carbide_hosts_in_use_count</td><td>gauge</td><td>The total number of hosts that are actively used by tenants as instances in the Forge site</td></tr>
+<tr><td>carbide_hosts_unhealthy_by_classification_count</td><td>gauge</td><td>The amount of ManagedHosts which are marked with a certain classification due to being unhealthy</td></tr>
+<tr><td>carbide_hosts_unhealthy_by_probe_id_count</td><td>gauge</td><td>The amount of ManagedHosts which reported a certain Health Probe Alert</td></tr>
 <tr><td>carbide_hosts_usable_count</td><td>gauge</td><td>The remaining number of hosts in the Forge site which are available for immediate instance creation</td></tr>
 <tr><td>carbide_hosts_with_bios_password_set</td><td>gauge</td><td>The total number of Hosts in the system that have their BIOS password set.</td></tr>
 <tr><td>carbide_ib_partitions_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_ib_partitions in the system</td></tr>
@@ -108,9 +110,11 @@ This file contains a list of metrics exported by NCX Infra Controller (NICo). Th
 <tr><td>carbide_site_exploration_expected_machines_sku_count</td><td>gauge</td><td>The total count of expected machines by SKU ID and device type</td></tr>
 <tr><td>carbide_site_exploration_identified_managed_hosts_count</td><td>gauge</td><td>The amount of Host+DPU pairs that has been identified in the last SiteExplorer run</td></tr>
 <tr><td>carbide_site_explorer_bmc_reset_count</td><td>gauge</td><td>The amount of BMC resets initiated in the last SiteExplorer run</td></tr>
+<tr><td>carbide_site_explorer_create_machines</td><td>gauge</td><td>Whether site-explorer machine creation is enabled (1) or disabled (0)</td></tr>
 <tr><td>carbide_site_explorer_create_machines_latency_milliseconds</td><td>histogram</td><td>The time it to perform create_machines inside site-explorer</td></tr>
 <tr><td>carbide_site_explorer_created_machines_count</td><td>gauge</td><td>The amount of Machine pairs that had been created by Site Explorer after being identified</td></tr>
 <tr><td>carbide_site_explorer_created_power_shelves_count</td><td>gauge</td><td>The amount of Power Shelves that had been created by Site Explorer after being identified</td></tr>
+<tr><td>carbide_site_explorer_enabled</td><td>gauge</td><td>Whether site-explorer is enabled (1) or paused (0)</td></tr>
 <tr><td>carbide_site_explorer_iteration_latency_milliseconds</td><td>histogram</td><td>The time it took to perform one site explorer iteration</td></tr>
 <tr><td>carbide_switches_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_switches in the system</td></tr>
 <tr><td>carbide_switches_iteration_latency_milliseconds</td><td>histogram</td><td>The elapsed time in the last state processor iteration to handle objects of type carbide_switches</td></tr>

--- a/crates/api-model/src/expected_entity.rs
+++ b/crates/api-model/src/expected_entity.rs
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::expected_machine::ExpectedMachine;
+use crate::expected_power_shelf::ExpectedPowerShelf;
+use crate::expected_switch::ExpectedSwitch;
+
+pub enum ExpectedEntity {
+    Machine(ExpectedMachine),
+    PowerShelf(ExpectedPowerShelf),
+    Switch(ExpectedSwitch),
+}
+
+impl ExpectedEntity {
+    pub fn bmc_credentials_data(&self) -> BmcCredentialsData<'_> {
+        match self {
+            Self::Machine(v) => BmcCredentialsData {
+                username: &v.data.bmc_username,
+                password: &v.data.bmc_password,
+                retain_credentials: v.data.bmc_retain_credentials.unwrap_or(false),
+            },
+            Self::PowerShelf(v) => BmcCredentialsData {
+                username: &v.bmc_username,
+                password: &v.bmc_password,
+                retain_credentials: v.bmc_retain_credentials.unwrap_or(false),
+            },
+            Self::Switch(v) => BmcCredentialsData {
+                username: &v.bmc_username,
+                password: &v.bmc_password,
+                retain_credentials: v.bmc_retain_credentials.unwrap_or(false),
+            },
+        }
+    }
+
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Machine(_) => "machine",
+            Self::PowerShelf(_) => "power shelf",
+            Self::Switch(_) => "switch",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct BmcCredentialsData<'a> {
+    pub username: &'a str,
+    pub password: &'a str,
+    pub retain_credentials: bool,
+}

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -75,7 +75,7 @@ pub struct ExpectedHostNic {
 // Important : new fields for expected machine should be Optional _and_ #[serde(default)],
 // unless you want to go update all the files in each production deployment that autoload
 // the expected machines on api startup
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct ExpectedMachine {
     #[serde(default)]
     pub id: Option<Uuid>,
@@ -84,7 +84,7 @@ pub struct ExpectedMachine {
     pub data: ExpectedMachineData,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Clone, Default, Deserialize)] // Do not add Debug here, it contains password
 pub struct ExpectedMachineData {
     pub bmc_username: String,
     pub bmc_password: String,

--- a/crates/api-model/src/expected_power_shelf.rs
+++ b/crates/api-model/src/expected_power_shelf.rs
@@ -29,7 +29,7 @@ use uuid::Uuid;
 
 use crate::metadata::{Metadata, default_metadata_for_deserializer};
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Clone, Default, Deserialize)] // Do not add Debug here. It contains password.
 pub struct ExpectedPowerShelf {
     #[serde(default)]
     pub expected_power_shelf_id: Option<Uuid>,

--- a/crates/api-model/src/expected_switch.rs
+++ b/crates/api-model/src/expected_switch.rs
@@ -29,7 +29,7 @@ use uuid::Uuid;
 
 use crate::metadata::{Metadata, default_metadata_for_deserializer};
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Clone, Deserialize)] // Do not add debug here, it contains passwords.
 #[serde(default)]
 pub struct ExpectedSwitch {
     #[serde(default)]

--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -46,6 +46,7 @@ pub mod dpa_interface;
 pub mod dpu_machine_update;
 pub mod dpu_remediation;
 pub mod errors;
+pub mod expected_entity;
 pub mod expected_machine;
 pub mod expected_power_shelf;
 pub mod expected_rack;

--- a/crates/api/src/handlers/bmc_endpoint_explorer.rs
+++ b/crates/api/src/handlers/bmc_endpoint_explorer.rs
@@ -23,6 +23,7 @@ use db::WithTransaction;
 use db::machine_interface::find_by_ip;
 use libredfish::RoleId;
 use mac_address::MacAddress;
+use model::expected_entity::ExpectedEntity;
 use model::machine::machine_id::try_parse_machine_id;
 use model::machine::{LoadSnapshotOptions, MachineInterfaceSnapshot};
 use model::site_explorer::PreingestionState;
@@ -450,12 +451,22 @@ pub(crate) async fn explore(
     let (bmc_addr, bmc_mac_address) = resolve_bmc_interface(api, &req).await?;
 
     let machine_interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
-    let expected_machine = crate::handlers::expected_machine::query(api, bmc_mac_address).await?;
+
     // TODO(chet): Track down Vinod's Jira to optimize code for
     // existing sites where there is no nvswitch or power shelf.
-    let expected_switch = crate::handlers::expected_switch::query(api, bmc_mac_address).await?;
-    let expected_power_shelf =
-        crate::handlers::expected_power_shelf::query(api, bmc_mac_address).await?;
+    let expected = if let Some(expected_machine) =
+        crate::handlers::expected_machine::query(api, bmc_mac_address).await?
+    {
+        Some(ExpectedEntity::Machine(expected_machine))
+    } else if let Some(expected_switch) =
+        crate::handlers::expected_switch::query(api, bmc_mac_address).await?
+    {
+        Some(ExpectedEntity::Switch(expected_switch))
+    } else {
+        crate::handlers::expected_power_shelf::query(api, bmc_mac_address)
+            .await?
+            .map(ExpectedEntity::PowerShelf)
+    };
 
     // Look up boot_interface_mac from existing explored endpoint if available
     let mut txn = api.txn_begin().await?;
@@ -470,9 +481,7 @@ pub(crate) async fn explore(
         .explore_endpoint(
             bmc_addr,
             &machine_interface,
-            expected_machine.as_ref(),
-            expected_power_shelf.as_ref(),
-            expected_switch.as_ref(),
+            expected.as_ref(),
             None,
             boot_interface_mac,
         )

--- a/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
+++ b/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
@@ -24,8 +24,7 @@ use forge_secrets::credentials::{CredentialManager, Credentials};
 use libredfish::model::oem::nvidia_dpu::NicMode;
 use libredfish::model::service_root::RedfishVendor;
 use mac_address::MacAddress;
-use model::expected_machine::ExpectedMachine;
-use model::expected_power_shelf::ExpectedPowerShelf;
+use model::expected_entity::{BmcCredentialsData, ExpectedEntity};
 use model::expected_switch::ExpectedSwitch;
 use model::machine::MachineInterfaceSnapshot;
 use model::site_explorer::{EndpointExplorationError, EndpointExplorationReport, LockdownStatus};
@@ -89,7 +88,7 @@ impl BmcEndpointExplorer {
         Ok(password)
     }
 
-    pub fn get_default_hardware_dpu_bmc_root_credentials(&self) -> Credentials {
+    fn get_default_hardware_dpu_bmc_root_credentials(&self) -> BmcCredentialsData<'static> {
         self.credential_client
             .get_default_hardware_dpu_bmc_root_credentials()
     }
@@ -221,71 +220,19 @@ impl BmcEndpointExplorer {
     // If we can log in using the factory credentials:
     // (1) use Redfish to set the machine's bmc root password to be the sitewide bmc root password.
     // (2) update the BMC specific root password path in vault
-    pub async fn set_sitewide_bmc_root_password(
+    async fn set_sitewide_bmc_root_password(
         &self,
         bmc_ip_address: SocketAddr,
         bmc_mac_address: MacAddress,
         vendor: RedfishVendor,
-        expected_machine: Option<&ExpectedMachine>,
-        expected_power_shelf: Option<&ExpectedPowerShelf>,
-        expected_switch: Option<&ExpectedSwitch>,
-    ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
-        let current_bmc_credentials;
-        let retain_credentials;
-
+        cred_data: BmcCredentialsData<'_>,
+    ) -> Result<Credentials, EndpointExplorationError> {
+        let current_bmc_credentials = Credentials::UsernamePassword {
+            username: cred_data.username.to_string(),
+            password: cred_data.password.to_string(),
+        };
+        let retain_credentials = cred_data.retain_credentials;
         tracing::info!(%bmc_ip_address, %bmc_mac_address, %vendor, "attempting to set the administrative credentials to the site password");
-
-        if let Some(expected_machine_credentials) = expected_machine {
-            tracing::info!(%bmc_ip_address, %bmc_mac_address, "Found an expected machine for this BMC mac address");
-            current_bmc_credentials = Credentials::UsernamePassword {
-                username: expected_machine_credentials.data.bmc_username.clone(),
-                password: expected_machine_credentials.data.bmc_password.clone(),
-            };
-            retain_credentials = expected_machine_credentials
-                .data
-                .bmc_retain_credentials
-                .unwrap_or(false);
-        } else if let Some(expected_power_shelf_credentials) = expected_power_shelf {
-            tracing::info!(%bmc_ip_address, %bmc_mac_address, "Found an expected power shelf for this BMC mac address");
-            current_bmc_credentials = Credentials::UsernamePassword {
-                username: expected_power_shelf_credentials.bmc_username.clone(),
-                password: expected_power_shelf_credentials.bmc_password.clone(),
-            };
-            retain_credentials = expected_power_shelf_credentials
-                .bmc_retain_credentials
-                .unwrap_or(false);
-        } else if let Some(expected_switch_credentials) = expected_switch {
-            tracing::info!(%bmc_ip_address, %bmc_mac_address, "Found an expected switch for this BMC mac address");
-            current_bmc_credentials = Credentials::UsernamePassword {
-                username: expected_switch_credentials.bmc_username.clone(),
-                password: expected_switch_credentials.bmc_password.clone(),
-            };
-            retain_credentials = expected_switch_credentials
-                .bmc_retain_credentials
-                .unwrap_or(false);
-        } else {
-            tracing::info!(%bmc_ip_address, %bmc_mac_address, %vendor, "No expected machine found, could be a BlueField");
-            // We dont know if this machine is a DPU at this point
-            // Check the vendor to see if it could be a DPU (the DPU's vendor is NVIDIA)
-            match vendor {
-                RedfishVendor::NvidiaDpu => {
-                    // This machine is a DPU.
-                    // Try the DPU hardware default password to handle the DPU case
-                    // This password will not work for a Viking host and we will return an error
-                    current_bmc_credentials = self.get_default_hardware_dpu_bmc_root_credentials();
-                    retain_credentials = false;
-                }
-                _ => {
-                    return Err(EndpointExplorationError::MissingCredentials {
-                        key: "expected_machine".to_owned(),
-                        cause: format!(
-                            "The expected machine credentials do not exist for {vendor} machine {bmc_ip_address}/{bmc_mac_address} "
-                        ),
-                    });
-                }
-            }
-        }
-
         let bmc_credentials = if retain_credentials {
             tracing::info!(
                 %bmc_ip_address, %bmc_mac_address, %vendor,
@@ -317,9 +264,7 @@ impl BmcEndpointExplorer {
         self.set_bmc_root_credentials(bmc_mac_address, &bmc_credentials)
             .await?;
 
-        self.redfish_client
-            .generate_exploration_report(bmc_ip_address, bmc_credentials, None, Some(vendor))
-            .await
+        Ok(bmc_credentials)
     }
 
     // Handle switch NVOS admin credentials setup
@@ -700,9 +645,7 @@ impl EndpointExplorer for BmcEndpointExplorer {
         &self,
         bmc_ip_address: SocketAddr,
         interface: &MachineInterfaceSnapshot,
-        expected_machine: Option<&ExpectedMachine>,
-        expected_power_shelf: Option<&ExpectedPowerShelf>,
-        expected_switch: Option<&ExpectedSwitch>,
+        expected: Option<&ExpectedEntity>,
         last_report: Option<&EndpointExplorationReport>,
         boot_interface_mac: Option<MacAddress>,
     ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
@@ -728,7 +671,7 @@ impl EndpointExplorer for BmcEndpointExplorer {
                 //
                 // In the future, if we want to expand this to other kinds of trays we can
                 // expand the pattern matching logic below.
-                let Some(eps) = expected_power_shelf else {
+                let Some(ExpectedEntity::PowerShelf(eps)) = expected else {
                     return Err(e);
                 };
 
@@ -823,23 +766,58 @@ impl EndpointExplorer for BmcEndpointExplorer {
             }
 
             Err(EndpointExplorationError::MissingCredentials { .. }) => {
-                tracing::info!(
-                    %bmc_ip_address,
-                    "Site explorer could not find an entry in vault at 'bmc/{bmc_mac_address}/root' - this is expected if the BMC has never been seen before.",
-                );
-
                 // The machine's BMC root password has not been set to the Forge Sitewide BMC root password
                 // 1) Try to login to the machine's BMC root account
                 // 2) Set the machine's BMC root password to the Forge Sitewide BMC root password
                 // 3) Set the password policy for the machine's BMC
                 // 4) Generate the report
-                self.set_sitewide_bmc_root_password(
+
+                tracing::info!(
+                    %bmc_ip_address,
+                    "Site explorer could not find an entry in vault at 'bmc/{bmc_mac_address}/root' - this is expected if the BMC has never been seen before.",
+                );
+
+                let bmc_cred_data = match expected {
+                    Some(v) => {
+                        tracing::info!(%bmc_ip_address, %bmc_mac_address, "Found an expected {} for this BMC mac address", v.name());
+                        v.bmc_credentials_data()
+                    }
+                    None => {
+                        tracing::info!(%bmc_ip_address, %bmc_mac_address, %vendor, "No expected machine found, could be a BlueField");
+                        // We dont know if this machine is a DPU at this point
+                        // Check the vendor to see if it could be a DPU (the DPU's vendor is NVIDIA)
+                        match vendor {
+                            RedfishVendor::NvidiaDpu => {
+                                // This machine is a DPU.
+                                // Try the DPU hardware default password to handle the DPU case
+                                // This password will not work for a Viking host and we will return an error
+                                self.get_default_hardware_dpu_bmc_root_credentials()
+                            }
+                            _ => {
+                                return Err(EndpointExplorationError::MissingCredentials {
+                                    key: "expected_machine".to_owned(),
+                                    cause: format!(
+                                        "The expected machine credentials do not exist for {vendor} machine {bmc_ip_address}/{bmc_mac_address} "
+                                    ),
+                                });
+                            }
+                        }
+                    }
+                };
+                let bmc_credentials = self
+                    .set_sitewide_bmc_root_password(
+                        bmc_ip_address,
+                        bmc_mac_address,
+                        vendor,
+                        bmc_cred_data,
+                    )
+                    .await?;
+
+                self.generate_exploration_report(
                     bmc_ip_address,
-                    bmc_mac_address,
-                    vendor,
-                    expected_machine,
-                    expected_power_shelf,
-                    expected_switch,
+                    bmc_credentials,
+                    None,
+                    Some(vendor),
                 )
                 .await?
             }
@@ -849,7 +827,7 @@ impl EndpointExplorer for BmcEndpointExplorer {
         };
 
         // Check for switch NVOS admin credentials if this is a switch
-        if let Some(expected_switch) = expected_switch
+        if let Some(ExpectedEntity::Switch(expected_switch)) = expected
             && expected_switch.nvos_username.is_some()
             && expected_switch.nvos_password.is_some()
         {
@@ -1127,7 +1105,7 @@ impl EndpointExplorer for BmcEndpointExplorer {
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
-                    "BMC endpoint explorer does not support set_nic_mode for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
+                    "BMC endpoint explorer does not support is_viking for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
                     bmc_mac_address,
                 );
                 Err(e)
@@ -1147,7 +1125,7 @@ impl EndpointExplorer for BmcEndpointExplorer {
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
-                    "BMC endpoint explorer does not support set_nic_mode for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
+                    "BMC endpoint explorer does not support clear_nvram for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
                     bmc_mac_address,
                 );
                 Err(e)
@@ -1171,7 +1149,7 @@ impl EndpointExplorer for BmcEndpointExplorer {
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
-                    "BMC endpoint explorer does not support set_nic_mode for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
+                    "BMC endpoint explorer does not support copy_bfb_to_dpu_rshim for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
                     bmc_mac_address,
                 );
                 Err(e)
@@ -1197,7 +1175,7 @@ impl EndpointExplorer for BmcEndpointExplorer {
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
-                    "BMC endpoint explorer does not support set_nic_mode for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
+                    "BMC endpoint explorer does not support create_bmc_user for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
                     bmc_mac_address,
                 );
                 Err(e)
@@ -1221,7 +1199,7 @@ impl EndpointExplorer for BmcEndpointExplorer {
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
-                    "BMC endpoint explorer does not support set_nic_mode for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
+                    "BMC endpoint explorer does not support delete_bmc_user for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
                     bmc_mac_address,
                 );
                 Err(e)

--- a/crates/api/src/site_explorer/credentials.rs
+++ b/crates/api/src/site_explorer/credentials.rs
@@ -21,6 +21,7 @@ use forge_secrets::credentials::{
     BmcCredentialType, CredentialKey, CredentialManager, CredentialType, Credentials,
 };
 use mac_address::MacAddress;
+use model::expected_entity::BmcCredentialsData;
 use model::site_explorer::EndpointExplorationError;
 
 use super::metrics::SiteExplorationMetrics;
@@ -163,10 +164,11 @@ impl CredentialClient {
             .await
     }
 
-    pub fn get_default_hardware_dpu_bmc_root_credentials(&self) -> Credentials {
-        Credentials::UsernamePassword {
-            username: "root".into(),
-            password: "0penBmc".into(),
+    pub fn get_default_hardware_dpu_bmc_root_credentials(&self) -> BmcCredentialsData<'static> {
+        BmcCredentialsData {
+            username: "root",
+            password: "0penBmc",
+            retain_credentials: false,
         }
     }
 

--- a/crates/api/src/site_explorer/endpoint_explorer.rs
+++ b/crates/api/src/site_explorer/endpoint_explorer.rs
@@ -20,9 +20,7 @@ use std::net::SocketAddr;
 use libredfish::RoleId;
 use libredfish::model::oem::nvidia_dpu::NicMode;
 use mac_address::MacAddress;
-use model::expected_machine::ExpectedMachine;
-use model::expected_power_shelf::ExpectedPowerShelf;
-use model::expected_switch::ExpectedSwitch;
+use model::expected_entity::ExpectedEntity;
 use model::machine::MachineInterfaceSnapshot;
 use model::site_explorer::{EndpointExplorationError, EndpointExplorationReport, LockdownStatus};
 
@@ -36,14 +34,11 @@ pub trait EndpointExplorer: Send + Sync + 'static {
     /// The query carries the information `MachineInterface` information that is derived
     /// from DHCP requests as well as the information that might have been fetched in
     /// a previous exploration.
-    #[allow(clippy::too_many_arguments)]
     async fn explore_endpoint(
         &self,
         address: SocketAddr,
         interface: &MachineInterfaceSnapshot,
-        expected: Option<&ExpectedMachine>,
-        expected_power_shelf: Option<&ExpectedPowerShelf>,
-        expected_switch: Option<&ExpectedSwitch>,
+        expected: Option<&ExpectedEntity>,
         last_report: Option<&EndpointExplorationReport>,
         boot_interface_mac: Option<MacAddress>,
     ) -> Result<EndpointExplorationReport, EndpointExplorationError>;

--- a/crates/api/src/site_explorer/explored_endpoint_index.rs
+++ b/crates/api/src/site_explorer/explored_endpoint_index.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 
 use mac_address::MacAddress;
+use model::expected_entity::ExpectedEntity;
 use model::expected_machine::ExpectedMachine;
 use model::expected_power_shelf::ExpectedPowerShelf;
 use model::expected_switch::ExpectedSwitch;
@@ -29,9 +30,7 @@ use model::site_explorer::ExploredEndpoint;
 pub struct ExploredEndpointIndex {
     explored_underlay_interfaces: HashMap<MacAddress, MachineInterfaceSnapshot>,
     explored_endpoints: HashMap<IpAddr, ExploredEndpoint>,
-    expected_machines: HashMap<MacAddress, ExpectedMachine>,
-    expected_power_shelves: HashMap<MacAddress, ExpectedPowerShelf>,
-    expected_switches: HashMap<MacAddress, ExpectedSwitch>,
+    expected: HashMap<MacAddress, ExpectedEntity>,
 
     // 2-level index: Look up the IpAddr to get the MacAddress, then look that up to get the actual data.
     underlay_interfaces_addr_index: HashMap<IpAddr, MacAddress>,
@@ -53,9 +52,9 @@ impl ExploredEndpointIndex {
         &self.explored_endpoints
     }
 
-    /// Get a HashMap of expected machines, indexed by their MAC address
-    pub fn expected_machines(&self) -> &HashMap<MacAddress, ExpectedMachine> {
-        &self.expected_machines
+    /// Get a HashMap of expected entities, indexed by their MAC address
+    pub fn expected(&self) -> &HashMap<MacAddress, ExpectedEntity> {
+        &self.expected
     }
 
     /// Get the underlay interface from `explored_underlay_interfaces` with the given address.
@@ -65,25 +64,48 @@ impl ExploredEndpointIndex {
             .and_then(|mac| self.explored_underlay_interfaces.get(mac))
     }
 
-    /// Get the [`ExpectedMachine`] that was matched with an ExploredEndpoint, if one was given.
-    pub fn matched_expected_machine(&self, addr: &IpAddr) -> Option<&ExpectedMachine> {
+    /// Get the [`ExpectedEntity`] that was matched with an ExploredEndpoint, if one was given.
+    pub fn matched_expected(&self, addr: &IpAddr) -> Option<&ExpectedEntity> {
         self.explored_machines_addr_index
             .get(addr)
-            .and_then(|mac| self.expected_machines.get(mac))
+            .or_else(|| self.explored_power_shelves_addr_index.get(addr))
+            .or_else(|| self.explored_switches_addr_index.get(addr))
+            .and_then(|mac| self.expected.get(mac))
+    }
+
+    /// Get the [`ExpectedMachine`] that was matched with an ExploredEndpoint, if one was given.
+    pub fn matched_expected_machine(&self, addr: &IpAddr) -> Option<&ExpectedMachine> {
+        self.explored_machines_addr_index.get(addr).and_then(|mac| {
+            if let Some(ExpectedEntity::Machine(v)) = self.expected.get(mac) {
+                Some(v)
+            } else {
+                None
+            }
+        })
     }
 
     /// Get the [`ExpectedPowerShelf`] that was matched with an ExploredEndpoint, if one was given.
     pub fn matched_expected_power_shelf(&self, addr: &IpAddr) -> Option<&ExpectedPowerShelf> {
         self.explored_power_shelves_addr_index
             .get(addr)
-            .and_then(|mac| self.expected_power_shelves.get(mac))
+            .and_then(|mac| {
+                if let Some(ExpectedEntity::PowerShelf(v)) = self.expected.get(mac) {
+                    Some(v)
+                } else {
+                    None
+                }
+            })
     }
 
     /// Get the [`ExpectedSwitch`] that was matched with an ExploredEndpoint, if one was given.
     pub fn matched_expected_switch(&self, addr: &IpAddr) -> Option<&ExpectedSwitch> {
-        self.explored_switches_addr_index
-            .get(addr)
-            .and_then(|mac| self.expected_switches.get(mac))
+        self.explored_switches_addr_index.get(addr).and_then(|mac| {
+            if let Some(ExpectedEntity::Switch(v)) = self.expected.get(mac) {
+                Some(v)
+            } else {
+                None
+            }
+        })
     }
 
     /// Get [`MachineInterfaceSnapshot`]s from `explored_underlay_interfaces` that do not have
@@ -107,10 +129,12 @@ impl ExploredEndpointIndex {
 
     /// Return the expected machines that were found in `explored_underlay_interfaces`
     pub fn all_matched_expected_machines(&self) -> HashMap<MacAddress, &ExpectedMachine> {
-        self.expected_machines
+        self.expected
             .iter()
-            .filter_map(|(mac, expected_machine)| {
-                if self.explored_underlay_interfaces.contains_key(mac) {
+            .filter_map(|(mac, expected)| {
+                if let ExpectedEntity::Machine(expected_machine) = expected
+                    && self.explored_underlay_interfaces.contains_key(mac)
+                {
                     Some((*mac, expected_machine))
                 } else {
                     None
@@ -130,9 +154,7 @@ impl ExploredEndpointIndex {
 pub struct ExploredEndpointIndexBuilder {
     explored_underlay_interfaces: HashMap<MacAddress, MachineInterfaceSnapshot>,
     explored_endpoints: HashMap<IpAddr, ExploredEndpoint>,
-    expected_machines: HashMap<MacAddress, ExpectedMachine>,
-    expected_power_shelves: HashMap<MacAddress, ExpectedPowerShelf>,
-    expected_switches: HashMap<MacAddress, ExpectedSwitch>,
+    expected: HashMap<MacAddress, ExpectedEntity>,
 
     // 2-level index: Look up the IpAddr to get the MacAddress, then look that up to get the actual data.
     underlay_interfaces_addr_index: HashMap<IpAddr, MacAddress>,
@@ -169,9 +191,7 @@ impl ExploredEndpointIndexBuilder {
             explored_underlay_interfaces,
             underlay_interfaces_addr_index,
             explored_endpoints,
-            expected_machines: Default::default(),
-            expected_power_shelves: Default::default(),
-            expected_switches: Default::default(),
+            expected: Default::default(),
             explored_machines_addr_index: Default::default(),
             explored_power_shelves_addr_index: Default::default(),
             explored_switches_addr_index: Default::default(),
@@ -199,8 +219,8 @@ impl ExploredEndpointIndexBuilder {
                         .insert(*addr, shelf.bmc_mac_address);
                 }
             }
-            self.expected_power_shelves
-                .insert(shelf.bmc_mac_address, shelf);
+            self.expected
+                .insert(shelf.bmc_mac_address, ExpectedEntity::PowerShelf(shelf));
         }
         self
     }
@@ -227,8 +247,8 @@ impl ExploredEndpointIndexBuilder {
                         .insert(*addr, switch.bmc_mac_address);
                 }
             }
-            self.expected_switches
-                .insert(switch.bmc_mac_address, switch);
+            self.expected
+                .insert(switch.bmc_mac_address, ExpectedEntity::Switch(switch));
         }
         self
     }
@@ -244,8 +264,8 @@ impl ExploredEndpointIndexBuilder {
                         .insert(*addr, machine.bmc_mac_address);
                 }
             }
-            self.expected_machines
-                .insert(machine.bmc_mac_address, machine);
+            self.expected
+                .insert(machine.bmc_mac_address, ExpectedEntity::Machine(machine));
         }
         self
     }
@@ -254,9 +274,7 @@ impl ExploredEndpointIndexBuilder {
         ExploredEndpointIndex {
             explored_underlay_interfaces: self.explored_underlay_interfaces,
             explored_endpoints: self.explored_endpoints,
-            expected_machines: self.expected_machines,
-            expected_power_shelves: self.expected_power_shelves,
-            expected_switches: self.expected_switches,
+            expected: self.expected,
             underlay_interfaces_addr_index: self.underlay_interfaces_addr_index,
             explored_machines_addr_index: self.explored_machines_addr_index,
             explored_power_shelves_addr_index: self.explored_power_shelves_addr_index,

--- a/crates/api/src/site_explorer/mod.rs
+++ b/crates/api/src/site_explorer/mod.rs
@@ -38,8 +38,8 @@ use itertools::Itertools;
 use libredfish::model::oem::nvidia_dpu::NicMode;
 use librms::RmsApi;
 use mac_address::MacAddress;
+use model::expected_entity::ExpectedEntity;
 use model::expected_power_shelf::ExpectedPowerShelf;
-use model::expected_switch::ExpectedSwitch;
 use model::machine::MachineInterfaceSnapshot;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::power_shelf::{NewPowerShelf, PowerShelfConfig};
@@ -75,7 +75,6 @@ mod managed_host;
 use db::ObjectColumnFilter;
 use db::work_lock_manager::WorkLockManagerHandle;
 pub use managed_host::is_endpoint_in_managed_host;
-use model::expected_machine::ExpectedMachine;
 use model::firmware::FirmwareComponentType;
 use model::machine_interface_address::MachineInterfaceAssociation;
 use model::network_segment::NetworkSegmentType;
@@ -154,7 +153,6 @@ pub(crate) async fn fetch_slot_and_tray(
     }
 }
 
-#[derive(Debug)]
 pub struct Endpoint<'a> {
     address: IpAddr,
     iface: &'a MachineInterfaceSnapshot,
@@ -162,9 +160,7 @@ pub struct Endpoint<'a> {
     last_ipmitool_bmc_reset: Option<chrono::DateTime<chrono::Utc>>,
     last_redfish_reboot: Option<chrono::DateTime<chrono::Utc>>,
     old_report: Option<(ConfigVersion, &'a EndpointExplorationReport)>,
-    pub(crate) expected: Option<&'a ExpectedMachine>,
-    pub(crate) expected_power_shelf: Option<&'a ExpectedPowerShelf>,
-    pub(crate) expected_switch: Option<&'a ExpectedSwitch>,
+    pub(crate) expected: Option<&'a ExpectedEntity>,
     pause_remediation: bool,
     boot_interface_mac: Option<MacAddress>,
 }
@@ -1392,9 +1388,7 @@ impl SiteExplorer {
                 old_report: Some((endpoint.report_version, &endpoint.report)),
                 pause_remediation: endpoint.pause_remediation,
                 boot_interface_mac: endpoint.boot_interface_mac,
-                expected_switch: index.matched_expected_switch(&address),
-                expected_power_shelf: index.matched_expected_power_shelf(&address),
-                expected: index.matched_expected_machine(&address),
+                expected: index.matched_expected(&address),
             });
         }
 
@@ -1411,11 +1405,9 @@ impl SiteExplorer {
                 last_ipmitool_bmc_reset: None,
                 last_redfish_reboot: None,
                 old_report: None,
-                expected_switch: index.matched_expected_switch(address),
-                expected_power_shelf: index.matched_expected_power_shelf(address),
-                expected: index.matched_expected_machine(address),
                 pause_remediation: false, // New endpoints haven't been explored yet, so pause_remediation defaults to false
                 boot_interface_mac: None, // boot_interface_mac not yet discovered for new endpoints
+                expected: index.matched_expected(address),
             });
         }
 
@@ -1437,11 +1429,9 @@ impl SiteExplorer {
                     last_ipmitool_bmc_reset: endpoint.last_ipmitool_bmc_reset,
                     last_redfish_reboot: endpoint.last_redfish_reboot,
                     old_report: Some((endpoint.report_version, &endpoint.report)),
-                    expected: index.matched_expected_machine(&address),
-                    expected_power_shelf: index.matched_expected_power_shelf(&address),
-                    expected_switch: index.matched_expected_switch(&address),
                     pause_remediation: endpoint.pause_remediation,
                     boot_interface_mac: endpoint.boot_interface_mac,
+                    expected: index.matched_expected(&address),
                 });
             }
         }
@@ -1484,8 +1474,6 @@ impl SiteExplorer {
                             bmc_target_addr,
                             endpoint.iface,
                             endpoint.expected,
-                            endpoint.expected_power_shelf,
-                            endpoint.expected_switch,
                             endpoint.old_report.map(|report| report.1),
                             endpoint.boot_interface_mac,
                         )
@@ -1630,10 +1618,8 @@ impl SiteExplorer {
                     }
                 }
                 None => {
-                    let should_pause_ingestion_and_poweron = pause_ingestion_and_poweron(
-                        index.expected_machines(),
-                        &endpoint.iface.mac_address,
-                    );
+                    let should_pause_ingestion_and_poweron =
+                        pause_ingestion_and_poweron(index.expected(), &endpoint.iface.mac_address);
                     match result {
                         Ok(mut report) => {
                             report.last_exploration_latency = Some(exploration_duration);
@@ -1665,7 +1651,9 @@ impl SiteExplorer {
                         }
                     }
 
-                    let power_shelf_manual_ingestion = endpoint.expected_power_shelf.is_some()
+                    let power_shelf_manual_ingestion = endpoint
+                        .expected
+                        .is_some_and(|v| matches!(v, ExpectedEntity::PowerShelf(_)))
                         && explore_power_shelves_from_static_ip;
 
                     if !self.config.create_machines.load(Ordering::Relaxed)
@@ -2491,10 +2479,12 @@ pub async fn get_machine_state_by_bmc_ip(
 }
 
 fn pause_ingestion_and_poweron(
-    expected_machines_by_mac: &HashMap<MacAddress, ExpectedMachine>,
+    expected_machines_by_mac: &HashMap<MacAddress, ExpectedEntity>,
     mac_address: &mac_address::MacAddress,
 ) -> bool {
-    if let Some(expected_machine) = expected_machines_by_mac.get(mac_address) {
+    if let Some(ExpectedEntity::Machine(expected_machine)) =
+        expected_machines_by_mac.get(mac_address)
+    {
         return expected_machine
             .data
             .default_pause_ingestion_and_poweron

--- a/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
@@ -21,9 +21,7 @@ use std::sync::{Arc, Mutex};
 use libredfish::RoleId;
 use libredfish::model::oem::nvidia_dpu::NicMode;
 use mac_address::MacAddress;
-use model::expected_machine::ExpectedMachine;
-use model::expected_power_shelf::ExpectedPowerShelf;
-use model::expected_switch::ExpectedSwitch;
+use model::expected_entity::ExpectedEntity;
 use model::machine::MachineInterfaceSnapshot;
 use model::site_explorer::{
     EndpointExplorationError, EndpointExplorationReport, InternalLockdownStatus, LockdownStatus,
@@ -82,9 +80,7 @@ impl EndpointExplorer for MockEndpointExplorer {
         &self,
         bmc_ip_address: SocketAddr,
         _interface: &MachineInterfaceSnapshot,
-        _expected: Option<&ExpectedMachine>,
-        _expected_power_shelf: Option<&ExpectedPowerShelf>,
-        _expected_switch: Option<&ExpectedSwitch>,
+        _expected: Option<&ExpectedEntity>,
         _last_report: Option<&EndpointExplorationReport>,
         _boot_interface_mac: Option<MacAddress>,
     ) -> Result<EndpointExplorationReport, EndpointExplorationError> {

--- a/crates/api/src/tests/common/api_fixtures/managed_host.rs
+++ b/crates/api/src/tests/common/api_fixtures/managed_host.rs
@@ -45,7 +45,7 @@ pub enum HardwareInfoTemplate {
 }
 
 /// Describes a Managed Host
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ManagedHostConfig {
     pub serial: String,
     pub bmc_mac_address: MacAddress,


### PR DESCRIPTION
## Description
Replace three parallel `Option<&ExpectedMachine/PowerShelf/Switch>` parameters with a single `Option<&ExpectedEntity>` sum type across the site explorer.

- Add `ExpectedEntity` enum in api-model with `bmc_credentials_data()` and `name()` helpers; `BmcCredentialsData<'a>` borrows to avoid cloning passwords.
- Simplify `EndpointExplorer::explore_endpoint` signature.
- Split `set_sitewide_bmc_root_password`: now returns `Credentials`; entity dispatch and DPU-default fallback move to `explore_endpoint`.
- Collapse three HashMaps in `ExploredEndpointIndex` into one keyed by `ExpectedEntity`; preserve typed accessors.
- Drop `Debug` from password-bearing expected-/ structs.
- Fix copy-paste error messages in several trait impl methods that incorrectly referred to `set_nic_mode`.

No behavioral change.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
