### PR TITLE
Have fern-preview actually log what's happening when fern build fails

### DIFF
--- a/.github/workflows/fern-docs-preview-comment.yml
+++ b/.github/workflows/fern-docs-preview-comment.yml
@@ -89,14 +89,23 @@ jobs:
           HEAD_REF: ${{ steps.metadata.outputs.head_ref }}
         working-directory: ./fern
         run: |
+          set -euo pipefail
           # Preview --id becomes part of the hostname; '/' and other chars are invalid.
           PREVIEW_ID=$(echo "${HEAD_REF:-preview}" | sed 's/[^a-zA-Z0-9._-]/-/g; s/-\{2,\}/-/g; s/^-//; s/-$//')
+          PREVIEW_ID="${PREVIEW_ID:-preview}"
+
+          # Actions bash uses -e; fern often exits non-zero on doc/link errors even when it logs a URL.
+          # Disable -e for the generate invocation so we always print output and can parse or fail clearly.
+          set +e
           OUTPUT=$(fern generate --docs --preview --force --id "$PREVIEW_ID" 2>&1)
+          FERN_EXIT=$?
+          set -e
           echo "$OUTPUT"
+
           # Fern prints "[docs]: Published docs to <url>" (older CLIs sometimes added " (…)" after the URL).
-          URL=$(echo "$OUTPUT" | grep -oE 'Published docs to https?://[^[:space:]()]+' | head -1 | sed 's/^Published docs to //')
+          URL=$(echo "$OUTPUT" | grep -oE 'Published docs to https?://[^[:space:]()]+' | head -1 | sed 's/^Published docs to //') || true
           if [ -z "$URL" ]; then
-            echo "::error::Failed to generate preview URL. See fern output above."
+            echo "::error::Failed to generate preview URL (fern exit ${FERN_EXIT}). See Fern output above."
             exit 1
           fi
           echo "preview_url=$URL" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
-e
Signed-off-by: Peter Gambrill <pgambrill@nvidia.com>

## Description
The fern-preview workflow tries to build the Fern docs. If build fails,
it currently does not return any helpful information in the log. 

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

