### PR TITLE
fix: treat zero-DPU hosts as admin-network for IB/NVLink partition teardown

### DIFF
--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -272,6 +272,24 @@ fn pick_boot_interface_mac(
         .map(|x| x.mac_address)
 }
 
+/// Derive a host-level `use_admin_network` from the per-DPU values for
+/// the host.
+///
+/// Split out from `ManagedHostStateSnapshot::use_admin_network` so it's
+/// more easily testable without building a full snapshot. The way this works is:
+/// - True when an empty slice (e.g. zero-DPU host or snapshots failed to load),
+///   because zero DPU hosts have no DPU to handle tenant overlay (and
+///   are always admin). In the snapshot failure case, it seemed more
+///   conservative to treat it as such.
+/// - Otherwise, walk across all of the use_admin_network values from the
+///   hosts DPU(s) and collect their values, defaulting to true otherwise.
+fn derive_use_admin_network(dpu_use_admin_network: &[Option<bool>]) -> bool {
+    dpu_use_admin_network.is_empty()
+        || dpu_use_admin_network
+            .iter()
+            .any(|flag| flag.unwrap_or(true))
+}
+
 impl ManagedHostStateSnapshot {
     /// Returns `true` if this managed host has no DPU snapshots attached.
     ///
@@ -303,6 +321,33 @@ impl ManagedHostStateSnapshot {
     /// `self.host_snapshot.associated_dpu_machine_ids().is_empty()`.
     pub fn is_zero_dpu(&self) -> bool {
         self.dpu_snapshots.is_empty()
+    }
+
+    /// Returns `true` if this managed host is currently operating on the
+    /// admin network (rather than a tenant overlay).
+    ///
+    /// The underlying `use_admin_network` flag is persisted per-DPU on
+    /// `ManagedHostNetworkConfig` (fwiw, the config is generic, but
+    /// site-explorer and the machine state controller only populate this
+    /// for DPUs. Default is true.
+    ///
+    /// Zero-DPU hosts always return `true`, because there's no DPU to
+    /// handle tenant overlay networking. This allows consumers like the
+    /// IB and NVLink partition monitors to treat the host as admin-only
+    /// and detach.
+    ///
+    /// Now, this helper doesn't change where the *flag* is stored. I'm
+    /// planning on doing that in a future PR, but it will be a bit more
+    /// disruptive. It may end up going into the host's network_config,
+    /// allowing us to drop the per-DPU copies, and then this helper can
+    /// just read the host's config value directly.
+    pub fn use_admin_network(&self) -> bool {
+        let dpu_use_admin_network: Vec<_> = self
+            .dpu_snapshots
+            .iter()
+            .map(|dpu| dpu.network_config.use_admin_network)
+            .collect();
+        derive_use_admin_network(&dpu_use_admin_network)
     }
 
     /// Returns the MAC address the host should boot from, if one can be
@@ -3265,6 +3310,36 @@ mod tests {
         )];
 
         assert_eq!(pick_boot_interface_mac(&interfaces), None);
+    }
+
+    // Zero-DPU hosts have no DPU snapshots at all. The helper must return
+    // `true` -- consumers (IB partition monitor, NVLink partition monitor)
+    // use this to decide whether to detach tenant partitions, and zero-DPU
+    // hosts never have a tenant overlay to protect.
+    #[test]
+    fn derive_use_admin_network_returns_true_for_empty_dpu_snapshots() {
+        assert!(derive_use_admin_network(&[]));
+    }
+
+    // Make sure the legacy default still works; when a DPU snapshot has no
+    // explicit value, treat it as admin-network. All or any "None" should
+    // therefore resolve to true.
+    #[test]
+    fn derive_use_admin_network_treats_none_as_true() {
+        assert!(derive_use_admin_network(&[None]));
+        assert!(derive_use_admin_network(&[None, None]));
+    }
+
+    // ...aand check OR semantics across DPUs: if any single DPU says admin,
+    // the whole host is treated as admin. Only "all DPUs explicitly say false"
+    // flips the host to tenant-network mode.
+    #[test]
+    fn derive_use_admin_network_ors_across_dpus() {
+        assert!(derive_use_admin_network(&[Some(false), Some(true)]));
+        assert!(derive_use_admin_network(&[Some(true), Some(true)]));
+        assert!(derive_use_admin_network(&[Some(false), None]));
+        assert!(!derive_use_admin_network(&[Some(false)]));
+        assert!(!derive_use_admin_network(&[Some(false), Some(false)]));
     }
 }
 

--- a/crates/api/src/ib_fabric_monitor/mod.rs
+++ b/crates/api/src/ib_fabric_monitor/mod.rs
@@ -699,15 +699,13 @@ async fn record_machine_infiniband_status_observation(
         .map(|instance| &instance.config.infiniband);
     let mut expected_pkeys = HashMap::new();
 
-    let mut use_admin_network = false;
-    for dpu in mh_snapshot.dpu_snapshots.iter() {
-        use_admin_network |= dpu.network_config.use_admin_network.unwrap_or(true);
-    }
-    // If we are on the tenant network, then the pkey configuration is the instances
-    // network configuration.
-    // If not - e.g. during Instance termination - there are no pkeys expected on any
-    // interface
-    let use_tenant_network = !use_admin_network;
+    // If we are on the tenant network, then the pkey configuration is the
+    // instances network configuration.
+    //
+    // If not (e.g. during instance termination, OR any zero-DPU host where
+    // no tenant overlay exists in the first place), then there are no pkeys
+    // expected on any interface.
+    let use_tenant_network = !mh_snapshot.use_admin_network();
     if use_tenant_network && let Some(expected_ib_config) = expected_ib_config {
         for iface in expected_ib_config.ib_interfaces.iter() {
             let Some(guid) = iface.guid.as_ref() else {

--- a/crates/api/src/nvl_partition_monitor/mod.rs
+++ b/crates/api/src/nvl_partition_monitor/mod.rs
@@ -1335,14 +1335,12 @@ impl NvlPartitionMonitor {
         mh: &ManagedHostStateSnapshot,
         partition_ctx: &mut PartitionProcessingContext,
     ) -> CarbideResult<()> {
-        // Check if machine is in admin network
-        let use_admin_network = mh
-            .dpu_snapshots
-            .iter()
-            .any(|dpu| dpu.network_config.use_admin_network.unwrap_or(true));
-
-        // If not on admin network, skip processing
-        if !use_admin_network {
+        // If not in admin-network mode, skip processing. GPUs should stay
+        // attached to tenant partitions, but zero-DPU hosts are always
+        // considered admin network (since they don't have a DPU to put them
+        // in an overlay network). In other words, zero-DPU hosts get GPU
+        // removals, but hosts with DPUs in tenant networks don't.
+        if !mh.use_admin_network() {
             return Ok(());
         }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/NVIDIA/ncx-infra-controller-core/issues/1011.

The `use_admin_network` flag drives whether the IB fabric and NVLink partition monitors detach tenant partition attachments during instance shutdown. It's stored per-DPU on `ManagedHostNetworkConfig`, and both monitors iterate `dpu_snapshots` and join the values together.

For zero-DPU hosts, the `dpu_snapshots` slice is empty, the "OR" of the join stays `false`. As a result, both monitors decide "*we're on the tenant network*", which is incorrect; a zero-DPU host has no DPU to manage tenant overlay, so it has no tenant partitions to keep attached in the first place! The result is that tenant partitions never get detached on instance release for zero-DPU hosts.

This adds a host-level derivation helper, `ManagedHostStateSnapshot::use_admin_network()`, that returns `true` for zero-DPU hosts and preserves the DPU checks across snapshots (including default `unwrap_or(true)` default per DPU). The two monitor sites subsequently now call this, helper instead of iterating inline.

It's worth noting the `use_admin_network` field location is unchanged -- the per-DPU copies are still authoritative for hosts with DPU(s), and the state controller writers continue to populate them as before. I'm planning on moving it in a later PR into the host's `network_config`, allowing us to drop the per-DPU copies and simplify the helper.

Changes more specifically are:
- Introduced a `ManagedHostStateSnapshot::use_admin_network()` on the snapshot.
- Introduced a `derive_use_admin_network` helper to make it more easily testable and give us some flexibility.
- `ib_fabric_monitor` and `nvl_partition_monitor` switch to the helper.
- ..no behavior change for hosts with DPU(s).

Integration tests included, which tests to make sure:
- An empty DPU slice stays on the admin network (zero-DPU).
- That `None` per-DPU values stay on the admin network (default preserved).
- That any explicit `true` or `None` stays on the admin network.
- That all explicit `false` "flips" to the tenant network.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->



Closes #1011
