### PR TITLE
docs: clean up legacy naming throughout docs

### DIFF
--- a/docs/architecture/health/health_probe_ids.md
+++ b/docs/architecture/health/health_probe_ids.md
@@ -49,7 +49,7 @@ Indicates that the serial number on a host does not match the serial number in t
 
 ### `OrphanManagedHost`
 
-Indicates that an already-ingested Managed Host's BMC MAC is no longer listed in the `expected_machines` table. Carbide continues to maintain the host, but the host will **not** be re-ingested if it is force-deleted. Clear the alert by either re-adding the entry to `expected_machines` or force-deleting the Managed Host. The alert is informational and does not block tenant allocations.
+Indicates that an already-ingested Managed Host's BMC MAC is no longer listed in the `expected_machines` table. NICo continues to maintain the host, but the host will **not** be re-ingested if it is force-deleted. Clear the alert by either re-adding the entry to `expected_machines` or force-deleting the Managed Host. The alert is informational and does not block tenant allocations.
 
 ## Hardware/BMC health probe identifiers
 
@@ -84,7 +84,7 @@ Indicates that a BGP session with a top-of-rack (TOR) switch could not be establ
 
 ### `BgpPeeringRouteServer`
 
-Indicates that a BGP session with the route server that is part of the part of the Carbide control plane could not be established by a host/DPU.
+Indicates that a BGP session with the route server that is part of the NICo control plane could not be established by a host/DPU.
 
 ### `BgpStats`
 
@@ -104,7 +104,7 @@ Indicates issues regarding the start of the DHCP server on the DPU
 
 ### `HeartbeatTimeout`
 
-Indicates that there was no communication between `dpu-agent` and `carbide-core` for a certain amount of time.
+Indicates that there was no communication between `dpu-agent` and NICo core for a certain amount of time.
 This condition usually implies that the DPU won't be able to apply any configuration changes.
 
 ### `StaleAgentVersion`

--- a/docs/architecture/health_aggregation.md
+++ b/docs/architecture/health_aggregation.md
@@ -4,7 +4,7 @@
 
 NICo integrates a variety of tools to continuously assess and report the health of any host under its management. It also allows site operators to configure and extend the set of health checks via runtime configurations and extension APIs.
 
-The health information that is obtained by these tools is rolled up within Carbide-Core into an "aggregated host health".
+The health information that is obtained by these tools is rolled up within NICo Core into an "aggregated host health".
 The aggregated host health information is used for multiple purposes:
 1. For NICo internal decision making - e.g. "is this host usable as a bare metal instance by a tenant" and "is the host allowed to transition between 2 states".
 2. The aggregated host health information is made available to NICo API users. Site administrators can use the information to assess host health and external fleet health automation systems can use it to trigger remediation workflows.
@@ -267,7 +267,7 @@ ranges or by interpreting the `health_ok` values provided by BMCs.
 
 ### BMC inventory monitoring
 
-The Site Explorer process within Carbide Core periodically queries all Host and DPU BMCs in order to record certain BMC properties (e.g. components within a host and firmware versions).
+The Site Explorer process within NICo Core periodically queries all Host and DPU BMCs in order to record certain BMC properties (e.g. components within a host and firmware versions).
 
 In certain conditions the scraping process will place a health alert on the host:
 - If the host BMC is not reachable

--- a/docs/architecture/infiniband/nic_selection.md
+++ b/docs/architecture/infiniband/nic_selection.md
@@ -465,11 +465,9 @@ GUIDs are different. Since the PCI slots are assumed to be deterministic
 for Machines with the same hardware configuration, tenants can assume their selection
 always affects the exact same piece of hardware.
 
-### Forge Metadata Service (FMDS)
+### NICo Metadata Service (FMDS)
 
-**This will be renamed to something else (likely just NICo Metadata Service as we move from the old code name**
-
-The Forge Metadata Service (FMDS) provides the Tenant's software
+The NICo Metadata Service (FMDS) provides the Tenant's software
 running on instance the capability to identify the infiniband configuration at
 runtime. It also provides the ability to execute a configuration script
 which configures the local Infiniband interfaces for the operating mode that the
@@ -484,7 +482,7 @@ allows them to send their traffic successfully to the connected Infiniband switc
 
 To perform this job, FMDS returns the applied instance configuration -
 which is the desired `InstanceInfinibandConfig` plus the configuration data that
-Forge allocates on behalf the tenant. This would be mostly the GUIDs.
+NICo allocates on behalf the tenant. This would be mostly the GUIDs.
 
 Putting it together, the tenant machine would retrieve the following data via
 FMDS, in a format that is still TBD:

--- a/docs/architecture/key_group_sync.md
+++ b/docs/architecture/key_group_sync.md
@@ -17,7 +17,7 @@ The key group update and synchronization mechanism in NICo REST API works as fol
         - sites being restored from backups and having outdated keygroup versions or missing keygroups
         - users triggering multiple keygroup updates in rapid succession
 7. NICo provides the ability to fully overwrite the content of a keygroup that is identified by a `(TenantOrg, GroupName)` tuple and indexed by a `Version`. It will echo the version of a keygroup as is back to the Cloud, and not change it by itself or interpret it in any way.
-8. The NICo REST API **could** expose the version number of key groups to users - however it does not have to. By exposing the version number, it can provide update APIs with `ifVersionNotMatch` semantics - which means adding the capability for UIs to fail changes to groups if a concurrent edit occurred. This prevents Forge Tenant Admins from accidentally overwriting changes that another Tenant Admin for the same org performed.
+8. The NICo REST API **could** expose the version number of key groups to users - however it does not have to. By exposing the version number, it can provide update APIs with `ifVersionNotMatch` semantics - which means adding the capability for UIs to fail changes to groups if a concurrent edit occurred. This prevents NICo Tenant Admins from accidentally overwriting changes that another Tenant Admin for the same org performed.
 
 ```mermaid
 sequenceDiagram

--- a/docs/architecture/networking_integrations.md
+++ b/docs/architecture/networking_integrations.md
@@ -57,7 +57,7 @@ To implement these workflows, the following patterns had been developed and prov
 There needs to be a mechanism that periodically compares the expected networking configuration with the desired networking configuration. If they are not in-sync, the respective components needs to take all the required actions to bring the configurations in sync.
 
 1. For networking technologies where an external service is used to control partitioning (NVLink, InfiniBand), the `Monitor` background tasks are used to achieve this goal. If they detect a configuration mismatch, they perform API calls to the external networking service to resolve the problem.
-2. For other integrations, an external agent can pull the desired configuration for any host, perform (potentially local) configuration changes, before reporting the new state back to Carbide. This approach is taken for DPUs.
+2. For other integrations, an external agent can pull the desired configuration for any host, perform (potentially local) configuration changes, before reporting the new state back to NICo. This approach is taken for DPUs.
 
 ### Instance lifecycle and "tenant feedback"
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -8,18 +8,18 @@ These control plane services have to be deployed to a Kubernetes cluster with a 
 ![NICo Architecture Diagram](../static/nico_arch_diagram.png)
 
 The Kubernetes cluster needs to have a variety of services deployed:
-1. [The Carbide control plane services](#carbide-control-plane-services). These services are specific to Carbide, and must be deployed together in order to allow Carbide to manage the lifecycle of hosts.
-2. [Dependency services](#dependency-services). Carbide requires "off-the-shelf" dependencies like Postgres, Vault and telemetry services deployed and accessible.
-3. [Optional services](#optional-services). A variety of services and tools within the deployment that interact with the Carbide deployment, but are not required continuously for the control plane to operate.
+1. [The NICo control plane services](#carbide-control-plane-services). These services are specific to NICo, and must be deployed together in order to allow NICo to manage the lifecycle of hosts.
+2. [Dependency services](#dependency-services). NICo requires "off-the-shelf" dependencies like Postgres, Vault and telemetry services deployed and accessible.
+3. [Optional services](#optional-services). A variety of services and tools within the deployment that interact with the NICo deployment, but are not required continuously for the control plane to operate.
 
 The following chapters look at each of these in more detail.
 
 {/* Source drawio file at ../static/site-controller.drawio */}
-![Carbide site controller](../static/site-controller-overview.png)
+![NICo site controller](../static/site-controller-overview.png)
 
 ## Managed Hosts
 
-A "Managed Host" is a host whose lifecycle is managed by Carbide.
+A "Managed Host" is a host whose lifecycle is managed by NICo.
 
 The managed host consists of various internal components that are all part of the same chassis or tray:
 
@@ -28,107 +28,107 @@ The managed host consists of various internal components that are all part of th
 - The BMC that is used to manage the host
 - The BMC that is used to manage the DPU
 
-Carbide deploys a set of binaries on these hosts during various points of their lifecycle:
+NICo deploys a set of binaries on these hosts during various points of their lifecycle:
 
 ### Scout
 
-[scout](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/scout) is an agent that Carbide runs on the host and DPU of managed hosts for a variety of tasks:
-- "Inventory" collection: Scout collects and transmits hardware properties of the host to [carbide-core](#carbide-core) which can not be determined through out-of-band tooling.
+[scout](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/scout) is an agent that NICo runs on the host and DPU of managed hosts for a variety of tasks:
+- "Inventory" collection: Scout collects and transmits hardware properties of the host to [NICo core](#carbide-core) which can not be determined through out-of-band tooling.
 - Execution of cleanup tasks whenever the bare metal instance using the host is released by a user
 - Execution of machine validation tests
 - Periodic Health checks
 
 ### DPU Agent
 
-[dpu-agent](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/agent) is an agent that Carbide runs exclusively on DPUS managed by Carbide as a daemon.
+[dpu-agent](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/agent) is an agent that NICo runs exclusively on DPUS managed by NICo as a daemon.
 
 DPU agent performs the following tasks:
 - Configuring the DPU as required at any state during the hosts lifecycle. This process is described more in depth in [DPU configuration](dpu_configuration.md).
 - Executing periodic health-checks on the DPU
-- Running the Forge metadata service (FMDS), which provides the users on the bare metal instance a HTTP based API to retrieve information about their running instance. Users can e.g. use FMDS to determine their Machine ID or certain Boot/OS information.
+- Running the NICo metadata service (FMDS), which provides the users on the bare metal instance a HTTP based API to retrieve information about their running instance. Users can e.g. use FMDS to determine their Machine ID or certain Boot/OS information.
 - Enabling auto-updates of the dpu-agent itself
 - Deploying hotfixes for the DPU OS. These hotfixes reduce the need to perform a full DPU OS reinstallation, and thereby avoid bare metal instances becoming unavailable for their users due to OS updates.
 
 ### DHCP Server
 
-Carbide runs a [custom DHCP server](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/dhcp-server) on the DPU, which handles all DHCP requests of the actual host. This means DHCP requests on the hosts primary networking interfaces will never leave the DPU and show up on the underlay network - which provides enhanced security and reliability.
+NICo runs a [custom DHCP server](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/dhcp-server) on the DPU, which handles all DHCP requests of the actual host. This means DHCP requests on the hosts primary networking interfaces will never leave the DPU and show up on the underlay network - which provides enhanced security and reliability.
 The DHCP server is configured by dpu-agent.
 
-## Carbide Control plane services
+## NICo Control plane services
 
-The carbide control plane consists of a number of services which work together to orchestrate the lifecycle of a managed host:
+The NICo control plane consists of a number of services which work together to orchestrate the lifecycle of a managed host:
 
-- [carbide-core](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/api): The Carbide core service is the entrypoint into the control plane. It provides a [gRPC](https://grpc.io) API that all other components as well as users (site providers/tenants/site administrators) interact with, as well as implements the lifecycle management of all Carbide managed resources (VPCs, prefixes, Infiniband and NVLink partitions and bare metal instances). The [Carbide Core](#carbide_core_architecture) section describes it further in detail.
+- [carbide-core](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/api): The NICo core service is the entrypoint into the control plane. It provides a [gRPC](https://grpc.io) API that all other components as well as users (site providers/tenants/site administrators) interact with, as well as implements the lifecycle management of all NICo managed resources (VPCs, prefixes, Infiniband and NVLink partitions and bare metal instances). The [NICo Core](#carbide_core_architecture) section describes it further in detail.
 - [carbide-dhcp (DHCP)](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/dhcp): The DHCP server responds to DHCP requests for all
   devices on underlay networks. This includes Host BMCs, DPU BMCs and DPU OOB addresses. carbide-dhcp can be thought of as a stateless proxy: It does not actually perform any IP address management - it just converts DHCP requests into gRPC format and forwards the gRPC based DHCP requests to carbide core.
 - [carbide-pxe (iPXE)](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/pxe): The PXE server provides boot artifacts like iPXE scripts, iPXE user-data and OS images to managed hosts at boot time over HTTP. It determines which OS data to provide for a specific host by requesting the respective data from carbide core - therefore the PXE server is also stateless.
   Currently, managed hosts are configured to always boot from PXE. If a local
   bootable device is found, the host will boot it. Hosts can also be configured to always boot from a
   particular image for stateless configurations.
-- [carbide-hw-health (Hardware health)](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/health): This service scrapes all host and DPU BMCs known by Carbide for system health information. It extracts measurements like fan speeds, temperatures and leak indicators. These measurements are emitted as prometheus metrics on a `/metrics` endpoint on port 9009. In addition to that, the service calls the carbide-core API `RecordHardwareHealthReport` to set health alerts based on issues identified within the metrics. These alerts are merged within carbide-core into the aggregated-host-health - which is emitted in overall health metrics and used to decide whether hosts are usable as bare metal instances for tenants.
-- [ssh-console](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/ssh-console): The SSH console provides bare metal-tenants and site-administrators virtual serial console access to hosts managed by Carbide. The ssh-console service also sends the output of each hosts serial console to
+- [carbide-hw-health (Hardware health)](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/health): This service scrapes all host and DPU BMCs known by NICo for system health information. It extracts measurements like fan speeds, temperatures and leak indicators. These measurements are emitted as prometheus metrics on a `/metrics` endpoint on port 9009. In addition to that, the service calls the carbide-core API `RecordHardwareHealthReport` to set health alerts based on issues identified within the metrics. These alerts are merged within carbide-core into the aggregated-host-health - which is emitted in overall health metrics and used to decide whether hosts are usable as bare metal instances for tenants.
+- [ssh-console](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/ssh-console): The SSH console provides bare metal-tenants and site-administrators virtual serial console access to hosts managed by NICo. The ssh-console service also sends the output of each hosts serial console to
   the logging system (Loki), from where it can be queried using Grafana and logcli. In order to provide this functionality, the ssh-console service *continuously* connects to all host BMCs. The ssh-console service only forwards logs to users ("bare metal tenants") if they connect to the service and get authenticated.
 - [carbide-dns (DNS)](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/dns): Domain name service (DNS) functionality
   is handled by two services. The `carbide-dns` service handles DNS queries from the site controller and managed nodes and is authoritative for delegated zones.
 
-## <a name="carbide_core_architecture"></a> Carbide Core
+## <a name="carbide_core_architecture"></a> NICo Core
 
-Carbide core is the binary which provides the most essential services within the Carbide control plane.
-It provides a [gRPC](https://grpc.io) API that all other components as well as users (site providers/tenants/site administrators) interact with, as well as implements the lifecycle management of all Carbide managed resources (VPCs, prefixes, Infiniband and NVLink partitions and bare metal instances).
+NICo core is the binary which provides the most essential services within the NICo control plane.
+It provides a [gRPC](https://grpc.io) API that all other components as well as users (site providers/tenants/site administrators) interact with, as well as implements the lifecycle management of all NICo managed resources (VPCs, prefixes, Infiniband and NVLink partitions and bare metal instances).
 
-Carbide core can be considered as a "collection of independent components that are deployed within the same binary". These components are shown the following diagram, and are described further below:
+NICo core can be considered as a "collection of independent components that are deployed within the same binary". These components are shown the following diagram, and are described further below:
 
-Carbide core is the only component within carbide which interacts with the postgres database. This simplifies the rollout of database migrations throughout the product lifecycle.
+NICo core is the only component within NICo which interacts with the postgres database. This simplifies the rollout of database migrations throughout the product lifecycle.
 
 {/* Source drawio file at ../static/carbide-core.drawio */}
-![Carbide site controller](../static/carbide-core.png)
+![NICo site controller](../static/carbide-core.png)
 
-### Carbide Core Components
+### NICo Core Components
 
 ### [gRPC](https://grpc.io) API handlers
 
-The API handlers accept gRPC requests from Carbide users and internal system components. They provide users the ability to inspect the current state of the system, and modify the desired state of various components (e.g. create or reconfigure bare metal instances).
-  API handlers are all implemented within the trait/interface `rpc::forge::forge_server::Forge`. Various implementations delegate to the `handlers` subdirectory. For resources managed by Carbide, API handlers do not directly change the actual state of the resources (e.g. the provisioning state of a host). Instead, they only change the required state (e.g. "provisioning required", "termination required", etc). The state changes will be performed by state machines (details below). The carbide-core gRPC API supports
+The API handlers accept gRPC requests from NICo users and internal system components. They provide users the ability to inspect the current state of the system, and modify the desired state of various components (e.g. create or reconfigure bare metal instances).
+  API handlers are all implemented within the trait/interface `rpc::forge::forge_server::Forge`. Various implementations delegate to the `handlers` subdirectory. For resources managed by NICo, API handlers do not directly change the actual state of the resources (e.g. the provisioning state of a host). Instead, they only change the required state (e.g. "provisioning required", "termination required", etc). The state changes will be performed by state machines (details below). The carbide-core gRPC API supports
 [gRPC reflection](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md) to provide a machine readable API
 description so clients can auto-generate code and RPC functions in the client.
 
 ### Debug Web UI
 
-Carbide core provides a debug UI under the `/admin` endpoint. The debug UI allows to inspect the state of all resources managed by Carbide via a variety of HTML pages. It e.g. allows to list details about all managed hosts and DPUs, or about the internal state of other components that are described within the Carbide Core section.
+NICo core provides a debug UI under the `/admin` endpoint. The debug UI allows to inspect the state of all resources managed by NICo via a variety of HTML pages. It e.g. allows to list details about all managed hosts and DPUs, or about the internal state of other components that are described within the NICo Core section.
 
 The Debug UI also provides access to various admin level tools. E.g. it
 - allows to change the power state of hosts, reset the BMC, and change boot orders
-- inspect the redfish tree of any BMC managed by Carbide
+- inspect the redfish tree of any BMC managed by NICo
 - allows admins to perform changes to a BMC (via HTTP POST) in a peer-reviewed and auditable fashion
 - inspect UFM responses
 
 ### State Machines
 
-Carbide implements State Machines for all resources managed by Carbide. The state machines are implemented as idempotent state handling functions calls, which are scheduled by the system.
+NICo implements State Machines for all resources managed by NICo. The state machines are implemented as idempotent state handling functions calls, which are scheduled by the system.
 State handling for various resource types is implemented independently, e.g. the lifecycle of hosts is managed by different tasks and different code than the lifecycle of InfiniBand partitions.
 
-Carbide implements state machines for
+NICo implements state machines for
 - Managed Hosts (Hosts + DPUs)
 - Network Segments
 - InfiniBand Partitions
 - NVLink Logical Partitions
 
-Details about the Carbide state handling implementation can be found [here](state_handling.md).
+Details about the NICo state handling implementation can be found [here](state_handling.md).
 
 ### Site Explorer
 
-Site Explorer is a process within Carbide Core that continuously monitors the state of all BMCs that are detected within the underlay network. The process acts as a "crawler". It continuously tries to perform redfish requests against all IPs on the underlay network that were provided by Carbide Core and records information that Carbide is required to manage the hosts in a follow-up. The information collected by Carbide is
+Site Explorer is a process within NICo Core that continuously monitors the state of all BMCs that are detected within the underlay network. The process acts as a "crawler". It continuously tries to perform redfish requests against all IPs on the underlay network that were provided by NICo Core and records information that NICo is required to manage the hosts in a follow-up. The information collected by NICo is
 - Serial Numbers
 - Certain inventory data, e.g. the amount, type and serial numbers of DPUs
 - Power State
 - Configuration data, e.g. boot order, lockdown mode
 - Firmware versions
 
-Carbide users can inspect the data that site explorer discovers using the `FindExploredEndpoints` APIs as well as using the Carbide Debug Web UI.
+NICo users can inspect the data that site explorer discovers using the `FindExploredEndpoints` APIs as well as using the NICo Debug Web UI.
 
-Site Explorer requires an "Expected Machines" manifest to be deployed. Expected Machines describes the set of Machines that is expected to be managed by the Carbide instance - it encodes BMC MAC addresses, hardware default passwords and other details of these Machines. The manifest can be updated using a set of APIs, e.g. `ReplaceAllExpectedMachines`.
+Site Explorer requires an "Expected Machines" manifest to be deployed. Expected Machines describes the set of Machines that is expected to be managed by the NICo instance - it encodes BMC MAC addresses, hardware default passwords and other details of these Machines. The manifest can be updated using a set of APIs, e.g. `ReplaceAllExpectedMachines`.
 
-Beyond the basic BMC data collection, Carbide also performs the following tasks:
+Beyond the basic BMC data collection, NICo also performs the following tasks:
 1. It matches hosts with associated DPUs based on the redfish reports of both components - e.g. both the host and DPU need to reference the same DPU serial number.
 2. It kickstarts the ingestion process of the host once the host is in an "ingestable" state (all components are found and have up to date firmware versions).
 
@@ -158,15 +158,15 @@ Host Power Manager is a component which orchestrates power actions against BMCs.
 
 ### IB (InfiniBand) Fabric Monitor
 
-InfiniBand fabric monitor is a periodic process within Carbide that performs all interactions with the InfiniBand fabric using UFM APIs.
+InfiniBand fabric monitor is a periodic process within NICo that performs all interactions with the InfiniBand fabric using UFM APIs.
 
 In each run, IBFabricMonitor performs the following task:
 - It checks the health of the fabric manager (UFM) by performing API calls
 - It checks whether all security configurations for multitenancy are applied on UFM and emits alerts in case of inappropriate settings
-- It fetches the actually applied InfiniBand partitioning information for each InfiniBand port on each host managed by Carbide and stores it in Carbide. The data can be inspected in the `Machine::ib_status` field in the gRPC API.
+- It fetches the actually applied InfiniBand partitioning information for each InfiniBand port on each host managed by NICo and stores it in NICo. The data can be inspected in the `Machine::ib_status` field in the gRPC API.
 - If calls UFM APIs to bind ports (guids) to partitions (pkeys) according to the configuration of each host. This happens continuously based on comparing the expected InfiniBand configuration of a host (whether it is used by a tenant or not, and how the tenant configured the InfiniBand interfaces) with the actually applied configuration (determined in the last step).
 
-InfiniBand Fabric Monitor is an optional component. It only needs to be enabled in the case Carbide managed InfiniBand is required.
+InfiniBand Fabric Monitor is an optional component. It only needs to be enabled in the case NICo managed InfiniBand is required.
 
 IB Fabric Monitor emits metrics with prefix `forge_ib_monitor_`.
 
@@ -176,7 +176,7 @@ In development. The NVLink monitor will have similar responsibilities as IBFabri
 
 ## Dependency services
 
-In addition to the Carbide API server components there are other supporting services run within the K8s site
+In addition to the NICo API server components there are other supporting services run within the K8s site
 controller nodes.
 
 ### K8s Persistent Storage Objects
@@ -189,7 +189,7 @@ pods. There are three different K8s statefulsets that run on the controller node
 - [Hashicorp Vault](https://www.vaultproject.io/) - Used by Kubernetes for certificate signing requests (CSRs). Vault
   uses three each (one per K8s control node) of the `data-vault` and `audit-vault` 10GB PVs to protect and distribute
   the data in the absence of a shared storage solution.
-- [Postgres](https://www.postgresql.org/) - Used to store state for any Carbide or site controller components that
+- [Postgres](https://www.postgresql.org/) - Used to store state for any NICo or site controller components that
   require it including the main "forgedb". There are three 10GB `pgdata` PVs deployed to protect and distribute
   the data in the absence of a shared storage solution. The `forgedb` database is stored here.
 
@@ -198,11 +198,11 @@ pods. There are three different K8s statefulsets that run on the controller node
 The point of having a site controller is to administer a site that has been populated with tenant managed hosts.
 Each managed host is a pairing of a Bluefield (BF) 2/3 DPUs and a host server (only two DPUs have been tested).
 During initial deployment [scout](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/scout) runs and
-informs carbide-api of any discovered DPUs. Carbide completes the installation of services on the DPU and boots
+informs carbide-api of any discovered DPUs. NICo completes the installation of services on the DPU and boots
 into regular operation mode. Thereafter the forge-dpu-agent starts as a daemon.
 
-Each DPU runs the forge-dpu-agent which connects via gRPC to the API service in Carbide to get configuration
+Each DPU runs the forge-dpu-agent which connects via gRPC to the API service in NICo to get configuration
 instructions.
 
-The forge-dpu-agent also runs the Forge metadata service (FMDS), which provides the users on the bare metal instance a HTTP based API to retrieve information about their running instance.
+The forge-dpu-agent also runs the NICo metadata service (FMDS), which provides the users on the bare metal instance a HTTP based API to retrieve information about their running instance.
 Users can e.g. use FMDS to determine their Machine ID or certain Boot/OS information.

--- a/docs/architecture/redfish_workflow.md
+++ b/docs/architecture/redfish_workflow.md
@@ -9,7 +9,7 @@ For the overall NICo architecture and component responsibilities, see [Overview 
 ```
 DHCP Request (BMC)
   → NICo DHCP (Kea hook)
-    → Carbide Core (gRPC discover_dhcp)
+    → NICo Core (gRPC discover_dhcp)
       → Site Explorer probes Redfish endpoint
         → Authenticates, collects inventory
           → Pairs DPUs to hosts via serial number matching
@@ -28,13 +28,13 @@ DHCP Request (BMC)
 
 ## 1. DHCP Discovery
 
-When a BMC on the underlay network sends a DHCP request, the NICo DHCP server (a Kea hook plugin) captures it and forwards the discovery information to Carbide Core.
+When a BMC on the underlay network sends a DHCP request, the NICo DHCP server (a Kea hook plugin) captures it and forwards the discovery information to NICo Core.
 
 The Kea hook is implemented as a Rust library with C FFI bindings. When a DHCP packet arrives, the hook:
 
 1. Extracts the MAC address, vendor class string, relay address, circuit ID, and remote ID from the DHCP packet
 2. Builds a `Discovery` struct with these fields
-3. Sends a gRPC `discover_dhcp()` request to Carbide Core with the MAC and vendor string
+3. Sends a gRPC `discover_dhcp()` request to NICo Core with the MAC and vendor string
 4. Receives back a `Machine` response containing the network configuration (IP address, gateway, etc.) to return to the BMC
 
 The vendor class string is parsed to identify the BMC type and capabilities. DHCP entries are tracked in the database by MAC address and associated with machine interfaces.
@@ -145,7 +145,7 @@ The power control operation supports multiple reset types: `On`, `ForceOff`, `Gr
 After PXE boot, the DPU:
 1. Fetches `carbide.efi` from the NICo PXE server over HTTP
 2. Receives cloud-init configuration with its `machine_id` and NICo API endpoint
-3. Installs and starts the DPU agent (`dpu-agent`), which connects back to Carbide Core via gRPC
+3. Installs and starts the DPU agent (`dpu-agent`), which connects back to NICo Core via gRPC
 
 **Key files:**
 - `crates/api/src/ipxe.rs` — iPXE instruction generation per architecture
@@ -250,7 +250,7 @@ GET /redfish/v1/Chassis/{id}/Sensors/{sensor_id}
 
 Sensor types include: Temperature (Cel), Rotational/Fan (RPM), Power (W), and Current (A).
 
-All sensor data is exported as Prometheus metrics on the `/metrics` endpoint (port 9009) and fed into Carbide Core via `RecordHardwareHealthReport` for health aggregation.
+All sensor data is exported as Prometheus metrics on the `/metrics` endpoint (port 9009) and fed into NICo Core via `RecordHardwareHealthReport` for health aggregation.
 
 **Key files:**
 - `crates/health/src/firmware_collector.rs` — `FirmwareCollector` using nv-redfish

--- a/docs/architecture/state_machines/switch.md
+++ b/docs/architecture/state_machines/switch.md
@@ -1,6 +1,6 @@
 # Switch State Diagram
 
-This document describes the Finite State Machine (FSM) for Switches in Carbide: lifecycle from creation through configuration, validation, ready, optional reprovisioning, and deletion.
+This document describes the Finite State Machine (FSM) for Switches in NICo: lifecycle from creation through configuration, validation, ready, optional reprovisioning, and deletion.
 
 ## High-Level Overview
 
@@ -51,7 +51,7 @@ Deleting --> [*] : final delete
 
 | State | Description |
 |-------|-------------|
-| **Created** | Switch record exists in Carbide; awaiting first controller tick. |
+| **Created** | Switch record exists in NICo; awaiting first controller tick. |
 | **Initializing** | Controller waits for expected switch NVOS MAC associations. Sub-state: `WaitForOsMachineInterface`. |
 | **Configuring** | Switch is being configured (rotate OS password). Sub-state: `RotateOsPassword`. |
 | **Validating** | Switch is being validated. Sub-state: `ValidationComplete`. |

--- a/docs/codebase_overview.md
+++ b/docs/codebase_overview.md
@@ -2,19 +2,19 @@
 
 bluefield/ - `dpu-agent` and other tools running on the DPU
 
-book/ - architecture of forge book.  aka "the book"
+book/ - architecture of the NICo book.  aka "the book"
 
 - admin/ - `carbide-admin-cli`: A command line client for the carbide API server
-- api/ - forge primary entrypoint for GRPC API calls. This component receives all the GRPC calls
+- api/ - NICo primary entrypoint for GRPC API calls. This component receives all the GRPC calls
 - scout/ - `forge-scout`. A binary that runs on NCX Infra Controller (NICo) managed hosts and DPUs and executes various parts workflows on behalf of the site controller
 
-dev/ - a catch all directory for things that are not code related but are used to support forge.  e.g. Dockerfiles, kubernetes yaml, etc.
+dev/ - a catch all directory for things that are not code related but are used to support the project.  e.g. Dockerfiles, kubernetes yaml, etc.
 
-dhcp/ - kea dhcp plugin.  Forge uses ISC Kea for a dhcp event loop.  This code intercepts `DHCPDISCOVER`s from dhcp-relays and passes the info to carbide-api
+dhcp/ - kea dhcp plugin.  NICo uses ISC Kea for a dhcp event loop.  This code intercepts `DHCPDISCOVER`s from dhcp-relays and passes the info to carbide-api
 
 dhcp-server/ - DHCP Server written in Rust. This server runs on the DPU and serves Host DHCP requests
 
-dns/ - provides DNS resolution for assets in forge database
+dns/ - provides DNS resolution for assets in the NICo database
 
 include/ - contains additional makefiles that are used by `cargo make` - as specified in `Makefile.toml`.
 

--- a/docs/design/machine-identity/spiffe-svid-sdd.md
+++ b/docs/design/machine-identity/spiffe-svid-sdd.md
@@ -24,15 +24,15 @@ The purpose of this document is to articulate the design of the software system,
 
 | Term/Acronym | Definition |
 | :---- | :---- |
-| Carbide | NVIDIA bare-metal life-cycle management system (project name: Bare metal manager) |
+| NICo | NVIDIA bare-metal life-cycle management system (project name: Bare metal manager) |
 | SDD | Software Design Document |
 | API | Application Programming Interface |
-| Tenant | A Carbide client/org/account that provisions/manages BM nodes through Carbide APIs. |
+| Tenant | A NICo client/org/account that provisions/manages BM nodes through NICo APIs. |
 | DPU | Data Processing Unit \- aka SmartNIC |
-| Carbide API server | A gRPC server deployed as part of Carbide site controller |
+| NICo API server | A gRPC server deployed as part of the NICo site controller |
 | Vault | Secrets management system (OSS version: openbao) |
-| Carbide REST server | An HTTP REST-based API server that manages/proxies multiple site controllers |
-| Carbide site controller | Carbide control plane services running on a local K8S cluster |
+| NICo REST server | An HTTP REST-based API server that manages/proxies multiple site controllers |
+| NICo site controller | NICo control plane services running on a local K8S cluster |
 | JWT | JSON Web Token |
 | SPIFFE | [SPIFFE](https://spiffe.io/) is an industry standard that provides strongly attested, cryptographic identities to workloads across a wide variety of platforms. |
 | SPIRE | A specific open source software implementation of SPIFFE standard |
@@ -45,11 +45,11 @@ The purpose of this document is to articulate the design of the software system,
 
 ## **1.3 Scope**
 
-This SDD covers the design for Carbide issuing SPIFFE compliant JWTs to nodes it manages. This includes the initial configuration, run-time and operational flows.
+This SDD covers the design for NICo issuing SPIFFE compliant JWTs to nodes it manages. This includes the initial configuration, run-time and operational flows.
 
 ### **1.3.1​ Assumptions, Constraints, Dependencies**
 
-* Must implement SPIFFE SVIDs as Carbide node identity
+* Must implement SPIFFE SVIDs as NICo node identity
 * Must rotate and expire SVIDs  
 * Must provide configurable audience in SVIDs  
 * Must enable delegating node identity signing  
@@ -60,19 +60,19 @@ This SDD covers the design for Carbide issuing SPIFFE compliant JWTs to nodes it
 
 ## **2.1 High-Level Architecture**
 
-From a high level, the goal for Carbide is to issue a JWT-SVID identity to the requesting nodes under Carbide’s management. A Carbide managed node will be part of a tenant (aka org), and the issued JWT-SVID embodies both tenant and machine identity that complies with the SPIFFE format.
+From a high level, the goal for NICo is to issue a JWT-SVID identity to the requesting nodes under NICo’s management. A NICo managed node will be part of a tenant (aka org), and the issued JWT-SVID embodies both tenant and machine identity that complies with the SPIFFE format.
 
 ![](carbide-spiffe-jwt-svid-flow.svg)
 
 *Figure-1 High-level architecture and flow diagram*
 
-1. The bare metal (BM) tenant process makes HTTP requests to the Carbide meta-data service (IMDS) over a link-local address(169.254.169.254). IMDS is running inside the DPU as part of the Carbide DPU agent.   
-2. IMDS in turn makes an mTLS authenticated request to the Carbide site controller gRPC server to sign a SPIFFE compliant node identity token (JWT-SVID).  
+1. The bare metal (BM) tenant process makes HTTP requests to the NICo meta-data service (IMDS) over a link-local address(169.254.169.254). IMDS is running inside the DPU as part of the NICo DPU agent.   
+2. IMDS in turn makes an mTLS authenticated request to the NICo site controller gRPC server to sign a SPIFFE compliant node identity token (JWT-SVID).  
    a. Pull keys and machine and org metadata from the database, decrypt private key and sign JWT-SVID. The token is returned to Host’s tenant process (implicit, not shown in the diagram).
 3. The tenant process subsequently makes a request to a service (say OpenBao/Vault) with the JWT-SVID token passed in the authentication header.  
-   a. The server-x using the prefetched public keys from Carbide will validate JWT-SVID
+   a. The server-x using the prefetched public keys from NICo will validate JWT-SVID
 
-An additional requirement for Carbide is to delegate the issuance of a JWT-SVID to an external system. The solution is to offer a callback API for Carbide tenants to intercept the signing request, validate the Carbide node identity, and issue new tenant specific JWT-SVID token (Figure-2). The delegation model offers tenants flexibility to customize their machine SVIDs.
+An additional requirement for NICo is to delegate the issuance of a JWT-SVID to an external system. The solution is to offer a callback API for NICo tenants to intercept the signing request, validate the NICo node identity, and issue new tenant specific JWT-SVID token (Figure-2). The delegation model offers tenants flexibility to customize their machine SVIDs.
 
 ![](carbide-spiffe-svid-token-exchange-flow.svg)
 
@@ -84,11 +84,11 @@ The system is composed of the following major components:
 
 | Component | Description |
 | :---- | :---- |
-| Meta-data service (IMDS) | A service part of Carbide DPU agent running inside DPU, listening on port 80 (def) |
-| Carbide API (gRPC) server | Site controller Carbide control plane API server  |
-| Carbide REST | Carbide REST API server, an aggregator service that controls multiple site controllers |
-| Database (Postgres) | Store Carbide node-lifecycle and accounting data  |
-| Token Exchange Server | Optional \- hosted by tenants to exchange Carbide node JWT-SVIDs with tenant-customized workload JWT-SVIDs. Follows token exchange API model defined in [RFC-8693](https://datatracker.ietf.org/doc/html/rfc8693) |
+| Meta-data service (IMDS) | A service part of the NICo DPU agent running inside DPU, listening on port 80 (def) |
+| NICo API (gRPC) server | Site controller NICo control plane API server  |
+| NICo REST | NICo REST API server, an aggregator service that controls multiple site controllers |
+| Database (Postgres) | Store NICo node-lifecycle and accounting data  |
+| Token Exchange Server | Optional \- hosted by tenants to exchange NICo node JWT-SVIDs with tenant-customized workload JWT-SVIDs. Follows token exchange API model defined in [RFC-8693](https://datatracker.ietf.org/doc/html/rfc8693) |
 
 # **3\. Detailed Design**
 
@@ -96,7 +96,7 @@ There are three different flows associated with implementing this feature:
 
 1. *Per-tenant signing key provisioning*: Describes how a new signing key associated with a tenant is provisioned, and optionally the token delegation/exchange flows.  
 2. *SPIFFE key bundle discovery*: Discusses how the signing public keys are distributed to interested parties (verifiers)  
-3. *JWT-SVID node identity request flow*: The run time flow used by tenant applications to fetch JWT-SVIDs from Carbide.
+3. *JWT-SVID node identity request flow*: The run time flow used by tenant applications to fetch JWT-SVIDs from NICo.
 
 Each of these flows are discussed below.
 
@@ -139,11 +139,11 @@ SetTenantIdentityConfiguration (PUT identity/config)
 
 ## **3.2 Per-tenant SPIFFE Key Bundle Discovery**
 
-[SPIFFE bundles](https://spiffe.io/docs/latest/spiffe-specs/spiffe_trust_domain_and_bundle/#4-spiffe-bundle-format) are represented as an [RFC 7517](https://tools.ietf.org/html/rfc7517) compliant JWK Set. Carbide exposes the signing public keys through Carbide-rest OIDC discovery and JWKS endpoints. Services that require JWT-SVID verification pull public keys to verify token signature. Review sequence diagrams Figure-4 and 5 for more details.
+[SPIFFE bundles](https://spiffe.io/docs/latest/spiffe-specs/spiffe_trust_domain_and_bundle/#4-spiffe-bundle-format) are represented as an [RFC 7517](https://tools.ietf.org/html/rfc7517) compliant JWK Set. NICo exposes the signing public keys through Carbide-rest OIDC discovery and JWKS endpoints. Services that require JWT-SVID verification pull public keys to verify token signature. Review sequence diagrams Figure-4 and 5 for more details.
 
 ```
 ┌────────┐       ┌───────────────┐       ┌─────────────┐       ┌──────────┐      
-│ Client │       │ Carbide-rest  │       │ Carbide API │       │ Database │      
+│ Client │       │ Carbide-rest  │       │  NICo API   │       │ Database │      
 │(e.g LL)│       │   (REST)      │       │   (gRPC)    │       │(Postgres)│      
 └───┬────┘       └──────┬────────┘       └──────┬──────┘       └────┬─────┘      
     │                   │                       │                   │                    
@@ -186,7 +186,7 @@ SetTenantIdentityConfiguration (PUT identity/config)
 
 ```
 ┌────────┐       ┌───────────────┐       ┌─────────────┐       ┌──────────┐       
-│ Client │       │ Carbide-rest  │       │ Carbide API │       │ Database │       
+│ Client │       │ Carbide-rest  │       │  NICo API   │       │ Database │       
 │        │       │   (REST)      │       │   (gRPC)    │       │(Postgres)│       
 └───┬────┘       └──────┬────────┘       └──────┬──────┘       └────┬─────┘       
     │                   │                       │                   │                    
@@ -245,11 +245,11 @@ This is the core part of this SDD – issuing JWT-SVID based node identity token
       │
       │ GET http://169.254.169.254:80/v1/meta-data/identity?aud=openbao
       ▼
-[ DPU Carbide IMDS ]
+[ DPU NICo IMDS ]
       │
       │ SignMachineIdentity(..)
       ▼
-[ Carbide API Server ]
+[ NICo API Server ]
       │
       │ Validates the request (and attest)
       ▼
@@ -262,20 +262,20 @@ JWT-SVID issued to workload/tenant
       │
       │ GET http://169.254.169.254:80/v1/meta-data/identity?aud=openbao
       ▼
-[ DPU Carbide IMDS ]
+[ DPU NICo IMDS ]
       │
       │ SignMachineIdentity(..)
       ▼
-[ Carbide API Server ]
+[ NICo API Server ]
       │
       │ Attest requesting machine and issue a scoped machine JWT-SVID
       ▼
 [ Tenant Token Exchange Server Callback API ]
       │
-      │ - Validates Carbide JWT-SVID signature using SPIFFE bundle
+      │ - Validates NICo JWT-SVID signature using SPIFFE bundle
       │ - Verifies iss, audience, TTL and additional lookups/checks
       ▼
-Carbide Tenant issue JWT-SVID to tenant workload, routed back through Carbide
+NICo Tenant issue JWT-SVID to tenant workload, routed back through NICo
 ```
 *Figure-7 Node Identity request flow with token exchange delegation*
 
@@ -298,12 +298,12 @@ A new table will be created to store tenant signing key pairs and optional token
 | `VARCHAR(512)` | `token_endpoint` | Token exchange endpoint URL (optional; from PUT identity/token-delegation) |
 | `token_delegation_auth_method_t` (ENUM) | `auth_method` | none, client_secret_basic. (optional) |
 | `TEXT` | `encrypted_auth_method_config` | Encrypted blob of method-specific fields. For example: to store client_id and client_secret. (optional) |
-| `VARCHAR(255)` | `subject_token_audience` | Audience to include in Carbide JWT-SVID sent to exchange. (optional) |
+| `VARCHAR(255)` | `subject_token_audience` | Audience to include in NICo JWT-SVID sent to exchange. (optional) |
 | `TIMESTAMPTZ` | `token_delegation_created_at` | When token delegation was first configured. (optional) |
 
 ### **3.4.2 Configuration**
 
-The JWT spec and vault related configs are passed to the Carbide API server during startup through `site_config.toml` config file. 
+The JWT spec and vault related configs are passed to the NICo API server during startup through `site_config.toml` config file. 
 
 ```bash
 # In site config file (e.g., site_config.toml)
@@ -361,11 +361,11 @@ When the `[machine_identity]` section exists but is incomplete or invalid, the f
 
 The subject format complies with the SPIFFE ID specification. The `iss` claim comes from the org's identity config `issuer`. The SPIFFE prefix for `sub` comes from the stored `subjectPrefix` (explicit or defaulted from `issuer` as above), combined with the workload path when issuing tokens.
 
-**Carbide JWT-SPIFFE (passed to Tenant Layer):**
+**NICo JWT-SPIFFE (passed to Tenant Layer):**
 
 ```json
 {
-  "sub": "spiffe://{carbide-domain}/{org-id}/machine-121",
+  "sub": "spiffe://{nico-domain}/{org-id}/machine-121",
   "iss": "https://{carbide-rest}/v2/org/{org-id}/carbide/site/{site-id}",
   "aud": [
     "tenant-layer-exchange-token-service"
@@ -381,10 +381,10 @@ The subject format complies with the SPIFFE ID specification. The `iss` claim co
 }
 ```
 
-The Carbide issues two types of JWT-SVIDs. Though they both are similar in structure and signed by the same key, the purpose and some fields are different.
+NICo issues two types of JWT-SVIDs. Though they both are similar in structure and signed by the same key, the purpose and some fields are different.
 
-1. If token delegation is registered, Carbide issues a JWT-SVID **subject token** with `aud` set to `subject_token_audience`, with **`exp`, `iat`, and `nbf` derived from the org identity config `tokenTtlSec`** (the same per-org field as direct issuance; constrained by site `token_ttl_min_sec` / `token_ttl_max_sec`). Workload audiences from the caller are carried in `request_meta_data.aud` (see example above). That subject token is sent to the org’s registered `token_endpoint` in an RFC 8693 token exchange. **The JSON token response eventually returned to the workload (`access_token`, `expires_in`, etc.) is whatever the tenant token endpoint returns**—`expires_in` there is not required to match `tokenTtlSec`.
-2. If no delegation is registered, Carbide issues a JWT-SVID directly to the workload (IMDS / `SignMachineIdentity`). Here `aud` is set from the caller’s requested audiences (validated against `allowedAudiences` / `defaultAudience`), and **token lifetime is `tokenTtlSec`** (`exp` / `iat` / `nbf`).
+1. If token delegation is registered, NICo issues a JWT-SVID **subject token** with `aud` set to `subject_token_audience`, with **`exp`, `iat`, and `nbf` derived from the org identity config `tokenTtlSec`** (the same per-org field as direct issuance; constrained by site `token_ttl_min_sec` / `token_ttl_max_sec`). Workload audiences from the caller are carried in `request_meta_data.aud` (see example above). That subject token is sent to the org’s registered `token_endpoint` in an RFC 8693 token exchange. **The JSON token response eventually returned to the workload (`access_token`, `expires_in`, etc.) is whatever the tenant token endpoint returns**—`expires_in` there is not required to match `tokenTtlSec`.
+2. If no delegation is registered, NICo issues a JWT-SVID directly to the workload (IMDS / `SignMachineIdentity`). Here `aud` is set from the caller’s requested audiences (validated against `allowedAudiences` / `defaultAudience`), and **token lifetime is `tokenTtlSec`** (`exp` / `iat` / `nbf`).
 
 **SPIFFE JWT-SVID Issued by Token Exchange Server:**
 
@@ -449,15 +449,15 @@ Content-Length: ...
 eyJhbGciOiJSUzI1NiIs...
 ```
 
-#### **3.5.1.2 Carbide Identity APIs**
+#### **3.5.1.2 NICo Identity APIs**
 
 ##### **Org Identity Configuration APIs**
 
-These APIs manage per-org identity configuration that controls how Carbide issues JWT-SVIDs for machines in that org. Admins use them to enable or disable the feature per org, and to set the issuer URI, allowed audiences, token TTL, and SPIFFE subject prefix. The configuration applies to all JWT-SVID tokens issued for the org's machines (via IMDS or token exchange). GET retrieves the current config, PUT creates or replaces it, and DELETE removes it (org no longer has machine identity).
+These APIs manage per-org identity configuration that controls how NICo issues JWT-SVIDs for machines in that org. Admins use them to enable or disable the feature per org, and to set the issuer URI, allowed audiences, token TTL, and SPIFFE subject prefix. The configuration applies to all JWT-SVID tokens issued for the org's machines (via IMDS or token exchange). GET retrieves the current config, PUT creates or replaces it, and DELETE removes it (org no longer has machine identity).
 
-**Carbide-rest config defaults:** Carbide-rest may still supply per-site defaults for `issuer`, `tokenTtlSec`, and related fields when a REST client omits them before calling the downstream gRPC `SetTenantIdentityConfiguration`. **`subjectPrefix` is optional in both REST and gRPC:** the Carbide API (site controller) derives a default SPIFFE prefix when it is unset or empty — `spiffe://<trust-domain-from-issuer>` — where the trust domain is taken from `issuer` (HTTPS URL host, `spiffe://…` URI trust domain segment, or bare DNS hostname per implementation). When the client **does** send `subjectPrefix`, it must be a `spiffe://` URI whose trust domain matches the trust domain derived from `issuer`, with path segments and encoding rules enforced by the API (see validation below). If Carbide-rest cannot satisfy required fields (e.g. `issuer`) and the client omits them, PUT may return **400 Bad Request** so the caller can supply values explicitly.
+**Carbide-rest config defaults:** Carbide-rest may still supply per-site defaults for `issuer`, `tokenTtlSec`, and related fields when a REST client omits them before calling the downstream gRPC `SetTenantIdentityConfiguration`. **`subjectPrefix` is optional in both REST and gRPC:** the NICo API (site controller) derives a default SPIFFE prefix when it is unset or empty — `spiffe://<trust-domain-from-issuer>` — where the trust domain is taken from `issuer` (HTTPS URL host, `spiffe://…` URI trust domain segment, or bare DNS hostname per implementation). When the client **does** send `subjectPrefix`, it must be a `spiffe://` URI whose trust domain matches the trust domain derived from `issuer`, with path segments and encoding rules enforced by the API (see validation below). If Carbide-rest cannot satisfy required fields (e.g. `issuer`) and the client omits them, PUT may return **400 Bad Request** so the caller can supply values explicitly.
 
-**Per-org key generation on PUT:** When PUT creates identity config for an org for the first time, Carbide generates a new per-org signing key pair using the global `algorithm`, encrypts the private key with the Vault master key, and stores it in `tenant_identity_config` DB table. On subsequent PUTs (updates), the key is not regenerated unless `rotateKey` is `true`. On DELETE, the identity config and the org's signing key are removed.
+**Per-org key generation on PUT:** When PUT creates identity config for an org for the first time, NICo generates a new per-org signing key pair using the global `algorithm`, encrypts the private key with the Vault master key, and stores it in `tenant_identity_config` DB table. On subsequent PUTs (updates), the key is not regenerated unless `rotateKey` is `true`. On DELETE, the identity config and the org's signing key are removed.
 
 **PUT when global is disabled:** If the global `enabled` setting in site config is `false`, PUT returns `503 Service Unavailable` with a message indicating that machine identity must be enabled at the site level first. This enforces the deployment order: global config must be enabled before per-org config can be created or updated.
 
@@ -488,7 +488,7 @@ PUT https://{carbide-rest}/v2/org/{org-id}/carbide/site/{site-id}/identity/confi
 | :---- | :--- | :------- | :---------- |
 | `orgId` | string | Yes | Org identifier |
 | `enabled` | boolean | No | Enable JWT-SVID for this org. Default `true` when unset. |
-| `issuer` | string | No | Issuer URI that appears in Carbide JWT-SVID. Optional in REST/JSON; required in gRPC `SetTenantIdentityConfiguration`. |
+| `issuer` | string | No | Issuer URI that appears in NICo JWT-SVID. Optional in REST/JSON; required in gRPC `SetTenantIdentityConfiguration`. |
 | `defaultAudience` | string | Yes | Default audience. Must be in `allowedAudiences` when provided. |
 | `allowedAudiences` | string[] | No | Permitted audiences. Optional; when empty or omitted, all audiences are allowed (permissive mode). When non-empty, only audiences in the list are allowed. |
 | `tokenTtlSec` | number | No | Token TTL in seconds (300–86400). Optional in REST/JSON; required in gRPC `SetTenantIdentityConfiguration`. |
@@ -519,17 +519,17 @@ Response:
 | :------------- | :---------- |
 | `keyId` | Key identifier for the org's signing key; matches the JWKS `kid` used for JWT verification. |
 
-#### **Carbide Token Exchange Server Registration APIs**
+#### **NICo Token Exchange Server Registration APIs**
 
-These APIs let Carbide tenants register a token exchange callback endpoint (RFC 8693). When delegation is enabled, Carbide issues a short-lived JWT-SVID to the tenant's exchange service, which validates it and returns a tenant-specific JWT-SVID or access token. This gives tenants control over token structure, lifecycle, and claims, especially when they have more context than Carbide (e.g., VM identity, application role) and need to issue tenant-customized tokens for workloads.
+These APIs let NICo tenants register a token exchange callback endpoint (RFC 8693). When delegation is enabled, NICo issues a short-lived JWT-SVID to the tenant's exchange service, which validates it and returns a tenant-specific JWT-SVID or access token. This gives tenants control over token structure, lifecycle, and claims, especially when they have more context than NICo (e.g., VM identity, application role) and need to issue tenant-customized tokens for workloads.
 
 **Interaction with global and per-org settings:**
 
 | Setting | Scope | Effect on token delegation |
 | :------ | :---- | :------------------------- |
 | `enabled` | Global | Master switch. If false, PUT token-delegation is rejected (same as identity/config). |
-| `token_endpoint_http_proxy` | Global | Outbound calls from Carbide to the tenant's token endpoint use this proxy (SSRF mitigation). |
-| Identity config (issuer, audiences, **`tokenTtlSec`**) | Per-org (with global defaults) | The subject JWT sent to the exchange server is signed using the org's effective identity config. Its **`exp` − `iat` equals `tokenTtlSec`** (same knob as directly issued tokens). The **outbound** token response `expires_in` comes from the tenant STS, not from Carbide. |
+| `token_endpoint_http_proxy` | Global | Outbound calls from NICo to the tenant's token endpoint use this proxy (SSRF mitigation). |
+| Identity config (issuer, audiences, **`tokenTtlSec`**) | Per-org (with global defaults) | The subject JWT sent to the exchange server is signed using the org's effective identity config. Its **`exp` − `iat` equals `tokenTtlSec`** (same knob as directly issued tokens). The **outbound** token response `expires_in` comes from the tenant STS, not from NICo. |
 | Token delegation config | Per-org | Each org registers its own `tokenEndpoint`, `subjectTokenAudience`, and auth method via oneof (`clientSecretBasic`, etc.). |
 
 **PUT token-delegation prerequisites:** Same as PUT identity/config, global `enabled` must be `true` and global config must be complete. If not, PUT returns `503 Service Unavailable`. Token delegation also requires org identity config to exist (the JWT sent to the exchange is built from it); if the org has no identity config, PUT token-delegation returns `404` or `503`.
@@ -610,9 +610,9 @@ Content-Length: ...
  }
 ```
 
-`expires_in` (and the lifetime of `access_token`) is defined by the tenant token endpoint; it is **not** necessarily equal to Carbide’s **`tokenTtlSec`** (which applies to the Carbide-signed **subject** JWT only).
+`expires_in` (and the lifetime of `access_token`) is defined by the tenant token endpoint; it is **not** necessarily equal to NICo’s **`tokenTtlSec`** (which applies to the NICo-signed **subject** JWT only).
 
-The exchange service serves an [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) token exchange endpoint for swapping Carbide-issued JWT-SVIDs with a tenant-specific issuer SVID or access token.
+The exchange service serves an [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) token exchange endpoint for swapping NICo-issued JWT-SVIDs with a tenant-specific issuer SVID or access token.
 
 #### **3.5.1.4 SPIFFE JWKS Endpoint**
 
@@ -635,7 +635,7 @@ https://{carbide-rest}/v2/org/{org-id}/carbide/site/{site-id}/.well-known/jwks.j
 
 #### **3.5.1.5 OIDC Discovery URL**
 
-Discovery reuses common OpenID Provider field names where helpful, but **Carbide does not issue OIDC `id_token`s**—only **JWT bearer** access tokens (machine identity). Verifiers should use `jwks_uri` (or `spiffe_jwks_uri` for SPIFFE-style `use`) and the **`alg`** (and `kid`) on keys from GetJWKS; `id_token_signing_alg_values_supported` stays empty.
+Discovery reuses common OpenID Provider field names where helpful, but **NICo does not issue OIDC `id_token`s**—only **JWT bearer** access tokens (machine identity). Verifiers should use `jwks_uri` (or `spiffe_jwks_uri` for SPIFFE-style `use`) and the **`alg`** (and `kid`) on keys from GetJWKS; `id_token_signing_alg_values_supported` stays empty.
 
 ```bash
 GET
@@ -889,7 +889,7 @@ Use standard gRPC `Status` codes, aligned with REST:
 
 ## **4.1 Security**
 
-1. All internal API gRPC calls to the Carbide API server use (existing) mTLS for authn/z and transport security. A future release also relies on attestation features.     
+1. All internal API gRPC calls to the NICo API server use (existing) mTLS for authn/z and transport security. A future release also relies on attestation features.     
 2. Carbide-rest is served over HTTPS and supports SSO integration  
 3. The IMDS service is exposed over link-local and is exposed only to the node instance. Short-lived tokens (configurable TTL) limit the replay window. Adding Metadata: true HTTP header to the requests to limit SSRF attacks. In order to ensure that requests are directly intended for IMDS and prevent unintended or unwanted redirection of requests, requests:  
   * Must contain the header `Metadata: true`  
@@ -897,6 +897,6 @@ Use standard gRPC `Status` codes, aligned with REST:
 
   Any request that doesn't meet both of these requirements is rejected by the service. 
 
-4. Requests to IMDS are limited to 3 requests per second. Requests exceeding this threshold will be rejected with 429 responses. This prevents DoS on DPU-agent and Carbide API server due to frequent IMDS calls.  
+4. Requests to IMDS are limited to 3 requests per second. Requests exceeding this threshold will be rejected with 429 responses. This prevents DoS on DPU-agent and NICo API server due to frequent IMDS calls.  
 5. Input validation: The input such as machine id will be validated using the database before issuing the token.  
 6. HTTPS and optional HTTP proxy support for route token exchange call to limit SSRF attacks on internal systems. 

--- a/docs/development.md
+++ b/docs/development.md
@@ -79,7 +79,7 @@ environment.
    more information on setting it up. Once you clone the `ncx-infra-controller-core` repo, you need to run `direnv allow` the first time you cd into your local copy.
    Running `direnv allow` exports the necessary environmental variables while in the repo and cleans up when not in the repo.
 
-   There are preset environment variables that are used throughout the repo. `${REPO_ROOT}` represents the top of the forge repo tree.
+   There are preset environment variables that are used throughout the repo. `${REPO_ROOT}` represents the top of the repo.
 
    For a list of preset environment variables, look in:
    `${REPO_ROOT}/.envrc`
@@ -173,7 +173,7 @@ Test!
 
 `cargo test`
 
-If the tests don't pass ask in Slack #swngc-forge-dev.
+If the tests don't pass ask in Slack #ncx-infra-controller.
 
 Cleanup, otherwise docker-compose won't work later:
 
@@ -194,7 +194,7 @@ The DPU has an ARM core. To build software that runs there such as `forge-dpu-ag
 Here's how I did it.
 
 One time build:
- - copy / edit the Docker file from https://gitlab-master.nvidia.com/grahamk/carbide/-/blob/trunk/dev/docker/Dockerfile.build-container-arm into `myarm/Dockerfile`.
+ - copy / edit the Docker file from the repo into `myarm/Dockerfile`.
  - delete these lines:
 ```
  RUN /root/.cargo/bin/cargo install cargo-cache cargo-make mdbook@0.4.52 mdbook-plantuml@0.8.0 mdbook-mermaid@0.16.2 sccache && /root/.cargo/bin/cargo cache -r registry-index,registry-sources
@@ -202,17 +202,17 @@ One time build:
  RUN cd /usr/local/bin && curl -fL https://getcli.jfrog.io | sh
 ```
  - `docker build -t myarm myarm` # give it a cooler name
- - `docker run -it -v /home/user/src/carbide:/carbide myarm /bin/bash`
+ - `docker run -it -v /home/user/src/ncx-infra-controller-core:/ncx-infra-controller-core myarm /bin/bash`
 
 Daily usage:
  - `docker start <container id or name>`
  - `docker attach <container id or name>`
 
-Now that you're in the container go into `/carbide` and work normally (`cargo build --release`). The binary rust produces will be aarch64. You can `scp` it to a DPU and run it.
+Now that you're in the container go into `/ncx-infra-controller-core` and work normally (`cargo build --release`). The binary rust produces will be aarch64. You can `scp` it to a DPU and run it.
 
 The build may hang the first time. I don't know why. Ctrl-C and try again. You may want to `docker commit` after it succeeds to update the image.
 
-Remember to `strip` before you scp so that scp goes faster. scp to DPU example (`nvinit` first): `scp -v -J grahamk@155.130.12.194 /home/graham/src/carbide/target/release/forge-dpu-agent ubuntu@10.180.198.23:.`
+Remember to `strip` before you scp so that scp goes faster. scp to DPU example (`nvinit` first): `scp -v /path/to/target/release/forge-dpu-agent ubuntu@<DPU_OOB_IP>:.`
 
 ## Next steps
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -20,8 +20,8 @@ https://cloudinit.readthedocs.io/en/latest/
 
 Cloud-init is the industry standard multi-distribution method for cross-platform cloud instance initialization. During boot, cloud-init identifies the cloud it is running on and initializes the system accordingly. Cloud instances will automatically be provisioned during first boot with networking, storage, ssh keys, packages and various other system aspects already configured.
 
-Cloud-init is used by Carbide to install components that are required on top of the base OS image:
-- DPUs use a Carbide provided cloud-init file to install Carbide related components
+Cloud-init is used by NICo to install components that are required on top of the base OS image:
+- DPUs use a NICo provided cloud-init file to install NICo related components
   on top of the base DPU image that is provided by the NVIDIA networking group.
 - Customers/tenants can provide a custom cloud-init automates installation for customer OSes
 
@@ -31,7 +31,7 @@ https://en.wikipedia.org/wiki/Dynamic_Host_Configuration_Protocol
 
 The Dynamic Host Configuration Protocol (DHCP) is a network management protocol used on Internet Protocol (IP) networks for automatically assigning IP addresses and other communication parameters to devices connected to the network using a client–server architecture.
 
-Within Carbide, both DPUs and Hosts are using DHCP request to resolve their IP. The Carbide infrastructure responds to those DHCP requests, and provides a response based on known information about the host.
+Within NICo, both DPUs and Hosts are using DHCP request to resolve their IP. The NICo infrastructure responds to those DHCP requests, and provides a response based on known information about the host.
 
 ### DNS (Domain Name System)
 
@@ -46,7 +46,7 @@ DPU - A [Mellanox BlueField 2 (or 3)](https://www.nvidia.com/en-us/networking/pr
 
 ### HBN (Host Based Networking)
 
-Software networking switch running in a container on the **DPU**. Manages network routing. Runs [Cumulus Linux](https://www.nvidia.com/en-us/networking/ethernet-switching/cumulus-linux/). Carbide controls it via VPC and `forge-dpu-agent`.
+Software networking switch running in a container on the **DPU**. Manages network routing. Runs [Cumulus Linux](https://www.nvidia.com/en-us/networking/ethernet-switching/cumulus-linux/). NICo controls it via VPC and `forge-dpu-agent`.
 
 https://docs.nvidia.com/doca/sdk/pdf/doca-hbn-service.pdf
 
@@ -72,9 +72,9 @@ iPXE is an open-source implementation of the [Preboot eXecution Environment (PXE
 
 ### Leaf
 
-In the Carbide project, we call "Leaf" the device that the host (which we want to make available for tenants) plugs into.
+In the NICo project, we call "Leaf" the device that the host (which we want to make available for tenants) plugs into.
 This is typically a DPU that will make the overlay network available
-to the tenant. In future iterations of the Carbide project, the Leaf might be a specialized switch instead of a DPU.
+to the tenant. In future iterations of the NICo project, the Leaf might be a specialized switch instead of a DPU.
 
 ### Machine
 
@@ -92,8 +92,8 @@ A Kubernetes thing
 
 In computing, the Preboot eXecution Environment, PXE specification describes a standardized client–server environment that boots a software assembly, retrieved from a network, on PXE-enabled clients.
 
-In Carbide, DPUs and Hosts are using PXE after startup to install both the
-Carbide specific software images as well as the images that the tenant
+In NICo, DPUs and Hosts are using PXE after startup to install both the
+NICo specific software images as well as the images that the tenant
 wants to run.
 
 ### VLAN

--- a/docs/manuals/breakfix_integration.md
+++ b/docs/manuals/breakfix_integration.md
@@ -90,7 +90,7 @@ The breakfix integration follows this automated repair cycle:
 
 ## Repair Status Labels
 
-Repair systems use machine metadata labels to communicate repair outcomes back to Forge:
+Repair systems use machine metadata labels to communicate repair outcomes back to NICo:
 
 ### Critical Label: `repair_status`
 | Value | Meaning | Result |

--- a/docs/manuals/metrics/core_metrics.md
+++ b/docs/manuals/metrics/core_metrics.md
@@ -8,10 +8,10 @@ This file contains a list of metrics exported by NCX Infra Controller (NICo). Th
 <tr><td>carbide_api_db_queries_total</td><td>counter</td><td>The amount of database queries that occurred inside a span</td></tr>
 <tr><td>carbide_api_db_span_query_time_milliseconds</td><td>histogram</td><td>Total time the request spent inside a span on database transactions</td></tr>
 <tr><td>carbide_api_grpc_server_duration_milliseconds</td><td>histogram</td><td>Processing time for a request on the carbide API server</td></tr>
-<tr><td>carbide_api_ready</td><td>gauge</td><td>Whether the Forge Site Controller API is running</td></tr>
+<tr><td>carbide_api_ready</td><td>gauge</td><td>Whether the NICo API is running</td></tr>
 <tr><td>carbide_api_tls_connection_attempted_total</td><td>counter</td><td>The amount of tls connections that were attempted</td></tr>
 <tr><td>carbide_api_tls_connection_success_total</td><td>counter</td><td>The amount of tls connections that were successful</td></tr>
-<tr><td>carbide_api_tracing_spans_open</td><td>gauge</td><td>Whether the Forge Site Controller API is running</td></tr>
+<tr><td>carbide_api_tracing_spans_open</td><td>gauge</td><td>Whether the NICo API is running</td></tr>
 <tr><td>carbide_api_vault_request_duration_milliseconds</td><td>histogram</td><td>the duration of outbound vault requests, in milliseconds</td></tr>
 <tr><td>carbide_api_vault_requests_attempted_total</td><td>counter</td><td>The amount of tls connections that were attempted</td></tr>
 <tr><td>carbide_api_vault_requests_failed_total</td><td>counter</td><td>The amount of tcp connections that were failures</td></tr>
@@ -22,7 +22,7 @@ This file contains a list of metrics exported by NCX Infra Controller (NICo). Th
 <tr><td>carbide_concurrent_machine_updates_available</td><td>gauge</td><td>The number of machines in the system that we will update concurrently.</td></tr>
 <tr><td>carbide_db_pool_idle_conns</td><td>gauge</td><td>The amount of idle connections in the carbide database pool</td></tr>
 <tr><td>carbide_db_pool_total_conns</td><td>gauge</td><td>The amount of total (active + idle) connections in the carbide database pool</td></tr>
-<tr><td>carbide_dpu_agent_version_count</td><td>gauge</td><td>The amount of Forge DPU agents which have reported a certain version.</td></tr>
+<tr><td>carbide_dpu_agent_version_count</td><td>gauge</td><td>The amount of DPU agents which have reported a certain version.</td></tr>
 <tr><td>carbide_dpu_firmware_version_count</td><td>gauge</td><td>The amount of DPUs which have reported a certain firmware version.</td></tr>
 <tr><td>carbide_dpus_healthy_count</td><td>gauge</td><td>The total number of DPUs in the system that have reported healthy in the last report. Healthy does not imply up - the report from the DPU might be outdated.</td></tr>
 <tr><td>carbide_dpus_up_count</td><td>gauge</td><td>The total number of DPUs in the system that are up. Up means we have received a health report less than 5 minutes ago.</td></tr>
@@ -33,14 +33,14 @@ This file contains a list of metrics exported by NCX Infra Controller (NICo). Th
 <tr><td>carbide_endpoint_exploration_machines_explored_overall_count</td><td>gauge</td><td>The total number of machines explored by machine type</td></tr>
 <tr><td>carbide_endpoint_exploration_success_count</td><td>gauge</td><td>The amount of endpoint explorations that have been successful</td></tr>
 <tr><td>carbide_endpoint_explorations_count</td><td>gauge</td><td>The amount of endpoint explorations that have been attempted</td></tr>
-<tr><td>carbide_gpus_in_use_count</td><td>gauge</td><td>The total number of GPUs that are actively used by tenants in instances in the Forge site</td></tr>
-<tr><td>carbide_gpus_total_count</td><td>gauge</td><td>The total number of GPUs available in the Forge site</td></tr>
-<tr><td>carbide_gpus_usable_count</td><td>gauge</td><td>The remaining number of GPUs in the Forge site which are available for immediate instance creation</td></tr>
+<tr><td>carbide_gpus_in_use_count</td><td>gauge</td><td>The total number of GPUs that are actively used by tenants in instances in the NICo deployment</td></tr>
+<tr><td>carbide_gpus_total_count</td><td>gauge</td><td>The total number of GPUs available in the NICo deployment</td></tr>
+<tr><td>carbide_gpus_usable_count</td><td>gauge</td><td>The remaining number of GPUs in the NICo deployment which are available for immediate instance creation</td></tr>
 <tr><td>carbide_hosts_by_sku_count</td><td>gauge</td><td>The amount of hosts by SKU and device type (&#x27;unknown&#x27; for hosts without SKU)</td></tr>
 <tr><td>carbide_hosts_health_overrides_count</td><td>gauge</td><td>The amount of health overrides that are configured in the site</td></tr>
 <tr><td>carbide_hosts_health_status_count</td><td>gauge</td><td>The total number of Managed Hosts in the system that have reported either a healthy or not healthy status - based on the presence of health probe alerts</td></tr>
-<tr><td>carbide_hosts_in_use_count</td><td>gauge</td><td>The total number of hosts that are actively used by tenants as instances in the Forge site</td></tr>
-<tr><td>carbide_hosts_usable_count</td><td>gauge</td><td>The remaining number of hosts in the Forge site which are available for immediate instance creation</td></tr>
+<tr><td>carbide_hosts_in_use_count</td><td>gauge</td><td>The total number of hosts that are actively used by tenants as instances in the NICo deployment</td></tr>
+<tr><td>carbide_hosts_usable_count</td><td>gauge</td><td>The remaining number of hosts in the NICo deployment which are available for immediate instance creation</td></tr>
 <tr><td>carbide_hosts_with_bios_password_set</td><td>gauge</td><td>The total number of Hosts in the system that have their BIOS password set.</td></tr>
 <tr><td>carbide_ib_partitions_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_ib_partitions in the system</td></tr>
 <tr><td>carbide_ib_partitions_iteration_latency_milliseconds</td><td>histogram</td><td>The elapsed time in the last state processor iteration to handle objects of type carbide_ib_partitions</td></tr>

--- a/docs/manuals/networking_requirements.md
+++ b/docs/manuals/networking_requirements.md
@@ -50,7 +50,7 @@ Ensure that a default route is provided to the overlay. Options for providing th
 
 ## Services and Integration
 
-* **OOB DHCP Relay**: The OOB network should be configured with a DHCP relay to forward DHCP requests of BMCs to the Carbide DHCP service IP.
+* **OOB DHCP Relay**: The OOB network should be configured with a DHCP relay to forward DHCP requests of BMCs to the NICo DHCP service IP.
 
 ## Hardware/Physical
 
@@ -60,7 +60,7 @@ Ensure that a default route is provided to the overlay. Options for providing th
 
 ## Autonomous System Number (ASN) Allocations
 
-* **Unique ASN per DPU**: Every DPU will be assigned a unique ASN from a pool of ASNs given to Carbide. In multi-DPU hosts, each DPU will have its own unique ASN.
+* **Unique ASN per DPU**: Every DPU will be assigned a unique ASN from a pool of ASNs given to NICo. In multi-DPU hosts, each DPU will have its own unique ASN.
 * **32-bit ASNs**: The use of 32-bit ASNs is required to ensure a sufficient number of unique numbers are available.
 * **Architecture**: The [RFC 7938](https://datatracker.ietf.org/doc/html/rfc7938) guidelines should be followed for data center routing to prevent path hunting and loops.
 * **Route-Servers (Optional)**: A specific ASN is needed for the BGP Route Servers (typically shared across the redundant route-server set).

--- a/docs/manuals/site-setup.md
+++ b/docs/manuals/site-setup.md
@@ -110,11 +110,11 @@ This section provides a high-level order of operations for installing components
 
    - **Temporal**: server up; register namespaces
 
-3.  Carbide core (forge‑system)
+3.  NICo core (forge‑system)
 
    - carbide-api and supporting services (DHCP/PXE/DNS/NTP as required)
 
-4.  Carbide REST components
+4.  NICo REST components
 
     - Deploy cloud‑api, cloud‑workflow (cloud‑worker & site‑worker), and cloud‑cert‑manager (credsmgr)
 
@@ -169,7 +169,7 @@ You must provide the following:
     - Cluster internal certs (service DNS SANs)
     - Any externally‑facing FQDNs you choose
 
-- Approver flows should allow your teams to create Certificate resources for the NVCarbide namespaces.
+- Approver flows should allow your teams to create Certificate resources for the NICo namespaces.
 
 **If you deploy the reference version**:
 
@@ -245,7 +245,7 @@ Vault is used by the following components:
     password `<POSTGRES_PASSWORD>`.
 
 -   Enable **TLS** (recommended) or allow secure network policy between
-    DB and the NVCarbide namespaces.
+    DB and the NICo namespaces.
 
 -   Create extensions (the apps expect these):
 
@@ -297,7 +297,7 @@ Vault is used by the following components:
 
 **If you already have Temporal**
 
--   Ensure the `frontend gRPC endpoint` is reachable from NVCarbide
+-   Ensure the `frontend gRPC endpoint` is reachable from NICo
     workloads and present the proper `mTLS`/CA if you require TLS.
 
 -   Register namespaces:

--- a/docs/manuals/sku_validation.md
+++ b/docs/manuals/sku_validation.md
@@ -9,7 +9,7 @@ Each host managed by NICo must have a SKU associated with it before it can be ma
 
 {/* TODO: did we actually implement this? */}
 
-Hardware configurations or SKUs are generated from existing machines by an admin and uploaded to forge via the CLI.
+Hardware configurations or SKUs are generated from existing machines by an admin and uploaded to NICo via the CLI.
 SKUs can be downloaded for modification or use with other sites.
 
 Machines that are assigned a SKU are automatically validated during ingestion based on their discovery information.
@@ -48,7 +48,7 @@ NICo maintains a version of the SKU schema used when a SKU is created.  This ens
 
 ### Configuration
 
-SKU validation is enabled or disabled for an entire site at once, using the forge configuration file.
+SKU validation is enabled or disabled for an entire site at once, using the NICo configuration file.
 The block that defines it is called `bom_validation`:
 
 ```toml
@@ -103,7 +103,7 @@ Where:
 
  - `<vendor>` is the first word of the "chassis" "vendor" field, e.g. `dell` or `lenovo`
  - `<model>` is the unique ending to the "chassis" "model" field, e.g. `r750` or `sr670v2`
- - `<node_type>` is one of the following types of node that are deployed in forge:
+ - `<node_type>` is one of the following types of node that are deployed in NICo:
     - `gpu`
     - `cpu`
     - `storage`
@@ -270,7 +270,7 @@ carbide-admin-cli sku unassign <machineid>
 ```
 
 ### Replacing an existing SKU
-If a SKU has a set of components that do not work for a set of machines (either due to bugs, or Carbide software updates) updating machines by unassigning and assigning a SKU would be challenging.  Replacing the components of a SKU can be done with the `sku replace` command.  This will force all machines to go through verification when no instance is allocated to the machine (all machines are verified when an instance is released).
+If a SKU has a set of components that do not work for a set of machines (either due to bugs, or NICo software updates) updating machines by unassigning and assigning a SKU would be challenging.  Replacing the components of a SKU can be done with the `sku replace` command.  This will force all machines to go through verification when no instance is allocated to the machine (all machines are verified when an instance is released).
 
 ```sh
 carbide-admin-cli sku replace <filename> [--id <sku_name>]

--- a/docs/playbooks/carbide_web_oauth2.md
+++ b/docs/playbooks/carbide_web_oauth2.md
@@ -2,7 +2,7 @@
 
 For managing client secrets and redirect URIs registered in the Entra portal.
 
-# Carbide Web
+# NICo Web
 
 The oauth2 in carbide-web has defaults for most settings:
 

--- a/docs/playbooks/force_delete.md
+++ b/docs/playbooks/force_delete.md
@@ -23,7 +23,7 @@ The following steps can be used to force-delete knowledge about a NICo host:
 
 ### 1. Obtain access to `carbide-admin-cli`
 
-See carbide-admin-cli access on a Carbide cluster.
+See carbide-admin-cli access on a NICo deployment.
 
 ### 2. Execute the `carbide-admin-cli machine force-delete` command
 
@@ -63,7 +63,7 @@ The following steps can be used to reinstall the host OS on a NICo host:
 
 ### 1. Obtain access to the `carbide-admin-cli` tool
 
-See carbide-admin-cli access on a Carbide cluster.
+See carbide-admin-cli access on a NICo deployment.
 
 ### 3. Execute the `carbide-admin-cli instance reboot --custom-pxe` command
 

--- a/docs/playbooks/machine_reboot.md
+++ b/docs/playbooks/machine_reboot.md
@@ -17,7 +17,7 @@ The following steps can be used to reboot a machine:
 
 ### 1. Obtain access to `carbide-admin-cli`
 
-See [carbide-admin-cli access on a Forge cluster](forge_admin_cli.md).
+See [carbide-admin-cli access on a NICo deployment](forge_admin_cli.md).
 
 ### 2. Execute the `carbide-admin-cli machine reboot` command
 
@@ -25,12 +25,12 @@ See [carbide-admin-cli access on a Forge cluster](forge_admin_cli.md).
 It always will require the machine's BMC IP and port to be specified.
 
 BMC credentials can either be explicitly passed, or the `--machine-id` parameter
-can be used to let the forge site-controller read the last known credentials
+can be used to let the NICo site controller read the last known credentials
 for the machine.
 
 Rebooting a machine will also always reset its boot order. The machine
 will PXE boot, and thereby will be able to retrieve new boot instructions from
-the Forge site controller.
+the NICo site controller.
 
 **Example:**
 

--- a/docs/playbooks/stuck_objects/adding_new_machines.md
+++ b/docs/playbooks/stuck_objects/adding_new_machines.md
@@ -1,6 +1,6 @@
 # Adding New Machines to an Existing Site
 
-This guide is intended to cover some of the basic things you should check to get a machine into a basic state where it can be discovered by Forge auto-ingestion.
+This guide is intended to cover some of the basic things you should check to get a machine into a basic state where it can be discovered by NICo auto-ingestion.
 
 Some of the configuration items that should be considered which could potentially cause issues:
 
@@ -221,14 +221,14 @@ To check the current Bluefield firmware versions installed on a DPU:
 
 ### Updating the Bluefield Firmware Versions
 
-***Note:*** If discovery is failing due to the firmware revision being too low, confirm with Forge Dev team what version you should update to before proceeding
+***Note:*** If discovery is failing due to the firmware revision being too low, confirm with the NICo dev team what version you should update to before proceeding
 
 DPU Firmware versions can be downloaded from the following locations:
 
 - BF2: [BF2 BMC Firmware release](https://confluence.nvidia.com/display/SW/BF2+BMC+Firmware+release)
 - BF3: [BF3 BMC Firmware release](https://confluence.nvidia.com/display/SW/BF3+BMC+Firmware+release)
 
-For the examples below, we are installing FW version 24.01-5, but confirm this with Forge Development team for your specific install before proceeding
+For the examples below, we are installing FW version 24.01-5, but confirm this with the development team for your specific install before proceeding
 
 1. Download the relevant packages for your DPU type:
 
@@ -318,7 +318,7 @@ For the examples below, we are installing FW version 24.01-5, but confirm this w
 
 ## DPU ARM OS: Checking Secure Boot Status
 
-To successfully boot from the Forge BFB image, the DPU ARM OS needs to have Secure Boot disabled and configured for HTTP PXE boot.
+To successfully boot from the NICo BFB image, the DPU ARM OS needs to have Secure Boot disabled and configured for HTTP PXE boot.
 
 ### Check current secure boot settings
 

--- a/docs/playbooks/stuck_objects/common_mitigations.md
+++ b/docs/playbooks/stuck_objects/common_mitigations.md
@@ -5,7 +5,7 @@ that show up. Many issues will require a unique mitigation that is tailored
 to the root cause of the object being stuck.
 
 Therefore operators are required to understand the requirements for state transitions
-and how Forge system components work together. The previous sections of this
+and how NICo system components work together. The previous sections of this
 runbook should help with this.
 
 However there exists a few common requirements for state transitions, and repeated
@@ -42,27 +42,27 @@ The following issues might prevent this call from happening:
 #### 4.1.2 Feedback from forge-dpu-agent
 
 Whenever the configuration of a ManagedHost changes (Instance gets created,
-Instance gets deleted, Provisioning), Forge requires the `forge-dpu-agent` to
+Instance gets deleted, Provisioning), NICo requires the `forge-dpu-agent` to
 acknowledge that the desired DPU configuration is applied and that the DPU and
 services running on it (like `HBN`) are in a healthy state.
 
 This often happens within a state called `WaitingForNetworkConfig`. For details
 about this see [WaitingForNetworkConfig](waiting_for_network_config.md).
 
-## Optional Step 5: Mitigation by deleting the object using the Forge Web UI or API
+## Optional Step 5: Mitigation by deleting the object using the API
 
 In order to fix the problem of instance or subnet stuck in provisioning,
 it often seems appealing to just delete the object and retry.
 
 **This mitigation will however only work if the object has not even
-been created on the Forge Site and if the source of the creation problem is
-within the scope of the Forge Cloud Backend.**
+been created on the NICo site and if the source of the creation problem is
+within the scope of the cloud backend.**
 
 If the object was already created on the site and is stuck in a certain
 provisioning state there, then the deletion attempt will not help getting
 the object unstuck. The lifecycle of any object is fully linear
 with no shortcuts. If the object isn't getting `Ready` it will also never
-be deleted. The object lifecycle is implemented this way in Forge in order to
+be deleted. The object lifecycle is implemented this way in NICo in order to
 avoid any important object creation or deletion steps accidentally being skipped due to
 skipping states.
 

--- a/docs/playbooks/stuck_objects/stuck_objects.md
+++ b/docs/playbooks/stuck_objects/stuck_objects.md
@@ -15,23 +15,22 @@ advance into the next state.
 
 ## Step 1: Is it a Cloud or Site problem?
 
-The state of Forge objects is tracked and advanced in 2 different systems:
-- The Forge cloud backend, which stores the states that are shown by the
-  Forge Web UI and ngc console.
-- The actual Forge site, which manages the lifecycle of each object inside the
+The state of NICo objects is tracked and advanced in 2 different systems:
+- The cloud backend, which stores the states that are shown by the
+  NGC console and web UI.
+- The actual NICo site, which manages the lifecycle of each object inside the
   site.
 
 If the state of an object doesn't advance, there might be multiple reasons for it:
-1. The state of the object isn't advanced on the actual Forge site
-2. The request to change the state of the object is not forwarded from the Forge
-    cloud to the Forge site. Or the notification about the state changed was
-    not forwarded from the Forge Site to the cloud.
+1. The state of the object isn't advanced on the actual NICo site
+2. The request to change the state of the object is not forwarded from the
+    cloud to the NICo site. Or the notification about the state changed was
+    not forwarded from the NICo site to the cloud.
 
 A rule of thumb for locating the source of the problem is:
 - If the states that are shown on the site and via the Cloud API are different,
   reason 1) will apply. This indicates a communication issue in the
-  paths between Forge Cloud Backend, Forge Site Agent and Forge Site
-  Controller.  
+  paths between the cloud backend, site agent and NICo site controller.  
   {/* TODO: Document steps to diagnose and remediate these issues */}
 - If the states match, then the state on the site isn't advanced as required.
 
@@ -39,13 +38,13 @@ The next chapters will describe on how to lookup the state of an object on
 the actual site and how to determine what prevents the object from moving
 into the next state on the site.
 
-### 1.1 Checking the state in the Forge Web UI or API
+### 1.1 Checking the state in the web UI or API
 
-Another initial check on whether the problem is a Forge Cloud or Site problem
-is to check whether the Cloud backend could actually send the state change
-request (e.g. instance release request) to the Site.
+Another initial check on whether the problem is a cloud or site problem
+is to check whether the cloud backend could actually send the state change
+request (e.g. instance release request) to the site.
 
-The `statusHistory` field on the Forge Cloud API can be helpful for this assessment. E.g. the history for the following Subnet indicates that
+The `statusHistory` field on the cloud API can be helpful for this assessment. E.g. the history for the following Subnet indicates that
 the deletion request was sent to the site, but deletion might be stuck there:
 
 ```json
@@ -89,13 +88,13 @@ the deletion request was sent to the site, but deletion might be stuck there:
 }
 ```
 
-In this example, we can see the Forge Cloud Backend indicated it transferred
-the deletion request to the Site. In this case, we should continue the
+In this example, we can see the cloud backend indicated it transferred
+the deletion request to the site. In this case, we should continue the
 investigation by checking the site state for this subnet.
 
-If you are using the Forge Web UI, not all API details like `statusHistory`
+If you are using the web UI, not all API details like `statusHistory`
 are displayed. However we can work around this by getting
-access to the raw Forge Cloud API response.
+access to the raw cloud API response.
 A browsers developer tools can be used for this:
 - While on the page that shows the status of the object (E.g. "Virtual
   Private Clouds"), open the browser developer tools. The F12 key will open
@@ -106,19 +105,19 @@ A browsers developer tools can be used for this:
   to force a request.
 - Click the `Response` tab.
 
-You should now see the raw Forge Cloud API response, as shown in the following
+You should now see the raw cloud API response, as shown in the following
 screenshot:
 ![](../../static/playbooks/stuck_objects/browser_devtools.png)
 
 
 ## Step 2: Determine the actual state an object is in
 
-The Forge Web UI only shows a simplified state for Forge users, like
+The web UI only shows a simplified state for users, like
 - Provisioning
 - Ready
 - Deleting
 
-However Forge sites use much more fine grained states, like
+However NICo sites use much more fine grained states, like
 `Assigned/BootingWithDiscoveryImage`. The `/` in this notion separates
 the main state of an object from its substate(s). In this example, `Assigned`
 is the main state of an object and `BootingWithDiscoveryImage` is the substate.
@@ -128,7 +127,7 @@ need to determine the full state. This can be done using multiple approaches:
 
 ### 2.1 Using carbide-admin-cli
 
-You can inspect the detailed state of a objects on Forge sites using `carbide-admin-cli`. Refer to [forge-admin-cli](forge_admin_cli.md) instructions
+You can inspect the detailed state of a objects on NICo sites using `carbide-admin-cli`. Refer to [forge-admin-cli](forge_admin_cli.md) instructions
 on how to utilize it.
 
 Using carbide-admin-cli, you can inspect the state of an object e.g. with the
@@ -197,10 +196,10 @@ DELETED   : Not Deleted
 STATE     : Ready
 ```
 
-### 2.2 Using the Forge dashboard
+### 2.2 Using the NICo dashboard
 
 In order to get a first impression of whether an object might be stuck in a
-state and why, you can use the [Forge Grafana Dashboard](https://ngcobservability-grafana.thanos.nvidiangn.net/d/WzX_VErVk/forge-site?orgId=1).
+state and why, you can use the NICo Grafana Dashboard.
 
 On the Dashboard, search for the graph which shows the amount of objects
 in a certain state. E.g. for ManagedHosts/Instances, check "ManagedHost States".
@@ -214,9 +213,9 @@ state, and that operator intervention is required to make them advance state.
 
 The dashboard will not tell us which ManagedHost is exactly stuck. But if only one
 ManagedHost is in a stuck state, we can deduct that this might be the ManagedHost a
-Forge user is concerned about.
+user is concerned about.
 
-For other objects whose lifecycle is controlled by Forge - e.g. Subnets,
+For other objects whose lifecycle is controlled by NICo - e.g. Subnets,
 Network Segments or Infiniband Partitions - a similar diagram will exist.
 
 Another diagram you can look at is the "Time in state" chart that exists
@@ -243,19 +242,19 @@ would actually need to happen in order to perform a state transition.
 The best documentation for these state changes is the actual state machine
 source code, which codifies the conditions for moving out of each state. Use
 the following links to look at the state machines for objects managed by
-Forge:
-- [ManagedHost State Machine](https://gitlab-master.nvidia.com/nvmetal/carbide/-/blob/trunk/api/src/state_controller/machine/handler.rs) (also used for the lifecycle of Forge instances)
-- [NetworkSegment/Subnet State Machine](https://gitlab-master.nvidia.com/nvmetal/carbide/-/blob/trunk/api/src/state_controller/network_segment/handler.rs)
-- [Infiniband Partition State Machine](https://gitlab-master.nvidia.com/nvmetal/carbide/-/blob/trunk/api/src/state_controller/ib_partition/handler.rs)
+NICo:
+- `crates/api/src/state_controller/machine/handler.rs` — ManagedHost State Machine (also used for the lifecycle of instances)
+- `crates/api/src/state_controller/network_segment/handler.rs` — NetworkSegment/Subnet State Machine
+- `crates/api/src/state_controller/ib_partition/handler.rs` — Infiniband Partition State Machine
 
 When looking at these files, consider that the software version deployed
-on the Forge site you are investigating might not match the latest `trunk`
+on the NICo site you are investigating might not match the latest `main`
 version of those state machines. You might then want to look at the version
 of the file which matches the version (git commit hash) of the actual site.
 
 The `handle_object_state` function in these files will be called for each
-object whose lifecycle is controlled by Forge in periodic intervals. The
-default period is 30s - but it could be changed in future Forge updates.
+object whose lifecycle is controlled by NICo in periodic intervals. The
+default period is 30s - but it could be changed in future NICo updates.
 
 This means that if the state of an object could not be advanced within one
 iteration of this function, it will automatically be retried 30s later.
@@ -291,12 +290,11 @@ is that we detected that the Host had been rebooted. It also describes that once
 the reboot is detected, we will move on into the `Assigned/SwitchToAdminNetwork`
 state.
 
-Inspecting the [`rebooted`](https://gitlab-master.nvidia.com/nvmetal/carbide/-/blob/38849aed602a2ab6e19a5315b342db3d4535b143/api/src/state_controller/machine/handler.rs#L494-504)
-function further will tell us that checks that the `last_reboot_time` timestamp
+Inspecting the `rebooted` function further will tell us that checks that the `last_reboot_time` timestamp
 is more recent than the time when we entered the state. And checking even
-further for where the `last_reboot_time` is updated, [we would learn that
+further for where the `last_reboot_time` is updated, we would learn that
 it happens when `forge-scout` is started and asks the `carbide-api` server
-via the `ForgeAgentControl` API call for instructions](https://gitlab-master.nvidia.com/nvmetal/carbide/-/blob/38849aed602a2ab6e19a5315b342db3d4535b143/api/src/api.rs#L2771-2772.)
+via the `ForgeAgentControl` API call for instructions.
 
 Therefore we can determine that possible sources of the ManagedHost being stuck are:
 - The Host is never rebooted
@@ -344,13 +342,12 @@ log line about any action which affected the state of the object, search also
 for the `span_id` in this log line. It will show all log messages that have
 been emitted as part of the same RPC request or the same state handler iteration.
 
-### 3.3 Learning more about failures from the Forge Grafana Dashboard
+### 3.3 Learning more about failures from the NICo Grafana Dashboard
 
-The [Forge Grafana Dashboard](https://ngcobservability-grafana.thanos.nvidiangn.net/d/WzX_VErVk/forge-site?orgId=1)
-can also provide a quick overview of why state transitions have failed.
+The NICo Grafana Dashboard can also provide a quick overview of why state transitions have failed.
 In case the state handler of a certain object returned an error, the error type
 will also be shown in the diagram which summarizes the amount of objects in a
-certain state for each Forge site.
+certain state for each NICo site.
 
 E.g. for the following example, we can see state handling for 1 ManagedHost in state
 `assigned waitingfornetworkconfig` failing due to a `redfish_client_creation_error`.

--- a/docs/playbooks/stuck_objects/waiting_for_network_config.md
+++ b/docs/playbooks/stuck_objects/waiting_for_network_config.md
@@ -1,7 +1,7 @@
 # `WaitingForNetworkConfig` and DPU health
 
 Whenever the configuration of a ManagedHost changes (Instance gets created,
-Instance gets deleted, Provisioning), Forge requires the `forge-dpu-agent` to
+Instance gets deleted, Provisioning), NICo requires the `forge-dpu-agent` to
 acknowledge that the desired DPU configuration is applied and that the DPU and
 services running on it (like `HBN`) are in a healthy state.
 
@@ -12,7 +12,7 @@ This feedback mechanism works in the following fashion:
    The configuration includes Version numbers, which increase whenever the
    configuration changes.
 2. `forge-dpu-agent` reports the version numbers of the currently applied
-   configurations back to Carbide using the `RecordDpuNetworkStatus` API.
+   configurations back to NICo using the `RecordDpuNetworkStatus` API.
    This report also includes the DPUs health in the form of a `HealthReport`.
 
 If the DPU has not recently reported that it is up, healthy and that the latest
@@ -147,8 +147,7 @@ Search strings for DPU can be:
 **Note that the query using the MachineId will only work if the DPU once had been fully ingested
 and is aware of its Machine ID. Otherwise only searches by `host_name` will work.**
 
-In case the DPU problem affects log forwarding, DPU logs need to be checked
-directly on the DPU.
+In case the DPU problem affects log forwarding, DPU logs need to be checked directly on the DPU.
 
 #### Checking logs on the DPU:
 
@@ -220,7 +219,7 @@ show `doca-hbn` container), and to search for associated logs.
 
 ### `DhcpRelay`/`DhcpServer`
 
-Indicates that the DHCP Relay or Server that Forge deploys on the DPU in order
+Indicates that the DHCP Relay or Server that NICo deploys on the DPU in order
 to respond to the DHCP requests from the Host are not running as intended.
 In these conditions, the Host would not be able to boot since nothing would respond
 to the DHCP request.

--- a/docs/playbooks/troubleshooting_noDpuLogsWarning_alerts.md
+++ b/docs/playbooks/troubleshooting_noDpuLogsWarning_alerts.md
@@ -1,11 +1,11 @@
 # Troubleshooting noDpuLogsWarning Alerts
 
-The Forge noDpuLogsWarning alert fires under the following conditions:
-1. Forge has been receiving logs from the DPU ARM OS within the last 30 days
+The noDpuLogsWarning alert fires under the following conditions:
+1. NICo has been receiving logs from the DPU ARM OS within the last 30 days
 2. It has not received any forge-dpu-agent.service log events within the last 10 minutes
 3. And opentelemetry-collector-prom end point running on the DPU ARM OS has been down for more than 5 minutes
 
-The format of the alert name is "\<Forge site ID\>-noDpuLogsWarning (\<Forge site ID\> \<DPU ARM OS hostname\> forge-monitoring/forge-monitoring-(\<Forge site ID\>-prometheus warning)
+The format of the alert name is "\<NICo site ID\>-noDpuLogsWarning (\<NICo site ID\> \<DPU ARM OS hostname\> forge-monitoring/forge-monitoring-(\<NICo site ID\>-prometheus warning)
 
 ## Common Causes of these alerts
 


### PR DESCRIPTION
## Description
Replace legacy naming with current NICo terminology across 25 files in docs/. Fix BlueField capitalization throughout. Remove stale URLs and replace with public equivalents. Rewrite informal developer notes professionally.

## Type of Change
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues
Fixes #1052

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [x] No testing required (docs, internal refactor, etc.)