### PR TITLE
chore(api): relocate use_admin_network onto host-level network_config

### DIFF
--- a/crates/api-db/migrations/20260427214705_host_network_config_use_admin_network.sql
+++ b/crates/api-db/migrations/20260427214705_host_network_config_use_admin_network.sql
@@ -1,0 +1,74 @@
+-- First, introduce a machine_group_member_ids(target_id) helper function.
+--
+-- A "machine group" is the host machine plus all DPU machines attached
+-- to it. Given any one machine ID in the group (whether host or DPU),
+-- this function returns every member's ID.
+--
+-- This is a two step process, where (1) we find the host of the group; if
+-- the target itself is a host, we're good. Otherwise, we'll search via
+-- machine_interfaces to get its host. This of course excludes the DPU's
+-- own self-reference. We now are able to derive that the group is that
+-- given host + every DPU with machine_id = host.id.
+--
+-- ..and then step (2). For a zero DPU host, this finds no DPUs, and the
+-- result is just the host. But for a DPU whose host isn't wired up yet,
+-- we'll fall back to the target_id, resulting in just the DPU -- and
+-- subsequent writes *after* the host is linked will see the full group.
+CREATE OR REPLACE FUNCTION machine_group_member_ids(target_id VARCHAR)
+RETURNS TABLE(id VARCHAR) AS $$
+    WITH host AS (
+        SELECT COALESCE(
+            (SELECT mi.machine_id
+             FROM machine_interfaces mi
+             WHERE mi.attached_dpu_machine_id = target_id
+               AND mi.machine_id != mi.attached_dpu_machine_id
+             LIMIT 1),
+            target_id
+        ) AS id
+    )
+    SELECT id FROM host
+    UNION
+    SELECT mi.attached_dpu_machine_id
+    FROM machine_interfaces mi
+    JOIN host ON mi.machine_id = host.id
+    WHERE mi.attached_dpu_machine_id IS NOT NULL
+      AND mi.machine_id != mi.attached_dpu_machine_id;
+$$ LANGUAGE SQL STABLE;
+
+-- And this is for backfilling use_admin_network onto host rows
+-- as part of the change.
+--
+-- The query walks host DPUs via `machine_interfaces.attached_dpu_machine_id`.
+-- For multi-DPU hosts, the inner subquery's `GROUP BY mi.machine_id`
+-- collapses all of a host's DPU interfaces into a single row, with `bool_and`
+-- aggregating across them; each host gets exactly one updated row regardless
+-- of DPU count.
+--
+-- If the DPUs disagree (shouldn't happen in practice, but just in case) we
+-- pick `false` (tenant), to ensure we don't incorrectly force a tenant-allocated
+-- host "back" to admin. The runtime self-corrects a single DPU back to admin
+-- when it has no tenant interface config (per `!dpu_has_tenant_interface_config`),
+-- so a DPU briefly seeing `false` for a host that should really be `true`
+-- recovers transparently.
+--
+-- Zero-DPU hosts have no attached DPU to copy from; their network_config
+-- default is `use_admin_network: true`, so no backfill is needed for them.
+UPDATE machines AS hosts
+SET network_config = jsonb_set(
+    hosts.network_config,
+    '{use_admin_network}',
+    to_jsonb(backfill.flag),
+    true
+)
+FROM (
+    SELECT mi.machine_id AS host_id,
+           bool_and(
+               COALESCE((dpu_m.network_config->>'use_admin_network')::bool, true)
+           ) AS flag
+    FROM machine_interfaces mi
+    JOIN machines dpu_m ON dpu_m.id = mi.attached_dpu_machine_id
+    WHERE mi.attached_dpu_machine_id IS NOT NULL
+      AND mi.attached_dpu_machine_id != mi.machine_id
+    GROUP BY mi.machine_id
+) AS backfill
+WHERE hosts.id = backfill.host_id;

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -22,6 +22,7 @@ use std::net::IpAddr;
 use std::ops::Deref;
 use std::str::FromStr;
 
+use carbide_uuid::dpa_interface::DpaInterfaceId;
 use carbide_uuid::instance_type::InstanceTypeId;
 use carbide_uuid::machine::{MachineId, MachineType};
 use chrono::{DateTime, Utc};
@@ -695,6 +696,26 @@ pub async fn lookup_host_machine_ids_by_dpu_ids(
         .map_err(|e| DatabaseError::query(query, e))
 }
 
+/// Returns the `use_admin_network` flag from the host that owns the
+/// given DPA interface.
+pub async fn get_host_use_admin_network_for_dpa_interface(
+    conn: impl DbReader<'_>,
+    dpa_interface_id: &DpaInterfaceId,
+) -> Result<bool, DatabaseError> {
+    let query = r#"
+        SELECT COALESCE((h.network_config->>'use_admin_network')::bool, true)
+        FROM dpa_interfaces da
+        JOIN machines h ON h.id = da.machine_id
+        WHERE da.id = $1
+        LIMIT 1"#;
+    let flag: Option<bool> = sqlx::query_scalar(query)
+        .bind(dpa_interface_id)
+        .fetch_optional(conn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+    Ok(flag.unwrap_or(true))
+}
+
 pub async fn find_dpus_by_host_machine_id(
     txn: &mut PgConnection,
     host_machine_id: &MachineId,
@@ -1083,34 +1104,59 @@ pub async fn force_cleanup(
     Ok(())
 }
 
-/// Updates the desired network configuration for a host
+/// Updates the `network_config` on the target machine row (host or
+/// DPU), and bumps the `network_config_version` on *every* machine
+/// row in the same "machine group" (host + every DPU attached to it)
+/// to the same new version, so all rows in the group stay version-equal.
+///
+/// The caller can pass any machine ID in the group; group membership is
+/// computed by the `machine_group_member_ids` Postgres function, which
+/// walks `machine_interfaces`. For zero-DPU hosts, the group is just the
+/// target itself.
 pub async fn try_update_network_config(
     txn: &mut PgConnection,
     machine_id: &MachineId,
     expected_version: ConfigVersion,
     new_state: &ManagedHostNetworkConfig,
 ) -> Result<bool, DatabaseError> {
-    // TODO: We currently need to persist the state on the DPU since it exists
-    // earlier than the host. But we might want to replicate it to the host machine,
-    // as we do with `controller_state`.
-
     let next_version = expected_version.increment();
 
-    let query = "UPDATE machines SET network_config_version=$1, network_config=$2::json
+    // First, do our usual "optimistic" lock update on the target row, which
+    // writes content and bumps to the next_version (which is conditional on
+    // the row currently being at `expected_version`).
+    let target_query = "UPDATE machines SET network_config_version=$1, network_config=$2::json
             WHERE id=$3 AND network_config_version=$4
             RETURNING id";
-    let query_result: Result<MachineId, _> = sqlx::query_as(query)
+    let target_result: Result<MachineId, _> = sqlx::query_as(target_query)
         .bind(next_version)
         .bind(sqlx::types::Json(new_state))
         .bind(machine_id)
         .bind(expected_version)
-        .fetch_one(txn)
+        .fetch_one(&mut *txn)
         .await;
 
-    match query_result {
-        Ok(_machine_id) => Ok(true),
+    match target_result {
+        Ok(_) => {
+            // ..and if the version bumped, THEN bump every other machine row
+            // in the "machine group" to the same new version. This is where
+            // we pull in the `machine_group_member_ids` Postgres function.
+            let group_query = r#"
+                UPDATE machines
+                SET network_config_version = $1
+                WHERE id != $2
+                  AND id IN (SELECT id FROM machine_group_member_ids($2))
+            "#;
+
+            sqlx::query(group_query)
+                .bind(next_version)
+                .bind(machine_id)
+                .execute(&mut *txn)
+                .await
+                .map_err(|e| DatabaseError::query(group_query, e))?;
+            Ok(true)
+        }
         Err(sqlx::Error::RowNotFound) => Ok(false),
-        Err(e) => Err(DatabaseError::query(query, e)),
+        Err(e) => Err(DatabaseError::query(target_query, e)),
     }
 }
 

--- a/crates/api-model/src/dpa_interface/mod.rs
+++ b/crates/api-model/src/dpa_interface/mod.rs
@@ -380,10 +380,6 @@ impl TryFrom<rpc::forge::DpaInterfaceCreationRequest> for NewDpaInterface {
 }
 
 impl DpaInterface {
-    pub fn use_admin_network(&self) -> bool {
-        self.network_config.use_admin_network.unwrap_or(true)
-    }
-
     pub fn get_machine_id(&self) -> MachineId {
         self.machine_id
     }
@@ -391,12 +387,6 @@ impl DpaInterface {
     pub fn managed_host_network_config_version_synced(&self) -> bool {
         let dpa_expected_version = self.network_config.version;
         let dpa_observation = self.network_status_observation.as_ref();
-
-        if self.use_admin_network()
-            && self.controller_state.value == DpaInterfaceControllerState::Provisioning
-        {
-            return true;
-        }
 
         let dpa_observed_version: ConfigVersion = match dpa_observation {
             Some(network_status) => match network_status.network_config_version {

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -276,24 +276,6 @@ fn pick_boot_interface_mac(
         .map(|x| x.mac_address)
 }
 
-/// Derive a host-level `use_admin_network` from the per-DPU values for
-/// the host.
-///
-/// Split out from `ManagedHostStateSnapshot::use_admin_network` so it's
-/// more easily testable without building a full snapshot. The way this works is:
-/// - True when an empty slice (e.g. zero-DPU host or snapshots failed to load),
-///   because zero DPU hosts have no DPU to handle tenant overlay (and
-///   are always admin). In the snapshot failure case, it seemed more
-///   conservative to treat it as such.
-/// - Otherwise, walk across all of the use_admin_network values from the
-///   hosts DPU(s) and collect their values, defaulting to true otherwise.
-fn derive_use_admin_network(dpu_use_admin_network: &[Option<bool>]) -> bool {
-    dpu_use_admin_network.is_empty()
-        || dpu_use_admin_network
-            .iter()
-            .any(|flag| flag.unwrap_or(true))
-}
-
 impl ManagedHostStateSnapshot {
     /// Returns `true` if this managed host has no DPU snapshots attached.
     ///
@@ -330,28 +312,15 @@ impl ManagedHostStateSnapshot {
     /// Returns `true` if this managed host is currently operating on the
     /// admin network (rather than a tenant overlay).
     ///
-    /// The underlying `use_admin_network` flag is persisted per-DPU on
-    /// `ManagedHostNetworkConfig` (fwiw, the config is generic, but
-    /// site-explorer and the machine state controller only populate this
-    /// for DPUs. Default is true.
-    ///
     /// Zero-DPU hosts always return `true`, because there's no DPU to
     /// handle tenant overlay networking. This allows consumers like the
     /// IB and NVLink partition monitors to treat the host as admin-only
     /// and detach.
-    ///
-    /// Now, this helper doesn't change where the *flag* is stored. I'm
-    /// planning on doing that in a future PR, but it will be a bit more
-    /// disruptive. It may end up going into the host's network_config,
-    /// allowing us to drop the per-DPU copies, and then this helper can
-    /// just read the host's config value directly.
     pub fn use_admin_network(&self) -> bool {
-        let dpu_use_admin_network: Vec<_> = self
-            .dpu_snapshots
-            .iter()
-            .map(|dpu| dpu.network_config.use_admin_network)
-            .collect();
-        derive_use_admin_network(&dpu_use_admin_network)
+        self.host_snapshot
+            .network_config
+            .use_admin_network
+            .unwrap_or(true)
     }
 
     /// Returns the MAC address the host should boot from, if one can be
@@ -598,6 +567,12 @@ impl ManagedHostStateSnapshot {
 
     /// Returns true if the desired managedhost networking configuration had been synced
     /// to **all** DPUs.
+    ///
+    /// Each DPU's check compares its own `network_config.version` against its
+    /// reported observation; per-DPU versions are kept equal to the host's via
+    /// its "machine group" (and `try_update_network_config`), so a change
+    /// anywhere in the machine group flips all per-DPU sync states to out of
+    /// sync until each agent has polled + re-sent an observation.
     pub fn managed_host_network_config_version_synced(&self) -> bool {
         for dpu_snapshot in self.dpu_snapshots.iter() {
             if !dpu_snapshot.managed_host_network_config_version_synced() {
@@ -990,10 +965,6 @@ impl Machine {
             Some(hw) => hw.bmc_vendor(),
             None => bmc_vendor::BMCVendor::Unknown,
         }
-    }
-
-    pub fn use_admin_network(&self) -> bool {
-        self.network_config.use_admin_network.unwrap_or(true)
     }
 
     /// Does the forge-dpu-agent on this DPU need upgrading?
@@ -3413,36 +3384,6 @@ mod tests {
         )];
 
         assert_eq!(pick_boot_interface_mac(&interfaces), None);
-    }
-
-    // Zero-DPU hosts have no DPU snapshots at all. The helper must return
-    // `true` -- consumers (IB partition monitor, NVLink partition monitor)
-    // use this to decide whether to detach tenant partitions, and zero-DPU
-    // hosts never have a tenant overlay to protect.
-    #[test]
-    fn derive_use_admin_network_returns_true_for_empty_dpu_snapshots() {
-        assert!(derive_use_admin_network(&[]));
-    }
-
-    // Make sure the legacy default still works; when a DPU snapshot has no
-    // explicit value, treat it as admin-network. All or any "None" should
-    // therefore resolve to true.
-    #[test]
-    fn derive_use_admin_network_treats_none_as_true() {
-        assert!(derive_use_admin_network(&[None]));
-        assert!(derive_use_admin_network(&[None, None]));
-    }
-
-    // ...aand check OR semantics across DPUs: if any single DPU says admin,
-    // the whole host is treated as admin. Only "all DPUs explicitly say false"
-    // flips the host to tenant-network mode.
-    #[test]
-    fn derive_use_admin_network_ors_across_dpus() {
-        assert!(derive_use_admin_network(&[Some(false), Some(true)]));
-        assert!(derive_use_admin_network(&[Some(true), Some(true)]));
-        assert!(derive_use_admin_network(&[Some(false), None]));
-        assert!(!derive_use_admin_network(&[Some(false)]));
-        assert!(!derive_use_admin_network(&[Some(false), Some(false)]));
     }
 }
 

--- a/crates/api-model/src/machine/network.rs
+++ b/crates/api-model/src/machine/network.rs
@@ -250,6 +250,11 @@ impl From<MachineNetworkStatusObservation> for rpc::DpuNetworkStatus {
 pub struct ManagedHostNetworkConfig {
     pub loopback_ip: Option<IpAddr>,
     pub secondary_overlay_vtep_ip: Option<IpAddr>,
+    /// This is a host-level field of the "consolidated" network
+    /// config served to all [DPU] agents within host machine group.
+    /// This is set in the config for the host-specific row in the
+    /// database, and we use it as a base layer of sorts for then
+    /// merging in DPU-specific configs.
     pub use_admin_network: Option<bool>,
     pub quarantine_state: Option<ManagedHostQuarantineState>,
 }

--- a/crates/api/src/handlers/dpu.rs
+++ b/crates/api/src/handlers/dpu.rs
@@ -52,6 +52,20 @@ use crate::{CarbideError, cfg, ethernet_virtualization};
 /// same subnet. It handles the encapsulation into VXLAN and VNI for cross-host comms.
 const HBN_SINGLE_VLAN_DEVICE: &str = "vxlan48";
 
+/// Consolidates host-level and DPU-level `ManagedHostNetworkConfig` into
+/// the single proto sent to `carbide-dpu-agent`. The host layer
+/// contributes shared fields (e.g. `use_admin_network`); the DPU layer
+/// contributes per-DPU fields (e.g. `loopback_ip`).
+fn build_consolidated_network_config(
+    host_network_config: &model::machine::network::ManagedHostNetworkConfig,
+    dpu_loopback_ip: IpAddr,
+) -> rpc::ManagedHostNetworkConfig {
+    rpc::ManagedHostNetworkConfig {
+        loopback_ip: dpu_loopback_ip.to_string(),
+        quarantine_state: host_network_config.quarantine_state.clone().map(Into::into),
+    }
+}
+
 pub(crate) async fn get_managed_host_network_config_inner(
     api: &Api,
     dpu_machine_id: MachineId,
@@ -149,10 +163,10 @@ pub(crate) async fn get_managed_host_network_config_inner(
                     })
             });
 
-    // If there is an instance, the state machine sets all DPUs to be on the tenant network.  But if there are
-    // no interfaces configured for this DPU, then override and put it back on the admin network.  This will
-    // prevent the host from using the DPU at all.
-    let use_admin_network = dpu_snapshot.use_admin_network() || !dpu_has_tenant_interface_config;
+    // If there is an instance, the state machine sets the host to tenant
+    // network. But if no interfaces are configured for this DPU, override
+    // and keep it on admin. This prevents the host from using the DPU at all.
+    let use_admin_network = snapshot.use_admin_network() || !dpu_has_tenant_interface_config;
 
     let mut network_virtualization_type = VpcVirtualizationType::EthernetVirtualizer;
 
@@ -439,15 +453,10 @@ pub(crate) async fn get_managed_host_network_config_inner(
         }
     };
 
-    let network_config = rpc::ManagedHostNetworkConfig {
-        loopback_ip: loopback_ip.to_string(),
-        quarantine_state: snapshot
-            .host_snapshot
-            .network_config
-            .quarantine_state
-            .clone()
-            .map(Into::into),
-    };
+    let network_config = build_consolidated_network_config(
+        &snapshot.host_snapshot.network_config.value,
+        loopback_ip,
+    );
 
     let asn = if network_virtualization_type == VpcVirtualizationType::Fnn {
         dpu_snapshot.asn.ok_or_else(|| {
@@ -612,7 +621,11 @@ pub(crate) async fn get_managed_host_network_config_inner(
         },
         site_global_vpc_vni: api.runtime_config.site_global_vpc_vni,
         managed_host_config: Some(network_config),
-        managed_host_config_version: dpu_snapshot.network_config.version.version_string(),
+        managed_host_config_version: snapshot
+            .host_snapshot
+            .network_config
+            .version
+            .version_string(),
         use_admin_network,
         admin_interface: Some(admin_interface_rpc),
         tenant_interfaces,
@@ -1268,4 +1281,72 @@ pub(crate) async fn get_bgp_password(
             });
         }
     })
+}
+
+#[cfg(test)]
+mod consolidated_network_config_tests {
+    use std::net::Ipv4Addr;
+
+    use model::machine::network::{
+        ManagedHostNetworkConfig, ManagedHostQuarantineMode, ManagedHostQuarantineState,
+    };
+
+    use super::*;
+
+    fn dpu_ip() -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))
+    }
+
+    // The DPU layer contributes loopback_ip; an empty host layer leaves
+    // quarantine_state absent.
+    #[test]
+    fn dpu_loopback_ip_carries_through_with_empty_host_layer() {
+        let host = ManagedHostNetworkConfig::default();
+        let consolidated = build_consolidated_network_config(&host, dpu_ip());
+        assert_eq!(consolidated.loopback_ip, "10.0.0.1");
+        assert!(consolidated.quarantine_state.is_none());
+    }
+
+    // The host layer contributes quarantine_state when set; the DPU layer
+    // still owns loopback_ip independently.
+    #[test]
+    fn host_quarantine_state_carries_through_alongside_dpu_loopback() {
+        let host = ManagedHostNetworkConfig {
+            quarantine_state: Some(ManagedHostQuarantineState {
+                reason: Some("test".to_string()),
+                mode: ManagedHostQuarantineMode::BlockAllTraffic,
+            }),
+            ..ManagedHostNetworkConfig::default()
+        };
+        let consolidated = build_consolidated_network_config(&host, dpu_ip());
+        assert_eq!(consolidated.loopback_ip, "10.0.0.1");
+        let qs = consolidated.quarantine_state.expect("quarantine_state");
+        assert_eq!(qs.reason.as_deref(), Some("test"));
+    }
+
+    // Host-layer fields that aren't part of the consolidated proto shape
+    // (loopback_ip on the host, secondary_overlay_vtep_ip, use_admin_network)
+    // do NOT leak into the response -- the consolidator deliberately picks
+    // only quarantine_state from the host layer. Catches accidental changes
+    // to that contract.
+    #[test]
+    fn host_layer_fields_outside_the_consolidated_shape_are_ignored() {
+        let host = ManagedHostNetworkConfig {
+            // loopback_ip on the host's row is meaningless and shouldn't
+            // be served to the DPU agent -- the DPU's own loopback_ip
+            // (passed separately) is what matters.
+            loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 99))),
+            secondary_overlay_vtep_ip: Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 100))),
+            // The host-level use_admin_network is reported in a separate
+            // top-level response field, not in this consolidated struct.
+            use_admin_network: Some(false),
+            quarantine_state: None,
+        };
+        let consolidated = build_consolidated_network_config(&host, dpu_ip());
+        assert_eq!(
+            consolidated.loopback_ip, "10.0.0.1",
+            "consolidator must use the dpu_loopback_ip arg, not host.loopback_ip"
+        );
+        assert!(consolidated.quarantine_state.is_none());
+    }
 }

--- a/crates/api/src/handlers/machine_discovery.rs
+++ b/crates/api/src/handlers/machine_discovery.rs
@@ -208,8 +208,7 @@ pub(crate) async fn discover_machine(
             })?
         };
 
-        let (network_config, _version) = db_machine.network_config.clone().take();
-        if network_config.loopback_ip.is_none() {
+        if db_machine.network_config.loopback_ip.is_none() {
             let loopback_ip = db::machine::allocate_loopback_ip(
                 &api.common_pools,
                 &mut txn,
@@ -217,13 +216,12 @@ pub(crate) async fn discover_machine(
             )
             .await?;
 
-            let (mut network_config, version) = db_machine.network_config.clone().take();
+            let mut network_config = db_machine.network_config.value.clone();
             network_config.loopback_ip = Some(loopback_ip);
-            network_config.use_admin_network = Some(true);
             db::machine::try_update_network_config(
                 &mut txn,
                 &stable_machine_id,
-                version,
+                db_machine.network_config.version,
                 &network_config,
             )
             .await?;
@@ -235,7 +233,10 @@ pub(crate) async fn discover_machine(
             .as_ref()
             .map(|vc| vc.secondary_overlay_support)
             .unwrap_or_default()
-            && network_config.secondary_overlay_vtep_ip.is_none()
+            && db_machine
+                .network_config
+                .secondary_overlay_vtep_ip
+                .is_none()
         {
             let secondary_vtep_ip = db::machine::allocate_secondary_vtep_ip(
                 &api.common_pools,
@@ -244,13 +245,12 @@ pub(crate) async fn discover_machine(
             )
             .await?;
 
-            let (mut network_config, version) = db_machine.network_config.clone().take();
+            let mut network_config = db_machine.network_config.value.clone();
             network_config.secondary_overlay_vtep_ip = Some(secondary_vtep_ip);
-            network_config.use_admin_network = Some(true);
             db::machine::try_update_network_config(
                 &mut txn,
                 &stable_machine_id,
-                version,
+                db_machine.network_config.version,
                 &network_config,
             )
             .await?;

--- a/crates/api/src/state_controller/dpa_interface/handler.rs
+++ b/crates/api/src/state_controller/dpa_interface/handler.rs
@@ -77,12 +77,19 @@ impl StateHandler for DpaInterfaceStateHandler {
 
         let dpa_info = ctx.services.dpa_info.clone().unwrap();
 
+        // DPAs follow the host-level `use_admin_network`.
+        let host_use_admin_network = db::machine::get_host_use_admin_network_for_dpa_interface(
+            &ctx.services.db_pool,
+            &state.id,
+        )
+        .await?;
+
         match controller_state {
             DpaInterfaceControllerState::Provisioning => {
                 // New DPA objects start off in the Provisioning state.
                 // They stay in that state until the first time the machine
                 // starts a transition from Ready to Assigned state.
-                if state.use_admin_network() {
+                if host_use_admin_network {
                     return Ok(StateHandlerOutcome::do_nothing());
                 }
 
@@ -102,7 +109,7 @@ impl StateHandler for DpaInterfaceStateHandler {
                     .clone()
                     .ok_or_else(|| StateHandlerError::GenericError(eyre!("Missing mqtt_client")))?;
 
-                if !state.use_admin_network() {
+                if !host_use_admin_network {
                     let new_state = DpaInterfaceControllerState::Unlocking;
                     tracing::info!(state = ?new_state, "Dpa Interface state transition");
 
@@ -249,7 +256,7 @@ impl StateHandler for DpaInterfaceStateHandler {
                     .clone()
                     .ok_or_else(|| StateHandlerError::GenericError(eyre!("Missing mqtt_client")))?;
 
-                if state.use_admin_network() {
+                if host_use_admin_network {
                     let new_state = DpaInterfaceControllerState::WaitingForResetVNI;
                     tracing::info!(state = ?new_state, "Dpa Interface state transition");
                     let txn = send_set_vni_command(
@@ -331,7 +338,7 @@ async fn do_heartbeat<'a>(
     if let Some(next_hb_time) = state.last_hb_time.checked_add_signed(hb_interval)
         && chrono::Utc::now() >= next_hb_time
     {
-        send_hb = true; // heartbeat interval elapsed since the last heartbeat 
+        send_hb = true; // heartbeat interval elapsed since the last heartbeat
     }
 
     if !state.managed_host_network_config_version_synced() {

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -45,6 +45,7 @@ use libredfish::{Boot, EnabledDisabled, PowerState, Redfish, RedfishError, Syste
 use machine_validation::{handle_machine_validation_requested, handle_machine_validation_state};
 use measured_boot::records::MeasurementMachineState;
 use model::DpuModel;
+use model::dpa_interface::DpaInterfaceControllerState;
 use model::firmware::{Firmware, FirmwareComponentType, FirmwareEntry};
 use model::instance::InstanceNetworkSyncStatus;
 use model::instance::config::network::{
@@ -801,6 +802,27 @@ impl MachineStateHandler {
 
                     // Clear if any reprovision (dpu or host) is set due to race scenario.
                     Self::clear_host_update_alert_and_reprov(mh_snapshot, &mut txn).await?;
+
+                    // Flip the host onto the tenant network. Setting
+                    // `use_admin_network = false` on the host row goes through
+                    // `try_update_network_config`, which fans the version bump out
+                    // to every DPU in the host machine group -- each DPU's sync state
+                    // then flips to "out of sync" until its agent has polled, applied,
+                    // and reported the new version. State-machine waits (e.g.
+                    // WaitingForNetworkReconfig, WaitingForNetworkSegmentToBeReady)
+                    // gate on that. DPAs follow the same flag (read host-level via the
+                    // snapshot), but use a separate per-interface ack mechanism for
+                    // SetVNI commands.
+                    let host_version = mh_snapshot.host_snapshot.network_config.version;
+                    let mut host_netconf = mh_snapshot.host_snapshot.network_config.value.clone();
+                    host_netconf.use_admin_network = Some(false);
+                    db::machine::try_update_network_config(
+                        &mut txn,
+                        &mh_snapshot.host_snapshot.id,
+                        host_version,
+                        &host_netconf,
+                    )
+                    .await?;
 
                     let mut next_state = ManagedHostState::Assigned {
                         instance_state: InstanceState::DpaProvisioning,
@@ -5819,33 +5841,31 @@ impl StateHandler for InstanceStateHandler {
                 }
 
                 InstanceState::SwitchToAdminNetwork => {
-                    // Tenant is gone and so is their network, switch back to admin network
+                    // Tenant is gone, switch back to admin by setting `use_admin_network`
+                    // to true on the host-level config, which, just like in the other
+                    // direction, version bumps the entire machine group (host + DPUs),
+                    // so they report "out of sync" until agents poll + apply + report,
+                    // where WaitingForNetworkReconfig waits on that.
                     let mut txn = ctx.services.db_pool.begin().await?;
-                    for dpu_snapshot in &mh_snapshot.dpu_snapshots {
-                        let (mut netconf, version) = dpu_snapshot.network_config.clone().take();
-                        netconf.use_admin_network = Some(true);
-                        db::machine::try_update_network_config(
-                            &mut txn,
-                            &dpu_snapshot.id,
-                            version,
-                            &netconf,
-                        )
-                        .await?;
-                    }
+                    let host_version = mh_snapshot.host_snapshot.network_config.version;
+                    let mut host_netconf = mh_snapshot.host_snapshot.network_config.value.clone();
+                    host_netconf.use_admin_network = Some(true);
+                    db::machine::try_update_network_config(
+                        &mut txn,
+                        &mh_snapshot.host_snapshot.id,
+                        host_version,
+                        &host_netconf,
+                    )
+                    .await?;
 
-                    // Machine is currently an instance, but the instance is being released and we
-                    // are switching the NICs to the admin network. Set use_admin_network to true
-                    // and update the network config version in the DPA interfaces. This will cause
-                    // the DPA State Controller to send SetVNI commands with the VNI being zero.
+                    // Bump each DPA interface's config version so the DPA State Controller
+                    // re-evaluates and sends SetVNI commands with VNI zero.
                     for dpa_interface in &mh_snapshot.dpa_interface_snapshots {
-                        let (mut netconf, version) = dpa_interface.network_config.clone().take();
-                        netconf.use_admin_network = Some(true);
-                        let dpa_interface_id = dpa_interface.id;
                         db::dpa_interface::try_update_network_config(
                             &mut txn,
-                            &dpa_interface_id,
-                            version,
-                            &netconf,
+                            &dpa_interface.id,
+                            dpa_interface.network_config.version,
+                            &dpa_interface.network_config.value,
                         )
                         .await?;
                     }
@@ -5895,6 +5915,16 @@ impl StateHandler for InstanceStateHandler {
                     // its network config (setting VNI to zero in this case).
                     if ctx.services.site_config.is_dpa_enabled() {
                         for dpa_interface in &mh_snapshot.dpa_interface_snapshots {
+                            // We're heading back to admin and a DPA still in
+                            // Provisioning has nothing to ack -- it never
+                            // applied a tenant-network SetVNI in the first
+                            // place. Treat it as trivially synced so we don't
+                            // block the state machine on uninitialized DPAs.
+                            if dpa_interface.controller_state.value
+                                == DpaInterfaceControllerState::Provisioning
+                            {
+                                continue;
+                            }
                             if !dpa_interface.managed_host_network_config_version_synced() {
                                 return Ok(StateHandlerOutcome::wait(
                                             "Waiting for DPA agent(s) to apply network config and report healthy network"
@@ -6091,23 +6121,19 @@ impl StateHandler for InstanceStateHandler {
                     .await
                 }
                 InstanceState::DpaProvisioning => {
-                    // An instance is being created.
-                    // So we set use_admin_network to false and tell each DPA interface to
-                    // update its network config. This will cause the DPA state controller
-                    // to transition to the DPAs from READY state to WaitingForSetVNI state
-                    // and send SetVNI commands to the DPA NICs.
-
+                    // An instance is being created. The host was already flipped
+                    // to tenant network in the Ready -> Assigned transition; here
+                    // we just bump each DPA interface's config version so the
+                    // DPA state controller re-evaluates with the new host value
+                    // (READY -> WaitingForSetVNI, triggering SetVNI).
                     let mut txn = ctx.services.db_pool.begin().await?;
                     if ctx.services.site_config.is_dpa_enabled() {
                         for dpa_interface in &mh_snapshot.dpa_interface_snapshots {
-                            let (mut netconf, version) =
-                                dpa_interface.network_config.clone().take();
-                            netconf.use_admin_network = Some(false);
                             db::dpa_interface::try_update_network_config(
                                 &mut txn,
                                 &dpa_interface.id,
-                                version,
-                                &netconf,
+                                dpa_interface.network_config.version,
+                                &dpa_interface.network_config.value,
                             )
                             .await?;
                         }
@@ -6133,24 +6159,14 @@ impl StateHandler for InstanceStateHandler {
                         }
                     }
 
-                    // Switch to using the network we just created for the tenant
-                    let mut txn = ctx.services.db_pool.begin().await?;
-                    for dpu_snapshot in &mh_snapshot.dpu_snapshots {
-                        let (mut netconf, version) = dpu_snapshot.network_config.clone().take();
-                        netconf.use_admin_network = Some(false);
-                        db::machine::try_update_network_config(
-                            &mut txn,
-                            &dpu_snapshot.id,
-                            version,
-                            &netconf,
-                        )
-                        .await?;
-                    }
-
+                    // The host was already flipped to tenant network in the
+                    // Ready -> Assigned transition; that write fanned out via
+                    // `try_update_network_config`'s group sync to bump every
+                    // DPU's version too, so no DPU bumps are needed here.
                     let next_state = ManagedHostState::Assigned {
                         instance_state: InstanceState::WaitingForNetworkSegmentToBeReady,
                     };
-                    Ok(StateHandlerOutcome::transition(next_state).with_txn(txn))
+                    Ok(StateHandlerOutcome::transition(next_state))
                 }
             }
         } else {

--- a/crates/api/src/tests/machine_network.rs
+++ b/crates/api/src/tests/machine_network.rs
@@ -173,12 +173,12 @@ async fn test_managed_host_network_config_multi_dpu(pool: sqlx::PgPool) {
         .expect("Error getting DPU1 network config")
         .into_inner();
 
-    // Assert: They should not have the same config version, since the managed_host_config_version
-    // represents the health of that particular DPU.
-    assert!(
-        dpu_1_network_config
-            .managed_host_config_version
-            .ne(&dpu_2_network_config.managed_host_config_version)
+    // Assert: Both DPUs report the same managed_host_config_version, because
+    // it's the host's network_config_version and group-sync keeps every member
+    // of the host's machine group at the same version.
+    assert_eq!(
+        dpu_1_network_config.managed_host_config_version,
+        dpu_2_network_config.managed_host_config_version,
     );
 }
 

--- a/crates/api/src/tests/machine_states.rs
+++ b/crates/api/src/tests/machine_states.rs
@@ -74,6 +74,138 @@ use crate::tests::common::api_fixtures::{
     on_demand_machine_validation, update_time_params,
 };
 
+// Verify the group-sync property of `db::machine::try_update_network_config`,
+// where any write to a row in the host's group (the host or any of its DPUs)
+// updates that row's content + version, AND fans the version bump out to every
+// other row in the "group", after which, the host + all of its DPUs network
+// config version are the same.
+#[crate::sqlx_test]
+async fn test_managed_host_network_config_group_sync(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+
+    // After ingestion brings the host to Ready, network_configured fixture
+    // calls have caught DPU observations up to their (per-DPU) expected
+    // versions, so sync is true at this point.
+    let mut txn = env.db_txn().await;
+    let snapshot = mh.snapshot(&mut txn).await;
+    assert!(
+        snapshot.managed_host_network_config_version_synced(),
+        "sync should be true after ingestion brings DPU observations up to expected version"
+    );
+
+    // Bump the HOST's network_config (write the same content back). The
+    // group-sync helper should also bump each DPU's version to the same
+    // new value.
+    let host_before = mh.host().db_machine(&mut txn).await;
+    db::machine::try_update_network_config(
+        txn.as_mut(),
+        &mh.id,
+        host_before.network_config.version,
+        &host_before.network_config.value,
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    let mut txn = env.db_txn().await;
+    let host_after_host_write = mh.host().db_machine(&mut txn).await;
+    let dpu_after_host_write = mh.dpu().db_machine(&mut txn).await;
+    assert_eq!(
+        host_after_host_write.network_config.version, dpu_after_host_write.network_config.version,
+        "group-sync: DPU's version should match host's after a host write"
+    );
+    assert_ne!(
+        host_after_host_write.network_config.version, host_before.network_config.version,
+        "host's version should have advanced"
+    );
+
+    // Sync should now be false; the DPU's expected has bumped (via the
+    // machine group bump), but its observation still reports the older
+    // version.
+    let snapshot = mh.snapshot(&mut txn).await;
+    assert!(
+        !snapshot.managed_host_network_config_version_synced(),
+        "sync should be false after the group bump until the DPU agent reports the new version"
+    );
+    txn.commit().await.unwrap();
+
+    // Simulate the DPU agent polling, applying, and reporting back.
+    common::api_fixtures::network_configured(&env, &mh.dpu_ids).await;
+    let mut txn = env.db_txn().await;
+    let snapshot = mh.snapshot(&mut txn).await;
+    assert!(
+        snapshot.managed_host_network_config_version_synced(),
+        "sync should flip back to true after the agent reports the new version"
+    );
+
+    // And now the converse direction -- bump a DPU's row (the shape of
+    // machine_discovery's loopback_ip allocation). The group-sync helper
+    // fans that bump out to the host's row too, keeping versions equal.
+    let dpu_before_dpu_write = mh.dpu().db_machine(&mut txn).await;
+    db::machine::try_update_network_config(
+        txn.as_mut(),
+        &dpu_before_dpu_write.id,
+        dpu_before_dpu_write.network_config.version,
+        &dpu_before_dpu_write.network_config.value,
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    let mut txn = env.db_txn().await;
+    let host_after_dpu_write = mh.host().db_machine(&mut txn).await;
+    let dpu_after_dpu_write = mh.dpu().db_machine(&mut txn).await;
+    assert_eq!(
+        host_after_dpu_write.network_config.version, dpu_after_dpu_write.network_config.version,
+        "group-sync: host's version should match DPU's after a DPU write"
+    );
+
+    // Sync flips to false again, since the DPU's expected just advanced
+    // beyond what it most recently observed.
+    let snapshot = mh.snapshot(&mut txn).await;
+    assert!(
+        !snapshot.managed_host_network_config_version_synced(),
+        "sync should be false after a DPU-row write bumps the group"
+    );
+}
+
+// A freshly-created host defaults to admin (`use_admin_network` = true);
+// flipping the host-level `network_config.use_admin_network` to false
+// must be reflected by `ManagedHostStateSnapshot::use_admin_network()`.
+#[crate::sqlx_test]
+async fn test_use_admin_network_reads_host_network_config(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+
+    let mut txn = env.db_txn().await;
+    let snapshot = mh.snapshot(&mut txn).await;
+    assert!(
+        snapshot.use_admin_network(),
+        "fresh host should default to admin network"
+    );
+
+    let host = mh.host().db_machine(&mut txn).await;
+    let mut netconf = host.network_config.value.clone();
+    netconf.use_admin_network = Some(false);
+    db::machine::try_update_network_config(
+        txn.as_mut(),
+        &mh.id,
+        host.network_config.version,
+        &netconf,
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    let mut txn = env.db_txn().await;
+    let snapshot = mh.snapshot(&mut txn).await;
+    assert!(
+        !snapshot.use_admin_network(),
+        "host with network_config.use_admin_network=false should report tenant"
+    );
+}
+
 #[crate::sqlx_test]
 async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
     let env = create_test_env(pool).await;

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -174,7 +174,7 @@ impl MachineCreator {
             let dpu_machine_id = *dpu_report.machine_id_if_valid_report()?;
             dpu_ids.push(dpu_machine_id);
 
-            if !self.create_dpu(&mut txn, dpu_report).await? {
+            let Some(dpu_machine) = self.create_dpu(&mut txn, dpu_report).await? else {
                 // Site explorer has already created a machine for this DPU previously.
                 //
                 // If the DPU's machine is not attached to its machine interface, do so here.
@@ -183,12 +183,19 @@ impl MachineCreator {
                     txn.commit().await?;
                 }
                 return Ok(false);
-            }
+            };
 
             let host_machine_id = self
                 .attach_dpu_to_host(&mut txn, &managed_host, dpu_report, machine_data)
                 .await?;
-            managed_host.machine_id = Some(host_machine_id)
+            managed_host.machine_id = Some(host_machine_id);
+
+            // Now that the host link exists in machine_interfaces, the
+            // machine group syncing in try_update_network_config keeps this
+            // DPU verison bump in sync with the host-level version (and any
+            // sibling DPUs already linked) network_config_version.
+            self.update_dpu_network_config(&mut txn, &dpu_machine)
+                .await?;
         }
 
         // Now since all DPUs are created, update host and DPUs state correctly.
@@ -407,24 +414,29 @@ impl MachineCreator {
     }
 
     // create_dpu does everything needed to create a DPU as part of a newly discovered managed host.
-    // If the DPU does not exist in the machines table, the function creates a new DPU machine and configures it appropriately. create_dpu returns true.
-    // If the DPU already exists in the machines table, this is a no-op. create_dpu returns false.
+    // If the DPU does not exist in the machines table, the function creates a new DPU machine and
+    // configures it appropriately, returning the new `Machine`.
+    // If the DPU already exists in the machines table, this is a no-op and returns `None`.
+    //
+    // The DPU's `network_config` is intentionally NOT written here -- the caller writes it after
+    // `attach_dpu_to_host` has wired the host link in `machine_interfaces`, so that
+    // `try_update_network_config`'s group sync observes both rows as siblings and keeps their
+    // versions equal.
     async fn create_dpu(
         &self,
         txn: &mut PgConnection,
         explored_dpu: &ExploredDpu,
-    ) -> SiteExplorerResult<bool> {
+    ) -> SiteExplorerResult<Option<Machine>> {
         if let Some(dpu_machine) = self.create_dpu_machine(txn, explored_dpu).await? {
             self.configure_dpu_interface(txn, explored_dpu).await?;
-            self.update_dpu_network_config(txn, &dpu_machine).await?;
             let dpu_machine_id: &MachineId = explored_dpu.report.machine_id.as_ref().unwrap();
             let dpu_bmc_info = explored_dpu.bmc_info();
             let dpu_hw_info = explored_dpu.hardware_info()?;
             self.update_machine_topology(txn, dpu_machine_id, dpu_bmc_info, dpu_hw_info)
                 .await?;
-            return Ok(true);
+            return Ok(Some(dpu_machine));
         }
-        Ok(false)
+        Ok(None)
     }
 
     // 1) Create a machine for this host using the passed machine_id
@@ -646,7 +658,6 @@ impl MachineCreator {
             network_config.secondary_overlay_vtep_ip = Some(secondary_vtep_ip);
         }
 
-        network_config.use_admin_network = Some(true);
         db::machine::try_update_network_config(txn, &dpu_machine.id, version, &network_config)
             .await?;
 


### PR DESCRIPTION
## Description

Second half of https://github.com/NVIDIA/ncx-infra-controller-core/issues/1011. https://github.com/NVIDIA/ncx-infra-controller-core/pull/1028 fixed the read side with a helper that returned `true` for zero-DPU hosts and or'd over DPUs otherwise; this moves the config location to populate the flag once on the machine-level `network_config` rather than across every DPU (and DPA) row.

State-controller transitions (`SwitchToAdminNetwork`, `DpaProvisioning`, `WaitingForDpaToBeReady`), as well as `machine-discovery`, and `site-explorer` initial discovery now write only the host row. DPU + DPA writes simplify to version bumps, so their state controllers [still] re-evaluate.

As part of the consolidation, some of the more primary changes are:
- `ManagedHostStateSnapshot::use_admin_network()` now reads the host's `network_config` directly.
- `DpuMachineSnapshot::use_admin_network()` and `DpaInterface::use_admin_network()` no longer exist. The one DPA-specific caller (`managed_host_network_config_version_synced`) takes the host-level flag as a parameter, which is loaded via a new `db::machine::get_host_use_admin_network_by_dpu_machine_id` helper.
- `GetManagedHostNetworkConfig` RPC now serves the host-row value to DPU agents end-to-end.

Worth noting migration the backfills the host-level value(s) from it's corresponding DPU value(s), and zero-DPU hosts just default to `true` (via the struct-level `Default`).

Tests added (well, "test", via `test_use_admin_network_reads_host_network_config`).

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->



Closes #1011
