### PR TITLE
refactor(api): move SiteExplorerConfig into site_explorer module

### DIFF
--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -19,14 +19,12 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::net::{Ipv4Addr, SocketAddr};
-use std::ops::Deref;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+use std::sync::atomic::AtomicBool;
 use std::time::SystemTime;
 use std::{fmt, fs};
 
-use arc_swap::ArcSwap;
 use bmc_vendor::BMCVendor;
 use carbide_authn::config::{AllowedCertCriteria, TrustConfig};
 use chrono::Duration;
@@ -50,9 +48,12 @@ use model::resource_pool::define::ResourcePoolDef;
 use model::site_explorer::{EndpointExplorationReport, ExploredEndpoint};
 use model::tenant::TENANT_IDENTITY_SIGNING_JWT_ALG;
 use regex::Regex;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use utils::HostPortPair;
+use serde::{Deserialize, Deserializer, Serialize};
+use utils::config::{
+    as_duration, as_std_duration, deserialize_arc_atomic_bool, serialize_arc_atomic_bool,
+};
 
+use crate::site_explorer::config::SiteExplorerConfig;
 use crate::state_controller::config::IterationConfig;
 
 const MAX_IB_PARTITION_PER_TENANT: i32 = 31;
@@ -1110,21 +1111,6 @@ fn vendor_model_to_key(vendor: bmc_vendor::BMCVendor, model: &str) -> String {
     format!("{vendor}:{}", model.to_lowercase())
 }
 
-/// As of now, chrono::Duration does not support Serialization, so we have to handle it manually.
-fn as_duration<S>(d: &Duration, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    serializer.serialize_str(&format!("{}s", d.num_seconds()))
-}
-
-fn as_std_duration<S>(d: &std::time::Duration, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    serializer.serialize_str(&format!("{}s", d.as_secs()))
-}
-
 /// MachineStateController related config.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct MachineStateControllerConfig {
@@ -1608,289 +1594,6 @@ impl NvLinkConfig {
     }
 }
 
-/// SiteExplorer related configuration for hardware discovery and ingestion.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct SiteExplorerConfig {
-    /// Whether SiteExplorer is enabled. Dynamically toggleable at runtime via SetDynamicConfig.
-    #[serde(
-        default = "SiteExplorerConfig::default_enabled",
-        deserialize_with = "deserialize_arc_atomic_bool",
-        serialize_with = "serialize_arc_atomic_bool"
-    )]
-    pub enabled: Arc<AtomicBool>,
-    /// The interval at which site explorer runs.
-    /// Defaults to 5 Minutes if not specified.
-    #[serde(
-        default = "SiteExplorerConfig::default_run_interval",
-        deserialize_with = "deserialize_duration",
-        serialize_with = "as_std_duration"
-    )]
-    pub run_interval: std::time::Duration,
-    /// The maximum amount of nodes that are explored concurrently.
-    /// Default is 5.
-    #[serde(default = "SiteExplorerConfig::default_concurrent_explorations")]
-    pub concurrent_explorations: u64,
-    /// How many nodes should be explored in a single run.
-    /// Default is 10.
-    /// This number divided by `concurrent_explorations` will determine how many
-    /// exploration batches are needed inside a run.
-    /// If the value is set too high the site exploration will take a lot of time
-    /// and the exploration report will be updated less frequent. Therefore it
-    /// is recommended to reduce `run_interval` instead of increasing
-    /// `explorations_per_run`.
-    #[serde(default = "SiteExplorerConfig::default_explorations_per_run")]
-    pub explorations_per_run: u64,
-
-    /// Whether SiteExplorer should create Managed Host state machine
-    #[serde(
-        default = "SiteExplorerConfig::default_create_machines",
-        deserialize_with = "deserialize_arc_atomic_bool",
-        serialize_with = "serialize_arc_atomic_bool"
-    )]
-    pub create_machines: Arc<AtomicBool>,
-
-    /// How many ManagedHosts should be created in a single run. Default is 4.
-    #[serde(default = "SiteExplorerConfig::default_machines_created_per_run")]
-    pub machines_created_per_run: u64,
-
-    /// Whether SiteExplorer should rotate/update Switch NVOS admin credentials
-    #[serde(
-        default = "SiteExplorerConfig::default_rotate_switch_nvos_credentials",
-        deserialize_with = "deserialize_arc_atomic_bool",
-        serialize_with = "serialize_arc_atomic_bool"
-    )]
-    pub rotate_switch_nvos_credentials: Arc<AtomicBool>,
-
-    /// DEPRECATED: Use `bmc_proxy` instead.
-    /// The IP address to connect to instead of the BMC that made the dhcp request.
-    /// This is a debug override and should not be used in production.
-    pub override_target_ip: Option<String>,
-
-    /// DEPRECATED: Use `bmc_proxy` instead.
-    /// The port to connect to for redfish requests.
-    /// This is a debug override and should not be used in production.
-    pub override_target_port: Option<u16>,
-
-    /// Whether to allow hosts with zero DPUs in site-explorer. This should typically be set to
-    /// false in production environments where we expect all hosts to have DPUs. When false, if we
-    /// encounter a host with no DPUs, site-explorer will throw an error for that host (because it
-    /// should be assumed that there's a bug in detecting the DPUs).
-    #[serde(default)]
-    pub allow_zero_dpu_hosts: bool,
-
-    /// The host:port to use as a proxy when making BMC calls to all hosts in NICo. This is used
-    /// for integration testing, and for local development with machine-a-tron/bmc-mock. Should not
-    /// be used in production.
-    #[serde(
-        default,
-        deserialize_with = "deserialize_bmc_proxy",
-        serialize_with = "serialize_bmc_proxy"
-    )]
-    pub bmc_proxy: Arc<ArcSwap<Option<HostPortPair>>>,
-
-    /// If set to `true`, the server will allow changes to the `bmc_proxy` setting at runtime.
-    /// Defaults to true if the server is launched with `bmc_proxy` set, false otherwise.
-    /// If explicitly set to true or false, that value is respected for the lifetime of the process.
-    #[serde(default)]
-    pub allow_changing_bmc_proxy: Option<bool>,
-
-    /// Minimum time between consecutive force-restarts or BMC resets initiated by SiteExplorer.
-    /// Default is 1 hour.
-    #[serde(
-        default = "SiteExplorerConfig::default_reset_rate_limit",
-        deserialize_with = "deserialize_duration_chrono",
-        serialize_with = "as_duration"
-    )]
-    pub reset_rate_limit: Duration,
-
-    /// When true, non-DPU hosts use the `HostInband` admin network segment type instead of `Admin`.
-    #[serde(
-        default = "SiteExplorerConfig::default_admin_segment_type_non_dpu",
-        deserialize_with = "deserialize_arc_atomic_bool",
-        serialize_with = "serialize_arc_atomic_bool"
-    )]
-    pub admin_segment_type_non_dpu: Arc<AtomicBool>,
-
-    /// Whether site-controller should allocate a secondary
-    /// VTEP IP or leave that to discovery.
-    /// Current secondary VTEP use-case is additional
-    /// VTEP IPs for GENEVE VTEPS (GTEPS) used by traffic-intercept users.
-    ///  Only sites expected to support
-    /// additional VTEPS would turn this on.
-    #[serde(default)]
-    pub allocate_secondary_vtep_ip: bool,
-
-    /// Whether SiteExplorer should create Power Shelf state machine
-    #[serde(
-        default = "SiteExplorerConfig::default_create_power_shelves",
-        deserialize_with = "deserialize_arc_atomic_bool",
-        serialize_with = "serialize_arc_atomic_bool"
-    )]
-    pub create_power_shelves: Arc<AtomicBool>,
-
-    /// Whether SiteExplorer should create Power Shelf state machine from static IP
-    #[serde(
-        default = "SiteExplorerConfig::default_explore_power_shelves_from_static_ip",
-        deserialize_with = "deserialize_arc_atomic_bool",
-        serialize_with = "serialize_arc_atomic_bool"
-    )]
-    pub explore_power_shelves_from_static_ip: Arc<AtomicBool>,
-
-    /// How many Power Shelves should be created in a single run.
-    /// Default is 1.
-    #[serde(default = "SiteExplorerConfig::default_power_shelves_created_per_run")]
-    pub power_shelves_created_per_run: u64,
-
-    /// Whether SiteExplorer should create Switch state machine
-    #[serde(
-        default = "SiteExplorerConfig::default_create_switches",
-        deserialize_with = "deserialize_arc_atomic_bool",
-        serialize_with = "serialize_arc_atomic_bool"
-    )]
-    pub create_switches: Arc<AtomicBool>,
-
-    /// How many Switches should be created in a single run.
-    /// Default is 9.
-    #[serde(default = "SiteExplorerConfig::default_switches_created_per_run")]
-    pub switches_created_per_run: u64,
-
-    /// Use onboard NIC for host networking instead of DPU NICs.
-    #[serde(
-        default = "SiteExplorerConfig::default_force_dpu_nic_mode",
-        deserialize_with = "deserialize_arc_atomic_bool",
-        serialize_with = "serialize_arc_atomic_bool"
-    )]
-    pub force_dpu_nic_mode: Arc<AtomicBool>,
-    /// Controls which Redfish client implementation is used
-    /// for hardware discovery (LibRedfish, NvRedfish, or
-    /// CompareResult for side-by-side validation).
-    #[serde(default = "SiteExplorerConfig::default_explore_mode")]
-    pub explore_mode: SiteExplorerExploreMode,
-}
-
-impl Default for SiteExplorerConfig {
-    fn default() -> Self {
-        SiteExplorerConfig {
-            enabled: Arc::new(true.into()),
-            run_interval: Self::default_run_interval(),
-            concurrent_explorations: Self::default_concurrent_explorations(),
-            explorations_per_run: Self::default_explorations_per_run(),
-            create_machines: Arc::new(true.into()),
-            machines_created_per_run: Self::default_machines_created_per_run(),
-            override_target_ip: None,
-            override_target_port: None,
-            allow_zero_dpu_hosts: false,
-            bmc_proxy: crate::dynamic_settings::bmc_proxy(None),
-            allow_changing_bmc_proxy: None,
-            reset_rate_limit: Self::default_reset_rate_limit(),
-            admin_segment_type_non_dpu: Self::default_admin_segment_type_non_dpu(),
-            allocate_secondary_vtep_ip: false,
-            create_power_shelves: Arc::new(true.into()),
-            explore_power_shelves_from_static_ip: Arc::new(true.into()),
-            power_shelves_created_per_run: Self::default_power_shelves_created_per_run(),
-            create_switches: Arc::new(true.into()),
-            switches_created_per_run: Self::default_switches_created_per_run(),
-            rotate_switch_nvos_credentials: Self::default_rotate_switch_nvos_credentials(),
-            force_dpu_nic_mode: Arc::new(false.into()),
-            explore_mode: Self::default_explore_mode(),
-        }
-    }
-}
-
-impl PartialEq for SiteExplorerConfig {
-    fn eq(&self, other: &SiteExplorerConfig) -> bool {
-        self.enabled.load(AtomicOrdering::Relaxed) == other.enabled.load(AtomicOrdering::Relaxed)
-            && self.run_interval == other.run_interval
-            && self.concurrent_explorations == other.concurrent_explorations
-            && self.explorations_per_run == other.explorations_per_run
-            && self.create_machines.load(AtomicOrdering::Relaxed)
-                == other.create_machines.load(AtomicOrdering::Relaxed)
-            && self.override_target_ip == other.override_target_ip
-            && self.override_target_port == other.override_target_port
-    }
-}
-
-impl SiteExplorerConfig {
-    pub const fn default_run_interval() -> std::time::Duration {
-        std::time::Duration::from_secs(120)
-    }
-
-    pub fn default_enabled() -> Arc<AtomicBool> {
-        Arc::new(true.into())
-    }
-
-    pub fn default_create_machines() -> Arc<AtomicBool> {
-        Arc::new(true.into())
-    }
-
-    pub const fn default_concurrent_explorations() -> u64 {
-        30
-    }
-
-    pub const fn default_explorations_per_run() -> u64 {
-        90
-    }
-
-    pub const fn default_machines_created_per_run() -> u64 {
-        4
-    }
-
-    pub fn default_rotate_switch_nvos_credentials() -> Arc<AtomicBool> {
-        Arc::new(false.into())
-    }
-
-    pub const fn default_reset_rate_limit() -> Duration {
-        Duration::hours(1)
-    }
-
-    pub fn default_admin_segment_type_non_dpu() -> Arc<AtomicBool> {
-        Arc::new(false.into())
-    }
-
-    pub fn default_create_power_shelves() -> Arc<AtomicBool> {
-        Arc::new(false.into())
-    }
-
-    pub fn default_explore_power_shelves_from_static_ip() -> Arc<AtomicBool> {
-        Arc::new(false.into())
-    }
-
-    pub const fn default_power_shelves_created_per_run() -> u64 {
-        1
-    }
-
-    pub fn default_create_switches() -> Arc<AtomicBool> {
-        Arc::new(false.into())
-    }
-
-    pub const fn default_switches_created_per_run() -> u64 {
-        9
-    }
-
-    pub fn default_force_dpu_nic_mode() -> Arc<AtomicBool> {
-        Arc::new(false.into())
-    }
-
-    pub const fn default_explore_mode() -> SiteExplorerExploreMode {
-        SiteExplorerExploreMode::LibRedfish
-    }
-}
-
-/// Selects the Redfish client backend used by SiteExplorer
-/// for BMC discovery.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-pub enum SiteExplorerExploreMode {
-    /// Use the libredfish Rust client.
-    #[serde(rename = "libredfish")]
-    LibRedfish,
-    /// Use the NVIDIA-specific Redfish client.
-    #[serde(rename = "nv-redfish")]
-    NvRedfish,
-    /// Run both clients and compare results for validation.
-    #[serde(rename = "compare-result")]
-    CompareResult,
-}
-
 impl DpaConfig {
     pub const fn default_hb_interval() -> chrono::Duration {
         Duration::minutes(2)
@@ -1912,45 +1615,6 @@ impl Default for DpaConfig {
             hb_interval: Self::default_hb_interval(),
             auth: MqttAuthConfig::default(),
         }
-    }
-}
-
-pub fn deserialize_arc_atomic_bool<'de, D>(deserializer: D) -> Result<Arc<AtomicBool>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let b = bool::deserialize(deserializer)?;
-    Ok(Arc::new(b.into()))
-}
-
-pub fn serialize_arc_atomic_bool<S>(cm: &Arc<AtomicBool>, s: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    s.serialize_bool(cm.load(AtomicOrdering::Relaxed))
-}
-
-pub fn deserialize_bmc_proxy<'de, D>(
-    deserializer: D,
-) -> Result<Arc<ArcSwap<Option<HostPortPair>>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let p = Option::deserialize(deserializer)?;
-    Ok(Arc::new(ArcSwap::new(Arc::new(p))))
-}
-
-pub fn serialize_bmc_proxy<S>(
-    val: &Arc<ArcSwap<Option<HostPortPair>>>,
-    s: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    if let Some(val) = val.load().deref().deref() {
-        s.serialize_str(val.to_string().as_str())
-    } else {
-        s.serialize_none()
     }
 }
 
@@ -3287,6 +2951,8 @@ pub fn default_host_intercept_bridge_port() -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::Ordering as AtomicOrdering;
+
     use carbide_authn::config::CertComponent;
     use chrono::Datelike;
     use figment::Figment;
@@ -3296,6 +2962,7 @@ mod tests {
     use model::resource_pool;
 
     use super::*;
+    use crate::site_explorer::config::SiteExplorerExploreMode;
 
     const TEST_DATA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src/cfg/test_data");
 
@@ -3590,7 +3257,7 @@ mod tests {
                 override_target_ip: None,
                 override_target_port: None,
                 allow_zero_dpu_hosts: false,
-                bmc_proxy: crate::dynamic_settings::bmc_proxy(None),
+                bmc_proxy: crate::site_explorer::config::bmc_proxy(None),
                 allow_changing_bmc_proxy: None,
                 reset_rate_limit: Duration::hours(1),
                 admin_segment_type_non_dpu: Arc::new(false.into()),
@@ -3763,7 +3430,7 @@ mod tests {
                 override_target_ip: Some("1.2.3.4".to_owned()),
                 override_target_port: Some(10443),
                 allow_zero_dpu_hosts: false,
-                bmc_proxy: crate::dynamic_settings::bmc_proxy(None),
+                bmc_proxy: crate::site_explorer::config::bmc_proxy(None),
                 allow_changing_bmc_proxy: None,
                 reset_rate_limit: Duration::hours(2),
                 admin_segment_type_non_dpu: Arc::new(false.into()),
@@ -4072,7 +3739,7 @@ mod tests {
                 override_target_ip: Some("1.2.3.4".to_owned()),
                 override_target_port: Some(10443),
                 allow_zero_dpu_hosts: false,
-                bmc_proxy: crate::dynamic_settings::bmc_proxy(None),
+                bmc_proxy: crate::site_explorer::config::bmc_proxy(None),
                 allow_changing_bmc_proxy: None,
                 reset_rate_limit: Duration::hours(2),
                 admin_segment_type_non_dpu: Arc::new(false.into()),

--- a/crates/api/src/dynamic_settings.rs
+++ b/crates/api/src/dynamic_settings.rs
@@ -77,7 +77,3 @@ impl DynamicSettings {
             .expect("Could not spawn dynamic_feature_reset task");
     }
 }
-
-pub fn bmc_proxy(s: Option<HostPortPair>) -> Arc<ArcSwap<Option<HostPortPair>>> {
-    Arc::new(ArcSwap::new(Arc::new(s)))
-}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -109,12 +109,12 @@ mod web;
 // Allow carbide_macros::sqlx_test to be referred as #[crate::sqlx_test]
 #[cfg(test)]
 pub(crate) use carbide_macros::sqlx_test;
-pub use cfg::file::SiteExplorerExploreMode;
 // TODO: temporary while migrating db to its own crate
 pub use db::{DatabaseError, DatabaseResult};
 // Save typing
 pub(crate) use errors::{CarbideError, CarbideResult};
 pub use site_explorer::BmcEndpointExplorer;
+pub use site_explorer::config::SiteExplorerExploreMode;
 
 // Stuff needed by main.rs and api-test
 pub use crate::{cfg::command_line::Command, cfg::command_line::Options, run::run};

--- a/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
+++ b/crates/api/src/site_explorer/bmc_endpoint_explorer.rs
@@ -36,11 +36,11 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::Mutex;
 use tokio::time::{Duration, sleep};
 
+use super::EndpointExplorer;
+use super::config::SiteExplorerExploreMode;
 use super::credentials::{CredentialClient, get_bmc_root_credential_key};
 use super::metrics::SiteExplorationMetrics;
 use super::redfish::RedfishClient;
-use crate::cfg::file::SiteExplorerExploreMode;
-use crate::site_explorer::EndpointExplorer;
 
 const UNIFIED_PREINGESTION_BFB_PATH: &str =
     "/forge-boot-artifacts/blobs/internal/aarch64/preingestion_unified_update.bfb";

--- a/crates/api/src/site_explorer/config.rs
+++ b/crates/api/src/site_explorer/config.rs
@@ -1,0 +1,340 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::ops::Deref;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+
+use arc_swap::ArcSwap;
+use chrono::Duration;
+use duration_str::{deserialize_duration, deserialize_duration_chrono};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use utils::HostPortPair;
+use utils::config::{
+    as_duration, as_std_duration, deserialize_arc_atomic_bool, serialize_arc_atomic_bool,
+};
+
+/// SiteExplorer related configuration for hardware discovery and ingestion.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SiteExplorerConfig {
+    /// Whether SiteExplorer is enabled. Dynamically toggleable at runtime via SetDynamicConfig.
+    #[serde(
+        default = "SiteExplorerConfig::default_enabled",
+        deserialize_with = "deserialize_arc_atomic_bool",
+        serialize_with = "serialize_arc_atomic_bool"
+    )]
+    pub enabled: Arc<AtomicBool>,
+    /// The interval at which site explorer runs.
+    /// Defaults to 5 Minutes if not specified.
+    #[serde(
+        default = "SiteExplorerConfig::default_run_interval",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub run_interval: std::time::Duration,
+    /// The maximum amount of nodes that are explored concurrently.
+    /// Default is 5.
+    #[serde(default = "SiteExplorerConfig::default_concurrent_explorations")]
+    pub concurrent_explorations: u64,
+    /// How many nodes should be explored in a single run.
+    /// Default is 10.
+    /// This number divided by `concurrent_explorations` will determine how many
+    /// exploration batches are needed inside a run.
+    /// If the value is set too high the site exploration will take a lot of time
+    /// and the exploration report will be updated less frequent. Therefore it
+    /// is recommended to reduce `run_interval` instead of increasing
+    /// `explorations_per_run`.
+    #[serde(default = "SiteExplorerConfig::default_explorations_per_run")]
+    pub explorations_per_run: u64,
+
+    /// Whether SiteExplorer should create Managed Host state machine
+    #[serde(
+        default = "SiteExplorerConfig::default_create_machines",
+        deserialize_with = "deserialize_arc_atomic_bool",
+        serialize_with = "serialize_arc_atomic_bool"
+    )]
+    pub create_machines: Arc<AtomicBool>,
+
+    /// How many ManagedHosts should be created in a single run. Default is 4.
+    #[serde(default = "SiteExplorerConfig::default_machines_created_per_run")]
+    pub machines_created_per_run: u64,
+
+    /// Whether SiteExplorer should rotate/update Switch NVOS admin credentials
+    #[serde(
+        default = "SiteExplorerConfig::default_rotate_switch_nvos_credentials",
+        deserialize_with = "deserialize_arc_atomic_bool",
+        serialize_with = "serialize_arc_atomic_bool"
+    )]
+    pub rotate_switch_nvos_credentials: Arc<AtomicBool>,
+
+    /// DEPRECATED: Use `bmc_proxy` instead.
+    /// The IP address to connect to instead of the BMC that made the dhcp request.
+    /// This is a debug override and should not be used in production.
+    pub override_target_ip: Option<String>,
+
+    /// DEPRECATED: Use `bmc_proxy` instead.
+    /// The port to connect to for redfish requests.
+    /// This is a debug override and should not be used in production.
+    pub override_target_port: Option<u16>,
+
+    /// Whether to allow hosts with zero DPUs in site-explorer. This should typically be set to
+    /// false in production environments where we expect all hosts to have DPUs. When false, if we
+    /// encounter a host with no DPUs, site-explorer will throw an error for that host (because it
+    /// should be assumed that there's a bug in detecting the DPUs).
+    #[serde(default)]
+    pub allow_zero_dpu_hosts: bool,
+
+    /// The host:port to use as a proxy when making BMC calls to all hosts in NICo. This is used
+    /// for integration testing, and for local development with machine-a-tron/bmc-mock. Should not
+    /// be used in production.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_bmc_proxy",
+        serialize_with = "serialize_bmc_proxy"
+    )]
+    pub bmc_proxy: Arc<ArcSwap<Option<HostPortPair>>>,
+
+    /// If set to `true`, the server will allow changes to the `bmc_proxy` setting at runtime.
+    /// Defaults to true if the server is launched with `bmc_proxy` set, false otherwise.
+    /// If explicitly set to true or false, that value is respected for the lifetime of the process.
+    #[serde(default)]
+    pub allow_changing_bmc_proxy: Option<bool>,
+
+    /// Minimum time between consecutive force-restarts or BMC resets initiated by SiteExplorer.
+    /// Default is 1 hour.
+    #[serde(
+        default = "SiteExplorerConfig::default_reset_rate_limit",
+        deserialize_with = "deserialize_duration_chrono",
+        serialize_with = "as_duration"
+    )]
+    pub reset_rate_limit: Duration,
+
+    /// When true, non-DPU hosts use the `HostInband` admin network segment type instead of `Admin`.
+    #[serde(
+        default = "SiteExplorerConfig::default_admin_segment_type_non_dpu",
+        deserialize_with = "deserialize_arc_atomic_bool",
+        serialize_with = "serialize_arc_atomic_bool"
+    )]
+    pub admin_segment_type_non_dpu: Arc<AtomicBool>,
+
+    /// Whether site-controller should allocate a secondary
+    /// VTEP IP or leave that to discovery.
+    /// Current secondary VTEP use-case is additional
+    /// VTEP IPs for GENEVE VTEPS (GTEPS) used by traffic-intercept users.
+    ///  Only sites expected to support
+    /// additional VTEPS would turn this on.
+    #[serde(default)]
+    pub allocate_secondary_vtep_ip: bool,
+
+    /// Whether SiteExplorer should create Power Shelf state machine
+    #[serde(
+        default = "SiteExplorerConfig::default_create_power_shelves",
+        deserialize_with = "deserialize_arc_atomic_bool",
+        serialize_with = "serialize_arc_atomic_bool"
+    )]
+    pub create_power_shelves: Arc<AtomicBool>,
+
+    /// Whether SiteExplorer should create Power Shelf state machine from static IP
+    #[serde(
+        default = "SiteExplorerConfig::default_explore_power_shelves_from_static_ip",
+        deserialize_with = "deserialize_arc_atomic_bool",
+        serialize_with = "serialize_arc_atomic_bool"
+    )]
+    pub explore_power_shelves_from_static_ip: Arc<AtomicBool>,
+
+    /// How many Power Shelves should be created in a single run.
+    /// Default is 1.
+    #[serde(default = "SiteExplorerConfig::default_power_shelves_created_per_run")]
+    pub power_shelves_created_per_run: u64,
+
+    /// Whether SiteExplorer should create Switch state machine
+    #[serde(
+        default = "SiteExplorerConfig::default_create_switches",
+        deserialize_with = "deserialize_arc_atomic_bool",
+        serialize_with = "serialize_arc_atomic_bool"
+    )]
+    pub create_switches: Arc<AtomicBool>,
+
+    /// How many Switches should be created in a single run.
+    /// Default is 9.
+    #[serde(default = "SiteExplorerConfig::default_switches_created_per_run")]
+    pub switches_created_per_run: u64,
+
+    /// Use onboard NIC for host networking instead of DPU NICs.
+    #[serde(
+        default = "SiteExplorerConfig::default_force_dpu_nic_mode",
+        deserialize_with = "deserialize_arc_atomic_bool",
+        serialize_with = "serialize_arc_atomic_bool"
+    )]
+    pub force_dpu_nic_mode: Arc<AtomicBool>,
+    /// Controls which Redfish client implementation is used
+    /// for hardware discovery (LibRedfish, NvRedfish, or
+    /// CompareResult for side-by-side validation).
+    #[serde(default = "SiteExplorerConfig::default_explore_mode")]
+    pub explore_mode: SiteExplorerExploreMode,
+}
+
+impl Default for SiteExplorerConfig {
+    fn default() -> Self {
+        SiteExplorerConfig {
+            enabled: Arc::new(true.into()),
+            run_interval: Self::default_run_interval(),
+            concurrent_explorations: Self::default_concurrent_explorations(),
+            explorations_per_run: Self::default_explorations_per_run(),
+            create_machines: Arc::new(true.into()),
+            machines_created_per_run: Self::default_machines_created_per_run(),
+            override_target_ip: None,
+            override_target_port: None,
+            allow_zero_dpu_hosts: false,
+            bmc_proxy: bmc_proxy(None),
+            allow_changing_bmc_proxy: None,
+            reset_rate_limit: Self::default_reset_rate_limit(),
+            admin_segment_type_non_dpu: Self::default_admin_segment_type_non_dpu(),
+            allocate_secondary_vtep_ip: false,
+            create_power_shelves: Arc::new(true.into()),
+            explore_power_shelves_from_static_ip: Arc::new(true.into()),
+            power_shelves_created_per_run: Self::default_power_shelves_created_per_run(),
+            create_switches: Arc::new(true.into()),
+            switches_created_per_run: Self::default_switches_created_per_run(),
+            rotate_switch_nvos_credentials: Self::default_rotate_switch_nvos_credentials(),
+            force_dpu_nic_mode: Arc::new(false.into()),
+            explore_mode: Self::default_explore_mode(),
+        }
+    }
+}
+
+impl PartialEq for SiteExplorerConfig {
+    fn eq(&self, other: &SiteExplorerConfig) -> bool {
+        self.enabled.load(AtomicOrdering::Relaxed) == other.enabled.load(AtomicOrdering::Relaxed)
+            && self.run_interval == other.run_interval
+            && self.concurrent_explorations == other.concurrent_explorations
+            && self.explorations_per_run == other.explorations_per_run
+            && self.create_machines.load(AtomicOrdering::Relaxed)
+                == other.create_machines.load(AtomicOrdering::Relaxed)
+            && self.override_target_ip == other.override_target_ip
+            && self.override_target_port == other.override_target_port
+    }
+}
+
+impl SiteExplorerConfig {
+    pub const fn default_run_interval() -> std::time::Duration {
+        std::time::Duration::from_secs(120)
+    }
+
+    pub fn default_enabled() -> Arc<AtomicBool> {
+        Arc::new(true.into())
+    }
+
+    pub fn default_create_machines() -> Arc<AtomicBool> {
+        Arc::new(true.into())
+    }
+
+    pub const fn default_concurrent_explorations() -> u64 {
+        30
+    }
+
+    pub const fn default_explorations_per_run() -> u64 {
+        90
+    }
+
+    pub const fn default_machines_created_per_run() -> u64 {
+        4
+    }
+
+    pub fn default_rotate_switch_nvos_credentials() -> Arc<AtomicBool> {
+        Arc::new(false.into())
+    }
+
+    pub const fn default_reset_rate_limit() -> Duration {
+        Duration::hours(1)
+    }
+
+    pub fn default_admin_segment_type_non_dpu() -> Arc<AtomicBool> {
+        Arc::new(false.into())
+    }
+
+    pub fn default_create_power_shelves() -> Arc<AtomicBool> {
+        Arc::new(false.into())
+    }
+
+    pub fn default_explore_power_shelves_from_static_ip() -> Arc<AtomicBool> {
+        Arc::new(false.into())
+    }
+
+    pub const fn default_power_shelves_created_per_run() -> u64 {
+        1
+    }
+
+    pub fn default_create_switches() -> Arc<AtomicBool> {
+        Arc::new(false.into())
+    }
+
+    pub const fn default_switches_created_per_run() -> u64 {
+        9
+    }
+
+    pub fn default_force_dpu_nic_mode() -> Arc<AtomicBool> {
+        Arc::new(false.into())
+    }
+
+    pub const fn default_explore_mode() -> SiteExplorerExploreMode {
+        SiteExplorerExploreMode::LibRedfish
+    }
+}
+
+pub fn bmc_proxy(s: Option<HostPortPair>) -> Arc<ArcSwap<Option<HostPortPair>>> {
+    Arc::new(ArcSwap::new(Arc::new(s)))
+}
+
+/// Selects the Redfish client backend used by SiteExplorer
+/// for BMC discovery.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub enum SiteExplorerExploreMode {
+    /// Use the libredfish Rust client.
+    #[serde(rename = "libredfish")]
+    LibRedfish,
+    /// Use the NVIDIA-specific Redfish client.
+    #[serde(rename = "nv-redfish")]
+    NvRedfish,
+    /// Run both clients and compare results for validation.
+    #[serde(rename = "compare-result")]
+    CompareResult,
+}
+
+pub fn deserialize_bmc_proxy<'de, D>(
+    deserializer: D,
+) -> Result<Arc<ArcSwap<Option<HostPortPair>>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let p = Option::deserialize(deserializer)?;
+    Ok(Arc::new(ArcSwap::new(Arc::new(p))))
+}
+
+pub fn serialize_bmc_proxy<S>(
+    val: &Arc<ArcSwap<Option<HostPortPair>>>,
+    s: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    if let Some(val) = val.load().deref().deref() {
+        s.serialize_str(val.to_string().as_str())
+    } else {
+        s.serialize_none()
+    }
+}

--- a/crates/api/src/site_explorer/metrics.rs
+++ b/crates/api/src/site_explorer/metrics.rs
@@ -25,7 +25,7 @@ use model::site_explorer::{EndpointExplorationError, MachineExpectation};
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Histogram, Meter};
 
-use crate::cfg::file::SiteExplorerConfig;
+use super::config::SiteExplorerConfig;
 
 /// Reasons why a host fails to pair with its DPU(s).
 /// These are issues that require manual intervention.

--- a/crates/api/src/site_explorer/mod.rs
+++ b/crates/api/src/site_explorer/mod.rs
@@ -29,6 +29,7 @@ use carbide_network::sanitized_mac;
 use carbide_uuid::machine::MachineType;
 use carbide_uuid::power_shelf::{PowerShelfIdSource, PowerShelfType};
 use chrono::Utc;
+use config::SiteExplorerConfig;
 use config_version::ConfigVersion;
 use db::{self, DatabaseError, ObjectFilter, Transaction, machine, power_shelf as db_power_shelf};
 use forge_secrets::credentials::CredentialManager;
@@ -56,7 +57,7 @@ use tracing::Instrument;
 use utils::periodic_timer::PeriodicTimer;
 use version_compare::Cmp;
 
-use crate::cfg::file::{FirmwareConfig, SiteExplorerConfig};
+use crate::cfg::file::FirmwareConfig;
 use crate::{CarbideError, CarbideResult};
 mod endpoint_explorer;
 pub use endpoint_explorer::EndpointExplorer;
@@ -82,6 +83,7 @@ mod switch_creator;
 use carbide_uuid::rack::RackId;
 use model::rack::Rack;
 pub use switch_creator::SwitchCreator;
+pub mod config;
 
 use self::metrics::{PairingBlockerReason, exploration_error_to_metric_label};
 use crate::site_explorer::explored_endpoint_index::ExploredEndpointIndex;

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -94,9 +94,9 @@ use crate::cfg::file::{
     MachineStateControllerConfig, MachineUpdater, MachineValidationConfig,
     MeasuredBootMetricsCollectorConfig, MqttAuthConfig, NetworkSecurityGroupConfig,
     NetworkSegmentStateControllerConfig, NvLinkConfig, PowerManagerOptions,
-    PowerShelfStateControllerConfig, RackStateControllerConfig, SiteExplorerConfig,
-    SiteExplorerExploreMode, SpdmConfig, SpdmStateControllerConfig, StateControllerConfig,
-    SwitchStateControllerConfig, VmaasConfig, VpcPeeringPolicy, default_max_find_by_ids,
+    PowerShelfStateControllerConfig, RackStateControllerConfig, SpdmConfig,
+    SpdmStateControllerConfig, StateControllerConfig, SwitchStateControllerConfig, VmaasConfig,
+    VpcPeeringPolicy, default_max_find_by_ids,
 };
 use crate::dpf::DpfOperations;
 use crate::ethernet_virtualization::{EthVirtData, SiteFabricPrefixList};
@@ -109,6 +109,7 @@ use crate::nvlink::NmxmClientPool;
 use crate::nvlink::test_support::NmxmSimClient;
 use crate::rack::rms_client::test_support::RmsSim;
 use crate::scout_stream;
+use crate::site_explorer::config::{SiteExplorerConfig, SiteExplorerExploreMode};
 use crate::site_explorer::{BmcEndpointExplorer, SiteExplorer};
 use crate::state_controller::common_services::CommonStateHandlerServices;
 use crate::state_controller::controller::{Enqueuer, StateController};

--- a/crates/api/src/tests/dynamic_config.rs
+++ b/crates/api/src/tests/dynamic_config.rs
@@ -140,7 +140,7 @@ async fn test_bmc_proxy_setting_parsed_config_unspecified(
         let mut config = get_config();
         // Leave allow_changing_bmc_proxy unspecified, it should behave as if false
         config.site_explorer.allow_changing_bmc_proxy = None;
-        config.site_explorer.bmc_proxy = crate::dynamic_settings::bmc_proxy(None);
+        config.site_explorer.bmc_proxy = crate::site_explorer::config::bmc_proxy(None);
         config.site_explorer.override_target_ip = None;
         config.site_explorer.override_target_port = None;
         let config_str = toml::to_string(&config)?;
@@ -186,9 +186,8 @@ async fn test_bmc_proxy_setting_parsed_config_unspecified_with_bmc_proxy_set(
         // Leave allow_changing_bmc_proxy unspecified, it should behave as if false
         config.site_explorer.allow_changing_bmc_proxy = None;
         config.site_explorer.bmc_proxy =
-            crate::dynamic_settings::bmc_proxy(Some("test:1234".parse().unwrap()));
+            crate::site_explorer::config::bmc_proxy(Some("test:1234".parse().unwrap()));
         let config_str = toml::to_string(&config)?;
-        println!("{config_str}");
         let parsed_config = parse_carbide_config(config_str, None)?;
         create_test_env_with_overrides(
             db_pool,

--- a/crates/api/src/tests/machine_creator.rs
+++ b/crates/api/src/tests/machine_creator.rs
@@ -35,8 +35,9 @@ use tonic::Request;
 use utils::models::arch::CpuArchitecture;
 
 use crate::CarbideError;
-use crate::cfg::file::{DpuConfig as InitialDpuConfig, SiteExplorerConfig};
+use crate::cfg::file::DpuConfig as InitialDpuConfig;
 use crate::site_explorer::MachineCreator;
+use crate::site_explorer::config::SiteExplorerConfig;
 use crate::state_controller::machine::handler::MachineStateHandlerBuilder;
 use crate::tests::common;
 use crate::tests::common::api_fixtures::TestEnvOverrides;

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -48,8 +48,8 @@ use rpc::site_explorer::{
 use rpc::{DiscoveryData, DiscoveryInfo, MachineDiscoveryInfo};
 use tonic::Request;
 
-use crate::cfg::file::{SiteExplorerConfig, SiteExplorerExploreMode};
 use crate::site_explorer::SiteExplorer;
+use crate::site_explorer::config::{SiteExplorerConfig, SiteExplorerExploreMode};
 use crate::tests::common;
 use crate::tests::common::api_fixtures;
 use crate::tests::common::api_fixtures::TestEnvOverrides;

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+
+use chrono::Duration;
+use serde::{Deserialize, Deserializer, Serializer};
+
+pub fn deserialize_arc_atomic_bool<'de, D>(deserializer: D) -> Result<Arc<AtomicBool>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let b = bool::deserialize(deserializer)?;
+    Ok(Arc::new(b.into()))
+}
+
+pub fn serialize_arc_atomic_bool<S>(cm: &Arc<AtomicBool>, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    s.serialize_bool(cm.load(AtomicOrdering::Relaxed))
+}
+
+/// As of now, chrono::Duration does not support Serialization, so we have to handle it manually.
+pub fn as_duration<S>(d: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&format!("{}s", d.num_seconds()))
+}
+
+pub fn as_std_duration<S>(d: &std::time::Duration, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&format!("{}s", d.as_secs()))
+}

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -20,6 +20,7 @@ use std::hash::Hash;
 use serde::{Serialize, Serializer};
 
 pub mod cmd;
+pub mod config;
 mod host_port_pair;
 pub mod managed_host_display;
 pub mod metrics;


### PR DESCRIPTION
## Description
Extract SiteExplorerConfig (and SiteExplorerExploreMode) from the 3000-line cfg/file.rs god-file into a new sibling module site_explorer/config.rs. The config now lives next to the code it configures — a prerequisite for eventually extracting site_explorer into its own crate.

The bmc_proxy-specific serde helpers stay with SiteExplorerConfig since they're specific to that field. Generic serde helpers used across many config structs (deserialize_arc_atomic_bool, serialize_arc_atomic_bool, as_duration, as_std_duration) are moved to a new carbide-utils::config module so other config types can share them.

`pub use site_explorer::config::SiteExplorerExploreMode` in lib.rs preserves the existing re-export. No behavioral changes.

Part of the effort to break up the carbide-api mega-crate.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

