### PR TITLE
feat: allow site admins to specify DPU mode per host (DPU or NIC mode)

### DIFF
--- a/crates/admin-cli/src/expected_machines/add/args.rs
+++ b/crates/admin-cli/src/expected_machines/add/args.rs
@@ -21,6 +21,7 @@ use carbide_uuid::rack::RackId;
 use clap::Parser;
 use mac_address::MacAddress;
 use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+use rpc::forge::DpuMode;
 use serde::{Deserialize, Serialize};
 use utils::has_duplicates;
 
@@ -129,6 +130,14 @@ pub struct Args {
         help = "When true, site-explorer skips BMC password rotation and stores factory-default credentials in Vault as-is"
     )]
     pub bmc_retain_credentials: Option<bool>,
+
+    #[clap(
+        long = "dpu-mode",
+        value_name = "DPU_MODE",
+        value_enum,
+        help = "Per-host DPU operating mode. `dpu-mode` (default): DPUs are managed by NICo; `nic-mode`: DPU hardware present but treated as a plain NIC; `no-dpu`: no DPU hardware at all. Unset keeps the site default (site-wide `force_dpu_nic_mode` flag still applies when no per-host value is set)."
+    )]
+    pub dpu_mode: Option<DpuMode>,
 }
 
 impl Args {
@@ -182,6 +191,7 @@ impl TryFrom<Args> for rpc::forge::ExpectedMachine {
             is_dpf_enabled: value.dpf_enabled,
             bmc_ip_address: value.bmc_ip_address.map(|ip| ip.to_string()),
             bmc_retain_credentials: value.bmc_retain_credentials,
+            dpu_mode: value.dpu_mode.map(|m| m as i32),
         })
     }
 }

--- a/crates/admin-cli/src/expected_machines/common.rs
+++ b/crates/admin-cli/src/expected_machines/common.rs
@@ -45,6 +45,10 @@ pub struct ExpectedMachineJson {
     pub bmc_ip_address: Option<String>,
     #[serde(default)]
     pub bmc_retain_credentials: Option<bool>,
+    /// Per-host DPU operating mode. None == site default (which
+    /// means to use the site-level `force_dpu_nic_mode` flag).
+    #[serde(default)]
+    pub dpu_mode: Option<rpc::forge::DpuMode>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/admin-cli/src/expected_machines/tests.rs
+++ b/crates/admin-cli/src/expected_machines/tests.rs
@@ -467,3 +467,137 @@ fn validate_patch_all_fields() {
         _ => panic!("expected Patch variant"),
     }
 }
+
+// parse_add_without_dpu_mode ensures the flag is optional and defaults to
+// unset; downstream, unset is treated as "use site default" (as in, use
+// the site-wide `force_dpu_nic_mode` flag).
+#[test]
+fn parse_add_without_dpu_mode() {
+    let cmd = Cmd::try_parse_from([
+        "expected-machine",
+        "add",
+        "--bmc-mac-address",
+        "1a:2b:3c:4d:5e:6f",
+        "--bmc-username",
+        "admin",
+        "--bmc-password",
+        "secret",
+        "--chassis-serial-number",
+        "SN12345",
+    ])
+    .expect("should parse without --dpu-mode");
+
+    match cmd {
+        Cmd::Add(args) => {
+            assert!(args.dpu_mode.is_none(), "--dpu-mode should be optional");
+        }
+        _ => panic!("expected Add variant"),
+    }
+}
+
+// parse_add_with_dpu_mode_nic ensures `--dpu-mode nic-mode`
+// parses to the NicMode variant.
+#[test]
+fn parse_add_with_dpu_mode_nic() {
+    let cmd = Cmd::try_parse_from([
+        "expected-machine",
+        "add",
+        "--bmc-mac-address",
+        "1a:2b:3c:4d:5e:6f",
+        "--bmc-username",
+        "admin",
+        "--bmc-password",
+        "secret",
+        "--chassis-serial-number",
+        "SN12345",
+        "--dpu-mode",
+        "nic-mode",
+    ])
+    .expect("should parse nic-mode");
+
+    match cmd {
+        Cmd::Add(args) => {
+            assert!(matches!(args.dpu_mode, Some(rpc::forge::DpuMode::NicMode)));
+        }
+        _ => panic!("expected Add variant"),
+    }
+}
+
+// parse_add_with_dpu_mode_no_dpu ensures `--dpu-mode no-dpu` parses
+// correctly (host with zero DPU hardware at all).
+#[test]
+fn parse_add_with_dpu_mode_no_dpu() {
+    let cmd = Cmd::try_parse_from([
+        "expected-machine",
+        "add",
+        "--bmc-mac-address",
+        "1a:2b:3c:4d:5e:6f",
+        "--bmc-username",
+        "admin",
+        "--bmc-password",
+        "secret",
+        "--chassis-serial-number",
+        "SN12345",
+        "--dpu-mode",
+        "no-dpu",
+    ])
+    .expect("should parse no-dpu");
+
+    match cmd {
+        Cmd::Add(args) => {
+            assert!(matches!(args.dpu_mode, Some(rpc::forge::DpuMode::NoDpu)));
+        }
+        _ => panic!("expected Add variant"),
+    }
+}
+
+// parse_add_with_dpu_mode_dpu ensures `--dpu-mode dpu-mode` parses.
+#[test]
+fn parse_add_with_dpu_mode_dpu() {
+    let cmd = Cmd::try_parse_from([
+        "expected-machine",
+        "add",
+        "--bmc-mac-address",
+        "1a:2b:3c:4d:5e:6f",
+        "--bmc-username",
+        "admin",
+        "--bmc-password",
+        "secret",
+        "--chassis-serial-number",
+        "SN12345",
+        "--dpu-mode",
+        "dpu-mode",
+    ])
+    .expect("should parse dpu-mode");
+
+    match cmd {
+        Cmd::Add(args) => {
+            assert!(matches!(args.dpu_mode, Some(rpc::forge::DpuMode::DpuMode)));
+        }
+        _ => panic!("expected Add variant"),
+    }
+}
+
+// parse_add_rejects_invalid_dpu_mode ensures clap rejects values that
+// don't match the enum.
+#[test]
+fn parse_add_rejects_invalid_dpu_mode() {
+    let result = Cmd::try_parse_from([
+        "expected-machine",
+        "add",
+        "--bmc-mac-address",
+        "1a:2b:3c:4d:5e:6f",
+        "--bmc-username",
+        "admin",
+        "--bmc-password",
+        "secret",
+        "--chassis-serial-number",
+        "SN12345",
+        "--dpu-mode",
+        "garbage",
+    ]);
+    assert!(
+        result.is_err(),
+        "clap should reject --dpu-mode with an invalid value"
+    );
+}

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -650,6 +650,9 @@ impl ApiClient {
             bmc_ip_address: bmc_ip_address.or(expected_machine.bmc_ip_address),
             bmc_retain_credentials: bmc_retain_credentials
                 .or(expected_machine.bmc_retain_credentials),
+            // Patch doesn't expose `--dpu-mode` yet; preserve the existing
+            // server-side value.
+            dpu_mode: expected_machine.dpu_mode,
         };
 
         Ok(self.0.update_expected_machine(request).await?)
@@ -684,6 +687,7 @@ impl ApiClient {
                     is_dpf_enabled: machine.dpf_enabled,
                     bmc_ip_address: machine.bmc_ip_address,
                     bmc_retain_credentials: machine.bmc_retain_credentials,
+                    dpu_mode: machine.dpu_mode.map(|m| m as i32),
                 })
                 .collect(),
         };

--- a/crates/api-db/migrations/20260420043607_expected_machines_dpu_mode.sql
+++ b/crates/api-db/migrations/20260420043607_expected_machines_dpu_mode.sql
@@ -1,0 +1,7 @@
+-- Per-host DPU operating mode (replaces the site-wide `force_dpu_nic_mode`
+-- config flag, which remains as a fallback for existing deployments). See
+-- the `ExpectedMachine.dpu_mode` field and `DpuMode` enum in `forge.proto`.
+CREATE TYPE dpu_mode_t AS ENUM ('dpu_mode', 'nic_mode', 'no_dpu');
+
+ALTER TABLE expected_machines
+  ADD COLUMN dpu_mode dpu_mode_t NOT NULL DEFAULT 'dpu_mode';

--- a/crates/api-db/src/expected_machine.rs
+++ b/crates/api-db/src/expected_machine.rs
@@ -208,9 +208,9 @@ pub async fn create(
 ) -> DatabaseResult<ExpectedMachine> {
     let id = machine.id.unwrap_or_else(Uuid::new_v4);
     let query = "INSERT INTO expected_machines
-            (id, bmc_mac_address, bmc_username, bmc_password, serial_number, fallback_dpu_serial_numbers, metadata_name, metadata_description, metadata_labels, sku_id, host_nics, rack_id, default_pause_ingestion_and_poweron, dpf_enabled, bmc_ip_address, bmc_retain_credentials)
+            (id, bmc_mac_address, bmc_username, bmc_password, serial_number, fallback_dpu_serial_numbers, metadata_name, metadata_description, metadata_labels, sku_id, host_nics, rack_id, default_pause_ingestion_and_poweron, dpf_enabled, bmc_ip_address, bmc_retain_credentials, dpu_mode)
             VALUES
-            ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::text[], $7, $8, $9::jsonb, $10::varchar, $11::jsonb, $12, $13, $14, $15::inet, $16) RETURNING *";
+            ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::text[], $7, $8, $9::jsonb, $10::varchar, $11::jsonb, $12, $13, $14, $15::inet, $16, $17) RETURNING *";
 
     sqlx::query_as(query)
         .bind(id)
@@ -234,6 +234,7 @@ pub async fn create(
         .bind(machine.data.dpf_enabled.unwrap_or_default())
         .bind(machine.data.bmc_ip_address)
         .bind(machine.data.bmc_retain_credentials.unwrap_or(false))
+        .bind(machine.data.dpu_mode)
         .fetch_one(txn)
         .await
         .map_err(|err: sqlx::Error| match err {
@@ -329,9 +330,9 @@ pub async fn clear(txn: &mut PgConnection) -> Result<(), DatabaseError> {
 /// `bmc_mac_address`. Includes `bmc_ip_address` when the operator configures a static BMC IP.
 pub async fn update(txn: &mut PgConnection, machine: &ExpectedMachine) -> DatabaseResult<()> {
     let (where_clause, target_id) = match machine.id {
-        Some(id) => ("id=$15::uuid", id.to_string()),
+        Some(id) => ("id=$16::uuid", id.to_string()),
         None => (
-            "bmc_mac_address=$15::macaddr",
+            "bmc_mac_address=$16::macaddr",
             machine.bmc_mac_address.to_string(),
         ),
     };
@@ -344,7 +345,8 @@ pub async fn update(txn: &mut PgConnection, machine: &ExpectedMachine) -> Databa
              default_pause_ingestion_and_poweron=COALESCE($11, default_pause_ingestion_and_poweron), \
              dpf_enabled=COALESCE($12, dpf_enabled), \
              bmc_ip_address=$13, \
-             bmc_retain_credentials=COALESCE($14, bmc_retain_credentials) \
+             bmc_retain_credentials=COALESCE($14, bmc_retain_credentials), \
+             dpu_mode=$15 \
          WHERE {where_clause}"
     );
 
@@ -363,6 +365,7 @@ pub async fn update(txn: &mut PgConnection, machine: &ExpectedMachine) -> Databa
         .bind(machine.data.dpf_enabled)
         .bind(machine.data.bmc_ip_address)
         .bind(machine.data.bmc_retain_credentials)
+        .bind(machine.data.dpu_mode)
         .bind(&target_id)
         .execute(&mut *txn)
         .await

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -28,6 +28,87 @@ use uuid::Uuid;
 
 use crate::metadata::Metadata;
 
+/// Per-host DPU operating mode declared by a site operator on an
+/// `ExpectedMachine`. This replaces the site-wide `force_dpu_nic_mode`
+/// config flag; the flag is still honored as a fallback when
+/// `DpuMode::default()` is in effect (i.e. the operator didn't set a
+/// per-host value). `force_dpu_nic_mode` will eventually go away.
+///
+/// Backed by the Postgres enum `dpu_mode_t`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, sqlx::Type, Serialize, Deserialize)]
+#[sqlx(type_name = "dpu_mode_t", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+#[allow(clippy::enum_variant_names)]
+pub enum DpuMode {
+    /// DPUs are managed by NICo as normal -- upgrades, overlay networking,
+    /// DPA agents, etc. The default.
+    #[default]
+    DpuMode,
+    /// DPU hardware is physically present but configured as a plain NIC;
+    /// NICo skips DPU ingest / management and treats the host as zero-DPU.
+    NicMode,
+    /// No DPU hardware at all -- a plain host NIC on the underlay.
+    NoDpu,
+}
+
+impl DpuMode {
+    /// Returns `true` when the host is not being managed as a host with DPUs
+    /// (`NicMode` or `NoDpu`). Used by site-explorer and the state
+    /// controller to skip DPU-specific work.
+    pub fn is_dpu_managed(&self) -> bool {
+        matches!(self, DpuMode::DpuMode)
+    }
+
+    /// Resolve a host's effective DPU mode from its (optional) per-host
+    /// `ExpectedMachine.dpu_mode` value and the site-wide
+    /// `force_dpu_nic_mode` "fallback" flag, which is deprecated more
+    /// than a fallback, but for now I'm treating it as a fallback.
+    ///
+    /// Notes!
+    /// - An explicit per-host `NicMode` or `NoDpu` always wins.
+    /// - `DpuMode` (the default) or no `ExpectedMachine` at all means
+    ///   back back to the site flag, where `force_dpu_nic_mode=true` means
+    ///   `NicMode`, otherwise `DpuMode`.
+    ///
+    /// This keeps backwards compatibility with deployments that still rely
+    /// on the `force_dpu_nic_mode` site-level flag; once all hosts have explicit
+    /// modes configured (or we're happy with the `None` default), the flag can
+    /// be retired.
+    pub fn resolve(expected_mode: Option<DpuMode>, site_force_nic_mode: bool) -> DpuMode {
+        match expected_mode {
+            Some(DpuMode::NicMode) => DpuMode::NicMode,
+            Some(DpuMode::NoDpu) => DpuMode::NoDpu,
+            // `DpuMode` (default) or missing == let the site flag decide.
+            _ if site_force_nic_mode => DpuMode::NicMode,
+            _ => DpuMode::DpuMode,
+        }
+    }
+}
+
+impl From<DpuMode> for rpc::forge::DpuMode {
+    fn from(mode: DpuMode) -> Self {
+        match mode {
+            DpuMode::DpuMode => rpc::forge::DpuMode::DpuMode,
+            DpuMode::NicMode => rpc::forge::DpuMode::NicMode,
+            DpuMode::NoDpu => rpc::forge::DpuMode::NoDpu,
+        }
+    }
+}
+
+impl From<rpc::forge::DpuMode> for DpuMode {
+    fn from(mode: rpc::forge::DpuMode) -> Self {
+        match mode {
+            rpc::forge::DpuMode::DpuMode => DpuMode::DpuMode,
+            rpc::forge::DpuMode::NicMode => DpuMode::NicMode,
+            rpc::forge::DpuMode::NoDpu => DpuMode::NoDpu,
+            // Unspecified (0) or any unknown value means "use the default",
+            // which preserves behavior for old clients that don't send the
+            // field at all.
+            rpc::forge::DpuMode::Unspecified => DpuMode::default(),
+        }
+    }
+}
+
 /// A request to identify an ExpectedMachine by either ID or MAC address.
 #[derive(Debug, Clone)]
 pub struct ExpectedMachineRequest {
@@ -118,6 +199,12 @@ pub struct ExpectedMachineData {
     /// factory-default credentials in Vault as-is.
     #[serde(default)]
     pub bmc_retain_credentials: Option<bool>,
+    /// Per-host DPU operating mode (default `DpuMode::DpuMode` for
+    /// backward compat). See `DpuMode` for semantics. Operators set
+    /// this to `NicMode` when a physically-present DPU should be treated
+    /// as a plain NIC, or to `NoDpu` when there's no DPU hardware at all.
+    #[serde(default)]
+    pub dpu_mode: DpuMode,
 }
 // Important : new fields for expected machine (and data) should be optional _and_ serde(default),
 // unless you want to go update all the files in each production deployment that autoload
@@ -152,6 +239,7 @@ impl<'r> FromRow<'r, PgRow> for ExpectedMachine {
                 dpf_enabled: row.try_get("dpf_enabled")?,
                 bmc_ip_address: row.try_get("bmc_ip_address")?,
                 bmc_retain_credentials: row.try_get("bmc_retain_credentials")?,
+                dpu_mode: row.try_get("dpu_mode")?,
             },
         })
     }
@@ -217,6 +305,12 @@ impl From<ExpectedMachine> for rpc::forge::ExpectedMachine {
                 .bmc_ip_address
                 .map(|ip| ip.to_string()),
             bmc_retain_credentials: expected_machine.data.bmc_retain_credentials.filter(|&v| v),
+            // Only emit `dpu_mode` when it's non-default (which matches the
+            // bmc_retain_credentials filter pattern above).
+            dpu_mode: match expected_machine.data.dpu_mode {
+                DpuMode::DpuMode => None,
+                other => Some(rpc::forge::DpuMode::from(other) as i32),
+            },
         }
     }
 }
@@ -270,6 +364,14 @@ impl TryFrom<rpc::forge::ExpectedMachine> for ExpectedMachineData {
                 })?),
             },
             bmc_retain_credentials: em.bmc_retain_credentials,
+            // `dpu_mode` is optional on the wire; missing / ::Unspecified
+            // both fall back to `DpuMode::default()`, which is ::DpuMode,
+            // so old clients continue to behave as before.
+            dpu_mode: em
+                .dpu_mode
+                .map(|i| rpc::forge::DpuMode::try_from(i).unwrap_or_default())
+                .map(DpuMode::from)
+                .unwrap_or_default(),
         })
     }
 }
@@ -297,3 +399,92 @@ fn metadata_from_request(
 }
 
 // default_uuid removed; ids are optional to support legacy rows with NULL ids
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A completely-unset mode (client didn't set the field) should behave
+    /// the same as `DpuMode` (default) for resolution purposes: the site
+    /// flag decides.
+    #[test]
+    fn resolve_no_expected_mode_with_site_flag_off_returns_dpu_mode() {
+        assert_eq!(DpuMode::resolve(None, false), DpuMode::DpuMode);
+    }
+
+    #[test]
+    fn resolve_no_expected_mode_with_site_flag_on_returns_nic_mode() {
+        assert_eq!(DpuMode::resolve(None, true), DpuMode::NicMode);
+    }
+
+    /// Explicit per-host `DpuMode` is indistinguishable from "not set" in
+    /// the storage type (the default). So it also defers to the site flag
+    /// -- existing `force_dpu_nic_mode` deployments keep working.
+    #[test]
+    fn resolve_explicit_dpu_mode_defers_to_site_flag() {
+        assert_eq!(
+            DpuMode::resolve(Some(DpuMode::DpuMode), false),
+            DpuMode::DpuMode
+        );
+        assert_eq!(
+            DpuMode::resolve(Some(DpuMode::DpuMode), true),
+            DpuMode::NicMode
+        );
+    }
+
+    /// An explicit per-host `NicMode` always wins, regardless of the site
+    /// flag. This is the "I want this specific host in NIC mode" override.
+    #[test]
+    fn resolve_nic_mode_always_wins() {
+        assert_eq!(
+            DpuMode::resolve(Some(DpuMode::NicMode), false),
+            DpuMode::NicMode
+        );
+        assert_eq!(
+            DpuMode::resolve(Some(DpuMode::NicMode), true),
+            DpuMode::NicMode
+        );
+    }
+
+    /// An explicit per-host `NoDpu` always wins. Useful for hosts where
+    /// the operator knows there's genuinely no DPU hardware (as opposed
+    /// to "DPU present but used as NIC", which is `NicMode`).
+    #[test]
+    fn resolve_no_dpu_always_wins() {
+        assert_eq!(
+            DpuMode::resolve(Some(DpuMode::NoDpu), false),
+            DpuMode::NoDpu
+        );
+        assert_eq!(DpuMode::resolve(Some(DpuMode::NoDpu), true), DpuMode::NoDpu);
+    }
+
+    /// `is_dpu_managed()` returns true only for the default `DpuMode`
+    /// variant -- the two "not managed by NICo as DPU" cases both return
+    /// false, which is what site-explorer and state handlers use to skip
+    /// DPU-specific work.
+    #[test]
+    fn is_dpu_managed_covers_both_skip_cases() {
+        assert!(DpuMode::DpuMode.is_dpu_managed());
+        assert!(!DpuMode::NicMode.is_dpu_managed());
+        assert!(!DpuMode::NoDpu.is_dpu_managed());
+    }
+
+    /// Unspecified (0) on the wire means "use the default." Old clients
+    /// sending no value land here, and we want to preserve the DpuMode
+    /// default so existing deployments keep their behavior.
+    #[test]
+    fn from_rpc_unspecified_maps_to_default() {
+        assert_eq!(
+            DpuMode::from(rpc::forge::DpuMode::Unspecified),
+            DpuMode::default()
+        );
+        assert_eq!(DpuMode::default(), DpuMode::DpuMode);
+    }
+
+    #[test]
+    fn rpc_enum_round_trips_all_named_variants() {
+        for mode in [DpuMode::DpuMode, DpuMode::NicMode, DpuMode::NoDpu] {
+            assert_eq!(DpuMode::from(rpc::forge::DpuMode::from(mode)), mode);
+        }
+    }
+}

--- a/crates/api/src/site_explorer/mod.rs
+++ b/crates/api/src/site_explorer/mod.rs
@@ -75,6 +75,7 @@ mod managed_host;
 use db::ObjectColumnFilter;
 use db::work_lock_manager::WorkLockManagerHandle;
 pub use managed_host::is_endpoint_in_managed_host;
+use model::expected_machine::DpuMode;
 use model::firmware::FirmwareComponentType;
 use model::machine_interface_address::MachineInterfaceAssociation;
 use model::network_segment::NetworkSegmentType;
@@ -840,21 +841,17 @@ impl SiteExplorer {
         explored_dpus: HashMap<IpAddr, ExploredEndpoint>,
         explored_hosts: HashMap<IpAddr, ExploredEndpoint>,
     ) -> CarbideResult<Vec<(ExploredManagedHost, EndpointExplorationReport)>> {
-        if self.config.force_dpu_nic_mode.load(Ordering::Relaxed) {
-            // Ignore the DPU and ingest the machine as a managed host
-            return Ok(explored_hosts
-                .values()
-                .map(|ep| {
-                    (
-                        ExploredManagedHost {
-                            host_bmc_ip: ep.address,
-                            dpus: vec![],
-                        },
-                        ep.report.clone(),
-                    )
-                })
-                .collect());
-        }
+        // Per-host DPU-mode resolution. The old/deprecated/fallback site-wide
+        // `force_dpu_nic_mode` flag is preserved as a fallback when no
+        // per-host override is declared; a per-host `NicMode` or `NoDpu`
+        // always wins.
+        let site_force_nic_mode = self.config.force_dpu_nic_mode.load(Ordering::Relaxed);
+        let effective_mode = |host_bmc_ip: &IpAddr| -> DpuMode {
+            let declared = expected_explored_endpoint_index
+                .matched_expected_machine(host_bmc_ip)
+                .map(|em| em.data.dpu_mode);
+            DpuMode::resolve(declared, site_force_nic_mode)
+        };
         // Match HOST and DPU using SerialNumber.
         // Compare DPU system.serial_number with HOST chassis.network_adapters[].serial_number
         let mut dpu_sn_to_endpoint = HashMap::new();
@@ -896,6 +893,13 @@ impl SiteExplorer {
         };
 
         for (_, ep) in explored_hosts {
+            // Resolve the operator-declared DPU mode for this host once;
+            // it drives both auto-correction (`check_and_configure_dpu_mode`
+            // below -- operator override wins over BF3 model heuristics)
+            // and the post-match attach decision (NicMode/NoDpu hosts emit
+            // a bare managed host regardless of what matched).
+            let host_dpu_mode = effective_mode(&ep.address);
+
             // the list of DPUs that the site-explorer has explored for this host
             let mut dpus_explored_for_host: Vec<ExploredDpu> = Vec::new();
             // the number of DPUs that the host reports are attached to it
@@ -915,7 +919,11 @@ impl SiteExplorer {
                         let dpu_ep = dpu_ep_entry.get();
                         if let Some(model) = pcie_device.part_number.as_ref() {
                             match self
-                                .check_and_configure_dpu_mode(dpu_ep, model.to_string())
+                                .check_and_configure_dpu_mode(
+                                    dpu_ep,
+                                    model.to_string(),
+                                    host_dpu_mode,
+                                )
                                 .await
                             {
                                 Ok(is_dpu_mode_configured_correctly) => {
@@ -969,7 +977,11 @@ impl SiteExplorer {
                             let dpu_ep = dpu_ep_entry.get();
                             if let Some(model) = network_adapter.part_number.as_ref() {
                                 match self
-                                    .check_and_configure_dpu_mode(dpu_ep, model.to_string())
+                                    .check_and_configure_dpu_mode(
+                                        dpu_ep,
+                                        model.to_string(),
+                                        host_dpu_mode,
+                                    )
                                     .await
                                 {
                                     Ok(is_dpu_mode_configured_correctly) => {
@@ -1155,10 +1167,20 @@ impl SiteExplorer {
                 });
             }
 
+            // For NicMode / NoDpu hosts, don't attach DPUs even if matching
+            // discovered some: the operator has declared "treat this host
+            // as zero-DPU". Any DPU hardware has already had `set_nic_mode`
+            // issued by the check-and-configure step above if it was in
+            // DPU mode; this cycle we just emit a bare host.
+            let dpus = match host_dpu_mode {
+                DpuMode::NicMode | DpuMode::NoDpu => Vec::new(),
+                DpuMode::DpuMode => dpus_explored_for_host,
+            };
+
             managed_hosts.push((
                 ExploredManagedHost {
                     host_bmc_ip: ep.address,
-                    dpus: dpus_explored_for_host,
+                    dpus,
                 },
                 ep.report,
             ));
@@ -2286,39 +2308,65 @@ impl SiteExplorer {
         Ok(ingest_host)
     }
 
-    // check_and_configure_dpu_mode returns a boolean indicating whether a DPU is configured correctly.
-    // check_and_configure_dpu_mode will always return true for BF2s
-    // check_and_configure_dpu_mode will return false if a BF3 SuperNIC is configured in DPU mode or if a BF3 DPU is configured in NIC mode. Otherwise, it will return true.
-    // if check_and_configure_dpu_mode returns false, it will try to configure the DPU appropriately (put a BF3 SuperNIC in NIC mode or put a BF3 DPU in DPU mode)
+    /// Returns `true` when the DPU's hardware NIC mode already matches the
+    /// desired target; `false` when the function has issued a `set_nic_mode`
+    /// to fix a mismatch (in which case the caller should skip this host
+    /// for the current site-explorer cycle -- the next cycle will pick up
+    /// the corrected mode).
+    ///
+    /// The target is resolved in priority order:
+    /// 1. If the operator explicitly declared `DpuMode::NicMode` on the
+    ///    `ExpectedMachine`, target NIC mode (per-host override).
+    /// 2. If the operator declared `DpuMode::NoDpu`, bail out -- the
+    ///    `MachineValidation` state handler is where "hardware reports a
+    ///    DPU but operator said no DPU" gets surfaced as a health alert;
+    ///    we don't try to reconfigure in that case.
+    /// 3. Otherwise (operator default `DpuMode::DpuMode`), fall back to
+    ///    the existing BF3 SuperNIC / BF3 DPU model-based heuristic for
+    ///    backward compat: BF3 SuperNIC → NIC mode, BF3 DPU → DPU mode,
+    ///    BF2 / unknown → no-op.
     async fn check_and_configure_dpu_mode(
         &self,
         dpu_ep: &ExploredEndpoint,
         dpu_model: String,
+        host_dpu_mode: DpuMode,
     ) -> CarbideResult<bool> {
-        match dpu_ep.report.nic_mode() {
-            Some(NicMode::Dpu) => {
+        // Compute the target NIC mode. `None` means "no opinion -- don't
+        // attempt to reconfigure" (e.g., BF2 where the heuristic doesn't
+        // apply, or NoDpu where we defer to the health-check path).
+        let target_nic_mode: Option<NicMode> = match host_dpu_mode {
+            DpuMode::NicMode => Some(NicMode::Nic),
+            DpuMode::NoDpu => None,
+            DpuMode::DpuMode => {
+                // Preserve existing BF3-model heuristics when the operator
+                // hasn't explicitly chosen a mode.
                 if is_bf3_supernic(&dpu_model) {
-                    tracing::warn!(
-                        "site explorer found a BF3 SuperNIC ({}) that is in DPU mode; will try setting it into NIC mode",
-                        dpu_ep.address
-                    );
-                    self.set_nic_mode(dpu_ep, NicMode::Nic).await?;
-                    Ok(false)
+                    Some(NicMode::Nic)
+                } else if is_bf3_dpu(&dpu_model) {
+                    Some(NicMode::Dpu)
                 } else {
-                    Ok(true)
+                    None
                 }
             }
-            Some(NicMode::Nic) => {
-                if is_bf3_dpu(&dpu_model) {
-                    tracing::warn!(
-                        "site explorer found a BF3 DPU ({}) that is in NIC mode; will try setting it into DPU mode",
-                        dpu_ep.address
-                    );
-                    self.set_nic_mode(dpu_ep, NicMode::Dpu).await?;
-                    Ok(false)
-                } else {
-                    Ok(true)
-                }
+        };
+
+        let Some(target_nic_mode) = target_nic_mode else {
+            return Ok(true);
+        };
+
+        match dpu_ep.report.nic_mode() {
+            Some(observed) if observed == target_nic_mode => Ok(true),
+            Some(observed) => {
+                tracing::warn!(
+                    address = %dpu_ep.address,
+                    model = %dpu_model,
+                    %observed,
+                    ?target_nic_mode,
+                    ?host_dpu_mode,
+                    "site explorer found a DPU with a mode that does not match the target; will try to reconfigure"
+                );
+                self.set_nic_mode(dpu_ep, target_nic_mode).await?;
+                Ok(false)
             }
             None => {
                 tracing::warn!(

--- a/crates/api/src/tests/common/api_fixtures/dpu.rs
+++ b/crates/api/src/tests/common/api_fixtures/dpu.rs
@@ -68,6 +68,11 @@ pub struct DpuConfig {
     pub last_exploration_error: Option<EndpointExplorationError>,
     pub override_hosts_uefi_device_path: Option<UefiDevicePath>,
     pub hardware_info_template: HardwareInfoTemplate,
+    /// The `nic_mode` value included in the DPU's `EndpointExplorationReport`.
+    /// Defaults to `Some(NicMode::Dpu)`; tests exercising the auto-correct
+    /// path override this to `Some(NicMode::Nic)` to simulate a DPU whose
+    /// hardware mode doesn't match the operator-declared mode.
+    pub nic_mode: Option<NicMode>,
 }
 
 impl DpuConfig {
@@ -99,6 +104,7 @@ impl Default for DpuConfig {
             last_exploration_error: None,
             override_hosts_uefi_device_path: None,
             hardware_info_template: HardwareInfoTemplate::Default,
+            nic_mode: Some(NicMode::Dpu),
         }
     }
 }
@@ -151,7 +157,7 @@ impl From<DpuConfig> for EndpointExplorationReport {
                 model: None,
                 serial_number: Some(value.serial.clone()),
                 attributes: ComputerSystemAttributes {
-                    nic_mode: Some(NicMode::Dpu),
+                    nic_mode: value.nic_mode,
                     is_infinite_boot_enabled: None,
                 },
                 pcie_devices: vec![

--- a/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
@@ -34,6 +34,10 @@ use crate::site_explorer::{EndpointExplorer, SiteExplorationMetrics};
 pub struct MockEndpointExplorer {
     pub reports:
         Arc<Mutex<HashMap<IpAddr, Result<EndpointExplorationReport, EndpointExplorationError>>>>,
+    /// Records every call to `set_nic_mode` (BMC address + requested target
+    /// mode) so tests can assert the auto-correct path fired with the
+    /// right arguments. Cleared on each `insert_endpoints` reset.
+    pub set_nic_mode_calls: Arc<Mutex<Vec<(SocketAddr, NicMode)>>>,
 }
 
 impl MockEndpointExplorer {
@@ -167,10 +171,14 @@ impl EndpointExplorer for MockEndpointExplorer {
 
     async fn set_nic_mode(
         &self,
-        _address: SocketAddr,
+        address: SocketAddr,
         _interface: &MachineInterfaceSnapshot,
-        _mode: NicMode,
+        mode: NicMode,
     ) -> Result<(), EndpointExplorationError> {
+        self.set_nic_mode_calls
+            .lock()
+            .unwrap()
+            .push((address, mode));
         Ok(())
     }
 

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -1646,6 +1646,7 @@ pub async fn create_test_env_with_overrides(
 
     let fake_endpoint_explorer = MockEndpointExplorer {
         reports: Arc::new(std::sync::Mutex::new(Default::default())),
+        set_nic_mode_calls: Arc::new(std::sync::Mutex::new(Default::default())),
     };
 
     // The API server is launched with a disabled site-explorer config so that it doesn't launch one

--- a/crates/api/src/tests/expected_machine.rs
+++ b/crates/api/src/tests/expected_machine.rs
@@ -88,6 +88,7 @@ async fn test_duplicate_fail_create(pool: sqlx::PgPool) -> Result<(), Box<dyn st
                 dpf_enabled: Some(true),
                 bmc_ip_address: None,
                 bmc_retain_credentials: None,
+                dpu_mode: Default::default(),
             },
         },
     )
@@ -734,6 +735,7 @@ async fn test_add_expected_machine_dpu_serials(pool: sqlx::PgPool) {
         is_dpf_enabled: Some(true),
         bmc_ip_address: None,
         bmc_retain_credentials: None,
+        dpu_mode: None,
         #[allow(deprecated)]
         dpf_enabled: true,
     };
@@ -2455,6 +2457,94 @@ async fn test_add_rejects_multiple_primary_host_nics(
 
     let err = result.expect_err("multi-primary ExpectedMachine should be rejected");
     assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+    Ok(())
+}
+
+/// Simple test to have some round-trip coverage for `ExpectedMachine.dpu_mode`
+/// to make sure a `NicMode` setting makes it from the API to the DB and back
+/// correctly. Verifies:
+/// - The RPC carrying `Some(DpuMode::NicMode)` persists.
+/// - The re-read RPC response replies `dpu_mode = Some(NicMode)` back
+/// - Other `dpu_mode` values do the same.
+#[crate::sqlx_test]
+async fn test_dpu_mode_round_trip_for_non_default_values(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    for (idx, mode) in [rpc::forge::DpuMode::NicMode, rpc::forge::DpuMode::NoDpu]
+        .iter()
+        .enumerate()
+    {
+        let mac = format!("5A:5B:5C:5D:5E:{idx:02X}");
+        let request = rpc::forge::ExpectedMachine {
+            bmc_mac_address: mac.clone(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: format!("EM-DPU-MODE-{idx}"),
+            dpu_mode: Some(*mode as i32),
+            ..Default::default()
+        };
+
+        env.api
+            .add_expected_machine(tonic::Request::new(request))
+            .await?;
+
+        let retrieved = env
+            .api
+            .get_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachineRequest {
+                bmc_mac_address: mac.clone(),
+                id: None,
+            }))
+            .await?
+            .into_inner();
+
+        assert_eq!(
+            retrieved.dpu_mode,
+            Some(*mode as i32),
+            "DPU mode {mode:?} should survive DB round-trip unchanged"
+        );
+    }
+
+    Ok(())
+}
+
+/// Also have some "round trip" coverage for the dpu_mode default case,
+/// when the operator didn't set `dpu_mode` on the wire. In this case,
+/// we should persist the Postgrs default (`DpuMode::DpuMode`) and return
+/// `None` on the wire (so old clients see the same thing they sent).
+#[crate::sqlx_test]
+async fn test_dpu_mode_default_value_omitted_on_wire(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    let mac = "5A:5B:5C:5D:5E:FF";
+    env.api
+        .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+            bmc_mac_address: mac.into(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: "EM-DPU-DEFAULT".into(),
+            dpu_mode: None,
+            ..Default::default()
+        }))
+        .await?;
+
+    let retrieved = env
+        .api
+        .get_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachineRequest {
+            bmc_mac_address: mac.into(),
+            id: None,
+        }))
+        .await?
+        .into_inner();
+
+    assert_eq!(
+        retrieved.dpu_mode, None,
+        "default DpuMode should not be emitted on the wire for stable round-trips"
+    );
 
     Ok(())
 }

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -1439,6 +1439,7 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
                 dpf_enabled: Some(true),
                 bmc_ip_address: None,
                 bmc_retain_credentials: None,
+                dpu_mode: Default::default(),
             },
         },
     )
@@ -1489,6 +1490,7 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
         dpf_enabled: Some(true),
         bmc_ip_address: None,
         bmc_retain_credentials: None,
+        dpu_mode: Default::default(),
     };
     db::expected_machine::update(&mut txn, &host1_expected_machine).await?;
     txn.commit().await?;
@@ -2453,6 +2455,7 @@ async fn test_machine_creation_with_sku(
                 dpf_enabled: Some(true),
                 bmc_ip_address: None,
                 bmc_retain_credentials: None,
+                dpu_mode: Default::default(),
             },
         },
     )
@@ -2588,6 +2591,7 @@ async fn test_expected_machine_device_type_metrics(
                 dpf_enabled: Some(true),
                 bmc_ip_address: None,
                 bmc_retain_credentials: None,
+                dpu_mode: Default::default(),
             },
         },
     )
@@ -2611,6 +2615,7 @@ async fn test_expected_machine_device_type_metrics(
                 dpf_enabled: Some(true),
                 bmc_ip_address: None,
                 bmc_retain_credentials: None,
+                dpu_mode: Default::default(),
             },
         },
     )
@@ -2634,6 +2639,7 @@ async fn test_expected_machine_device_type_metrics(
                 dpf_enabled: Some(true),
                 bmc_ip_address: None,
                 bmc_retain_credentials: None,
+                dpu_mode: Default::default(),
             },
         },
     )
@@ -4744,6 +4750,86 @@ async fn test_get_machine_position_info_no_endpoint(
     assert_eq!(info.compute_tray_index, None);
     assert_eq!(info.topology_id, None);
     assert_eq!(info.revision_id, None);
+
+    Ok(())
+}
+
+/// Integration regression guard for the auto-correct path: when an
+/// `ExpectedMachine` declares `DpuMode::NicMode` but the discovered DPU
+/// hardware is reporting `nic_mode: Dpu`, site-explorer should call
+/// `set_nic_mode(Nic)` on the DPU during its per-host matching loop.
+///
+/// This exercises the full wire (site-explorer iteration → per-host mode
+/// resolution → `check_and_configure_dpu_mode` → mock Redfish
+/// `set_nic_mode`) that the unit tests only cover in pieces.
+#[crate::sqlx_test]
+async fn test_site_explorer_auto_corrects_nic_mode_per_expected_machine(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use libredfish::model::oem::nvidia_dpu::NicMode;
+    use model::expected_machine::{DpuMode, ExpectedMachine, ExpectedMachineData};
+
+    let env = common::api_fixtures::create_test_env(pool).await;
+
+    // DPU hardware reports DPU mode (so it looks like a "properly
+    // configured" DPU to the BF3-DPU heuristic) -- the operator-declared
+    // override is what forces the correction to NIC mode.
+    let dpu_config = common::api_fixtures::dpu::DpuConfig {
+        nic_mode: Some(NicMode::Dpu),
+        ..Default::default()
+    };
+    let mock_host =
+        common::api_fixtures::managed_host::ManagedHostConfig::with_dpus(vec![dpu_config.clone()]);
+    let host_bmc_mac = mock_host.bmc_mac_address;
+
+    // Seed an ExpectedMachine with `dpu_mode: NicMode` that matches the
+    // mock host's BMC MAC. Site-explorer's per-host resolution will look
+    // this up by IP via the expected-endpoint index after DHCP assigns
+    // the host its BMC IP.
+    let mut txn = env.pool.begin().await?;
+    db::expected_machine::create(
+        &mut txn,
+        ExpectedMachine {
+            id: None,
+            bmc_mac_address: host_bmc_mac,
+            data: ExpectedMachineData {
+                bmc_username: "ADMIN".to_string(),
+                bmc_password: "PASS".to_string(),
+                serial_number: "EM-866-NIC-OVERRIDE".to_string(),
+                metadata: model::metadata::Metadata::new_with_default_name(),
+                dpu_mode: DpuMode::NicMode,
+                ..Default::default()
+            },
+        },
+    )
+    .await?;
+    txn.commit().await?;
+
+    // Drive the same ingestion flow as the singledpu fixture test: BMC
+    // DHCP for host + DPU, seed mock exploration results, run site-
+    // explorer iteration. We don't care about the final managed host
+    // state here -- we only care that `set_nic_mode` was called with the
+    // right target during the matching loop.
+    common::api_fixtures::site_explorer::MockExploredHost::new(&env, mock_host)
+        .discover_dhcp_host_bmc(|_, _| Ok(()))
+        .await?
+        .discover_dhcp_dpu_bmc(0, |_, _| Ok(()))
+        .await?
+        .insert_site_exploration_results()?
+        // First iteration: initial endpoint exploration.
+        .run_site_explorer_iteration()
+        .await
+        .mark_preingestion_complete()
+        .await?
+        // Second iteration: per-host DPU matching + check_and_configure_dpu_mode.
+        .run_site_explorer_iteration()
+        .await;
+
+    let calls = env.endpoint_explorer.set_nic_mode_calls.lock().unwrap();
+    assert!(
+        calls.iter().any(|(_, mode)| *mode == NicMode::Nic),
+        "expected at least one set_nic_mode(Nic) call triggered by the operator's NicMode declaration; calls so far: {calls:?}"
+    );
 
     Ok(())
 }

--- a/crates/api/src/tests/sku.rs
+++ b/crates/api/src/tests/sku.rs
@@ -797,6 +797,7 @@ pub mod tests {
                     dpf_enabled: Some(true),
                     bmc_ip_address: None,
                     bmc_retain_credentials: None,
+                    dpu_mode: Default::default(),
                 },
             },
         )
@@ -890,6 +891,7 @@ pub mod tests {
                     dpf_enabled: Some(true),
                     bmc_ip_address: None,
                     bmc_retain_credentials: None,
+                    dpu_mode: Default::default(),
                 },
             },
         )
@@ -958,6 +960,7 @@ pub mod tests {
                     dpf_enabled: Some(true),
                     bmc_ip_address: None,
                     bmc_retain_credentials: None,
+                    dpu_mode: Default::default(),
                 },
             },
         )
@@ -1043,6 +1046,7 @@ pub mod tests {
                     dpf_enabled: Some(true),
                     bmc_ip_address: None,
                     bmc_retain_credentials: None,
+                    dpu_mode: Default::default(),
                 },
             },
         )
@@ -1479,6 +1483,7 @@ pub mod tests {
                     dpf_enabled: Some(true),
                     bmc_ip_address: None,
                     bmc_retain_credentials: None,
+                    dpu_mode: Default::default(),
                 },
             },
         )

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -523,6 +523,7 @@ impl ApiClient {
                 is_dpf_enabled: Some(true),
                 bmc_ip_address: None,
                 bmc_retain_credentials: None,
+                dpu_mode: None,
             })
             .await
             .map_err(ClientApiError::InvocationError)

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -35,6 +35,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ".forge.DeletedFilter",
             "#[cfg_attr(feature = \"cli\", derive(clap::ValueEnum))]",
         )
+        .type_attribute(
+            ".forge.DpuMode",
+            "#[cfg_attr(feature = \"cli\", derive(clap::ValueEnum))]",
+        )
+        .type_attribute(
+            ".forge.DpuMode",
+            "#[derive(serde::Serialize, serde::Deserialize)]",
+        )
         .extern_path(".google.protobuf.Duration", "crate::Duration")
         .extern_path(".google.protobuf.Timestamp", "crate::Timestamp")
         .extern_path(".common.DomainId", "::carbide_uuid::domain::DomainId")

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -5183,6 +5183,25 @@ message ExpectedHostNic {
   optional bool primary = 6;
 }
 
+// Per-host DPU operating mode. Ultimately replaces the site-wide
+// `force_dpu_nic_mode` config flag, so site operators can mix DPU-mode,
+// NIC-mode, and no-DPU hosts within a single site.
+//
+// - DPU_MODE: The default. Attached DPUs are managed by NICo (DPU upgrades,
+//   overlay networking, etc).
+// - NIC_MODE: DPUs are present physically but operate as plain NICs. Site
+//   explorer skips DPU ingest; the host is tracked as if it had no DPUs.
+// - NO_DPU: no DPU hardware at all -- a plain host NIC on the underlay.
+//
+// Unset and `DPU_MODE_UNSPECIFIED` both mean "use the site default," which
+// is DPU_MODE unless the site-wide `force_dpu_nic_mode` config flag is on.
+enum DpuMode {
+  DPU_MODE_UNSPECIFIED = 0;
+  DPU_MODE = 1;
+  NIC_MODE = 2;
+  NO_DPU = 3;
+}
+
 message ExpectedMachine {
   string bmc_mac_address = 1;
   string bmc_username = 2;
@@ -5206,6 +5225,10 @@ message ExpectedMachine {
   // When true, site-explorer skips BMC password rotation and stores the
   // factory-default credentials in Vault as-is.
   optional bool bmc_retain_credentials = 15;
+  // Per-host DPU operating mode. See `DpuMode` above. Unset means "site
+  // default" -- the site-wide `force_dpu_nic_mode` config flag still applies
+  // when no per-host override is set, so existing deployments keep working.
+  optional DpuMode dpu_mode = 16;
 }
 
 message ExpectedMachineRequest {


### PR DESCRIPTION
## Description

Closes https://github.com/NVIDIA/ncx-infra-controller-core/issues/866.

Site operators can now declare on each `ExpectedMachine` whether its attached DPUs should be in DPU mode or NIC mode (or treated as absent entriely). This replaces the site-wide `force_dpu_nic_mode` parameter, which has no per-host granularity, and can't support mixed deployments on the same site controller (some DPUs managed, some not). The site flag IS being preserved [as a fallback] though, so existing deployments keep working as expected. We can get rid of it later.

With this change, `site-explorer` now consults the new `ExpectedMachine.dpu_mode` field during its per-host DPU match-and-validate loop. When the observed DPU NIC mode *doesn't* match the config-declared mode, the existing `check_and_configure_dpu_mode` path fires `set_nic_mode` over Redfish and returns `false` -- the host is then skipped for that cycle, and the next `site-explorer pass` picks up the corrected hardware. After matching, `NicMode` and `NoDpu` hosts emit a bare managed host (empty `dpus`), matching the behavior of the `force_dpu_nic_mode` flag for those hosts specifically.

To make this all happen, this change includes:
- A new `DpuMode` enum and `dpu_mode_t`, which defaults to `::DpuMode`.
- A suporting `DpuMode::resolve(expected_mode, site_force_nic_mode)` function to figure out what `DpuMode` should be set for a DPU.
- Updating `check_and_configure_dpu_mode` with a new `host_dpu_mode` parameter, which leverages the site admin intent from `dpu_mode` to pick the target NIC mode (existing BF3 model-based checks are preserved as a fallback if the admin didn't set an explicit value.
- Added `--dpu-mode` to the `carbide-admin-cli` to `expected-machine add`, `update`, and `replace-all`.

Integration tests included to test:
- Leveraging `bmc-mock` to make sure `site-explorer` correctly detects + fires off calls to flip DPUs from observed -> expected state.
- `DpuMode::resolve` works as expected for various situations.
- Proto enum conversions work as expected.
- DB enum conversions work as expected.
- `admin-cli` parser accepts `dpu-mode` as expected.

TODO is to also wire in a `MachineValidation` check here. If for some reason something got through, or something happened in between tenancies, we should drop a health report and file an alert that there is now `DpuMode` mismatch.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->



Closes #866
