### PR TITLE
fix: Mount opt/forge into dpu agent's init-container

### DIFF
--- a/bluefield/charts/carbide-dpu-agent/templates/daemonset.yaml
+++ b/bluefield/charts/carbide-dpu-agent/templates/daemonset.yaml
@@ -72,6 +72,8 @@ spec:
               mountPath: /host-cpu-info
             - name: proc-mem-info
               mountPath: /host-mem-info
+            - name: forge-certs
+              mountPath: /opt/forge
       containers:
         - name: forge-dpu-agent
           securityContext:

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -89,7 +89,7 @@ pub const NVUE_MINIMUM_HBN_VERSION: &str = "2.0.0-doca2.5.0";
 
 // Downloads cert (pem) file in case of dpu-agent is running as initcontainer.
 async fn download_cert() -> eyre::Result<()> {
-    let url = "http://carbide-pxe.forge/api/v0/tls/root_ca.pem";
+    let url = "http://carbide-pxe.forge/api/v0/tls/root_ca";
     let output_file = "/opt/forge/forge_root.pem";
     let permissions = std::fs::Permissions::from_mode(0o644);
 

--- a/crates/dhcp-server/src/main.rs
+++ b/crates/dhcp-server/src/main.rs
@@ -72,7 +72,7 @@ async fn run_dhcp_server(args: Args, cancel_token: CancellationToken) {
 
     let dhcp_timestamps = Arc::new(Mutex::new({
         let d = DhcpTimestamps::new(if let ServerMode::Dpu = args.mode {
-            DhcpTimestampsFilePath::Hbn
+            DhcpTimestampsFilePath::HbnTmp
         } else {
             DhcpTimestampsFilePath::NotSet
         });
@@ -602,7 +602,7 @@ async fn process(
         if let Err(e) = dhcp_timestamps.write() {
             tracing::error!(
                 "Failed writing to {}: {e}",
-                DhcpTimestampsFilePath::Hbn.path_str()
+                DhcpTimestampsFilePath::HbnTmp.path_str()
             );
         }
     }

--- a/crates/utils/src/models/dhcp.rs
+++ b/crates/utils/src/models/dhcp.rs
@@ -207,6 +207,7 @@ pub struct DhcpTimestamps {
 }
 
 pub enum DhcpTimestampsFilePath {
+    HbnTmp,
     Hbn,
     Dpu,
     Test,
@@ -216,7 +217,8 @@ pub enum DhcpTimestampsFilePath {
 impl DhcpTimestampsFilePath {
     pub fn path_str(&self) -> &str {
         match self {
-            Self::Hbn => DHCP_TIMESTAMP_FILE_HBN_TMP,
+            Self::HbnTmp => DHCP_TIMESTAMP_FILE_HBN_TMP,
+            Self::Hbn => DHCP_TIMESTAMP_FILE_HBN,
             Self::Dpu => DHCP_TIMESTAMP_FILE_DPU,
             Self::Test => DHCP_TIMESTAMP_FILE_TEST,
             Self::NotSet => "Not set",
@@ -258,7 +260,7 @@ impl DhcpTimestamps {
             .open(self.path.path_str())?;
 
         serde_json::to_writer(timestamp_file, self)?;
-        if let DhcpTimestampsFilePath::Hbn = self.path {
+        if let DhcpTimestampsFilePath::HbnTmp = self.path {
             // Rename the file.
             fs::rename(DHCP_TIMESTAMP_FILE_HBN_TMP, DHCP_TIMESTAMP_FILE_HBN)?;
         }


### PR DESCRIPTION
## Description
dpu-agent's init-container failed since /opt/forge is not available to write the cert.
and
1. Read dhcp-timestamp from correct file path.
2. Fix the root_ca url.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

