### PR TITLE
fix: verify and reset BIOS boot order on zero-DPU hosts

### DIFF
--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -3526,6 +3526,9 @@ impl DpuMachineStateHandler {
                 )
                 .await
                 {
+                    // TODO(chet): I don't know if this is still a thing, but I'm pretty sure
+                    // it hasn't been fixed/addressed yet, and it appears to be logged all over
+                    // the place now.
                     let msg = format!(
                         "redfish machine_setup failed for DPU {}, potentially due to known race condition between UEFI POST and BMC. issuing a force-restart. err: {}",
                         dpu_snapshot.id, e
@@ -9353,63 +9356,57 @@ async fn handle_instance_host_platform_config(
             }
         }
         HostPlatformConfigurationState::CheckHostConfig => {
-            let configure_host_boot_order = if !mh_snapshot.is_zero_dpu() {
-                // Given that we are checking the boot order of a server immediately after a power cycle, we
-                // should do some waiting to ensure that the host is not reporting stale redfish information from
-                // before Carbide powered it off.
-                // This check guarantees that the host has finished loading the BIOS after the DPUs have come up.
-                // If Carbide is still reading an incorrect boot order at this point, something is wrong, and
-                // we should configure this host properly.
-                if !are_dpus_up_trigger_reboot_if_needed(mh_snapshot, reachability_params, ctx)
+            // For hosts with DPU(s), wait for DPU(s) to come up before reading
+            // BIOS state -- the host can report stale Redfish info from before the
+            // power cycle until the DPUs have finished initializing. Zero-DPU
+            // hosts skip this wait, because there are no DPUs to come up.
+            if !mh_snapshot.is_zero_dpu()
+                && !are_dpus_up_trigger_reboot_if_needed(mh_snapshot, reachability_params, ctx)
                     .await
-                {
-                    return Ok(StateHandlerOutcome::wait(
-                        "Waiting for DPUs to come up.".to_string(),
-                    ));
-                }
+            {
+                return Ok(StateHandlerOutcome::wait(
+                    "Waiting for DPUs to come up.".to_string(),
+                ));
+            }
 
-                let primary_interface = mh_snapshot
-                    .host_snapshot
-                    .interfaces
-                    .iter()
-                    .find(|x| x.primary_interface)
-                    .ok_or_else(|| {
-                        StateHandlerError::GenericError(eyre::eyre!(
-                            "Missing primary interface from host: {}",
-                            mh_snapshot.host_snapshot.id
-                        ))
-                    })?;
+            // Resolve the MAC whose interface should be first in the boot
+            // order. For hosts with DPUs, this is the DPU-facing PF (set as
+            // the primary_interface by site-explorer during DPU attach).
+            //
+            // For zero-DPU hosts, it's the operator-declared primary host
+            // NIC (which comes from `ExpectedHostNic.primary`) *or* the
+            // "lowest" deterministic-fallback host NIC.
+            let boot_interface_mac = mh_snapshot.boot_interface_mac().ok_or_else(|| {
+                StateHandlerError::GenericError(eyre::eyre!(
+                    "Missing boot interface MAC for host: {}",
+                    mh_snapshot.host_snapshot.id
+                ))
+            })?;
 
-                let vendor = mh_snapshot.host_snapshot.bmc_vendor();
+            let vendor = mh_snapshot.host_snapshot.bmc_vendor();
 
-                log_host_config(redfish_client.as_ref(), mh_snapshot).await;
+            log_host_config(redfish_client.as_ref(), mh_snapshot).await;
 
-                if !(redfish_client
-                    .is_boot_order_setup(&primary_interface.mac_address.to_string())
-                    .await
-                    .map_err(|e| StateHandlerError::RedfishError {
-                        operation: "is_boot_order_setup",
-                        error: e,
-                    })?)
-                {
-                    tracing::warn!(
-                        machine_id = %mh_snapshot.host_snapshot.id,
-                        bmc_vendor = %vendor,
-                        "Host boot order is not configured properly"
-                    );
-
-                    true
-                } else {
-                    tracing::info!(
-                        machine_id = %mh_snapshot.host_snapshot.id,
-                        bmc_vendor = %vendor,
-                        "Host boot order is configured properly"
-                    );
-
-                    false
-                }
-            } else {
+            let configure_host_boot_order = if redfish_client
+                .is_boot_order_setup(&boot_interface_mac.to_string())
+                .await
+                .map_err(|e| StateHandlerError::RedfishError {
+                    operation: "is_boot_order_setup",
+                    error: e,
+                })? {
+                tracing::info!(
+                    machine_id = %mh_snapshot.host_snapshot.id,
+                    bmc_vendor = %vendor,
+                    "Host boot order is configured properly"
+                );
                 false
+            } else {
+                tracing::warn!(
+                    machine_id = %mh_snapshot.host_snapshot.id,
+                    bmc_vendor = %vendor,
+                    "Host boot order is not configured properly"
+                );
+                true
             };
 
             if configure_host_boot_order {
@@ -9552,6 +9549,9 @@ async fn configure_host_bios(
     )
     .await
     {
+        // TODO(chet): I don't know if this is still a thing, but I'm pretty sure
+        // it hasn't been fixed/addressed yet, and it appears to be logged all over
+        // the place now.
         tracing::warn!(
             "redfish machine_setup failed for {}, potentially due to known race condition between UEFI POST and BMC. triggering force-restart if needed. err: {}",
             mh_snapshot.host_snapshot.id,
@@ -9583,15 +9583,16 @@ async fn configure_host_bios(
             )
             .await?
         };
-        // Return WaitingForReboot instead of Err to ensure the transaction is committed
-        // and last_reboot_requested is persisted. Returning Err would cause a transaction
-        // rollback, leading to a tight reboot loop since the reboot timestamp is lost.
+        // Return WaitingForReboot instead of Err to ensure the transaction is
+        // committed, and last_reboot_requested is persisted. Returning Err would
+        // cause a transaction rollback, leading to a tight reboot loop (since the
+        // reboot timestamp would be lost).
         return Ok(BiosConfigOutcome::WaitingForReboot(format!(
             "redfish machine_setup failed: {e}; triggered host reboot: {reboot_status:#?}"
         )));
     };
 
-    // Host needs to be rebooted to pick up the changes after calling machine_setup
+    // Host needs to be rebooted to pick up the changes after calling machine_setup.
     handler_host_power_control(mh_snapshot, ctx, SystemPowerControl::ForceRestart).await?;
     Ok(BiosConfigOutcome::Done)
 }
@@ -9605,85 +9606,81 @@ async fn set_host_boot_order(
 ) -> Result<SetBootOrderOutcome, StateHandlerError> {
     match set_boot_order_info.set_boot_order_state {
         SetBootOrderState::SetBootOrder => {
-            if mh_snapshot.is_zero_dpu() {
-                // MachineState::SetBootOrder is a NO-OP for the Zero-DPU case
-                Ok(SetBootOrderOutcome::Done)
-            } else {
-                let primary_interface = mh_snapshot
-                    .host_snapshot
-                    .interfaces
-                    .iter()
-                    .find(|x| x.primary_interface)
-                    .ok_or_else(|| {
-                        StateHandlerError::GenericError(eyre::eyre!(
-                            "Missing primary interface from host: {}",
-                            mh_snapshot.host_snapshot.id
-                        ))
-                    })?;
+            // Resolve the boot NIC MAC the same way `CheckHostConfig` does,
+            // supporting hosts with DPU(s) and zero DPUs alike.
+            let boot_interface_mac = mh_snapshot.boot_interface_mac().ok_or_else(|| {
+                StateHandlerError::GenericError(eyre::eyre!(
+                    "Missing boot interface MAC for host: {}",
+                    mh_snapshot.host_snapshot.id
+                ))
+            })?;
 
-                let jid = match set_boot_order_dpu_first_and_handle_no_dpu_error(
-                    redfish_client,
-                    &primary_interface.mac_address.to_string(),
-                    mh_snapshot.host_snapshot.associated_dpu_machine_ids().len(),
-                    &ctx.services.site_config,
-                )
-                .await
-                {
-                    Ok(jid) => jid,
-                    Err(e) => {
-                        tracing::warn!(
-                            "redfish set_boot_order_dpu_first failed for {}, potentially due to known race condition between UEFI POST and BMC. triggering force-restart if needed. err: {}",
-                            mh_snapshot.host_snapshot.id,
-                            e
-                        );
+            let jid = match set_boot_order_dpu_first_and_handle_no_dpu_error(
+                redfish_client,
+                &boot_interface_mac.to_string(),
+                mh_snapshot.host_snapshot.associated_dpu_machine_ids().len(),
+                &ctx.services.site_config,
+            )
+            .await
+            {
+                Ok(jid) => jid,
+                Err(e) => {
+                    // TODO(chet): I don't know if this is still a thing, but I'm pretty sure
+                    // it hasn't been fixed/addressed yet, and it appears to be logged all over
+                    // the place now.
+                    tracing::warn!(
+                        "redfish set_boot_order_dpu_first failed for {}, potentially due to known race condition between UEFI POST and BMC. triggering force-restart if needed. err: {}",
+                        mh_snapshot.host_snapshot.id,
+                        e
+                    );
 
-                        let reboot_status =
-                            if mh_snapshot.host_snapshot.last_reboot_requested.is_none() {
-                                handler_host_power_control(
-                                    mh_snapshot,
-                                    ctx,
-                                    SystemPowerControl::ForceRestart,
-                                )
-                                .await?;
+                    let reboot_status = if mh_snapshot.host_snapshot.last_reboot_requested.is_none()
+                    {
+                        handler_host_power_control(
+                            mh_snapshot,
+                            ctx,
+                            SystemPowerControl::ForceRestart,
+                        )
+                        .await?;
 
-                                RebootStatus {
-                                    increase_retry_count: true,
-                                    status: "Restarted host".to_string(),
-                                }
-                            } else {
-                                trigger_reboot_if_needed(
-                                    &mh_snapshot.host_snapshot,
-                                    mh_snapshot,
-                                    None,
-                                    reachability_params,
-                                    ctx,
-                                )
-                                .await?
-                            };
-
-                        // Log boot options and PCIe device list whenever a fresh reboot is
-                        // triggered so we capture full diagnostic context (UEFI device paths +
-                        // PCIe inventory) before state resets. Skipped when waiting on an
-                        // already-in-progress reboot to avoid redundant Redfish calls.
-                        if reboot_status.increase_retry_count {
-                            log_host_config(redfish_client, mh_snapshot).await;
+                        RebootStatus {
+                            increase_retry_count: true,
+                            status: "Restarted host".to_string(),
                         }
+                    } else {
+                        trigger_reboot_if_needed(
+                            &mh_snapshot.host_snapshot,
+                            mh_snapshot,
+                            None,
+                            reachability_params,
+                            ctx,
+                        )
+                        .await?
+                    };
 
-                        // Return wait instead of Err to ensure the transaction is committed
-                        // and last_reboot_requested is persisted. Returning Err would cause a transaction
-                        // rollback, leading to a tight reboot loop since the reboot timestamp is lost.
-                        return Ok(SetBootOrderOutcome::WaitingForReboot(format!(
-                            "redfish set_boot_order_dpu_first failed: {e}; triggered host reboot: {reboot_status:#?}"
-                        )));
+                    // Log boot options and PCIe device list whenever a fresh reboot is
+                    // triggered so we capture full diagnostic context (UEFI device paths +
+                    // PCIe inventory) before state resets. Skipped when waiting on an
+                    // already-in-progress reboot to avoid redundant Redfish calls.
+                    if reboot_status.increase_retry_count {
+                        log_host_config(redfish_client, mh_snapshot).await;
                     }
-                };
 
-                Ok(SetBootOrderOutcome::Continue(SetBootOrderInfo {
-                    set_boot_order_jid: jid,
-                    set_boot_order_state: SetBootOrderState::WaitForSetBootOrderJobScheduled,
-                    retry_count: set_boot_order_info.retry_count,
-                }))
-            }
+                    // Return WaitingForReboot instead of Err to ensure the transaction is
+                    // committed, and last_reboot_requested is persisted. Returning Err would
+                    // cause a transaction rollback, leading to a tight reboot loop (since the
+                    // reboot timestamp would be lost).
+                    return Ok(SetBootOrderOutcome::WaitingForReboot(format!(
+                        "redfish set_boot_order_dpu_first failed: {e}; triggered host reboot: {reboot_status:#?}"
+                    )));
+                }
+            };
+
+            Ok(SetBootOrderOutcome::Continue(SetBootOrderInfo {
+                set_boot_order_jid: jid,
+                set_boot_order_state: SetBootOrderState::WaitForSetBootOrderJobScheduled,
+                retry_count: set_boot_order_info.retry_count,
+            }))
         }
         SetBootOrderState::WaitForSetBootOrderJobScheduled => {
             if let Some(job_id) = &set_boot_order_info.set_boot_order_jid {
@@ -9906,20 +9903,15 @@ async fn set_host_boot_order(
 
             let retry_count = set_boot_order_info.retry_count;
 
-            let primary_interface = mh_snapshot
-                .host_snapshot
-                .interfaces
-                .iter()
-                .find(|x| x.primary_interface)
-                .ok_or_else(|| {
-                    StateHandlerError::GenericError(eyre::eyre!(
-                        "Missing primary interface from host: {}",
-                        mh_snapshot.host_snapshot.id
-                    ))
-                })?;
+            let boot_interface_mac = mh_snapshot.boot_interface_mac().ok_or_else(|| {
+                StateHandlerError::GenericError(eyre::eyre!(
+                    "Missing boot interface MAC for host: {}",
+                    mh_snapshot.host_snapshot.id
+                ))
+            })?;
 
             let boot_order_configured = redfish_client
-                .is_boot_order_setup(&primary_interface.mac_address.to_string())
+                .is_boot_order_setup(&boot_interface_mac.to_string())
                 .await
                 .map_err(|e| StateHandlerError::RedfishError {
                     operation: "is_boot_order_setup",

--- a/crates/api/src/tests/instance_allocate.rs
+++ b/crates/api/src/tests/instance_allocate.rs
@@ -17,10 +17,11 @@
 use std::ops::DerefMut;
 
 use ::rpc::forge::ManagedHostNetworkConfigRequest;
+use carbide_redfish::libredfish::test_support::RedfishSimAction;
 use forge::forge_server::Forge;
 use ipnetwork::IpNetwork;
 use itertools::Itertools;
-use model::machine::ManagedHostStateSnapshot;
+use model::machine::{ManagedHostState, ManagedHostStateSnapshot};
 use rpc::forge;
 
 use crate::tests::common;
@@ -854,6 +855,52 @@ async fn test_single_dpu_instance_allocation(
 
     assert_eq!(inst.machine_id, Some(mid));
     assert_eq!(inst.id, Some(instid));
+
+    Ok(())
+}
+
+/// Make sure we take care of setting the boot order for zero DPU hosts.
+/// This test ingests a zero-DPU host and drives things forward. We record
+/// each Redfish `is_boot_order_setup` call, and then then assert at least
+/// one such call was made. If something happens, we'll dump all recorded
+/// Redfish actions to provide some feedback about where the state machine
+/// left off/got stuck.
+#[crate::sqlx_test]
+async fn test_zero_dpu_host_verifies_boot_order_during_platform_configuration(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_for_instance_allocation(pool.clone(), None).await;
+
+    let timepoint = env.redfish_sim.timepoint();
+
+    // Ingest zero-DPU host. site-explorer runs it through the machine state
+    // controller, which hits HostInit -> HostPlatformConfiguration, where
+    // `CheckHostConfig` lives.
+    let config = ManagedHostConfig::with_dpus(vec![]);
+    let zero_dpu_host = api_fixtures::site_explorer::new_host(&env, config).await?;
+
+    // Advance the state controller until the host converges on Ready.
+    // `new_host` itself drives most of the transitions through HostInit
+    // (including SetBootOrder to CheckBootOrder, where `is_boot_order_setup`
+    // is called).
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &zero_dpu_host.host_snapshot.id,
+        10,
+        ManagedHostState::Ready,
+    )
+    .await;
+
+    let actions = env.redfish_sim.actions_since(&timepoint);
+    let all_actions = actions.all_hosts();
+
+    assert!(
+        all_actions
+            .iter()
+            .any(|a| matches!(a, RedfishSimAction::IsBootOrderSetup { .. })),
+        "Expected at least one Redfish is_boot_order_setup call during the zero DPU host HostPlatformConfiguration flow. host id: {}. Recorded actions: {:?}",
+        zero_dpu_host.host_snapshot.id,
+        all_actions,
+    );
 
     Ok(())
 }

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -125,6 +125,20 @@ pub enum RedfishSimAction {
     MachineSetup {
         oem_manager_profiles: libredfish::BiosProfileVendor,
     },
+    /// Records a call to `Redfish::is_boot_order_setup`, letting
+    /// tests assert that the managed-host state controller actually
+    /// asked the BMC about boot order for a given MAC. Mainly used
+    /// a regression check for zero-DPU hosts to make sure we're still
+    /// giving them the love they deserve.
+    IsBootOrderSetup {
+        boot_interface_mac: String,
+    },
+    /// Records a call to `Redfish::set_boot_order_dpu_first`, which is
+    /// used to make the given MAC the first boot device (which zero DPU
+    /// hosts flow through as well using the host NIC MAC).
+    SetBootOrderDpuFirst {
+        boot_interface_mac: String,
+    },
 }
 
 pub struct RedfishSimActions {
@@ -871,8 +885,15 @@ impl Redfish for RedfishSimClient {
 
     async fn set_boot_order_dpu_first(
         &self,
-        _mac_address: &str,
+        mac_address: &str,
     ) -> Result<Option<String>, RedfishError> {
+        let mut state = self.state.lock().unwrap();
+        let host_state = state.hosts.get_mut(&self._host).unwrap();
+        host_state
+            .actions
+            .push(RedfishSimAction::SetBootOrderDpuFirst {
+                boot_interface_mac: mac_address.to_string(),
+            });
         Ok(None)
     }
 
@@ -993,7 +1014,12 @@ impl Redfish for RedfishSimClient {
         Ok(None)
     }
 
-    async fn is_boot_order_setup(&self, _boot_interface_mac: &str) -> Result<bool, RedfishError> {
+    async fn is_boot_order_setup(&self, boot_interface_mac: &str) -> Result<bool, RedfishError> {
+        let mut state = self.state.lock().unwrap();
+        let host_state = state.hosts.get_mut(&self._host).unwrap();
+        host_state.actions.push(RedfishSimAction::IsBootOrderSetup {
+            boot_interface_mac: boot_interface_mac.to_string(),
+        });
         Ok(true)
     }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/NVIDIA/ncx-infra-controller-core/issues/884.

Zero-DPU host previously short-circuited the BIOS boot-order verify/reset flow in the MH state machine. It worked for initial ingest, because nothing on the host ever changed the BIOS boot order, BUT, after a tenant instance OS install flipped the boot device to local disk during provisioning, releasing the instance left the boot order wrong, which meant the `scout` image couldn't boot back up, and the host got stuck instead of returning to `Ready`.

This change unifies the DPU and zero-DPU boot-order code paths around `ManagedHostStateSnapshot::boot_interface_mac()`, the helper https://github.com/NVIDIA/ncx-infra-controller-core/pull/1025 introduced for Redfish `machine_setup`. For hosts with DPUs), it continues to resolve to the DPU-facing PF MAC. For zero-DPU hosts, it resolves to the `ExpectedMachine`/operator-declared primary NIC (via `ExpectedHostNic.primary`), OR a deterministic fallback when no primary was declared.

Both host types now go through the same verify-and-reset flow, so the reset after instance release works for both.

Changes include:
- `CheckHostConfig`: removed the `!is_zero_dpu()` guard; the path now verifies the BMC's reported boot order for zero-DPU hosts too.
- `SetBootOrder`: removed the zero-DPU no-op; it now actually sets the  boot order to the host NIC for zero-DPU hosts.
- `CheckBootOrder`: unified the inline `primary_interface` lookup on `boot_interface_mac()` -- the inline path errored for zero-DPU hosts that hadn't explicitly declared a primary, so the fallback-driven path wasn't actually reachable.

Integration tests included!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->



Closes #884
