### PR TITLE
feat: add per-host lifecycle config in expected machines to facilitate disabling host lockdown in the state machine

### DIFF
--- a/crates/admin-cli/src/expected_machines/add/args.rs
+++ b/crates/admin-cli/src/expected_machines/add/args.rs
@@ -142,7 +142,7 @@ pub struct Args {
     #[clap(
         long = "disable-lockdown",
         value_name = "DISABLE_LOCKDOWN",
-        help = "If true, do not lock down the server while ingesting the managed host into a Ready state within the state machine. If unset or false, preserve the default behavior of locking down the server after configuring the BIOS."
+        help = "If true, do not lock down the server as part of lifecycle management within the state machine. If unset or false, preserve the default behavior of locking down the server after configuring the BIOS."
     )]
     pub disable_lockdown: Option<bool>,
 }
@@ -199,7 +199,11 @@ impl TryFrom<Args> for rpc::forge::ExpectedMachine {
             bmc_ip_address: value.bmc_ip_address.map(|ip| ip.to_string()),
             bmc_retain_credentials: value.bmc_retain_credentials,
             dpu_mode: value.dpu_mode.map(|m| m as i32),
-            disable_lockdown: value.disable_lockdown,
+            host_lifecycle_profile: value.disable_lockdown.map(|dl| {
+                rpc::forge::HostLifecycleProfile {
+                    disable_lockdown: Some(dl),
+                }
+            }),
         })
     }
 }

--- a/crates/admin-cli/src/expected_machines/add/args.rs
+++ b/crates/admin-cli/src/expected_machines/add/args.rs
@@ -138,6 +138,13 @@ pub struct Args {
         help = "Per-host DPU operating mode. `dpu-mode` (default): DPUs are managed by NICo; `nic-mode`: DPU hardware present but treated as a plain NIC; `no-dpu`: no DPU hardware at all. Unset keeps the site default (site-wide `force_dpu_nic_mode` flag still applies when no per-host value is set)."
     )]
     pub dpu_mode: Option<DpuMode>,
+
+    #[clap(
+        long = "disable-lockdown",
+        value_name = "DISABLE_LOCKDOWN",
+        help = "If true, do not lock down the server while ingesting the managed host into a Ready state within the state machine. If unset or false, preserve the default behavior of locking down the server after configuring the BIOS."
+    )]
+    pub disable_lockdown: Option<bool>,
 }
 
 impl Args {
@@ -192,6 +199,7 @@ impl TryFrom<Args> for rpc::forge::ExpectedMachine {
             bmc_ip_address: value.bmc_ip_address.map(|ip| ip.to_string()),
             bmc_retain_credentials: value.bmc_retain_credentials,
             dpu_mode: value.dpu_mode.map(|m| m as i32),
+            disable_lockdown: value.disable_lockdown,
         })
     }
 }

--- a/crates/admin-cli/src/expected_machines/common.rs
+++ b/crates/admin-cli/src/expected_machines/common.rs
@@ -49,6 +49,11 @@ pub struct ExpectedMachineJson {
     /// means to use the site-level `force_dpu_nic_mode` flag).
     #[serde(default)]
     pub dpu_mode: Option<rpc::forge::DpuMode>,
+    /// If true, do not lock down the server while ingesting the managed host into a Ready state
+    /// within the state machine. If unset or false, preserve the default behavior of locking down
+    /// the server after configuring the BIOS.
+    #[serde(default)]
+    pub disable_lockdown: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/admin-cli/src/expected_machines/common.rs
+++ b/crates/admin-cli/src/expected_machines/common.rs
@@ -49,9 +49,16 @@ pub struct ExpectedMachineJson {
     /// means to use the site-level `force_dpu_nic_mode` flag).
     #[serde(default)]
     pub dpu_mode: Option<rpc::forge::DpuMode>,
-    /// If true, do not lock down the server while ingesting the managed host into a Ready state
-    /// within the state machine. If unset or false, preserve the default behavior of locking down
-    /// the server after configuring the BIOS.
+    /// Per-host lifecycle profile for settings that affect state-machine progression.
+    #[serde(default)]
+    pub host_lifecycle_profile: Option<HostLifecycleProfile>,
+}
+
+/// JSON shape for `host_lifecycle_profile` nested object.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct HostLifecycleProfile {
+    /// If true, do not lock down the server as part of lifecycle management within the state machine.
+    /// If unset or false, preserve the default behavior of locking down the server after configuring the BIOS.
     #[serde(default)]
     pub disable_lockdown: Option<bool>,
 }

--- a/crates/admin-cli/src/expected_machines/patch/mod.rs
+++ b/crates/admin-cli/src/expected_machines/patch/mod.rs
@@ -50,7 +50,10 @@ impl Run for Args {
                 self.dpf_enabled,
                 self.bmc_ip_address,
                 self.bmc_retain_credentials,
-                self.disable_lockdown,
+                self.disable_lockdown
+                    .map(|dl| ::rpc::forge::HostLifecycleProfile {
+                        disable_lockdown: Some(dl),
+                    }),
             )
             .await?;
         Ok(())

--- a/crates/admin-cli/src/expected_machines/patch/mod.rs
+++ b/crates/admin-cli/src/expected_machines/patch/mod.rs
@@ -50,6 +50,7 @@ impl Run for Args {
                 self.dpf_enabled,
                 self.bmc_ip_address,
                 self.bmc_retain_credentials,
+                self.disable_lockdown,
             )
             .await?;
         Ok(())

--- a/crates/admin-cli/src/expected_machines/show/cmd.rs
+++ b/crates/admin-cli/src/expected_machines/show/cmd.rs
@@ -182,7 +182,8 @@ async fn convert_and_print_into_nice_table(
                 .unwrap_or(expected_machine.dpf_enabled)
                 .to_string(),
             expected_machine
-                .disable_lockdown
+                .host_lifecycle_profile
+                .and_then(|hlp| hlp.disable_lockdown)
                 .unwrap_or_default()
                 .to_string(),
         ]);

--- a/crates/admin-cli/src/expected_machines/show/cmd.rs
+++ b/crates/admin-cli/src/expected_machines/show/cmd.rs
@@ -132,6 +132,7 @@ async fn convert_and_print_into_nice_table(
         "SKU ID",
         "Pause On Ingestion",
         "DPF Enabled",
+        "Disable Lockdown",
     ]);
 
     for expected_machine in &expected_machines.expected_machines {
@@ -179,6 +180,10 @@ async fn convert_and_print_into_nice_table(
             expected_machine
                 .is_dpf_enabled
                 .unwrap_or(expected_machine.dpf_enabled)
+                .to_string(),
+            expected_machine
+                .disable_lockdown
+                .unwrap_or_default()
                 .to_string(),
         ]);
     }

--- a/crates/admin-cli/src/expected_machines/update/mod.rs
+++ b/crates/admin-cli/src/expected_machines/update/mod.rs
@@ -68,7 +68,11 @@ impl Run for Args {
                 expected_machine.dpf_enabled,
                 expected_machine.bmc_ip_address,
                 expected_machine.bmc_retain_credentials,
-                expected_machine.disable_lockdown,
+                expected_machine.host_lifecycle_profile.map(|hlp| {
+                    ::rpc::forge::HostLifecycleProfile {
+                        disable_lockdown: hlp.disable_lockdown,
+                    }
+                }),
             )
             .await?;
         Ok(())

--- a/crates/admin-cli/src/expected_machines/update/mod.rs
+++ b/crates/admin-cli/src/expected_machines/update/mod.rs
@@ -68,6 +68,7 @@ impl Run for Args {
                 expected_machine.dpf_enabled,
                 expected_machine.bmc_ip_address,
                 expected_machine.bmc_retain_credentials,
+                expected_machine.disable_lockdown,
             )
             .await?;
         Ok(())

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -616,7 +616,7 @@ impl ApiClient {
         dpf_enabled: Option<bool>,
         bmc_ip_address: Option<String>,
         bmc_retain_credentials: Option<bool>,
-        disable_lockdown: Option<bool>,
+        host_lifecycle_profile: Option<::rpc::forge::HostLifecycleProfile>,
     ) -> Result<(), CarbideCliError> {
         let get_req = match (bmc_mac_address, id) {
             (Some(_), Some(_)) => {
@@ -701,7 +701,8 @@ impl ApiClient {
             // Patch doesn't expose `--dpu-mode` yet; preserve the existing
             // server-side value.
             dpu_mode: expected_machine.dpu_mode,
-            disable_lockdown: disable_lockdown.or(expected_machine.disable_lockdown),
+            host_lifecycle_profile: host_lifecycle_profile
+                .or(expected_machine.host_lifecycle_profile),
         };
 
         Ok(self.0.update_expected_machine(request).await?)
@@ -737,7 +738,11 @@ impl ApiClient {
                     bmc_ip_address: machine.bmc_ip_address,
                     bmc_retain_credentials: machine.bmc_retain_credentials,
                     dpu_mode: machine.dpu_mode.map(|m| m as i32),
-                    disable_lockdown: machine.disable_lockdown,
+                    host_lifecycle_profile: machine.host_lifecycle_profile.map(|hlp| {
+                        ::rpc::forge::HostLifecycleProfile {
+                            disable_lockdown: hlp.disable_lockdown,
+                        }
+                    }),
                 })
                 .collect(),
         };

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -616,6 +616,7 @@ impl ApiClient {
         dpf_enabled: Option<bool>,
         bmc_ip_address: Option<String>,
         bmc_retain_credentials: Option<bool>,
+        disable_lockdown: Option<bool>,
     ) -> Result<(), CarbideCliError> {
         let get_req = match (bmc_mac_address, id) {
             (Some(_), Some(_)) => {
@@ -700,6 +701,7 @@ impl ApiClient {
             // Patch doesn't expose `--dpu-mode` yet; preserve the existing
             // server-side value.
             dpu_mode: expected_machine.dpu_mode,
+            disable_lockdown: disable_lockdown.or(expected_machine.disable_lockdown),
         };
 
         Ok(self.0.update_expected_machine(request).await?)
@@ -735,6 +737,7 @@ impl ApiClient {
                     bmc_ip_address: machine.bmc_ip_address,
                     bmc_retain_credentials: machine.bmc_retain_credentials,
                     dpu_mode: machine.dpu_mode.map(|m| m as i32),
+                    disable_lockdown: machine.disable_lockdown,
                 })
                 .collect(),
         };

--- a/crates/api-db/migrations/20260423120000_expected_machines_host_lifecycle_profile.sql
+++ b/crates/api-db/migrations/20260423120000_expected_machines_host_lifecycle_profile.sql
@@ -1,0 +1,2 @@
+ALTER TABLE expected_machines ADD COLUMN host_lifecycle_profile JSONB NOT NULL DEFAULT '{"disable_lockdown": false}';
+ALTER TABLE machines ADD COLUMN host_profile JSONB NOT NULL DEFAULT '{"disable_lockdown": false}';

--- a/crates/api-db/migrations/20260423120000_expected_machines_host_lifecycle_profile.sql
+++ b/crates/api-db/migrations/20260423120000_expected_machines_host_lifecycle_profile.sql
@@ -1,2 +1,2 @@
-ALTER TABLE expected_machines ADD COLUMN host_lifecycle_profile JSONB NOT NULL DEFAULT '{"disable_lockdown": false}';
+ALTER TABLE expected_machines ADD COLUMN host_lifecycle_profile JSONB NOT NULL DEFAULT '{}';
 ALTER TABLE machines ADD COLUMN host_profile JSONB NOT NULL DEFAULT '{"disable_lockdown": false}';

--- a/crates/api-db/src/expected_machine.rs
+++ b/crates/api-db/src/expected_machine.rs
@@ -266,9 +266,9 @@ pub async fn create(
 ) -> DatabaseResult<ExpectedMachine> {
     let id = machine.id.unwrap_or_else(Uuid::new_v4);
     let query = "INSERT INTO expected_machines
-            (id, bmc_mac_address, bmc_username, bmc_password, serial_number, fallback_dpu_serial_numbers, metadata_name, metadata_description, metadata_labels, sku_id, host_nics, rack_id, default_pause_ingestion_and_poweron, dpf_enabled, bmc_ip_address, bmc_retain_credentials, dpu_mode)
+            (id, bmc_mac_address, bmc_username, bmc_password, serial_number, fallback_dpu_serial_numbers, metadata_name, metadata_description, metadata_labels, sku_id, host_nics, rack_id, default_pause_ingestion_and_poweron, dpf_enabled, bmc_ip_address, bmc_retain_credentials, dpu_mode, host_lifecycle_profile)
             VALUES
-            ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::text[], $7, $8, $9::jsonb, $10::varchar, $11::jsonb, $12, $13, $14, $15::inet, $16, $17) RETURNING *";
+            ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::text[], $7, $8, $9::jsonb, $10::varchar, $11::jsonb, $12, $13, $14, $15::inet, $16, $17, $18::jsonb) RETURNING *";
 
     sqlx::query_as(query)
         .bind(id)
@@ -293,6 +293,7 @@ pub async fn create(
         .bind(machine.data.bmc_ip_address)
         .bind(machine.data.bmc_retain_credentials.unwrap_or(false))
         .bind(machine.data.dpu_mode)
+        .bind(sqlx::types::Json(&machine.data.host_lifecycle_profile))
         .fetch_one(txn)
         .await
         .map_err(|err: sqlx::Error| match err {
@@ -388,9 +389,9 @@ pub async fn clear(txn: &mut PgConnection) -> Result<(), DatabaseError> {
 /// `bmc_mac_address`. Includes `bmc_ip_address` when the operator configures a static BMC IP.
 pub async fn update(txn: &mut PgConnection, machine: &ExpectedMachine) -> DatabaseResult<()> {
     let (where_clause, target_id) = match machine.id {
-        Some(id) => ("id=$16::uuid", id.to_string()),
+        Some(id) => ("id=$17::uuid", id.to_string()),
         None => (
-            "bmc_mac_address=$16::macaddr",
+            "bmc_mac_address=$17::macaddr",
             machine.bmc_mac_address.to_string(),
         ),
     };
@@ -404,7 +405,8 @@ pub async fn update(txn: &mut PgConnection, machine: &ExpectedMachine) -> Databa
              dpf_enabled=COALESCE($12, dpf_enabled), \
              bmc_ip_address=$13, \
              bmc_retain_credentials=COALESCE($14, bmc_retain_credentials), \
-             dpu_mode=$15 \
+             dpu_mode=$15, \
+             host_lifecycle_profile=COALESCE($16, host_lifecycle_profile) \
          WHERE {where_clause}"
     );
 
@@ -424,6 +426,10 @@ pub async fn update(txn: &mut PgConnection, machine: &ExpectedMachine) -> Databa
         .bind(machine.data.bmc_ip_address)
         .bind(machine.data.bmc_retain_credentials)
         .bind(machine.data.dpu_mode)
+        .bind(
+            (!machine.data.host_lifecycle_profile.is_empty())
+                .then_some(sqlx::types::Json(&machine.data.host_lifecycle_profile)),
+        )
         .bind(&target_id)
         .execute(&mut *txn)
         .await

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -42,8 +42,9 @@ use model::machine::network::{
 use model::machine::nvlink::MachineNvLinkStatusObservation;
 use model::machine::upgrade_policy::AgentUpgradePolicy;
 use model::machine::{
-    Dpf, DpuInfo, FailureDetails, Machine, MachineInterfaceSnapshot, MachineLastRebootRequested,
-    MachineLastRebootRequestedMode, ManagedHostState, ReprovisionRequest, UpgradeDecision,
+    Dpf, DpuInfo, FailureDetails, HostProfile, Machine, MachineInterfaceSnapshot,
+    MachineLastRebootRequested, MachineLastRebootRequestedMode, ManagedHostState,
+    ReprovisionRequest, UpgradeDecision,
 };
 use model::machine_interface_address::MachineInterfaceAssociation;
 use model::metadata::Metadata;
@@ -1290,6 +1291,7 @@ pub async fn create(
         Some(data) => data.dpf_enabled.unwrap_or(false), // EM entry exists
         None => true,                                    // EM entry does not exist
     };
+    let host_profile = HostProfile::from_expected_machine(expected_machine_data);
 
     // Host and DPU machines are created in same `discover_machine` call. Update same
     // state in both machines.
@@ -1323,8 +1325,8 @@ pub async fn create(
     };
 
     let query = r#"INSERT INTO machines(
-                            id, controller_state_version, controller_state, network_config_version, network_config, machine_state_model_version, asn, version, name, description, labels, rack_id, hw_sku, dpf)
-                            VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::json, $12, $13, $14) RETURNING id"#;
+                            id, controller_state_version, controller_state, network_config_version, network_config, machine_state_model_version, asn, version, name, description, labels, rack_id, hw_sku, dpf, host_profile)
+                            VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::json, $12, $13, $14, $15) RETURNING id"#;
     let machine_id: MachineId = sqlx::query_as(query)
         .bind(&stable_machine_id_string)
         .bind(state_version)
@@ -1343,6 +1345,7 @@ pub async fn create(
             enabled: dpf_enabled,
             used_for_ingestion: false,
         }))
+        .bind(sqlx::types::Json(&host_profile))
         .fetch_one(&mut *txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -205,10 +205,37 @@ pub struct ExpectedMachineData {
     /// as a plain NIC, or to `NoDpu` when there's no DPU hardware at all.
     #[serde(default)]
     pub dpu_mode: DpuMode,
+    /// Per-host profile for settings that affect state-machine progression.
+    /// Stored as a JSONB column on `expected_machines`; future state-machine
+    /// knobs should be added here rather than as new flat columns.
+    #[serde(default)]
+    pub host_lifecycle_profile: HostLifecycleProfile,
 }
 // Important : new fields for expected machine (and data) should be optional _and_ serde(default),
 // unless you want to go update all the files in each production deployment that autoload
 // the expected machines on api startup
+
+/// Per-host lifecycle profile for settings that affect state-machine progression.
+/// `Option<bool>` fields support CLI patch semantics (`None` = not specified,
+/// keep existing DB value via `COALESCE`). Converts to the runtime `HostProfile`
+/// (plain `bool` fields) at machine discovery time.
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct HostLifecycleProfile {
+    /// If true, do not lock down the server while ingesting the managed host
+    /// into a Ready state within the state machine. If unset or false, preserve
+    /// the default behavior of locking down the server after configuring the BIOS.
+    #[serde(default)]
+    pub disable_lockdown: Option<bool>,
+}
+
+impl HostLifecycleProfile {
+    /// Returns `true` when every field is `None`, meaning the caller did not
+    /// specify any profile value. Used by the UPDATE path to send SQL `NULL`
+    /// so that `COALESCE` preserves the existing DB row.
+    pub fn is_empty(&self) -> bool {
+        self.disable_lockdown.is_none()
+    }
+}
 
 impl<'r> FromRow<'r, PgRow> for ExpectedMachine {
     fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
@@ -240,6 +267,9 @@ impl<'r> FromRow<'r, PgRow> for ExpectedMachine {
                 bmc_ip_address: row.try_get("bmc_ip_address")?,
                 bmc_retain_credentials: row.try_get("bmc_retain_credentials")?,
                 dpu_mode: row.try_get("dpu_mode")?,
+                host_lifecycle_profile: row
+                    .try_get::<sqlx::types::Json<HostLifecycleProfile>, _>("host_lifecycle_profile")
+                    .map(|j| j.0)?,
             },
         })
     }
@@ -311,6 +341,10 @@ impl From<ExpectedMachine> for rpc::forge::ExpectedMachine {
                 DpuMode::DpuMode => None,
                 other => Some(rpc::forge::DpuMode::from(other) as i32),
             },
+            disable_lockdown: expected_machine
+                .data
+                .host_lifecycle_profile
+                .disable_lockdown,
         }
     }
 }
@@ -392,6 +426,9 @@ impl TryFrom<rpc::forge::ExpectedMachine> for ExpectedMachineData {
                 .map(|i| rpc::forge::DpuMode::try_from(i).unwrap_or_default())
                 .map(DpuMode::from)
                 .unwrap_or_default(),
+            host_lifecycle_profile: HostLifecycleProfile {
+                disable_lockdown: em.disable_lockdown,
+            },
         })
     }
 }
@@ -506,5 +543,106 @@ mod tests {
         for mode in [DpuMode::DpuMode, DpuMode::NicMode, DpuMode::NoDpu] {
             assert_eq!(DpuMode::from(rpc::forge::DpuMode::from(mode)), mode);
         }
+    }
+
+    fn make_rpc_expected_machine(disable_lockdown: Option<bool>) -> rpc::forge::ExpectedMachine {
+        rpc::forge::ExpectedMachine {
+            bmc_mac_address: "AA:BB:CC:DD:EE:FF".into(),
+            bmc_username: "root".into(),
+            bmc_password: "pass".into(),
+            chassis_serial_number: "SN-1".into(),
+            disable_lockdown,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn disable_lockdown_true_round_trips_through_proto() {
+        let rpc_em = make_rpc_expected_machine(Some(true));
+        let data = ExpectedMachineData::try_from(rpc_em).unwrap();
+        assert_eq!(data.host_lifecycle_profile.disable_lockdown, Some(true));
+
+        let em = ExpectedMachine {
+            id: None,
+            bmc_mac_address: "AA:BB:CC:DD:EE:FF".parse().unwrap(),
+            data,
+        };
+        let back: rpc::forge::ExpectedMachine = em.into();
+        assert_eq!(back.disable_lockdown, Some(true));
+    }
+
+    #[test]
+    fn disable_lockdown_false_round_trips_through_proto() {
+        let rpc_em = make_rpc_expected_machine(Some(false));
+        let data = ExpectedMachineData::try_from(rpc_em).unwrap();
+        assert_eq!(data.host_lifecycle_profile.disable_lockdown, Some(false));
+
+        let em = ExpectedMachine {
+            id: None,
+            bmc_mac_address: "AA:BB:CC:DD:EE:FF".parse().unwrap(),
+            data,
+        };
+        let back: rpc::forge::ExpectedMachine = em.into();
+        assert_eq!(back.disable_lockdown, Some(false));
+    }
+
+    #[test]
+    fn disable_lockdown_none_round_trips_through_proto() {
+        let rpc_em = make_rpc_expected_machine(None);
+        let data = ExpectedMachineData::try_from(rpc_em).unwrap();
+        assert_eq!(data.host_lifecycle_profile.disable_lockdown, None);
+
+        let em = ExpectedMachine {
+            id: None,
+            bmc_mac_address: "AA:BB:CC:DD:EE:FF".parse().unwrap(),
+            data,
+        };
+        let back: rpc::forge::ExpectedMachine = em.into();
+        assert_eq!(back.disable_lockdown, None);
+    }
+
+    #[test]
+    fn host_lifecycle_profile_defaults_when_missing_from_json() {
+        let json = r#"{
+            "bmc_mac_address": "AA:BB:CC:DD:EE:FF",
+            "bmc_username": "root",
+            "bmc_password": "pass",
+            "serial_number": "SN-1"
+        }"#;
+        let em: ExpectedMachine = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            em.data.host_lifecycle_profile,
+            HostLifecycleProfile::default()
+        );
+        assert_eq!(em.data.host_lifecycle_profile.disable_lockdown, None);
+    }
+
+    #[test]
+    fn host_lifecycle_profile_parses_from_json_when_present() {
+        let json = r#"{
+            "bmc_mac_address": "AA:BB:CC:DD:EE:FF",
+            "bmc_username": "root",
+            "bmc_password": "pass",
+            "serial_number": "SN-1",
+            "host_lifecycle_profile": {"disable_lockdown": true}
+        }"#;
+        let em: ExpectedMachine = serde_json::from_str(json).unwrap();
+        assert_eq!(em.data.host_lifecycle_profile.disable_lockdown, Some(true));
+    }
+
+    #[test]
+    fn host_lifecycle_profile_is_empty_when_all_fields_none() {
+        let hlp = HostLifecycleProfile::default();
+        assert!(hlp.is_empty());
+
+        let hlp = HostLifecycleProfile {
+            disable_lockdown: Some(true),
+        };
+        assert!(!hlp.is_empty());
+
+        let hlp = HostLifecycleProfile {
+            disable_lockdown: Some(false),
+        };
+        assert!(!hlp.is_empty());
     }
 }

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -221,9 +221,8 @@ pub struct ExpectedMachineData {
 /// (plain `bool` fields) at machine discovery time.
 #[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct HostLifecycleProfile {
-    /// If true, do not lock down the server while ingesting the managed host
-    /// into a Ready state within the state machine. If unset or false, preserve
-    /// the default behavior of locking down the server after configuring the BIOS.
+    /// If true, do not lock down the server as part of lifecycle management within the state machine.
+    /// If unset or false, preserve the default behavior of locking down the server after configuring the BIOS.
     #[serde(default)]
     pub disable_lockdown: Option<bool>,
 }
@@ -341,10 +340,12 @@ impl From<ExpectedMachine> for rpc::forge::ExpectedMachine {
                 DpuMode::DpuMode => None,
                 other => Some(rpc::forge::DpuMode::from(other) as i32),
             },
-            disable_lockdown: expected_machine
-                .data
-                .host_lifecycle_profile
-                .disable_lockdown,
+            host_lifecycle_profile: Some(rpc::forge::HostLifecycleProfile {
+                disable_lockdown: expected_machine
+                    .data
+                    .host_lifecycle_profile
+                    .disable_lockdown,
+            }),
         }
     }
 }
@@ -426,9 +427,12 @@ impl TryFrom<rpc::forge::ExpectedMachine> for ExpectedMachineData {
                 .map(|i| rpc::forge::DpuMode::try_from(i).unwrap_or_default())
                 .map(DpuMode::from)
                 .unwrap_or_default(),
-            host_lifecycle_profile: HostLifecycleProfile {
-                disable_lockdown: em.disable_lockdown,
-            },
+            host_lifecycle_profile: em
+                .host_lifecycle_profile
+                .map(|hlp| HostLifecycleProfile {
+                    disable_lockdown: hlp.disable_lockdown,
+                })
+                .unwrap_or_default(),
         })
     }
 }
@@ -551,7 +555,9 @@ mod tests {
             bmc_username: "root".into(),
             bmc_password: "pass".into(),
             chassis_serial_number: "SN-1".into(),
-            disable_lockdown,
+            host_lifecycle_profile: disable_lockdown.map(|dl| rpc::forge::HostLifecycleProfile {
+                disable_lockdown: Some(dl),
+            }),
             ..Default::default()
         }
     }
@@ -568,7 +574,10 @@ mod tests {
             data,
         };
         let back: rpc::forge::ExpectedMachine = em.into();
-        assert_eq!(back.disable_lockdown, Some(true));
+        assert_eq!(
+            back.host_lifecycle_profile.unwrap().disable_lockdown,
+            Some(true)
+        );
     }
 
     #[test]
@@ -583,7 +592,10 @@ mod tests {
             data,
         };
         let back: rpc::forge::ExpectedMachine = em.into();
-        assert_eq!(back.disable_lockdown, Some(false));
+        assert_eq!(
+            back.host_lifecycle_profile.unwrap().disable_lockdown,
+            Some(false)
+        );
     }
 
     #[test]
@@ -598,7 +610,7 @@ mod tests {
             data,
         };
         let back: rpc::forge::ExpectedMachine = em.into();
-        assert_eq!(back.disable_lockdown, None);
+        assert_eq!(back.host_lifecycle_profile.unwrap().disable_lockdown, None);
     }
 
     #[test]

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -340,16 +340,13 @@ impl From<ExpectedMachine> for rpc::forge::ExpectedMachine {
                 DpuMode::DpuMode => None,
                 other => Some(rpc::forge::DpuMode::from(other) as i32),
             },
-            host_lifecycle_profile: (!expected_machine
-                .data
-                .host_lifecycle_profile
-                .is_empty())
-            .then_some(rpc::forge::HostLifecycleProfile {
-                disable_lockdown: expected_machine
-                    .data
-                    .host_lifecycle_profile
-                    .disable_lockdown,
-            }),
+            host_lifecycle_profile: (!expected_machine.data.host_lifecycle_profile.is_empty())
+                .then_some(rpc::forge::HostLifecycleProfile {
+                    disable_lockdown: expected_machine
+                        .data
+                        .host_lifecycle_profile
+                        .disable_lockdown,
+                }),
         }
     }
 }

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -340,7 +340,11 @@ impl From<ExpectedMachine> for rpc::forge::ExpectedMachine {
                 DpuMode::DpuMode => None,
                 other => Some(rpc::forge::DpuMode::from(other) as i32),
             },
-            host_lifecycle_profile: Some(rpc::forge::HostLifecycleProfile {
+            host_lifecycle_profile: (!expected_machine
+                .data
+                .host_lifecycle_profile
+                .is_empty())
+            .then_some(rpc::forge::HostLifecycleProfile {
                 disable_lockdown: expected_machine
                     .data
                     .host_lifecycle_profile
@@ -610,7 +614,7 @@ mod tests {
             data,
         };
         let back: rpc::forge::ExpectedMachine = em.into();
-        assert_eq!(back.host_lifecycle_profile.unwrap().disable_lockdown, None);
+        assert!(back.host_lifecycle_profile.is_none());
     }
 
     #[test]

--- a/crates/api-model/src/machine/json.rs
+++ b/crates/api-model/src/machine/json.rs
@@ -33,7 +33,7 @@ use crate::machine::network::{MachineNetworkStatusObservation, ManagedHostNetwor
 use crate::machine::nvlink::MachineNvLinkStatusObservation;
 use crate::machine::topology::MachineTopology;
 use crate::machine::{
-    Dpf, FailureDetails, HostReprovisionRequest, Machine, MachineInterfaceSnapshot,
+    Dpf, FailureDetails, HostProfile, HostReprovisionRequest, Machine, MachineInterfaceSnapshot,
     MachineLastRebootRequested, ManagedHostState, ReprovisionRequest, UpgradeDecision,
 };
 use crate::metadata::Metadata;
@@ -100,6 +100,8 @@ pub struct MachineSnapshotPgJson {
     pub update_complete: bool,
     pub nvlink_info: Option<MachineNvLinkInfo>,
     pub dpf: Dpf,
+    #[serde(default)]
+    pub host_profile: HostProfile,
     #[serde(default)]
     pub rack_fw_details: Option<RackFirmwareUpgradeStatus>,
     #[serde(default)]
@@ -211,6 +213,7 @@ impl TryFrom<MachineSnapshotPgJson> for Machine {
             update_complete: value.update_complete,
             nvlink_info: value.nvlink_info,
             dpf: value.dpf,
+            host_profile: value.host_profile,
             rack_fw_details: value.rack_fw_details,
             slot_number: value.slot_number,
             tray_index: value.tray_index,

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -57,6 +57,7 @@ use super::sku::SkuStatus;
 use crate::controller_outcome::PersistentStateHandlerOutcome;
 use crate::dpa_interface::DpaInterface;
 use crate::errors::{ModelError, ModelResult};
+use crate::expected_machine::ExpectedMachineData;
 use crate::firmware::FirmwareComponentType;
 use crate::hardware_info::{HardwareInfo, MachineNvLinkInfo};
 use crate::instance::config::network::DeviceLocator;
@@ -908,6 +909,11 @@ pub struct Machine {
     /// Whether the DPF is enabled for this machine
     pub dpf: Dpf,
 
+    /// Per-host profile for state-machine-affecting settings, seeded from the
+    /// expected-machine record. Future per-host knobs that influence ingestion
+    /// or state transitions should be added here.
+    pub host_profile: HostProfile,
+
     /// Timestamp when manual firmware upgrade was marked as completed
     /// TEMPORARY: Used for workflow where manual upgrades are required before automatic ones
     /// TODO: Remove after upgrade-through-scout is complete
@@ -930,6 +936,36 @@ pub struct Dpf {
     pub enabled: bool,
     // If dpf is used for ingestion.
     pub used_for_ingestion: bool,
+}
+
+/// Per-host profile for settings that affect state-machine progression,
+/// seeded from the expected-machine record at discovery time. Add new
+/// per-host knobs here rather than creating separate JSONB columns.
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct HostProfile {
+    /// When `true` the ingestion state machine skips re-enabling lockdown
+    /// after BIOS/UEFI configuration.
+    pub disable_lockdown: bool,
+}
+
+impl HostProfile {
+    /// Resolve a runtime `HostProfile` from an optional expected-machine
+    /// record. When `None` (no expected-machine entry) every field falls
+    /// back to its default.
+    ///
+    /// New profile fields should be resolved here so the
+    /// expected-machine → machine conversion stays in one place.
+    pub fn from_expected_machine(data: Option<&ExpectedMachineData>) -> Self {
+        match data {
+            Some(d) => Self {
+                disable_lockdown: d
+                    .host_lifecycle_profile
+                    .disable_lockdown
+                    .unwrap_or_default(),
+            },
+            None => Self::default(),
+        }
+    }
 }
 
 impl From<Machine> for ::rpc::forge::dpf_state_response::DpfState {
@@ -3408,6 +3444,105 @@ mod tests {
         )];
 
         assert_eq!(pick_boot_interface_mac(&interfaces), None);
+    }
+
+    // Zero-DPU hosts have no DPU snapshots at all. The helper must return
+    // `true` -- consumers (IB partition monitor, NVLink partition monitor)
+    // use this to decide whether to detach tenant partitions, and zero-DPU
+    // hosts never have a tenant overlay to protect.
+    #[test]
+    fn derive_use_admin_network_returns_true_for_empty_dpu_snapshots() {
+        assert!(derive_use_admin_network(&[]));
+    }
+
+    // Make sure the legacy default still works; when a DPU snapshot has no
+    // explicit value, treat it as admin-network. All or any "None" should
+    // therefore resolve to true.
+    #[test]
+    fn derive_use_admin_network_treats_none_as_true() {
+        assert!(derive_use_admin_network(&[None]));
+        assert!(derive_use_admin_network(&[None, None]));
+    }
+
+    // ...aand check OR semantics across DPUs: if any single DPU says admin,
+    // the whole host is treated as admin. Only "all DPUs explicitly say false"
+    // flips the host to tenant-network mode.
+    #[test]
+    fn derive_use_admin_network_ors_across_dpus() {
+        assert!(derive_use_admin_network(&[Some(false), Some(true)]));
+        assert!(derive_use_admin_network(&[Some(true), Some(true)]));
+        assert!(derive_use_admin_network(&[Some(false), None]));
+        assert!(!derive_use_admin_network(&[Some(false)]));
+        assert!(!derive_use_admin_network(&[Some(false), Some(false)]));
+    }
+
+    #[test]
+    fn host_profile_defaults_to_lockdown_enabled() {
+        let profile = HostProfile::default();
+        assert!(!profile.disable_lockdown);
+    }
+
+    #[test]
+    fn host_profile_serde_round_trip_lockdown_true() {
+        let profile = HostProfile {
+            disable_lockdown: true,
+        };
+        let json = serde_json::to_string(&profile).unwrap();
+        assert_eq!(json, r#"{"disable_lockdown":true}"#);
+        let back: HostProfile = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, profile);
+    }
+
+    #[test]
+    fn host_profile_serde_round_trip_lockdown_false() {
+        let profile = HostProfile {
+            disable_lockdown: false,
+        };
+        let json = serde_json::to_string(&profile).unwrap();
+        assert_eq!(json, r#"{"disable_lockdown":false}"#);
+        let back: HostProfile = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, profile);
+    }
+
+    #[test]
+    fn host_profile_deserializes_from_db_default() {
+        let db_default = r#"{"disable_lockdown": false}"#;
+        let profile: HostProfile = serde_json::from_str(db_default).unwrap();
+        assert!(!profile.disable_lockdown);
+    }
+
+    #[test]
+    fn host_profile_default_used_when_parent_field_missing() {
+        assert_eq!(
+            HostProfile::default(),
+            HostProfile {
+                disable_lockdown: false
+            }
+        );
+    }
+
+    #[test]
+    fn host_profile_from_expected_none_uses_defaults() {
+        let profile = HostProfile::from_expected_machine(None);
+        assert_eq!(profile, HostProfile::default());
+    }
+
+    #[test]
+    fn host_profile_from_expected_empty_profile_uses_defaults() {
+        let data = ExpectedMachineData::default();
+        let profile = HostProfile::from_expected_machine(Some(&data));
+        assert!(!profile.disable_lockdown);
+    }
+
+    #[test]
+    fn host_profile_from_expected_resolves_disable_lockdown() {
+        let mut data = ExpectedMachineData::default();
+
+        data.host_lifecycle_profile.disable_lockdown = Some(true);
+        assert!(HostProfile::from_expected_machine(Some(&data)).disable_lockdown);
+
+        data.host_lifecycle_profile.disable_lockdown = Some(false);
+        assert!(!HostProfile::from_expected_machine(Some(&data)).disable_lockdown);
     }
 }
 

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -3446,36 +3446,6 @@ mod tests {
         assert_eq!(pick_boot_interface_mac(&interfaces), None);
     }
 
-    // Zero-DPU hosts have no DPU snapshots at all. The helper must return
-    // `true` -- consumers (IB partition monitor, NVLink partition monitor)
-    // use this to decide whether to detach tenant partitions, and zero-DPU
-    // hosts never have a tenant overlay to protect.
-    #[test]
-    fn derive_use_admin_network_returns_true_for_empty_dpu_snapshots() {
-        assert!(derive_use_admin_network(&[]));
-    }
-
-    // Make sure the legacy default still works; when a DPU snapshot has no
-    // explicit value, treat it as admin-network. All or any "None" should
-    // therefore resolve to true.
-    #[test]
-    fn derive_use_admin_network_treats_none_as_true() {
-        assert!(derive_use_admin_network(&[None]));
-        assert!(derive_use_admin_network(&[None, None]));
-    }
-
-    // ...aand check OR semantics across DPUs: if any single DPU says admin,
-    // the whole host is treated as admin. Only "all DPUs explicitly say false"
-    // flips the host to tenant-network mode.
-    #[test]
-    fn derive_use_admin_network_ors_across_dpus() {
-        assert!(derive_use_admin_network(&[Some(false), Some(true)]));
-        assert!(derive_use_admin_network(&[Some(true), Some(true)]));
-        assert!(derive_use_admin_network(&[Some(false), None]));
-        assert!(!derive_use_admin_network(&[Some(false)]));
-        assert!(!derive_use_admin_network(&[Some(false), Some(false)]));
-    }
-
     #[test]
     fn host_profile_defaults_to_lockdown_enabled() {
         let profile = HostProfile::default();

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -4992,6 +4992,27 @@ impl StateHandler for HostMachineStateHandler {
                 MachineState::WaitingForLockdown { lockdown_info } => {
                     match &lockdown_info.state {
                         LockdownState::SetLockdown => {
+                            if lockdown_info.mode == LockdownMode::Enable
+                                && mh_snapshot.host_snapshot.host_profile.disable_lockdown
+                            {
+                                tracing::info!(
+                                    machine_id = %host_machine_id,
+                                    "Lockdown disabled per expected-machine config, skipping lockdown enable"
+                                );
+                                return Ok(StateHandlerOutcome::transition(
+                                    ManagedHostState::BomValidating {
+                                        bom_validating_state: BomValidating::MatchingSku(
+                                            BomValidatingContext {
+                                                machine_validation_context: Some(
+                                                    "Discovery".to_string(),
+                                                ),
+                                                ..BomValidatingContext::default()
+                                            },
+                                        ),
+                                    },
+                                ));
+                            }
+
                             tracing::info!(
                                 machine_id = %host_machine_id,
                                 mode = ?lockdown_info.mode,
@@ -7241,9 +7262,9 @@ impl HostUpgradeState {
                 }
             }
         };
-        if lockdown_disabled {
+
+        if lockdown_disabled && !state.host_snapshot.host_profile.disable_lockdown {
             tracing::debug!("host firmware update: Reenabling lockdown");
-            // Already disabled, we need to reenable.
             if let Err(e) = redfish_client
                 .lockdown(libredfish::EnabledDisabled::Enabled)
                 .await
@@ -7251,31 +7272,42 @@ impl HostUpgradeState {
                 tracing::error!("Could not set lockdown for {machine_id}: {e}");
                 return Ok(StateHandlerOutcome::do_nothing());
             }
-            // Reenabling lockdown will poll lockdown status to verify settings are applied.
             match scenario {
-                HostFirmwareScenario::Ready => Ok(StateHandlerOutcome::transition(
-                    ManagedHostState::HostInit {
-                        machine_state: MachineState::WaitingForLockdown {
-                            lockdown_info: LockdownInfo {
-                                state: LockdownState::PollingLockdownStatus,
-                                mode: Enable,
+                HostFirmwareScenario::Ready => {
+                    return Ok(StateHandlerOutcome::transition(
+                        ManagedHostState::HostInit {
+                            machine_state: MachineState::WaitingForLockdown {
+                                lockdown_info: LockdownInfo {
+                                    state: LockdownState::PollingLockdownStatus,
+                                    mode: Enable,
+                                },
                             },
                         },
-                    },
-                )),
+                    ));
+                }
                 HostFirmwareScenario::Instance => {
                     handler_host_power_control(state, ctx, SystemPowerControl::ForceRestart)
                         .await?;
-                    Ok(StateHandlerOutcome::transition(scenario.complete_state()))
+                    return Ok(StateHandlerOutcome::transition(scenario.complete_state()));
                 }
             }
-        } else {
-            tracing::debug!("host firmware update: Don't need to reenable lockdown");
-            if let HostFirmwareScenario::Instance = scenario {
-                handler_host_power_control(state, ctx, SystemPowerControl::ForceRestart).await?;
-            }
-            Ok(StateHandlerOutcome::transition(scenario.complete_state()))
         }
+
+        if lockdown_disabled && state.host_snapshot.host_profile.disable_lockdown {
+            tracing::info!(
+                %machine_id,
+                "host firmware update: host is NOT locked down -- skipping lockdown re-enable per expected-machine config"
+            );
+        } else if !lockdown_disabled {
+            tracing::debug!(
+                "host firmware update: Don't need to reenable lockdown -- host is already locked down"
+            );
+        }
+
+        if let HostFirmwareScenario::Instance = scenario {
+            handler_host_power_control(state, ctx, SystemPowerControl::ForceRestart).await?;
+        }
+        Ok(StateHandlerOutcome::transition(scenario.complete_state()))
     }
 
     async fn by_script(
@@ -9845,13 +9877,20 @@ async fn handle_instance_host_platform_config(
             }
         }
         HostPlatformConfigurationState::LockHost => {
-            redfish_client
-                .lockdown_bmc(EnabledDisabled::Enabled)
-                .await
-                .map_err(|e| StateHandlerError::RedfishError {
-                    operation: "lockdown_bmc",
-                    error: e,
-                })?;
+            if mh_snapshot.host_snapshot.host_profile.disable_lockdown {
+                tracing::info!(
+                    machine_id = %mh_snapshot.host_snapshot.id,
+                    "Skipping lockdown re-enable in platform config per expected-machine config"
+                );
+            } else {
+                redfish_client
+                    .lockdown_bmc(EnabledDisabled::Enabled)
+                    .await
+                    .map_err(|e| StateHandlerError::RedfishError {
+                        operation: "lockdown_bmc",
+                        error: e,
+                    })?;
+            }
 
             InstanceState::WaitingForDpusToUp
         }

--- a/crates/api/src/tests/expected_machine.rs
+++ b/crates/api/src/tests/expected_machine.rs
@@ -729,7 +729,7 @@ async fn test_add_expected_machine_dpu_serials(pool: sqlx::PgPool) {
         bmc_ip_address: None,
         bmc_retain_credentials: None,
         dpu_mode: None,
-        disable_lockdown: None,
+        host_lifecycle_profile: None,
         #[allow(deprecated)]
         dpf_enabled: true,
     };

--- a/crates/api/src/tests/expected_machine.rs
+++ b/crates/api/src/tests/expected_machine.rs
@@ -88,6 +88,7 @@ async fn test_duplicate_fail_create(pool: sqlx::PgPool) -> Result<(), Box<dyn st
                 bmc_ip_address: None,
                 bmc_retain_credentials: None,
                 dpu_mode: Default::default(),
+                host_lifecycle_profile: Default::default(),
             },
         },
     )
@@ -728,6 +729,7 @@ async fn test_add_expected_machine_dpu_serials(pool: sqlx::PgPool) {
         bmc_ip_address: None,
         bmc_retain_credentials: None,
         dpu_mode: None,
+        disable_lockdown: None,
         #[allow(deprecated)]
         dpf_enabled: true,
     };

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -1440,6 +1440,7 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
                 bmc_ip_address: None,
                 bmc_retain_credentials: None,
                 dpu_mode: Default::default(),
+                host_lifecycle_profile: Default::default(),
             },
         },
     )
@@ -1491,6 +1492,7 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
         bmc_ip_address: None,
         bmc_retain_credentials: None,
         dpu_mode: Default::default(),
+        host_lifecycle_profile: Default::default(),
     };
     db::expected_machine::update(&mut txn, &host1_expected_machine).await?;
     txn.commit().await?;
@@ -2460,6 +2462,7 @@ async fn test_machine_creation_with_sku(
                 bmc_ip_address: None,
                 bmc_retain_credentials: None,
                 dpu_mode: Default::default(),
+                host_lifecycle_profile: Default::default(),
             },
         },
     )
@@ -2596,6 +2599,7 @@ async fn test_expected_machine_device_type_metrics(
                 bmc_ip_address: None,
                 bmc_retain_credentials: None,
                 dpu_mode: Default::default(),
+                host_lifecycle_profile: Default::default(),
             },
         },
     )
@@ -2620,6 +2624,7 @@ async fn test_expected_machine_device_type_metrics(
                 bmc_ip_address: None,
                 bmc_retain_credentials: None,
                 dpu_mode: Default::default(),
+                host_lifecycle_profile: Default::default(),
             },
         },
     )
@@ -2644,6 +2649,7 @@ async fn test_expected_machine_device_type_metrics(
                 bmc_ip_address: None,
                 bmc_retain_credentials: None,
                 dpu_mode: Default::default(),
+                host_lifecycle_profile: Default::default(),
             },
         },
     )

--- a/crates/api/src/tests/sku.rs
+++ b/crates/api/src/tests/sku.rs
@@ -798,6 +798,7 @@ pub mod tests {
                     bmc_ip_address: None,
                     bmc_retain_credentials: None,
                     dpu_mode: Default::default(),
+                    host_lifecycle_profile: Default::default(),
                 },
             },
         )
@@ -892,6 +893,7 @@ pub mod tests {
                     bmc_ip_address: None,
                     bmc_retain_credentials: None,
                     dpu_mode: Default::default(),
+                    host_lifecycle_profile: Default::default(),
                 },
             },
         )
@@ -961,6 +963,7 @@ pub mod tests {
                     bmc_ip_address: None,
                     bmc_retain_credentials: None,
                     dpu_mode: Default::default(),
+                    host_lifecycle_profile: Default::default(),
                 },
             },
         )
@@ -1047,6 +1050,7 @@ pub mod tests {
                     bmc_ip_address: None,
                     bmc_retain_credentials: None,
                     dpu_mode: Default::default(),
+                    host_lifecycle_profile: Default::default(),
                 },
             },
         )
@@ -1484,6 +1488,7 @@ pub mod tests {
                     bmc_ip_address: None,
                     bmc_retain_credentials: None,
                     dpu_mode: Default::default(),
+                    host_lifecycle_profile: Default::default(),
                 },
             },
         )

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -524,7 +524,7 @@ impl ApiClient {
                 bmc_ip_address: None,
                 bmc_retain_credentials: None,
                 dpu_mode: None,
-                disable_lockdown: None,
+                host_lifecycle_profile: None,
             })
             .await
             .map_err(ClientApiError::InvocationError)

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -524,6 +524,7 @@ impl ApiClient {
                 bmc_ip_address: None,
                 bmc_retain_credentials: None,
                 dpu_mode: None,
+                disable_lockdown: None,
             })
             .await
             .map_err(ClientApiError::InvocationError)

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -488,6 +488,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .type_attribute("MachineValidationRun", "#[derive(serde::Serialize)]")
         .type_attribute("ExpectedHostNic", "#[derive(serde::Serialize)]")
         .type_attribute("ExpectedHostNic", "#[derive(serde::Deserialize)]")
+        .type_attribute("HostLifecycleProfile", "#[derive(serde::Serialize, serde::Deserialize)]")
         .type_attribute("ExpectedMachine", "#[derive(serde::Serialize)]")
         .type_attribute("ExpectedPowerShelf", "#[derive(serde::Serialize)]")
         .type_attribute("ExpectedSwitch", "#[derive(serde::Serialize)]")

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -5388,6 +5388,15 @@ enum DpuMode {
   NO_DPU = 3;
 }
 
+// Per-host lifecycle profile for settings that affect state-machine progression.
+// When the outer field is unset on ExpectedMachine, the server preserves the
+// existing DB value (patch semantics).
+message HostLifecycleProfile {
+  // If true, do not lock down the server as part of host lifecycle management. If unset or false, preserve
+  // the default behavior of locking down the server after configuring the BIOS.
+  optional bool disable_lockdown = 1;
+}
+
 message ExpectedMachine {
   string bmc_mac_address = 1;
   string bmc_username = 2;
@@ -5415,10 +5424,9 @@ message ExpectedMachine {
   // default" -- the site-wide `force_dpu_nic_mode` config flag still applies
   // when no per-host override is set, so existing deployments keep working.
   optional DpuMode dpu_mode = 16;
-  // If true, do not lock down the server while ingesting the managed host
-  // into a Ready state within the state machine. If unset or false, preserve
-  // the default behavior of locking down the server after configuring the BIOS.
-  optional bool disable_lockdown = 17;
+  // Per-host lifecycle profile. When unset in a patch/update request, the
+  // existing DB value is preserved via COALESCE.
+  optional HostLifecycleProfile host_lifecycle_profile = 17;
 }
 
 message ExpectedMachineRequest {

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -5415,6 +5415,10 @@ message ExpectedMachine {
   // default" -- the site-wide `force_dpu_nic_mode` config flag still applies
   // when no per-host override is set, so existing deployments keep working.
   optional DpuMode dpu_mode = 16;
+  // If true, do not lock down the server while ingesting the managed host
+  // into a Ready state within the state machine. If unset or false, preserve
+  // the default behavior of locking down the server after configuring the BIOS.
+  optional bool disable_lockdown = 17;
 }
 
 message ExpectedMachineRequest {

--- a/docs/manuals/ingesting_machines.md
+++ b/docs/manuals/ingesting_machines.md
@@ -97,11 +97,9 @@ Each entry supports additional optional fields:
 
 - **`host_lifecycle_profile`** (object): Per-host profile for settings that affect
   state-machine progression. Future per-host knobs should be added here.
-  - **`disable_lockdown`** (bool, default `false`): When `true`, the ingestion state machine
-    skips re-enabling BMC/BIOS lockdown after UEFI/platform configuration completes. This is
-    useful for automation workflows that need lockdown persistently disabled. Lockdown is still
-    temporarily disabled during BIOS setup regardless of this flag; the flag only controls
-    whether it is **re-enabled** afterward.
+  - **`disable_lockdown`** (bool, default `false`): When `true`, the state machine
+    does not lockdown the host during lifecycle management. This is useful for automation
+    workflows that need lockdown persistently disabled.
 
   ```json
   {

--- a/docs/manuals/ingesting_machines.md
+++ b/docs/manuals/ingesting_machines.md
@@ -91,6 +91,36 @@ Prepare an `expected_machines.json` file as follows:
 
 Only servers listed in this table will be ingested, so you must include all servers in this file.
 
+### Optional Per-Host Fields
+
+Each entry supports additional optional fields:
+
+- **`host_lifecycle_profile`** (object): Per-host profile for settings that affect
+  state-machine progression. Future per-host knobs should be added here.
+  - **`disable_lockdown`** (bool, default `false`): When `true`, the ingestion state machine
+    skips re-enabling BMC/BIOS lockdown after UEFI/platform configuration completes. This is
+    useful for automation workflows that need lockdown persistently disabled. Lockdown is still
+    temporarily disabled during BIOS setup regardless of this flag; the flag only controls
+    whether it is **re-enabled** afterward.
+
+  ```json
+  {
+    "bmc_mac_address": "C4:5A:B1:C8:38:0D",
+    "bmc_username": "root",
+    "bmc_password": "default-password1",
+    "chassis_serial_number": "SERIAL-1",
+    "host_lifecycle_profile": {
+      "disable_lockdown": true
+    }
+  }
+  ```
+
+- **`dpf_enabled`** (bool): Enable/disable DPF for this host.
+- **`dpu_mode`** (`"dpu_mode"` | `"nic_mode"` | `"no_dpu"`): Per-host DPU operating mode.
+- **`bmc_retain_credentials`** (bool): Skip BMC password rotation.
+- **`default_pause_ingestion_and_poweron`** (bool): Pause ingestion and power-on for this host.
+- **`bmc_ip_address`** (string): Static BMC IP (pre-allocates a machine interface).
+
 When the file is ready, upload it to the site with the following command:
 
 ```bash

--- a/docs/manuals/metrics/core_metrics.md
+++ b/docs/manuals/metrics/core_metrics.md
@@ -119,5 +119,5 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_switches_object_tasks_enqueued_total</td><td>counter</td><td>The amount of types that object handling tasks that have been freshly enqueued for objects of type carbide_switches</td></tr>
 <tr><td>carbide_switches_total</td><td>gauge</td><td>The total number of carbide_switches in the system</td></tr>
 <tr><td>carbide_total_ips_count</td><td>gauge</td><td>The total number of ips in the site</td></tr>
-<tr><td>carbide_unavailable_dpu_nic_firmware_update_count</td><td>gauge</td><td>The number of machines in the system that need a firmware update but are unavailble for update.</td></tr>
-</table>
+<tr><td>carbide_unavailable_dpu_nic_firmware_update_count</td><td>gauge</td><td>The number of machines in the system that need a firmware update but are unavailable for update.</td></tr>
+<table>


### PR DESCRIPTION
## Description

feat: add per-host lifecycle config in expected machines. start by adding a flag to this config that provides a knob for disabling bios lockdown in lifecycle management for a single host


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

