### PR TITLE
chore: Enable access to nico-core on macOS from K8s by making the cert match ip used from Colima when reaching localhost

### DIFF
--- a/dev/certs/localhost/gen-certs.sh
+++ b/dev/certs/localhost/gen-certs.sh
@@ -17,7 +17,9 @@
 #
 set -euo pipefail
 
-# Generate openssl.cfg for v3 extensions
+# Generate openssl.cnf for v3 extensions.
+# IP SANs cover both Docker Desktop (192.168.65.254) and Colima (192.168.5.2)
+# so the cert works regardless of container runtime if needed.
 cat > openssl.cnf <<EOF
 [ req ]
 distinguished_name = req_distinguished_name
@@ -46,12 +48,12 @@ keyUsage = digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth, clientAuth
 subjectAltName = @alt_names
 
-# host.docker.internal and 192.168.65.254 are docker 'magic' name/ip to communicate with host on macOS.
 [ alt_names ]
 DNS.1 = localhost
 DNS.2 = host.docker.internal
 IP.1 = 127.0.0.1
 IP.2 = 192.168.65.254
+IP.3 = 192.168.5.2
 EOF
 
 # Generate CA key and self-signed certificate

--- a/dev/mac-local-dev/README.md
+++ b/dev/mac-local-dev/README.md
@@ -80,6 +80,7 @@ The script:
   does not exist.
 - Wires up TLS using the locally-generated certs from `dev/certs/localhost/`
   (the same CA that `run-carbide-api.sh` configures the server to trust).
+- certs provided are compatible with access to localhost or host.docker.internal (from Docker or Colima).
 - Can be run from any directory.
 
 ### Global flags

--- a/dev/mac-local-dev/run-carbide-api.sh
+++ b/dev/mac-local-dev/run-carbide-api.sh
@@ -146,6 +146,7 @@ export VAULT_KV_MOUNT_LOCATION="secrets"
 export VAULT_PKI_MOUNT_LOCATION="certs"
 export VAULT_PKI_ROLE_NAME="role"
 export VAULT_TOKEN="$(cat "$TOKEN_FILE")"
+export VAULT_CACERT="$REPO_ROOT/dev/certs/localhost/ca.crt"
 
 # -----------------------------------------------------------------------------
 # Firmware directory (carbide expects this)

--- a/dev/mac-local-dev/run-carbide-api.sh
+++ b/dev/mac-local-dev/run-carbide-api.sh
@@ -146,7 +146,6 @@ export VAULT_KV_MOUNT_LOCATION="secrets"
 export VAULT_PKI_MOUNT_LOCATION="certs"
 export VAULT_PKI_ROLE_NAME="role"
 export VAULT_TOKEN="$(cat "$TOKEN_FILE")"
-export VAULT_CACERT="$REPO_ROOT/dev/certs/localhost/ca.crt"
 
 # -----------------------------------------------------------------------------
 # Firmware directory (carbide expects this)


### PR DESCRIPTION
## Description
Enable access to nico-core on macOS from K8s by making the cert match ip used from Colima when reaching localhost.

## Type of Change
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes: no.

## Testing
- [X] Manual testing performed
