### PR TITLE
fix(web-ui): Display vpc.status.vni not vpc.vni

### DIFF
--- a/crates/api/src/tests/web/mod.rs
+++ b/crates/api/src/tests/web/mod.rs
@@ -23,6 +23,7 @@ use crate::tests::common;
 use crate::web::routes;
 mod machine_health;
 mod managed_host;
+mod vpc;
 
 fn make_test_app(env: &TestEnv) -> Router {
     let r = routes(env.api.clone()).unwrap();

--- a/crates/api/src/tests/web/vpc.rs
+++ b/crates/api/src/tests/web/vpc.rs
@@ -1,0 +1,162 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use axum::body::Body;
+use axum::response::Response;
+use http_body_util::BodyExt;
+use hyper::http::StatusCode;
+use rpc::forge;
+use rpc::forge::forge_server::Forge;
+use tower::ServiceExt;
+
+use crate::tests::common::api_fixtures::{create_test_env, get_vpc_fixture_id};
+use crate::tests::web::{make_test_app, web_request_builder};
+
+/// Collects a web response body into a UTF-8 string.
+async fn response_body(response: Response) -> String {
+    // Collect the full response body before converting it to text.
+    let body_bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("empty response body")
+        .to_bytes();
+
+    String::from_utf8(body_bytes.to_vec()).expect("invalid UTF-8 in response body")
+}
+
+#[crate::sqlx_test]
+async fn vpc_pages_show_status_vni(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let app = make_test_app(&env);
+
+    // Create a VPC with an auto-allocated VNI stored in status.
+    env.create_vpc_and_tenant_segment().await;
+    let vpc_id = get_vpc_fixture_id(&env).await;
+    let mut vpcs = env
+        .api
+        .find_vpcs_by_ids(tonic::Request::new(forge::VpcsByIdsRequest {
+            vpc_ids: vec![vpc_id],
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .vpcs;
+    let vpc = vpcs.pop().expect("expected fixture VPC");
+    let vni = vpc
+        .status
+        .as_ref()
+        .and_then(|status| status.vni)
+        .expect("expected status VNI")
+        .to_string();
+
+    // Ensure this test would fail if the UI still read the old VPC vni field.
+    assert!(vpc.vni.is_none());
+
+    // Add a VPC prefix so the IPAM prefix detail page can render parent VPC data.
+    let vpc_prefix = env
+        .api
+        .create_vpc_prefix(tonic::Request::new(forge::VpcPrefixCreationRequest {
+            id: None,
+            prefix: String::new(),
+            name: String::new(),
+            vpc_id: Some(vpc_id),
+            config: Some(forge::VpcPrefixConfig {
+                prefix: "192.0.2.0/25".to_string(),
+            }),
+            metadata: Some(forge::Metadata {
+                name: "Test VPC prefix".to_string(),
+                description: String::new(),
+                labels: Vec::new(),
+            }),
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    let vpc_prefix_id = vpc_prefix.id.expect("expected VPC prefix ID");
+
+    // Verify the VPC overview renders status.vni.
+    let response = app
+        .clone()
+        .oneshot(
+            web_request_builder()
+                .uri("/admin/vpc")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response_body(response)
+            .await
+            .contains(&format!("<td>{vni}</td>"))
+    );
+
+    // Verify the VPC detail page renders status.vni.
+    let response = app
+        .clone()
+        .oneshot(
+            web_request_builder()
+                .uri(format!("/admin/vpc/{vpc_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response_body(response)
+            .await
+            .contains(&format!("<tr><th>VNI</th><td>{vni}</td></tr>"))
+    );
+
+    // Verify the IPAM overlay overview renders status.vni.
+    let response = app
+        .clone()
+        .oneshot(
+            web_request_builder()
+                .uri("/admin/ipam/overlay")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response_body(response)
+            .await
+            .contains(&format!("<td>{vni}</td>"))
+    );
+
+    // Verify the IPAM overlay prefix detail page renders status.vni.
+    let response = app
+        .oneshot(
+            web_request_builder()
+                .uri(format!("/admin/ipam/overlay/prefix/{vpc_prefix_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response_body(response)
+            .await
+            .contains(&format!("<tr><td>VNI</td><td>{vni}</td></tr>"))
+    );
+}

--- a/crates/api/src/web/ipam.rs
+++ b/crates/api/src/web/ipam.rs
@@ -564,7 +564,12 @@ pub async fn overlay_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
                     .as_ref()
                     .map(|m| m.name.clone())
                     .unwrap_or_default(),
-                vni: vpc.vni.map(|v| v.to_string()).unwrap_or_default(),
+                vni: vpc
+                    .status
+                    .as_ref()
+                    .and_then(|status| status.vni)
+                    .map(|vni| vni.to_string())
+                    .unwrap_or_default(),
                 tenant: vpc.tenant_organization_id,
                 prefixes,
             }
@@ -686,7 +691,11 @@ pub async fn overlay_prefix_html(
                         .as_ref()
                         .map(|m| m.name.clone())
                         .unwrap_or_default(),
-                    vpc.vni.map(|v| v.to_string()).unwrap_or_default(),
+                    vpc.status
+                        .as_ref()
+                        .and_then(|status| status.vni)
+                        .map(|vni| vni.to_string())
+                        .unwrap_or_default(),
                 )
             }
             _ => (String::new(), String::new()),

--- a/crates/api/src/web/vpc.rs
+++ b/crates/api/src/web/vpc.rs
@@ -53,7 +53,12 @@ impl From<forgerpc::Vpc> for VpcRowDisplay {
             tenant_organization_id: vpc.tenant_organization_id,
             tenant_keyset_id: vpc.tenant_keyset_id.unwrap_or_default(),
             routing_profile_type: vpc.routing_profile_type.unwrap_or("None".to_string()),
-            vni: vpc.vni.map(|vni| vni.to_string()).unwrap_or_default(),
+            vni: vpc
+                .status
+                .as_ref()
+                .and_then(|status| status.vni)
+                .map(|vni| vni.to_string())
+                .unwrap_or_default(),
         }
     }
 }
@@ -144,7 +149,12 @@ impl From<forgerpc::Vpc> for VpcDetail {
             tenant_organization_id: vpc.tenant_organization_id,
             tenant_keyset_id: vpc.tenant_keyset_id.unwrap_or_default(),
             routing_profile_type: vpc.routing_profile_type.unwrap_or("None".to_string()),
-            vni: vpc.vni.map(|vni| vni.to_string()).unwrap_or_default(),
+            vni: vpc
+                .status
+                .as_ref()
+                .and_then(|status| status.vni)
+                .map(|vni| vni.to_string())
+                .unwrap_or_default(),
             metadata_detail: super::MetadataDetail {
                 metadata: vpc.metadata.unwrap_or_default(),
                 metadata_version: vpc.version,


### PR DESCRIPTION
## Description
The allocated VPC VNI moved to vpc.status.vni

Web VPC and IPAM overlay pages now display allocated VPC VNIs from Vpc.status.vni

I included a test but I'm really not sure it's necessary...


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

