### PR TITLE
fix: refactor(rpc): extract OnDemandRackMaintenanceScope message

### DIFF
--- a/book/src/architecture/state_machines/rack.md
+++ b/book/src/architecture/state_machines/rack.md
@@ -106,12 +106,16 @@ message MaintenanceActivityConfig {
   }
 }
 
+message RackMaintenanceScope {
+  repeated string machine_ids = 1;
+  repeated string switch_ids = 2;
+  repeated string power_shelf_ids = 3;
+  repeated MaintenanceActivityConfig activities = 4;  // empty = all
+}
+
 message RackMaintenanceOnDemandRequest {
   common.RackId rack_id = 1;
-  repeated string machine_ids = 2;
-  repeated string switch_ids = 3;
-  repeated string power_shelf_ids = 4;
-  repeated MaintenanceActivityConfig activities = 5;  // empty = all
+  RackMaintenanceScope scope = 2;  // unset/empty = full rack, all activities
 }
 
 message RackMaintenanceOnDemandResponse {}

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -1548,10 +1548,12 @@ impl ApiClient {
     ) -> CarbideCliResult<rpc::RackMaintenanceOnDemandResponse> {
         let request = rpc::RackMaintenanceOnDemandRequest {
             rack_id: Some(rack_id),
-            machine_ids,
-            switch_ids,
-            power_shelf_ids,
-            activities,
+            scope: Some(rpc::RackMaintenanceScope {
+                machine_ids,
+                switch_ids,
+                power_shelf_ids,
+                activities,
+            }),
         };
         Ok(self.0.on_demand_rack_maintenance(request).await?)
     }

--- a/crates/api/src/handlers/component_manager.rs
+++ b/crates/api/src/handlers/component_manager.rs
@@ -698,17 +698,19 @@ pub(crate) async fn update_component_firmware(
 
     let maintenance_req = Request::new(rpc::RackMaintenanceOnDemandRequest {
         rack_id: Some(rack_id),
-        machine_ids: rack_machine_ids.clone(),
-        switch_ids: rack_switch_ids.clone(),
-        power_shelf_ids: vec![],
-        activities: vec![rpc::MaintenanceActivityConfig {
-            activity: Some(rpc::maintenance_activity_config::Activity::FirmwareUpgrade(
-                rpc::FirmwareUpgradeActivity {
-                    firmware_version: req.target_version,
-                    components: component_names,
-                },
-            )),
-        }],
+        scope: Some(rpc::RackMaintenanceScope {
+            machine_ids: rack_machine_ids.clone(),
+            switch_ids: rack_switch_ids.clone(),
+            power_shelf_ids: vec![],
+            activities: vec![rpc::MaintenanceActivityConfig {
+                activity: Some(rpc::maintenance_activity_config::Activity::FirmwareUpgrade(
+                    rpc::FirmwareUpgradeActivity {
+                        firmware_version: req.target_version,
+                        components: component_names,
+                    },
+                )),
+            }],
+        }),
     });
 
     crate::handlers::rack::on_demand_rack_maintenance(api, maintenance_req).await?;

--- a/crates/api/src/handlers/rack.rs
+++ b/crates/api/src/handlers/rack.rs
@@ -572,7 +572,9 @@ pub(crate) async fn on_demand_rack_maintenance(
 
     use rpc::maintenance_activity_config::Activity as ProtoActivity;
 
-    let activities: Vec<MaintenanceActivity> = req
+    let proto_scope = req.scope.unwrap_or_default();
+
+    let activities: Vec<MaintenanceActivity> = proto_scope
         .activities
         .iter()
         .map(|entry| match &entry.activity {
@@ -595,19 +597,19 @@ pub(crate) async fn on_demand_rack_maintenance(
         .collect::<Result<Vec<_>, _>>()?;
 
     let scope = MaintenanceScope {
-        machine_ids: req
+        machine_ids: proto_scope
             .machine_ids
             .iter()
             .map(|s| MachineId::from_str(s))
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| CarbideError::InvalidArgument(format!("Invalid machine_id: {e}")))?,
-        switch_ids: req
+        switch_ids: proto_scope
             .switch_ids
             .iter()
             .map(|s| SwitchId::from_str(s))
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| CarbideError::InvalidArgument(format!("Invalid switch_id: {e}")))?,
-        power_shelf_ids: req
+        power_shelf_ids: proto_scope
             .power_shelf_ids
             .iter()
             .map(|s| PowerShelfId::from_str(s))

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -5536,16 +5536,24 @@ message MaintenanceActivityConfig {
   }
 }
 
+// Scope of an on-demand rack maintenance request: which devices to include
+// and which activities to run. When all three device-id lists are empty the
+// full rack is maintained. When the activities list is empty all activities
+// are run.
+message RackMaintenanceScope {
+  repeated string machine_ids = 1;
+  repeated string switch_ids = 2;
+  repeated string power_shelf_ids = 3;
+  // Which maintenance activities to run. Empty means all activities.
+  repeated MaintenanceActivityConfig activities = 4;
+}
+
 // On-demand rack maintenance – supports full-rack or partial (subset of
-// machines, switches, power shelves).  When all device-id lists are empty
-// the full rack is maintained.
+// machines, switches, power shelves).  When `scope` is unset, or all of its
+// device-id lists are empty, the full rack is maintained.
 message RackMaintenanceOnDemandRequest {
   common.RackId rack_id = 1;
-  repeated string machine_ids = 2;
-  repeated string switch_ids = 3;
-  repeated string power_shelf_ids = 4;
-  // Which maintenance activities to run. Empty means all activities.
-  repeated MaintenanceActivityConfig activities = 5;
+  RackMaintenanceScope scope = 2;
 }
 
 message RackMaintenanceOnDemandResponse {


### PR DESCRIPTION
Group the device-id lists (machine_ids, switch_ids, power_shelf_ids) and the activities list of RackMaintenanceOnDemandRequest into a dedicated OnDemandRackMaintenanceScope message. This keeps the request focused on the rack identifier and lets the scope be passed around or defaulted as a single value, while preserving existing semantics: unset/empty scope means full rack, empty activities means all activities.

Update the admin-cli, component-manager firmware-update handler, and the on_demand_rack_maintenance RPC handler to construct/consume the new nested message, and refresh the architecture doc snippet to match.

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

