### PR TITLE
fix: health service unify serial number handling for switch/machine

### DIFF
--- a/crates/health/src/endpoint/model.rs
+++ b/crates/health/src/endpoint/model.rs
@@ -118,6 +118,15 @@ pub enum EndpointMetadata {
     Switch(SwitchData),
 }
 
+impl EndpointMetadata {
+    pub fn serial_number(&self) -> Option<&str> {
+        match self {
+            EndpointMetadata::Machine(machine) => machine.machine_serial.as_deref(),
+            EndpointMetadata::Switch(switch) => Some(switch.serial.as_str()),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct MachineData {
     pub machine_id: MachineId,

--- a/crates/health/src/sink/events.rs
+++ b/crates/health/src/sink/events.rs
@@ -59,9 +59,10 @@ impl EventContext {
         }
     }
 
-    pub fn switch_serial(&self) -> Option<&str> {
+    pub fn serial_number(&self) -> Option<&String> {
         match &self.metadata {
-            Some(EndpointMetadata::Switch(switch)) => Some(switch.serial.as_str()),
+            Some(EndpointMetadata::Machine(machine)) => machine.machine_serial.as_ref(),
+            Some(EndpointMetadata::Switch(switch)) => Some(&switch.serial),
             _ => None,
         }
     }

--- a/crates/health/src/sink/events.rs
+++ b/crates/health/src/sink/events.rs
@@ -59,12 +59,10 @@ impl EventContext {
         }
     }
 
-    pub fn serial_number(&self) -> Option<&String> {
-        match &self.metadata {
-            Some(EndpointMetadata::Machine(machine)) => machine.machine_serial.as_ref(),
-            Some(EndpointMetadata::Switch(switch)) => Some(&switch.serial),
-            _ => None,
-        }
+    pub fn serial_number(&self) -> Option<&str> {
+        self.metadata
+            .as_ref()
+            .and_then(EndpointMetadata::serial_number)
     }
 
     pub fn rack_id(&self) -> Option<&RackId> {

--- a/crates/health/src/sink/prometheus.rs
+++ b/crates/health/src/sink/prometheus.rs
@@ -97,8 +97,8 @@ impl PrometheusSink {
         if let Some(machine_id) = context.machine_id() {
             labels.push((Cow::Borrowed("machine_id"), machine_id.to_string()));
         }
-        if let Some(serial) = context.switch_serial() {
-            labels.push((Cow::Borrowed("switch_serial"), serial.to_string()));
+        if let Some(serial) = context.serial_number() {
+            labels.push((Cow::Borrowed("serial_number"), serial.to_string()));
         }
 
         labels


### PR DESCRIPTION
## Description
Right now health reports only swtich serial in special field for metrics, this PR makes it unified `serial_number` label

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

