### PR TITLE
chore: extend component management interface for compute tray power control

### DIFF
--- a/crates/admin-cli/src/expected_machines/patch/args.rs
+++ b/crates/admin-cli/src/expected_machines/patch/args.rs
@@ -153,6 +153,13 @@ pub struct Args {
         help = "When true, site-explorer skips BMC password rotation and stores factory-default credentials in Vault as-is"
     )]
     pub bmc_retain_credentials: Option<bool>,
+
+    #[clap(
+        long = "disable-lockdown",
+        value_name = "DISABLE_LOCKDOWN",
+        help = "If true, do not lock down the server as part of lifecycle management within the state machine. If unset or false, preserve the default behavior of locking down the server after configuring the BIOS."
+    )]
+    pub disable_lockdown: Option<bool>,
 }
 
 impl Args {

--- a/crates/api/src/handlers/component_manager.rs
+++ b/crates/api/src/handlers/component_manager.rs
@@ -578,7 +578,13 @@ pub(crate) async fn component_power_control(
                     Err(e) => results.push(error_result(&id_str, e.to_string())),
                 }
             }
-            txn.commit().await?;
+
+            if let Err(e) = txn.commit().await {
+                tracing::warn!(
+                    ?e,
+                    "failed to commit read-only endpoint resolution txn; proceeding with already-resolved data"
+                );
+            }
 
             for (machine_id, bmc_endpoint_request) in resolved {
                 let id_str = machine_id.to_string();
@@ -685,6 +691,30 @@ async fn power_control_health_override(
     result.is_ok()
 }
 
+fn desired_power_state(action: PowerAction) -> rpc::PowerState {
+    match action {
+        PowerAction::On
+        | PowerAction::ForceRestart
+        | PowerAction::GracefulRestart
+        | PowerAction::AcPowercycle => rpc::PowerState::On,
+        PowerAction::GracefulShutdown | PowerAction::ForceOff => rpc::PowerState::Off,
+    }
+}
+
+fn redfish_power_action(
+    action: PowerAction,
+) -> rpc::admin_power_control_request::SystemPowerControl {
+    use rpc::admin_power_control_request::SystemPowerControl;
+    match action {
+        PowerAction::On => SystemPowerControl::On,
+        PowerAction::ForceRestart => SystemPowerControl::ForceRestart,
+        PowerAction::GracefulRestart => SystemPowerControl::GracefulRestart,
+        PowerAction::AcPowercycle => SystemPowerControl::AcPowercycle,
+        PowerAction::GracefulShutdown => SystemPowerControl::GracefulShutdown,
+        PowerAction::ForceOff => SystemPowerControl::ForceOff,
+    }
+}
+
 /*
 machine_power_control facilitates power control against compute trays:
     1. Configures the desired power state for the machine in the power-manager
@@ -698,22 +728,8 @@ async fn machine_power_control(
     bmc_endpoint: BmcEndpointRequest,
     action: PowerAction,
 ) -> Result<(), Status> {
-    use rpc::admin_power_control_request::SystemPowerControl;
-
-    let (desired_power_state, redfish_action) = match action {
-        PowerAction::On => (rpc::PowerState::On as i32, SystemPowerControl::On),
-        PowerAction::ForceRestart => (rpc::PowerState::On as i32, SystemPowerControl::ForceRestart),
-        PowerAction::GracefulRestart => (
-            rpc::PowerState::On as i32,
-            SystemPowerControl::GracefulRestart,
-        ),
-        PowerAction::AcPowercycle => (rpc::PowerState::On as i32, SystemPowerControl::AcPowercycle),
-        PowerAction::GracefulShutdown => (
-            rpc::PowerState::Off as i32,
-            SystemPowerControl::GracefulShutdown,
-        ),
-        PowerAction::ForceOff => (rpc::PowerState::Off as i32, SystemPowerControl::ForceOff),
-    };
+    let desired_power_state = desired_power_state(action) as i32;
+    let redfish_action = redfish_power_action(action);
 
     let power_req = rpc::PowerOptionUpdateRequest {
         machine_id: Some(machine_id),
@@ -1847,5 +1863,70 @@ mod tests {
             rpc::ComponentManagerStatusCode::InternalError as i32,
         );
         assert!(r.error.contains("could not resolve endpoint"));
+    }
+
+    #[test]
+    fn desired_power_state_on_variants() {
+        use super::desired_power_state;
+        assert_eq!(
+            desired_power_state(PowerAction::On),
+            self::rpc::PowerState::On
+        );
+        assert_eq!(
+            desired_power_state(PowerAction::ForceRestart),
+            self::rpc::PowerState::On
+        );
+        assert_eq!(
+            desired_power_state(PowerAction::GracefulRestart),
+            self::rpc::PowerState::On
+        );
+        assert_eq!(
+            desired_power_state(PowerAction::AcPowercycle),
+            self::rpc::PowerState::On
+        );
+    }
+
+    #[test]
+    fn desired_power_state_off_variants() {
+        use super::desired_power_state;
+        assert_eq!(
+            desired_power_state(PowerAction::GracefulShutdown),
+            self::rpc::PowerState::Off
+        );
+        assert_eq!(
+            desired_power_state(PowerAction::ForceOff),
+            self::rpc::PowerState::Off
+        );
+    }
+
+    #[test]
+    fn redfish_power_action_mapping() {
+        use self::rpc::admin_power_control_request::SystemPowerControl;
+        use super::redfish_power_action;
+
+        assert_eq!(
+            redfish_power_action(PowerAction::On),
+            SystemPowerControl::On
+        );
+        assert_eq!(
+            redfish_power_action(PowerAction::ForceRestart),
+            SystemPowerControl::ForceRestart
+        );
+        assert_eq!(
+            redfish_power_action(PowerAction::GracefulRestart),
+            SystemPowerControl::GracefulRestart
+        );
+        assert_eq!(
+            redfish_power_action(PowerAction::AcPowercycle),
+            SystemPowerControl::AcPowercycle
+        );
+        assert_eq!(
+            redfish_power_action(PowerAction::GracefulShutdown),
+            SystemPowerControl::GracefulShutdown
+        );
+        assert_eq!(
+            redfish_power_action(PowerAction::ForceOff),
+            SystemPowerControl::ForceOff
+        );
     }
 }

--- a/crates/api/src/handlers/component_manager.rs
+++ b/crates/api/src/handlers/component_manager.rs
@@ -556,10 +556,43 @@ pub(crate) async fn component_power_control(
 
             (results, ips)
         }
-        rpc::component_power_control_request::Target::MachineIds(_list) => {
-            return Err(Status::unimplemented(
-                "machine power control should use AdminPowerControl",
-            ));
+        rpc::component_power_control_request::Target::MachineIds(list) => {
+            let mut txn = api.txn_begin().await?;
+            let mut resolved = Vec::with_capacity(list.machine_ids.len());
+            let mut results = Vec::with_capacity(list.machine_ids.len());
+            let mut ips = Vec::new();
+
+            for machine_id in &list.machine_ids {
+                let id_str = machine_id.to_string();
+                match crate::handlers::bmc_endpoint_explorer::validate_and_complete_bmc_endpoint_request(
+                    &mut txn,
+                    None,
+                    Some(*machine_id),
+                )
+                .await
+                {
+                    Ok((req, _)) => resolved.push((*machine_id, req)),
+                    Err(e) => results.push(error_result(&id_str, e.to_string())),
+                };
+            }
+            txn.commit().await?;
+
+            for (machine_id, bmc_endpoint_request) in resolved {
+                let id_str = machine_id.to_string();
+
+                if let Ok(ip) = bmc_endpoint_request.ip_address.parse() {
+                    ips.push(ip);
+                }
+
+                let outcome = compute_power_control(api, machine_id, action).await;
+
+                match outcome {
+                    Ok(()) => results.push(success_result(&id_str)),
+                    Err(e) => results.push(error_result(&id_str, e.message().into())),
+                }
+            }
+
+            (results, ips)
         }
     };
 
@@ -572,6 +605,134 @@ pub(crate) async fn component_power_control(
     Ok(Response::new(rpc::ComponentPowerControlResponse {
         results,
     }))
+}
+
+async fn compute_power_control(
+    api: &Api,
+    machine_id: carbide_uuid::machine::MachineId,
+    action: PowerAction,
+) -> Result<(), Status> {
+    let override_inserted = power_control_health_override(api, machine_id, true).await;
+
+    let result = machine_power_control(api, machine_id, action).await;
+
+    if override_inserted {
+        power_control_health_override(api, machine_id, false).await;
+    }
+
+    result
+}
+
+const MACHINE_POWER_OVERRIDE_SOURCE: &str = "component_power_control";
+const MACHINE_POWER_OVERRIDE_ALERT_ID: &str = "component-management-maintenance";
+const MACHINE_POWER_OVERRIDE_MESSAGE: &str = "Compute-Tray component power control in progress";
+
+/// Best-effort insert or removal of the health report override used to
+/// suppress external alerting during compute power control.
+/// Returns `true` when the operation succeeded.
+async fn power_control_health_override(
+    api: &Api,
+    machine_id: carbide_uuid::machine::MachineId,
+    insert: bool,
+) -> bool {
+    let result = if insert {
+        let req = rpc::InsertHealthReportOverrideRequest {
+            machine_id: Some(machine_id),
+            health_report_entry: Some(rpc::HealthReportEntry {
+                report: Some(::rpc::health::HealthReport {
+                    source: MACHINE_POWER_OVERRIDE_SOURCE.to_string(),
+                    triggered_by: None,
+                    observed_at: None,
+                    successes: vec![],
+                    alerts: vec![::rpc::health::HealthProbeAlert {
+                        id: MACHINE_POWER_OVERRIDE_ALERT_ID.to_string(),
+                        target: None,
+                        in_alert_since: None,
+                        message: MACHINE_POWER_OVERRIDE_MESSAGE.to_string(),
+                        tenant_message: None,
+                        classifications: vec![
+                            health_report::HealthAlertClassification::suppress_external_alerting()
+                                .to_string(),
+                        ],
+                    }],
+                }),
+                mode: rpc::HealthReportApplyMode::Replace as i32,
+            }),
+        };
+        crate::handlers::health::insert_health_report_override(api, Request::new(req))
+            .await
+            .map(|_| ())
+    } else {
+        let req = rpc::RemoveHealthReportOverrideRequest {
+            machine_id: Some(machine_id),
+            source: MACHINE_POWER_OVERRIDE_SOURCE.to_string(),
+        };
+        crate::handlers::health::remove_health_report_override(api, Request::new(req))
+            .await
+            .map(|_| ())
+    };
+
+    if let Err(e) = &result {
+        let action = if insert { "insert" } else { "remove" };
+        tracing::warn!(
+            %machine_id,
+            error = %e,
+            "failed to {action} health report override for power control"
+        );
+    }
+
+    result.is_ok()
+}
+
+async fn machine_power_control(
+    api: &Api,
+    machine_id: carbide_uuid::machine::MachineId,
+    action: PowerAction,
+) -> Result<(), Status> {
+    use rpc::admin_power_control_request::SystemPowerControl;
+
+    let (desired_power_state, redfish_action) = match action {
+        PowerAction::On => (rpc::PowerState::On as i32, SystemPowerControl::On),
+        PowerAction::ForceRestart => {
+            (rpc::PowerState::On as i32, SystemPowerControl::ForceRestart)
+        }
+        PowerAction::GracefulRestart => {
+            (rpc::PowerState::On as i32, SystemPowerControl::GracefulRestart)
+        }
+        PowerAction::AcPowercycle => {
+            (rpc::PowerState::On as i32, SystemPowerControl::AcPowercycle)
+        }
+        PowerAction::GracefulShutdown => {
+            (rpc::PowerState::Off as i32, SystemPowerControl::GracefulShutdown)
+        }
+        PowerAction::ForceOff => (rpc::PowerState::Off as i32, SystemPowerControl::ForceOff),
+    };
+
+    let power_req = rpc::PowerOptionUpdateRequest {
+        machine_id: Some(machine_id),
+        power_state: desired_power_state,
+    };
+    match crate::handlers::power_options::update_power_option(api, Request::new(power_req)).await {
+        Ok(_) => {}
+        Err(e) if e.code() == Code::InvalidArgument && e.message().contains("already set as") => {
+            tracing::debug!(
+                %machine_id,
+                desired_power_state,
+                "power option already in desired state, skipping"
+            );
+        }
+        Err(e) => return Err(e),
+    }
+
+    let admin_req = rpc::AdminPowerControlRequest {
+        bmc_endpoint_request: None,
+        machine_id: Some(machine_id.to_string()),
+        action: redfish_action as i32,
+    };
+    crate::handlers::bmc_endpoint_explorer::admin_power_control(api, Request::new(admin_req))
+        .await?;
+
+    Ok(())
 }
 
 /// Best-effort: flag BMC/PMC endpoints for re-exploration so the site

--- a/crates/api/src/handlers/component_manager.rs
+++ b/crates/api/src/handlers/component_manager.rs
@@ -19,7 +19,7 @@ use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 
 use ::rpc::common::SystemPowerControl;
-use ::rpc::forge as rpc;
+use ::rpc::forge::{self as rpc, BmcEndpointRequest};
 use carbide_uuid::power_shelf::PowerShelfId;
 use carbide_uuid::switch::SwitchId;
 use component_manager::component_manager::ComponentManager;
@@ -34,6 +34,9 @@ use model::rack::{FirmwareUpgradeJob, MaintenanceActivity};
 use tonic::{Code, Request, Response, Status};
 
 use crate::api::{Api, log_request_data};
+
+const MACHINE_POWER_OVERRIDE_SOURCE: &str = "component_power_control";
+const MACHINE_POWER_OVERRIDE_MESSAGE: &str = "Compute-Tray component power control in progress";
 
 fn require_component_manager(api: &Api) -> Result<&ComponentManager, Status> {
     api.component_manager
@@ -573,7 +576,7 @@ pub(crate) async fn component_power_control(
                 {
                     Ok((req, _)) => resolved.push((*machine_id, req)),
                     Err(e) => results.push(error_result(&id_str, e.to_string())),
-                };
+                }
             }
             txn.commit().await?;
 
@@ -584,11 +587,12 @@ pub(crate) async fn component_power_control(
                     ips.push(ip);
                 }
 
-                let outcome = compute_power_control(api, machine_id, action).await;
+                let outcome =
+                    compute_power_control(api, machine_id, bmc_endpoint_request, action).await;
 
                 match outcome {
                     Ok(()) => results.push(success_result(&id_str)),
-                    Err(e) => results.push(error_result(&id_str, e.message().into())),
+                    Err(e) => results.push(error_result(&id_str, e.message().to_string())),
                 }
             }
 
@@ -610,11 +614,12 @@ pub(crate) async fn component_power_control(
 async fn compute_power_control(
     api: &Api,
     machine_id: carbide_uuid::machine::MachineId,
+    bmc_endpoint: BmcEndpointRequest,
     action: PowerAction,
 ) -> Result<(), Status> {
     let override_inserted = power_control_health_override(api, machine_id, true).await;
 
-    let result = machine_power_control(api, machine_id, action).await;
+    let result = machine_power_control(api, machine_id, bmc_endpoint, action).await;
 
     if override_inserted {
         power_control_health_override(api, machine_id, false).await;
@@ -622,10 +627,6 @@ async fn compute_power_control(
 
     result
 }
-
-const MACHINE_POWER_OVERRIDE_SOURCE: &str = "component_power_control";
-const MACHINE_POWER_OVERRIDE_ALERT_ID: &str = "component-management-maintenance";
-const MACHINE_POWER_OVERRIDE_MESSAGE: &str = "Compute-Tray component power control in progress";
 
 /// Best-effort insert or removal of the health report override used to
 /// suppress external alerting during compute power control.
@@ -645,7 +646,7 @@ async fn power_control_health_override(
                     observed_at: None,
                     successes: vec![],
                     alerts: vec![::rpc::health::HealthProbeAlert {
-                        id: MACHINE_POWER_OVERRIDE_ALERT_ID.to_string(),
+                        id: health_report::HealthProbeId::internal_maintenance().to_string(),
                         target: None,
                         in_alert_since: None,
                         message: MACHINE_POWER_OVERRIDE_MESSAGE.to_string(),
@@ -684,27 +685,33 @@ async fn power_control_health_override(
     result.is_ok()
 }
 
+/*
+machine_power_control facilitates power control against compute trays:
+    1. Configures the desired power state for the machine in the power-manager
+    2. Synchronously sends the redfish command to the compute tray's BMC to perform the action specified
+On success, the power manager will have the desired power state set for the machine and the redfish command will have been successfully sent to the compute BMC
+In the case of partial failure, the power manager may have the desired power state updated for the machine but the redfish command may have failed. We will leave reconvergence in this case to the power manager.
+*/
 async fn machine_power_control(
     api: &Api,
     machine_id: carbide_uuid::machine::MachineId,
+    bmc_endpoint: BmcEndpointRequest,
     action: PowerAction,
 ) -> Result<(), Status> {
     use rpc::admin_power_control_request::SystemPowerControl;
 
     let (desired_power_state, redfish_action) = match action {
         PowerAction::On => (rpc::PowerState::On as i32, SystemPowerControl::On),
-        PowerAction::ForceRestart => {
-            (rpc::PowerState::On as i32, SystemPowerControl::ForceRestart)
-        }
-        PowerAction::GracefulRestart => {
-            (rpc::PowerState::On as i32, SystemPowerControl::GracefulRestart)
-        }
-        PowerAction::AcPowercycle => {
-            (rpc::PowerState::On as i32, SystemPowerControl::AcPowercycle)
-        }
-        PowerAction::GracefulShutdown => {
-            (rpc::PowerState::Off as i32, SystemPowerControl::GracefulShutdown)
-        }
+        PowerAction::ForceRestart => (rpc::PowerState::On as i32, SystemPowerControl::ForceRestart),
+        PowerAction::GracefulRestart => (
+            rpc::PowerState::On as i32,
+            SystemPowerControl::GracefulRestart,
+        ),
+        PowerAction::AcPowercycle => (rpc::PowerState::On as i32, SystemPowerControl::AcPowercycle),
+        PowerAction::GracefulShutdown => (
+            rpc::PowerState::Off as i32,
+            SystemPowerControl::GracefulShutdown,
+        ),
         PowerAction::ForceOff => (rpc::PowerState::Off as i32, SystemPowerControl::ForceOff),
     };
 
@@ -725,7 +732,7 @@ async fn machine_power_control(
     }
 
     let admin_req = rpc::AdminPowerControlRequest {
-        bmc_endpoint_request: None,
+        bmc_endpoint_request: Some(bmc_endpoint),
         machine_id: Some(machine_id.to_string()),
         action: redfish_action as i32,
     };


### PR DESCRIPTION
## Description
chore: extend component management interface for compute tray power control

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

