### PR TITLE
docs: restructure navigation for operator workflow

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -15,14 +15,26 @@ navigation:
     - page: Introduction
       path: README.md
 
-    - page: Hardware Compatibility List
-      path: hcl.md
-
-    - page: Release Notes
-      path: release-notes.md
-
-    - page: FAQs
-      path: faq.md
+    - section: Getting Started
+      contents:
+        - page: Site Reference Architecture
+          path: manuals/site-reference-arch.md
+        - page: Site Setup
+          path: manuals/site-setup.md
+        - page: Networking Requirements
+          path: manuals/networking_requirements.md
+        - page: Building NICo Containers
+          path: manuals/building_nico_containers.md
+        - page: Ingesting Hosts
+          path: manuals/ingesting_machines.md
+        - page: Updating Expected Hosts Manifest
+          path: manuals/expected_machine_update.md
+        - section: Kubernetes
+          contents:
+            - page: Bootstrap New Cluster
+              path: kubernetes/bootstrap.md
+            - page: TLS
+              path: kubernetes/tls.md
 
     - section: Architecture
       contents:
@@ -46,7 +58,7 @@ navigation:
           path: architecture/health/health_alert_classifications.md
         - page: Key Group Synchronization
           path: architecture/key_group_sync.md
-        - section: Infiniband Support
+        - section: InfiniBand Support
           contents:
             - page: NIC and Port Selection
               path: architecture/infiniband/nic_selection.md
@@ -59,22 +71,10 @@ navigation:
             - page: Rack State Machine
               path: architecture/state_machines/rack.md
 
-    - section: Manuals
+    - section: Operations
       contents:
-        - page: Site Setup
-          path: manuals/site-setup.md
-        - page: Site Reference Architecture
-          path: manuals/site-reference-arch.md
-        - page: Networking Requirements
-          path: manuals/networking_requirements.md
-        - page: Building NICo Containers
-          path: manuals/building_nico_containers.md
         - page: Cargo via Docker on macOS
           path: manuals/cargo-via-docker-macos.md
-        - page: Ingesting Hosts
-          path: manuals/ingesting_machines.md
-        - page: Updating Expected Hosts Manifest
-          path: manuals/expected_machine_update.md
         - page: Host Validation
           path: manuals/machine_validation.md
         - page: SKU Validation
@@ -83,6 +83,8 @@ navigation:
           path: manuals/nvlink_partitioning.md
         - page: Release Instance API Enhancements
           path: manuals/breakfix_integration.md
+        - page: BlueField DPU Operations
+          path: dpu-operations.md
         - section: Managing VPCs
           contents:
             - page: VPC Routing Profiles
@@ -94,10 +96,32 @@ navigation:
             - page: Core Metrics
               path: manuals/metrics/core_metrics.md
 
-    - section: Design
+    - section: Playbooks
       contents:
-        - page: SPIFFE SVID Design
-          path: design/machine-identity/spiffe-svid-sdd.md
+        - page: Azure OIDC for NCX Infra Controller Web UI
+          path: playbooks/carbide_web_oauth2.md
+        - page: Force Deleting and Rebuilding Hosts
+          path: playbooks/force_delete.md
+        - page: Rebooting a Machine
+          path: playbooks/machine_reboot.md
+        - page: InfiniBand Setup
+          path: playbooks/ib_runbook.md
+        - section: Stuck Objects
+          contents:
+            - page: Overview and General Troubleshooting
+              path: playbooks/stuck_objects/stuck_objects.md
+            - page: Common Mitigations
+              path: playbooks/stuck_objects/common_mitigations.md
+            - page: Stuck in WaitingForNetworkConfig and DPU Health
+              path: playbooks/stuck_objects/waiting_for_network_config.md
+            - page: Adding New Machines to an Existing Site
+              path: playbooks/stuck_objects/adding_new_machines.md
+            - page: Troubleshooting noDpuLogsWarning Alerts
+              path: playbooks/troubleshooting_noDpuLogsWarning_alerts.md
+        - section: Debugging Machine
+          contents:
+            - page: Collecting Debug Bundles
+              path: playbooks/debugging_machine/debug_bundle.md
 
     - section: Development
       contents:
@@ -119,45 +143,17 @@ navigation:
               path: development/schema.md
         - page: Adding Support for New Hardware
           path: development/new_hardware_support.md
-        - page: DPU/Bluefield Operations
-          path: dpu-operations.md
 
-    - section: Kubernetes
+    - section: Reference
       contents:
-        - page: Bootstrap New Cluster
-          path: kubernetes/bootstrap.md
-        - page: TLS
-          path: kubernetes/tls.md
-
-    - section: Playbooks
-      contents:
-        - page: Azure OIDC for NCX Infra Controller Web UI
-          path: playbooks/carbide_web_oauth2.md
-        - page: Force Deleting and Rebuilding Forge Hosts
-          path: playbooks/force_delete.md
-        - page: Rebooting a Machine
-          path: playbooks/machine_reboot.md
-        - section: Instance/Subnet/etc is Stuck in a State
-          contents:
-            - page: Overview and General Troubleshooting
-              path: playbooks/stuck_objects/stuck_objects.md
-            - page: Common Mitigations
-              path: playbooks/stuck_objects/common_mitigations.md
-            - page: Stuck in WaitingForNetworkConfig and DPU Health
-              path: playbooks/stuck_objects/waiting_for_network_config.md
-            - page: Adding New Machines to an Existing Site
-              path: playbooks/stuck_objects/adding_new_machines.md
-            - page: Troubleshooting noDpuLogsWarning Alerts
-              path: playbooks/troubleshooting_noDpuLogsWarning_alerts.md
-        - section: Debugging Machine
-          contents:
-            - page: Collecting Debug Bundles
-              path: playbooks/debugging_machine/debug_bundle.md
-        - page: InfiniBand Setup
-          path: playbooks/ib_runbook.md
-
-    - page: Glossary
-      path: glossary.md
+        - page: Hardware Compatibility List
+          path: hcl.md
+        - page: Release Notes
+          path: release-notes.md
+        - page: FAQs
+          path: faq.md
+        - page: Glossary
+          path: glossary.md
 
   - tab: api
     layout:


### PR DESCRIPTION
## Description
Restructure `docs/index.yml` to better serve operators:

- Add **Getting Started** section (site setup, networking, containers, ingesting hosts, Kubernetes)
- Rename **Manuals → Operations** for ongoing operator tasks
- Remove internal **Design** section not intended for public docs
- Add **Reference** section grouping HCL, release notes, FAQs, and glossary
- Fix navigation label accuracy (legacy naming, incorrect capitalization)

## Type of Change
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues
Fixes #1053

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [x] No testing required (docs, internal refactor, etc.)