### PR TITLE
refactor(ipmi): extract IPMI tool into carbide-ipmi crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,6 +998,7 @@ version = "0.1.0"
 dependencies = [
  "arc-swap",
  "carbide-api",
+ "carbide-ipmi",
  "carbide-secrets",
  "clap",
  "libredfish",
@@ -1355,6 +1356,7 @@ dependencies = [
  "carbide-dpf",
  "carbide-health-report",
  "carbide-host-support",
+ "carbide-ipmi",
  "carbide-ipxe-renderer",
  "carbide-libmlx",
  "carbide-macros",
@@ -2063,6 +2065,22 @@ dependencies = [
  "tower-service",
  "tracing",
  "tryhard",
+]
+
+[[package]]
+name = "carbide-ipmi"
+version = "0.0.1"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "carbide-secrets",
+ "carbide-utils",
+ "carbide-uuid",
+ "eyre",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -41,6 +41,7 @@ carbide-secrets = { path = "../secrets" }
 carbide-version = { path = "../version" }
 carbide-health-report = { path = "../health-report" }
 carbide-ipxe-renderer = { path = "../ipxe-renderer" }
+carbide-ipmi = { path = "../ipmi" }
 dns-record = { path = "../dns-record" }
 libnmxm = { path = "../libnmxm" }
 logfmt = { path = "../logfmt" }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -82,7 +82,6 @@ mod handlers;
 mod ib;
 mod ib_fabric_monitor;
 mod instance;
-mod ipmitool;
 mod ipxe;
 mod listener;
 mod logging;
@@ -117,7 +116,6 @@ pub use cfg::file::SiteExplorerExploreMode;
 pub use db::{DatabaseError, DatabaseResult};
 // Save typing
 pub(crate) use errors::{CarbideError, CarbideResult};
-pub use ipmitool::IPMIToolTestImpl;
 pub use nv_redfish::NvRedfishClientPool;
 pub use redfish::RedfishClientPoolImpl;
 pub use site_explorer::BmcEndpointExplorer;

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -21,6 +21,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
+use carbide_ipmi::IPMITool;
 use db::machine::update_dpu_asns;
 use db::resource_pool::DefineResourcePoolError;
 use db::{Transaction, work_lock_manager};
@@ -57,7 +58,6 @@ use crate::firmware_downloader::FirmwareDownloader;
 use crate::handlers::machine_validation::apply_config_on_startup;
 use crate::ib::{self, IBFabricManager};
 use crate::ib_fabric_monitor::IbFabricMonitor;
-use crate::ipmitool::{IPMITool, IPMIToolHttpImpl, IPMIToolImpl, IPMIToolTestImpl};
 use crate::listener::ApiListenMode;
 use crate::logging::log_limiter::LogLimiter;
 use crate::logging::service_health_metrics::{
@@ -193,18 +193,15 @@ pub fn create_ipmi_tool(
     match carbide_config.dpu_ipmi_tool_impl.as_deref() {
         Some("test") => {
             tracing::info!("Disabling ipmitool");
-            Arc::new(IPMIToolTestImpl {})
+            carbide_ipmi::test_support()
         }
         Some("bmc-mock") => {
             tracing::info!("Using HTTP IPMI transport via bmc_proxy");
-            Arc::new(IPMIToolHttpImpl::new(bmc_proxy))
+            carbide_ipmi::bmc_mock(bmc_proxy)
         }
         _ => {
             tracing::info!("Using lanplus IPMI transport (/usr/bin/ipmitool)");
-            Arc::new(IPMIToolImpl::new(
-                credential_reader,
-                &carbide_config.dpu_ipmi_reboot_attempts,
-            ))
+            carbide_ipmi::tool(credential_reader, carbide_config.dpu_ipmi_reboot_attempts)
         }
     }
 }

--- a/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
+++ b/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
@@ -20,6 +20,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use carbide_ipmi::IPMITool;
 use forge_secrets::credentials::{CredentialManager, Credentials};
 use libredfish::model::oem::nvidia_dpu::NicMode;
 use libredfish::model::service_root::RedfishVendor;
@@ -37,7 +38,6 @@ use super::credentials::{CredentialClient, get_bmc_root_credential_key};
 use super::metrics::SiteExplorationMetrics;
 use super::redfish::RedfishClient;
 use crate::cfg::file::SiteExplorerExploreMode;
-use crate::ipmitool::IPMITool;
 use crate::nv_redfish::NvRedfishClientPool;
 use crate::redfish::RedfishClientPool;
 use crate::site_explorer::EndpointExplorer;

--- a/crates/api/src/state_controller/common_services.rs
+++ b/crates/api/src/state_controller/common_services.rs
@@ -17,6 +17,7 @@
 
 use std::sync::Arc;
 
+use carbide_ipmi::IPMITool;
 use db::db_read::PgPoolReader;
 use forge_secrets::credentials::CredentialManager;
 use libredfish::Redfish;
@@ -28,7 +29,6 @@ use sqlx::PgPool;
 use crate::cfg::file::CarbideConfig;
 use crate::dpa::handler::DpaInfo;
 use crate::ib::IBFabricManager;
-use crate::ipmitool::IPMITool;
 use crate::redfish::RedfishClientPool;
 use crate::state_controller::state_handler::StateHandlerError;
 

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -27,6 +27,7 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
+use carbide_ipmi::IPMITool;
 use carbide_uuid::instance::InstanceId;
 use carbide_uuid::instance_type::InstanceTypeId;
 use carbide_uuid::machine::MachineId;
@@ -99,7 +100,6 @@ use crate::dpf::DpfOperations;
 use crate::ethernet_virtualization::{EthVirtData, SiteFabricPrefixList};
 use crate::ib::{self, IBFabricManagerImpl, IBFabricManagerType};
 use crate::ib_fabric_monitor::IbFabricMonitor;
-use crate::ipmitool::IPMIToolTestImpl;
 use crate::logging::level_filter::ActiveLevel;
 use crate::logging::log_limiter::LogLimiter;
 use crate::nv_redfish::NvRedfishClientPool;
@@ -336,7 +336,7 @@ pub struct TestEnv {
     pub redfish_sim: Arc<RedfishSim>,
     pub ib_fabric_monitor: Arc<IbFabricMonitor>,
     pub ib_fabric_manager: Arc<IBFabricManagerImpl>,
-    pub ipmi_tool: Arc<IPMIToolTestImpl>,
+    pub ipmi_tool: Arc<dyn IPMITool>,
     machine_state_controller: Arc<Mutex<StateController<MachineStateControllerIO>>>,
     spdm_state_controller: Arc<Mutex<StateController<SpdmStateControllerIO>>>,
     pub machine_state_handler: SwapHandler<MachineStateHandler>,
@@ -1473,12 +1473,11 @@ pub async fn create_test_env_with_overrides(
         tracing_enabled: Arc::new(false.into()),
     };
 
-    let ipmi_tool = Arc::new(IPMIToolTestImpl {});
     let bmc_proxy = Arc::new(ArcSwap::new(None.into()));
     let bmc_explorer = Arc::new(BmcEndpointExplorer::new(
         redfish_sim.clone(),
         Arc::new(NvRedfishClientPool::new(bmc_proxy)),
-        ipmi_tool.clone(),
+        carbide_ipmi::test_support(),
         composite_manager.clone(),
         Arc::new(std::sync::atomic::AtomicBool::new(false)),
         // Tests use MockEndpointExplorer. So this doesn't affect anything.
@@ -1521,7 +1520,7 @@ pub async fn create_test_env_with_overrides(
     });
 
     let attestation_enabled = config.attestation_enabled;
-    let ipmi_tool = Arc::new(IPMIToolTestImpl {});
+    let ipmi_tool = carbide_ipmi::test_support();
     let mut power_options: PowerOptionConfig = config.power_manager_options.clone().into();
     if let Some(v) = overrides.power_manager_enabled {
         power_options.enabled = v;

--- a/crates/bmc-explorer-cli/Cargo.toml
+++ b/crates/bmc-explorer-cli/Cargo.toml
@@ -10,6 +10,7 @@ authors.workspace = true
 # DO NOT PUT DEPENDENCIES OTHER THAN LOCAL DEPS HERE, THEY SHOULD ALL HAVE 'path =' IN THEM.
 carbide-api = { path = "../api", default-features = false }
 carbide-secrets = { path = "../secrets" }
+carbide-ipmi = { path = "../ipmi" }
 # DO NOT PUT DEPENDENCIES OTHER THAN LOCAL DEPS HERE, THEY SHOULD ALL HAVE 'path =' IN THEM
 
 #these are alphabetized

--- a/crates/bmc-explorer-cli/src/main.rs
+++ b/crates/bmc-explorer-cli/src/main.rs
@@ -19,8 +19,7 @@ use std::time::Instant;
 
 use arc_swap::ArcSwap;
 use carbide::{
-    BmcEndpointExplorer, IPMIToolTestImpl, NvRedfishClientPool, RedfishClientPoolImpl,
-    SiteExplorerExploreMode,
+    BmcEndpointExplorer, NvRedfishClientPool, RedfishClientPoolImpl, SiteExplorerExploreMode,
 };
 use clap::Parser;
 use forge_secrets::credentials::{Credentials, TestCredentialManager};
@@ -86,7 +85,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         rf_pool,
         proxy_address.clone(),
     ));
-    let ipmi_tool = Arc::new(IPMIToolTestImpl {});
     let mode = match args.mode.as_str() {
         "libredfish" => SiteExplorerExploreMode::LibRedfish,
         "nv-redfish" => SiteExplorerExploreMode::NvRedfish,
@@ -103,7 +101,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let explorer = BmcEndpointExplorer::new(
         redfish_client_pool,
         Arc::new(NvRedfishClientPool::new(proxy_address)),
-        ipmi_tool,
+        carbide_ipmi::test_support(),
         credential_provider.clone(),
         rotate_switch_nvos_credentials,
         mode,

--- a/crates/ipmi/Cargo.toml
+++ b/crates/ipmi/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "carbide-ipmi"
+version = "0.0.1"
+edition.workspace = true
+description = "Carbide IPMI"
+license.workspace = true
+authors.workspace = true
+
+[lib]
+name = "carbide_ipmi"
+
+[dependencies]
+carbide-secrets = { path = "../secrets", default-features = false }
+carbide-utils = { path = "../utils", default-features = false }
+carbide-uuid = { path = "../uuid" }
+
+#these are alphabetized
+arc-swap = { workspace = true }
+async-trait = { workspace = true }
+eyre = { workspace = true }
+reqwest = { workspace = true }
+serde = { features = ["derive"], workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+

--- a/crates/ipmi/src/bmc_mock.rs
+++ b/crates/ipmi/src/bmc_mock.rs
@@ -1,0 +1,131 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::net::IpAddr;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use async_trait::async_trait;
+use carbide_uuid::machine::MachineId;
+use eyre::eyre;
+use forge_secrets::credentials::CredentialKey;
+use utils::HostPortPair;
+
+use crate::IPMITool;
+
+/// HTTP-based IPMI implementation for testing with bmc-mock.
+/// Sends JSON requests to bmc_proxy which routes to appropriate machine.
+pub struct IPMIToolHttpImpl {
+    bmc_proxy: Arc<ArcSwap<Option<HostPortPair>>>,
+}
+
+impl IPMIToolHttpImpl {
+    pub fn new(bmc_proxy: Arc<ArcSwap<Option<HostPortPair>>>) -> Self {
+        Self { bmc_proxy }
+    }
+
+    async fn execute_action(&self, action: &str, bmc_ip: IpAddr) -> Result<(), eyre::Report> {
+        let proxy = self.bmc_proxy.load();
+
+        // Determine the target URL and headers based on whether a proxy is configured
+        let (url, forwarded_header) = match proxy.as_ref() {
+            Some(proxy) => {
+                // Use proxy - send to proxy with Forwarded header containing BMC IP
+                let proxy_url = match proxy {
+                    HostPortPair::HostAndPort(h, p) => format!("https://{}:{}", h, p),
+                    HostPortPair::HostOnly(h) => format!("https://{}:443", h),
+                    HostPortPair::PortOnly(p) => format!("https://127.0.0.1:{}", p),
+                };
+                (
+                    format!("{}/ipmi", proxy_url),
+                    Some(format!("host={}", bmc_ip)),
+                )
+            }
+            None => {
+                // No proxy - send directly to BMC
+                (format!("https://{}/ipmi", bmc_ip), None)
+            }
+        };
+
+        let client = reqwest::Client::builder()
+            .danger_accept_invalid_certs(true)
+            .build()
+            .map_err(|e| eyre!("failed to create HTTP client: {}", e))?;
+
+        let mut request = client
+            .post(&url)
+            .json(&serde_json::json!({"action": action}));
+
+        if let Some(header) = forwarded_header {
+            request = request.header("Forwarded", header);
+        }
+
+        let resp = request
+            .send()
+            .await
+            .map_err(|e| eyre!("HTTP request to {} failed: {}", url, e))?;
+
+        if !resp.status().is_success() {
+            return Err(eyre!("HTTP error: {}", resp.status()));
+        }
+
+        #[derive(serde::Deserialize)]
+        struct IpmiHttpResponse {
+            success: bool,
+            error: Option<String>,
+        }
+
+        let body: IpmiHttpResponse = resp
+            .json()
+            .await
+            .map_err(|e| eyre!("failed to parse response: {}", e))?;
+
+        if !body.success {
+            return Err(eyre!(
+                "IPMI action failed: {}",
+                body.error.unwrap_or_else(|| "unknown error".to_string())
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl IPMITool for IPMIToolHttpImpl {
+    async fn bmc_cold_reset(
+        &self,
+        bmc_ip: IpAddr,
+        _credential_key: &CredentialKey,
+    ) -> Result<(), eyre::Report> {
+        self.execute_action("bmc_cold_reset", bmc_ip).await
+    }
+
+    async fn restart(
+        &self,
+        _machine_id: &MachineId,
+        bmc_ip: IpAddr,
+        legacy_boot: bool,
+        _credential_key: &CredentialKey,
+    ) -> Result<(), eyre::Report> {
+        if legacy_boot && self.execute_action("dpu_legacy_boot", bmc_ip).await.is_ok() {
+            return Ok(());
+        }
+        // Fall through to chassis_power_reset if legacy_boot fails or is false
+        self.execute_action("chassis_power_reset", bmc_ip).await
+    }
+}

--- a/crates/ipmi/src/lib.rs
+++ b/crates/ipmi/src/lib.rs
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::net::IpAddr;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use async_trait::async_trait;
+use carbide_uuid::machine::MachineId;
+use forge_secrets::credentials::{CredentialKey, CredentialReader};
+use utils::HostPortPair;
+
+mod bmc_mock;
+mod test_support;
+mod tool;
+
+#[async_trait]
+pub trait IPMITool: Send + Sync + 'static {
+    async fn bmc_cold_reset(
+        &self,
+        bmc_ip: IpAddr,
+        credential_key: &CredentialKey,
+    ) -> Result<(), eyre::Report>;
+
+    async fn restart(
+        &self,
+        machine_id: &MachineId,
+        bmc_ip: IpAddr,
+        legacy_boot: bool,
+        credential_key: &CredentialKey,
+    ) -> Result<(), eyre::Report>;
+}
+
+pub fn tool(cred_provider: Arc<dyn CredentialReader>, attempts: Option<u32>) -> Arc<dyn IPMITool> {
+    Arc::new(tool::IPMIToolImpl::new(cred_provider, attempts))
+}
+
+pub fn bmc_mock(bmc_proxy: Arc<ArcSwap<Option<HostPortPair>>>) -> Arc<dyn IPMITool> {
+    Arc::new(bmc_mock::IPMIToolHttpImpl::new(bmc_proxy))
+}
+
+pub fn test_support() -> Arc<dyn IPMITool> {
+    Arc::new(test_support::IPMIToolTestImpl {})
+}

--- a/crates/ipmi/src/test_support.rs
+++ b/crates/ipmi/src/test_support.rs
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::net::IpAddr;
+
+use async_trait::async_trait;
+use carbide_uuid::machine::MachineId;
+use forge_secrets::credentials::CredentialKey;
+
+use crate::IPMITool;
+
+pub struct IPMIToolTestImpl {}
+
+#[async_trait]
+impl IPMITool for IPMIToolTestImpl {
+    async fn restart(
+        &self,
+        _machine_id: &MachineId,
+        _bmc_ip: IpAddr,
+        _legacy_boot: bool,
+        _credential_key: &CredentialKey,
+    ) -> Result<(), eyre::Report> {
+        Ok(())
+    }
+
+    async fn bmc_cold_reset(
+        &self,
+        _bmc_ip: IpAddr,
+        _credential_key: &CredentialKey,
+    ) -> Result<(), eyre::Report> {
+        Ok(())
+    }
+}

--- a/crates/ipmi/src/tool.rs
+++ b/crates/ipmi/src/tool.rs
@@ -18,30 +18,13 @@
 use std::net::IpAddr;
 use std::sync::Arc;
 
-use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use carbide_uuid::machine::MachineId;
 use eyre::eyre;
 use forge_secrets::credentials::{CredentialKey, CredentialReader, Credentials};
-use utils::HostPortPair;
 use utils::cmd::{CmdError, CmdResult, TokioCmd};
 
-#[async_trait]
-pub trait IPMITool: Send + Sync + 'static {
-    async fn bmc_cold_reset(
-        &self,
-        bmc_ip: IpAddr,
-        credential_key: &CredentialKey,
-    ) -> Result<(), eyre::Report>;
-
-    async fn restart(
-        &self,
-        machine_id: &MachineId,
-        bmc_ip: IpAddr,
-        legacy_boot: bool,
-        credential_key: &CredentialKey,
-    ) -> Result<(), eyre::Report>;
-}
+use crate::IPMITool;
 
 pub struct IPMIToolImpl {
     credential_reader: Arc<dyn CredentialReader>,
@@ -53,7 +36,7 @@ impl IPMIToolImpl {
     const IPMITOOL_BMC_RESET_COMMAND_ARGS: &'static str = "-I lanplus -C 17 bmc reset cold";
     const DPU_LEGACY_IPMITOOL_COMMAND_ARGS: &'static str = "-I lanplus -C 17 raw 0x32 0xA1 0x01";
 
-    pub fn new(credential_reader: Arc<dyn CredentialReader>, attempts: &Option<u32>) -> Self {
+    pub fn new(credential_reader: Arc<dyn CredentialReader>, attempts: Option<u32>) -> Self {
         IPMIToolImpl {
             credential_reader,
             attempts: attempts.unwrap_or(3),
@@ -174,131 +157,6 @@ impl IPMIToolImpl {
     }
 }
 
-pub struct IPMIToolTestImpl {}
-
-#[async_trait]
-impl IPMITool for IPMIToolTestImpl {
-    async fn restart(
-        &self,
-        _machine_id: &MachineId,
-        _bmc_ip: IpAddr,
-        _legacy_boot: bool,
-        _credential_key: &CredentialKey,
-    ) -> Result<(), eyre::Report> {
-        Ok(())
-    }
-
-    async fn bmc_cold_reset(
-        &self,
-        _bmc_ip: IpAddr,
-        _credential_key: &CredentialKey,
-    ) -> Result<(), eyre::Report> {
-        Ok(())
-    }
-}
-
-/// HTTP-based IPMI implementation for testing with bmc-mock.
-/// Sends JSON requests to bmc_proxy which routes to appropriate machine.
-pub struct IPMIToolHttpImpl {
-    bmc_proxy: Arc<ArcSwap<Option<HostPortPair>>>,
-}
-
-impl IPMIToolHttpImpl {
-    pub fn new(bmc_proxy: Arc<ArcSwap<Option<HostPortPair>>>) -> Self {
-        Self { bmc_proxy }
-    }
-
-    async fn execute_action(&self, action: &str, bmc_ip: IpAddr) -> Result<(), eyre::Report> {
-        let proxy = self.bmc_proxy.load();
-
-        // Determine the target URL and headers based on whether a proxy is configured
-        let (url, forwarded_header) = match proxy.as_ref() {
-            Some(proxy) => {
-                // Use proxy - send to proxy with Forwarded header containing BMC IP
-                let proxy_url = match proxy {
-                    HostPortPair::HostAndPort(h, p) => format!("https://{}:{}", h, p),
-                    HostPortPair::HostOnly(h) => format!("https://{}:443", h),
-                    HostPortPair::PortOnly(p) => format!("https://127.0.0.1:{}", p),
-                };
-                (
-                    format!("{}/ipmi", proxy_url),
-                    Some(format!("host={}", bmc_ip)),
-                )
-            }
-            None => {
-                // No proxy - send directly to BMC
-                (format!("https://{}/ipmi", bmc_ip), None)
-            }
-        };
-
-        let client = reqwest::Client::builder()
-            .danger_accept_invalid_certs(true)
-            .build()
-            .map_err(|e| eyre!("failed to create HTTP client: {}", e))?;
-
-        let mut request = client
-            .post(&url)
-            .json(&serde_json::json!({"action": action}));
-
-        if let Some(header) = forwarded_header {
-            request = request.header("Forwarded", header);
-        }
-
-        let resp = request
-            .send()
-            .await
-            .map_err(|e| eyre!("HTTP request to {} failed: {}", url, e))?;
-
-        if !resp.status().is_success() {
-            return Err(eyre!("HTTP error: {}", resp.status()));
-        }
-
-        #[derive(serde::Deserialize)]
-        struct IpmiHttpResponse {
-            success: bool,
-            error: Option<String>,
-        }
-
-        let body: IpmiHttpResponse = resp
-            .json()
-            .await
-            .map_err(|e| eyre!("failed to parse response: {}", e))?;
-
-        if !body.success {
-            return Err(eyre!(
-                "IPMI action failed: {}",
-                body.error.unwrap_or_else(|| "unknown error".to_string())
-            ));
-        }
-
-        Ok(())
-    }
-}
-
-#[async_trait]
-impl IPMITool for IPMIToolHttpImpl {
-    async fn bmc_cold_reset(
-        &self,
-        bmc_ip: IpAddr,
-        _credential_key: &CredentialKey,
-    ) -> Result<(), eyre::Report> {
-        self.execute_action("bmc_cold_reset", bmc_ip).await
-    }
-
-    async fn restart(
-        &self,
-        _machine_id: &MachineId,
-        bmc_ip: IpAddr,
-        legacy_boot: bool,
-        _credential_key: &CredentialKey,
-    ) -> Result<(), eyre::Report> {
-        if legacy_boot && self.execute_action("dpu_legacy_boot", bmc_ip).await.is_ok() {
-            return Ok(());
-        }
-        // Fall through to chassis_power_reset if legacy_boot fails or is false
-        self.execute_action("chassis_power_reset", bmc_ip).await
-    }
-}
 #[cfg(test)]
 mod test {
     use std::sync::Arc;
@@ -311,7 +169,7 @@ mod test {
             username: "user".to_string(),
             password: "password".to_string(),
         }));
-        let tool = super::IPMIToolImpl::new(cp, &Some(1));
+        let tool = super::IPMIToolImpl::new(cp, Some(1));
 
         assert_eq!(tool.attempts, 1);
     }


### PR DESCRIPTION
## Description
Move the IPMI tool implementations out of the api crate into a new standalone crate, carbide-ipmi, as part of the ongoing effort to shrink the api mega-crate.

The new crate exposes only the IPMITool trait and three constructor functions returning Arc<dyn IPMITool>:

  - carbide_ipmi::tool         (lanplus via /usr/bin/ipmitool)
  - carbide_ipmi::bmc_mock     (HTTP transport for bmc-mock)
  - carbide_ipmi::test_support (no-op for tests)

Concrete impls (IPMIToolImpl, IPMIToolHttpImpl, IPMIToolTestImpl) are now private to their submodules; callers depend on the trait only.

Also cleans up IPMIToolImpl::new to take Option<u32> by value instead of &Option<u32> (Option<u32> is Copy).

Callers updated: api (setup, site_explorer, state_controller, test fixtures) and bmc-explorer-cli.

No behavior change.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

