### PR TITLE
refactor(preingestion-manager): introduce module-local error type

### DIFF
--- a/crates/api/src/preingestion_manager/errors.rs
+++ b/crates/api/src/preingestion_manager/errors.rs
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use db::DatabaseError;
+
+#[derive(thiserror::Error, Debug)]
+pub enum PreingestionManagerError {
+    #[error("Database error: {0}")]
+    DatabaseError(#[from] DatabaseError),
+    #[error("Error in libredfish: {0}")]
+    RedfishError(#[from] libredfish::RedfishError),
+    #[error("Argument is invalid: {0}")]
+    InvalidArgument(String),
+    #[error("Internal error: {message}")]
+    Internal { message: String },
+}
+
+impl PreingestionManagerError {
+    /// Creates a `Internal` error with the given error message
+    pub fn internal(message: String) -> Self {
+        Self::Internal { message }
+    }
+}
+
+pub type PreingestionManagerResult<T> = Result<T, PreingestionManagerError>;

--- a/crates/api/src/preingestion_manager/mod.rs
+++ b/crates/api/src/preingestion_manager/mod.rs
@@ -16,6 +16,7 @@
  */
 
 mod config;
+mod errors;
 mod metrics;
 
 use std::collections::HashMap;
@@ -49,8 +50,8 @@ use tokio_util::sync::CancellationToken;
 use utils::periodic_timer::PeriodicTimer;
 
 use crate::firmware_downloader::FirmwareDownloader;
+use crate::preingestion_manager::errors::{PreingestionManagerError, PreingestionManagerResult};
 use crate::preingestion_manager::metrics::PreingestionMetrics;
-use crate::{CarbideError, CarbideResult};
 
 const NOT_FOUND: u16 = 404;
 
@@ -166,7 +167,7 @@ impl PreingestionManager {
 
     /// run_single_iteration runs a single iteration of the state machine across all explored endpoints in the preingestion state.
     /// Returns true if we stopped early due to a timeout.
-    pub async fn run_single_iteration(&self) -> CarbideResult<()> {
+    pub async fn run_single_iteration(&self) -> PreingestionManagerResult<()> {
         let mut metrics = PreingestionMetrics::new();
         let db = self.database_connection.clone();
 
@@ -271,7 +272,7 @@ async fn one_endpoint(
     db: &PgPool,
     endpoint: &ExploredEndpoint,
     static_info: Arc<PreingestionManagerStatic>,
-) -> CarbideResult<EndpointResult> {
+) -> PreingestionManagerResult<EndpointResult> {
     tracing::debug!("Preingestion on endpoint {:?}", endpoint);
 
     // Main state machine match.
@@ -296,7 +297,7 @@ async fn one_endpoint(
                         .await?
                 }
                 Err(e) => {
-                    if let CarbideError::Internal { message } = e {
+                    if let PreingestionManagerError::Internal { message } = e {
                         tracing::error!(
                             "{} internal error checking BMC time sync: {message}, failing preingestion",
                             endpoint.address
@@ -465,7 +466,7 @@ impl PreingestionManagerStatic {
         &self,
         db: &PgPool,
         endpoint: &ExploredEndpoint,
-    ) -> CarbideResult<bool> {
+    ) -> PreingestionManagerResult<bool> {
         // First, we need to check if it's appropriate to upgrade at this point or wait until later.
         let fw_info = match self.find_fw_info_for_host(endpoint) {
             None => {
@@ -534,7 +535,7 @@ impl PreingestionManagerStatic {
         db: &PgPool,
         endpoint: &ExploredEndpoint,
         repeat: bool,
-    ) -> CarbideResult<bool> {
+    ) -> PreingestionManagerResult<bool> {
         if endpoint.waiting_for_explorer_refresh {
             tracing::debug!(
                 "start_firmware_uploads_or_continue {}: Waiting for explorer refresh",
@@ -670,7 +671,7 @@ impl PreingestionManagerStatic {
         &self,
         db: &PgPool,
         args: &InUpgradeFirmwareWaitArgs<'_>,
-    ) -> CarbideResult<()> {
+    ) -> PreingestionManagerResult<()> {
         let (endpoint, task_id, final_version, upgrade_type, power_drains_needed, firmware_number) = (
             args.endpoint,
             args.task_id,
@@ -685,8 +686,10 @@ impl PreingestionManagerStatic {
             .create_client_for_ingested_host(endpoint.address, None, db)
             .await
             .map_err(|e| match e {
-                RedfishClientCreationError::RedfishError(e) => CarbideError::RedfishError(e),
-                _ => CarbideError::internal(format!("{e}")),
+                RedfishClientCreationError::RedfishError(e) => {
+                    PreingestionManagerError::RedfishError(e)
+                }
+                _ => PreingestionManagerError::internal(format!("{e}")),
             }) {
             Ok(redfish_client) => redfish_client,
             Err(e) => {
@@ -865,7 +868,7 @@ impl PreingestionManagerStatic {
         db: &PgPool,
         endpoint: &ExploredEndpoint,
         state: &PreingestionState,
-    ) -> CarbideResult<()> {
+    ) -> PreingestionManagerResult<()> {
         let (
             final_version,
             upgrade_type,
@@ -887,7 +890,7 @@ impl PreingestionManagerStatic {
                 last_power_drain_operation,
             ),
             _ => {
-                return Err(CarbideError::InvalidArgument(
+                return Err(PreingestionManagerError::InvalidArgument(
                     "Wrong enum in_reset_for_new_firmware".to_string(),
                 ));
             }
@@ -898,8 +901,10 @@ impl PreingestionManagerStatic {
             .create_client_for_ingested_host(endpoint.address, None, db)
             .await
             .map_err(|e| match e {
-                RedfishClientCreationError::RedfishError(e) => CarbideError::RedfishError(e),
-                _ => CarbideError::internal(format!("{e}")),
+                RedfishClientCreationError::RedfishError(e) => {
+                    PreingestionManagerError::RedfishError(e)
+                }
+                _ => PreingestionManagerError::internal(format!("{e}")),
             }) {
             Ok(redfish_client) => redfish_client,
             Err(e) => {
@@ -1138,7 +1143,7 @@ impl PreingestionManagerStatic {
         final_version: &str,
         upgrade_type: &FirmwareComponentType,
         previous_reset_time: &Option<i64>,
-    ) -> CarbideResult<()> {
+    ) -> PreingestionManagerResult<()> {
         if let Some(fw_info) = self.find_fw_info_for_host(endpoint) {
             if let Some(current_version) = endpoint.find_version(&fw_info, *upgrade_type) {
                 if current_version != final_version {
@@ -1397,7 +1402,7 @@ impl PreingestionManagerStatic {
         endpoint: &ExploredEndpoint,
         phase: &TimeSyncResetPhase,
         last_time: Option<&DateTime<Utc>>,
-    ) -> CarbideResult<bool> {
+    ) -> PreingestionManagerResult<bool> {
         let redfish_client = match self
             .redfish_client_pool
             .create_client_for_ingested_host(endpoint.address, None, db)
@@ -1414,7 +1419,7 @@ impl PreingestionManagerStatic {
             TimeSyncResetPhase::Start => {
                 if let Err(e) = redfish_client.set_utc_timezone().await {
                     tracing::error!("Could not set UTC timezone on {}: {e}", endpoint.address);
-                    return Err(CarbideError::RedfishError(e));
+                    return Err(PreingestionManagerError::RedfishError(e));
                 }
                 if !self
                     .execute_power_off_and_bmc_reset(redfish_client.as_ref(), endpoint)
@@ -1494,7 +1499,7 @@ impl PreingestionManagerStatic {
                         Ok(false)
                     }
                     Err(e) => {
-                        if let CarbideError::Internal { message } = e {
+                        if let PreingestionManagerError::Internal { message } = e {
                             // Error checking time sync after reset, fail now
                             tracing::error!(
                                 "{} internal error checking BMC time sync after reset: {message}, failing preingestion",
@@ -1677,15 +1682,17 @@ impl PreingestionManagerStatic {
         &self,
         db: &PgPool,
         endpoint: &ExploredEndpoint,
-    ) -> CarbideResult<bool> {
+    ) -> PreingestionManagerResult<bool> {
         tracing::debug!("Checking BMC time sync for {:?}", endpoint);
         let redfish_client = match self
             .redfish_client_pool
             .create_client_for_ingested_host(endpoint.address, None, db)
             .await
             .map_err(|e| match e {
-                RedfishClientCreationError::RedfishError(e) => CarbideError::RedfishError(e),
-                _ => CarbideError::internal(format!("{e}")),
+                RedfishClientCreationError::RedfishError(e) => {
+                    PreingestionManagerError::RedfishError(e)
+                }
+                _ => PreingestionManagerError::internal(format!("{e}")),
             }) {
             Ok(redfish_client) => redfish_client,
             Err(e) => {
@@ -1697,12 +1704,14 @@ impl PreingestionManagerStatic {
         let bmc_time = match redfish_client
             .get_manager()
             .await
-            .map_err(CarbideError::RedfishError)?
+            .map_err(PreingestionManagerError::RedfishError)?
             .date_time
         {
             Some(time) => time,
             None => {
-                return Err(CarbideError::internal("Failed to get BMC time".to_string()));
+                return Err(PreingestionManagerError::internal(
+                    "Failed to get BMC time".to_string(),
+                ));
             }
         };
 


### PR DESCRIPTION
## Description
Add `PreingestionManagerError` and `PreingestionManagerResult` to decouple preingestion manager from `carbide-api` global `CarbideError` / `CarbideResult`.

This keeps the module’s error surface local and explicit, maps database and Redfish errors directly, and leaves room for further extraction of preingestion manager into its own crate without depending on API-wide error types.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
