### PR TITLE
Modify fern docs preview workflow for doc struct change

### DIFF
--- a/.github/workflows/fern-docs-preview-build.yml
+++ b/.github/workflows/fern-docs-preview-build.yml
@@ -15,9 +15,7 @@
 
 # Workflow 1 of 2 for Fern doc previews.
 #
-# Collects fern/ sources and PR metadata and uploads an artifact. Does not run
-# checkout/scripts on arbitrary fork heads: same-repo PRs only, or copy-pr-bot
-# push to pull-request/<n> after /ok-to-test (see copy-pr-bot docs / ci.yaml).
+# Collects fern/, docs/, and PR metadata and uploads an artifact.
 #
 # The companion workflow (fern-docs-preview-comment.yml) runs after this one;
 # it skips cleanly when no artifact exists (e.g. skipped fork pull_request).
@@ -28,12 +26,14 @@ on:
   pull_request:
     paths:
       - 'fern/**'
+      - 'docs/**'
       - '.github/workflows/fern-docs-preview-build.yml'
   push:
     branches:
       - 'pull-request/[0-9]+'
     paths:
       - 'fern/**'
+      - 'docs/**'
       - '.github/workflows/fern-docs-preview-build.yml'
 
 permissions:
@@ -69,11 +69,12 @@ jobs:
             git diff --name-only "origin/${DEFAULT_BRANCH}...HEAD" -- '*.md' > preview-metadata/changed_md_files 2>/dev/null || true
           fi
 
-      - name: Upload fern sources and metadata
+      - name: Upload Fern docs inputs and metadata
         uses: actions/upload-artifact@v4
         with:
           name: fern-preview
           path: |
             fern/
+            docs/
             preview-metadata/
           retention-days: 1


### PR DESCRIPTION
-e
Signed-off-by: Peter Gambrill <pgambrill@nvidia.com>

## Description

The fern docs preview workflow is failing because it wasn't updated for the change to Fern that
placed source .md files into the /docs directory. This commit should resolve this issue.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

