### PR TITLE
feat: generic component manager api -> rack state controller integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2959,6 +2959,7 @@ dependencies = [
  "carbide-macros",
  "carbide-sqlx-testing",
  "carbide-uuid",
+ "chrono",
  "librms",
  "mac_address",
  "prost 0.14.1",

--- a/crates/api-db/src/power_shelf.rs
+++ b/crates/api-db/src/power_shelf.rs
@@ -418,6 +418,35 @@ pub async fn find_bmc_info_by_power_shelf_ids(
         .map_err(|err| DatabaseError::new("power_shelf::find_bmc_info_by_power_shelf_ids", err))
 }
 
+/// A power shelf resolved by its BMC MAC address, along with the rack it
+/// belongs to. Used by the Component Manager state controller wrapper to
+/// build a rack-level `MaintenanceScope` for the power shelves it's been
+/// asked to act on.
+#[derive(Debug, sqlx::FromRow)]
+pub struct PowerShelfIdByBmcMac {
+    pub bmc_mac_address: MacAddress,
+    pub id: PowerShelfId,
+    pub rack_id: Option<RackId>,
+}
+
+/// Resolve BMC MAC addresses to `PowerShelfId`s + `rack_id`s.
+pub async fn find_ids_by_bmc_macs(
+    db: impl crate::db_read::DbReader<'_>,
+    macs: &[MacAddress],
+) -> DatabaseResult<Vec<PowerShelfIdByBmcMac>> {
+    let sql = r#"
+        SELECT ps.bmc_mac_address, ps.id, ps.rack_id
+        FROM power_shelves ps
+        WHERE ps.bmc_mac_address = ANY($1)
+    "#;
+
+    sqlx::query_as(sql)
+        .bind(macs)
+        .fetch_all(db)
+        .await
+        .map_err(|err| DatabaseError::new("power_shelf::find_ids_by_bmc_macs", err))
+}
+
 /// RMS identity for a power shelf: the power shelf ID (used as the RMS
 /// node_id), the BMC MAC address, and the rack_id.
 #[derive(Debug, sqlx::FromRow)]

--- a/crates/api-db/src/switch.rs
+++ b/crates/api-db/src/switch.rs
@@ -538,6 +538,34 @@ pub async fn find_bmc_info_by_switch_ids(
         .map_err(|err| DatabaseError::new("switch::find_bmc_info_by_switch_ids", err))
 }
 
+/// A switch resolved by its BMC MAC address, along with the rack it belongs
+/// to. Used by the Component Manager state controller wrapper to build a
+/// rack-level `MaintenanceScope` for the switches it's been asked to act on.
+#[derive(Debug, sqlx::FromRow)]
+pub struct SwitchIdByBmcMac {
+    pub bmc_mac_address: MacAddress,
+    pub id: SwitchId,
+    pub rack_id: Option<RackId>,
+}
+
+/// Resolve BMC MAC addresses to `SwitchId`s + `rack_id`s.
+pub async fn find_ids_by_bmc_macs(
+    db: impl crate::db_read::DbReader<'_>,
+    macs: &[MacAddress],
+) -> DatabaseResult<Vec<SwitchIdByBmcMac>> {
+    let sql = r#"
+        SELECT s.bmc_mac_address, s.id, s.rack_id
+        FROM switches s
+        WHERE s.bmc_mac_address = ANY($1)
+    "#;
+
+    sqlx::query_as(sql)
+        .bind(macs)
+        .fetch_all(db)
+        .await
+        .map_err(|err| DatabaseError::new("switch::find_ids_by_bmc_macs", err))
+}
+
 /// RMS identity for a switch: the switch ID (used as the RMS node_id),
 /// the BMC MAC address, and the rack_id.
 #[derive(Debug, sqlx::FromRow)]

--- a/crates/api-model/src/component_manager.rs
+++ b/crates/api-model/src/component_manager.rs
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use serde::{Deserialize, Serialize};
+
+/// Power action shared across Switch (NVSwitch) and PowerShelf backends.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PowerAction {
+    On,
+    GracefulShutdown,
+    ForceOff,
+    GracefulRestart,
+    ForceRestart,
+    AcPowercycle,
+}
+
+/// Firmware update lifecycle state shared across Switch and PowerShelf backends.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FirmwareState {
+    Unknown,
+    Queued,
+    InProgress,
+    Verifying,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+/// Updatable components of an Switch tray.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NvSwitchComponent {
+    Bmc,
+    Cpld,
+    Bios,
+    Nvos,
+}
+
+/// Updatable components of a PowerShelf.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PowerShelfComponent {
+    Pmc,
+    Psu,
+}

--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -37,6 +37,7 @@ pub mod address_selection_strategy;
 pub mod allocation_type;
 pub mod attestation;
 pub mod bmc_info;
+pub mod component_manager;
 pub mod compute_allocation;
 pub mod controller_outcome;
 pub mod dhcp_entry;

--- a/crates/api-model/src/power_shelf/mod.rs
+++ b/crates/api-model/src/power_shelf/mod.rs
@@ -99,6 +99,7 @@ pub struct PowerShelf {
 
     /// The rack that this power shelf is associated with.
     pub rack_id: Option<RackId>,
+
     // Columns for these exist, but are unused in rust code
     // pub created: DateTime<Utc>,
     // pub updated: DateTime<Utc>,

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -17,7 +17,10 @@
 use std::collections::HashMap;
 use std::fmt::Display;
 
+use carbide_uuid::machine::MachineId;
+use carbide_uuid::power_shelf::PowerShelfId;
 use carbide_uuid::rack::{RackId, RackProfileId};
+use carbide_uuid::switch::SwitchId;
 use chrono::{DateTime, Utc};
 use config_version::{ConfigVersion, Versioned};
 use rpc::Timestamp;
@@ -26,6 +29,7 @@ use sqlx::postgres::PgRow;
 use sqlx::{FromRow, Row};
 
 use crate::StateSla;
+use crate::component_manager::PowerAction;
 use crate::controller_outcome::PersistentStateHandlerOutcome;
 use crate::health::HealthReportSources;
 use crate::metadata::Metadata;
@@ -507,6 +511,79 @@ impl MachineRvLabels {
 // RACK CONFIG & HISTORY
 // ============================================================================
 
+/// Individual maintenance activities that can be performed during on-demand
+/// rack maintenance. When the activities list on `MaintenanceScope` is
+/// empty, all activities are performed.
+///
+/// Activity-specific configuration is carried inline on the variant
+/// (e.g. `FirmwareUpgrade` holds the optional target firmware version,
+/// `PowerControl` carries the desired power action).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MaintenanceActivity {
+    FirmwareUpgrade {
+        /// Target firmware version. `None` means RMS uses its default/latest.
+        #[serde(default)]
+        firmware_version: Option<String>,
+    },
+    ConfigureNmxCluster,
+    PowerSequence,
+    /// Per-device power control, dispatched by the rack state controller to
+    /// the listed devices on its next tick. Framed out here for the component
+    /// manager routing path; the rack state handler side is a follow-up.
+    PowerControl {
+        action: PowerAction,
+    },
+}
+
+impl MaintenanceActivity {
+    /// Returns `true` if two activities are the same kind, ignoring any
+    /// per-activity configuration (e.g. firmware version, power action).
+    pub fn same_kind(&self, other: &Self) -> bool {
+        std::mem::discriminant(self) == std::mem::discriminant(other)
+    }
+}
+
+impl Display for MaintenanceActivity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MaintenanceActivity::FirmwareUpgrade { .. } => write!(f, "FirmwareUpgrade"),
+            MaintenanceActivity::ConfigureNmxCluster => write!(f, "ConfigureNmxCluster"),
+            MaintenanceActivity::PowerSequence => write!(f, "PowerSequence"),
+            MaintenanceActivity::PowerControl { .. } => write!(f, "PowerControl"),
+        }
+    }
+}
+
+/// Specifies which devices in the rack should be included in an on-demand
+/// maintenance cycle. When all three device-id lists are empty, the full rack
+/// is maintained.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct MaintenanceScope {
+    #[serde(default)]
+    pub machine_ids: Vec<MachineId>,
+    #[serde(default)]
+    pub switch_ids: Vec<SwitchId>,
+    #[serde(default)]
+    pub power_shelf_ids: Vec<PowerShelfId>,
+    /// Which maintenance activities to perform. Empty means all activities.
+    #[serde(default)]
+    pub activities: Vec<MaintenanceActivity>,
+}
+
+impl MaintenanceScope {
+    /// Returns `true` when no specific devices were selected, meaning the
+    /// maintenance applies to every device in the rack.
+    pub fn is_full_rack(&self) -> bool {
+        self.machine_ids.is_empty() && self.switch_ids.is_empty() && self.power_shelf_ids.is_empty()
+    }
+
+    /// Returns `true` if the given activity should be performed. When the
+    /// activities list is empty, all activities are considered requested.
+    pub fn should_run(&self, activity: &MaintenanceActivity) -> bool {
+        self.activities.is_empty() || self.activities.iter().any(|a| a.same_kind(activity))
+    }
+}
+
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct RackConfig {
     /// When set, the Ready state handler will transition back to Maintenance
@@ -518,6 +595,60 @@ pub struct RackConfig {
     /// because a tray was replaced (rack topology change).
     #[serde(default)]
     pub topology_changed: bool,
+
+    /// On-demand maintenance request. When `Some`, the rack state handler
+    /// (in Ready or Error) transitions the rack to Maintenance. The scope
+    /// selects full-rack vs partial-rack and which activities to run.
+    #[serde(default)]
+    pub maintenance_requested: Option<MaintenanceScope>,
+}
+
+/// Reason a rack will not accept a new on-demand maintenance request.
+/// See `Rack::check_accepts_maintenance`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RackMaintenanceRejection {
+    /// The rack is not in `Ready` or `Error`. Carries the current state so
+    /// callers can report exactly what state they saw.
+    NotReadyOrError(RackState),
+    /// A maintenance request is already pending on this rack.
+    AlreadyPending,
+}
+
+impl Display for RackMaintenanceRejection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RackMaintenanceRejection::NotReadyOrError(state) => write!(
+                f,
+                "rack is not in Ready or Error state (current: {state:?}); \
+                 maintenance can only be requested from those states",
+            ),
+            RackMaintenanceRejection::AlreadyPending => {
+                write!(f, "rack already has a pending maintenance request")
+            }
+        }
+    }
+}
+
+impl Rack {
+    /// Tells us if this rack will accept a new on-demand maintenance requests
+    /// right now. Used by every caller that writes to `RackConfig::maintenance_requested`
+    /// (e.g. the on-demand-maintenance gRPC handler + and the Component Manager
+    /// state controller wrappers). This gives us a way to gate maintenance requests
+    /// making their way into the backing `maintenance_requested` data in `RackConfig`.
+    pub fn check_accepts_maintenance(&self) -> Result<(), RackMaintenanceRejection> {
+        if !matches!(
+            *self.controller_state,
+            RackState::Ready | RackState::Error { .. }
+        ) {
+            return Err(RackMaintenanceRejection::NotReadyOrError(
+                self.controller_state.value.clone(),
+            ));
+        }
+        if self.config.maintenance_requested.is_some() {
+            return Err(RackMaintenanceRejection::AlreadyPending);
+        }
+        Ok(())
+    }
 }
 
 // ============================================================================

--- a/crates/api/src/handlers/component_manager.rs
+++ b/crates/api/src/handlers/component_manager.rs
@@ -26,10 +26,10 @@ use component_manager::component_manager::ComponentManager;
 use component_manager::error::ComponentManagerError;
 use component_manager::nv_switch_manager::SwitchEndpoint;
 use component_manager::power_shelf_manager::{PowerShelfEndpoint, PowerShelfVendor};
-use component_manager::types::{NvSwitchComponent, PowerAction, PowerShelfComponent};
 use db::{self, WithTransaction};
 use futures_util::FutureExt;
 use mac_address::MacAddress;
+use model::component_manager::{NvSwitchComponent, PowerAction, PowerShelfComponent};
 use tonic::{Request, Response, Status};
 
 use crate::api::{Api, log_request_data};
@@ -287,8 +287,8 @@ fn ps_mac_to_id_str(mac: &MacAddress, mac_to_id: &HashMap<MacAddress, PowerShelf
         .unwrap_or_else(|| mac.to_string())
 }
 
-fn map_fw_state(state: component_manager::types::FirmwareState) -> i32 {
-    use component_manager::types::FirmwareState;
+fn map_fw_state(state: model::component_manager::FirmwareState) -> i32 {
+    use model::component_manager::FirmwareState;
     match state {
         FirmwareState::Unknown => rpc::FirmwareUpdateState::FwStateUnknown as i32,
         FirmwareState::Queued => rpc::FirmwareUpdateState::FwStateQueued as i32,
@@ -861,7 +861,7 @@ pub(crate) async fn list_component_firmware_versions(
 
 #[cfg(test)]
 mod tests {
-    use component_manager::types::FirmwareState;
+    use model::component_manager::FirmwareState;
     use tonic::Code;
 
     use super::*;

--- a/crates/component-manager/Cargo.toml
+++ b/crates/component-manager/Cargo.toml
@@ -26,6 +26,7 @@ async-trait = { workspace = true }
 carbide-api-db = { path = "../api-db", default-features = false }
 carbide-api-model = { path = "../api-model" }
 carbide-uuid = { path = "../uuid" }
+chrono = { workspace = true }
 librms = { workspace = true }
 mac_address = { workspace = true }
 sqlx = { workspace = true, features = ["postgres"] }

--- a/crates/component-manager/src/component_manager.rs
+++ b/crates/component-manager/src/component_manager.rs
@@ -10,6 +10,7 @@ use crate::config::ComponentManagerConfig;
 use crate::error::ComponentManagerError;
 use crate::nv_switch_manager::NvSwitchManager;
 use crate::power_shelf_manager::PowerShelfManager;
+use crate::state_controller::{StateControllerNvSwitch, StateControllerPowerShelf};
 
 /// Holds the configured backend implementations for each component type.
 #[derive(Debug, Clone)]
@@ -73,6 +74,23 @@ pub async fn build_component_manager(
         }
     };
 
+    // If nv_switch_use_state_controller is enabled, then build a state
+    // controller integrated backend for switches, wrapping the configured
+    // "backend" within our StateControllerNvSwitch backend. This allows
+    // Component Manager API calls to flow into our state controller aware
+    // backend, and then allows the state controller to have .direct()
+    // access to the actual backend (e.g. nsm, rms, etc).
+    let nv_switch = if config.nv_switch_use_state_controller {
+        let db = db.clone().ok_or_else(|| {
+            ComponentManagerError::InvalidArgument(
+                "nv_switch_use_state_controller is true but database pool is not configured".into(),
+            )
+        })?;
+        Arc::new(StateControllerNvSwitch::new(db, nv_switch)) as Arc<dyn NvSwitchManager>
+    } else {
+        nv_switch
+    };
+
     let power_shelf: Arc<dyn PowerShelfManager> = match config.power_shelf_backend.as_str() {
         "psm" => {
             let endpoint = config.psm.as_ref().ok_or_else(|| {
@@ -107,6 +125,24 @@ pub async fn build_component_manager(
         }
     };
 
+    // If power_shelf_use_state_controller is enabled, then build a state
+    // controller integrated backend for power shelves, wrapping the configured
+    // "backend" within our StateControllerPowerShelf backend. This allows
+    // Component Manager API calls to flow into our state controller aware
+    // backend, and then allows the state controller to have .direct()
+    // access to the actual backend (e.g. psm, rms, etc).
+    let power_shelf = if config.power_shelf_use_state_controller {
+        let db = db.clone().ok_or_else(|| {
+            ComponentManagerError::InvalidArgument(
+                "power_shelf_use_state_controller is true but database pool is not configured"
+                    .into(),
+            )
+        })?;
+        Arc::new(StateControllerPowerShelf::new(db, power_shelf)) as Arc<dyn PowerShelfManager>
+    } else {
+        power_shelf
+    };
+
     Ok(ComponentManager::new(nv_switch, power_shelf))
 }
 
@@ -120,8 +156,7 @@ mod tests {
         let config = ComponentManagerConfig {
             nv_switch_backend: "mock".into(),
             power_shelf_backend: "mock".into(),
-            nsm: None,
-            psm: None,
+            ..Default::default()
         };
         let cm = build_component_manager(&config, None, None).await.unwrap();
         assert_eq!(cm.nv_switch.name(), "mock-nsm");
@@ -133,8 +168,7 @@ mod tests {
         let config = ComponentManagerConfig {
             nv_switch_backend: "bogus".into(),
             power_shelf_backend: "mock".into(),
-            nsm: None,
-            psm: None,
+            ..Default::default()
         };
         let err = build_component_manager(&config, None, None)
             .await
@@ -149,8 +183,7 @@ mod tests {
         let config = ComponentManagerConfig {
             nv_switch_backend: "mock".into(),
             power_shelf_backend: "bogus".into(),
-            nsm: None,
-            psm: None,
+            ..Default::default()
         };
         let err = build_component_manager(&config, None, None)
             .await
@@ -165,8 +198,7 @@ mod tests {
         let config = ComponentManagerConfig {
             nv_switch_backend: "nsm".into(),
             power_shelf_backend: "mock".into(),
-            nsm: None,
-            psm: None,
+            ..Default::default()
         };
         let err = build_component_manager(&config, None, None)
             .await
@@ -179,12 +211,47 @@ mod tests {
         let config = ComponentManagerConfig {
             nv_switch_backend: "mock".into(),
             power_shelf_backend: "psm".into(),
-            nsm: None,
-            psm: None,
+            ..Default::default()
         };
         let err = build_component_manager(&config, None, None)
             .await
             .unwrap_err();
         assert!(matches!(err, ComponentManagerError::InvalidArgument(_)));
+    }
+
+    #[tokio::test]
+    async fn build_state_controller_switch_requires_db() {
+        let config = ComponentManagerConfig {
+            nv_switch_backend: "mock".into(),
+            power_shelf_backend: "mock".into(),
+            nv_switch_use_state_controller: true,
+            ..Default::default()
+        };
+        let err = build_component_manager(&config, None, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ComponentManagerError::InvalidArgument(msg)
+                if msg.contains("nv_switch_use_state_controller") && msg.contains("database pool")
+        ));
+    }
+
+    #[tokio::test]
+    async fn build_state_controller_power_shelf_requires_db() {
+        let config = ComponentManagerConfig {
+            nv_switch_backend: "mock".into(),
+            power_shelf_backend: "mock".into(),
+            power_shelf_use_state_controller: true,
+            ..Default::default()
+        };
+        let err = build_component_manager(&config, None, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ComponentManagerError::InvalidArgument(msg)
+                if msg.contains("power_shelf_use_state_controller") && msg.contains("database pool")
+        ));
     }
 }

--- a/crates/component-manager/src/config.rs
+++ b/crates/component-manager/src/config.rs
@@ -13,6 +13,25 @@ pub struct ComponentManagerConfig {
     pub nsm: Option<BackendEndpointConfig>,
     #[serde(default)]
     pub psm: Option<BackendEndpointConfig>,
+
+    /// When `true`, Switch power control and firmware update calls go
+    /// through the switch state controller, instead of being dispatched
+    /// directly to the device.
+    ///
+    /// Status reads and firmware-catalog reads still pass through to
+    /// the "direct" backend.
+    ///
+    /// Defaults to `false` (existing direct-dispatch behaviour).
+    #[serde(default)]
+    pub nv_switch_use_state_controller: bool,
+
+    /// When `true`, power shelf power control and firmware update calls
+    /// go through the power shelf state controller instead of being dispatched
+    /// directly.
+    ///
+    /// Defaults to `false`.
+    #[serde(default)]
+    pub power_shelf_use_state_controller: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -87,6 +106,8 @@ impl Default for ComponentManagerConfig {
             power_shelf_backend: default_psm_backend(),
             nsm: None,
             psm: None,
+            nv_switch_use_state_controller: false,
+            power_shelf_use_state_controller: false,
         }
     }
 }

--- a/crates/component-manager/src/lib.rs
+++ b/crates/component-manager/src/lib.rs
@@ -10,6 +10,9 @@ pub mod nv_switch_manager;
 pub mod power_shelf_manager;
 pub mod psm;
 pub mod rms;
+pub mod state_controller;
+#[cfg(test)]
+mod test_support;
 pub mod tls;
 pub mod types;
 

--- a/crates/component-manager/src/mock.rs
+++ b/crates/component-manager/src/mock.rs
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use model::component_manager::{
+    FirmwareState, NvSwitchComponent, PowerAction, PowerShelfComponent,
+};
+
 use crate::error::ComponentManagerError;
 use crate::nv_switch_manager::{
     NvSwitchManager, SwitchComponentResult, SwitchEndpoint, SwitchFirmwareUpdateStatus,
@@ -9,7 +13,6 @@ use crate::power_shelf_manager::{
     PowerShelfComponentResult, PowerShelfEndpoint, PowerShelfFirmwareUpdateStatus,
     PowerShelfFirmwareVersions, PowerShelfManager,
 };
-use crate::types::{FirmwareState, NvSwitchComponent, PowerAction, PowerShelfComponent};
 
 #[derive(Debug, Default)]
 pub struct MockNvSwitchManager;

--- a/crates/component-manager/src/nsm.rs
+++ b/crates/component-manager/src/nsm.rs
@@ -4,6 +4,7 @@
 use std::collections::HashMap;
 
 use mac_address::MacAddress;
+use model::component_manager::{FirmwareState, NvSwitchComponent, PowerAction};
 use tonic::transport::Channel;
 use tracing::instrument;
 
@@ -13,7 +14,7 @@ use crate::nv_switch_manager::{
     NvSwitchManager, SwitchComponentResult, SwitchEndpoint, SwitchFirmwareUpdateStatus,
 };
 use crate::proto::nsm;
-use crate::types::{FirmwareState, NvSwitchComponent, PowerAction, parse_mac};
+use crate::types::parse_mac;
 
 #[derive(Debug)]
 pub struct NsmSwitchBackend {

--- a/crates/component-manager/src/nv_switch_manager.rs
+++ b/crates/component-manager/src/nv_switch_manager.rs
@@ -5,9 +5,9 @@ use std::fmt::Debug;
 use std::net::IpAddr;
 
 use mac_address::MacAddress;
+use model::component_manager::{FirmwareState, NvSwitchComponent, PowerAction};
 
 use crate::error::ComponentManagerError;
-use crate::types::{FirmwareState, NvSwitchComponent, PowerAction};
 
 /// Physical network identifiers for an NV-Switch, used to register with and
 /// operate against the backend service (NSM).

--- a/crates/component-manager/src/power_shelf_manager.rs
+++ b/crates/component-manager/src/power_shelf_manager.rs
@@ -5,9 +5,9 @@ use std::fmt::Debug;
 use std::net::IpAddr;
 
 use mac_address::MacAddress;
+use model::component_manager::{FirmwareState, PowerAction, PowerShelfComponent};
 
 use crate::error::ComponentManagerError;
-use crate::types::{FirmwareState, PowerAction, PowerShelfComponent};
 
 /// Physical network identifiers for a power shelf, used to register with and
 /// operate against the backend service (PSM).

--- a/crates/component-manager/src/psm.rs
+++ b/crates/component-manager/src/psm.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use model::component_manager::{FirmwareState, PowerAction, PowerShelfComponent};
 use tonic::transport::Channel;
 use tracing::instrument;
 
@@ -11,7 +12,7 @@ use crate::power_shelf_manager::{
     PowerShelfFirmwareVersions, PowerShelfManager, PowerShelfVendor,
 };
 use crate::proto::psm;
-use crate::types::{FirmwareState, PowerAction, PowerShelfComponent, parse_mac};
+use crate::types::parse_mac;
 
 #[derive(Debug)]
 pub struct PsmPowerShelfBackend {

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -21,6 +21,9 @@ use std::sync::{Arc, Mutex};
 use librms::RmsApi;
 use librms::protos::rack_manager as rms;
 use mac_address::MacAddress;
+use model::component_manager::{
+    FirmwareState, NvSwitchComponent, PowerAction, PowerShelfComponent,
+};
 use sqlx::PgPool;
 use tracing::instrument;
 
@@ -32,7 +35,6 @@ use crate::power_shelf_manager::{
     PowerShelfComponentResult, PowerShelfEndpoint, PowerShelfFirmwareUpdateStatus,
     PowerShelfFirmwareVersions, PowerShelfManager,
 };
-use crate::types::{FirmwareState, NvSwitchComponent, PowerAction, PowerShelfComponent};
 
 /// RMS identity for a device: the node_id and rack_id that RMS needs
 /// to address it. Used for both power shelves and switches.
@@ -689,18 +691,15 @@ impl NvSwitchManager for RmsBackend {
 #[cfg(test)]
 mod tests {
     use api_test_helper::mock_rms::MockRmsApi;
-    use carbide_uuid::power_shelf::{PowerShelfId, PowerShelfIdSource, PowerShelfType};
+    use carbide_uuid::power_shelf::PowerShelfId;
     use carbide_uuid::rack::RackId;
-    use carbide_uuid::switch::{SwitchId, SwitchIdSource, SwitchType};
-    use model::expected_power_shelf::ExpectedPowerShelf;
-    use model::expected_switch::ExpectedSwitch;
-    use model::metadata::Metadata;
-    use model::power_shelf::{NewPowerShelf, PowerShelfConfig};
-    use model::rack::RackConfig;
-    use model::switch::{NewSwitch, SwitchConfig};
+    use carbide_uuid::switch::SwitchId;
 
     use super::*;
     use crate::power_shelf_manager::PowerShelfVendor;
+    use crate::test_support::{
+        PS_MAC_1, PS_MAC_2, SW_MAC_1, SW_MAC_2, UNKNOWN_MAC, seed_test_data,
+    };
 
     // ---- Mapping unit tests ----
 
@@ -796,12 +795,6 @@ mod tests {
 
     // ---- Test helpers ----
 
-    const PS_MAC_1: &str = "AA:BB:CC:DD:EE:01";
-    const PS_MAC_2: &str = "AA:BB:CC:DD:EE:02";
-    const SW_MAC_1: &str = "AA:BB:CC:DD:FF:01";
-    const SW_MAC_2: &str = "AA:BB:CC:DD:FF:02";
-    const UNKNOWN_MAC: &str = "FF:FF:FF:FF:FF:FF";
-
     fn make_ps_endpoint(mac: &str) -> PowerShelfEndpoint {
         PowerShelfEndpoint {
             pmc_ip: "10.0.0.1".parse().unwrap(),
@@ -817,147 +810,6 @@ mod tests {
             nvos_ip: "10.0.0.2".parse().unwrap(),
             nvos_mac: "11:22:33:44:55:66".parse().unwrap(),
         }
-    }
-
-    fn test_power_shelf_id(label: &str) -> PowerShelfId {
-        let mut hash = [0u8; 32];
-        let bytes = label.as_bytes();
-        hash[..bytes.len().min(32)].copy_from_slice(&bytes[..bytes.len().min(32)]);
-        PowerShelfId::new(
-            PowerShelfIdSource::ProductBoardChassisSerial,
-            hash,
-            PowerShelfType::Rack,
-        )
-    }
-
-    fn test_switch_id(label: &str) -> SwitchId {
-        let mut hash = [0u8; 32];
-        let bytes = label.as_bytes();
-        hash[..bytes.len().min(32)].copy_from_slice(&bytes[..bytes.len().min(32)]);
-        SwitchId::new(SwitchIdSource::Tpm, hash, SwitchType::NvLink)
-    }
-
-    /// Seed a rack + two power shelves + two switches into the database.
-    async fn seed_test_data(
-        pool: &sqlx::PgPool,
-    ) -> (RackId, PowerShelfId, PowerShelfId, SwitchId, SwitchId) {
-        let mut txn = pool.begin().await.unwrap();
-
-        let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
-        db::rack::create(&mut txn, &rack_id, None, &RackConfig::default(), None)
-            .await
-            .expect("failed to create rack");
-
-        let ps1 = seed_power_shelf(&mut txn, PS_MAC_1, "PS-001", &rack_id).await;
-        let ps2 = seed_power_shelf(&mut txn, PS_MAC_2, "PS-002", &rack_id).await;
-        let sw1 = seed_switch(&mut txn, SW_MAC_1, "SW-001", &rack_id).await;
-        let sw2 = seed_switch(&mut txn, SW_MAC_2, "SW-002", &rack_id).await;
-
-        txn.commit().await.unwrap();
-        (rack_id, ps1, ps2, sw1, sw2)
-    }
-
-    async fn seed_power_shelf(
-        txn: &mut sqlx::PgConnection,
-        mac: &str,
-        label: &str,
-        rack_id: &RackId,
-    ) -> PowerShelfId {
-        let ps_id = test_power_shelf_id(label);
-        let mac: MacAddress = mac.parse().unwrap();
-
-        db::expected_power_shelf::create(
-            &mut *txn,
-            ExpectedPowerShelf {
-                expected_power_shelf_id: None,
-                bmc_mac_address: mac,
-                serial_number: label.to_owned(),
-                bmc_username: "admin".into(),
-                bmc_password: "pass".into(),
-                bmc_ip_address: None,
-                metadata: Metadata::default(),
-                rack_id: Some(rack_id.clone()),
-                bmc_retain_credentials: None,
-            },
-        )
-        .await
-        .expect("failed to create expected power shelf");
-
-        db::power_shelf::create(
-            &mut *txn,
-            &NewPowerShelf {
-                id: ps_id,
-                config: PowerShelfConfig {
-                    name: label.to_owned(),
-                    capacity: None,
-                    voltage: None,
-                },
-                metadata: Some(Metadata::default()),
-                rack_id: Some(rack_id.clone()),
-            },
-        )
-        .await
-        .expect("failed to create power shelf");
-
-        sqlx::query("UPDATE power_shelves SET bmc_mac_address = $1 WHERE id = $2")
-            .bind(mac)
-            .bind(ps_id)
-            .execute(&mut *txn)
-            .await
-            .expect("failed to set power shelf bmc_mac_address");
-
-        ps_id
-    }
-
-    async fn seed_switch(
-        txn: &mut sqlx::PgConnection,
-        mac: &str,
-        label: &str,
-        rack_id: &RackId,
-    ) -> SwitchId {
-        let sw_id = test_switch_id(label);
-        let mac: MacAddress = mac.parse().unwrap();
-
-        db::expected_switch::create(
-            &mut *txn,
-            ExpectedSwitch {
-                expected_switch_id: None,
-                serial_number: label.to_owned(),
-                bmc_mac_address: mac,
-                bmc_ip_address: None,
-                bmc_username: "admin".into(),
-                bmc_password: "pass".into(),
-                nvos_username: None,
-                nvos_password: None,
-                nvos_mac_addresses: vec![],
-                metadata: Metadata::default(),
-                rack_id: Some(rack_id.clone()),
-                bmc_retain_credentials: None,
-            },
-        )
-        .await
-        .expect("failed to create expected switch");
-
-        db::switch::create(
-            &mut *txn,
-            &NewSwitch {
-                id: sw_id,
-                config: SwitchConfig {
-                    name: label.to_owned(),
-                    enable_nmxc: false,
-                    fabric_manager_config: None,
-                },
-                bmc_mac_address: Some(mac),
-                metadata: Some(Metadata::default()),
-                rack_id: Some(rack_id.clone()),
-                slot_number: None,
-                tray_index: None,
-            },
-        )
-        .await
-        .expect("failed to create switch");
-
-        sw_id
     }
 
     /// Create a backend with a real DB pool seeded with test data.

--- a/crates/component-manager/src/state_controller/mod.rs
+++ b/crates/component-manager/src/state_controller/mod.rs
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Component Manager state controller wrapper backends.
+//!
+//! These backends implement the same `PowerShelfManager` and `NvSwitchManager`
+//! traits as the direct backends (`NsmBackend`, `PsmBackend`, `RmsBackend`),
+//! so they plug straight into `ComponentManager` via config. The difference:
+//! instead of dispatching directly to a device, they resolve the affected
+//! endpoints to a single rack, build a `model::rack::MaintenanceScope`
+//! carrying the device IDs and a single `model::rack::MaintenanceActivity`,
+//! and persist it into `racks.config.maintenance_requested`.
+//!
+//! The rack state controller picks the request up on its next iteration and
+//! drives the work. When it's time to actually touch hardware, it can reach
+//! through the wrapper's `direct` field to the underlying backend; this
+//! layer only records intent.
+//!
+//! Calls that don't map cleanly to rack-level maintenance (reading firmware
+//! status, listing firmware catalogs, per-device inventory) are passed
+//! through to the wrapped direct backend.
+
+use std::collections::HashSet;
+
+use carbide_uuid::rack::RackId;
+
+use crate::error::ComponentManagerError;
+
+pub mod nv_switch;
+pub mod power_shelf;
+
+pub use nv_switch::StateControllerNvSwitch;
+pub use power_shelf::StateControllerPowerShelf;
+
+/// Returns the single rack_id every endpoint agrees on.
+///
+/// Errors if any endpoint has a `None` rack_id (because we can't
+/// schedule maintenance on a device we don't know rack info about),
+/// OR or if the endpoints disagree on which rack they belong to.
+///
+/// A single component-manager request must target exactly one
+/// rack because `MaintenanceScope` lives on one `RackConfig`.
+///
+/// Maybe we can change this later, but right now the idea is we
+/// will get a bunch of devices we want to include in a maintenance
+/// request, so we want to resolve the rack_id for each device,
+/// make sure they all have a rack_id, and make sure all of the
+/// rack_id's match.
+pub(crate) fn unique_rack_id<'a>(
+    rack_ids: impl IntoIterator<Item = Option<&'a RackId>>,
+    device_kind: &'static str,
+) -> Result<RackId, ComponentManagerError> {
+    let mut unique: HashSet<RackId> = HashSet::new();
+    let mut missing = false;
+    for rack in rack_ids {
+        match rack {
+            Some(r) => {
+                unique.insert(r.clone());
+            }
+            None => missing = true,
+        }
+    }
+    if missing {
+        return Err(ComponentManagerError::InvalidArgument(format!(
+            "one or more {device_kind} have no rack_id; cannot schedule rack maintenance",
+        )));
+    }
+    if unique.len() > 1 {
+        return Err(ComponentManagerError::InvalidArgument(format!(
+            "{device_kind} span {} racks; component-manager requests must target a single rack",
+            unique.len()
+        )));
+    }
+    unique.into_iter().next().ok_or_else(|| {
+        ComponentManagerError::InvalidArgument(format!(
+            "no resolved {device_kind} to schedule maintenance for",
+        ))
+    })
+}

--- a/crates/component-manager/src/state_controller/nv_switch.rs
+++ b/crates/component-manager/src/state_controller/nv_switch.rs
@@ -1,0 +1,480 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A Component Manager `NvSwitchManager` implementation that routes write
+//! operations to the rack state controller (by writing a `MaintenanceScope`
+//! onto `racks.config.maintenance_requested`) and passes reads through to
+//! the wrapped direct backend.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use carbide_uuid::rack::RackId;
+use carbide_uuid::switch::SwitchId;
+use db::ObjectColumnFilter;
+use mac_address::MacAddress;
+use model::component_manager::{NvSwitchComponent, PowerAction};
+use model::rack::{MaintenanceActivity, MaintenanceScope};
+use sqlx::PgPool;
+use tracing::instrument;
+
+use super::unique_rack_id;
+use crate::error::ComponentManagerError;
+use crate::nv_switch_manager::{
+    NvSwitchManager, SwitchComponentResult, SwitchEndpoint, SwitchFirmwareUpdateStatus,
+};
+
+const UNKNOWN_MAC_ERROR: &str = "no switch row found for this BMC MAC address";
+const DEVICE_KIND: &str = "switches";
+
+/// Wraps a direct `NvSwitchManager` backend (e.g., `RmsBackend`, `NsmBackend`)
+/// and routes state-changing operations through the rack state controller
+/// instead of dispatching them directly.
+///
+/// `direct` is deliberately public so the rack state controller can reach
+/// through to it for the real dispatch.
+pub struct StateControllerNvSwitch {
+    db: PgPool,
+    pub direct: Arc<dyn NvSwitchManager>,
+}
+
+impl std::fmt::Debug for StateControllerNvSwitch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StateControllerNvSwitch")
+            .field("direct", &self.direct.name())
+            .finish()
+    }
+}
+
+impl StateControllerNvSwitch {
+    pub fn new(db: PgPool, direct: Arc<dyn NvSwitchManager>) -> Self {
+        Self { db, direct }
+    }
+
+    /// Resolve endpoints, preflight, write a `MaintenanceScope` to the rack,
+    /// and return the per-endpoint result vector. Shared by `power_control`
+    /// and `queue_firmware_updates`.
+    async fn write_scope(
+        &self,
+        endpoints: &[SwitchEndpoint],
+        activity: MaintenanceActivity,
+    ) -> Result<Vec<SwitchComponentResult>, ComponentManagerError> {
+        let macs: Vec<MacAddress> = endpoints.iter().map(|ep| ep.bmc_mac).collect();
+        let resolved = db::switch::find_ids_by_bmc_macs(&self.db, &macs)
+            .await
+            .map_err(|e| {
+                ComponentManagerError::Internal(format!("failed to resolve switch IDs by MAC: {e}"))
+            })?;
+
+        let id_by_mac: HashMap<MacAddress, (SwitchId, Option<RackId>)> = resolved
+            .into_iter()
+            .map(|r| (r.bmc_mac_address, (r.id, r.rack_id)))
+            .collect();
+
+        if id_by_mac.is_empty() {
+            return Ok(endpoints
+                .iter()
+                .map(|ep| unknown_mac_result(ep.bmc_mac))
+                .collect());
+        }
+
+        let rack_id = unique_rack_id(
+            endpoints
+                .iter()
+                .filter_map(|ep| id_by_mac.get(&ep.bmc_mac).map(|(_, rack)| rack.as_ref())),
+            DEVICE_KIND,
+        )?;
+
+        let switch_ids: Vec<SwitchId> = endpoints
+            .iter()
+            .filter_map(|ep| id_by_mac.get(&ep.bmc_mac).map(|(id, _)| *id))
+            .collect();
+
+        self.persist_scope(&rack_id, switch_ids, activity).await?;
+
+        Ok(endpoints
+            .iter()
+            .map(|ep| {
+                if id_by_mac.contains_key(&ep.bmc_mac) {
+                    SwitchComponentResult {
+                        bmc_mac: ep.bmc_mac,
+                        success: true,
+                        error: None,
+                    }
+                } else {
+                    unknown_mac_result(ep.bmc_mac)
+                }
+            })
+            .collect())
+    }
+
+    async fn persist_scope(
+        &self,
+        rack_id: &RackId,
+        switch_ids: Vec<SwitchId>,
+        activity: MaintenanceActivity,
+    ) -> Result<(), ComponentManagerError> {
+        let mut txn = self.db.begin().await.map_err(|e| {
+            ComponentManagerError::Internal(format!("failed to begin transaction: {e}"))
+        })?;
+
+        let rack = db::rack::find_by(
+            txn.as_mut(),
+            ObjectColumnFilter::One(db::rack::IdColumn, rack_id),
+        )
+        .await
+        .map_err(|e| ComponentManagerError::Internal(format!("failed to load rack: {e}")))?
+        .pop()
+        .ok_or_else(|| ComponentManagerError::NotFound(format!("rack {rack_id} not found")))?;
+
+        rack.check_accepts_maintenance()
+            .map_err(|r| ComponentManagerError::InvalidArgument(format!("rack {rack_id}: {r}")))?;
+
+        let scope = MaintenanceScope {
+            machine_ids: vec![],
+            switch_ids,
+            power_shelf_ids: vec![],
+            activities: vec![activity],
+        };
+
+        let mut new_config = rack.config.clone();
+        new_config.maintenance_requested = Some(scope);
+        db::rack::update(txn.as_mut(), rack_id, &new_config)
+            .await
+            .map_err(|e| {
+                ComponentManagerError::Internal(format!("failed to write maintenance scope: {e}"))
+            })?;
+
+        txn.commit().await.map_err(|e| {
+            ComponentManagerError::Internal(format!("failed to commit transaction: {e}"))
+        })?;
+
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl NvSwitchManager for StateControllerNvSwitch {
+    fn name(&self) -> &str {
+        "state-controller"
+    }
+
+    #[instrument(skip(self), fields(backend = "state-controller"))]
+    async fn power_control(
+        &self,
+        endpoints: &[SwitchEndpoint],
+        action: PowerAction,
+    ) -> Result<Vec<SwitchComponentResult>, ComponentManagerError> {
+        self.write_scope(endpoints, MaintenanceActivity::PowerControl { action })
+            .await
+    }
+
+    #[instrument(skip(self), fields(backend = "state-controller"))]
+    async fn queue_firmware_updates(
+        &self,
+        endpoints: &[SwitchEndpoint],
+        bundle_version: &str,
+        _components: &[NvSwitchComponent],
+    ) -> Result<Vec<SwitchComponentResult>, ComponentManagerError> {
+        let firmware_version = if bundle_version.is_empty() {
+            None
+        } else {
+            Some(bundle_version.to_owned())
+        };
+        self.write_scope(
+            endpoints,
+            MaintenanceActivity::FirmwareUpgrade { firmware_version },
+        )
+        .await
+    }
+
+    async fn get_firmware_status(
+        &self,
+        endpoints: &[SwitchEndpoint],
+    ) -> Result<Vec<SwitchFirmwareUpdateStatus>, ComponentManagerError> {
+        self.direct.get_firmware_status(endpoints).await
+    }
+
+    async fn list_firmware_bundles(&self) -> Result<Vec<String>, ComponentManagerError> {
+        self.direct.list_firmware_bundles().await
+    }
+}
+
+fn unknown_mac_result(bmc_mac: MacAddress) -> SwitchComponentResult {
+    SwitchComponentResult {
+        bmc_mac,
+        success: false,
+        error: Some(UNKNOWN_MAC_ERROR.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use model::rack::{FirmwareUpgradeState, RackMaintenanceState};
+
+    use super::*;
+    use crate::test_support::{SW_MAC_1, SW_MAC_2, UNKNOWN_MAC, seed_test_data, set_rack_state};
+
+    #[derive(Debug, Default)]
+    struct RecordingDirect {
+        power_control_calls: Mutex<usize>,
+        queue_firmware_updates_calls: Mutex<usize>,
+        get_firmware_status_calls: Mutex<usize>,
+        list_firmware_bundles_calls: Mutex<usize>,
+    }
+
+    #[async_trait::async_trait]
+    impl NvSwitchManager for RecordingDirect {
+        fn name(&self) -> &str {
+            "recording"
+        }
+
+        async fn power_control(
+            &self,
+            _endpoints: &[SwitchEndpoint],
+            _action: PowerAction,
+        ) -> Result<Vec<SwitchComponentResult>, ComponentManagerError> {
+            *self.power_control_calls.lock().unwrap() += 1;
+            Ok(vec![])
+        }
+
+        async fn queue_firmware_updates(
+            &self,
+            _endpoints: &[SwitchEndpoint],
+            _bundle_version: &str,
+            _components: &[NvSwitchComponent],
+        ) -> Result<Vec<SwitchComponentResult>, ComponentManagerError> {
+            *self.queue_firmware_updates_calls.lock().unwrap() += 1;
+            Ok(vec![])
+        }
+
+        async fn get_firmware_status(
+            &self,
+            endpoints: &[SwitchEndpoint],
+        ) -> Result<Vec<SwitchFirmwareUpdateStatus>, ComponentManagerError> {
+            *self.get_firmware_status_calls.lock().unwrap() += 1;
+            Ok(endpoints
+                .iter()
+                .map(|ep| SwitchFirmwareUpdateStatus {
+                    bmc_mac: ep.bmc_mac,
+                    state: model::component_manager::FirmwareState::Unknown,
+                    target_version: String::new(),
+                    error: None,
+                })
+                .collect())
+        }
+
+        async fn list_firmware_bundles(&self) -> Result<Vec<String>, ComponentManagerError> {
+            *self.list_firmware_bundles_calls.lock().unwrap() += 1;
+            Ok(vec!["fw-1.0".into()])
+        }
+    }
+
+    fn make_ep(mac: &str) -> SwitchEndpoint {
+        SwitchEndpoint {
+            bmc_ip: "10.0.0.1".parse().unwrap(),
+            bmc_mac: mac.parse().unwrap(),
+            nvos_ip: "10.0.0.2".parse().unwrap(),
+            nvos_mac: "11:22:33:44:55:66".parse().unwrap(),
+        }
+    }
+
+    async fn load_maintenance_scope(pool: &PgPool, rack_id: &RackId) -> Option<MaintenanceScope> {
+        let mut conn = pool.acquire().await.unwrap();
+        let rack = db::rack::find_by(
+            &mut *conn,
+            db::ObjectColumnFilter::One(db::rack::IdColumn, rack_id),
+        )
+        .await
+        .expect("find rack")
+        .pop()
+        .expect("rack exists");
+        rack.config.maintenance_requested
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn power_control_writes_maintenance_scope(pool: PgPool) {
+        let (rack_id, _, _, sw1, sw2) = seed_test_data(&pool).await;
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerNvSwitch::new(pool.clone(), direct.clone());
+
+        let eps = vec![make_ep(SW_MAC_1), make_ep(SW_MAC_2)];
+        let results = wrapper
+            .power_control(&eps, PowerAction::AcPowercycle)
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|r| r.success));
+
+        let scope = load_maintenance_scope(&pool, &rack_id)
+            .await
+            .expect("scope");
+        assert!(scope.machine_ids.is_empty());
+        assert!(scope.power_shelf_ids.is_empty());
+        assert_eq!(scope.switch_ids, vec![sw1, sw2]);
+        match &scope.activities[0] {
+            MaintenanceActivity::PowerControl { action } => {
+                assert_eq!(*action, PowerAction::AcPowercycle);
+            }
+            other => panic!("expected PowerControl activity, got {other:?}"),
+        }
+        assert_eq!(*direct.power_control_calls.lock().unwrap(), 0);
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn queue_firmware_updates_writes_maintenance_scope(pool: PgPool) {
+        let (rack_id, _, _, sw1, _) = seed_test_data(&pool).await;
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerNvSwitch::new(pool.clone(), direct.clone());
+
+        let eps = vec![make_ep(SW_MAC_1)];
+        let results = wrapper
+            .queue_firmware_updates(&eps, "nvos-3.0", &[NvSwitchComponent::Bmc])
+            .await
+            .unwrap();
+
+        assert!(results[0].success);
+
+        let scope = load_maintenance_scope(&pool, &rack_id)
+            .await
+            .expect("scope");
+        assert_eq!(scope.switch_ids, vec![sw1]);
+        match &scope.activities[0] {
+            MaintenanceActivity::FirmwareUpgrade { firmware_version } => {
+                assert_eq!(firmware_version.as_deref(), Some("nvos-3.0"));
+            }
+            other => panic!("expected FirmwareUpgrade activity, got {other:?}"),
+        }
+        assert_eq!(*direct.queue_firmware_updates_calls.lock().unwrap(), 0);
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn partial_unknown_mac_known_still_written(pool: PgPool) {
+        let (rack_id, _, _, _, sw2) = seed_test_data(&pool).await;
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerNvSwitch::new(pool.clone(), direct);
+
+        let eps = vec![make_ep(UNKNOWN_MAC), make_ep(SW_MAC_2)];
+        let results = wrapper.power_control(&eps, PowerAction::On).await.unwrap();
+
+        assert!(!results[0].success);
+        assert!(results[0].error.as_deref().unwrap().contains("no switch"));
+        assert!(results[1].success);
+
+        let scope = load_maintenance_scope(&pool, &rack_id)
+            .await
+            .expect("scope");
+        assert_eq!(scope.switch_ids, vec![sw2]);
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn all_unknown_macs_no_scope_written(pool: PgPool) {
+        let (rack_id, _, _, _, _) = seed_test_data(&pool).await;
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerNvSwitch::new(pool.clone(), direct);
+
+        let eps = vec![make_ep(UNKNOWN_MAC)];
+        let results = wrapper.power_control(&eps, PowerAction::On).await.unwrap();
+
+        assert!(!results[0].success);
+        assert!(load_maintenance_scope(&pool, &rack_id).await.is_none());
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn rack_not_ready_or_error_is_rejected(pool: PgPool) {
+        let (rack_id, _, _, _, _) = seed_test_data(&pool).await;
+        set_rack_state(
+            &pool,
+            &rack_id,
+            model::rack::RackState::Maintenance {
+                maintenance_state: RackMaintenanceState::FirmwareUpgrade {
+                    rack_firmware_upgrade: FirmwareUpgradeState::Start,
+                },
+            },
+        )
+        .await;
+
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerNvSwitch::new(pool.clone(), direct);
+
+        let eps = vec![make_ep(SW_MAC_1)];
+        let err = wrapper
+            .power_control(&eps, PowerAction::On)
+            .await
+            .unwrap_err();
+        match err {
+            ComponentManagerError::InvalidArgument(msg) => {
+                assert!(msg.contains("Ready or Error"), "unexpected: {msg}");
+            }
+            other => panic!("expected InvalidArgument, got {other:?}"),
+        }
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn maintenance_already_pending_is_rejected(pool: PgPool) {
+        let (rack_id, _, _, _, _) = seed_test_data(&pool).await;
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerNvSwitch::new(pool.clone(), direct);
+
+        let eps = vec![make_ep(SW_MAC_1)];
+        wrapper.power_control(&eps, PowerAction::On).await.unwrap();
+
+        let err = wrapper
+            .power_control(&eps, PowerAction::ForceOff)
+            .await
+            .unwrap_err();
+        match err {
+            ComponentManagerError::InvalidArgument(msg) => {
+                assert!(msg.contains("already has a pending"), "unexpected: {msg}");
+            }
+            other => panic!("expected InvalidArgument, got {other:?}"),
+        }
+
+        let scope = load_maintenance_scope(&pool, &rack_id)
+            .await
+            .expect("scope");
+        match &scope.activities[0] {
+            MaintenanceActivity::PowerControl { action } => {
+                assert_eq!(*action, PowerAction::On);
+            }
+            other => panic!("expected PowerControl::On, got {other:?}"),
+        }
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn get_firmware_status_passes_through(pool: PgPool) {
+        seed_test_data(&pool).await;
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerNvSwitch::new(pool, direct.clone());
+
+        let eps = vec![make_ep(SW_MAC_1)];
+        let statuses = wrapper.get_firmware_status(&eps).await.unwrap();
+
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(*direct.get_firmware_status_calls.lock().unwrap(), 1);
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn list_firmware_bundles_passes_through(pool: PgPool) {
+        seed_test_data(&pool).await;
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerNvSwitch::new(pool, direct.clone());
+
+        let bundles = wrapper.list_firmware_bundles().await.unwrap();
+
+        assert_eq!(bundles, vec!["fw-1.0".to_string()]);
+        assert_eq!(*direct.list_firmware_bundles_calls.lock().unwrap(), 1);
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn direct_field_exposes_underlying_backend(pool: PgPool) {
+        seed_test_data(&pool).await;
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerNvSwitch::new(pool, direct);
+
+        assert_eq!(wrapper.direct.name(), "recording");
+    }
+}

--- a/crates/component-manager/src/state_controller/power_shelf.rs
+++ b/crates/component-manager/src/state_controller/power_shelf.rs
@@ -1,0 +1,532 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A Component Manager `PowerShelfManager` implementation that routes write
+//! operations to the rack state controller (by writing a `MaintenanceScope`
+//! onto `racks.config.maintenance_requested`) and passes reads through to
+//! the wrapped direct backend.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use carbide_uuid::power_shelf::PowerShelfId;
+use carbide_uuid::rack::RackId;
+use db::ObjectColumnFilter;
+use mac_address::MacAddress;
+use model::component_manager::{PowerAction, PowerShelfComponent};
+use model::rack::{MaintenanceActivity, MaintenanceScope};
+use sqlx::PgPool;
+use tracing::instrument;
+
+use super::unique_rack_id;
+use crate::error::ComponentManagerError;
+use crate::power_shelf_manager::{
+    PowerShelfComponentResult, PowerShelfEndpoint, PowerShelfFirmwareUpdateStatus,
+    PowerShelfFirmwareVersions, PowerShelfManager,
+};
+
+const UNKNOWN_MAC_ERROR: &str = "no power shelf row found for this BMC MAC address";
+const DEVICE_KIND: &str = "power shelves";
+
+/// Wraps a direct `PowerShelfManager` backend (e.g., `RmsBackend`,
+/// `PsmBackend`) and routes state-changing operations through the rack state
+/// controller instead of dispatching them directly.
+///
+/// `direct` is deliberately public so the rack state controller can reach
+/// through to it for the real dispatch.
+pub struct StateControllerPowerShelf {
+    db: PgPool,
+    pub direct: Arc<dyn PowerShelfManager>,
+}
+
+impl std::fmt::Debug for StateControllerPowerShelf {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StateControllerPowerShelf")
+            .field("direct", &self.direct.name())
+            .finish()
+    }
+}
+
+impl StateControllerPowerShelf {
+    pub fn new(db: PgPool, direct: Arc<dyn PowerShelfManager>) -> Self {
+        Self { db, direct }
+    }
+
+    /// Resolve endpoints, preflight, write a `MaintenanceScope` to the rack,
+    /// and return the per-endpoint result vector. Shared by `power_control`
+    /// and `update_firmware`.
+    async fn write_scope(
+        &self,
+        endpoints: &[PowerShelfEndpoint],
+        activity: MaintenanceActivity,
+    ) -> Result<Vec<PowerShelfComponentResult>, ComponentManagerError> {
+        let macs: Vec<MacAddress> = endpoints.iter().map(|ep| ep.pmc_mac).collect();
+        let resolved = db::power_shelf::find_ids_by_bmc_macs(&self.db, &macs)
+            .await
+            .map_err(|e| {
+                ComponentManagerError::Internal(format!(
+                    "failed to resolve power shelf IDs by MAC: {e}"
+                ))
+            })?;
+
+        let id_by_mac: HashMap<MacAddress, (PowerShelfId, Option<RackId>)> = resolved
+            .into_iter()
+            .map(|r| (r.bmc_mac_address, (r.id, r.rack_id)))
+            .collect();
+
+        // All MACs unknown: no rack to target; just return per-endpoint errors.
+        if id_by_mac.is_empty() {
+            return Ok(endpoints
+                .iter()
+                .map(|ep| unknown_mac_result(ep.pmc_mac))
+                .collect());
+        }
+
+        let rack_id = unique_rack_id(
+            endpoints
+                .iter()
+                .filter_map(|ep| id_by_mac.get(&ep.pmc_mac).map(|(_, rack)| rack.as_ref())),
+            DEVICE_KIND,
+        )?;
+
+        let power_shelf_ids: Vec<PowerShelfId> = endpoints
+            .iter()
+            .filter_map(|ep| id_by_mac.get(&ep.pmc_mac).map(|(id, _)| *id))
+            .collect();
+
+        self.persist_scope(&rack_id, power_shelf_ids, activity)
+            .await?;
+
+        Ok(endpoints
+            .iter()
+            .map(|ep| {
+                if id_by_mac.contains_key(&ep.pmc_mac) {
+                    PowerShelfComponentResult {
+                        pmc_mac: ep.pmc_mac,
+                        success: true,
+                        error: None,
+                    }
+                } else {
+                    unknown_mac_result(ep.pmc_mac)
+                }
+            })
+            .collect())
+    }
+
+    async fn persist_scope(
+        &self,
+        rack_id: &RackId,
+        power_shelf_ids: Vec<PowerShelfId>,
+        activity: MaintenanceActivity,
+    ) -> Result<(), ComponentManagerError> {
+        let mut txn = self.db.begin().await.map_err(|e| {
+            ComponentManagerError::Internal(format!("failed to begin transaction: {e}"))
+        })?;
+
+        let rack = db::rack::find_by(
+            txn.as_mut(),
+            ObjectColumnFilter::One(db::rack::IdColumn, rack_id),
+        )
+        .await
+        .map_err(|e| ComponentManagerError::Internal(format!("failed to load rack: {e}")))?
+        .pop()
+        .ok_or_else(|| ComponentManagerError::NotFound(format!("rack {rack_id} not found")))?;
+
+        rack.check_accepts_maintenance()
+            .map_err(|r| ComponentManagerError::InvalidArgument(format!("rack {rack_id}: {r}")))?;
+
+        let scope = MaintenanceScope {
+            machine_ids: vec![],
+            switch_ids: vec![],
+            power_shelf_ids,
+            activities: vec![activity],
+        };
+
+        let mut new_config = rack.config.clone();
+        new_config.maintenance_requested = Some(scope);
+        db::rack::update(txn.as_mut(), rack_id, &new_config)
+            .await
+            .map_err(|e| {
+                ComponentManagerError::Internal(format!("failed to write maintenance scope: {e}"))
+            })?;
+
+        txn.commit().await.map_err(|e| {
+            ComponentManagerError::Internal(format!("failed to commit transaction: {e}"))
+        })?;
+
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl PowerShelfManager for StateControllerPowerShelf {
+    fn name(&self) -> &str {
+        "state-controller"
+    }
+
+    #[instrument(skip(self), fields(backend = "state-controller"))]
+    async fn power_control(
+        &self,
+        endpoints: &[PowerShelfEndpoint],
+        action: PowerAction,
+    ) -> Result<Vec<PowerShelfComponentResult>, ComponentManagerError> {
+        self.write_scope(endpoints, MaintenanceActivity::PowerControl { action })
+            .await
+    }
+
+    #[instrument(skip(self), fields(backend = "state-controller"))]
+    async fn update_firmware(
+        &self,
+        endpoints: &[PowerShelfEndpoint],
+        target_version: &str,
+        _components: &[PowerShelfComponent],
+    ) -> Result<Vec<PowerShelfComponentResult>, ComponentManagerError> {
+        let firmware_version = if target_version.is_empty() {
+            None
+        } else {
+            Some(target_version.to_owned())
+        };
+        self.write_scope(
+            endpoints,
+            MaintenanceActivity::FirmwareUpgrade { firmware_version },
+        )
+        .await
+    }
+
+    async fn get_firmware_status(
+        &self,
+        endpoints: &[PowerShelfEndpoint],
+    ) -> Result<Vec<PowerShelfFirmwareUpdateStatus>, ComponentManagerError> {
+        self.direct.get_firmware_status(endpoints).await
+    }
+
+    async fn list_firmware(
+        &self,
+        endpoints: &[PowerShelfEndpoint],
+    ) -> Result<Vec<PowerShelfFirmwareVersions>, ComponentManagerError> {
+        self.direct.list_firmware(endpoints).await
+    }
+}
+
+fn unknown_mac_result(pmc_mac: MacAddress) -> PowerShelfComponentResult {
+    PowerShelfComponentResult {
+        pmc_mac,
+        success: false,
+        error: Some(UNKNOWN_MAC_ERROR.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use model::rack::{FirmwareUpgradeState, RackMaintenanceState};
+
+    use super::*;
+    use crate::power_shelf_manager::PowerShelfVendor;
+    use crate::test_support::{PS_MAC_1, PS_MAC_2, UNKNOWN_MAC, seed_test_data, set_rack_state};
+
+    /// Minimal recording direct backend that only records calls.
+    /// Tests use it to assert we only hit the direct for reads.
+    #[derive(Debug, Default)]
+    struct RecordingDirect {
+        power_control_calls: Mutex<usize>,
+        update_firmware_calls: Mutex<usize>,
+        get_firmware_status_calls: Mutex<usize>,
+        list_firmware_calls: Mutex<usize>,
+    }
+
+    #[async_trait::async_trait]
+    impl PowerShelfManager for RecordingDirect {
+        fn name(&self) -> &str {
+            "recording"
+        }
+
+        async fn power_control(
+            &self,
+            _endpoints: &[PowerShelfEndpoint],
+            _action: PowerAction,
+        ) -> Result<Vec<PowerShelfComponentResult>, ComponentManagerError> {
+            *self.power_control_calls.lock().unwrap() += 1;
+            Ok(vec![])
+        }
+
+        async fn update_firmware(
+            &self,
+            _endpoints: &[PowerShelfEndpoint],
+            _target_version: &str,
+            _components: &[PowerShelfComponent],
+        ) -> Result<Vec<PowerShelfComponentResult>, ComponentManagerError> {
+            *self.update_firmware_calls.lock().unwrap() += 1;
+            Ok(vec![])
+        }
+
+        async fn get_firmware_status(
+            &self,
+            endpoints: &[PowerShelfEndpoint],
+        ) -> Result<Vec<PowerShelfFirmwareUpdateStatus>, ComponentManagerError> {
+            *self.get_firmware_status_calls.lock().unwrap() += 1;
+            Ok(endpoints
+                .iter()
+                .map(|ep| PowerShelfFirmwareUpdateStatus {
+                    pmc_mac: ep.pmc_mac,
+                    state: model::component_manager::FirmwareState::Unknown,
+                    target_version: String::new(),
+                    error: None,
+                })
+                .collect())
+        }
+
+        async fn list_firmware(
+            &self,
+            endpoints: &[PowerShelfEndpoint],
+        ) -> Result<Vec<PowerShelfFirmwareVersions>, ComponentManagerError> {
+            *self.list_firmware_calls.lock().unwrap() += 1;
+            Ok(endpoints
+                .iter()
+                .map(|ep| PowerShelfFirmwareVersions {
+                    pmc_mac: ep.pmc_mac,
+                    versions: vec!["1.0".into()],
+                    error: None,
+                })
+                .collect())
+        }
+    }
+
+    fn make_ep(mac: &str) -> PowerShelfEndpoint {
+        PowerShelfEndpoint {
+            pmc_ip: "10.0.0.1".parse().unwrap(),
+            pmc_mac: mac.parse().unwrap(),
+            pmc_vendor: PowerShelfVendor::Liteon,
+        }
+    }
+
+    async fn load_maintenance_scope(pool: &PgPool, rack_id: &RackId) -> Option<MaintenanceScope> {
+        let mut conn = pool.acquire().await.unwrap();
+        let rack = db::rack::find_by(
+            &mut *conn,
+            db::ObjectColumnFilter::One(db::rack::IdColumn, rack_id),
+        )
+        .await
+        .expect("find rack")
+        .pop()
+        .expect("rack exists");
+        rack.config.maintenance_requested
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn power_control_writes_maintenance_scope(pool: PgPool) {
+        let (rack_id, ps1, ps2, _, _) = seed_test_data(&pool).await;
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerPowerShelf::new(pool.clone(), direct.clone());
+
+        let eps = vec![make_ep(PS_MAC_1), make_ep(PS_MAC_2)];
+        let results = wrapper
+            .power_control(&eps, PowerAction::GracefulShutdown)
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|r| r.success));
+
+        let scope = load_maintenance_scope(&pool, &rack_id)
+            .await
+            .expect("scope");
+        assert!(scope.machine_ids.is_empty());
+        assert!(scope.switch_ids.is_empty());
+        assert_eq!(scope.power_shelf_ids, vec![ps1, ps2]);
+        assert_eq!(scope.activities.len(), 1);
+        match &scope.activities[0] {
+            MaintenanceActivity::PowerControl { action } => {
+                assert_eq!(*action, PowerAction::GracefulShutdown);
+            }
+            other => panic!("expected PowerControl activity, got {other:?}"),
+        }
+        assert_eq!(*direct.power_control_calls.lock().unwrap(), 0);
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn update_firmware_writes_maintenance_scope(pool: PgPool) {
+        let (rack_id, ps1, _, _, _) = seed_test_data(&pool).await;
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerPowerShelf::new(pool.clone(), direct.clone());
+
+        let eps = vec![make_ep(PS_MAC_1)];
+        let results = wrapper
+            .update_firmware(&eps, "fw-2.0.0", &[PowerShelfComponent::Pmc])
+            .await
+            .unwrap();
+
+        assert!(results[0].success);
+
+        let scope = load_maintenance_scope(&pool, &rack_id)
+            .await
+            .expect("scope");
+        assert_eq!(scope.power_shelf_ids, vec![ps1]);
+        match &scope.activities[0] {
+            MaintenanceActivity::FirmwareUpgrade { firmware_version } => {
+                assert_eq!(firmware_version.as_deref(), Some("fw-2.0.0"));
+            }
+            other => panic!("expected FirmwareUpgrade activity, got {other:?}"),
+        }
+        assert_eq!(*direct.update_firmware_calls.lock().unwrap(), 0);
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn update_firmware_empty_version_becomes_none(pool: PgPool) {
+        let (rack_id, _, _, _, _) = seed_test_data(&pool).await;
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerPowerShelf::new(pool.clone(), direct);
+
+        let eps = vec![make_ep(PS_MAC_1)];
+        wrapper.update_firmware(&eps, "", &[]).await.unwrap();
+
+        let scope = load_maintenance_scope(&pool, &rack_id)
+            .await
+            .expect("scope");
+        match &scope.activities[0] {
+            MaintenanceActivity::FirmwareUpgrade { firmware_version } => {
+                assert!(firmware_version.is_none());
+            }
+            other => panic!("expected FirmwareUpgrade activity, got {other:?}"),
+        }
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn partial_unknown_mac_known_still_written(pool: PgPool) {
+        let (rack_id, _, ps2, _, _) = seed_test_data(&pool).await;
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerPowerShelf::new(pool.clone(), direct);
+
+        let eps = vec![make_ep(UNKNOWN_MAC), make_ep(PS_MAC_2)];
+        let results = wrapper.power_control(&eps, PowerAction::On).await.unwrap();
+
+        assert!(!results[0].success);
+        assert!(
+            results[0]
+                .error
+                .as_deref()
+                .unwrap()
+                .contains("no power shelf")
+        );
+        assert!(results[1].success);
+
+        let scope = load_maintenance_scope(&pool, &rack_id)
+            .await
+            .expect("scope");
+        assert_eq!(scope.power_shelf_ids, vec![ps2]);
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn all_unknown_macs_no_scope_written(pool: PgPool) {
+        let (rack_id, _, _, _, _) = seed_test_data(&pool).await;
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerPowerShelf::new(pool.clone(), direct);
+
+        let eps = vec![make_ep(UNKNOWN_MAC)];
+        let results = wrapper.power_control(&eps, PowerAction::On).await.unwrap();
+
+        assert!(!results[0].success);
+        assert!(load_maintenance_scope(&pool, &rack_id).await.is_none());
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn rack_not_ready_or_error_is_rejected(pool: PgPool) {
+        let (rack_id, _, _, _, _) = seed_test_data(&pool).await;
+        set_rack_state(
+            &pool,
+            &rack_id,
+            model::rack::RackState::Maintenance {
+                maintenance_state: RackMaintenanceState::FirmwareUpgrade {
+                    rack_firmware_upgrade: FirmwareUpgradeState::Start,
+                },
+            },
+        )
+        .await;
+
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerPowerShelf::new(pool.clone(), direct);
+
+        let eps = vec![make_ep(PS_MAC_1)];
+        let err = wrapper
+            .power_control(&eps, PowerAction::On)
+            .await
+            .unwrap_err();
+        match err {
+            ComponentManagerError::InvalidArgument(msg) => {
+                assert!(msg.contains("Ready or Error"), "unexpected message: {msg}");
+            }
+            other => panic!("expected InvalidArgument, got {other:?}"),
+        }
+
+        assert!(load_maintenance_scope(&pool, &rack_id).await.is_none());
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn maintenance_already_pending_is_rejected(pool: PgPool) {
+        let (rack_id, _, _, _, _) = seed_test_data(&pool).await;
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerPowerShelf::new(pool.clone(), direct);
+
+        let eps = vec![make_ep(PS_MAC_1)];
+        wrapper.power_control(&eps, PowerAction::On).await.unwrap();
+
+        // Second call should be rejected because scope is already pending.
+        let err = wrapper
+            .power_control(&eps, PowerAction::ForceOff)
+            .await
+            .unwrap_err();
+        match err {
+            ComponentManagerError::InvalidArgument(msg) => {
+                assert!(msg.contains("already has a pending"), "unexpected: {msg}");
+            }
+            other => panic!("expected InvalidArgument, got {other:?}"),
+        }
+
+        // First call's scope is preserved unchanged.
+        let scope = load_maintenance_scope(&pool, &rack_id)
+            .await
+            .expect("scope");
+        match &scope.activities[0] {
+            MaintenanceActivity::PowerControl { action } => {
+                assert_eq!(*action, PowerAction::On);
+            }
+            other => panic!("expected PowerControl::On, got {other:?}"),
+        }
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn get_firmware_status_passes_through(pool: PgPool) {
+        seed_test_data(&pool).await;
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerPowerShelf::new(pool, direct.clone());
+
+        let eps = vec![make_ep(PS_MAC_1)];
+        let statuses = wrapper.get_firmware_status(&eps).await.unwrap();
+
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(*direct.get_firmware_status_calls.lock().unwrap(), 1);
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn list_firmware_passes_through(pool: PgPool) {
+        seed_test_data(&pool).await;
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerPowerShelf::new(pool, direct.clone());
+
+        let eps = vec![make_ep(PS_MAC_1)];
+        let versions = wrapper.list_firmware(&eps).await.unwrap();
+
+        assert_eq!(versions[0].versions, vec!["1.0"]);
+        assert_eq!(*direct.list_firmware_calls.lock().unwrap(), 1);
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn direct_field_exposes_underlying_backend(pool: PgPool) {
+        seed_test_data(&pool).await;
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerPowerShelf::new(pool, direct);
+
+        assert_eq!(wrapper.direct.name(), "recording");
+    }
+}

--- a/crates/component-manager/src/test_support.rs
+++ b/crates/component-manager/src/test_support.rs
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use carbide_uuid::power_shelf::{PowerShelfId, PowerShelfIdSource, PowerShelfType};
+use carbide_uuid::rack::RackId;
+use carbide_uuid::switch::{SwitchId, SwitchIdSource, SwitchType};
+use mac_address::MacAddress;
+use model::expected_power_shelf::ExpectedPowerShelf;
+use model::expected_switch::ExpectedSwitch;
+use model::metadata::Metadata;
+use model::power_shelf::{NewPowerShelf, PowerShelfConfig};
+use model::rack::{RackConfig, RackState};
+use model::switch::{NewSwitch, SwitchConfig};
+use sqlx::PgPool;
+
+pub(crate) const PS_MAC_1: &str = "AA:BB:CC:DD:EE:01";
+pub(crate) const PS_MAC_2: &str = "AA:BB:CC:DD:EE:02";
+pub(crate) const SW_MAC_1: &str = "AA:BB:CC:DD:FF:01";
+pub(crate) const SW_MAC_2: &str = "AA:BB:CC:DD:FF:02";
+pub(crate) const UNKNOWN_MAC: &str = "FF:FF:FF:FF:FF:FF";
+
+pub(crate) fn test_power_shelf_id(label: &str) -> PowerShelfId {
+    let mut hash = [0u8; 32];
+    let bytes = label.as_bytes();
+    hash[..bytes.len().min(32)].copy_from_slice(&bytes[..bytes.len().min(32)]);
+    PowerShelfId::new(
+        PowerShelfIdSource::ProductBoardChassisSerial,
+        hash,
+        PowerShelfType::Rack,
+    )
+}
+
+pub(crate) fn test_switch_id(label: &str) -> SwitchId {
+    let mut hash = [0u8; 32];
+    let bytes = label.as_bytes();
+    hash[..bytes.len().min(32)].copy_from_slice(&bytes[..bytes.len().min(32)]);
+    SwitchId::new(SwitchIdSource::Tpm, hash, SwitchType::NvLink)
+}
+
+/// Seed a rack + two power shelves + two switches into the database. Returns
+/// the IDs so tests can assert against them. The rack is transitioned into
+/// `Ready` so component-manager wrapper preflight accepts it.
+pub(crate) async fn seed_test_data(
+    pool: &PgPool,
+) -> (RackId, PowerShelfId, PowerShelfId, SwitchId, SwitchId) {
+    let mut txn = pool.begin().await.unwrap();
+
+    let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
+    let rack = db::rack::create(&mut txn, &rack_id, None, &RackConfig::default(), None)
+        .await
+        .expect("failed to create rack");
+
+    let ps1 = seed_power_shelf(&mut txn, PS_MAC_1, "PS-001", &rack_id).await;
+    let ps2 = seed_power_shelf(&mut txn, PS_MAC_2, "PS-002", &rack_id).await;
+    let sw1 = seed_switch(&mut txn, SW_MAC_1, "SW-001", &rack_id).await;
+    let sw2 = seed_switch(&mut txn, SW_MAC_2, "SW-002", &rack_id).await;
+
+    // Advance the freshly-created rack into Ready so on-demand-maintenance
+    // preflight accepts it. Tests that want to exercise the non-Ready path
+    // override the state after seeding via `set_rack_state`.
+    let next_version = rack.controller_state.version.increment();
+    let advanced = db::rack::try_update_controller_state(
+        &mut txn,
+        &rack_id,
+        rack.controller_state.version,
+        next_version,
+        &RackState::Ready,
+    )
+    .await
+    .expect("failed to advance rack to Ready");
+    assert!(advanced, "rack controller_state version mismatch");
+
+    txn.commit().await.unwrap();
+    (rack_id, ps1, ps2, sw1, sw2)
+}
+
+/// Forcibly override the rack's controller state. Used by tests that want to
+/// exercise preflight behaviour (e.g. rejecting a request when the rack is
+/// mid-maintenance).
+pub(crate) async fn set_rack_state(pool: &PgPool, rack_id: &RackId, state: RackState) {
+    let mut txn = pool.begin().await.unwrap();
+    let rack = db::rack::find_by(
+        txn.as_mut(),
+        db::ObjectColumnFilter::One(db::rack::IdColumn, rack_id),
+    )
+    .await
+    .expect("find_by")
+    .pop()
+    .expect("rack exists");
+    let next_version = rack.controller_state.version.increment();
+    let advanced = db::rack::try_update_controller_state(
+        &mut txn,
+        rack_id,
+        rack.controller_state.version,
+        next_version,
+        &state,
+    )
+    .await
+    .expect("try_update_controller_state");
+    assert!(advanced, "rack controller_state version mismatch");
+    txn.commit().await.unwrap();
+}
+
+pub(crate) async fn seed_power_shelf(
+    txn: &mut sqlx::PgConnection,
+    mac: &str,
+    label: &str,
+    rack_id: &RackId,
+) -> PowerShelfId {
+    let ps_id = test_power_shelf_id(label);
+    let mac: MacAddress = mac.parse().unwrap();
+
+    db::expected_power_shelf::create(
+        &mut *txn,
+        ExpectedPowerShelf {
+            expected_power_shelf_id: None,
+            bmc_mac_address: mac,
+            serial_number: label.to_owned(),
+            bmc_username: "admin".into(),
+            bmc_password: "pass".into(),
+            bmc_ip_address: None,
+            metadata: Metadata::default(),
+            rack_id: Some(rack_id.clone()),
+            bmc_retain_credentials: None,
+        },
+    )
+    .await
+    .expect("failed to create expected power shelf");
+
+    db::power_shelf::create(
+        &mut *txn,
+        &NewPowerShelf {
+            id: ps_id,
+            config: PowerShelfConfig {
+                name: label.to_owned(),
+                capacity: None,
+                voltage: None,
+            },
+            metadata: Some(Metadata::default()),
+            rack_id: Some(rack_id.clone()),
+        },
+    )
+    .await
+    .expect("failed to create power shelf");
+
+    sqlx::query("UPDATE power_shelves SET bmc_mac_address = $1 WHERE id = $2")
+        .bind(mac)
+        .bind(ps_id)
+        .execute(&mut *txn)
+        .await
+        .expect("failed to set power shelf bmc_mac_address");
+
+    ps_id
+}
+
+pub(crate) async fn seed_switch(
+    txn: &mut sqlx::PgConnection,
+    mac: &str,
+    label: &str,
+    rack_id: &RackId,
+) -> SwitchId {
+    let sw_id = test_switch_id(label);
+    let mac: MacAddress = mac.parse().unwrap();
+
+    db::expected_switch::create(
+        &mut *txn,
+        ExpectedSwitch {
+            expected_switch_id: None,
+            serial_number: label.to_owned(),
+            bmc_mac_address: mac,
+            bmc_ip_address: None,
+            bmc_username: "admin".into(),
+            bmc_password: "pass".into(),
+            nvos_username: None,
+            nvos_password: None,
+            nvos_mac_addresses: vec![],
+            metadata: Metadata::default(),
+            rack_id: Some(rack_id.clone()),
+            bmc_retain_credentials: None,
+        },
+    )
+    .await
+    .expect("failed to create expected switch");
+
+    db::switch::create(
+        &mut *txn,
+        &NewSwitch {
+            id: sw_id,
+            config: SwitchConfig {
+                name: label.to_owned(),
+                enable_nmxc: false,
+                fabric_manager_config: None,
+            },
+            bmc_mac_address: Some(mac),
+            metadata: Some(Metadata::default()),
+            rack_id: Some(rack_id.clone()),
+            slot_number: None,
+            tray_index: None,
+        },
+    )
+    .await
+    .expect("failed to create switch");
+
+    sw_id
+}

--- a/crates/component-manager/src/types.rs
+++ b/crates/component-manager/src/types.rs
@@ -5,45 +5,6 @@ use mac_address::MacAddress;
 
 use crate::error::ComponentManagerError;
 
-/// Power action shared across NV-Switch and PowerShelf backends.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PowerAction {
-    On,
-    GracefulShutdown,
-    ForceOff,
-    GracefulRestart,
-    ForceRestart,
-    AcPowercycle,
-}
-
-/// Firmware update lifecycle state shared across NV-Switch and PowerShelf backends.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum FirmwareState {
-    Unknown,
-    Queued,
-    InProgress,
-    Verifying,
-    Completed,
-    Failed,
-    Cancelled,
-}
-
-/// Updatable components of an NV-Switch tray.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum NvSwitchComponent {
-    Bmc,
-    Cpld,
-    Bios,
-    Nvos,
-}
-
-/// Updatable components of a power shelf.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PowerShelfComponent {
-    Pmc,
-    Psu,
-}
-
 pub fn parse_mac(s: &str) -> Result<MacAddress, ComponentManagerError> {
     s.parse::<MacAddress>()
         .map_err(|e| ComponentManagerError::Internal(format!("invalid MAC from backend: {e}")))


### PR DESCRIPTION
## Description

This introduces the ability for Component Manager API calls to integrate with the underlying rack state controller(s) for rack, switch, and powershelf management.

The general idea is you can *maintain* your existing `nv_switch_backend` and `power_shelf_backend` backends (e.g. `"nsm"`, `"psm"`, `"rms"`), but *now* there is a configuration option in `"[component_manager]"` to enable state controller integration, instead of the current behavior which is passthrough; the current behavior completely ignores the state of the rack and it's components, and our goal here is to integrate with the state controllers to ensure actions are properly gated and orchestrated.

To enable the state controller flow for a given `nv_switch_backend` or `power_shelf_backend`, you simply configure as such:
```
[component_manager]
nv_switch_backend = < nsm | rms >
power_shelf_backend = < psm | rms >

nv_switch_use_state_controller = true
power_shelf_use_state_controller = true
```

I made it independent per component type to allow us to fiddle/independently test as needed.

This entire flow is accomplished by introducing two new `PowerShelfManager` and `NvSwitchManager` trait implementations called `StateControllerPowerShelf` and `StateControllerSwitch`.

When a given component has `"<component>_use_state_controller = true"` set, what we do is "wrap" the underlying `"<component>_backend"` with the state controller variant of the implementation, and register that as the backend for Component Manager. These variants have a `.direct()` method that gives the state controller access to the underlying "component" backend, so if the `nv_switch_backend` is `nsm`, it the state controller (if it chooses to), can use it.

From there, when API calls flow through, our `StateController` implementation will either:
- Make a `.direct()` backend call to the underlying backend for things like `get()` and `list()` operations that are querying the state things.
- Interact with the component-specific state controller by making a "request" for the given action.

For the state controller interactions, we ensure the following "request" capabilities now exist in the component-specific tables (we had things partially filled in, and this does it across the board):
- `power_shelf.firmware_update_requested`
- `power_shelf.power_action_requested`
- `power_shelf.power_shelf_reprovisioning_requested`
- `switch.power_action_requested`
- `switch.firmware_update_requested`
- `switch.switch_reprovisioning_requested`

Each column has a new `Request` model type that we store.

What this does NOT do is actually make state controler changes or *integrate* with the state controller. The idea here is to get the Component Manager API calls wired in to provide the state controller with requests, and that's where the contract ends; it's up to us to implement any code to look for pending requests and then transition the state machine accordingly. Again, we do it in a couple of places, and this is how we do it for other components (machines, specifically); we just need to fill it in here now.

Unit and integration tests added!

## A fancy AI diagram which captures the implementation
```
                    ┌────────────────────────────────────────────┐
                    │  gRPC: ComponentPowerControl,              │
                    │        UpdateComponentFirmware,            │
                    │        GetComponentFirmwareStatus, etc.    │
                    └──────────────────────┬─────────────────────┘
                                           ▼
                    ┌────────────────────────────────────────────┐
                    │  api/src/handlers/component_manager.rs     │
                    │  resolves endpoints, dispatches via        │
                    │  Arc<dyn PowerShelfManager | NvSwitchManager>
                    └──────────────────────┬─────────────────────┘
                                           │
               ┌───────────────────────────┴───────────────────────────┐
   use_state_controller = false                     use_state_controller = true
          (default)                                         (opt-in)
               │                                                       │
               ▼                                                       ▼
      ┌─────────────────┐                         ┌────────────────────────────┐
      │  DIRECT BACKEND │                         │ STATE-CTRL WRAPPER         │
      │                 │                         │  db + Arc<dyn Manager>     │
      │  RmsBackend     │◀── passes through ─────▶│                            │
      │  NsmBackend     │  (reads, status, list)  │  writes  →  *_requested    │
      │  PsmBackend     │                         │  nudges  →  *_queued_objs  │
      │  MockBackend    │                         └─────────────┬──────────────┘
      └────────┬────────┘                                       │  returns fast
               │                                                │  ("accepted")
               │   RPC / HTTPS / Redfish                        ▼
               │                                    ┌────────────────────────────┐
               │                                    │ state controller picks up  │
               │                                    │ on next iteration, dispatch│
               │                                    │ via direct, clears request │
               │                                    │  request on completion     │
               │                                    └─────────────┬──────────────┘
               │                                                  │
               │            ┌─────────────────────────────────────┘
               ▼            ▼  (same backend, different call site)
         ┌──────────────────────────────────────────────┐
         │       REAL DEVICE  (via RMS / BMC)           │
         └──────────────────────────────────────────────┘
```

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

