### PR TITLE
docs: rewrite Overview section and add landing page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -103,10 +103,10 @@ For details on NICo REST, please refer to [NICo REST Github Repository](https://
 ### Managed Hosts
 
 The point of having a site controller is to administer a site that has been populated with managed hosts.
-Each managed host is a pairing of a single BlueField 2/3 DPU and a host server.
+Each managed host is a pairing of a host server and one or more BlueField 2/3 DPUs.
 During initial deployment, the `scout` service runs, informing the NICo Core gRPC API of any discovered DPUs. NICo completes the installation of services on the DPU and boots into regular operation mode. Thereafter, the `dpu-agent` starts as a daemon.
 
-Each DPU runs the `dpu-agent` which connects to NICo Core gRPC API to retrieve configuration instructions.
+Each DPU runs the `dpu-agent` which periodically connects to NICo Core gRPC API to retrieve configuration instructions.
 
 ### Metrics and Logs
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -102,8 +102,8 @@ For details on NICo REST, please refer to [NICo REST Github Repository](https://
 
 ### Managed Hosts
 
-The point of having a Site Controller is to administer a Site that has been populated with managed hosts.
-Each managed host is a pairing of a single BlueField (BF) 2/3 DPU and a host server.
+The point of having a site controller is to administer a site that has been populated with managed hosts.
+Each managed host is a pairing of a single BlueField 2/3 DPU and a host server.
 During initial deployment, the `scout` service runs, informing the NICo Core gRPC API of any discovered DPUs. NICo completes the installation of services on the DPU and boots into regular operation mode. Thereafter, the `dpu-agent` starts as a daemon.
 
 Each DPU runs the `dpu-agent` which connects to NICo Core gRPC API to retrieve configuration instructions.

--- a/docs/bootable_artifacts.md
+++ b/docs/bootable_artifacts.md
@@ -22,12 +22,15 @@ Because you cannot build `aarch64` artifacts on an `x86_64` host, we only create
 cd $NICo_ROOT_DIR/pxe && cargo make mkdir-static-aarch64
 ```
 
-> **NOTE**: Running NICo using `docker-compose` and QEMU `clients` only works with `x86_64` binaries. CI/CD is used for testing on `aarch64` systems such as a Bluefield
+
+
+> **NOTE**: Running NICo using `docker-compose` and QEMU `clients` only works with `x86_64` binaries. CI/CD is used for testing on `aarch64` systems such as a BlueField
+
 
 or
 
 download pre-built artifacts - ideal if the `ipxe-x86_64` gives you
-errors. Extract the latest [from Artifactory](https://urm.nvidia.com/ui/native/swngc-ngcc-generic-local/nvmetal/boot-artifacts/x86_64/)
+errors. Extract the latest boot artifacts (available from your NICo distribution package)
 into `$NICo_ROOT_DIR/pxe/static/blobs/internal/x86_64/` (you'll need
 to create the hierarchy).
 

--- a/docs/development/issuer_ca_recreate.md
+++ b/docs/development/issuer_ca_recreate.md
@@ -58,7 +58,7 @@ Now, the engine responsible for generating client certificates has type pki. You
         "cluster.local",
         "*.svc",
         "*.svc.cluster.local",
-        "*.frg.nvidia.com"
+        "*.nico.example.com"
         ],
         "allowed_domains_template": false,
         "allowed_other_sans": [],

--- a/docs/development/vm_pxe_client.md
+++ b/docs/development/vm_pxe_client.md
@@ -123,11 +123,9 @@ sudo qemu-system-x86_64 -boot n -nographic -display none \
 
 On Fedora change the `-bios` line to `-bios /usr/share/OVMF/OVMF_CODE.fd`.
 
-**Note**: As of a prior commit, there is a bug that will cause the ipxe dhcp to fail the first time it is run. Wait for it to fail,
-and in the EFI Shell just type `reset` and it will restart the whole pxe process and it will run the ipxe image properly the second time.
-See https://jirasw.nvidia.com/browse/FORGE-243 for more information.
+**Note**: There is a known issue where iPXE DHCP fails on the first run. If this occurs, type `reset` in the EFI Shell to restart the PXE process; it will complete successfully on the second attempt.
 
-**Note:** I had to validate that the /usr/share/ovmf path was correct, it depends on where ovmf installed the file, sometimes its under a subdirectory called "x64", sometimes not.
+**Note:** Verify the OVMF path for your system — depending on how the `ovmf` package was installed, the file may be under a subdirectory called `x64`.
 
 **Note:** Known older issue on first boot that you'll land on a UEFI shell, have to `exit` back into the BIOS and select "Continue" in order to proceed into normal login.
 

--- a/docs/dpu-operations.md
+++ b/docs/dpu-operations.md
@@ -1,4 +1,4 @@
-# Operating Bluefield/DPU
+# Operating BlueField DPUs
 
 ### Connecting to DPU
 The DPU shares a physical 1GB ethernet connection for both BMC and OOB access.
@@ -30,7 +30,7 @@ the DPU OS.
 #### Updating to the latest BFB on a DPU
 
 
-Download the latest BFB from artifactory - https://urm.nvidia.com/artifactory/list/sw-mlnx-bluefield-generic/Ubuntu20.04/
+Download the latest BFB from the NVIDIA DOCA download portal (requires NVIDIA developer account access).
 
 In order to upgrade the OS you will need to `scp` the BFB file to a specific directory on the DPU.
 `scp DOCA_1.3.0_BSP_3.9.0_Ubuntu_20.04-3.20220315.bfb root@bmc_ip:/dev/rshim0/boot` once the file is copied the DPU reboots and completes the install of the new BFB.

--- a/docs/hcl.md
+++ b/docs/hcl.md
@@ -59,6 +59,6 @@ This list outlines platforms that are under development and have not undergone f
 
 | DPU          | Firmware / Software Version                       |
 |--------------|---------------------------------------------------|
-| Bluefield-2  | DOCA 3.2.0                                        |
-| Bluefield-3  | DOCA 3.2.0                                        |
+| BlueField 2  | DOCA 3.2.0                                        |
+| BlueField 3  | DOCA 3.2.0                                        |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ NICo is open source under the Apache 2.0 license.
 | **Start here** | [Site Reference Architecture](manuals/site-reference-arch.md) | [Architecture Overview](architecture/overview.md) | [What is NICo?](overview/what-is-nico.md) |
 | **Then** | [Site Setup](manuals/site-setup.md) | [Redfish Workflow](architecture/redfish_workflow.md) | [Key Capabilities](overview/capabilities.md) |
 | **Then** | [Networking Requirements](manuals/networking_requirements.md) | [Redfish Endpoints Reference](architecture/redfish/endpoints_reference.md) | [Day 0/1/2 Lifecycle](overview/lifecycle.md) |
-| **Then** | [Ingesting Hosts](manuals/ingesting_machines.md) | [REST API Reference](#api) | [HCL](hcl.md) + [FAQs](faq.md) |
+| **Then** | [Ingesting Hosts](manuals/ingesting_machines.md) | [REST API Reference](/infra-controller/api) | [HCL](hcl.md) + [FAQs](faq.md) |
 
 ## Quick Links
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,22 @@
+# NICo — NVIDIA Infra Controller Documentation
+
+NICo is an open source suite of microservices for site-local, zero-trust bare-metal lifecycle management. It automates hardware discovery, firmware validation, DPU provisioning, network isolation, and tenant sanitization — enabling NVIDIA Cloud Partners (NCPs) and infrastructure operators to stand up and operate AI factory-scale infrastructure.
+
+NICo is open source under the Apache 2.0 license.
+
+## Where do you want to start?
+
+| | **Deploy & Operate NICo** | **Integrate with NICo** | **Evaluate NICo** |
+|---|---|---|---|
+| **Who** | NCP infrastructure operators deploying and managing bare-metal fleets | ISV developers and platform engineers building on NICo's APIs | Architects and decision-makers evaluating NICo for their stack |
+| **Start here** | [Site Reference Architecture](manuals/site-reference-arch.md) | [Architecture Overview](architecture/overview.md) | [What is NICo?](overview/what-is-nico.md) |
+| **Then** | [Site Setup](manuals/site-setup.md) | [Redfish Workflow](architecture/redfish_workflow.md) | [Key Capabilities](overview/capabilities.md) |
+| **Then** | [Networking Requirements](manuals/networking_requirements.md) | [Redfish Endpoints Reference](architecture/redfish/endpoints_reference.md) | [Day 0/1/2 Lifecycle](overview/lifecycle.md) |
+| **Then** | [Ingesting Hosts](manuals/ingesting_machines.md) | [REST API Reference](#api) | [HCL](hcl.md) + [FAQs](faq.md) |
+
+## Quick Links
+
+- [Hardware Compatibility List](hcl.md) — Supported servers and DPUs
+- [Release Notes](release-notes.md) — What's new in each version
+- [FAQs](faq.md) — Common questions answered
+- [GitHub: NICo Core](https://github.com/NVIDIA/ncx-infra-controller-core) | [NICo REST](https://github.com/NVIDIA/ncx-infra-controller-rest)

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -12,8 +12,23 @@ navigation:
 
     layout:
 
-    - page: Introduction
-      path: README.md
+    - page: Home
+      path: index.md
+
+    - section: Overview
+      contents:
+        - page: What is NICo?
+          path: overview/what-is-nico.md
+          slug: what-is-nico
+        - page: Key Capabilities
+          path: overview/capabilities.md
+        - page: Operational Principles
+          path: overview/operational-principles.md
+        - page: Day 0 / Day 1 / Day 2 Lifecycle
+          path: overview/lifecycle.md
+        - page: Scope and Boundaries
+          path: overview/scope-and-boundaries.md
+          slug: scope-and-boundaries
 
     - section: Getting Started
       contents:
@@ -25,6 +40,7 @@ navigation:
           path: manuals/networking_requirements.md
         - page: Building NICo Containers
           path: manuals/building_nico_containers.md
+          slug: building-nico-containers
         - page: Ingesting Hosts
           path: manuals/ingesting_machines.md
         - page: Updating Expected Hosts Manifest
@@ -73,8 +89,6 @@ navigation:
 
     - section: Operations
       contents:
-        - page: Cargo via Docker on macOS
-          path: manuals/cargo-via-docker-macos.md
         - page: Host Validation
           path: manuals/machine_validation.md
         - page: SKU Validation

--- a/docs/manuals/machine_validation.md
+++ b/docs/manuals/machine_validation.md
@@ -205,7 +205,7 @@ carbide-admin-cli machine-validation tests enable --test-id <test_id> --version 
 carbide-admin-cli machine-validation tests verify --test-id <test_id> --version  <test version>
 ```
 
-Note: There is a bug, a workaround is to use two commands. Will be fixed in coming releases.
+Note: Due to a current limitation, enable and verify must be run as separate commands.
 
 For example, to enable forge_CudaSample, execute following steps:
 

--- a/docs/manuals/site-reference-arch.md
+++ b/docs/manuals/site-reference-arch.md
@@ -6,7 +6,7 @@ This page provides guidelines for hardware and configuration for NVIDIA Infra Co
 
 The section provides a hardware baseline for the two kinds of hosts, the site controller and compute systems.
 
-The site controller and compute systems must be qualified for one dual-port NVIDIA Bluefield DPU with 2 x 200 Gb network interfaces and a 1 Gb network interface for the BMC. The BlueField-3 B3220 P-Series DPU is suitable (200GbE/NDR200 dual-port QSFP112 Network Adaptor (900-9D3B6-00CV-AA0)). Other network interface controllers on the machine are automatically disabled during site software installation.
+The site controller and compute systems must be qualified for one dual-port NVIDIA BlueField DPU with 2 x 200 Gb network interfaces and a 1 Gb network interface for the BMC. The BlueField-3 B3220 P-Series DPU is suitable (200GbE/NDR200 dual-port QSFP112 Network Adaptor (900-9D3B6-00CV-AA0)). Other network interface controllers on the machine are automatically disabled during site software installation.
 
 ### Site Controller Requirements
 

--- a/docs/overview/capabilities.md
+++ b/docs/overview/capabilities.md
@@ -15,7 +15,7 @@ NICo manages the BlueField DPU throughout its lifecycle:
 
 - Installs the DPU OS and provisions HBN (Host-Based Networking with Containerized Cumulus, configured via NVUE)
 - Manages all DPU firmware components: BMC, NIC, UEFI, ATF
-- Runs the DPU agent, which maintains a persistent gRPC connection to NICo and executes configuration instructions
+- Runs the DPU agent, which periodically fetches desired configuration from NICo over gRPC and executes configuration instructions
 - Disables in-band BMC access from within the host, enforcing out-of-band-only management
 
 ## Secure Multi-Tenancy and Network Isolation

--- a/docs/overview/capabilities.md
+++ b/docs/overview/capabilities.md
@@ -1,0 +1,73 @@
+# Key Capabilities
+
+## Hardware Readiness and Validation
+
+NICo automates hardware onboarding before any host is made available to tenants:
+
+- **Auto-discovery via Redfish** — BMCs are discovered over the OOB network; DPUs and hosts are linked automatically via LLDP and serial number matching.
+- **SKU validation** — confirms that each machine has the expected hardware components and flags incomplete or misconfigured hosts.
+- **Hardware burn-in and testing** — validates single- and multi-node setups, including NVLink and InfiniBand connectivity, before provisioning.
+- **Firmware baseline enforcement** — inventories UEFI and BMC firmware on ingestion and brings any out-of-baseline host into compliance before it becomes available.
+
+## DPU Lifecycle Management
+
+NICo manages the BlueField DPU throughout its lifecycle:
+
+- Installs the DPU OS and provisions HBN (Host-Based Networking with Containerized Cumulus, configured via NVUE)
+- Manages all DPU firmware components: BMC, NIC, UEFI, ATF
+- Runs the DPU agent, which maintains a persistent gRPC connection to NICo and executes configuration instructions
+- Disables in-band BMC access from within the host, enforcing out-of-band-only management
+
+## Secure Multi-Tenancy and Network Isolation
+
+NICo enforces workload isolation across all network planes without reconfiguring physical switches:
+
+| Plane | Mechanism |
+|---|---|
+| Ethernet (N/S) | BlueField HBN — L3 VXLAN/EVPN, VRFs, Network Security Groups |
+| InfiniBand (E/W) | UFM-based P_Key partition assignment per tenant |
+| NVLink | NMX-M API partition management |
+| Spectrum-X (E/W) | SP-X partitioning for high-performance East-West traffic |
+
+VPC and subnet configuration are API-driven. Tenant transitions fully clear and re-establish isolation boundaries.
+
+## Trust and Attestation
+
+NICo treats every host as untrustworthy by default:
+
+- Host attestation via Measured Boot PCR checking and TPM signature verification through the TPM Manufacturer CA
+- UEFI lockdown during active use — prevents unauthorized BIOS changes while a tenant has the host
+- Managed BMC credentials (per site) and UEFI credentials (per device)
+- Secure erase of NVMe storage, GPU memory, and system memory between tenant uses
+- Out-of-band monitoring only — NICo never relies on in-band host reporting for security decisions
+
+## Continuous Compliance and Firmware Control
+
+NICo maintains a consistent hardware baseline across the fleet on an ongoing basis:
+
+- Schedules UEFI and BMC firmware updates on healthy, unoccupied hosts
+- Continuously monitors hardware health via Redfish and the DPU agent
+- Exports metrics in Prometheus format for integration with operator monitoring stacks
+- Alerts on firmware or configuration discrepancies against the site baseline
+- Maintains a full inventory of firmware versions per machine per site
+
+## Flexible Deployment and Integration
+
+- **API-first** — REST API for operator and ISV integration; gRPC API and admin CLI for direct administration; debugging UI for engineering use
+- **JWT authentication** — integrates with Keycloak and compatible IAM solutions
+- **Any OS** — any operating system installable via iPXE is supported; NICo imposes no OS requirements
+- **BYO monitoring** — Prometheus metrics export; integrates with Grafana, Loki, and OpenTelemetry-compatible stacks
+- **Kubernetes-native** — deploys on any conformant Kubernetes v1.30+ environment
+- **Broad hardware support** — NVIDIA L40/L40S PCIe, HGX/DGX A100/H100/B200, GB200 NVL72, CPU-only x86 and Grace systems
+
+## GB200 NVL72 and Rack-Scale Capabilities
+
+For GB200 NVL72 SuperCluster deployments, NICo extends lifecycle management to the rack level:
+
+**Rack-Level Administration (RLA)** treats racks and NVL domains as first-class management entities rather than collections of individual hosts. It sequences power operations, firmware updates, and maintenance workflows safely across rack components — preventing unsafe actions and ensuring correct ordering across dense, multi-tray systems.
+
+**NVLink Clustering** manages NVLink domain formation, health monitoring, and partition management. NICo gates instance allocation on cluster readiness — if the NVLink fabric is not healthy or fully formed, provisioning is blocked until it is.
+
+**Leakage Detection** integrates BMS and tray sensor signals and applies configurable, policy-based responses: graceful shutdown of affected trays, gravity-aware handling of trays below a leak source, and rack-level isolation decisions. Critical safety actions remain with BMS; NICo handles orchestration and automation for non-critical conditions.
+
+**Domain Power Provisioning** supports Max-P and Max-Q power profiles per instance. NICo coordinates with the external power engine before and after lifecycle events (power-on, firmware updates, maintenance) to prevent unsafe power states and enable optimal power utilization across racks.

--- a/docs/overview/lifecycle.md
+++ b/docs/overview/lifecycle.md
@@ -16,7 +16,7 @@ Before ingestion, NICo validates that each machine matches its expected SKU — 
 NICo inventories UEFI and BMC firmware and updates any host that does not meet the site's baseline before making it available. Hosts that cannot be brought to baseline are quarantined automatically.
 
 **DPU provisioning**
-NICo installs the DPU OS, provisions HBN (Host-Based Networking with Containerized Cumulus), and configures all DPU firmware components (BMC, NIC, UEFI, ATF). The DPU agent starts after provisioning and maintains a persistent gRPC connection to NICo for ongoing configuration.
+NICo installs the DPU OS, provisions HBN (Host-Based Networking with Containerized Cumulus), and configures all DPU firmware components (BMC, NIC, UEFI, ATF). The DPU agent starts after provisioning, periodically fetches desired configuration from NICo over gRPC, and reports applied state back.
 
 **Attestation**
 NICo attests each host via Measured Boot PCR checking and TPM signature verification before it enters the available pool.

--- a/docs/overview/lifecycle.md
+++ b/docs/overview/lifecycle.md
@@ -1,0 +1,73 @@
+# Day 0 / Day 1 / Day 2 Lifecycle
+
+NICo organizes bare-metal lifecycle management into three phases: Day 0 (bringup), Day 1 (configuration), and Day 2 (operations).
+
+## Day 0 — Discovery, Validation, and Ingestion
+
+Day 0 covers everything from hardware arriving in the rack to a host being declared ready for tenant use. The design goal is zero-touch: once a host is racked and cabled, NICo handles discovery through provisioning-ready.
+
+**Hardware discovery**
+NICo discovers hardware via Redfish over the OOB (out-of-band) network. The site controller's crawler probes BMC endpoints, collects full hardware inventory (CPU, GPU, NIC, DPU, storage), and links each DPU to its host server via LLDP and serial number matching. No manual inventory entry is required.
+
+**SKU validation and burn-in**
+Before ingestion, NICo validates that each machine matches its expected SKU — flagging any missing or unexpected components. It then runs hardware and connectivity tests, including multi-node tests for systems participating in InfiniBand or NVLink fabrics.
+
+**Firmware baseline**
+NICo inventories UEFI and BMC firmware and updates any host that does not meet the site's baseline before making it available. Hosts that cannot be brought to baseline are quarantined automatically.
+
+**DPU provisioning**
+NICo installs the DPU OS, provisions HBN (Host-Based Networking with Containerized Cumulus), and configures all DPU firmware components (BMC, NIC, UEFI, ATF). The DPU agent starts after provisioning and maintains a persistent gRPC connection to NICo for ongoing configuration.
+
+**Attestation**
+NICo attests each host via Measured Boot PCR checking and TPM signature verification before it enters the available pool.
+
+**Network and IP setup**
+IP address pools (BGP, loopback, host OS), DHCP, and DNS are allocated and configured automatically as part of the ingestion workflow.
+
+---
+
+## Day 1 — Isolation, Lockdown, and Provisioning
+
+Day 1 covers the configuration of isolation boundaries and the provisioning of hosts for tenant use.
+
+**Network isolation**
+Before a host is assigned to a tenant, NICo establishes isolation across all applicable network planes:
+- **Ethernet** — BlueField HBN enforces L3 VXLAN/EVPN boundaries and per-tenant VRFs. No leaf switch configuration changes are required.
+- **InfiniBand** — UFM assigns P_Key partitions to the host's IB ports for the specific tenant.
+- **NVLink** — NMX-M APIs configure NVLink partition assignments for the tenant's NVL domain.
+
+**Host lockdown**
+NICo applies UEFI lockdown (preventing unauthorized BIOS changes during tenant use), configures BMC security settings, and disables in-band host-to-BMC communications.
+
+**OS provisioning**
+NICo coordinates the PXE/iPXE boot sequence to install the tenant's chosen OS image. It sets UEFI boot order, applies security settings, and hands off to the caller once the host is booting. NICo does not manage what is installed beyond the boot handoff — OS configuration is the operator's or tenant's responsibility.
+
+**Instance management**
+Operators define instance types (hardware classes such as GPU node configurations) and allocate hosts to tenants as instances via the REST API or gRPC API. For GB200 NVL72 systems, allocations are NVL domain-batched to preserve NVLink topology integrity.
+
+---
+
+## Day 2 — Operations, Health, and Tenant Transitions
+
+Day 2 covers the ongoing operation of active infrastructure and the lifecycle between tenant uses.
+
+**Continuous monitoring**
+NICo continuously monitors hardware health via Redfish polling and DPU agent telemetry. Metrics are exported in Prometheus format and can be consumed by operator monitoring stacks (Grafana, Loki, OpenTelemetry). Hardware events and health anomalies are surfaced via the NICo API and alerting integrations.
+
+**Firmware updates**
+NICo schedules UEFI and BMC firmware updates on healthy, unoccupied hosts — entirely out-of-band, without disrupting active tenants. Updates are applied against the site baseline and tracked in the per-machine firmware inventory.
+
+**Tenant transitions (sanitization)**
+When a tenant releases a host, NICo performs a full cleanup sequence before the host re-enters the available pool:
+1. Secure erase of all NVMe storage
+2. GPU memory and system memory wipe
+3. TPM reset
+4. Re-attestation via Measured Boot and TPM verification
+5. Firmware integrity re-validation
+6. Network isolation state cleared and re-provisioned for the next tenant
+
+**Break-fix**
+NICo supports directed provisioning for break-fix workflows: targeted machine provisioning to specific hosts, machine labels for tracking machines under repair, and issue reporting APIs for integration with service management tooling.
+
+**Rack-scale health response (GB200)**
+For GB200 NVL72 systems, NICo's rack-level management layer responds to health signals — leakage events, power anomalies, NVLink fabric degradation — with configurable, policy-based automated responses, including graceful workload shutdown, rack isolation, and recovery sequencing.

--- a/docs/overview/operational-principles.md
+++ b/docs/overview/operational-principles.md
@@ -1,0 +1,23 @@
+# Operational Principles
+
+NICo is designed around five foundational principles that shape its architecture and operational model.
+
+## The machine is untrustworthy
+
+NICo never relies on software running inside the host OS to make security or isolation decisions. The BlueField DPU is the enforcement boundary. It operates independently of the host and cannot be influenced or compromised by anything running above it. A host that has been tampered with cannot subvert the isolation NICo enforces.
+
+## Operating system requirements are not imposed on the machine
+
+NICo does not require any agents, daemons, or specific configurations inside the host OS. Any operating system installable via iPXE is supported. OS management — patching, upgrades, configuration — is the operator's responsibility. NICo hands off after boot and does not re-enter the host during tenant use.
+
+## After being racked, machines must become ready for use with no human intervention
+
+Once racked, cabled, and powered on, NICo automates the full path from discovery to provisioning-ready — validation, firmware alignment, DPU provisioning, and attestation — without manual steps.
+
+## All monitoring of the machine must be done using out-of-band methods
+
+NICo monitors hardware health, firmware state, and machine status exclusively via Redfish and the DPU agent — never via in-band paths that a compromised or unresponsive host OS could influence, block, or spoof. This ensures that monitoring remains reliable regardless of the state of the host.
+
+## The network fabric stays static even during tenancy changes
+
+Leaf switches and routers are not reconfigured when tenants change or when hosts are provisioned and released. Isolation is enforced entirely at the DPU layer (Ethernet via HBN) and via fabric management APIs (InfiniBand via UFM, NVLink via NMX-M). Keeping the physical underlay stable reduces operational risk and simplifies network operations at scale.

--- a/docs/overview/scope-and-boundaries.md
+++ b/docs/overview/scope-and-boundaries.md
@@ -1,0 +1,40 @@
+# Scope and Boundaries
+
+NICo manages the infrastructure lifecycle layer: hardware discovery, firmware management, DPU provisioning, network isolation, and tenant sanitization. Everything above the boot handoff and below the physical network underlay is outside NICo's scope.
+
+This page defines the boundaries between NICo and the platform, orchestration, or automation layer that sits above it — so operators and integrators know what NICo handles and what their software needs to cover.
+
+## Host OS and Application Layer
+
+| NICo handles | Your platform handles |
+|---|---|
+| OS image delivery via PXE/iPXE | OS patching, upgrades, and runtime configuration |
+| UEFI boot order and secure boot settings | Application software (Kubernetes, SLURM, storage) |
+| Host attestation on ingestion and between tenants | In-band monitoring and agents during tenant use |
+
+NICo provisions the OS and hands off at boot. It runs no agents or daemons inside the host OS during tenant use, and does not attest hosts continuously — attestation occurs on ingestion and between tenant transitions.
+
+## Cluster Assembly and Workload Scheduling
+
+| NICo handles | Your platform handles |
+|---|---|
+| Individual host provisioning and lifecycle | Assembling hosts into clusters (SLURM, K8s) |
+| Instance type definitions and host allocation via API | Workload scheduling and resource allocation |
+| Network isolation per tenant | Cluster networking (CNI, service mesh) |
+
+NICo provisions hosts and assigns them to tenants as instances via API. Building those hosts into a functioning cluster — installing Kubernetes, configuring SLURM, deploying workloads — is handled by the ISV control plane, BMaaS layer, or orchestration system consuming NICo's APIs.
+
+## Network Underlay
+
+| NICo handles | Your network team handles |
+|---|---|
+| Tenant isolation at the DPU layer (Ethernet via HBN) | Leaf switch, spine switch, and router configuration |
+| InfiniBand partition assignment via UFM APIs | UFM deployment and management |
+| NVLink partition management via NMX-M APIs | NMX-M deployment and management |
+| BGP route advertisement from DPUs | Physical underlay design and cabling |
+
+NICo enforces isolation without reconfiguring physical switches — the underlay is expected to be stable and pre-configured. NICo does not install or manage Cumulus Linux on switches, UFM, or network observability tools such as NetQ.
+
+## External Dependencies
+
+NICo depends on several services that must be pre-deployed and managed externally. NICo coordinates with these services but does not install, configure, or operate them. For the full list with configuration details, see [Prerequisite Components](what-is-nico.md#prerequisite-components).

--- a/docs/overview/what-is-nico.md
+++ b/docs/overview/what-is-nico.md
@@ -1,0 +1,99 @@
+# What is NICo?
+
+NICo (NVIDIA Infra Controller) is an open source suite of microservices for site-local, zero-trust bare-metal lifecycle management. It automates hardware discovery, firmware validation, DPU provisioning, network isolation, and tenant sanitization — enabling NVIDIA Cloud Partners (NCPs) and infrastructure operators to stand up and operate AI factory-scale infrastructure.
+
+NICo is open source under the Apache 2.0 license.
+
+## Why NICo exists
+
+AI factory-scale infrastructure requires rack-level management, host lifecycle automation, and network isolation that existing tools do not provide as an integrated solution. Without purpose-built infrastructure management, operators face:
+
+- Manual hardware discovery, firmware alignment, and network setup that slow rack bringup
+- No unified enforcement of workload isolation across Ethernet, InfiniBand, and NVLink
+- Custom scripts for tenant sanitization, attestation, and trust re-establishment
+- Firmware and configuration drift across mixed hardware generations
+
+NICo fills this gap — it enables physical servers to behave like cloud instances: deploy, manage, and scale bare-metal infrastructure through APIs.
+
+## What NICo does
+
+NICo manages the full lifecycle of bare-metal hosts — from initial rack discovery through tenant provisioning, ongoing operations, and secure reuse.
+
+Each managed host is a **BlueField DPU + host server pair**. The DPU acts as the enforcement boundary for network isolation and security; NICo provisions and manages it directly, independently of what runs on the host.
+
+NICo's core responsibilities:
+
+- Provision and manage DPU OS, firmware, and HBN configuration
+- Maintain hardware inventory of all managed hosts
+- Automate discovery, validation, and attestation via Redfish (out-of-band)
+- Monitor hardware health continuously and react to health state changes
+- Manage host firmware (UEFI, BMC) and enforce security lockdown
+- Manage BMC and UEFI credentials per device via Redfish
+- Allocate IP addresses, configure BGP routing, and manage DNS
+- Enforce network isolation across Ethernet, InfiniBand, and NVLink planes
+- Orchestrate host provisioning (PXE/iPXE), tenant release, and sanitization
+
+## Architecture overview
+
+![NICo architecture diagram](../static/nico_arch_diagram.png)
+
+NICo is deployed as a suite of microservices on a Kubernetes cluster co-located in the datacenter it manages. This suite of microservices forms the control plane, known as the **Site Controller**. The Kubernetes cluster requires a minimum of three nodes for high availability, and all NICo control plane services communicate over mTLS/gRPC.
+
+### NICo Components
+
+The green boxes in the architecture diagram are the services that NICo provides.
+
+**Site Controller services:**
+
+- **API Service (NICo Core)** — the central control plane and single source of truth. All other NICo services communicate with it over mTLS/gRPC. It is the only service that reads from and writes to PostgreSQL. Implements state machines for all managed resources (hosts, network segments, InfiniBand and NVLink partitions). Exposes a debug web UI on `/admin` for operators via HTTPS with OIDC authentication.
+- **DHCP Server** — responds to DHCP requests from all underlay devices (host BMCs, DPU BMCs, DPU OOB interfaces). Stateless — converts DHCP requests into gRPC calls to the API Service, which performs the actual IP address management.
+- **PXE Service** — serves boot artifacts (iPXE scripts, cloud-init user-data, OS images) to managed hosts and DPUs over HTTP. Fetches the correct artifact for each host from the API Service via mTLS/gRPC.
+- **Hardware Health** — scrapes host and DPU BMCs via Redfish HTTPS for sensor data (temperature, fan speed, power, current) and firmware inventory. Exports metrics on a Prometheus `/metrics` endpoint and reports health alerts to the API Service via mTLS/gRPC.
+- **SSH Console Service** — maintains persistent SSH/IPMI connections to all host BMCs for serial console access. Streams console output to Loki for logging and provides live console access to tenants and administrators. Connects to the API Service via mTLS/gRPC.
+- **Authoritative DNS Service** — handles DNS queries from the site controller and managed nodes. Authoritative for NICo-delegated zones. Connects to the API Service via mTLS/gRPC.
+- **Recursive DNS (unbound)** — provides recursive DNS resolution to managed machines and tenant instances via the OOB network.
+- **Site Agent** — maintains a Temporal connection to NICo REST (JSON API), syncing data and delegating gRPC requests to the on-site API Service. Enables NICo REST to be deployed centrally in cloud while the site controller runs on-premises.
+- **JSON API (NICo REST)** — exposes NICo capabilities as a REST API for operators and ISVs. Can be deployed co-located with the site controller or centrally in cloud. Orchestrators and admins connect over HTTP/JWT. Multiple site controllers can connect to a single NICo REST deployment through their respective Site Agents.
+- **Admin CLI** — command-line interface for site administrators, connecting directly to the API Service via mTLS/gRPC.
+
+**Managed Host agents:**
+
+- **Scout** — a temporary agent that runs on the x86 host during discovery (before a tenant is assigned). Collects hardware inventory that cannot be determined out-of-band, runs machine validation tests, and reports to the API Service via mTLS/gRPC.
+- **DPU Agent** — a persistent daemon on the DPU (ARM OS). Polls the API Service every 30 seconds for desired network configuration, applies it via HBN (Host-Based Networking with Containerized Cumulus), and reports observed state back. Also manages DPU health checks, the Metadata Service, auto-updates, and hotfix deployment.
+- **Metadata Service (FMDS)** — runs on the DPU. Provides tenant workloads with instance metadata (machine ID, boot info) via a local HTTP API on the host-facing interface.
+- **DHCP (DPU)** — a per-host DHCP server running on the DPU. Handles all host DHCP requests locally so host DHCP traffic never reaches the underlay network. Configured by the DPU Agent.
+
+### Prerequisite Components
+
+The white boxes in the architecture diagram are off-the-shelf services that NICo depends on but does not build. They must be deployed before NICo installation. See [Site Setup](../manuals/site-setup.md) for validated versions and configuration details.
+
+- **PostgreSQL** — stores all NICo system state in the `forge_system_carbide` database. Only the API Service reads from and writes to it. The reference deployment uses the Zalando Postgres Operator with Spilo-15.
+- **Vault** — provides a PKI engine for certificate issuance and a KV secrets engine for credential storage. Consumed by the API Service and credsmgr (cloud-cert-manager). Uses Kubernetes authentication to authorize NICo service accounts.
+- **Temporal** — workflow orchestration engine used by NICo REST for multi-step operations (instance provisioning, reboot, release). The Site Agent connects to NICo REST through Temporal. Requires registered namespaces: `cloud`, `site`, and a per-site UUID.
+- **cert-manager** — issues and rotates the TLS certificates that NICo services use for mTLS/gRPC communication. Includes approver-policy for certificate request authorization.
+- **External Secrets Operator (ESO)** — syncs secrets from Vault into Kubernetes Secret objects, making credentials (database, PKI, bootstrap material) available to NICo workloads in each namespace.
+- **Telemetry and Logging (Prometheus, Grafana, OpenTelemetry, Loki)** — collects metrics and logs from all NICo services and managed hosts. Prometheus scrapes the Hardware Health `/metrics` endpoint. Loki aggregates logs from the SSH Console Service and DPU agents. OpenTelemetry Collector ships telemetry from both the site controller and DPUs. Optional but strongly recommended.
+- **MetalLB** — provides load-balanced virtual IPs for NICo services on the Kubernetes cluster, making them reachable from the underlay network.
+- **ArgoCD** — GitOps-based continuous delivery for deploying and updating NICo components. Optional.
+- **NGC Registry** — NVIDIA's container registry, used to pull NICo service images during deployment and upgrades.
+- **IDP (KeyCloak)** — identity provider for admin web UI authentication via OIDC. Optional.
+
+For a deeper look at each component and the state machine design, see [Architecture: Overview and Components](../architecture/overview.md).
+
+## Where NICo fits
+
+NICo sits below Kubernetes and platform layers. It exposes REST and gRPC APIs that higher-level systems — BMaaS, VMaaS, orchestration engines, ISV control planes — can consume directly. It does not dictate how scheduling, tenancy policy, or workloads are managed above it.
+
+```
+┌─────────────────────────────────────┐
+│   ISV / NCP Control Plane           │
+├─────────────────────────────────────┤
+│   Kubernetes / BMaaS / VMaaS        │
+├─────────────────────────────────────┤
+│   NICo  ◄── you are here            │
+├─────────────────────────────────────┤
+│   BlueField DPU + Host Hardware     │
+└─────────────────────────────────────┘
+```
+
+NICo is the layer that makes the hardware predictable, repeatable, and safe — so the layers above it can treat bare metal as a reliable building block.

--- a/docs/overview/what-is-nico.md
+++ b/docs/overview/what-is-nico.md
@@ -19,7 +19,7 @@ NICo fills this gap — it enables physical servers to behave like cloud instanc
 
 NICo manages the full lifecycle of bare-metal hosts — from initial rack discovery through tenant provisioning, ongoing operations, and secure reuse.
 
-Each managed host is a **BlueField DPU + host server pair**. The DPU acts as the enforcement boundary for network isolation and security; NICo provisions and manages it directly, independently of what runs on the host.
+Each managed host is a **host server with one or more BlueField DPUs**. The attached DPUs act as enforcement boundaries for network isolation and security; NICo provisions and manages them directly, independently of what runs on the host.
 
 NICo's core responsibilities:
 

--- a/docs/playbooks/ib_runbook.md
+++ b/docs/playbooks/ib_runbook.md
@@ -397,7 +397,7 @@ curl -v -s --cert-type PEM --cacert ca.crt --key tls.key --cert tls.crt -XGET  h
 *  start date: Jun 18 02:52:24 2024 GMT
 *  expire date: Jul 18 02:52:54 2024 GMT
 *  subjectAltName: host "carbide-api.forge" matched cert's "carbide-api.forge"
-*  issuer: O=NVIDIA Corporation; CN=NVIDIA Forge Intermediate CA 2023 - pdx-qa2
+*  issuer: O=NVIDIA Corporation; CN=NVIDIA NICo Intermediate CA - <site-name>
 *  SSL certificate verify ok.
 } [5 bytes data]
 > GET /ufmRest/app/ufm_version HTTP/1.1

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,10 +1,10 @@
 # Release Notes
 
-This document contains release notes for the NVIDIA Infra Controller (NICo) project.
+This document contains release notes for the NCX Infra Controller (NICo) project.
 
-## Infra Controller 0.2.0
+## NCX Infra Controller 0.2.0
 
-This release of DIA Infra Controller is open-source software (OSS).
+This release of NCX Infra Controller (NICo) is open-source software (OSS).
 
 ### Improvements
 
@@ -27,7 +27,7 @@ This release of DIA Infra Controller is open-source software (OSS).
 
 - The above `nv-redfish` package update fixes a critical bug with the BMC cache, which caused multiple cache miss errors, preventing the health monitor from re-discovery of monitored entities.
 
-## Infra Controller EA
+## NCX Infra Controller EA
 
 ### What This Release Enables
 


### PR DESCRIPTION
## Summary

- **Landing page** (`docs/index.md`): persona-based entry points for operators, integrators, and evaluators — replaces the stale Introduction page
- **Overview section** (5 pages): complete rewrite covering What is NICo, Key Capabilities, Operational Principles, Day 0/1/2 Lifecycle, and Scope and Boundaries
- **What is NICo** (`what-is-nico.md`): architecture overview with NICo Components (green boxes) and Prerequisite Components (white boxes) matching the architecture diagram; "Why NICo exists" framing sourced from VDR and Code Yellow docs
- **Scope and Boundaries** (renamed from "What NICo Does Not Cover"): two-column tables showing NICo vs platform/operator responsibilities at each boundary
- **Nav fixes**: explicit slugs to prevent Fern from mangling NICo in URLs (e.g. `what-is-ni-co` → `what-is-nico`)

## Context

Part of the NICo Docs Code Yellow (FORGE-8168). Follows the IA recommendation from CDEVS-2173 for the Overview section structure and landing page.

## Test plan

- [ ] Preview with `fern docs dev` — verify all nav links resolve, no broken internal links
- [ ] Verify Overview sidebar matches: Home → What is NICo? → Key Capabilities → Operational Principles → Day 0/1/2 Lifecycle → Scope and Boundaries
- [ ] Verify landing page persona table links resolve to correct pages
- [ ] Verify URL slugs use `what-is-nico` and `scope-and-boundaries` (not `what-is-ni-co`)
- [ ] Review component descriptions in architecture overview against the architecture diagram

🤖 Generated with [Claude Code](https://claude.com/claude-code)