### PR TITLE
fix: don't import VPC VRFs when there aren't any VPCs

### DIFF
--- a/crates/agent/src/nvue.rs
+++ b/crates/agent/src/nvue.rs
@@ -1919,4 +1919,42 @@ mod tests {
             include_str!("../templates/tests/nvue_build_fnn_dual_stack.yaml.expected"),
         );
     }
+
+    /// `serde_yaml::Value::Null` indicates a YAML key with no value (i.e. a
+    /// bare `key:` followed by nothing). In cases like this, YAML parsing fails,
+    /// and NVUE subsequently rejects with something like `Error: 'set' operation
+    /// values must not be 'null'`.
+    /// This helper exists so we can check for empty leaf renderings in general for
+    /// any tests that would like to check for such a situation.
+    fn has_null_leaf(v: &serde_yaml::Value) -> bool {
+        match v {
+            serde_yaml::Value::Null => true,
+            serde_yaml::Value::Mapping(m) => m.values().any(has_null_leaf),
+            serde_yaml::Value::Sequence(s) => s.iter().any(has_null_leaf),
+            _ => false,
+        }
+    }
+
+    /// When a DPU has no tenant VPCs assigned, the rendered FNN YAML must contain
+    /// no null config leaves (like a `list:` with no entries, or `from-vrf:` with
+    /// no subsequent config, etc).
+    #[test]
+    fn test_build_fnn_with_no_vpcs_emits_no_yaml_nulls() {
+        let mut conf = minimal_nvue_config();
+        conf.is_fnn = true;
+        conf.vpc_virtualization_type = VpcVirtualizationType::Fnn;
+        // For this one, we'll intentionally leave ct_port_configs / ct_access_vlans empty
+        // to ensure $tenant.Vpcs is empty in the template, and that route-import
+        // blocks that would otherwise have an empty VPC VRF list are excluded.
+        assert!(conf.ct_port_configs.is_empty());
+
+        let output = build(conf).expect("build should succeed with empty ct_port_configs");
+        let parsed: serde_yaml::Value =
+            serde_yaml::from_str(&output).expect("rendered YAML must parse");
+
+        assert!(
+            !has_null_leaf(&parsed),
+            "rendered YAML contains a null leaf:\n\n{output}"
+        );
+    }
 }

--- a/crates/agent/templates/nvue_startup_fnn.conf
+++ b/crates/agent/templates/nvue_startup_fnn.conf
@@ -633,7 +633,9 @@
                     includes a broad filter for permitted tenant-announcemed prefixes.                               
                     When we implement per-tenant announcement controls, we could gate the VRF imports to only happen 
                     if there is at least one VPC leaking host routes or accepting tenant announcements.              
+                    If there are no VPCs, then skip this block entirely.
 */}}
+                {{- if $tenant.Vpcs }}
                 route-import:
                   from-vrf:
                     route-map: leak_to_underlay
@@ -642,6 +644,7 @@
                     {{- range $vpc := $tenant.Vpcs }}
                       {{ $vpc.VrfName }}: {}
                     {{- end}}
+                {{- end}}
               ipv6-unicast:
                 enable: on
                 multipaths:
@@ -654,7 +657,9 @@
                     includes a broad filter for permitted tenant-announcemed prefixes.                               
                     When we implement per-tenant announcement controls, we could gate the VRF imports to only happen 
                     if there is at least one VPC leaking host routes or accepting tenant announcements.              
+                    If there are no VPCs, then skip this block entirely.
 */}}
+                {{- if $tenant.Vpcs }}
                 route-import:
                   from-vrf:
                     route-map: leak_to_underlay_ipv6
@@ -663,6 +668,7 @@
                     {{- range $vpc := $tenant.Vpcs }}
                       {{ $vpc.VrfName }}: {}
                     {{- end}}
+                {{- end}}
               l2vpn-evpn:
                 enable: on
             enable: on


### PR DESCRIPTION
## Description

Small bug fix! https://github.com/NVIDIA/ncx-infra-controller-core/pull/649 introduced some new config options to allow default-route leak support.

### The Problem

The problem is there are a couple of spots that drop a `list:` block with the expectation there are `tenant.Vpcs` to iterate over (to list VRFs to import), but when there are no VPCs, you end up with an empty `list:` that looks like this:

```
                route-import:
                  from-vrf:
                    route-map: leak_to_underlay
                    enable: on
                    list: <-- the problem
              ipv6-unicast:
```

...which breaks the YAML parser, and we get an error, which shows up in logs:

```
level=ERROR msg="update_nvue post command failed: cmd 'ip vrf exec mgmt
crictl exec <hbn-container-id> nv config replace
/var/support/nvue_startup.yaml' failed with status: exit status: 1, stderr:
Error: 'set' operation values must not be 'null'.
execing command in container <hbn-container-id>: command terminated with
exit code 1, stdout: " location="crates/agent/src/nvue.rs:754"
level=ERROR msg="Writing network configuration" error="..."
location="crates/agent/src/main_loop.rs:801"
```

### The Fix

The fix is to wrap the entire `route-import:` block in an `{{- if $tenant.Vpcs }} ... {{- end}}`. When there are no tenant VPCs, the import section is omitted.

Verified this by actually modifying + reloading the config on one of the broken DPUs to make sure the fix was the fix.

I had *also* tried to just block off the `from-vrf:` section, but that leaves you with an empty `route-import:` block, and puts you back in the same spot. The fix is to just drop the entire `route-import` block that we're adding entirely (which was the thing added in the original PR).

..and then once the DPU is fed VPCs, the agent will fill it all back out.

Also added a test + generic test helper while I'm in here!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

