### PR TITLE
chore: bump nv-redfish to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6767,9 +6767,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89af886c6d5fe2a3296b2c3a20b93fd5cedcf6d20f421550c1b42b4cdf439f0a"
+checksum = "53e3eefc00d5963fedb771a0280f95300c2650bfe6ca4b9280c35385361f41c3"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -6783,9 +6783,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-bmc-http"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00fcb3fea4212eac654f9c64f39145938bc36ce9f9b41083abcfdd2db4521c83"
+checksum = "70eea8ae021e8349762ce3969a30a42c39d6e974882ee64e163aeb7dec29cda4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -6803,9 +6803,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-core"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7464778f7f5174af13481491d8ac2e60c1541158d7b7848f34e9d7df7eea8d45"
+checksum = "e02c2e01f5f0350fbf773c9b95cbb25419b9c30c8819bc34223c71e9388251bc"
 dependencies = [
  "futures-core",
  "rust_decimal",
@@ -6817,9 +6817,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-csdl-compiler"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05fb324cb8daa29ced5b019fa2ebd8a0374417a141331b0629df9438e31eb2c"
+checksum = "6084a8fd9e1415503f3935e339788cf6df86f1f2ca07ba694f48a107fb4ba028"
 dependencies = [
  "clap",
  "clap_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,12 +59,7 @@ tracing-appender = "0.2.4"
 tracing-opentelemetry = "0.29.0"
 
 # NV-Redfish
-nv-redfish = { version = "0.6.1", features = [
-  "bmc-http",
-  "std-redfish",
-  "update-service",
-  "resource-status",
-] }
+nv-redfish = { version = "0.7.0" }
 
 ########
 # MARK: - Pinned packages that we can't upgrade due to conflicts or just bugs

--- a/crates/bmc-explorer-cli/src/main.rs
+++ b/crates/bmc-explorer-cli/src/main.rs
@@ -10,9 +10,6 @@
  * its affiliates is strictly prohibited.
  */
 
-// Needed because of using nv-redfish that has deep structures.
-#![recursion_limit = "256"]
-
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;

--- a/crates/bmc-explorer/Cargo.toml
+++ b/crates/bmc-explorer/Cargo.toml
@@ -33,7 +33,18 @@ carbide-api-model = { path = "../api-model", default-features = false }
 itertools = { workspace = true }
 mac_address = { workspace = true }
 nv-redfish = { workspace = true, features = [
-    "std-redfish",
+    "assembly",
+    "bios",
+    "boot-options",
+    "chassis",
+    "computer-systems",
+    "ethernet-interfaces",
+    "host-interfaces",
+    "network-adapters",
+    "network-device-functions",
+    "managers",
+    "pcie-devices",
+    "secure-boot",
     "oem-nvidia-bluefield",
     "oem-nvidia-baseboard",
     "oem-dell-attributes",

--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -15,10 +15,6 @@
  * limitations under the License.
  */
 
-// Needed for nv-redfish that requires deep recursion for Redfish
-// object type tree.
-#![recursion_limit = "256"]
-
 mod chassis;
 mod computer_system;
 mod error;

--- a/crates/bmc-explorer/tests/bluefield3_explore.rs
+++ b/crates/bmc-explorer/tests/bluefield3_explore.rs
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![recursion_limit = "256"]
-
 mod common;
 
 use bmc_explorer::nv_generate_exploration_report;

--- a/crates/bmc-explorer/tests/dell_poweredge_r750_explore.rs
+++ b/crates/bmc-explorer/tests/dell_poweredge_r750_explore.rs
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![recursion_limit = "256"]
-
 mod common;
 
 use bmc_explorer::nv_generate_exploration_report;

--- a/crates/bmc-explorer/tests/nvidia_switch_explore.rs
+++ b/crates/bmc-explorer/tests/nvidia_switch_explore.rs
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![recursion_limit = "256"]
-
 mod common;
 
 use bmc_explorer::nv_generate_exploration_report;

--- a/crates/bmc-explorer/tests/powershelf_explore.rs
+++ b/crates/bmc-explorer/tests/powershelf_explore.rs
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![recursion_limit = "256"]
-
 mod common;
 
 use bmc_explorer::nv_generate_exploration_report;

--- a/crates/bmc-explorer/tests/wiwynn_gb200_explore.rs
+++ b/crates/bmc-explorer/tests/wiwynn_gb200_explore.rs
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![recursion_limit = "256"]
-
 mod common;
 
 use bmc_explorer::nv_generate_exploration_report;

--- a/crates/bmc-mock/src/test_support/axum_http_client.rs
+++ b/crates/bmc-mock/src/test_support/axum_http_client.rs
@@ -193,7 +193,7 @@ impl HttpClient for AxumRouterHttpClient {
         Err(Error::NotSupported("DELETE is not supported yet"))
     }
 
-    async fn sse<T: Sized + for<'a> serde::Deserialize<'a> + Send + 'static>(
+    async fn sse<T: Send + Sized + for<'a> serde::Deserialize<'a>>(
         &self,
         _url: Url,
         _credentials: &BmcCredentials,

--- a/crates/health/Cargo.toml
+++ b/crates/health/Cargo.toml
@@ -56,7 +56,21 @@ tonic = { workspace = true }
 tonic-prost = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
-nv-redfish = { workspace = true }
+nv-redfish = { workspace = true, features = [
+  "bmc-http",
+  "chassis",
+  "computer-systems",
+  "event-service",
+  "log-services",
+  "managers",
+  "memory",
+  "power-supplies",
+  "processors",
+  "sensors",
+  "storages",
+  "update-service",
+  "resource-status",
+] }
 rand = { workspace = true }
 url = { workspace = true }
 

--- a/crates/health/src/collectors/runtime.rs
+++ b/crates/health/src/collectors/runtime.rs
@@ -604,8 +604,7 @@ async fn run_iteration_with_auth_refresh<C: PeriodicCollector<BmcClient>>(
             })?;
 
             // We set credentials and wait till next iteration, to avoid credential fetch loop.
-            bmc.set_credentials(credentials.into())
-                .map_err(HealthError::GenericError)?;
+            bmc.set_credentials(credentials.into());
             Err(error)
         }
         Err(error) => Err(error),

--- a/crates/health/src/lib.rs
+++ b/crates/health/src/lib.rs
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-#![recursion_limit = "256"]
-
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/crates/health/src/main.rs
+++ b/crates/health/src/main.rs
@@ -15,10 +15,6 @@
  * limitations under the License.
  */
 
-// Redfish models have a very high recursion (Root->Chassis->Storage->Drive->Metric->etc)
-// This param is required to make it compile while using nv-redfish
-#![recursion_limit = "256"]
-
 use carbide_health::{Config, HealthError};
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::EnvFilter;

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -15,10 +15,6 @@
  * limitations under the License.
  */
 
-// Needed for nv-redfish that requires deep recursion for Redfish
-// object type tree.
-#![recursion_limit = "256"]
-
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::fmt::Display;


### PR DESCRIPTION
## Description

Update nv-redfish crates to 0.7.0, switch consumers to explicit feature sets, and drop no-longer-needed recursion_limit attrs.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
