### PR TITLE
refactor(firmware): introduce explicit firmware config snapshots

### DIFF
--- a/crates/api/src/handlers/firmware.rs
+++ b/crates/api/src/handlers/firmware.rs
@@ -80,7 +80,12 @@ pub(crate) fn list_host_firmware(
     _request: Request<rpc::ListHostFirmwareRequest>,
 ) -> Result<Response<rpc::ListHostFirmwareResponse>, Status> {
     let mut ret = vec![];
-    for (_, entry) in api.runtime_config.get_firmware_config().map() {
+    for entry in api
+        .runtime_config
+        .get_firmware_config()
+        .create_snapshot()
+        .into_values()
+    {
         for (component, component_info) in entry.components {
             for firmware in component_info.known_firmware {
                 if firmware.default {
@@ -114,7 +119,7 @@ pub(crate) fn get_desired_firmware_versions(
     let entries = api
         .runtime_config
         .get_firmware_config()
-        .map()
+        .create_snapshot()
         .into_values()
         .map(|firmware| {
             let vendor = firmware.vendor;

--- a/crates/api/src/machine_update_manager/host_firmware.rs
+++ b/crates/api/src/machine_update_manager/host_firmware.rs
@@ -67,8 +67,9 @@ impl MachineUpdateModule for HostFirmwareUpdate {
                     < firmware_dir_mod_time // Using an auto firmware directory, and a new file has been created or this is the first run
             })) {
                 // Save the firmware config in an SQL table so that we can filter for hosts with non-matching firmware there.
-                tracing::info!("Firmware config now: {:?}", self.firmware_config.map());
-                let models = self.firmware_config.map().into_values().collect::<Vec<_>>();
+                let fw_config_snapshot = self.firmware_config.create_snapshot();
+                tracing::info!("Firmware config now: {:?}", fw_config_snapshot);
+                let models = fw_config_snapshot.into_values().collect::<Vec<_>>();
                 desired_firmware::snapshot_desired_firmware(txn, &models).await?;
                 *firmware_dir_last_read =
                     Some(firmware_dir_mod_time.unwrap_or(std::time::SystemTime::now()));

--- a/crates/api/src/preingestion_manager/mod.rs
+++ b/crates/api/src/preingestion_manager/mod.rs
@@ -477,7 +477,7 @@ impl PreingestionManagerStatic {
             }
         };
         let model = endpoint.report.model()?;
-        self.host_info.find(vendor, &model)
+        self.host_info.create_snapshot().find(vendor, &model)
     }
 
     /// check_firmware_versions_below_preingestion will check if we actually need to do firmware upgrades before

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -24,7 +24,7 @@ use std::str::FromStr;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
-use carbide_firmware::FirmwareConfig;
+use carbide_firmware::{FirmwareConfig, FirmwareConfigSnapshot};
 use carbide_uuid::machine::MachineId;
 use chrono::{DateTime, Duration, Utc};
 use config_version::{ConfigVersion, Versioned};
@@ -1463,6 +1463,7 @@ impl MachineStateHandler {
                     )));
                 }
 
+                let fw_config_snapshot = self.dpu_handler.hardware_models.create_snapshot();
                 for dpu_snapshot in &mh_snapshot.dpu_snapshots {
                     // TODO: Optimization Possible: We can have another outcome something like
                     // TransitionNotPossible. This will be valid for the sync states (States where
@@ -1477,7 +1478,7 @@ impl MachineStateHandler {
                             &MachineNextStateResolver,
                             dpu_snapshot,
                             ctx,
-                            &self.dpu_handler.hardware_models,
+                            &fw_config_snapshot,
                             self.dpu_handler.dpf_sdk.as_deref(),
                         )
                         .await?
@@ -2545,7 +2546,7 @@ async fn handle_dpu_reprovision(
     next_state_resolver: &impl NextState,
     dpu_snapshot: &Machine,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
-    hardware_models: &FirmwareConfig,
+    hardware_models: &FirmwareConfigSnapshot,
     dpf_sdk: Option<&dyn DpfOperations>,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     let dpu_machine_id = &dpu_snapshot.id;
@@ -2923,7 +2924,7 @@ pub async fn try_wait_for_dpu_discovery(
 async fn check_fw_component_version(
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     dpu_snapshot: &Machine,
-    hardware_models: &FirmwareConfig,
+    hardware_models: &FirmwareConfigSnapshot,
 ) -> Result<Option<StateHandlerOutcome<ManagedHostState>>, StateHandlerError> {
     let redfish_client = ctx
         .services
@@ -3496,8 +3497,12 @@ impl DpuMachineStateHandler {
                     }
                 };
 
-                if let Some(outcome) =
-                    check_fw_component_version(ctx, dpu_snapshot, &self.hardware_models).await?
+                if let Some(outcome) = check_fw_component_version(
+                    ctx,
+                    dpu_snapshot,
+                    &self.hardware_models.create_snapshot(),
+                )
+                .await?
                 {
                     return Ok(outcome);
                 }
@@ -5935,6 +5940,7 @@ impl StateHandler for InstanceStateHandler {
                         )));
                     }
 
+                    let fw_config_snapshot = self.hardware_models.create_snapshot();
                     for dpu_snapshot in &mh_snapshot.dpu_snapshots {
                         if let outcome @ StateHandlerOutcome::Transition { .. } =
                             handle_dpu_reprovision(
@@ -5943,7 +5949,7 @@ impl StateHandler for InstanceStateHandler {
                                 &InstanceNextStateResolver,
                                 dpu_snapshot,
                                 ctx,
-                                &self.hardware_models,
+                                &fw_config_snapshot,
                                 self.dpf_sdk.as_deref(),
                             )
                             .await?
@@ -6895,7 +6901,11 @@ impl HostUpgradeState {
             )));
         };
 
-        let Some(fw_info) = self.parsed_hosts.find_fw_info_for_host(&explored_endpoint) else {
+        let Some(fw_info) = self
+            .parsed_hosts
+            .create_snapshot()
+            .find_fw_info_for_host(&explored_endpoint)
+        else {
             return Ok(StateHandlerOutcome::transition(scenario.complete_state()));
         };
 
@@ -7576,8 +7586,10 @@ impl HostUpgradeState {
                         // If we have multiple firmware files to be uploaded, do the next one.
                         if let Some(endpoint) =
                             find_explored_refreshed_endpoint(state, machine_id, ctx).await?
-                            && let Some(fw_info) =
-                                self.parsed_hosts.find_fw_info_for_host(&endpoint)
+                            && let Some(fw_info) = self
+                                .parsed_hosts
+                                .create_snapshot()
+                                .find_fw_info_for_host(&endpoint)
                             && let Some(component_info) = fw_info.components.get(firmware_type)
                             && let Some(selected_firmware) =
                                 component_info.known_firmware.iter().find(|&x| x.default)
@@ -7688,7 +7700,10 @@ impl HostUpgradeState {
                             return Ok(StateHandlerOutcome::do_nothing());
                         };
 
-                        if let Some(fw_info) = self.parsed_hosts.find_fw_info_for_host(&endpoint)
+                        if let Some(fw_info) = self
+                            .parsed_hosts
+                            .create_snapshot()
+                            .find_fw_info_for_host(&endpoint)
                             && let Some(current_version) =
                                 endpoint.find_version(&fw_info, *firmware_type)
                             && current_version == final_version
@@ -7962,7 +7977,11 @@ impl HostUpgradeState {
             return Ok(StateHandlerOutcome::do_nothing());
         };
 
-        let Some(fw_info) = self.parsed_hosts.find_fw_info_for_host(&endpoint) else {
+        let Some(fw_info) = self
+            .parsed_hosts
+            .create_snapshot()
+            .find_fw_info_for_host(&endpoint)
+        else {
             tracing::error!("Could no longer find firmware info for {machine_id}");
             return Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
                 HostReprovisionState::CheckingFirmwareRepeatV2 {

--- a/crates/api/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api/src/tests/host_bmc_firmware_test.rs
@@ -896,6 +896,7 @@ known_firmware = [
     let cfg = cfg.get_firmware_config();
 
     let model = cfg
+        .create_snapshot()
         .find(bmc_vendor::BMCVendor::Dell, "PowerEdge R750")
         .unwrap();
 

--- a/crates/firmware/README.md
+++ b/crates/firmware/README.md
@@ -36,8 +36,23 @@ This crate is intentionally narrow:
 ### `FirmwareConfig`
 
 The main entry point. Constructed from a base map (populated from
-`CarbideConfig`) and a `firmware_directory` path. Offers lookup
-methods keyed by vendor + model:
+`CarbideConfig`) and a `firmware_directory` path. It is responsible
+for loading, merging, and refreshing firmware metadata.
+
+It exposes disk-state observation:
+
+- `create_snapshot()` — produce a merged firmware snapshot (reads
+  disk each call).
+- `config_update_time()` — modification time of `firmware_directory`,
+  used by callers that want to detect on-disk changes.
+
+### `FirmwareConfigSnapshot`
+
+An immutable point-in-time view of the merged firmware catalog.
+Snapshots are created via `FirmwareConfig::create_snapshot()` and
+can be queried without re-reading the disk.
+
+It exposes lookup helpers keyed by vendor and model:
 
 - `find(vendor, model)` — look up firmware metadata for a specific
   vendor/model pair.
@@ -45,24 +60,19 @@ methods keyed by vendor + model:
   an explored endpoint.
 - `find_fw_info_for_host_report(report)` — same, given the
   exploration report directly.
-
-It also exposes disk-state observation:
-
-- `map()` — produce the merged firmware map (reads disk each call).
-- `config_update_time()` — modification time of `firmware_directory`,
-  used by callers that want to detect on-disk changes.
+- `values()` / `into_values()` — iterate over snapshot contents.
 
 ## Loading behavior
 
 `FirmwareConfig` is a **live view** over the firmware directory, not
-a snapshot. Every call to a lookup method re-reads the directory,
+a snapshot. Every call to `create_snapshot()` re-reads the directory,
 parses every `metadata.toml`, and re-merges the entries on top of
 the base map.
 
 This lets operators add new firmware metadata at runtime without
-restarting Carbide: the next lookup picks it up. Consumers that want
+restarting Carbide: the next snapshot picks it up. Consumers that want
 cheap in-memory lookups (or explicit snapshot semantics) should
-cache the result themselves.
+cache a `FirmwareConfigSnapshot` and reuse it.
 
 Merge rules, applied in oldest-to-newest directory order:
 
@@ -84,6 +94,16 @@ Currently used (directly or indirectly) by:
   `machine_update_manager` (hot-reload detection),
   `handlers/firmware.rs` (HTTP API), `preingestion_manager`,
   `site_explorer`, `state_controller`, tests.
+
+## Snapshot semantics
+
+A lightweight `FirmwareConfigSnapshot` type has been introduced to
+provide an immutable point-in-time view of the firmware catalog.
+Snapshots are created via `FirmwareConfig::create_snapshot()` and
+contain a `data: HashMap<String, Firmware>` that can be queried
+without re-reading the disk. This avoids the hidden disk I/O that
+would otherwise occur on each refresh and enables efficient sharing
+(`Arc<FirmwareConfigSnapshot>`) across concurrent code paths.
 
 ## Future direction
 

--- a/crates/firmware/src/lib.rs
+++ b/crates/firmware/src/lib.rs
@@ -30,6 +30,54 @@ use model::firmware::Firmware;
 use model::site_explorer::{EndpointExplorationReport, ExploredEndpoint};
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug)]
+pub struct FirmwareConfigSnapshot {
+    data: HashMap<String, Firmware>,
+}
+
+impl FirmwareConfigSnapshot {
+    pub fn values(&self) -> impl Iterator<Item = &Firmware> {
+        self.data.values()
+    }
+
+    pub fn into_values(self) -> impl Iterator<Item = Firmware> {
+        self.data.into_values()
+    }
+
+    pub fn find(&self, vendor: bmc_vendor::BMCVendor, model: &str) -> Option<Firmware> {
+        let dpu_model = DpuModel::from(model);
+        let key = if dpu_model != DpuModel::Unknown {
+            vendor_model_to_key(vendor, &dpu_model.to_string())
+        } else {
+            vendor_model_to_key(vendor, model)
+        };
+        let ret = self.data.get(&key).map(|x| x.to_owned());
+        tracing::debug!("FirmwareConfig::find: key {key} found {ret:?}");
+        ret
+    }
+
+    /// find_fw_info_for_host looks up the firmware config for the given endpoint
+    pub fn find_fw_info_for_host(&self, endpoint: &ExploredEndpoint) -> Option<Firmware> {
+        self.find_fw_info_for_host_report(&endpoint.report)
+    }
+
+    /// find_fw_info_for_host_report looks up the firmware config for the given endpoint report
+    pub fn find_fw_info_for_host_report(
+        &self,
+        report: &EndpointExplorationReport,
+    ) -> Option<Firmware> {
+        report.vendor.and_then(|vendor| {
+            // Use report.model if it is already filled or use model()
+            // function to extract model from the report.
+            report
+                .model
+                .as_ref()
+                .and_then(|model| self.find(vendor, model))
+                .or_else(|| report.model().and_then(|model| self.find(vendor, &model)))
+        })
+    }
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct FirmwareConfig {
     base_map: HashMap<String, Firmware>,
@@ -65,56 +113,23 @@ impl FirmwareConfig {
         }
     }
 
-    pub fn find(&self, vendor: bmc_vendor::BMCVendor, model: &str) -> Option<Firmware> {
-        let dpu_model = DpuModel::from(model);
-        let key = if dpu_model != DpuModel::Unknown {
-            vendor_model_to_key(vendor, &dpu_model.to_string())
-        } else {
-            vendor_model_to_key(vendor, model)
-        };
-        let ret = self.map().get(&key).map(|x| x.to_owned());
-        tracing::debug!("FirmwareConfig::find: key {key} found {ret:?}");
-        ret
-    }
-
-    /// find_fw_info_for_host looks up the firmware config for the given endpoint
-    pub fn find_fw_info_for_host(&self, endpoint: &ExploredEndpoint) -> Option<Firmware> {
-        self.find_fw_info_for_host_report(&endpoint.report)
-    }
-
-    /// find_fw_info_for_host_report looks up the firmware config for the given endpoint report
-    pub fn find_fw_info_for_host_report(
-        &self,
-        report: &EndpointExplorationReport,
-    ) -> Option<Firmware> {
-        report.vendor.and_then(|vendor| {
-            // Use report.model if it is already filled or use model()
-            // function to extract model from the report.
-            report
-                .model
-                .as_ref()
-                .and_then(|model| self.find(vendor, model))
-                .or_else(|| report.model().and_then(|model| self.find(vendor, &model)))
-        })
-    }
-
-    pub fn map(&self) -> HashMap<String, Firmware> {
-        let mut map = self.base_map.clone();
+    pub fn create_snapshot(&self) -> FirmwareConfigSnapshot {
+        let mut data = self.base_map.clone();
         if self.firmware_directory.to_string_lossy() != "" {
-            self.merge_firmware_configs(&mut map, &self.firmware_directory);
+            self.merge_firmware_configs(&mut data, &self.firmware_directory);
         }
 
         #[cfg(test)]
         {
             // Fake configs to merge for unit tests
             for ovrd in &self.test_overrides {
-                if let Err(err) = self.merge_from_string(&mut map, ovrd.clone()) {
+                if let Err(err) = self.merge_from_string(&mut data, ovrd.clone()) {
                     tracing::error!("Bad override {ovrd}: {err}");
                 }
             }
         }
 
-        map
+        FirmwareConfigSnapshot { data }
     }
 
     pub fn config_update_time(&self) -> Option<std::time::SystemTime> {

--- a/crates/firmware/src/tests/desired_firmware_versions.rs
+++ b/crates/firmware/src/tests/desired_firmware_versions.rs
@@ -93,7 +93,11 @@ current_version_reported_as = "^2$"
     let mut txn = pool.begin().await?;
     desired_firmware::snapshot_desired_firmware(
         &mut txn,
-        config.map().into_values().collect::<Vec<_>>().as_slice(),
+        config
+            .create_snapshot()
+            .into_values()
+            .collect::<Vec<_>>()
+            .as_slice(),
     )
     .await?;
     txn.commit().await?;

--- a/crates/firmware/src/tests/mod.rs
+++ b/crates/firmware/src/tests/mod.rs
@@ -65,8 +65,8 @@ default = true
     config.add_test_override(cfg2.to_string());
 
     println!("{config:#?}");
-    let map = config.map();
-    let server = map.get("dell:poweredge r750").unwrap();
+    let snapshot = config.create_snapshot();
+    let server = snapshot.data.get("dell:poweredge r750").unwrap();
     assert_eq!(
         server
             .components

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -1474,6 +1474,7 @@ impl SiteExplorer {
         // the number of expected machines we've actually "seen."
         metrics.endpoint_explorations_expected_machines_missing_overall_count =
             expected_count - index.all_matched_expected_machines().len();
+        let fw_config_snapshot = Arc::new(self.firmware_config.create_snapshot());
 
         for endpoint in explore_endpoint_data.into_iter() {
             let endpoint_explorer = self.endpoint_explorer.clone();
@@ -1481,7 +1482,7 @@ impl SiteExplorer {
 
             let bmc_target_port = self.config.override_target_port.unwrap_or(443);
             let bmc_target_addr = SocketAddr::new(endpoint.address, bmc_target_port);
-            let firmware_config = self.firmware_config.clone();
+            let fw_config_snapshot = fw_config_snapshot.clone();
             let database_connection = self.database_connection.clone();
 
             task_set.push(
@@ -1529,7 +1530,7 @@ impl SiteExplorer {
                                 tracing::error!(%error, "Can not generate MachineId for explored endpoint");
                             }
                             report.model = report.model();
-                            if let Some(fw_info) = firmware_config.find_fw_info_for_host_report(report)
+                            if let Some(fw_info) = fw_config_snapshot.find_fw_info_for_host_report(report)
                             {
                                 let components_without_version = report.parse_versions(&fw_info);
                                 if !components_without_version.is_empty() {


### PR DESCRIPTION
## Description

Split firmware loading from firmware lookup by introducing `FirmwareConfigSnapshot` as an explicit immutable point-in-time view over merged firmware metadata.

Previously, `FirmwareConfig::map()` rebuilt a merged `HashMap` on each call and some lookup helpers hid that cost by reading from the live config directly. This change makes snapshot creation explicit via `FirmwareConfig::create_snapshot()` and moves lookup-oriented methods onto `FirmwareConfigSnapshot`.

This makes the API clearer about when disk-backed firmware metadata is loaded and when callers are operating on an in-memory snapshot.

It also improves performance in hot paths:
- site-explorer now creates one firmware snapshot and shares it across endpoint exploration tasks instead of repeatedly rebuilding firmware state per endpoint
- machine update code reuses a single snapshot when persisting desired firmware state instead of rebuilding it multiple times
- state-controller call sites now use explicit snapshot-based lookups

Tests and firmware crate documentation are updated to reflect the new snapshot-based API and semantics.

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

