### PR TITLE
chore(web): direct type usage in templates instead of copy

### DIFF
--- a/crates/api/src/web/domain.rs
+++ b/crates/api/src/web/domain.rs
@@ -24,35 +24,13 @@ use axum::response::{Html, IntoResponse, Response};
 use hyper::http::StatusCode;
 use rpc::forge::forge_server::Forge;
 
+use super::filters;
 use crate::api::Api;
 
 #[derive(Template)]
 #[template(path = "domain_show.html")]
 struct DomainShow {
-    domains: Vec<DomainRowDisplay>,
-}
-
-struct DomainRowDisplay {
-    id: String,
-    name: String,
-    created: String,
-    updated: String,
-    deleted: String,
-}
-
-impl From<::rpc::protos::dns::Domain> for DomainRowDisplay {
-    fn from(d: ::rpc::protos::dns::Domain) -> Self {
-        Self {
-            id: d.id.unwrap_or_default().to_string(),
-            name: d.name,
-            created: d.created.unwrap_or_default().to_string(),
-            updated: d.updated.unwrap_or_default().to_string(),
-            deleted: d
-                .deleted
-                .map(|x| x.to_string())
-                .unwrap_or("Not Deleted".to_string()),
-        }
-    }
+    domains: Vec<::rpc::protos::dns::Domain>,
 }
 
 /// List domains
@@ -65,15 +43,11 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
         }
     };
 
-    let mut out = Vec::new();
-    for domain in domains.domains.into_iter() {
-        out.push(domain.into());
-    }
-
-    let tmpl = DomainShow { domains: out };
+    let tmpl = DomainShow {
+        domains: domains.domains,
+    };
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
-
 pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let domains = match fetch_domains(state).await {
         Ok(m) => m,

--- a/crates/api/src/web/dpa.rs
+++ b/crates/api/src/web/dpa.rs
@@ -26,33 +26,14 @@ use rpc::forge as forgerpc;
 use rpc::forge::forge_server::Forge;
 use uuid::Uuid;
 
+use super::filters;
 use super::state_history::StateHistoryTable;
 use crate::api::Api;
 
 #[derive(Template)]
 #[template(path = "dpa_show.html")]
 struct DpaShow {
-    dpas: Vec<DpaRowDisplay>,
-}
-
-struct DpaRowDisplay {
-    id: String,
-    machine_id: String,
-    state: String,
-    created: String,
-    macaddr: String,
-}
-
-impl From<forgerpc::DpaInterface> for DpaRowDisplay {
-    fn from(dpa: forgerpc::DpaInterface) -> Self {
-        Self {
-            id: dpa.id.map(|i| i.to_string()).unwrap_or_default(),
-            machine_id: dpa.machine_id.map(|i| i.to_string()).unwrap_or_default(),
-            created: dpa.created.map(|c| c.to_string()).unwrap_or_default(),
-            macaddr: dpa.mac_addr,
-            state: dpa.controller_state,
-        }
-    }
+    dpas: Vec<forgerpc::DpaInterface>,
 }
 
 /// List DPAs
@@ -65,9 +46,7 @@ pub async fn show_dpas_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
         }
     };
 
-    let tmpl = DpaShow {
-        dpas: dpas.into_iter().map(Into::into).collect(),
-    };
+    let tmpl = DpaShow { dpas };
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
@@ -118,50 +97,17 @@ async fn fetch_dpas(api: Arc<Api>) -> Result<Vec<forgerpc::DpaInterface>, tonic:
 #[derive(Template)]
 #[template(path = "dpa_detail.html")]
 struct DpaDetail {
-    id: String,
-    machine_id: String,
-    macaddr: String,
-    created: String,
-    updated: String,
-    deleted: String,
-    underlay_ip: String,
-    overlay_ip: String,
-    state: String,
-    state_version: String,
-    network_config: String,
-    network_config_version: String,
-    network_status_observation: String,
+    dpa: forgerpc::DpaInterface,
     history: StateHistoryTable,
 }
 
 impl From<forgerpc::DpaInterface> for DpaDetail {
     fn from(dpa: forgerpc::DpaInterface) -> Self {
-        let mut history_records = Vec::new();
-
-        for record in dpa.history.into_iter().rev() {
-            history_records.push(record.into());
-        }
-
         let history = StateHistoryTable {
-            records: history_records,
+            records: dpa.history.iter().rev().cloned().map(Into::into).collect(),
         };
 
-        Self {
-            id: dpa.id.map(|i| i.to_string()).unwrap_or_default(),
-            machine_id: dpa.machine_id.map(|i| i.to_string()).unwrap_or_default(),
-            macaddr: dpa.mac_addr,
-            created: dpa.created.map(|c| c.to_string()).unwrap_or_default(),
-            updated: dpa.updated.map(|c| c.to_string()).unwrap_or_default(),
-            deleted: dpa.deleted.map(|c| c.to_string()).unwrap_or_default(),
-            underlay_ip: dpa.underlay_ip,
-            overlay_ip: dpa.overlay_ip,
-            state: dpa.controller_state,
-            state_version: dpa.controller_state_version,
-            network_config: dpa.network_config,
-            network_config_version: dpa.network_config_version,
-            network_status_observation: dpa.network_status_observation,
-            history,
-        }
+        Self { dpa, history }
     }
 }
 

--- a/crates/api/src/web/filters.rs
+++ b/crates/api/src/web/filters.rs
@@ -222,6 +222,13 @@ pub fn option_fmt(value: &Option<impl Display>) -> askama::Result<String> {
     })
 }
 
+pub fn option_fmt_or(value: &Option<impl Display>, default: &str) -> askama::Result<String> {
+    Ok(match value {
+        Some(value) => value.to_string(),
+        None => default.to_string(),
+    })
+}
+
 pub(crate) fn normalize_state_label(state: impl Display) -> String {
     state_and_substate_labels(state).0
 }

--- a/crates/api/src/web/ib_fabric.rs
+++ b/crates/api/src/web/ib_fabric.rs
@@ -30,11 +30,7 @@ use crate::api::Api;
 #[derive(Template)]
 #[template(path = "ib_fabric_show.html")]
 struct IbFabricShow {
-    fabrics: Vec<IbFabricRowDisplay>,
-}
-
-struct IbFabricRowDisplay {
-    id: String,
+    fabrics: Vec<String>,
 }
 
 /// List fabrics
@@ -51,12 +47,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
         }
     };
 
-    let tmpl = IbFabricShow {
-        fabrics: fabrics
-            .into_iter()
-            .map(|id| IbFabricRowDisplay { id })
-            .collect(),
-    };
+    let tmpl = IbFabricShow { fabrics };
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 

--- a/crates/api/src/web/ipxe_template.rs
+++ b/crates/api/src/web/ipxe_template.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use askama::Template;
@@ -25,37 +26,26 @@ use hyper::http::StatusCode;
 use rpc::forge as forgerpc;
 use rpc::forge::forge_server::Forge;
 
+fn ipxe_template_scope_fmt(scope: &i32) -> Cow<'static, str> {
+    rpc::forge::IpxeTemplateScope::try_from(*scope)
+        .map(|scope| Cow::Owned(format!("{scope:?}")))
+        .unwrap_or(Cow::Borrowed("Unknown"))
+}
+
+mod filters {
+    pub use super::super::filters::option_fmt;
+
+    pub fn ipxe_template_scope_fmt(scope: &i32) -> askama::Result<super::Cow<'static, str>> {
+        Ok(super::ipxe_template_scope_fmt(scope))
+    }
+}
+
 use crate::api::Api;
 
 #[derive(Template)]
 #[template(path = "ipxe_template_show.html")]
 struct IpxeTemplateShow {
-    templates: Vec<IpxeTemplateRowDisplay>,
-}
-
-struct IpxeTemplateRowDisplay {
-    id: String,
-    name: String,
-    description: String,
-    scope: String,
-    required_params_count: usize,
-    required_artifacts_count: usize,
-}
-
-impl From<&forgerpc::IpxeTemplate> for IpxeTemplateRowDisplay {
-    fn from(tmpl: &forgerpc::IpxeTemplate) -> Self {
-        let scope = forgerpc::IpxeTemplateScope::try_from(tmpl.scope)
-            .map(|s| format!("{s:?}"))
-            .unwrap_or_else(|_| "Unknown".to_string());
-        Self {
-            id: tmpl.id.as_ref().map(|u| u.to_string()).unwrap_or_default(),
-            name: tmpl.name.clone(),
-            description: tmpl.description.clone(),
-            scope,
-            required_params_count: tmpl.required_params.len(),
-            required_artifacts_count: tmpl.required_artifacts.len(),
-        }
-    }
+    templates: Vec<forgerpc::IpxeTemplate>,
 }
 
 pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
@@ -71,9 +61,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
         }
     };
 
-    let tmpl = IpxeTemplateShow {
-        templates: templates.iter().map(Into::into).collect(),
-    };
+    let tmpl = IpxeTemplateShow { templates };
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
@@ -103,29 +91,12 @@ async fn fetch_templates(api: Arc<Api>) -> Result<Vec<forgerpc::IpxeTemplate>, t
 #[derive(Template)]
 #[template(path = "ipxe_template_detail.html")]
 struct IpxeTemplateDetail {
-    name: String,
-    description: String,
-    scope: String,
-    required_params: Vec<String>,
-    reserved_params: Vec<String>,
-    required_artifacts: Vec<String>,
-    template_text: String,
+    tmpl: forgerpc::IpxeTemplate,
 }
 
 impl From<forgerpc::IpxeTemplate> for IpxeTemplateDetail {
     fn from(tmpl: forgerpc::IpxeTemplate) -> Self {
-        let scope = forgerpc::IpxeTemplateScope::try_from(tmpl.scope)
-            .map(|s| format!("{s:?}"))
-            .unwrap_or_else(|_| "Unknown".to_string());
-        Self {
-            name: tmpl.name,
-            description: tmpl.description,
-            scope,
-            required_params: tmpl.required_params,
-            reserved_params: tmpl.reserved_params,
-            required_artifacts: tmpl.required_artifacts,
-            template_text: tmpl.template,
-        }
+        Self { tmpl }
     }
 }
 

--- a/crates/api/src/web/rack.rs
+++ b/crates/api/src/web/rack.rs
@@ -32,16 +32,7 @@ use crate::api::Api;
 #[derive(Template)]
 #[template(path = "rack_show.html")]
 struct Racks {
-    racks: Vec<RackRecord>,
-}
-
-#[derive(Debug, serde::Serialize)]
-struct RackRecord {
-    id: String,
-    rack_state: String,
-    compute_trays: String,
-    power_shelves: String,
-    switches: String,
+    racks: Vec<rpc::forge::Rack>,
 }
 
 #[derive(Template)]
@@ -74,31 +65,7 @@ pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
         }
     };
 
-    let racks = racks
-        .racks
-        .into_iter()
-        .map(|rack| RackRecord {
-            id: rack.id.map(|id| id.to_string()).unwrap_or_default(),
-            rack_state: rack.rack_state,
-            compute_trays: format!(
-                "{} / {}",
-                rack.compute_trays.len(),
-                rack.expected_compute_trays.len()
-            ),
-            power_shelves: format!(
-                "{} / {}",
-                rack.power_shelves.len(),
-                rack.expected_power_shelves.len()
-            ),
-            switches: format!(
-                "{} / {}",
-                rack.switches.len(),
-                rack.expected_nvlink_switches.len()
-            ),
-        })
-        .collect();
-
-    let display = Racks { racks };
+    let display = Racks { racks: racks.racks };
     (StatusCode::OK, Html(display.render().unwrap())).into_response()
 }
 

--- a/crates/api/src/web/resource_pool.rs
+++ b/crates/api/src/web/resource_pool.rs
@@ -25,41 +25,29 @@ use hyper::http::StatusCode;
 use rpc::forge as forgerpc;
 use rpc::forge::forge_server::Forge;
 
+mod filters {
+    pub fn resource_pool_allocated_fmt(
+        pool: &super::forgerpc::ResourcePool,
+    ) -> askama::Result<String> {
+        Ok(format!(
+            "{} ({:.0}%)",
+            pool.allocated,
+            pool.allocated as f64 / pool.total as f64 * 100.0
+        ))
+    }
+}
+
 use crate::api::Api;
 
 #[derive(Template)]
 #[template(path = "resource_pool_show.html")]
 struct ResourcePoolShow {
-    pools: Vec<ResourcePoolDisplay>,
-}
-
-struct ResourcePoolDisplay {
-    name: String,
-    min: String,
-    max: String,
-    size: u64,
-    allocated: String,
-}
-
-impl From<forgerpc::ResourcePool> for ResourcePoolDisplay {
-    fn from(pool: forgerpc::ResourcePool) -> Self {
-        Self {
-            name: pool.name,
-            min: pool.min,
-            max: pool.max,
-            size: pool.total,
-            allocated: format!(
-                "{} ({:.0}%)",
-                pool.allocated,
-                pool.allocated as f64 / pool.total as f64 * 100.0
-            ),
-        }
-    }
+    pools: Vec<forgerpc::ResourcePool>,
 }
 
 /// List resource pools
 pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
-    let out = match fetch_resource_pools(state).await {
+    let pools = match fetch_resource_pools(state).await {
         Ok(m) => m,
         Err(err) => {
             tracing::error!(%err, "admin_list_resource_pools");
@@ -70,10 +58,6 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
                 .into_response();
         }
     };
-    let mut pools: Vec<ResourcePoolDisplay> = Vec::new();
-    for rp in out.into_iter() {
-        pools.push(rp.into());
-    }
     let tmpl = ResourcePoolShow { pools };
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }

--- a/crates/api/templates/domain_show.html
+++ b/crates/api/templates/domain_show.html
@@ -19,11 +19,11 @@
 	<tbody>
 		{% for domain in domains %}
 			<tr>
-				<td>{{ domain.id }}</td>
+				<td>{{ domain.id|option_fmt }}</td>
 				<td>{{ domain.name }}</td>
-				<td>{{ domain.created }}</td>
-				<td>{{ domain.updated }}</td>
-				<td>{{ domain.deleted }}</td>
+				<td>{{ domain.created|option_fmt }}</td>
+				<td>{{ domain.updated|option_fmt }}</td>
+				<td>{{ domain.deleted|option_fmt_or("Not Deleted") }}</td>
 			</tr>
 		{% endfor %}
 	</tbody>

--- a/crates/api/templates/dpa_detail.html
+++ b/crates/api/templates/dpa_detail.html
@@ -7,19 +7,19 @@
 <h1>DPA Detail</h1>
 
 <table class="detailsview">
-	<tr><th>ID</th><td>{{ id }}</td></tr>
-	<tr><th>Machine ID</th><td>{{ machine_id }}</td></tr>
-	<tr><th>MacAddr</th><td>{{ macaddr }}</td></tr>
-	<tr><th>Created</th><td>{{ created }}</td></tr>
-	<tr><th>Updated</th><td>{{ updated }}</td></tr>
-	<tr><th>Deleted</th><td>{{ deleted }}</td></tr>
-	<tr><th>State</th><td>{{ state }}</td></tr>
-	<tr><th>Underlay IP</th><td>{{ underlay_ip }}</td></tr>
-	<tr><th>Overlay IP</th><td>{{ overlay_ip }}</td></tr>
-	<tr><th>State Version</th><td>{{ state_version }}</td></tr>
-	<tr><th>Network Config</th><td>{{ network_config }}</td></tr>
-	<tr><th>Network Config Version</th><td>{{ network_config_version }}</td></tr>
-	<tr><th>Network Status Observation</th><td>{{ network_status_observation }}</td></tr>
+	<tr><th>ID</th><td>{{ dpa.id|option_fmt }}</td></tr>
+	<tr><th>Machine ID</th><td>{{ dpa.machine_id|option_fmt }}</td></tr>
+	<tr><th>MacAddr</th><td>{{ dpa.mac_addr }}</td></tr>
+	<tr><th>Created</th><td>{{ dpa.created|option_fmt }}</td></tr>
+	<tr><th>Updated</th><td>{{ dpa.updated|option_fmt }}</td></tr>
+	<tr><th>Deleted</th><td>{{ dpa.deleted|option_fmt }}</td></tr>
+	<tr><th>State</th><td>{{ dpa.controller_state }}</td></tr>
+	<tr><th>Underlay IP</th><td>{{ dpa.underlay_ip }}</td></tr>
+	<tr><th>Overlay IP</th><td>{{ dpa.overlay_ip }}</td></tr>
+	<tr><th>State Version</th><td>{{ dpa.controller_state_version }}</td></tr>
+	<tr><th>Network Config</th><td>{{ dpa.network_config }}</td></tr>
+	<tr><th>Network Config Version</th><td>{{ dpa.network_config_version }}</td></tr>
+	<tr><th>Network Status Observation</th><td>{{ dpa.network_status_observation }}</td></tr>
 </table>
 
 <h3>History</h3>

--- a/crates/api/templates/dpa_show.html
+++ b/crates/api/templates/dpa_show.html
@@ -17,11 +17,11 @@
 	<tbody>
 		{% for dpa in dpas %}
 		<tr>
-			<td><a href="/admin/dpa/{{ dpa.id }}">{{ dpa.id }}</a></td>
-			<td>{{ dpa.machine_id }}</td>
-			<td>{{ dpa.macaddr }}</td>
-			<td>{{ dpa.state }}</td>
-			<td>{{ dpa.created }}</td>
+			<td><a href="/admin/dpa/{{ dpa.id|option_fmt }}">{{ dpa.id|option_fmt }}</a></td>
+			<td>{{ dpa.machine_id|option_fmt }}</td>
+			<td>{{ dpa.mac_addr }}</td>
+			<td>{{ dpa.controller_state }}</td>
+			<td>{{ dpa.created|option_fmt }}</td>
 		</tr>
 		{% endfor %}
 	</tbody>

--- a/crates/api/templates/ib_fabric_show.html
+++ b/crates/api/templates/ib_fabric_show.html
@@ -13,7 +13,7 @@
 	<tbody>
 		{% for f in fabrics %}
 		<tr>
-			<td>{{ f.id }}</td>
+			<td>{{ f }}</td>
 		</tr>
 		{% endfor %}
 	</tbody>

--- a/crates/api/templates/ipxe_template_detail.html
+++ b/crates/api/templates/ipxe_template_detail.html
@@ -1,24 +1,24 @@
 {% extends "base.html" %}
 
-{% block title %}iPXE Template {{ name }}{% endblock %}
+{% block title %}iPXE Template {{ tmpl.name }}{% endblock %}
 
 {% block content %}
-<h1>iPXE Template: {{ name }}</h1>
+<h1>iPXE Template: {{ tmpl.name }}</h1>
 
 <table class="detailsview">
-	<tr><th>Name</th><td>{{ name }}</td></tr>
-	<tr><th>Description</th><td>{{ description }}</td></tr>
-	<tr><th>Scope</th><td>{{ scope }}</td></tr>
+	<tr><th>Name</th><td>{{ tmpl.name }}</td></tr>
+	<tr><th>Description</th><td>{{ tmpl.description }}</td></tr>
+	<tr><th>Scope</th><td>{{ tmpl.scope|ipxe_template_scope_fmt }}</td></tr>
 </table>
 
-{% if !required_params.is_empty() %}
+{% if !tmpl.required_params.is_empty() %}
 <h2>Required Parameters</h2>
 <table class="sortable overview">
 	<thead>
 		<th>Name</th>
 	</thead>
 	<tbody>
-		{% for param in required_params %}
+		{% for param in tmpl.required_params %}
 		<tr>
 			<td>{{ param }}</td>
 		</tr>
@@ -27,14 +27,14 @@
 </table>
 {% endif %}
 
-{% if !reserved_params.is_empty() %}
+{% if !tmpl.reserved_params.is_empty() %}
 <h2>Reserved Parameters</h2>
 <table class="sortable overview">
 	<thead>
 		<th>Name</th>
 	</thead>
 	<tbody>
-		{% for param in reserved_params %}
+		{% for param in tmpl.reserved_params %}
 		<tr>
 			<td>{{ param }}</td>
 		</tr>
@@ -43,14 +43,14 @@
 </table>
 {% endif %}
 
-{% if !required_artifacts.is_empty() %}
+{% if !tmpl.required_artifacts.is_empty() %}
 <h2>Required Artifacts</h2>
 <table class="sortable overview">
 	<thead>
 		<th>Name</th>
 	</thead>
 	<tbody>
-		{% for artifact in required_artifacts %}
+		{% for artifact in tmpl.required_artifacts %}
 		<tr>
 			<td>{{ artifact }}</td>
 		</tr>
@@ -60,6 +60,6 @@
 {% endif %}
 
 <h2>Template</h2>
-<textarea disabled rows="30" cols="100" style="width:100%;font-family:monospace;">{{ template_text }}</textarea>
+<textarea disabled rows="30" cols="100" style="width:100%;font-family:monospace;">{{ tmpl.template }}</textarea>
 
 {% endblock %}

--- a/crates/api/templates/ipxe_template_show.html
+++ b/crates/api/templates/ipxe_template_show.html
@@ -17,11 +17,11 @@
 	<tbody>
 		{% for tmpl in templates %}
 		<tr>
-			<td><a href="/admin/ipxe-template/{{ tmpl.id }}">{{ tmpl.name }}</a></td>
+			<td><a href="/admin/ipxe-template/{{ tmpl.id|option_fmt }}">{{ tmpl.name }}</a></td>
 			<td>{{ tmpl.description }}</td>
-			<td>{{ tmpl.scope }}</td>
-			<td>{{ tmpl.required_params_count }}</td>
-			<td>{{ tmpl.required_artifacts_count }}</td>
+			<td>{{ tmpl.scope|ipxe_template_scope_fmt }}</td>
+			<td>{{ tmpl.required_params.len() }}</td>
+			<td>{{ tmpl.required_artifacts.len() }}</td>
 		</tr>
 		{% endfor %}
 	</tbody>

--- a/crates/api/templates/rack_show.html
+++ b/crates/api/templates/rack_show.html
@@ -32,11 +32,11 @@
                             <tbody>
                             {% for rack in racks %}
                             <tr>
-                                <td>{{ rack.id|rack_id_link|safe }}</td>
+                                <td>{{ rack.id|option_fmt|rack_id_link|safe }}</td>
                                 <td>{{ rack.rack_state }}</td>
-                                <td>{{ rack.compute_trays }}</td>
-                                <td>{{ rack.power_shelves }}</td>
-                                <td>{{ rack.switches }}</td>
+                                <td>{{ rack.compute_trays.len() }} / {{ rack.expected_compute_trays.len() }}</td>
+                                <td>{{ rack.power_shelves.len() }} / {{ rack.expected_power_shelves.len() }}</td>
+                                <td>{{ rack.switches.len() }} / {{ rack.expected_nvlink_switches.len() }}</td>
                             </tr>
                             {% endfor %}
                             </tbody>

--- a/crates/api/templates/resource_pool_show.html
+++ b/crates/api/templates/resource_pool_show.html
@@ -21,8 +21,8 @@
 			<td>{{ pool.name }}</td>
 			<td>{{ pool.min }}</td>
 			<td>{{ pool.max }}</td>
-			<td>{{ pool.size }}</td>
-			<td>{{ pool.allocated }}</td>
+			<td>{{ pool.total }}</td>
+			<td>{{ pool|resource_pool_allocated_fmt }}</td>
 		</tr>
 		{% endfor %}
 	</tbody>


### PR DESCRIPTION
## Description
In many cases in Web we create intermediate data structure and copy data there without
any necessity. It is simpler just use filters and RPC types.

This PR removes some such places. 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

