### PR TITLE
docs: Spelling, grammar, and ambiguity cleanup

### DIFF
--- a/book/src/README.md
+++ b/book/src/README.md
@@ -65,7 +65,7 @@ The NICo deployment includes a number of core services:
   - `carbide-dns`: Handles DNS queries from the site controller and managed nodes.
   - `unbound`: Provides recursive DNS services to managed machines and instances.
 
-These set of services are also referred to as the **Site Controller**
+This set of services is also referred to as the **Site Controller**
 
 ### Component and Service Dependencies
 

--- a/book/src/architecture/health/health_alert_classifications.md
+++ b/book/src/architecture/health/health_alert_classifications.md
@@ -9,7 +9,7 @@ An instance creation request using the hosts Machine ID will fail, unless the ta
 
 ### `PreventHostStateChanges`
 
-Hosts with this classification won't move between certain states during the hosts lifecycle.
+Hosts with this classification won't move between certain states during the host's lifecycle.
 The classification is mostly used to prevent a host from moving between states while it is uncertain whether all necessary configurations have been applied.
 
 ### `SuppressExternalAlerting`
@@ -20,7 +20,7 @@ site-wide fleet-health. This is achieved by metrics/alerting queries ignoring th
 ### `ExcludeFromStateMachineSla`
 
 Hosts with this classification will not be counted towards state machine transition time SLA.
-This classification is mostly used to prevent state machine keep alerting when some manual operations are being performed on the machine.
+This classification is mostly used to prevent the state machine from continuously alerting when some manual operations are being performed on the machine.
 
 ### `StopRebootForAutomaticRecoveryFromStateMachine`
 

--- a/book/src/architecture/health_aggregation.md
+++ b/book/src/architecture/health_aggregation.md
@@ -13,7 +13,7 @@ The aggregated host health information is used for multiple purposes:
 ## Health check types
 
 Health checks roughly fall into 3 categories:
-1. Out of band health checks: These continuous health checks are able to continuously assess the health of a host - independent of whether there the host is used as a bare metal instance or not. Within this category, NICo provides the following types of health checks
+1. Out of band health checks: These continuous health checks are able to continuously assess the health of a host - independent of whether the host is used as a bare metal instance or not. Within this category, NICo provides the following types of health checks
     1. [BMC health metric based health monitoring](#bmc-health-monitoring)
     2. [BMC inventory based health monitoring](#bmc-inventory-monitoring)
     3. [dpu-agent based health monitoring](#dpu-agent-based-health-monitoring)
@@ -214,7 +214,7 @@ The set of classifications that are currently interpreted by NICo is described i
 
 ### Host validation tests
 
-NICo will schedule the execution of validation tests at via the `scout` tool on the actual host host at various points
+NICo will schedule the execution of validation tests via the `scout` tool on the actual host at various points
 in the lifecycle of a managed host:
 1. When the host is ingested into NICo
 2. After an instance is released by tenant and got cleaned up
@@ -233,7 +233,7 @@ Details can be found in the [Machine validation manual](../manuals/machine_valid
 ### SKU validation tests
 
 SKU validation is a feature in NICo which validates that a host contains all the hardware it is expected to contain by validating it to "conform to a certain SKU".
-The SKU is the definition of hardware components within the host. And the SKU validation workflow compares it the the set of hardware components that have been detected via NICo hardware discovery workflows - which utilize inband data as well as out of band data.
+The SKU is the definition of hardware components within the host. And the SKU validation workflow compares it to the set of hardware components that have been detected via NICo hardware discovery workflows - which utilize inband data as well as out of band data.
 
 SKU validation can thereby e.g. detect
 - whether a host has the right type of CPU installed
@@ -279,7 +279,7 @@ In certain conditions the scraping process will place a health alert on the host
 - whether BGP sessions are established to peers according to the current configuration of the DPU
 - whether all required services on the DPU are running
 - whether the DPU is configured in restricted mode
-- whether the disk utilization ib below a threshold
+- whether the disk utilization is below a threshold
 
 ## Health report overrides
 
@@ -292,13 +292,13 @@ The override API offers 2 different modes of operation:
   to derive the aggregate host health status. **This mode is meant to augment the internal health monitoring mechanism with additional sources of health data**
 1. `replace` - In this mode, the health probe alerts reported by builtin NICo
   monitoring tools will be ignored. Only alerts that are passed as part of the
-  override will be taking into account. If the override list is empty, the system
+  override will be taken into account. If the override list is empty, the system
   will behave as if the Host would be fully healthy. **This mode is meant to bypass the internal health data in case the site operator desires a different behavior**
 
 The API allows to apply multiple `merge` overrides to a hosts health at the same time by using a different `HealthReport::source` identifier.
 This allows to integrate health information from multiple external systems and users which are not at risk of overriding each others data. E.g. health information from an external fleet health monitoring system and from SREs can be stored independently.
 
-If a ManagedHosts health is overriden, the remaining behavior is exactly the same
+If a ManagedHost's health is overridden, the remaining behavior is exactly the same
 as if the overridden Health report would have been directly derived from monitoring
 hardware health:
 - The host will be allocatable depending on whether any `PreventAllocations` classification is present in the aggregate host health
@@ -307,7 +307,7 @@ hardware health:
   - A ManagedHost whose health status is overridden from healthy to not-healthy
     will stop performing certain state transitions that require the host to be healthy.
   - A ManagedHost whose health status is overridden from not-healthy to healthy
-    will perform state transitions that it would eitherwise not have performed.
+    will perform state transitions that it would otherwise not have performed.
     This is useful for unblocking hosts in certain operational scenarios - e.g.
     where the integrated health monitoring system reported a host as non-healthy
     for an invalid reason.

--- a/book/src/architecture/infiniband/nic_selection.md
+++ b/book/src/architecture/infiniband/nic_selection.md
@@ -10,7 +10,7 @@ makes them available for selection by a tenant during instance creation.
 ## Requirements
 
 1. Hosts with the identical hardware configuration should be reported by NICo as having the exact same machine capabilities. E.g. a Machine having 2 Infiniband NICs that each have 2 ports that are connected to different Infiniband fabrics (4 fabrics in total), should be exactly reported as such.
-2. If NICo tenants configure multiple hosts of the same instance type with the same infiniband configuration and run the same operating system, they should find exactly the exact same device names on the host. This allows them to e.g. statically use certain Infiniband devices in applications and containers without a need for complex run-time enumeration on the tenant side. E.g. a tenant should be able to rely on the devices `ibp202s0f0` and `ibp202s0f1` always being available and connected their desired configuration.
+2. If NICo tenants configure multiple hosts of the same instance type with the same infiniband configuration and run the same operating system, they should find exactly the exact same device names on the host. This allows them to e.g. statically use certain Infiniband devices in applications and containers without a need for complex run-time enumeration on the tenant side. E.g. a tenant should be able to rely on the devices `ibp202s0f0` and `ibp202s0f1` always being available and connected to their desired configuration.
 
 ## Recommendation
 
@@ -53,7 +53,7 @@ While the devices for the 2 ports seem mostly independent, there are still a few
                                        domain:bus:dev.fn=0000:ca:00.0 addr.reg=88 data.reg=92 cr_bar.gw_offset=-1
                                        Chip revision is: 00
     ```
-    This breaks the illusion of 2 independent devices. Since the tenant can install and use those tools without the availability of a NIC firmware lockdown, they are be able to inspect these properties. There however doesn't seem to be an obvious problem with it.
+    This breaks the illusion of 2 independent devices. Since the tenant can install and use those tools without the availability of a NIC firmware lockdown, they are able to inspect these properties. There however doesn't seem to be an obvious problem with it.
 3. Due to 2), the port configurations for both ports are performed by manipulating a single device object in the Mellanox Firmware tools. E.g. both of the following commands
     ```
     mlxconfig -d /dev/mst/mt4123_pciconf0 set LINK_TYPE_P1=2 LINK_TYPE_P2=2
@@ -187,7 +187,7 @@ model reduces the amount of data that needs to be transferred between the Rest A
 backend and NICo users since it doesn't need to explain every individual component
 in detail. It also has the advantage that "machine capabilities" can describe
 groups of similar machines ("instance types") instead of just a single machine.
-Each machine the that adheres to an instance type shares the same capabilities.
+Each machine that adheres to an instance type shares the same capabilities.
 
 To support Infiniband, we can extend the existing capabilities model of the
 NICo REST API backend to cover infiniband:
@@ -207,7 +207,7 @@ NICo REST API backend to cover infiniband:
   since their existence can be controlled by configuring the associated
   Physical Function (PF).
 - Hardware details like PCI slots and hardware GUIDs are not shown in this
-  model. Since they could be different from Machine to Machine, they they can not
+  model. Since they could be different from Machine to Machine, they cannot
   be used in the data model that is shared across a range of Machines.
 
 ```json
@@ -404,7 +404,7 @@ needs to map to the following hardware interface information:
 The `fabric` is directly copied, and the `model` fields map
 to the `device` fields. The `vendor` field can be resolved by looking for any
 `device` with the specified device name.
-Thereby the only challenge is how to map `instance` in an non ambiguous fashion.
+Thereby the only challenge is how to map `instance` in a non-ambiguous fashion.
 We can achieve this by sorting the interfaces based on the PCI `slot`,
 and pick the N-th slot that satisfies the criteria.
 
@@ -477,7 +477,7 @@ Tenant desired for this instance. This script needs to configure all network int
 on the host. This includes
 - setting the correct number of VFs per physical device
 - writing GUIDs that NICo allocated for VF interfaces to the locations the OS
-  expects them it
+  expects them
 
 Applying these settings configure the interfaces in software in a way that
 allows them to send their traffic successfully to the connected Infiniband switches.
@@ -522,7 +522,7 @@ FMDS, in a format that is still TBD:
 
 The FMDS client needs to perform the mapping from configuration
 parameters to the actual Linux devicename (in `/sys/class/infiniband`) to apply
-the necessary configuration. This requires the same knowledege about
+the necessary configuration. This requires the same knowledge about
 the unique mapping of the configuration to the actual hardware that is residing
 in NICo. A challenge here is however that the client running
 on a tenants host is not able to resolve the fabric per interface. Since
@@ -556,8 +556,8 @@ guid of the associated physical function in every interface. Along:
 
 ### Interface configuration via unique PCI address (`device_slot`)
 
-The APIs described above make it slightly ambigiuos which `device` (in terms of
-PCI slot) a tenant would use for an interface. They tenant specifies the following
+The APIs described above make it slightly ambiguous which `device` (in terms of
+PCI slot) a tenant would use for an interface. The tenant specifies the following
 in an instance creation request
 ```json
 {

--- a/book/src/architecture/key_group_sync.md
+++ b/book/src/architecture/key_group_sync.md
@@ -10,14 +10,14 @@ The key group update and synchronization mechanism in NICo REST API works as fol
 4. The NICo REST API backend synchronizes the contents of the key groups to all NICo sites that the tenant selected (or potentially even just all sites that the tenant is enabled for).
 5. The NICo REST API stores for each Site/Tenant/KeyGroupName combination, which version is already stored on a site. By having this information available, the NICo REST API can efficiently look up whether key groups have been synced to required destinations by comparing the most recent key group version (owned by the cloud) with the synchronized key group version.
 6. After a NICo Tenant changed the contents of a key group in the NICo REST API, the Cloud needs to update all target sites with the latest state. There are multiple approaches for this:
-    1. The NICo Tenant explicitly triggers the sync via UI. Triggering the sync will let the Cloud Backend compare the latest deployed state of a keygroup on one site with the version in the Cloud database, and update it if required. This approach is not required because it requires the NICo tenant to monitor the deployment status on all sites.
-    2. The NICo REST API periodically syncs the state of all Key Groups to all sites. It can iterate over all the gropus it has knowledge about and all sites, and update the group contents for sites where there is a mismatch. This requires some extra work for groups where no content changes occurred, but is otherwise fairly straightforward to implement and free from race conditions.
+    1. The NICo Tenant explicitly triggers the sync via UI. Triggering the sync will let the Cloud Backend compare the latest deployed state of a keygroup on one site with the version in the Cloud database, and update it if required. This approach is not ideal because it requires the NICo tenant to monitor the deployment status on all sites.
+    2. The NICo REST API periodically syncs the state of all Key Groups to all sites. It can iterate over all the groups it has knowledge about and all sites, and update the group contents for sites where there is a mismatch. This requires some extra work for groups where no content changes occurred, but is otherwise fairly straightforward to implement and free from race conditions.
     3. NICo REST API only schedules updates for key groups if the NICo Tenant updated the state of a group. This is a bit more efficient, but harder to cover all edge-cases. E.g. the Cloud needs to account for
         - sites being temporarily offline during the sync
         - sites being restored from backups and having outdated keygroup versions or missing keygroups
         - users triggering multiple keygroup updates in rapid succession
 7. NICo provides the ability to fully overwrite the content of a keygroup that is identified by a `(TenantOrg, GroupName)` tuple and indexed by a `Version`. It will echo the version of a keygroup as is back to the Cloud, and not change it by itself or interpret it in any way.
-8. The NICo REST API **could** expose the version number of key groups to users - however it does not have to. By exposing the version number, it can provide update APIs with `ifVersionNotMatch` semantics - which means adding the capability for UIs to fail changes to groups if a concurrent edit occurred. This avoids Forge Tenant Admins from accidentally overwriting changes that another Tenant Admin for the same org performed.
+8. The NICo REST API **could** expose the version number of key groups to users - however it does not have to. By exposing the version number, it can provide update APIs with `ifVersionNotMatch` semantics - which means adding the capability for UIs to fail changes to groups if a concurrent edit occurred. This prevents Forge Tenant Admins from accidentally overwriting changes that another Tenant Admin for the same org performed.
 
 ```mermaid
 sequenceDiagram
@@ -52,7 +52,7 @@ sequenceDiagram
     U->>C: GetKeyGroups()
     C->>U: KeyGroups([name="MyKeys", keys=[Key1, Key2], sync=Done])
 
-    Note over U, C: Adding the more keys
+    Note over U, C: Adding more keys
 
     U->>C: UpdateKeyGroup(name="MyKeys", content="[Key1, Key2, Key3]", ifVersionMatch="V2-T1666644937952400")
     C-->C: Schedule Sync of keys to all sites or affected sites

--- a/book/src/architecture/networking_integrations.md
+++ b/book/src/architecture/networking_integrations.md
@@ -8,7 +8,7 @@ Networking integrations in NICo achieve this through the following patterns:
 
 ### Tenant partition management
 
-1. Tenants have APIs for mananging a set of network partitions for their instances. Examples of these partitions are
+1. Tenants have APIs for managing a set of network partitions for their instances. Examples of these partitions are
    - VPCs (for ethernet)
    - InfiniBand partitions
    - NVLink logical partitions
@@ -30,10 +30,10 @@ Networking integrations in NICo achieve this through the following patterns:
 
 - Tenants need to know how they can actually configure their instances. Valid configurations depend on the hardware. E.g. in an instance with 4 connected InfiniBand ports, tenants can associate each of these ports with a separate partition. However tenants are not able to configure instances without InfiniBand ports for IB.
 - Tenants learn about the support configurations via "Instance Types", which hold a list of capabilities. Each type of networking capability informs a tenant on how the respective interface can be configured. This means for each configurable interface, the instance type should list a respective capability.
-- The set of capabilies encoded in instance types must match or be a subset of the capabilities associated with a `Machine`. Machine capabilities are detected during the hardware discovery and ingestion phases. They are viewable by site administrators via debug tools.
+- The set of capabilities encoded in instance types must match or be a subset of the capabilities associated with a `Machine`. Machine capabilities are detected during the hardware discovery and ingestion phases. They are viewable by site administrators via debug tools.
     - During Machine ingestion, data about all network interfaces is collected both in-band (using scout) and out-of-band (using site-explorer). The data is stored within `machine` and `machine_topologies` tables
-    - Based on the raw discovery data, "machine capabilities" (type `MachineCapabilitiesSet`) are computed by the core service and presented to site administrators. These capabilities inform users about the amount of interfaces which are configurable. For each network integration, a new type of machine capability is required. E.g. InfiniBand uses the `MachineCapabilityAttributesInfiniband` capabiltiy, while nvlink uses the `MachineCapabilityAttributesGpu` capability.
-- The SKU validation feature can can include checks whether any newly ingested host includes the expected amount of network interfaces - where each network interface is typcially described as a machine capability.
+    - Based on the raw discovery data, "machine capabilities" (type `MachineCapabilitiesSet`) are computed by the core service and presented to site administrators. These capabilities inform users about the amount of interfaces which are configurable. For each network integration, a new type of machine capability is required. E.g. InfiniBand uses the `MachineCapabilityAttributesInfiniband` capability, while nvlink uses the `MachineCapabilityAttributesGpu` capability.
+- The SKU validation feature can include checks whether any newly ingested host includes the expected amount of network interfaces - where each network interface is typically described as a machine capability.
 
 ## Implementation requirements and considerations
 
@@ -41,7 +41,7 @@ To implement these workflows, the following patterns had been developed and prov
 
 ### Desired state vs actual state of network interfaces
 
-- For each network interface on each machine, NICo tracks both the the desired state (target network partition and other configs) as well as the actual state.
+- For each network interface on each machine, NICo tracks both the desired state (target network partition and other configs) as well as the actual state.
 - The desired state is a combination of the "tenant requested state" as well as a set of configurations internally managed by NICo.
   - The tenant requested state is stored fully in the `InstanceConfig` object
   - The internal requested state is stored in the `ManagedHostNetworkConfig` that is part of the `machine` table in the database. The most important field here is the `use_admin_network` field which controls whether tenant configurations are overridden and that the machine should indeed be placed onto an isolated/admin network.
@@ -54,7 +54,7 @@ To implement these workflows, the following patterns had been developed and prov
 
 ### State reconciliation
 
-There needs to be a mechanism that periodically compares the expected networking configuration with the desired netowrking configuration. If they are not in-sync, the respective components needs to take all the required actions to bring the configurations in sync.
+There needs to be a mechanism that periodically compares the expected networking configuration with the desired networking configuration. If they are not in-sync, the respective components needs to take all the required actions to bring the configurations in sync.
 
 1. For networking technologies where an external service is used to control partitioning (NVLink, InfiniBand), the `Monitor` background tasks are used to achieve this goal. If they detect a configuration mismatch, they perform API calls to the external networking service to resolve the problem.
 2. For other integrations, an external agent can pull the desired configuration for any host, perform (potentially local) configuration changes, before reporting the new state back to Carbide. This approach is taken for DPUs.
@@ -65,7 +65,7 @@ There needs to be a mechanism that periodically compares the expected networking
     - The value of the per-technology `configs_synced` fields should be derived by comparing the desired network configurations to the actual configuration as stored in the `Machine` object. This is implemented within `InstanceStatus::from_config_and_observation`.
     - The value of the aggregate `configs_synced` field is the logical **and** of all individual `configs_synced` fields in the `InstanceStatus` message.
 2. The instances tenant status (as communicated via `Instance::status::tenant::state`) should take into account whether the desired configuration is applied:
-    - If an instance is still in one of the provisionig states (anything before `Ready`), it will show a tenant status of `Provisioning`.
+    - If an instance is still in one of the provisioning states (anything before `Ready`), it will show a tenant status of `Provisioning`.
     - If the instance ever had been `Ready`, and the actual network configuration deviates from the intended configuration, the status should show `Configuring`.
     - If instance termination has been requested, the instances status should show `Terminating` independent of network configurations.
 3. The instance state machine should have guards in certain states that wait until the desired network configurations are applied:

--- a/book/src/architecture/overview.md
+++ b/book/src/architecture/overview.md
@@ -2,15 +2,15 @@
 
 This page discusses the high level architecture of a site running NCX Infra Controller (NICo).
 
-NICo orchestrates the lifecycle of ["Managed Hosts"](#managed-hosts) and other resources via set of cooperating control plane services.
+NICo orchestrates the lifecycle of ["Managed Hosts"](#managed-hosts) and other resources via a set of cooperating control plane services.
 These control plane services have to be deployed to a Kubernetes cluster with a size of at least 3 nodes (for high availability).
 
 ![NICo Architecture Diagram](../static/nico_arch_diagram.png)
 
-The Kubernetes cluster needs to have variety of services deployed:
-1. [The Carbide control plane services](#carbide-control-plane-services). These services are specific to Carbide, and must be deployed together in order to allow Carbide to manage the lifecyle of hosts.
-2. [Dependency services](#dependency-servies). Carbide requires "off-the-shelf" dependencies like Postgres, Vault and telemetry services deployed and accessible.
-3. [Optional services](#optional-services). A variety of services in tools within the deployment that interfact with the Carbide deployment, but are not required continuously for the control plane to operate.
+The Kubernetes cluster needs to have a variety of services deployed:
+1. [The Carbide control plane services](#carbide-control-plane-services). These services are specific to Carbide, and must be deployed together in order to allow Carbide to manage the lifecycle of hosts.
+2. [Dependency services](#dependency-services). Carbide requires "off-the-shelf" dependencies like Postgres, Vault and telemetry services deployed and accessible.
+3. [Optional services](#optional-services). A variety of services and tools within the deployment that interact with the Carbide deployment, but are not required continuously for the control plane to operate.
 
 The following chapters look at each of these in more detail.
 
@@ -60,12 +60,12 @@ The carbide control plane consists of a number of services which work together t
 
 - [carbide-core](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/api): The Carbide core service is the entrypoint into the control plane. It provides a [gRPC](https://grpc.io) API that all other components as well as users (site providers/tenants/site administrators) interact with, as well as implements the lifecycle management of all Carbide managed resources (VPCs, prefixes, Infiniband and NVLink partitions and bare metal instances). The [Carbide Core](#carbide_core_architecture) section describes it further in detail.
 - [carbide-dhcp (DHCP)](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/dhcp): The DHCP server responds to DHCP requests for all
-  devices on underlay networks. This includes Host BMCs, DPU BMCs and DPU OOB addresses. carbide-dhcp can be thought of as a stateless proxy: It does not acutally perform any IP address management - it just converts DHCP requests into gRPC format and forwards the gRPC based DHCP requests to carbide core.
+  devices on underlay networks. This includes Host BMCs, DPU BMCs and DPU OOB addresses. carbide-dhcp can be thought of as a stateless proxy: It does not actually perform any IP address management - it just converts DHCP requests into gRPC format and forwards the gRPC based DHCP requests to carbide core.
 - [carbide-pxe (iPXE)](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/pxe): The PXE server provides boot artifacts like iPXE scripts, iPXE user-data and OS images to managed hosts at boot time over HTTP. It determines which OS data to provide for a specific host by requesting the respective data from carbide core - therefore the PXE server is also stateless.
   Currently, managed hosts are configured to always boot from PXE. If a local
   bootable device is found, the host will boot it. Hosts can also be configured to always boot from a
   particular image for stateless configurations.
-- [carbide-hw-health (Hardware health)](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/health): This service scrapes all host and DPU BMCs known by Carbide for system health information. It extracts measurements like fan speeds, temperaturs and leak indicators. These measurements are emitted as prometheus metrics on a `/metrics` endpoint on port 9009. In addition to that, the service calls the carbide-core API `RecordHardwareHealthReport` to set health alerts based on issues identified within the metrics. These alerts are merged within carbide-core into the aggregated-host-health - which is emitted in overall health metrics and used to decide whether hosts are usable as bare metal instances for tenants.
+- [carbide-hw-health (Hardware health)](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/health): This service scrapes all host and DPU BMCs known by Carbide for system health information. It extracts measurements like fan speeds, temperatures and leak indicators. These measurements are emitted as prometheus metrics on a `/metrics` endpoint on port 9009. In addition to that, the service calls the carbide-core API `RecordHardwareHealthReport` to set health alerts based on issues identified within the metrics. These alerts are merged within carbide-core into the aggregated-host-health - which is emitted in overall health metrics and used to decide whether hosts are usable as bare metal instances for tenants.
 - [ssh-console](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/ssh-console): The SSH console provides bare metal-tenants and site-administrators virtual serial console access to hosts managed by Carbide. The ssh-console service also sends the output of each hosts serial console to
   the logging system (Loki), from where it can be queried using Grafana and logcli. In order to provide this functionality, the ssh-console service *continuously* connects to all host BMCs. The ssh-console service only forwards logs to users ("bare metal tenants") if they connect to the service and get authenticated.
 - [carbide-dns (DNS)](https://github.com/NVIDIA/ncx-infra-controller-core/blob/main/crates/dns): Domain name service (DNS) functionality
@@ -88,7 +88,7 @@ Carbide core is the only component within carbide which interacts with the postg
 ### [gRPC](https://grpc.io) API handlers
 
 The API handlers accept gRPC requests from Carbide users and internal system components. They provide users the ability to inspect the current state of the system, and modify the desired state of various components (e.g. create or reconfigure bare metal instances).
-  API handlers are all implemented within the trait/interface `rpc::forge::forge_server::Forge`. Various implementations delegate to the `handlers` subdirectory. For resources managed by Carbide, API handlers do not directly change the actual state of the resources (e.g. the provisioning state of a host). Instead of it, they only change the required state (e.g. "provisioning required", "termination required", etc). The state changes will be performed by state machines (details below). The carbide-core gRPC API supports
+  API handlers are all implemented within the trait/interface `rpc::forge::forge_server::Forge`. Various implementations delegate to the `handlers` subdirectory. For resources managed by Carbide, API handlers do not directly change the actual state of the resources (e.g. the provisioning state of a host). Instead, they only change the required state (e.g. "provisioning required", "termination required", etc). The state changes will be performed by state machines (details below). The carbide-core gRPC API supports
 [gRPC reflection](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md) to provide a machine readable API
 description so clients can auto-generate code and RPC functions in the client.
 
@@ -105,7 +105,7 @@ The Debug UI also provides access to various admin level tools. E.g. it
 ### State Machines
 
 Carbide implements State Machines for all resources managed by Carbide. The state machines are implemented as idempotent state handling functions calls, which are scheduled by the system.
-State handling for various resource types is implemented indepently, e.g. the lifecycle of hosts is managed by different tasks and different code than the lifecycle of InfiniBand partitions.
+State handling for various resource types is implemented independently, e.g. the lifecycle of hosts is managed by different tasks and different code than the lifecycle of InfiniBand partitions.
 
 Carbide implements state machines for
 - Managed Hosts (Hosts + DPUs)
@@ -129,14 +129,14 @@ Carbide users can inspect the data that site explorer discovers using the `FindE
 Site Explorer requires an "Expected Machines" manifest to be deployed. Expected Machines describes the set of Machines that is expected to be managed by the Carbide instance - it encodes BMC MAC addresses, hardware default passwords and other details of these Machines. The manifest can be updated using a set of APIs, e.g. `ReplaceAllExpectedMachines`.
 
 Beyond the basic BMC data collection, Carbide also performs the following tasks:
-1. It matches hosts with associated DPUs based on the redfish reports of both components - e.g. both the host an DPU need to reference the same DPU serial number.
+1. It matches hosts with associated DPUs based on the redfish reports of both components - e.g. both the host and DPU need to reference the same DPU serial number.
 2. It kickstarts the ingestion process of the host once the host is in an "ingestable" state (all components are found and have up to date firmware versions).
 
-Site Explorer emits metris with the prefix `forge_endpoint_ ` and `forge_site_explorer_`.
+Site Explorer emits metrics with the prefix `forge_endpoint_` and `forge_site_explorer_`.
 
 ### Preingestion Manager
 
-Preingestion Manager is a component which updates the firmware of hosts that are below the minimum required firmware version that is required to be ingestable. Usually firmware updates to hosts are deplyoed within the main machine lifecycle, as managed by the ManagedHost state machine.
+Preingestion Manager is a component which updates the firmware of hosts that are below the minimum required firmware version that is required to be ingestable. Usually firmware updates to hosts are deployed within the main machine lifecycle, as managed by the ManagedHost state machine.
 
 In some rare cases - e.g. with very old host or DPU BMCs - the host ingestion process can't be started yet - e.g. because the BMC does not provide the necessary information to map the host to DPUs. In this case the firmware needs to be updated before ingestion, and preingestion manager performs this task.
 
@@ -164,7 +164,7 @@ In each run, IBFabricMonitor performs the following task:
 - It checks the health of the fabric manager (UFM) by performing API calls
 - It checks whether all security configurations for multitenancy are applied on UFM and emits alerts in case of inappropriate settings
 - It fetches the actually applied InfiniBand partitioning information for each InfiniBand port on each host managed by Carbide and stores it in Carbide. The data can be inspected in the `Machine::ib_status` field in the gRPC API.
-- If calls UFM APIs to bind ports (guids) to partitions (pkeys) according to the configuration of each host. This happens continuosly based on comparing the expected InfiniBand configuration of a host (whether it is used by a tenant or not, and how the tenant configured the InfiniBand interfaces) with the actually applied configuration (determined in the last step).
+- If calls UFM APIs to bind ports (guids) to partitions (pkeys) according to the configuration of each host. This happens continuously based on comparing the expected InfiniBand configuration of a host (whether it is used by a tenant or not, and how the tenant configured the InfiniBand interfaces) with the actually applied configuration (determined in the last step).
 
 InfiniBand Fabric Monitor is an optional component. It only needs to be enabled in the case Carbide managed InfiniBand is required.
 
@@ -184,7 +184,7 @@ controller nodes.
 Some site controller node services require persistent, durable storage to maintain state for their attendant
 pods. There are three different K8s statefulsets that run on the controller nodes:
 
-- [Loki](https://grafana.com/oss/loki/) - The loki/loki-0 pod instatites a single 50GB persistent volume and is used to
+- [Loki](https://grafana.com/oss/loki/) - The loki/loki-0 pod instantiates a single 50GB persistent volume and is used to
   store logs for the site controller components.
 - [Hashicorp Vault](https://www.vaultproject.io/) - Used by Kubernetes for certificate signing requests (CSRs). Vault
   uses three each (one per K8s control node) of the `data-vault` and `audit-vault` 10GB PVs to protect and distribute

--- a/book/src/codebase_overview.md
+++ b/book/src/codebase_overview.md
@@ -5,7 +5,7 @@ bluefield/ - `dpu-agent` and other tools running on the DPU
 book/ - architecture of forge book.  aka "the book"
 
 - admin/ - `carbide-admin-cli`: A command line client for the carbide API server
-- api/ - forge primary entrypoint for GRPC API calls. This component receives all the  GRPC calls
+- api/ - forge primary entrypoint for GRPC API calls. This component receives all the GRPC calls
 - scout/ - `forge-scout`. A binary that runs on NCX Infra Controller (NICo) managed hosts and DPUs and executes various parts workflows on behalf of the site controller
 
 dev/ - a catch all directory for things that are not code related but are used to support forge.  e.g. Dockerfiles, kubernetes yaml, etc.

--- a/book/src/design/machine-identity/spiffe-svid-sdd.md
+++ b/book/src/design/machine-identity/spiffe-svid-sdd.md
@@ -7,7 +7,7 @@
 | Version | Date | Modified By | Description |
 | :---: | :---: | :---- | :---- |
 | 0.1 | 02/24/2026 | Binu Ramakrishnan | Initial version |
-| 0.2 | 03/11/2026 | Binu Ramakrishnan | gRPC/API updates and incorporated reivew feedback |
+| 0.2 | 03/11/2026 | Binu Ramakrishnan | gRPC/API updates and incorporated review feedback |
 |  |  |  |  |
 
 # **1\. Introduction**
@@ -41,7 +41,7 @@ The purpose of this document is to articulate the design of the software system,
 | JWKS | A JSON Web Key ([JWK](https://datatracker.ietf.org/doc/html/rfc7517)) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key.  JSON Web Key Set (JWKS) defines a JSON data structure that represents a set of JWKs. |
 | IMDS | Instance Meta-data Service |
 | BM | A bare metal machine \- often referred as a machine or node in this document.  |
-| Token Exchange Server | A service capable of validating security tokens provided to it and issuing new security tokens in response, which enables clients to obtain appropriate access credentials for resources in heterogeneous environments or across security domains. Defined in [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693). This document also refer this as 'token endpoints' and 'token delegation server'  |
+| Token Exchange Server | A service capable of validating security tokens provided to it and issuing new security tokens in response, which enables clients to obtain appropriate access credentials for resources in heterogeneous environments or across security domains. Defined in [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693). This document also refers to this as 'token endpoints' and 'token delegation server'  |
 
 ## **1.3 Scope**
 
@@ -95,7 +95,7 @@ The system is composed of the following major components:
 There are three different flows associated with implementing this feature:
 
 1. *Per-tenant signing key provisioning*: Describes how a new signing key associated with a tenant is provisioned, and optionally the token delegation/exchange flows.  
-2. *SPIFFE key bundle discovery*: Discuss about how the signing public keys are distributed to interested parties (verifiers)  
+2. *SPIFFE key bundle discovery*: Discusses how the signing public keys are distributed to interested parties (verifiers)  
 3. *JWT-SVID node identity request flow*: The run time flow used by tenant applications to fetch JWT-SVIDs from Carbide.
 
 Each of these flows are discussed below.

--- a/book/src/development.md
+++ b/book/src/development.md
@@ -65,7 +65,7 @@ environment.
 
    Fedora - `sudo dnf install -y postgresql`
 
-7. Install qemu and ovmf firmware for starting VM's to simulate PXE clients
+7. Install qemu and ovmf firmware for starting VMs to simulate PXE clients
 
    Arch - `sudo pacman -S qemu edk2-omvf`
 
@@ -81,7 +81,7 @@ environment.
 
    There are preset environment variables that are used throughout the repo. `${REPO_ROOT}` represents the top of the forge repo tree.
 
-   For a list environment variables, we predefined look in:
+   For a list of preset environment variables, look in:
    `${REPO_ROOT}/.envrc`
 
    Arch - `sudo pacman -S direnv`
@@ -216,7 +216,7 @@ Remember to `strip` before you scp so that scp goes faster. scp to DPU example (
 
 ## Next steps
 
-Setup a QEMU host for your docker-compose services to manager:
+Set up a QEMU host for your docker-compose services to manage:
 
 1. [Build iPXE and bootable artifacts image](bootable_artifacts.md)
 1. [Start QEMU server](vm_pxe_client.md)

--- a/book/src/development/issuer_ca_recreate.md
+++ b/book/src/development/issuer_ca_recreate.md
@@ -33,7 +33,7 @@ Now, the engine responsible for generating client certificates has type pki. You
     447e5fb7-65d8-3829-d1b4-416a3d795ede
     ```
 6. Have a look at the issuer itself: `vault read -tls-skip-verify forgeca/issuer/447e5fb7-65d8-3829-d1b4-416a3d795ed` (one can add -format json for a JSON output). Parse the cert displayed with `openssl x509 -in mycert.pem -text` to double check it's the actual culprit by looking at the `NotAfter` field.
-7. Check the role (the name of the role forge-cluster is the value of VAULT_PKI_ROLE_NAME env var in carbine-api deployment/pod)
+7. Check the role (the name of the role forge-cluster is the value of VAULT_PKI_ROLE_NAME env var in carbide-api deployment/pod)
     <details>
     <summary>Get Issuer Role</summary>
 

--- a/book/src/development/vm_pxe_client.md
+++ b/book/src/development/vm_pxe_client.md
@@ -40,7 +40,7 @@ swtpm_setup --tpmstate /tmp/emulated_tpm --tpm2 --create-ek-cert --create-platfo
 
 If you get an error in this step, try the following steps:
 - Run `/usr/share/swtpm/swtpm-create-user-config-files`. Potentially with `--overwrite`.
-  This writes the file files:
+  This writes the following files:
   - `~/.config/swtpm_setup.conf`
   - `~/.config/swtpm-localca.conf`
   - `~/.config/swtpm-localca.options`
@@ -86,7 +86,7 @@ You can also use graphical interface `virt-manager`.
 
 The virtual machine should fail to PXE boot from IPv4 (but gets an IP address) and IPv6, and then succeed from "HTTP boot IPv4", getting both an IP address and a boot image.
 
-This should boot you into the prexec image. The user is `root` and password
+This should boot you into the pre-exec image. The user is `root` and password
 is specified in the [mkosi.default](https://github.com/NVIDIA/ncx-infra-controller-core/tree/main/pxe) file.
 
 In order to exit out of console use `ctrl-a x`

--- a/book/src/development/vscode_remote.md
+++ b/book/src/development/vscode_remote.md
@@ -39,7 +39,7 @@ Start `VS Code` using the `code` command in the same shell after running `nvinit
 
 Click the remote button on the lower left of the IDE window:
 ![](../static/remote_button.png).
-Select "Connect to Host", choose the remote hostname define in [Prerequisites](#Prerequisites), and connect. A new Visual Studio Code window should open, which is now on that host.
+Select "Connect to Host", choose the remote hostname defined in [Prerequisites](#Prerequisites), and connect. A new Visual Studio Code window should open, which is now on that host.
 Inside that window, open the folder which contains the NICo project.
 
 Assuming that remote machine already has all dev tools installed, and you want to
@@ -114,8 +114,8 @@ To work inside the remote container, the following steps are performed:
 
 ### Enabling postgres inside the dev container
 
-While the last step will you allow to build the project and run some unit-tests,
-all unit-tests which require a database will. To fix this, start the postgres
+While the last step will allow you to build the project and run some unit tests,
+all unit tests which require a database will fail. To fix this, start the postgres
 server inside the development container:
 
 1. Open another internal terminal tab
@@ -158,13 +158,13 @@ json config file:
   owned by `root`, which can prevent working on them from your regular desktop.
   You might need to reset ownership when going back to your regular environment:
   ```
-  sudio chown -R yourAlias carbide/*
+  sudo chown -R yourAlias carbide/*
   ```
 - The same applies for using git inside the container as root. It will make
   files in `.git` be owned by `root`
 
 Those problems might be avoidable by being able to set `remoteUser` in `devcontainer.json`
-to ones alias. However when doing that I wasn't able to build the devcontainer image
+to one's alias. However when doing that I wasn't able to build the devcontainer image
 anymore, since it is missing my user alias in `/etc/passwd`.
 
 

--- a/book/src/dpu-operations.md
+++ b/book/src/dpu-operations.md
@@ -6,7 +6,7 @@ This one interface has two different MAC addresses. So, while the physical
 connection is shared the OOB and BMC have unique IP addresses.
 
 The BMC OS is a basic `busybox` shell,  so the available commands are limited.
-To connect the BMC, ssh to the IP address listed under `DPU BMC IP` address
+To connect to the BMC, ssh to the IP address listed under `DPU BMC IP` address
 using credentials in the `DPU BMC Credentials` table above.
 
 To then connect to the 'console' of the DPU you use `microcom` on the
@@ -52,7 +52,7 @@ From the ArmOS BMC you can instruct the DPU to restart using
 
 `echo "SW_RESET 1" > /dev/rshim0/misc`
 
-The DPU Might require the following udev rules to enable auto-negotiation.  You can look if that is already enable
+The DPU might require the following udev rules to enable auto-negotiation. You can check if that is already enabled
 
 ```
 echo 'SUBSYSTEM=="net", ACTION=="add", NAME=="p0", RUN+="/sbin/ethtool -s p0 autoneg on"' >> /etc/udev/rules.d/83-net-speed.rules

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -41,7 +41,7 @@ Yes, NICo supports NVLink partitioning.
 * **Ethernet**: VXLAN with EVPN for VPC creation on DPU
 * **E/W Ethernet (Spectrum-X)**: CX-based FW called DPA to do VXLan on CX (as part of future release)
 * **Infiniband**: UFM-based partition key (P_Key) assignment
-* **NVLInk**: NMX-M based partition management
+* **NVLink**: NMX-M based partition management
 
 DPUs enforce Ethernet isolation in hardware, UFM enforces IB isolation, and NMX-M enforces NVLink isolation--all coordinated by NICo.
 
@@ -80,7 +80,7 @@ NICo is more than an OS installation tool. It certainly helps with OS provisioni
 
 **Do I need to change the OOB management TOR to configure a separate VLN for the NICo managed hosts and DPU (DPU OOB, Host OOB), with DHCP relay point to NICo DHCP?**
 
-Yes, that's usually how it's done.  Each VLAN (sometimes the whole switch is a VLAN) - or SVI port - needs to have it's DHCP relay for the machines and DPUs you wish to manage with NICo pointing to NICo's DHCP server address you setup.
+Yes, that's usually how it's done.  Each VLAN (sometimes the whole switch is a VLAN) - or SVI port - needs to have its DHCP relay for the machines and DPUs you wish to manage with NICo pointing to NICo's DHCP server address you setup.
 
 **Do I need to change existing infrastructure if separate VLANs are used?**
 
@@ -92,11 +92,11 @@ The IP addresses issued to the DPU RJ45 port are from the "network segments" (wh
 
 **The host overlay interfaces addresses on top of vxlan and DPU is allocated via NICo through the control NIC on NICo, through overlay networking. So I assume no DHCP relay configuration needed on any switches. While is this overlay need to be manually configured on NICo control hosts' NIC?**
 
-The DHCP relay is required only on the switches connected to the DPU OOBs/BMCs and Host BMCs.  The in-band ToRs just need to be configured for bgp unnumbered as "routed port".  The "overlay" networks that NICo will assign IPs from to the host are defined as "network segements" with the "overlay" type, then the overlay network is referenced when creating an instance.
+The DHCP relay is required only on the switches connected to the DPU OOBs/BMCs and Host BMCs.  The in-band ToRs just need to be configured for bgp unnumbered as "routed port".  The "overlay" networks that NICo will assign IPs from to the host are defined as "network segments" with the "overlay" type, then the overlay network is referenced when creating an instance.
 
-**Do I need to seperate the PXE of NICo like this as well to isolate the PXE installation process from site PXE server?**
+**Do I need to separate the PXE of NICo like this as well to isolate the PXE installation process from site PXE server?**
 
-There is a separate PXE server that NICo needs to serve it's own images we ship as part of the software (i.e. DPU software, iPXE, etc). But if the DHCP is configured correctly and there's connectivity from the Host to the NICo PXE service, then it will be fine to live side-by-side.
+There is a separate PXE server that NICo needs to serve its own images we ship as part of the software (i.e. DPU software, iPXE, etc). But if the DHCP is configured correctly and there's connectivity from the Host to the NICo PXE service, then it will be fine to live side-by-side.
 
 **How does NICo select which bare metal to pick to satisfy the request for an instance? What selection criteria is supported?**
 

--- a/book/src/glossary.md
+++ b/book/src/glossary.md
@@ -23,7 +23,7 @@ Cloud-init is the industry standard multi-distribution method for cross-platform
 Cloud-init is used by Carbide to install components that are required on top of the base OS image:
 - DPUs use a Carbide provided cloud-init file to install Carbide related components
   on top of the base DPU image that is provided by the NVIDIA networking group.
-- Customers/tenants can provide a custom cloud-init will do the work of automating installation for customer OS's
+- Customers/tenants can provide a custom cloud-init automates installation for customer OSes
 
 ### DHCP (Dynamic Host Configuration Protocol)
 
@@ -31,7 +31,7 @@ https://en.wikipedia.org/wiki/Dynamic_Host_Configuration_Protocol
 
 The Dynamic Host Configuration Protocol (DHCP) is a network management protocol used on Internet Protocol (IP) networks for automatically assigning IP addresses and other communication parameters to devices connected to the network using a client–server architecture.
 
-Within Carbide, both DPUs and Hosts are using DHCP request to resolve their IP. The Carbide infrastructure responds to those DHCP requests, an provides a response based on known information about the host.
+Within Carbide, both DPUs and Hosts are using DHCP request to resolve their IP. The Carbide infrastructure responds to those DHCP requests, and provides a response based on known information about the host.
 
 ### DNS (Domain Name System)
 
@@ -72,7 +72,7 @@ iPXE is an open-source implementation of the [Preboot eXecution Environment (PXE
 
 ### Leaf
 
-In the Carbide project, we call "Leaf" the device that the host (which we to make available for tenants) plugs into.
+In the Carbide project, we call "Leaf" the device that the host (which we want to make available for tenants) plugs into.
 This is typically a DPU that will make the overlay network available
 to the tenant. In future iterations of the Carbide project, the Leaf might be a specialized switch instead of a DPU.
 
@@ -82,7 +82,7 @@ Generic term for either a **DPU** or a **Host**. Compare with **ManagedHost**.
 
 ### ManagedHost
 
-A **ManagedHost** is a box in a data center. It contains two **Machine**: one **DPU** and one **Host**.
+A **ManagedHost** is a box in a data center. It contains two **Machines**: one **DPU** and one **Host**.
 
 ### POD
 

--- a/book/src/kubernetes/tls.md
+++ b/book/src/kubernetes/tls.md
@@ -41,7 +41,7 @@ With SPIFFE formatted `Certificates`, the only field populated is the SAN (Subje
 
 **NOTE**
 > The TLS key generated in every pod never leaves the host which
-> it was generated on. If a migration even occurs, the CSR/key are
+> it was generated on. If a migration event occurs, the CSR/key are
 > regenerated, submitted to CertManager, and then signed again.
 
 ### How to obtain a SPIFFE formatted cert

--- a/book/src/manuals/expected_machine_update.md
+++ b/book/src/manuals/expected_machine_update.md
@@ -9,4 +9,4 @@ There is a table in the carbide-api database, that holds the following informati
 
 There is a `carbide-admin-cli` command to manipulate expected machines table. `update`, `add`, `delete` commands allow operating on individual elements of the expected machines table. `erase` and `replace-all` operate on all the entries at once.
 
-Additionally, the expected machines table can be exported as a JSON file with `carbide-admin-cli -f json em show` command. Likewise, a JSON file can be used to import and overwrite all existing values with `forge-admin-cli em replace-all <filename>` command.
+Additionally, the expected machines table can be exported as a JSON file with `carbide-admin-cli -f json em show` command. Likewise, a JSON file can be used to import and overwrite all existing values with `carbide-admin-cli em replace-all <filename>` command.

--- a/book/src/manuals/machine_validation.md
+++ b/book/src/manuals/machine_validation.md
@@ -58,7 +58,7 @@ This page provides a workflow for machine validation in NCX Infra Controller (NI
 
 Machine validation is a process of testing and verifying the hardware components and peripherals of a machine before handing it over to a tenant. The purpose of machine validation is to avoid disruption of tenant usage and ensure that the machine meets the expected benchmarks and performance. Machine validation involves running a series of regression tests and burn-in tests to stress the machine to its maximum capability and identify any potential issues or failures. Machine validation provides several benefits for the tenant. By performing machine validation, NICo ensures that machine is in optimal condition and ready for tenant usage. Machine validation helps to detect and resolve any hardware issues or failures before they affect the tenant's workloads
 
-Machine validation is performed using a different tool, these are available in the discovery image. Most of these tools require root privileges and are non-interactive. The tool(s) runs tests and sends result to Site controller
+Machine validation is performed using various tools that are available in the discovery image. Most of these tools require root privileges and are non-interactive. The tool(s) runs tests and sends results to the Site controller
 
 **Purpose**
 
@@ -80,11 +80,11 @@ SRE, Provider admin, Developer
 
 #### Feature gate {#feature-gate}
 
-The NICo site controller has site settings. These settings provide mechanisms to enable and disable features. Machine Validation feature controlled using these settings.  The feature gate enables or disables machine validation features at deploy time.
+The NICo site controller has site settings. These settings provide mechanisms to enable and disable features. Machine Validation feature is controlled using these settings.  The feature gate enables or disables machine validation features at deploy time.
 
 #### Test case management {#test-case-management}
 
-Test Case Management is the process of  adding, updating test cases. There are two types of test cases
+Test Case Management is the process of adding and updating test cases. There are two types of test cases
 
 1) Test cases added during deploy- These are common across all the sites and these are read-only test cases. Test cases are added through NICo DB migration.
 2) Site specific test case - Added by site admin
@@ -207,7 +207,7 @@ To enable add below section in api site config toml [forged/](https://gitlab-mas
 [machine_validation_config]
 enabled = true
 
-Machine Validation allows site operators to configure the NGC container registry.  This allows machine validation to use private container in
+Machine Validation allows site operators to configure the NGC container registry.  This allows machine validation to use private containers in
 
 Finally add the config to site
 
@@ -557,7 +557,7 @@ Options:
 
       --version <VERSION>
 
-          Version to be verify
+          Version to be verified
 
       --contexts <CONTEXTS>
 
@@ -631,7 +631,7 @@ Options:
 
           Print help
 
-We can selectively update fields of test cases. Once the test case is updated the verify flag is set to false. Site admin hs to explicitly set the flag as verified.
+We can selectively update fields of test cases. Once the test case is updated the verify flag is set to false. Site admin has to explicitly set the flag as verified.
 
         user@host:admin$ carbide-admin-cli machine-validation tests update  --test-id forge_NewTest --version V1-T1736492939564126 --args updatenewtest
 
@@ -669,9 +669,9 @@ We can selectively update fields of test cases. Once the test case is updated th
 
 Machine validation has 3 Contexts
 
-1) Discovery - Tests cases with this context will be executed during node ingestion time.
-2) Cleanup - Tests cases with context will be executed during node cleanup(between tenants).
-3) On-Demand - Tests cases with context will be executed when on demand machine validation is triggered.
+1) Discovery - Test cases with this context will be executed during node ingestion time.
+2) Cleanup - Test cases with this context will be executed during node cleanup(between tenants).
+3) On-Demand - Test cases with this context will be executed when on demand machine validation is triggered.
 
         user@host:admin$ carbide-admin-cli machine-validation on-demand start  --help
 

--- a/book/src/manuals/metrics/core_metrics.md
+++ b/book/src/manuals/metrics/core_metrics.md
@@ -5,7 +5,7 @@ This file contains a list of metrics exported by NCX Infra Controller (NICo). Th
 <table>
 <tr><td>Name</td><td>Type</td><td>Description</td></tr>
 <tr><td>carbide_active_host_firmware_update_count</td><td>gauge</td><td>The number of host machines in the system currently working on updating their firmware.</td></tr>
-<tr><td>carbide_api_db_queries_total</td><td>counter</td><td>The amount of database queries that occured inside a span</td></tr>
+<tr><td>carbide_api_db_queries_total</td><td>counter</td><td>The amount of database queries that occurred inside a span</td></tr>
 <tr><td>carbide_api_db_span_query_time_milliseconds</td><td>histogram</td><td>Total time the request spent inside a span on database transactions</td></tr>
 <tr><td>carbide_api_grpc_server_duration_milliseconds</td><td>histogram</td><td>Processing time for a request on the carbide API server</td></tr>
 <tr><td>carbide_api_ready</td><td>gauge</td><td>Whether the Forge Site Controller API is running</td></tr>
@@ -38,7 +38,7 @@ This file contains a list of metrics exported by NCX Infra Controller (NICo). Th
 <tr><td>carbide_gpus_usable_count</td><td>gauge</td><td>The remaining number of GPUs in the Forge site which are available for immediate instance creation</td></tr>
 <tr><td>carbide_hosts_by_sku_count</td><td>gauge</td><td>The amount of hosts by SKU and device type (&#x27;unknown&#x27; for hosts without SKU)</td></tr>
 <tr><td>carbide_hosts_health_overrides_count</td><td>gauge</td><td>The amount of health overrides that are configured in the site</td></tr>
-<tr><td>carbide_hosts_health_status_count</td><td>gauge</td><td>The total number of Managed Hosts in the system that have reported any a healthy nor not healthy status - based on the presence of health probe alerts</td></tr>
+<tr><td>carbide_hosts_health_status_count</td><td>gauge</td><td>The total number of Managed Hosts in the system that have reported either a healthy or not healthy status - based on the presence of health probe alerts</td></tr>
 <tr><td>carbide_hosts_in_use_count</td><td>gauge</td><td>The total number of hosts that are actively used by tenants as instances in the Forge site</td></tr>
 <tr><td>carbide_hosts_usable_count</td><td>gauge</td><td>The remaining number of hosts in the Forge site which are available for immediate instance creation</td></tr>
 <tr><td>carbide_hosts_with_bios_password_set</td><td>gauge</td><td>The total number of Hosts in the system that have their BIOS password set.</td></tr>
@@ -47,7 +47,7 @@ This file contains a list of metrics exported by NCX Infra Controller (NICo). Th
 <tr><td>carbide_ib_partitions_object_tasks_enqueued_total</td><td>counter</td><td>The amount of types that object handling tasks that have been freshly enqueued for objects of type carbide_ib_partitions</td></tr>
 <tr><td>carbide_ib_partitions_total</td><td>gauge</td><td>The total number of carbide_ib_partitions in the system</td></tr>
 <tr><td>carbide_machine_reboot_duration_seconds</td><td>histogram</td><td>Time taken for machine/host to reboot in seconds</td></tr>
-<tr><td>carbide_machine_updates_started_count</td><td>gauge</td><td>The number of machines in the system that in the process of updating.</td></tr>
+<tr><td>carbide_machine_updates_started_count</td><td>gauge</td><td>The number of machines in the system that are in the process of updating.</td></tr>
 <tr><td>carbide_machine_validation_completed</td><td>gauge</td><td>Count of machine validation that have completed successfully</td></tr>
 <tr><td>carbide_machine_validation_failed</td><td>gauge</td><td>Count of machine validation that have failed</td></tr>
 <tr><td>carbide_machine_validation_in_progress</td><td>gauge</td><td>Count of machine validation that are in progress</td></tr>
@@ -94,7 +94,7 @@ This file contains a list of metrics exported by NCX Infra Controller (NICo). Th
 <tr><td>carbide_power_shelves_object_tasks_enqueued_total</td><td>counter</td><td>The amount of types that object handling tasks that have been freshly enqueued for objects of type carbide_power_shelves</td></tr>
 <tr><td>carbide_power_shelves_total</td><td>gauge</td><td>The total number of carbide_power_shelves in the system</td></tr>
 <tr><td>carbide_preingestion_total</td><td>gauge</td><td>The amount of known machines currently being evaluated prior to ingestion</td></tr>
-<tr><td>carbide_preingestion_waiting_download</td><td>gauge</td><td>The amount of machines that are waiting for firmware downloads on other machines to complete before doing thier own</td></tr>
+<tr><td>carbide_preingestion_waiting_download</td><td>gauge</td><td>The amount of machines that are waiting for firmware downloads on other machines to complete before doing their own</td></tr>
 <tr><td>carbide_preingestion_waiting_installation</td><td>gauge</td><td>The amount of machines which have had firmware uploaded to them and are currently in the process of installing that firmware</td></tr>
 <tr><td>carbide_racks_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_racks in the system</td></tr>
 <tr><td>carbide_racks_iteration_latency_milliseconds</td><td>histogram</td><td>The elapsed time in the last state processor iteration to handle objects of type carbide_racks</td></tr>
@@ -104,12 +104,12 @@ This file contains a list of metrics exported by NCX Infra Controller (NICo). Th
 <tr><td>carbide_reserved_ips_count</td><td>gauge</td><td>The total number of reserved ips in the site</td></tr>
 <tr><td>carbide_resourcepool_free_count</td><td>gauge</td><td>Count of values in the pool currently available for allocation</td></tr>
 <tr><td>carbide_resourcepool_used_count</td><td>gauge</td><td>Count of values in the pool currently allocated</td></tr>
-<tr><td>carbide_running_dpu_updates_count</td><td>gauge</td><td>The number of machines in the system that running a firmware update.</td></tr>
+<tr><td>carbide_running_dpu_updates_count</td><td>gauge</td><td>The number of machines in the system that are running a firmware update.</td></tr>
 <tr><td>carbide_site_exploration_expected_machines_sku_count</td><td>gauge</td><td>The total count of expected machines by SKU ID and device type</td></tr>
 <tr><td>carbide_site_exploration_identified_managed_hosts_count</td><td>gauge</td><td>The amount of Host+DPU pairs that has been identified in the last SiteExplorer run</td></tr>
 <tr><td>carbide_site_explorer_bmc_reset_count</td><td>gauge</td><td>The amount of BMC resets initiated in the last SiteExplorer run</td></tr>
 <tr><td>carbide_site_explorer_create_machines</td><td>gauge</td><td>Whether site-explorer machine creation is enabled (1) or disabled (0)</td></tr>
-<tr><td>carbide_site_explorer_create_machines_latency_milliseconds</td><td>histogram</td><td>The time it to perform create_machines inside site-explorer</td></tr>
+<tr><td>carbide_site_explorer_create_machines_latency_milliseconds</td><td>histogram</td><td>The time it took to perform create_machines inside site-explorer</td></tr>
 <tr><td>carbide_site_explorer_created_machines_count</td><td>gauge</td><td>The amount of Machine pairs that had been created by Site Explorer after being identified</td></tr>
 <tr><td>carbide_site_explorer_created_power_shelves_count</td><td>gauge</td><td>The amount of Power Shelves that had been created by Site Explorer after being identified</td></tr>
 <tr><td>carbide_site_explorer_enabled</td><td>gauge</td><td>Whether site-explorer is enabled (1) or paused (0)</td></tr>
@@ -119,5 +119,5 @@ This file contains a list of metrics exported by NCX Infra Controller (NICo). Th
 <tr><td>carbide_switches_object_tasks_enqueued_total</td><td>counter</td><td>The amount of types that object handling tasks that have been freshly enqueued for objects of type carbide_switches</td></tr>
 <tr><td>carbide_switches_total</td><td>gauge</td><td>The total number of carbide_switches in the system</td></tr>
 <tr><td>carbide_total_ips_count</td><td>gauge</td><td>The total number of ips in the site</td></tr>
-<tr><td>carbide_unavailable_dpu_nic_firmware_update_count</td><td>gauge</td><td>The number of machines in the system that need a firmware update but are unavailble for update.</td></tr>
+<tr><td>carbide_unavailable_dpu_nic_firmware_update_count</td><td>gauge</td><td>The number of machines in the system that need a firmware update but are unavailable for update.</td></tr>
 <table>

--- a/book/src/manuals/networking_requirements.md
+++ b/book/src/manuals/networking_requirements.md
@@ -6,7 +6,7 @@ Here is an overview of the requirements, which will be detailed in the following
 
 * **VNIs**: Datacenter-unique VNIs allocated based on the expected number of VPCs.
 * **ASNs**: Globally-unique 32-bit ASNs allocated based on the expected number of DPUs.
-* **IPv4 prefixes**: A single, globally-unique IPv4 prefix with a total number of IP allocation based on the following formula: `(expected number of servers + the expected number of DPUs) * 2 + 2`
+* **IPv4 prefixes**: A single, globally-unique IPv4 prefix with a total IP allocation size based on the following formula: `(expected number of servers + the expected number of DPUs) * 2 + 2`
   * One or more additional, globally-unique IPv4 prefixes with a total IP allocation amount based on the following formula: `expected number of DPUs * 2`.  Minimum individual prefix size is /31.
 * **Routing**: A mechanism for route-propagation and a default route for the tenant EVPN overlay network. Options for providing this include the following:
   * Allowing additional L2VPN-EVPN sessions with LEAF TORs and configuring the same sessions at each tier of the network (refer to simplified diagram below for reference).
@@ -30,7 +30,7 @@ Here is an overview of the requirements, which will be detailed in the following
 
 ### Overlay Options
 
-* **Option 1 - Dual-stacked Ipv4/EVPN sessions with TOR**
+* **Option 1 - Dual-stacked IPv4/EVPN sessions with TOR**
   * Configure peering as follows:
     * TORs should be configured to accept EVPN sessions with the DPUs in addition to the existing IPv4 sessions.
     * At a minimum, spines should be configured for EVPN sessions with the TORs. Ideally, all tiers of the network should be configured with EVPN sessions.

--- a/book/src/manuals/nvlink_partitioning.md
+++ b/book/src/manuals/nvlink_partitioning.md
@@ -27,9 +27,9 @@ In general, the steps are:
 
 > **Note**: To ensure that machines in the same Rack are assigned to the same NVLink Partition, an Instance Type can be created for the Rack and all Machines in the Rack assigned to the same Instance Type. Alternatively users can use the [Batch Instance creation REST API endpoint](https://nvidia.github.io/ncx-infra-controller-rest/#tag/Instance/operation/batch-create-instances) and set `topologyOptimized` to `true`.
 
-3. If the users does not want to specify NVLink Interfaces for each GPU when creating an Instance, they can:
+3. If the user does not want to specify NVLink Interfaces for each GPU when creating an Instance, they can:
 
-   a. Create a new VPC with specifying a value for `nvLinkLogicalPartitionId` or update an existing VPC with no Instances to set the `nvLinkLogicalPartitionId` attribute. We will refer to this as the *default NVLink Logical Partition* for the VPC.
+   a. Create a new VPC by specifying a value for `nvLinkLogicalPartitionId` or update an existing VPC with no Instances to set the `nvLinkLogicalPartitionId` attribute. We will refer to this as the *default NVLink Logical Partition* for the VPC.
 
    b. When creating an Instance in this VPC, user does not need to specify NVLink Interfaces, NICo will automatically generate NVLink Interfaces for the Instance and assign them to the VPC's NVLink Logical Partition.
 

--- a/book/src/manuals/site-reference-arch.md
+++ b/book/src/manuals/site-reference-arch.md
@@ -57,7 +57,7 @@ The following versions indicate the tested baseline for the NICo site controller
 * **CNI**: Calico backend or equivalent (VXLAN or BGP; choose per network policy/MTU needs)
 * **Control-plane footprint**: 3-node minimum for HA; 5-node control plane recommended for large GB200-class sites (e.g. YTL deployment)
 * **Time sync**: chrony or equivalent, synced to enterprise NTP
-* **Logging/metrics**: Ship system and pod logs off‑host (e.g. to your centralized stack). All logs are collected and shipped using `otel-collector-contrib `(Both Site controller and DPU). All Metrics are scraped and shipped using Prometheus (Both Site controller and DPU).
+* **Logging/metrics**: Ship system and pod logs off‑host (e.g. to your centralized stack). All logs are collected and shipped using `otel-collector-contrib` (both site controller and DPU). All metrics are scraped and shipped using Prometheus (both site controller and DPU).
 
 ## Networking Best Practices
 
@@ -125,7 +125,7 @@ This pool is required for the services running on the control plane cluster.
 
 * The IP allocation in this network is managed by NICo. 
 * The allocation can be split into multiple pools. 
-* These subnets must be configured on the out-of-band connected switches, with a DHCP relay configuration pointing to the NICo DHCP service NICo must be informed about them.
+* These subnets must be configured on the out-of-band connected switches, with a DHCP relay configuration pointing to the NICo DHCP service. NICo must be informed about them.
 
 ### DPU Loopback Pool
 

--- a/book/src/manuals/site-setup.md
+++ b/book/src/manuals/site-setup.md
@@ -58,7 +58,7 @@ This section lists all software dependencies, including the versions validated f
 
 ### Monitoring and Telemetry (OPTIONAL)
 
-These components are not required for NICo setup, but are recommended site metrics.
+These components are not required for NICo setup, but are recommended for site metrics.
 
 - **Monitoring System**:  Prometheus Operator v0.68.0; Prometheus v2.47.0; Alertmanager v0.26.0
 

--- a/book/src/manuals/sku_validation.md
+++ b/book/src/manuals/sku_validation.md
@@ -10,7 +10,7 @@ Each host managed by NICo must have a SKU associated with it before it can be ma
 <!-- TODO: did we actually implement this? -->
 
 Hardware configurations or SKUs are generated from existing machines by an admin and uploaded to forge via the CLI.
-SKU's can be downloaded for modification or use with other sites.
+SKUs can be downloaded for modification or use with other sites.
 
 Machines that are assigned a SKU are automatically validated during ingestion based on their discovery information.
 Hardware validation occurs during initial ingestion and after an instance is released and new discovery information is received.
@@ -35,7 +35,7 @@ bring-up process. However, for now, SKUs are only manually added to sites. It is
 the SKU assignments for individual machines are added automatically by NICo as those machines are reconfigured.
 
 ### BOM Validation States
-Verifying a SKU against a machine goes through several steps to aquire updated machine inventory and perform the validation.  Depending on the inventory of the machine and the SKU configuration, the state machine needs to handle several situations.  The bom validation process is broken down into the following sub-states:
+Verifying a SKU against a machine goes through several steps to acquire updated machine inventory and perform the validation.  Depending on the inventory of the machine and the SKU configuration, the state machine needs to handle several situations.  The bom validation process is broken down into the following sub-states:
 - `MatchingSku` - The state machine will attempt to find an existing SKU that matches the machine inventory.
 - `UpdatingInventory` - NICo is requesting that scout re-inventory the machine.  This ensures that other operations are using a recent version of the machine inventory
 - `VerifyingSku` - NICo is comparing the machine inventory against the SKU
@@ -121,7 +121,7 @@ Some example SKU names:
 ### Browse SKUs, their configuration, and assigned machines
 
 You can view all the SKUs for a site, and click into their specific configurations and list assigned machines
-by visting the admin page for a site and clicking "SKUs" from the left-side navigation bar.
+by visiting the admin page for a site and clicking "SKUs" from the left-side navigation bar.
 
 ### Viewing SKU information
 
@@ -273,7 +273,7 @@ carbide-admin-cli sku unassign <machineid>
 If a SKU has a set of components that do not work for a set of machines (either due to bugs, or Carbide software updates) updating machines by unassigning and assigning a SKU would be challenging.  Replacing the components of a SKU can be done with the `sku replace` command.  This will force all machines to go through verification when no instance is allocated to the machine (all machines are verified when an instance is released).
 
 ```sh
-forge-acmin-cli sku replace <filename> [--id <sku_name>]
+carbide-admin-cli sku replace <filename> [--id <sku_name>]
 ```
 
 ### Remove a SKU from a site
@@ -288,7 +288,7 @@ carbide-admin-cli sku delete <sku_name>
 ```
 
 #### Upgrading a SKU to the current version example
-When a new version of NICo is released that changes how SKUs behave, existing SKUs maintain their previous behavior.  In order to use the new version of the SKU, a manual "upgrade" process is required using the the `sku replace` command.
+When a new version of NICo is released that changes how SKUs behave, existing SKUs maintain their previous behavior.  In order to use the new version of the SKU, a manual "upgrade" process is required using the `sku replace` command.
 
 The existing SKU is below.  Note that the "Storage Devices" section includes a device with a model of "NO_MODEL" and there is no TPM.  The extra storage device is created by the raid card and may not always exist and should not have been included in the SKU.
 
@@ -389,7 +389,7 @@ carbide-admin-cli -f json -o /tmp/xe9680.json sku g fm100hti7olik00gefc9qlma831n
 
 Then replace the old SKU
 ```sh
-carbide-admin-clisku replace /tmp/xe9680.json
+carbide-admin-cli sku replace /tmp/xe9680.json
 +--------+---------------------------------------+------------------+-----------------------------+
 | ID     | Description                           | Model            | Created                     |
 +========+=======================================+==================+=============================+

--- a/book/src/manuals/vpc/vpc_peering_management.md
+++ b/book/src/manuals/vpc/vpc_peering_management.md
@@ -32,7 +32,7 @@ carbide-admin-cli vpc-peering create e65a9d69-39d2-4872-a53e-e5cb87c84e75 366de8
 - The operator should confirm with both VPC owners (VPC tenant org) that they approve the peering before creating the connection
 - The VPC IDs can be provided in any order
 - The system will automatically enforce canonical ordering (smaller ID becomes `vpc1_id`)
-- If a peering connection already exists between the two VPCs, the command will return error indicating a peering connection already exists
+- If a peering connection already exists between the two VPCs, the command will return an error indicating a peering connection already exists
 - Both VPCs must exist before creating the peering connection
 
 ### Listing VPC Peering Connections

--- a/book/src/manuals/vpc/vpc_routing_profiles.md
+++ b/book/src/manuals/vpc/vpc_routing_profiles.md
@@ -17,7 +17,7 @@ A VPC has a `network_virtualization_type` that determines how the platform imple
 - `FNN`: The production networking model
 - `ETHERNET_VIRTUALIZER`: A legacy, deprecated, and not officially supported model. It may still appear in existing objects or older workflows, but it should not be treated as the target model for production planning.
 
-> **Important**: If no virtualization type is supplied when a VPC is created, the API currently defaults the VPC to `ETHERNET_VIRTUALIZER`. This default should be understood as compatibility behavior, not as a production recommendation. The `FNN` option should always be sepcified for VPCs on a production site.
+> **Important**: If no virtualization type is supplied when a VPC is created, the API currently defaults the VPC to `ETHERNET_VIRTUALIZER`. This default should be understood as compatibility behavior, not as a production recommendation. The `FNN` option should always be specified for VPCs on a production site.
 
 ### Routing Profile Type
 

--- a/book/src/playbooks/force_delete.md
+++ b/book/src/playbooks/force_delete.md
@@ -10,7 +10,7 @@ automatically recover.
 
 ## Important note
 
-*This this is not a site-provider facing workflow, since force-deleting a machine
+*This is not a site-provider facing workflow, since force-deleting a machine
 does skip any cleanup on the machine and leaves it in an undefined state where the tenants OS could be still running.
 force-deleting machines is purely an operational tool. The operator which executed the
 command needs to make sure that either no tenant image is running anymore, or take additional steps
@@ -19,7 +19,7 @@ Site providers would get a safe version of this workflow later on that moves the
 
 ## Force-Deletion Steps
 
-The following steps can be used to force-delete knowledge about a a NICo host:
+The following steps can be used to force-delete knowledge about a NICo host:
 
 ### 1. Obtain access to `carbide-admin-cli`
 
@@ -40,7 +40,7 @@ Example:
 /opt/carbide/carbide-admin-cli -c https://127.0.0.1:1079 machine force-delete --machine="60cef902-9779-4666-8362-c9bb4b37184f"
 ```
 
-### 3. Use the returned BMP IP/port and machine-id to reboot the host
+### 3. Use the returned BMC IP/port and machine-id to reboot the host
 
 See [Rebooting a machine](machine_reboot.md).
 Supply the BMC IP and port of the managed host, as well as its `machine_id`

--- a/book/src/playbooks/ib_runbook.md
+++ b/book/src/playbooks/ib_runbook.md
@@ -2,7 +2,7 @@
 
 ## Motivation
 
-[Infiniband](https://en.wikipedia.org/wiki/InfiniBand) This runbook describes the steps on infrastructure setup and configuration of enable Infiniband.
+[Infiniband](https://en.wikipedia.org/wiki/InfiniBand) This runbook describes the steps on infrastructure setup and configuration of enabling Infiniband.
 
 ## Unified Fabric Manager (UFM)
 
@@ -127,7 +127,7 @@ curl -k -u admin:123456 -X GET https://<ufm host name>/ufmRest/jobs/1 | jq
     "SiteName": null
 }
 ```
-Once Job will be completed, path on UFM server to generated topoconfig file will be part of job completion message (Summary). Default generated topoconfig file location location: `/tmp/ibdiagnet_out/generated_topoconfig.conf`
+Once Job will be completed, path on UFM server to generated topoconfig file will be part of job completion message (Summary). Default generated topoconfig file location: `/tmp/ibdiagnet_out/generated_topoconfig.conf`
 
 #### Configurations per UFM
 
@@ -218,7 +218,7 @@ No additional steps are required to enable Infiniband in NCX Infra Controller (N
 
 #### UFM Credential
 
-One of two options can be selected to UFM Authentication mechanism such as `token authentication` or `client authentication`.
+One of two options can be selected for UFM authentication: `token authentication` or `client authentication`.
 Follow the instructions in the section that applies to the selected option.
 
 ##### Token Authentication
@@ -464,10 +464,10 @@ endpoints = ["https://10.217.161.194:443/"]
 pkeys = [{ start = "256", end = "2303" }]
 ```
 
-Note that currently NICo only supports only a single IB fabric. Therefore only
+Note that currently NICo supports only a single IB fabric. Therefore only
 the fabric ID `default` will be accepted here.
 
-**NOTE**: A pkey will be generated for all partitions that are managed by NICo; ensure sure the range does not conflict with the existing pkey in UFM (if any).
+**NOTE**: A pkey will be generated for all partitions that are managed by NICo; ensure the range does not conflict with the existing pkey in UFM (if any).
 
 Update the configmap `carbide-api-site-config-files` to enable Infiniband features as follows:
 
@@ -476,7 +476,7 @@ Update the configmap `carbide-api-site-config-files` to enable Infiniband featur
 enabled = true
 ```
 
-To enable the monitor of IB, update the the configmap `carbide-api-site-config-files`  as follows:
+To enable the monitor of IB, update the configmap `carbide-api-site-config-files`  as follows:
 
 ```toml
 [ib_fabric_monitor]
@@ -575,7 +575,7 @@ The `username` here encodes the UFM address, while the `password` identifies the
 
 SRE can also check the InfiniBand fabric monitor metrics emitted by NICo to determine whether it can reach UFM. E.g. the following graph shows a scenario where
 
-* First NICo could not connect to UFM to invalid credentials
+* First NICo could not connect to UFM due to invalid credentials
 * Fixing the credentials provided access and lead UFM metrics (version number) to be emitted
 
 ![alt text](../static/playbooks/ib_ufm_ver.png)

--- a/book/src/playbooks/machine_reboot.md
+++ b/book/src/playbooks/machine_reboot.md
@@ -1,11 +1,11 @@
 # Rebooting a machine
 
-This page describes how to reboot a machine managed by NCX Infra Controller (NICo) (i.e. amanaged host or DPU)
+This page describes how to reboot a machine managed by NCX Infra Controller (NICo) (i.e. a managed host or DPU)
 in any potential state of its lifecycle.
 
 ## Important note
 
-*This this is not a facing site-provider or tenant facing workflow.
+*This is not a site-provider or tenant facing workflow.
 Rebooting a machine while it is in-use for a tenant can have unexpected
 side effects. If a tenant requires a reboot, they should use the
 `InvokeInstancePower` request - which is properly integrated into the
@@ -24,7 +24,7 @@ See [carbide-admin-cli access on a Forge cluster](forge_admin_cli.md).
 `carbide-admin-cli machine reboot` can be used to restart a machine.
 It always will require the machine's BMC IP and port to be specified.
 
-BMC credentials can either be explicitely passed, or the `--machine-id` parameter
+BMC credentials can either be explicitly passed, or the `--machine-id` parameter
 can be used to let the forge site-controller read the last known credentials
 for the machine.
 

--- a/book/src/playbooks/stuck_objects/adding_new_machines.md
+++ b/book/src/playbooks/stuck_objects/adding_new_machines.md
@@ -1,7 +1,6 @@
 # Adding New Machines to an Existing Site
 
-This guide is intended to cover some of the basic things you should check to get a machine into a
-a basic state where it can be discovered by Forge auto-ingestion.
+This guide is intended to cover some of the basic things you should check to get a machine into a basic state where it can be discovered by Forge auto-ingestion.
 
 Some of the configuration items that should be considered which could potentially cause issues:
 
@@ -50,7 +49,7 @@ in expected machines or change the password on the Host BMC to match.
 
 ### Checking site vault data
 
-To check of the Host BMC has currently any passwords in vault on a site:
+To check if the Host BMC has currently any passwords in vault on a site:
 
 1. Connect to the Kubernetes environment for the site you are working on
 2. Retrieve the decoded vault secret for the site:
@@ -91,7 +90,7 @@ To check of the Host BMC has currently any passwords in vault on a site:
 
 For a new/undiscovered DPU BMC, ensure that it is set to the default BMC username/password
 
-### Resting DPU BMC password to default - From DPU BMC
+### Resetting DPU BMC password to default - From DPU BMC
 
 To reset to factory defaults from the DPU BMC:
 
@@ -376,7 +375,7 @@ To successfully boot from the Forge BFB image, the DPU ARM OS needs to have Secu
 
 ### Disable Secure Boot
 
-To disable if Secure Boot if it is enabled:
+To disable Secure Boot if it is enabled:
 
 1. Run the command to disable Secure Boot:
 
@@ -423,7 +422,7 @@ If the "SecureBootCurrentBoot" setting is not shown, attempt to install DOCA 2.5
     ```
 
 4. After the DPU ARM OS boots, log into the DPU ARM OS using the default password
-5. Switch to root and set the default username passwod back to the default
+5. Switch to root and set the default username password back to the default
 6. Ensure that the DOCA firmware is up to date:
 
     ```bash
@@ -466,7 +465,7 @@ If the "SecureBootCurrentBoot" setting is not shown, attempt to install DOCA 2.5
     bfcfg
     ```
 
-12. Verify that the boot order is no set to NET-OOB-IPV4-HTTP as default:
+12. Verify that the boot order is now set to NET-OOB-IPV4-HTTP as default:
 
     ```bash
     efibootmgr

--- a/book/src/playbooks/stuck_objects/common_mitigations.md
+++ b/book/src/playbooks/stuck_objects/common_mitigations.md
@@ -26,7 +26,7 @@ The following issues might prevent this call from happening:
 - The machine reboots, but can either not obtain an IP address via DHCP or
   can not PXE boot. The serial console that is accessible via the BMC of a machine
   or via `forge-ssh-console` can be used to determine whether the Machine booted
-  successfully, or whether it bootloops and not obtain an IP or load an image.
+  successfully, or whether it bootloops and cannot obtain an IP or load an image.
   If the boot process does not succeed, check carbide-dhcp and carbide-pxe for
   further logs.
   <!-- TODO: Better runbooks for DHCP failures -->
@@ -68,5 +68,5 @@ skipping states.
 
 **Due to this reason, it is usually not helpful to initiate deletion of
 objects stuck in Provisioning. Instead of this, the reason for an object
-stuck in provisioning should be inspected and the underlying issue being
+stuck in provisioning should be inspected and the underlying issue should be
 resolved.**

--- a/book/src/playbooks/stuck_objects/stuck_objects.md
+++ b/book/src/playbooks/stuck_objects/stuck_objects.md
@@ -45,7 +45,7 @@ Another initial check on whether the problem is a Forge Cloud or Site problem
 is to check whether the Cloud backend could actually send the state change
 request (e.g. instance release request) to the Site.
 
-The `statusHistory` field on the Forge Cloud API can be belpful for this assessment. E.g. the history for the following Subnet indicates that
+The `statusHistory` field on the Forge Cloud API can be helpful for this assessment. E.g. the history for the following Subnet indicates that
 the deletion request was sent to the site, but deletion might be stuck there:
 
 ```json
@@ -210,7 +210,7 @@ The graph might look like:
 In this diagram we can observe ManagedHosts in various transient states
 (like `assigned bootingwithdiscoverimage` or `dpunotready waitingfornetworkconfig`)
 for multiple hours. Thereby we can assume those objects are stuck in this
-state, and that operator invention is required to make them advance state.
+state, and that operator intervention is required to make them advance state.
 
 The dashboard will not tell us which ManagedHost is exactly stuck. But if only one
 ManagedHost is in a stuck state, we can deduct that this might be the ManagedHost a
@@ -249,7 +249,7 @@ Forge:
 - [Infiniband Partition State Machine](https://gitlab-master.nvidia.com/nvmetal/carbide/-/blob/trunk/api/src/state_controller/ib_partition/handler.rs)
 
 When looking at these files, consider that the software version deployed
-on the Forge site you are investiating might not match the latest `trunk`
+on the Forge site you are investigating might not match the latest `trunk`
 version of those state machines. You might then want to look at the version
 of the file which matches the version (git commit hash) of the actual site.
 
@@ -295,13 +295,13 @@ Inspecting the [`rebooted`](https://gitlab-master.nvidia.com/nvmetal/carbide/-/b
 function further will tell us that checks that the `last_reboot_time` timestamp
 is more recent than the time when we entered the state. And checking even
 further for where the `last_reboot_time` is updated, [we would learn that
-it happens when `forge-scout` is started and asks the the `carbide-api` server
+it happens when `forge-scout` is started and asks the `carbide-api` server
 via the `ForgeAgentControl` API call for instructions](https://gitlab-master.nvidia.com/nvmetal/carbide/-/blob/38849aed602a2ab6e19a5315b342db3d4535b143/api/src/api.rs#L2771-2772.)
 
-Therefore we can determine that possibles sources of the ManagedHost being stuck are:
+Therefore we can determine that possible sources of the ManagedHost being stuck are:
 - The Host is never rebooted
 - The Host is rebooted, but does not boot into the discovery image
-- The Host is rebooted and boots into the dsicovery image, but `forge-scout` is
+- The Host is rebooted and boots into the discovery image, but `forge-scout` is
   not running or might not be able to reach the API server.
 
 We can now continue troubleshooting by inspecting which of these steps might have

--- a/book/src/playbooks/troubleshooting_noDpuLogsWarning_alerts.md
+++ b/book/src/playbooks/troubleshooting_noDpuLogsWarning_alerts.md
@@ -1,15 +1,15 @@
 # Troubleshooting noDpuLogsWarning Alerts
 
 The Forge noDpuLogsWarning alert fires under the following conditions:
-1. Forge has been receiving logs from the DPU ARM OS with in the last 30 days
-2. It has not received any forge-dpu-agent.service lg events within the last 10 minutes
+1. Forge has been receiving logs from the DPU ARM OS within the last 30 days
+2. It has not received any forge-dpu-agent.service log events within the last 10 minutes
 3. And opentelemetry-collector-prom end point running on the DPU ARM OS has been down for more than 5 minutes
 
-The format of the alert name is "\<Forge site ID\>-noDpuLogsWarning (\<Forge site ID\> \<DPU ARM OS hostname\> forge-montioring/forge-monitoring-(\<Forge site ID\>-prometheus warning)
+The format of the alert name is "\<Forge site ID\>-noDpuLogsWarning (\<Forge site ID\> \<DPU ARM OS hostname\> forge-monitoring/forge-monitoring-(\<Forge site ID\>-prometheus warning)
 
 ## Common Causes of these alerts
 
-1. The machine is currently being re-provisioned and taken longer than expected to completed provisioning
+1. The machine is currently being re-provisioned and taking longer than expected to complete provisioning
 
 2. The machine is being worked on by another SRE team member. The machine might be powered off, undergoing maintenance or might have been force-deleted.
 
@@ -27,7 +27,7 @@ curl 127.0.0.1:9999/metrics | grep telemetry_stats
 telemetry_stats_log_records_total{component="telemetry_stats",grouping="logs_by_component",host_name="localhost",http_scheme="http",instance="127.0.0.1:8890",job="log-stats",log_component="journald",machine_id="fm100dsekkqjprbu96gq67vd6p24rc1uqnct6dv15opjka9he3qlbk3doc0",net_host_port="8890",service_instance_id="127.0.0.1:8890",service_name="log-stats",source="telemetrystatsprocessor:0.0.1",systemd_unit="kernel"} 272
 ...
 ```
-In the example above, the hostname being used by the otelcol-contrib service (host_name="localhost") is set to localhost. The host_name should be set to the hostname of the DPU ARM OS. To resolve this issue, restart the OpenTelemrty Collector service:
+In the example above, the hostname being used by the otelcol-contrib service (host_name="localhost") is set to localhost. The host_name should be set to the hostname of the DPU ARM OS. To resolve this issue, restart the OpenTelemetry Collector service:
 ```bash
 systemctl restart otelcol-contrib
 ```
@@ -44,7 +44,7 @@ In this example the host_name is now set to 192-168-134-165.nico.example.org.
 ```bash
 kubectl logs carbide-hardware-health-67c95c7775-bd4mw -n forge-system --timestamps
 ```
-If errors are being send against the endpoint, but it is available on the network (You can ping it, ssh to the DPU ARM OS and all services appear to be running with no errors), you can attempt to restart the carbide-hardware-health pod to see if this resolves the issues:
+If errors are being sent against the endpoint, but it is available on the network (You can ping it, ssh to the DPU ARM OS and all services appear to be running with no errors), you can attempt to restart the carbide-hardware-health pod to see if this resolves the issues:
 ```bash
 kubectl delete pod carbide-hardware-health-67c95c7775-bd4mw -n forge-system
 ```

--- a/book/src/release-notes.md
+++ b/book/src/release-notes.md
@@ -9,7 +9,7 @@ This release of Bare Metal Manager is open-source software (OSS).
 ### Improvements
 
 - The REST API now supports external identity providers (IdPs) for JWT authentication.
-- The new `/carbide/instance/batch` REST API endpoint allows for batch instances creation.
+- The new `/carbide/instance/batch` REST API endpoint allows for batch instance creation.
 - Instances can now be rebooted by passing an `instance_id` argument, in addition to the existing `machine_id` argument.
 - The State Controller is now split into two independent components: The `PeriodicEnqueuer`, which periodically enqueues state handling tasks using the `Enqueuer::enqueue_object` API for each resource/object managed by NICo, and the `StateProcessor`, which continuously de-queues the state handling tasks for each object type and executes the state handler on them.
 - The state handler for objects is now scheduled again whenever the outcome of the state handler is `Transition`. This reduces the wait time for many state transitions by up to 30 seconds.
@@ -59,7 +59,7 @@ The following key functionalities should be available for testing via the Admin 
 | Software | Vault, postgres, k8s cluster, Certificate Management, Temporal | Partners are required to bring in NICo dependencies |
 | Hardware | Supported server and switch functionality(e.g. x86 nodes, specific NIC firmware, compatible BMCs, Switches that support BGP, EVPN, and RFC 5549 (unnumbered IPs)) | The code assumes predictable hardware attributes; unsupported SKUs may require custom configuration. |
 | Network Topology | L2/L3 connectivity, DHCP/PXE servers, out-of-band management networks, specific switch side port configurations | All modules (e.g. discovery, provisioning) require pre-configured subnets and routing policies, as well as delegation of IP prefixes, ASN numbers, and EVPN VNI numbers. |
-| External Systems | DNS resolvers/recursers, NTP, Authentication (Azure OIDC, Keycloak), Observability Stack | NICo provides clients with DNS resolver and NTP server information in the DHCP response. External authentication source that supports OIDC. NICo sends open-telemetry metrics and logs into an existing visualization/storage system |
+| External Systems | DNS resolvers/recursors, NTP, Authentication (Azure OIDC, Keycloak), Observability Stack | NICo provides clients with DNS resolver and NTP server information in the DHCP response. External authentication source that supports OIDC. NICo sends open-telemetry metrics and logs into an existing visualization/storage system |
 
 **Supported Switches**:
 

--- a/crates/api/src/logging/sqlx_query_tracing.rs
+++ b/crates/api/src/logging/sqlx_query_tracing.rs
@@ -325,7 +325,7 @@ impl DatabaseMetricEmitters {
         // per span. It thereby counts the amount of spans - not the amount of DB queries.
         let db_queries_counter = meter
             .u64_counter("carbide-api.db.queries")
-            .with_description("The amount of database queries that occured inside a span")
+            .with_description("The amount of database queries that occurred inside a span")
             .build();
 
         let db_span_query_times = meter

--- a/crates/api/src/machine_update_manager/dpu_nic_firmware_metrics.rs
+++ b/crates/api/src/machine_update_manager/dpu_nic_firmware_metrics.rs
@@ -56,7 +56,7 @@ impl DpuNicFirmwareUpdateMetrics {
         meter
             .u64_observable_gauge("carbide_unavailable_dpu_nic_firmware_update_count")
             .with_description(
-                "The number of machines in the system that need a firmware update but are unavailble for update.",
+                "The number of machines in the system that need a firmware update but are unavailable for update.",
             )
             .with_callback(move |observer| {
                 observer.observe(unavailable_dpu_updates.load(Relaxed), &[]);
@@ -66,7 +66,7 @@ impl DpuNicFirmwareUpdateMetrics {
         meter
             .u64_observable_gauge("carbide_running_dpu_updates_count")
             .with_description(
-                "The number of machines in the system that running a firmware update.",
+                "The number of machines in the system that are running a firmware update.",
             )
             .with_callback(move |observer| {
                 observer.observe(running_dpu_updates.load(Relaxed), &[]);

--- a/crates/api/src/machine_update_manager/metrics.rs
+++ b/crates/api/src/machine_update_manager/metrics.rs
@@ -49,7 +49,7 @@ impl MachineUpdateManagerMetrics {
         meter
             .u64_observable_gauge("carbide_machine_updates_started_count")
             .with_description(
-                "The number of machines in the system that in the process of updating.",
+                "The number of machines in the system that are in the process of updating.",
             )
             .with_callback(move |observer| {
                 observer.observe(machine_updates_started.load(Ordering::Relaxed), &[])

--- a/crates/api/src/state_controller/machine/metrics.rs
+++ b/crates/api/src/state_controller/machine/metrics.rs
@@ -268,7 +268,7 @@ impl MetricsEmitter for MachineMetricsEmitter {
             let metrics = shared_metrics.clone();
             meter
                 .u64_observable_gauge("carbide_hosts_health_status_count")
-                .with_description("The total number of Managed Hosts in the system that have reported any a healthy nor not healthy status - based on the presence of health probe alerts")
+                .with_description("The total number of Managed Hosts in the system that have reported either a healthy or not healthy status - based on the presence of health probe alerts")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
                         for healthy in [true, false] {

--- a/crates/api/src/tests/metrics_fixtures/test_dpu_nic_firmware_metrics.txt
+++ b/crates/api/src/tests/metrics_fixtures/test_dpu_nic_firmware_metrics.txt
@@ -1,9 +1,9 @@
 # HELP carbide_pending_dpu_nic_firmware_update_count The number of machines in the system that need a firmware update.
 # TYPE carbide_pending_dpu_nic_firmware_update_count gauge
 carbide_pending_dpu_nic_firmware_update_count 5
-# HELP carbide_running_dpu_updates_count The number of machines in the system that running a firmware update.
+# HELP carbide_running_dpu_updates_count The number of machines in the system that are running a firmware update.
 # TYPE carbide_running_dpu_updates_count gauge
 carbide_running_dpu_updates_count 10
-# HELP carbide_unavailable_dpu_nic_firmware_update_count The number of machines in the system that need a firmware update but are unavailble for update.
+# HELP carbide_unavailable_dpu_nic_firmware_update_count The number of machines in the system that need a firmware update but are unavailable for update.
 # TYPE carbide_unavailable_dpu_nic_firmware_update_count gauge
 carbide_unavailable_dpu_nic_firmware_update_count 15

--- a/crates/api/src/tests/metrics_fixtures/test_machine_update_manager_metrics.txt
+++ b/crates/api/src/tests/metrics_fixtures/test_machine_update_manager_metrics.txt
@@ -1,4 +1,4 @@
-# HELP carbide_machine_updates_started_count The number of machines in the system that in the process of updating.
+# HELP carbide_machine_updates_started_count The number of machines in the system that are in the process of updating.
 # TYPE carbide_machine_updates_started_count gauge
 carbide_machine_updates_started_count 100
 # HELP carbide_machines_in_maintenance_count The total number of machines in the system that are in maintenance.

--- a/crates/preingestion-manager/src/fixtures/test_metrics_collector.txt
+++ b/crates/preingestion-manager/src/fixtures/test_metrics_collector.txt
@@ -1,7 +1,7 @@
 # HELP carbide_preingestion_total The amount of known machines currently being evaluated prior to ingestion
 # TYPE carbide_preingestion_total gauge
 carbide_preingestion_total 20
-# HELP carbide_preingestion_waiting_download The amount of machines that are waiting for firmware downloads on other machines to complete before doing thier own
+# HELP carbide_preingestion_waiting_download The amount of machines that are waiting for firmware downloads on other machines to complete before doing their own
 # TYPE carbide_preingestion_waiting_download gauge
 carbide_preingestion_waiting_download 10
 # HELP carbide_preingestion_waiting_installation The amount of machines which have had firmware uploaded to them and are currently in the process of installing that firmware

--- a/crates/preingestion-manager/src/metrics.rs
+++ b/crates/preingestion-manager/src/metrics.rs
@@ -67,7 +67,7 @@ fn hydrate_meter(meter: Meter, shared_metrics: SharedMetricsHolder<PreingestionM
         let metrics = shared_metrics;
         meter
             .u64_observable_gauge("carbide_preingestion_waiting_download")
-            .with_description("The amount of machines that are waiting for firmware downloads on other machines to complete before doing thier own")
+            .with_description("The amount of machines that are waiting for firmware downloads on other machines to complete before doing their own")
             .with_callback(move |observer| {
                 metrics.if_available(|metrics, attrs| {
                     observer.observe(

--- a/crates/site-explorer/src/metrics.rs
+++ b/crates/site-explorer/src/metrics.rs
@@ -469,7 +469,7 @@ impl SiteExplorerInstruments {
 
         let site_explorer_create_machines_latency = meter
             .f64_histogram("carbide_site_explorer_create_machines_latency")
-            .with_description("The time it to perform create_machines inside site-explorer")
+            .with_description("The time it took to perform create_machines inside site-explorer")
             .with_unit("ms")
             .build();
 


### PR DESCRIPTION
## Description

This PR cleans up most (if not all) typos and grammatical errors in the NICo book.

- Fixes typos (duplicate/missing/misspelled words)
- Completes incomplete sentences and fills in context
- Cleans up extraneous spaces in sentences/code blocks
- Repairs grammatical errors

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
Closes #1065 

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

Verified each change by hand, to ensure no links were broken and no significant doc content was changed.



