### PR TITLE
refactor(site_explorer): introduce SiteExplorerError

### DIFF
--- a/crates/api/src/errors.rs
+++ b/crates/api/src/errors.rs
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 use std::backtrace::{Backtrace, BacktraceStatus};
-use std::net::IpAddr;
 
 use ::rpc::errors::RpcDataConversionError;
 use carbide_redfish::libredfish::RedfishClientCreationError;
@@ -29,7 +28,6 @@ use mac_address::MacAddress;
 use model::errors::ModelError;
 use model::hardware_info::HardwareInfoError;
 use model::network_devices::LldpError;
-use model::site_explorer::EndpointExplorationError;
 use model::tenant::TenantError;
 use model::{ConfigValidationError, resource_pool};
 use tonic::Status;
@@ -201,9 +199,6 @@ pub enum CarbideError {
     #[error("Attest Bind Key Error: {0}")]
     AttestBindKeyError(String),
 
-    #[error("Explored machine at {0} has no DPUs")]
-    NoDpusInMachine(IpAddr),
-
     #[error("{requested_ip} resolves to {found_mac} not {requested_mac}")]
     BmcMacIpMismatch {
         /// The BMC endpoint IP requested by the caller
@@ -216,13 +211,6 @@ pub enum CarbideError {
 
     #[error("{0}")]
     FailedPrecondition(String),
-
-    #[error("EndpointExplorationError for {action}: {err}")]
-    EndpointExplorationError {
-        action: &'static str,
-        /// The actual BMC MAC address found associated with the endpoint IP
-        err: EndpointExplorationError,
-    },
 
     #[error("Failed to map device to dpu: {0}")]
     DpuMappingError(String),

--- a/crates/api/src/site_explorer/errors.rs
+++ b/crates/api/src/site_explorer/errors.rs
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::net::IpAddr;
+
+use db::DatabaseError;
+use model::errors::ModelError;
+use model::site_explorer::EndpointExplorationError;
+
+#[derive(thiserror::Error, Debug)]
+pub enum SiteExplorerError {
+    #[error("Database error: {0}")]
+    DatabaseError(#[from] DatabaseError),
+    #[error("Model error: {0}")]
+    ModelError(#[from] ModelError),
+    #[error("Explored machine at {0} has no DPUs")]
+    NoDpusInMachine(IpAddr),
+    #[error("{kind} already exists: {id}")]
+    AlreadyFoundError {
+        /// The type of the resource that already exists (e.g. Machine)
+        kind: &'static str,
+        /// The ID of the resource that already exists.
+        id: String,
+    },
+    #[error("{kind} not found: {id}")]
+    NotFoundError {
+        /// The type of the resource that was not found (e.g. Machine)
+        kind: &'static str,
+        /// The ID of the resource that was not found
+        id: String,
+    },
+    #[error("Argument is invalid: {0}")]
+    InvalidArgument(String),
+    #[error("EndpointExplorationError for {action}: {err}")]
+    EndpointExplorationError {
+        action: &'static str,
+        /// Actual endpiing exploration error.
+        err: EndpointExplorationError,
+    },
+    #[error("Internal error: {message}")]
+    Internal { message: String },
+}
+
+impl SiteExplorerError {
+    /// Creates a `Internal` error with the given error message
+    pub fn internal(message: String) -> Self {
+        Self::Internal { message }
+    }
+}
+
+pub type SiteExplorerResult<T> = Result<T, SiteExplorerError>;

--- a/crates/api/src/site_explorer/machine_creator.rs
+++ b/crates/api/src/site_explorer/machine_creator.rs
@@ -40,10 +40,10 @@ use model::site_explorer::{EndpointExplorationReport, ExploredDpu, ExploredManag
 use sqlx::{PgConnection, PgPool};
 
 use crate::site_explorer::SiteExplorerConfig;
+use crate::site_explorer::errors::{SiteExplorerError, SiteExplorerResult};
 use crate::site_explorer::explored_endpoint_index::ExploredEndpointIndex;
 use crate::site_explorer::managed_host::ManagedHost;
 use crate::site_explorer::metrics::SiteExplorationMetrics;
-use crate::{CarbideError, CarbideResult};
 
 pub struct MachineCreator {
     database_connection: PgPool,
@@ -77,7 +77,7 @@ impl MachineCreator {
         metrics: &mut SiteExplorationMetrics,
         explored_managed_hosts: &mut [(ExploredManagedHost, EndpointExplorationReport)],
         expected_explored_endpoint_index: &ExploredEndpointIndex,
-    ) -> CarbideResult<()> {
+    ) -> SiteExplorerResult<()> {
         // TODO: Improve the efficiency of this method. Right now we perform 3 database transactions
         // for every identified ManagedHost even if we don't create any objects.
         // We can perform a single query upfront to identify which ManagedHosts don't yet have Machines
@@ -112,7 +112,7 @@ impl MachineCreator {
         report: &mut EndpointExplorationReport,
         expected_machine: Option<&ExpectedMachine>,
         pool: &PgPool,
-    ) -> CarbideResult<bool> {
+    ) -> SiteExplorerResult<bool> {
         let machine_data = expected_machine.map(|em| &em.data);
         let mut managed_host = ManagedHost::init(explored_host);
 
@@ -140,7 +140,8 @@ impl MachineCreator {
         // Zero-dpu case: If the explored host had no DPUs, we can create the machine now
         if managed_host.explored_host.dpus.is_empty() {
             if !self.config.allow_zero_dpu_hosts {
-                let error = CarbideError::NoDpusInMachine(managed_host.explored_host.host_bmc_ip);
+                let error =
+                    SiteExplorerError::NoDpusInMachine(managed_host.explored_host.host_bmc_ip);
                 tracing::error!(%error, "Cannot create managed host for explored endpoint with no DPUs: Zero-dpu hosts are disallowed by config");
                 return Err(error);
             }
@@ -182,11 +183,12 @@ impl MachineCreator {
         }
 
         // Now since all DPUs are created, update host and DPUs state correctly.
-        let host_machine_id = managed_host
-            .machine_id
-            .ok_or(CarbideError::internal(format!(
-                "Failed to get machine ID for host: {managed_host:#?}"
-            )))?;
+        let host_machine_id =
+            managed_host
+                .machine_id
+                .ok_or(SiteExplorerError::internal(format!(
+                    "Failed to get machine ID for host: {managed_host:#?}"
+                )))?;
 
         db::machine::update_state(
             &mut txn,
@@ -275,7 +277,7 @@ impl MachineCreator {
         managed_host: &ManagedHost<'_>,
         report: &mut EndpointExplorationReport,
         machine_data: Option<&ExpectedMachineData>,
-    ) -> CarbideResult<Option<MachineId>> {
+    ) -> SiteExplorerResult<Option<MachineId>> {
         // If there's already a machine with the same MAC address as this endpoint, return false. We
         // can't rely on matching the machine_id, as it may have migrated to a stable MachineID
         // already.
@@ -365,7 +367,7 @@ impl MachineCreator {
                         %existing_machine_id,
                         "BUG! Found existing machine_interface with this MAC address, we should not have gotten here!"
                     );
-                    return Err(CarbideError::AlreadyFoundError {
+                    return Err(SiteExplorerError::AlreadyFoundError {
                         kind: "MachineInterface",
                         id: mac_address.to_string(),
                     });
@@ -402,7 +404,7 @@ impl MachineCreator {
         &self,
         txn: &mut PgConnection,
         explored_dpu: &ExploredDpu,
-    ) -> CarbideResult<bool> {
+    ) -> SiteExplorerResult<bool> {
         if let Some(dpu_machine) = self.create_dpu_machine(txn, explored_dpu).await? {
             self.configure_dpu_interface(txn, explored_dpu).await?;
             self.update_dpu_network_config(txn, &dpu_machine).await?;
@@ -424,7 +426,7 @@ impl MachineCreator {
         managed_host: &ManagedHost<'_>,
         predicted_machine_id: &MachineId,
         machine_data: Option<&ExpectedMachineData>,
-    ) -> CarbideResult<()> {
+    ) -> SiteExplorerResult<()> {
         _ = db::machine::create(
             txn,
             Some(&self.common_pools),
@@ -451,7 +453,7 @@ impl MachineCreator {
         &self,
         txn: &mut PgConnection,
         explored_dpu: &ExploredDpu,
-    ) -> CarbideResult<bool> {
+    ) -> SiteExplorerResult<bool> {
         let dpu_machine_id: &MachineId = explored_dpu.report.machine_id.as_ref().unwrap();
         let oob_net0_mac = explored_dpu.report.systems.iter().find_map(|x| {
             x.ethernet_interfaces.iter().find_map(|x| {
@@ -503,7 +505,7 @@ impl MachineCreator {
         &self,
         txn: &mut PgConnection,
         explored_dpu: &ExploredDpu,
-    ) -> CarbideResult<Option<Machine>> {
+    ) -> SiteExplorerResult<Option<Machine>> {
         let dpu_machine_id = explored_dpu.report.machine_id.as_ref().unwrap();
         match db::machine::find_one(&mut *txn, dpu_machine_id, MachineSearchConfig::default())
             .await?
@@ -538,7 +540,7 @@ impl MachineCreator {
         explored_host: &ManagedHost<'_>,
         explored_dpu: &ExploredDpu,
         machine_data: Option<&ExpectedMachineData>,
-    ) -> CarbideResult<MachineId> {
+    ) -> SiteExplorerResult<MachineId> {
         let dpu_hw_info = explored_dpu.hardware_info()?;
         // Create Host proactively.
         // In case host interface is created, this method will return existing one, instead
@@ -552,7 +554,7 @@ impl MachineCreator {
             .await?;
 
         if host_machine_interface.machine_id.is_some() {
-            return Err(CarbideError::internal(format!(
+            return Err(SiteExplorerError::internal(format!(
                 "The host's machine interface for DPU {} already has the machine ID set--something is wrong: {:#?}",
                 explored_dpu.report.machine_id.as_ref().unwrap(),
                 host_machine_interface
@@ -585,7 +587,7 @@ impl MachineCreator {
         machine_id: &MachineId,
         mut bmc_info: BmcInfo,
         hardware_info: HardwareInfo,
-    ) -> CarbideResult<()> {
+    ) -> SiteExplorerResult<()> {
         let _topology =
             db::machine_topology::create_or_update(txn, machine_id, &hardware_info).await?;
 
@@ -611,7 +613,7 @@ impl MachineCreator {
         &self,
         txn: &mut PgConnection,
         dpu_machine: &Machine,
-    ) -> CarbideResult<()> {
+    ) -> SiteExplorerResult<()> {
         let (mut network_config, version) = dpu_machine.network_config.clone().take();
         if network_config.loopback_ip.is_none() {
             let loopback_ip = db::machine::allocate_loopback_ip(
@@ -663,7 +665,7 @@ impl MachineCreator {
         host_machine_interface: &MachineInterfaceSnapshot,
         explored_dpu: &ExploredDpu,
         machine_data: Option<&ExpectedMachineData>,
-    ) -> CarbideResult<MachineId> {
+    ) -> SiteExplorerResult<MachineId> {
         match &explored_host.machine_id {
             Some(host_machine_id) => {
                 // This is not the primary interface for this host
@@ -711,10 +713,11 @@ impl MachineCreator {
         explored_host: &ExploredManagedHost,
         explored_dpu: &ExploredDpu,
         machine_data: Option<&ExpectedMachineData>,
-    ) -> CarbideResult<MachineId> {
+    ) -> SiteExplorerResult<MachineId> {
         let dpu_hw_info = explored_dpu.hardware_info()?;
-        let predicted_machine_id = host_id_from_dpu_hardware_info(&dpu_hw_info)
-            .map_err(|e| CarbideError::InvalidArgument(format!("hardware info missing: {e}")))?;
+        let predicted_machine_id = host_id_from_dpu_hardware_info(&dpu_hw_info).map_err(|e| {
+            SiteExplorerError::InvalidArgument(format!("hardware info missing: {e}"))
+        })?;
 
         let _host_machine = db::machine::create(
             txn,

--- a/crates/api/src/site_explorer/mod.rs
+++ b/crates/api/src/site_explorer/mod.rs
@@ -58,7 +58,6 @@ use utils::periodic_timer::PeriodicTimer;
 use version_compare::Cmp;
 
 use crate::cfg::file::FirmwareConfig;
-use crate::{CarbideError, CarbideResult};
 mod endpoint_explorer;
 pub use endpoint_explorer::EndpointExplorer;
 mod credentials;
@@ -85,6 +84,9 @@ use carbide_uuid::rack::RackId;
 use model::rack::Rack;
 pub use switch_creator::SwitchCreator;
 pub mod config;
+pub mod errors;
+
+use errors::{SiteExplorerError, SiteExplorerResult};
 
 use self::metrics::{PairingBlockerReason, exploration_error_to_metric_label};
 use crate::site_explorer::explored_endpoint_index::ExploredEndpointIndex;
@@ -97,13 +99,11 @@ use crate::site_explorer::explored_endpoint_index::ExploredEndpointIndex;
 pub(crate) async fn ensure_rack_exists(
     txn: &mut sqlx::PgConnection,
     rack_id: &RackId,
-) -> CarbideResult<Option<Rack>> {
+) -> SiteExplorerResult<Option<Rack>> {
     match db::rack::find_by(txn, ObjectColumnFilter::One(db::rack::IdColumn, rack_id)).await {
         Ok(mut racks) if !racks.is_empty() => Ok(racks.pop()),
         Ok(_) | Err(DatabaseError::NotFoundError { .. }) => {
-            let expected = db::expected_rack::find_by_rack_id(&mut *txn, rack_id)
-                .await
-                .map_err(CarbideError::from)?;
+            let expected = db::expected_rack::find_by_rack_id(&mut *txn, rack_id).await?;
 
             let Some(expected) = expected else {
                 tracing::warn!(
@@ -122,12 +122,11 @@ pub(crate) async fn ensure_rack_exists(
                 &config,
                 Some(&expected.metadata),
             )
-            .await
-            .map_err(CarbideError::from)?;
+            .await?;
 
             Ok(Some(rack))
         }
-        Err(e) => Err(CarbideError::from(e)),
+        Err(e) => Err(e.into()),
     }
 }
 
@@ -295,12 +294,12 @@ impl SiteExplorer {
     // https://github.com/rust-lang/rust/issues/110011 will be
     // implemented
     #[track_caller]
-    fn txn_begin(&self) -> impl Future<Output = CarbideResult<db::Transaction<'_>>> {
+    fn txn_begin(&self) -> impl Future<Output = SiteExplorerResult<db::Transaction<'_>>> {
         let loc = Location::caller();
         db::Transaction::begin_with_location(&self.database_connection, loc).map_err(Into::into)
     }
 
-    pub async fn run_single_iteration(&self) -> CarbideResult<SiteIdentifiedHosts> {
+    pub async fn run_single_iteration(&self) -> SiteExplorerResult<SiteIdentifiedHosts> {
         let mut metrics = SiteExplorationMetrics::new();
 
         let _work_lock = match self
@@ -310,7 +309,7 @@ impl SiteExplorer {
         {
             Ok(lock) => lock,
             Err(e) => {
-                return Err(CarbideError::internal(format!(
+                return Err(SiteExplorerError::internal(format!(
                     "Failed to acquire connection: {e}"
                 )));
             }
@@ -394,7 +393,7 @@ impl SiteExplorer {
         &self,
         metrics: &mut SiteExplorationMetrics,
         expected_endpoint_index: &ExploredEndpointIndex,
-    ) -> CarbideResult<()> {
+    ) -> SiteExplorerResult<()> {
         let mut txn = self.txn_begin().await?;
 
         // Grab them all because we care about everything,
@@ -567,7 +566,7 @@ impl SiteExplorer {
     async fn explore_site(
         &self,
         metrics: &mut SiteExplorationMetrics,
-    ) -> CarbideResult<SiteIdentifiedHosts> {
+    ) -> SiteExplorerResult<SiteIdentifiedHosts> {
         self.check_preconditions(metrics).await?;
         let expected_endpoint_index = self.update_explored_endpoints(metrics).await?;
 
@@ -610,7 +609,7 @@ impl SiteExplorer {
 
         if self.config.create_power_shelves.load(Ordering::Relaxed) {
             let start_create_power_shelves = std::time::Instant::now();
-            let create_power_shelves_res: Result<(), CarbideError> = self
+            let create_power_shelves_res = self
                 .create_power_shelves(metrics, explored_power_shelves, &expected_endpoint_index)
                 .await;
             metrics.create_power_shelves_latency = Some(start_create_power_shelves.elapsed());
@@ -622,7 +621,7 @@ impl SiteExplorer {
 
         if self.config.create_switches.load(Ordering::Relaxed) {
             let start_create_switches = std::time::Instant::now();
-            let create_switches_res: Result<(), CarbideError> = self
+            let create_switches_res = self
                 .switch_creator
                 .create_switches(metrics, &explored_switches, &expected_endpoint_index)
                 .await;
@@ -642,7 +641,7 @@ impl SiteExplorer {
         metrics: &mut SiteExplorationMetrics,
         explored_power_shelves: Vec<(ExploredEndpoint, EndpointExplorationReport)>,
         expected_endpoint_index: &ExploredEndpointIndex,
-    ) -> CarbideResult<()> {
+    ) -> SiteExplorerResult<()> {
         for (endpoint, _report) in explored_power_shelves {
             let address = endpoint.address;
             let Some(expected_power_shelf) =
@@ -682,7 +681,7 @@ impl SiteExplorer {
         explored_endpoint: ExploredEndpoint,
         expected_shelf: &ExpectedPowerShelf,
         pool: &PgPool,
-    ) -> CarbideResult<bool> {
+    ) -> SiteExplorerResult<bool> {
         let mut txn = pool
             .begin()
             .await
@@ -734,7 +733,7 @@ impl SiteExplorer {
             Ok(id) => id,
             Err(e) => {
                 tracing::error!(%e, "Failed to create power shelf ID");
-                return Err(CarbideError::InvalidArgument(format!(
+                return Err(SiteExplorerError::InvalidArgument(format!(
                     "Failed to create power shelf ID: {e}"
                 )));
             }
@@ -791,7 +790,7 @@ impl SiteExplorer {
     async fn identify_machines_to_ingest(
         &self,
         metrics: &mut SiteExplorationMetrics,
-    ) -> CarbideResult<(
+    ) -> SiteExplorerResult<(
         HashMap<IpAddr, ExploredEndpoint>,
         HashMap<IpAddr, ExploredEndpoint>,
     )> {
@@ -842,7 +841,7 @@ impl SiteExplorer {
         expected_explored_endpoint_index: &ExploredEndpointIndex,
         explored_dpus: HashMap<IpAddr, ExploredEndpoint>,
         explored_hosts: HashMap<IpAddr, ExploredEndpoint>,
-    ) -> CarbideResult<Vec<(ExploredManagedHost, EndpointExplorationReport)>> {
+    ) -> SiteExplorerResult<Vec<(ExploredManagedHost, EndpointExplorationReport)>> {
         // Per-host DPU-mode resolution. The old/deprecated/fallback site-wide
         // `force_dpu_nic_mode` flag is preserved as a fallback when no
         // per-host override is declared; a per-host `NicMode` or `NoDpu`
@@ -1213,7 +1212,7 @@ impl SiteExplorer {
 
     async fn identify_power_shelves_to_ingest(
         &self,
-    ) -> CarbideResult<Vec<(ExploredEndpoint, EndpointExplorationReport)>> {
+    ) -> SiteExplorerResult<Vec<(ExploredEndpoint, EndpointExplorationReport)>> {
         let mut txn = self
             .database_connection
             .begin()
@@ -1241,7 +1240,7 @@ impl SiteExplorer {
         Ok(explored_power_shelves)
     }
 
-    async fn identify_switches_to_ingest(&self) -> CarbideResult<Vec<ExploredManagedSwitch>> {
+    async fn identify_switches_to_ingest(&self) -> SiteExplorerResult<Vec<ExploredManagedSwitch>> {
         let mut txn = self
             .database_connection
             .begin()
@@ -1271,17 +1270,20 @@ impl SiteExplorer {
     ///
     /// Doing this upfront avoids the risk of trying to log into BMCs without
     /// the necessary credentials - which could trigger a lockout.
-    async fn check_preconditions(&self, metrics: &mut SiteExplorationMetrics) -> CarbideResult<()> {
+    async fn check_preconditions(
+        &self,
+        metrics: &mut SiteExplorationMetrics,
+    ) -> SiteExplorerResult<()> {
         self.endpoint_explorer
             .check_preconditions(metrics)
             .await
-            .map_err(|e| CarbideError::internal(e.to_string()))
+            .map_err(|e| SiteExplorerError::internal(e.to_string()))
     }
 
     async fn update_explored_endpoints(
         &self,
         metrics: &mut SiteExplorationMetrics,
-    ) -> CarbideResult<ExploredEndpointIndex> {
+    ) -> SiteExplorerResult<ExploredEndpointIndex> {
         let mut txn = self.txn_begin().await?;
 
         let underlay_segments =
@@ -1845,7 +1847,7 @@ impl SiteExplorer {
         }
     }
 
-    pub async fn ipmitool_reset_bmc(&self, endpoint: &Endpoint<'_>) -> CarbideResult<()> {
+    pub async fn ipmitool_reset_bmc(&self, endpoint: &Endpoint<'_>) -> SiteExplorerResult<()> {
         tracing::info!(
             "SiteExplorer is initiating a cold BMC reset through IPMI to IP {}",
             endpoint.address
@@ -1868,14 +1870,14 @@ impl SiteExplorer {
 
                 Ok(())
             }
-            Err(e) => Err(CarbideError::internal(format!(
+            Err(e) => Err(SiteExplorerError::internal(format!(
                 "site-explorer failed to cold reset bmc through ipmitool {}: {:#?}",
                 endpoint.address, e
             ))),
         }
     }
 
-    pub async fn redfish_reset_bmc(&self, endpoint: &Endpoint<'_>) -> CarbideResult<()> {
+    pub async fn redfish_reset_bmc(&self, endpoint: &Endpoint<'_>) -> SiteExplorerResult<()> {
         tracing::info!(
             "SiteExplorer is initiating a BMC reset through Redfish to IP {}",
             endpoint.address
@@ -1897,7 +1899,7 @@ impl SiteExplorer {
 
                 Ok(())
             }
-            Err(e) => Err(CarbideError::internal(format!(
+            Err(e) => Err(SiteExplorerError::internal(format!(
                 "site-explorer failed to reset bmc through redfish {}: {:#?}",
                 endpoint.address, e
             ))),
@@ -1919,7 +1921,7 @@ impl SiteExplorer {
             }
         }
     }
-    pub async fn clear_nvram(&self, endpoint: &Endpoint<'_>) -> CarbideResult<()> {
+    pub async fn clear_nvram(&self, endpoint: &Endpoint<'_>) -> SiteExplorerResult<()> {
         tracing::info!(
             "SiteExplorer is issuing a clean_nvram through Redfish to IP {}",
             endpoint.address
@@ -1931,7 +1933,7 @@ impl SiteExplorer {
             .clear_nvram(bmc_target_addr, endpoint.iface)
             .await
             .map_err(|err| {
-                CarbideError::internal(format!(
+                SiteExplorerError::internal(format!(
                     "site-explorer failed to clear nvram {}: {:#?}",
                     endpoint.address, err
                 ))
@@ -1940,7 +1942,7 @@ impl SiteExplorer {
         self.force_restart(endpoint).await
     }
 
-    pub async fn force_restart(&self, endpoint: &Endpoint<'_>) -> CarbideResult<()> {
+    pub async fn force_restart(&self, endpoint: &Endpoint<'_>) -> SiteExplorerResult<()> {
         tracing::info!(
             "SiteExplorer is initiating a reboot through Redfish to IP {}",
             endpoint.address
@@ -1965,7 +1967,7 @@ impl SiteExplorer {
 
                 Ok(())
             }
-            Err(e) => Err(CarbideError::internal(format!(
+            Err(e) => Err(SiteExplorerError::internal(format!(
                 "site-explorer failed to reboot {}: {:#?}",
                 endpoint.address, e
             ))),
@@ -1975,7 +1977,7 @@ impl SiteExplorer {
     async fn is_managed_host_created_for_endpoint(
         &self,
         bmc_ip_address: IpAddr,
-    ) -> CarbideResult<bool> {
+    ) -> SiteExplorerResult<bool> {
         let mut txn = self.txn_begin().await?;
 
         let is_endpoint_in_managed_host =
@@ -1992,7 +1994,7 @@ impl SiteExplorer {
         &self,
         metrics: &mut SiteExplorationMetrics,
         dpu_endpoint: &ExploredEndpoint,
-    ) -> CarbideResult<bool> {
+    ) -> SiteExplorerResult<bool> {
         let is_managed_host_created_for_endpoint = match self
             .is_managed_host_created_for_endpoint(dpu_endpoint.address)
             .await
@@ -2046,7 +2048,7 @@ impl SiteExplorer {
         &self,
         dpu_endpoint: &ExploredEndpoint,
         mode: NicMode,
-    ) -> CarbideResult<()> {
+    ) -> SiteExplorerResult<()> {
         let bmc_target_port = self.config.override_target_port.unwrap_or(443);
         let bmc_target_addr = SocketAddr::new(dpu_endpoint.address, bmc_target_port);
 
@@ -2057,7 +2059,7 @@ impl SiteExplorer {
         self.endpoint_explorer
             .set_nic_mode(bmc_target_addr, &interface, mode)
             .await
-            .map_err(|err| CarbideError::EndpointExplorationError {
+            .map_err(|err| SiteExplorerError::EndpointExplorationError {
                 action: "set_nic_mode",
                 err,
             })
@@ -2067,7 +2069,7 @@ impl SiteExplorer {
         &self,
         bmc_ip_address: IpAddr,
         action: libredfish::SystemPowerControl,
-    ) -> CarbideResult<()> {
+    ) -> SiteExplorerResult<()> {
         let bmc_target_port = self.config.override_target_port.unwrap_or(443);
         let bmc_target_addr = SocketAddr::new(bmc_ip_address, bmc_target_port);
 
@@ -2076,13 +2078,13 @@ impl SiteExplorer {
         self.endpoint_explorer
             .redfish_power_control(bmc_target_addr, &interface, action)
             .await
-            .map_err(|err| CarbideError::EndpointExplorationError {
+            .map_err(|err| SiteExplorerError::EndpointExplorationError {
                 action: "redfish_power_control",
                 err,
             })
     }
 
-    async fn redfish_powercycle(&self, bmc_ip_address: IpAddr) -> CarbideResult<()> {
+    async fn redfish_powercycle(&self, bmc_ip_address: IpAddr) -> SiteExplorerResult<()> {
         self.redfish_power_control(bmc_ip_address, libredfish::SystemPowerControl::PowerCycle)
             .await?;
 
@@ -2096,7 +2098,7 @@ impl SiteExplorer {
     async fn find_machine_interface_for_ip(
         &self,
         ip_address: IpAddr,
-    ) -> CarbideResult<MachineInterfaceSnapshot> {
+    ) -> SiteExplorerResult<MachineInterfaceSnapshot> {
         let mut txn = self.txn_begin().await?;
 
         let machine_interface = db::machine_interface::find_by_ip(&mut txn, ip_address).await?;
@@ -2105,7 +2107,7 @@ impl SiteExplorer {
 
         match machine_interface {
             Some(interface) => Ok(interface),
-            None => Err(CarbideError::NotFoundError {
+            None => Err(SiteExplorerError::NotFoundError {
                 kind: "machine_interface",
                 id: format!("remote_ip={ip_address:?}"),
             }),
@@ -2123,7 +2125,7 @@ impl SiteExplorer {
         &self,
         metrics: &mut SiteExplorationMetrics,
         host_endpoint: &ExploredEndpoint,
-    ) -> CarbideResult<bool> {
+    ) -> SiteExplorerResult<bool> {
         let is_managed_host_created_for_endpoint = match self
             .is_managed_host_created_for_endpoint(host_endpoint.address)
             .await
@@ -2332,7 +2334,7 @@ impl SiteExplorer {
         dpu_ep: &ExploredEndpoint,
         dpu_model: String,
         host_dpu_mode: DpuMode,
-    ) -> CarbideResult<bool> {
+    ) -> SiteExplorerResult<bool> {
         // Compute the target NIC mode. `None` means "no opinion -- don't
         // attempt to reconfigure" (e.g., BF2 where the heuristic doesn't
         // apply, or NoDpu where we defer to the health-check path).

--- a/crates/api/src/site_explorer/switch_creator.rs
+++ b/crates/api/src/site_explorer/switch_creator.rs
@@ -21,8 +21,8 @@ use model::expected_switch::ExpectedSwitch;
 use model::site_explorer::ExploredManagedSwitch;
 use sqlx::{PgConnection, PgPool};
 
-use crate::CarbideResult;
 use crate::site_explorer::SiteExplorerConfig;
+use crate::site_explorer::errors::SiteExplorerResult;
 use crate::site_explorer::explored_endpoint_index::ExploredEndpointIndex;
 use crate::site_explorer::metrics::SiteExplorationMetrics;
 
@@ -44,7 +44,7 @@ impl SwitchCreator {
         metrics: &mut SiteExplorationMetrics,
         explored_managed_switches: &[ExploredManagedSwitch],
         expected_explored_endpoint_index: &ExploredEndpointIndex,
-    ) -> CarbideResult<()> {
+    ) -> SiteExplorerResult<()> {
         for explored_managed_switch in explored_managed_switches {
             let expected_switch = match expected_explored_endpoint_index
                 .matched_expected_switch(&explored_managed_switch.bmc_ip)
@@ -87,7 +87,7 @@ impl SwitchCreator {
         explored_managed_switch: &ExploredManagedSwitch,
         expected_switch: &ExpectedSwitch,
         pool: &PgPool,
-    ) -> CarbideResult<bool> {
+    ) -> SiteExplorerResult<bool> {
         let mut txn = pool
             .begin()
             .await
@@ -110,7 +110,7 @@ impl SwitchCreator {
         txn: &mut PgConnection,
         explored_managed_switch: &ExploredManagedSwitch,
         expected_switch: &ExpectedSwitch,
-    ) -> CarbideResult<Option<SwitchId>> {
+    ) -> SiteExplorerResult<Option<SwitchId>> {
         if !explored_managed_switch.nv_os_mac_addresses.is_empty() {
             let explored_macs = explored_managed_switch.nv_os_mac_addresses.clone();
             if *explored_macs != expected_switch.nvos_mac_addresses {
@@ -150,7 +150,7 @@ impl SwitchCreator {
         txn: &mut PgConnection,
         expected_switch: &ExpectedSwitch,
         switch_id: SwitchId,
-    ) -> CarbideResult<()> {
+    ) -> SiteExplorerResult<()> {
         let name = match expected_switch.metadata.name.is_empty() {
             true => expected_switch.serial_number.to_string(),
             false => expected_switch.metadata.name.to_string(),

--- a/crates/api/src/tests/machine_creator.rs
+++ b/crates/api/src/tests/machine_creator.rs
@@ -34,10 +34,10 @@ use rpc::{BlockDevice, DiscoveryData, DiscoveryInfo, MachineDiscoveryInfo};
 use tonic::Request;
 use utils::models::arch::CpuArchitecture;
 
-use crate::CarbideError;
 use crate::cfg::file::DpuConfig as InitialDpuConfig;
 use crate::site_explorer::MachineCreator;
 use crate::site_explorer::config::SiteExplorerConfig;
+use crate::site_explorer::errors::SiteExplorerError;
 use crate::state_controller::machine::handler::MachineStateHandlerBuilder;
 use crate::tests::common;
 use crate::tests::common::api_fixtures::TestEnvOverrides;
@@ -111,7 +111,7 @@ async fn test_site_explorer_reject_zero_dpu_hosts(
         dpus: vec![],
     };
 
-    let Err(CarbideError::NoDpusInMachine(_)) = machine_creator
+    let Err(SiteExplorerError::NoDpusInMachine(_)) = machine_creator
         .create_managed_host(
             &exploration_report,
             &mut EndpointExplorationReport::default(),


### PR DESCRIPTION
## Description
As a prerequisite to extracting site_explorer into its own crate, give it its own error type and remove the dependency on CarbideError.

New SiteExplorerError in site_explorer/errors.rs covers the variants previously used by this module: DatabaseError, ModelError, NoDpusInMachine, AlreadyFoundError, NotFoundError, InvalidArgument, EndpointExplorationError, and a generic Internal for ad-hoc messages.

Corresponding variants removed from CarbideError where they were only constructed by site_explorer code:
  - NoDpusInMachine
  - EndpointExplorationError

AlreadyFoundError / NotFoundError / InvalidArgument remain in CarbideError because they are also used elsewhere in carbide-api; their SiteExplorerError counterparts are independent variants local to this module.

All site_explorer functions now return SiteExplorerResult<T>. Only the site_explorer module and its tests reference the new error type; no other code path in carbide-api bubbles it up.

Part of the effort to break up the carbide-api mega-crate.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

