### PR TITLE
chore(admin-cli): health override -> health report

### DIFF
--- a/crates/admin-cli/src/debug_bundle/cmds.rs
+++ b/crates/admin-cli/src/debug_bundle/cmds.rs
@@ -883,10 +883,10 @@ pub async fn handle_debug_bundle(
     println!("   Alerts: {} records collected", alert_count);
 
     println!("\nFetching health alert overrides...");
-    let alert_overrides = get_alert_overrides(api_client, &debug_bundle.host_id).await?;
+    let alert_entries = get_alert_entries(api_client, &debug_bundle.host_id).await?;
     println!(
         "   Overrides: {} overrides collected",
-        alert_overrides.health_report_entries.len()
+        alert_entries.health_report_entries.len()
     );
 
     println!("\nFetching site controller details...");
@@ -920,7 +920,7 @@ pub async fn handle_debug_bundle(
     );
     println!(
         "   Health Alert Overrides: {} overrides",
-        alert_overrides.health_report_entries.len()
+        alert_entries.health_report_entries.len()
     );
     println!("   Site Controller Details: Collected");
     println!("   Machine State Information: Collected");
@@ -941,7 +941,7 @@ pub async fn handle_debug_bundle(
         &dpu_batch_links,
         loki_uid.as_deref(),
         &health_alerts,
-        &alert_overrides,
+        &alert_entries,
         &site_controller_analysis,
         &machine_analysis,
     )?;
@@ -1042,8 +1042,8 @@ async fn get_health_alerts(
     Ok(response)
 }
 
-/// Collect alert overrides for a machine (current state)
-async fn get_alert_overrides(
+/// Collect health report entries for a machine (current state)
+async fn get_alert_entries(
     api_client: &ApiClient,
     host_id: &str,
 ) -> CarbideCliResult<::rpc::forge::ListHealthReportResponse> {
@@ -1363,7 +1363,7 @@ impl<'a> ZipBundleCreator<'a> {
         dpu_batch_links: &[(String, String, usize, String)],
         loki_uid: Option<&str>,
         health_alerts: &::rpc::forge::HealthHistories,
-        alert_overrides: &::rpc::forge::ListHealthReportResponse,
+        alert_entries: &::rpc::forge::ListHealthReportResponse,
         site_controller_analysis: &SiteControllerAnalysis,
         machine_analysis: &MachineAnalysis,
     ) -> CarbideCliResult<String> {
@@ -1390,7 +1390,7 @@ impl<'a> ZipBundleCreator<'a> {
             options,
         )?;
         self.add_alerts_json(&mut zip, health_alerts, options)?;
-        self.add_alert_overrides_json(&mut zip, alert_overrides, options)?;
+        self.add_alert_entries_json(&mut zip, alert_entries, options)?;
         self.add_site_controller_analysis_json(&mut zip, site_controller_analysis, options)?;
         self.add_machine_analysis_json(&mut zip, machine_analysis, options)?;
         self.add_metadata(
@@ -1403,7 +1403,7 @@ impl<'a> ZipBundleCreator<'a> {
             dpu_batch_links,
             loki_uid,
             health_alerts,
-            alert_overrides,
+            alert_entries,
             site_controller_analysis,
             machine_analysis,
             options,
@@ -1425,7 +1425,7 @@ impl<'a> ZipBundleCreator<'a> {
                 .get(&self.config.host_id)
                 .map(|h| h.records.len())
                 .unwrap_or(0),
-            alert_overrides.health_report_entries.len()
+            alert_entries.health_report_entries.len()
         );
 
         Ok(filepath)
@@ -1517,10 +1517,10 @@ impl<'a> ZipBundleCreator<'a> {
         Ok(())
     }
 
-    fn add_alert_overrides_json(
+    fn add_alert_entries_json(
         &self,
         zip: &mut ZipWriter<File>,
-        alert_overrides: &::rpc::forge::ListHealthReportResponse,
+        alert_entries: &::rpc::forge::ListHealthReportResponse,
         options: FileOptions,
     ) -> CarbideCliResult<()> {
         zip.start_file("health_alert_overrides.json", options)
@@ -1533,10 +1533,10 @@ impl<'a> ZipBundleCreator<'a> {
         // Build JSON using serde_json::json! macro
         let json_output = serde_json::json!({
             "summary": {
-                "total_overrides": alert_overrides.health_report_entries.len()
+                "total_overrides": alert_entries.health_report_entries.len()
             },
-            "overrides": alert_overrides.health_report_entries.iter().map(|override_entry| {
-                let mode_str = match override_entry.mode {
+            "overrides": alert_entries.health_report_entries.iter().map(|entry| {
+                let mode_str = match entry.mode {
                     1 => "Merge",
                     2 => "Replace",
                     _ => "Unknown"
@@ -1544,7 +1544,7 @@ impl<'a> ZipBundleCreator<'a> {
 
                 serde_json::json!({
                     "mode": mode_str,
-                    "report": override_entry.report.as_ref().map(|report| {
+                    "report": entry.report.as_ref().map(|report| {
                         serde_json::json!({
                             "source": &report.source,
                             "alerts": report.alerts.iter().map(|alert| {
@@ -1816,7 +1816,7 @@ impl<'a> ZipBundleCreator<'a> {
         dpu_batch_links: &[(String, String, usize, String)],
         loki_uid: Option<&str>,
         health_alerts: &::rpc::forge::HealthHistories,
-        alert_overrides: &::rpc::forge::ListHealthReportResponse,
+        alert_entries: &::rpc::forge::ListHealthReportResponse,
         site_controller_analysis: &SiteControllerAnalysis,
         machine_analysis: &MachineAnalysis,
         options: FileOptions,
@@ -1878,9 +1878,9 @@ impl<'a> ZipBundleCreator<'a> {
         writeln!(
             zip,
             "  Total Overrides: {}",
-            alert_overrides.health_report_entries.len()
+            alert_entries.health_report_entries.len()
         )?;
-        let active_overrides = alert_overrides
+        let active_entries = alert_entries
             .health_report_entries
             .iter()
             .filter(|o| {
@@ -1891,7 +1891,7 @@ impl<'a> ZipBundleCreator<'a> {
                 }
             })
             .count();
-        writeln!(zip, "  Active Overrides: {}", active_overrides)?;
+        writeln!(zip, "  Active Entries: {}", active_entries)?;
         writeln!(zip)?;
 
         // Add Site Controller Details
@@ -2071,7 +2071,7 @@ fn create_debug_bundle_zip(
     dpu_batch_links: &[(String, String, usize, String)],
     loki_uid: Option<&str>,
     health_alerts: &::rpc::forge::HealthHistories,
-    alert_overrides: &::rpc::forge::ListHealthReportResponse,
+    alert_entries: &::rpc::forge::ListHealthReportResponse,
     site_controller_analysis: &SiteControllerAnalysis,
     machine_analysis: &MachineAnalysis,
 ) -> CarbideCliResult<()> {
@@ -2084,7 +2084,7 @@ fn create_debug_bundle_zip(
         dpu_batch_links,
         loki_uid,
         health_alerts,
-        alert_overrides,
+        alert_entries,
         site_controller_analysis,
         machine_analysis,
     )?;

--- a/crates/admin-cli/src/dpu/reprovision/cmd.rs
+++ b/crates/admin-cli/src/dpu/reprovision/cmd.rs
@@ -28,7 +28,7 @@ pub async fn reprovision(api_client: &ApiClient, reprov: Args) -> CarbideCliResu
     match reprov {
         Args::Set(data) => {
             if let Some(update_message) = &data.update_message {
-                apply_health_override(api_client, data.id, update_message.clone()).await?;
+                apply_health_report(api_client, data.id, update_message.clone()).await?;
             }
             let req: DpuReprovisioningRequest = (&data).into();
             api_client.0.trigger_dpu_reprovisioning(req).await?;
@@ -48,12 +48,12 @@ pub async fn reprovision(api_client: &ApiClient, reprov: Args) -> CarbideCliResu
     }
 }
 
-async fn apply_health_override(
+async fn apply_health_report(
     api_client: &ApiClient,
     id: carbide_uuid::machine::MachineId,
     update_message: String,
 ) -> CarbideCliResult<()> {
-    // Set a HostUpdateInProgress health override on the Host
+    // Set a HostUpdateInProgress health report entry on the Host
     let host_id = match id.machine_type() {
         MachineType::Host => Some(id),
         MachineType::Dpu => {
@@ -79,7 +79,7 @@ async fn apply_health_override(
         }
     };
 
-    // Check host must not have host-update override
+    // Check host must not already have a host-update health report entry
     if let Some(host_machine_id) = &host_id {
         let host_machine = api_client
             .get_machines_by_ids(&[*host_machine_id])
@@ -95,7 +95,7 @@ async fn apply_health_override(
                 .any(|or| or.source == "host-update")
         {
             return Err(CarbideCliError::GenericError(format!(
-                "Host machine: {:?} already has a \"host-update\" override.",
+                "Host machine: {:?} already has a \"host-update\" health report entry.",
                 host_machine.id,
             )));
         }

--- a/crates/admin-cli/src/health_utils.rs
+++ b/crates/admin-cli/src/health_utils.rs
@@ -19,20 +19,20 @@ use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
 use ::rpc::forge::{self as forgerpc};
 use prettytable::{Table, row};
 
-use crate::machine::health_override::cmd::get_empty_template;
+use crate::machine::health_report::cmd::get_empty_template;
 use crate::machine::{HealthReportTemplates, get_health_report};
 
-/// Display a list of health report overrides.
-pub fn display_overrides(
-    overrides: Vec<forgerpc::HealthReportEntry>,
+/// Display a list of health report entries.
+pub fn display_health_reports(
+    entries: Vec<forgerpc::HealthReportEntry>,
     output_format: OutputFormat,
 ) -> CarbideCliResult<()> {
     let mut rows = vec![];
-    for r#override in overrides {
-        let report = r#override.report.ok_or(CarbideCliError::GenericError(
+    for entry in entries {
+        let report = entry.report.ok_or(CarbideCliError::GenericError(
             "missing response".to_string(),
         ))?;
-        let mode = match forgerpc::HealthReportApplyMode::try_from(r#override.mode)
+        let mode = match forgerpc::HealthReportApplyMode::try_from(entry.mode)
             .map_err(|_| CarbideCliError::GenericError("invalide response".to_string()))?
         {
             forgerpc::HealthReportApplyMode::Merge => "Merge",
@@ -85,7 +85,7 @@ pub fn resolve_health_report(
     }
 }
 
-/// Print the empty health override template.
+/// Print the empty health report template.
 pub fn print_empty_template() {
     println!(
         "{}",

--- a/crates/admin-cli/src/host/reprovision/cmd.rs
+++ b/crates/admin-cli/src/host/reprovision/cmd.rs
@@ -29,7 +29,7 @@ pub async fn trigger_reprovisioning_set(
     api_client: &ApiClient,
 ) -> CarbideCliResult<()> {
     if let Some(update_message) = data.update_message.clone() {
-        // Set a HostUpdateInProgress health override on the Host
+        // Set a HostUpdateInProgress health report entry on the Host
 
         let host_machine = api_client
             .get_machines_by_ids(&[data.id])
@@ -45,7 +45,7 @@ pub async fn trigger_reprovisioning_set(
                 .any(|or| or.source == "host-update")
         {
             return Err(CarbideCliError::GenericError(format!(
-                "Host machine: {:?} already has a \"host-update\" override.",
+                "Host machine: {:?} already has a \"host-update\" health report entry.",
                 host_machine.id,
             )));
         }

--- a/crates/admin-cli/src/machine/health_report/args.rs
+++ b/crates/admin-cli/src/machine/health_report/args.rs
@@ -20,13 +20,13 @@ use clap::{ArgGroup, Parser, ValueEnum};
 
 #[derive(Parser, Debug)]
 pub enum Args {
-    #[clap(about = "List the health reports overrides")]
+    #[clap(about = "List the health report entries")]
     Show { machine_id: MachineId },
-    #[clap(about = "Insert a health report override")]
+    #[clap(about = "Insert a health report entry")]
     Add(HealthAddOptions),
-    #[clap(about = "Print a empty health override template, which user can modify and use")]
+    #[clap(about = "Print an empty health report template, which user can modify and use")]
     PrintEmptyTemplate,
-    #[clap(about = "Remove a health report override")]
+    #[clap(about = "Remove a health report entry")]
     Remove {
         machine_id: MachineId,
         report_source: String,
@@ -34,7 +34,7 @@ pub enum Args {
 }
 
 #[derive(Parser, Debug)]
-#[clap(group(ArgGroup::new("override_health").required(true).args(&["health_report", "template"])))]
+#[clap(group(ArgGroup::new("health_report_source").required(true).args(&["health_report", "template"])))]
 pub struct HealthAddOptions {
     pub machine_id: MachineId,
     #[clap(long, help = "New health report as json")]

--- a/crates/admin-cli/src/machine/health_report/cmd.rs
+++ b/crates/admin-cli/src/machine/health_report/cmd.rs
@@ -146,7 +146,7 @@ pub fn get_health_report(template: HealthReportTemplates, message: Option<String
     report
 }
 
-pub async fn handle_override(
+pub async fn handle_health_report(
     command: Args,
     output_format: OutputFormat,
     api_client: &ApiClient,
@@ -157,7 +157,7 @@ pub async fn handle_override(
                 .0
                 .list_health_report_overrides(machine_id)
                 .await?;
-            health_utils::display_overrides(response.health_report_entries, output_format)?;
+            health_utils::display_health_reports(response.health_report_entries, output_format)?;
         }
         Args::Add(options) => {
             let report = health_utils::resolve_health_report(

--- a/crates/admin-cli/src/machine/health_report/mod.rs
+++ b/crates/admin-cli/src/machine/health_report/mod.rs
@@ -26,7 +26,7 @@ use crate::cfg::runtime::RuntimeContext;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
-        cmd::handle_override(self, ctx.config.format, &ctx.api_client).await?;
+        cmd::handle_health_report(self, ctx.config.format, &ctx.api_client).await?;
         Ok(())
     }
 }

--- a/crates/admin-cli/src/machine/mod.rs
+++ b/crates/admin-cli/src/machine/mod.rs
@@ -19,7 +19,7 @@ pub mod auto_update;
 pub mod common;
 pub mod force_delete;
 pub mod hardware_info;
-pub mod health_override;
+pub mod health_report;
 pub mod metadata;
 pub mod network;
 pub mod nvlink_info;
@@ -34,8 +34,8 @@ mod tests;
 pub use auto_update::args::Args as MachineAutoupdate;
 use clap::Parser;
 pub use common::{MachineQuery, NetworkConfigQuery};
-pub use health_override::args::HealthReportTemplates;
-pub use health_override::cmd::get_health_report;
+pub use health_report::args::HealthReportTemplates;
+pub use health_report::cmd::get_health_report;
 pub use show::args::Args as ShowMachine;
 pub use show::cmd::{get_next_free_machine, handle_show};
 
@@ -53,7 +53,7 @@ pub enum Cmd {
         visible_alias = "hr",
         alias = "health-override"
     )]
-    HealthReport(health_override::Args),
+    HealthReport(health_report::Args),
     #[clap(about = "Reboot a machine")]
     Reboot(reboot::Args),
     #[clap(about = "Force delete a machine")]

--- a/crates/admin-cli/src/machine/tests.rs
+++ b/crates/admin-cli/src/machine/tests.rs
@@ -25,10 +25,10 @@
 // ValueEnum Parsing - Test string parsing for types deriving claps ValueEnum.
 
 use clap::{CommandFactory, Parser};
-use health_override::args::{Args as OverrideCommand, HealthReportTemplates};
 use metadata::args::Args as MachineMetadataCommand;
 use network::args::Args as NetworkCommand;
 
+use self::health_report::args::{Args as HealthReportCommand, HealthReportTemplates};
 use super::*;
 
 // Define a basic/working MachineId for testing.
@@ -138,10 +138,10 @@ fn parse_health_override_show() {
         .expect("should parse health-override show");
 
     match cmd {
-        Cmd::HealthReport(OverrideCommand::Show { machine_id }) => {
+        Cmd::HealthReport(HealthReportCommand::Show { machine_id }) => {
             assert_eq!(machine_id.to_string(), TEST_MACHINE_ID);
         }
-        _ => panic!("expected HealthOverride Show variant"),
+        _ => panic!("expected HealthReport Show variant"),
     }
 }
 
@@ -160,11 +160,26 @@ fn parse_health_override_add_with_template() {
     .expect("should parse health-override add with template");
 
     match cmd {
-        Cmd::HealthReport(OverrideCommand::Add(args)) => {
+        Cmd::HealthReport(HealthReportCommand::Add(args)) => {
             assert!(args.template.is_some());
             assert!(args.health_report.is_none());
         }
-        _ => panic!("expected HealthOverride Add variant"),
+        _ => panic!("expected HealthReport Add variant"),
+    }
+}
+
+// parse_health_report_show ensures health-report
+// show parses (new primary command name).
+#[test]
+fn parse_health_report_show() {
+    let cmd = Cmd::try_parse_from(["machine", "health-report", "show", TEST_MACHINE_ID])
+        .expect("should parse health-report show");
+
+    match cmd {
+        Cmd::HealthReport(HealthReportCommand::Show { machine_id }) => {
+            assert_eq!(machine_id.to_string(), TEST_MACHINE_ID);
+        }
+        _ => panic!("expected HealthReport Show variant"),
     }
 }
 

--- a/crates/admin-cli/src/power_shelf/health_report/add/args.rs
+++ b/crates/admin-cli/src/power_shelf/health_report/add/args.rs
@@ -21,7 +21,7 @@ use clap::{ArgGroup, Parser};
 use crate::machine::HealthReportTemplates;
 
 #[derive(Parser, Debug)]
-#[clap(group(ArgGroup::new("override_health").required(true).args(&["health_report", "template"])))]
+#[clap(group(ArgGroup::new("health_report_source").required(true).args(&["health_report", "template"])))]
 pub struct Args {
     pub power_shelf_id: PowerShelfId,
     #[clap(long, help = "New health report as json")]

--- a/crates/admin-cli/src/power_shelf/health_report/show/cmd.rs
+++ b/crates/admin-cli/src/power_shelf/health_report/show/cmd.rs
@@ -30,6 +30,6 @@ pub async fn show(
         .0
         .list_power_shelf_health_reports(args.power_shelf_id)
         .await?;
-    health_utils::display_overrides(response.health_report_entries, format)?;
+    health_utils::display_health_reports(response.health_report_entries, format)?;
     Ok(())
 }

--- a/crates/admin-cli/src/switch/health_report/add/args.rs
+++ b/crates/admin-cli/src/switch/health_report/add/args.rs
@@ -21,7 +21,7 @@ use clap::{ArgGroup, Parser};
 use crate::machine::HealthReportTemplates;
 
 #[derive(Parser, Debug)]
-#[clap(group(ArgGroup::new("override_health").required(true).args(&["health_report", "template"])))]
+#[clap(group(ArgGroup::new("health_report_source").required(true).args(&["health_report", "template"])))]
 pub struct Args {
     pub switch_id: SwitchId,
     #[clap(long, help = "New health report as json")]

--- a/crates/admin-cli/src/switch/health_report/show/cmd.rs
+++ b/crates/admin-cli/src/switch/health_report/show/cmd.rs
@@ -30,6 +30,6 @@ pub async fn show(
         .0
         .list_switch_health_reports(args.switch_id)
         .await?;
-    health_utils::display_overrides(response.health_report_entries, format)?;
+    health_utils::display_health_reports(response.health_report_entries, format)?;
     Ok(())
 }


### PR DESCRIPTION
## Description

This is an internal `admin-cli` specific name refactoring change only, working on https://github.com/NVIDIA/ncx-infra-controller-core/issues/995 (and following on https://github.com/NVIDIA/ncx-infra-controller-core/pull/975 and https://github.com/NVIDIA/ncx-infra-controller-core/pull/999 which have been chipping away at this).

This takes "health override(s)" and contextually turns it into either:
- "health report(s)"
- "health report entry"

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

