### PR TITLE
refactor(preingestion-manager): introduce module-local config

### DIFF
--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -50,6 +50,7 @@ use utils::config::{
     as_duration, as_std_duration, deserialize_arc_atomic_bool, serialize_arc_atomic_bool,
 };
 
+use crate::preingestion_manager::PreingestionManagerConfig;
 use crate::state_controller::config::IterationConfig;
 
 const MAX_IB_PARTITION_PER_TENANT: i32 = 31;
@@ -1083,6 +1084,27 @@ impl CarbideConfig {
             .as_ref()
             .filter(|conf| conf.enabled)
             .map(|conf| conf.mqtt_broker_port)
+    }
+
+    /// Returns preingestion manager config.
+    pub fn preingestion_manager(&self) -> PreingestionManagerConfig {
+        PreingestionManagerConfig {
+            run_interval: self
+                .firmware_global
+                .run_interval
+                .to_std()
+                .unwrap_or(std::time::Duration::from_secs(30)),
+            concurrency_limit: self.firmware_global.concurrency_limit,
+            hgx_bmc_gpu_reboot_delay: self
+                .firmware_global
+                .hgx_bmc_gpu_reboot_delay
+                .to_std()
+                .unwrap_or(std::time::Duration::from_secs(30)),
+            max_concurrent_bfb_copies: self.firmware_global.max_concurrent_bfb_copies,
+            autoupdate: self.firmware_global.autoupdate,
+            no_reset_retries: self.firmware_global.no_reset_retries,
+            firmware: self.get_firmware_config(),
+        }
     }
 }
 

--- a/crates/api/src/preingestion_manager/config.rs
+++ b/crates/api/src/preingestion_manager/config.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::time::Duration;
+
+use carbide_firmware::FirmwareConfig;
+
+#[derive(Clone)]
+pub struct PreingestionManagerConfig {
+    pub run_interval: Duration,
+    pub concurrency_limit: usize,
+    pub hgx_bmc_gpu_reboot_delay: Duration,
+    pub max_concurrent_bfb_copies: usize,
+    pub autoupdate: bool,
+    pub no_reset_retries: bool,
+    pub firmware: FirmwareConfig,
+}

--- a/crates/api/src/preingestion_manager/mod.rs
+++ b/crates/api/src/preingestion_manager/mod.rs
@@ -15,16 +15,19 @@
  * limitations under the License.
  */
 
+mod config;
+mod metrics;
+
 use std::collections::HashMap;
 use std::default::Default;
 use std::io;
 use std::sync::Arc;
 use std::time::Duration;
 
-use carbide_firmware::FirmwareConfig;
 use carbide_redfish::libredfish::{RedfishClientCreationError, RedfishClientPool};
 use carbide_site_explorer::EndpointExplorer;
 use chrono::{DateTime, Utc};
+pub use config::PreingestionManagerConfig;
 use db::work_lock_manager::WorkLockManagerHandle;
 use db::{DatabaseError, WithTransaction};
 use forge_secrets::credentials::{BmcCredentialType, CredentialKey, CredentialReader, Credentials};
@@ -45,12 +48,9 @@ use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use utils::periodic_timer::PeriodicTimer;
 
-use crate::cfg::file::{CarbideConfig, FirmwareGlobal};
 use crate::firmware_downloader::FirmwareDownloader;
 use crate::preingestion_manager::metrics::PreingestionMetrics;
 use crate::{CarbideError, CarbideResult};
-
-mod metrics;
 
 const NOT_FOUND: u16 = 404;
 
@@ -76,14 +76,10 @@ pub struct PreingestionManager {
 
 #[derive(Clone)]
 struct PreingestionManagerStatic {
-    run_interval: Duration,
-    firmware_global: FirmwareGlobal,
-    host_info: FirmwareConfig,
+    config: PreingestionManagerConfig,
     redfish_client_pool: Arc<dyn RedfishClientPool>,
     downloader: FirmwareDownloader,
     upload_limiter: Arc<Semaphore>,
-    concurrency_limit: usize,
-    hgx_bmc_gpu_reboot_delay: Duration,
     upgrade_script_state: Arc<UpdateScriptManager>,
     credential_reader: Option<Arc<dyn CredentialReader>>,
     work_lock_manager_handle: WorkLockManagerHandle,
@@ -101,7 +97,7 @@ impl PreingestionManager {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         database_connection: sqlx::PgPool,
-        config: Arc<CarbideConfig>,
+        config: PreingestionManagerConfig,
         redfish_client_pool: Arc<dyn RedfishClientPool>,
         meter: Meter,
         downloader: Option<FirmwareDownloader>,
@@ -111,40 +107,23 @@ impl PreingestionManager {
         endpoint_explorer: Arc<dyn EndpointExplorer>,
     ) -> PreingestionManager {
         let hold_period = config
-            .firmware_global
             .run_interval
-            .to_std()
-            .unwrap_or(std::time::Duration::from_secs(30))
             .saturating_add(std::time::Duration::from_secs(60));
 
         let metric_holder = Arc::new(metrics::MetricHolder::new(meter, hold_period));
 
         PreingestionManager {
             static_info: Arc::new(PreingestionManagerStatic {
-                run_interval: config
-                    .firmware_global
-                    .run_interval
-                    .to_std()
-                    .unwrap_or(Duration::from_secs(30)),
-                firmware_global: config.firmware_global.clone(),
-                host_info: config.get_firmware_config(),
                 redfish_client_pool,
                 downloader: downloader.unwrap_or_default(),
                 upload_limiter: upload_limiter.unwrap_or(Arc::new(Semaphore::new(5))),
-                concurrency_limit: config.firmware_global.concurrency_limit,
                 upgrade_script_state: Default::default(),
                 credential_reader,
-                hgx_bmc_gpu_reboot_delay: config
-                    .firmware_global
-                    .hgx_bmc_gpu_reboot_delay
-                    .to_std()
-                    .unwrap_or(Duration::from_secs(30)),
                 work_lock_manager_handle,
                 endpoint_explorer,
                 bfb_copy_state: Default::default(),
-                bfb_copy_limiter: Arc::new(Semaphore::new(
-                    config.firmware_global.max_concurrent_bfb_copies,
-                )),
+                bfb_copy_limiter: Arc::new(Semaphore::new(config.max_concurrent_bfb_copies)),
+                config,
             }),
             metric_holder,
             database_connection,
@@ -164,7 +143,7 @@ impl PreingestionManager {
     }
 
     async fn run(&self, cancel_token: CancellationToken) {
-        let timer = PeriodicTimer::new(self.static_info.run_interval);
+        let timer = PeriodicTimer::new(self.static_info.config.run_interval);
         loop {
             let tick = timer.tick();
             let res = self.run_single_iteration().await;
@@ -230,7 +209,7 @@ impl PreingestionManager {
         // Limit the number of concurrent preingestion tasks.
         // This does not affect how many endpoints are done in a single iteration, it just avoids opening
         // too many simultaneous postgres transactions, which can cause things to deadlock.
-        let limit_sem = Arc::new(Semaphore::new(self.static_info.concurrency_limit));
+        let limit_sem = Arc::new(Semaphore::new(self.static_info.config.concurrency_limit));
         let mut task_set = JoinSet::new();
 
         for endpoint in items.into_iter() {
@@ -477,7 +456,7 @@ impl PreingestionManagerStatic {
             }
         };
         let model = endpoint.report.model()?;
-        self.host_info.create_snapshot().find(vendor, &model)
+        self.config.firmware.create_snapshot().find(vendor, &model)
     }
 
     /// check_firmware_versions_below_preingestion will check if we actually need to do firmware upgrades before
@@ -567,7 +546,7 @@ impl PreingestionManagerStatic {
 
         // Determine if auto updates should be enabled.
         // We can't check machine IDs here as they may not be available yet, so use the global value only.
-        if !self.firmware_global.autoupdate {
+        if !self.config.autoupdate {
             tracing::debug!(
                 "start_firmware_uploads_or_continue {}: Auto updates disabled",
                 endpoint.address
@@ -1104,7 +1083,7 @@ impl PreingestionManagerStatic {
                 tracing::error!("Failed to power off {}: {e}", &endpoint.address);
                 return Ok(());
             }
-            tokio::time::sleep(self.hgx_bmc_gpu_reboot_delay).await;
+            tokio::time::sleep(self.config.hgx_bmc_gpu_reboot_delay).await;
             if let Err(e) = redfish_client.power(SystemPowerControl::On).await {
                 tracing::error!("Failed to power on {}: {e}", &endpoint.address);
                 return Ok(());
@@ -1164,7 +1143,7 @@ impl PreingestionManagerStatic {
             if let Some(current_version) = endpoint.find_version(&fw_info, *upgrade_type) {
                 if current_version != final_version {
                     // Still not reporting the new version.
-                    if !self.firmware_global.no_reset_retries
+                    if !self.config.no_reset_retries
                         && let Some(previous_reset_time) = previous_reset_time
                         && previous_reset_time + 30 * 60 <= Utc::now().timestamp()
                     {

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -1049,7 +1049,7 @@ pub async fn initialize_and_start_controllers(
 
     PreingestionManager::new(
         db_pool.clone(),
-        carbide_config.clone(),
+        carbide_config.preingestion_manager(),
         shared_redfish_pool.clone(),
         meter.clone(),
         Some(downloader.clone()),

--- a/crates/api/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api/src/tests/host_bmc_firmware_test.rs
@@ -67,7 +67,7 @@ async fn test_preingestion_bmc_upgrade(
 
     let mgr = PreingestionManager::new(
         pool.clone(),
-        env.config.clone(),
+        env.config.preingestion_manager(),
         env.redfish_sim.clone(),
         env.test_meter.meter(),
         None,
@@ -258,7 +258,7 @@ async fn test_preingestion_upgrade_script(
 
     let mgr = PreingestionManager::new(
         pool.clone(),
-        env.config.clone(),
+        env.config.preingestion_manager(),
         env.redfish_sim.clone(),
         env.test_meter.meter(),
         None,
@@ -959,7 +959,7 @@ async fn test_preingestion_preupdate_powercycling(
 
     let mgr = PreingestionManager::new(
         pool.clone(),
-        env.config.clone(),
+        env.config.preingestion_manager(),
         env.redfish_sim.clone(),
         env.test_meter.meter(),
         None,
@@ -2168,7 +2168,7 @@ async fn test_preingestion_time_sync_ok(
 
     let mgr = PreingestionManager::new(
         pool.clone(),
-        env.config.clone(),
+        env.config.preingestion_manager(),
         env.redfish_sim.clone(),
         env.test_meter.meter(),
         None,
@@ -2220,7 +2220,7 @@ async fn test_preingestion_time_sync_reset_flow(
 
     let mgr = PreingestionManager::new(
         pool.clone(),
-        env.config.clone(),
+        env.config.preingestion_manager(),
         env.redfish_sim.clone(),
         env.test_meter.meter(),
         None,
@@ -2345,7 +2345,7 @@ async fn test_preingestion_time_sync_check_error_fails(
 
     let mgr = PreingestionManager::new(
         pool.clone(),
-        env.config.clone(),
+        env.config.preingestion_manager(),
         env.redfish_sim.clone(),
         env.test_meter.meter(),
         None,
@@ -2402,7 +2402,7 @@ async fn test_preingestion_time_sync_retry_logic(
 
     let mgr = PreingestionManager::new(
         pool.clone(),
-        env.config.clone(),
+        env.config.preingestion_manager(),
         env.redfish_sim.clone(),
         env.test_meter.meter(),
         None,


### PR DESCRIPTION
## Description
Extract a dedicated `PreingestionManagerConfig` and update preingestion manager to depend on it instead of the full `CarbideConfig`.

This narrows the module boundary to only the configuration values preingestion manager actually consumes, while preserving existing defaults and behavior. It is a preparatory step toward moving preingestion manager out of `carbide-api` into a more isolated module/crate without depending directly on API-global config types.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
