### PR TITLE
chore: bump libredfish to v0.43.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5937,7 +5937,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.43.10#4ac933a88a6911afb2d34fc88db3e30616911032"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.43.11#696fcdef426d728a66e88e93a3ec6d7b29c1775f"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.43.10" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.43.11" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.9.beta-rc2" }
 ansi-to-html = "0.2.2"
 


### PR DESCRIPTION
## Description

chore: bump libredfish to v0.43.11 to pull in changes to avoid anonymously querying the chassis subsystem as part of querying the base redfish service root.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

