### PR TITLE
chore(nv-redfish): unified get of service root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2546,7 +2546,6 @@ dependencies = [
  "libredfish",
  "librms",
  "mac_address",
- "nv-redfish",
  "opentelemetry",
  "rand 0.9.2",
  "regex",

--- a/crates/api/src/run.rs
+++ b/crates/api/src/run.rs
@@ -17,7 +17,6 @@
 
 use std::sync::Arc;
 
-use carbide_redfish::nv_redfish::NvRedfishClientPool;
 use eyre::WrapErr;
 use forge_secrets::credentials::{CredentialReader, CredentialWriter};
 use forge_secrets::{CredentialConfig, create_credential_manager_from, create_vault_client};
@@ -234,9 +233,8 @@ pub async fn run(
         )
     };
 
-    let nv_redfish_pool = Arc::new(NvRedfishClientPool::new(
-        carbide_config.site_explorer.bmc_proxy.clone(),
-    ));
+    let nv_redfish_pool =
+        carbide_redfish::nv_redfish::new_pool(carbide_config.site_explorer.bmc_proxy.clone());
 
     setup::start_api(
         &mut join_set,

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -25,7 +25,7 @@ use carbide_firmware::FirmwareDownloader;
 use carbide_ipmi::IPMITool;
 use carbide_redfish::libredfish::RedfishClientPool;
 use carbide_redfish::nv_redfish::NvRedfishClientPool;
-use carbide_site_explorer::{BmcEndpointExplorer, SiteExplorer};
+use carbide_site_explorer::SiteExplorer;
 use db::machine::update_dpu_asns;
 use db::resource_pool::DefineResourcePoolError;
 use db::{Transaction, work_lock_manager};
@@ -377,7 +377,7 @@ pub async fn start_api(
         ListenMode::PlaintextHttp2 => ApiListenMode::PlaintextHttp2,
     };
 
-    let bmc_explorer = Arc::new(BmcEndpointExplorer::new(
+    let bmc_explorer = carbide_site_explorer::new_bmc_explorer(
         shared_redfish_pool.clone(),
         shared_nv_redfish_pool,
         ipmi_tool.clone(),
@@ -387,7 +387,7 @@ pub async fn start_api(
             .rotate_switch_nvos_credentials
             .clone(),
         carbide_config.site_explorer.explore_mode,
-    ));
+    );
 
     let nvlink_config = carbide_config.nvlink_config.clone().unwrap_or_default();
 

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -29,9 +29,8 @@ use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use carbide_ipmi::IPMITool;
 use carbide_redfish::libredfish::test_support::RedfishSim;
-use carbide_redfish::nv_redfish::NvRedfishClientPool;
+use carbide_site_explorer::SiteExplorer;
 use carbide_site_explorer::config::{SiteExplorerConfig, SiteExplorerExploreMode};
-use carbide_site_explorer::{BmcEndpointExplorer, SiteExplorer};
 use carbide_uuid::instance::InstanceId;
 use carbide_uuid::instance_type::InstanceTypeId;
 use carbide_uuid::machine::MachineId;
@@ -1478,15 +1477,15 @@ pub async fn create_test_env_with_overrides(
     };
 
     let bmc_proxy = Arc::new(ArcSwap::new(None.into()));
-    let bmc_explorer = Arc::new(BmcEndpointExplorer::new(
+    let bmc_explorer = carbide_site_explorer::new_bmc_explorer(
         redfish_sim.clone(),
-        Arc::new(NvRedfishClientPool::new(bmc_proxy)),
+        carbide_redfish::nv_redfish::new_pool(bmc_proxy),
         carbide_ipmi::test_support(),
         composite_manager.clone(),
         Arc::new(std::sync::atomic::AtomicBool::new(false)),
         // Tests use MockEndpointExplorer. So this doesn't affect anything.
         SiteExplorerExploreMode::NvRedfish,
-    ));
+    );
 
     let reachability_params = ReachabilityParams {
         dpu_wait_time: Duration::seconds(0),

--- a/crates/api/src/tests/mod.rs
+++ b/crates/api/src/tests/mod.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 pub(crate) mod common;
 mod compute_allocation;
 mod connected_device;

--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -52,12 +52,6 @@ use nv_redfish::resource::ResourceNameRef;
 use nv_redfish::service_root::{Product, Vendor};
 use nv_redfish::{Bmc, Resource, ServiceRoot};
 
-pub async fn explore_root<B: Bmc>(bmc: Arc<B>) -> Result<ServiceRoot<B>, Error<B>> {
-    nv_redfish::ServiceRoot::new(bmc)
-        .await
-        .map_err(Error::nv_redfish("service_root"))
-}
-
 #[derive(PartialEq, Eq)]
 pub enum ErrorClass {
     HttpNotFound,
@@ -72,17 +66,7 @@ pub struct Config<'a, B: Bmc> {
 }
 
 pub async fn nv_generate_exploration_report<B: Bmc>(
-    bmc: Arc<B>,
-    config: &Config<'_, B>,
-) -> Result<EndpointExplorationReport, Error<B>> {
-    let root = ServiceRoot::new(bmc)
-        .await
-        .map_err(Error::nv_redfish("service_root"))?;
-    nv_generate_exploration_report_from_root(root, config).await
-}
-
-pub async fn nv_generate_exploration_report_from_root<B: Bmc>(
-    mut root: ServiceRoot<B>,
+    mut root: Arc<ServiceRoot<B>>,
     config: &Config<'_, B>,
 ) -> Result<EndpointExplorationReport, Error<B>> {
     let chassis_explore_config = chassis::Config {
@@ -107,7 +91,7 @@ pub async fn nv_generate_exploration_report_from_root<B: Bmc>(
     let explored_inventories = ExploredInventories::explore(&root).await?;
 
     if explored_chassis.is_bluefield2() {
-        root = root.restrict_expand();
+        root = root.as_ref().clone().restrict_expand().into();
     }
 
     let mut systems_iter = root

--- a/crates/bmc-explorer/tests/bluefield3_explore.rs
+++ b/crates/bmc-explorer/tests/bluefield3_explore.rs
@@ -23,8 +23,8 @@ use tokio::test;
 
 #[test]
 async fn explore_bluefield3_baseline() {
-    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default());
-    let report = nv_generate_exploration_report(h.bmc, &common::explorer_config())
+    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default()).await;
+    let report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
         .await
         .unwrap();
 
@@ -54,8 +54,8 @@ async fn explore_bluefield3_without_system_eth_interfaces() {
         exposes_oob_eth: false,
         ..Default::default()
     };
-    let h = test_support::dell_poweredge_r750_bluefield3_bmc(settings);
-    let report = nv_generate_exploration_report(h.bmc, &common::explorer_config())
+    let h = test_support::dell_poweredge_r750_bluefield3_bmc(settings).await;
+    let report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
         .await
         .unwrap();
     assert_eq!(report.endpoint_type, EndpointType::Bmc);
@@ -73,10 +73,11 @@ async fn explore_bluefield3_without_system_eth_interfaces() {
 async fn explore_bluefield3_retries_transient_404_on_system_eth_interfaces() {
     let settings = DpuSettings::default();
 
-    let h = test_support::dell_poweredge_r750_bluefield3_bmc(settings.clone());
-    let baseline = nv_generate_exploration_report(h.bmc.clone(), &common::explorer_config())
-        .await
-        .unwrap();
+    let h = test_support::dell_poweredge_r750_bluefield3_bmc(settings.clone()).await;
+    let baseline =
+        nv_generate_exploration_report(h.service_root.clone(), &common::explorer_config())
+            .await
+            .unwrap();
 
     h.state.injected_bugs.update_args(bmc_mock::bug::Args {
         http_error: Some(bmc_mock::bug::HttpErrorRule {
@@ -88,7 +89,7 @@ async fn explore_bluefield3_retries_transient_404_on_system_eth_interfaces() {
         ..Default::default()
     });
 
-    let report = nv_generate_exploration_report(h.bmc, &common::explorer_config())
+    let report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
         .await
         .unwrap();
 
@@ -99,7 +100,7 @@ async fn explore_bluefield3_retries_transient_404_on_system_eth_interfaces() {
 
 #[test]
 async fn explore_bluefield3_permanent_404_on_system_eth_interfaces_fails_without_hanging() {
-    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default());
+    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default()).await;
 
     h.state.injected_bugs.update_args(bmc_mock::bug::Args {
         http_error: Some(bmc_mock::bug::HttpErrorRule {
@@ -113,7 +114,7 @@ async fn explore_bluefield3_permanent_404_on_system_eth_interfaces_fails_without
 
     let result = tokio::time::timeout(
         std::time::Duration::from_secs(5),
-        nv_generate_exploration_report(h.bmc, &common::explorer_config()),
+        nv_generate_exploration_report(h.service_root, &common::explorer_config()),
     )
     .await;
 
@@ -126,8 +127,8 @@ async fn explore_bluefield3_permanent_404_on_system_eth_interfaces_fails_without
 
 #[test]
 async fn explore_bluefield3_skips_erot_chassis() {
-    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default());
-    let report = nv_generate_exploration_report(h.bmc, &common::explorer_config())
+    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default()).await;
+    let report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
         .await
         .unwrap();
 
@@ -145,7 +146,7 @@ async fn explore_bluefield3_skips_erot_chassis() {
 
 #[test]
 async fn explore_bluefield3_succeeds_when_erot_hangs() {
-    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default());
+    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default()).await;
 
     h.state.injected_bugs.update_args(bmc_mock::bug::Args {
         long_response: Some(bmc_mock::bug::LongResponse {
@@ -157,7 +158,7 @@ async fn explore_bluefield3_succeeds_when_erot_hangs() {
 
     let result = tokio::time::timeout(
         std::time::Duration::from_secs(5),
-        nv_generate_exploration_report(h.bmc, &common::explorer_config()),
+        nv_generate_exploration_report(h.service_root, &common::explorer_config()),
     )
     .await;
 
@@ -175,7 +176,7 @@ async fn explore_bluefield3_succeeds_when_erot_hangs() {
 
 #[test]
 async fn explore_bluefield3_succeeds_when_erot_returns_error() {
-    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default());
+    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default()).await;
 
     h.state.injected_bugs.update_args(bmc_mock::bug::Args {
         http_error: Some(bmc_mock::bug::HttpErrorRule {
@@ -187,7 +188,7 @@ async fn explore_bluefield3_succeeds_when_erot_returns_error() {
         ..Default::default()
     });
 
-    let report = nv_generate_exploration_report(h.bmc, &common::explorer_config())
+    let report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
         .await
         .expect("exploration must succeed even when ERoT returns 500");
 

--- a/crates/bmc-explorer/tests/dell_poweredge_r750_explore.rs
+++ b/crates/bmc-explorer/tests/dell_poweredge_r750_explore.rs
@@ -23,8 +23,8 @@ use tokio::test;
 
 #[test]
 async fn explore_dell_poweredge_r750() {
-    let h = test_support::dell_poweredge_r750_bmc();
-    let report = nv_generate_exploration_report(h.bmc, &common::explorer_config())
+    let h = test_support::dell_poweredge_r750_bmc().await;
+    let report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
         .await
         .unwrap();
 

--- a/crates/bmc-explorer/tests/nvidia_switch_explore.rs
+++ b/crates/bmc-explorer/tests/nvidia_switch_explore.rs
@@ -23,8 +23,8 @@ use tokio::test;
 
 #[test]
 async fn explore_nvidia_switch() {
-    let h = test_support::nvidia_switch_nd5200_ld_bmc();
-    let report = nv_generate_exploration_report(h.bmc, &common::explorer_config())
+    let h = test_support::nvidia_switch_nd5200_ld_bmc().await;
+    let report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
         .await
         .unwrap();
 

--- a/crates/bmc-explorer/tests/powershelf_explore.rs
+++ b/crates/bmc-explorer/tests/powershelf_explore.rs
@@ -23,8 +23,8 @@ use tokio::test;
 
 #[test]
 async fn explore_liteon_power_shelf() {
-    let h = test_support::liteon_powershelf_bmc();
-    let report = nv_generate_exploration_report(h.bmc, &common::explorer_config())
+    let h = test_support::liteon_powershelf_bmc().await;
+    let report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
         .await
         .unwrap();
 

--- a/crates/bmc-explorer/tests/wiwynn_gb200_explore.rs
+++ b/crates/bmc-explorer/tests/wiwynn_gb200_explore.rs
@@ -23,8 +23,8 @@ use tokio::test;
 
 #[test]
 async fn explore_wiwynn_gb200() {
-    let h = test_support::wiwynn_gb200_bmc();
-    let report = nv_generate_exploration_report(h.bmc, &common::explorer_config())
+    let h = test_support::wiwynn_gb200_bmc().await;
+    let report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
         .await
         .unwrap();
 

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -51,26 +51,27 @@ pub type TestBmc = HttpBmc<AxumRouterHttpClient>;
 
 #[derive(Clone)]
 pub struct TestBmcHandle {
-    pub bmc: Arc<TestBmc>,
+    pub service_root: Arc<nv_redfish::ServiceRoot<TestBmc>>,
     pub state: BmcState,
 }
 
-fn test_bmc((router, state): (axum::Router, BmcState)) -> TestBmcHandle {
+async fn test_bmc((router, state): (axum::Router, BmcState)) -> TestBmcHandle {
     let client = AxumRouterHttpClient::new(router);
     let endpoint = Url::parse("https://bmc-mock.local").expect("valid URL");
     let credentials = BmcCredentials::new("root".to_string(), "password".to_string());
+    let bmc = Arc::new(HttpBmc::new(
+        client,
+        endpoint,
+        credentials,
+        CacheSettings::with_capacity(32),
+    ));
     TestBmcHandle {
-        bmc: Arc::new(HttpBmc::new(
-            client,
-            endpoint,
-            credentials,
-            CacheSettings::with_capacity(32),
-        )),
+        service_root: nv_redfish::ServiceRoot::new(bmc).await.unwrap().into(),
         state,
     }
 }
 
-pub fn wiwynn_gb200_bmc() -> TestBmcHandle {
+pub async fn wiwynn_gb200_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
         MachineInfo::Host(HostMachineInfo::new(
             HostHardwareType::WiwynnGB200Nvl,
@@ -82,9 +83,10 @@ pub fn wiwynn_gb200_bmc() -> TestBmcHandle {
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
     ))
+    .await
 }
 
-pub fn liteon_powershelf_bmc() -> TestBmcHandle {
+pub async fn liteon_powershelf_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
         MachineInfo::Host(HostMachineInfo::new(
             HostHardwareType::LiteOnPowerShelf,
@@ -93,9 +95,10 @@ pub fn liteon_powershelf_bmc() -> TestBmcHandle {
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
     ))
+    .await
 }
 
-pub fn nvidia_switch_nd5200_ld_bmc() -> TestBmcHandle {
+pub async fn nvidia_switch_nd5200_ld_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
         MachineInfo::Host(HostMachineInfo::new(
             HostHardwareType::NvidiaSwitchNd5200Ld,
@@ -104,9 +107,10 @@ pub fn nvidia_switch_nd5200_ld_bmc() -> TestBmcHandle {
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
     ))
+    .await
 }
 
-pub fn dell_poweredge_r750_bmc() -> TestBmcHandle {
+pub async fn dell_poweredge_r750_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
         MachineInfo::Host(HostMachineInfo::new(
             HostHardwareType::DellPowerEdgeR750,
@@ -115,9 +119,10 @@ pub fn dell_poweredge_r750_bmc() -> TestBmcHandle {
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
     ))
+    .await
 }
 
-pub fn dell_poweredge_r750_bluefield3_bmc(settings: DpuSettings) -> TestBmcHandle {
+pub async fn dell_poweredge_r750_bluefield3_bmc(settings: DpuSettings) -> TestBmcHandle {
     test_bmc(machine_router(
         MachineInfo::Dpu(DpuMachineInfo::new(
             HostHardwareType::DellPowerEdgeR750,
@@ -126,6 +131,7 @@ pub fn dell_poweredge_r750_bluefield3_bmc(settings: DpuSettings) -> TestBmcHandl
         Arc::new(NoopCallbacks),
         "test-dpu-id".to_string(),
     ))
+    .await
 }
 
 #[cfg(test)]

--- a/crates/redfish/src/nv_redfish/mod.rs
+++ b/crates/redfish/src/nv_redfish/mod.rs
@@ -21,18 +21,27 @@ use std::sync::{Arc, Mutex};
 
 use arc_swap::ArcSwap;
 use forge_secrets::credentials::Credentials;
+pub use nv_redfish::bmc_http::reqwest::BmcError;
 use nv_redfish::bmc_http::reqwest::{
-    Client as NvRedfishReqwestClient, ClientParams as NvRedfishReqwestClientParams,
+    Client as RedfishReqwestClient, ClientParams as RedfishReqwestClientParams,
 };
 use nv_redfish::bmc_http::{BmcCredentials, CacheSettings, HttpBmc};
+use nv_redfish::oem::hpe::ilo_service_ext::ManagerType as HpeManagerType;
+use nv_redfish::{Error as NvError, ServiceRoot as NvServiceRoot};
 use reqwest::header::HeaderMap;
 use utils::HostPortPair;
 
-pub type NvRedfishBmc = HttpBmc<NvRedfishReqwestClient>;
+pub type RedfishBmc = HttpBmc<RedfishReqwestClient>;
+pub type ServiceRoot = NvServiceRoot<RedfishBmc>;
+pub type Error = NvError<RedfishBmc>;
+
+pub fn new_pool(proxy_address: Arc<ArcSwap<Option<HostPortPair>>>) -> Arc<NvRedfishClientPool> {
+    NvRedfishClientPool::new(proxy_address).into()
+}
 
 pub struct NvRedfishClientPool {
     proxy_address: Arc<ArcSwap<Option<HostPortPair>>>,
-    cache: Arc<Mutex<HashMap<PoolKey, Arc<NvRedfishBmc>>>>,
+    cache: Arc<Mutex<HashMap<PoolKey, Arc<ServiceRoot>>>>,
 }
 
 #[derive(Hash, PartialEq, Eq)]
@@ -50,11 +59,49 @@ impl NvRedfishClientPool {
         }
     }
 
-    pub fn cached_nv_redfish_bmc(
+    pub async fn service_root(
         &self,
         bmc_address: SocketAddr,
         credentials: Credentials,
-    ) -> Option<Arc<NvRedfishBmc>> {
+    ) -> Result<Arc<ServiceRoot>, Error> {
+        if let Some(sevice_root) = self.cached_root(bmc_address, credentials.clone()) {
+            Ok(sevice_root)
+        } else {
+            let bmc = self.create_bmc(bmc_address, credentials.clone(), false)?;
+            let service_root = ServiceRoot::new(bmc).await?;
+            let service_root = if service_root.vendor()
+                == Some(nv_redfish::service_root::Vendor::new("HPE"))
+                && let Some(HpeManagerType::Ilo(version)) = service_root
+                    .oem_hpe_ilo_service_ext()
+                    .ok()
+                    .as_ref()
+                    .and_then(|v| v.as_ref())
+                    .and_then(|v| v.manager_type())
+                && version < 7
+            {
+                // Handle HPE BMC that closing connection right after
+                // response. In this case, we add Connection: Close
+                // HTTP header to prevent trying to reuse this
+                // connection. Otherwise, race condition may happen
+                // when reqwest thinks that connection is alive but it
+                // is about to close by server. Reusing such
+                // connections causes errors.
+                let bmc = self.create_bmc(bmc_address, credentials.clone(), true)?;
+                service_root.replace_bmc(bmc.clone())
+            } else {
+                service_root
+            };
+            let service_root = Arc::new(service_root);
+            self.update_cache(bmc_address, credentials, service_root.clone());
+            Ok(service_root)
+        }
+    }
+
+    pub fn cached_root(
+        &self,
+        bmc_address: SocketAddr,
+        credentials: Credentials,
+    ) -> Option<Arc<ServiceRoot>> {
         let proxy_address = self.proxy_address.load();
         let key = PoolKey {
             proxy_address: proxy_address.clone(),
@@ -68,11 +115,11 @@ impl NvRedfishClientPool {
             .cloned()
     }
 
-    pub fn update_cache(
+    fn update_cache(
         &self,
         bmc_address: SocketAddr,
         credentials: Credentials,
-        bmc: Arc<NvRedfishBmc>,
+        root: Arc<ServiceRoot>,
     ) {
         let proxy_address = self.proxy_address.load();
         let key = PoolKey {
@@ -84,15 +131,15 @@ impl NvRedfishClientPool {
             .cache
             .lock()
             .expect("nv-redish client cache mutex poisoned");
-        cache.insert(key, bmc);
+        cache.insert(key, root);
     }
 
-    pub fn create_nv_redfish_bmc(
+    fn create_bmc(
         &self,
         bmc_address: SocketAddr,
         Credentials::UsernamePassword { username, password }: Credentials,
         connection_close: bool,
-    ) -> Result<Arc<NvRedfishBmc>, reqwest::Error> {
+    ) -> Result<Arc<RedfishBmc>, Error> {
         let proxy_address = self.proxy_address.load();
         let bmc_url = match proxy_address.as_ref() {
             // No override
@@ -120,10 +167,11 @@ impl NvRedfishClientPool {
             );
         }
 
-        let client = NvRedfishReqwestClient::with_params(
-            NvRedfishReqwestClientParams::new().accept_invalid_certs(true),
-        )?;
-        Ok(Arc::new(NvRedfishBmc::with_custom_headers(
+        let client = RedfishReqwestClient::with_params(
+            RedfishReqwestClientParams::new().accept_invalid_certs(true),
+        )
+        .map_err(|err| Error::Bmc(err.into()))?;
+        Ok(Arc::new(RedfishBmc::with_custom_headers(
             client,
             bmc_url,
             BmcCredentials::new(username, password),

--- a/crates/site-explorer/Cargo.toml
+++ b/crates/site-explorer/Cargo.toml
@@ -38,7 +38,6 @@ http = { workspace = true }
 libredfish = { workspace = true }
 librms = { workspace = true }
 mac_address = { workspace = true }
-nv-redfish = { workspace = true, features = ["bmc-http", "oem-hpe"] }
 opentelemetry = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -84,11 +84,35 @@ use model::rack::Rack;
 pub use switch_creator::SwitchCreator;
 pub mod config;
 pub mod errors;
+use std::sync::atomic::AtomicBool;
 
+use carbide_ipmi::IPMITool;
+use carbide_redfish::libredfish::RedfishClientPool;
+use carbide_redfish::nv_redfish::NvRedfishClientPool;
 use errors::{SiteExplorerError, SiteExplorerResult};
 
 use self::metrics::{PairingBlockerReason, exploration_error_to_metric_label};
+use crate::config::SiteExplorerExploreMode;
 use crate::explored_endpoint_index::ExploredEndpointIndex;
+
+pub fn new_bmc_explorer(
+    redfish_client_pool: Arc<dyn RedfishClientPool>,
+    nv_redfish_client_pool: Arc<NvRedfishClientPool>,
+    ipmi_tool: Arc<dyn IPMITool>,
+    credential_manager: Arc<dyn CredentialManager>,
+    rotate_switch_nvos_credentials: Arc<AtomicBool>,
+    mode: SiteExplorerExploreMode,
+) -> Arc<BmcEndpointExplorer> {
+    BmcEndpointExplorer::new(
+        redfish_client_pool,
+        nv_redfish_client_pool,
+        ipmi_tool,
+        credential_manager,
+        rotate_switch_nvos_credentials,
+        mode,
+    )
+    .into()
+}
 
 /// Ensures a rack row exists for the given `rack_id`.
 ///

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -37,7 +37,6 @@ use model::site_explorer::{
     InternalLockdownStatus, Inventory, LockdownStatus, MachineSetupDiff, MachineSetupStatus,
     Manager, NetworkAdapter, PCIeDevice, SecureBootStatus, Service, UefiDevicePath,
 };
-use nv_redfish::oem::hpe::ilo_service_ext::ManagerType as HpeManagerType;
 use regex::Regex;
 
 const NOT_FOUND: u16 = 404;
@@ -330,61 +329,20 @@ impl RedfishClient {
         credentials: Credentials,
         boot_interface_mac: Option<MacAddress>,
     ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
-        if let Some(bmc) = self
+        let service_root = self
             .nv_redfish_client_pool
-            .cached_nv_redfish_bmc(bmc_ip_address, credentials.clone())
-        {
-            bmc_explorer::nv_generate_exploration_report(
-                bmc,
-                &nv_bmc_explore_config(boot_interface_mac),
-            )
+            .service_root(bmc_ip_address, credentials)
             .await
-            .map_err(map_nv_redfish_explore_error)
-        } else {
-            let bmc = self
-                .nv_redfish_client_pool
-                .create_nv_redfish_bmc(bmc_ip_address, credentials.clone(), false)
-                .map_err(|err| EndpointExplorationError::Other {
-                    details: format!("Cannot build redfish client: {err}"),
-                })?;
-            let root = bmc_explorer::explore_root(bmc.clone())
-                .await
-                .map_err(map_nv_redfish_explore_error)?;
-            let (root, bmc) = if root.vendor() == Some(nv_redfish::service_root::Vendor::new("HPE"))
-                && let Some(HpeManagerType::Ilo(version)) = root
-                    .oem_hpe_ilo_service_ext()
-                    .ok()
-                    .as_ref()
-                    .and_then(|v| v.as_ref())
-                    .and_then(|v| v.manager_type())
-                && version < 7
-            {
-                // Handle HPE BMC that closing connection right after
-                // response. In this case, we add Connection: Close
-                // HTTP header to prevent trying to reuse this
-                // connection. Otherwise, race condition may happen
-                // when reqwest thinks that connection is alive but it
-                // is about to close by server. Reusing such
-                // connections causes errors.
-                let bmc = self
-                    .nv_redfish_client_pool
-                    .create_nv_redfish_bmc(bmc_ip_address, credentials.clone(), true)
-                    .map_err(|err| EndpointExplorationError::Other {
-                        details: format!("Cannot build redfish client: {err}"),
-                    })?;
-                (root.replace_bmc(bmc.clone()), bmc)
-            } else {
-                (root, bmc)
-            };
-            self.nv_redfish_client_pool
-                .update_cache(bmc_ip_address, credentials, bmc);
-            bmc_explorer::nv_generate_exploration_report_from_root(
-                root,
-                &nv_bmc_explore_config(boot_interface_mac),
-            )
-            .await
-            .map_err(map_nv_redfish_explore_error)
-        }
+            .map_err(|err| EndpointExplorationError::Other {
+                details: format!("Cannot Redfish service root: {err}"),
+            })?;
+
+        bmc_explorer::nv_generate_exploration_report(
+            service_root,
+            &nv_bmc_explore_config(boot_interface_mac),
+        )
+        .await
+        .map_err(map_nv_redfish_explore_error)
     }
 
     pub async fn reset_bmc(
@@ -1300,9 +1258,9 @@ pub(crate) fn map_redfish_error(error: RedfishError) -> EndpointExplorationError
 }
 
 fn nv_error_classifier(
-    err: &<carbide_redfish::nv_redfish::NvRedfishBmc as nv_redfish::Bmc>::Error,
+    err: &carbide_redfish::nv_redfish::BmcError,
 ) -> Option<bmc_explorer::ErrorClass> {
-    type BmcError = nv_redfish::bmc_http::reqwest::BmcError;
+    type BmcError = carbide_redfish::nv_redfish::BmcError;
     match err {
         BmcError::InvalidResponse {
             status: http::StatusCode::NOT_FOUND,
@@ -1314,7 +1272,7 @@ fn nv_error_classifier(
 
 fn nv_bmc_explore_config(
     boot_interface_mac: Option<MacAddress>,
-) -> bmc_explorer::Config<'static, carbide_redfish::nv_redfish::NvRedfishBmc> {
+) -> bmc_explorer::Config<'static, carbide_redfish::nv_redfish::RedfishBmc> {
     bmc_explorer::Config {
         boot_interface_mac,
         error_classifier: &nv_error_classifier,
@@ -1326,12 +1284,13 @@ fn nv_bmc_explore_config(
 }
 
 fn map_nv_redfish_explore_error(
-    err: bmc_explorer::Error<carbide_redfish::nv_redfish::NvRedfishBmc>,
+    err: bmc_explorer::Error<carbide_redfish::nv_redfish::RedfishBmc>,
 ) -> EndpointExplorationError {
-    type BmcError = nv_redfish::bmc_http::reqwest::BmcError;
+    type BmcError = carbide_redfish::nv_redfish::BmcError;
+    use carbide_redfish::nv_redfish::Error;
     match err {
         bmc_explorer::Error::NvRedfish { context, err } => match err {
-            nv_redfish::Error::Bmc(err) => match err {
+            Error::Bmc(err) => match err {
                 BmcError::ReqwestError(err) => {
                     let details = format!(
                         "context: {context}; network error: {err}; source: {:?}",
@@ -1389,7 +1348,7 @@ fn map_nv_redfish_explore_error(
                     response_code: None,
                 },
             },
-            nv_redfish::Error::Json(err) => EndpointExplorationError::RedfishError {
+            Error::Json(err) => EndpointExplorationError::RedfishError {
                 details: format!("context: {context}; json error: {err}"),
                 response_body: None,
                 response_code: None,


### PR DESCRIPTION
## Description

nb-redfish pool now caches service root handle instead of BMC. It gives following benefits:
1. HPE-specific code is move out from site-explorer.
2. Site-explorer doesn't depend on nv-redfish crate anymore. All dependecies are transient from bmc-explorer and carbide-redfish.
3. Cached service root can be used to implement Actions like reset BMC etc.
4. It saves one Redfish call for all next endpoint explorations. We don't expect any dynamic data in service root.

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
