### PR TITLE
refactor(nvlink-manager): extract NVLink code and config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,6 +1375,7 @@ dependencies = [
  "carbide-macros",
  "carbide-measured-boot",
  "carbide-network",
+ "carbide-nvlink-manager",
  "carbide-preingestion-manager",
  "carbide-prost-builder",
  "carbide-redfish",
@@ -2330,6 +2331,35 @@ dependencies = [
  "serde_json",
  "sqlx",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "carbide-nvlink-manager"
+version = "0.0.1"
+dependencies = [
+ "async-trait",
+ "carbide-api-db",
+ "carbide-api-model",
+ "carbide-rpc",
+ "carbide-secrets",
+ "carbide-utils",
+ "carbide-uuid",
+ "chrono",
+ "config-version",
+ "duration-str",
+ "eyre",
+ "http",
+ "libnmxm",
+ "opentelemetry",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/api-db/src/lib.rs
+++ b/crates/api-db/src/lib.rs
@@ -734,6 +734,19 @@ impl WithTransaction for PgPool {
     }
 }
 
+pub trait TransactionVending {
+    fn txn_begin(&self) -> impl Future<Output = Result<Transaction<'_>, DatabaseError>>;
+}
+
+impl TransactionVending for PgPool {
+    #[track_caller]
+    // This returns an `impl Future` instead of being async, so that we can use #[track_caller],
+    // which is unsupported with async fn's.
+    fn txn_begin(&self) -> impl Future<Output = Result<Transaction<'_>, DatabaseError>> {
+        Transaction::begin(self)
+    }
+}
+
 #[cfg(test)]
 #[ctor::ctor]
 fn setup_test_logging() {

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -47,6 +47,7 @@ carbide-ipmi = { path = "../ipmi" }
 carbide-redfish = { path = "../redfish" }
 carbide-site-explorer = { path = "../site-explorer" }
 carbide-preingestion-manager = { path = "../preingestion-manager" }
+carbide-nvlink-manager = { path = "../nvlink-manager" }
 dns-record = { path = "../dns-record" }
 libnmxm = { path = "../libnmxm" }
 logfmt = { path = "../logfmt" }
@@ -211,6 +212,7 @@ rcgen = { workspace = true }
 carbide-macros = { path = "../macros" }
 carbide-sqlx-testing = { path = "../sqlx-testing", default-features = false }
 carbide-prost-builder = { path = "../prost-builder" }
+carbide-nvlink-manager = { path = "../nvlink-manager", features = [ "test-support" ] }
 carbide-redfish = { path = "../redfish", features = [ "test-support" ] }
 carbide-utils = { path = "../utils", features = ["test-support"] }
 state-controller = { path = "../state-controller", features = ["test-support"] }

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -30,6 +30,7 @@ use ::rpc::protos::dns::{
     UpdateDomainRequest,
 };
 use ::rpc::protos::{measured_boot as measured_boot_pb, mlx_device as mlx_device_pb};
+use carbide_nvlink_manager::nvlink::NmxmClientPool;
 use carbide_redfish::libredfish::RedfishClientPool;
 use carbide_site_explorer::EndpointExplorer;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
@@ -42,7 +43,7 @@ use librms::RmsApi;
 use model::machine::Machine;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::resource_pool::common::CommonPools;
-use sqlx::{PgPool, PgTransaction};
+use sqlx::PgTransaction;
 use tokio_stream::Stream;
 use tonic::{Request, Response, Status, Streaming};
 
@@ -54,7 +55,6 @@ use crate::dynamic_settings::DynamicSettings;
 use crate::ethernet_virtualization::EthVirtData;
 use crate::ib::IBFabricManager;
 use crate::logging::log_limiter::LogLimiter;
-use crate::nvlink::NmxmClientPool;
 use crate::rack::bms_client::BmsDsxExchangeHandle;
 use crate::scout_stream::ConnectionRegistry;
 use crate::state_controller::controller::Enqueuer;
@@ -3324,19 +3324,6 @@ pub(crate) fn truncate(mut s: String, len: usize) -> String {
         s.replace_range(len - 2..len, "..");
     }
     s
-}
-
-pub trait TransactionVending {
-    fn txn_begin(&self) -> impl Future<Output = Result<db::Transaction<'_>, DatabaseError>>;
-}
-
-impl TransactionVending for PgPool {
-    #[track_caller]
-    // This returns an `impl Future` instead of being async, so that we can use #[track_caller],
-    // which is unsupported with async fn's.
-    fn txn_begin(&self) -> impl Future<Output = Result<db::Transaction<'_>, DatabaseError>> {
-        db::Transaction::begin(self)
-    }
 }
 
 impl Api {

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -25,6 +25,7 @@ use std::sync::atomic::AtomicBool;
 use bmc_vendor::BMCVendor;
 use carbide_authn::config::{AllowedCertCriteria, TrustConfig};
 use carbide_firmware::FirmwareConfig;
+use carbide_nvlink_manager::config::NvLinkConfig;
 use carbide_preingestion_manager::PreingestionManagerConfig;
 use carbide_site_explorer::config::SiteExplorerConfig;
 use chrono::Duration;
@@ -1558,62 +1559,6 @@ impl IBFabricConfig {
         let service_level = i32::deserialize(deserializer)?;
 
         IBServiceLevel::try_from(service_level).map_err(|e| serde::de::Error::custom(e.to_string()))
-    }
-}
-
-/// NvLink related configuration.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-pub struct NvLinkConfig {
-    /// Enables NvLink partitioning.
-    #[serde(default)]
-    pub enabled: bool,
-
-    /// Defaults to 1 Minute if not specified.
-    #[serde(
-        default = "NvLinkConfig::default_monitor_run_interval",
-        deserialize_with = "deserialize_duration",
-        serialize_with = "as_std_duration"
-    )]
-    pub monitor_run_interval: std::time::Duration,
-
-    /// Timeout for pending NMX-M operations. Defaults to 10 seconds if not specified.
-    #[serde(
-        default = "NvLinkConfig::default_nmx_m_operation_timeout",
-        deserialize_with = "deserialize_duration",
-        serialize_with = "as_std_duration"
-    )]
-    pub nmx_m_operation_timeout: std::time::Duration,
-
-    /// NMX-M endpoint (name or IP address) used to create client connections,
-    /// include port number as well if required eg. https://127.0.0.1:4010
-    #[serde(default = "default_nmx_m_endpoint")]
-    pub nmx_m_endpoint: String,
-    /// Set to true if NMX-M doesn't adhere to security requirements. Defaults to false
-    pub allow_insecure: bool,
-}
-
-fn default_nmx_m_endpoint() -> String {
-    "localhost".to_string()
-}
-
-impl Default for NvLinkConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            monitor_run_interval: Self::default_monitor_run_interval(),
-            nmx_m_operation_timeout: Self::default_nmx_m_operation_timeout(),
-            nmx_m_endpoint: "localhost".to_string(),
-            allow_insecure: false,
-        }
-    }
-}
-
-impl NvLinkConfig {
-    pub const fn default_monitor_run_interval() -> std::time::Duration {
-        std::time::Duration::from_secs(60)
-    }
-    pub const fn default_nmx_m_operation_timeout() -> std::time::Duration {
-        std::time::Duration::from_secs(10)
     }
 }
 
@@ -3862,23 +3807,6 @@ mqtt_endpoint = "mqtt.forge"
                 subnet_ip: Ipv4Addr::UNSPECIFIED,
                 subnet_mask: 0_i32,
                 auth: MqttAuthConfig::default(),
-            }
-        );
-    }
-
-    #[test]
-    fn deserialize_serialize_nvlink_config() {
-        let value_json = r#"{"enabled": true, "allow_insecure": true, "monitor_run_interval": "33", "nmx_m_operation_timeout": "21", "nmx_m_endpoint": "localhost"}"#;
-
-        let nvlink_config: NvLinkConfig = serde_json::from_str(value_json).unwrap();
-        assert_eq!(
-            nvlink_config,
-            NvLinkConfig {
-                enabled: true,
-                monitor_run_interval: std::time::Duration::from_secs(33),
-                nmx_m_operation_timeout: std::time::Duration::from_secs(21),
-                nmx_m_endpoint: "localhost".to_string(),
-                allow_insecure: true,
             }
         );
     }

--- a/crates/api/src/handlers/bmc_metadata.rs
+++ b/crates/api/src/handlers/bmc_metadata.rs
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 use ::rpc::forge as rpc;
+use db::TransactionVending;
 use forge_secrets::credentials::{BmcCredentialType, CredentialKey, CredentialReader, Credentials};
 use sqlx::PgPool;
 
 use crate::CarbideError;
-use crate::api::{Api, TransactionVending, log_request_data};
+use crate::api::{Api, log_request_data};
 use crate::handlers::bmc_endpoint_explorer::validate_and_complete_bmc_endpoint_request;
 
 pub(crate) async fn get(

--- a/crates/api/src/handlers/credential.rs
+++ b/crates/api/src/handlers/credential.rs
@@ -20,6 +20,7 @@ use std::io::Write;
 
 use ::rpc::errors::RpcDataConversionError;
 use ::rpc::forge as rpc;
+use carbide_nvlink_manager::DEFAULT_NMX_M_NAME;
 use forge_secrets::credentials::{
     BgpCredentialType, BmcCredentialType, CredentialKey, CredentialType, Credentials,
 };
@@ -35,8 +36,6 @@ use crate::handlers::utils::convert_and_log_machine_id;
 
 /// Default Username for the admin BMC account.
 const DEFAULT_FORGE_ADMIN_BMC_USERNAME: &str = "root";
-
-pub const DEFAULT_NMX_M_NAME: &str = "forge-nmx-m";
 
 /// The maximum size that will be accepted in the underlying BGP config
 /// on the DPU.  This was directly verified by checking the maximum accepted

--- a/crates/api/src/handlers/machine_discovery.rs
+++ b/crates/api/src/handlers/machine_discovery.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 pub use ::rpc::forge as rpc;
+use carbide_nvlink_manager::config::NvLinkConfig;
 use carbide_uuid::nvlink::NvLinkDomainId;
 use db::WithTransaction;
 use futures_util::FutureExt;
@@ -31,7 +32,6 @@ use model::machine::{DpuInitState, DpuInitStates, ManagedHostState};
 use tonic::{Request, Response, Status};
 
 use crate::api::{Api, log_machine_id, log_request_data};
-use crate::cfg::file::NvLinkConfig;
 use crate::handlers::utils::convert_and_log_machine_id;
 use crate::{CarbideError, CarbideResult, attestation as attest};
 

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -58,8 +58,6 @@ mod machine_validation;
 mod measured_boot;
 mod mqtt_state_change_hook;
 mod network_segment;
-mod nvl_partition_monitor;
-mod nvlink;
 mod rack;
 mod redfish;
 mod run;

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -23,6 +23,8 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use carbide_firmware::FirmwareDownloader;
 use carbide_ipmi::IPMITool;
+use carbide_nvlink_manager::NvlPartitionMonitor;
+use carbide_nvlink_manager::nvlink::{NmxmClientPool, NmxmClientPoolImpl};
 use carbide_preingestion_manager::PreingestionManager;
 use carbide_redfish::libredfish::RedfishClientPool;
 use carbide_redfish::nv_redfish::NvRedfishClientPool;
@@ -71,8 +73,6 @@ use crate::logging::service_health_metrics::{
 use crate::machine_update_manager::MachineUpdateManager;
 use crate::measured_boot::metrics_collector::MeasuredBootMetricsCollector;
 use crate::mqtt_state_change_hook::hook::MqttStateChangeHook;
-use crate::nvl_partition_monitor::NvlPartitionMonitor;
-use crate::nvlink::{NmxmClientPool, NmxmClientPoolImpl};
 use crate::rack::bms_client::BmsDsxExchangeHandle;
 use crate::scout_stream::ConnectionRegistry;
 use crate::state_controller::common_services::CommonStateHandlerServices;

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -28,6 +28,10 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use carbide_ipmi::IPMITool;
+use carbide_nvlink_manager::NvlPartitionMonitor;
+use carbide_nvlink_manager::config::NvLinkConfig;
+use carbide_nvlink_manager::nvlink::NmxmClientPool;
+use carbide_nvlink_manager::nvlink::test_support::NmxmSimClient;
 use carbide_redfish::libredfish::test_support::RedfishSim;
 use carbide_site_explorer::SiteExplorer;
 use carbide_site_explorer::config::{SiteExplorerConfig, SiteExplorerExploreMode};
@@ -95,10 +99,9 @@ use crate::cfg::file::{
     IBFabricConfig, IbFabricDefinition, IbPartitionStateControllerConfig, ListenMode,
     MachineStateControllerConfig, MachineUpdater, MachineValidationConfig,
     MeasuredBootMetricsCollectorConfig, MqttAuthConfig, NetworkSecurityGroupConfig,
-    NetworkSegmentStateControllerConfig, NvLinkConfig, PowerManagerOptions,
-    PowerShelfStateControllerConfig, RackStateControllerConfig, SpdmConfig,
-    SpdmStateControllerConfig, StateControllerConfig, SwitchStateControllerConfig, VmaasConfig,
-    VpcPeeringPolicy, default_max_find_by_ids,
+    NetworkSegmentStateControllerConfig, PowerManagerOptions, PowerShelfStateControllerConfig,
+    RackStateControllerConfig, SpdmConfig, SpdmStateControllerConfig, StateControllerConfig,
+    SwitchStateControllerConfig, VmaasConfig, VpcPeeringPolicy, default_max_find_by_ids,
 };
 use crate::dpf::DpfOperations;
 use crate::ethernet_virtualization::{EthVirtData, SiteFabricPrefixList};
@@ -106,9 +109,6 @@ use crate::ib::{self, IBFabricManagerImpl, IBFabricManagerType};
 use crate::ib_fabric_monitor::IbFabricMonitor;
 use crate::logging::level_filter::ActiveLevel;
 use crate::logging::log_limiter::LogLimiter;
-use crate::nvl_partition_monitor::NvlPartitionMonitor;
-use crate::nvlink::NmxmClientPool;
-use crate::nvlink::test_support::NmxmSimClient;
 use crate::rack::rms_client::test_support::RmsSim;
 use crate::scout_stream;
 use crate::state_controller::common_services::CommonStateHandlerServices;

--- a/crates/nvlink-manager/Cargo.toml
+++ b/crates/nvlink-manager/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "carbide-nvlink-manager"
+version = "0.0.1"
+edition.workspace = true
+description = "Carbide NVLink Manager"
+license.workspace = true
+authors.workspace = true
+
+[lib]
+name = "carbide_nvlink_manager"
+
+[features]
+default = []
+test-support = []
+
+[dependencies]
+carbide-api-db = { path = "../api-db" }
+carbide-api-model = { path = "../api-model" }
+carbide-rpc = { path = "../rpc" } # TODO: it is only for Errors, can be improved. 
+carbide-secrets = { path = "../secrets" }
+carbide-utils = { path = "../utils" }
+carbide-uuid = { path = "../uuid" }
+config-version = { path = "../config-version" }
+libnmxm = { path = "../libnmxm" }
+
+# these are alphabetized
+async-trait = { workspace = true }
+chrono = { workspace = true }
+duration-str = { workspace = true }
+eyre = { workspace = true }
+http = { workspace = true }
+opentelemetry = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sqlx = { workspace = true, features = ["postgres"] }
+rand = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
+uuid = { features = ["v4", "serde"], workspace = true }
+
+[lints]
+workspace = true

--- a/crates/nvlink-manager/src/config.rs
+++ b/crates/nvlink-manager/src/config.rs
@@ -1,0 +1,98 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use duration_str::deserialize_duration;
+use serde::{Deserialize, Serialize};
+use utils::config::as_std_duration;
+
+/// NvLink related configuration.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct NvLinkConfig {
+    /// Enables NvLink partitioning.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Defaults to 1 Minute if not specified.
+    #[serde(
+        default = "NvLinkConfig::default_monitor_run_interval",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub monitor_run_interval: std::time::Duration,
+
+    /// Timeout for pending NMX-M operations. Defaults to 10 seconds if not specified.
+    #[serde(
+        default = "NvLinkConfig::default_nmx_m_operation_timeout",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub nmx_m_operation_timeout: std::time::Duration,
+
+    /// NMX-M endpoint (name or IP address) used to create client connections,
+    /// include port number as well if required eg. https://127.0.0.1:4010
+    #[serde(default = "default_nmx_m_endpoint")]
+    pub nmx_m_endpoint: String,
+    /// Set to true if NMX-M doesn't adhere to security requirements. Defaults to false
+    pub allow_insecure: bool,
+}
+
+fn default_nmx_m_endpoint() -> String {
+    "localhost".to_string()
+}
+
+impl Default for NvLinkConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            monitor_run_interval: Self::default_monitor_run_interval(),
+            nmx_m_operation_timeout: Self::default_nmx_m_operation_timeout(),
+            nmx_m_endpoint: "localhost".to_string(),
+            allow_insecure: false,
+        }
+    }
+}
+
+impl NvLinkConfig {
+    pub const fn default_monitor_run_interval() -> std::time::Duration {
+        std::time::Duration::from_secs(60)
+    }
+    pub const fn default_nmx_m_operation_timeout() -> std::time::Duration {
+        std::time::Duration::from_secs(10)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn deserialize_serialize_nvlink_config() {
+        let value_json = r#"{"enabled": true, "allow_insecure": true, "monitor_run_interval": "33", "nmx_m_operation_timeout": "21", "nmx_m_endpoint": "localhost"}"#;
+
+        let nvlink_config: NvLinkConfig = serde_json::from_str(value_json).unwrap();
+        assert_eq!(
+            nvlink_config,
+            NvLinkConfig {
+                enabled: true,
+                monitor_run_interval: std::time::Duration::from_secs(33),
+                nmx_m_operation_timeout: std::time::Duration::from_secs(21),
+                nmx_m_endpoint: "localhost".to_string(),
+                allow_insecure: true,
+            }
+        );
+    }
+}

--- a/crates/nvlink-manager/src/errors.rs
+++ b/crates/nvlink-manager/src/errors.rs
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use db::DatabaseError;
+use rpc::errors::RpcDataConversionError;
+
+#[derive(thiserror::Error, Debug)]
+pub enum NvLinkManagerError {
+    #[error("Database error: {0}")]
+    DatabaseError(#[from] DatabaseError),
+    #[error("Can not convert between RPC data model and internal data model - {0}")]
+    RpcDataConversionError(#[from] RpcDataConversionError),
+    #[error("Internal error: {message}")]
+    Internal { message: String },
+}
+
+impl NvLinkManagerError {
+    /// Creates a `Internal` error with the given error message
+    pub fn internal(message: String) -> Self {
+        Self::Internal { message }
+    }
+}
+
+pub type NvLinkManagerResult<T> = Result<T, NvLinkManagerError>;

--- a/crates/nvlink-manager/src/lib.rs
+++ b/crates/nvlink-manager/src/lib.rs
@@ -14,6 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+pub mod config;
+mod errors;
+mod metrics;
+pub mod nvlink;
+
 use std::collections::HashMap;
 use std::io;
 use std::sync::Arc;
@@ -22,13 +28,15 @@ use std::time::Duration;
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::nvlink::{NvLinkDomainId, NvLinkLogicalPartitionId, NvLinkPartitionId};
 use chrono::Utc;
+use config::NvLinkConfig;
 use config_version::Versioned;
 use db::machine::find_machine_ids;
 use db::managed_host::load_by_machine_ids;
 use db::nvl_logical_partition::IdColumn as LpIdColumn;
 use db::nvl_partition::IdColumn;
 use db::work_lock_manager::WorkLockManagerHandle;
-use db::{self, ObjectColumnFilter, machine};
+use db::{self, ObjectColumnFilter, TransactionVending, machine};
+use errors::{NvLinkManagerError, NvLinkManagerResult};
 use metrics::{AppliedChange, NmxmPartitionOperationStatus, NvlPartitionMonitorMetrics};
 use model::hardware_info::{MachineNvLinkInfo, NvLinkGpu};
 use model::instance::status::SyncState;
@@ -44,12 +52,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 use utils::periodic_timer::PeriodicTimer;
 
-use crate::api::TransactionVending;
-use crate::cfg::file::NvLinkConfig;
 use crate::nvlink::NmxmClientPool;
-use crate::{CarbideError, CarbideResult};
 
-mod metrics;
+pub const DEFAULT_NMX_M_NAME: &str = "forge-nmx-m";
 
 #[derive(Debug, Clone)]
 struct NmxmPartitionOperation {
@@ -371,9 +376,9 @@ impl PartitionProcessingContext {
         &mut self,
         ctx: &GpuProcessingContext,
         gpus_to_keep: Vec<String>,
-    ) -> CarbideResult<()> {
+    ) -> NvLinkManagerResult<()> {
         let Some(logical_partition_id) = ctx.logical_partition_id else {
-            return Err(CarbideError::internal(
+            return Err(NvLinkManagerError::internal(
                 "Logical partition ID is required for GPU removal".to_string(),
             ));
         };
@@ -443,7 +448,7 @@ impl PartitionProcessingContext {
         partition_nmx_m_id: &str,
         gpu_nmx_m_id: &str,
         gpus_to_keep: Vec<String>,
-    ) -> CarbideResult<()> {
+    ) -> NvLinkManagerResult<()> {
         if gpus_to_keep.is_empty() {
             let operation = NmxmPartitionOperation {
                 domain_uuid: None,
@@ -506,9 +511,9 @@ impl PartitionProcessingContext {
     fn handle_gpu_addition_new_partition(
         &mut self,
         ctx: &GpuProcessingContext,
-    ) -> CarbideResult<()> {
+    ) -> NvLinkManagerResult<()> {
         let Some(logical_partition_id) = ctx.logical_partition_id else {
-            return Err(CarbideError::internal(
+            return Err(NvLinkManagerError::internal(
                 "Logical partition ID is required for GPU addition to new partition".to_string(),
             ));
         };
@@ -542,9 +547,9 @@ impl PartitionProcessingContext {
         &mut self,
         ctx: &GpuProcessingContext,
         partition: &NvlPartition,
-    ) -> CarbideResult<()> {
+    ) -> NvLinkManagerResult<()> {
         let Some(logical_partition_id) = ctx.logical_partition_id else {
-            return Err(CarbideError::internal(
+            return Err(NvLinkManagerError::internal(
                 "Logical partition ID is required for GPU addition to existing partition"
                     .to_string(),
             ));
@@ -562,7 +567,7 @@ impl PartitionProcessingContext {
                         .collect();
                 }
                 libnmxm::nmxm_model::PartitionMembers::InnerStructs(_) => {
-                    return Err(CarbideError::internal(
+                    return Err(NvLinkManagerError::internal(
                         "Partition members are location-based, expected GPU-ID-based".to_string(),
                     ));
                 }
@@ -571,7 +576,7 @@ impl PartitionProcessingContext {
                 }
             }
         } else {
-            return Err(CarbideError::internal(
+            return Err(NvLinkManagerError::internal(
                 "NMX-M partition not found for GPU addition to existing partition".to_string(),
             ));
         }
@@ -683,7 +688,7 @@ impl NvlPartitionMonitor {
         }
     }
 
-    pub async fn run_single_iteration(&self) -> CarbideResult<usize> {
+    pub async fn run_single_iteration(&self) -> NvLinkManagerResult<usize> {
         let mut metrics = NvlPartitionMonitorMetrics::new();
         let span_id: String = format!("{:#x}", u64::from_le_bytes(rand::random::<[u8; 8]>()));
         let check_nvl_partition_span = tracing::span!(
@@ -714,7 +719,7 @@ impl NvlPartitionMonitor {
     async fn run_single_iteration_inner(
         &self,
         metrics: &mut NvlPartitionMonitorMetrics,
-    ) -> CarbideResult<usize> {
+    ) -> NvLinkManagerResult<usize> {
         let _lock = match self
             .work_lock_manager_handle
             .try_acquire_lock(Self::ITERATION_WORK_KEY.into())
@@ -739,7 +744,7 @@ impl NvlPartitionMonitor {
             .await
             .map_err(|e| {
                 metrics.nmxm.connect_error = "Failed to create NMXM client".to_string();
-                CarbideError::internal(format!("Failed to create NMXM client: {e}"))
+                NvLinkManagerError::internal(format!("Failed to create NMXM client: {e}"))
             })?;
 
         // Gather instances and NMX-M GPU info from DB, and partitions list from NMX-M.
@@ -762,12 +767,12 @@ impl NvlPartitionMonitor {
 
         let nmx_m_partitions = nmxm_client.get_partitions_list().await.map_err(|e| {
             metrics.nmxm.connect_error = "Failed to get NMXM partitions list".to_string();
-            CarbideError::internal(format!("Failed to get NMXM partitions list: {e}"))
+            NvLinkManagerError::internal(format!("Failed to get NMXM partitions list: {e}"))
         })?;
 
         let nmx_m_gpus = nmxm_client.get_gpu(None).await.map_err(|e| {
             metrics.nmxm.connect_error = "Failed to get NMXM gpu list".to_string();
-            CarbideError::internal(format!("Failed to get NMXM gpu list: {e}"))
+            NvLinkManagerError::internal(format!("Failed to get NMXM gpu list: {e}"))
         })?;
 
         // Validate machine_nvlink_info is consistent with nmx-m get_gpu information.
@@ -834,7 +839,7 @@ impl NvlPartitionMonitor {
         let nmx_m_partitions = nmxm_client.get_partitions_list().await.map_err(|e| {
             metrics.nmxm.connect_error =
                 "Failed to get NMXM partitions list when updating db".to_string();
-            CarbideError::internal(format!("Failed to get NMXM partitions list: {e}"))
+            NvLinkManagerError::internal(format!("Failed to get NMXM partitions list: {e}"))
         })?;
 
         // Update db.
@@ -863,7 +868,7 @@ impl NvlPartitionMonitor {
         db_nvl_partitions: Vec<NvlPartition>,
         nmx_m_partitions: &[libnmxm::nmxm_model::Partition],
         metrics: &mut NvlPartitionMonitorMetrics,
-    ) -> CarbideResult<(
+    ) -> NvLinkManagerResult<(
         HashMap<MachineId, Option<MachineNvLinkInfo>>,
         Vec<NvlPartition>,
     )> {
@@ -1019,7 +1024,7 @@ impl NvlPartitionMonitor {
         partition_ctx: &mut PartitionProcessingContext,
         mh_snapshots: HashMap<MachineId, ManagedHostStateSnapshot>,
         metrics: &mut NvlPartitionMonitorMetrics,
-    ) -> CarbideResult<HashMap<MachineId, MachineNvLinkStatusObservation>> {
+    ) -> NvLinkManagerResult<HashMap<MachineId, MachineNvLinkStatusObservation>> {
         let mut machine_gpu_statuses = HashMap::new();
 
         for mh in mh_snapshots.values() {
@@ -1334,7 +1339,7 @@ impl NvlPartitionMonitor {
         &self,
         mh: &ManagedHostStateSnapshot,
         partition_ctx: &mut PartitionProcessingContext,
-    ) -> CarbideResult<()> {
+    ) -> NvLinkManagerResult<()> {
         // If not in admin-network mode, skip processing. GPUs should stay
         // attached to tenant partitions, but zero-DPU hosts are always
         // considered admin network (since they don't have a DPU to put them
@@ -1405,9 +1410,9 @@ impl NvlPartitionMonitor {
     async fn record_nvlink_status_observation(
         &self,
         observations: HashMap<MachineId, MachineNvLinkStatusObservation>,
-    ) -> CarbideResult<()> {
+    ) -> NvLinkManagerResult<()> {
         let mut obs_txn = self.db_pool.begin().await.map_err(|e| {
-            CarbideError::internal(format!(
+            NvLinkManagerError::internal(format!(
                 "Failed to create transaction for nvlink status observation: {e}"
             ))
         })?;
@@ -1416,7 +1421,7 @@ impl NvlPartitionMonitor {
                 .await?;
         }
         obs_txn.commit().await.map_err(|e| {
-            CarbideError::internal(format!(
+            NvLinkManagerError::internal(format!(
                 "Failed to commit transaction for nvlink status observation: {e}"
             ))
         })?;
@@ -1426,12 +1431,14 @@ impl NvlPartitionMonitor {
     async fn execute_nmx_m_operations(
         &self,
         nmx_m_operations: HashMap<NvLinkLogicalPartitionId, Vec<NmxmPartitionOperation>>,
-    ) -> CarbideResult<HashMap<NvLinkLogicalPartitionId, Vec<NmxmPartitionOperation>>> {
+    ) -> NvLinkManagerResult<HashMap<NvLinkLogicalPartitionId, Vec<NmxmPartitionOperation>>> {
         let nmxm_client = self
             .nmxm_client_pool
             .create_client(&self.config.nmx_m_endpoint, None)
             .await
-            .map_err(|e| CarbideError::internal(format!("Failed to create NMXM client: {e}")))?;
+            .map_err(|e| {
+                NvLinkManagerError::internal(format!("Failed to create NMXM client: {e}"))
+            })?;
 
         let mut pending_operations: HashMap<NvLinkLogicalPartitionId, Vec<NmxmPartitionOperation>> =
             HashMap::new();
@@ -1547,7 +1554,7 @@ impl NvlPartitionMonitor {
                             .delete_partition(nmx_m_partition_id.clone())
                             .await
                             .map_err(|e| {
-                                CarbideError::internal(format!(
+                                NvLinkManagerError::internal(format!(
                                     "Failed to delete default partition: {e}"
                                 ))
                             })?;
@@ -1651,7 +1658,7 @@ impl NvlPartitionMonitor {
         &self,
         pending_nmx_m_operations: HashMap<NvLinkLogicalPartitionId, Vec<NmxmPartitionOperation>>,
         metrics: &mut NvlPartitionMonitorMetrics,
-    ) -> CarbideResult<HashMap<NvLinkLogicalPartitionId, Vec<NmxmPartitionOperation>>> {
+    ) -> NvLinkManagerResult<HashMap<NvLinkLogicalPartitionId, Vec<NmxmPartitionOperation>>> {
         let nmxm_client = self
             .nmxm_client_pool
             .create_client(&self.config.nmx_m_endpoint, None)
@@ -1659,7 +1666,7 @@ impl NvlPartitionMonitor {
             .map_err(|e| {
                 metrics.nmxm.connect_error =
                     "Failed to create NMXM client while polling for completion".to_string();
-                CarbideError::internal(format!("Failed to create NMXM client: {e}"))
+                NvLinkManagerError::internal(format!("Failed to create NMXM client: {e}"))
             })?;
 
         let timeout_duration = self.config.nmx_m_operation_timeout;
@@ -1692,7 +1699,7 @@ impl NvlPartitionMonitor {
                         .map_err(|e| {
                             metrics.nmxm.connect_error =
                                 "Failed to get operation from NMXM".to_string();
-                            CarbideError::internal(format!(
+                            NvLinkManagerError::internal(format!(
                                 "Failed to get operation from NMXM: {e}"
                             ))
                         })?;
@@ -1836,7 +1843,7 @@ impl NvlPartitionMonitor {
         completed_nmx_m_operations: HashMap<NvLinkLogicalPartitionId, Vec<NmxmPartitionOperation>>,
         db_nvl_logical_partitions: &[LogicalPartition],
         nmx_m_partitions: &[libnmxm::nmxm_model::Partition],
-    ) -> CarbideResult<()> {
+    ) -> NvLinkManagerResult<()> {
         for (logical_partition_id, operations) in completed_nmx_m_operations {
             for mut operation in operations {
                 // operation type will change to Pending after it has been enqueued. Restore the original operation type
@@ -1909,7 +1916,7 @@ impl NvlPartitionMonitor {
     async fn load_mnnvl_managed_host_snapshots(
         &self,
         txn: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-    ) -> CarbideResult<HashMap<MachineId, ManagedHostStateSnapshot>> {
+    ) -> NvLinkManagerResult<HashMap<MachineId, ManagedHostStateSnapshot>> {
         let mnvvl_machine_ids = find_machine_ids(
             txn.as_mut(),
             MachineSearchConfig {
@@ -1929,7 +1936,7 @@ impl NvlPartitionMonitor {
             },
         )
         .await
-        .map_err(CarbideError::from)
+        .map_err(NvLinkManagerError::from)
     }
 }
 

--- a/crates/nvlink-manager/src/metrics.rs
+++ b/crates/nvlink-manager/src/metrics.rs
@@ -25,7 +25,7 @@ use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Counter, Histogram, Meter};
 use serde::Serialize;
 
-use crate::nvl_partition_monitor::NmxmPartitionOperationType;
+use crate::NmxmPartitionOperationType;
 
 /// Metrics that are gathered in a single nvl partition monitor run
 #[derive(Clone, Debug)]

--- a/crates/nvlink-manager/src/nvlink.rs
+++ b/crates/nvlink-manager/src/nvlink.rs
@@ -20,7 +20,7 @@ use db::DatabaseError;
 use forge_secrets::credentials::{CredentialKey, CredentialReader, Credentials};
 use libnmxm::{Nmxm, NmxmApiError};
 
-use crate::handlers::credential::DEFAULT_NMX_M_NAME;
+use crate::DEFAULT_NMX_M_NAME;
 
 #[allow(dead_code)]
 #[derive(thiserror::Error, Debug)]
@@ -100,7 +100,7 @@ impl<C: CredentialReader + 'static> NmxmClientPool for NmxmClientPoolImpl<C> {
     }
 }
 
-#[cfg(test)]
+#[cfg(feature = "test-support")]
 pub mod test_support {
     use std::sync::{Arc, Mutex};
 


### PR DESCRIPTION
## Description
This is part of decomposition of "too large" carbide-api crate. Previous steps: #1038 #1094 #1109 . Epic: #613 .

- move NvlPartitionMonitor and NMX-M client pool into new crate
- move NvLinkConfig and DEFAULT_NMX_M_NAME out of api
- add crate-local NvLinkManagerError/Result
- move TransactionVending to api-db

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

