### PR TITLE
fix: dpf: various fixes for feds and nevus rest API access from dpu-agent

### DIFF
--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -135,10 +135,15 @@ pub async fn setup_and_run(
             fmds_address = fmds_addr,
             "Using FmdsUpdater::External FMDS service"
         );
-        let fmds_client = crate::fmds_client::FmdsGrpcClient::connect(fmds_addr)
-            .await
-            .wrap_err("Failed to connect to external FMDS service")?;
-        FmdsUpdater::External(fmds_client)
+        match crate::fmds_client::FmdsGrpcClient::connect(fmds_addr).await {
+            Ok(fmds_client) => FmdsUpdater::External(fmds_client),
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to connect to external FMDS service: {e:#}, falling back to embedded"
+                );
+                FmdsUpdater::Embedded(instance_metadata_state.clone())
+            }
+        }
     } else {
         if options.enable_metadata_service {
             crate::metadata_service::spawn_metadata_service(

--- a/crates/api/src/dpf_services.rs
+++ b/crates/api/src/dpf_services.rs
@@ -57,13 +57,13 @@ pub const DHCP_SERVER_SERVICE_MTU: i64 = 1500;
 // DPU Agent Service Definitions
 pub const DPU_AGENT_SERVICE_NAME: &str = "carbide-dpu-agent";
 pub const DPU_AGENT_SERVICE_HELM_NAME: &str = "carbide-dpu-agent";
-pub const DPU_AGENT_SERVICE_HELM_VERSION: &str = "0.9.0";
+pub const DPU_AGENT_SERVICE_HELM_VERSION: &str = "0.9.6";
 pub const DPU_AGENT_SERVICE_IMAGE_NAME: &str = "forge-dpu-agent";
-pub const DPU_AGENT_SERVICE_IMAGE_TAG: &str = "v0.5-arm64-multistage";
+pub const DPU_AGENT_SERVICE_IMAGE_TAG: &str = "v0.9.5-arm64-multistage";
 
 /// FMDS Agent Service Definitions
 pub const FMDS_SERVICE_HELM_NAME: &str = "carbide-fmds";
-pub const FMDS_SERVICE_HELM_VERSION: &str = "0.1.0";
+pub const FMDS_SERVICE_HELM_VERSION: &str = "0.2.0";
 pub const FMDS_SERVICE_IMAGE_NAME: &str = "carbide-fmds";
 pub const FMDS_SERVICE_NAD_NAME: &str = "mybrsfc-fmds";
 pub const FMDS_SERVICE_IMAGE_TAG: &str = "v0.1-arm64-distroless";
@@ -74,6 +74,9 @@ fn doca_hbn_service_interfaces() -> Vec<ServiceInterface> {
 }
 fn dhcp_server_service_interfaces() -> Vec<ServiceInterface> {
     dpu_service_interfaces(DHCP_SERVER_SERVICE_NAME, DHCP_SERVER_SERVICE_NAD_NAME)
+}
+fn fmds_service_interfaces() -> Vec<ServiceInterface> {
+    dpu_service_interfaces(FMDS_SERVICE_NAME, FMDS_SERVICE_NAD_NAME)
 }
 
 fn dpu_service_interfaces(service_name: &str, network: &str) -> Vec<ServiceInterface> {
@@ -154,10 +157,7 @@ pub fn doca_hbn_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinition
             "configuration": {
                 "user": {
                     "create": true,
-                    "username": {
-                        "secretName": "hbn-user-password",
-                        "secretKey": "username",
-                    },
+                    "username": "carbide",
                     "password": {
                         "secretName": "hbn-user-password",
                         "secretKey": "password",
@@ -231,7 +231,6 @@ pub fn dpu_agent_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinitio
             "hbn": {
                 "nvue_https_address": "nvue",
                 "nvue_credentials_secret_name": "hbn-user-password",
-                "nvue_username_key": "username",
                 "nvue_password_key": "password",
             },
         })),
@@ -244,6 +243,9 @@ pub fn dpu_agent_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinitio
             },
             "carbide_fmds": {
                 "service_name": "{{ (index .Services \"carbide-fmds\").Name }}"
+            },
+            "hbn": {
+                "nvue_https_address": "{{ (index .Services \"doca-hbn\").Name }}"
             }
         })),
 
@@ -312,10 +314,7 @@ pub fn fmds_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinition {
             }
         })),
 
-        interfaces: vec![ServiceInterface {
-            name: "f_pf0hpf_if".to_string(),
-            network: FMDS_SERVICE_NAD_NAME.to_string(),
-        }],
+        interfaces: fmds_service_interfaces(),
 
         service_daemon_set_annotations: Some(BTreeMap::new()),
 

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -647,6 +647,9 @@ pub fn build_deployment<L: ResourceLabeler>(
                             DpuDeploymentServicesDependsOn {
                                 name: FMDS_SERVICE_NAME.to_string(),
                             },
+                            DpuDeploymentServicesDependsOn {
+                                name: DOCA_HBN_SERVICE_NAME.to_string(),
+                            },
                         ])
                     } else {
                         None
@@ -762,6 +765,7 @@ pub fn build_dpu_interfaces_vec() -> Vec<DpuServiceInterfaceTemplateDefinition> 
             chained_svc_if: Some(vec![
                 (DOCA_HBN_SERVICE_NAME.into(), "pf0hpf_if".into()),
                 (DHCP_SERVER_SERVICE_NAME.into(), "d_pf0hpf_if".into()),
+                (FMDS_SERVICE_NAME.into(), "f_pf0hpf_if".into()),
             ]),
         },
         DpuServiceInterfaceTemplateDefinition {


### PR DESCRIPTION
## Description
1. don't break main_loop if fmds is not reachable.
2. Using nvue username as plain text (as suported by helm values)
3. Generate nuve service name via templating
4. Interface handling for fmds generic

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

