### PR TITLE
chore(machine-a-tron): remove unused config fields

### DIFF
--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -870,7 +870,6 @@ where
                 hw_type,
                 host_count,
                 dpu_per_host_count,
-                boot_delay: 1,
                 dpu_reboot_delay: 1,
                 host_reboot_delay: 1,
                 template_dir: test_env
@@ -899,11 +898,8 @@ where
         pxe_server_host: None,
         pxe_server_port: None,
         bmc_mock_port: 0, // unused, we're using dynamic ports on localhost
-        dhcp_server_address: None,
         interface: String::from("UNUSED"), // unused, we're using dynamic ports on localhost
         tui_enabled: false,
-        sudo_command: None,
-        use_dhcp_api: true,
         use_single_bmc_mock: false, // unused, we're constructing machines ourselves
         configure_carbide_bmc_proxy_host: None,
         persist_dir: None,

--- a/crates/machine-a-tron/config/mac.toml
+++ b/crates/machine-a-tron/config/mac.toml
@@ -43,12 +43,6 @@ interface = "lo0"
 
 # interface = "cni0"
 
-# Set this to false if you want machine-a-tron to make real DHCP requests over
-# UDP to the configured DHCP relays. If set to true, it will use the carbide API
-# to simulate DHCP requests.
-#
-# use_dhcp_api = true
-
 # Set use_pxe_api to true if you want to avoid running a PXE server and instead
 # have machine-a-tron use the carbide API to simulate PXE requests.
 # pxe_server_host and pxe_server_port can be omitted if use_pxe_api=true.
@@ -71,19 +65,12 @@ pxe_server_port = "8080"
 #
 bmc_mock_port = 2000
 
-# Set this to "sudo" or "doas" if you're not running this as root. This allows
-# the DHCP mocks to bind to interfaces in the assigned IP range. Must be
-# configured to run without a password.
-#
-# sudo_command = "/usr/bin/sudo" # default: not set, will require root
-
 [machines.config]
 host_count = 3
 vpc_count = 3
 # vpc_count = 10
 dpu_per_host_count = 1
 subnets_per_vpc = 2
-boot_delay = 10
 dpu_reboot_delay = 10  # in units of seconds
 host_reboot_delay = 10 # in units of seconds
 

--- a/crates/machine-a-tron/config/mat.toml
+++ b/crates/machine-a-tron/config/mat.toml
@@ -36,12 +36,6 @@ log_file = "/tmp/mat.log"
 # assign new addresses to this interface via `ip address add`.
 interface = "cni0"
 
-# Set this to false if you want machine-a-tron to make real DHCP requests over
-# UDP to the configured DHCP relays. If set to true, it will use the carbide API
-# to simulate DHCP requests.
-#
-# use_dhcp_api = true
-
 # Set use_pxe_api to true if you want to avoid running a PXE server and instead
 # have machine-a-tron use the carbide API to simulate PXE requests.
 # pxe_server_host and pxe_server_port can be omitted if use_pxe_api=true.
@@ -64,18 +58,11 @@ pxe_server_port = "8080"
 #
 bmc_mock_port = 2000
 
-# Set this to "sudo" or "doas" if you're not running this as root. This allows
-# the DHCP mocks to bind to interfaces in the assigned IP range. Must be
-# configured to run without a password.
-#
-# sudo_command = "/usr/bin/sudo" # default: not set, will require root
-
 [machines.config]
 host_count = 3
 vpc_count = 10
 dpu_per_host_count = 1
 subnets_per_vpc = 2
-boot_delay = 10
 dpu_reboot_delay = 20  # in units of seconds
 host_reboot_delay = 20 # in units of seconds
 

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -73,7 +73,6 @@ pub struct MachineConfig {
     pub vpc_count: u32,
     pub subnets_per_vpc: u32,
     pub dpu_per_host_count: u32,
-    pub boot_delay: u32,
     pub dpu_reboot_delay: u64,  // in units of seconds
     pub host_reboot_delay: u64, // in units of seconds
     #[serde(
@@ -189,9 +188,6 @@ pub struct MachineATronConfig {
     #[serde(default = "default_true")]
     pub tui_enabled: bool,
 
-    #[serde(default = "default_true")]
-    pub use_dhcp_api: bool,
-    pub dhcp_server_address: Option<String>,
     #[serde(default = "default_bmc_mock_port")]
     pub bmc_mock_port: u16,
 
@@ -217,7 +213,6 @@ pub struct MachineATronConfig {
     pub use_pxe_api: bool,
     pub pxe_server_host: Option<String>,
     pub pxe_server_port: Option<String>,
-    pub sudo_command: Option<String>,
     /// Set this to a hostname or IP If you want machine-a-tron to register its BMC-mock as the bmc_proxy host (this will be combined with bmc_mock_port.)
     pub configure_carbide_bmc_proxy_host: Option<String>,
 
@@ -472,8 +467,6 @@ carbide_api_url = "https://carbide-api.forge:443"
 log_file = "mat.log"
 interface = "br-77cbb29de011"
 tui_enabled = true
-use_dhcp_api = true
-dhcp_server_address = "192.168.176.5"
 pxe_server_host = "192.168.176.7"
 pxe_server_port = "8080"
 bmc_mock_port = 1266
@@ -485,7 +478,6 @@ configure_carbide_bmc_proxy_host = "192.168.1.20"
 [machines.config]
 host_count = 10
 dpu_per_host_count = 2
-boot_delay = 1
 dpu_reboot_delay = 1 # in units of seconds
 host_reboot_delay = 1 # in units of seconds
 vpc_count = 0

--- a/dev/deployment/devspace/machine-a-tron.yaml
+++ b/dev/deployment/devspace/machine-a-tron.yaml
@@ -12,7 +12,6 @@ data:
     carbide_api_url = "https://carbide-api.forge-system.svc.cluster.local:1079"
     interface = "NOTUSED"
     tui_enabled = false
-    use_dhcp_api = true
     use_pxe_api = true
     bmc_mock_host_tar = "/opt/machine-a-tron/dell_poweredge_r750.tar.gz"
     bmc_mock_dpu_tar = "/opt/machine-a-tron/nvidia_dpu.tar.gz"
@@ -26,7 +25,6 @@ data:
     [machines.config]
     host_count = 10
     dpu_per_host_count = 2
-    boot_delay = 10
     dpu_reboot_delay = 1 # in units of seconds
     host_reboot_delay = 1 # in units of seconds
     vpc_count = 0

--- a/dev/docker-env/mat.toml
+++ b/dev/docker-env/mat.toml
@@ -36,12 +36,6 @@ log_file = "/tmp/mat.log"
 # assign new addresses to this interface via `ip address add`.
 interface = "carbide0"
 
-# Set this to false if you want machine-a-tron to make real DHCP requests over
-# UDP to the configured DHCP relays. If set to true, it will use the carbide API
-# to simulate DHCP requests.
-#
-# use_dhcp_api = true
-
 # Set use_pxe_api to true if you want to avoid running a PXE server and instead
 # have machine-a-tron use the carbide API to simulate PXE requests.
 # pxe_server_host and pxe_server_port can be omitted if use_pxe_api=true.
@@ -64,17 +58,10 @@ pxe_server_port = "1083"
 #
 # bmc_mock_port = 2000
 
-# Set this to "sudo" or "doas" if you're not running this as root. This allows
-# the DHCP mocks to bind to interfaces in the assigned IP range. Must be
-# configured to run without a password.
-#
-sudo_command = "/usr/bin/sudo" # default: not set, will require root
-
 [machines.config]
 host_count = 1
 vpc_count = 2
 dpu_per_host_count = 1
-boot_delay = 10
 dpu_reboot_delay = 20  # in units of seconds
 host_reboot_delay = 20 # in units of seconds
 subnets_per_vpc = 2


### PR DESCRIPTION
## Description

Remove four config fields from `machine-a-tron` that are declared but never read at runtime:

- `MachineConfig.boot_delay`
- `MachineATronConfig.use_dhcp_api`
- `MachineATronConfig.dhcp_server_address`
- `MachineATronConfig.sudo_command`.  Actual sudo resolution is done via `find_sudo_command()` in `machine_utils.rs`, which searches `PATH` and ignores this field.

## Motivation

Dead config fields are a hallucination trap for AI coding assistants. I hit this myself with `use_dhcp_api`, where the assistant confidently wired logic around a field that does nothing.
 

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

