### PR TITLE
fix: build of standalone carbide-api crate

### DIFF
--- a/crates/bmc-explorer/Cargo.toml
+++ b/crates/bmc-explorer/Cargo.toml
@@ -44,6 +44,8 @@ nv-redfish = { workspace = true, features = [
     "network-device-functions",
     "managers",
     "pcie-devices",
+    "power-supplies",
+    "update-service",
     "secure-boot",
     "oem-nvidia-bluefield",
     "oem-nvidia-baseboard",


### PR DESCRIPTION
## Description

Fix of cargo-api build if it is build alone (cargo build -p carbide-api). In this case nv-redfish didn't get all required features. 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

#1089 

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

