### PR TITLE
chore: add explicit zero-DPU checks/guards to instance state handlers

### DIFF
--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -251,6 +251,22 @@ impl ManagedHostStateSnapshot {
     /// failed to load". Those sites intentionally inspect both fields and
     /// should NOT be rewritten to use this helper alone. Maybe we can enhance
     /// that later, but for now this keeps it simple.
+    ///
+    /// NOTE(chet): When called from state-controller handlers (anything reached
+    /// via `MachineStateHandler::handle_object_state`), there is an upstream
+    /// guard that short-circuits with an error if topology reports DPUs but
+    /// `dpu_snapshots` is empty -- i.e. the DPU snapshots failed to load.
+    /// That guard runs before the `ManagedHostState` dispatch, so by the time
+    /// a state handler asks `is_zero_dpu()`, the potential bug of "topology
+    /// has DPUs, but snapshots are empty, so we think it's zero DPU" has
+    /// already been filtered out. A `true` return in that context means
+    /// genuinely zero-DPU (both topology and snapshots agree).
+    ///
+    /// Now, callers OUTSIDE the state-controller path DON'T get that upstream
+    /// guard; if you need the stronger guarantee there, you'll need to
+    /// check both:
+    /// `self.dpu_snapshots.is_empty()` and
+    /// `self.host_snapshot.associated_dpu_machine_ids().is_empty()`.
     pub fn is_zero_dpu(&self) -> bool {
         self.dpu_snapshots.is_empty()
     }

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -5268,6 +5268,16 @@ impl StateHandler for InstanceStateHandler {
                     Ok(StateHandlerOutcome::transition(next_state))
                 }
                 InstanceState::WaitingForExtensionServicesConfig => {
+                    // Extension services run on DPUs. A zero-DPU host has no
+                    // DPUs to run them on, so there is nothing to wait for;
+                    // skip straight to the next state.
+                    if mh_snapshot.is_zero_dpu() {
+                        let next_state = ManagedHostState::Assigned {
+                            instance_state: InstanceState::WaitingForRebootToReady,
+                        };
+                        return Ok(StateHandlerOutcome::transition(next_state));
+                    }
+
                     // If no extension services are configured, skip the wait and proceed
                     if instance
                         .config
@@ -5553,12 +5563,16 @@ impl StateHandler for InstanceStateHandler {
                     .await
                 }
                 InstanceState::WaitingForDpusToUp => {
-                    if !are_dpus_up_trigger_reboot_if_needed(
-                        mh_snapshot,
-                        &self.reachability_params,
-                        ctx,
-                    )
-                    .await
+                    // A zero-DPU host has no DPUs to wait for. Skip the
+                    // readiness check and proceed with the rest of the
+                    // handler (custom-PXE reboot, termination flow, etc).
+                    if !mh_snapshot.is_zero_dpu()
+                        && !are_dpus_up_trigger_reboot_if_needed(
+                            mh_snapshot,
+                            &self.reachability_params,
+                            ctx,
+                        )
+                        .await
                     {
                         return Ok(StateHandlerOutcome::wait(
                             "Waiting for DPUs to come up.".to_string(),
@@ -5908,6 +5922,17 @@ impl StateHandler for InstanceStateHandler {
                     Ok(StateHandlerOutcome::transition(next_state).with_txn(txn))
                 }
                 InstanceState::DPUReprovision { .. } => {
+                    // Reaching DPUReprovision with no DPUs is technically a
+                    // bug/violation; the reprovision branch should have been
+                    // skipped upstream. But, without this guard, the empty loop
+                    // below falls through to `do_nothing()` and the host
+                    // would/could sit in `DPUReprovision` forever.
+                    if mh_snapshot.is_zero_dpu() {
+                        return Err(StateHandlerError::GenericError(eyre!(
+                            "DPUReprovision state entered on zero-DPU host {host_machine_id}; reprovision requires DPUs"
+                        )));
+                    }
+
                     for dpu_snapshot in &mh_snapshot.dpu_snapshots {
                         if let outcome @ StateHandlerOutcome::Transition { .. } =
                             handle_dpu_reprovision(

--- a/crates/api/src/tests/machine_states.rs
+++ b/crates/api/src/tests/machine_states.rs
@@ -17,17 +17,23 @@
 use std::collections::HashMap;
 
 use base64::prelude::*;
+use carbide_uuid::machine::MachineId;
 use chrono::Duration;
 use common::api_fixtures::dpu::{
     create_dpu_machine, create_dpu_machine_in_waiting_for_network_install,
 };
 use common::api_fixtures::host::{host_discover_dhcp, host_discover_machine, host_uefi_setup};
+use common::api_fixtures::network_segment::{
+    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY, FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY,
+    create_host_inband_network_segment,
+};
 use common::api_fixtures::tpm_attestation::{CA_CERT_SERIALIZED, EK_CERT_SERIALIZED};
 use common::api_fixtures::{
-    TestManagedHost, create_managed_host, create_test_env, create_test_env_with_overrides,
-    get_config,
+    TestEnv, TestManagedHost, create_managed_host, create_managed_host_with_config,
+    create_test_env, create_test_env_with_overrides, get_config,
 };
 use health_report::HealthReport;
+use ipnetwork::IpNetwork;
 use measured_boot::bundle::MeasurementBundle;
 use measured_boot::pcr::PcrRegisterValue;
 use measured_boot::records::MeasurementBundleState;
@@ -36,8 +42,9 @@ use model::controller_outcome::PersistentStateHandlerOutcome;
 use model::hardware_info::TpmEkCertificate;
 use model::machine::health_override::HARDWARE_HEALTH_OVERRIDE_PREFIX;
 use model::machine::{
-    DpuInitState, FailureCause, FailureDetails, FailureSource, InstanceState, LockdownMode,
-    MachineState, MachineValidatingState, ManagedHostState, MeasuringState, ValidationState,
+    DpuInitState, DpuReprovisionStates, FailureCause, FailureDetails, FailureSource, InstanceState,
+    LockdownMode, MachineState, MachineValidatingState, ManagedHostState, MeasuringState,
+    ValidationState,
 };
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{HealthReportEntry, InsertHealthReportOverrideRequest, TpmCaCert, TpmCaCertId};
@@ -1874,4 +1881,166 @@ async fn test_tpm_logging(pool: sqlx::PgPool) {
         "Expected TPM mismatch error, got: {}",
         err.message()
     );
+}
+
+/// Spins up a test env configured for zero-DPU hosts plus a zero-DPU
+/// managed host, and inserts a bare `instances` row attached to it,
+/// which is the minimal state needed to exercise the state controller
+/// for an assigned host (which would otherwise bail early if
+/// `mh_snapshot.instance` is `None`).
+async fn zero_dpu_host_with_instance(pool: sqlx::PgPool) -> (TestEnv, TestManagedHost) {
+    let env = create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides {
+            allow_zero_dpu_hosts: Some(true),
+            site_prefixes: Some(vec![
+                IpNetwork::new(
+                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+                IpNetwork::new(
+                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+            ]),
+            ..Default::default()
+        },
+    )
+    .await;
+    create_host_inband_network_segment(&env.api, None).await;
+
+    let mh = create_managed_host_with_config(&env, ManagedHostConfig::with_dpus(Vec::new())).await;
+    assert!(
+        mh.dpu_ids.is_empty(),
+        "zero-DPU fixture should produce no DPU machines"
+    );
+
+    // Provide valid empty configs explicitly so the state controller can
+    // load the snapshot.
+    //
+    // TODO(chet): It looks like a handful of `instances` column "defaults"
+    // are stale JSON shapes that don't match the current Rust structs (e.g.
+    // `network_config` defaults to '{}' but `InstanceNetworkConfig` requires
+    // an `interfaces` field; and `nvlink_config` defaults to '{"nvlink_gpus": []}'
+    // but the struct expects `gpu_configs`). I want to say lol here, so lol.
+    let mut txn = env.pool.begin().await.unwrap();
+    sqlx::query(
+        "INSERT INTO instances (machine_id, network_config, nvlink_config) \
+         VALUES ($1, '{\"interfaces\": []}'::jsonb, '{\"gpu_configs\": []}'::jsonb)",
+    )
+    .bind(mh.host().id)
+    .execute(txn.as_mut())
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    (env, mh)
+}
+
+/// Set the host directly into an `Assigned { instance_state }` state
+/// and commit so the next state controller iteration picks it up.
+async fn set_assigned_state(env: &TestEnv, host_id: &MachineId, instance_state: InstanceState) {
+    let mut txn = env.db_txn().await;
+    db::machine::update_state(
+        txn.as_mut(),
+        host_id,
+        &ManagedHostState::Assigned { instance_state },
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+}
+
+async fn load_host_state(env: &TestEnv, host_id: &MachineId) -> ManagedHostState {
+    db::machine::find_one(
+        &env.pool,
+        host_id,
+        model::machine::machine_search_config::MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .expect("host should exist")
+    .current_state()
+    .clone()
+}
+
+#[crate::sqlx_test]
+async fn test_waiting_for_extension_services_config_skips_for_zero_dpu(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (env, mh) = zero_dpu_host_with_instance(pool).await;
+    set_assigned_state(
+        &env,
+        &mh.host().id,
+        InstanceState::WaitingForExtensionServicesConfig,
+    )
+    .await;
+
+    env.run_machine_state_controller_iteration().await;
+
+    assert!(matches!(
+        load_host_state(&env, &mh.host().id).await,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::WaitingForRebootToReady,
+        }
+    ));
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_waiting_for_dpus_to_up_skips_wait_for_zero_dpu(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (env, mh) = zero_dpu_host_with_instance(pool).await;
+    set_assigned_state(&env, &mh.host().id, InstanceState::WaitingForDpusToUp).await;
+
+    env.run_machine_state_controller_iteration().await;
+
+    // Without the zero-DPU guard the handler would have returned a
+    // "Waiting for DPUs to come up" wait and the state would be
+    // unchanged. With the guard, we proceed past the wait into the
+    // termination/reboot path.
+    let state = load_host_state(&env, &mh.host().id).await;
+    assert!(
+        !matches!(
+            state,
+            ManagedHostState::Assigned {
+                instance_state: InstanceState::WaitingForDpusToUp,
+            }
+        ),
+        "expected to advance past WaitingForDpusToUp, got: {state:?}"
+    );
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_dpu_reprovision_errors_for_zero_dpu(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (env, mh) = zero_dpu_host_with_instance(pool).await;
+    set_assigned_state(
+        &env,
+        &mh.host().id,
+        InstanceState::DPUReprovision {
+            dpu_states: DpuReprovisionStates {
+                states: HashMap::new(),
+            },
+        },
+    )
+    .await;
+
+    env.run_machine_state_controller_iteration().await;
+
+    // The guard returns an error, which the state controller surfaces
+    // as a handler failure rather than silently advancing. The host
+    // should not have transitioned out of DPUReprovision.
+    assert!(matches!(
+        load_host_state(&env, &mh.host().id).await,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::DPUReprovision { .. },
+        }
+    ));
+    Ok(())
 }


### PR DESCRIPTION
## Description

Previously, these states relied on empty `dpu_snapshots` to "noop" for zero-DPY hosts. That worked today purely because empty collections fall through quietly, not because the handlers were actually zero-DPU aware/safe.

This PR makes a zero-DPU path explicit in a few `InstanceState` variants that have DPU-related transitioning, including:
- `WaitingForExtensionServicesConfig` -- there's no DPU, so no extension services. Just transition along.
- `WaitingForDpusToUp` -- there are no DPUs coming. Works today because `are_dpus_up_trigger_reboot_if_needed()`returns true if there aren't any.
- `DPUReprovision` -- return an error. For a zero DPU host, we shouldn't have actually gotten here.

It's worth noticing I was originally going to have it also block on:
- `SwitchToAdminNetwork` -- there's no "switch" here, because there's no DPU to give config to.

...but then realized that there *might* be DPAs, and it's totally valid that a machine might have a dumb N/S NIC but E/W SuperNICs. It might not be common, but there's no reason to not allow it, at least not that I can think of.

Integration tests included.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

