### PR TITLE
fix: exclude soft-deleted partitions from IB partition tenant cap during create

### DIFF
--- a/crates/api-db/src/ib_partition.rs
+++ b/crates/api-db/src/ib_partition.rs
@@ -69,7 +69,7 @@ pub async fn create(
                 controller_state,
                 status)
             SELECT $1, $2, $3::json, $4, $5, $6, $7, $8, $9, $10, $11, $12, $14
-            WHERE (SELECT COUNT(*) FROM ib_partitions WHERE organization_id = $6) < $13
+            WHERE (SELECT COUNT(*) FROM ib_partitions WHERE organization_id = $6 AND deleted IS NULL) < $13
             RETURNING *";
     let segment: IBPartition = sqlx::query_as(query)
         .bind(value.id)

--- a/crates/api/src/tests/ib_partition_lifecycle.rs
+++ b/crates/api/src/tests/ib_partition_lifecycle.rs
@@ -260,6 +260,58 @@ async fn test_create_ib_partition_over_max_limit(
 }
 
 #[crate::sqlx_test]
+async fn test_create_ib_partition_cap_excludes_soft_deleted(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Cap subquery in db::ib_partition::create must filter out soft-deleted
+    // rows; otherwise tenants that create + soft-delete partitions hit the cap
+    // with phantom deleted entries before the state controller hard-deletes
+    // them.
+    let cap: i32 = 2;
+
+    let make_partition = |name: &str| NewIBPartition {
+        id: IBPartitionId::new(),
+        config: IBPartitionConfig {
+            name: name.to_string(),
+            pkey: None,
+            tenant_organization_id: FIXTURE_TENANT_ORG_ID.to_string().try_into().unwrap(),
+            mtu: Some(IBMtu::default()),
+            rate_limit: Some(IBRateLimit::default()),
+            service_level: Some(IBServiceLevel::default()),
+        },
+        metadata: Metadata {
+            name: name.to_string(),
+            labels: HashMap::new(),
+            description: "soft-delete cap test".to_string(),
+        },
+    };
+
+    let status = |pkey: u16| IBPartitionStatus {
+        partition: None,
+        mtu: None,
+        rate_limit: None,
+        service_level: None,
+        pkey: Some(pkey.try_into().unwrap()),
+    };
+
+    let mut txn = pool.begin().await?;
+    let p1 = db::ib_partition::create(make_partition("p1"), &mut txn, cap, status(42)).await?;
+    let _p2 = db::ib_partition::create(make_partition("p2"), &mut txn, cap, status(43)).await?;
+
+    db::ib_partition::mark_as_deleted(&p1, &mut txn).await?;
+
+    let result = db::ib_partition::create(make_partition("p3"), &mut txn, cap, status(44)).await;
+    assert!(
+        result.is_ok(),
+        "soft-deleted partitions must not count toward the per-tenant cap. got: {:?}",
+        result.err()
+    );
+
+    txn.commit().await?;
+    Ok(())
+}
+
+#[crate::sqlx_test]
 async fn test_reject_create_with_invalid_metadata(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Description

`db::ib_partition::create` enforces `max_partition_per_tenant` via a sub-select during partition creation. The problem is it excluded soft-deleted partitions, so a tenant who might now [think they] have zero partitions could in theory run into this, and be confused (until said partitions got hard-deleted).

This updates the sub-select to exclude soft-deleted partitions, which is a more accurate representaton for the purpose of partition creation.

Test added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

