### PR TITLE
chore: Move health information into status fields

### DIFF
--- a/crates/api-model/src/power_shelf/mod.rs
+++ b/crates/api-model/src/power_shelf/mod.rs
@@ -177,6 +177,17 @@ impl TryFrom<PowerShelf> for rpc::PowerShelf {
 
     fn try_from(src: PowerShelf) -> Result<Self, Self::Error> {
         let controller_state = serde_json::to_string(&src.controller_state.value).unwrap();
+        let health = derive_power_shelf_aggregate_health(&src.health_reports);
+        let health_sources = src
+            .health_reports
+            .clone()
+            .into_iter()
+            .map(|(hr, m)| rpc::HealthSourceOrigin {
+                mode: m as i32,
+                source: hr.source,
+            })
+            .collect();
+
         let status = Some(match src.status {
             Some(s) => rpc::PowerShelfStatus {
                 state_reason: None, // TODO: implement state_reason
@@ -188,6 +199,8 @@ impl TryFrom<PowerShelf> for rpc::PowerShelf {
                 power_state: Some(s.power_state),
                 health_status: Some(s.health_status),
                 controller_state: Some(controller_state.clone()),
+                health: Some(health.into()),
+                health_sources,
             },
             None => rpc::PowerShelfStatus {
                 state_reason: None,
@@ -199,6 +212,8 @@ impl TryFrom<PowerShelf> for rpc::PowerShelf {
                 power_state: None,
                 health_status: None,
                 controller_state: Some(controller_state.clone()),
+                health: Some(health.into()),
+                health_sources,
             },
         });
 
@@ -208,16 +223,6 @@ impl TryFrom<PowerShelf> for rpc::PowerShelf {
             voltage: src.config.voltage.map(|v| v as i32),
         };
 
-        let health = derive_power_shelf_aggregate_health(&src.health_reports);
-        let health_sources = src
-            .health_reports
-            .clone()
-            .into_iter()
-            .map(|(hr, m)| rpc::HealthSourceOrigin {
-                mode: m as i32,
-                source: hr.source,
-            })
-            .collect();
         let deleted = if src.deleted.is_some() {
             Some(src.deleted.unwrap().into())
         } else {
@@ -235,8 +240,6 @@ impl TryFrom<PowerShelf> for rpc::PowerShelf {
             bmc_info: None,
             state_version,
             rack_id: src.rack_id,
-            health: Some(health.into()),
-            health_sources,
         })
     }
 }

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -179,10 +179,13 @@ impl From<Rack> for rpc::forge::Rack {
             created: Some(Timestamp::from(value.created)),
             updated: Some(Timestamp::from(value.updated)),
             deleted: value.deleted.map(Timestamp::from),
-            health: Some(health.into()),
-            health_sources,
             metadata: Some(value.metadata.into()),
             version: value.version.version_string(),
+            config: Some(rpc::forge::RackConfig {}),
+            status: Some(rpc::forge::RackStatus {
+                health: Some(health.into()),
+                health_sources,
+            }),
         }
     }
 }

--- a/crates/api-model/src/switch/mod.rs
+++ b/crates/api-model/src/switch/mod.rs
@@ -231,6 +231,16 @@ impl TryFrom<Switch> for rpc::Switch {
         let state_reason = src.controller_state_outcome.map(|r| r.into());
         let sla = state_sla(&src.controller_state.value, &src.controller_state.version).into();
         let controller_state = serde_json::to_string(&src.controller_state.value).unwrap();
+        let health = derive_switch_aggregate_health(&src.health_reports);
+        let health_sources = src
+            .health_reports
+            .clone()
+            .into_iter()
+            .map(|(hr, m)| rpc::HealthSourceOrigin {
+                mode: m as i32,
+                source: hr.source,
+            })
+            .collect();
         let status = Some(match src.status {
             Some(s) => rpc::SwitchStatus {
                 state_reason,
@@ -239,6 +249,8 @@ impl TryFrom<Switch> for rpc::Switch {
                 power_state: Some(s.power_state),
                 health_status: Some(s.health_status),
                 controller_state: Some(controller_state.clone()),
+                health: Some(health.into()),
+                health_sources,
             },
             None => rpc::SwitchStatus {
                 state_reason,
@@ -247,6 +259,8 @@ impl TryFrom<Switch> for rpc::Switch {
                 power_state: None,
                 health_status: None,
                 controller_state: Some(controller_state.clone()),
+                health: Some(health.into()),
+                health_sources,
             },
         });
 
@@ -266,16 +280,6 @@ impl TryFrom<Switch> for rpc::Switch {
             enable_nmxc: src.config.enable_nmxc,
         };
 
-        let health = derive_switch_aggregate_health(&src.health_reports);
-        let health_sources = src
-            .health_reports
-            .clone()
-            .into_iter()
-            .map(|(hr, m)| rpc::HealthSourceOrigin {
-                mode: m as i32,
-                source: hr.source,
-            })
-            .collect();
         let deleted = if src.deleted.is_some() {
             Some(src.deleted.unwrap().into())
         } else {
@@ -294,8 +298,6 @@ impl TryFrom<Switch> for rpc::Switch {
             version: src.version.version_string(),
             rack_id: src.rack_id,
             placement_in_rack,
-            health: Some(health.into()),
-            health_sources,
         })
     }
 }

--- a/crates/api/src/tests/power_shelf_health.rs
+++ b/crates/api/src/tests/power_shelf_health.rs
@@ -308,18 +308,22 @@ async fn test_health_visible_in_find_power_shelves(
 
     assert_eq!(resp.power_shelves.len(), 1);
     let ps = &resp.power_shelves[0];
+    let ps_status = ps.status.as_ref().unwrap();
 
-    assert!(ps.health.is_some(), "Power shelf should have health field");
-    let health: HealthReport = ps.health.clone().unwrap().try_into().unwrap();
+    assert!(
+        ps_status.health.is_some(),
+        "Power shelf should have health field"
+    );
+    let health: HealthReport = ps_status.health.clone().unwrap().try_into().unwrap();
     assert!(
         !health.alerts.is_empty(),
         "Power shelf health should contain alerts"
     );
 
-    assert_eq!(ps.health_sources.len(), 1);
-    assert_eq!(ps.health_sources[0].source, "external-monitor");
+    assert_eq!(ps_status.health_sources.len(), 1);
+    assert_eq!(ps_status.health_sources[0].source, "external-monitor");
     assert_eq!(
-        ps.health_sources[0].mode,
+        ps_status.health_sources[0].mode,
         rpc_forge::HealthReportApplyMode::Merge as i32
     );
 

--- a/crates/api/src/tests/rack_health.rs
+++ b/crates/api/src/tests/rack_health.rs
@@ -583,18 +583,24 @@ async fn test_rack_health_visible_in_find_racks_by_ids(
 
     assert_eq!(rack_resp.racks.len(), 1);
     let rack = &rack_resp.racks[0];
-
-    assert!(rack.health.is_some(), "Rack should have health field");
-    let health: HealthReport = rack.health.clone().unwrap().try_into().unwrap();
+    let rack_status = rack.status.as_ref().unwrap();
+    assert!(
+        rack_status.health.is_some(),
+        "Rack should have health field"
+    );
+    let health: HealthReport = rack_status.health.clone().unwrap().try_into().unwrap();
     assert!(
         !health.alerts.is_empty(),
         "Rack health should contain alerts"
     );
 
-    assert_eq!(rack.health_sources.len(), 1);
-    assert_eq!(rack.health_sources[0].source, "dsx-exchange-consumer");
+    assert_eq!(rack_status.health_sources.len(), 1);
     assert_eq!(
-        rack.health_sources[0].mode,
+        rack_status.health_sources[0].source,
+        "dsx-exchange-consumer"
+    );
+    assert_eq!(
+        rack_status.health_sources[0].mode,
         rpc_forge::HealthReportApplyMode::Merge as i32
     );
 

--- a/crates/api/src/tests/switch_health.rs
+++ b/crates/api/src/tests/switch_health.rs
@@ -281,17 +281,21 @@ async fn test_switch_health_visible_in_find_switches(
     assert_eq!(switch_resp.switches.len(), 1);
     let switch = &switch_resp.switches[0];
 
-    assert!(switch.health.is_some(), "Switch should have health field");
-    let health: HealthReport = switch.health.clone().unwrap().try_into().unwrap();
+    let switch_status = switch.status.as_ref().unwrap();
+    assert!(
+        switch_status.health.is_some(),
+        "Switch should have health field"
+    );
+    let health: HealthReport = switch_status.health.clone().unwrap().try_into().unwrap();
     assert!(
         !health.alerts.is_empty(),
         "Switch health should contain alerts"
     );
 
-    assert_eq!(switch.health_sources.len(), 1);
-    assert_eq!(switch.health_sources[0].source, "external-monitor");
+    assert_eq!(switch_status.health_sources.len(), 1);
+    assert_eq!(switch_status.health_sources[0].source, "external-monitor");
     assert_eq!(
-        switch.health_sources[0].mode,
+        switch_status.health_sources[0].mode,
         rpc_forge::HealthReportApplyMode::Merge as i32
     );
 

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -752,7 +752,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "#[derive(serde::Deserialize,serde::Serialize)]",
         )
         .type_attribute(
+            "forge.RackConfig",
+            "#[derive(serde::Deserialize,serde::Serialize)]",
+        )
+        .type_attribute(
             "forge.RackList",
+            "#[derive(serde::Deserialize,serde::Serialize)]",
+        )
+        .type_attribute(
+            "forge.RackStatus",
             "#[derive(serde::Deserialize,serde::Serialize)]",
         )
         .type_attribute("forge.PowerShelf", "#[derive(serde::Serialize)]")

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1809,6 +1809,9 @@ message PowerShelfStatus {
   optional string health_status = 5;
   // The controller state machine state (e.g. "initializing", "ready", "error")
   optional string controller_state = 6;
+
+  health.HealthReport health = 7;
+  repeated HealthSourceOrigin health_sources = 8;
 }
 
 // Describe a PowerShelf configuration and status
@@ -1835,8 +1838,8 @@ message PowerShelf {
 
   // The rack that this powershelf is associated with
   optional common.RackId rack_id = 10;
-  health.HealthReport health = 11;
-  repeated HealthSourceOrigin health_sources = 12;
+
+  reserved 11, 12;
 }
 
 message PowerShelfList {
@@ -1960,6 +1963,9 @@ message SwitchStatus {
   optional string health_status = 5;
   // The controller state machine state (e.g. "initializing", "ready", "error")
   optional string controller_state = 6;
+
+  health.HealthReport health = 7;
+  repeated HealthSourceOrigin health_sources = 8;
 }
 
 message PlacementInRack {
@@ -1992,8 +1998,8 @@ message Switch {
   // The rack that this switch is associated with
   optional common.RackId rack_id = 10;
   optional PlacementInRack placement_in_rack = 11;
-  health.HealthReport health = 12;
-  repeated HealthSourceOrigin health_sources = 13;
+
+  reserved 12, 13;
 }
 
 message SwitchList {
@@ -6510,10 +6516,20 @@ message Rack {
   google.protobuf.Timestamp created = 9;
   google.protobuf.Timestamp updated = 10;
   google.protobuf.Timestamp deleted = 11;
-  health.HealthReport health = 12;
-  repeated HealthSourceOrigin health_sources = 13;
+  reserved 12, 13;
   Metadata metadata = 14;
   string version = 15;
+  RackConfig config = 16;
+  RackStatus status = 17;
+}
+
+message RackConfig {
+
+}
+
+message RackStatus {
+  health.HealthReport health = 7;
+  repeated HealthSourceOrigin health_sources = 8;
 }
 
 message RackStateHistoriesRequest {


### PR DESCRIPTION
## Description

For each component that carries a health property (except Machines), move the health fields into the status property.

Machines is not modified because its heavily in use and the object requires bigger changes to migrate into a better pattern.

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [x] This PR contains breaking changes

Any user that pulled health from old fields has to consume it from the new ones.
However there are no known users so far.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

