### PR TITLE
chore(docs): update architecture docs for extracted core modules

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -117,28 +117,32 @@ Details about the NICo state handling implementation can be found [here](state_h
 
 ### Site Explorer
 
-Site Explorer is a process within NICo Core that continuously monitors the state of all BMCs that are detected within the underlay network. The process acts as a "crawler". It continuously tries to perform redfish requests against all IPs on the underlay network that were provided by NICo Core and records information that NICo is required to manage the hosts in a follow-up. The information collected by NICo is
+Site Explorer is a background module within the `carbide-api` binary that continuously monitors the state of all BMCs detected on the underlay network. Its implementation lives in the separate `crates/site-explorer` crate to keep the `crates/api` crate smaller, but it is still started and run as part of NICo Core.
+
+The process acts as a "crawler". It continuously tries to perform Redfish requests against all IPs on the underlay network that were provided by NICo Core and records information that NICo needs to manage hosts later. The information collected by NICo includes:
 - Serial Numbers
 - Certain inventory data, e.g. the amount, type and serial numbers of DPUs
 - Power State
 - Configuration data, e.g. boot order, lockdown mode
 - Firmware versions
 
-NICo users can inspect the data that site explorer discovers using the `FindExploredEndpoints` APIs as well as using the NICo Debug Web UI.
+NICo users can inspect the data that Site Explorer discovers using the `FindExploredEndpoints` APIs as well as using the NICo Debug Web UI.
 
 Site Explorer requires an "Expected Machines" manifest to be deployed. Expected Machines describes the set of Machines that is expected to be managed by the NICo instance - it encodes BMC MAC addresses, hardware default passwords and other details of these Machines. The manifest can be updated using a set of APIs, e.g. `ReplaceAllExpectedMachines`.
 
-Beyond the basic BMC data collection, NICo also performs the following tasks:
-1. It matches hosts with associated DPUs based on the redfish reports of both components - e.g. both the host and DPU need to reference the same DPU serial number.
+Beyond the basic BMC data collection, Site Explorer also performs the following tasks:
+1. It matches hosts with associated DPUs based on the Redfish reports of both components - e.g. both the host and DPU need to reference the same DPU serial number.
 2. It kickstarts the ingestion process of the host once the host is in an "ingestable" state (all components are found and have up to date firmware versions).
 
-Site Explorer emits metrics with the prefix `forge_endpoint_` and `forge_site_explorer_`.
+Site Explorer emits metrics with the prefix `carbide_endpoint_exploration_` and `carbide_site_explorer_`.
 
 ### Preingestion Manager
 
-Preingestion Manager is a component which updates the firmware of hosts that are below the minimum required firmware version that is required to be ingestable. Usually firmware updates to hosts are deployed within the main machine lifecycle, as managed by the ManagedHost state machine.
+Preingestion Manager is a background module within the `carbide-api` binary. Its implementation lives in the separate `crates/preingestion-manager` crate to keep the `crates/api` crate smaller, but it is still started and run as part of NICo Core.
 
-In some rare cases - e.g. with very old host or DPU BMCs - the host ingestion process can't be started yet - e.g. because the BMC does not provide the necessary information to map the host to DPUs. In this case the firmware needs to be updated before ingestion, and preingestion manager performs this task.
+Preingestion Manager updates hosts that are below the minimum firmware version required for ingestion. Usually firmware updates to hosts are deployed within the main machine lifecycle, as managed by the ManagedHost state machine.
+
+In some rare cases - e.g. with very old host or DPU BMCs - the host ingestion process can't be started yet because the BMC does not provide the necessary information to map the host to DPUs. In this case the firmware needs to be updated before ingestion, and Preingestion Manager performs this task. It also drives pre-ingestion reset flows and DPU BFB recovery/copy flows that must complete before normal ingestion can proceed.
 
 ### Machine Update Manager
 
@@ -170,9 +174,11 @@ InfiniBand Fabric Monitor is an optional component. It only needs to be enabled 
 
 IB Fabric Monitor emits metrics with prefix `forge_ib_monitor_`.
 
-### NVLink Monitor
+### NVLink Manager
 
-In development. The NVLink monitor will have similar responsibilities as IBFabricMonitor, but is used for monitoring and configuring NVLink. It will therefore interact with NMX APIs.
+NVLink Manager is a background module within the `carbide-api` binary. Its implementation lives in the separate `crates/nvlink-manager` crate to keep the `crates/api` crate smaller, but it is still started and run as part of NICo Core.
+
+Its `NvlPartitionMonitor` reconciles NVLink logical partition desired state with the state reported by NMX-M. In each run, it loads MNNVL-capable machines and NVLink partition records from the database, queries NMX-M for GPU and partition state, records `MachineNvLinkStatusObservation` data, and creates, updates, or removes NMX-M partitions as needed.
 
 ## Dependency services
 

--- a/docs/architecture/redfish_workflow.md
+++ b/docs/architecture/redfish_workflow.md
@@ -80,8 +80,8 @@ With an authenticated session, Site Explorer queries a comprehensive set of Redf
 Serial numbers are trimmed of whitespace. If `system.serial_number` is missing, the chassis serial number is used as a fallback.
 
 **Key files:**
-- `crates/api/src/site_explorer/redfish.rs` — `RedfishClient`: `probe_redfish_endpoint()`, `create_redfish_client()`, inventory queries
-- `crates/api/src/site_explorer/bmc_endpoint_explorer.rs` — `BmcEndpointExplorer` orchestrates credential lookup and exploration
+- `crates/site-explorer/src/redfish.rs` — `RedfishClient`: `probe_redfish_endpoint()`, `create_redfish_client()`, inventory queries
+- `crates/site-explorer/src/bmc_endpoint_explorer.rs` — `BmcEndpointExplorer` orchestrates credential lookup and exploration
 - `crates/api-model/src/bmc_info.rs` — `BmcInfo` model (IP, port, MAC, firmware version)
 
 ## 3. DPU-Host Pairing
@@ -116,7 +116,7 @@ Before accepting a pairing, NICo validates:
 Once all DPUs are matched and validated, the host enters an "ingestable" state and Site Explorer kickstarts the ingestion process via the ManagedHost state machine.
 
 **Key file:**
-- `crates/api/src/site_explorer/mod.rs` — `identify_managed_hosts()` with the complete pairing algorithm
+- `crates/site-explorer/src/lib.rs`: `identify_managed_hosts()` with the complete pairing algorithm
 
 ## 4. DPU Provisioning
 
@@ -194,8 +194,8 @@ Body: {"ResetType": "GracefulRestart"}
 Power cycles are rate-limited to avoid excessive reboots (checked via `time_since_redfish_powercycle` against `config.reset_rate_limit`).
 
 **Key files:**
-- `crates/api/src/site_explorer/redfish.rs` — `set_boot_order_dpu_first()`, `redfish_powercycle()`
-- `crates/api/src/site_explorer/bmc_endpoint_explorer.rs` — Orchestrates boot order with credential lookup
+- `crates/site-explorer/src/redfish.rs` — `set_boot_order_dpu_first()`, `redfish_powercycle()`
+- `crates/site-explorer/src/bmc_endpoint_explorer.rs` — Orchestrates boot order with credential lookup
 
 ## 6. Ongoing Monitoring
 
@@ -259,12 +259,12 @@ All sensor data is exported as Prometheus metrics on the `/metrics` endpoint (po
 
 ## Redfish Libraries
 
-NICo uses two Redfish client libraries concurrently. **nv-redfish** is replacing **libredfish** over time.
+NICo uses two Redfish client libraries concurrently. **nv-redfish** is replacing **libredfish** over time. Versions are pinned in the workspace dependencies in `Cargo.toml`.
 
 | Library | Version | Language | Used For | Location in Code |
 |---|---|---|---|---|
-| [libredfish](https://github.com/NVIDIA/libredfish) | 0.39.3 | Rust | Site Explorer: discovery, boot config, power control, BIOS, account management | `crates/api/src/site_explorer/` |
-| [nv-redfish](https://github.com/NVIDIA/nv-redfish) | 0.1.4 | Rust | Health monitoring: firmware inventory collection | `crates/health/src/` |
+| [libredfish](https://github.com/NVIDIA/libredfish) | v0.43.11 | Rust | Site Explorer: discovery, boot config, power control, BIOS, account management | `crates/site-explorer/`, via `crates/redfish/` |
+| [nv-redfish](https://github.com/NVIDIA/nv-redfish) | 0.7.1 | Rust | Site Explorer exploration and hardware health inventory collection | `crates/site-explorer/`, `crates/redfish/`, `crates/health/src/` |
 
 **libredfish** provides a `Redfish` trait with vendor-specific implementations (Dell, HPE, Lenovo, Supermicro, NVIDIA DPU/GB200/GH200/Viking). It handles the full breadth of BMC operations.
 

--- a/docs/codebase_overview.md
+++ b/docs/codebase_overview.md
@@ -1,29 +1,26 @@
 # Codebase overview
 
-bluefield/ - `dpu-agent` and other tools running on the DPU
+The repository is organized as a Rust workspace plus deployment, documentation, and development support directories.
 
-book/ - architecture of the NICo book.  aka "the book"
+`bluefield/` - `dpu-agent` and other tools running on the DPU.
 
-- admin/ - `carbide-admin-cli`: A command line client for the carbide API server
-- api/ - NICo primary entrypoint for GRPC API calls. This component receives all the GRPC calls
-- scout/ - `forge-scout`. A binary that runs on NCX Infra Controller (NICo) managed hosts and DPUs and executes various parts workflows on behalf of the site controller
+`crates/` - source code for the Rust crates that make up NICo. Important crates include:
 
-dev/ - a catch all directory for things that are not code related but are used to support the project.  e.g. Dockerfiles, kubernetes yaml, etc.
+- `admin-cli/` - `carbide-admin-cli`, a command line client for the carbide API server.
+- `api/` - the `carbide-api` binary and NICo primary entrypoint for gRPC/API calls. It wires together and starts the core background modules and state controllers.
+- `site-explorer/` - Site Explorer implementation. This code is compiled into and run by the `carbide-api` binary.
+- `preingestion-manager/` - Preingestion Manager implementation. This code is compiled into and run by the `carbide-api` binary.
+- `nvlink-manager/` - NVLink Manager / `NvlPartitionMonitor` implementation. This code is compiled into and run by the `carbide-api` binary.
+- `scout/` - `forge-scout`, a binary that runs on NICo managed hosts and DPUs and executes workflows on behalf of the site controller.
+- `dhcp/` - Kea DHCP integration. It intercepts `DHCPDISCOVER`s from DHCP relays and forwards the information to `carbide-api`.
+- `dhcp-server/` - DHCP server written in Rust. This server runs on the DPU and serves host DHCP requests.
+- `dns/` - DNS resolution for assets in the NICo database.
+- `log-parser/` - service which parses SSH console logs and generates health alerts based on them.
+- `pxe/` - `forge-pxe`, a web service which provides iPXE and cloud-init data to machines.
+- `rpc/` - protobuf definitions and a Rust library for marshalling data between gRPC and native Rust types.
 
-dhcp/ - kea dhcp plugin.  NICo uses ISC Kea for a dhcp event loop.  This code intercepts `DHCPDISCOVER`s from dhcp-relays and passes the info to carbide-api
+`dev/` - support files that are not product code, such as Dockerfiles, Kubernetes YAML, and local development helpers.
 
-dhcp-server/ - DHCP Server written in Rust. This server runs on the DPU and serves Host DHCP requests
+`docs/` - product documentation used by the documentation site.
 
-dns/ - provides DNS resolution for assets in the NICo database
-
-include/ - contains additional makefiles that are used by `cargo make` - as specified in `Makefile.toml`.
-
-log-parser/ - Service which parses SSH console logs and generates health alerts based on them
-
-pxe/ - forge-pxe is a web service which provides iPXE and cloud-init data to
-machines
-
-rpc/ - protobuf definitions and a rust library which handles marshalling
-data from/to GRPC to native rust types
-
-crates/ - contains the source code for the various crates that make up the NICo project
+`include/` - additional makefiles used by `cargo make`, as specified in `Makefile.toml`.

--- a/docs/development/new_hardware_support.md
+++ b/docs/development/new_hardware_support.md
@@ -12,8 +12,8 @@ NICo discovers and manages bare-metal hosts through their BMC (Baseboard Managem
 
 | Library | Role | Where Used |
 |---|---|---|
-| **[nv-redfish](https://github.com/NVIDIA/nv-redfish)** | Schema-driven, fast: site exploration reports, firmware inventory, sensor collection, health monitoring. **Preferred for exploration.** | Site Explorer exploration (`crates/api/src/site_explorer/`), Hardware Health (`crates/health/src/`) |
-| **[libredfish](https://github.com/NVIDIA/libredfish)** | Stateful BMC interactions: boot config, BIOS setup, power control, account/credential management, lockdown | Site Explorer state controller operations (`crates/api/src/site_explorer/`) |
+| **[nv-redfish](https://github.com/NVIDIA/nv-redfish)** | Schema-driven, fast: site exploration reports, firmware inventory, sensor collection, health monitoring. **Preferred for exploration.** | Site Explorer exploration (`crates/site-explorer/`), Hardware Health (`crates/health/src/`) |
+| **[libredfish](https://github.com/NVIDIA/libredfish)** | Stateful BMC interactions: boot config, BIOS setup, power control, account/credential management, lockdown | Site Explorer state controller operations (`crates/site-explorer/`) |
 
 Site Explorer supports both libraries for generating `EndpointExplorationReport`s, controlled by the `explore_mode` configuration setting (`SiteExplorerExploreMode`):
 


### PR DESCRIPTION
## Description

Clarify that Site Explorer, Preingestion Manager, and NVLink Manager still run inside the carbide-api binary while their implementations live in separate crates. Update stale Site Explorer source paths, Redfish library versions, and codebase overview entries.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes
## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

