### PR TITLE
fix: remove check when checking nvlink config sync in instance creation/deletion code path

### DIFF
--- a/crates/api-model/src/machine/nvlink.rs
+++ b/crates/api-model/src/machine/nvlink.rs
@@ -90,11 +90,6 @@ pub fn nvlink_config_synced(
     let Some(observation) = observation.as_ref() else {
         return Err(NvLinkConfigNotSyncedReason("Due to missing NvLink status observation, it can't be verified whether the NvLink config is applied to NMX-M".to_string()));
     };
-    if config.gpu_configs.len() != observation.nvlink_gpus.len() {
-        return Err(NvLinkConfigNotSyncedReason(
-            "the number of configured GPUs does not match the number of observed GPUs".to_string(),
-        ));
-    }
 
     for gpu_config in config.gpu_configs.iter() {
         let Some(gpu_observation) = observation


### PR DESCRIPTION


## Description
Don't expect nvlink config gpus and status observation vectors to be the same length; when a tenant creates a partition with subset of GPUs, the gpu configs vector will be shorter than the status observation vector because we generate status observations regardless of whether the GPU is in a partition or not. This was causing an instance nvlink config to appear as not synced.
## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

