### PR TITLE
fix(api/logging): let user override hardcoded default log levels

### DIFF
--- a/crates/api/src/logging/level_filter.rs
+++ b/crates/api/src/logging/level_filter.rs
@@ -19,6 +19,7 @@ use std::fmt;
 
 use arc_swap::ArcSwap;
 use chrono::{DateTime, Utc};
+use std::sync::Arc;
 use tracing_subscriber::{EnvFilter, reload};
 
 use crate::logging::setup::dep_log_filter;
@@ -99,8 +100,9 @@ impl ActiveLevel {
         let current = dep_log_filter(EnvFilter::builder().parse(filter)?);
         self.expiry.store(until.into());
         if let Some(handle) = self.reload_handle.as_ref() {
-            handle.reload(current)?;
+            handle.reload(current.clone())?;
         }
+        self.current.store(Arc::new(current.to_string()));
         Ok(())
     }
 

--- a/crates/api/src/logging/level_filter.rs
+++ b/crates/api/src/logging/level_filter.rs
@@ -16,10 +16,10 @@
  */
 
 use std::fmt;
+use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 use chrono::{DateTime, Utc};
-use std::sync::Arc;
 use tracing_subscriber::{EnvFilter, reload};
 
 use crate::logging::setup::dep_log_filter;

--- a/crates/api/src/logging/setup.rs
+++ b/crates/api/src/logging/setup.rs
@@ -54,25 +54,20 @@ pub struct Metrics {
 }
 
 pub fn dep_log_filter(env_filter: EnvFilter) -> EnvFilter {
-    [
-        "sqlxmq::runner=warn",
-        "sqlx::query=warn",
-        "sqlx::extract_query_data=warn",
-        "rustify=off",
-        "hyper=error",
-        "rustls=warn",
-        "tokio_util::codec=warn",
-        "vaultrs=error",
-        "h2=warn",
-    ]
-    .iter()
-    .fold(env_filter, |f, filter_str| {
-        f.add_directive(
-            filter_str
-                .parse()
-                .unwrap_or_else(|err| panic!("{filter_str} must be parsed; error: {err}")),
-        )
-    })
+    const DEPS: &str = "sqlxmq::runner=warn,sqlx::query=warn,\
+        sqlx::extract_query_data=warn,rustify=off,hyper=error,\
+        rustls=warn,tokio_util::codec=warn,vaultrs=error,h2=warn";
+
+    let user = env_filter.to_string();
+    let combined = if user.is_empty() {
+        DEPS.to_string()
+    } else {
+        format!("{DEPS},{user}")
+    };
+
+    EnvFilter::builder()
+        .parse(&combined)
+        .unwrap_or_else(|err| panic!("could not reparse combined filter '{combined}': {err}"))
 }
 
 pub fn setup_logging(
@@ -391,5 +386,73 @@ mod tests {
                 assert!(!encoded.contains(r#"mygauge{error="ErrC",state="mystate"} 1"#));
             }
         }
+    }
+
+    /// Install `dep_log_filter(user_directives)` as the thread-local subscriber
+    /// for the duration of `f`, so `tracing::enabled!` calls inside reflect the
+    /// effective filter.
+    fn with_filter<R>(user_directives: &str, f: impl FnOnce() -> R) -> R {
+        use tracing_subscriber::prelude::*;
+
+        let user = EnvFilter::builder().parse(user_directives).unwrap();
+        let subscriber = tracing_subscriber::registry().with(dep_log_filter(user));
+        tracing::subscriber::with_default(subscriber, f)
+    }
+
+    #[test]
+    fn user_directives_override_defaults() {
+        with_filter("info,vaultrs=debug,rustify=trace", || {
+            assert!(
+                tracing::enabled!(target: "vaultrs", tracing::Level::DEBUG),
+                "user's vaultrs=debug should win over the dep cap"
+            );
+            assert!(
+                tracing::enabled!(target: "rustify", tracing::Level::TRACE),
+                "user's rustify=trace should win over rustify=off"
+            );
+            // Unspecified dep target still capped at error.
+            assert!(
+                !tracing::enabled!(target: "hyper", tracing::Level::INFO),
+                "hyper should still be capped at error by dep default"
+            );
+        });
+    }
+
+    #[test]
+    fn bare_default_does_not_override_dep_defaults() {
+        // RUST_LOG=info; user only sets a default, no per-target directives.
+        with_filter("info", || {
+            // User's default applies to unrelated targets.
+            assert!(tracing::enabled!(target: "carbide", tracing::Level::INFO));
+            assert!(!tracing::enabled!(target: "carbide", tracing::Level::DEBUG));
+            // Dep caps still apply where the user didn't override.
+            assert!(!tracing::enabled!(target: "hyper", tracing::Level::INFO));
+            assert!(tracing::enabled!(target: "hyper", tracing::Level::ERROR));
+            assert!(!tracing::enabled!(target: "vaultrs", tracing::Level::INFO));
+            assert!(tracing::enabled!(target: "vaultrs", tracing::Level::ERROR));
+        });
+    }
+
+    #[test]
+    fn user_target_overrides_default_without_touching_others() {
+        // RUST_LOG=info,carbide=debug; raises one target; deps stay capped.
+        with_filter("info,carbide=debug", || {
+            assert!(tracing::enabled!(target: "carbide", tracing::Level::DEBUG));
+            // Unrelated target still at the INFO default.
+            assert!(tracing::enabled!(target: "other", tracing::Level::INFO));
+            assert!(!tracing::enabled!(target: "other", tracing::Level::DEBUG));
+            // Dep caps unaffected.
+            assert!(!tracing::enabled!(target: "hyper", tracing::Level::INFO));
+        });
+    }
+
+    #[test]
+    fn unmentioned_dep_default_stays_when_user_raises_another() {
+        // User raises vaultrs but says nothing about hyper, hyper stays default.
+        with_filter("info,vaultrs=trace", || {
+            assert!(tracing::enabled!(target: "vaultrs", tracing::Level::TRACE));
+            assert!(!tracing::enabled!(target: "hyper", tracing::Level::INFO));
+            assert!(tracing::enabled!(target: "hyper", tracing::Level::ERROR));
+        });
     }
 }

--- a/crates/api/src/logging/setup.rs
+++ b/crates/api/src/logging/setup.rs
@@ -455,4 +455,19 @@ mod tests {
             assert!(tracing::enabled!(target: "hyper", tracing::Level::ERROR));
         });
     }
+
+    #[test]
+    fn regression_debug_default_directive_survives_dep_filter() {
+        // Make sure with_default_directive is not ignored
+        let initial = EnvFilter::builder()
+            .with_default_directive(LevelFilter::DEBUG.into())
+            .parse("")
+            .unwrap();
+
+        let subscriber = tracing_subscriber::registry().with(dep_log_filter(initial));
+        tracing::subscriber::with_default(subscriber, || {
+            assert!(tracing::enabled!(target: "carbide", tracing::Level::DEBUG));
+            assert!(!tracing::enabled!(target: "carbide", tracing::Level::TRACE));
+        });
+    }
 }

--- a/crates/api/src/tests/level_filter.rs
+++ b/crates/api/src/tests/level_filter.rs
@@ -23,6 +23,7 @@ use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing_subscriber::filter::EnvFilter;
 
+use crate::logging::setup::dep_log_filter;
 use crate::tests::common;
 
 #[crate::sqlx_test]
@@ -46,24 +47,31 @@ async fn test_dynamic_log_filter(db_pool: sqlx::PgPool) -> eyre::Result<()> {
     let base = env.api.log_filter_string();
     assert_eq!(local, base, "Startup log filter does not match RUST_LOG");
 
-    // 2. set_log_filter changes it correctly
+    // 2. Apply default dep log levels (as in fn setup_logging(...))
+    let local = dep_log_filter(local.clone().into());
+
+    // 3. set_log_filter changes it correctly
     let req = rpc::forge::SetDynamicConfigRequest {
         setting: rpc::forge::ConfigSetting::LogFilter.into(),
-        value: "trace".to_string(),
+        value: "debug".to_string(),
         expiry: Some("500ms".to_string()),
     };
     env.api.set_dynamic_config(tonic::Request::new(req)).await?;
     let current = env.api.log_filter_string();
-    // it should be something like: "trace until 2024-03-27 18:20:33.723829221 UTC"
+    // it should be something like: "...,debug until 2024-03-27 18:20:33.723829221 UTC"
     assert!(
-        current.starts_with("trace until "),
+        current.contains("debug until "),
         "set_log_filter did not update log to expected"
     );
 
-    // 3. After 'expiry' it automatically reverts
+    // 4. After 'expiry' it automatically reverts
     tokio::time::sleep(Duration::from_secs(1)).await;
     let base = env.api.log_filter_string();
-    assert_eq!(local, base, "Expiry task did not revert log filter");
+    assert_eq!(
+        local.to_string(),
+        base,
+        "Expiry task did not revert log filter"
+    );
 
     cancel_token.cancel();
     join_set.join_all().await;


### PR DESCRIPTION
## Description
- User-provided `RUST_LOG` directives (e.g. `vaultrs=debug`) were being shadowed by hardcoded dependencies in dep_log_filter, making it impossible to raise log levels for filtered deps at runtime.
- Reorder directive precedence so dep defaults are applied first and the user's filter is appended last, letting user directives override defaults while deps unmentioned by the user stay capped.
- Fix the runtime reload path in `ActiveLevel::reload` to also update `self.current` so the stored filter string reflects what's actually active on the web frontend.

## Fix test_dynamic_log_filter test
`assert_eq!(local, base, "Expiry task did not revert log filter");` Started to fail after the fix because before the fix the `base` variable (env.api.log_filter_string()) wasn't updated by the gRPC endpoint at all. `ActiveLevel::update` reloaded the subscriber but never wrote the new value into `self.current`, so the assertion passed vacuously.
  
1. Apply default dep log levels (as in fn setup_logging(...)) to local (initial state)
2. Changing override to "debug" so it's different from the baseline. The old "trace" was a no-op that wouldn't have caught a broken override path
3. Use `contains` method instead of `starts_with` correctly accounts for dep caps being prepended in the serialized form.


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

