### PR TITLE
Fix(switch state machine): switch state machine NVOS update and NMXC synchronization flow

### DIFF
--- a/crates/admin-cli/src/rack_firmware/get/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/get/cmd.rs
@@ -15,11 +15,62 @@
  * limitations under the License.
  */
 
+use std::collections::BTreeMap;
+
 use ::rpc::admin_cli::{CarbideCliError, OutputFormat};
 use prettytable::{Cell, Row, Table, row};
+use serde::Deserialize;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
+
+#[derive(Debug, Deserialize, Default)]
+struct ParsedFirmwareLookupTable {
+    #[serde(default)]
+    devices: BTreeMap<String, BTreeMap<String, FirmwareLookupEntry>>,
+    #[serde(default)]
+    switch_system_images: BTreeMap<String, BTreeMap<String, SwitchSystemImageLookupEntry>>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct FirmwareLookupEntry {
+    #[serde(default)]
+    component: String,
+    #[serde(default)]
+    bundle: String,
+    #[serde(default)]
+    firmware_type: String,
+    #[serde(default)]
+    target: String,
+    #[serde(default)]
+    subcomponents: Vec<FirmwareSubcomponent>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct FirmwareSubcomponent {
+    #[serde(default)]
+    component: String,
+    #[serde(default)]
+    version: String,
+    #[serde(default)]
+    skuid: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SwitchSystemImageLookupEntry {
+    #[serde(default)]
+    component: String,
+    #[serde(default)]
+    package_name: String,
+    #[serde(default)]
+    version: String,
+    #[serde(default)]
+    image_filename: String,
+    #[serde(default)]
+    location_type: String,
+    #[serde(default)]
+    firmware_type: String,
+}
 
 pub async fn get(
     opts: Args,
@@ -57,100 +108,113 @@ pub async fn get(
         table.printstd();
 
         // Display parsed firmware components.
-        if !result.parsed_components.is_empty() && result.parsed_components != "{}" {
-            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&result.parsed_components)
-                && let Some(devices) = parsed.get("devices").and_then(|d| d.as_object())
-            {
-                for (device_type, components) in devices {
-                    println!("\n[{}]", device_type);
-
-                    let mut component_table = Table::new();
-                    component_table.set_titles(Row::new(vec![
-                        Cell::new("Component"),
-                        Cell::new("Type"),
-                        Cell::new("Bundle"),
-                        Cell::new("Target"),
-                    ]));
-
-                    // Collect components with their subcomponents for display
-                    let mut component_subcomps: Vec<(String, &[serde_json::Value])> = Vec::new();
-
-                    if let Some(comp_map) = components.as_object() {
-                        for (_key, entry) in comp_map {
-                            let component = entry
-                                .get("component")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("-");
-                            let bundle =
-                                entry.get("bundle").and_then(|v| v.as_str()).unwrap_or("-");
-                            let fw_type = entry
-                                .get("firmware_type")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("-");
-                            let target =
-                                entry.get("target").and_then(|v| v.as_str()).unwrap_or("-");
-
-                            component_table.add_row(Row::new(vec![
-                                Cell::new(component),
-                                Cell::new(&fw_type.to_uppercase()),
-                                Cell::new(bundle),
-                                Cell::new(target),
-                            ]));
-
-                            // Collect subcomponents for later display
-                            if let Some(subcomps) =
-                                entry.get("subcomponents").and_then(|s| s.as_array())
-                                && !subcomps.is_empty()
-                            {
-                                component_subcomps.push((component.to_string(), subcomps));
-                            }
-                        }
-                    }
-
-                    component_table.printstd();
-
-                    // Print subcomponents for each component
-                    for (comp_name, subcomps) in component_subcomps {
-                        println!("\n  {} Subcomponents:", comp_name);
-
-                        let mut sub_table = Table::new();
-                        sub_table.set_titles(Row::new(vec![
-                            Cell::new("Component"),
-                            Cell::new("Version"),
-                            Cell::new("SKUID"),
-                        ]));
-
-                        for subcomp in subcomps {
-                            let sub_name = subcomp
-                                .get("component")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("-");
-                            let sub_version = subcomp
-                                .get("version")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("-");
-                            let sub_skuid =
-                                subcomp.get("skuid").and_then(|v| v.as_str()).unwrap_or("-");
-
-                            sub_table.add_row(Row::new(vec![
-                                Cell::new(sub_name),
-                                Cell::new(sub_version),
-                                Cell::new(sub_skuid),
-                            ]));
-                        }
-
-                        // Indent the table output
-                        let table_str = sub_table.to_string();
-                        for line in table_str.lines() {
-                            println!("  {}", line);
-                        }
-                    }
-                }
-            }
-        } else {
+        if should_show_not_downloaded(&result.parsed_components) {
             println!("\nFirmware Components: (not yet downloaded)");
+        } else {
+            match serde_json::from_str::<ParsedFirmwareLookupTable>(&result.parsed_components) {
+                Ok(parsed) if print_parsed_components(&parsed) => {}
+                _ => println!("\nFirmware Components: (not yet downloaded)"),
+            }
         }
     }
 
     Ok(())
+}
+
+fn should_show_not_downloaded(parsed_components: &str) -> bool {
+    parsed_components.is_empty() || parsed_components == "{}"
+}
+
+fn print_parsed_components(parsed: &ParsedFirmwareLookupTable) -> bool {
+    let mut printed = false;
+
+    for (device_type, components) in &parsed.devices {
+        printed = true;
+        println!("\n[{}]", device_type);
+
+        let mut component_table = Table::new();
+        component_table.set_titles(Row::new(vec![
+            Cell::new("Component"),
+            Cell::new("Type"),
+            Cell::new("Bundle"),
+            Cell::new("Target"),
+        ]));
+
+        let mut component_subcomps: Vec<(&str, &[FirmwareSubcomponent])> = Vec::new();
+
+        for entry in components.values() {
+            component_table.add_row(Row::new(vec![
+                Cell::new(display_value(&entry.component)),
+                Cell::new(&display_value(&entry.firmware_type).to_uppercase()),
+                Cell::new(display_value(&entry.bundle)),
+                Cell::new(display_value(&entry.target)),
+            ]));
+
+            if !entry.subcomponents.is_empty() {
+                component_subcomps.push((display_value(&entry.component), &entry.subcomponents));
+            }
+        }
+
+        component_table.printstd();
+
+        for (comp_name, subcomps) in component_subcomps {
+            println!("\n  {} Subcomponents:", comp_name);
+
+            let mut sub_table = Table::new();
+            sub_table.set_titles(Row::new(vec![
+                Cell::new("Component"),
+                Cell::new("Version"),
+                Cell::new("SKUID"),
+            ]));
+
+            for subcomp in subcomps {
+                let sub_skuid = subcomp.skuid.as_deref().unwrap_or("-");
+
+                sub_table.add_row(Row::new(vec![
+                    Cell::new(display_value(&subcomp.component)),
+                    Cell::new(display_value(&subcomp.version)),
+                    Cell::new(display_value(sub_skuid)),
+                ]));
+            }
+
+            let table_str = sub_table.to_string();
+            for line in table_str.lines() {
+                println!("  {}", line);
+            }
+        }
+    }
+
+    for (device_type, images) in &parsed.switch_system_images {
+        printed = true;
+        println!("\n[Switch System Images: {}]", device_type);
+
+        let mut image_table = Table::new();
+        image_table.set_titles(Row::new(vec![
+            Cell::new("Component"),
+            Cell::new("Type"),
+            Cell::new("Package"),
+            Cell::new("Image Filename"),
+            Cell::new("Version"),
+            Cell::new("Location Type"),
+        ]));
+
+        for entry in images.values() {
+            image_table.add_row(Row::new(vec![
+                Cell::new(display_value(&entry.component)),
+                Cell::new(&display_value(&entry.firmware_type).to_uppercase()),
+                Cell::new(display_value(&entry.package_name)),
+                Cell::new(display_value(&entry.image_filename)),
+                Cell::new(display_value(&entry.version)),
+                Cell::new(display_value(&entry.location_type)),
+            ]));
+        }
+
+        image_table.printstd();
+    }
+
+    printed
+}
+
+fn display_value(value: &str) -> &str {
+    if value.is_empty() { "-" } else { value }
 }

--- a/crates/admin-cli/src/switch/list/args.rs
+++ b/crates/admin-cli/src/switch/list/args.rs
@@ -32,4 +32,8 @@ pub struct Args {
     /// Filter by BMC MAC address
     #[clap(long)]
     pub bmc_mac: Option<MacAddress>,
+
+    /// Filter by NVOS MAC address
+    #[clap(long)]
+    pub nvos_mac: Option<MacAddress>,
 }

--- a/crates/admin-cli/src/switch/list/cmd.rs
+++ b/crates/admin-cli/src/switch/list/cmd.rs
@@ -34,6 +34,7 @@ pub async fn list_switches(
         deleted: args.deleted as i32,
         controller_state: args.controller_state,
         bmc_mac: args.bmc_mac.map(|m| m.to_string()),
+        nvos_mac: args.nvos_mac.map(|m| m.to_string()),
     };
     let response = api_client
         .get_all_switches(filter, config.page_size)

--- a/crates/api-db/src/switch.rs
+++ b/crates/api-db/src/switch.rs
@@ -169,6 +169,10 @@ pub async fn find_ids(
         qb.push(" JOIN machine_interfaces mi ON mi.switch_id = s.id");
     }
 
+    if filter.nvos_mac.is_some() {
+        qb.push(" JOIN expected_switches es_nvos ON es_nvos.bmc_mac_address = s.bmc_mac_address");
+    }
+
     qb.push(" WHERE TRUE");
 
     if filter.rack_id.is_some() {
@@ -190,6 +194,12 @@ pub async fn find_ids(
     if let Some(mac) = filter.bmc_mac {
         qb.push(" AND mi.mac_address = ");
         qb.push_bind(mac);
+    }
+
+    if let Some(mac) = filter.nvos_mac {
+        qb.push(" AND ");
+        qb.push_bind(mac);
+        qb.push(" = ANY(es_nvos.nvos_mac_addresses)");
     }
 
     qb.build_query_as()

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -218,6 +218,18 @@ impl SwitchNvosUpdateStatus {
     pub fn is_in_progress(&self) -> bool {
         self.ended_at.is_none()
     }
+
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self.status,
+            SwitchNvosUpdateState::Completed | SwitchNvosUpdateState::Failed { .. }
+        )
+    }
+
+    pub fn is_current_for(&self, requested_at: DateTime<Utc>) -> bool {
+        self.ended_at.is_some_and(|ts| ts >= requested_at)
+            || self.started_at.is_some_and(|ts| ts >= requested_at)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -433,7 +445,9 @@ pub enum RackMaintenanceState {
     NVOSUpdate {
         nvos_update: NvosUpdateState,
     },
-    ConfigureNmxCluster,
+    ConfigureNmxCluster {
+        configure_nmx_cluster: ConfigureNmxClusterState,
+    },
     PowerSequence {
         rack_power: RackPowerState,
     },
@@ -451,11 +465,36 @@ impl Display for RackMaintenanceState {
             RackMaintenanceState::NVOSUpdate { nvos_update } => {
                 write!(f, "NVOSUpdate({})", nvos_update)
             }
-            RackMaintenanceState::ConfigureNmxCluster => write!(f, "ConfigureNmxCluster"),
+            RackMaintenanceState::ConfigureNmxCluster {
+                configure_nmx_cluster,
+            } => {
+                write!(f, "ConfigureNmxCluster({})", configure_nmx_cluster)
+            }
             RackMaintenanceState::PowerSequence { rack_power } => {
                 write!(f, "PowerSequence({})", rack_power)
             }
             RackMaintenanceState::Completed => write!(f, "Completed"),
+        }
+    }
+}
+
+/// Sub-states of `RackMaintenanceState::ConfigureNmxCluster`.
+///
+/// `Start` selects a primary switch and asks RMS to configure the
+/// NMX cluster. `WaitForFabricStatus` polls
+/// `GetScaleUpFabricServicesStatus` and persists the per-switch
+/// `fabric_manager_status` before advancing.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ConfigureNmxClusterState {
+    Start,
+    WaitForFabricStatus,
+}
+
+impl Display for ConfigureNmxClusterState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConfigureNmxClusterState::Start => write!(f, "Start"),
+            ConfigureNmxClusterState::WaitForFabricStatus => write!(f, "WaitForFabricStatus"),
         }
     }
 }

--- a/crates/api-model/src/switch/mod.rs
+++ b/crates/api-model/src/switch/mod.rs
@@ -417,10 +417,15 @@ pub enum BomValidatingState {
 
 /// Sub-state for SwitchControllerState::ReProvisioning
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[allow(clippy::enum_variant_names)]
 pub enum ReProvisioningState {
     /// Rack-level firmware upgrade in progress; the rack state machine manages the
     /// upgrade and clears `switch_reprovisioning_requested` when done.
     WaitingForRackFirmwareUpgrade,
+    /// Rack-level NVOS upgrade in progress.
+    WaitingForNVOSUpgrade,
+    /// Rack-level NMX-C configuration in progress.
+    WaitingForNMXCConfigure,
 }
 
 /// State of a Switch as tracked by the controller
@@ -506,6 +511,7 @@ pub struct SwitchSearchFilter {
     pub deleted: crate::DeletedFilter,
     pub controller_state: Option<String>,
     pub bmc_mac: Option<MacAddress>,
+    pub nvos_mac: Option<MacAddress>,
 }
 
 impl From<rpc::SwitchSearchFilter> for SwitchSearchFilter {
@@ -515,6 +521,7 @@ impl From<rpc::SwitchSearchFilter> for SwitchSearchFilter {
             deleted: crate::DeletedFilter::from(filter.deleted),
             controller_state: filter.controller_state,
             bmc_mac: filter.bmc_mac.and_then(|m| m.parse::<MacAddress>().ok()),
+            nvos_mac: filter.nvos_mac.and_then(|m| m.parse::<MacAddress>().ok()),
         }
     }
 }

--- a/crates/api/src/handlers/mod.rs
+++ b/crates/api/src/handlers/mod.rs
@@ -73,6 +73,7 @@ pub mod scout_stream;
 pub mod site_explorer;
 pub mod sku;
 pub mod switch;
+mod switch_artifacts;
 pub mod tenant;
 pub mod tenant_identity_config;
 pub mod tenant_keyset;

--- a/crates/api/src/handlers/rack_firmware.rs
+++ b/crates/api/src/handlers/rack_firmware.rs
@@ -34,6 +34,7 @@ use tonic::{Request, Response, Status};
 
 use crate::api::Api;
 use crate::errors::CarbideError;
+use crate::handlers::switch_artifacts::{SwitchSystemImageArtifact, collect_switch_system_images};
 use crate::rack::firmware_update::{
     build_firmware_update_batches, load_rack_firmware_inventory, submit_firmware_update_batches,
 };
@@ -81,39 +82,6 @@ struct FirmwareLocation {
     firmware_type: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct SwitchSystemImageArtifact {
-    device_type: String,
-    component: String,
-    version: String,
-    firmware_type: String,
-    package_name: String,
-    location: String,
-    location_type: String,
-    required: bool,
-    image_filename: String,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct RawSwitchSystemImageArtifact {
-    #[serde(rename = "DeviceType")]
-    device_type: String,
-    #[serde(rename = "Component")]
-    component: String,
-    #[serde(rename = "Version")]
-    version: String,
-    #[serde(rename = "Type")]
-    firmware_type: String,
-    #[serde(rename = "PackageName")]
-    package_name: String,
-    #[serde(rename = "Location")]
-    location: String,
-    #[serde(rename = "LocationType")]
-    location_type: String,
-    #[serde(rename = "Required", default = "default_true")]
-    required: bool,
-}
-
 // Structs for firmware lookup table
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -155,32 +123,6 @@ struct SwitchSystemImageLookupEntry {
     image_filename: String,
     location_type: String,
     firmware_type: String,
-}
-
-fn filename_from_location(location: &str) -> Result<String, String> {
-    location
-        .split('/')
-        .next_back()
-        .filter(|name| !name.is_empty())
-        .map(str::to_string)
-        .ok_or_else(|| format!("Location must end with a filename: {location}"))
-}
-
-fn default_true() -> bool {
-    true
-}
-
-fn format_switch_system_images_deserialize_error(error: serde_json::Error) -> String {
-    let message = error.to_string();
-
-    if let Some(field) = message
-        .strip_prefix("missing field `")
-        .and_then(|s| s.strip_suffix('`'))
-    {
-        return format!("Invalid SwitchSystemImages: {field} is required");
-    }
-
-    format!("Invalid SwitchSystemImages: {message}")
 }
 
 /// Parse rack firmware JSON to extract firmware components
@@ -339,77 +281,6 @@ fn parse_rack_firmware_json(config: &Value) -> Result<ParsedFirmwareComponents, 
     })
 }
 
-fn parse_switch_system_images(config: &Value) -> Result<Vec<SwitchSystemImageArtifact>, String> {
-    let Some(entries) = config.get("SwitchSystemImages") else {
-        return Ok(Vec::new());
-    };
-
-    let entries: Vec<RawSwitchSystemImageArtifact> = serde_json::from_value(entries.clone())
-        .map_err(format_switch_system_images_deserialize_error)?;
-
-    let mut parsed = Vec::with_capacity(entries.len());
-
-    for (idx, entry) in entries.iter().enumerate() {
-        let device_type = entry.device_type.as_str();
-        if device_type != "Switch Tray" {
-            return Err(format!(
-                "SwitchSystemImages[{idx}].DeviceType must be 'Switch Tray'"
-            ));
-        }
-
-        let component = entry.component.as_str();
-        if component != "NVOS" {
-            return Err(format!(
-                "SwitchSystemImages[{idx}].Component must be 'NVOS'"
-            ));
-        }
-
-        let version = entry.version.trim();
-        if version.is_empty() {
-            return Err(format!("SwitchSystemImages[{idx}].Version is required"));
-        }
-
-        let firmware_type = entry.firmware_type.trim();
-        if firmware_type.is_empty() {
-            return Err(format!("SwitchSystemImages[{idx}].Type is required"));
-        }
-        let firmware_type = firmware_type.to_lowercase();
-
-        let package_name = entry.package_name.trim();
-        if package_name.is_empty() {
-            return Err(format!("SwitchSystemImages[{idx}].PackageName is required"));
-        }
-
-        let location = entry.location.trim();
-        if location.is_empty() {
-            return Err(format!("SwitchSystemImages[{idx}].Location is required"));
-        }
-
-        let location_type = entry.location_type.trim();
-        if location_type.is_empty() {
-            return Err(format!(
-                "SwitchSystemImages[{idx}].LocationType is required"
-            ));
-        }
-
-        let required = entry.required;
-
-        parsed.push(SwitchSystemImageArtifact {
-            device_type: device_type.to_string(),
-            component: component.to_string(),
-            version: version.to_string(),
-            firmware_type,
-            package_name: package_name.to_string(),
-            location: location.to_string(),
-            location_type: location_type.to_string(),
-            required,
-            image_filename: filename_from_location(location)?,
-        });
-    }
-
-    Ok(parsed)
-}
-
 /// Create a new Rack firmware configuration
 pub async fn create(
     api: &Api,
@@ -463,7 +334,7 @@ pub async fn create(
     };
 
     let switch_system_images =
-        parse_switch_system_images(&config).map_err(CarbideError::InvalidArgument)?;
+        collect_switch_system_images(&config).map_err(CarbideError::InvalidArgument)?;
     if !switch_system_images.is_empty() {
         tracing::info!(
             "Parsed {} switch system images from rack firmware config {}",

--- a/crates/api/src/handlers/switch_artifacts.rs
+++ b/crates/api/src/handlers/switch_artifacts.rs
@@ -1,0 +1,518 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct SwitchSystemImageArtifact {
+    pub(crate) device_type: String,
+    pub(crate) component: String,
+    pub(crate) version: String,
+    pub(crate) firmware_type: String,
+    pub(crate) package_name: String,
+    pub(crate) location: String,
+    pub(crate) location_type: String,
+    pub(crate) required: bool,
+    pub(crate) image_filename: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct RawSwitchArtifactsConfig {
+    #[serde(rename = "SwitchSystemImages", default)]
+    switch_system_images: Vec<RawSwitchSystemImageArtifact>,
+    #[serde(rename = "BoardSKUs", default)]
+    board_skus: Vec<RawBoardSku>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawSwitchSystemImageArtifact {
+    #[serde(rename = "DeviceType")]
+    device_type: String,
+    #[serde(rename = "Component")]
+    component: String,
+    #[serde(rename = "Version")]
+    version: String,
+    #[serde(rename = "Type")]
+    firmware_type: String,
+    #[serde(rename = "PackageName")]
+    package_name: String,
+    #[serde(rename = "Location")]
+    location: String,
+    #[serde(rename = "LocationType")]
+    location_type: String,
+    #[serde(rename = "Required", default = "default_true")]
+    required: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct RawBoardSku {
+    #[serde(rename = "Name", default)]
+    name: String,
+    #[serde(rename = "Type", default)]
+    sku_type: String,
+    #[serde(rename = "Components", default)]
+    components: RawBoardSkuComponents,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct RawBoardSkuComponents {
+    #[serde(rename = "Software", default)]
+    software: Vec<RawSoftwareComponent>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct RawSoftwareComponent {
+    #[serde(rename = "Component", default)]
+    component: String,
+    #[serde(rename = "Version", default)]
+    version: String,
+    #[serde(rename = "Type", default)]
+    firmware_type: String,
+    #[serde(rename = "Locations", default)]
+    locations: Vec<RawSoftwareLocation>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct RawSoftwareLocation {
+    #[serde(rename = "Name", default)]
+    name: String,
+    #[serde(rename = "Location", default)]
+    location: String,
+    #[serde(rename = "LocationType", default)]
+    location_type: String,
+    #[serde(rename = "PackageName", default)]
+    package_name: String,
+    #[serde(rename = "Required", default = "default_true")]
+    required: bool,
+}
+
+pub(crate) fn collect_switch_system_images(
+    config: &Value,
+) -> Result<Vec<SwitchSystemImageArtifact>, String> {
+    let raw: RawSwitchArtifactsConfig = serde_json::from_value(config.clone())
+        .map_err(format_switch_artifacts_deserialize_error)?;
+
+    let mut parsed = Vec::new();
+    let mut seen_keys = HashSet::new();
+
+    for (idx, entry) in raw.switch_system_images.iter().enumerate() {
+        let device_type = entry.device_type.trim();
+        if device_type != "Switch Tray" {
+            return Err(format!(
+                "SwitchSystemImages[{idx}].DeviceType must be 'Switch Tray'"
+            ));
+        }
+
+        let component = entry.component.trim();
+        if component != "NVOS" {
+            return Err(format!(
+                "SwitchSystemImages[{idx}].Component must be 'NVOS'"
+            ));
+        }
+
+        let version = entry.version.trim();
+        if version.is_empty() {
+            return Err(format!("SwitchSystemImages[{idx}].Version is required"));
+        }
+
+        let firmware_type = entry.firmware_type.trim();
+        if firmware_type.is_empty() {
+            return Err(format!("SwitchSystemImages[{idx}].Type is required"));
+        }
+        let firmware_type = firmware_type.to_lowercase();
+
+        let package_name = entry.package_name.trim();
+        if package_name.is_empty() {
+            return Err(format!("SwitchSystemImages[{idx}].PackageName is required"));
+        }
+
+        let location = entry.location.trim();
+        if location.is_empty() {
+            return Err(format!("SwitchSystemImages[{idx}].Location is required"));
+        }
+
+        let location_type = entry.location_type.trim();
+        if location_type.is_empty() {
+            return Err(format!(
+                "SwitchSystemImages[{idx}].LocationType is required"
+            ));
+        }
+
+        let key = (
+            device_type.to_string(),
+            component.to_string(),
+            firmware_type.clone(),
+        );
+        if seen_keys.insert(key) {
+            parsed.push(SwitchSystemImageArtifact {
+                device_type: device_type.to_string(),
+                component: component.to_string(),
+                version: version.to_string(),
+                firmware_type,
+                package_name: package_name.to_string(),
+                location: location.to_string(),
+                location_type: location_type.to_string(),
+                required: entry.required,
+                image_filename: filename_from_location(location)?,
+            });
+        }
+    }
+
+    for (board_idx, board_sku) in raw.board_skus.iter().enumerate() {
+        if board_sku.sku_type.trim() != "Switch Tray" {
+            continue;
+        }
+
+        let board_context = if board_sku.name.trim().is_empty() {
+            format!("BoardSKUs[{board_idx}]")
+        } else {
+            format!("BoardSKUs[{board_idx}] ({})", board_sku.name.trim())
+        };
+
+        let board_nvos_package_name = board_sku
+            .components
+            .software
+            .iter()
+            .filter(|software| software.component.trim() == "NVOS")
+            .flat_map(|software| software.locations.iter())
+            .map(|location| location.package_name.trim())
+            .find(|package_name| !package_name.is_empty());
+
+        for (software_idx, software) in board_sku.components.software.iter().enumerate() {
+            if software.component.trim() != "NVOS" {
+                continue;
+            }
+
+            let context = format!("{board_context}.Components.Software[{software_idx}]");
+            let version = software.version.trim();
+            if version.is_empty() {
+                return Err(format!("{context}.Version is required"));
+            }
+
+            let firmware_type = software.firmware_type.trim();
+            if firmware_type.is_empty() {
+                return Err(format!("{context}.Type is required"));
+            }
+            let firmware_type = firmware_type.to_lowercase();
+
+            let software_package_name = software
+                .locations
+                .iter()
+                .map(|location| location.package_name.trim())
+                .find(|package_name| !package_name.is_empty());
+
+            let mut candidates = Vec::new();
+            for (location_idx, location) in software.locations.iter().enumerate() {
+                let location_value = location.location.trim();
+                if location_value.is_empty() {
+                    continue;
+                }
+
+                let image_filename = filename_from_location(location_value)?;
+                if !image_filename.to_ascii_lowercase().ends_with(".bin") {
+                    continue;
+                }
+
+                let name_upper = location.name.to_ascii_uppercase();
+                let filename_upper = image_filename.to_ascii_uppercase();
+                let location_upper = location_value.to_ascii_uppercase();
+                let mut score = 0;
+                if name_upper.contains("NVOS") || filename_upper.contains("NVOS") {
+                    score += 2;
+                }
+                if name_upper.contains("AMD64")
+                    || filename_upper.contains("AMD64")
+                    || location_upper.contains("/AMD64/")
+                {
+                    score += 1;
+                }
+
+                candidates.push((location_idx, score, image_filename));
+            }
+
+            if candidates.is_empty() {
+                return Err(format!(
+                    "{context}.Locations must include an NVOS .bin image location"
+                ));
+            }
+
+            let best_score = candidates
+                .iter()
+                .map(|(_, score, _)| *score)
+                .max()
+                .expect("candidates is not empty");
+            let best_candidates: Vec<_> = candidates
+                .iter()
+                .filter(|(_, score, _)| *score == best_score)
+                .collect();
+            if best_candidates.len() != 1 {
+                return Err(format!(
+                    "{context}.Locations contains multiple NVOS .bin image candidates"
+                ));
+            }
+
+            let (location_idx, _, image_filename) = best_candidates[0];
+            let selected_location = &software.locations[*location_idx];
+            let location = selected_location.location.trim();
+            let location_type = selected_location.location_type.trim();
+            if location_type.is_empty() {
+                return Err(format!(
+                    "{context}.Locations[{location_idx}].LocationType is required"
+                ));
+            }
+
+            let selected_package_name = selected_location.package_name.trim();
+            let package_name = if selected_package_name.is_empty() {
+                software_package_name.or(board_nvos_package_name)
+            } else {
+                Some(selected_package_name)
+            }
+            .ok_or_else(|| {
+                format!("{context}.Locations[{location_idx}].PackageName is required")
+            })?;
+
+            let key = (
+                "Switch Tray".to_string(),
+                "NVOS".to_string(),
+                firmware_type.clone(),
+            );
+            if seen_keys.insert(key) {
+                parsed.push(SwitchSystemImageArtifact {
+                    device_type: "Switch Tray".to_string(),
+                    component: "NVOS".to_string(),
+                    version: version.to_string(),
+                    firmware_type,
+                    package_name: package_name.to_string(),
+                    location: location.to_string(),
+                    location_type: location_type.to_string(),
+                    required: selected_location.required,
+                    image_filename: image_filename.to_string(),
+                });
+            }
+        }
+    }
+
+    Ok(parsed)
+}
+
+fn filename_from_location(location: &str) -> Result<String, String> {
+    location
+        .split('/')
+        .next_back()
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| format!("Location must end with a filename: {location}"))
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn format_switch_artifacts_deserialize_error(error: serde_json::Error) -> String {
+    let message = error.to_string();
+
+    if let Some(field) = message
+        .strip_prefix("missing field `")
+        .and_then(|s| s.strip_suffix('`'))
+    {
+        return format!("Invalid SwitchSystemImages: {field} is required");
+    }
+
+    format!("Invalid switch artifacts: {message}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derives_nvos_from_board_sku_software() {
+        let config = serde_json::json!({
+            "BoardSKUs": [
+                {
+                    "Name": "P4978-Juliet_Switch",
+                    "Type": "Switch Tray",
+                    "Components": {
+                        "Software": [
+                            {
+                                "Component": "NVOS",
+                                "Version": "25.02.2553",
+                                "Type": "Prod",
+                                "Locations": [
+                                    {
+                                        "Name": "NVOS_Prod_AMD64",
+                                        "Location": "https://example.invalid/release/25.02.2553/amd64/prod/nvos-amd64-25.02.2553.bin",
+                                        "LocationType": "HTTPS",
+                                        "PackageName": "GB300_NVOS",
+                                        "Required": true
+                                    },
+                                    {
+                                        "Name": "NVOS_OpenAPI_Spec",
+                                        "Location": "https://example.invalid/release/25.02.2553/openapi.json",
+                                        "LocationType": "HTTPS",
+                                        "PackageName": "GB300_NVOS",
+                                        "Required": true
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        });
+
+        let artifacts = collect_switch_system_images(&config).unwrap();
+
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(artifacts[0].device_type, "Switch Tray");
+        assert_eq!(artifacts[0].component, "NVOS");
+        assert_eq!(artifacts[0].version, "25.02.2553");
+        assert_eq!(artifacts[0].firmware_type, "prod");
+        assert_eq!(artifacts[0].package_name, "GB300_NVOS");
+        assert_eq!(artifacts[0].image_filename, "nvos-amd64-25.02.2553.bin");
+    }
+
+    #[test]
+    fn uses_board_sku_nvos_package_name_fallback() {
+        let config = serde_json::json!({
+            "BoardSKUs": [
+                {
+                    "Name": "P4978-Juliet_Switch",
+                    "Type": "Switch Tray",
+                    "Components": {
+                        "Software": [
+                            {
+                                "Component": "NVOS",
+                                "Version": "25.02.2553",
+                                "Type": "Prod",
+                                "Locations": [
+                                    {
+                                        "Name": "NVOS_Prod_AMD64",
+                                        "Location": "https://example.invalid/prod/nvos-amd64-25.02.2553.bin",
+                                        "LocationType": "HTTPS",
+                                        "PackageName": "GB300_NVOS"
+                                    }
+                                ]
+                            },
+                            {
+                                "Component": "NVOS",
+                                "Version": "25.02.2553",
+                                "Type": "Dev",
+                                "Locations": [
+                                    {
+                                        "Name": "NVOS_Dev_AMD64",
+                                        "Location": "https://example.invalid/dev/nvos-amd64-25.02.2553.bin",
+                                        "LocationType": "HTTPS",
+                                        "PackageName": ""
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        });
+
+        let artifacts = collect_switch_system_images(&config).unwrap();
+
+        let dev = artifacts
+            .iter()
+            .find(|artifact| artifact.firmware_type == "dev")
+            .expect("expected dev NVOS artifact");
+        assert_eq!(dev.package_name, "GB300_NVOS");
+    }
+
+    #[test]
+    fn explicit_switch_system_image_wins_over_derived() {
+        let config = serde_json::json!({
+            "SwitchSystemImages": [
+                {
+                    "DeviceType": "Switch Tray",
+                    "Component": "NVOS",
+                    "Version": "explicit",
+                    "Type": "Prod",
+                    "PackageName": "EXPLICIT_NVOS",
+                    "Location": "https://example.invalid/explicit.bin",
+                    "LocationType": "HTTPS"
+                }
+            ],
+            "BoardSKUs": [
+                {
+                    "Type": "Switch Tray",
+                    "Components": {
+                        "Software": [
+                            {
+                                "Component": "NVOS",
+                                "Version": "derived",
+                                "Type": "Prod",
+                                "Locations": [
+                                    {
+                                        "Name": "NVOS_Prod_AMD64",
+                                        "Location": "https://example.invalid/derived.bin",
+                                        "LocationType": "HTTPS",
+                                        "PackageName": "DERIVED_NVOS"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        });
+
+        let artifacts = collect_switch_system_images(&config).unwrap();
+
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(artifacts[0].version, "explicit");
+        assert_eq!(artifacts[0].package_name, "EXPLICIT_NVOS");
+    }
+
+    #[test]
+    fn rejects_nvos_software_without_bin_location() {
+        let config = serde_json::json!({
+            "BoardSKUs": [
+                {
+                    "Type": "Switch Tray",
+                    "Components": {
+                        "Software": [
+                            {
+                                "Component": "NVOS",
+                                "Version": "25.02.2553",
+                                "Type": "Prod",
+                                "Locations": [
+                                    {
+                                        "Name": "NVOS_OpenAPI_Spec",
+                                        "Location": "https://example.invalid/openapi.json",
+                                        "LocationType": "HTTPS",
+                                        "PackageName": "GB300_NVOS"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        });
+
+        let error = collect_switch_system_images(&config).unwrap_err();
+
+        assert!(error.contains("must include an NVOS .bin image location"));
+    }
+}

--- a/crates/api/src/rack/firmware_update.rs
+++ b/crates/api/src/rack/firmware_update.rs
@@ -263,7 +263,7 @@ pub fn build_firmware_update_batches(
                 }),
                 firmware_targets: target_map,
                 activate,
-                force_update: true,
+                force_update: false,
                 ..Default::default()
             },
         });

--- a/crates/api/src/state_controller/rack/io.rs
+++ b/crates/api/src/state_controller/rack/io.rs
@@ -141,7 +141,7 @@ impl StateControllerIO for RackStateControllerIO {
             RackState::Maintenance { maintenance_state } => match maintenance_state {
                 RackMaintenanceState::FirmwareUpgrade { .. } => ("maintenance", "firmware_upgrade"),
                 RackMaintenanceState::NVOSUpdate { .. } => ("maintenance", "nvos_update"),
-                RackMaintenanceState::ConfigureNmxCluster => {
+                RackMaintenanceState::ConfigureNmxCluster { .. } => {
                     ("maintenance", "configure_nmx_cluster")
                 }
                 RackMaintenanceState::PowerSequence { .. } => ("maintenance", "power_sequence"),

--- a/crates/api/src/state_controller/rack/maintenance.rs
+++ b/crates/api/src/state_controller/rack/maintenance.rs
@@ -25,19 +25,19 @@ use db::{
 };
 use librms::protos::rack_manager as rms;
 use model::rack::{
-    FirmwareUpgradeDeviceInfo, FirmwareUpgradeDeviceStatus, FirmwareUpgradeState,
-    MaintenanceActivity, MaintenanceScope, NvosUpdateJob, NvosUpdateState, NvosUpdateSwitchStatus,
-    Rack, RackFirmwareUpgradeState, RackFirmwareUpgradeStatus, RackMaintenanceState,
-    RackPowerState, RackState, RackValidationState, ResolvedNvosArtifact, SwitchNvosUpdateState,
-    SwitchNvosUpdateStatus,
+    ConfigureNmxClusterState, FirmwareUpgradeDeviceInfo, FirmwareUpgradeDeviceStatus,
+    FirmwareUpgradeState, MaintenanceActivity, MaintenanceScope, NvosUpdateJob, NvosUpdateState,
+    NvosUpdateSwitchStatus, Rack, RackFirmwareUpgradeState, RackFirmwareUpgradeStatus,
+    RackMaintenanceState, RackPowerState, RackState, RackValidationState, ResolvedNvosArtifact,
+    SwitchNvosUpdateState, SwitchNvosUpdateStatus,
 };
 use model::rack_firmware::{RackFirmware, RackFirmwareSearchFilter};
 use model::rack_type::RackHardwareType;
 
 use crate::rack::firmware_update::{
-    RackFirmwareInventory, build_firmware_update_batches, build_new_node_info,
-    firmware_type_for_profile, load_rack_firmware_inventory, load_rack_switch_firmware_inventory,
-    submit_firmware_update_batches,
+    RackFirmwareInventory, RackSwitchFirmwareInventory, build_firmware_update_batches,
+    build_new_node_info, firmware_type_for_profile, load_rack_firmware_inventory,
+    load_rack_switch_firmware_inventory, submit_firmware_update_batches,
 };
 use crate::rack::rms_client::SwitchSystemImageRmsClient;
 use crate::state_controller::rack::context::RackStateHandlerContextObjects;
@@ -318,7 +318,9 @@ async fn clear_maintenance_requested_on_error(
 /// activities not requested in the scope.
 fn next_state_after_firmware(scope: &MaintenanceScope) -> RackMaintenanceState {
     if scope.should_run(&MaintenanceActivity::ConfigureNmxCluster) {
-        RackMaintenanceState::ConfigureNmxCluster
+        RackMaintenanceState::ConfigureNmxCluster {
+            configure_nmx_cluster: ConfigureNmxClusterState::Start,
+        }
     } else {
         next_state_after_configure(scope)
     }
@@ -374,6 +376,31 @@ fn filter_inventory_by_scope(
                 Err(_) => false,
             }
         });
+    }
+
+    if scope.switch_ids.is_empty() {
+        inventory.switch_ids.clear();
+        inventory.switches.clear();
+    } else {
+        let allowed: std::collections::HashSet<_> = scope.switch_ids.iter().collect();
+        inventory.switch_ids.retain(|id| allowed.contains(id));
+        inventory.switches.retain(
+            |d| match d.node_id.parse::<carbide_uuid::switch::SwitchId>() {
+                Ok(ref id) => allowed.contains(id),
+                Err(_) => false,
+            },
+        );
+    }
+
+    inventory
+}
+
+fn filter_switch_inventory_by_scope(
+    mut inventory: RackSwitchFirmwareInventory,
+    scope: &MaintenanceScope,
+) -> RackSwitchFirmwareInventory {
+    if scope.is_full_rack() {
+        return inventory;
     }
 
     if scope.switch_ids.is_empty() {
@@ -1421,22 +1448,29 @@ pub async fn handle_maintenance(
                 };
 
                 for switch in job.switches.iter() {
-                    let mac: mac_address::MacAddress = match switch.mac.parse() {
-                        Ok(mac) => mac,
-                        Err(_) => continue,
+                    let switch_id = if !switch.node_id.is_empty() {
+                        switch
+                            .node_id
+                            .parse::<carbide_uuid::switch::SwitchId>()
+                            .ok()
+                    } else {
+                        let mac: mac_address::MacAddress = match switch.mac.parse() {
+                            Ok(mac) => mac,
+                            Err(_) => continue,
+                        };
+                        db_switch::find_ids(
+                            txn.as_mut(),
+                            model::switch::SwitchSearchFilter {
+                                bmc_mac: Some(mac),
+                                rack_id: Some(id.clone()),
+                                ..Default::default()
+                            },
+                        )
+                        .await?
+                        .first()
+                        .copied()
                     };
-                    if let Some(switch_id) = db_switch::find_ids(
-                        txn.as_mut(),
-                        model::switch::SwitchSearchFilter {
-                            bmc_mac: Some(mac),
-                            rack_id: Some(id.clone()),
-                            ..Default::default()
-                        },
-                    )
-                    .await?
-                    .first()
-                    .copied()
-                    {
+                    if let Some(switch_id) = switch_id {
                         let nvos_status = build_status(switch);
                         db_switch::update_nvos_update_status(
                             txn.as_mut(),
@@ -1444,6 +1478,11 @@ pub async fn handle_maintenance(
                             Some(&nvos_status),
                         )
                         .await?;
+                    } else {
+                        tracing::error!(
+                            "switch {} not found in database for NVOS update",
+                            switch.mac
+                        );
                     }
                 }
 
@@ -1488,225 +1527,251 @@ pub async fn handle_maintenance(
                     next_state = %next,
                     "Rack NVOS update complete, advancing"
                 );
-                db_rack::update_nvos_update_job(txn.as_mut(), id, None).await?;
-                state.nvos_update_job = None;
+                db_rack::update_nvos_update_job(txn.as_mut(), id, Some(&job)).await?;
+                state.nvos_update_job = Some(job);
                 Ok(StateHandlerOutcome::transition(RackState::Maintenance {
                     maintenance_state: next,
                 })
                 .with_txn(txn))
             }
         },
-        RackMaintenanceState::ConfigureNmxCluster => {
-            let Some(rms_client) = ctx.services.rms_client.as_ref() else {
-                return transition_to_rack_error(id, state, "RMS client not configured", ctx).await;
-            };
-            let mut switch_inventory = load_rack_switch_firmware_inventory(
-                &ctx.services.db_pool,
-                ctx.services.credential_manager.as_ref(),
-                id,
-            )
-            .await
-            .map_err(|error| {
-                StateHandlerError::GenericError(eyre::eyre!(
-                    "failed to load rack switch firmware inventory for ConfigureNmxCluster: {}",
-                    error
-                ))
-            })?;
-            if !scope.is_full_rack() {
-                if scope.switch_ids.is_empty() {
-                    switch_inventory.switch_ids.clear();
-                    switch_inventory.switches.clear();
-                } else {
-                    let allowed: std::collections::HashSet<_> = scope.switch_ids.iter().collect();
-                    switch_inventory
-                        .switch_ids
-                        .retain(|switch_id| allowed.contains(switch_id));
-                    switch_inventory.switches.retain(|device| match device
-                        .node_id
-                        .parse::<carbide_uuid::switch::SwitchId>(
-                    ) {
-                        Ok(ref switch_id) => allowed.contains(switch_id),
-                        Err(_) => false,
-                    });
-                }
-            }
-
-            if switch_inventory.switches.is_empty() {
-                return Ok(skip_configure_nmx_cluster_outcome(
+        RackMaintenanceState::ConfigureNmxCluster {
+            configure_nmx_cluster,
+        } => match configure_nmx_cluster {
+            ConfigureNmxClusterState::Start => {
+                let Some(rms_client) = ctx.services.rms_client.as_ref() else {
+                    return transition_to_rack_error(id, state, "RMS client not configured", ctx)
+                        .await;
+                };
+                let switch_inventory = load_rack_switch_firmware_inventory(
+                    &ctx.services.db_pool,
+                    ctx.services.credential_manager.as_ref(),
                     id,
-                    "rack has no switches in inventory",
-                    scope,
-                ));
-            }
-
-            if let Err(cause) =
-                validate_switch_inventory_for_nmx_cluster(&switch_inventory.switches)
-            {
-                return transition_to_rack_error(id, state, cause, ctx).await;
-            }
-
-            let rack_profile_label = rack_profile_id
-                .map(|profile_id| profile_id.to_string())
-                .unwrap_or_else(|| "<none>".to_string());
-            let Some(profile) = super::resolve_profile(id, rack_profile_id, ctx) else {
-                return transition_to_rack_error(
-                    id,
-                    state,
-                    format!(
-                        "rack profile '{}' is missing or unknown; cannot resolve rack_hardware_topology",
-                        rack_profile_label
-                    ),
-                    ctx,
                 )
-                .await;
-            };
-            let Some(rack_hardware_topology) = profile.rack_hardware_topology else {
-                return transition_to_rack_error(
-                    id,
-                    state,
-                    format!(
-                        "rack profile '{}' does not define rack_hardware_topology",
-                        rack_profile_label
-                    ),
-                    ctx,
-                )
-                .await;
-            };
-
-            let response = match rms_client
-                .get_device_info_by_device_list(build_switch_device_info_request(
-                    id,
-                    &switch_inventory.switches,
-                ))
                 .await
-            {
-                Ok(response) => response,
-                Err(error) => {
-                    return transition_to_rack_error(
+                .map_err(|error| {
+                    StateHandlerError::GenericError(eyre::eyre!(
+                        "failed to load rack switch firmware inventory for ConfigureNmxCluster: {}",
+                        error
+                    ))
+                })?;
+                let switch_inventory = filter_switch_inventory_by_scope(switch_inventory, scope);
+
+                if switch_inventory.switches.is_empty() {
+                    return Ok(skip_configure_nmx_cluster_outcome(
                         id,
-                        state,
-                        format!("RMS GetDeviceInfoByDeviceList failed: {}", error),
-                        ctx,
-                    )
-                    .await;
+                        "rack has no switches in inventory",
+                        scope,
+                    ));
                 }
-            };
-            let primary_switch = match select_primary_switch(&switch_inventory.switches, &response)
-            {
-                Ok(primary_switch) => primary_switch,
-                Err(cause) => return transition_to_rack_error(id, state, cause, ctx).await,
-            };
-            {
-                let mut txn = ctx.services.db_pool.begin().await?;
+
                 if let Err(cause) =
-                    persist_primary_switch(txn.as_mut(), id, &primary_switch.device.node_id).await
+                    validate_switch_inventory_for_nmx_cluster(&switch_inventory.switches)
                 {
-                    drop(txn);
                     return transition_to_rack_error(id, state, cause, ctx).await;
                 }
-                txn.commit().await?;
-            }
 
-            let topology_type = rack_hardware_topology.to_string();
-            tracing::info!(
-                rack_id = %id,
-                primary_switch = %primary_switch.device.node_id,
-                tray_index = primary_switch.tray_index,
-                slot_number = primary_switch.slot_number,
-                topology_type = %topology_type,
-                switch_count = switch_inventory.switches.len(),
-                "Configuring NMX cluster on primary switch"
-            );
-            let response = match rms_client
-                .configure_scale_up_fabric_manager(rms::ConfigureScaleUpFabricManagerRequest {
-                    device: Some(build_new_node_info(
-                        id,
-                        &primary_switch.device,
-                        rms::NodeType::Switch,
-                    )),
-                    topology_type: topology_type.clone(),
-                    verify_ssl: false,
-                    ..Default::default()
-                })
-                .await
-            {
-                Ok(response) => response,
-                Err(error) => {
+                let rack_profile_label = rack_profile_id
+                    .map(|profile_id| profile_id.to_string())
+                    .unwrap_or_else(|| "<none>".to_string());
+                let Some(profile) = super::resolve_profile(id, rack_profile_id, ctx) else {
                     return transition_to_rack_error(
                         id,
                         state,
                         format!(
-                            "RMS ConfigureScaleUpFabricManager failed for switch {}: {}",
-                            primary_switch.device.node_id, error
+                            "rack profile '{}' is missing or unknown; cannot resolve rack_hardware_topology",
+                            rack_profile_label
                         ),
                         ctx,
                     )
                     .await;
-                }
-            };
-
-            if response.status != rms::ReturnCode::Success as i32 {
-                let message = if response.message.trim().is_empty() {
-                    "no error details provided".to_string()
-                } else {
-                    response.message
                 };
-                return transition_to_rack_error(
-                    id,
-                    state,
-                    format!(
-                        "RMS ConfigureScaleUpFabricManager failed for switch {}: {}",
-                        primary_switch.device.node_id, message
-                    ),
-                    ctx,
-                )
-                .await;
-            }
+                let Some(rack_hardware_topology) = profile.rack_hardware_topology else {
+                    return transition_to_rack_error(
+                        id,
+                        state,
+                        format!(
+                            "rack profile '{}' does not define rack_hardware_topology",
+                            rack_profile_label
+                        ),
+                        ctx,
+                    )
+                    .await;
+                };
 
-            let fabric_status_response = match get_scale_up_fabric_services_status(
-                &ctx.services.site_config.rms,
-                id,
-                &switch_inventory.switches,
-            )
-            .await
-            {
-                Ok(response) => response,
-                Err(cause) => return transition_to_rack_error(id, state, cause, ctx).await,
-            };
-            let mut txn = ctx.services.db_pool.begin().await?;
-            if let Err(cause) = persist_fabric_manager_statuses(
-                txn.as_mut(),
-                id,
-                &switch_inventory.switches,
-                &fabric_status_response,
-            )
-            .await
-            {
-                drop(txn);
-                return transition_to_rack_error(id, state, cause, ctx).await;
+                let response = match rms_client
+                    .get_device_info_by_device_list(build_switch_device_info_request(
+                        id,
+                        &switch_inventory.switches,
+                    ))
+                    .await
+                {
+                    Ok(response) => response,
+                    Err(error) => {
+                        return transition_to_rack_error(
+                            id,
+                            state,
+                            format!("RMS GetDeviceInfoByDeviceList failed: {}", error),
+                            ctx,
+                        )
+                        .await;
+                    }
+                };
+                let primary_switch =
+                    match select_primary_switch(&switch_inventory.switches, &response) {
+                        Ok(primary_switch) => primary_switch,
+                        Err(cause) => return transition_to_rack_error(id, state, cause, ctx).await,
+                    };
+                {
+                    let mut txn = ctx.services.db_pool.begin().await?;
+                    if let Err(cause) =
+                        persist_primary_switch(txn.as_mut(), id, &primary_switch.device.node_id)
+                            .await
+                    {
+                        drop(txn);
+                        return transition_to_rack_error(id, state, cause, ctx).await;
+                    }
+                    txn.commit().await?;
+                }
+
+                let topology_type = rack_hardware_topology.to_string();
+                tracing::info!(
+                    rack_id = %id,
+                    primary_switch = %primary_switch.device.node_id,
+                    tray_index = primary_switch.tray_index,
+                    slot_number = primary_switch.slot_number,
+                    topology_type = %topology_type,
+                    switch_count = switch_inventory.switches.len(),
+                    "Configuring NMX cluster on primary switch"
+                );
+                let response = match rms_client
+                    .configure_scale_up_fabric_manager(rms::ConfigureScaleUpFabricManagerRequest {
+                        device: Some(build_new_node_info(
+                            id,
+                            &primary_switch.device,
+                            rms::NodeType::Switch,
+                        )),
+                        topology_type: topology_type.clone(),
+                        verify_ssl: false,
+                        ..Default::default()
+                    })
+                    .await
+                {
+                    Ok(response) => response,
+                    Err(error) => {
+                        tracing::error!(
+                            rack_id = %id,
+                            primary_switch = %primary_switch.device.node_id,
+                            error = %error,
+                            "RMS ConfigureScaleUpFabricManager failed for switch, continuing",
+                        );
+                        return Ok(StateHandlerOutcome::transition(RackState::Maintenance {
+                            maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+                                configure_nmx_cluster:
+                                    ConfigureNmxClusterState::WaitForFabricStatus,
+                            },
+                        }));
+                    }
+                };
+
+                if response.status != rms::ReturnCode::Success as i32 {
+                    let message = if response.message.trim().is_empty() {
+                        "no error details provided".to_string()
+                    } else {
+                        response.message
+                    };
+                    tracing::error!(
+                        rack_id = %id,
+                        primary_switch = %primary_switch.device.node_id,
+                        message = %message,
+                        "RMS ConfigureScaleUpFabricManager failed for switch, advancing to WaitForFabricStatus",
+                    );
+                    return Ok(StateHandlerOutcome::transition(RackState::Maintenance {
+                        maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+                            configure_nmx_cluster: ConfigureNmxClusterState::WaitForFabricStatus,
+                        },
+                    }));
+                }
+
+                tracing::info!(
+                    rack_id = %id,
+                    primary_switch = %primary_switch.device.node_id,
+                    tray_index = primary_switch.tray_index,
+                    slot_number = primary_switch.slot_number,
+                    topology_type = %topology_type,
+                    topology_used = %if response.topology_used.is_empty() {
+                        topology_type.clone()
+                    } else {
+                        response.topology_used.clone()
+                    },
+                    scale_up_fabric_state_enabled = response.scale_up_fabric_state_enabled,
+                    grpc_enabled = response.grpc_enabled,
+                    "ConfigureScaleUpFabricManager succeeded; advancing to WaitForFabricStatus"
+                );
+                Ok(StateHandlerOutcome::transition(RackState::Maintenance {
+                    maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+                        configure_nmx_cluster: ConfigureNmxClusterState::WaitForFabricStatus,
+                    },
+                }))
             }
-            let next = next_state_after_configure(scope);
-            tracing::info!(
-                rack_id = %id,
-                primary_switch = %primary_switch.device.node_id,
-                tray_index = primary_switch.tray_index,
-                slot_number = primary_switch.slot_number,
-                topology_type = %topology_type,
-                topology_used = %if response.topology_used.is_empty() {
-                    topology_type.clone()
-                } else {
-                    response.topology_used.clone()
-                },
-                scale_up_fabric_state_enabled = response.scale_up_fabric_state_enabled,
-                grpc_enabled = response.grpc_enabled,
-                next_state = %next,
-                "Rack ConfigureNmxCluster complete, FabricManager status persisted, advancing"
-            );
-            Ok(StateHandlerOutcome::transition(RackState::Maintenance {
-                maintenance_state: next,
-            })
-            .with_txn(txn))
-        }
+            ConfigureNmxClusterState::WaitForFabricStatus => {
+                let switch_inventory = load_rack_switch_firmware_inventory(
+                    &ctx.services.db_pool,
+                    ctx.services.credential_manager.as_ref(),
+                    id,
+                )
+                .await
+                .map_err(|error| {
+                    StateHandlerError::GenericError(eyre::eyre!(
+                        "failed to load rack switch firmware inventory for WaitForFabricStatus: {}",
+                        error
+                    ))
+                })?;
+                let switch_inventory = filter_switch_inventory_by_scope(switch_inventory, scope);
+
+                if switch_inventory.switches.is_empty() {
+                    return Ok(skip_configure_nmx_cluster_outcome(
+                        id,
+                        "rack has no switches in inventory",
+                        scope,
+                    ));
+                }
+
+                let fabric_status_response = match get_scale_up_fabric_services_status(
+                    &ctx.services.site_config.rms,
+                    id,
+                    &switch_inventory.switches,
+                )
+                .await
+                {
+                    Ok(response) => response,
+                    Err(cause) => return transition_to_rack_error(id, state, cause, ctx).await,
+                };
+                let mut txn = ctx.services.db_pool.begin().await?;
+                if let Err(cause) = persist_fabric_manager_statuses(
+                    txn.as_mut(),
+                    id,
+                    &switch_inventory.switches,
+                    &fabric_status_response,
+                )
+                .await
+                {
+                    drop(txn);
+                    return transition_to_rack_error(id, state, cause, ctx).await;
+                }
+                let next = next_state_after_configure(scope);
+                tracing::info!(
+                    rack_id = %id,
+                    switch_count = switch_inventory.switches.len(),
+                    next_state = %next,
+                    "WaitForFabricStatus complete, FabricManager status persisted, advancing"
+                );
+                Ok(StateHandlerOutcome::transition(RackState::Maintenance {
+                    maintenance_state: next,
+                })
+                .with_txn(txn))
+            }
+        },
         RackMaintenanceState::PowerSequence { rack_power } => match rack_power {
             RackPowerState::PoweringOn => {
                 tracing::info!("Rack {} power sequence (on) - stubbed", id);
@@ -1754,8 +1819,8 @@ pub async fn handle_maintenance(
 #[cfg(test)]
 mod tests {
     use model::rack::{
-        FirmwareUpgradeDeviceInfo, FirmwareUpgradeState, MaintenanceActivity, MaintenanceScope,
-        RackMaintenanceState, RackPowerState,
+        ConfigureNmxClusterState, FirmwareUpgradeDeviceInfo, FirmwareUpgradeState,
+        MaintenanceActivity, MaintenanceScope, RackMaintenanceState, RackPowerState,
     };
 
     use super::{
@@ -1824,7 +1889,9 @@ mod tests {
         };
         assert_eq!(
             first_maintenance_state(&scope),
-            RackMaintenanceState::ConfigureNmxCluster,
+            RackMaintenanceState::ConfigureNmxCluster {
+                configure_nmx_cluster: ConfigureNmxClusterState::Start,
+            },
         );
     }
 
@@ -1853,7 +1920,9 @@ mod tests {
         };
         assert_eq!(
             first_maintenance_state(&scope),
-            RackMaintenanceState::ConfigureNmxCluster,
+            RackMaintenanceState::ConfigureNmxCluster {
+                configure_nmx_cluster: ConfigureNmxClusterState::Start,
+            },
         );
     }
 
@@ -1864,7 +1933,9 @@ mod tests {
         let scope = MaintenanceScope::default();
         assert_eq!(
             next_state_after_firmware(&scope),
-            RackMaintenanceState::ConfigureNmxCluster,
+            RackMaintenanceState::ConfigureNmxCluster {
+                configure_nmx_cluster: ConfigureNmxClusterState::Start,
+            },
         );
     }
 

--- a/crates/api/src/state_controller/switch/io.rs
+++ b/crates/api/src/state_controller/switch/io.rs
@@ -57,6 +57,7 @@ impl StateControllerIO for SwitchStateControllerIO {
                 deleted: model::DeletedFilter::Include,
                 controller_state: None,
                 bmc_mac: None,
+                ..Default::default()
             },
         )
         .await

--- a/crates/api/src/state_controller/switch/ready.rs
+++ b/crates/api/src/state_controller/switch/ready.rs
@@ -41,7 +41,8 @@ pub async fn handle_ready(
     if let Some(req) = &state.switch_reprovisioning_requested {
         if req.initiator.starts_with("rack-") {
             tracing::info!(
-                "Rack-level firmware upgrade requested — transitioning to WaitingForRackFirmwareUpgrade"
+                initiator = %req.initiator,
+                "Rack-level switch reprovisioning requested — transitioning to ReProvisioning"
             );
             return Ok(StateHandlerOutcome::transition(
                 SwitchControllerState::ReProvisioning {

--- a/crates/api/src/state_controller/switch/reprovisioning.rs
+++ b/crates/api/src/state_controller/switch/reprovisioning.rs
@@ -62,23 +62,108 @@ pub async fn handle_reprovisioning(
                 ));
             }
 
-            let mut txn = ctx.services.db_pool.begin().await?;
-            db_switch::clear_switch_reprovisioning_requested(txn.as_mut(), *switch_id).await?;
             match &firmware_upgrade_status.status {
-                model::rack::RackFirmwareUpgradeState::Completed => {
-                    Ok(StateHandlerOutcome::transition(SwitchControllerState::Ready).with_txn(txn))
-                }
-                model::rack::RackFirmwareUpgradeState::Failed { cause } => Ok(
-                    StateHandlerOutcome::transition(SwitchControllerState::Error {
-                        cause: cause.clone(),
-                    })
-                    .with_txn(txn),
+                model::rack::RackFirmwareUpgradeState::Completed => Ok(
+                    StateHandlerOutcome::transition(SwitchControllerState::ReProvisioning {
+                        reprovisioning_state: ReProvisioningState::WaitingForNVOSUpgrade,
+                    }),
                 ),
+                model::rack::RackFirmwareUpgradeState::Failed { cause } => {
+                    let mut txn = ctx.services.db_pool.begin().await?;
+                    db_switch::clear_switch_reprovisioning_requested(txn.as_mut(), *switch_id)
+                        .await?;
+                    Ok(
+                        StateHandlerOutcome::transition(SwitchControllerState::Error {
+                            cause: cause.clone(),
+                        })
+                        .with_txn(txn),
+                    )
+                }
                 model::rack::RackFirmwareUpgradeState::Started
                 | model::rack::RackFirmwareUpgradeState::InProgress => Ok(
                     StateHandlerOutcome::wait("waiting for switch firmware completion".into()),
                 ),
             }
+        }
+        ReProvisioningState::WaitingForNVOSUpgrade => {
+            let requested_at = state
+                .switch_reprovisioning_requested
+                .as_ref()
+                .map(|request| request.requested_at)
+                .expect("WaitingForNVOSUpgrade requires a rack reprovision request");
+            let Some(nvos_update_status) = state.nvos_update_status.as_ref() else {
+                return Ok(StateHandlerOutcome::wait(
+                    "waiting for switch NVOS update status".into(),
+                ));
+            };
+            if !nvos_update_status.is_current_for(requested_at) {
+                return Ok(StateHandlerOutcome::wait(
+                    "waiting for current rack NVOS cycle".into(),
+                ));
+            }
+            if !nvos_update_status.is_terminal() {
+                return Ok(StateHandlerOutcome::wait(
+                    "waiting for switch NVOS completion".into(),
+                ));
+            }
+
+            match &nvos_update_status.status {
+                model::rack::SwitchNvosUpdateState::Completed => Ok(
+                    StateHandlerOutcome::transition(SwitchControllerState::ReProvisioning {
+                        reprovisioning_state: ReProvisioningState::WaitingForNMXCConfigure,
+                    }),
+                ),
+                model::rack::SwitchNvosUpdateState::Failed { cause } => {
+                    let mut txn = ctx.services.db_pool.begin().await?;
+                    db_switch::clear_switch_reprovisioning_requested(txn.as_mut(), *switch_id)
+                        .await?;
+                    Ok(
+                        StateHandlerOutcome::transition(SwitchControllerState::Error {
+                            cause: cause.clone(),
+                        })
+                        .with_txn(txn),
+                    )
+                }
+                model::rack::SwitchNvosUpdateState::Started
+                | model::rack::SwitchNvosUpdateState::InProgress => Ok(StateHandlerOutcome::wait(
+                    "waiting for switch NVOS completion".into(),
+                )),
+            }
+        }
+        ReProvisioningState::WaitingForNMXCConfigure => {
+            let Some(fabric_manager_status) = state.fabric_manager_status.as_ref() else {
+                return Ok(StateHandlerOutcome::wait(
+                    "waiting for switch fabric manager status".into(),
+                ));
+            };
+            if fabric_manager_status.display_status() != "running" {
+                if let Some(cause) = fabric_manager_status.error_message.as_ref() {
+                    let mut txn = ctx.services.db_pool.begin().await?;
+                    db_switch::clear_switch_reprovisioning_requested(txn.as_mut(), *switch_id)
+                        .await?;
+                    return Ok(
+                        StateHandlerOutcome::transition(SwitchControllerState::Error {
+                            cause: cause.clone(),
+                        })
+                        .with_txn(txn),
+                    );
+                }
+                if let Some(reason) = fabric_manager_status.reason.as_ref() {
+                    if !reason.is_empty() {
+                        let mut txn = ctx.services.db_pool.begin().await?;
+                        db_switch::clear_switch_reprovisioning_requested(txn.as_mut(), *switch_id)
+                            .await?;
+                        return Ok(
+                            StateHandlerOutcome::transition(SwitchControllerState::Ready)
+                                .with_txn(txn),
+                        );
+                    }
+                    return Ok(StateHandlerOutcome::wait(reason.clone()));
+                }
+            }
+            let mut txn = ctx.services.db_pool.begin().await?;
+            db_switch::clear_switch_reprovisioning_requested(txn.as_mut(), *switch_id).await?;
+            Ok(StateHandlerOutcome::transition(SwitchControllerState::Ready).with_txn(txn))
         }
     }
 }

--- a/crates/api/src/tests/machine_creator.rs
+++ b/crates/api/src/tests/machine_creator.rs
@@ -68,6 +68,8 @@ async fn test_site_explorer_reject_zero_dpu_hosts(
         power_shelves_created_per_run: 1,
         create_switches: Arc::new(true.into()),
         switches_created_per_run: 1,
+        force_dpu_nic_mode: Arc::new(false.into()),
+        allow_zero_dpu_hosts: false,
         ..Default::default()
     };
     let machine_creator = MachineCreator::new(

--- a/crates/api/src/tests/rack_firmware.rs
+++ b/crates/api/src/tests/rack_firmware.rs
@@ -134,6 +134,62 @@ fn create_valid_rack_firmware_json_with_switch_system_image(id: &str) -> String 
     .to_string()
 }
 
+fn create_valid_rack_firmware_json_with_nvos_software(id: &str) -> String {
+    serde_json::json!({
+        "Id": id,
+        "Name": "Test Rack Firmware Config With NVOS Software",
+        "Description": "A test configuration for rack firmware with NVOS under Switch Tray software",
+        "BoardSKUs": [
+            {
+                "SKUID": "switch-sku-001",
+                "Name": "P4978-Juliet_Switch",
+                "Type": "Switch Tray",
+                "Components": {
+                    "Software": [
+                        {
+                            "Component": "NVOS",
+                            "Version": "25.02.2553",
+                            "Type": "Prod",
+                            "Locations": [
+                                {
+                                    "Name": "NVOS_Prod_AMD64",
+                                    "Location": "https://urm.nvidia.com/artifactory/sw-nbu-sws-nvos-generic-local/release/25.02.2553/amd64/prod/nvos-amd64-25.02.2553.bin",
+                                    "LocationType": "HTTPS",
+                                    "PackageName": "GB300_NVOS",
+                                    "Required": true
+                                },
+                                {
+                                    "Name": "NVOS_OpenAPI_Spec",
+                                    "Location": "https://urm.nvidia.com/artifactory/sw-nbu-sws-nvos-generic-local/release/25.02.2553/openapi.json",
+                                    "LocationType": "HTTPS",
+                                    "PackageName": "GB300_NVOS",
+                                    "Required": true
+                                }
+                            ]
+                        },
+                        {
+                            "Component": "NVOS",
+                            "Version": "25.02.2553",
+                            "Type": "Dev",
+                            "Locations": [
+                                {
+                                    "Name": "NVOS_Dev_AMD64",
+                                    "Location": "https://urm.nvidia.com/artifactory/sw-nbu-sws-nvos-generic-local/release/25.02.2553/amd64/dev/nvos-amd64-25.02.2553.bin",
+                                    "LocationType": "HTTPS",
+                                    "PackageName": "",
+                                    "Required": true
+                                }
+                            ]
+                        }
+                    ],
+                    "Firmware": []
+                }
+            }
+        ]
+    })
+    .to_string()
+}
+
 // ============================================================================
 // CREATE TESTS
 // ============================================================================
@@ -216,6 +272,53 @@ async fn test_create_rack_firmware_with_switch_system_image(
         switch_system_images[0]["image_filename"],
         "nvos-amd64-25.02.2553.bin"
     );
+
+    Ok(())
+}
+
+#[crate::sqlx_test()]
+async fn test_create_rack_firmware_derives_nvos_from_switch_tray_software(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    let firmware_id = "test-firmware-nvos-software-001";
+    let config_json = create_valid_rack_firmware_json_with_nvos_software(firmware_id);
+
+    let request = tonic::Request::new(RackFirmwareCreateRequest {
+        rack_hardware_type: Some(rpc::common::RackHardwareType {
+            value: "any".to_string(),
+        }),
+        config_json,
+        artifactory_token: "test-token-123".to_string(),
+    });
+
+    let response = env.api.create_rack_firmware(request).await?;
+    let firmware = response.into_inner();
+
+    assert_eq!(firmware.id, firmware_id);
+
+    let db_firmware = db::rack_firmware::find_by_id(&env.pool, firmware_id).await?;
+    let parsed = db_firmware.parsed_components.unwrap();
+    let switch_system_images = parsed["switch_system_images"].as_array().unwrap();
+    assert_eq!(switch_system_images.len(), 2);
+
+    let prod = switch_system_images
+        .iter()
+        .find(|image| image["firmware_type"] == "prod")
+        .expect("expected prod NVOS image");
+    assert_eq!(prod["device_type"], "Switch Tray");
+    assert_eq!(prod["component"], "NVOS");
+    assert_eq!(prod["version"], "25.02.2553");
+    assert_eq!(prod["package_name"], "GB300_NVOS");
+    assert_eq!(prod["image_filename"], "nvos-amd64-25.02.2553.bin");
+
+    let dev = switch_system_images
+        .iter()
+        .find(|image| image["firmware_type"] == "dev")
+        .expect("expected dev NVOS image");
+    assert_eq!(dev["package_name"], "GB300_NVOS");
+    assert_eq!(dev["image_filename"], "nvos-amd64-25.02.2553.bin");
 
     Ok(())
 }

--- a/crates/api/src/tests/rack_state_controller/handler.rs
+++ b/crates/api/src/tests/rack_state_controller/handler.rs
@@ -26,9 +26,10 @@ use librms::protos::rack_manager as rms;
 use model::expected_machine::ExpectedMachineData;
 use model::expected_rack::ExpectedRack;
 use model::rack::{
-    FirmwareUpgradeDeviceStatus, FirmwareUpgradeJob, FirmwareUpgradeState, NvosUpdateState,
-    NvosUpdateSwitchStatus, Rack, RackConfig, RackFirmwareUpgradeState, RackMaintenanceState,
-    RackPowerState, RackState, RackValidationState, ResolvedNvosArtifact,
+    ConfigureNmxClusterState, FirmwareUpgradeDeviceStatus, FirmwareUpgradeJob,
+    FirmwareUpgradeState, NvosUpdateState, NvosUpdateSwitchStatus, Rack, RackConfig,
+    RackFirmwareUpgradeState, RackMaintenanceState, RackPowerState, RackState, RackValidationState,
+    ResolvedNvosArtifact,
 };
 use model::rack_type::{
     RackCapabilitiesSet, RackCapabilityCompute, RackCapabilityPowerShelf, RackCapabilitySwitch,
@@ -1115,7 +1116,9 @@ async fn test_firmware_upgrade_start_without_default_skips_to_configure_nmx_clus
                 matches!(
                     next_state,
                     RackState::Maintenance {
-                        maintenance_state: RackMaintenanceState::ConfigureNmxCluster,
+                        maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+                            configure_nmx_cluster: ConfigureNmxClusterState::Start,
+                        },
                     }
                 ),
                 "FirmwareUpgrade(Start) should skip to ConfigureNmxCluster, got {:?}",
@@ -1194,7 +1197,9 @@ async fn test_firmware_upgrade_start_with_unavailable_default_skips_to_configure
                 matches!(
                     next_state,
                     RackState::Maintenance {
-                        maintenance_state: RackMaintenanceState::ConfigureNmxCluster,
+                        maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+                            configure_nmx_cluster: ConfigureNmxClusterState::Start,
+                        },
                     }
                 ),
                 "FirmwareUpgrade(Start) should skip to ConfigureNmxCluster when default firmware is unavailable, got {:?}",

--- a/crates/api/src/tests/rack_state_controller/mod.rs
+++ b/crates/api/src/tests/rack_state_controller/mod.rs
@@ -27,8 +27,8 @@ use model::expected_machine::ExpectedMachineData;
 use model::machine::ManagedHostState;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::rack::{
-    FirmwareUpgradeState, NvosUpdateState, Rack, RackConfig, RackMaintenanceState, RackState,
-    RackValidationState, ResolvedNvosArtifact,
+    ConfigureNmxClusterState, FirmwareUpgradeState, NvosUpdateState, Rack, RackConfig,
+    RackMaintenanceState, RackState, RackValidationState, ResolvedNvosArtifact,
 };
 use rpc::forge::StateHistoryRecord;
 use rpc::forge::forge_server::Forge;
@@ -108,9 +108,11 @@ impl StateHandler for TestRackStateHandler {
                     },
                 },
                 RackMaintenanceState::NVOSUpdate { .. } => RackState::Maintenance {
-                    maintenance_state: RackMaintenanceState::ConfigureNmxCluster,
+                    maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+                        configure_nmx_cluster: ConfigureNmxClusterState::Start,
+                    },
                 },
-                RackMaintenanceState::ConfigureNmxCluster => RackState::Maintenance {
+                RackMaintenanceState::ConfigureNmxCluster { .. } => RackState::Maintenance {
                     maintenance_state: RackMaintenanceState::Completed,
                 },
                 RackMaintenanceState::Completed => RackState::Validating {

--- a/crates/api/src/tests/switch_state_controller/mod.rs
+++ b/crates/api/src/tests/switch_state_controller/mod.rs
@@ -302,7 +302,7 @@ async fn test_switch_waiting_for_rack_firmware_upgrade_waits_for_terminal_status
 }
 
 #[crate::sqlx_test]
-async fn test_switch_waiting_for_rack_firmware_upgrade_returns_ready_on_completion(
+async fn test_switch_waiting_for_rack_firmware_upgrade_transitions_to_waiting_for_nvos_on_completion(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env(pool.clone()).await;
@@ -349,9 +349,11 @@ async fn test_switch_waiting_for_rack_firmware_upgrade_returns_ready_on_completi
         .expect("switch should exist");
     assert!(matches!(
         switch.controller_state.value,
-        SwitchControllerState::Ready
+        SwitchControllerState::ReProvisioning {
+            reprovisioning_state: model::switch::ReProvisioningState::WaitingForNVOSUpgrade,
+        }
     ));
-    assert!(switch.switch_reprovisioning_requested.is_none());
+    assert!(switch.switch_reprovisioning_requested.is_some());
 
     Ok(())
 }
@@ -391,6 +393,157 @@ async fn test_switch_waiting_for_rack_firmware_upgrade_accepts_completion_when_o
             status: model::rack::RackFirmwareUpgradeState::Completed,
             started_at: Some(requested_at - chrono::Duration::seconds(1)),
             ended_at: Some(requested_at + chrono::Duration::seconds(1)),
+        }),
+    )
+    .await?;
+    txn.commit().await?;
+
+    env.run_switch_controller_iteration().await;
+
+    let mut txn = pool.acquire().await?;
+    let switch = db_switch::find_by_id(&mut txn, &switch_id)
+        .await?
+        .expect("switch should exist");
+    assert!(matches!(
+        switch.controller_state.value,
+        SwitchControllerState::ReProvisioning {
+            reprovisioning_state: model::switch::ReProvisioningState::WaitingForNVOSUpgrade,
+        }
+    ));
+    assert!(switch.switch_reprovisioning_requested.is_some());
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_switch_ready_routes_rack_requests_to_waiting_for_rack_firmware_upgrade(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let switch_id = common::api_fixtures::site_explorer::new_switch(&env, None, None).await?;
+
+    let mut txn = pool.begin().await?;
+    db_switch::set_switch_reprovisioning_requested(txn.as_mut(), switch_id, "rack-test").await?;
+    let switch = db_switch::find_by_id(txn.as_mut(), &switch_id)
+        .await?
+        .expect("switch should exist");
+    db_switch::try_update_controller_state(
+        txn.as_mut(),
+        switch_id,
+        switch.controller_state.version,
+        switch.controller_state.version.increment(),
+        &SwitchControllerState::Ready,
+    )
+    .await?;
+    txn.commit().await?;
+
+    env.run_switch_controller_iteration().await;
+
+    let mut txn = pool.acquire().await?;
+    let switch = db_switch::find_by_id(&mut txn, &switch_id)
+        .await?
+        .expect("switch should exist");
+    assert!(matches!(
+        switch.controller_state.value,
+        SwitchControllerState::ReProvisioning {
+            reprovisioning_state: model::switch::ReProvisioningState::WaitingForRackFirmwareUpgrade,
+        }
+    ));
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_switch_waiting_for_nvos_upgrade_transitions_to_waiting_for_nmxc_on_completion(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let switch_id = common::api_fixtures::site_explorer::new_switch(&env, None, None).await?;
+
+    let mut txn = pool.begin().await?;
+    db_switch::set_switch_reprovisioning_requested(txn.as_mut(), switch_id, "rack-nvos-test")
+        .await?;
+    let switch = db_switch::find_by_id(txn.as_mut(), &switch_id)
+        .await?
+        .expect("switch should exist");
+    let requested_at = switch
+        .switch_reprovisioning_requested
+        .as_ref()
+        .expect("switch reprovision request should exist")
+        .requested_at;
+    db_switch::try_update_controller_state(
+        txn.as_mut(),
+        switch_id,
+        switch.controller_state.version,
+        switch.controller_state.version.increment(),
+        &SwitchControllerState::ReProvisioning {
+            reprovisioning_state: model::switch::ReProvisioningState::WaitingForNVOSUpgrade,
+        },
+    )
+    .await?;
+    db_switch::update_nvos_update_status(
+        txn.as_mut(),
+        switch_id,
+        Some(&model::switch::SwitchNvosUpdateStatus {
+            task_id: "nvos-job".to_string(),
+            firmware_id: "fw-1".to_string(),
+            image_filename: "nvos-image.bin".to_string(),
+            status: model::switch::SwitchNvosUpdateState::Completed,
+            started_at: Some(requested_at),
+            ended_at: Some(chrono::Utc::now()),
+        }),
+    )
+    .await?;
+    txn.commit().await?;
+
+    env.run_switch_controller_iteration().await;
+
+    let mut txn = pool.acquire().await?;
+    let switch = db_switch::find_by_id(&mut txn, &switch_id)
+        .await?
+        .expect("switch should exist");
+    assert!(matches!(
+        switch.controller_state.value,
+        SwitchControllerState::ReProvisioning {
+            reprovisioning_state: model::switch::ReProvisioningState::WaitingForNMXCConfigure,
+        }
+    ));
+    assert!(switch.switch_reprovisioning_requested.is_some());
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_switch_waiting_for_nmxc_configure_returns_ready_when_fm_is_running(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let switch_id = common::api_fixtures::site_explorer::new_switch(&env, None, None).await?;
+
+    let mut txn = pool.begin().await?;
+    db_switch::set_switch_reprovisioning_requested(txn.as_mut(), switch_id, "rack-nmxc-test")
+        .await?;
+    let switch = db_switch::find_by_id(txn.as_mut(), &switch_id)
+        .await?
+        .expect("switch should exist");
+    db_switch::try_update_controller_state(
+        txn.as_mut(),
+        switch_id,
+        switch.controller_state.version,
+        switch.controller_state.version.increment(),
+        &SwitchControllerState::ReProvisioning {
+            reprovisioning_state: model::switch::ReProvisioningState::WaitingForNMXCConfigure,
+        },
+    )
+    .await?;
+    db_switch::update_fabric_manager_status(
+        txn.as_mut(),
+        switch_id,
+        Some(&model::switch::FabricManagerStatus {
+            fabric_manager_state: model::switch::FabricManagerState::Ok,
+            addition_info: Some("CONTROL_PLANE_STATE_CONFIGURED".to_string()),
+            reason: None,
+            error_message: None,
         }),
     )
     .await?;

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -2106,6 +2106,8 @@ message SwitchSearchFilter {
   optional string controller_state = 3;
   // Filter by BMC MAC address via machine_interfaces
   optional string bmc_mac = 4;
+  // Filter by NVOS MAC address via expected_switches.nvos_mac_addresses
+  optional string nvos_mac = 5;
 }
 
 message SwitchesByIdsRequest {


### PR DESCRIPTION
## Description
- Fix the switch state machine by adding the required substates to persist NVOS update status, configure NMXC, and keep switch progress synchronized with the rack state machine.
- Add a wait state after NMXC configuration is applied so the controller can query fabric/NMXC status before completing the flow.
- Fix NVOS component parsing for SOT download and lookup in rack firmware. This is temporary and will move to RMS in `0.8.0`.

```mermaid
sequenceDiagram
    autonumber
    participant Admin as Admin / API
    participant RackSM as Rack State Machine
    participant DB as DB
    participant RMS as RMS / NMX-C
    participant SwitchSM as Switch State Machine
    participant FW as Rack Firmware / SOT

    Admin->>RackSM: Request on-demand maintenance<br/>NVOS update + ConfigureNMXC

    RackSM->>FW: Resolve rack_firmware_id<br/>or default rack firmware
    FW-->>RackSM: NVOS/SOT artifact info

    RackSM->>DB: Persist nvos_update_job
    RackSM->>DB: Persist per-switch nvos_update_status
    RackSM->>DB: Mark target switches<br/>switch_reprovisioning_requested

    RackSM->>RMS: Start NVOS update
    RackSM->>RackSM: Maintenance::NVOSUpdate<br/>WaitForComplete

    SwitchSM->>DB: Detect rack-level reprovision request
    SwitchSM->>SwitchSM: Ready -> ReProvisioning<br/>WaitingForNVOSUpgrade

    loop Until NVOS completes
        RackSM->>RMS: Poll NVOS job/status
        RMS-->>RackSM: Per-switch NVOS status
        RackSM->>DB: Persist current-cycle<br/>nvos_update_status

        SwitchSM->>DB: Read nvos_update_status
        alt Status is current-cycle and completed
            SwitchSM->>SwitchSM: WaitingForNVOSUpgrade<br/>-> WaitingForNMXCConfigure
        else Status failed
            SwitchSM->>DB: Clear reprovision request
            SwitchSM->>SwitchSM: -> Error
        else Missing/stale/in-progress
            SwitchSM->>SwitchSM: Stay WaitingForNVOSUpgrade
        end
    end

    RackSM->>RackSM: NVOS complete
    RackSM->>RMS: Apply ConfigureNMXC
    RackSM->>RackSM: ConfigureNmxCluster::Start<br/>-> WaitForFabricStatus

    loop Until NMXC/Fabric status is ready
        RackSM->>RMS: Query fabric/NMXC status
        RMS-->>RackSM: Fabric manager status
        RackSM->>DB: Persist fabric_manager_status

        SwitchSM->>DB: Read fabric_manager_status
        alt Fabric manager running
            SwitchSM->>DB: Clear reprovision request
            SwitchSM->>SwitchSM: WaitingForNMXCConfigure<br/>-> Ready
        else Not ready
            SwitchSM->>SwitchSM: Stay WaitingForNMXCConfigure
        end
    end

    RackSM->>RackSM: Continue remaining maintenance<br/>PowerSequence / Validation / Ready

```
## Type of Change
- [ ] **Fix** - switch state machine by adding the required substates to persist NVOS update status, configure NMXC, and keep switch progress synchronized with the rack state machine

## Testing
-  Issue surfaced on 36x1
- Fix needs to be tested.

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

