### PR TITLE
Have sync-openapi delete the remote branch first

### DIFF
--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           token: ${{ secrets.FERN_OPENAPI_SYNC_TOKEN }}
       # Action pinned to v2 commit; requires fern-api/sync-openapi to be part of the allow-list.
+      - name: Delete remote branch if exists
+        run: git push origin --delete fern/update-api || true
       - name: Update API with Fern
         uses: fern-api/sync-openapi@8e936a4bac8ad11d698d7114f3074fa3397398ea
         with:


### PR DESCRIPTION
Currently, if the "fern/update-api" remote branch already exists, the non-force push fails if it has commits the fresh checkout doesn't have. This new action provides a workaround.
-e

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

