### PR TITLE
dpf: Update dhcp-grpc-server and fmds-grpc-server parameter in DPF dpu-agent services.

### DIFF
--- a/bluefield/charts/carbide-dpu-agent/templates/daemonset.yaml
+++ b/bluefield/charts/carbide-dpu-agent/templates/daemonset.yaml
@@ -54,6 +54,8 @@ spec:
             - "--hbn-config-mode=nvue-rest"
             - "--agent-platform-type=containerized"
             - "--discovery-info-file={{ .Values.discovery.hardware_file }}"
+            - "--dhcp-grpc-server={{ .Values.dhcp_server.service_name }}.dpf-operator-system.svc.cluster.local:10079"
+            - "--fmds-grpc-server={{ .Values.fmds.service_name }}.dpf-operator-system.svc.cluster.local:50052"
             {{- if not (empty .Values.dhcp_server.interface_prepend) }}
             - "--dhcp-server-interface-prepend={{ .Values.dhcp_server.interface_prepend }}"
             {{ end }}

--- a/bluefield/charts/carbide-dpu-agent/values.yaml
+++ b/bluefield/charts/carbide-dpu-agent/values.yaml
@@ -37,3 +37,8 @@ dhcp_server:
   # If interface_prepend is set to a non-empty string, it will
   # be turned into a --dhcp-server-interface-prepend argument.
   interface_prepend: ""
+  # Will be updated in dpf_services.rs
+  service_name: ""
+fmds:
+  # Will be updated in dpf_services.rs
+  service_name: ""

--- a/bluefield/charts/carbide-fmds/templates/daemonset.yaml
+++ b/bluefield/charts/carbide-fmds/templates/daemonset.yaml
@@ -67,6 +67,8 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          args:
+            - "--grpc-address=$(POD_IP):50052"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with toYaml .Values.serviceDaemonSet.resources }}
           resources:

--- a/crates/api/src/dpf_services.rs
+++ b/crates/api/src/dpf_services.rs
@@ -211,7 +211,6 @@ pub fn otelcol_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinition 
     svc
 }
 
-// TODO: wire into setup.rs when carbide services are deployed to DPUs
 /// Forge DPU Agent service definition.
 pub fn dpu_agent_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinition {
     ServiceDefinition {


### PR DESCRIPTION
## Description
Adds service_name fields to dhcp_server and fmds in values.yaml, passes them as --dhcp-grpc-server and --fmds-grpc-server args in the daemonset, and injects the resolved service names into dpu-agent helm values via DPF service template references.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

