### PR TITLE
Update name of branch created by sync-openapi workflow

### DIFF
--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -19,6 +19,6 @@ jobs:
         with:
           update_from_source: true
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: 'update-api'
+          branch: 'fern/update-api'
           auto_merge: false
           add_timestamp: true


### PR DESCRIPTION
The sync-openapi workflow is currently broken because it tries to create an "update-api" branch, but branch creation is restricted.

The branch name is too generic for an auto-generated branch. The new 'fern/update-api' name clarifies that this is a Fern workflow and can be safely deleted. This name needs to be added as a branch-creation exception before this PR is merged.

-e

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

