### PR TITLE
feat: enhance expected + managed racks with label support in RackSearchFilter

### DIFF
--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -287,7 +287,10 @@ impl ApiClient {
     }
 
     async fn get_rack_ids(&self) -> CarbideCliResult<rpc::RackIdList> {
-        Ok(self.0.find_rack_ids().await?)
+        Ok(self
+            .0
+            .find_rack_ids(rpc::RackSearchFilter::default())
+            .await?)
     }
 
     pub async fn get_all_switches(

--- a/crates/api-db/src/rack.rs
+++ b/crates/api-db/src/rack.rs
@@ -57,15 +57,50 @@ where
 
 pub async fn find_ids(
     txn: impl DbReader<'_>,
-    _filter: model::rack::RackSearchFilter,
+    filter: model::rack::RackSearchFilter,
 ) -> Result<Vec<RackId>, DatabaseError> {
     let mut builder = sqlx::QueryBuilder::new("SELECT id FROM racks WHERE TRUE "); // The TRUE will be optimized away.
+
+    if let Some(label) = filter.label {
+        match (label.key.is_empty(), label.value) {
+            // Label key is empty, label value is set.
+            (true, Some(value)) => {
+                builder.push(
+                    " AND EXISTS (
+                        SELECT 1
+                        FROM jsonb_each_text(labels) AS kv
+                        WHERE kv.value = ",
+                );
+                builder.push_bind(value);
+                builder.push(")");
+            }
+            // Label key is empty, label value is not set.
+            (true, None) => {
+                return Err(DatabaseError::InvalidArgument(
+                    "finding racks based on label needs either key or a value.".to_string(),
+                ));
+            }
+            // Label key is not empty, label value is not set.
+            (false, None) => {
+                builder.push(" AND labels ->> ");
+                builder.push_bind(label.key);
+                builder.push(" IS NOT NULL");
+            }
+            // Label key is not empty, label value is set.
+            (false, Some(value)) => {
+                builder.push(" AND labels ->> ");
+                builder.push_bind(label.key);
+                builder.push(" = ");
+                builder.push_bind(value);
+            }
+        }
+    }
 
     let query = builder.build_query_as();
     query
         .fetch_all(txn)
         .await
-        .map_err(|e| DatabaseError::new("instance::find_ids", e))
+        .map_err(|e| DatabaseError::new("rack::find_ids", e))
 }
 
 pub async fn create(

--- a/crates/api-model/src/expected_rack.rs
+++ b/crates/api-model/src/expected_rack.rs
@@ -38,7 +38,9 @@ pub struct ExpectedRack {
     /// the rack hardware type, topology, and rack capabilities.
     pub rack_profile_id: RackProfileId,
 
-    /// User-defined metadata for the rack.
+    /// User-defined metadata for the rack. Physical-chassis and
+    /// physical-location attributes are recorded as well-known label keys
+    /// on this Metadata (see api-model::rack for the well-known keys).
     #[serde(default = "default_metadata_for_deserializer")]
     pub metadata: Metadata,
 }

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -35,6 +35,35 @@ use crate::controller_outcome::PersistentStateHandlerOutcome;
 use crate::health::HealthReportSources;
 use crate::metadata::Metadata;
 
+// Well-known label keys!
+//
+// For rack chassis and location, there are currently a few labels that we
+// are passing through from the NICo REST API into NICo. These labels get
+// used by orchestration systems and tooling who want to work on, and have
+// awareness of, racks based on their physical location.
+//
+// At the time of this writing, these are all new and optional, but it made
+// the most sense to put them in as labels due to their optional and flexible
+// nature as we smooth things out. In the interim, it seemed to make sense
+// to at least have some "well known" defs for now, which may very well
+// change over time.
+//
+// These labels apply to both ExpectedRack AND Rack metadata labels, which
+// are applied from Expected -> Managed at promition time.
+//
+// First, rack chassis info labels, which physically identifies the rack
+// hardware itself.
+pub const LABEL_CHASSIS_MANUFACTURER: &str = "chassis.manufacturer";
+pub const LABEL_CHASSIS_SERIAL_NUMBER: &str = "chassis.serial-number";
+pub const LABEL_CHASSIS_MODEL: &str = "chassis.model";
+
+// Next, rack location info labels, which identifies where the rack
+// physically lives.
+pub const LABEL_LOCATION_REGION: &str = "location.region";
+pub const LABEL_LOCATION_DATACENTER: &str = "location.datacenter";
+pub const LABEL_LOCATION_ROOM: &str = "location.room";
+pub const LABEL_LOCATION_POSITION: &str = "location.position";
+
 #[derive(Debug, Clone)]
 pub struct Rack {
     pub id: RackId,
@@ -288,11 +317,15 @@ impl From<Rack> for rpc::forge::Rack {
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct RackSearchFilter {}
+pub struct RackSearchFilter {
+    pub label: Option<crate::metadata::LabelFilter>,
+}
 
 impl From<rpc::forge::RackSearchFilter> for RackSearchFilter {
-    fn from(_filter: rpc::forge::RackSearchFilter) -> Self {
-        RackSearchFilter {}
+    fn from(filter: rpc::forge::RackSearchFilter) -> Self {
+        RackSearchFilter {
+            label: filter.label.map(crate::metadata::LabelFilter::from),
+        }
     }
 }
 
@@ -1059,5 +1092,40 @@ mod tests {
         let rejection = RackMaintenanceRejection::AlreadyPending;
         let msg = rejection.to_string();
         assert!(msg.contains("already has a pending maintenance request"));
+    }
+
+    #[test]
+    fn rack_search_filter_from_rpc_with_label_key_and_value() {
+        let rpc_filter = rpc::forge::RackSearchFilter {
+            label: Some(rpc::forge::Label {
+                key: LABEL_LOCATION_DATACENTER.to_string(),
+                value: Some("az01".to_string()),
+            }),
+        };
+        let filter = RackSearchFilter::from(rpc_filter);
+        let label = filter.label.unwrap();
+        assert_eq!(label.key, LABEL_LOCATION_DATACENTER);
+        assert_eq!(label.value, Some("az01".to_string()));
+    }
+
+    #[test]
+    fn rack_search_filter_from_rpc_with_label_key_only() {
+        let rpc_filter = rpc::forge::RackSearchFilter {
+            label: Some(rpc::forge::Label {
+                key: LABEL_CHASSIS_MANUFACTURER.to_string(),
+                value: None,
+            }),
+        };
+        let filter = RackSearchFilter::from(rpc_filter);
+        let label = filter.label.unwrap();
+        assert_eq!(label.key, LABEL_CHASSIS_MANUFACTURER);
+        assert!(label.value.is_none());
+    }
+
+    #[test]
+    fn rack_search_filter_from_rpc_no_label() {
+        let rpc_filter = rpc::forge::RackSearchFilter { label: None };
+        let filter = RackSearchFilter::from(rpc_filter);
+        assert!(filter.label.is_none());
     }
 }

--- a/crates/api/src/state_controller/rack/io.rs
+++ b/crates/api/src/state_controller/rack/io.rs
@@ -53,7 +53,7 @@ impl StateControllerIO for RackStateControllerIO {
         &self,
         txn: &mut PgConnection,
     ) -> Result<Vec<Self::ObjectId>, DatabaseError> {
-        db_rack::find_ids(txn, RackSearchFilter {}).await
+        db_rack::find_ids(txn, RackSearchFilter::default()).await
     }
 
     /// Loads a state snapshot from the database

--- a/crates/api/src/tests/rack_find.rs
+++ b/crates/api/src/tests/rack_find.rs
@@ -43,7 +43,7 @@ async fn test_find_rack_by_id(pool: sqlx::PgPool) {
 
     let rack_ids = env
         .api
-        .find_rack_ids(tonic::Request::new(rpc::forge::RackSearchFilter {}))
+        .find_rack_ids(tonic::Request::new(rpc::forge::RackSearchFilter::default()))
         .await
         .unwrap()
         .into_inner()

--- a/crates/api/src/web/rack.rs
+++ b/crates/api/src/web/rack.rs
@@ -82,7 +82,7 @@ pub async fn show_json(state: AxumState<Arc<Api>>) -> Response {
 }
 
 pub async fn fetch_racks(api: &Api) -> Result<rpc::forge::RackList, tonic::Status> {
-    let request = tonic::Request::new(rpc::forge::RackSearchFilter {});
+    let request = tonic::Request::new(rpc::forge::RackSearchFilter::default());
 
     let rack_ids = api.find_rack_ids(request).await?.into_inner().rack_ids;
 

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -2163,6 +2163,8 @@ message ExpectedRack {
   // The rack profile ID. Determines expected counts of compute trays, switches, and power shelves.
   common.RackProfileId rack_profile_id = 2;
   // Metadata that will be associated with the rack.
+  // This includes things like chassis and location attributes,
+  // which has some "well known" definitions in api-model::rack.
   Metadata metadata = 3;
 }
 
@@ -6614,6 +6616,8 @@ message RackList {
 }
 
 message RackSearchFilter {
+  // Supports filtering on key, value, or key and value.
+  optional Label label = 1;
 }
 
 message RackIdList {


### PR DESCRIPTION
## Description

This updates `RackSearchFilter` to accept metadata labels, which exist on `ExpectedRack` and `Rack`, so that we query for racks based on their labels.

This also adds some "well known" labels while we're in here, providing awareness that some well known labels exist!

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

