### PR TITLE
chore(health): renaming crate-level remnants of override -> report/entry/etc

### DIFF
--- a/crates/admin-cli/src/debug_bundle/cmds.rs
+++ b/crates/admin-cli/src/debug_bundle/cmds.rs
@@ -724,7 +724,7 @@ async fn get_machine_analysis(
 /// 2. **Carbide-API Logs**: API server logs from Loki (filtered by `k8s_container_name`)
 /// 3. **DPU Agent Logs**: DPU agent service logs from Loki (filtered by `systemd_unit` and `host_machine_id`)
 /// 4. **Health Alerts**: Historical health alerts for the machine within the specified time range
-/// 5. **Health Alert Overrides**: Current alert overrides configured for the machine
+/// 5. **Health Report Entries**: Current health report entries configured for the machine
 /// 6. **Site Controller Details**: BMC/Redfish exploration data including:
 ///    - BMC IP and MAC addresses
 ///    - Systems, Managers, and Chassis information
@@ -755,7 +755,7 @@ async fn get_machine_analysis(
 /// - `carbide_api_logs.txt` - API server logs
 /// - `dpu_agent_logs_<machine_id>.txt` - DPU agent service logs
 /// - `health_alerts.json` - Health alerts history
-/// - `health_alert_overrides.json` - Active alert overrides
+/// - `health_alert_overrides.json` - Active health report entries
 /// - `site_controller_details.json` - BMC/Redfish exploration data
 /// - `machine_info.json` - Machine state and validation data
 /// - `metadata.txt` - Summary and Grafana links
@@ -882,10 +882,10 @@ pub async fn handle_debug_bundle(
         .unwrap_or(0);
     println!("   Alerts: {} records collected", alert_count);
 
-    println!("\nFetching health alert overrides...");
+    println!("\nFetching health report entries...");
     let alert_entries = get_alert_entries(api_client, &debug_bundle.host_id).await?;
     println!(
-        "   Overrides: {} overrides collected",
+        "   Entries: {} entries collected",
         alert_entries.health_report_entries.len()
     );
 
@@ -919,7 +919,7 @@ pub async fn handle_debug_bundle(
             .unwrap_or(0)
     );
     println!(
-        "   Health Alert Overrides: {} overrides",
+        "   Health Report Entries: {} entries",
         alert_entries.health_report_entries.len()
     );
     println!("   Site Controller Details: Collected");
@@ -929,7 +929,7 @@ pub async fn handle_debug_bundle(
         host_logs.len() + carbide_api_logs.len() + dpu_agent_logs.len()
     );
 
-    // Create ZIP file with logs, health alerts, health alert overrides, site controller details, and machine info
+    // Create ZIP file with logs, health alerts, health report entries, site controller details, and machine info
     println!("\nCreating ZIP file...");
     create_debug_bundle_zip(
         &debug_bundle,
@@ -1056,7 +1056,7 @@ async fn get_alert_entries(
         CarbideCliError::GenericError(format!("Invalid machine ID '{}': {}", host_id, e))
     })?;
 
-    // Call API to get current overrides
+    // Call API to get current health report entries
     let response = api_client
         .0
         .list_health_report_overrides(machine_id)
@@ -1414,7 +1414,7 @@ impl<'a> ZipBundleCreator<'a> {
 
         println!("ZIP created: {filepath}");
         println!(
-            "Files: host_logs_{}.txt ({} logs), carbide_api_logs.txt ({} logs), dpu_agent_logs_{}.txt ({} logs), health_alerts.json ({} records), health_alert_overrides.json ({} overrides), site_controller_details.json, machine_info.json, metadata.txt",
+            "Files: host_logs_{}.txt ({} logs), carbide_api_logs.txt ({} logs), dpu_agent_logs_{}.txt ({} logs), health_alerts.json ({} records), health_alert_overrides.json ({} entries), site_controller_details.json, machine_info.json, metadata.txt",
             self.config.host_id,
             host_logs.len(),
             carbide_logs.len(),
@@ -1569,7 +1569,7 @@ impl<'a> ZipBundleCreator<'a> {
 
         // Write pretty-formatted JSON to ZIP
         let json_string = serde_json::to_string_pretty(&json_output).map_err(|e| {
-            CarbideCliError::GenericError(format!("Failed to serialize overrides to JSON: {e}"))
+            CarbideCliError::GenericError(format!("Failed to serialize entries to JSON: {e}"))
         })?;
 
         write!(zip, "{}", json_string)?;
@@ -1873,11 +1873,11 @@ impl<'a> ZipBundleCreator<'a> {
         writeln!(zip, "  Total Alerts: {}", total_alerts)?;
         writeln!(zip)?;
 
-        // Add Health Alert Overrides Info
-        writeln!(zip, "Health Alert Overrides:")?;
+        // Add Health Report Entries Info
+        writeln!(zip, "Health Report Entries:")?;
         writeln!(
             zip,
-            "  Total Overrides: {}",
+            "  Total Entries: {}",
             alert_entries.health_report_entries.len()
         )?;
         let active_entries = alert_entries

--- a/crates/admin-cli/src/managed_host/show/cmd.rs
+++ b/crates/admin-cli/src/managed_host/show/cmd.rs
@@ -356,7 +356,7 @@ fn show_managed_host_details_view(m: utils::ManagedHostOutput) -> CarbideCliResu
             "    Probe Alerts",
             Some(format_health_alerts(&m.health.alerts, width)),
         ),
-        ("    Overrides", Some(m.health_sources.join(","))),
+        ("    Health Reports", Some(m.health_sources.join(","))),
     ];
     data.append(&mut health_details);
 

--- a/crates/health/benches/sink_pipeline.rs
+++ b/crates/health/benches/sink_pipeline.rs
@@ -24,8 +24,8 @@ use std::sync::Arc;
 use carbide_health::endpoint::{BmcAddr, EndpointMetadata, MachineData};
 use carbide_health::metrics::MetricsManager;
 use carbide_health::sink::{
-    Classification, CollectorEvent, CompositeDataSink, DataSink, EventContext, HealthOverrideSink,
-    HealthReport, LogRecord, PrometheusSink, ReportSource, SensorHealthData,
+    Classification, CollectorEvent, CompositeDataSink, DataSink, EventContext, HealthReport,
+    HealthReportSink, LogRecord, PrometheusSink, ReportSource, SensorHealthData,
 };
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use health_report::HealthReport as CarbideHealthReport;
@@ -194,17 +194,17 @@ fn health_report_with_alerts(alert_count: usize) -> HealthReport {
     report
 }
 
-struct HealthOverrideBenchState {
-    sink: HealthOverrideSink,
+struct HealthReportBenchState {
+    sink: HealthReportSink,
     context: EventContext,
     distinct_contexts: Vec<EventContext>,
     sensor_event: CollectorEvent,
     leak_event: CollectorEvent,
 }
 
-impl HealthOverrideBenchState {
+impl HealthReportBenchState {
     fn new() -> Self {
-        let sink = HealthOverrideSink::new_for_bench().expect("bench sink should initialize");
+        let sink = HealthReportSink::new_for_bench().expect("bench sink should initialize");
         let context = event_context();
         let distinct_contexts = MACHINE_IDS
             .into_iter()
@@ -233,12 +233,12 @@ impl HealthOverrideBenchState {
     }
 }
 
-fn filled_health_override_sink(
+fn filled_health_report_sink(
     contexts: &[EventContext],
     event: &CollectorEvent,
     leak_event: &CollectorEvent,
-) -> HealthOverrideSink {
-    let sink = HealthOverrideSink::new_for_bench().expect("bench sink should initialize");
+) -> HealthReportSink {
+    let sink = HealthReportSink::new_for_bench().expect("bench sink should initialize");
     for context in contexts {
         sink.handle_event(context, event);
         sink.handle_event(context, leak_event);
@@ -246,7 +246,7 @@ fn filled_health_override_sink(
     sink
 }
 
-fn drain_pending(sink: &HealthOverrideSink) -> usize {
+fn drain_pending(sink: &HealthReportSink) -> usize {
     let mut drained = 0;
     while sink.pop_pending_for_bench().is_some() {
         drained += 1;
@@ -254,7 +254,7 @@ fn drain_pending(sink: &HealthOverrideSink) -> usize {
     drained
 }
 
-fn drain_and_convert_pending(sink: &HealthOverrideSink) -> usize {
+fn drain_and_convert_pending(sink: &HealthReportSink) -> usize {
     let mut drained = 0;
     while let Some((_machine_id, report)) = sink.pop_pending_for_bench() {
         let converted: CarbideHealthReport = report
@@ -267,12 +267,12 @@ fn drain_and_convert_pending(sink: &HealthOverrideSink) -> usize {
     drained
 }
 
-fn bench_health_override_sink(c: &mut Criterion) {
-    let mut group = c.benchmark_group("sink_health_override");
+fn bench_health_report_sink(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sink_health_report");
     let batch_size = 20_000usize;
     group.throughput(Throughput::Elements(batch_size as u64));
 
-    let state = HealthOverrideBenchState::new();
+    let state = HealthReportBenchState::new();
 
     group.bench_with_input(BenchmarkId::new("enqueue", "report"), &state, |b, state| {
         b.iter(|| {
@@ -287,7 +287,7 @@ fn bench_health_override_sink(c: &mut Criterion) {
     group.bench_with_input(BenchmarkId::new("drain", "report"), &state, |b, state| {
         b.iter_batched(
             || {
-                filled_health_override_sink(
+                filled_health_report_sink(
                     &state.distinct_contexts,
                     &state.sensor_event,
                     &state.leak_event,
@@ -306,7 +306,7 @@ fn bench_health_override_sink(c: &mut Criterion) {
         |b, state| {
             b.iter_batched(
                 || {
-                    filled_health_override_sink(
+                    filled_health_report_sink(
                         &state.distinct_contexts,
                         &state.sensor_event,
                         &state.leak_event,
@@ -445,7 +445,7 @@ criterion_group!(
     benches,
     bench_prometheus_sink,
     bench_composite_sink,
-    bench_health_override_sink,
+    bench_health_report_sink,
     bench_otlp_sink,
     bench_queue_key_construction,
 );

--- a/crates/health/example/config.bmc-mock.toml
+++ b/crates/health/example/config.bmc-mock.toml
@@ -40,8 +40,8 @@ enabled = true
 [sinks.prometheus]
 enabled = true
 
-[sinks.health_override]
+[sinks.health_report]
 enabled = false
 
-[sinks.rack_health_override]
+[sinks.rack_health_report]
 enabled = false

--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -69,7 +69,7 @@ endpoint = "http://localhost:4317"
 batch_size = 512
 flush_interval = "2s"
 
-[sinks.health_override]
+[sinks.health_report]
 root_ca = "/var/run/secrets/spiffe.io/ca.crt"
 client_cert = "/var/run/secrets/spiffe.io/tls.crt"
 client_key = "/var/run/secrets/spiffe.io/tls.key"

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -127,12 +127,13 @@ pub struct SinksConfig {
     /// Prometheus sink: stores metric events in Prometheus exporter format.
     pub prometheus: Configurable<PrometheusSinkConfig>,
 
-    /// Health override sink: sends health override events to Carbide API.
-    #[serde(alias = "carbide_override")]
-    pub health_override: Configurable<HealthOverrideSinkConfig>,
+    /// Health report sink: sends health report events to Carbide API.
+    #[serde(alias = "carbide_override", alias = "health_override")]
+    pub health_report: Configurable<HealthReportSinkConfig>,
 
-    /// Rack health override sink: sends rack-level health overrides to Carbide API.
-    pub rack_health_override: Configurable<RackHealthOverrideSinkConfig>,
+    /// Rack health report sink: sends rack-level health reports to Carbide API.
+    #[serde(alias = "rack_health_override")]
+    pub rack_health_report: Configurable<RackHealthReportSinkConfig>,
 
     /// Log file sink: writes log events as JSONL to rotating files on disk.
     pub log_file: Configurable<LogFileSinkConfig>,
@@ -146,8 +147,8 @@ impl Default for SinksConfig {
         Self {
             tracing: Configurable::Disabled,
             prometheus: Configurable::Enabled(PrometheusSinkConfig::default()),
-            health_override: Configurable::Enabled(HealthOverrideSinkConfig::default()),
-            rack_health_override: Configurable::Enabled(RackHealthOverrideSinkConfig::default()),
+            health_report: Configurable::Enabled(HealthReportSinkConfig::default()),
+            rack_health_report: Configurable::Enabled(RackHealthReportSinkConfig::default()),
             log_file: Configurable::Disabled,
             otlp: Configurable::Disabled,
         }
@@ -229,7 +230,7 @@ impl Default for CarbideApiConnectionConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
-pub struct HealthOverrideSinkConfig {
+pub struct HealthReportSinkConfig {
     #[serde(flatten)]
     pub connection: CarbideApiConnectionConfig,
 
@@ -237,7 +238,7 @@ pub struct HealthOverrideSinkConfig {
     pub workers: usize,
 }
 
-impl Default for HealthOverrideSinkConfig {
+impl Default for HealthReportSinkConfig {
     fn default() -> Self {
         Self {
             connection: CarbideApiConnectionConfig::default(),
@@ -248,7 +249,7 @@ impl Default for HealthOverrideSinkConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
-pub struct RackHealthOverrideSinkConfig {
+pub struct RackHealthReportSinkConfig {
     #[serde(flatten)]
     pub connection: CarbideApiConnectionConfig,
 
@@ -256,7 +257,7 @@ pub struct RackHealthOverrideSinkConfig {
     pub workers: usize,
 }
 
-impl Default for RackHealthOverrideSinkConfig {
+impl Default for RackHealthReportSinkConfig {
     fn default() -> Self {
         Self {
             connection: CarbideApiConnectionConfig::default(),
@@ -643,10 +644,10 @@ impl Config {
             );
         }
 
-        if let Configurable::Enabled(health_override) = &self.sinks.health_override
-            && health_override.workers == 0
+        if let Configurable::Enabled(health_report) = &self.sinks.health_report
+            && health_report.workers == 0
         {
-            return Err("sinks.health_override.workers must be greater than 0".to_string());
+            return Err("sinks.health_report.workers must be greater than 0".to_string());
         }
 
         if let Configurable::Enabled(logs) = &self.collectors.logs {
@@ -750,14 +751,14 @@ mod tests {
             panic!("carbide api empty for sources")
         }
 
-        if let Configurable::Enabled(ref health_override) = config.sinks.health_override {
+        if let Configurable::Enabled(ref health_report) = config.sinks.health_report {
             assert_eq!(
-                health_override.connection.root_ca,
+                health_report.connection.root_ca,
                 "/var/run/secrets/spiffe.io/ca.crt"
             );
-            assert_eq!(health_override.workers, 8);
+            assert_eq!(health_report.workers, 8);
         } else {
-            panic!("health override sink is disabled")
+            panic!("health report sink is disabled")
         }
 
         if let Configurable::Enabled(ref rate_limit) = config.rate_limit {
@@ -830,7 +831,7 @@ password = "pass"
 [endpoint_sources.carbide_api]
 enabled = false
 
-[sinks.health_override]
+[sinks.health_report]
 enabled = false
 
 [collectors.sensors]
@@ -855,7 +856,7 @@ cache_size = 50
             .expect("failed to parse");
 
         assert!(!config.endpoint_sources.carbide_api.is_enabled());
-        assert!(!config.sinks.health_override.is_enabled());
+        assert!(!config.sinks.health_report.is_enabled());
 
         assert_eq!(config.endpoint_sources.static_bmc_endpoints.len(), 1);
         assert_eq!(
@@ -922,13 +923,13 @@ cache_size = 50
 
         config.processors.leak_detection =
             Configurable::Enabled(LeakDetectionProcessorConfig::default());
-        config.sinks.health_override = Configurable::Enabled(HealthOverrideSinkConfig {
+        config.sinks.health_report = Configurable::Enabled(HealthReportSinkConfig {
             workers: 0,
-            ..HealthOverrideSinkConfig::default()
+            ..HealthReportSinkConfig::default()
         });
         assert!(config.validate().is_err());
 
-        config.sinks.health_override = Configurable::Enabled(HealthOverrideSinkConfig::default());
+        config.sinks.health_report = Configurable::Enabled(HealthReportSinkConfig::default());
 
         config.collectors.logs = Configurable::Enabled(LogsCollectorConfig {
             mode: LogCollectionMode::Periodic,
@@ -994,7 +995,7 @@ cache_size = 50
 [endpoint_sources.carbide_api]
 enabled = false
 
-[sinks.health_override]
+[sinks.health_report]
 enabled = false
 
 [collectors.nvue.rest]
@@ -1035,7 +1036,7 @@ request_timeout = "45s"
 [endpoint_sources.carbide_api]
 enabled = false
 
-[sinks.health_override]
+[sinks.health_report]
 enabled = false
 
 [collectors.nvue]
@@ -1057,7 +1058,7 @@ enabled = false
 [endpoint_sources.carbide_api]
 enabled = false
 
-[sinks.health_override]
+[sinks.health_report]
 enabled = false
 
 [collectors.nvue.rest]
@@ -1082,7 +1083,7 @@ poll_interval = "1m"
 [endpoint_sources.carbide_api]
 enabled = false
 
-[sinks.health_override]
+[sinks.health_report]
 enabled = false
 
 [collectors.nvue.rest]
@@ -1121,7 +1122,7 @@ interfaces_enabled = false
 [endpoint_sources.carbide_api]
 enabled = false
 
-[sinks.health_override]
+[sinks.health_report]
 enabled = false
 
 [[endpoint_sources.static_bmc_endpoints]]
@@ -1178,10 +1179,10 @@ switch_serial = "SN-SW-001"
                 .as_deref(),
             Some("SN-SWITCH-001")
         );
-        if let Configurable::Enabled(ref health_override) = config.sinks.health_override {
-            assert_eq!(health_override.workers, 8);
+        if let Configurable::Enabled(ref health_report) = config.sinks.health_report {
+            assert_eq!(health_report.workers, 8);
         } else {
-            panic!("health override sink is disabled");
+            panic!("health report sink is disabled");
         }
     }
 

--- a/crates/health/src/lib.rs
+++ b/crates/health/src/lib.rs
@@ -48,8 +48,8 @@ use crate::processor::{
 use crate::sharding::ShardManager;
 use crate::sink::event_mapper::{OpenBmcEventMapper, RedfishEventMapper};
 use crate::sink::{
-    CompositeDataSink, DataSink, HealthOverrideSink, LogFileSink, OtlpSink, PrometheusSink,
-    RackHealthOverrideSink, TracingSink,
+    CompositeDataSink, DataSink, HealthReportSink, LogFileSink, OtlpSink, PrometheusSink,
+    RackHealthReportSink, TracingSink,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -159,7 +159,7 @@ fn build_data_sink(
     }
 
     if config.sinks.tracing.is_enabled()
-        || config.sinks.health_override.is_enabled()
+        || config.sinks.health_report.is_enabled()
         || config.processors.leak_detection.is_enabled()
     {
         processors.push(Arc::new(HealthReportProcessor::new()));
@@ -183,12 +183,12 @@ fn build_data_sink(
         ));
     }
 
-    if let Configurable::Enabled(ref sink_cfg) = config.sinks.health_override {
-        sinks.push(Arc::new(HealthOverrideSink::new(sink_cfg)?));
+    if let Configurable::Enabled(ref sink_cfg) = config.sinks.health_report {
+        sinks.push(Arc::new(HealthReportSink::new(sink_cfg)?));
     }
 
-    if let Configurable::Enabled(ref sink_cfg) = config.sinks.rack_health_override {
-        sinks.push(Arc::new(RackHealthOverrideSink::new(sink_cfg)?));
+    if let Configurable::Enabled(ref sink_cfg) = config.sinks.rack_health_report {
+        sinks.push(Arc::new(RackHealthReportSink::new(sink_cfg)?));
     }
 
     if let Configurable::Enabled(ref otlp_cfg) = config.sinks.otlp {

--- a/crates/health/src/sink/dedup_queue.rs
+++ b/crates/health/src/sink/dedup_queue.rs
@@ -18,7 +18,7 @@
 //! Latest-wins dedup queue.
 //!
 //! Generic queue keyed by `K` that replaces the value when the same key
-//! is pushed again. Used by health override sinks (keyed by machine/rack
+//! is pushed again. Used by health report sinks (keyed by machine/rack
 //! + report source) and OtlpSink (keyed by event type identity string).
 
 use std::collections::{HashMap, VecDeque};
@@ -32,12 +32,12 @@ struct QueueState<K: Eq + Hash, V> {
     ready: VecDeque<K>,
 }
 
-pub(crate) struct OverrideQueue<K: Eq + Hash + Clone, V> {
+pub(crate) struct DedupQueue<K: Eq + Hash + Clone, V> {
     state: Mutex<QueueState<K, V>>,
     notify: Notify,
 }
 
-impl<K: Eq + Hash + Clone, V> OverrideQueue<K, V> {
+impl<K: Eq + Hash + Clone, V> DedupQueue<K, V> {
     pub fn new() -> Self {
         Self {
             state: Mutex::new(QueueState {
@@ -52,7 +52,7 @@ impl<K: Eq + Hash + Clone, V> OverrideQueue<K, V> {
     pub fn save_latest(&self, key: K, value: V) -> bool {
         let replaced;
         {
-            let mut state = self.state.lock().expect("override queue mutex poisoned");
+            let mut state = self.state.lock().expect("dedup queue mutex poisoned");
             if state.values.contains_key(&key) {
                 state.values.insert(key, value);
                 replaced = true;
@@ -76,7 +76,7 @@ impl<K: Eq + Hash + Clone, V> OverrideQueue<K, V> {
     }
 
     pub fn pop(&self) -> Option<(K, V)> {
-        let mut state = self.state.lock().expect("override queue mutex poisoned");
+        let mut state = self.state.lock().expect("dedup queue mutex poisoned");
         while let Some(key) = state.ready.pop_front() {
             if let Some(value) = state.values.remove(&key) {
                 return Some((key, value));
@@ -97,7 +97,7 @@ mod tests {
 
     #[test]
     fn deduplicates_by_key() {
-        let queue = OverrideQueue::<String, i32>::new();
+        let queue = DedupQueue::<String, i32>::new();
 
         queue.save_latest("a".into(), 1);
         queue.save_latest("a".into(), 2);
@@ -112,7 +112,7 @@ mod tests {
 
     #[test]
     fn different_keys_are_separate() {
-        let queue = OverrideQueue::<String, i32>::new();
+        let queue = DedupQueue::<String, i32>::new();
 
         queue.save_latest("a".into(), 1);
         queue.save_latest("b".into(), 2);
@@ -126,7 +126,7 @@ mod tests {
 
     #[test]
     fn preserves_fifo_order() {
-        let queue = OverrideQueue::<String, i32>::new();
+        let queue = DedupQueue::<String, i32>::new();
 
         queue.save_latest("first".into(), 1);
         queue.save_latest("second".into(), 2);
@@ -138,7 +138,7 @@ mod tests {
 
     #[test]
     fn update_replaces_value_but_keeps_position() {
-        let queue = OverrideQueue::<String, i32>::new();
+        let queue = DedupQueue::<String, i32>::new();
 
         queue.save_latest("a".into(), 1);
         queue.save_latest("b".into(), 2);

--- a/crates/health/src/sink/health_report.rs
+++ b/crates/health/src/sink/health_report.rs
@@ -19,27 +19,27 @@ use std::sync::Arc;
 
 use carbide_uuid::machine::MachineId;
 
-use super::override_queue::OverrideQueue;
+use super::dedup_queue::DedupQueue;
 use super::{CollectorEvent, DataSink, EventContext, HealthReport, ReportSource};
 use crate::HealthError;
 use crate::api_client::ApiClientWrapper;
-use crate::config::HealthOverrideSinkConfig;
+use crate::config::HealthReportSinkConfig;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-struct OverrideKey {
+struct HealthReportKey {
     id: MachineId,
     source: ReportSource,
 }
 
-pub struct HealthOverrideSink {
-    queue: Arc<OverrideQueue<OverrideKey, Arc<HealthReport>>>,
+pub struct HealthReportSink {
+    queue: Arc<DedupQueue<HealthReportKey, Arc<HealthReport>>>,
 }
 
-impl HealthOverrideSink {
-    pub fn new(config: &HealthOverrideSinkConfig) -> Result<Self, HealthError> {
+impl HealthReportSink {
+    pub fn new(config: &HealthReportSinkConfig) -> Result<Self, HealthError> {
         let handle = tokio::runtime::Handle::try_current().map_err(|error| {
             HealthError::GenericError(format!(
-                "health override sink requires active Tokio runtime: {error}"
+                "health report sink requires active Tokio runtime: {error}"
             ))
         })?;
 
@@ -50,8 +50,8 @@ impl HealthOverrideSink {
             &config.connection.api_url,
         ));
 
-        let queue: Arc<OverrideQueue<OverrideKey, Arc<HealthReport>>> =
-            Arc::new(OverrideQueue::new());
+        let queue: Arc<DedupQueue<HealthReportKey, Arc<HealthReport>>> =
+            Arc::new(DedupQueue::new());
 
         for worker_id in 0..config.workers {
             let worker_client = Arc::clone(&client);
@@ -65,11 +65,7 @@ impl HealthOverrideSink {
                             if let Err(error) =
                                 worker_client.submit_health_report(&key.id, converted).await
                             {
-                                tracing::warn!(
-                                    ?error,
-                                    worker_id,
-                                    "Failed to submit health override report"
-                                );
+                                tracing::warn!(?error, worker_id, "Failed to submit health report");
                             }
                         }
                         Err(error) => {
@@ -77,7 +73,7 @@ impl HealthOverrideSink {
                                 ?error,
                                 worker_id,
                                 machine_id = %key.id,
-                                "Failed to convert health override report"
+                                "Failed to convert health report"
                             );
                         }
                     }
@@ -91,7 +87,7 @@ impl HealthOverrideSink {
     #[cfg(feature = "bench-hooks")]
     pub fn new_for_bench() -> Result<Self, HealthError> {
         Ok(Self {
-            queue: Arc::new(OverrideQueue::new()),
+            queue: Arc::new(DedupQueue::new()),
         })
     }
 
@@ -101,15 +97,15 @@ impl HealthOverrideSink {
     }
 }
 
-impl DataSink for HealthOverrideSink {
+impl DataSink for HealthReportSink {
     fn sink_type(&self) -> &'static str {
-        "health_override_sink"
+        "health_report_sink"
     }
 
     fn handle_event(&self, context: &EventContext, event: &CollectorEvent) {
         if let CollectorEvent::HealthReport(report) = event {
             if let Some(machine_id) = context.machine_id() {
-                let key = OverrideKey {
+                let key = HealthReportKey {
                     id: machine_id,
                     source: report.source,
                 };
@@ -134,8 +130,8 @@ mod tests {
         value.parse().expect("valid machine id")
     }
 
-    fn key(id: MachineId, source: ReportSource) -> OverrideKey {
-        OverrideKey { id, source }
+    fn key(id: MachineId, source: ReportSource) -> HealthReportKey {
+        HealthReportKey { id, source }
     }
 
     fn report(source: ReportSource) -> Arc<HealthReport> {
@@ -149,7 +145,7 @@ mod tests {
 
     #[tokio::test]
     async fn latest_reports_are_preserved() {
-        let queue: OverrideQueue<OverrideKey, Arc<HealthReport>> = OverrideQueue::new();
+        let queue: DedupQueue<HealthReportKey, Arc<HealthReport>> = DedupQueue::new();
         let machine_a = machine_id("fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0");
         let machine_b = machine_id("fm100htjsaledfasinabqqer70e2ua5ksqj4kfjii0v0a90vulps48c1h7g");
         let machine_c = machine_id("fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30");
@@ -185,7 +181,7 @@ mod tests {
 
     #[tokio::test]
     async fn reinserting_hot_key_moves_it_to_back() {
-        let queue: OverrideQueue<OverrideKey, Arc<HealthReport>> = OverrideQueue::new();
+        let queue: DedupQueue<HealthReportKey, Arc<HealthReport>> = DedupQueue::new();
         let machine_a = machine_id("fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0");
         let machine_b = machine_id("fm100htjsaledfasinabqqer70e2ua5ksqj4kfjii0v0a90vulps48c1h7g");
 

--- a/crates/health/src/sink/mod.rs
+++ b/crates/health/src/sink/mod.rs
@@ -16,17 +16,17 @@
  */
 
 mod composite;
+mod dedup_queue;
 #[cfg(not(feature = "bench-hooks"))]
 pub(crate) mod event_mapper;
 #[cfg(feature = "bench-hooks")]
 pub mod event_mapper;
 mod events;
-mod health_override;
+mod health_report;
 mod log_file;
 pub(crate) mod otlp;
-mod override_queue;
 mod prometheus;
-mod rack_health_override;
+mod rack_health_report;
 mod tracing;
 
 pub use composite::CompositeDataSink;
@@ -34,10 +34,10 @@ pub use events::{
     Classification, CollectorEvent, EventContext, FirmwareInfo, HealthReport, HealthReportAlert,
     HealthReportSuccess, LogRecord, Probe, ReportSource, SensorHealthContext, SensorHealthData,
 };
-pub use health_override::HealthOverrideSink;
+pub use health_report::HealthReportSink;
 pub use log_file::LogFileSink;
 pub use prometheus::PrometheusSink;
-pub use rack_health_override::RackHealthOverrideSink;
+pub use rack_health_report::RackHealthReportSink;
 pub use tracing::TracingSink;
 
 #[cfg(not(feature = "bench-hooks"))]

--- a/crates/health/src/sink/otlp.rs
+++ b/crates/health/src/sink/otlp.rs
@@ -19,15 +19,15 @@ use std::sync::Arc;
 
 use prometheus::Counter;
 
+use super::dedup_queue::DedupQueue;
 use super::event_mapper::RedfishEventMapper;
-use super::override_queue::OverrideQueue;
 use super::{CollectorEvent, DataSink, EventContext};
 use crate::HealthError;
 use crate::config::OtlpSinkConfig;
 use crate::metrics::MetricsManager;
 use crate::otlp::drain::OtlpDrainTask;
 
-pub(crate) type OtlpQueue = OverrideQueue<String, (EventContext, CollectorEvent)>;
+pub(crate) type OtlpQueue = DedupQueue<String, (EventContext, CollectorEvent)>;
 
 #[cfg(not(feature = "bench-hooks"))]
 pub(crate) struct OtlpSink {
@@ -63,7 +63,7 @@ impl OtlpSink {
             HealthError::GenericError(format!("otlp sink requires active tokio runtime: {e}"))
         })?;
 
-        let queue: Arc<OtlpQueue> = Arc::new(OverrideQueue::new());
+        let queue: Arc<OtlpQueue> = Arc::new(DedupQueue::new());
 
         let replaced_total = Counter::new(
             format!("{prefix}_otlp_sink_replaced_total"),
@@ -93,7 +93,7 @@ impl OtlpSink {
 impl OtlpSink {
     pub fn new_for_bench(mapper: Arc<dyn RedfishEventMapper>) -> Self {
         Self {
-            queue: Arc::new(OverrideQueue::new()),
+            queue: Arc::new(DedupQueue::new()),
             replaced_total: Counter::new("bench_replaced", "bench").unwrap(),
             mapper,
         }

--- a/crates/health/src/sink/rack_health_report.rs
+++ b/crates/health/src/sink/rack_health_report.rs
@@ -19,27 +19,27 @@ use std::sync::Arc;
 
 use carbide_uuid::rack::RackId;
 
-use super::override_queue::OverrideQueue;
+use super::dedup_queue::DedupQueue;
 use super::{CollectorEvent, DataSink, EventContext, HealthReport, ReportSource};
 use crate::HealthError;
 use crate::api_client::ApiClientWrapper;
-use crate::config::RackHealthOverrideSinkConfig;
+use crate::config::RackHealthReportSinkConfig;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-struct RackOverrideKey {
+struct RackHealthReportKey {
     id: RackId,
     source: ReportSource,
 }
 
-pub struct RackHealthOverrideSink {
-    queue: Arc<OverrideQueue<RackOverrideKey, Arc<HealthReport>>>,
+pub struct RackHealthReportSink {
+    queue: Arc<DedupQueue<RackHealthReportKey, Arc<HealthReport>>>,
 }
 
-impl RackHealthOverrideSink {
-    pub fn new(config: &RackHealthOverrideSinkConfig) -> Result<Self, HealthError> {
+impl RackHealthReportSink {
+    pub fn new(config: &RackHealthReportSinkConfig) -> Result<Self, HealthError> {
         let handle = tokio::runtime::Handle::try_current().map_err(|error| {
             HealthError::GenericError(format!(
-                "rack health override sink requires active Tokio runtime: {error}"
+                "rack health report sink requires active Tokio runtime: {error}"
             ))
         })?;
 
@@ -50,8 +50,8 @@ impl RackHealthOverrideSink {
             &config.connection.api_url,
         ));
 
-        let queue: Arc<OverrideQueue<RackOverrideKey, Arc<HealthReport>>> =
-            Arc::new(OverrideQueue::new());
+        let queue: Arc<DedupQueue<RackHealthReportKey, Arc<HealthReport>>> =
+            Arc::new(DedupQueue::new());
 
         for worker_id in 0..config.workers {
             let worker_client = Arc::clone(&client);
@@ -70,7 +70,7 @@ impl RackHealthOverrideSink {
                                     ?error,
                                     worker_id,
                                     rack_id = %key.id,
-                                    "Failed to submit rack health override report"
+                                    "Failed to submit rack health report"
                                 );
                             }
                         }
@@ -79,7 +79,7 @@ impl RackHealthOverrideSink {
                                 ?error,
                                 worker_id,
                                 rack_id = %key.id,
-                                "Failed to convert rack health override report"
+                                "Failed to convert rack health report"
                             );
                         }
                     }
@@ -91,9 +91,9 @@ impl RackHealthOverrideSink {
     }
 }
 
-impl DataSink for RackHealthOverrideSink {
+impl DataSink for RackHealthReportSink {
     fn sink_type(&self) -> &'static str {
-        "rack_health_override_sink"
+        "rack_health_report_sink"
     }
 
     fn handle_event(&self, context: &EventContext, event: &CollectorEvent) {
@@ -113,7 +113,7 @@ impl DataSink for RackHealthOverrideSink {
             return;
         };
 
-        let key = RackOverrideKey {
+        let key = RackHealthReportKey {
             id: rack_id.clone(),
             source: report.source,
         };


### PR DESCRIPTION
## Description

This is continuing the work for https://github.com/NVIDIA/ncx-infra-controller-core/issues/995 (and PRs #975, #999, #1015, #1029, #1162, #1165, #1168), and renames "override" things in `crates/health` to be more aligned with "report" or "entry".

Includes `#[serde(alias...)]` tweaks to allow the old config nomenclature to keep working.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

