### PR TITLE
refactor: move PeriodicTimer into carbide-utils

### DIFF
--- a/crates/api/src/ib_fabric_monitor/mod.rs
+++ b/crates/api/src/ib_fabric_monitor/mod.rs
@@ -43,10 +43,10 @@ use sqlx::{PgConnection, PgPool};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
+use utils::periodic_timer::PeriodicTimer;
 
 use crate::cfg::file::{CarbideConfig, IbFabricDefinition};
 use crate::ib::{GetPartitionOptions, IBFabricManager, IBFabricManagerType};
-use crate::periodic_timer::PeriodicTimer;
 use crate::{CarbideError, CarbideResult};
 
 /// `IbFabricMonitor` monitors the health of all connected InfiniBand fabrics in periodic intervals

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -95,7 +95,6 @@ mod network_segment;
 mod nv_redfish;
 mod nvl_partition_monitor;
 mod nvlink;
-mod periodic_timer;
 mod preingestion_manager;
 mod rack;
 mod redfish;

--- a/crates/api/src/machine_update_manager/mod.rs
+++ b/crates/api/src/machine_update_manager/mod.rs
@@ -38,12 +38,12 @@ use model::machine_update_module::HOST_UPDATE_HEALTH_REPORT_SOURCE;
 use sqlx::{PgConnection, PgPool};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
+use utils::periodic_timer::PeriodicTimer;
 
 use self::dpu_nic_firmware::DpuNicFirmwareUpdate;
 use self::metrics::MachineUpdateManagerMetrics;
 use crate::CarbideResult;
 use crate::cfg::file::{CarbideConfig, MaxConcurrentUpdates};
-use crate::periodic_timer::PeriodicTimer;
 
 /// The MachineUpdateManager periodically runs [modules](machine_update_module::MachineUpdateModule) to initiate upgrades of machine components.
 /// On each iteration the MachineUpdateManager will:

--- a/crates/api/src/machine_validation/mod.rs
+++ b/crates/api/src/machine_validation/mod.rs
@@ -24,11 +24,11 @@ use std::sync::Arc;
 use db::ObjectFilter;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
+use utils::periodic_timer::PeriodicTimer;
 
 use self::metrics::MachineValidationMetrics;
 use crate::CarbideResult;
 use crate::cfg::file::MachineValidationConfig;
-use crate::periodic_timer::PeriodicTimer;
 
 pub struct MachineValidationManager {
     database_connection: sqlx::PgPool,

--- a/crates/api/src/nvl_partition_monitor/mod.rs
+++ b/crates/api/src/nvl_partition_monitor/mod.rs
@@ -42,11 +42,11 @@ use sqlx::PgPool;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
+use utils::periodic_timer::PeriodicTimer;
 
 use crate::api::TransactionVending;
 use crate::cfg::file::NvLinkConfig;
 use crate::nvlink::NmxmClientPool;
-use crate::periodic_timer::PeriodicTimer;
 use crate::{CarbideError, CarbideResult};
 
 mod metrics;

--- a/crates/api/src/preingestion_manager/mod.rs
+++ b/crates/api/src/preingestion_manager/mod.rs
@@ -40,10 +40,10 @@ use tokio::io::AsyncBufReadExt;
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
+use utils::periodic_timer::PeriodicTimer;
 
 use crate::cfg::file::{CarbideConfig, FirmwareConfig, FirmwareGlobal};
 use crate::firmware_downloader::FirmwareDownloader;
-use crate::periodic_timer::PeriodicTimer;
 use crate::preingestion_manager::metrics::PreingestionMetrics;
 use crate::redfish::{RedfishClientCreationError, RedfishClientPool};
 use crate::site_explorer::EndpointExplorer;

--- a/crates/api/src/site_explorer/mod.rs
+++ b/crates/api/src/site_explorer/mod.rs
@@ -53,10 +53,10 @@ use sqlx::PgPool;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
+use utils::periodic_timer::PeriodicTimer;
 use version_compare::Cmp;
 
 use crate::cfg::file::{FirmwareConfig, SiteExplorerConfig};
-use crate::periodic_timer::PeriodicTimer;
 use crate::{CarbideError, CarbideResult};
 mod endpoint_explorer;
 pub use endpoint_explorer::EndpointExplorer;

--- a/crates/api/src/state_controller/controller/periodic_enqueuer.rs
+++ b/crates/api/src/state_controller/controller/periodic_enqueuer.rs
@@ -22,8 +22,8 @@ use ::db::work_lock_manager::WorkLockManagerHandle;
 use opentelemetry::metrics::{Counter, Histogram, Meter};
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
+use utils::periodic_timer::PeriodicTimer;
 
-use crate::periodic_timer::PeriodicTimer;
 use crate::state_controller::config::IterationConfig;
 use crate::state_controller::controller::{
     ControllerIteration, ControllerIterationId, IterationError, db,

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -23,6 +23,7 @@ pub mod cmd;
 mod host_port_pair;
 pub mod managed_host_display;
 pub mod models;
+pub mod periodic_timer;
 pub mod sku;
 
 pub use host_port_pair::{HostPortPair, HostPortParseError};

--- a/crates/utils/src/periodic_timer.rs
+++ b/crates/utils/src/periodic_timer.rs
@@ -38,7 +38,7 @@ use std::time::{Duration, Instant};
 /// }
 /// ```
 #[derive(Debug, Clone)]
-pub(crate) struct PeriodicTimer {
+pub struct PeriodicTimer {
     interval: Duration,
 }
 
@@ -47,20 +47,20 @@ pub(crate) struct PeriodicTimer {
 /// the Tick::sleep routine can subtract the elapsed time from the
 /// configured interval.
 #[derive(Debug)]
-pub(crate) struct Tick {
+pub struct Tick {
     interval: Duration,
     started_at: Instant,
 }
 
 impl PeriodicTimer {
-    pub(crate) fn new(interval: Duration) -> Self {
+    pub fn new(interval: Duration) -> Self {
         Self { interval }
     }
 
     /// tick() begins a new tick. This is intended to be called
     /// before running the iteration work, and is used to track
     /// the time of the iteration.
-    pub(crate) fn tick(&self) -> Tick {
+    pub fn tick(&self) -> Tick {
         Tick {
             interval: self.interval,
             started_at: Instant::now(),
@@ -72,12 +72,12 @@ impl Tick {
     /// remaining returns how long to sleep so that the total cycle time
     /// (iteration + sleep) is as close to the configured run interval as
     /// possible.
-    pub(crate) fn remaining(&self) -> Duration {
+    pub fn remaining(&self) -> Duration {
         self.interval.saturating_sub(self.started_at.elapsed())
     }
 
     /// sleep sleeps for the remaining time in this Tick.
-    pub(crate) async fn sleep(self) {
+    pub async fn sleep(self) {
         tokio::time::sleep(self.remaining()).await;
     }
 
@@ -85,7 +85,7 @@ impl Tick {
     /// Used in adaptive situations (e.g. ib_fabric_monitor) which may
     /// want a shorter interval under certain conditions (e.g. when changes
     /// were detected) while still subtracting elapsed time.
-    pub(crate) fn set_interval(&mut self, interval: Duration) {
+    pub fn set_interval(&mut self, interval: Duration) {
         self.interval = interval;
     }
 }


### PR DESCRIPTION
## Description

Part of the effort to break up the carbide-api mega-crate. PeriodicTimer is a generic timer with no api-specific dependencies and is used by eight different modules inside carbide-api (ib_fabric_monitor, machine_validation, machine_update_manager, nvl_partition_monitor, preingestion_manager, site_explorer, state_controller, ...).

Move it to carbide-utils where shared utilities already live, and widen visibility from pub(crate) to pub. All call sites updated to `use utils::periodic_timer::PeriodicTimer`.

No behavioral changes.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
