### PR TITLE
fix: dont unwrap/panic on commit failure in machine_validation handlers

### DIFF
--- a/crates/api/src/handlers/machine_validation.rs
+++ b/crates/api/src/handlers/machine_validation.rs
@@ -254,7 +254,7 @@ pub(crate) async fn persist_validation_result(
     .await?;
 
     db::machine_validation_result::create(validation_result, &mut txn).await?;
-    txn.commit().await.unwrap();
+    txn.commit().await?;
     Ok(tonic::Response::new(()))
 }
 
@@ -525,7 +525,7 @@ pub(crate) async fn remove_machine_validation_external_config(
     let mut txn = api.txn_begin().await?;
 
     let _ = db::machine_validation_config::remove_config(&mut txn, &req.name).await?;
-    txn.commit().await.unwrap();
+    txn.commit().await?;
 
     Ok(tonic::Response::new(()))
 }


### PR DESCRIPTION
## Description

Noticed this when I was poking at machine validation stuff. We `txn.commit().unwrap()` instead of `?`, which, in addition to not propagating the error back to the caller, will also result in a panic in the event of an actual error condition, which we also don't want.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

