### PR TITLE
Fix: Don't start dhcp-server on secondary DPU.

### DIFF
--- a/crates/agent/src/dhcp.rs
+++ b/crates/agent/src/dhcp.rs
@@ -85,6 +85,7 @@ pub fn build_server_host_config(
         hbn_devic_names.reps[0],
         hbn_devic_names.virt_rep_begin,
         hbn_devic_names.sf_id,
+        true,
     )?)?)
 }
 

--- a/crates/agent/src/dhcp_server_grpc_client.rs
+++ b/crates/agent/src/dhcp_server_grpc_client.rs
@@ -89,9 +89,11 @@ impl From<ModelHostConfig> for proto::HostConfig {
 pub async fn get_dhcp_timestamps(
     grpc_addr: &str,
 ) -> eyre::Result<Vec<::rpc::forge::LastDhcpRequest>> {
-    let channel = tonic::transport::Endpoint::new(grpc_addr.to_string())?
+    let channel = tonic::transport::Endpoint::new(grpc_addr.to_string())
+        .map_err(|e| eyre::eyre!("invalid dhcp-server gRPC endpoint {grpc_addr}: {e}"))?
         .connect()
-        .await?;
+        .await
+        .map_err(|e| eyre::eyre!("connect to dhcp-server gRPC at {grpc_addr}: {e}"))?;
     let mut client = DhcpServerControlClient::new(channel);
 
     let entries = client
@@ -124,9 +126,11 @@ pub async fn get_dhcp_timestamps(
 /// The gRPC control server remains running after this call so that a future
 /// [`update_and_reload`] call can restart the DHCP process.
 pub async fn stop_server(grpc_addr: &str) -> eyre::Result<()> {
-    let channel = tonic::transport::Endpoint::new(grpc_addr.to_string())?
+    let channel = tonic::transport::Endpoint::new(grpc_addr.to_string())
+        .map_err(|e| eyre::eyre!("invalid dhcp-server gRPC endpoint {grpc_addr}: {e}"))?
         .connect()
-        .await?;
+        .await
+        .map_err(|e| eyre::eyre!("connect to dhcp-server gRPC at {grpc_addr}: {e}"))?;
     let mut client = DhcpServerControlClient::new(channel);
 
     client
@@ -149,9 +153,11 @@ pub async fn update_and_reload(
     host_config: Option<ModelHostConfig>,
     interfaces: Vec<String>,
 ) -> eyre::Result<()> {
-    let channel = tonic::transport::Endpoint::new(grpc_addr.to_string())?
+    let channel = tonic::transport::Endpoint::new(grpc_addr.to_string())
+        .map_err(|e| eyre::eyre!("invalid dhcp-server gRPC endpoint {grpc_addr}: {e}"))?
         .connect()
-        .await?;
+        .await
+        .map_err(|e| eyre::eyre!("connect to dhcp-server gRPC at {grpc_addr}: {e}"))?;
     let mut client = DhcpServerControlClient::new(channel);
 
     client

--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -536,10 +536,11 @@ pub async fn update_nvue(
         NvueUpdateFlavor::RestApi { nvue_client } => {
             let config = NvueConfig::from_yaml(&next_contents)
                 .map_err(|e| eyre::eyre!("Couldn't parse NVUE config as YAML: {e}"))?;
-            let _result = nvue_client
+            let revision_id = nvue_client
                 .push_config(&config)
                 .await
-                .map_err(|e| eyre::eyre!("Couldn't push new config to NVUE server: {e}"));
+                .map_err(|e| eyre::eyre!("Couldn't push new config to NVUE server: {e}"))?;
+            tracing::debug!(revision_id, "Applied NVUE config via REST API");
             Ok(true)
         }
     }
@@ -799,7 +800,9 @@ pub async fn update_interface_state(nc: &ManagedHostNetworkConfigResponse) -> ey
 /// Returns `Ok(false)` (matching the file-write path convention) to signal
 /// that no active DHCP service reload occurred.
 async fn stop_dhcp_via_grpc(grpc_addr: &str) -> eyre::Result<bool> {
-    crate::dhcp_server_grpc_client::stop_server(grpc_addr).await?;
+    crate::dhcp_server_grpc_client::stop_server(grpc_addr)
+        .await
+        .wrap_err_with(|| format!("stop_dhcp_via_grpc({grpc_addr})"))?;
     Ok(false)
 }
 
@@ -863,19 +866,24 @@ async fn update_dhcp_via_grpc(
         nameservers_v4,
         loopback_ip,
     )?;
-    let host_config = utils::models::dhcp::HostConfig::try_from(
+    let mut host_config = utils::models::dhcp::HostConfig::try_from(
         network_config.clone(),
         hbn_device_names.reps[0],
         hbn_device_names.virt_rep_begin,
         hbn_device_names.sf_id,
+        false,
     )?;
-    let interfaces: Vec<String> = host_config.host_ip_addresses.keys().cloned().collect();
 
-    let interfaces = if let Some(translation_mode) = interface_translation_mode {
-        translation_mode.translate_list(&interfaces)
-    } else {
-        interfaces
-    };
+    // Update the interface names if translation is needed.
+    if let Some(translation_mode) = interface_translation_mode {
+        host_config.host_ip_addresses = host_config
+            .host_ip_addresses
+            .into_iter()
+            .map(|(name, info)| (translation_mode.translate(&name), info))
+            .collect();
+    }
+
+    let interfaces: Vec<String> = host_config.host_ip_addresses.keys().cloned().collect();
 
     crate::dhcp_server_grpc_client::update_and_reload(
         grpc_addr,
@@ -883,7 +891,8 @@ async fn update_dhcp_via_grpc(
         Some(host_config),
         interfaces,
     )
-    .await?;
+    .await
+    .wrap_err_with(|| format!("update_dhcp_via_grpc({grpc_addr})"))?;
     Ok(true)
 }
 
@@ -913,14 +922,24 @@ pub async fn update_dhcp(
         if stop_server {
             return stop_dhcp_via_grpc(addr).await;
         }
-        return update_dhcp_via_grpc(
-            addr,
-            network_config,
-            service_addrs,
-            hbn_device_names,
-            interface_translation_mode,
-        )
-        .await;
+
+        let needed_state = needed_interface_state(
+            network_config.is_primary_dpu,
+            network_config.use_admin_network,
+        );
+
+        if needed_state == InterfaceState::Up {
+            return update_dhcp_via_grpc(
+                addr,
+                network_config,
+                service_addrs,
+                hbn_device_names,
+                interface_translation_mode,
+            )
+            .await;
+        }
+
+        return Ok(false);
     }
 
     let path_dhcp_relay = FPath(hbn_root.join(dhcp::RELAY_PATH));
@@ -1670,20 +1689,6 @@ impl InterfaceTranslationMode {
                 format!("{prefix}{input_interface_name}")
             }
         }
-    }
-
-    pub fn translate_list<S, I>(&self, input_interface_names: I) -> Vec<String>
-    where
-        I: IntoIterator<Item = S>,
-        S: AsRef<str>,
-    {
-        input_interface_names
-            .into_iter()
-            .map(|name| {
-                let name = name.as_ref();
-                self.translate(name)
-            })
-            .collect()
     }
 }
 
@@ -3159,7 +3164,7 @@ mod tests {
         let dhcp_host_config: HostConfig = serde_yaml::from_str(&super::read_limited(i.path())?)?;
         validate_host_config(
             dhcp_host_config,
-            HostConfig::try_from(network_config.clone(), "pf0hpf_sf", "pf0vf", "_sf")?,
+            HostConfig::try_from(network_config.clone(), "pf0hpf_sf", "pf0vf", "_sf", true)?,
         );
 
         // tenant host config.
@@ -3223,7 +3228,7 @@ mod tests {
         let dhcp_host_config: HostConfig = serde_yaml::from_str(&super::read_limited(i.path())?)?;
         validate_host_config(
             dhcp_host_config,
-            HostConfig::try_from(network_config, "pf0hpf_sf", "pf0vf", "_sf")?,
+            HostConfig::try_from(network_config, "pf0hpf_sf", "pf0vf", "_sf", true)?,
         );
 
         Ok(())
@@ -3345,6 +3350,27 @@ mod tests {
         let interface_name = "i0";
         let translated_interface_name = translation.translate(interface_name);
         assert_eq!(translated_interface_name.as_str(), "pre_i0");
+    }
+
+    #[test]
+    fn test_stop_server_matches_needed_state_down() {
+        // `update_dhcp` short-circuits to `stop_dhcp_via_grpc` when
+        // `use_admin_network && !is_primary_dpu`. That condition must remain
+        // identical to "needed_interface_state == Down". If either condition
+        // changes independently, the new `if needed_state == Up { ... } else
+        // { Ok(false) }` branch in update_dhcp becomes reachable and the
+        // invariant in this test pins the divergence.
+        for &is_primary in &[true, false] {
+            for &use_admin in &[true, false] {
+                let stop_server = use_admin && !is_primary;
+                let needed_down =
+                    needed_interface_state(is_primary, use_admin) == InterfaceState::Down;
+                assert_eq!(
+                    stop_server, needed_down,
+                    "stop_server flag must match needed_state==Down (is_primary_dpu={is_primary}, use_admin_network={use_admin})"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -717,8 +717,11 @@ impl MainLoop {
 
                     let joined_result = match (update_result, dhcp_result) {
                         (Ok(a), Ok(b)) => Ok(a | b),
-                        (Err(e1), Err(e2)) => Err(eyre::eyre!("errors update: {e1}, dhcp: {e2}")),
-                        (Err(err), _) | (_, Err(err)) => Err(err),
+                        (Err(e1), Err(e2)) => Err(eyre::eyre!(
+                            "network update failed: update={e1:#}, dhcp={e2:#}"
+                        )),
+                        (Err(err), Ok(_)) => Err(err.wrap_err("network update failed (update)")),
+                        (Ok(_), Err(err)) => Err(err.wrap_err("network update failed (dhcp)")),
                     };
                     match joined_result {
                         Ok(has_changed) => {
@@ -815,7 +818,10 @@ impl MainLoop {
 
                     // In case of secondary DPU, the interface must be disabled if on admin network, else enabled.
                     // Note that the nvue config handles the blocking of traffic on the interface.  This is only so that the host link reflects the correct state.
-                    if let Err(err) = ethernet_virtualization::update_interface_state(&conf).await {
+                    if self.options.agent_platform_type.is_dpu_os()
+                        && let Err(err) =
+                            ethernet_virtualization::update_interface_state(&conf).await
+                    {
                         tracing::error!(error = format!("{err:#}"), "Updating interface state.");
                     }
                 }

--- a/crates/api/src/dpf_services.rs
+++ b/crates/api/src/dpf_services.rs
@@ -243,7 +243,8 @@ pub fn dpu_agent_service(reg: &CarbideServiceRegistryConfig) -> ServiceDefinitio
 
         config_values: Some(serde_json::json!({
             "dhcp_server": {
-                "service_name": "{{ (index .Services \"carbide-dhcp-server\").Name }}"
+                "service_name": "{{ (index .Services \"carbide-dhcp-server\").Name }}",
+                "interface_prepend": "d_"
             },
             "fmds": {
                 "service_name": "{{ (index .Services \"carbide-fmds\").Name }}"

--- a/crates/dhcp-server/src/main.rs
+++ b/crates/dhcp-server/src/main.rs
@@ -241,7 +241,9 @@ async fn handle_update_config(
         .await
         .unwrap_or_default();
     if current_dhcp != dhcp_yaml {
-        tokio::fs::write(&new_dhcp, &dhcp_yaml).await?;
+        tokio::fs::write(&new_dhcp, &dhcp_yaml)
+            .await
+            .map_err(|e| -> Box<dyn Error> { format!("write {new_dhcp}: {e}").into() })?;
         tracing::info!("dhcp_config changed – staged at {new_dhcp}");
     }
 
@@ -249,7 +251,9 @@ async fn handle_update_config(
         let new_host = format!("{}_new", path);
         let current_host = tokio::fs::read_to_string(path).await.unwrap_or_default();
         if current_host != yaml {
-            tokio::fs::write(&new_host, &yaml).await?;
+            tokio::fs::write(&new_host, &yaml)
+                .await
+                .map_err(|e| -> Box<dyn Error> { format!("write {new_host}: {e}").into() })?;
             tracing::info!("host_config changed – staged at {new_host}");
         }
     }
@@ -305,12 +309,23 @@ async fn handle_reload(
 
     // Atomically replace live config files.
     if has_new_dhcp {
-        tokio::fs::rename(&new_dhcp, &args.dhcp_config).await?;
+        tokio::fs::rename(&new_dhcp, &args.dhcp_config)
+            .await
+            .map_err(|e| -> Box<dyn Error> {
+                format!("rename {} -> {}: {e}", new_dhcp, args.dhcp_config).into()
+            })?;
     }
     if let Some(host_path) = &args.host_config {
         let new_host = format!("{}_new", host_path);
-        if tokio::fs::try_exists(&new_host).await? {
-            tokio::fs::rename(&new_host, host_path).await?;
+        let exists = tokio::fs::try_exists(&new_host)
+            .await
+            .map_err(|e| -> Box<dyn Error> { format!("try_exists {new_host}: {e}").into() })?;
+        if exists {
+            tokio::fs::rename(&new_host, host_path)
+                .await
+                .map_err(|e| -> Box<dyn Error> {
+                    format!("rename {new_host} -> {host_path}: {e}").into()
+                })?;
         }
     }
 
@@ -340,7 +355,11 @@ async fn run_with_grpc_control(
     if let Some(dir) = std::path::Path::new(&args.dhcp_config).parent()
         && !tokio::fs::try_exists(dir).await.unwrap_or(false)
     {
-        tokio::fs::create_dir_all(dir).await?;
+        tokio::fs::create_dir_all(dir)
+            .await
+            .map_err(|e| -> Box<dyn Error> {
+                format!("create_dir_all {}: {e}", dir.display()).into()
+            })?;
         tracing::info!("Created config directory {}", dir.display());
     }
 

--- a/crates/utils/src/models/dhcp.rs
+++ b/crates/utils/src/models/dhcp.rs
@@ -132,6 +132,7 @@ impl HostConfig {
         physical_rep: &str,
         virt_rep_begin: &str,
         sf_id: &str,
+        is_dpu_os: bool,
     ) -> Result<Self, DhcpDataError> {
         let mut host_ip_addresses = BTreeMap::new();
         let virtualization_type = value.network_virtualization_type();
@@ -146,8 +147,10 @@ impl HostConfig {
         };
 
         for interface in interface_configs {
-            let interface_name = if virtualization_type == ::rpc::forge::VpcVirtualizationType::Fnn
-                && !interface.is_l2_segment
+            let interface_name = if (virtualization_type
+                == ::rpc::forge::VpcVirtualizationType::Fnn
+                && !interface.is_l2_segment)
+                || !is_dpu_os
             {
                 if interface.function_type() == InterfaceFunctionType::Physical {
                     // pf0hpf_sf/if


### PR DESCRIPTION
## Description
dhcp-server shall not server on secondary DPU until not on tenant network. This was handled till now by bringing the physical interface down, but dhcp-server used to listen at vlan interface. This way there was no need to bring the dhcp-server down. Now we are not disabling the interface down at dhcp-serevr container, so better not to start dhcp-server at all.

This PR also contains changes to use physical interfaces names in case of container similar to FNN with "d_" prepended for dhcp-server.

++ few logs addition for later debugging.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

