### PR TITLE
web-ui: Render lifecycle related fields with a new template

### DIFF
--- a/crates/api/src/web/filters.rs
+++ b/crates/api/src/web/filters.rs
@@ -222,6 +222,62 @@ pub fn option_fmt(value: &Option<impl Display>) -> askama::Result<String> {
     })
 }
 
+pub(crate) fn normalize_state_label(state: impl Display) -> String {
+    state_and_substate_labels(state).0
+}
+
+pub(crate) fn state_and_substate_labels(state_json: impl Display) -> (String, String) {
+    let state_json = state_json.to_string();
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&state_json) else {
+        return (state_json, String::new());
+    };
+    let Some(object) = value.as_object() else {
+        return (state_json, String::new());
+    };
+    let Some(state) = object.get("state").and_then(|value| value.as_str()) else {
+        return (state_json, String::new());
+    };
+
+    let state_specific_key = format!("{state}_state");
+    let substate = object
+        .get(&state_specific_key)
+        .or_else(|| {
+            object
+                .iter()
+                .find(|(key, _)| key.as_str() != "state" && key.ends_with("_state"))
+                .map(|(_, value)| value)
+        })
+        .map(format_substate_label)
+        .unwrap_or_default();
+
+    (capitalize_state(state), substate)
+}
+
+pub fn state_with_substate_label(state: impl Display) -> ::askama::Result<String> {
+    let (state, substate) = state_and_substate_labels(state);
+    Ok(if substate.is_empty() {
+        state
+    } else {
+        format!("{state}/{substate}")
+    })
+}
+
+fn format_substate_label(value: &serde_json::Value) -> String {
+    value
+        .as_str()
+        .or_else(|| value.get("state").and_then(|value| value.as_str()))
+        .map(capitalize_state)
+        .unwrap_or_else(|| value.to_string())
+}
+
+fn capitalize_state(state: &str) -> String {
+    let mut chars = state.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+    }
+}
+
 /// Formats the boot order list
 pub fn boot_order_fmt(
     boot_order: &Option<rpc::site_explorer::BootOrder>,

--- a/crates/api/src/web/machine.rs
+++ b/crates/api/src/web/machine.rs
@@ -431,10 +431,7 @@ struct MachineDetail<'a> {
     id: String,
     host_id: String,
     rack_id: String,
-    state_version: String,
-    time_in_state: String,
-    state_display: super::StateDisplay,
-    state_sla_detail: super::StateSlaDetail,
+    lifecycle_detail: super::LifecycleDetail,
     last_reboot: String,
     machine_type: String,
     is_host: bool,
@@ -644,34 +641,12 @@ impl From<forgerpc::Machine> for MachineDetail<'_> {
         MachineDetail {
             id: machine_id.clone(),
             rack_id: m.rack_id.map(|id| id.to_string()).unwrap_or_default(),
-            time_in_state: config_version::since_state_change_humanized(&m.state_version),
-            state_version: m.state_version,
-            state_display: super::StateDisplay {
-                state: m.state,
-                time_in_state_above_sla: m
-                    .state_sla
-                    .as_ref()
-                    .map(|sla| sla.time_in_state_above_sla)
-                    .unwrap_or_default(),
-            },
-            state_sla_detail: super::StateSlaDetail {
-                state_sla: m
-                    .state_sla
-                    .as_ref()
-                    .and_then(|sla| sla.sla)
-                    .map(|sla| {
-                        config_version::format_duration(
-                            chrono::TimeDelta::try_from(sla).unwrap_or(chrono::TimeDelta::MAX),
-                        )
-                    })
-                    .unwrap_or_default(),
-                time_in_state_above_sla: m
-                    .state_sla
-                    .as_ref()
-                    .map(|sla| sla.time_in_state_above_sla)
-                    .unwrap_or_default(),
-                state_reason: m.state_reason,
-            },
+            lifecycle_detail: super::LifecycleDetail::new(
+                m.state,
+                m.state_version,
+                m.state_reason,
+                m.state_sla,
+            ),
             last_reboot: to_time(m.last_reboot_time, Some(&machine_id))
                 .unwrap_or("N/A".to_string()),
             metadata_detail: super::MetadataDetail {

--- a/crates/api/src/web/mod.rs
+++ b/crates/api/src/web/mod.rs
@@ -80,6 +80,74 @@ pub(crate) struct StateSlaDetail {
     pub state_reason: Option<rpc::forge::ControllerStateReason>,
 }
 
+/// Reusable template for rendering lifecycle fields.
+/// Render with `{{ lifecycle_detail|safe }}`.
+#[derive(Template)]
+#[template(path = "lifecycle_detail.html")]
+pub(crate) struct LifecycleDetail {
+    pub state_display: StateDisplay,
+    pub json_state: Option<String>,
+    pub version: String,
+    pub time_in_state: String,
+    pub state_sla: String,
+    pub time_in_state_above_sla: bool,
+    pub state_reason: Option<rpc::forge::ControllerStateReason>,
+}
+
+impl LifecycleDetail {
+    pub fn new(
+        state: String,
+        version: String,
+        state_reason: Option<forgerpc::ControllerStateReason>,
+        sla: Option<forgerpc::StateSla>,
+    ) -> Self {
+        let time_in_state_above_sla = sla
+            .as_ref()
+            .map(|sla| sla.time_in_state_above_sla)
+            .unwrap_or_default();
+        let json_state = verify_json(&state);
+        Self {
+            state_display: StateDisplay {
+                state,
+                time_in_state_above_sla,
+            },
+            json_state,
+            time_in_state: config_version::since_state_change_humanized(&version),
+            version,
+            state_sla: format_state_sla(sla.as_ref()),
+            time_in_state_above_sla,
+            state_reason,
+        }
+    }
+}
+
+impl From<forgerpc::LifecycleStatus> for LifecycleDetail {
+    fn from(lifecycle: forgerpc::LifecycleStatus) -> Self {
+        LifecycleDetail::new(
+            lifecycle.state,
+            lifecycle.version,
+            lifecycle.state_reason,
+            lifecycle.sla,
+        )
+    }
+}
+
+fn verify_json(state: &str) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(state)
+        .ok()
+        .map(|_| state.to_string())
+}
+
+fn format_state_sla(sla: Option<&forgerpc::StateSla>) -> String {
+    sla.and_then(|sla| sla.sla)
+        .map(|sla| {
+            config_version::format_duration(
+                chrono::TimeDelta::try_from(sla).unwrap_or(chrono::TimeDelta::MAX),
+            )
+        })
+        .unwrap_or_default()
+}
+
 mod action_status;
 mod attestation;
 mod auth;

--- a/crates/api/src/web/network_segment.rs
+++ b/crates/api/src/web/network_segment.rs
@@ -205,8 +205,7 @@ struct NetworkSegmentDetail {
     created: String,
     updated: String,
     deleted: String,
-    state_display: super::StateDisplay,
-    state_sla_detail: super::StateSlaDetail,
+    lifecycle_detail: super::LifecycleDetail,
     domain_id: String,
     domain_name: String,
     segment_type: String,
@@ -250,10 +249,15 @@ impl From<forgerpc::NetworkSegment> for NetworkSegmentDetail {
                 version: h.version,
             });
         }
+        let state = format!(
+            "{:?}",
+            forgerpc::TenantState::try_from(segment.state).unwrap_or_default()
+        );
+        let version = segment.version;
         Self {
             id: segment.id.unwrap_or_default().to_string(),
             name: segment.name,
-            version: segment.version,
+            version: version.clone(),
             vpc_id: segment.vpc_id.map(|id| id.to_string()).unwrap_or_default(),
             created: segment.created.unwrap_or_default().to_string(),
             updated: segment.updated.unwrap_or_default().to_string(),
@@ -261,35 +265,14 @@ impl From<forgerpc::NetworkSegment> for NetworkSegmentDetail {
                 .deleted
                 .map(|x| x.to_string())
                 .unwrap_or("Not Deleted".to_string()),
-            state_display: super::StateDisplay {
-                state: format!(
-                    "{:?}",
-                    forgerpc::TenantState::try_from(segment.state).unwrap_or_default()
-                ),
-                time_in_state_above_sla: segment
-                    .state_sla
-                    .as_ref()
-                    .map(|sla| sla.time_in_state_above_sla)
-                    .unwrap_or_default(),
-            },
-            state_sla_detail: super::StateSlaDetail {
-                state_sla: segment
-                    .state_sla
-                    .as_ref()
-                    .and_then(|sla| sla.sla)
-                    .map(|sla| {
-                        config_version::format_duration(
-                            chrono::TimeDelta::try_from(sla).unwrap_or(chrono::TimeDelta::MAX),
-                        )
-                    })
-                    .unwrap_or_default(),
-                time_in_state_above_sla: segment
-                    .state_sla
-                    .as_ref()
-                    .map(|sla| sla.time_in_state_above_sla)
-                    .unwrap_or_default(),
-                state_reason: segment.state_reason,
-            },
+            // TODO: This version field is wrong. We should be showing the controller state version,
+            // but it isn't exposed over gRPC
+            lifecycle_detail: super::LifecycleDetail::new(
+                state,
+                version,
+                segment.state_reason,
+                segment.state_sla,
+            ),
             domain_id: segment.subdomain_id.unwrap_or_default().to_string(),
             domain_name: String::new(), // filled in later
             segment_type: format!(

--- a/crates/api/src/web/power_shelf.rs
+++ b/crates/api/src/web/power_shelf.rs
@@ -120,10 +120,7 @@ pub async fn show_json(state: AxumState<Arc<Api>>) -> Response {
 struct PowerShelfDetail {
     id: String,
     rack_id: String,
-    controller_state: String,
-    state_version: String,
-    time_in_state: String,
-    state_reason: Option<rpc::forge::ControllerStateReason>,
+    lifecycle_detail: super::LifecycleDetail,
     power_state: Option<String>,
     name: String,
     capacity: String,
@@ -140,15 +137,12 @@ impl PowerShelfDetail {
             .map(|id| id.to_string())
             .unwrap_or_default();
         let config = shelf.config.unwrap_or_default();
-        let state_reason = shelf.status.as_ref().and_then(|s| s.state_reason.clone());
-        let power_state = shelf.status.as_ref().and_then(|s| s.power_state.clone());
-        let controller_state = shelf
+        let lifecycle = shelf
             .status
             .as_ref()
-            .and_then(|s| s.controller_state.clone())
-            .map(|s| capitalize(&s))
-            .unwrap_or_else(|| "Unknown".to_string());
-        let time_in_state = config_version::since_state_change_humanized(&shelf.state_version);
+            .and_then(|s| s.lifecycle.clone())
+            .unwrap_or_default();
+        let power_state = shelf.status.as_ref().and_then(|s| s.power_state.clone());
         let metadata_detail = super::MetadataDetail {
             metadata: shelf.metadata.unwrap_or_default(),
             metadata_version: shelf.version,
@@ -156,10 +150,7 @@ impl PowerShelfDetail {
         Self {
             id,
             rack_id: shelf.rack_id.map(|id| id.to_string()).unwrap_or_default(),
-            controller_state,
-            state_version: shelf.state_version,
-            time_in_state,
-            state_reason,
+            lifecycle_detail: lifecycle.into(),
             power_state,
             name: config.name,
             capacity: config

--- a/crates/api/src/web/rack.rs
+++ b/crates/api/src/web/rack.rs
@@ -48,10 +48,7 @@ struct RackRecord {
 #[template(path = "rack_detail.html")]
 struct RackDetail {
     id: String,
-    rack_state: String,
-    state_version: String,
-    time_in_state: String,
-    state_reason: Option<rpc::forge::ControllerStateReason>,
+    lifecycle_detail: super::LifecycleDetail,
     version: String,
     associated_machines: Vec<String>,
     associated_switches: Vec<String>,
@@ -227,19 +224,15 @@ pub async fn detail(
         }
     };
 
-    let rack_state = maybe_rack
-        .as_ref()
-        .map(|r| r.rack_state.clone())
-        .unwrap_or_default();
-
     let version = maybe_rack
         .as_ref()
         .map(|r| r.version.clone())
         .unwrap_or_default();
 
-    let time_in_state = maybe_rack
+    let lifecycle = maybe_rack
         .as_ref()
-        .map(|r| config_version::since_state_change_humanized(&r.version))
+        .and_then(|r| r.status.as_ref())
+        .and_then(|s| s.lifecycle.clone())
         .unwrap_or_default();
 
     let metadata_detail = super::MetadataDetail {
@@ -254,10 +247,7 @@ pub async fn detail(
 
     let display = RackDetail {
         id: rack_id.to_string(),
-        rack_state,
-        state_version: version.clone(),
-        time_in_state,
-        state_reason: None,
+        lifecycle_detail: lifecycle.into(),
         version,
         associated_machines,
         associated_switches,

--- a/crates/api/src/web/switch.rs
+++ b/crates/api/src/web/switch.rs
@@ -58,7 +58,12 @@ pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
         .switches
         .into_iter()
         .map(|switch| {
-            let state = parse_controller_state(&switch.controller_state);
+            let state = switch
+                .status
+                .as_ref()
+                .and_then(|status| status.lifecycle.as_ref())
+                .map(|lifecycle| super::filters::normalize_state_label(&lifecycle.state))
+                .unwrap_or_else(|| "Unknown".to_string());
 
             let config = switch.config.unwrap_or_default();
             SwitchRecord {
@@ -132,35 +137,16 @@ async fn fetch_switches(api: &Api) -> Result<rpc::forge::SwitchList, tonic::Stat
     Ok(rpc::forge::SwitchList { switches })
 }
 
-/// Parse the JSON controller_state string into a human-friendly state name.
-fn parse_controller_state(controller_state: &str) -> String {
-    serde_json::from_str::<serde_json::Value>(controller_state)
-        .ok()
-        .and_then(|v| v.get("state")?.as_str().map(capitalize))
-        .unwrap_or_else(|| "Unknown".to_string())
-}
-
-fn capitalize(s: &str) -> String {
-    let mut c = s.chars();
-    match c.next() {
-        None => String::new(),
-        Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
-    }
-}
-
 #[derive(Template)]
 #[template(path = "switch_detail.html")]
 struct SwitchDetail {
     id: String,
     rack_id: String,
-    controller_state: String,
-    state_version: String,
-    time_in_state: String,
     name: String,
     slot_number: String,
     tray_index: String,
     enable_nmxc: bool,
-    state_reason: Option<rpc::forge::ControllerStateReason>,
+    lifecycle_detail: super::LifecycleDetail,
     power_state: Option<String>,
     health_status: Option<String>,
     bmc_info: Option<rpc::forge::BmcInfo>,
@@ -175,10 +161,13 @@ impl SwitchDetail {
             .map(|id| id.to_string())
             .unwrap_or_default();
         let config = switch.config.unwrap_or_default();
-        let state_reason = switch.status.as_ref().and_then(|s| s.state_reason.clone());
+        let lifecycle = switch
+            .status
+            .as_ref()
+            .and_then(|s| s.lifecycle.clone())
+            .unwrap_or_default();
         let power_state = switch.status.as_ref().and_then(|s| s.power_state.clone());
         let health_status = switch.status.as_ref().and_then(|s| s.health_status.clone());
-        let time_in_state = config_version::since_state_change_humanized(&switch.state_version);
         let metadata_detail = super::MetadataDetail {
             metadata: switch.metadata.unwrap_or_default(),
             metadata_version: switch.version,
@@ -186,9 +175,6 @@ impl SwitchDetail {
         Self {
             id,
             rack_id: switch.rack_id.map(|id| id.to_string()).unwrap_or_default(),
-            controller_state: parse_controller_state(&switch.controller_state),
-            state_version: switch.state_version,
-            time_in_state,
             name: config.name,
             slot_number: switch
                 .placement_in_rack
@@ -203,7 +189,7 @@ impl SwitchDetail {
                 .map(|v| v.to_string())
                 .unwrap_or_else(|| "N/A".to_string()),
             enable_nmxc: config.enable_nmxc,
-            state_reason,
+            lifecycle_detail: lifecycle.into(),
             power_state,
             health_status,
             bmc_info: switch.bmc_info,
@@ -260,37 +246,4 @@ async fn fetch_switch(api: &Api, switch_id: &str) -> Result<Option<rpc::forge::S
     };
 
     Ok(response.switches.into_iter().next())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_controller_state_ready() {
-        assert_eq!(parse_controller_state(r#"{"state":"ready"}"#), "Ready");
-    }
-
-    #[test]
-    fn parse_controller_state_initializing() {
-        assert_eq!(
-            parse_controller_state(
-                r#"{"state":"initializing","initializing_state":"WaitForOsMachineInterface"}"#
-            ),
-            "Initializing"
-        );
-    }
-
-    #[test]
-    fn parse_controller_state_error() {
-        assert_eq!(
-            parse_controller_state(r#"{"state":"error","cause":"something broke"}"#),
-            "Error"
-        );
-    }
-
-    #[test]
-    fn parse_controller_state_invalid_json() {
-        assert_eq!(parse_controller_state("not json"), "Unknown");
-    }
 }

--- a/crates/api/templates/lifecycle_detail.html
+++ b/crates/api/templates/lifecycle_detail.html
@@ -1,0 +1,18 @@
+<h2>Lifecycle</h2>
+<table class="detailsview">
+	<tr>
+		<th>State</th>
+		<td>{{ state_display|safe }}</td>
+	</tr>
+	{% if let Some(json_state) = json_state %}
+	<tr>
+		<th>JSON State</th>
+		<td><div style="overflow: auto;"><pre><code class="prettyjson">{{ json_state }}</code></pre></div></td>
+	</tr>
+	{% endif %}
+	<tr><th>State Version</th><td>{{ version|config_version|safe }}</td></tr>
+	<tr><th>Time in state</th><td>{{ time_in_state }}</td></tr>
+	<tr><th>State SLA</th><td>{{ state_sla }}</td></tr>
+	<tr><th>Time in State is above SLA</th><td>{{ time_in_state_above_sla }}</td></tr>
+	<tr><th>State Handler Outcome</th><td>{{ state_reason|controller_state_reason_fmt|safe }}</td></tr>
+</table>

--- a/crates/api/templates/machine_detail.html
+++ b/crates/api/templates/machine_detail.html
@@ -21,13 +21,7 @@
 		</td>
 	</tr>
 	<tr><th>Rack ID</th><td>{{ rack_id|rack_id_link|safe }}</td></tr>
-	<tr><th>State</th>
-		<td>{{ state_display|safe }}</td>
-	</tr>
-	<tr><th>State Version</th><td>{{ state_version|config_version|safe }}</td></tr>
-	<tr><th>Time in state</th><td>{{ time_in_state }}</td></tr>
 	<tr><th>Last Reboot</th><td>{{ last_reboot }}</td></tr>
-	{{ state_sla_detail|safe }}
 
 	{% if !network_config.is_empty() %}
 	<tr>
@@ -60,6 +54,8 @@
 		{% endif %}
 	{% endif %}
 </table>
+
+{{ lifecycle_detail|safe }}
 
 <h3>Metadata</h3>
 {{ metadata_detail|safe }}

--- a/crates/api/templates/network_segment_detail.html
+++ b/crates/api/templates/network_segment_detail.html
@@ -14,12 +14,12 @@
 	<tr><th>Created </th><td>{{ created }}</td></tr>
 	<tr><th>Updated</th><td>{{ updated }}</td></tr>
 	<tr><th>Deleted</th><td>{{ deleted }}</td></tr>
-			<tr><th>State</th><td>{{ state_display|safe }}</td></tr>
-	{{ state_sla_detail|safe }}
 	<tr><th>Domain id</th><td><a href="/admin/domain">{{ domain_id }}</a></td></tr>
 	<tr><th>Domain name</th><td>{{ domain_name }}</td></tr>
 	<tr><th>Type</th><td>{{ segment_type }}</td></tr>
 </table>
+
+{{ lifecycle_detail|safe }}
 
 <h3>Prefixes</h3>
 {% for prefix in prefixes %}

--- a/crates/api/templates/power_shelf_detail.html
+++ b/crates/api/templates/power_shelf_detail.html
@@ -15,30 +15,6 @@
 		<td>{{ id }}</td>
 	</tr>
 	<tr><th>Rack ID</th><td>{{ rack_id|rack_id_link|safe }}</td></tr>
-	<tr>
-		<th>State</th>
-		<td>
-			{% if controller_state == "Ready" %}
-				<span class="bubble success">{{ controller_state }}</span>
-			{% else if controller_state.to_lowercase().contains("error") || controller_state.to_lowercase().contains("failed") %}
-				<span class="bubble error">{{ controller_state }}</span>
-			{% else %}
-				<span class="bubble">{{ controller_state }}</span>
-			{% endif %}
-		</td>
-	</tr>
-	<tr>
-		<th>State Handler Outcome</th>
-		<td>{{ state_reason|controller_state_reason_fmt|safe }}</td>
-	</tr>
-	<tr>
-		<th>State Version</th>
-		<td>{{ state_version|config_version|safe }}</td>
-	</tr>
-	<tr>
-		<th>Time in State</th>
-		<td>{{ time_in_state }}</td>
-	</tr>
 	{% if let Some(power_state) = power_state %}
 	<tr>
 		<th>Power State</th>
@@ -46,6 +22,8 @@
 	</tr>
 	{% endif %}
 </table>
+
+{{ lifecycle_detail|safe }}
 
 <h2>Configuration</h2>
 <table class="detailsview">

--- a/crates/api/templates/rack_detail.html
+++ b/crates/api/templates/rack_detail.html
@@ -15,34 +15,12 @@
 		<td>{{ id }}</td>
 	</tr>
 	<tr>
-		<th>State</th>
-		<td>
-			{% if rack_state == "Ready" %}
-				<span class="bubble success">{{ rack_state }}</span>
-			{% else if rack_state.to_lowercase().contains("error") || rack_state.to_lowercase().contains("failed") %}
-				<span class="bubble error">{{ rack_state }}</span>
-			{% else %}
-				<span class="bubble">{{ rack_state }}</span>
-			{% endif %}
-		</td>
-	</tr>
-	<tr>
-		<th>State Handler Outcome</th>
-		<td>{{ state_reason|controller_state_reason_fmt|safe }}</td>
-	</tr>
-	<tr>
-		<th>State Version</th>
-		<td>{{ state_version|config_version|safe }}</td>
-	</tr>
-	<tr>
-		<th>Time in State</th>
-		<td>{{ time_in_state }}</td>
-	</tr>
-	<tr>
 		<th>Version</th>
 		<td>{{ version }}</td>
 	</tr>
 </table>
+
+{{ lifecycle_detail|safe }}
 
 <h2>Metadata</h2>
 {{ metadata_detail|safe }}

--- a/crates/api/templates/state_display.html
+++ b/crates/api/templates/state_display.html
@@ -1,9 +1,10 @@
-{% if state.to_lowercase().contains("failed") %}
-	<span class="bubble error">{{ state }}{% if time_in_state_above_sla %} ⏱️{% endif %}</span>
+{% set display_state = state|state_with_substate_label %}
+{% if display_state.to_lowercase().contains("failed") %}
+	<span class="bubble error">{{ display_state }}{% if time_in_state_above_sla %} ⏱️{% endif %}</span>
 {% else if time_in_state_above_sla %}
-	<span class="bubble warning">{{ state }} ⏱️</span>
-{% else if state == "Ready" || state == "Assigned/Ready" %}
-	<span class="bubble success">{{ state }}</span>
+	<span class="bubble warning">{{ display_state }} ⏱️</span>
+{% else if display_state == "Ready" || display_state == "Assigned/Ready" %}
+	<span class="bubble success">{{ display_state }}</span>
 {% else %}
-	<span class="bubble">{{ state }}</span>
+	<span class="bubble">{{ display_state }}</span>
 {% endif %}

--- a/crates/api/templates/switch_detail.html
+++ b/crates/api/templates/switch_detail.html
@@ -15,30 +15,6 @@
 		<td>{{ id }}</td>
 	</tr>
 	<tr><th>Rack ID</th><td>{{ rack_id|rack_id_link|safe }}</td></tr>
-	<tr>
-		<th>State</th>
-		<td>
-			{% if controller_state == "Ready" %}
-				<span class="bubble success">{{ controller_state }}</span>
-			{% else if controller_state.to_lowercase().contains("error") || controller_state.to_lowercase().contains("failed") %}
-				<span class="bubble error">{{ controller_state }}</span>
-			{% else %}
-				<span class="bubble">{{ controller_state }}</span>
-			{% endif %}
-		</td>
-	</tr>
-	<tr>
-		<th>State Handler Outcome</th>
-		<td>{{ state_reason|controller_state_reason_fmt|safe }}</td>
-	</tr>
-	<tr>
-		<th>State Version</th>
-		<td>{{ state_version|config_version|safe }}</td>
-	</tr>
-	<tr>
-		<th>Time in State</th>
-		<td>{{ time_in_state }}</td>
-	</tr>
 	{% if let Some(power_state) = power_state %}
 	<tr>
 		<th>Power State</th>
@@ -60,6 +36,8 @@
 	</tr>
 	{% endif %}
 </table>
+
+{{ lifecycle_detail|safe }}
 
 <h2>Configuration</h2>
 <table class="detailsview">


### PR DESCRIPTION
## Description

Consistently renders all lifecycle related details (current state, state version, handler outcome) across all object types.

For fields which already expose it, use the `status_lifecycle` fields as source of information.

## Type of Change

- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

