### PR TITLE
fix: Guard ACPowercycle against unexpected chassis power-on

### DIFF
--- a/crates/api/src/preingestion_manager/mod.rs
+++ b/crates/api/src/preingestion_manager/mod.rs
@@ -967,6 +967,47 @@ impl PreingestionManagerStatic {
                 Some(PowerDrainState::Off) => {
                     if endpoint.report.vendor.unwrap_or_default().is_lenovo() {
                         tracing::info!("Doing powercycle now for {}", &endpoint.address);
+                        match redfish_client.get_power_state().await {
+                            Ok(power_state) if power_state != PowerState::Off => {
+                                tracing::warn!(
+                                    address = %endpoint.address,
+                                    %power_state,
+                                    "ACPowercycle requires chassis to be Off, forcing off first"
+                                );
+                                if let Err(e) =
+                                    redfish_client.power(SystemPowerControl::ForceOff).await
+                                {
+                                    tracing::error!(
+                                        "Failed to force off {}: {e}",
+                                        &endpoint.address
+                                    );
+                                    return Ok(());
+                                }
+                                let delay = time::Duration::seconds(60);
+                                db.with_txn(|txn| {
+                                    db::explored_endpoints::set_preingestion_reset_for_new_firmware(
+                                        endpoint.address,
+                                        final_version,
+                                        upgrade_type,
+                                        Some(*power_drains_needed),
+                                        Some(delay),
+                                        Some(PowerDrainState::Off),
+                                        txn,
+                                    )
+                                    .boxed()
+                                })
+                                .await??;
+                                return Ok(());
+                            }
+                            Ok(_) => {}
+                            Err(e) => {
+                                tracing::error!(
+                                    "Failed to get power state for {}: {e}",
+                                    &endpoint.address
+                                );
+                                return Ok(());
+                            }
+                        }
                         if let Err(e) = redfish_client.power(SystemPowerControl::ACPowercycle).await
                         {
                             tracing::error!("Failed to power cycle {}: {e}", &endpoint.address);

--- a/crates/api/src/preingestion_manager/mod.rs
+++ b/crates/api/src/preingestion_manager/mod.rs
@@ -983,7 +983,11 @@ impl PreingestionManagerStatic {
                                     );
                                     return Ok(());
                                 }
-                                let delay = time::Duration::seconds(60);
+                                let delay = if *power_drains_needed < 1000 {
+                                    time::Duration::seconds(60)
+                                } else {
+                                    time::Duration::seconds(0)
+                                };
                                 db.with_txn(|txn| {
                                     db::explored_endpoints::set_preingestion_reset_for_new_firmware(
                                         endpoint.address,

--- a/crates/api/src/redfish.rs
+++ b/crates/api/src/redfish.rs
@@ -100,6 +100,27 @@ pub async fn host_power_control_with_location(
                     .map_err(CarbideError::RedfishError)?
             }
         }
+    } else if action == SystemPowerControl::ACPowercycle {
+        let power_state = redfish_client
+            .get_power_state()
+            .await
+            .map_err(CarbideError::RedfishError)?;
+        if power_state != PowerState::Off {
+            tracing::warn!(
+                machine_id = machine.id.to_string(),
+                %power_state,
+                "ACPowercycle requires chassis to be Off, forcing off first"
+            );
+            redfish_client
+                .power(SystemPowerControl::ForceOff)
+                .await
+                .map_err(CarbideError::RedfishError)?;
+            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        }
+        redfish_client
+            .power(action)
+            .await
+            .map_err(CarbideError::RedfishError)?
     } else {
         redfish_client
             .power(action)


### PR DESCRIPTION
 

## Description
- **Fixes #1072**: `ResetForNewFirmware` power drain gets stuck in an infinite retry loop when the chassis is unexpectedly powered on between `ForceOff` and `ACPowercycle`.
- In `host_power_control_with_location` (`redfish.rs`): before issuing `ACPowercycle`, verify the actual chassis power state via Redfish. If the chassis is not off, re-issue `ForceOff` and wait 10 seconds before retrying `ACPowercycle`.
- In `preingestion_manager`: apply the same guard — check power state before `ACPowercycle`, and if the chassis is on, issue `ForceOff` and re-enter the `Off` state with a 60-second delay instead of advancing to `Powercycle`.


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

