### PR TITLE
fix(site-explorer): use an uninitialized client when rotating the BMC password

### DIFF
--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -55,6 +55,16 @@ struct RedfishSimState {
     secure_boot: AtomicBool,
     machine_setup_bios_job_id: Option<String>,
     job_state_sequence: VecDeque<JobState>,
+    /// Records every call to `RedfishClientPool::create_client` so tests can
+    /// assert what vendor was passed at each call site.
+    create_client_calls: Vec<CreateClientCall>,
+}
+
+/// Snapshot of a single `RedfishClientPool::create_client` invocation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateClientCall {
+    pub host: String,
+    pub vendor: Option<RedfishVendor>,
 }
 
 #[derive(Debug)]
@@ -120,6 +130,23 @@ impl RedfishSim {
 
     pub fn set_job_state_sequence(&self, states: Vec<JobState>) {
         self.state.lock().unwrap().job_state_sequence = VecDeque::from(states);
+    }
+
+    /// Returns a snapshot of every `create_client` call made through this sim,
+    /// in the order they happened. Useful for asserting which vendor was
+    /// passed at a given call site.
+    pub fn create_client_calls(&self) -> Vec<CreateClientCall> {
+        self.state.lock().unwrap().create_client_calls.clone()
+    }
+
+    /// Seed a user account so calls like `change_password` /
+    /// `change_password_by_id` see it as already present.
+    pub fn seed_user(&self, username: &str, password: &str) {
+        self.state
+            .lock()
+            .unwrap()
+            .users
+            .insert(username.to_string(), password.to_string());
     }
 }
 
@@ -1374,13 +1401,15 @@ impl RedfishClientPool for RedfishSim {
         host: &str,
         port: Option<u16>,
         _auth: RedfishAuth,
-        _vendor: Option<RedfishVendor>,
+        vendor: Option<RedfishVendor>,
     ) -> Result<Box<dyn Redfish>, RedfishClientCreationError> {
         {
-            self.state
-                .clone()
-                .lock()
-                .unwrap()
+            let mut state = self.state.lock().unwrap();
+            state.create_client_calls.push(CreateClientCall {
+                host: host.to_string(),
+                vendor,
+            });
+            state
                 .hosts
                 .entry(host.to_string())
                 .or_insert(RedfishSimHostState {
@@ -1388,8 +1417,8 @@ impl RedfishClientPool for RedfishSim {
                     lockdown: EnabledDisabled::Disabled,
                     actions: Default::default(),
                 });
-            if self.state.clone().lock().unwrap().fw_version.is_empty() {
-                self.state.clone().lock().unwrap().fw_version = Arc::new("24.10-17".to_string());
+            if state.fw_version.is_empty() {
+                state.fw_version = Arc::new("24.10-17".to_string());
             }
         }
         Ok(Box::new(RedfishSimClient {

--- a/crates/site-explorer/Cargo.toml
+++ b/crates/site-explorer/Cargo.toml
@@ -50,5 +50,9 @@ tracing = { workspace = true }
 thiserror = { workspace = true }
 version-compare = { workspace = true }
 
+[dev-dependencies]
+carbide-redfish = { path = "../redfish", features = ["test-support"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
+
 [lints]
 workspace = true

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -145,19 +145,28 @@ impl RedfishClient {
         let (curr_user, curr_password) = match &current_bmc_root_credentials {
             Credentials::UsernamePassword { username, password } => (username, password),
         };
-        // Create a vendor-specific client based on the provided
-        // vendor hardware attempting to set the BMC root password.
-        // NOTE(chet): This used to use a "standard"/Unknown client,
-        // but after adding support for vendored clients, I was able
-        // to change it. If this ends up causing problems in some
-        // way, presumably the "fix" should end up being a libredfish
-        // (or eventually nv-redfish) vendor implementation change (I
-        // would think).
+        // We're about to PATCH /AccountService to rotate the BMC password.
+        // That's the only Redfish endpoint we need at this stage, so use an
+        // uninitialized "Unknown" client to skip libredfish's full init
+        // path (which fetches /Systems, /Managers, /Chassis up front).
+        //
+        // Those fetches are unnecessary here, and they actively break
+        // rotation on factory BMCs that refuse reads until the password
+        // has been changed. Notably, NVIDIA GBx00 in factory state
+        // authenticates the supplied creds just fine, but returns HTTP 403
+        // with "Base.1.18.1.PasswordChangeRequired" on /Systems -- so if
+        // we let libredfish initialize first, we never reach the PATCH
+        // that would actually unblock us.
+        //
+        // The vendor-specific client is created below, *after* the rotation
+        // has succeeded, so set_machine_password_policy gets the right
+        // vendor impl (e.g. Lite-On's, which omits
+        // AccountLockoutCounterResetAfter).
         let client = self
             .create_direct_redfish_client(
                 bmc_ip_address,
                 current_bmc_root_credentials.clone(),
-                Some(vendor),
+                Some(RedfishVendor::Unknown),
             )
             .await
             .map_err(|e| {
@@ -1378,5 +1387,126 @@ fn map_nv_redfish_explore_error(
         err => EndpointExplorationError::Other {
             details: err.to_string(),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::sync::Arc;
+
+    use arc_swap::ArcSwap;
+    use carbide_redfish::libredfish::test_support::RedfishSim;
+    use carbide_redfish::nv_redfish::NvRedfishClientPool;
+    use forge_secrets::credentials::Credentials;
+    use libredfish::model::service_root::RedfishVendor;
+
+    use super::RedfishClient;
+
+    fn test_addr() -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 443)
+    }
+
+    fn build_redfish_client(sim: Arc<RedfishSim>) -> RedfishClient {
+        let proxy_address = Arc::new(ArcSwap::new(Arc::new(None)));
+        let nv_pool = Arc::new(NvRedfishClientPool::new(proxy_address));
+        RedfishClient::new(sim, nv_pool)
+    }
+
+    /// Test to check that when site-explorer rotates a BMC's root password,
+    /// it first uses an uninitialized client (`Some(RedfishVendor::Unknown)`)
+    /// to make the actual `change_password_by_id` call, and NOT a
+    /// vendor-specific client.
+    ///
+    /// The vendor-specific client triggers libredfish's full init path
+    /// (fetches `/Systems`, `/Managers`, `/Chassis`) which is unnecessary
+    /// just to PATCH `/AccountService`. Worse, factory BMCs like NVIDIA
+    /// GBx00 authenticate the supplied creds but return HTTP 403
+    /// `Base.1.18.1.PasswordChangeRequired` on `/Systems` until the
+    /// password is rotated -- so an init-first flow blocks the very PATCH
+    /// that would unblock it.
+    ///
+    /// Only the SECOND client (used to set the password policy after the
+    /// rotation has succeeded) should be vendor-specific so we get the right
+    /// `set_machine_password_policy` impl (e.g. Lite-On omits
+    /// `AccountLockoutCounterResetAfter`).
+    #[tokio::test]
+    async fn set_bmc_root_password_uses_unknown_vendor_for_password_change_client() {
+        let sim = Arc::new(RedfishSim::default());
+        sim.seed_user("root", "factory_pass");
+
+        let redfish = build_redfish_client(sim.clone());
+
+        let factory_creds = Credentials::UsernamePassword {
+            username: "root".to_string(),
+            password: "factory_pass".to_string(),
+        };
+
+        redfish
+            .set_bmc_root_password(
+                test_addr(),
+                RedfishVendor::LiteOnPowerShelf,
+                factory_creds,
+                "site_pass".to_string(),
+            )
+            .await
+            .expect("set_bmc_root_password should succeed against the sim");
+
+        let calls = sim.create_client_calls();
+        assert_eq!(
+            calls.len(),
+            2,
+            "expected exactly two create_client calls (one for password change, one for policy), got {calls:?}"
+        );
+        assert_eq!(
+            calls[0].vendor,
+            Some(RedfishVendor::Unknown),
+            "the FIRST client (password change) must be uninitialized (Unknown) so \
+             libredfish skips its /Systems, /Managers, /Chassis fetches. Passing the \
+             real vendor regresses to those fetches, which factory BMCs (e.g. NVIDIA \
+             GBx00) reject with HTTP 403 PasswordChangeRequired -- blocking the very \
+             PATCH that would unblock them. got: {:?}",
+            calls[0].vendor,
+        );
+        assert_eq!(
+            calls[1].vendor,
+            Some(RedfishVendor::LiteOnPowerShelf),
+            "the SECOND client (set_machine_password_policy) must use the real vendor \
+             so vendor-specific impls (e.g. Lite-On omitting AccountLockoutCounterResetAfter) \
+             are dispatched. got: {:?}",
+            calls[1].vendor,
+        );
+    }
+
+    /// Same regression guard, but for a non-Lite-On vendor that also needs
+    /// vendor dispatch on the second client (NvidiaDpu uses
+    /// `change_password_by_id`). Locks in that the Unknown-vs-vendor split
+    /// is consistent across vendors.
+    #[tokio::test]
+    async fn set_bmc_root_password_uses_unknown_vendor_for_nvidia_dpu_too() {
+        let sim = Arc::new(RedfishSim::default());
+        sim.seed_user("root", "factory_pass");
+
+        let redfish = build_redfish_client(sim.clone());
+
+        let factory_creds = Credentials::UsernamePassword {
+            username: "root".to_string(),
+            password: "factory_pass".to_string(),
+        };
+
+        redfish
+            .set_bmc_root_password(
+                test_addr(),
+                RedfishVendor::NvidiaDpu,
+                factory_creds,
+                "site_pass".to_string(),
+            )
+            .await
+            .expect("set_bmc_root_password should succeed against the sim");
+
+        let calls = sim.create_client_calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].vendor, Some(RedfishVendor::Unknown));
+        assert_eq!(calls[1].vendor, Some(RedfishVendor::NvidiaDpu));
     }
 }


### PR DESCRIPTION
## Description

Fixes an internal bug report.

Tail between legs here. #878 made `site-explorer` BMC client creation vendor-aware by replacing `initialize: bool` with `vendor: Option<RedfishVendor>`, with the idea being that, without a vendor, we'd fall back to a "standard" client. As part of that, I went a little further and changed `set_bmc_root_password` to create its firs client with `Some(vendor)` (a vendor-specific client) instead of the previous "uninitialized" client (which I left a `NOTE(chet)` about, as foreshadowing, apparently).

The problem is that first client is the one we use to actually call `change_password_by_id` (or `change_password`) with the *factory* credentials, before we've rotated anything. With `Some(vendor)`, `libredfish` runs its full inititialization path (aka what was previously `initialize: true`), which [attempts to] fetch `/Systems`, `/Managers`, `/Chassis`, etc, *before* the password change happens.

For BMCs that gate those endpoints behind a successful password rotation, those fetches fail with 401, and we never get to actually rotate the password.

In other words, the prior `initialize: false` semantics are/were "don't do the init fetches", and that behavior got mangled.

To fix this, we now pass `Some(RedfishVendor::Unknown)` for the first client. This ensures we hit the special case in `RedfishClientPoolImpl` which routes to `create_standard_client_with_custom_headers`; this is an uninitialized client with zero HTTP calls. The `change_password{,_by_id}` call only needs `/AccountService` access, which factory creds always have.

And then, the *second* client (the one we use after the rotation, for `set_machine_password_policy`) keeps its `Some(vendor)`, because we want the vendor-specific impl there (e.g. Lite-On's omits `AccountLockoutCounterResetAfter`, which is the whole reason #878 existed to begin with, and then I tried to get overly-elegant).

Added a couple of unit tests to verify behaviors work as intended, and also so we don't fall back into the same hole. To make them possible, I made it so `RedfishSim` now records every `create_client` invocation (host + vendor) and exposes them via `create_client_calls()`, plus a small `seed_user` helper. The new tests verify both that the first client uses `Some(Unknown)`, and that the second keeps its vendor (which covers both the original Lite-On case, and the DPU case).

**I tried to make sure there were ample comments at the adjusted call sites AND tests to:**
- Make sure I am conveying my understanding here.
- Make sure people who look through this understand what is going on.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

