### PR TITLE
fix(api): delete_sku now reports correct count of in-use machines

### DIFF
--- a/crates/api/src/handlers/sku.rs
+++ b/crates/api/src/handlers/sku.rs
@@ -70,13 +70,13 @@ pub(crate) async fn delete(api: &Api, request: Request<SkuIdList>) -> Result<Res
 
     let machine_ids =
         db::machine::find_machine_ids_by_sku_ids(&mut txn, std::slice::from_ref(&sku.id)).await?;
-    if machine_ids
+    let machines_using_sku = machine_ids
         .get(&sku.id)
-        .is_some_and(|machine_ids| !machine_ids.is_empty())
-    {
+        .map(|machine_ids| machine_ids.len())
+        .unwrap_or(0);
+    if machines_using_sku > 0 {
         return Err(CarbideError::InvalidArgument(format!(
-            "The SKUs are in use by {} machines",
-            machine_ids.len()
+            "The SKU is in use by {machines_using_sku} machines"
         ))
         .into());
     }

--- a/crates/api/src/tests/sku.rs
+++ b/crates/api/src/tests/sku.rs
@@ -1988,4 +1988,41 @@ pub mod tests {
 
         Ok(())
     }
+
+    #[crate::sqlx_test]
+    async fn test_delete_sku_in_use_reports_correct_machine_count(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        use rpc::forge::SkuIdList;
+        use rpc::forge::forge_server::Forge;
+
+        let env = create_test_env(pool.clone()).await;
+        let (machine_id_1, _dpu1) = create_managed_host(&env).await.into();
+        let (machine_id_2, _dpu2) = create_managed_host(&env).await.into();
+
+        let sku_id = {
+            let mut txn = pool.begin().await?;
+            let sku = db::sku::generate_sku_from_machine(txn.as_mut(), &machine_id_1).await?;
+            db::sku::create(&mut txn, &sku).await?;
+            db::machine::assign_sku(&mut txn, &machine_id_1, &sku.id).await?;
+            db::machine::assign_sku(&mut txn, &machine_id_2, &sku.id).await?;
+            txn.commit().await?;
+            sku.id
+        };
+
+        let err = env
+            .api
+            .delete_sku(tonic::Request::new(SkuIdList { ids: vec![sku_id] }))
+            .await
+            .expect_err("expected delete of in-use SKU to fail");
+
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(
+            err.message().contains("in use by 2 machines"),
+            "expected error to report 2 machines but got: {}",
+            err.message()
+        );
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Description

`delete_sku` calls `db::machine::find_machine_ids_by_sku_ids`, which returns `HashMap<String, Vec<MachineId>>`. The `String` key is the SKU id, with the `Vec` of machines that hold each SKU as the value. In the previous code, the handler called `machine_ids.len()` and put that into the error message:

```
  "The SKUs are in use by {} machines"
```

The problem was `machine_ids.len()` was returning the number of keys in the map (the number of SKUs), not the number of machines for the given SKU, so generally it would just say "*The SKUs are in use by 1 machines*", even if there were multiple machines for the given SKU.

This replaces that logic with the length of the `Vec` instead.

Test added to make sure it all wires up correctly.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

