### PR TITLE
fix(machine-a-tron): prevent DPU discovery race before SetUefiHttpBoot (devspace setup)

### DIFF
--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -609,6 +609,25 @@ impl MachineStateMachine {
             PxeResponse::Scout => OsImage::Scout,
             PxeResponse::DpuAgent => OsImage::DpuAgent,
         };
+        // A DPU only actually loads the BFB (DpuAgent) when its BMC has been
+        // configured to network-boot via BootSourceOverride=UefiHttp/Pxe.
+        let next_boot_kind = self
+            .live_state
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .next_boot_kind;
+        let os = if matches!(self.machine_info, MachineInfo::Dpu(_))
+            && os == OsImage::DpuAgent
+            && next_boot_kind != Some(BootOptionKind::Network)
+        {
+            tracing::debug!(
+                "DPU PXE response was DpuAgent but BootSourceOverride is not Network; \
+                 falling back to installed_os."
+            );
+            self.installed_os
+        } else {
+            os
+        };
         match os {
             OsImage::None => Ok(os),
             OsImage::DpuAgent => {


### PR DESCRIPTION
## Description

### Problem
Carbide-api logging next errors in devspace:

`ERROR Argument is invalid: Machine id <id> was not discovered by site-explorer. location="crates/api/src/errors.rs:340"`

This happened because the mock DPU (machine-a-tron) calls `discover_machine` against the API before the controller's host-side had run `SetUefiHttpBoot`. At that point the DPU's row hadn't been INSERTed by site-explorer yet, so the API rejected the discovery as referencing an unknown machine id.

This error is not fatal because in next restart request DhcpDiscovering finished successfully.

### Why it happens

The mock's FSM cycles through DHCP → PXE → MachineUp{DpuAgent(Discovery)} → InitialDiscoveryRequest on every boot, regardless of how the BMC's BootSourceOverride is configured. Real hardware ( **I suppose** ) doesn't behave that way: the BFB only loads when BootNext points at `UefiHttp`. 

### Fix

In pxe_boot_request, when the controller's PXE response says DpuAgent for a DPU but `next_boot_kind` (resolved from the mock BMC's BootSourceOverride) isn't Network, fall back to `installed_os`. 
  


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

