### PR TITLE
Truncate scout firmware upgrade status output

### DIFF
--- a/crates/scout/src/main.rs
+++ b/crates/scout/src/main.rs
@@ -62,6 +62,7 @@ struct DevEnv {
 static IN_QEMU_VM: Lazy<RwLock<DevEnv>> = Lazy::new(|| RwLock::new(DevEnv { in_qemu: false }));
 const POLL_INTERVAL: Duration = Duration::from_secs(60);
 pub const REBOOT_COMPLETED_PATH: &str = "/tmp/reboot_completed";
+const MAX_FIRMWARE_UPGRADE_STATUS_FIELD_SIZE: usize = 1500;
 
 async fn check_if_running_in_qemu() {
     use tokio::process::Command;
@@ -504,12 +505,35 @@ async fn report_firmware_upgrade_status(
         machine_id: Some(*machine_id),
         success: result.success,
         exit_code: result.exit_code,
-        stdout: result.stdout.clone(),
-        stderr: result.stderr.clone(),
-        error: result.error.clone(),
+        stdout: truncate(&result.stdout, MAX_FIRMWARE_UPGRADE_STATUS_FIELD_SIZE),
+        stderr: truncate(&result.stderr, MAX_FIRMWARE_UPGRADE_STATUS_FIELD_SIZE),
+        error: truncate(&result.error, MAX_FIRMWARE_UPGRADE_STATUS_FIELD_SIZE),
     });
     client.report_scout_firmware_upgrade_status(request).await?;
     Ok(())
+}
+
+fn truncate(value: &str, limit: usize) -> String {
+    if value.len() <= limit {
+        return value.to_string();
+    }
+
+    if limit < 3 {
+        let mut end = limit;
+        while !value.is_char_boundary(end) {
+            end -= 1;
+        }
+        return value[..end].to_string();
+    }
+
+    let mut end = limit - 2;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut truncated = String::with_capacity(end + 2);
+    truncated.push_str(&value[..end]);
+    truncated.push_str("..");
+    truncated
 }
 
 // carbide sent us an Action::MlxReport command in response to our
@@ -926,5 +950,33 @@ fn check_certs_validity(client_cert_path: &str) -> CarbideClientResult<bool> {
         Err(CarbideClientError::GenericError(format!(
             "Could not parse NotAfter timestamp: {not_after}"
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_handles_short_long_and_utf8_values() {
+        // Short values are preserved unchanged.
+        assert_eq!(truncate("ok", MAX_FIRMWARE_UPGRADE_STATUS_FIELD_SIZE), "ok");
+
+        // Long values are capped and marked as truncated.
+        let value = "x".repeat(MAX_FIRMWARE_UPGRADE_STATUS_FIELD_SIZE + 100);
+        let truncated = truncate(&value, MAX_FIRMWARE_UPGRADE_STATUS_FIELD_SIZE);
+        assert_eq!(truncated.len(), MAX_FIRMWARE_UPGRADE_STATUS_FIELD_SIZE);
+        assert!(truncated.ends_with(".."));
+
+        // Multi-byte characters are never split.
+        let value = "é".repeat(MAX_FIRMWARE_UPGRADE_STATUS_FIELD_SIZE);
+        let truncated = truncate(&value, MAX_FIRMWARE_UPGRADE_STATUS_FIELD_SIZE);
+        assert!(truncated.len() <= MAX_FIRMWARE_UPGRADE_STATUS_FIELD_SIZE);
+        assert!(truncated.ends_with(".."));
+
+        // Degenerate limits still respect the requested size.
+        assert_eq!(truncate("hello", 0), "");
+        assert_eq!(truncate("hello", 1), "h");
+        assert_eq!(truncate("é", 1), "");
     }
 }


### PR DESCRIPTION
## Description
Truncating scout firmware upgrade status output before sending it over to carbide because sometimes they can get too big.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

