### PR TITLE
chore(devspace): use nv-redfish explore mode

### DIFF
--- a/dev/deployment/devspace/values.base.yaml
+++ b/dev/deployment/devspace/values.base.yaml
@@ -94,6 +94,7 @@ carbide-api:
       machines_created_per_run = 1000
       explorations_per_run = 1000
       concurrent_explorations = 100
+      explore_mode = "nv-redfish"
 
       [firmware_global]
       autoupdate = true


### PR DESCRIPTION
## Description
According to [new_hardware_support.md](https://github.com/NVIDIA/ncx-infra-controller-core/blob/34499ddfa496d4e29d5ec7e0c16813d2948b6309/book/src/development/new_hardware_support.md#L4) the `nv-redfish` is preferred. 

The current devspace config doesn't specify `explore_mode` so libredfish is used as default. 

This change fixes  `Machine Setup: Mismatch: HttpDev1Interface is 'NIC.Slot.1-1' expected ''` error

<img width="2103" height="814" alt="image" src="https://github.com/user-attachments/assets/9a574fc4-8bea-451c-b964-cb368e049203" />

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

