### PR TITLE
Fixes for dpu-agent to update hbn via nvue-api

### DIFF
--- a/bluefield/containers/forge-dpu-agent/Dockerfile
+++ b/bluefield/containers/forge-dpu-agent/Dockerfile
@@ -19,8 +19,7 @@ FROM --platform=linux/arm64 debian:bookworm-slim AS builder
 # Get libraries and install MFT (provides flint for DPU firmware enumeration)
 RUN apt-get update && apt-get install -y \
      libudev1 \
-     bash \
-     curl
+     bash
 
 # Working flint extraction
 COPY mft-4.35.0-159-aarch64-deb/DEBS/mft_4.35.0-159_arm64.deb /tmp/mstflint.deb
@@ -38,13 +37,11 @@ RUN mkdir -p /deps && \
 # Stage 2
 FROM --platform=linux/arm64 ${IMG}:${TAG}-${DISTROLESS_DEBUG_TAG}
 
-# Copy bash binary, libraries, mft, and curl from builder
+# Copy bash binary, libraries, and mft from builder
 COPY --from=builder /lib/aarch64-linux-gnu/libudev.so.1 /lib/aarch64-linux-gnu/libudev.so.1
 COPY --from=builder --chmod=755 /bin/bash /bin/bash
 COPY --from=builder --chmod=755 /extract/usr/bin/ /usr/bin/
 COPY --from=builder /deps/* /lib/
-COPY --from=builder --chmod=755 /usr/bin/curl /usr/bin/curl
-COPY --from=builder /usr/lib/aarch64-linux-gnu/libcurl.so.4 /lib/aarch64-linux-gnu/libcurl.so.4
 
 # Copy forge-dpu-agent and set entry point
 COPY --chmod=755 target/aarch64-unknown-linux-gnu/release/forge-dpu-agent /usr/bin/forge-dpu-agent

--- a/crates/agent/templates/nvue_startup_etv.conf
+++ b/crates/agent/templates/nvue_startup_etv.conf
@@ -178,9 +178,12 @@
               '10':
                 action:
                   deny: {}
+    system:
+      api:
+        listening-address:
+          0.0.0.0: {}
 {{- if $nvueConfig.StatefulAclsEnabled }}
   {{- if .Tenant.HasNetworkSecurityGroup }}
-    system:
       reflexive-acl:
         enable: on                  
   {{- end }}

--- a/crates/agent/templates/nvue_startup_fnn.conf
+++ b/crates/agent/templates/nvue_startup_fnn.conf
@@ -592,8 +592,11 @@
               '65535':
                 action:
                   deny: {}
-{{- if $nvueConfig.StatefulAclsEnabled }}
     system:
+      api:
+        listening-address:
+          0.0.0.0: {}
+{{- if $nvueConfig.StatefulAclsEnabled }}
       reflexive-acl:
         enable: on                  
 {{- end }}

--- a/crates/agent/templates/tests/full_nvue_startup_etv.yaml.expected
+++ b/crates/agent/templates/tests/full_nvue_startup_etv.yaml.expected
@@ -87,6 +87,9 @@
                 action:
                   deny: {}
     system:
+      api:
+        listening-address:
+          0.0.0.0: {}
       reflexive-acl:
         enable: on
     vrf:

--- a/crates/agent/templates/tests/full_nvue_startup_fnn_classic.yaml.expected
+++ b/crates/agent/templates/tests/full_nvue_startup_fnn_classic.yaml.expected
@@ -153,6 +153,10 @@
               '65535':
                 action:
                   deny: {}
+    system:
+      api:
+        listening-address:
+          0.0.0.0: {}
     vrf:
       default:
         router:

--- a/crates/agent/templates/tests/full_nvue_startup_fnn_l3.yaml.expected
+++ b/crates/agent/templates/tests/full_nvue_startup_fnn_l3.yaml.expected
@@ -341,6 +341,9 @@
                 action:
                   deny: {}
     system:
+      api:
+        listening-address:
+          0.0.0.0: {}
       reflexive-acl:
         enable: on
     vrf:

--- a/crates/agent/templates/tests/nvue_build_etv_deny_prefix_offset.yaml.expected
+++ b/crates/agent/templates/tests/nvue_build_etv_deny_prefix_offset.yaml.expected
@@ -83,6 +83,10 @@
               '10':
                 action:
                   deny: {}
+    system:
+      api:
+        listening-address:
+          0.0.0.0: {}
     vrf:
       default:
         router:

--- a/crates/agent/templates/tests/nvue_build_etv_ipv4_only.yaml.expected
+++ b/crates/agent/templates/tests/nvue_build_etv_ipv4_only.yaml.expected
@@ -89,6 +89,10 @@
               '10':
                 action:
                   deny: {}
+    system:
+      api:
+        listening-address:
+          0.0.0.0: {}
     vrf:
       default:
         router:

--- a/crates/agent/templates/tests/nvue_build_etv_ipv6_data.yaml.expected
+++ b/crates/agent/templates/tests/nvue_build_etv_ipv6_data.yaml.expected
@@ -89,6 +89,10 @@
               '10':
                 action:
                   deny: {}
+    system:
+      api:
+        listening-address:
+          0.0.0.0: {}
     vrf:
       default:
         router:

--- a/crates/agent/templates/tests/nvue_build_fnn_dual_stack.yaml.expected
+++ b/crates/agent/templates/tests/nvue_build_fnn_dual_stack.yaml.expected
@@ -309,6 +309,10 @@
               '65535':
                 action:
                   deny: {}
+    system:
+      api:
+        listening-address:
+          0.0.0.0: {}
     vrf:
       default:
         router:

--- a/crates/agent/templates/tests/nvue_build_fnn_ipv6_acls.yaml.expected
+++ b/crates/agent/templates/tests/nvue_build_fnn_ipv6_acls.yaml.expected
@@ -320,6 +320,10 @@
               '65535':
                 action:
                   deny: {}
+    system:
+      api:
+        listening-address:
+          0.0.0.0: {}
     vrf:
       default:
         router:

--- a/crates/agent/templates/tests/nvue_build_fnn_ipv6_only_vpc.yaml.expected
+++ b/crates/agent/templates/tests/nvue_build_fnn_ipv6_only_vpc.yaml.expected
@@ -310,6 +310,10 @@
               '65535':
                 action:
                   deny: {}
+    system:
+      api:
+        listening-address:
+          0.0.0.0: {}
     vrf:
       default:
         router:

--- a/crates/agent/templates/tests/nvue_build_fnn_multi_port_ipv6.yaml.expected
+++ b/crates/agent/templates/tests/nvue_build_fnn_multi_port_ipv6.yaml.expected
@@ -319,6 +319,10 @@
               '65535':
                 action:
                   deny: {}
+    system:
+      api:
+        listening-address:
+          0.0.0.0: {}
     vrf:
       default:
         router:

--- a/crates/agent/templates/tests/nvue_startup.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup.yaml.expected
@@ -139,6 +139,10 @@
               '10':
                 action:
                   deny: {}
+    system:
+      api:
+        listening-address:
+          0.0.0.0: {}
     vrf:
       default:
         router:

--- a/crates/agent/templates/tests/nvue_startup_fnn_classic.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_classic.yaml.expected
@@ -406,6 +406,10 @@
               '65535':
                 action:
                   deny: {}
+    system:
+      api:
+        listening-address:
+          0.0.0.0: {}
     vrf:
       default:
         router:

--- a/crates/agent/templates/tests/nvue_startup_fnn_classic_with_empty_nsg_default_deny.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_classic_with_empty_nsg_default_deny.yaml.expected
@@ -415,6 +415,9 @@
                 action:
                   deny: {}
     system:
+      api:
+        listening-address:
+          0.0.0.0: {}
       reflexive-acl:
         enable: on
     vrf:

--- a/crates/agent/templates/tests/nvue_startup_fnn_l3.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_l3.yaml.expected
@@ -230,6 +230,10 @@
               '65535':
                 action:
                   deny: {}
+    system:
+      api:
+        listening-address:
+          0.0.0.0: {}
     vrf:
       default:
         router:

--- a/crates/agent/templates/tests/nvue_startup_fnn_with_leaks.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_with_leaks.yaml.expected
@@ -573,6 +573,10 @@
               '65535':
                 action:
                   deny: {}
+    system:
+      api:
+        listening-address:
+          0.0.0.0: {}
     vrf:
       default:
         router:

--- a/crates/agent/templates/tests/nvue_startup_quarantined.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_quarantined.yaml.expected
@@ -154,6 +154,9 @@
                 action:
                   deny: {}
     system:
+      api:
+        listening-address:
+          0.0.0.0: {}
       reflexive-acl:
         enable: on
     vrf:

--- a/crates/agent/templates/tests/nvue_startup_quarantined_fnn.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_quarantined_fnn.yaml.expected
@@ -427,6 +427,9 @@
                 action:
                   deny: {}
     system:
+      api:
+        listening-address:
+          0.0.0.0: {}
       reflexive-acl:
         enable: on
     vrf:

--- a/crates/agent/templates/tests/nvue_startup_with_bridge.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_with_bridge.yaml.expected
@@ -139,6 +139,10 @@
               '10':
                 action:
                   deny: {}
+    system:
+      api:
+        listening-address:
+          0.0.0.0: {}
     vrf:
       default:
         router:

--- a/crates/agent/templates/tests/nvue_startup_with_empty_nsg_default_deny.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_with_empty_nsg_default_deny.yaml.expected
@@ -142,6 +142,9 @@
                 action:
                   deny: {}
     system:
+      api:
+        listening-address:
+          0.0.0.0: {}
       reflexive-acl:
         enable: on
     vrf:

--- a/crates/agent/templates/tests/nvue_startup_with_nsg.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_with_nsg.yaml.expected
@@ -142,6 +142,9 @@
                 action:
                   deny: {}
     system:
+      api:
+        listening-address:
+          0.0.0.0: {}
       reflexive-acl:
         enable: on
     vrf:

--- a/crates/nvue-client/src/client.rs
+++ b/crates/nvue-client/src/client.rs
@@ -131,7 +131,13 @@ impl NvueClient {
         config.remove_rev_id();
         // The startup templates wrap the payload in a [{header:...},{set:...}] list.
         // The REST API expects only the inner config object, so strip the wrapper.
-        let mut config = config.extract_set_payload().unwrap_or(config);
+        // If the config is a top-level array but has no "set" entry that is a
+        // schema error — surface it now rather than letting the API reject it
+        // with a cryptic response.
+        let mut config = match config.extract_set_payload()? {
+            Some(inner) => inner,
+            None => config,
+        };
         // pf0dpu* interfaces lack a `type` field and are rejected by the REST API;
         // skip them for now.
         config.remove_pf0dpu_interfaces();

--- a/crates/nvue-client/src/client.rs
+++ b/crates/nvue-client/src/client.rs
@@ -129,6 +129,12 @@ impl NvueClient {
         // Just in case the config we got was derived from an older one,
         // let's clear the rev-id from the header.
         config.remove_rev_id();
+        // The startup templates wrap the payload in a [{header:...},{set:...}] list.
+        // The REST API expects only the inner config object, so strip the wrapper.
+        let mut config = config.extract_set_payload().unwrap_or(config);
+        // pf0dpu* interfaces lack a `type` field and are rejected by the REST API;
+        // skip them for now.
+        config.remove_pf0dpu_interfaces();
         let builder = builder.json(&config);
         let request = builder.build()?;
         let _response = self.execute(request).await?;

--- a/crates/nvue-client/src/config.rs
+++ b/crates/nvue-client/src/config.rs
@@ -1,3 +1,5 @@
+use crate::client::NvueClientError;
+
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[serde(transparent)]
 pub struct NvueConfig {
@@ -21,20 +23,32 @@ impl NvueConfig {
 
     /// Extract the value under the `set` key from the top-level list structure
     /// produced by the NVUE startup templates (i.e. `[{header: ...}, {set: ...}]`).
-    /// Returns `None` if the config is not in that list form.
-    pub fn extract_set_payload(&self) -> Option<Self> {
+    ///
+    /// Returns:
+    /// - `Ok(Some(_))` if the config was a template-wrapped array and a `set`
+    ///   entry was found.
+    /// - `Ok(None)` if the config is not an array, i.e. it is already a plain
+    ///   object and can be used as-is.
+    /// - `Err(SchemaMismatch)` if the config *is* a top-level array but
+    ///   contains no `set` entry — this is an unexpected shape that would
+    ///   produce a hard-to-debug REST API rejection if sent as-is.
+    pub fn extract_set_payload(&self) -> Result<Option<Self>, NvueClientError> {
         if let serde_json::Value::Array(arr) = &self.config_json {
             for item in arr {
                 if let serde_json::Value::Object(map) = item
                     && let Some(set_value) = map.get("set")
                 {
-                    return Some(Self {
+                    return Ok(Some(Self {
                         config_json: set_value.clone(),
-                    });
+                    }));
                 }
             }
+            Err(NvueClientError::SchemaMismatch(
+                "config is a top-level array but contains no \"set\" entry",
+            ))
+        } else {
+            Ok(None)
         }
-        None
     }
 
     /// Remove any interfaces whose names start with `pf0dpu` from the config.

--- a/crates/nvue-client/src/config.rs
+++ b/crates/nvue-client/src/config.rs
@@ -18,6 +18,35 @@ impl NvueConfig {
             let _ = header_object.remove("rev-id");
         }
     }
+
+    /// Extract the value under the `set` key from the top-level list structure
+    /// produced by the NVUE startup templates (i.e. `[{header: ...}, {set: ...}]`).
+    /// Returns `None` if the config is not in that list form.
+    pub fn extract_set_payload(&self) -> Option<Self> {
+        if let serde_json::Value::Array(arr) = &self.config_json {
+            for item in arr {
+                if let serde_json::Value::Object(map) = item {
+                    if let Some(set_value) = map.get("set") {
+                        return Some(Self {
+                            config_json: set_value.clone(),
+                        });
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Remove any interfaces whose names start with `pf0dpu` from the config.
+    /// These interfaces lack a `type` field, which the NVUE REST API rejects;
+    /// they are left to be configured by other means.
+    pub fn remove_pf0dpu_interfaces(&mut self) {
+        if let serde_json::Value::Object(root) = &mut self.config_json
+            && let Some(serde_json::Value::Object(ifaces)) = root.get_mut("interface")
+        {
+            ifaces.retain(|key, _| !key.starts_with("pf0dpu"));
+        }
+    }
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]

--- a/crates/nvue-client/src/config.rs
+++ b/crates/nvue-client/src/config.rs
@@ -25,12 +25,12 @@ impl NvueConfig {
     pub fn extract_set_payload(&self) -> Option<Self> {
         if let serde_json::Value::Array(arr) = &self.config_json {
             for item in arr {
-                if let serde_json::Value::Object(map) = item {
-                    if let Some(set_value) = map.get("set") {
-                        return Some(Self {
-                            config_json: set_value.clone(),
-                        });
-                    }
+                if let serde_json::Value::Object(map) = item
+                    && let Some(set_value) = map.get("set")
+                {
+                    return Some(Self {
+                        config_json: set_value.clone(),
+                    });
                 }
             }
         }


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
1. Make a change to the way we generate the payload for PATCH when sending via NVUE API. The headers and ;set' were removed to match what is expected by NVUE_REST_API
2. Add a hack to temporarily filter out pf0dpu*_if interfaces which are not being configured on hbn. The config was being rejected because of this
3. Made a change to reset the listening address to 0.0.0.0:8765 after the nvue configuration is loaded, else it was reverting to 127.0.0.1:8765
4. Removed incomplete references to curl from the dpu agent dockerfile

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

