### PR TITLE
[feature] : Nmxc fabricstatus on rack state machine

### DIFF
--- a/crates/admin-cli/src/switch/show/cmd.rs
+++ b/crates/admin-cli/src/switch/show/cmd.rs
@@ -39,6 +39,7 @@ pub fn show_switches(switches: Vec<Switch>, output_format: OutputFormat) -> Resu
                 "Tray",
                 "Power State",
                 "Health",
+                "FabricManager(nmxc)",
                 "State"
             ]);
 
@@ -87,6 +88,9 @@ pub fn show_switches(switches: Vec<Switch>, output_format: OutputFormat) -> Resu
                     .and_then(|status| status.health_status.as_deref())
                     .unwrap_or("N/A");
 
+                let fabric_manager_status =
+                    switch.fabric_manager_status.as_deref().unwrap_or("N/A");
+
                 table.add_row(row![
                     id,
                     name,
@@ -95,6 +99,7 @@ pub fn show_switches(switches: Vec<Switch>, output_format: OutputFormat) -> Resu
                     tray_index,
                     power_state,
                     health,
+                    fabric_manager_status,
                     switch.controller_state,
                 ]);
             }
@@ -119,6 +124,7 @@ pub fn show_switches(switches: Vec<Switch>, output_format: OutputFormat) -> Resu
                 "Tray",
                 "Power State",
                 "Health",
+                "FabricManager(nmxc)",
                 "State"
             ]);
 
@@ -167,6 +173,9 @@ pub fn show_switches(switches: Vec<Switch>, output_format: OutputFormat) -> Resu
                     .and_then(|status| status.health_status.as_deref())
                     .unwrap_or("N/A");
 
+                let fabric_manager_status =
+                    switch.fabric_manager_status.as_deref().unwrap_or("N/A");
+
                 table.add_row(row![
                     id,
                     name,
@@ -175,6 +184,7 @@ pub fn show_switches(switches: Vec<Switch>, output_format: OutputFormat) -> Resu
                     tray_index,
                     power_state,
                     health,
+                    fabric_manager_status,
                     switch.controller_state,
                 ]);
             }

--- a/crates/api-db/migrations/20260417090000_switch_fabric_manager_status.sql
+++ b/crates/api-db/migrations/20260417090000_switch_fabric_manager_status.sql
@@ -1,0 +1,1 @@
+ALTER TABLE switches ADD COLUMN fabric_manager_status VARCHAR;

--- a/crates/api-db/src/switch.rs
+++ b/crates/api-db/src/switch.rs
@@ -111,6 +111,7 @@ pub async fn create(txn: &mut PgConnection, new_switch: &NewSwitch) -> DatabaseR
         controller_state_outcome: None,
         switch_reprovisioning_requested: None,
         firmware_upgrade_status: None,
+        fabric_manager_status: None,
         metadata,
         version,
         rack_id: new_switch.rack_id.clone(),
@@ -298,6 +299,20 @@ pub async fn update_firmware_upgrade_status(
     Ok(())
 }
 
+pub async fn update_fabric_manager_status(
+    txn: &mut PgConnection,
+    switch_id: SwitchId,
+    status: Option<&str>,
+) -> DatabaseResult<()> {
+    let query = "UPDATE switches SET fabric_manager_status = $1 WHERE id = $2 RETURNING id";
+    sqlx::query_as::<_, SwitchId>(query)
+        .bind(status)
+        .bind(switch_id)
+        .fetch_optional(txn)
+        .await
+        .map_err(|e| DatabaseError::new("update_fabric_manager_status", e))?;
+    Ok(())
+}
 pub async fn update_slot_and_tray(
     txn: &mut PgConnection,
     switch_id: &SwitchId,

--- a/crates/api-model/src/switch/mod.rs
+++ b/crates/api-model/src/switch/mod.rs
@@ -139,6 +139,8 @@ pub struct Switch {
     /// Firmware upgrade status during ReProvisioning, set by the rack state machine.
     pub firmware_upgrade_status: Option<RackFirmwareUpgradeStatus>,
 
+    /// FabricManager / NMX-C status set by the rack state machine.
+    pub fabric_manager_status: Option<String>,
     /// The rack that this switch is associated with.
     pub rack_id: Option<RackId>,
     // Columns for these exist, but are unused in rust code
@@ -163,6 +165,7 @@ impl<'r> FromRow<'r, PgRow> for Switch {
             row.try_get("switch_reprovisioning_requested").ok();
         let firmware_upgrade_status: Option<sqlx::types::Json<RackFirmwareUpgradeStatus>> =
             row.try_get("firmware_upgrade_status").ok();
+        let fabric_manager_status: Option<String> = row.try_get("fabric_manager_status").ok();
 
         // DB column is still named "health_report_overrides" for backward compatibility.
         let health_report_sources: HealthReportSources = row
@@ -188,6 +191,7 @@ impl<'r> FromRow<'r, PgRow> for Switch {
             controller_state_outcome: controller_state_outcome.map(|o| o.0),
             switch_reprovisioning_requested: switch_reprovisioning_requested.map(|j| j.0),
             firmware_upgrade_status: firmware_upgrade_status.map(|j| j.0),
+            fabric_manager_status,
             metadata,
             version: row.try_get("version")?,
             rack_id: row.try_get("rack_id").ok().flatten(),
@@ -294,6 +298,7 @@ impl TryFrom<Switch> for rpc::Switch {
             version: src.version.version_string(),
             rack_id: src.rack_id,
             placement_in_rack,
+            fabric_manager_status: src.fabric_manager_status,
             health: Some(health.into()),
             health_sources,
         })
@@ -459,6 +464,7 @@ mod tests {
             }),
             switch_reprovisioning_requested: None,
             firmware_upgrade_status: None,
+            fabric_manager_status: Some("running".to_string()),
             metadata: Metadata::default(),
             version: ConfigVersion::initial(),
             rack_id: None,
@@ -476,6 +482,10 @@ mod tests {
         assert!(status.state_sla.is_some(), "state_sla should be populated");
         assert_eq!(status.power_state, Some("on".to_string()));
         assert_eq!(status.health_status, Some("ok".to_string()));
+        assert_eq!(
+            rpc_switch.fabric_manager_status,
+            Some("running".to_string())
+        );
     }
 
     #[test]
@@ -500,6 +510,7 @@ mod tests {
             }),
             switch_reprovisioning_requested: None,
             firmware_upgrade_status: None,
+            fabric_manager_status: None,
             metadata: Metadata::default(),
             version: ConfigVersion::initial(),
             rack_id: None,
@@ -518,6 +529,7 @@ mod tests {
         );
         assert_eq!(status.power_state, None);
         assert_eq!(status.health_status, None);
+        assert_eq!(rpc_switch.fabric_manager_status, None);
     }
 
     #[test]

--- a/crates/api/src/rack/firmware_update.rs
+++ b/crates/api/src/rack/firmware_update.rs
@@ -340,7 +340,7 @@ fn build_firmware_targets(
         .collect())
 }
 
-fn build_new_node_info(
+pub(crate) fn build_new_node_info(
     rack_id: &RackId,
     device: &FirmwareUpgradeDeviceInfo,
     node_type: rms::NodeType,

--- a/crates/api/src/state_controller/rack/maintenance.rs
+++ b/crates/api/src/state_controller/rack/maintenance.rs
@@ -188,6 +188,161 @@ fn build_switch_device_info_request(
     }
 }
 
+fn build_scale_up_fabric_services_status_request(
+    rack_id: &RackId,
+    switches: &[FirmwareUpgradeDeviceInfo],
+) -> rms::GetScaleUpFabricServicesStatusRequest {
+    rms::GetScaleUpFabricServicesStatusRequest {
+        nodes: Some(rms::NodeSet {
+            devices: switches
+                .iter()
+                .map(|switch| build_new_node_info(rack_id, switch, rms::NodeType::Switch))
+                .collect(),
+        }),
+        verify_ssl: false,
+        ..Default::default()
+    }
+}
+
+async fn get_scale_up_fabric_services_status(
+    rms_config: crate::cfg::file::RmsConfig,
+    rack_id: &RackId,
+    switches: &[FirmwareUpgradeDeviceInfo],
+) -> Result<rms::GetScaleUpFabricServicesStatusResponse, String> {
+    let Some(url) = rms_config.api_url.as_deref().filter(|url| !url.is_empty()) else {
+        return Err("RMS client not configured".to_string());
+    };
+
+    // The pinned librms::RmsApi trait does not yet expose this RPC, so keep
+    // the direct concrete-client use local to ConfigureNmxCluster.
+    let rms_client_config = librms::client_config::RmsClientConfig::new(
+        rms_config.root_ca_path.clone(),
+        rms_config.client_cert.clone(),
+        rms_config.client_key.clone(),
+        rms_config.enforce_tls,
+    );
+    let rms_api_config = librms::client::RmsApiConfig::new(url, &rms_client_config);
+    let rms_client = librms::RackManagerApi::new(&rms_api_config);
+
+    rms_client
+        .client
+        .get_scale_up_fabric_services_status(build_scale_up_fabric_services_status_request(
+            rack_id, switches,
+        ))
+        .await
+        .map_err(|error| format!("RMS GetScaleUpFabricServicesStatus failed: {}", error))
+}
+
+fn fabric_manager_status_from_entry(
+    node_id: &str,
+    entry: &rms::ScaleUpFabricServiceStatusEntry,
+) -> &'static str {
+    if !entry.error_message.trim().is_empty() {
+        return "not_running";
+    }
+
+    if entry.status_json.trim().is_empty() {
+        return "not_running";
+    }
+
+    let status_json = match serde_json::from_str::<serde_json::Value>(&entry.status_json) {
+        Ok(status_json) => status_json,
+        Err(error) => {
+            tracing::warn!(
+                switch_id = %node_id,
+                %error,
+                status_json = %entry.status_json,
+                "Failed to parse RMS fabric-manager status JSON"
+            );
+            return "not_running";
+        }
+    };
+
+    let status = status_json
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    let addition_info = status_json
+        .get("addition-info")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+
+    if status == "ok" && addition_info == "CONTROL_PLANE_STATE_CONFIGURED" {
+        "running"
+    } else {
+        "not_running"
+    }
+}
+
+async fn persist_fabric_manager_statuses(
+    txn: &mut sqlx::PgConnection,
+    rack_id: &RackId,
+    switches: &[FirmwareUpgradeDeviceInfo],
+    response: &rms::GetScaleUpFabricServicesStatusResponse,
+) -> Result<(), String> {
+    if response.status != rms::ReturnCode::Success as i32 {
+        return Err(
+            "RMS GetScaleUpFabricServicesStatus returned failure for ConfigureNmxCluster"
+                .to_string(),
+        );
+    }
+
+    let expected_node_ids: HashSet<&str> = switches
+        .iter()
+        .map(|switch| switch.node_id.as_str())
+        .collect();
+    let unexpected_switches = response
+        .device_info_result
+        .keys()
+        .filter(|node_id| !expected_node_ids.contains(node_id.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    if !unexpected_switches.is_empty() {
+        return Err(format!(
+            "RMS returned fabric-manager status for unexpected switches: {}",
+            unexpected_switches.join(", ")
+        ));
+    }
+
+    for switch in switches {
+        let Some(entry) = response.device_info_result.get(switch.node_id.as_str()) else {
+            return Err(format!(
+                "RMS did not return fabric-manager status for switch {}",
+                switch.node_id
+            ));
+        };
+        let switch_id = switch
+            .node_id
+            .parse::<carbide_uuid::switch::SwitchId>()
+            .map_err(|error| {
+                format!(
+                    "invalid switch id {} while persisting fabric-manager status: {}",
+                    switch.node_id, error
+                )
+            })?;
+        let fabric_manager_status = fabric_manager_status_from_entry(&switch.node_id, entry);
+
+        db_switch::update_fabric_manager_status(txn, switch_id, Some(fabric_manager_status))
+            .await
+            .map_err(|error| {
+                format!(
+                    "failed to persist fabric-manager status for switch {}: {}",
+                    switch.node_id, error
+                )
+            })?;
+
+        tracing::info!(
+            rack_id = %rack_id,
+            switch_id = %switch.node_id,
+            fabric_manager_status,
+            error_message = %entry.error_message,
+            "Persisted FabricManager status for switch"
+        );
+    }
+
+    Ok(())
+}
+
 #[derive(Debug, Clone)]
 struct SwitchPlacement {
     device: FirmwareUpgradeDeviceInfo,
@@ -902,6 +1057,28 @@ pub async fn handle_maintenance(
                 ));
             }
 
+            let fabric_status_response = match get_scale_up_fabric_services_status(
+                ctx.services.site_config.rms.clone(),
+                id,
+                &inventory.switches,
+            )
+            .await
+            {
+                Ok(response) => response,
+                Err(cause) => return Ok(transition_to_rack_error(id, cause)),
+            };
+            let mut txn = ctx.services.db_pool.begin().await?;
+            if let Err(cause) = persist_fabric_manager_statuses(
+                txn.as_mut(),
+                id,
+                &inventory.switches,
+                &fabric_status_response,
+            )
+            .await
+            {
+                return Ok(transition_to_rack_error(id, cause));
+            }
+
             tracing::info!(
                 rack_id = %id,
                 primary_switch = %primary_switch.device.node_id,
@@ -915,9 +1092,9 @@ pub async fn handle_maintenance(
                 },
                 scale_up_fabric_state_enabled = response.scale_up_fabric_state_enabled,
                 grpc_enabled = response.grpc_enabled,
-                "Rack ConfigureNmxCluster complete, advancing to PowerSequence"
+                "Rack ConfigureNmxCluster complete, FabricManager status persisted, advancing to PowerSequence"
             );
-            Ok(transition_to_power_sequence())
+            Ok(transition_to_power_sequence().with_txn(txn))
         }
         RackMaintenanceState::PowerSequence { rack_power } => match rack_power {
             RackPowerState::PoweringOn => {

--- a/crates/api/src/state_controller/rack/maintenance.rs
+++ b/crates/api/src/state_controller/rack/maintenance.rs
@@ -17,6 +17,7 @@
 
 //! Handler for RackState::Maintenance.
 
+use std::collections::{HashMap, HashSet};
 use carbide_uuid::rack::{RackId, RackProfileId};
 use db::{
     host_machine_update as db_host_machine_update, machine as db_machine,
@@ -24,14 +25,15 @@ use db::{
     switch as db_switch,
 };
 use model::rack::{
-    FirmwareUpgradeDeviceStatus, FirmwareUpgradeState, Rack, RackFirmwareUpgradeState,
-    RackFirmwareUpgradeStatus, RackMaintenanceState, RackPowerState, RackState,
-    RackValidationState,
+    FirmwareUpgradeDeviceInfo, FirmwareUpgradeDeviceStatus, FirmwareUpgradeState, Rack,
+    RackFirmwareUpgradeState, RackFirmwareUpgradeStatus, RackMaintenanceState, RackPowerState,
+    RackState, RackValidationState,
 };
+use librms::protos::rack_manager as rms;
 
 use crate::rack::firmware_update::{
     build_firmware_update_batches, firmware_type_for_profile, load_rack_firmware_inventory,
-    submit_firmware_update_batches,
+    submit_firmware_update_batches, build_new_node_info,
 };
 use crate::state_controller::rack::context::RackStateHandlerContextObjects;
 use crate::state_controller::rack::validating::strip_rv_labels;
@@ -124,8 +126,147 @@ fn transition_to_rack_error(
     cause: impl Into<String>,
 ) -> StateHandlerOutcome<RackState> {
     let cause = cause.into();
-    tracing::warn!(rack_id = %rack_id, %cause, "Rack firmware upgrade failed before polling started");
+    tracing::warn!(rack_id = %rack_id, %cause, "Rack maintenance operation failed");
     StateHandlerOutcome::transition(RackState::Error { cause })
+}
+
+fn transition_to_power_sequence() -> StateHandlerOutcome<RackState> {
+    StateHandlerOutcome::transition(RackState::Maintenance {
+        maintenance_state: RackMaintenanceState::PowerSequence {
+            rack_power: RackPowerState::PoweringOn,
+        },
+    })
+}
+
+fn skip_configure_nmx_cluster_outcome(
+    rack_id: &RackId,
+    reason: impl AsRef<str>,
+) -> StateHandlerOutcome<RackState> {
+    tracing::info!(
+        rack_id = %rack_id,
+        reason = %reason.as_ref(),
+        "Skipping ConfigureNmxCluster and advancing to PowerSequence"
+    );
+    transition_to_power_sequence()
+}
+
+fn validate_switch_inventory_for_nmx_cluster(
+    switches: &[FirmwareUpgradeDeviceInfo],
+) -> Result<(), String> {
+    for switch in switches {
+        if switch.os_ip.as_deref().unwrap_or_default().is_empty() {
+            return Err(format!(
+                "switch {} is missing an NVOS IP address for ConfigureNmxCluster",
+                switch.node_id
+            ));
+        }
+        if switch.os_username.as_deref().unwrap_or_default().is_empty()
+            || switch.os_password.as_deref().unwrap_or_default().is_empty()
+        {
+            return Err(format!(
+                "switch {} is missing NVOS credentials for ConfigureNmxCluster",
+                switch.node_id
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn build_switch_device_info_request(
+    rack_id: &RackId,
+    switches: &[FirmwareUpgradeDeviceInfo],
+) -> rms::GetDeviceInfoByDeviceListRequest {
+    rms::GetDeviceInfoByDeviceListRequest {
+        nodes: Some(rms::NodeSet {
+            devices: switches
+                .iter()
+                .map(|switch| build_new_node_info(rack_id, switch, rms::NodeType::Switch))
+                .collect(),
+        }),
+        ..Default::default()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SwitchPlacement {
+    device: FirmwareUpgradeDeviceInfo,
+    tray_index: i32,
+    slot_number: Option<i32>,
+}
+
+fn select_primary_switch(
+    switches: &[FirmwareUpgradeDeviceInfo],
+    response: &rms::GetDeviceInfoByDeviceListResponse,
+) -> Result<SwitchPlacement, String> {
+    if response.status != rms::ReturnCode::Success as i32 {
+        let details = if response.message.trim().is_empty() {
+            "no error details provided".to_string()
+        } else {
+            response.message.clone()
+        };
+        return Err(format!("RMS GetDeviceInfoByDeviceList failed: {}", details));
+    }
+
+    let switches_by_node_id: HashMap<&str, &FirmwareUpgradeDeviceInfo> = switches
+        .iter()
+        .map(|switch| (switch.node_id.as_str(), switch))
+        .collect();
+    let mut placements = Vec::with_capacity(response.node_device_info.len());
+    let mut seen_node_ids = HashSet::with_capacity(response.node_device_info.len());
+
+    for node_info in &response.node_device_info {
+        let Some(device) = switches_by_node_id.get(node_info.node_id.as_str()) else {
+            return Err(format!(
+                "RMS returned device info for unexpected switch {}",
+                node_info.node_id
+            ));
+        };
+        let Some(tray_index) = node_info.tray_index else {
+            return Err(format!(
+                "RMS did not return tray_index for switch {}",
+                node_info.node_id
+            ));
+        };
+        placements.push(SwitchPlacement {
+            device: (*device).clone(),
+            tray_index,
+            slot_number: node_info.slot_number,
+        });
+        seen_node_ids.insert(node_info.node_id.as_str());
+    }
+
+    if placements.is_empty() {
+        return Err("RMS returned no switch device info for ConfigureNmxCluster".to_string());
+    }
+
+    if placements.len() != switches.len() {
+        let missing = switches
+            .iter()
+            .filter(|switch| !seen_node_ids.contains(switch.node_id.as_str()))
+            .map(|switch| switch.node_id.clone())
+            .collect::<Vec<_>>();
+        return Err(format!(
+            "RMS did not return device info for switches: {}",
+            missing.join(", ")
+        ));
+    }
+
+    placements.sort_by(|left, right| {
+        left.tray_index
+            .cmp(&right.tray_index)
+            .then_with(|| {
+                left.slot_number
+                    .unwrap_or(i32::MAX)
+                    .cmp(&right.slot_number.unwrap_or(i32::MAX))
+            })
+            .then_with(|| left.device.node_id.cmp(&right.device.node_id))
+    });
+
+    Ok(placements
+        .into_iter()
+        .next()
+        .expect("placements cannot be empty after explicit guard"))
 }
 
 /// Submit compute and switch firmware-update batches to RMS and persist the
@@ -645,15 +786,138 @@ pub async fn handle_maintenance(
             }
         },
         RackMaintenanceState::ConfigureNmxCluster => {
+            let Some(rms_client) = ctx.services.rms_client.as_ref() else {
+                return Ok(transition_to_rack_error(id, "RMS client not configured"));
+            };
+            let inventory = load_rack_firmware_inventory(
+                &ctx.services.db_pool,
+                ctx.services.credential_manager.as_ref(),
+                id,
+            )
+            .await
+            .map_err(|error| {
+                StateHandlerError::GenericError(eyre::eyre!(
+                    "failed to load rack firmware inventory for ConfigureNmxCluster: {}",
+                    error
+                ))
+            })?;
+
+            if inventory.switches.is_empty() {
+                return Ok(skip_configure_nmx_cluster_outcome(
+                    id,
+                    "rack has no switches in inventory",
+                ));
+            }
+
+            if let Err(cause) = validate_switch_inventory_for_nmx_cluster(&inventory.switches) {
+                return Ok(transition_to_rack_error(id, cause));
+            }
+
+            let Some(capabilities) = super::resolve_capabilities(id, config, ctx) else {
+                return Ok(transition_to_rack_error(
+                    id,
+                    format!(
+                        "rack_type {:?} is missing or unknown; cannot resolve rack_hardware_topology",
+                        config.rack_type
+                    ),
+                ));
+            };
+            let Some(rack_hardware_topology) = capabilities.rack_hardware_topology else {
+                return Ok(transition_to_rack_error(
+                    id,
+                    format!(
+                        "rack_type {:?} does not define rack_hardware_topology",
+                        config.rack_type
+                    ),
+                ));
+            };
+
+            let response = match rms_client
+                .get_device_info_by_device_list(build_switch_device_info_request(
+                    id,
+                    &inventory.switches,
+                ))
+                .await
+            {
+                Ok(response) => response,
+                Err(error) => {
+                    return Ok(transition_to_rack_error(
+                        id,
+                        format!("RMS GetDeviceInfoByDeviceList failed: {}", error),
+                    ));
+                }
+            };
+            let primary_switch = match select_primary_switch(&inventory.switches, &response) {
+                Ok(primary_switch) => primary_switch,
+                Err(cause) => return Ok(transition_to_rack_error(id, cause)),
+            };
+
+            let topology_type = rack_hardware_topology.to_string();
             tracing::info!(
-                "Rack {} ConfigureNmxCluster - stubbed, advancing to Completed",
-                id
+                rack_id = %id,
+                primary_switch = %primary_switch.device.node_id,
+                tray_index = primary_switch.tray_index,
+                slot_number = primary_switch.slot_number,
+                topology_type = %topology_type,
+                switch_count = inventory.switches.len(),
+                "Configuring NMX cluster on primary switch"
             );
-            Ok(StateHandlerOutcome::transition(RackState::Maintenance {
-                maintenance_state: RackMaintenanceState::PowerSequence {
-                    rack_power: RackPowerState::PoweringOn,
+            let response = match rms_client
+                .configure_scale_up_fabric_manager(rms::ConfigureScaleUpFabricManagerRequest {
+                    device: Some(build_new_node_info(
+                        id,
+                        &primary_switch.device,
+                        rms::NodeType::Switch,
+                    )),
+                    topology_type: topology_type.clone(),
+                    verify_ssl: false,
+                    ..Default::default()
+                })
+                .await
+            {
+                Ok(response) => response,
+                Err(error) => {
+                    return Ok(transition_to_rack_error(
+                        id,
+                        format!(
+                            "RMS ConfigureScaleUpFabricManager failed for switch {}: {}",
+                            primary_switch.device.node_id, error
+                        ),
+                    ));
+                }
+            };
+
+            if response.status != rms::ReturnCode::Success as i32 {
+                let message = if response.message.trim().is_empty() {
+                    "no error details provided".to_string()
+                } else {
+                    response.message
+                };
+                return Ok(transition_to_rack_error(
+                    id,
+                    format!(
+                        "RMS ConfigureScaleUpFabricManager failed for switch {}: {}",
+                        primary_switch.device.node_id, message
+                    ),
+                ));
+            }
+
+            tracing::info!(
+                rack_id = %id,
+                primary_switch = %primary_switch.device.node_id,
+                tray_index = primary_switch.tray_index,
+                slot_number = primary_switch.slot_number,
+                topology_type = %topology_type,
+                topology_used = %if response.topology_used.is_empty() {
+                    topology_type.clone()
+                } else {
+                    response.topology_used.clone()
                 },
-            }))
+                scale_up_fabric_state_enabled = response.scale_up_fabric_state_enabled,
+                grpc_enabled = response.grpc_enabled,
+                "Rack ConfigureNmxCluster complete, advancing to PowerSequence"
+            );
+            Ok(transition_to_power_sequence())
         }
         RackMaintenanceState::PowerSequence { rack_power } => match rack_power {
             RackPowerState::PoweringOn => {

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1987,6 +1987,7 @@ message Switch {
   optional PlacementInRack placement_in_rack = 11;
   health.HealthReport health = 12;
   repeated HealthSourceOrigin health_sources = 13;
+  optional string fabric_manager_status = 14;
 }
 
 message SwitchList {


### PR DESCRIPTION
## Description
- Fetch nmxc status and persists to switch table
- Integrate with forge-admin-cli sw show 

## Type of Change
- [ ] **Add** - Show nmx-c status per switch

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Testing
TBD

