### PR TITLE
refactor(api-model): move CURRENT_STATE_MODEL_VERSION into api-model

### DIFF
--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -109,6 +109,9 @@ fn default_true() -> bool {
     true
 }
 
+// This should be updated on each new model introduction
+pub const CURRENT_STATE_MODEL_VERSION: i16 = 2;
+
 /// Represents the current state of `Machine`
 #[derive(Debug, Clone)]
 pub struct ManagedHostStateSnapshot {

--- a/crates/api/src/measured_boot/tests/common.rs
+++ b/crates/api/src/measured_boot/tests/common.rs
@@ -24,10 +24,8 @@ use std::str::FromStr;
 use carbide_uuid::machine::MachineId;
 use measured_boot::machine::CandidateMachine;
 use model::hardware_info::HardwareInfo;
-use model::machine::ManagedHostState;
+use model::machine::{CURRENT_STATE_MODEL_VERSION, ManagedHostState};
 use sqlx::PgConnection;
-
-use crate::state_controller::machine::io::CURRENT_STATE_MODEL_VERSION;
 
 pub fn load_topology_json(path: &str) -> HardwareInfo {
     const TEST_DATA_DIR: &str = concat!(

--- a/crates/api/src/measured_boot/tests/rpc.rs
+++ b/crates/api/src/measured_boot/tests/rpc.rs
@@ -27,12 +27,11 @@ mod tests {
     use carbide_uuid::measured_boot::TrustedMachineId;
     use measured_boot::pcr::PcrRegisterValue;
     use measured_boot::records::MeasurementApprovedMachineRecord;
-    use model::machine::ManagedHostState;
+    use model::machine::{CURRENT_STATE_MODEL_VERSION, ManagedHostState};
     use rpc::protos::measured_boot as mbrpc;
 
     use crate::measured_boot::rpc::{bundle, journal, machine, profile, report, site};
     use crate::measured_boot::tests::common::{create_test_machine, load_topology_json};
-    use crate::state_controller::machine::io::CURRENT_STATE_MODEL_VERSION;
     use crate::tests::common::api_fixtures::create_test_env;
 
     // test_measurement_system_profiles is used to test all of the different

--- a/crates/api/src/site_explorer/machine_creator.rs
+++ b/crates/api/src/site_explorer/machine_creator.rs
@@ -29,7 +29,8 @@ use model::hardware_info::HardwareInfo;
 use model::machine::machine_id::host_id_from_dpu_hardware_info;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{
-    DpuDiscoveringState, DpuDiscoveringStates, Machine, MachineInterfaceSnapshot, ManagedHostState,
+    CURRENT_STATE_MODEL_VERSION, DpuDiscoveringState, DpuDiscoveringStates, Machine,
+    MachineInterfaceSnapshot, ManagedHostState,
 };
 use model::machine_interface_address::MachineInterfaceAssociation;
 use model::network_segment::NetworkSegmentType;
@@ -42,7 +43,6 @@ use crate::site_explorer::SiteExplorerConfig;
 use crate::site_explorer::explored_endpoint_index::ExploredEndpointIndex;
 use crate::site_explorer::managed_host::ManagedHost;
 use crate::site_explorer::metrics::SiteExplorationMetrics;
-use crate::state_controller::machine::io::CURRENT_STATE_MODEL_VERSION;
 use crate::{CarbideError, CarbideResult};
 
 pub struct MachineCreator {

--- a/crates/api/src/state_controller/machine/io.rs
+++ b/crates/api/src/state_controller/machine/io.rs
@@ -33,9 +33,6 @@ use crate::state_controller::io::StateControllerIO;
 use crate::state_controller::machine::context::MachineStateHandlerContextObjects;
 use crate::state_controller::machine::metrics::MachineMetricsEmitter;
 
-// This should be updated on each new model introduction
-pub const CURRENT_STATE_MODEL_VERSION: i16 = 2;
-
 /// State Controller IO implementation for Machines
 #[derive(Default, Debug)]
 pub struct MachineStateControllerIO {


### PR DESCRIPTION
## Description

It's a data model version constant and belongs next to ManagedHostStateSnapshot, not inside state_controller::machine::io. All call sites updated.

Removes one more carbide-api coupling from site_explorer.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes