### PR TITLE
fix: prevent stale power-state report from blocking host power-on when pairing

### DIFF
--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -1219,6 +1219,15 @@ impl EndpointExplorationError {
             || matches!(self, EndpointExplorationError::AvoidLockout)
     }
 
+    pub fn is_unreachable(&self) -> bool {
+        matches!(
+            self,
+            EndpointExplorationError::ConnectionTimeout { .. }
+                | EndpointExplorationError::ConnectionRefused { .. }
+                | EndpointExplorationError::Unreachable { .. }
+        )
+    }
+
     pub fn is_redfish(&self) -> bool {
         matches!(self, EndpointExplorationError::RedfishError { .. })
             || matches!(

--- a/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
@@ -109,6 +109,14 @@ impl EndpointExplorer for MockEndpointExplorer {
         Ok(())
     }
 
+    async fn redfish_get_power_state(
+        &self,
+        _address: SocketAddr,
+        _interface: &MachineInterfaceSnapshot,
+    ) -> Result<libredfish::PowerState, EndpointExplorationError> {
+        Ok(libredfish::PowerState::On)
+    }
+
     async fn redfish_power_control(
         &self,
         _address: SocketAddr,

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -896,6 +896,30 @@ impl EndpointExplorer for BmcEndpointExplorer {
             })
     }
 
+    async fn redfish_get_power_state(
+        &self,
+        bmc_ip_address: SocketAddr,
+        interface: &MachineInterfaceSnapshot,
+    ) -> Result<libredfish::PowerState, EndpointExplorationError> {
+        let bmc_mac_address = interface.mac_address;
+
+        match self.get_bmc_root_credentials(bmc_mac_address).await {
+            Ok(credentials) => {
+                self.redfish_client
+                    .get_power_state(bmc_ip_address, credentials)
+                    .await
+            }
+            Err(e) => {
+                tracing::info!(
+                    %bmc_ip_address,
+                    "Site explorer cannot fetch live power state for an endpoint without credentials: could not find an entry in vault at 'bmc/{}/root'.",
+                    bmc_mac_address,
+                );
+                Err(e)
+            }
+        }
+    }
+
     async fn redfish_power_control(
         &self,
         bmc_ip_address: SocketAddr,

--- a/crates/site-explorer/src/endpoint_explorer.rs
+++ b/crates/site-explorer/src/endpoint_explorer.rs
@@ -67,6 +67,12 @@ pub trait EndpointExplorer: Send + Sync + 'static {
         interface: &MachineInterfaceSnapshot,
     ) -> Result<(), EndpointExplorationError>;
 
+    async fn redfish_get_power_state(
+        &self,
+        address: SocketAddr,
+        interface: &MachineInterfaceSnapshot,
+    ) -> Result<libredfish::PowerState, EndpointExplorationError>;
+
     async fn redfish_power_control(
         &self,
         address: SocketAddr,

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -2170,41 +2170,81 @@ impl SiteExplorer {
         }
 
         let mut ingest_host = true;
+        let interface = match self
+            .find_machine_interface_for_ip(host_endpoint.address)
+            .await
+        {
+            Ok(interface) => Some(interface),
+            Err(e) => {
+                tracing::warn!(
+                    bmc_ip_address = %host_endpoint.address,
+                    error = %e,
+                    "Site Explorer could not find machine interface for host endpoint",
+                );
+                None
+            }
+        };
 
-        if !matches!(system.power_state, PowerState::On) {
+        // If the last exploration failed, the stored `systems` data may be stale —
+        // a host that is actually off can itself be the cause of BMC errors, so we
+        // refresh the power state via a single live Redfish call instead of
+        // trusting the cached value. `None` means we have no trustworthy reading;
+        // we fall back to the cached state for remediation decisions only and
+        // defer ingestion to a later run.
+        let fresh_power_state: Option<PowerState> =
+            match host_endpoint.report.last_exploration_error.as_ref() {
+                None => Some(system.power_state),
+                Some(err) if err.is_unauthorized() || err.is_unreachable() => None,
+                Some(_) => match interface.as_ref() {
+                    Some(interface) => self
+                        .endpoint_explorer
+                        .redfish_get_power_state(bmc_target_addr, interface)
+                        .await
+                        .ok()
+                        .map(PowerState::from),
+                    None => None,
+                },
+            };
+
+        let effective_power_state = fresh_power_state.unwrap_or(system.power_state);
+
+        if fresh_power_state.is_none() {
+            ingest_host = false;
+        }
+
+        if !matches!(effective_power_state, PowerState::On) {
+            ingest_host = false;
+
             if host_endpoint.pause_remediation {
                 tracing::info!(
                     "Site Explorer found an uningested host (bmc_ip_address: {}) that is off, but remediation is paused — skipping power-on",
                     host_endpoint.address,
                 );
-            } else {
+            } else if fresh_power_state.is_some() {
                 tracing::warn!(
                     "Site Explorer found an uningested host (bmc_ip_address: {}) that isnt on: {:#?}",
                     host_endpoint.address,
-                    system.power_state
+                    effective_power_state
                 );
 
-                let interface = self
-                    .find_machine_interface_for_ip(host_endpoint.address)
-                    .await?;
-
-                self.endpoint_explorer
-                    .redfish_power_control(
-                        bmc_target_addr,
-                        &interface,
-                        libredfish::SystemPowerControl::On,
-                    )
-                    .await
-                    .map_err(|err| {
-                        tracing::error!(
-                            "Site Explorer failed to turn on host (bmc_ip_address: {}) through redfish: {}",
-                            host_endpoint.address,
-                            err
+                if let Some(interface) = interface.as_ref() {
+                    self.endpoint_explorer
+                        .redfish_power_control(
+                            bmc_target_addr,
+                            interface,
+                            libredfish::SystemPowerControl::On,
                         )
-                    }).ok();
+                        .await
+                        .map_err(|err| {
+                            tracing::error!(
+                                "Site Explorer failed to turn on host (bmc_ip_address: {}) through redfish: {}",
+                                host_endpoint.address,
+                                err
+                            )
+                        })
+                        .ok();
+                }
             }
-
-            ingest_host = false;
         }
 
         if host_endpoint.report.vendor.unwrap_or_default().is_nvidia() {

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -2185,17 +2185,17 @@ impl SiteExplorer {
             }
         };
 
-        // If the last exploration failed, the stored `systems` data may be stale —
-        // a host that is actually off can itself be the cause of BMC errors, so we
-        // refresh the power state via a single live Redfish call instead of
-        // trusting the cached value. `None` means we have no trustworthy reading;
-        // we fall back to the cached state for remediation decisions only and
-        // defer ingestion to a later run.
+        // The cached `systems[].power_state` may be stale when this endpoint was
+        // not refreshed in the current iteration, so prefer a live Redfish power
+        // state check for uningested hosts. The exceptions are auth/lockout and
+        // unreachable failures, where another live read is either unsafe or very
+        // unlikely to help. `None` means we have no trustworthy reading; we fall
+        // back to the cached state for remediation decisions only and defer
+        // ingestion to a later run.
         let fresh_power_state: Option<PowerState> =
             match host_endpoint.report.last_exploration_error.as_ref() {
-                None => Some(system.power_state),
                 Some(err) if err.is_unauthorized() || err.is_unreachable() => None,
-                Some(_) => match interface.as_ref() {
+                _ => match interface.as_ref() {
                     Some(interface) => self
                         .endpoint_explorer
                         .redfish_get_power_state(bmc_target_addr, interface)

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -402,6 +402,19 @@ impl RedfishClient {
         Ok(())
     }
 
+    pub async fn get_power_state(
+        &self,
+        bmc_ip_address: SocketAddr,
+        credentials: Credentials,
+    ) -> Result<libredfish::PowerState, EndpointExplorationError> {
+        let client = self
+            .create_authenticated_redfish_client(bmc_ip_address, credentials)
+            .await
+            .map_err(map_redfish_client_creation_error)?;
+
+        client.get_power_state().await.map_err(map_redfish_error)
+    }
+
     pub async fn power(
         &self,
         bmc_ip_address: SocketAddr,


### PR DESCRIPTION
## Description
This PR changes `can_ingest_host_endpoint()` to stop trusting cached `systems[].power_state` from the exploration report when the previous exploration failed. Previously, if the cached report said a host was powered on when it was actually powered off, site-explorer could skip the required power-on step before creating a managed host.

Now, site-explorer does a live redfish `get_power_state()` check before deciding whether the host is actually `On`. If the host is `Off`, it issues `SystemPowerControl::On` and defers ingestion to a later pass instead of relying on stale report data.

This intentionally does not issue a live power-state check when the exploration error is `Unauthorized` or `Unreachable`.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
NV-Bug: 6101260

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

