### PR TITLE
chore(devspace): ship carbide-admin-cli in api image

### DIFF
--- a/dev/deployment/devspace/Dockerfile.api
+++ b/dev/deployment/devspace/Dockerfile.api
@@ -12,9 +12,9 @@ COPY . .
 
 RUN --mount=type=cache,id=nico-devspace-cargo-home,target=/cargo-home,sharing=locked \
   --mount=type=cache,id=nico-devspace-cargo-target,target=/cargo-target,sharing=locked \
-  cargo build -p carbide-api --bin carbide-api --locked && \
+  cargo build -p carbide-api --bin carbide-api -p carbide-admin-cli --bin carbide-admin-cli --locked && \
   mkdir -p /artifacts && \
-  cp /cargo-target/debug/carbide-api /artifacts/carbide-api
+  cp /cargo-target/debug/carbide-api /cargo-target/debug/carbide-admin-cli /artifacts/
 
 FROM ubuntu:24.04
 
@@ -31,6 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN mkdir -p /opt/carbide /opt/carbide/firmware /mnt/persistence /var/run/kea
 
 COPY --from=builder /artifacts/carbide-api /opt/carbide/carbide-api
+COPY --from=builder /artifacts/carbide-admin-cli /opt/carbide/carbide-admin-cli
 COPY crates/api/casbin-policy.csv /opt/carbide/casbin-policy.csv
 
 ENV CASBIN_POLICY_FILE=/opt/carbide/casbin-policy.csv


### PR DESCRIPTION
## Description

Build and install the admin CLI alongside carbide-api so developers can invoke it in-cluster via kubectl exec without the TLS/cert configuration needed to run it from the host.

### Examples
from host machine:
```bash
kubectl -n forge-system exec -it deploy/carbide-api -- /opt/carbide/carbide-admin-cli set log-filter --filter "info,carbide::api=debug" --expiry 900min
IGNORING SERVER CERT, Please ensure that I am removed to actually validate TLS.
IGNORING SERVER CERT, Please ensure that I am removed to actually validate TLS.
```
inside pod:
```bash
root@carbide-api-75d6966664-k59dv:/# /opt/carbide/carbide-admin-cli set log-filter --filter "info,carbide::api=debug" --expiry 900min
IGNORING SERVER CERT, Please ensure that I am removed to actually validate TLS.
IGNORING SERVER CERT, Please ensure that I am removed to actually validate TLS.
```

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

