### PR TITLE
Correlate scout firmware upgrades and fix deadlines

### DIFF
--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1737,6 +1737,7 @@ pub enum HostReprovisionState {
     },
     WaitingForRackFirmwareUpgrade,
     WaitingForScoutUpgrade {
+        upgrade_task_id: String,
         component_type: FirmwareComponentType,
         target_version: String,
         started_at: DateTime<Utc>,

--- a/crates/api/src/handlers/host_reprovisioning.rs
+++ b/crates/api/src/handlers/host_reprovisioning.rs
@@ -159,34 +159,38 @@ pub async fn report_scout_firmware_upgrade_status(
     let (machine, mut txn) = api.load_machine(&machine_id, Default::default()).await?;
 
     // Verify machine is in WaitingForScoutUpgrade state
-    let (component_type, target_version, started_at, deadline, task_json, retry_count) =
-        match machine.current_state() {
-            ManagedHostState::HostReprovision {
-                reprovision_state:
-                    HostReprovisionState::WaitingForScoutUpgrade {
-                        component_type,
-                        target_version,
-                        started_at,
-                        deadline,
-                        task_json,
-                        ..
-                    },
-                retry_count,
-            } => (
-                *component_type,
-                target_version.clone(),
-                *started_at,
-                *deadline,
-                task_json.clone(),
-                *retry_count,
-            ),
-            _ => {
-                return Err(CarbideError::FailedPrecondition(format!(
-                    "Machine {machine_id} is not in WaitingForScoutUpgrade state"
-                ))
-                .into());
-            }
-        };
+    let ManagedHostState::HostReprovision {
+        reprovision_state:
+            HostReprovisionState::WaitingForScoutUpgrade {
+                upgrade_task_id,
+                component_type,
+                target_version,
+                started_at,
+                deadline,
+                task_json,
+                ..
+            },
+        retry_count,
+    } = machine.current_state().clone()
+    else {
+        return Err(CarbideError::FailedPrecondition(format!(
+            "Machine {machine_id} is not in WaitingForScoutUpgrade state"
+        ))
+        .into());
+    };
+
+    if req.upgrade_task_id != upgrade_task_id {
+        tracing::warn!(
+            %machine_id,
+            expected_upgrade_task_id = %upgrade_task_id,
+            reported_upgrade_task_id = %req.upgrade_task_id,
+            "Rejecting stale scout firmware upgrade status report",
+        );
+        return Err(CarbideError::FailedPrecondition(format!(
+            "Scout firmware upgrade status task ID mismatch for machine {machine_id}"
+        ))
+        .into());
+    }
 
     // Cap stdout/stderr/error so the JSON state row stays small; full output
     // is available in the scout logs if an operator needs to dig deeper.
@@ -194,6 +198,7 @@ pub async fn report_scout_firmware_upgrade_status(
 
     let new_state = ManagedHostState::HostReprovision {
         reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
+            upgrade_task_id,
             component_type,
             target_version,
             started_at,

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -122,6 +122,33 @@ pub const MAX_FIRMWARE_UPGRADE_RETRIES: u32 = 5;
 #[cfg(test)]
 pub const MAX_FIRMWARE_UPGRADE_RETRIES: u32 = 2; // Faster for tests
 
+// Compute the API-side deadline for a scout firmware upgrade from scout's
+// timeout envelope: fixed script download timeout, script execution timeout,
+// one artifact download timeout per file artifact, and report/slack time.
+// Saturating arithmetic prevents overflow from malformed configs, and the
+// final cap prevents the API from waiting indefinitely for an absurd task.
+fn scout_firmware_upgrade_deadline(
+    started_at: DateTime<Utc>,
+    execution_timeout_seconds: u32,
+    artifact_download_timeout_seconds: u32,
+    file_artifact_count: usize,
+) -> DateTime<Utc> {
+    // Must match crates/scout/src/firmware_upgrade.rs::SCRIPT_DOWNLOAD_TIMEOUT.
+    const SCRIPT_DOWNLOAD_TIMEOUT_SECONDS: i64 = 30;
+    const DEADLINE_SLACK: Duration = Duration::minutes(30);
+    const MAX_DEADLINE_DURATION_SECONDS: i64 = 5 * 60 * 60;
+
+    let artifact_download_seconds = i64::from(artifact_download_timeout_seconds)
+        .saturating_mul(i64::try_from(file_artifact_count).unwrap_or(i64::MAX));
+    let deadline_seconds = SCRIPT_DOWNLOAD_TIMEOUT_SECONDS
+        .saturating_add(i64::from(execution_timeout_seconds))
+        .saturating_add(artifact_download_seconds)
+        .saturating_add(DEADLINE_SLACK.num_seconds())
+        .min(MAX_DEADLINE_DURATION_SECONDS);
+
+    started_at + Duration::seconds(deadline_seconds)
+}
+
 /// Reachability params to check if DPU is up or not.
 #[derive(Copy, Clone, Debug)]
 pub struct ReachabilityParams {
@@ -7087,7 +7114,10 @@ impl HostUpgradeState {
                         format!("{PXE_URL}/public/firmware/{relative}")
                     };
 
+                    let upgrade_task_id = uuid::Uuid::new_v4().to_string();
+                    let file_artifact_count = to_install.files.len();
                     let task = serde_json::json!({
+                        "upgrade_task_id": &upgrade_task_id,
                         "component_type": firmware_type.to_string(),
                         "target_version": to_install.version,
                         "script": {
@@ -7104,18 +7134,18 @@ impl HostUpgradeState {
                         }).collect::<Vec<_>>(),
                     });
 
-                    // Scout respects its own execution/download timeouts; slack covers clock
-                    // skew and the round-trip for the report RPC to reach us.
-                    const DEADLINE_SLACK: chrono::TimeDelta = chrono::TimeDelta::minutes(30);
+                    // Scout uses a fixed timeout for the script download and applies the artifact
+                    // download timeout per file
                     let started_at = Utc::now();
-                    let deadline = started_at
-                        + chrono::TimeDelta::seconds(
-                            i64::from(scout_config.execution_timeout_seconds)
-                                + i64::from(scout_config.artifact_download_timeout_seconds),
-                        )
-                        + DEADLINE_SLACK;
+                    let deadline = scout_firmware_upgrade_deadline(
+                        started_at,
+                        scout_config.execution_timeout_seconds,
+                        scout_config.artifact_download_timeout_seconds,
+                        file_artifact_count,
+                    );
                     return Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
                         HostReprovisionState::WaitingForScoutUpgrade {
+                            upgrade_task_id,
                             component_type: firmware_type,
                             target_version: to_install.version,
                             started_at,
@@ -10504,6 +10534,31 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
+
+    #[test]
+    fn scout_firmware_upgrade_deadline_accounts_for_each_artifact() {
+        let started_at = chrono::DateTime::<Utc>::from_str("2026-04-28T00:00:00Z").unwrap();
+
+        let deadline = scout_firmware_upgrade_deadline(started_at, 300, 120, 3);
+
+        assert_eq!(
+            deadline,
+            started_at
+                + Duration::seconds(30)
+                + Duration::seconds(300)
+                + Duration::seconds(120 * 3)
+                + Duration::minutes(30)
+        );
+    }
+
+    #[test]
+    fn scout_firmware_upgrade_deadline_is_capped() {
+        let started_at = chrono::DateTime::<Utc>::from_str("2026-04-28T00:00:00Z").unwrap();
+
+        let deadline = scout_firmware_upgrade_deadline(started_at, u32::MAX, u32::MAX, usize::MAX);
+
+        assert_eq!(deadline, started_at + Duration::hours(5));
+    }
 
     /// Verify that `oem_manager_profiles` from the site config is forwarded to `machine_setup`.
     ///

--- a/crates/api/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api/src/tests/host_bmc_firmware_test.rs
@@ -2647,6 +2647,8 @@ async fn test_manual_firmware_upgrade_workflow(pool: sqlx::PgPool) -> CarbideRes
 
 #[crate::sqlx_test]
 async fn test_report_scout_firmware_upgrade_status(pool: sqlx::PgPool) -> CarbideResult<()> {
+    const UPGRADE_TASK_ID: &str = "scout-upgrade-task-id";
+
     let env = create_test_env(pool).await;
     let mh = common::api_fixtures::create_managed_host(&env).await;
 
@@ -2655,6 +2657,7 @@ async fn test_report_scout_firmware_upgrade_status(pool: sqlx::PgPool) -> Carbid
     let host = mh.host().db_machine(&mut txn).await;
     let waiting_state = ManagedHostState::HostReprovision {
         reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
+            upgrade_task_id: UPGRADE_TASK_ID.to_string(),
             component_type: FirmwareComponentType::Bmc,
             target_version: "1.2.3".to_string(),
             started_at: chrono::Utc::now(),
@@ -2679,6 +2682,7 @@ async fn test_report_scout_firmware_upgrade_status(pool: sqlx::PgPool) -> Carbid
                 stdout: "upgrade complete".to_string(),
                 stderr: String::new(),
                 error: String::new(),
+                upgrade_task_id: UPGRADE_TASK_ID.to_string(),
             },
         ))
         .await
@@ -2709,6 +2713,8 @@ async fn test_report_scout_firmware_upgrade_status(pool: sqlx::PgPool) -> Carbid
 async fn test_report_scout_firmware_upgrade_status_failure(
     pool: sqlx::PgPool,
 ) -> CarbideResult<()> {
+    const UPGRADE_TASK_ID: &str = "scout-upgrade-task-id";
+
     let env = create_test_env(pool).await;
     let mh = common::api_fixtures::create_managed_host(&env).await;
 
@@ -2717,6 +2723,7 @@ async fn test_report_scout_firmware_upgrade_status_failure(
     let host = mh.host().db_machine(&mut txn).await;
     let waiting_state = ManagedHostState::HostReprovision {
         reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
+            upgrade_task_id: UPGRADE_TASK_ID.to_string(),
             component_type: FirmwareComponentType::Bmc,
             target_version: "1.2.3".to_string(),
             started_at: chrono::Utc::now(),
@@ -2741,6 +2748,7 @@ async fn test_report_scout_firmware_upgrade_status_failure(
                 stdout: "starting upgrade".to_string(),
                 stderr: "permission denied".to_string(),
                 error: "script failed".to_string(),
+                upgrade_task_id: UPGRADE_TASK_ID.to_string(),
             },
         ))
         .await
@@ -2781,6 +2789,7 @@ async fn test_report_scout_firmware_upgrade_status_wrong_state(
         .report_scout_firmware_upgrade_status(Request::new(
             rpc::forge::ScoutFirmwareUpgradeStatusRequest {
                 machine_id: Some(mh.host().id),
+                upgrade_task_id: "scout-upgrade-task-id".to_string(),
                 success: true,
                 exit_code: 0,
                 stdout: String::new(),
@@ -2797,9 +2806,81 @@ async fn test_report_scout_firmware_upgrade_status_wrong_state(
 }
 
 #[crate::sqlx_test]
+async fn test_report_scout_firmware_upgrade_status_rejects_stale_task_id(
+    pool: sqlx::PgPool,
+) -> CarbideResult<()> {
+    const CURRENT_TASK_ID: &str = "current-scout-upgrade-task-id";
+    const STALE_TASK_ID: &str = "stale-scout-upgrade-task-id";
+
+    let env = create_test_env(pool).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let host = mh.host().db_machine(&mut txn).await;
+    let waiting_state = ManagedHostState::HostReprovision {
+        reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
+            upgrade_task_id: CURRENT_TASK_ID.to_string(),
+            component_type: FirmwareComponentType::Bmc,
+            target_version: "1.2.3".to_string(),
+            started_at: chrono::Utc::now(),
+            deadline: chrono::Utc::now() + chrono::TimeDelta::minutes(60),
+            task_json: String::new(),
+            result: None,
+        },
+        retry_count: 0,
+    };
+    db::machine::advance(&host, &mut txn, &waiting_state, None)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    let err = env
+        .api
+        .report_scout_firmware_upgrade_status(Request::new(
+            rpc::forge::ScoutFirmwareUpgradeStatusRequest {
+                machine_id: Some(mh.host().id),
+                success: true,
+                exit_code: 0,
+                stdout: "stale success".to_string(),
+                stderr: String::new(),
+                error: String::new(),
+                upgrade_task_id: STALE_TASK_ID.to_string(),
+            },
+        ))
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let host = mh.host().db_machine(&mut txn).await;
+    let ManagedHostState::HostReprovision {
+        reprovision_state, ..
+    } = host.current_state()
+    else {
+        panic!("Not in HostReprovision");
+    };
+    let HostReprovisionState::WaitingForScoutUpgrade {
+        upgrade_task_id,
+        result,
+        ..
+    } = reprovision_state
+    else {
+        panic!("Not in WaitingForScoutUpgrade");
+    };
+    assert_eq!(upgrade_task_id, CURRENT_TASK_ID);
+    assert!(result.is_none());
+    txn.commit().await.unwrap();
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
 async fn test_report_scout_firmware_upgrade_status_truncates_output(
     pool: sqlx::PgPool,
 ) -> CarbideResult<()> {
+    const UPGRADE_TASK_ID: &str = "scout-upgrade-task-id";
+
     let env = create_test_env(pool).await;
     let mh = common::api_fixtures::create_managed_host(&env).await;
 
@@ -2808,6 +2889,7 @@ async fn test_report_scout_firmware_upgrade_status_truncates_output(
     let host = mh.host().db_machine(&mut txn).await;
     let waiting_state = ManagedHostState::HostReprovision {
         reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
+            upgrade_task_id: UPGRADE_TASK_ID.to_string(),
             component_type: FirmwareComponentType::Bmc,
             target_version: "1.2.3".to_string(),
             started_at: chrono::Utc::now(),
@@ -2833,6 +2915,7 @@ async fn test_report_scout_firmware_upgrade_status_truncates_output(
                 stdout: large_output.clone(),
                 stderr: large_output.clone(),
                 error: large_output.clone(),
+                upgrade_task_id: UPGRADE_TASK_ID.to_string(),
             },
         ))
         .await
@@ -2870,6 +2953,7 @@ async fn put_in_waiting_for_scout_upgrade(
     let machine = host.db_machine(&mut txn).await;
     let state = ManagedHostState::HostReprovision {
         reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
+            upgrade_task_id: "scout-upgrade-task-id".to_string(),
             component_type: FirmwareComponentType::Bmc,
             target_version: "1.2.3".to_string(),
             started_at: chrono::Utc::now(),

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -5366,6 +5366,7 @@ message ScoutFirmwareUpgradeStatusRequest {
   string stdout = 4;
   string stderr = 5;
   string error = 6;
+  string upgrade_task_id = 7;
 }
 
 // enum MachineValidationState {

--- a/crates/scout/src/firmware_upgrade.rs
+++ b/crates/scout/src/firmware_upgrade.rs
@@ -30,6 +30,7 @@ const DOWNLOAD_MAX_RETRIES: u32 = 3;
 // carbide-api via ForgeAgentControl when Action::FirmwareUpgrade is set.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FirmwareUpgradeTask {
+    pub upgrade_task_id: String,
     pub component_type: String,
     pub target_version: String,
     pub script: FileArtifact,
@@ -316,6 +317,7 @@ mod tests {
         .await;
 
         let task = FirmwareUpgradeTask {
+            upgrade_task_id: "test-upgrade-task-id".into(),
             component_type: "cpld".into(),
             target_version: "1.2.3".into(),
             script: script_artifact(&base, "/scripts/upgrade.sh", script),
@@ -345,6 +347,7 @@ mod tests {
         let base = start_file_server(vec![("/scripts/fail.sh", script)]).await;
 
         let task = FirmwareUpgradeTask {
+            upgrade_task_id: "test-upgrade-task-id".into(),
             component_type: "bios".into(),
             target_version: "2.0.0".into(),
             script: script_artifact(&base, "/scripts/fail.sh", script),
@@ -366,6 +369,7 @@ mod tests {
         let base = start_file_server(vec![("/scripts/slow.sh", script)]).await;
 
         let task = FirmwareUpgradeTask {
+            upgrade_task_id: "test-upgrade-task-id".into(),
             component_type: "cpld".into(),
             target_version: "1.0.0".into(),
             script: script_artifact(&base, "/scripts/slow.sh", script),
@@ -387,6 +391,7 @@ mod tests {
         let base = start_file_server(vec![("/scripts/env.sh", script)]).await;
 
         let task = FirmwareUpgradeTask {
+            upgrade_task_id: "test-upgrade-task-id".into(),
             component_type: "cpldmb".into(),
             target_version: "3.4.5".into(),
             script: script_artifact(&base, "/scripts/env.sh", script),
@@ -408,6 +413,7 @@ mod tests {
         let base = start_file_server(vec![]).await;
 
         let task = FirmwareUpgradeTask {
+            upgrade_task_id: "test-upgrade-task-id".into(),
             component_type: "cpld".into(),
             target_version: "1.0.0".into(),
             script: FileArtifact {
@@ -435,6 +441,7 @@ mod tests {
         .await;
 
         let task = FirmwareUpgradeTask {
+            upgrade_task_id: "test-upgrade-task-id".into(),
             component_type: "cpld".into(),
             target_version: "1.0.0".into(),
             script: script_artifact(&base, "/scripts/upgrade.sh", script),
@@ -458,6 +465,7 @@ mod tests {
         let base = start_file_server(vec![("/scripts/upgrade.sh", script)]).await;
 
         let task = FirmwareUpgradeTask {
+            upgrade_task_id: "test-upgrade-task-id".into(),
             component_type: "cpld".into(),
             target_version: "1.0.0".into(),
             script: FileArtifact {
@@ -478,6 +486,7 @@ mod tests {
     #[tokio::test]
     async fn test_task_json_ser_deser_roundtrip() {
         let task = FirmwareUpgradeTask {
+            upgrade_task_id: "roundtrip-upgrade-task-id".into(),
             component_type: "cpld".into(),
             target_version: "1.2.3".into(),
             script: FileArtifact {
@@ -496,6 +505,7 @@ mod tests {
         let parsed: FirmwareUpgradeTask = serde_json::from_str(&json).unwrap();
 
         assert_eq!(parsed.component_type, "cpld");
+        assert_eq!(parsed.upgrade_task_id, "roundtrip-upgrade-task-id");
         assert_eq!(parsed.target_version, "1.2.3");
         assert_eq!(parsed.script.url, "http://example.com/script.sh");
         assert_eq!(parsed.script.sha256, "scripthash");

--- a/crates/scout/src/main.rs
+++ b/crates/scout/src/main.rs
@@ -484,7 +484,7 @@ async fn handle_firmware_upgrade_action(
         result.exit_code,
     );
 
-    report_firmware_upgrade_status(config, machine_id, &result).await?;
+    report_firmware_upgrade_status(config, machine_id, task.upgrade_task_id, &result).await?;
 
     if !result.success {
         return Err(CarbideClientError::GenericError(format!(
@@ -498,6 +498,7 @@ async fn handle_firmware_upgrade_action(
 async fn report_firmware_upgrade_status(
     config: &Options,
     machine_id: &MachineId,
+    upgrade_task_id: String,
     result: &firmware_upgrade::FirmwareUpgradeResult,
 ) -> Result<(), CarbideClientError> {
     let mut client = client::create_forge_client(config).await?;
@@ -508,6 +509,7 @@ async fn report_firmware_upgrade_status(
         stdout: truncate(&result.stdout, MAX_FIRMWARE_UPGRADE_STATUS_FIELD_SIZE),
         stderr: truncate(&result.stderr, MAX_FIRMWARE_UPGRADE_STATUS_FIELD_SIZE),
         error: truncate(&result.error, MAX_FIRMWARE_UPGRADE_STATUS_FIELD_SIZE),
+        upgrade_task_id,
     });
     client.report_scout_firmware_upgrade_status(request).await?;
     Ok(())


### PR DESCRIPTION
## Description
Fixing two things in the scout-based upgrade workflow:

1. Fixing the timeout deadline to consider `file_artifact_count` because that's how the scout calculates the timeout on its end.
2. Correlating upgrade attempts by using an ID. There can be a case when the attempt times out on the API side but the scout may report success/fail later. Now the IDs will need to match.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)


<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

