### PR TITLE
Fix out-of-date Fern CI code that was generating invalid preview URLs

### DIFF
--- a/.github/workflows/fern-docs-preview-comment.yml
+++ b/.github/workflows/fern-docs-preview-comment.yml
@@ -89,9 +89,12 @@ jobs:
           HEAD_REF: ${{ steps.metadata.outputs.head_ref }}
         working-directory: ./fern
         run: |
-          OUTPUT=$(fern generate --docs --preview --id "$HEAD_REF" 2>&1)
+          # Preview --id becomes part of the hostname; '/' and other chars are invalid.
+          PREVIEW_ID=$(echo "${HEAD_REF:-preview}" | sed 's/[^a-zA-Z0-9._-]/-/g; s/-\{2,\}/-/g; s/^-//; s/-$//')
+          OUTPUT=$(fern generate --docs --preview --force --id "$PREVIEW_ID" 2>&1)
           echo "$OUTPUT"
-          URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()')
+          # Fern prints "[docs]: Published docs to <url>" (older CLIs sometimes added " (…)" after the URL).
+          URL=$(echo "$OUTPUT" | grep -oE 'Published docs to https?://[^[:space:]()]+' | head -1 | sed 's/^Published docs to //')
           if [ -z "$URL" ]; then
             echo "::error::Failed to generate preview URL. See fern output above."
             exit 1


### PR DESCRIPTION
-e
Signed-off-by: Peter Gambrill <pgambrill@nvidia.com>

## Description
Code for fern-docs-preview-comment workflow is not parsing the URLs generated
by Fern correctly, and might fail to parse the branch name as well. This fix aligns behavior
with current Fern preview.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

