### PR TITLE
fix(api): Add explicit order-by for any for-update queries

### DIFF
--- a/crates/api-db/src/compute_allocation.rs
+++ b/crates/api-db/src/compute_allocation.rs
@@ -138,6 +138,7 @@ pub async fn find_ids(
     }
 
     if for_update {
+        builder.push(" ORDER BY id ");
         builder.push(" FOR UPDATE ");
     }
 
@@ -176,6 +177,7 @@ pub async fn find_by_ids(
     }
 
     if for_update {
+        builder.push(" ORDER BY id ");
         builder.push(" FOR UPDATE ");
     }
 

--- a/crates/api-db/src/extension_service.rs
+++ b/crates/api-db/src/extension_service.rs
@@ -329,6 +329,7 @@ pub async fn find_by_ids(
     builder.push(")");
 
     if for_update {
+        builder.push(" ORDER BY id ");
         builder.push(" FOR UPDATE");
     }
 

--- a/crates/api-db/src/instance_type.rs
+++ b/crates/api-db/src/instance_type.rs
@@ -114,6 +114,7 @@ pub async fn find_ids(
         sqlx::QueryBuilder::new("SELECT id FROM instance_types WHERE deleted is NULL");
 
     if for_update {
+        builder.push(" ORDER BY id ");
         builder.push(" FOR UPDATE ");
     }
 
@@ -143,6 +144,7 @@ pub async fn find_by_ids(
     builder.push(") ");
 
     if for_update {
+        builder.push(" ORDER BY id ");
         builder.push(" FOR UPDATE ");
     }
 

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -264,10 +264,6 @@ pub async fn find(
         builder.push(" AND m.network_config->>'quarantine_state' IS NOT NULL ");
     }
 
-    if search_config.for_update {
-        builder.push(" FOR UPDATE OF machines");
-    };
-
     if let Some(id) = search_config.instance_type_id {
         builder.push(" AND m.instance_type_id = ");
         builder.push_bind(id);
@@ -277,6 +273,11 @@ pub async fn find(
         builder.push(" AND m.rack_id = ");
         builder.push_bind(rack_id);
     }
+
+    if search_config.for_update {
+        builder.push(" ORDER BY m.id ");
+        builder.push(" FOR UPDATE OF machines ");
+    };
 
     let all_machines: Vec<Machine> = builder
         .build_query_as()
@@ -332,6 +333,7 @@ pub async fn find_ids_by_instance_type_id(
     builder.push_bind(instance_type_id);
 
     if for_update {
+        builder.push(" ORDER BY id ");
         builder.push(" FOR UPDATE ");
     }
 
@@ -1742,6 +1744,7 @@ pub async fn find_machine_ids(
     }
 
     if search_config.for_update {
+        qb.push(" ORDER BY id ");
         qb.push(" FOR UPDATE");
     }
 

--- a/crates/api-db/src/network_security_group.rs
+++ b/crates/api-db/src/network_security_group.rs
@@ -113,6 +113,7 @@ pub async fn find_ids(
     }
 
     if for_update {
+        builder.push(" ORDER BY id ");
         builder.push(" FOR UPDATE ");
     }
 
@@ -151,6 +152,7 @@ pub async fn find_by_ids(
     }
 
     if for_update {
+        builder.push(" ORDER BY id ");
         builder.push(" FOR UPDATE ");
     }
 


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->

Adding in explicit ordering when FOR UPDATE is requested in any of the DB queries to avoid potential deadlock.

It's possible for two requests to use FOR UPDATE and grab the rows in a different order, which means row locks in a different order, which means potential for deadlock.  No associated bug/issue ticket because we haven't seen it happen, but why wait. :smile: 

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

