### PR TITLE
chore: Move state controller related fields into LifecycleStatus message

### DIFF
--- a/crates/api-model/src/power_shelf/mod.rs
+++ b/crates/api-model/src/power_shelf/mod.rs
@@ -18,7 +18,7 @@
 use std::collections::HashMap;
 
 use ::rpc::errors::RpcDataConversionError;
-use ::rpc::forge as rpc;
+use ::rpc::forge::{self as rpc, LifecycleStatus};
 use carbide_uuid::power_shelf::PowerShelfId;
 use carbide_uuid::rack::RackId;
 use chrono::prelude::*;
@@ -176,7 +176,6 @@ impl TryFrom<PowerShelf> for rpc::PowerShelf {
     type Error = RpcDataConversionError;
 
     fn try_from(src: PowerShelf) -> Result<Self, Self::Error> {
-        let controller_state = serde_json::to_string(&src.controller_state.value).unwrap();
         let health = derive_power_shelf_aggregate_health(&src.health_reports);
         let health_sources = src
             .health_reports
@@ -187,6 +186,17 @@ impl TryFrom<PowerShelf> for rpc::PowerShelf {
                 source: hr.source,
             })
             .collect();
+
+        let lifecycle = LifecycleStatus {
+            state: serde_json::to_string(&src.controller_state.value).unwrap_or_default(),
+            version: src.controller_state.version.version_string(),
+            state_reason: src.controller_state_outcome.map(Into::into),
+            sla: Some(rpc::StateSla {
+                sla: None, // TODO: Calculate SLA properly
+                time_in_state_above_sla: false,
+            }),
+        };
+        let controller_state = lifecycle.state.clone();
 
         let status = Some(match src.status {
             Some(s) => rpc::PowerShelfStatus {
@@ -201,6 +211,7 @@ impl TryFrom<PowerShelf> for rpc::PowerShelf {
                 controller_state: Some(controller_state.clone()),
                 health: Some(health.into()),
                 health_sources,
+                lifecycle: Some(lifecycle),
             },
             None => rpc::PowerShelfStatus {
                 state_reason: None,
@@ -214,6 +225,7 @@ impl TryFrom<PowerShelf> for rpc::PowerShelf {
                 controller_state: Some(controller_state.clone()),
                 health: Some(health.into()),
                 health_sources,
+                lifecycle: Some(lifecycle),
             },
         });
 

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -24,6 +24,7 @@ use carbide_uuid::switch::SwitchId;
 use chrono::{DateTime, Utc};
 use config_version::{ConfigVersion, Versioned};
 use rpc::Timestamp;
+use rpc::forge::LifecycleStatus;
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgRow;
 use sqlx::{FromRow, Row};
@@ -167,6 +168,16 @@ impl From<Rack> for rpc::forge::Rack {
             })
             .collect();
 
+        let lifecycle = LifecycleStatus {
+            state: serde_json::to_string(&value.controller_state.value).unwrap_or_default(),
+            version: value.controller_state.version.version_string(),
+            state_reason: value.controller_state_outcome.map(Into::into),
+            sla: Some(rpc::forge::StateSla {
+                sla: None, // TODO: Calculate SLA properly
+                time_in_state_above_sla: false,
+            }),
+        };
+
         rpc::forge::Rack {
             id: Some(value.id),
             rack_state: value.controller_state.value.to_string(),
@@ -185,6 +196,7 @@ impl From<Rack> for rpc::forge::Rack {
             status: Some(rpc::forge::RackStatus {
                 health: Some(health.into()),
                 health_sources,
+                lifecycle: Some(lifecycle),
             }),
         }
     }

--- a/crates/api-model/src/switch/mod.rs
+++ b/crates/api-model/src/switch/mod.rs
@@ -18,7 +18,7 @@
 use std::collections::HashMap;
 
 use ::rpc::errors::RpcDataConversionError;
-use ::rpc::forge as rpc;
+use ::rpc::forge::{self as rpc, LifecycleStatus};
 use carbide_uuid::rack::RackId;
 use carbide_uuid::switch::SwitchId;
 use chrono::prelude::*;
@@ -228,9 +228,6 @@ impl TryFrom<Switch> for rpc::Switch {
     type Error = RpcDataConversionError;
 
     fn try_from(src: Switch) -> Result<Self, Self::Error> {
-        let state_reason = src.controller_state_outcome.map(|r| r.into());
-        let sla = state_sla(&src.controller_state.value, &src.controller_state.version).into();
-        let controller_state = serde_json::to_string(&src.controller_state.value).unwrap();
         let health = derive_switch_aggregate_health(&src.health_reports);
         let health_sources = src
             .health_reports
@@ -241,26 +238,38 @@ impl TryFrom<Switch> for rpc::Switch {
                 source: hr.source,
             })
             .collect();
+
+        let sla = state_sla(&src.controller_state.value, &src.controller_state.version);
+        let lifecycle = LifecycleStatus {
+            state: serde_json::to_string(&src.controller_state.value).unwrap_or_default(),
+            version: src.controller_state.version.version_string(),
+            state_reason: src.controller_state_outcome.map(Into::into),
+            sla: Some(sla.clone().into()),
+        };
+        let controller_state = lifecycle.state.clone();
+
         let status = Some(match src.status {
             Some(s) => rpc::SwitchStatus {
-                state_reason,
-                state_sla: Some(sla),
+                state_reason: lifecycle.state_reason.clone(),
+                state_sla: Some(sla.into()),
                 switch_name: Some(s.switch_name),
                 power_state: Some(s.power_state),
                 health_status: Some(s.health_status),
-                controller_state: Some(controller_state.clone()),
+                controller_state: Some(lifecycle.state.clone()),
                 health: Some(health.into()),
                 health_sources,
+                lifecycle: Some(lifecycle),
             },
             None => rpc::SwitchStatus {
-                state_reason,
-                state_sla: Some(sla),
+                state_reason: lifecycle.state_reason.clone(),
+                state_sla: Some(sla.into()),
                 switch_name: None,
                 power_state: None,
                 health_status: None,
-                controller_state: Some(controller_state.clone()),
+                controller_state: Some(lifecycle.state.clone()),
                 health: Some(health.into()),
                 health_sources,
+                lifecycle: Some(lifecycle),
             },
         });
 

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -209,6 +209,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "#[derive(serde::Serialize, serde::Deserialize)]",
         )
         .type_attribute(
+            "forge.LifecycleStatus",
+            "#[derive(serde::Serialize)]",
+        )
+        .type_attribute(
             "forge.InstancePhoneHomeLastContactRequest",
             "#[derive(serde::Serialize)]",
         )
@@ -736,20 +740,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "#[derive(serde::Deserialize,serde::Serialize)]",
         )
         .type_attribute(
-            "forge.GetRackRequest",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.GetRackResponse",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.DeleteRackRequest",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
-        )
-        .type_attribute(
             "forge.Rack",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
+            "#[derive(serde::Serialize)]",
         )
         .type_attribute(
             "forge.RackConfig",
@@ -757,11 +749,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .type_attribute(
             "forge.RackList",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
+            "#[derive(serde::Serialize)]",
         )
         .type_attribute(
             "forge.RackStatus",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
+            "#[derive(serde::Serialize)]",
         )
         .type_attribute("forge.PowerShelf", "#[derive(serde::Serialize)]")
         .type_attribute("forge.PowerShelfConfig", "#[derive(serde::Serialize)]")

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -896,6 +896,18 @@ service Forge {
   rpc UpdateOperatingSystemCachableIpxeTemplateArtifacts(UpdateOperatingSystemIpxeTemplateArtifactRequest) returns (IpxeTemplateArtifactList);
 }
 
+// Indicates the lifecycle state of a resource that is controlled by a state controller
+message LifecycleStatus {
+  // The current state of the resource
+  string state = 1;
+  // The state version. This version number is incremented each time the resource transitions into a new state
+  string version = 2;
+  // The result of last state controller run - its outcome and an optional reason for that outcome
+  optional ControllerStateReason state_reason = 3;
+  // The SLA that is associated with the current state
+  StateSla sla = 4;
+}
+
 message AttestationIdsRequest {
 
 }
@@ -1797,8 +1809,10 @@ message PowerShelfConfig {
 // Describe the status and applied configuration of a PowerShelf
 message PowerShelfStatus {
   // The result of last state controller run - its outcome and an optional reason for that outcome
+  // deprecated: Use lifecycle field
   optional ControllerStateReason state_reason = 1;
   // The SLA for the current state - and whether the SLA has been breached
+  // deprecated: Use lifecycle field
   StateSla state_sla = 2;
 
   // The shelf name of PowerShelf
@@ -1812,6 +1826,8 @@ message PowerShelfStatus {
 
   health.HealthReport health = 7;
   repeated HealthSourceOrigin health_sources = 8;
+  // Lifecycle related status
+  LifecycleStatus lifecycle = 9;
 }
 
 // Describe a PowerShelf configuration and status
@@ -1951,8 +1967,10 @@ message FabricManagerConfig {
 // Describe the status and applied configuration of a Switch
 message SwitchStatus {
   // The result of last state controller run - its outcome and an optional reason for that outcome
+  // deprecated: Use lifecycle field
   optional ControllerStateReason state_reason = 1;
   // The SLA for the current state - and whether the SLA has been breached
+  // deprecated: Use lifecycle field
   StateSla state_sla = 2;
 
   // The name of Switch
@@ -1966,6 +1984,8 @@ message SwitchStatus {
 
   health.HealthReport health = 7;
   repeated HealthSourceOrigin health_sources = 8;
+  // Lifecycle related status
+  LifecycleStatus lifecycle = 9;
 }
 
 message PlacementInRack {
@@ -1984,7 +2004,7 @@ message Switch {
   // Timestamp when the switch was marked as deleted
   optional google.protobuf.Timestamp deleted = 4;
 
-  // Deprecated: use status.controller_state instead
+  // Deprecated: use status.lifecycle instead
   string controller_state = 5;
 
   BmcInfo bmc_info = 6;
@@ -3315,10 +3335,13 @@ message HealthSourceOrigin {
   string source = 2;
 }
 
-// Result of last state controller iteration
+// Result of last state handler invocation
 message ControllerStateReason {
+  // Return value of last state handler invocation
   ControllerStateOutcome outcome = 1;
+  // Message associated with the return value of the last state handler invocation
   optional string outcome_msg = 2;
+  // Reference to source code where the outcome was generated
   optional ControllerStateSourceReference source_ref = 3;
 }
 
@@ -6506,6 +6529,7 @@ message RacksByIdsRequest {
 
 message Rack {
   common.RackId id = 1;
+  // deprecated: Use status.lifecycle field
   string rack_state = 2;
   repeated string expected_compute_trays = 3;
   repeated string expected_power_shelves = 4;
@@ -6530,6 +6554,8 @@ message RackConfig {
 message RackStatus {
   health.HealthReport health = 7;
   repeated HealthSourceOrigin health_sources = 8;
+  // Lifecycle related status
+  LifecycleStatus lifecycle = 9;
 }
 
 message RackStateHistoriesRequest {


### PR DESCRIPTION
## Description

Moves everything state and state controller related into a new field to avoid duplication. A switch state can be accessed e.g. via `switch.status.lifecycle.state` after this.

The reasoning for calling the new data type `LifecycleStatus` and adding it via a `lifecycle` property are:
- Field access shouldn't look like `instance.status.status.state`. That's too confusing (what is each state?)
- While `ControllerState` seems a good description on where and how something are stored and updated, it seems less descriptive for API users than Lifecycle . They don't need to know that there is a "controller"

The change is so far done only for new resources, but we should be able to retrofit it gracefully for older data types and slowly migrate nico-rest off.

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

