### PR TITLE
fix(api-db): handle concurrent vpc::increment_vpc_version callers

### DIFF
--- a/crates/api-db/src/vpc.rs
+++ b/crates/api-db/src/vpc.rs
@@ -368,11 +368,20 @@ pub async fn increment_vpc_version(
 
     let new_version = current_version.increment();
 
-    let update_query = "UPDATE vpcs SET version = $1 WHERE id = $2 RETURNING version";
-    sqlx::query_as(update_query)
+    let update_query =
+        "UPDATE vpcs SET version = $1 WHERE id = $2 AND version = $3 RETURNING version";
+    let updated: Option<(ConfigVersion,)> = sqlx::query_as(update_query)
         .bind(new_version)
         .bind(id)
-        .fetch_one(txn)
+        .bind(current_version)
+        .fetch_optional(&mut *txn)
         .await
-        .map_err(|e| DatabaseError::query(update_query, e))
+        .map_err(|e| DatabaseError::query(update_query, e))?;
+
+    updated
+        .map(|(v,)| v)
+        .ok_or(DatabaseError::ConcurrentModificationError(
+            "vpc",
+            current_version.to_string(),
+        ))
 }

--- a/crates/api/src/ib_fabric_monitor/mod.rs
+++ b/crates/api/src/ib_fabric_monitor/mod.rs
@@ -1125,7 +1125,7 @@ async fn set_ib_port_down_alert(
     db::machine::insert_health_report_override(
         &mut conn,
         machine_id,
-        OverrideMode::Merge,
+        HealthReportApplyMode::Merge,
         &health_report,
         false, // overwrite existing
     )
@@ -1147,7 +1147,7 @@ async fn clear_ib_port_down_alert(
     db::machine::remove_health_report_override(
         &mut conn,
         machine_id,
-        OverrideMode::Merge,
+        HealthReportApplyMode::Merge,
         IB_PORT_DOWN_OVERRIDE_SOURCE,
     )
     .await

--- a/crates/api/src/tests/vpc.rs
+++ b/crates/api/src/tests/vpc.rs
@@ -1023,3 +1023,91 @@ async fn create_update_network_security_group_for_vpc(
 
     Ok(())
 }
+
+#[crate::sqlx_test]
+async fn test_increment_vpc_version_detects_concurrent_writes(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Two concurrent `increment_vpc_version` calls on the same VPC
+    // should not silently lose an increment. Exactly one caller wins
+    // (their `WHERE version=$old` matches and updates), and the loser
+    // sees 0 rows updated and returns `ConcurrentModificationError`.
+    let env = create_test_env(pool.clone()).await;
+    let vpc_id: VpcId = env
+        .api
+        .create_vpc(
+            VpcCreationRequest::builder("vpc-bump", "2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                .tonic_request(),
+        )
+        .await
+        .unwrap()
+        .into_inner()
+        .id
+        .unwrap();
+
+    let initial_version_nr = {
+        let vpcs =
+            db::vpc::find_by(&pool, ObjectColumnFilter::One(db::vpc::IdColumn, &vpc_id)).await?;
+        vpcs[0].version.version_nr()
+    };
+
+    // Open two transactions, have both read the current version, then race!
+    let pool_a = pool.clone();
+    let pool_b = pool.clone();
+    let (a, b) = tokio::join!(
+        tokio::spawn(async move {
+            let mut txn = pool_a.begin().await.unwrap();
+            let result = db::vpc::increment_vpc_version(&mut txn, vpc_id).await;
+            if result.is_ok() {
+                txn.commit().await.unwrap();
+            } else {
+                txn.rollback().await.unwrap();
+            }
+            result
+        }),
+        tokio::spawn(async move {
+            let mut txn = pool_b.begin().await.unwrap();
+            let result = db::vpc::increment_vpc_version(&mut txn, vpc_id).await;
+            if result.is_ok() {
+                txn.commit().await.unwrap();
+            } else {
+                txn.rollback().await.unwrap();
+            }
+            result
+        }),
+    );
+    let (a, b) = (a.unwrap(), b.unwrap());
+
+    let outcomes = [&a, &b];
+    let successes = outcomes.iter().filter(|r| r.is_ok()).count();
+    let conflicts = outcomes
+        .iter()
+        .filter(|r| {
+            matches!(
+                r,
+                Err(db::DatabaseError::ConcurrentModificationError("vpc", _))
+            )
+        })
+        .count();
+    assert_eq!(
+        successes, 1,
+        "exactly 1 of 2 concurrent increments should succeed; got {successes} (a={a:?}, b={b:?})"
+    );
+    assert_eq!(
+        conflicts, 1,
+        "the losing race should get a ConcurrentModificationError; got {conflicts} (a={a:?}, b={b:?})"
+    );
+
+    let final_version_nr = {
+        let vpcs =
+            db::vpc::find_by(&pool, ObjectColumnFilter::One(db::vpc::IdColumn, &vpc_id)).await?;
+        vpcs[0].version.version_nr()
+    };
+    assert_eq!(
+        final_version_nr - initial_version_nr,
+        1,
+        "exactly one increment should have happened after the race"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

`db::vpc::increment_vpc_version` was written in a way where two concurrent transactions on the same VPC could end up bumping to the same `version + 1`, resulting in one being silently dropped.

This updates the logic to match how we do optimistic-locking/CAS for all other `ConfigVersion` bumping across the DB layer.

Test included!

P.S. It looks like some bug made its way into main with health override renames somehow, so this is pulling in that fix too.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

