### PR TITLE
fix: reject zero-DPU instance allocation with non-inband network segments

### DIFF
--- a/crates/api/src/instance/mod.rs
+++ b/crates/api/src/instance/mod.rs
@@ -44,6 +44,7 @@ use model::machine::{
     HostHealthConfig, LoadSnapshotOptions, Machine, ManagedHostStateSnapshot, NotAllocatableReason,
 };
 use model::metadata::Metadata;
+use model::network_segment::NetworkSegmentType;
 use model::os::OperatingSystemVariant;
 use model::tenant::TenantOrganizationId;
 use model::vpc_prefix::VpcPrefix;
@@ -840,6 +841,36 @@ pub async fn batch_allocate_instances(
                 .map(|vc| vc.allow_instance_vf)
                 .unwrap_or(true),
         )?;
+
+        // Reject instance configs whose network interfaces reference segments
+        // the host can't actually serve. For a zero-DPU host, this means
+        // anything beyond its HostInband segments; there's no DPU to handle
+        // overlay/tenant networking, so accepting the request would leave a
+        // zero-DPU instance stuck in Provisioning with no path to completion.
+        if mh_snapshot.is_zero_dpu() {
+            let allowed_segment_ids: HashSet<_> = mh_snapshot
+                .host_snapshot
+                .interfaces
+                .iter()
+                .filter(|iface| {
+                    matches!(
+                        iface.network_segment_type,
+                        Some(NetworkSegmentType::HostInband)
+                    )
+                })
+                .map(|iface| iface.segment_id)
+                .collect();
+            for iface in &request.config.network.interfaces {
+                if let Some(ns_id) = iface.network_segment_id
+                    && !allowed_segment_ids.contains(&ns_id)
+                {
+                    return Err(CarbideError::InvalidArgument(format!(
+                        "zero-DPU host {} cannot serve an instance interface on network segment {ns_id}. must be a HostInband segment only (allowed: {allowed_segment_ids:?}).",
+                        mh_snapshot.host_snapshot.id,
+                    )));
+                }
+            }
+        }
 
         processed_requests.push((request, mh_snapshot));
     }

--- a/crates/api/src/tests/instance_allocate.rs
+++ b/crates/api/src/tests/instance_allocate.rs
@@ -904,3 +904,74 @@ async fn test_zero_dpu_host_verifies_boot_order_during_platform_configuration(
 
     Ok(())
 }
+
+/// a zero-DPU host has no DPU to handle overlay/tenant networking, so an
+/// instance allocation request that puts a non-DPU (zero-DPU) host NIC
+/// interface on a tenant (DPU-managed) segment must be rejected up front.
+#[crate::sqlx_test]
+async fn test_reject_zero_dpu_instance_with_tenant_network_segment(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_for_instance_allocation(pool.clone(), None).await;
+    let config = ManagedHostConfig::with_dpus(vec![]);
+
+    let zero_dpu_host = api_fixtures::site_explorer::new_host(&env, config).await?;
+
+    let tenant_segment =
+        db::network_segment::find_by_name(env.pool.begin().await?.deref_mut(), "TENANT").await?;
+
+    let result = crate::handlers::instance::allocate(
+        env.api.as_ref(),
+        tonic::Request::new(forge::InstanceAllocationRequest {
+            machine_id: Some(zero_dpu_host.host_snapshot.id),
+            instance_type_id: None,
+            config: Some(forge::InstanceConfig {
+                tenant: Some(forge::TenantConfig {
+                    tenant_organization_id: "2829bbe3-c169-4cd9-8b2a-19a8b1618a93".to_string(),
+                    hostname: None,
+                    tenant_keyset_ids: vec![],
+                }),
+                network_security_group_id: None,
+                os: Some(forge::InstanceOperatingSystemConfig {
+                    phone_home_enabled: false,
+                    run_provisioning_instructions_on_every_boot: false,
+                    user_data: None,
+                    variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
+                        forge::InlineIpxe {
+                            ipxe_script: "exit".to_string(),
+                            user_data: None,
+                        },
+                    )),
+                }),
+                network: Some(forge::InstanceNetworkConfig {
+                    interfaces: vec![forge::InstanceInterfaceConfig {
+                        function_type: forge::InterfaceFunctionType::Physical as i32,
+                        network_segment_id: Some(tenant_segment.id),
+                        network_details: None,
+                        device: None,
+                        device_instance: 0u32,
+                        virtual_function_id: None,
+                        ip_address: None,
+                        ipv6_interface_config: None,
+                    }],
+                }),
+                infiniband: None,
+                dpu_extension_services: None,
+                nvlink: None,
+            }),
+            instance_id: None,
+            metadata: None,
+            allow_unhealthy_machine: false,
+        }),
+    )
+    .await;
+
+    match result {
+        Err(e) if e.code() == tonic::Code::InvalidArgument => {}
+        _ => panic!(
+            "Expected zero-DPU host to reject tenant-segment instance allocation (no DPU to manage overlay networking), got: {result:?}"
+        ),
+    };
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

Fixes https://github.com/NVIDIA/ncx-infra-controller-core/issues/952.

A tenant allocating an instance on a zero-DPU host with an interface pointing at a `Tenant` (overlay) network segment should not succeed. There's no DPU on a zero-DPU host to manage overlay networking, so the downstream config-sync step has no way to complete/succeed -- the instance will get stuck in `Provisioning` with `configs_synced: Pending` indefinitely, which is the current situation when people try this.

This adds a guard in the allocation path (both `allocate_instance` / `batch_allocate_instances`) for a zero-DPU host: any interface whose resolved `network_segment_id` falls outside the host's own `HostInband` segment(s) now is rejected with `InvalidArgument`. The host's `instance_network_restrictions` already describes which segments a zero-DPU host can serve -- this PR enforces those restrictions server-side (instead of trusting clients to respect it). This affects zero-DPU only (and only engages when `.is_zero_dpu()`); DPU flows unaffected.

In other words, zero-DPU hosts now fail (with a clear error message at allocation time), instead of leaving the instance stranded in `Provisioning`, with some useful error information so callers know what the problem is. Existing DPU-specific flows are unaffected.

Integration test included to test that a zero-DPU host tenant segment interface allocation request returns an `InvalidArgument`, instead of letting it succeed and subsequently get stuck.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

