### PR TITLE
fix: dpf: Various fixes for DPF

### DIFF
--- a/bluefield/charts/carbide-dpu-agent/templates/daemonset.yaml
+++ b/bluefield/charts/carbide-dpu-agent/templates/daemonset.yaml
@@ -82,8 +82,8 @@ spec:
             - run
             - "--hbn-config-mode=nvue-rest"
             - "--agent-platform-type=containerized"
-            - "--dhcp-grpc-server={{ .Values.dhcp_server.service_name }}.dpf-operator-system.svc.cluster.local:10079"
-            - "--fmds-grpc-server={{ .Values.fmds.service_name }}.dpf-operator-system.svc.cluster.local:50052"
+            - "--dhcp-grpc-server=carbide-dpf-cluster-{{ .Values.dhcp_server.service_name }}.dpf-operator-system.svc.cluster.local:10079"
+            - "--fmds-grpc-server=carbide-dpf-cluster-{{ .Values.fmds.service_name }}.dpf-operator-system.svc.cluster.local:50052"
             {{- if not (empty .Values.dhcp_server.interface_prepend) }}
             - "--dhcp-server-interface-prepend={{ .Values.dhcp_server.interface_prepend }}"
             {{ end }}

--- a/bluefield/charts/carbide-dpu-agent/values.yaml
+++ b/bluefield/charts/carbide-dpu-agent/values.yaml
@@ -15,7 +15,9 @@ image:
   pullPolicy: IfNotPresent
   tag: ""
 imagePullSecrets: []
-podSecurityContext: {}
+podSecurityContext:
+  runAsUser: 0
+  runAsGroup: 0
 securityContext:
   capabilities:
     add:

--- a/bluefield/charts/carbide-fmds/templates/daemonset.yaml
+++ b/bluefield/charts/carbide-fmds/templates/daemonset.yaml
@@ -50,7 +50,7 @@ spec:
           args:
             - "--grpc-address=$(POD_IP):50052"
           command:
-            - /bin/sh
+            - /busybox/sh
             - -c
             - |
               echo "Waiting for forge certificates in /opt/forge ..."

--- a/crates/api/src/dpf.rs
+++ b/crates/api/src/dpf.rs
@@ -176,8 +176,8 @@ impl ResourceLabeler for CarbideDPFLabeler {
 
     fn node_context_labels(&self, info: &DpuNodeInfo) -> BTreeMap<String, String> {
         BTreeMap::from([(
-            "carbide.nvidia.com/host-machine-id".to_string(),
-            info.host_machine_id.clone(),
+            "carbide.nvidia.com/host-bmc-ip".to_string(),
+            info.host_bmc_ip.clone(),
         )])
     }
 

--- a/crates/dpf/src/services.rs
+++ b/crates/dpf/src/services.rs
@@ -46,7 +46,14 @@ impl Default for ServiceRegistryConfig {
 pub fn dts_service(reg: &ServiceRegistryConfig) -> ServiceDefinition {
     ServiceDefinition {
         helm_values: Some(serde_json::json!({
-            "exposedPorts": { "ports": { "httpserverport": true } }
+            "exposedPorts": { "ports": { "httpserverport": true } },
+            "serviceDaemonSet": {
+                "resources": {
+                    "requests": { "memory": "320Mi", "cpu": "200m" },
+                    "limits":   { "memory": "320Mi", "cpu": "1" }
+                }
+            }
+
         })),
         config_ports: Some(vec![ServiceConfigPort {
             name: "httpserverport".to_string(),


### PR DESCRIPTION
## Description
1. Carbide use distress image which is based on busy box. The path of sh is different unlike ubuntu.
2. To access dev and sys from host, init-container needs to be run as root.
3. DPF adds a prefix `carbide-dpf-cluster-` in all the SVCs. Carbide also has to add this prefix.
4. host-machine-id is useless as a DPUNode label as it will be replaced by a permanent id after ingestion. It is better to use bmc-ip as a label to identify host better.
5. DTS was killed with default memory limit of 200Mi. Updated it to 320Mi.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

