### PR TITLE
fix(api): distinguish empty vs multiple domains in create_initial_networks

### DIFF
--- a/crates/api/src/db_init.rs
+++ b/crates/api/src/db_init.rs
@@ -69,7 +69,11 @@ pub async fn create_initial_networks(
         ObjectColumnFilter::<db::dns::domain::IdColumn>::All,
     )
     .await?;
-    if all_domains.len() != 1 {
+    if all_domains.is_empty() {
+        tracing::warn!("No domain configured, skipping initial network creation");
+        return Ok(());
+    }
+    if all_domains.len() > 1 {
         // We only create initial networks if we only have a single domain - usually created
         // as initial_domain_name in config file.
         // Having multiple domains is fine, it means we probably created the network much


### PR DESCRIPTION
## Description

- `create_initial_networks` previously logged "Multiple domains, skipping..." whenever `all_domains.len() != 1`,
  which is misleading when `initial_domain_name` is not configured and zero domains exist.
- Split the check: empty domains now warns "No domain configured", multiple domains keeps the original message.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

