### PR TITLE
fix(bmc-explorer): ignore BlueField BIOS 500 in NIC mode

### DIFF
--- a/crates/bmc-explorer/src/computer_system.rs
+++ b/crates/bmc-explorer/src/computer_system.rs
@@ -49,6 +49,9 @@ lazy_static::lazy_static! {
 pub struct Config<'a, B: Bmc> {
     pub need_oem_nvidia_bluefield: bool,
     // Temporary workaround for BlueField DPU BMCs that intermittently return
+    // HTTP 500 for the BIOS resource while the DPU is in NIC mode.
+    pub ignore_500_on_bios_fetch: bool,
+    // Temporary workaround for BlueField DPU BMCs that intermittently return
     // HTTP 404 for the OOB interface or the full EthernetInterfaces collection.
     // This is expected to be fixed in BMC firmware 24.10-39, which adds
     // internal retries.
@@ -83,7 +86,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
             vec![]
         };
 
-        let bios = system.bios().await.map_err(Error::nv_redfish("bios"))?;
+        let bios = Self::fetch_bios(&system, config).await?;
 
         let ethernet_interfaces = Self::fetch_eth_interfaces(&system, config)
             .await
@@ -113,6 +116,28 @@ impl<B: Bmc> ExploredComputerSystem<B> {
         })
     }
 
+    async fn fetch_bios(
+        system: &ComputerSystem<B>,
+        config: &Config<'_, B>,
+    ) -> Result<Option<Bios<B>>, Error<B>> {
+        match system.bios().await {
+            Ok(bios) => Ok(bios),
+            Err(err) if config.ignore_500_on_bios_fetch => {
+                if let nv_redfish::Error::Bmc(bmc_error) = &err
+                    && (config.explore.error_classifier)(bmc_error)
+                        == Some(ErrorClass::InternalServerError)
+                {
+                    // Ignore BlueField DPU BIOS HTTP 500 because it may fail in NIC mode.
+                    tracing::warn!("ignoring HTTP 500 while fetching BlueField DPU BIOS");
+                    Ok(None)
+                } else {
+                    Err(Error::nv_redfish("bios")(err))
+                }
+            }
+            Err(err) => Err(Error::nv_redfish("bios")(err)),
+        }
+    }
+
     async fn fetch_eth_interfaces(
         system: &ComputerSystem<B>,
         config: &Config<'_, B>,
@@ -130,7 +155,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
                 Err(err) if config.retry_404_on_eth_interfaces && retries_remaining != 0 => {
                     if let nv_redfish::Error::Bmc(bmc_error) = &err
                         && (config.explore.error_classifier)(bmc_error)
-                            == Some(ErrorClass::HttpNotFound)
+                            == Some(ErrorClass::NotFound)
                     {
                         tracing::warn!(
                             "received 404 on system's ethernet collection fetch. Retrying. {retries_remaining} tries left"
@@ -145,7 +170,6 @@ impl<B: Bmc> ExploredComputerSystem<B> {
             }
         }
     }
-
     pub fn to_model(
         &self,
         hw_type: Option<hw::HwType>,

--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -54,7 +54,8 @@ use nv_redfish::{Bmc, Resource, ServiceRoot};
 
 #[derive(PartialEq, Eq)]
 pub enum ErrorClass {
-    HttpNotFound,
+    NotFound,
+    InternalServerError,
 }
 
 pub type ErrorClassifier<'a, B> = &'a (dyn Fn(&<B as Bmc>::Error) -> Option<ErrorClass> + Sync);
@@ -122,9 +123,11 @@ pub async fn nv_generate_exploration_report<B: Bmc>(
         .next()
         .ok_or_else(Error::bmc_not_provided("at least one manager"))?;
 
+    let is_bluefield_system = system.id().into_inner() == "Bluefield";
     let system_explore_config = computer_system::Config {
-        need_oem_nvidia_bluefield: system.id().into_inner() == "Bluefield",
-        retry_404_on_eth_interfaces: system.id().into_inner() == "Bluefield",
+        need_oem_nvidia_bluefield: is_bluefield_system,
+        ignore_500_on_bios_fetch: is_bluefield_system,
+        retry_404_on_eth_interfaces: is_bluefield_system,
         explore: config,
     };
     let explored_system = ExploredComputerSystem::explore(system, &system_explore_config).await?;

--- a/crates/bmc-explorer/tests/bluefield3_explore.rs
+++ b/crates/bmc-explorer/tests/bluefield3_explore.rs
@@ -199,3 +199,32 @@ async fn explore_bluefield3_succeeds_when_erot_returns_error() {
     );
     assert_eq!(report.chassis.len(), 3);
 }
+
+#[test]
+async fn explore_bluefield3_ignores_500_on_bios_fetch() {
+    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default()).await;
+
+    h.state.injected_bugs.update_args(bmc_mock::bug::Args {
+        http_error: Some(bmc_mock::bug::HttpErrorRule {
+            method: Some("GET".into()),
+            path: "/redfish/v1/Systems/Bluefield/Bios".to_string(),
+            status: 500,
+            remaining: 100,
+        }),
+        ..Default::default()
+    });
+
+    let report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
+        .await
+        .expect("exploration must succeed when BlueField BIOS fetch returns 500");
+
+    assert_eq!(report.endpoint_type, EndpointType::Bmc);
+    assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Nvidia));
+    assert!(
+        report
+            .machine_setup_status
+            .as_ref()
+            .is_some_and(|status| !status.diffs.is_empty() || status.is_done),
+        "machine setup status must be present and structurally valid"
+    );
+}

--- a/crates/bmc-explorer/tests/common.rs
+++ b/crates/bmc-explorer/tests/common.rs
@@ -24,10 +24,11 @@ use bmc_mock::test_support::axum_http_client::Error as TestBmcError;
 
 pub fn error_classifier(err: &<TestBmc as nv_redfish::Bmc>::Error) -> Option<ErrorClass> {
     match err {
-        TestBmcError::InvalidResponse {
-            status: StatusCode::NOT_FOUND,
-            ..
-        } => Some(ErrorClass::HttpNotFound),
+        TestBmcError::InvalidResponse { status, .. } => match *status {
+            StatusCode::NOT_FOUND => Some(ErrorClass::NotFound),
+            StatusCode::INTERNAL_SERVER_ERROR => Some(ErrorClass::InternalServerError),
+            _ => None,
+        },
         _ => None,
     }
 }

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -1275,10 +1275,13 @@ fn nv_error_classifier(
 ) -> Option<bmc_explorer::ErrorClass> {
     type BmcError = carbide_redfish::nv_redfish::BmcError;
     match err {
-        BmcError::InvalidResponse {
-            status: http::StatusCode::NOT_FOUND,
-            ..
-        } => Some(bmc_explorer::ErrorClass::HttpNotFound),
+        BmcError::InvalidResponse { status, .. } => match *status {
+            http::StatusCode::NOT_FOUND => Some(bmc_explorer::ErrorClass::NotFound),
+            http::StatusCode::INTERNAL_SERVER_ERROR => {
+                Some(bmc_explorer::ErrorClass::InternalServerError)
+            }
+            _ => None,
+        },
         _ => None,
     }
 }


### PR DESCRIPTION
## Description

BlueField DPU BMCs can return HTTP 500 when fetching the BIOS resource while the DPU is in NIC mode. This currently makes endpoint exploration fail even though the rest of the Redfish tree is still usable and BIOS-dependent checks can be skipped safely.

Add an explicit `ignore_500_on_bios_fetch` exploration workaround flag and enable it for BlueField systems. When the flag is set, BIOS fetch HTTP 500 is logged and treated as missing BIOS instead of aborting exploration.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
