### PR TITLE
Fix sync_openapi PR duplication behavior

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -693,21 +693,6 @@ jobs:
     secrets: inherit
 
   # ============================================================================
-  # BUILD STAGE - Publish Documentation
-  # ============================================================================
-
-  build-publish-documentation:
-    if: false
-    needs:
-      - prepare
-      - build-container-x86_64
-    uses: ./.github/workflows/docs.yml
-    with:
-      build_container: ${{ format('nvcr.io/0837451325059433/carbide-dev/build-container-x86_64:{0}', (needs['build-container-x86_64'].result == 'success' && needs.prepare.outputs.version) || 'latest') }}
-      runner: linux-amd64-cpu4
-    secrets: inherit
-
-  # ============================================================================
   # SECURITY STAGE
   # ============================================================================
 

--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -12,13 +12,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.FERN_OPENAPI_SYNC_TOKEN }}
       # Action pinned to v2 commit; requires fern-api/sync-openapi to be part of the allow-list.
       - name: Update API with Fern
         uses: fern-api/sync-openapi@8e936a4bac8ad11d698d7114f3074fa3397398ea
         with:
           update_from_source: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.FERN_OPENAPI_SYNC_TOKEN }}
           branch: 'fern/update-api'
           auto_merge: false
-          add_timestamp: true
+          add_timestamp: false


### PR DESCRIPTION
## Description
The Fern task in the sync_openapi workflow is adding a timestamp to the branch name of the auto-generated PR, so PRs API spec updates are proliferating instead of staying in a single PR.

This PR does the following:
- Disables adding a timestamp to the branch name and changes the token to a PAT so CI can work properly.
- Removes unused build-publish-documentation call from Carbide CI, which is triggering a "workflow is not reusable" error on the ci.yml workflow.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

