### PR TITLE
Fix outdated Fern doc URL redirects

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -78,10 +78,10 @@ products:
         path: ../docs/index.yml
 
 redirects:
-  - source: "/ncx-infra-controller/index.html"
-    destination: "/ncx-infra-controller/"
-  - source: "/ncx-infra-controller/dev/index.html"
-    destination: "/ncx-infra-controller/dev/"
+  - source: "/infra-controller/index.html"
+    destination: "/infra-controller/"
+  - source: "/infra-controller/dev/index.html"
+    destination: "/infra-controller/dev/"
 
 experimental:
   mdx-components:


### PR DESCRIPTION
## Description
Fern doc redirects didn't reflect the updated docs URL, which is https://docs.nvidia.com/infra-controller/.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

