### PR TITLE
Revert change in RBAC unit-test

### DIFF
--- a/crates/api/src/auth/internal_rbac_rules.rs
+++ b/crates/api/src/auth/internal_rbac_rules.rs
@@ -1097,7 +1097,9 @@ mod rbac_rule_tests {
     #[test]
     fn all_requests_listed() -> Result<(), eyre::Report> {
         let mut messages = vec![];
-        let proto = File::open("../rpc/proto/forge.proto")?;
+        let proto = File::open(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../rpc/proto/forge.proto"),
+        )?;
         let reader = BufReader::new(proto);
         for line in reader.lines() {
             let line = line?;


### PR DESCRIPTION
## Description

The reference to the manifest directory was removed in commit 65ef61f779f8646e81fea4bd1993877875d809c0. This leads to issues in CI. This PR adds it again.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

