### PR TITLE
fix: dpf: imagePullSecrets, exec bits on binaries, NVUE error context

### DIFF
--- a/bluefield/containers/carbide-fmds/Dockerfile
+++ b/bluefield/containers/carbide-fmds/Dockerfile
@@ -13,6 +13,6 @@ ARG DISTROLESS_DEBUG_TAG=${DEBUG_DISTROLESS:+"dev"} # 'dev' provides a busybox s
 # NVIDIA Distroless Container
 FROM --platform=linux/arm64 ${IMG}:${TAG}-${DISTROLESS_DEBUG_TAG}
 
-COPY target/aarch64-unknown-linux-gnu/release/carbide-fmds /usr/bin/carbide-fmds
+COPY --chmod=755 target/aarch64-unknown-linux-gnu/release/carbide-fmds /usr/bin/carbide-fmds
 
 ENTRYPOINT ["/usr/bin/carbide-fmds"]

--- a/bluefield/containers/forge-dhcp-server/Dockerfile
+++ b/bluefield/containers/forge-dhcp-server/Dockerfile
@@ -13,6 +13,6 @@ ARG DISTROLESS_DEBUG_TAG=${DEBUG_DISTROLESS:+"dev"} # 'dev' provides a busybox s
 # NVIDIA Distroless Container
 FROM --platform=linux/arm64 ${IMG}:${TAG}-${DISTROLESS_DEBUG_TAG}
 
-COPY target/aarch64-unknown-linux-gnu/release/forge-dhcp-server /var/support/forge-dhcp/bin/forge-dhcp-server
+COPY --chmod=755 target/aarch64-unknown-linux-gnu/release/forge-dhcp-server /var/support/forge-dhcp/bin/forge-dhcp-server
 
 ENTRYPOINT ["/var/support/forge-dhcp/bin/forge-dhcp-server"]

--- a/bluefield/containers/forge-dpu-otel-agent/Dockerfile
+++ b/bluefield/containers/forge-dpu-otel-agent/Dockerfile
@@ -13,7 +13,7 @@ ARG DISTROLESS_DEBUG_TAG=${DEBUG_DISTROLESS:+"dev"} # 'dev' provides a busybox s
 # NVIDIA Distroless Container
 FROM --platform=linux/arm64 ${IMG}:${TAG}-${DISTROLESS_DEBUG_TAG}
 
-COPY target/aarch64-unknown-linux-gnu/release/forge-dpu-otel-agent /usr/bin/forge-dpu-otel-agent
+COPY --chmod=755 target/aarch64-unknown-linux-gnu/release/forge-dpu-otel-agent /usr/bin/forge-dpu-otel-agent
 
 ENTRYPOINT ["/usr/bin/forge-dpu-otel-agent"]
 CMD ["--config-path=/etc/forge-dpu-otel-agent/config.toml", "run", "--source-tls-cert-path=/opt/forge/machine_cert.pem", "--source-tls-key-path=/opt/forge/machine_cert.key"]

--- a/bluefield/containers/otelcol-contrib/Dockerfile
+++ b/bluefield/containers/otelcol-contrib/Dockerfile
@@ -57,7 +57,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Collector binary
-COPY --from=builder /build/ocb-build/otelcol-contrib /usr/bin/otelcol-contrib
+COPY --from=builder --chmod=755 /build/ocb-build/otelcol-contrib /usr/bin/otelcol-contrib
 
 # Wrapper scripts
 COPY bluefield/otel/otelcol-wrapper /etc/otelcol-contrib/otelcol-wrapper

--- a/crates/api/src/dpf_services.rs
+++ b/crates/api/src/dpf_services.rs
@@ -272,6 +272,11 @@ pub fn dpu_agent_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
                 "nvue_credentials_secret_name": "hbn-user-password",
                 "nvue_password_key": "password",
             },
+            "imagePullSecrets": [
+                {
+                    "name": "dpf-pull-secret"
+                }
+            ]
         })),
 
         service_daemon_set_annotations: Some(BTreeMap::new()),
@@ -305,7 +310,12 @@ pub fn dhcp_server_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
             "image": {
                 "repository": cfg.docker_repo_url,
                 "tag": cfg.docker_image_tag,
-            }
+            },
+            "imagePullSecrets": [
+                {
+                    "name": "dpf-pull-secret"
+                }
+            ]
         })),
 
         interfaces: dhcp_server_service_interfaces(),
@@ -336,7 +346,12 @@ pub fn fmds_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
             "image": {
                 "repository": cfg.docker_repo_url,
                 "tag": cfg.docker_image_tag,
-            }
+            },
+            "imagePullSecrets": [
+                {
+                    "name": "dpf-pull-secret"
+                }
+            ]
         })),
 
         interfaces: fmds_service_interfaces(),
@@ -368,7 +383,12 @@ pub fn otel_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
             "image": {
                 "repository": cfg.docker_repo_url,
                 "tag": cfg.docker_image_tag,
-            }
+            },
+            "imagePullSecrets": [
+                {
+                    "name": "dpf-pull-secret"
+                }
+            ]
         })),
         config_ports: Some(vec![ServiceConfigPort {
             name: "prometheus".to_string(),

--- a/crates/nvue-client/src/client.rs
+++ b/crates/nvue-client/src/client.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 
 use reqwest::header::{ACCEPT, HeaderMap, HeaderValue};
-use reqwest::{Client, ClientBuilder, Method, Response};
+use reqwest::{Client, ClientBuilder, Method, Response, Url};
 pub use serde_json::Value as JsonValue;
 
 use crate::NvueConfig;
@@ -60,11 +60,24 @@ impl NvueClient {
     }
 
     async fn execute(&self, request: reqwest::Request) -> Result<Response, NvueClientError> {
+        let method = request.method().clone();
+        let url = request.url().clone();
+        let body = request
+            .body()
+            .and_then(|b| b.as_bytes())
+            .map(|b| String::from_utf8_lossy(b).into_owned());
         self.client
             .execute(request)
             .await
             .and_then(|response| response.error_for_status())
-            .map_err(NvueClientError::from)
+            .map_err(|source| {
+                NvueClientError::RequestFailed(Box::new(RequestFailed {
+                    method,
+                    url,
+                    body,
+                    source,
+                }))
+            })
     }
 
     pub async fn get_api(&self) -> Result<Response, NvueClientError> {
@@ -300,9 +313,23 @@ pub enum NvueClientError {
     #[error("Reqwest client error: {0}")]
     ReqwestError(#[from] reqwest::Error),
 
+    #[error(transparent)]
+    RequestFailed(Box<RequestFailed>),
+
     #[error("Environment variable error ({0}): {1}")]
     EnvVarError(&'static str, std::env::VarError),
 
     #[error("Schema mismatch between NVUE client and server: {0}")]
     SchemaMismatch(&'static str),
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("NVUE request failed ({method} {url}{}): {source}",
+    body.as_deref().map(|b| format!(" body={b}")).unwrap_or_default())]
+pub struct RequestFailed {
+    pub method: Method,
+    pub url: Url,
+    pub body: Option<String>,
+    #[source]
+    pub source: reqwest::Error,
 }


### PR DESCRIPTION
## Description
Contains fix for:
1. Setting executable bit on the binaries.
2. Add more context to nevus error logs.
3. Add imagepullsecret to fetch nvcr images.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

