### PR TITLE
Avoid allocating when logging the machine ID

### DIFF
--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -3294,7 +3294,7 @@ pub(crate) fn log_request_data_redacted(s: impl AsRef<str>) {
 
 /// Logs the Machine ID in the current tracing span
 pub(crate) fn log_machine_id(machine_id: &MachineId) {
-    tracing::Span::current().record("forge.machine_id", tracing::field::DisplayValue(machine_id));
+    tracing::Span::current().record("forge.machine_id", tracing::field::display(machine_id));
 }
 
 pub(crate) fn log_tenant_organization_id(organization_id: &str) {

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -3294,7 +3294,7 @@ pub(crate) fn log_request_data_redacted(s: impl AsRef<str>) {
 
 /// Logs the Machine ID in the current tracing span
 pub(crate) fn log_machine_id(machine_id: &MachineId) {
-    tracing::Span::current().record("forge.machine_id", machine_id.to_string());
+    tracing::Span::current().record("forge.machine_id", tracing::field::DisplayValue(machine_id));
 }
 
 pub(crate) fn log_tenant_organization_id(organization_id: &str) {


### PR DESCRIPTION
## Description
I noticed this when reviewing another change, that we call `.to_string()` on the logged machine ID, which incurs an allocation, when we could instead wrap it in a DisplayValue, which later calls the Display::fmt function on the value when building the log string, without incurring an additional allocation (MachineId's Display impl does not allocate anything.)

## Type of Change
- [ ] **Add** - New feature or capability
- [X] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes