### PR TITLE
Wire scout firmware upgrade into host reprovisioning

### DIFF
--- a/crates/api-model/src/firmware.rs
+++ b/crates/api-model/src/firmware.rs
@@ -215,6 +215,23 @@ pub struct FirmwareEntry {
     pub pre_update_resets: bool,
     #[serde(default)]
     pub script: Option<PathBuf>,
+    #[serde(default)]
+    pub files: Vec<FirmwareFileArtifact>,
+    #[serde(default)]
+    pub scout: Option<ScoutConfig>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+pub struct FirmwareFileArtifact {
+    pub filename: String,
+    pub sha256: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ScoutConfig {
+    pub script: FirmwareFileArtifact,
+    pub execution_timeout_seconds: u32,
+    pub artifact_download_timeout_seconds: u32,
 }
 
 impl FirmwareEntry {
@@ -233,6 +250,8 @@ impl FirmwareEntry {
             preingestion_exclusive_config: false,
             pre_update_resets: false,
             script: None,
+            files: vec![],
+            scout: None,
         }
     }
     pub fn standard_multiple_filenames(version: &str) -> Self {

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1720,6 +1720,11 @@ pub enum HostReprovisionState {
         component_type: FirmwareComponentType,
         target_version: String,
         started_at: DateTime<Utc>,
+        /// Absolute deadline; the API declares failure past this time.
+        /// Derived from scout's execution/download timeouts plus slack.
+        deadline: DateTime<Utc>,
+        /// Serialized FirmwareUpgradeTask JSON for the scout
+        task_json: String,
         #[serde(default)]
         result: Option<ScoutUpgradeResult>,
     },

--- a/crates/api/src/handlers/host_reprovisioning.rs
+++ b/crates/api/src/handlers/host_reprovisioning.rs
@@ -159,30 +159,37 @@ pub async fn report_scout_firmware_upgrade_status(
     let (machine, mut txn) = api.load_machine(&machine_id, Default::default()).await?;
 
     // Verify machine is in WaitingForScoutUpgrade state
-    let (component_type, target_version, started_at, retry_count) = match machine.current_state() {
-        ManagedHostState::HostReprovision {
-            reprovision_state:
-                HostReprovisionState::WaitingForScoutUpgrade {
-                    component_type,
-                    target_version,
-                    started_at,
-                    ..
-                },
-            retry_count,
-        } => (
-            *component_type,
-            target_version.clone(),
-            *started_at,
-            *retry_count,
-        ),
-        _ => {
-            return Err(CarbideError::FailedPrecondition(format!(
-                "Machine {machine_id} is not in WaitingForScoutUpgrade state"
-            ))
-            .into());
-        }
-    };
+    let (component_type, target_version, started_at, deadline, task_json, retry_count) =
+        match machine.current_state() {
+            ManagedHostState::HostReprovision {
+                reprovision_state:
+                    HostReprovisionState::WaitingForScoutUpgrade {
+                        component_type,
+                        target_version,
+                        started_at,
+                        deadline,
+                        task_json,
+                        ..
+                    },
+                retry_count,
+            } => (
+                *component_type,
+                target_version.clone(),
+                *started_at,
+                *deadline,
+                task_json.clone(),
+                *retry_count,
+            ),
+            _ => {
+                return Err(CarbideError::FailedPrecondition(format!(
+                    "Machine {machine_id} is not in WaitingForScoutUpgrade state"
+                ))
+                .into());
+            }
+        };
 
+    // Cap stdout/stderr/error so the JSON state row stays small; full output
+    // is available in the scout logs if an operator needs to dig deeper.
     const MAX_STORED_OUTPUT_SIZE: usize = 1500;
 
     let new_state = ManagedHostState::HostReprovision {
@@ -190,6 +197,8 @@ pub async fn report_scout_firmware_upgrade_status(
             component_type,
             target_version,
             started_at,
+            deadline,
+            task_json,
             result: Some(ScoutUpgradeResult {
                 success: req.success,
                 exit_code: req.exit_code,

--- a/crates/api/src/handlers/machine_scout.rs
+++ b/crates/api/src/handlers/machine_scout.rs
@@ -18,9 +18,9 @@ use ::rpc::forge as rpc;
 use ::rpc::forge_agent_control_response::forge_agent_control_extra_info::KeyValuePair;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{
-    BomValidating, CleanupState, FailureCause, FailureDetails, FailureSource, InstanceState,
-    MachineState, MachineValidatingState, ManagedHostState, MeasuringState, ValidationState,
-    get_action_for_dpu_state,
+    BomValidating, CleanupState, FailureCause, FailureDetails, FailureSource, HostReprovisionState,
+    InstanceState, MachineState, MachineValidatingState, ManagedHostState, MeasuringState,
+    ValidationState, get_action_for_dpu_state,
 };
 use model::machine_validation::{MachineValidationState, MachineValidationStatus};
 use tonic::{Request, Response, Status};
@@ -295,6 +295,33 @@ pub(crate) async fn forge_agent_control(
                         (Action::Noop, None, None)
                     }
                 }
+            }
+
+            ManagedHostState::HostReprovision {
+                reprovision_state:
+                    HostReprovisionState::WaitingForScoutUpgrade {
+                        task_json,
+                        result: None,
+                        ..
+                    },
+                ..
+            } => {
+                tracing::info!(
+                    machine_id = %machine.id,
+                    "Sending firmware upgrade task to scout",
+                );
+                (
+                    Action::FirmwareUpgrade,
+                    Some(
+                        rpc::forge_agent_control_response::ForgeAgentControlExtraInfo {
+                            pair: vec![KeyValuePair {
+                                key: "firmware_upgrade_task".to_string(),
+                                value: task_json.clone(),
+                            }],
+                        },
+                    ),
+                    Some(txn),
+                )
             }
 
             _ => {

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -6682,9 +6682,64 @@ impl HostUpgradeState {
                 self.host_new_firmware_reported_wait(state, ctx, details, machine_id, scenario)
                     .await
             }
-            HostReprovisionState::WaitingForScoutUpgrade { .. } => {
-                // TODO: will be implemented in a follow-up (@jrakhmonov)
-                Ok(StateHandlerOutcome::do_nothing())
+            HostReprovisionState::WaitingForScoutUpgrade {
+                component_type,
+                deadline,
+                result,
+                ..
+            } => {
+                if let Some(result) = result {
+                    if result.success {
+                        tracing::info!(
+                            "Scout firmware upgrade succeeded for {}",
+                            state.host_snapshot.id
+                        );
+                        Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
+                            HostReprovisionState::CheckingFirmwareRepeatV2 {
+                                firmware_type: None,
+                                firmware_number: None,
+                            },
+                            state.managed_state.get_host_repro_retry_count(),
+                        )))
+                    } else {
+                        let reason = if result.error.is_empty() {
+                            format!("Scout upgrade failed with exit code {}", result.exit_code)
+                        } else {
+                            result.error.clone()
+                        };
+                        tracing::warn!(
+                            "Scout firmware upgrade failed for {}: {}",
+                            state.host_snapshot.id,
+                            reason
+                        );
+                        Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
+                            HostReprovisionState::FailedFirmwareUpgrade {
+                                firmware_type: *component_type,
+                                report_time: Some(Utc::now()),
+                                reason: Some(reason),
+                            },
+                            state.managed_state.get_host_repro_retry_count(),
+                        )))
+                    }
+                } else if Utc::now() > *deadline {
+                    tracing::warn!(
+                        "Scout firmware upgrade timed out for {} (deadline {})",
+                        state.host_snapshot.id,
+                        deadline,
+                    );
+                    Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
+                        HostReprovisionState::FailedFirmwareUpgrade {
+                            firmware_type: *component_type,
+                            report_time: Some(Utc::now()),
+                            reason: Some(format!(
+                                "Scout firmware upgrade timed out (deadline {deadline})"
+                            )),
+                        },
+                        state.managed_state.get_host_repro_retry_count(),
+                    )))
+                } else {
+                    Ok(StateHandlerOutcome::do_nothing())
+                }
             }
             HostReprovisionState::FailedFirmwareUpgrade { report_time, .. } => {
                 let can_retry = retry_count < MAX_FIRMWARE_UPGRADE_RETRIES;
@@ -6925,6 +6980,61 @@ impl HostUpgradeState {
             if let Some(to_install) =
                 need_host_fw_upgrade(&explored_endpoint, &fw_info, firmware_type)
             {
+                if let Some(scout_config) = &to_install.scout {
+                    let firmware_dir = ctx
+                        .services
+                        .site_config
+                        .firmware_global
+                        .firmware_directory
+                        .to_string_lossy();
+                    const PXE_URL: &str = "http://carbide-pxe.forge:8080";
+                    let to_pxe_url = |path: &str| -> String {
+                        let relative = path
+                            .strip_prefix(firmware_dir.as_ref())
+                            .unwrap_or(path)
+                            .trim_start_matches('/');
+                        format!("{PXE_URL}/public/firmware/{relative}")
+                    };
+
+                    let task = serde_json::json!({
+                        "component_type": firmware_type.to_string(),
+                        "target_version": to_install.version,
+                        "script": {
+                            "url": to_pxe_url(&scout_config.script.filename),
+                            "sha256": scout_config.script.sha256,
+                        },
+                        "execution_timeout_seconds": scout_config.execution_timeout_seconds,
+                        "artifact_download_timeout_seconds": scout_config.artifact_download_timeout_seconds,
+                        "file_artifacts": to_install.files.iter().map(|f| {
+                            serde_json::json!({
+                                "url": to_pxe_url(&f.filename),
+                                "sha256": f.sha256,
+                            })
+                        }).collect::<Vec<_>>(),
+                    });
+
+                    // Scout respects its own execution/download timeouts; slack covers clock
+                    // skew and the round-trip for the report RPC to reach us.
+                    const DEADLINE_SLACK: chrono::TimeDelta = chrono::TimeDelta::minutes(30);
+                    let started_at = Utc::now();
+                    let deadline = started_at
+                        + chrono::TimeDelta::seconds(
+                            i64::from(scout_config.execution_timeout_seconds)
+                                + i64::from(scout_config.artifact_download_timeout_seconds),
+                        )
+                        + DEADLINE_SLACK;
+                    return Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
+                        HostReprovisionState::WaitingForScoutUpgrade {
+                            component_type: firmware_type,
+                            target_version: to_install.version,
+                            started_at,
+                            deadline,
+                            task_json: task.to_string(),
+                            result: None,
+                        },
+                        state.managed_state.get_host_repro_retry_count(),
+                    )));
+                }
                 if to_install.script.is_some() {
                     return self
                         .by_script(to_install, state, explored_endpoint, scenario)

--- a/crates/api/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api/src/tests/host_bmc_firmware_test.rs
@@ -2658,6 +2658,8 @@ async fn test_report_scout_firmware_upgrade_status(pool: sqlx::PgPool) -> Carbid
             component_type: FirmwareComponentType::Bmc,
             target_version: "1.2.3".to_string(),
             started_at: chrono::Utc::now(),
+            deadline: chrono::Utc::now() + chrono::TimeDelta::minutes(60),
+            task_json: String::new(),
             result: None,
         },
         retry_count: 0,
@@ -2718,6 +2720,8 @@ async fn test_report_scout_firmware_upgrade_status_failure(
             component_type: FirmwareComponentType::Bmc,
             target_version: "1.2.3".to_string(),
             started_at: chrono::Utc::now(),
+            deadline: chrono::Utc::now() + chrono::TimeDelta::minutes(60),
+            task_json: String::new(),
             result: None,
         },
         retry_count: 0,
@@ -2807,6 +2811,8 @@ async fn test_report_scout_firmware_upgrade_status_truncates_output(
             component_type: FirmwareComponentType::Bmc,
             target_version: "1.2.3".to_string(),
             started_at: chrono::Utc::now(),
+            deadline: chrono::Utc::now() + chrono::TimeDelta::minutes(60),
+            task_json: String::new(),
             result: None,
         },
         retry_count: 0,
@@ -2849,6 +2855,229 @@ async fn test_report_scout_firmware_upgrade_status_truncates_output(
     assert!(result.stderr.len() <= 1500);
     assert!(result.error.len() <= 1500);
     txn.commit().await.unwrap();
+
+    Ok(())
+}
+
+/// Helper: set `host` to WaitingForScoutUpgrade with the given deadline and result.
+async fn put_in_waiting_for_scout_upgrade(
+    env: &common::api_fixtures::TestEnv,
+    host: &common::api_fixtures::test_machine::TestMachine,
+    deadline: chrono::DateTime<chrono::Utc>,
+    result: Option<model::machine::ScoutUpgradeResult>,
+) {
+    let mut txn = env.pool.begin().await.unwrap();
+    let machine = host.db_machine(&mut txn).await;
+    let state = ManagedHostState::HostReprovision {
+        reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
+            component_type: FirmwareComponentType::Bmc,
+            target_version: "1.2.3".to_string(),
+            started_at: chrono::Utc::now(),
+            deadline,
+            task_json: String::new(),
+            result,
+        },
+        retry_count: 0,
+    };
+    db::machine::advance(&machine, &mut txn, &state, None)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+}
+
+#[crate::sqlx_test]
+async fn test_waiting_for_scout_upgrade_success_transitions_to_repeat_check(
+    pool: sqlx::PgPool,
+) -> CarbideResult<()> {
+    let env = create_test_env(pool).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+
+    put_in_waiting_for_scout_upgrade(
+        &env,
+        &mh.host(),
+        chrono::Utc::now() + chrono::TimeDelta::minutes(60),
+        Some(model::machine::ScoutUpgradeResult {
+            success: true,
+            exit_code: 0,
+            stdout: "ok".to_string(),
+            stderr: String::new(),
+            error: String::new(),
+        }),
+    )
+    .await;
+
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let host = mh.host().db_machine(&mut txn).await;
+    let ManagedHostState::HostReprovision {
+        reprovision_state, ..
+    } = host.current_state()
+    else {
+        panic!("Not in HostReprovision");
+    };
+    assert!(
+        matches!(
+            reprovision_state,
+            HostReprovisionState::CheckingFirmwareRepeatV2 { .. }
+        ),
+        "expected CheckingFirmwareRepeatV2, got {reprovision_state:?}",
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_waiting_for_scout_upgrade_failure_uses_error_as_reason(
+    pool: sqlx::PgPool,
+) -> CarbideResult<()> {
+    let env = create_test_env(pool).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+
+    put_in_waiting_for_scout_upgrade(
+        &env,
+        &mh.host(),
+        chrono::Utc::now() + chrono::TimeDelta::minutes(60),
+        Some(model::machine::ScoutUpgradeResult {
+            success: false,
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: String::new(),
+            error: "boom".to_string(),
+        }),
+    )
+    .await;
+
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let host = mh.host().db_machine(&mut txn).await;
+    let ManagedHostState::HostReprovision {
+        reprovision_state, ..
+    } = host.current_state()
+    else {
+        panic!("Not in HostReprovision");
+    };
+    let HostReprovisionState::FailedFirmwareUpgrade { reason, .. } = reprovision_state else {
+        panic!("expected FailedFirmwareUpgrade, got {reprovision_state:?}");
+    };
+    assert_eq!(reason.as_deref(), Some("boom"));
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_waiting_for_scout_upgrade_failure_without_error_uses_exit_code(
+    pool: sqlx::PgPool,
+) -> CarbideResult<()> {
+    let env = create_test_env(pool).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+
+    put_in_waiting_for_scout_upgrade(
+        &env,
+        &mh.host(),
+        chrono::Utc::now() + chrono::TimeDelta::minutes(60),
+        Some(model::machine::ScoutUpgradeResult {
+            success: false,
+            exit_code: 7,
+            stdout: String::new(),
+            stderr: String::new(),
+            error: String::new(),
+        }),
+    )
+    .await;
+
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let host = mh.host().db_machine(&mut txn).await;
+    let ManagedHostState::HostReprovision {
+        reprovision_state, ..
+    } = host.current_state()
+    else {
+        panic!("Not in HostReprovision");
+    };
+    let HostReprovisionState::FailedFirmwareUpgrade { reason, .. } = reprovision_state else {
+        panic!("expected FailedFirmwareUpgrade, got {reprovision_state:?}");
+    };
+    assert_eq!(
+        reason.as_deref(),
+        Some("Scout upgrade failed with exit code 7"),
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_waiting_for_scout_upgrade_past_deadline_times_out(
+    pool: sqlx::PgPool,
+) -> CarbideResult<()> {
+    let env = create_test_env(pool).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+
+    put_in_waiting_for_scout_upgrade(
+        &env,
+        &mh.host(),
+        chrono::Utc::now() - chrono::TimeDelta::minutes(1),
+        None,
+    )
+    .await;
+
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let host = mh.host().db_machine(&mut txn).await;
+    let ManagedHostState::HostReprovision {
+        reprovision_state, ..
+    } = host.current_state()
+    else {
+        panic!("Not in HostReprovision");
+    };
+    let HostReprovisionState::FailedFirmwareUpgrade { reason, .. } = reprovision_state else {
+        panic!("expected FailedFirmwareUpgrade, got {reprovision_state:?}");
+    };
+    assert!(
+        reason
+            .as_deref()
+            .is_some_and(|r| r.starts_with("Scout firmware upgrade timed out")),
+        "unexpected reason: {reason:?}",
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_waiting_for_scout_upgrade_before_deadline_waits(
+    pool: sqlx::PgPool,
+) -> CarbideResult<()> {
+    let env = create_test_env(pool).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+
+    put_in_waiting_for_scout_upgrade(
+        &env,
+        &mh.host(),
+        chrono::Utc::now() + chrono::TimeDelta::minutes(60),
+        None,
+    )
+    .await;
+
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let host = mh.host().db_machine(&mut txn).await;
+    let ManagedHostState::HostReprovision {
+        reprovision_state, ..
+    } = host.current_state()
+    else {
+        panic!("Not in HostReprovision");
+    };
+    assert!(
+        matches!(
+            reprovision_state,
+            HostReprovisionState::WaitingForScoutUpgrade { result: None, .. }
+        ),
+        "expected to remain in WaitingForScoutUpgrade, got {reprovision_state:?}",
+    );
 
     Ok(())
 }

--- a/crates/scout/src/main.rs
+++ b/crates/scout/src/main.rs
@@ -439,8 +439,8 @@ async fn handle_action(
 // from carbide-api via ForgeAgentControl. The task data is a JSON-serialized
 // FirmwareUpgradeTask in the "firmware_upgrade_task" key-value pair.
 async fn handle_firmware_upgrade_action(
-    _config: &Options,
-    _machine_id: &MachineId,
+    config: &Options,
+    machine_id: &MachineId,
     data: Option<ForgeAgentControlExtraInfo>,
 ) -> Result<(), CarbideClientError> {
     let extra = data.ok_or_else(|| {
@@ -475,21 +475,41 @@ async fn handle_firmware_upgrade_action(
 
     let result = firmware_upgrade::handle_firmware_upgrade(&http_client, &task).await;
 
-    // TODO: Report upgrade status back to carbide-api via ReportScoutFirmwareUpgradeStatus RPC when it is ready.
+    tracing::info!(
+        "[firmware_upgrade] upgrade finished: success={} component={} version={} exit_code={}",
+        result.success,
+        task.component_type,
+        task.target_version,
+        result.exit_code,
+    );
 
-    if result.success {
-        tracing::info!(
-            "[firmware_upgrade] completed successfully for component={} version={}",
-            task.component_type,
-            task.target_version,
-        );
-        Ok(())
-    } else {
-        Err(CarbideClientError::GenericError(format!(
-            "[firmware_upgrade] failed for component={} version={}: {}",
-            task.component_type, task.target_version, result.error,
-        )))
+    report_firmware_upgrade_status(config, machine_id, &result).await?;
+
+    if !result.success {
+        return Err(CarbideClientError::GenericError(format!(
+            "firmware upgrade failed for component={} version={}: exit_code={} error={}",
+            task.component_type, task.target_version, result.exit_code, result.error,
+        )));
     }
+    Ok(())
+}
+
+async fn report_firmware_upgrade_status(
+    config: &Options,
+    machine_id: &MachineId,
+    result: &firmware_upgrade::FirmwareUpgradeResult,
+) -> Result<(), CarbideClientError> {
+    let mut client = client::create_forge_client(config).await?;
+    let request = tonic::Request::new(rpc_forge::ScoutFirmwareUpgradeStatusRequest {
+        machine_id: Some(*machine_id),
+        success: result.success,
+        exit_code: result.exit_code,
+        stdout: result.stdout.clone(),
+        stderr: result.stderr.clone(),
+        error: result.error.clone(),
+    });
+    client.report_scout_firmware_upgrade_status(request).await?;
+    Ok(())
 }
 
 // carbide sent us an Action::MlxReport command in response to our


### PR DESCRIPTION
## Description

This is the last part of the "scout based firmware upgrade" work. It wires things together.

Two main changes:

1. Scout reports its status back to carbide.
2. State machine handling of the scout firmware upgrade.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)