### PR TITLE
feat: Init container for DPU-Agent for running hardware enumeration.

### DIFF
--- a/bluefield/charts/carbide-dpu-agent/templates/daemonset.yaml
+++ b/bluefield/charts/carbide-dpu-agent/templates/daemonset.yaml
@@ -44,6 +44,35 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: forge-dpu-agent-init
+          securityContext:
+            privileged: true
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          args:
+            - hardware
+            - "--agent-platform-type=init-container"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: RUST_BACKTRACE
+              value: "full"
+            - name: RUST_LIB_BACKTRACE
+              value: "0"
+            - name: RUST_LOG
+              value: "info"
+          volumeMounts:
+            - name: hw-cache
+              mountPath: /data
+            - name: sys
+              mountPath: /sys
+            - name: dev
+              mountPath: /dev
+            - name: run-udev
+              mountPath: /run/udev
+            - name: proc-cpu-info
+              mountPath: /host-cpu-info
+            - name: proc-mem-info
+              mountPath: /host-mem-info
       containers:
         - name: forge-dpu-agent
           securityContext:
@@ -53,7 +82,6 @@ spec:
             - run
             - "--hbn-config-mode=nvue-rest"
             - "--agent-platform-type=containerized"
-            - "--discovery-info-file={{ .Values.discovery.hardware_file }}"
             {{- if not (empty .Values.dhcp_server.interface_prepend) }}
             - "--dhcp-server-interface-prepend={{ .Values.dhcp_server.interface_prepend }}"
             {{ end }}
@@ -103,11 +131,31 @@ spec:
           volumeMounts:
             - name: forge-certs
               mountPath: /opt/forge
+            - name: hw-cache
+              mountPath: /data
+              readOnly: true
       volumes:
         - name: forge-certs
           hostPath:
             path: /opt/forge
             type: DirectoryOrCreate
+        - name: hw-cache
+          emptyDir: {}
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: dev
+          hostPath:
+            path: /dev
+        - name: run-udev
+          hostPath:
+            path: /run/udev
+        - name: proc-cpu-info
+          hostPath:
+            path: /proc/cpuinfo
+        - name: proc-mem-info
+          hostPath:
+            path: /proc/meminfo
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/bluefield/charts/carbide-dpu-agent/values.yaml
+++ b/bluefield/charts/carbide-dpu-agent/values.yaml
@@ -31,8 +31,6 @@ hbn:
   nvue_credentials_secret_name: ""
   nvue_username_key: "username"
   nvue_password_key: "password"
-discovery:
-  hardware_file: "/etc/carbide/discovery_info.json"
 dhcp_server:
   # If interface_prepend is set to a non-empty string, it will
   # be turned into a --dhcp-server-interface-prepend argument.

--- a/crates/agent/src/command_line.rs
+++ b/crates/agent/src/command_line.rs
@@ -320,16 +320,10 @@ pub struct RunOptions {
     #[clap(
         long,
         default_value = "dpu-os",
-        help = "Set the platform type. Specify \"dpu-os\" or \"containerized\".",
+        help = "Set the platform type. Specify \"dpu-os\", \"containerized\", or \"init-container\".",
         env = "AGENT_PLATFORM_TYPE"
     )]
     pub agent_platform_type: AgentPlatformType,
-    #[clap(
-        help = "Load discovery info from the specified file, rather than trying to probe hardware ourselves. This should be a JSON-serialized DiscoveryInfo message.",
-        env = "DISCOVERY_INFO_FILE"
-    )]
-    pub discovery_info_file: Option<PathBuf>,
-
     #[clap(
         long,
         help = "Prepend this string to interface names before sending them to the DHCP server",
@@ -395,7 +389,7 @@ impl FromStr for AgentPlatformType {
         match s {
             "dpu-os" => Ok(DpuOs),
             "containerized" => Ok(Containerized),
-            "init" => Ok(ContainerInitializer),
+            "init-container" => Ok(ContainerInitializer),
             unknown_type => Err(eyre::eyre!("Unknown platform type \"{unknown_type}\"")),
         }
     }
@@ -411,7 +405,7 @@ pub struct HardwareOptions {
     #[clap(
         long,
         default_value = "dpu-os",
-        help = "Set the platform type. Specify \"dpu-os\", \"containerized\", or \"init\".",
+        help = "Set the platform type. Specify \"dpu-os\", \"containerized\", or \"init-container\".",
         env = "AGENT_PLATFORM_TYPE"
     )]
     pub agent_platform_type: AgentPlatformType,
@@ -472,7 +466,7 @@ mod tests {
             AgentPlatformType::Containerized
         ));
         assert!(matches!(
-            "init".parse::<AgentPlatformType>().unwrap(),
+            "init-container".parse::<AgentPlatformType>().unwrap(),
             AgentPlatformType::ContainerInitializer
         ));
     }

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -1,4 +1,3 @@
-use std::path::Path;
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
@@ -24,7 +23,7 @@ use ::rpc::forge_tls_client::ForgeClientConfig;
 use ::rpc::machine_discovery::DpuData;
 use carbide_host_support::agent_config::AgentConfig;
 use carbide_host_support::hardware_enumeration::{
-    HW_CACHE_PATH, enumerate_and_save_hardware, enumerate_hardware, load_hardware_from_cache,
+    enumerate_and_save_hardware, enumerate_hardware, load_hardware_from_cache,
 };
 use carbide_host_support::registration::register_machine;
 pub use command_line::{AgentCommand, AgentPlatformType, Options, RunOptions, WriteTarget};
@@ -130,25 +129,12 @@ pub async fn start(cmdline: command_line::Options) -> eyre::Result<()> {
                 tracing::warn!("Upgrades disabled. Dev only");
             }
 
-            // For Containerized mode, fall back to the hardware cache written by the init
-            // container if no explicit discovery file was provided.
-            let hw_cache_path = Path::new(HW_CACHE_PATH);
-            let discovery_info_file = match &options.agent_platform_type {
-                AgentPlatformType::Containerized => Some(
-                    options
-                        .discovery_info_file
-                        .as_deref()
-                        .unwrap_or(hw_cache_path),
-                ),
-                _ => options.discovery_info_file.as_deref(),
-            };
-
             let Registration {
                 machine_id,
                 factory_mac_address,
             } = match options.override_machine_id {
                 // Normal case
-                None => register(&agent, discovery_info_file)
+                None => register(&agent, &options.agent_platform_type)
                     .await
                     .wrap_err("registration error")?,
                 // Dev / test override
@@ -213,7 +199,7 @@ pub async fn start(cmdline: command_line::Options) -> eyre::Result<()> {
         // One-off network monitor check.
         // dumps JSON-formatted peer DPU network reachability and latency status
         Some(AgentCommand::Network(options)) => {
-            let machine_id = register(&agent, None)
+            let machine_id = register(&agent, &AgentPlatformType::DpuOs)
                 .await
                 .wrap_err("network check machine registration error")?
                 .machine_id;
@@ -252,7 +238,7 @@ pub async fn start(cmdline: command_line::Options) -> eyre::Result<()> {
             // host_machine_id files, we need to make a registration call to
             // get the machine_id, and a carbide api request to get the
             // host_machine_id.
-            let Registration { machine_id, .. } = register(&agent, None)
+            let Registration { machine_id, .. } = register(&agent, &AgentPlatformType::DpuOs)
                 .await
                 .wrap_err("registration error")?;
 
@@ -468,15 +454,15 @@ impl HBNDeviceNames {
 }
 
 /// Discover hardware, register DPU with carbide-api, and return machine id.
-/// If discovery_info_file is set, we'll load the rpc::DiscoveryInfo message
-/// from that instead of trying to probe hardware ourselves.
 async fn register(
     agent: &AgentConfig,
-    discovery_info_file: Option<&Path>,
+    platform_type: &AgentPlatformType,
 ) -> Result<Registration, eyre::Report> {
-    let mut hardware_info = match discovery_info_file {
-        Some(discovery_info_file) => load_discovery_info_file(discovery_info_file).await,
-        None => enumerate_hardware().wrap_err("enumerate_hardware failed"),
+    let mut hardware_info = match platform_type {
+        AgentPlatformType::Containerized => {
+            load_hardware_from_cache().wrap_err("load_hardware_from_cache failed")
+        }
+        _ => enumerate_hardware().wrap_err("enumerate_hardware failed"),
     }?;
 
     // Pretend to be a bluefield DPU for local dev.
@@ -519,12 +505,6 @@ async fn register(
         machine_id,
         factory_mac_address,
     })
-}
-
-async fn load_discovery_info_file(discovery_info_file: &Path) -> eyre::Result<DiscoveryInfo> {
-    let contents = tokio::fs::read_to_string(discovery_info_file).await?;
-    let discovery_info = serde_json::from_str(&contents)?;
-    Ok(discovery_info)
 }
 
 pub fn pretty_cmd(c: &Command) -> String {

--- a/crates/agent/src/tests/common/mod.rs
+++ b/crates/agent/src/tests/common/mod.rs
@@ -117,7 +117,6 @@ pub fn setup_agent_run_env(
             fmds_grpc_server: None,
             hbn_config_mode: crate::command_line::HbnConfigMode::ContainerExec,
             agent_platform_type: crate::command_line::AgentPlatformType::DpuOs,
-            discovery_info_file: None,
             dhcp_server_interface_prepend: None,
         }))),
     };

--- a/crates/host-support/src/hardware_enumeration.rs
+++ b/crates/host-support/src/hardware_enumeration.rs
@@ -374,11 +374,12 @@ fn get_cpu_info(
 }
 
 pub fn enumerate_hardware() -> Result<rpc_discovery::DiscoveryInfo, HardwareEnumerationError> {
-    enumerate_hardware_inner("/proc/cpuinfo")
+    enumerate_hardware_inner("/proc/cpuinfo", "/proc/meminfo")
 }
 
 fn enumerate_hardware_inner(
     cpu_info_path: &str,
+    mem_info_path: &str,
 ) -> Result<rpc_discovery::DiscoveryInfo, HardwareEnumerationError> {
     let context = libudev::Context::new()?;
 
@@ -810,23 +811,13 @@ fn enumerate_hardware_inner(
             }
         }
         Err(err) => {
-            warn!("Could not discover host memory using smbios device, using /proc/meminfo: {err}");
-            let mut mem = 0u32;
-            let meminfo = std::fs::read_to_string("/proc/meminfo").map_err(|e| {
-                HardwareEnumerationError::GenericError(format!("Err reading /proc/meminfo: {e}"))
+            warn!(
+                "Could not discover host memory using smbios device, using {mem_info_path}: {err}"
+            );
+            let meminfo = std::fs::read_to_string(mem_info_path).map_err(|e| {
+                HardwareEnumerationError::GenericError(format!("Err reading {mem_info_path}: {e}"))
             })?;
-            for line in meminfo.lines() {
-                // line is "MemTotal:       32572708 kB"
-                if line.starts_with("MemTotal:") {
-                    mem = line
-                        .split_ascii_whitespace()
-                        .nth(1)
-                        .unwrap_or("0")
-                        .parse()
-                        .unwrap_or_default();
-                    break;
-                }
-            }
+            let mem = parse_memtotal_kb(&meminfo);
 
             memory_devices.push(MemoryDevice {
                 size_mb: Some(mem / 1024),
@@ -873,6 +864,9 @@ fn enumerate_hardware_inner(
 /// Path where the host's `/proc/cpuinfo` is bind-mounted inside the init container.
 const INIT_CPU_INFO_PATH: &str = "/host-cpu-info";
 
+/// Path where the host's `/proc/meminfo` is bind-mounted inside the init container.
+const INIT_MEM_INFO_PATH: &str = "/host-mem-info";
+
 /// Enumerate hardware and save the result as JSON to [`HW_CACHE_PATH`].
 ///
 /// Used by the init container to snapshot host hardware info so the containerized agent can
@@ -882,7 +876,7 @@ const INIT_CPU_INFO_PATH: &str = "/host-cpu-info";
 /// bind-mounts the host's `/proc/cpuinfo`.
 pub fn enumerate_and_save_hardware()
 -> Result<rpc_discovery::DiscoveryInfo, HardwareEnumerationError> {
-    let info = enumerate_hardware_inner(INIT_CPU_INFO_PATH)?;
+    let info = enumerate_hardware_inner(INIT_CPU_INFO_PATH, INIT_MEM_INFO_PATH)?;
     save_hardware_to(&info, HW_CACHE_PATH)?;
     Ok(info)
 }
@@ -921,6 +915,23 @@ fn load_hardware_from(
             "Failed to parse hardware cache from {path}: {e}"
         ))
     })
+}
+
+/// Parse `MemTotal` from `/proc/meminfo` content, returning the value in kB.
+/// Returns 0 if the line is absent or unparseable.
+fn parse_memtotal_kb(meminfo: &str) -> u32 {
+    for line in meminfo.lines() {
+        // line format: "MemTotal:       32572708 kB"
+        if line.starts_with("MemTotal:") {
+            return line
+                .split_ascii_whitespace()
+                .nth(1)
+                .unwrap_or("0")
+                .parse()
+                .unwrap_or_default();
+        }
+    }
+    0
 }
 
 #[cfg(test)]
@@ -992,5 +1003,66 @@ mod tests {
         assert_eq!(loaded.block_devices.len(), 1);
         assert_eq!(loaded.block_devices[0].model, "test-disk");
         assert_eq!(loaded.block_devices[0].serial, "SN123");
+    }
+
+    #[test]
+    fn test_init_container_paths_match_daemonset_mounts() {
+        assert_eq!(INIT_CPU_INFO_PATH, "/host-cpu-info");
+        assert_eq!(INIT_MEM_INFO_PATH, "/host-mem-info");
+        assert_eq!(HW_CACHE_PATH, "/data/hw_output.json");
+    }
+
+    #[test]
+    fn test_parse_memtotal_kb_typical() {
+        let meminfo = "MemTotal:       32572708 kB\nMemFree:        16000000 kB\n";
+        assert_eq!(parse_memtotal_kb(meminfo), 32572708);
+    }
+
+    #[test]
+    fn test_parse_memtotal_kb_missing_returns_zero() {
+        let meminfo = "MemFree:        16000000 kB\nSwapTotal:      0 kB\n";
+        assert_eq!(parse_memtotal_kb(meminfo), 0);
+    }
+
+    #[test]
+    fn test_parse_memtotal_kb_empty_returns_zero() {
+        assert_eq!(parse_memtotal_kb(""), 0);
+    }
+
+    #[test]
+    fn test_parse_memtotal_kb_malformed_value_returns_zero() {
+        let meminfo = "MemTotal:       not_a_number kB\n";
+        assert_eq!(parse_memtotal_kb(meminfo), 0);
+    }
+
+    #[test]
+    fn test_parse_memtotal_kb_realistic_meminfo() {
+        let meminfo = "\
+HugePages_Total: 0
+MemTotal:        8192000 kB
+MemFree:         4096000 kB
+Buffers:          512000 kB
+";
+        assert_eq!(parse_memtotal_kb(meminfo), 8192000);
+    }
+
+    #[test]
+    fn test_enumerate_and_save_writes_readable_cache() {
+        use std::fs;
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let cache_path = tmp_dir.path().join("hw_output.json");
+        let cache_path_str = cache_path.to_str().unwrap();
+
+        let info = minimal_discovery_info();
+        save_hardware_to(&info, cache_path_str).unwrap();
+
+        let loaded = load_hardware_from(cache_path_str).unwrap();
+        assert_eq!(loaded.machine_type, info.machine_type);
+
+        let raw = fs::read_to_string(cache_path_str).unwrap();
+        assert!(
+            raw.contains("machine_type"),
+            "cache should be JSON with known field"
+        );
     }
 }


### PR DESCRIPTION
## Description
Addition of init-container into dpu-agent. init-container is needed so that dpu-agent can run hardware enumeration from the main container, without making it privileged. Also, the changes to mount /proc/meminfo for reading the host memory info as a backup if smbios fails.

Few more code cleanup, and rename.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

PS: Testing is done by running the container via docker. Helm based testing is pending.

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

