### PR TITLE
fix(api): Loosened compute-allocation enforcement to allow targeted instance creation

### DIFF
--- a/crates/api-db/src/instance.rs
+++ b/crates/api-db/src/instance.rs
@@ -749,7 +749,7 @@ pub async fn batch_persist<'a>(
                             vals.os_phone_home_enabled, vals.name, vals.description, 
                             vals.labels::json, vals.config_version, vals.hostname, 
                             vals.network_security_group_id, true,
-                            m.instance_type_id, vals.extension_services_config::json, 
+                            vals.instance_type_id, vals.extension_services_config::json, 
                             vals.extension_services_config_version, vals.nvlink_config::json, 
                             vals.nvlink_config_version
                     FROM (VALUES ";

--- a/crates/api/src/instance/mod.rs
+++ b/crates/api/src/instance/mod.rs
@@ -511,26 +511,18 @@ pub async fn batch_allocate_instances(
     // ==== Phase 2: Check against allocations for tenants in requests ====
 
     // To support batching, we'll need to create a unique set of (tenant, instance_type_id)
+    // Since we'll filter out any requests that didn't send instance type ID,
+    // this means we'll only ever enforce allocation limits when instance type is sent in.
+    // That's intentional and allows "targeted" instance creation to bypass allocation enforcement.
     let allocation_validations: HashMap<(&TenantOrganizationId, &InstanceTypeId), usize> = requests
         .iter()
         .filter_map(|request| {
-            let Some(instance_type_id) = request.instance_type_id.as_ref() else {
-                // # enforce_if_present:  Instance type required in creation request.
-                // # always:              Instance type required in creation request.
-                // # warn_only (default): Instance type not required in creation request.
-                return match &api.runtime_config.compute_allocation_enforcement {
-                    ComputeAllocationEnforcement::Always
-                    | ComputeAllocationEnforcement::EnforceIfPresent => {
-                        Some(Err(CarbideError::MissingArgument("instance_type_id")))
-                    }
-                    ComputeAllocationEnforcement::WarnOnly => None, // Do nothing.  We'll warn later.
-                };
-            };
-
-            Some(Ok((
-                &request.config.tenant.tenant_organization_id,
-                instance_type_id,
-            )))
+            request.instance_type_id.as_ref().map(|instance_type_id| {
+                Ok((
+                    &request.config.tenant.tenant_organization_id,
+                    instance_type_id,
+                ))
+            })
         })
         .collect::<Result<Vec<_>, CarbideError>>()?
         .into_iter()
@@ -574,9 +566,9 @@ pub async fn batch_allocate_instances(
             req_count + db::instance::find_ids(&mut txn, filter).await?.len();
 
         if new_total_instance_count > compute_allocation_total as usize {
-            // # enforce_if_present:  Instance type required in creation request.  If allocations are found for instance type ID, enforce it; otherwise, it's like no limits.
-            // # always:              Instance type required in creation request. "default deny".  Enforce allocations.  If none are found, its a constraint value of 0 (i.e., you get nothing).
-            // # warn_only (default): Instance type not required in creation request.  If sent in and allocations are found, don't enforce, but log what would have happened if they were enforced.
+            // # enforce_if_present:  Instance type not required in creation request. If sent and allocations are found for instance type ID, enforce it; otherwise, it's like no limits.
+            // # always:              Instance type not required in creation request. If sent, enforce allocations.  If none are found, its a constraint value of 0 (i.e., you get nothing / default-deny).
+            // # warn_only (default): Instance type not required in creation request. If sent in and allocations are found, don't enforce, but log what would have happened if they were enforced.
             match (
                 has_allocations,
                 &api.runtime_config.compute_allocation_enforcement,

--- a/crates/api/src/tests/compute_allocation.rs
+++ b/crates/api/src/tests/compute_allocation.rs
@@ -69,7 +69,7 @@ async fn create_compute_allocation(
 async fn allocate_instance(
     env: &TestEnv,
     host: &TestManagedHost,
-    instance_type_id: &str,
+    instance_type_id: Option<&str>,
     segment_id: NetworkSegmentId,
 ) -> Result<tonic::Response<rpc::forge::Instance>, tonic::Status> {
     // Attempt instance allocation for this case.
@@ -78,7 +78,7 @@ async fn allocate_instance(
         .allocate_instance(Request::new(rpc::forge::InstanceAllocationRequest {
             instance_id: None,
             machine_id: Some(host.id),
-            instance_type_id: Some(instance_type_id.to_string()),
+            instance_type_id: instance_type_id.map(str::to_string),
             config: Some(rpc::forge::InstanceConfig {
                 tenant: Some(rpc::forge::TenantConfig {
                     tenant_organization_id: TENANT_ORG.to_string(),
@@ -274,7 +274,7 @@ async fn test_create_instance_no_allocations(
 
     // Try allocation with no existing limits.
     // Expected pass/fail depends on mode.
-    let result = allocate_instance(&env, &host, &instance_type_id, segment_id).await;
+    let result = allocate_instance(&env, &host, Some(instance_type_id.as_str()), segment_id).await;
     if should_pass {
         result.unwrap();
     } else {
@@ -305,6 +305,98 @@ async fn test_create_instance_no_allocations_always(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     test_create_instance_no_allocations(pool, ComputeAllocationEnforcement::Always, false).await
+}
+
+async fn test_create_instance_without_instance_type_id_no_allocations(
+    pool: sqlx::PgPool,
+    enforcement: ComputeAllocationEnforcement,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Build env with selected enforcement mode.
+    // Expect success because omitted instance type IDs skip allocation enforcement.
+    let env = create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides {
+            ..Default::default()
+        }
+        .with_compute_allocation_enforcement(enforcement),
+    )
+    .await;
+
+    let instance_type_id = get_instance_type_fixture_id(&env).await;
+    // Create tenant for allocation FK checks.
+    // Expect success in isolated test DB.
+    env.api
+        .create_tenant(Request::new(rpc::forge::CreateTenantRequest {
+            organization_id: TENANT_ORG.to_string(),
+            routing_profile_type: None,
+            metadata: Some(metadata("compute-allocation-test-tenant")),
+        }))
+        .await
+        .unwrap();
+
+    let host = create_managed_host(&env).await;
+    // Bind host to this instance type.
+    // Expect success for a fresh host.
+    env.api
+        .associate_machines_with_instance_type(Request::new(
+            rpc::forge::AssociateMachinesWithInstanceTypeRequest {
+                instance_type_id: instance_type_id.clone(),
+                machine_ids: vec![host.id.to_string()],
+            },
+        ))
+        .await
+        .unwrap();
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+
+    // Allocate without sending instance_type_id.
+    // Expect success even in enforcing modes.
+    let instance = allocate_instance(&env, &host, None, segment_id)
+        .await
+        .unwrap()
+        .into_inner();
+
+    // Verify the immediate response.
+    // Expect no explicit instance type on the created instance.
+    assert!(instance.instance_type_id.is_none());
+
+    // Read the instance back from the API.
+    // Expect no explicit instance type to be persisted.
+    let persisted = env
+        .api
+        .find_instances_by_ids(Request::new(rpc::forge::InstancesByIdsRequest {
+            instance_ids: vec![instance.id.unwrap()],
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .instances
+        .pop()
+        .unwrap();
+    assert!(persisted.instance_type_id.is_none());
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_create_instance_no_allocations_without_instance_type_id_enforce_if_present(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    test_create_instance_without_instance_type_id_no_allocations(
+        pool,
+        ComputeAllocationEnforcement::EnforceIfPresent,
+    )
+    .await
+}
+
+#[crate::sqlx_test]
+async fn test_create_instance_no_allocations_without_instance_type_id_always(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    test_create_instance_without_instance_type_id_no_allocations(
+        pool,
+        ComputeAllocationEnforcement::Always,
+    )
+    .await
 }
 
 async fn test_create_instance_with_enough_allocations(
@@ -355,7 +447,7 @@ async fn test_create_instance_with_enough_allocations(
 
     // Allocate one instance against limit 1.
     // Expect success in all enforcement modes.
-    allocate_instance(&env, &host, &instance_type_id, segment_id)
+    allocate_instance(&env, &host, Some(instance_type_id.as_str()), segment_id)
         .await
         .unwrap();
 
@@ -448,13 +540,14 @@ async fn test_create_instance_with_insufficient_allocations(
 
     // First allocation consumes full limit.
     // Expect success.
-    allocate_instance(&env, &host_1, &instance_type_id, segment_id)
+    allocate_instance(&env, &host_1, Some(instance_type_id.as_str()), segment_id)
         .await
         .unwrap();
 
     // Second allocation exceeds limit=1.
     // Outcome depends on enforcement mode.
-    let second = allocate_instance(&env, &host_2, &instance_type_id, segment_id).await;
+    let second =
+        allocate_instance(&env, &host_2, Some(instance_type_id.as_str()), segment_id).await;
     if second_should_pass {
         second.unwrap();
     } else {
@@ -497,6 +590,110 @@ async fn test_create_instance_insufficient_allocations_always(
         pool,
         ComputeAllocationEnforcement::Always,
         false,
+    )
+    .await
+}
+
+async fn test_create_instance_without_instance_type_id_skips_insufficient_allocations(
+    pool: sqlx::PgPool,
+    enforcement: ComputeAllocationEnforcement,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Build env with selected enforcement mode.
+    // Expect omitted instance type IDs to bypass allocation enforcement.
+    let env = create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides {
+            ..Default::default()
+        }
+        .with_compute_allocation_enforcement(enforcement),
+    )
+    .await;
+
+    let instance_type_id = get_instance_type_fixture_id(&env).await;
+    // Create tenant for allocation FK checks.
+    // Expect success in isolated test DB.
+    env.api
+        .create_tenant(Request::new(rpc::forge::CreateTenantRequest {
+            organization_id: TENANT_ORG.to_string(),
+            routing_profile_type: None,
+            metadata: Some(metadata("compute-allocation-test-tenant")),
+        }))
+        .await
+        .unwrap();
+
+    let host_1 = create_managed_host(&env).await;
+    let host_2 = create_managed_host(&env).await;
+    // Bind both hosts to the same instance type.
+    // Expect success for fresh hosts.
+    env.api
+        .associate_machines_with_instance_type(Request::new(
+            rpc::forge::AssociateMachinesWithInstanceTypeRequest {
+                instance_type_id: instance_type_id.clone(),
+                machine_ids: vec![host_1.id.to_string(), host_2.id.to_string()],
+            },
+        ))
+        .await
+        .unwrap();
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+
+    let alloc_name = format!("alloc-insufficient-omit-type-{}", Uuid::new_v4());
+    // Seed one allocation for this tenant/type.
+    // Expect success with valid tenant/type.
+    let _allocation = create_compute_allocation(&env, &instance_type_id, 1, &alloc_name).await;
+
+    // Consume the single allocation using an explicit instance type ID.
+    // Expect success.
+    allocate_instance(&env, &host_1, Some(instance_type_id.as_str()), segment_id)
+        .await
+        .unwrap();
+
+    // Allocate without sending instance_type_id after the limit is exhausted.
+    // Expect success because omitted instance type IDs skip enforcement.
+    let instance = allocate_instance(&env, &host_2, None, segment_id)
+        .await
+        .unwrap()
+        .into_inner();
+
+    // Verify the immediate response.
+    // Expect no explicit instance type on the created instance.
+    assert!(instance.instance_type_id.is_none());
+
+    // Read the instance back from the API.
+    // Expect no explicit instance type to be persisted.
+    let persisted = env
+        .api
+        .find_instances_by_ids(Request::new(rpc::forge::InstancesByIdsRequest {
+            instance_ids: vec![instance.id.unwrap()],
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .instances
+        .pop()
+        .unwrap();
+    assert!(persisted.instance_type_id.is_none());
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_create_instance_insufficient_allocations_without_instance_type_id_enforce_if_present(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    test_create_instance_without_instance_type_id_skips_insufficient_allocations(
+        pool,
+        ComputeAllocationEnforcement::EnforceIfPresent,
+    )
+    .await
+}
+
+#[crate::sqlx_test]
+async fn test_create_instance_insufficient_allocations_without_instance_type_id_always(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    test_create_instance_without_instance_type_id_skips_insufficient_allocations(
+        pool,
+        ComputeAllocationEnforcement::Always,
     )
     .await
 }
@@ -614,7 +811,7 @@ async fn test_delete_allocation_when_instances_present_and_sufficient_remain_pas
 
     // Create one active instance before delete.
     // Expect success with cap=2.
-    allocate_instance(&env, &host_1, &instance_type_id, segment_id)
+    allocate_instance(&env, &host_1, Some(instance_type_id.as_str()), segment_id)
         .await
         .unwrap();
 
@@ -675,7 +872,7 @@ async fn test_delete_allocation_when_instances_present_and_insufficient_remain_f
 
     // Create one active instance before delete.
     // Expect success with cap=1.
-    allocate_instance(&env, &host, &instance_type_id, segment_id)
+    allocate_instance(&env, &host, Some(instance_type_id.as_str()), segment_id)
         .await
         .unwrap();
 
@@ -750,7 +947,7 @@ async fn test_update_allocation_reduce_when_sufficient_remains_passes(
 
     // Create one active instance first.
     // Expect success with cap=2.
-    allocate_instance(&env, &host_1, &instance_type_id, segment_id)
+    allocate_instance(&env, &host_1, Some(instance_type_id.as_str()), segment_id)
         .await
         .unwrap();
 
@@ -816,7 +1013,7 @@ async fn test_update_allocation_reduce_when_insufficient_remains_fails(
 
     // Create one active instance first.
     // Expect success with cap=1.
-    allocate_instance(&env, &host, &instance_type_id, segment_id)
+    allocate_instance(&env, &host, Some(instance_type_id.as_str()), segment_id)
         .await
         .unwrap();
 

--- a/crates/api/src/tests/instance.rs
+++ b/crates/api/src/tests/instance.rs
@@ -2930,8 +2930,8 @@ async fn test_allocate_with_instance_type_id(
 
     assert_eq!(good_id, instance.instance_type_id.unwrap());
 
-    // Try that one more time, but this time with no type id
-    // to see if we inherit it from the machine.
+    // Try that one more time, but this time with no type id.
+    // The request should succeed, but we should not persist an explicit instance type.
     let instance = env
         .api
         .allocate_instance(
@@ -2952,7 +2952,25 @@ async fn test_allocate_with_instance_type_id(
         .unwrap()
         .into_inner();
 
-    assert_eq!(good_id, instance.instance_type_id.unwrap());
+    // Verify the immediate response.
+    // Expect no explicit instance type on the created instance.
+    assert!(instance.instance_type_id.is_none());
+
+    // Read the instance back from the API.
+    // Expect no explicit instance type to have been persisted.
+    let persisted = env
+        .api
+        .find_instances_by_ids(tonic::Request::new(rpc::forge::InstancesByIdsRequest {
+            instance_ids: vec![instance.id.unwrap()],
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .instances
+        .pop()
+        .unwrap();
+
+    assert!(persisted.instance_type_id.is_none());
 
     Ok(())
 }

--- a/crates/api/src/tests/instance_batch_allocate.rs
+++ b/crates/api/src/tests/instance_batch_allocate.rs
@@ -24,10 +24,12 @@ use common::api_fixtures::instance::{
     default_os_config, default_tenant_config, single_interface_network_config,
 };
 use common::api_fixtures::{
-    TestEnv, create_managed_host, create_test_env, populate_network_security_groups,
+    TestEnv, TestEnvOverrides, create_managed_host, create_test_env,
+    create_test_env_with_overrides, get_instance_type_fixture_id, populate_network_security_groups,
 };
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 
+use crate::cfg::file::ComputeAllocationEnforcement;
 use crate::tests::common;
 use crate::tests::common::api_fixtures::TestManagedHost;
 
@@ -240,6 +242,158 @@ async fn test_batch_allocate_instances_with_same_nsg(_: PgPoolOptions, options: 
         .into_inner();
 
     assert_eq!(response.instances.len(), 2);
+}
+
+/// Allocate a batch where every request omits instance_type_id.
+/// Expect the batch to succeed even when enforcement is set to Always.
+#[crate::sqlx_test]
+async fn test_batch_allocate_instances_without_instance_type_id_skips_allocation_enforcement(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
+    let env = create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides::default()
+            .with_compute_allocation_enforcement(ComputeAllocationEnforcement::Always),
+    )
+    .await;
+
+    let instance_type_id = get_instance_type_fixture_id(&env).await;
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+    let mh1 = create_managed_host(&env).await;
+    let mh2 = create_managed_host(&env).await;
+
+    // Bind both hosts to the same instance type.
+    // Expect success for fresh hosts.
+    env.api
+        .associate_machines_with_instance_type(tonic::Request::new(
+            rpc::forge::AssociateMachinesWithInstanceTypeRequest {
+                instance_type_id: instance_type_id.clone(),
+                machine_ids: vec![mh1.host().id.to_string(), mh2.host().id.to_string()],
+            },
+        ))
+        .await
+        .unwrap();
+
+    // Build requests that omit instance_type_id.
+    // Expect both requests to bypass allocation enforcement.
+    let response = env
+        .api
+        .allocate_instances(tonic::Request::new(
+            rpc::forge::BatchInstanceAllocationRequest {
+                instance_requests: vec![
+                    build_test_instance_allocation_request(&env, &mh1, segment_id),
+                    build_test_instance_allocation_request(&env, &mh2, segment_id),
+                ],
+            },
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+
+    // Verify the immediate response.
+    // Expect no explicit instance type on either returned instance.
+    assert_eq!(response.instances.len(), 2);
+    assert!(
+        response
+            .instances
+            .iter()
+            .all(|instance| instance.instance_type_id.is_none())
+    );
+
+    let instance_ids = response
+        .instances
+        .iter()
+        .map(|instance| instance.id.unwrap())
+        .collect::<Vec<_>>();
+
+    // Read the instances back from the API.
+    // Expect no explicit instance types to be persisted.
+    let persisted = env
+        .api
+        .find_instances_by_ids(tonic::Request::new(rpc::forge::InstancesByIdsRequest {
+            instance_ids,
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .instances;
+
+    assert_eq!(persisted.len(), 2);
+    assert!(
+        persisted
+            .iter()
+            .all(|instance| instance.instance_type_id.is_none())
+    );
+}
+
+/// Send a mixed batch where one request sends instance_type_id and one omits it.
+/// Expect the typed request to enforce limits and roll back the entire batch.
+#[crate::sqlx_test]
+async fn test_batch_allocate_instances_mixed_instance_type_id_rolls_back_on_enforced_request(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
+    let env = create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides::default()
+            .with_compute_allocation_enforcement(ComputeAllocationEnforcement::Always),
+    )
+    .await;
+
+    let instance_type_id = get_instance_type_fixture_id(&env).await;
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+    let mh1 = create_managed_host(&env).await;
+    let mh2 = create_managed_host(&env).await;
+
+    // Bind both hosts to the same instance type.
+    // Expect success for fresh hosts.
+    env.api
+        .associate_machines_with_instance_type(tonic::Request::new(
+            rpc::forge::AssociateMachinesWithInstanceTypeRequest {
+                instance_type_id: instance_type_id.clone(),
+                machine_ids: vec![mh1.host().id.to_string(), mh2.host().id.to_string()],
+            },
+        ))
+        .await
+        .unwrap();
+
+    // Build a mixed batch with one enforced request and one omitted instance_type_id.
+    // Expect the typed request to fail under Always with no allocations configured.
+    let mut req1 = build_test_instance_allocation_request(&env, &mh1, segment_id);
+    req1.instance_type_id = Some(instance_type_id);
+
+    let req2 = build_test_instance_allocation_request(&env, &mh2, segment_id);
+
+    let err = env
+        .api
+        .allocate_instances(tonic::Request::new(
+            rpc::forge::BatchInstanceAllocationRequest {
+                instance_requests: vec![req1, req2],
+            },
+        ))
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+
+    // Verify the failed batch rolled back both instance creations.
+    // Expect no persisted instances on either host.
+    let mut txn = env.db_txn().await;
+    for host_id in [mh1.host().id, mh2.host().id] {
+        let snapshot = db::managed_host::load_snapshot(
+            txn.as_mut(),
+            &host_id,
+            model::machine::LoadSnapshotOptions::default(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert!(snapshot.instance.is_none());
+    }
 }
 
 // Helper function to build a test instance allocation request

--- a/crates/api/src/tests/instance_find.rs
+++ b/crates/api/src/tests/instance_find.rs
@@ -19,8 +19,11 @@ use ::rpc::forge as rpc;
 use base64::prelude::*;
 use carbide_uuid::instance::InstanceId;
 use rpc::forge_server::Forge;
+use tonic::Request;
 
-use crate::tests::common::api_fixtures::instance::default_tenant_config;
+use crate::tests::common::api_fixtures::instance::{
+    default_os_config, default_tenant_config, single_interface_network_config,
+};
 use crate::tests::common::api_fixtures::{create_managed_host, create_test_env};
 
 #[crate::sqlx_test]
@@ -56,10 +59,27 @@ async fn test_find_instance_ids(pool: sqlx::PgPool) {
                 .await
                 .unwrap();
 
-            mh.instance_builer(&env)
-                .single_interface_network_config(segment_id)
-                .build()
-                .await;
+            // Allocate with an explicit instance type ID so it is persisted.
+            // Expect these instances to be returned by instance_type_id filtering.
+            env.api
+                .allocate_instance(Request::new(rpc::InstanceAllocationRequest {
+                    instance_id: None,
+                    machine_id: Some(mh.id),
+                    instance_type_id: Some(instance_type_id.clone()),
+                    config: Some(rpc::InstanceConfig {
+                        tenant: Some(default_tenant_config()),
+                        os: Some(default_os_config()),
+                        network: Some(single_interface_network_config(segment_id)),
+                        infiniband: None,
+                        network_security_group_id: None,
+                        dpu_extension_services: None,
+                        nvlink: None,
+                    }),
+                    metadata: None,
+                    allow_unhealthy_machine: false,
+                }))
+                .await
+                .unwrap();
         } else {
             mh.instance_builer(&env)
                 .single_interface_network_config(segment_id)


### PR DESCRIPTION


## Description
<!-- Describe what this PR does -->

To support  "targeted instance creation," we need to allow the creation of instances that bypass allocation enforcement.

The changes to make that happen are...
- Instances can be requested without instance type ID and compute allocations will only be enforced if instance type ID were passed.
- Instances can/will be stored without instance type ID if not sent in. I.e., instances won't simply inherit the instance type ID of the source machine.

Instance type allocation stats would get thrown off in the same way that unhealthy machines can throw them off.  A machine associated with an instance type that is then used for creating a targeted instance is being "stolen" from that instance type pool.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
Satisfies https://github.com/NVIDIA/ncx-infra-controller-core/issues/523
