### PR TITLE
Restrict the service traffic policy to local node

### DIFF
--- a/bluefield/charts/carbide-dhcp-server/templates/service.yaml
+++ b/bluefield/charts/carbide-dhcp-server/templates/service.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "carbide-dhcp-server.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Local
   selector:
     {{- include "carbide-dhcp-server.selectorLabels" . | nindent 4 }}
     {{- with .Values.serviceDaemonSet.labels }}

--- a/bluefield/charts/carbide-fmds/templates/daemonset.yaml
+++ b/bluefield/charts/carbide-fmds/templates/daemonset.yaml
@@ -47,8 +47,6 @@ spec:
       initContainers:
         - name: wait-for-certs
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          args:
-            - "--grpc-address=$(POD_IP):50052"
           command:
             - /busybox/sh
             - -c

--- a/bluefield/charts/carbide-fmds/templates/service.yaml
+++ b/bluefield/charts/carbide-fmds/templates/service.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "carbide-fmds.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Local
   selector:
     {{- include "carbide-fmds.selectorLabels" . | nindent 4 }}
     {{- with .Values.serviceDaemonSet.labels }}


### PR DESCRIPTION
## Description
- Added a change to restrict the service policy to local node. Without this the dpu agent notifications to dhcp and fmds containers was crossing the node boundaries.
- Removed a duplicate argument for init container in carbide-fmds

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

