### PR TITLE
chore: Reduce tests duration during CI/CD by lowering DB durability

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -835,8 +835,10 @@ jobs:
 
       # PostgreSQL is required because sqlx proc macros (sqlx::query!) connect to
       # a local database at compile time to validate SQL queries and return types.
+      # Durability settings are disabled for speed in CI/DC.
       - name: Start PostgreSQL
         run: |
+          printf 'fsync = off\nsynchronous_commit = off\nfull_page_writes = off\n' | tee -a /etc/postgresql/*/main/postgresql.conf
           /etc/init.d/postgresql start
           sudo -u postgres psql -c "ALTER USER root WITH SUPERUSER;"
           createdb root


### PR DESCRIPTION
## Description
Reduce test duration by lowering durability of Postgres and speeding DB interactions.
Shown to reduce tests duration by 30% in dev setup.

## Type of Change
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes: no.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)
