### PR TITLE
docs(book/SUMMARY): fix 'Hardware Compatbility' -> 'Hardware Compatibility'

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,7 +1,7 @@
 # NCX Infra Controller
 
 - [Introduction](README.md)
-- [Hardware Compatbility List](hcl.md)
+- [Hardware Compatibility List](hcl.md)
 - [Release Notes](release-notes.md)
 - [FAQs](faq.md)
 


### PR DESCRIPTION
## Summary

\`book/src/SUMMARY.md\` line 4 said 'Hardware Compatbility List' (missing 'i'). Fixed to 'Hardware Compatibility List'. This is the mdBook navigation entry so the typo is user-visible on the rendered book.

Closes #1039

## Testing

Docs-only change.