### PR TITLE
chore: exercise full instance lifecycle on zero-DPU and NIC-mode hosts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,6 +1411,7 @@ dependencies = [
  "mac_address",
  "md5",
  "mockall",
+ "mockito",
  "mqttea",
  "nras",
  "num-bigint-dig",

--- a/book/src/manuals/metrics/core_metrics.md
+++ b/book/src/manuals/metrics/core_metrics.md
@@ -40,8 +40,6 @@ This file contains a list of metrics exported by NCX Infra Controller (NICo). Th
 <tr><td>carbide_hosts_health_overrides_count</td><td>gauge</td><td>The amount of health overrides that are configured in the site</td></tr>
 <tr><td>carbide_hosts_health_status_count</td><td>gauge</td><td>The total number of Managed Hosts in the system that have reported any a healthy nor not healthy status - based on the presence of health probe alerts</td></tr>
 <tr><td>carbide_hosts_in_use_count</td><td>gauge</td><td>The total number of hosts that are actively used by tenants as instances in the Forge site</td></tr>
-<tr><td>carbide_hosts_unhealthy_by_classification_count</td><td>gauge</td><td>The amount of ManagedHosts which are marked with a certain classification due to being unhealthy</td></tr>
-<tr><td>carbide_hosts_unhealthy_by_probe_id_count</td><td>gauge</td><td>The amount of ManagedHosts which reported a certain Health Probe Alert</td></tr>
 <tr><td>carbide_hosts_usable_count</td><td>gauge</td><td>The remaining number of hosts in the Forge site which are available for immediate instance creation</td></tr>
 <tr><td>carbide_hosts_with_bios_password_set</td><td>gauge</td><td>The total number of Hosts in the system that have their BIOS password set.</td></tr>
 <tr><td>carbide_ib_partitions_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_ib_partitions in the system</td></tr>

--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -562,17 +562,43 @@ async fn test_machine_a_tron_zerodpu(
         bmc_mock_registry,
         admin_dhcp_relay_address,
         |machine_handle| {
+            let carbide_api_addrs = &test_env.carbide_api_addrs;
             async move {
                 machine_handle
                     .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(90))
                     .await?;
                 let machine_id = machine_handle
                     .observed_machine_id()
-                    .expect("Machine ID should be set if host is ready")
-                    .to_string();
-                tracing::info!("Machine {machine_id} has made it to Ready.");
-                // TODO: ZERO DPU's instance handling is not yet clear. Removing this code until
-                // carbide starts supporting ZERO DPUs instance creation.
+                    .expect("Machine ID should be set if host is ready");
+                tracing::info!("Machine {machine_id} has made it to Ready, allocating instance");
+
+                // Zero-DPU tenants don't pass any network config; the allocator instead
+                // auto-picks a HostInband segment for them (which is covered as part of
+                // the test_zero_dpu_instance_allocation_no_network_config test).
+                let instance_id = instance::create(
+                    carbide_api_addrs,
+                    &machine_id,
+                    None,
+                    None,
+                    false,
+                    false,
+                    &[],
+                )
+                .await?;
+
+                machine_handle
+                    .wait_until_machine_up_with_api_state("Assigned/Ready", Duration::from_secs(60))
+                    .await?;
+                tracing::info!(
+                    "Machine {machine_id} has made it to Assigned/Ready, releasing instance"
+                );
+
+                instance::release(carbide_api_addrs, &machine_id, &instance_id, false).await?;
+
+                machine_handle
+                    .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(60))
+                    .await?;
+                tracing::info!("Machine {machine_id} has made it to Ready again, all done");
                 Ok::<(), eyre::Report>(())
             }
         },
@@ -595,17 +621,43 @@ async fn test_machine_a_tron_singledpu_nic_mode(
         bmc_mock_registry,
         admin_dhcp_relay_address,
         |machine_handle| {
+            let carbide_api_addrs = &test_env.carbide_api_addrs;
             async move {
                 machine_handle
                     .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(60))
                     .await?;
                 let machine_id = machine_handle
                     .observed_machine_id()
-                    .expect("Machine ID should be set if host is ready")
-                    .to_string();
+                    .expect("Machine ID should be set if host is ready");
                 tracing::info!("Machine {machine_id} has made it to Ready, allocating instance");
-                // TODO: ZERO DPU/DPU in NIC mode's instance handling is not yet clear. Removing this code until
-                // carbide starts supporting ZERO DPUs instance creation.
+
+                // For a DPU in NIC-mode, the DPU is treated as a plain NIC, meaning
+                // allocation goes through HostInband the same way the zero-DPU path
+                // allocation does; no network config, and the allocator auto-picks.
+                let instance_id = instance::create(
+                    carbide_api_addrs,
+                    &machine_id,
+                    None,
+                    None,
+                    false,
+                    false,
+                    &[],
+                )
+                .await?;
+
+                machine_handle
+                    .wait_until_machine_up_with_api_state("Assigned/Ready", Duration::from_secs(60))
+                    .await?;
+                tracing::info!(
+                    "Machine {machine_id} has made it to Assigned/Ready, releasing instance"
+                );
+
+                instance::release(carbide_api_addrs, &machine_id, &instance_id, false).await?;
+
+                machine_handle
+                    .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(60))
+                    .await?;
+                tracing::info!("Machine {machine_id} has made it to Ready again, all done");
                 Ok::<(), eyre::Report>(())
             }
         },

--- a/crates/api-test-helper/src/instance.rs
+++ b/crates/api-test-helper/src/instance.rs
@@ -67,9 +67,11 @@ pub async fn create(
             },
             "os": os,
         }),
-        // omit network from config if we're not specifying a segment
+        // omit network from config if we're not specifying a segment (in
+        // the zero-DPU case, the allocator auto-picks a HostInband segment).
         None => serde_json::json!({
             "tenant": tenant,
+            "os": os,
         }),
     };
 


### PR DESCRIPTION
## Description

This removes the "*instance handling is not yet clear*" `TODO` from `test_machine_a_tron_zerodpu` and `test_machine_a_tron_singledpu_nic_mode`, and is a follow up to all of the work that has happened to support https://github.com/NVIDIA/ncx-infra-controller-core/issues/870 (including #902, #994, #1010, #1025, #1026, #1027, #1028, #1029). Both tests now drive through `allocate_instance` -> `Assigned/Ready` → `release` -> `Ready` (unassigned). Both hit the same `HostInband` allocation path, so one working should imply the other, but it's good to cover both!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

