### PR TITLE
fix: boot-MAC plumbing + optional "primary" ExpectedHostNic

### DIFF
--- a/crates/admin-cli/src/expected_machines/add/args.rs
+++ b/crates/admin-cli/src/expected_machines/add/args.rs
@@ -148,6 +148,7 @@ impl TryFrom<Args> for rpc::forge::ExpectedMachine {
             description: value.meta_description.unwrap_or_default(),
             labels,
         };
+
         let host_nics = value
             .host_nics
             .map(|s| serde_json::from_str::<Vec<MacAddress>>(&s))
@@ -160,6 +161,7 @@ impl TryFrom<Args> for rpc::forge::ExpectedMachine {
                 fixed_ip: None,
                 fixed_mask: None,
                 fixed_gateway: None,
+                primary: None,
             })
             .collect();
 

--- a/crates/api-db/src/expected_machine.rs
+++ b/crates/api-db/src/expected_machine.rs
@@ -90,12 +90,13 @@ pub async fn find_by_host_mac_address(
     txn: &mut PgConnection,
     host_mac_address: MacAddress,
 ) -> DatabaseResult<Option<ExpectedMachine>> {
-    let sql = "SELECT * FROM expected_machines WHERE host_nics->>'mac_address'=$1";
-    sqlx::query_as(sql)
-        .bind(host_mac_address.to_string().to_ascii_lowercase())
+    let query = "SELECT * FROM expected_machines WHERE host_nics @> $1::jsonb";
+    let mac_address = serde_json::json!([{ "mac_address": host_mac_address.to_string() }]);
+    sqlx::query_as(query)
+        .bind(sqlx::types::Json(mac_address))
         .fetch_optional(txn)
         .await
-        .map_err(|err| DatabaseError::query(sql, err))
+        .map_err(|err| DatabaseError::query(query, err))
 }
 
 pub async fn find_one_linked(

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -278,14 +278,33 @@ pub async fn find_one(
 }
 
 // Returns (MachineInterface, newly_created_interface).
-// newly_created_interface indicates that we couldn't find a MachineInterface so created new
-// one.
+// newly_created_interface indicates that we couldn't find a
+// MachineInterface, so created new one.
+//
+// `is_primary` integrates `ExpectedHostNic.primary` into machine
+// interface creation. If True, this NIC is declared the primary
+// boot NIC (which is/was the previous default behavior anyway,
+// meaning None does the same thing), and this is fine, because
+// at the end of the day, site-explorer will end up demoting it
+// as part of attaching a DPU.
+//
+// Now, if it's *False*, there's a different NIC on this host declared
+// as the boot NIC, so we actually overide the new interface and
+// explicitly mark it as non-primary here. We *could* bake this in
+// as part of validate_existing_mac_and_create, but since this is
+// the only call-site that cares about it, I'm making it specific
+// to here.
+// TODO(chet): ...but consider plumbing it through.
+//
+// If we're not making a new interface, then existing interfaces
+// are returned untouched.
 pub async fn find_or_create_machine_interface(
     txn: &mut PgConnection,
     machine_id: Option<MachineId>,
     mac_address: MacAddress,
     relay: IpAddr,
     host_nic: Option<ExpectedHostNic>,
+    is_primary: Option<bool>,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
     match machine_id {
         None => {
@@ -294,7 +313,17 @@ pub async fn find_or_create_machine_interface(
                 %relay,
                 "Found no existing machine with mac address {mac_address} using network with relay {relay}",
             );
-            Ok(validate_existing_mac_and_create(&mut *txn, mac_address, relay, host_nic).await?)
+            // validate_existing_mac_and_create hardcodes primary_interface: true
+            // at creation. If the caller has explicitly declared a *different*
+            // NIC as this machine's primary (i.e. is_primary == false), override the
+            // true/default here.
+            let mut interface =
+                validate_existing_mac_and_create(&mut *txn, mac_address, relay, host_nic).await?;
+            if is_primary == Some(false) && interface.primary_interface {
+                set_primary_interface(&interface.id, false, &mut *txn).await?;
+                interface.primary_interface = false;
+            }
+            Ok(interface)
         }
         Some(_) => {
             let mut ifcs = find_by_mac_address(&mut *txn, mac_address).await?;
@@ -1109,7 +1138,8 @@ pub async fn create_host_machine_dpu_interface_proactively(
     let existing_machine = crate::machine::find_existing_machine(txn, host_mac, gateway).await?;
 
     let machine_interface =
-        find_or_create_machine_interface(txn, existing_machine, host_mac, gateway, None).await?;
+        find_or_create_machine_interface(txn, existing_machine, host_mac, gateway, None, None)
+            .await?;
     associate_interface_with_dpu_machine(&machine_interface.id, dpu_id, txn).await?;
 
     Ok(machine_interface)

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -70,6 +70,15 @@ pub struct ExpectedHostNic {
     pub fixed_ip: Option<String>,
     pub fixed_mask: Option<String>,
     pub fixed_gateway: Option<String>,
+    /// When true, `primary` flags this NIC as the host's boot (primary)
+    /// interface. At most one NIC per ExpectedMachine may be marked primary
+    /// (which is enforced in the API). This ultimately propagates into the
+    /// machine_interfaces table, but, in today's world, only really applies
+    /// to zero-DPU. A machine *with* a DPU will end up taking over when
+    /// site-explorer finds a DPU for the machine (and update the primary
+    /// interface accordingly).
+    #[serde(default)]
+    pub primary: Option<bool>,
 }
 
 // Important : new fields for expected machine should be Optional _and_ #[serde(default)],
@@ -156,6 +165,7 @@ impl From<ExpectedHostNic> for rpc::forge::ExpectedHostNic {
             fixed_ip: expected_host_nic.fixed_ip,
             fixed_mask: expected_host_nic.fixed_mask,
             fixed_gateway: expected_host_nic.fixed_gateway,
+            primary: expected_host_nic.primary,
         }
     }
 }
@@ -168,6 +178,7 @@ impl From<rpc::forge::ExpectedHostNic> for ExpectedHostNic {
             fixed_ip: expected_host_nic.fixed_ip,
             fixed_mask: expected_host_nic.fixed_mask,
             fixed_gateway: expected_host_nic.fixed_gateway,
+            primary: expected_host_nic.primary,
         }
     }
 }

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -238,6 +238,40 @@ impl From<ManagedHostStateSnapshotError> for sqlx::Error {
     }
 }
 
+/// Pick the MAC address the host should boot from, given its interfaces.
+///
+/// See `ManagedHostStateSnapshot::boot_interface_mac` for the caller-facing
+/// details. I split this out as a function so it can be unit-tested directly
+/// without constructing a full `ManagedHostStateSnapshot`.
+///
+/// Ordering:
+/// 1. Any interface with `primary_interface == true` wins. This is the
+///    path operators can drive explicitly via `ExpectedHostNic.primary`,
+///    in the case of zero DPU hosts, and is also how hosts with DPU(s)
+///    end up with a boot MAC automatically during site-explorer ingestion.
+/// 2. If there's no primary interface, the interface outside the management
+///    segment with the "smallest" MAC address wins -- mainly so we can
+///    have some sense of a stable MAC for zero-DPU hosts where no operator
+///    explicitly declared a primary NIC (and ingestion didn't assign one either).
+/// 3. `None` -- This is the "I don't have any candidate interfaces yet" case,
+///    so it's on the caller to figure out. What this usually means is the
+///    caller passes `boot_interface_mac: None` to machine_setup, and then
+///    subsequent logic flows from there (e.g. ::NoDpu handling).
+fn pick_boot_interface_mac(
+    interfaces: &[MachineInterfaceSnapshot],
+) -> Option<mac_address::MacAddress> {
+    // The primary wins!
+    if let Some(primary) = interfaces.iter().find(|x| x.primary_interface) {
+        return Some(primary.mac_address);
+    }
+    // ..no primary, so lets try to find *some* interface.
+    interfaces
+        .iter()
+        .filter(|x| x.network_segment_type != Some(NetworkSegmentType::Underlay))
+        .min_by_key(|x| x.mac_address)
+        .map(|x| x.mac_address)
+}
+
 impl ManagedHostStateSnapshot {
     /// Returns `true` if this managed host has no DPU snapshots attached.
     ///
@@ -271,7 +305,28 @@ impl ManagedHostStateSnapshot {
         self.dpu_snapshots.is_empty()
     }
 
-    /// Returns `true` if override report is hw_health, `false` otherwise
+    /// Returns the MAC address the host should boot from, if one can be
+    /// determined from this snapshot.
+    ///
+    /// For hosts with DPUs, this is the DPU-facing "primary" `machine_interface`,
+    /// flagged as `primary_interface: true` during site-explorer ingestion.
+    ///
+    /// For zero-DPU hosts, the `primary_interface` flag is not (yet) set at
+    /// ingestion time, so this method "falls back" to the first non-underlay
+    /// `machine_interface` (i.e. not the BMC) sorted deterministically by MAC.
+    ///
+    /// Returns `None` if the host has no non-underlay interfaces yet -- e.g.
+    /// only the BMC has been discovered, or the host's primary NIC hasn't
+    /// DHCP'd yet.
+    ///
+    /// This helper exists to centralize the boot MAC selection logic that used
+    /// to be duplicated at every state controller callsite needing to pass a MAC
+    /// into things like machine_setup, is_bios_setup, etc.
+    pub fn boot_interface_mac(&self) -> Option<mac_address::MacAddress> {
+        pick_boot_interface_mac(&self.host_snapshot.interfaces)
+    }
+
+    /// Returns `true` if override report is hw_health, `false` otherwise.
     fn merge_override_report_with_hw_health(
         output: &mut HealthReport,
         source: &str,
@@ -3139,6 +3194,77 @@ mod tests {
         let rpc_info: rpc::forge::DpuInfo = info.into();
         assert_eq!(rpc_info.id, "dpu-123");
         assert_eq!(rpc_info.loopback_ip, "10.0.0.1");
+    }
+
+    /// Build a mock `MachineInterfaceSnapshot` with the fields
+    /// `pick_boot_interface_mac` actually inspects (MAC, primary flag,
+    /// segment type) set, and everything else left at the mock default.
+    fn build_mock_interface(
+        mac: &str,
+        primary: bool,
+        segment_type: Option<NetworkSegmentType>,
+    ) -> MachineInterfaceSnapshot {
+        MachineInterfaceSnapshot {
+            primary_interface: primary,
+            network_segment_type: segment_type,
+            ..MachineInterfaceSnapshot::mock_with_mac(mac.parse().unwrap())
+        }
+    }
+
+    // Whichever interface is flagged `primary_interface` wins, regardless
+    // of MAC ordering or segment type of the other interfaces. This covers
+    // both paths that can set the flag, whether it be site-explorer w/ DPU
+    // ingestion, or operator-driven `ExpectedHostNic.primary` for zero-DPU
+    // hosts.
+    #[test]
+    fn pick_boot_interface_mac_returns_primary_interface_when_set() {
+        let primary_mac = "10:00:00:00:00:01";
+        let other_mac = "05:00:00:00:00:01"; // numerically lower but not primary
+        let interfaces = vec![
+            build_mock_interface(other_mac, false, Some(NetworkSegmentType::HostInband)),
+            build_mock_interface(primary_mac, true, Some(NetworkSegmentType::Admin)),
+        ];
+
+        assert_eq!(
+            pick_boot_interface_mac(&interfaces),
+            Some(primary_mac.parse().unwrap())
+        );
+    }
+
+    // This is our zero DPU fallback case -- no interface is flagged primary,
+    // so pick the lowest-MAC non-underlay interface. Verifies (a) the underlay
+    // BMC interface is excluded, and (b) ordering is deterministic across
+    // multiple non-underlay candidates.
+    #[test]
+    fn pick_boot_interface_mac_falls_back_to_lowest_non_underlay_mac_when_no_primary() {
+        let bmc_mac = "01:00:00:00:00:01"; // numerically lowest, but BMC!
+        let onboard_mac_lo = "10:00:00:00:00:01";
+        let onboard_mac_hi = "20:00:00:00:00:01";
+        let interfaces = vec![
+            build_mock_interface(bmc_mac, false, Some(NetworkSegmentType::Underlay)),
+            build_mock_interface(onboard_mac_hi, false, Some(NetworkSegmentType::HostInband)),
+            build_mock_interface(onboard_mac_lo, false, Some(NetworkSegmentType::HostInband)),
+        ];
+
+        assert_eq!(
+            pick_boot_interface_mac(&interfaces),
+            Some(onboard_mac_lo.parse().unwrap())
+        );
+    }
+
+    // Check the case  where only the BMC has been discovered so far (which
+    // is common during early ingestion). In this case, there's no valid boot MAC
+    // yet; callers fall back to the `::NoDpu` handling downstream.
+    #[test]
+    fn pick_boot_interface_mac_returns_none_when_only_underlay_interfaces() {
+        let bmc_mac = "01:00:00:00:00:01";
+        let interfaces = vec![build_mock_interface(
+            bmc_mac,
+            false,
+            Some(NetworkSegmentType::Underlay),
+        )];
+
+        assert_eq!(pick_boot_interface_mac(&interfaces), None);
     }
 }
 

--- a/crates/api/src/dhcp/discover.rs
+++ b/crates/api/src/dhcp/discover.rs
@@ -184,6 +184,11 @@ pub async fn discover_dhcp(
     let relay_ip = IpAddr::from_str(&relay_address)?;
     let address_family = relay_ip.address_family();
     let mut host_nic: Option<ExpectedHostNic> = None;
+    // `is_primary_nic` reflects the matched ExpectedHostNic's `primary` flag.
+    // - `Some(true)` -- the operator flagged this NIC as the host's boot interface.
+    // - `Some(false)` -- another NIC on this host is the declared primary.
+    // - `None` -- no declaration, use the default at interface creation time.
+    let mut is_primary_nic: Option<bool> = None;
 
     let parsed_mac: MacAddress = mac_address.parse()?;
 
@@ -236,10 +241,20 @@ pub async fn discover_dhcp(
                                     .map_err(CarbideError::from)?;
                             if let Some(m) = expected_machine {
                                 // select ip segment from Underlay for BMC, Admin for BF3/Onboard
-                                for nic in m.data.host_nics {
+                                for nic in &m.data.host_nics {
                                     if nic.mac_address == parsed_mac {
-                                        host_nic = Some(nic);
+                                        host_nic = Some(nic.clone());
                                     }
+                                }
+                                // If any NIC on this host declares primary=true,
+                                // then this NIC is primary iff it's that one.
+                                // Handler-side validation keeps at most one
+                                // primary=true per ExpectedMachine.
+                                if let Some(declared_primary) =
+                                    m.data.host_nics.iter().find(|n| n.primary == Some(true))
+                                {
+                                    is_primary_nic =
+                                        Some(declared_primary.mac_address == parsed_mac);
                                 }
                             }
                         }
@@ -255,6 +270,7 @@ pub async fn discover_dhcp(
         parsed_mac,
         parsed_relay,
         host_nic,
+        is_primary_nic,
     )
     .await?;
 

--- a/crates/api/src/handlers/expected_machine.rs
+++ b/crates/api/src/handlers/expected_machine.rs
@@ -17,7 +17,9 @@
 use ::rpc::forge as rpc;
 use lazy_static::lazy_static;
 use mac_address::MacAddress;
-use model::expected_machine::{ExpectedMachine, ExpectedMachineData, ExpectedMachineRequest};
+use model::expected_machine::{
+    ExpectedHostNic, ExpectedMachine, ExpectedMachineData, ExpectedMachineRequest,
+};
 use regex::Regex;
 use uuid::Uuid;
 
@@ -108,6 +110,8 @@ pub(crate) async fn add(
         data: db_data,
     };
 
+    validate_at_most_one_primary_host_nic(&machine.data.host_nics)?;
+
     let mut txn = api.txn_begin().await?;
 
     // Pre-allocate BMC interface if bmc_ip_address is set.
@@ -191,6 +195,8 @@ pub(crate) async fn update(
         bmc_mac_address: parsed_mac,
         data,
     };
+
+    validate_at_most_one_primary_host_nic(&machine.data.host_nics)?;
 
     let mut txn = api.txn_begin().await?;
 
@@ -282,6 +288,26 @@ pub(crate) async fn delete_all(
     txn.commit().await?;
 
     Ok(tonic::Response::new(()))
+}
+
+/// Rejects an ExpectedMachine payload that declares more than one host NIC
+/// with `primary: true`, returning an InvalidArgument if found.
+fn validate_at_most_one_primary_host_nic(
+    host_nics: &[ExpectedHostNic],
+) -> Result<(), CarbideError> {
+    let primaries: Vec<_> = host_nics
+        .iter()
+        .filter(|n| n.primary == Some(true))
+        .map(|n| n.mac_address.to_string())
+        .collect();
+    if primaries.len() > 1 {
+        return Err(CarbideError::InvalidArgument(format!(
+            "at most one host_nic may be flagged primary=true, got {}: {}",
+            primaries.len(),
+            primaries.join(", ")
+        )));
+    }
+    Ok(())
 }
 
 /// Helper function to sanitize expected machine and return parsed IDs (ID+MAC)

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -1450,6 +1450,19 @@ impl MachineStateHandler {
                 }
             }
             ManagedHostState::DPUReprovision { .. } => {
+                // Reaching host-level DPUReprovision with no DPUs is an
+                // invariant violation -- the caller (Ready handler) only
+                // enters this state when `dpu_reprovisioning_needed()` is
+                // true, which requires non-empty DPUs. Without this guard
+                // the empty loop below falls through to `do_nothing()` and
+                // the host would sit in DPUReprovision forever.
+                if mh_snapshot.is_zero_dpu() {
+                    return Err(StateHandlerError::GenericError(eyre!(
+                        "DPUReprovision state entered on zero-DPU host {host_machine_id}; \
+                         reprovision requires DPUs"
+                    )));
+                }
+
                 for dpu_snapshot in &mh_snapshot.dpu_snapshots {
                     // TODO: Optimization Possible: We can have another outcome something like
                     // TransitionNotPossible. This will be valid for the sync states (States where
@@ -4749,22 +4762,8 @@ impl StateHandler for HostMachineStateHandler {
                         .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)
                         .await?;
 
-                    let boot_interface_mac = if !mh_snapshot.is_zero_dpu() {
-                        let primary_interface = mh_snapshot
-                            .host_snapshot
-                            .interfaces
-                            .iter()
-                            .find(|x| x.primary_interface)
-                            .ok_or_else(|| {
-                                StateHandlerError::GenericError(eyre::eyre!(
-                                    "Missing primary interface from host: {}",
-                                    mh_snapshot.host_snapshot.id
-                                ))
-                            })?;
-                        Some(primary_interface.mac_address.to_string())
-                    } else {
-                        None
-                    };
+                    let boot_interface_mac =
+                        mh_snapshot.boot_interface_mac().map(|m| m.to_string());
 
                     match redfish_client
                         .is_bios_setup(boot_interface_mac.as_deref())
@@ -8967,12 +8966,15 @@ fn can_restart_reprovision(dpu_snapshots: &[Machine], version: ConfigVersion) ->
     dpu_reprovision_restart_requested_after_state_transition(version, *latest_requested_at)
 }
 
-/// Call [`Redfish::machine_setup`], but ignore any [`RedfishError::NoDpu`] if we expect there to be no DPUs.
+/// Call machine_setup, but ignore any RedfishError::NoDpu if we expect there
+/// to be no DPUs.
 ///
-/// TODO(ken): This is a temporary workaround for work-in-progress on zero-DPU support (August 2024)
-/// The way we should do this going forward is to plumb the actual non-DPU MAC address we want to
-/// boot from, but that information is not in scope at this time. Once it is, and we pass it to
-/// machine_setup, we should no longer expect a NoDpu error and can thus call vanilla machine_setup again.
+/// So, callers can *now* plumb a "dumb" host-NIC MAC for zero-DPU hosts via
+/// boot_interface_mac(), meaning the ::NoDpu handling below is expected to
+/// fire only when `machine_setup` has DPU-specific assumptions beyond the MAC
+/// (e.g. Attribute-path checks that still require a DPU to be present). When
+/// that dependency is fully removed, this wrapper can collapse into a plain
+/// `machine_setup` call.
 async fn call_machine_setup_and_handle_no_dpu_error(
     redfish_client: &dyn Redfish,
     boot_interface_mac: Option<&str>,
@@ -9458,22 +9460,7 @@ async fn handle_instance_host_platform_config(
                 },
             };
 
-            let boot_interface_mac = if !mh_snapshot.is_zero_dpu() {
-                let primary_interface = mh_snapshot
-                    .host_snapshot
-                    .interfaces
-                    .iter()
-                    .find(|x| x.primary_interface)
-                    .ok_or_else(|| {
-                        StateHandlerError::GenericError(eyre::eyre!(
-                            "Missing primary interface from host: {}",
-                            mh_snapshot.host_snapshot.id
-                        ))
-                    })?;
-                Some(primary_interface.mac_address.to_string())
-            } else {
-                None
-            };
+            let boot_interface_mac = mh_snapshot.boot_interface_mac().map(|m| m.to_string());
 
             match redfish_client
                 .is_bios_setup(boot_interface_mac.as_deref())
@@ -9555,23 +9542,7 @@ async fn configure_host_bios(
     redfish_client: &dyn Redfish,
     mh_snapshot: &ManagedHostStateSnapshot,
 ) -> Result<BiosConfigOutcome, StateHandlerError> {
-    let boot_interface_mac = if !mh_snapshot.is_zero_dpu() {
-        let primary_interface = mh_snapshot
-            .host_snapshot
-            .interfaces
-            .iter()
-            .find(|x| x.primary_interface)
-            .ok_or_else(|| {
-                StateHandlerError::GenericError(eyre::eyre!(
-                    "Missing primary interface from host: {}",
-                    mh_snapshot.host_snapshot.id
-                ))
-            })?;
-        Some(primary_interface.mac_address.to_string())
-    } else {
-        // This is the Zero-DPU case
-        None
-    };
+    let boot_interface_mac = mh_snapshot.boot_interface_mac().map(|m| m.to_string());
 
     if let Err(e) = call_machine_setup_and_handle_no_dpu_error(
         redfish_client,

--- a/crates/api/src/tests/expected_machine.rs
+++ b/crates/api/src/tests/expected_machine.rs
@@ -16,7 +16,9 @@
  */
 use std::default::Default;
 
-use common::api_fixtures::create_test_env;
+use common::api_fixtures::{
+    TestEnvOverrides, create_test_env, create_test_env_with_overrides, get_config,
+};
 use db::{self};
 use mac_address::MacAddress;
 use model::expected_machine::{ExpectedMachine, ExpectedMachineData};
@@ -2096,6 +2098,7 @@ async fn test_add_with_host_nic_fixed_ip_creates_interface(
                 fixed_ip: Some(fixed_ip.into()),
                 fixed_mask: None,
                 fixed_gateway: None,
+                primary: None,
             }],
             ..Default::default()
         }))
@@ -2150,6 +2153,7 @@ async fn test_dhcp_discover_uses_fixed_ip_from_host_nics(
                 fixed_ip: Some(fixed_ip.into()),
                 fixed_mask: None,
                 fixed_gateway: None,
+                primary: None,
             }],
             ..Default::default()
         }))
@@ -2271,6 +2275,186 @@ async fn test_update_preserves_bmc_retain_credentials(
         Some(true),
         "bmc_retain_credentials should be preserved after update with None"
     );
+
+    Ok(())
+}
+
+/// When an ExpectedMachine's host_nics entry is flagged `primary: true`,
+/// the matching NIC's DHCP should land as `machine_interfaces.primary_interface=true`.
+#[crate::sqlx_test]
+async fn test_dhcp_honors_primary_host_nic(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // rack_management_enabled is required for discover_dhcp to consult
+    // ExpectedMachine records for unknown MACs -- that's the path that
+    // reads the matched host_nic's `primary` flag.
+    let env = {
+        let mut config = get_config();
+        config.rack_management_enabled = true;
+        create_test_env_with_overrides(pool, TestEnvOverrides::with_config(config)).await
+    };
+    let bmc_mac: MacAddress = "9A:9B:9C:9D:9E:01".parse().unwrap();
+    let primary_mac: MacAddress = "9A:9B:9C:9D:9E:02".parse().unwrap();
+
+    env.api
+        .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+            id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: "EM-PRIMARY-001".into(),
+            host_nics: vec![rpc::forge::ExpectedHostNic {
+                mac_address: primary_mac.to_string(),
+                nic_type: Some("onboard".into()),
+                fixed_ip: None,
+                fixed_mask: None,
+                fixed_gateway: None,
+                primary: Some(true),
+            }],
+            ..Default::default()
+        }))
+        .await?;
+
+    // DHCP discover with the declared primary MAC.
+    let primary_mac_str = primary_mac.to_string();
+    env.api
+        .discover_dhcp(
+            common::rpc_builder::DhcpDiscovery::builder(
+                &primary_mac_str,
+                common::api_fixtures::FIXTURE_DHCP_RELAY_ADDRESS,
+            )
+            .tonic_request(),
+        )
+        .await?;
+
+    // Verify the created machine_interface is flagged primary=true.
+    let mut txn = env.pool.begin().await?;
+    let ifaces = db::machine_interface::find_by_mac_address(&mut *txn, primary_mac).await?;
+    assert_eq!(ifaces.len(), 1);
+    assert!(
+        ifaces[0].primary_interface,
+        "host_nic primary=true should flow to machine_interfaces.primary_interface"
+    );
+
+    Ok(())
+}
+
+/// When one host_nics entry is flagged `primary: true`, a DHCP from a
+/// *different* MAC on the same host should land as `primary_interface: false`.
+/// Verifies the "operator declared some other NIC primary, so this one
+/// must not inherit the default primary=true" branch, protecting the DB's
+/// one_primary_interface_per_machine unique constraint once the primary
+/// MAC's interface eventually lands.
+#[crate::sqlx_test]
+async fn test_dhcp_marks_non_primary_mac_as_non_primary(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = {
+        let mut config = get_config();
+        config.rack_management_enabled = true;
+        create_test_env_with_overrides(pool, TestEnvOverrides::with_config(config)).await
+    };
+    let bmc_mac: MacAddress = "9A:9B:9C:9D:9E:10".parse().unwrap();
+    let primary_mac: MacAddress = "9A:9B:9C:9D:9E:11".parse().unwrap();
+    let other_mac: MacAddress = "9A:9B:9C:9D:9E:12".parse().unwrap();
+
+    env.api
+        .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+            id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: "EM-PRIMARY-002".into(),
+            host_nics: vec![
+                rpc::forge::ExpectedHostNic {
+                    mac_address: primary_mac.to_string(),
+                    nic_type: Some("onboard".into()),
+                    fixed_ip: None,
+                    fixed_mask: None,
+                    fixed_gateway: None,
+                    primary: Some(true),
+                },
+                rpc::forge::ExpectedHostNic {
+                    mac_address: other_mac.to_string(),
+                    nic_type: Some("onboard".into()),
+                    fixed_ip: None,
+                    fixed_mask: None,
+                    fixed_gateway: None,
+                    primary: None,
+                },
+            ],
+            ..Default::default()
+        }))
+        .await?;
+
+    // DHCP for the non-primary MAC on this machine.
+    let other_mac_str = other_mac.to_string();
+    env.api
+        .discover_dhcp(
+            common::rpc_builder::DhcpDiscovery::builder(
+                &other_mac_str,
+                common::api_fixtures::FIXTURE_DHCP_RELAY_ADDRESS,
+            )
+            .tonic_request(),
+        )
+        .await?;
+
+    let mut txn = env.pool.begin().await?;
+    let ifaces = db::machine_interface::find_by_mac_address(&mut *txn, other_mac).await?;
+    assert_eq!(ifaces.len(), 1);
+    assert!(
+        !ifaces[0].primary_interface,
+        "a MAC that isn't the declared primary should not land as primary_interface=true"
+    );
+
+    Ok(())
+}
+
+/// An ExpectedMachine with two host_nics entries both flagged `primary: true`
+/// must be rejected at the API boundary -- the handler enforces at most one
+/// primary NIC per machine (anchoring the DB's `one_primary_interface_per_machine`
+/// unique constraint to a single declaration).
+#[crate::sqlx_test]
+async fn test_add_rejects_multiple_primary_host_nics(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "9A:9B:9C:9D:9E:20".parse().unwrap();
+    let mac_a: MacAddress = "9A:9B:9C:9D:9E:21".parse().unwrap();
+    let mac_b: MacAddress = "9A:9B:9C:9D:9E:22".parse().unwrap();
+
+    let result = env
+        .api
+        .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+            id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: "EM-DUPLICATE-PRIMARY-001".into(),
+            host_nics: vec![
+                rpc::forge::ExpectedHostNic {
+                    mac_address: mac_a.to_string(),
+                    nic_type: Some("onboard".into()),
+                    fixed_ip: None,
+                    fixed_mask: None,
+                    fixed_gateway: None,
+                    primary: Some(true),
+                },
+                rpc::forge::ExpectedHostNic {
+                    mac_address: mac_b.to_string(),
+                    nic_type: Some("onboard".into()),
+                    fixed_ip: None,
+                    fixed_mask: None,
+                    fixed_gateway: None,
+                    primary: Some(true),
+                },
+            ],
+            ..Default::default()
+        }))
+        .await;
+
+    let err = result.expect_err("multi-primary ExpectedMachine should be rejected");
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
 
     Ok(())
 }

--- a/crates/api/src/tests/machine_states.rs
+++ b/crates/api/src/tests/machine_states.rs
@@ -2044,3 +2044,42 @@ async fn test_dpu_reprovision_errors_for_zero_dpu(
     ));
     Ok(())
 }
+
+/// Host-level `ManagedHostState::DPUReprovision` (different from the
+/// instance-scoped `InstanceState::DPUReprovision` covered above) is only
+/// entered from `Ready` when `dpu_reprovisioning_needed()` returns true;
+/// this requires non-empty DPUs. Reaching it with a zero-DPU host is a
+/// bug: without the explicit guard the empty loop would fall through
+/// to `do_nothing()` and the host would sit in the state forever.
+/// Verify the guard surfaces a loud error instead.
+#[crate::sqlx_test]
+async fn test_host_level_dpu_reprovision_errors_for_zero_dpu(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (env, mh) = zero_dpu_host_with_instance(pool).await;
+
+    let mut txn = env.db_txn().await;
+    db::machine::update_state(
+        txn.as_mut(),
+        &mh.host().id,
+        &ManagedHostState::DPUReprovision {
+            dpu_states: DpuReprovisionStates {
+                states: HashMap::new(),
+            },
+        },
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    env.run_machine_state_controller_iteration().await;
+
+    // The guard returns an error, which the state controller surfaces as
+    // a handler failure rather than silently advancing. The host stays in
+    // DPUReprovision.
+    assert!(matches!(
+        load_host_state(&env, &mh.host().id).await,
+        ManagedHostState::DPUReprovision { .. }
+    ));
+    Ok(())
+}

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -5171,6 +5171,16 @@ message ExpectedHostNic {
   optional string fixed_ip = 3;
   optional string fixed_mask = 4;
   optional string fixed_gateway = 5;
+  // When true, this flags the given NIC as the host's primary (boot)
+  // interface (used in cases of zero DPU).
+  //
+  // Up to one NIC per ExpectedMachine may be marked primary, if set at
+  // all. Propagates to `machine_interfaces.primary_interface` during DHCP
+  // when this NIC is first discovered.
+  //
+  // Some day this could be even possibly used to say "this dumb NIC
+  // *is* the primary interface, even though I know I have a DPU."
+  optional bool primary = 6;
 }
 
 message ExpectedMachine {


### PR DESCRIPTION
## Description

For a machine with a DPU, the DPU MAC is always the boot interface (at least currently), and every downstream path that needs the host's boot NIC just looks at the DPU. Zero-DPU hosts have no such luxury -- a dumb host NIC sits directly on the physical network -- so operators need a way to tell the system which host NIC should boot. Until now, the only mechanism was an implied one: the DPU, and `machine_interfaces.primary_interface` had no hint other than whichever NIC DHCP'd first.

This change centralizes boot MAC selection on the host-state snapshot side (*which actually takes care of a `TODO` from August 2024 about passing a non-DPU MAC into `machine_setup`*), adds a `DPUReprovision` zero-DPU guard at the instance-state level, and wires a new `primary` flag on `ExpectedHostNic` through to `machine_interfaces.primary_interface` during DHCP.

Operators can now declare a "dumb" host boot NIC by flipping `primary: true` on one entry in the `ExpectedMachine.host_nics` (and yes, the API rejects configs with more than one primary).

Changes included:
 - Centralize boot-MAC selection: `ManagedHostStateSnapshot::boot_interface_mac()` + `pick_boot_interface_mac` pure helper (which closes that August 2024 `TODO`).
 - `DPUReprovision` state-handler guard for zero-DPU hosts (which I meant to do in https://github.com/NVIDIA/ncx-infra-controller-core/pull/1010).
 - `ExpectedHostNic.primary` + handler-side `validate_at_most_one_primary_host_nic`; DHCP propagates through `find_or_create_machine_interface` into `machine_interfaces.primary_interface`.
 - Updated `find_by_host_mac_address` to use `@>` containment like we do other places, partly because the previous query was silently broken anyway (which I noticed during tests).

Unit and integration tests included, including:
 - DHCP lands `primary_interface=true` when the matching `host_nic` has `primary: true`.
 - DHCP demotes `primary_interface=false` when a *different* NIC on the same host is the declared primary (protects the `one_primary_interface_per_machine` unique index).
 - API rejects ExpectedMachine payloads with more than one `primary: true` host_nic (`InvalidArgument`).

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

