### PR TITLE
chore: implement list_component_firmware_versions for compute trays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3058,6 +3058,7 @@ dependencies = [
  "carbide-api-model",
  "carbide-api-test-helper",
  "carbide-macros",
+ "carbide-secrets",
  "carbide-sqlx-testing",
  "carbide-uuid",
  "chrono",

--- a/crates/admin-cli/src/component_manager/versions/cmd.rs
+++ b/crates/admin-cli/src/component_manager/versions/cmd.rs
@@ -23,6 +23,10 @@ use super::args::Args;
 use crate::component_manager::common;
 use crate::rpc::ApiClient;
 
+/// Formats a raw proto `ComputeTrayComponent` value for display.
+///
+/// Keep in sync with `map_compute_tray_component_names` and
+/// `firmware_component_type_to_proto` in `api/src/handlers/component_manager.rs`.
 fn format_compute_tray_component(value: i32) -> String {
     match ComputeTrayComponent::try_from(value) {
         Ok(ComputeTrayComponent::Bmc) => "BMC".to_string(),
@@ -35,7 +39,8 @@ fn format_compute_tray_component(value: i32) -> String {
         Ok(ComputeTrayComponent::CombinedBmcUefi) => "COMBINED_BMC_UEFI".to_string(),
         Ok(ComputeTrayComponent::Gpu) => "GPU".to_string(),
         Ok(ComputeTrayComponent::Cx7) => "CX7".to_string(),
-        _ => format!("UNKNOWN({value})"),
+        Ok(ComputeTrayComponent::Unknown) => format!("UNKNOWN({value})"),
+        Err(e) => format!("UNRECOGNIZED({value}: {e})"),
     }
 }
 
@@ -87,26 +92,26 @@ pub async fn list_versions(
         for device in &response.devices {
             let (component_id, result_status, error) =
                 common::component_result_fields(device.result.as_ref());
-            let versions = if !device.compute_fw_versions.is_empty() {
-                device
-                    .compute_fw_versions
-                    .iter()
-                    .map(|cv| {
-                        let name = format_compute_tray_component(cv.component);
-                        let v = common::join_or_dash(&cv.versions);
-                        format!("{name}: {v}")
-                    })
-                    .collect::<Vec<_>>()
-                    .join(", ")
+            if !device.compute_fw_versions.is_empty() {
+                for cv in &device.compute_fw_versions {
+                    let name = format_compute_tray_component(cv.component);
+                    let versions = common::join_or_dash(&cv.versions);
+                    table.add_row(Row::new(vec![
+                        Cell::new(&component_id),
+                        Cell::new(&result_status),
+                        Cell::new(&format!("{name}: {versions}")),
+                        Cell::new(&error),
+                    ]));
+                }
             } else {
-                common::join_or_dash(&device.versions)
-            };
-            table.add_row(Row::new(vec![
-                Cell::new(&component_id),
-                Cell::new(&result_status),
-                Cell::new(&versions),
-                Cell::new(&error),
-            ]));
+                let versions = common::join_or_dash(&device.versions);
+                table.add_row(Row::new(vec![
+                    Cell::new(&component_id),
+                    Cell::new(&result_status),
+                    Cell::new(&versions),
+                    Cell::new(&error),
+                ]));
+            }
         }
 
         table.printstd();

--- a/crates/admin-cli/src/component_manager/versions/cmd.rs
+++ b/crates/admin-cli/src/component_manager/versions/cmd.rs
@@ -16,11 +16,28 @@
  */
 
 use ::rpc::admin_cli::{CarbideCliError, OutputFormat};
+use ::rpc::forge::ComputeTrayComponent;
 use prettytable::{Cell, Row, Table};
 
 use super::args::Args;
 use crate::component_manager::common;
 use crate::rpc::ApiClient;
+
+fn format_compute_tray_component(value: i32) -> String {
+    match ComputeTrayComponent::try_from(value) {
+        Ok(ComputeTrayComponent::Bmc) => "BMC".to_string(),
+        Ok(ComputeTrayComponent::Bios) => "BIOS".to_string(),
+        Ok(ComputeTrayComponent::Cec) => "CEC".to_string(),
+        Ok(ComputeTrayComponent::Nic) => "NIC".to_string(),
+        Ok(ComputeTrayComponent::CpldMb) => "CPLD_MB".to_string(),
+        Ok(ComputeTrayComponent::CpldPdb) => "CPLD_PDB".to_string(),
+        Ok(ComputeTrayComponent::HgxBmc) => "HGX_BMC".to_string(),
+        Ok(ComputeTrayComponent::CombinedBmcUefi) => "COMBINED_BMC_UEFI".to_string(),
+        Ok(ComputeTrayComponent::Gpu) => "GPU".to_string(),
+        Ok(ComputeTrayComponent::Cx7) => "CX7".to_string(),
+        _ => format!("UNKNOWN({value})"),
+    }
+}
 
 pub async fn list_versions(
     opts: Args,
@@ -38,10 +55,23 @@ pub async fn list_versions(
             .devices
             .iter()
             .map(|device| {
-                serde_json::json!({
+                let compute_fw_versions: serde_json::Map<String, serde_json::Value> = device
+                    .compute_fw_versions
+                    .iter()
+                    .map(|cv| {
+                        let name = format_compute_tray_component(cv.component);
+                        (name, serde_json::json!(cv.versions))
+                    })
+                    .collect();
+
+                let mut obj = serde_json::json!({
                     "result": common::component_result_json(device.result.as_ref()),
                     "versions": device.versions,
-                })
+                });
+                if !compute_fw_versions.is_empty() {
+                    obj["compute_fw_versions"] = serde_json::Value::Object(compute_fw_versions);
+                }
+                obj
             })
             .collect::<Vec<_>>();
         println!("{}", serde_json::to_string_pretty(&devices)?);
@@ -57,7 +87,20 @@ pub async fn list_versions(
         for device in &response.devices {
             let (component_id, result_status, error) =
                 common::component_result_fields(device.result.as_ref());
-            let versions = common::join_or_dash(&device.versions);
+            let versions = if !device.compute_fw_versions.is_empty() {
+                device
+                    .compute_fw_versions
+                    .iter()
+                    .map(|cv| {
+                        let name = format_compute_tray_component(cv.component);
+                        let v = common::join_or_dash(&cv.versions);
+                        format!("{name}: {v}")
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            } else {
+                common::join_or_dash(&device.versions)
+            };
             table.add_row(Row::new(vec![
                 Cell::new(&component_id),
                 Cell::new(&result_status),

--- a/crates/api/src/handlers/component_manager.rs
+++ b/crates/api/src/handlers/component_manager.rs
@@ -27,10 +27,13 @@ use component_manager::error::ComponentManagerError;
 use component_manager::nv_switch_manager::SwitchEndpoint;
 use component_manager::power_shelf_manager::{PowerShelfEndpoint, PowerShelfVendor};
 use db::{self, WithTransaction};
+use forge_secrets::credentials::{
+    BmcCredentialType, CredentialKey, CredentialManager, Credentials,
+};
 use futures_util::FutureExt;
 use mac_address::MacAddress;
 use model::component_manager::{PowerAction, PowerShelfComponent};
-use model::firmware::DesiredFirmwareVersions;
+use model::firmware::FirmwareComponentType;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::rack::{FirmwareUpgradeJob, MaintenanceActivity};
 use tonic::{Code, Request, Response, Status};
@@ -268,11 +271,34 @@ fn map_compute_tray_component_names(raw: &[i32]) -> Result<Vec<String>, Status> 
         .map(|&v| match rpc::ComputeTrayComponent::try_from(v) {
             Ok(rpc::ComputeTrayComponent::Bmc) => Ok("BMC".to_string()),
             Ok(rpc::ComputeTrayComponent::Bios) => Ok("BIOS".to_string()),
+            Ok(rpc::ComputeTrayComponent::Cec) => Ok("CEC".to_string()),
+            Ok(rpc::ComputeTrayComponent::Nic) => Ok("NIC".to_string()),
+            Ok(rpc::ComputeTrayComponent::CpldMb) => Ok("CPLD_MB".to_string()),
+            Ok(rpc::ComputeTrayComponent::CpldPdb) => Ok("CPLD_PDB".to_string()),
+            Ok(rpc::ComputeTrayComponent::HgxBmc) => Ok("HGX_BMC".to_string()),
+            Ok(rpc::ComputeTrayComponent::CombinedBmcUefi) => Ok("COMBINED_BMC_UEFI".to_string()),
+            Ok(rpc::ComputeTrayComponent::Gpu) => Ok("GPU".to_string()),
             _ => Err(Status::invalid_argument(format!(
                 "unknown compute tray component: {v}"
             ))),
         })
         .collect()
+}
+
+fn firmware_component_type_to_proto(fct: &FirmwareComponentType) -> rpc::ComputeTrayComponent {
+    match fct {
+        FirmwareComponentType::Bmc => rpc::ComputeTrayComponent::Bmc,
+        FirmwareComponentType::Uefi => rpc::ComputeTrayComponent::Bios,
+        FirmwareComponentType::Cec => rpc::ComputeTrayComponent::Cec,
+        FirmwareComponentType::Nic => rpc::ComputeTrayComponent::Nic,
+        FirmwareComponentType::Cx7 => rpc::ComputeTrayComponent::Cx7,
+        FirmwareComponentType::CpldMb => rpc::ComputeTrayComponent::CpldMb,
+        FirmwareComponentType::CpldPdb => rpc::ComputeTrayComponent::CpldPdb,
+        FirmwareComponentType::HGXBmc => rpc::ComputeTrayComponent::HgxBmc,
+        FirmwareComponentType::CombinedBmcUefi => rpc::ComputeTrayComponent::CombinedBmcUefi,
+        FirmwareComponentType::Gpu => rpc::ComputeTrayComponent::Gpu,
+        FirmwareComponentType::Unknown => rpc::ComputeTrayComponent::Unknown,
+    }
 }
 
 fn map_nv_switch_component_names(raw: &[i32]) -> Result<Vec<String>, Status> {
@@ -315,6 +341,45 @@ struct SwitchEndpoints {
     unresolved: Vec<SwitchId>,
 }
 
+async fn fetch_switch_bmc_credentials(
+    credential_manager: &dyn CredentialManager,
+    bmc_mac: MacAddress,
+) -> Result<Credentials, ComponentManagerError> {
+    let key = CredentialKey::BmcCredentials {
+        credential_type: BmcCredentialType::BmcRoot {
+            bmc_mac_address: bmc_mac,
+        },
+    };
+
+    match credential_manager.get_credentials(&key).await {
+        Ok(Some(c)) => Ok(c),
+        Ok(None) => Err(ComponentManagerError::NotFound(format!(
+            "no BMC credentials found for {bmc_mac}"
+        ))),
+        Err(e) => Err(ComponentManagerError::Internal(format!(
+            "failed to fetch BMC credentials for {bmc_mac}: {e}"
+        ))),
+    }
+}
+
+async fn fetch_switch_nvos_credentials(
+    credential_manager: &dyn CredentialManager,
+    bmc_mac: MacAddress,
+) -> Result<Credentials, ComponentManagerError> {
+    let key = CredentialKey::SwitchNvosAdmin {
+        bmc_mac_address: bmc_mac,
+    };
+    match credential_manager.get_credentials(&key).await {
+        Ok(Some(c)) => Ok(c),
+        Ok(None) => Err(ComponentManagerError::NotFound(format!(
+            "no NVOS credentials found for {bmc_mac}"
+        ))),
+        Err(e) => Err(ComponentManagerError::Internal(format!(
+            "failed to fetch NVOS credentials for {bmc_mac}: {e}"
+        ))),
+    }
+}
+
 async fn resolve_switch_endpoints(
     api: &Api,
     switch_ids: &[SwitchId],
@@ -339,12 +404,43 @@ async fn resolve_switch_endpoints(
             continue;
         };
         resolved_ids.insert(row.switch_id);
+
+        let bmc_credentials = match fetch_switch_bmc_credentials(
+            api.credential_manager.as_ref(),
+            row.bmc_mac,
+        )
+        .await
+        {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(switch_id = %row.switch_id, error = %e, "skipping switch: BMC credentials unavailable");
+                unresolved.push(row.switch_id);
+                continue;
+            }
+        };
+
+        let nvos_credentials = match fetch_switch_nvos_credentials(
+            api.credential_manager.as_ref(),
+            row.bmc_mac,
+        )
+        .await
+        {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(switch_id = %row.switch_id, error = %e, "skipping switch: NVOS credentials unavailable");
+                unresolved.push(row.switch_id);
+                continue;
+            }
+        };
+
         mac_to_id.insert(row.bmc_mac, row.switch_id);
         endpoints.push(SwitchEndpoint {
             bmc_ip: row.bmc_ip,
             bmc_mac: row.bmc_mac,
             nvos_ip,
             nvos_mac,
+            bmc_credentials,
+            nvos_credentials,
         });
     }
 
@@ -371,6 +467,27 @@ async fn resolve_switch_endpoints(
     })
 }
 
+async fn fetch_powershelf_pmc_credentials(
+    credential_manager: &dyn CredentialManager,
+    pmc_mac: MacAddress,
+) -> Result<Credentials, ComponentManagerError> {
+    let key = CredentialKey::BmcCredentials {
+        credential_type: BmcCredentialType::BmcRoot {
+            bmc_mac_address: pmc_mac,
+        },
+    };
+
+    match credential_manager.get_credentials(&key).await {
+        Ok(Some(c)) => Ok(c),
+        Ok(None) => Err(ComponentManagerError::NotFound(format!(
+            "no PMC credentials found for {pmc_mac}"
+        ))),
+        Err(e) => Err(ComponentManagerError::Internal(format!(
+            "failed to fetch PMC credentials for {pmc_mac}: {e}"
+        ))),
+    }
+}
+
 struct ResolvedPowerShelfEndpoints {
     endpoints: Vec<PowerShelfEndpoint>,
     mac_to_id: HashMap<MacAddress, PowerShelfId>,
@@ -394,20 +511,36 @@ async fn resolve_power_shelf_endpoints(
 
     let mut endpoints = Vec::with_capacity(rows.len());
     let mut mac_to_id = HashMap::with_capacity(rows.len());
+    let mut unresolved = Vec::new();
     let mut resolved_ids = HashSet::with_capacity(rows.len());
 
     for row in rows {
         resolved_ids.insert(row.power_shelf_id);
+
+        let pmc_credentials = match fetch_powershelf_pmc_credentials(
+            api.credential_manager.as_ref(),
+            row.pmc_mac,
+        )
+        .await
+        {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(power_shelf_id = %row.power_shelf_id, error = %e, "skipping power shelf: PMC credentials unavailable");
+                unresolved.push(row.power_shelf_id);
+                continue;
+            }
+        };
+
         mac_to_id.insert(row.pmc_mac, row.power_shelf_id);
         endpoints.push(PowerShelfEndpoint {
             pmc_ip: row.pmc_ip,
             pmc_mac: row.pmc_mac,
             // TODO: retrieve vendor from DB instead of using a hardcoded default
             pmc_vendor: PowerShelfVendor::DEFAULT,
+            pmc_credentials,
         });
     }
 
-    let mut unresolved = Vec::new();
     for id in power_shelf_ids {
         if !resolved_ids.contains(id) {
             tracing::warn!(power_shelf_id = %id, "power shelf not found in expected_power_shelves");
@@ -1260,6 +1393,7 @@ pub(crate) async fn list_component_firmware_versions(
                         "could not resolve endpoint for switch".into(),
                     )),
                     versions: vec![],
+                    compute_fw_versions: vec![],
                 })
                 .collect();
 
@@ -1279,6 +1413,7 @@ pub(crate) async fn list_component_firmware_versions(
                 devices.push(rpc::DeviceFirmwareVersions {
                     result: Some(success_result(&id)),
                     versions: versions.clone(),
+                    compute_fw_versions: vec![],
                 });
             }
 
@@ -1299,6 +1434,7 @@ pub(crate) async fn list_component_firmware_versions(
                         "could not resolve endpoint for power shelf".into(),
                     )),
                     versions: vec![],
+                    compute_fw_versions: vec![],
                 })
                 .collect();
 
@@ -1323,6 +1459,7 @@ pub(crate) async fn list_component_firmware_versions(
                 devices.push(rpc::DeviceFirmwareVersions {
                     result: Some(result),
                     versions: fv.versions,
+                    compute_fw_versions: vec![],
                 });
             }
 
@@ -1331,6 +1468,10 @@ pub(crate) async fn list_component_firmware_versions(
             }))
         }
         rpc::list_component_firmware_versions_request::Target::MachineIds(list) => {
+            if list.machine_ids.is_empty() {
+                return Err(Status::invalid_argument("machine_ids must not be empty"));
+            }
+
             let fw_snapshot = api.runtime_config.get_firmware_config().create_snapshot();
 
             let machines = db::machine::find(
@@ -1363,28 +1504,105 @@ pub(crate) async fn list_component_firmware_versions(
                 .map(|machine_id| {
                     let id_str = machine_id.to_string();
 
-                    let versions: Vec<String> = machine_by_id
-                        .get(machine_id)
-                        .and_then(|m| m.bmc_info.ip.as_ref()?.parse::<IpAddr>().ok())
-                        .and_then(|ip| endpoint_by_ip.get(&ip))
-                        .and_then(|ep| fw_snapshot.find_fw_info_for_host(ep))
-                        .map(|fw| {
-                            DesiredFirmwareVersions::from(fw)
-                                .versions
-                                .into_values()
-                                .collect()
-                        })
-                        .unwrap_or_default();
-
-                    let result = if versions.is_empty() {
-                        error_result(&id_str, "no firmware config found for machine".into())
-                    } else {
-                        success_result(&id_str)
+                    let Some(machine) = machine_by_id.get(machine_id) else {
+                        return rpc::DeviceFirmwareVersions {
+                            result: Some(not_found_component_result(
+                                &id_str,
+                                format!("machine {machine_id} not found"),
+                            )),
+                            versions: vec![],
+                            compute_fw_versions: vec![],
+                        };
                     };
 
+                    let Some(ip_str) = machine.bmc_info.ip.as_ref() else {
+                        return rpc::DeviceFirmwareVersions {
+                            result: Some(invalid_argument_component_result(
+                                &id_str,
+                                format!("machine {machine_id} has no BMC IP configured"),
+                            )),
+                            versions: vec![],
+                            compute_fw_versions: vec![],
+                        };
+                    };
+
+                    let Ok(ip) = ip_str.parse::<IpAddr>() else {
+                        tracing::warn!(
+                            machine_id = %machine_id,
+                            bmc_ip = %ip_str,
+                            "BMC IP failed to parse as a valid address"
+                        );
+                        return rpc::DeviceFirmwareVersions {
+                            result: Some(invalid_argument_component_result(
+                                &id_str,
+                                format!(
+                                    "machine {machine_id} has unparseable BMC IP: {ip_str}"
+                                ),
+                            )),
+                            versions: vec![],
+                            compute_fw_versions: vec![],
+                        };
+                    };
+
+                    let Some(endpoint) = endpoint_by_ip.get(&ip) else {
+                        return rpc::DeviceFirmwareVersions {
+                            result: Some(not_found_component_result(
+                                &id_str,
+                                format!(
+                                    "no explored endpoint found for machine {machine_id} (BMC IP {ip})"
+                                ),
+                            )),
+                            versions: vec![],
+                            compute_fw_versions: vec![],
+                        };
+                    };
+
+                    let Some(fw) = fw_snapshot.find_fw_info_for_host(endpoint) else {
+                        return rpc::DeviceFirmwareVersions {
+                            result: Some(not_found_component_result(
+                                &id_str,
+                                format!(
+                                    "no firmware config matches endpoint for machine {machine_id}"
+                                ),
+                            )),
+                            versions: vec![],
+                            compute_fw_versions: vec![],
+                        };
+                    };
+
+                    let compute_fw_versions: Vec<rpc::ComputeTrayFirmwareVersions> = fw
+                        .components
+                        .iter()
+                        .map(|(component_type, component)| {
+                            let versions = component
+                                .known_firmware
+                                .iter()
+                                .map(|entry| entry.version.clone())
+                                .collect();
+                            rpc::ComputeTrayFirmwareVersions {
+                                component: firmware_component_type_to_proto(component_type).into(),
+                                versions,
+                            }
+                        })
+                        .collect();
+
+                    if compute_fw_versions.is_empty() {
+                        return rpc::DeviceFirmwareVersions {
+                            result: Some(not_found_component_result(
+                                &id_str,
+                                format!(
+                                    "firmware config for machine {machine_id} has no component entries"
+                                ),
+                            )),
+                            versions: vec![],
+                            compute_fw_versions: vec![],
+                        };
+                    }
+
                     rpc::DeviceFirmwareVersions {
-                        result: Some(result),
-                        versions,
+                        result: Some(success_result(&id_str)),
+                        versions: vec![],
+                        compute_fw_versions,
                     }
                 })
                 .collect();
@@ -1438,6 +1656,7 @@ pub(crate) async fn list_component_firmware_versions(
                                 format!("rack {rack_id} not found"),
                             )),
                             versions: vec![],
+                            compute_fw_versions: vec![],
                         };
                     };
 
@@ -1448,6 +1667,7 @@ pub(crate) async fn list_component_firmware_versions(
                                 format!("rack {rack_id} has no rack_profile_id"),
                             )),
                             versions: vec![],
+                            compute_fw_versions: vec![],
                         };
                     };
 
@@ -1459,6 +1679,7 @@ pub(crate) async fn list_component_firmware_versions(
                                 format!("rack profile {profile_id} not found"),
                             )),
                             versions: vec![],
+                            compute_fw_versions: vec![],
                         };
                     };
 
@@ -1471,6 +1692,7 @@ pub(crate) async fn list_component_firmware_versions(
                                 ),
                             )),
                             versions: vec![],
+                            compute_fw_versions: vec![],
                         };
                     };
 
@@ -1486,6 +1708,7 @@ pub(crate) async fn list_component_firmware_versions(
                     rpc::DeviceFirmwareVersions {
                         result: Some(success_result(rack_id.as_ref())),
                         versions,
+                        compute_fw_versions: vec![],
                     }
                 })
                 .collect();
@@ -1818,6 +2041,47 @@ mod tests {
         ];
         for (input, expected) in cases {
             assert_eq!(map_fw_state(input), expected, "mismatch for {input:?}");
+        }
+    }
+
+    #[test]
+    fn firmware_component_type_to_proto_round_trip() {
+        use model::firmware::FirmwareComponentType;
+
+        let cases = [
+            (FirmwareComponentType::Bmc, rpc::ComputeTrayComponent::Bmc),
+            (FirmwareComponentType::Uefi, rpc::ComputeTrayComponent::Bios),
+            (FirmwareComponentType::Cec, rpc::ComputeTrayComponent::Cec),
+            (FirmwareComponentType::Nic, rpc::ComputeTrayComponent::Nic),
+            (
+                FirmwareComponentType::CpldMb,
+                rpc::ComputeTrayComponent::CpldMb,
+            ),
+            (
+                FirmwareComponentType::CpldPdb,
+                rpc::ComputeTrayComponent::CpldPdb,
+            ),
+            (
+                FirmwareComponentType::HGXBmc,
+                rpc::ComputeTrayComponent::HgxBmc,
+            ),
+            (
+                FirmwareComponentType::CombinedBmcUefi,
+                rpc::ComputeTrayComponent::CombinedBmcUefi,
+            ),
+            (FirmwareComponentType::Gpu, rpc::ComputeTrayComponent::Gpu),
+            (FirmwareComponentType::Cx7, rpc::ComputeTrayComponent::Cx7),
+            (
+                FirmwareComponentType::Unknown,
+                rpc::ComputeTrayComponent::Unknown,
+            ),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                firmware_component_type_to_proto(&input),
+                expected,
+                "mismatch for {input:?}"
+            );
         }
     }
 

--- a/crates/api/src/handlers/component_manager.rs
+++ b/crates/api/src/handlers/component_manager.rs
@@ -265,9 +265,12 @@ fn map_power_action(raw: i32) -> Result<PowerAction, Status> {
     }
 }
 
+/// Maps raw proto `ComputeTrayComponent` values to display-name strings.
+///
+/// Keep in sync with [`firmware_component_type_to_proto`] (same file) and
+/// `format_compute_tray_component` in `admin-cli/src/component_manager/versions/cmd.rs`.
 fn map_compute_tray_component_names(raw: &[i32]) -> Result<Vec<String>, Status> {
     raw.iter()
-        .filter(|&&v| v != rpc::ComputeTrayComponent::Unknown as i32)
         .map(|&v| match rpc::ComputeTrayComponent::try_from(v) {
             Ok(rpc::ComputeTrayComponent::Bmc) => Ok("BMC".to_string()),
             Ok(rpc::ComputeTrayComponent::Bios) => Ok("BIOS".to_string()),
@@ -278,13 +281,21 @@ fn map_compute_tray_component_names(raw: &[i32]) -> Result<Vec<String>, Status> 
             Ok(rpc::ComputeTrayComponent::HgxBmc) => Ok("HGX_BMC".to_string()),
             Ok(rpc::ComputeTrayComponent::CombinedBmcUefi) => Ok("COMBINED_BMC_UEFI".to_string()),
             Ok(rpc::ComputeTrayComponent::Gpu) => Ok("GPU".to_string()),
-            _ => Err(Status::invalid_argument(format!(
-                "unknown compute tray component: {v}"
+            Ok(rpc::ComputeTrayComponent::Cx7) => Ok("CX7".to_string()),
+            Ok(rpc::ComputeTrayComponent::Unknown) => Err(Status::invalid_argument(
+                "compute tray component must not be Unknown",
+            )),
+            Err(e) => Err(Status::invalid_argument(format!(
+                "unrecognized compute tray component value {v}: {e}"
             ))),
         })
         .collect()
 }
 
+/// Converts a [`FirmwareComponentType`] to its proto equivalent.
+///
+/// Keep in sync with [`map_compute_tray_component_names`] (same file) and
+/// `format_compute_tray_component` in `admin-cli/src/component_manager/versions/cmd.rs`.
 fn firmware_component_type_to_proto(fct: &FirmwareComponentType) -> rpc::ComputeTrayComponent {
     match fct {
         FirmwareComponentType::Bmc => rpc::ComputeTrayComponent::Bmc,
@@ -298,6 +309,96 @@ fn firmware_component_type_to_proto(fct: &FirmwareComponentType) -> rpc::Compute
         FirmwareComponentType::CombinedBmcUefi => rpc::ComputeTrayComponent::CombinedBmcUefi,
         FirmwareComponentType::Gpu => rpc::ComputeTrayComponent::Gpu,
         FirmwareComponentType::Unknown => rpc::ComputeTrayComponent::Unknown,
+    }
+}
+
+fn get_compute_tray_firmware_version(
+    compute_machine_id: &carbide_uuid::machine::MachineId,
+    bmc_info: &model::bmc_info::BmcInfo,
+    endpoint_by_ip: &HashMap<IpAddr, model::site_explorer::ExploredEndpoint>,
+    fw_snapshot: &carbide_firmware::FirmwareConfigSnapshot,
+) -> rpc::DeviceFirmwareVersions {
+    let id_str = compute_machine_id.to_string();
+
+    let Some(ip_str) = bmc_info.ip.as_ref() else {
+        return rpc::DeviceFirmwareVersions {
+            result: Some(invalid_argument_component_result(
+                &id_str,
+                format!("machine {compute_machine_id} has no BMC IP configured"),
+            )),
+            ..Default::default()
+        };
+    };
+
+    let Ok(ip) = ip_str.parse::<IpAddr>() else {
+        tracing::warn!(
+            machine_id = %compute_machine_id,
+            bmc_ip = %ip_str,
+            "BMC IP failed to parse as a valid address"
+        );
+        return rpc::DeviceFirmwareVersions {
+            result: Some(error_result(
+                &id_str,
+                format!("machine {compute_machine_id} has unparseable BMC IP: {ip_str}"),
+            )),
+            ..Default::default()
+        };
+    };
+
+    let Some(endpoint) = endpoint_by_ip.get(&ip) else {
+        return rpc::DeviceFirmwareVersions {
+            result: Some(not_found_component_result(
+                &id_str,
+                format!(
+                    "no explored endpoint found for machine {compute_machine_id} (BMC IP {ip})"
+                ),
+            )),
+            ..Default::default()
+        };
+    };
+
+    let Some(fw) = fw_snapshot.find_fw_info_for_host(endpoint) else {
+        return rpc::DeviceFirmwareVersions {
+            result: Some(not_found_component_result(
+                &id_str,
+                format!("no firmware config matches endpoint for machine {compute_machine_id}"),
+            )),
+            ..Default::default()
+        };
+    };
+
+    let compute_fw_versions: Vec<rpc::ComputeTrayFirmwareVersions> = fw
+        .components
+        .iter()
+        .map(|(component_type, component)| {
+            let versions = component
+                .known_firmware
+                .iter()
+                .map(|entry| entry.version.clone())
+                .collect();
+            rpc::ComputeTrayFirmwareVersions {
+                component: firmware_component_type_to_proto(component_type).into(),
+                versions,
+            }
+        })
+        .collect();
+
+    if compute_fw_versions.is_empty() {
+        return rpc::DeviceFirmwareVersions {
+            result: Some(not_found_component_result(
+                &id_str,
+                format!(
+                    "firmware config for machine {compute_machine_id} has no component entries"
+                ),
+            )),
+            ..Default::default()
+        };
+    }
+
+    rpc::DeviceFirmwareVersions {
+        result: Some(success_result(&id_str)),
+        compute_fw_versions,
+        ..Default::default()
     }
 }
 
@@ -331,6 +432,17 @@ fn map_power_shelf_components(raw: &[i32]) -> Result<Vec<PowerShelfComponent>, S
 
 // ---- Endpoint resolution helpers ----
 
+struct UnresolvedDevice<Id> {
+    id: Id,
+    reason: String,
+}
+
+impl<Id: std::fmt::Display> std::fmt::Display for UnresolvedDevice<Id> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.id, self.reason)
+    }
+}
+
 struct ResolvedSwitchEndpoints {
     endpoints: Vec<SwitchEndpoint>,
     mac_to_id: HashMap<MacAddress, SwitchId>,
@@ -338,7 +450,22 @@ struct ResolvedSwitchEndpoints {
 
 struct SwitchEndpoints {
     resolved: ResolvedSwitchEndpoints,
-    unresolved: Vec<SwitchId>,
+    unresolved: Vec<UnresolvedDevice<SwitchId>>,
+}
+
+async fn fetch_credentials(
+    credential_manager: &dyn CredentialManager,
+    key: CredentialKey,
+) -> Result<Credentials, ComponentManagerError> {
+    match credential_manager.get_credentials(&key).await {
+        Ok(Some(c)) => Ok(c),
+        Ok(None) => Err(ComponentManagerError::NotFound(format!(
+            "no credentials found for {key:?}"
+        ))),
+        Err(e) => Err(ComponentManagerError::Internal(format!(
+            "failed to fetch credentials for {key:?}: {e}"
+        ))),
+    }
 }
 
 async fn fetch_switch_bmc_credentials(
@@ -350,16 +477,7 @@ async fn fetch_switch_bmc_credentials(
             bmc_mac_address: bmc_mac,
         },
     };
-
-    match credential_manager.get_credentials(&key).await {
-        Ok(Some(c)) => Ok(c),
-        Ok(None) => Err(ComponentManagerError::NotFound(format!(
-            "no BMC credentials found for {bmc_mac}"
-        ))),
-        Err(e) => Err(ComponentManagerError::Internal(format!(
-            "failed to fetch BMC credentials for {bmc_mac}: {e}"
-        ))),
-    }
+    fetch_credentials(credential_manager, key).await
 }
 
 async fn fetch_switch_nvos_credentials(
@@ -369,15 +487,19 @@ async fn fetch_switch_nvos_credentials(
     let key = CredentialKey::SwitchNvosAdmin {
         bmc_mac_address: bmc_mac,
     };
-    match credential_manager.get_credentials(&key).await {
-        Ok(Some(c)) => Ok(c),
-        Ok(None) => Err(ComponentManagerError::NotFound(format!(
-            "no NVOS credentials found for {bmc_mac}"
-        ))),
-        Err(e) => Err(ComponentManagerError::Internal(format!(
-            "failed to fetch NVOS credentials for {bmc_mac}: {e}"
-        ))),
-    }
+    fetch_credentials(credential_manager, key).await
+}
+
+async fn fetch_powershelf_pmc_credentials(
+    credential_manager: &dyn CredentialManager,
+    pmc_mac: MacAddress,
+) -> Result<Credentials, ComponentManagerError> {
+    let key = CredentialKey::BmcCredentials {
+        credential_type: BmcCredentialType::BmcRoot {
+            bmc_mac_address: pmc_mac,
+        },
+    };
+    fetch_credentials(credential_manager, key).await
 }
 
 async fn resolve_switch_endpoints(
@@ -395,11 +517,12 @@ async fn resolve_switch_endpoints(
 
     for row in rows {
         let (Some(nvos_mac), Some(nvos_ip)) = (row.nvos_mac, row.nvos_ip) else {
-            tracing::warn!(
-                switch_id = %row.switch_id,
-                "skipping switch: NVOS MAC or IP not available"
-            );
-            unresolved.push(row.switch_id);
+            let u = UnresolvedDevice {
+                id: row.switch_id,
+                reason: "NVOS MAC or IP not available".into(),
+            };
+            tracing::warn!(%u, "skipping switch");
+            unresolved.push(u);
             resolved_ids.insert(row.switch_id);
             continue;
         };
@@ -413,25 +536,30 @@ async fn resolve_switch_endpoints(
         {
             Ok(c) => c,
             Err(e) => {
-                tracing::warn!(switch_id = %row.switch_id, error = %e, "skipping switch: BMC credentials unavailable");
-                unresolved.push(row.switch_id);
+                let u = UnresolvedDevice {
+                    id: row.switch_id,
+                    reason: format!("BMC credentials unavailable: {e}"),
+                };
+                tracing::warn!(%u, "skipping switch");
+                unresolved.push(u);
                 continue;
             }
         };
 
-        let nvos_credentials = match fetch_switch_nvos_credentials(
-            api.credential_manager.as_ref(),
-            row.bmc_mac,
-        )
-        .await
-        {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::warn!(switch_id = %row.switch_id, error = %e, "skipping switch: NVOS credentials unavailable");
-                unresolved.push(row.switch_id);
-                continue;
-            }
-        };
+        let nvos_credentials =
+            match fetch_switch_nvos_credentials(api.credential_manager.as_ref(), row.bmc_mac).await
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    let u = UnresolvedDevice {
+                        id: row.switch_id,
+                        reason: format!("NVOS credentials unavailable: {e}"),
+                    };
+                    tracing::warn!(%u, "skipping switch");
+                    unresolved.push(u);
+                    continue;
+                }
+            };
 
         mac_to_id.insert(row.bmc_mac, row.switch_id);
         endpoints.push(SwitchEndpoint {
@@ -446,8 +574,12 @@ async fn resolve_switch_endpoints(
 
     for id in switch_ids {
         if !resolved_ids.contains(id) {
-            tracing::warn!(switch_id = %id, "switch not found in expected_switches");
-            unresolved.push(*id);
+            let u = UnresolvedDevice {
+                id: *id,
+                reason: "switch not found in database".into(),
+            };
+            tracing::warn!(%u, "skipping switch");
+            unresolved.push(u);
         }
     }
 
@@ -467,27 +599,6 @@ async fn resolve_switch_endpoints(
     })
 }
 
-async fn fetch_powershelf_pmc_credentials(
-    credential_manager: &dyn CredentialManager,
-    pmc_mac: MacAddress,
-) -> Result<Credentials, ComponentManagerError> {
-    let key = CredentialKey::BmcCredentials {
-        credential_type: BmcCredentialType::BmcRoot {
-            bmc_mac_address: pmc_mac,
-        },
-    };
-
-    match credential_manager.get_credentials(&key).await {
-        Ok(Some(c)) => Ok(c),
-        Ok(None) => Err(ComponentManagerError::NotFound(format!(
-            "no PMC credentials found for {pmc_mac}"
-        ))),
-        Err(e) => Err(ComponentManagerError::Internal(format!(
-            "failed to fetch PMC credentials for {pmc_mac}: {e}"
-        ))),
-    }
-}
-
 struct ResolvedPowerShelfEndpoints {
     endpoints: Vec<PowerShelfEndpoint>,
     mac_to_id: HashMap<MacAddress, PowerShelfId>,
@@ -495,7 +606,7 @@ struct ResolvedPowerShelfEndpoints {
 
 struct PowerShelfEndpoints {
     resolved: ResolvedPowerShelfEndpoints,
-    unresolved: Vec<PowerShelfId>,
+    unresolved: Vec<UnresolvedDevice<PowerShelfId>>,
 }
 
 async fn resolve_power_shelf_endpoints(
@@ -517,19 +628,21 @@ async fn resolve_power_shelf_endpoints(
     for row in rows {
         resolved_ids.insert(row.power_shelf_id);
 
-        let pmc_credentials = match fetch_powershelf_pmc_credentials(
-            api.credential_manager.as_ref(),
-            row.pmc_mac,
-        )
-        .await
-        {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::warn!(power_shelf_id = %row.power_shelf_id, error = %e, "skipping power shelf: PMC credentials unavailable");
-                unresolved.push(row.power_shelf_id);
-                continue;
-            }
-        };
+        let pmc_credentials =
+            match fetch_powershelf_pmc_credentials(api.credential_manager.as_ref(), row.pmc_mac)
+                .await
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    let u = UnresolvedDevice {
+                        id: row.power_shelf_id,
+                        reason: format!("PMC credentials unavailable: {e}"),
+                    };
+                    tracing::warn!(%u, "skipping power shelf");
+                    unresolved.push(u);
+                    continue;
+                }
+            };
 
         mac_to_id.insert(row.pmc_mac, row.power_shelf_id);
         endpoints.push(PowerShelfEndpoint {
@@ -543,8 +656,12 @@ async fn resolve_power_shelf_endpoints(
 
     for id in power_shelf_ids {
         if !resolved_ids.contains(id) {
-            tracing::warn!(power_shelf_id = %id, "power shelf not found in expected_power_shelves");
-            unresolved.push(*id);
+            let u = UnresolvedDevice {
+                id: *id,
+                reason: "power shelf not found in database".into(),
+            };
+            tracing::warn!(%u, "skipping power shelf");
+            unresolved.push(u);
         }
     }
 
@@ -614,12 +731,7 @@ pub(crate) async fn component_power_control(
             let mut results: Vec<_> = endpoints
                 .unresolved
                 .iter()
-                .map(|id| {
-                    error_result(
-                        &id.to_string(),
-                        "could not resolve endpoint for switch".into(),
-                    )
-                })
+                .map(|u| error_result(&u.id.to_string(), u.reason.clone()))
                 .collect();
 
             tracing::info!(
@@ -657,12 +769,7 @@ pub(crate) async fn component_power_control(
             let mut results: Vec<_> = endpoints
                 .unresolved
                 .iter()
-                .map(|id| {
-                    error_result(
-                        &id.to_string(),
-                        "could not resolve endpoint for power shelf".into(),
-                    )
-                })
+                .map(|u| error_result(&u.id.to_string(), u.reason.clone()))
                 .collect();
 
             tracing::info!(
@@ -1117,12 +1224,7 @@ pub(crate) async fn update_component_firmware(
             let mut results: Vec<_> = endpoints
                 .unresolved
                 .iter()
-                .map(|id| {
-                    error_result(
-                        &id.to_string(),
-                        "could not resolve endpoint for power shelf".into(),
-                    )
-                })
+                .map(|u| error_result(&u.id.to_string(), u.reason.clone()))
                 .collect();
 
             let backend_results = cm
@@ -1251,11 +1353,8 @@ pub(crate) async fn get_component_firmware_status(
             let mut statuses: Vec<_> = endpoints
                 .unresolved
                 .iter()
-                .map(|id| rpc::FirmwareUpdateStatus {
-                    result: Some(error_result(
-                        &id.to_string(),
-                        "could not resolve endpoint for switch".into(),
-                    )),
+                .map(|u| rpc::FirmwareUpdateStatus {
+                    result: Some(error_result(&u.id.to_string(), u.reason.clone())),
                     state: rpc::FirmwareUpdateState::FwStateUnknown as i32,
                     target_version: String::new(),
                     updated_at: None,
@@ -1289,11 +1388,8 @@ pub(crate) async fn get_component_firmware_status(
             let mut statuses: Vec<_> = endpoints
                 .unresolved
                 .iter()
-                .map(|id| rpc::FirmwareUpdateStatus {
-                    result: Some(error_result(
-                        &id.to_string(),
-                        "could not resolve endpoint for power shelf".into(),
-                    )),
+                .map(|u| rpc::FirmwareUpdateStatus {
+                    result: Some(error_result(&u.id.to_string(), u.reason.clone())),
                     state: rpc::FirmwareUpdateState::FwStateUnknown as i32,
                     target_version: String::new(),
                     updated_at: None,
@@ -1387,13 +1483,9 @@ pub(crate) async fn list_component_firmware_versions(
             let mut devices: Vec<rpc::DeviceFirmwareVersions> = endpoints
                 .unresolved
                 .iter()
-                .map(|id| rpc::DeviceFirmwareVersions {
-                    result: Some(error_result(
-                        &id.to_string(),
-                        "could not resolve endpoint for switch".into(),
-                    )),
-                    versions: vec![],
-                    compute_fw_versions: vec![],
+                .map(|u| rpc::DeviceFirmwareVersions {
+                    result: Some(error_result(&u.id.to_string(), u.reason.clone())),
+                    ..Default::default()
                 })
                 .collect();
 
@@ -1413,7 +1505,7 @@ pub(crate) async fn list_component_firmware_versions(
                 devices.push(rpc::DeviceFirmwareVersions {
                     result: Some(success_result(&id)),
                     versions: versions.clone(),
-                    compute_fw_versions: vec![],
+                    ..Default::default()
                 });
             }
 
@@ -1428,13 +1520,9 @@ pub(crate) async fn list_component_firmware_versions(
             let mut devices: Vec<rpc::DeviceFirmwareVersions> = endpoints
                 .unresolved
                 .iter()
-                .map(|id| rpc::DeviceFirmwareVersions {
-                    result: Some(error_result(
-                        &id.to_string(),
-                        "could not resolve endpoint for power shelf".into(),
-                    )),
-                    versions: vec![],
-                    compute_fw_versions: vec![],
+                .map(|u| rpc::DeviceFirmwareVersions {
+                    result: Some(error_result(&u.id.to_string(), u.reason.clone())),
+                    ..Default::default()
                 })
                 .collect();
 
@@ -1459,7 +1547,7 @@ pub(crate) async fn list_component_firmware_versions(
                 devices.push(rpc::DeviceFirmwareVersions {
                     result: Some(result),
                     versions: fv.versions,
-                    compute_fw_versions: vec![],
+                    ..Default::default()
                 });
             }
 
@@ -1485,6 +1573,8 @@ pub(crate) async fn list_component_firmware_versions(
             let bmc_ips: Vec<IpAddr> = machines
                 .iter()
                 .filter_map(|m| m.bmc_info.ip.as_ref()?.parse().ok())
+                .collect::<HashSet<_>>()
+                .into_iter()
                 .collect();
 
             let endpoints = db::explored_endpoints::find_by_ips(api.db_reader().as_mut(), bmc_ips)
@@ -1502,108 +1592,21 @@ pub(crate) async fn list_component_firmware_versions(
                 .machine_ids
                 .iter()
                 .map(|machine_id| {
-                    let id_str = machine_id.to_string();
-
                     let Some(machine) = machine_by_id.get(machine_id) else {
                         return rpc::DeviceFirmwareVersions {
                             result: Some(not_found_component_result(
-                                &id_str,
+                                &machine_id.to_string(),
                                 format!("machine {machine_id} not found"),
                             )),
-                            versions: vec![],
-                            compute_fw_versions: vec![],
+                            ..Default::default()
                         };
                     };
-
-                    let Some(ip_str) = machine.bmc_info.ip.as_ref() else {
-                        return rpc::DeviceFirmwareVersions {
-                            result: Some(invalid_argument_component_result(
-                                &id_str,
-                                format!("machine {machine_id} has no BMC IP configured"),
-                            )),
-                            versions: vec![],
-                            compute_fw_versions: vec![],
-                        };
-                    };
-
-                    let Ok(ip) = ip_str.parse::<IpAddr>() else {
-                        tracing::warn!(
-                            machine_id = %machine_id,
-                            bmc_ip = %ip_str,
-                            "BMC IP failed to parse as a valid address"
-                        );
-                        return rpc::DeviceFirmwareVersions {
-                            result: Some(invalid_argument_component_result(
-                                &id_str,
-                                format!(
-                                    "machine {machine_id} has unparseable BMC IP: {ip_str}"
-                                ),
-                            )),
-                            versions: vec![],
-                            compute_fw_versions: vec![],
-                        };
-                    };
-
-                    let Some(endpoint) = endpoint_by_ip.get(&ip) else {
-                        return rpc::DeviceFirmwareVersions {
-                            result: Some(not_found_component_result(
-                                &id_str,
-                                format!(
-                                    "no explored endpoint found for machine {machine_id} (BMC IP {ip})"
-                                ),
-                            )),
-                            versions: vec![],
-                            compute_fw_versions: vec![],
-                        };
-                    };
-
-                    let Some(fw) = fw_snapshot.find_fw_info_for_host(endpoint) else {
-                        return rpc::DeviceFirmwareVersions {
-                            result: Some(not_found_component_result(
-                                &id_str,
-                                format!(
-                                    "no firmware config matches endpoint for machine {machine_id}"
-                                ),
-                            )),
-                            versions: vec![],
-                            compute_fw_versions: vec![],
-                        };
-                    };
-
-                    let compute_fw_versions: Vec<rpc::ComputeTrayFirmwareVersions> = fw
-                        .components
-                        .iter()
-                        .map(|(component_type, component)| {
-                            let versions = component
-                                .known_firmware
-                                .iter()
-                                .map(|entry| entry.version.clone())
-                                .collect();
-                            rpc::ComputeTrayFirmwareVersions {
-                                component: firmware_component_type_to_proto(component_type).into(),
-                                versions,
-                            }
-                        })
-                        .collect();
-
-                    if compute_fw_versions.is_empty() {
-                        return rpc::DeviceFirmwareVersions {
-                            result: Some(not_found_component_result(
-                                &id_str,
-                                format!(
-                                    "firmware config for machine {machine_id} has no component entries"
-                                ),
-                            )),
-                            versions: vec![],
-                            compute_fw_versions: vec![],
-                        };
-                    }
-
-                    rpc::DeviceFirmwareVersions {
-                        result: Some(success_result(&id_str)),
-                        versions: vec![],
-                        compute_fw_versions,
-                    }
+                    get_compute_tray_firmware_version(
+                        machine_id,
+                        &machine.bmc_info,
+                        &endpoint_by_ip,
+                        &fw_snapshot,
+                    )
                 })
                 .collect();
 
@@ -1655,8 +1658,7 @@ pub(crate) async fn list_component_firmware_versions(
                                 rack_id.as_ref(),
                                 format!("rack {rack_id} not found"),
                             )),
-                            versions: vec![],
-                            compute_fw_versions: vec![],
+                            ..Default::default()
                         };
                     };
 
@@ -1666,8 +1668,7 @@ pub(crate) async fn list_component_firmware_versions(
                                 rack_id.as_ref(),
                                 format!("rack {rack_id} has no rack_profile_id"),
                             )),
-                            versions: vec![],
-                            compute_fw_versions: vec![],
+                            ..Default::default()
                         };
                     };
 
@@ -1678,8 +1679,7 @@ pub(crate) async fn list_component_firmware_versions(
                                 rack_id.as_ref(),
                                 format!("rack profile {profile_id} not found"),
                             )),
-                            versions: vec![],
-                            compute_fw_versions: vec![],
+                            ..Default::default()
                         };
                     };
 
@@ -1691,8 +1691,7 @@ pub(crate) async fn list_component_firmware_versions(
                                     "rack profile {profile_id} does not define rack_hardware_type"
                                 ),
                             )),
-                            versions: vec![],
-                            compute_fw_versions: vec![],
+                            ..Default::default()
                         };
                     };
 
@@ -1708,7 +1707,7 @@ pub(crate) async fn list_component_firmware_versions(
                     rpc::DeviceFirmwareVersions {
                         result: Some(success_result(rack_id.as_ref())),
                         versions,
-                        compute_fw_versions: vec![],
+                        ..Default::default()
                     }
                 })
                 .collect();
@@ -2162,33 +2161,47 @@ mod tests {
     }
 
     #[test]
-    fn unresolved_switch_produces_error_result() {
+    fn unresolved_switch_produces_error_result_with_reason() {
         let id = test_switch_id();
-        let r = error_result(
-            &id.to_string(),
-            "could not resolve endpoint for switch".into(),
-        );
+        let u = UnresolvedDevice {
+            id,
+            reason: "BMC credentials unavailable: no BMC credentials found".into(),
+        };
+        let r = error_result(&u.id.to_string(), u.reason);
         assert_eq!(r.component_id, id.to_string());
         assert_eq!(
             r.status,
             rpc::ComponentManagerStatusCode::InternalError as i32,
         );
-        assert!(r.error.contains("could not resolve endpoint"));
+        assert!(r.error.contains("BMC credentials unavailable"));
     }
 
     #[test]
-    fn unresolved_power_shelf_produces_error_result() {
+    fn unresolved_power_shelf_produces_error_result_with_reason() {
         let id = test_power_shelf_id();
-        let r = error_result(
-            &id.to_string(),
-            "could not resolve endpoint for power shelf".into(),
-        );
+        let u = UnresolvedDevice {
+            id,
+            reason: "PMC credentials unavailable: no PMC credentials found".into(),
+        };
+        let r = error_result(&u.id.to_string(), u.reason);
         assert_eq!(r.component_id, id.to_string());
         assert_eq!(
             r.status,
             rpc::ComponentManagerStatusCode::InternalError as i32,
         );
-        assert!(r.error.contains("could not resolve endpoint"));
+        assert!(r.error.contains("PMC credentials unavailable"));
+    }
+
+    #[test]
+    fn unresolved_device_display() {
+        let id = test_switch_id();
+        let u = UnresolvedDevice {
+            id,
+            reason: "NVOS MAC or IP not available".into(),
+        };
+        let display = u.to_string();
+        assert!(display.contains(&id.to_string()));
+        assert!(display.contains("NVOS MAC or IP not available"));
     }
 
     #[test]
@@ -2254,5 +2267,182 @@ mod tests {
             redfish_power_action(PowerAction::ForceOff),
             SystemPowerControl::ForceOff
         );
+    }
+
+    // ---- get_compute_tray_firmware_version tests ----
+
+    use carbide_uuid::machine::{MachineIdSource, MachineType};
+    use model::bmc_info::BmcInfo;
+    use model::site_explorer::ExploredEndpoint;
+
+    fn test_machine_id() -> carbide_uuid::machine::MachineId {
+        carbide_uuid::machine::MachineId::new(MachineIdSource::Tpm, [0u8; 32], MachineType::Host)
+    }
+
+    fn stub_endpoint(ip: IpAddr) -> ExploredEndpoint {
+        ExploredEndpoint {
+            address: ip,
+            report: Default::default(),
+            report_version: ConfigVersion::initial(),
+            preingestion_state: model::site_explorer::PreingestionState::Initial,
+            waiting_for_explorer_refresh: false,
+            exploration_requested: false,
+            last_redfish_bmc_reset: None,
+            last_ipmitool_bmc_reset: None,
+            last_redfish_reboot: None,
+            last_redfish_powercycle: None,
+            pause_ingestion_and_poweron: false,
+            pause_remediation: false,
+            boot_interface_mac: None,
+        }
+    }
+
+    fn fw_snapshot_from(
+        models: HashMap<String, model::firmware::Firmware>,
+    ) -> carbide_firmware::FirmwareConfigSnapshot {
+        carbide_firmware::FirmwareConfig::new(std::path::PathBuf::new(), &models, &HashMap::new())
+            .create_snapshot()
+    }
+
+    fn empty_fw_snapshot() -> carbide_firmware::FirmwareConfigSnapshot {
+        fw_snapshot_from(HashMap::new())
+    }
+
+    #[test]
+    fn compute_fw_versions_no_bmc_ip() {
+        let id = test_machine_id();
+        let bmc = BmcInfo::default();
+        let result =
+            get_compute_tray_firmware_version(&id, &bmc, &HashMap::new(), &empty_fw_snapshot());
+        let r = result.result.unwrap();
+        assert_eq!(
+            r.status,
+            rpc::ComponentManagerStatusCode::InvalidArgument as i32,
+        );
+        assert!(r.error.contains("no BMC IP configured"));
+    }
+
+    #[test]
+    fn compute_fw_versions_unparseable_ip() {
+        let id = test_machine_id();
+        let bmc = BmcInfo {
+            ip: Some("not-an-ip".into()),
+            ..Default::default()
+        };
+        let result =
+            get_compute_tray_firmware_version(&id, &bmc, &HashMap::new(), &empty_fw_snapshot());
+        let r = result.result.unwrap();
+        assert_eq!(
+            r.status,
+            rpc::ComponentManagerStatusCode::InternalError as i32,
+        );
+        assert!(r.error.contains("unparseable BMC IP"));
+    }
+
+    #[test]
+    fn compute_fw_versions_no_explored_endpoint() {
+        let id = test_machine_id();
+        let bmc = BmcInfo {
+            ip: Some("10.0.0.1".into()),
+            ..Default::default()
+        };
+        let result =
+            get_compute_tray_firmware_version(&id, &bmc, &HashMap::new(), &empty_fw_snapshot());
+        let r = result.result.unwrap();
+        assert_eq!(r.status, rpc::ComponentManagerStatusCode::NotFound as i32);
+        assert!(r.error.contains("no explored endpoint found"));
+    }
+
+    #[test]
+    fn compute_fw_versions_no_firmware_config() {
+        let id = test_machine_id();
+        let ip: IpAddr = "10.0.0.1".parse().unwrap();
+        let bmc = BmcInfo {
+            ip: Some("10.0.0.1".into()),
+            ..Default::default()
+        };
+        let endpoints = HashMap::from([(ip, stub_endpoint(ip))]);
+        let result = get_compute_tray_firmware_version(&id, &bmc, &endpoints, &empty_fw_snapshot());
+        let r = result.result.unwrap();
+        assert_eq!(r.status, rpc::ComponentManagerStatusCode::NotFound as i32);
+        assert!(r.error.contains("no firmware config matches"));
+    }
+
+    #[test]
+    fn compute_fw_versions_empty_components() {
+        use model::firmware::Firmware;
+
+        let id = test_machine_id();
+        let ip: IpAddr = "10.0.0.1".parse().unwrap();
+        let bmc = BmcInfo {
+            ip: Some("10.0.0.1".into()),
+            ..Default::default()
+        };
+
+        let mut endpoint = stub_endpoint(ip);
+        endpoint.report.vendor = Some(bmc_vendor::BMCVendor::Nvidia);
+        endpoint.report.model = Some("TestModel".into());
+        let endpoints = HashMap::from([(ip, endpoint)]);
+
+        let fw = Firmware {
+            vendor: bmc_vendor::BMCVendor::Nvidia,
+            model: "TestModel".into(),
+            components: HashMap::new(),
+            ..Default::default()
+        };
+        let models = HashMap::from([("TestModel".into(), fw)]);
+        let fw_snapshot = fw_snapshot_from(models);
+
+        let result = get_compute_tray_firmware_version(&id, &bmc, &endpoints, &fw_snapshot);
+        let r = result.result.unwrap();
+        assert_eq!(r.status, rpc::ComponentManagerStatusCode::NotFound as i32);
+        assert!(r.error.contains("no component entries"));
+    }
+
+    #[test]
+    fn compute_fw_versions_success() {
+        use model::firmware::{Firmware, FirmwareComponent, FirmwareEntry};
+
+        let id = test_machine_id();
+        let ip: IpAddr = "10.0.0.1".parse().unwrap();
+        let bmc = BmcInfo {
+            ip: Some("10.0.0.1".into()),
+            ..Default::default()
+        };
+
+        let mut endpoint = stub_endpoint(ip);
+        endpoint.report.vendor = Some(bmc_vendor::BMCVendor::Nvidia);
+        endpoint.report.model = Some("TestModel".into());
+        let endpoints = HashMap::from([(ip, endpoint)]);
+
+        let mut components = HashMap::new();
+        components.insert(
+            FirmwareComponentType::Bmc,
+            FirmwareComponent {
+                known_firmware: vec![FirmwareEntry {
+                    version: "1.2.3".into(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        );
+        let fw = Firmware {
+            vendor: bmc_vendor::BMCVendor::Nvidia,
+            model: "TestModel".into(),
+            components,
+            ..Default::default()
+        };
+        let models = HashMap::from([("TestModel".into(), fw)]);
+        let fw_snapshot = fw_snapshot_from(models);
+
+        let result = get_compute_tray_firmware_version(&id, &bmc, &endpoints, &fw_snapshot);
+        let r = result.result.unwrap();
+        assert_eq!(r.status, rpc::ComponentManagerStatusCode::Success as i32);
+        assert_eq!(result.compute_fw_versions.len(), 1);
+        assert_eq!(
+            result.compute_fw_versions[0].component,
+            rpc::ComputeTrayComponent::Bmc as i32,
+        );
+        assert_eq!(result.compute_fw_versions[0].versions, vec!["1.2.3"]);
     }
 }

--- a/crates/api/src/handlers/component_manager.rs
+++ b/crates/api/src/handlers/component_manager.rs
@@ -30,6 +30,8 @@ use db::{self, WithTransaction};
 use futures_util::FutureExt;
 use mac_address::MacAddress;
 use model::component_manager::{PowerAction, PowerShelfComponent};
+use model::firmware::DesiredFirmwareVersions;
+use model::machine::machine_search_config::MachineSearchConfig;
 use model::rack::{FirmwareUpgradeJob, MaintenanceActivity};
 use tonic::{Code, Request, Response, Status};
 
@@ -1328,9 +1330,69 @@ pub(crate) async fn list_component_firmware_versions(
                 devices,
             }))
         }
-        rpc::list_component_firmware_versions_request::Target::MachineIds(_) => Err(
-            Status::unimplemented("machine firmware versions are not supported via this RPC"),
-        ),
+        rpc::list_component_firmware_versions_request::Target::MachineIds(list) => {
+            let fw_snapshot = api.runtime_config.get_firmware_config().create_snapshot();
+
+            let machines = db::machine::find(
+                api.db_reader().as_mut(),
+                db::ObjectFilter::List(&list.machine_ids),
+                MachineSearchConfig::default(),
+            )
+            .await
+            .map_err(|e| Status::internal(format!("failed to look up machines: {e}")))?;
+
+            let bmc_ips: Vec<IpAddr> = machines
+                .iter()
+                .filter_map(|m| m.bmc_info.ip.as_ref()?.parse().ok())
+                .collect();
+
+            let endpoints = db::explored_endpoints::find_by_ips(api.db_reader().as_mut(), bmc_ips)
+                .await
+                .map_err(|e| {
+                    Status::internal(format!("failed to look up explored endpoints: {e}"))
+                })?;
+
+            let endpoint_by_ip: HashMap<IpAddr, _> =
+                endpoints.into_iter().map(|ep| (ep.address, ep)).collect();
+
+            let machine_by_id: HashMap<_, _> = machines.into_iter().map(|m| (m.id, m)).collect();
+
+            let devices = list
+                .machine_ids
+                .iter()
+                .map(|machine_id| {
+                    let id_str = machine_id.to_string();
+
+                    let versions: Vec<String> = machine_by_id
+                        .get(machine_id)
+                        .and_then(|m| m.bmc_info.ip.as_ref()?.parse::<IpAddr>().ok())
+                        .and_then(|ip| endpoint_by_ip.get(&ip))
+                        .and_then(|ep| fw_snapshot.find_fw_info_for_host(ep))
+                        .map(|fw| {
+                            DesiredFirmwareVersions::from(fw)
+                                .versions
+                                .into_values()
+                                .collect()
+                        })
+                        .unwrap_or_default();
+
+                    let result = if versions.is_empty() {
+                        error_result(&id_str, "no firmware config found for machine".into())
+                    } else {
+                        success_result(&id_str)
+                    };
+
+                    rpc::DeviceFirmwareVersions {
+                        result: Some(result),
+                        versions,
+                    }
+                })
+                .collect();
+
+            Ok(Response::new(rpc::ListComponentFirmwareVersionsResponse {
+                devices,
+            }))
+        }
         rpc::list_component_firmware_versions_request::Target::RackIds(list) => {
             if list.rack_ids.is_empty() {
                 return Err(Status::invalid_argument("rack_ids must not be empty"));

--- a/crates/component-manager/Cargo.toml
+++ b/crates/component-manager/Cargo.toml
@@ -25,6 +25,7 @@ authors.workspace = true
 async-trait = { workspace = true }
 carbide-api-db = { path = "../api-db", default-features = false }
 carbide-api-model = { path = "../api-model" }
+carbide-secrets = { path = "../secrets" }
 carbide-uuid = { path = "../uuid" }
 chrono = { workspace = true }
 librms = { workspace = true }

--- a/crates/component-manager/src/nsm.rs
+++ b/crates/component-manager/src/nsm.rs
@@ -59,6 +59,17 @@ fn map_nsm_update_state(state: i32) -> FirmwareState {
     }
 }
 
+fn credentials_to_nsm(creds: &forge_secrets::credentials::Credentials) -> nsm::Credentials {
+    match creds {
+        forge_secrets::credentials::Credentials::UsernamePassword { username, password } => {
+            nsm::Credentials {
+                username: username.clone(),
+                password: password.clone(),
+            }
+        }
+    }
+}
+
 /// Builds a single registration request for an endpoint.
 fn build_registration(ep: &SwitchEndpoint) -> nsm::RegisterNvSwitchRequest {
     nsm::RegisterNvSwitchRequest {
@@ -66,13 +77,13 @@ fn build_registration(ep: &SwitchEndpoint) -> nsm::RegisterNvSwitchRequest {
         bmc: Some(nsm::Subsystem {
             mac_address: ep.bmc_mac.to_string(),
             ip_address: ep.bmc_ip.to_string(),
-            credentials: None,
+            credentials: Some(credentials_to_nsm(&ep.bmc_credentials)),
             port: 0,
         }),
         nvos: Some(nsm::Subsystem {
             mac_address: ep.nvos_mac.to_string(),
             ip_address: ep.nvos_ip.to_string(),
-            credentials: None,
+            credentials: Some(credentials_to_nsm(&ep.nvos_credentials)),
             port: 0,
         }),
         rack_id: String::new(),
@@ -326,6 +337,8 @@ impl NvSwitchManager for NsmSwitchBackend {
 
 #[cfg(test)]
 mod tests {
+    use forge_secrets::credentials::Credentials;
+
     use super::*;
 
     #[test]
@@ -401,6 +414,14 @@ mod tests {
             bmc_mac: "AA:BB:CC:DD:EE:01".parse().unwrap(),
             nvos_ip: "10.0.0.2".parse().unwrap(),
             nvos_mac: "AA:BB:CC:DD:EE:02".parse().unwrap(),
+            bmc_credentials: Credentials::UsernamePassword {
+                username: "admin".to_string(),
+                password: "bmc_pass".to_string(),
+            },
+            nvos_credentials: Credentials::UsernamePassword {
+                username: "nvadmin".to_string(),
+                password: "nvos_pass".to_string(),
+            },
         };
         let req = build_registration(&ep);
         assert_eq!(req.vendor, nsm::Vendor::Nvidia as i32);
@@ -408,10 +429,16 @@ mod tests {
         let bmc = req.bmc.as_ref().unwrap();
         assert_eq!(bmc.ip_address, "10.0.0.1");
         assert_eq!(bmc.mac_address, "AA:BB:CC:DD:EE:01");
+        let bmc_creds = bmc.credentials.as_ref().unwrap();
+        assert_eq!(bmc_creds.username, "admin");
+        assert_eq!(bmc_creds.password, "bmc_pass");
 
         let nvos = req.nvos.as_ref().unwrap();
         assert_eq!(nvos.ip_address, "10.0.0.2");
         assert_eq!(nvos.mac_address, "AA:BB:CC:DD:EE:02");
+        let nvos_creds = nvos.credentials.as_ref().unwrap();
+        assert_eq!(nvos_creds.username, "nvadmin");
+        assert_eq!(nvos_creds.password, "nvos_pass");
     }
 
     #[test]

--- a/crates/component-manager/src/nv_switch_manager.rs
+++ b/crates/component-manager/src/nv_switch_manager.rs
@@ -4,6 +4,7 @@
 use std::fmt::Debug;
 use std::net::IpAddr;
 
+use forge_secrets::credentials::Credentials;
 use mac_address::MacAddress;
 use model::component_manager::{FirmwareState, NvSwitchComponent, PowerAction};
 
@@ -17,6 +18,8 @@ pub struct SwitchEndpoint {
     pub bmc_mac: MacAddress,
     pub nvos_ip: IpAddr,
     pub nvos_mac: MacAddress,
+    pub bmc_credentials: Credentials,
+    pub nvos_credentials: Credentials,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/component-manager/src/power_shelf_manager.rs
+++ b/crates/component-manager/src/power_shelf_manager.rs
@@ -4,6 +4,7 @@
 use std::fmt::Debug;
 use std::net::IpAddr;
 
+use forge_secrets::credentials::Credentials;
 use mac_address::MacAddress;
 use model::component_manager::{FirmwareState, PowerAction, PowerShelfComponent};
 
@@ -16,6 +17,7 @@ pub struct PowerShelfEndpoint {
     pub pmc_ip: IpAddr,
     pub pmc_mac: MacAddress,
     pub pmc_vendor: PowerShelfVendor,
+    pub pmc_credentials: Credentials,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/component-manager/src/psm.rs
+++ b/crates/component-manager/src/psm.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use forge_secrets::credentials::Credentials;
 use model::component_manager::{FirmwareState, PowerAction, PowerShelfComponent};
 use tonic::transport::Channel;
 use tracing::instrument;
@@ -48,6 +49,15 @@ fn map_vendor(v: &PowerShelfVendor) -> i32 {
     }
 }
 
+fn credentials_to_psm(creds: &Credentials) -> psm::Credentials {
+    match creds {
+        Credentials::UsernamePassword { username, password } => psm::Credentials {
+            username: username.clone(),
+            password: password.clone(),
+        },
+    }
+}
+
 fn to_psm_component(c: &PowerShelfComponent) -> psm::PowershelfComponent {
     match c {
         PowerShelfComponent::Pmc => psm::PowershelfComponent::Pmc,
@@ -72,7 +82,7 @@ async fn register_with_psm(
             pmc_mac_address: ep.pmc_mac.to_string(),
             pmc_ip_address: ep.pmc_ip.to_string(),
             pmc_vendor: map_vendor(&ep.pmc_vendor),
-            pmc_credentials: None,
+            pmc_credentials: Some(credentials_to_psm(&ep.pmc_credentials)),
         })
         .collect();
 
@@ -433,11 +443,19 @@ mod tests {
                 pmc_ip: "10.0.0.1".parse().unwrap(),
                 pmc_mac: "AA:BB:CC:DD:EE:01".parse().unwrap(),
                 pmc_vendor: PowerShelfVendor::Liteon,
+                pmc_credentials: Credentials::UsernamePassword {
+                    username: "admin".into(),
+                    password: "pass".into(),
+                },
             },
             PowerShelfEndpoint {
                 pmc_ip: "10.0.0.2".parse().unwrap(),
                 pmc_mac: "AA:BB:CC:DD:EE:02".parse().unwrap(),
                 pmc_vendor: PowerShelfVendor::Unknown,
+                pmc_credentials: Credentials::UsernamePassword {
+                    username: "admin".into(),
+                    password: "pass".into(),
+                },
             },
         ];
         let macs = mac_strings(&eps);

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -796,19 +796,33 @@ mod tests {
     // ---- Test helpers ----
 
     fn make_ps_endpoint(mac: &str) -> PowerShelfEndpoint {
+        use forge_secrets::credentials::Credentials;
         PowerShelfEndpoint {
             pmc_ip: "10.0.0.1".parse().unwrap(),
             pmc_mac: mac.parse().unwrap(),
             pmc_vendor: PowerShelfVendor::Liteon,
+            pmc_credentials: Credentials::UsernamePassword {
+                username: "admin".into(),
+                password: "pass".into(),
+            },
         }
     }
 
     fn make_sw_endpoint(mac: &str) -> SwitchEndpoint {
+        use forge_secrets::credentials::Credentials;
         SwitchEndpoint {
             bmc_ip: "10.0.0.1".parse().unwrap(),
             bmc_mac: mac.parse().unwrap(),
             nvos_ip: "10.0.0.2".parse().unwrap(),
             nvos_mac: "11:22:33:44:55:66".parse().unwrap(),
+            bmc_credentials: Credentials::UsernamePassword {
+                username: "admin".to_string(),
+                password: "pass".to_string(),
+            },
+            nvos_credentials: Credentials::UsernamePassword {
+                username: "admin".to_string(),
+                password: "pass".to_string(),
+            },
         }
     }
 

--- a/crates/component-manager/src/state_controller/nv_switch.rs
+++ b/crates/component-manager/src/state_controller/nv_switch.rs
@@ -276,11 +276,20 @@ mod tests {
     }
 
     fn make_ep(mac: &str) -> SwitchEndpoint {
+        use forge_secrets::credentials::Credentials;
         SwitchEndpoint {
             bmc_ip: "10.0.0.1".parse().unwrap(),
             bmc_mac: mac.parse().unwrap(),
             nvos_ip: "10.0.0.2".parse().unwrap(),
             nvos_mac: "11:22:33:44:55:66".parse().unwrap(),
+            bmc_credentials: Credentials::UsernamePassword {
+                username: "admin".to_string(),
+                password: "pass".to_string(),
+            },
+            nvos_credentials: Credentials::UsernamePassword {
+                username: "admin".to_string(),
+                password: "pass".to_string(),
+            },
         }
     }
 

--- a/crates/component-manager/src/state_controller/power_shelf.rs
+++ b/crates/component-manager/src/state_controller/power_shelf.rs
@@ -223,6 +223,7 @@ fn unknown_mac_result(pmc_mac: MacAddress) -> PowerShelfComponentResult {
 mod tests {
     use std::sync::Mutex;
 
+    use forge_secrets::credentials::Credentials;
     use model::rack::{FirmwareUpgradeState, RackMaintenanceState};
 
     use super::*;
@@ -301,6 +302,10 @@ mod tests {
             pmc_ip: "10.0.0.1".parse().unwrap(),
             pmc_mac: mac.parse().unwrap(),
             pmc_vendor: PowerShelfVendor::Liteon,
+            pmc_credentials: Credentials::UsernamePassword {
+                username: "admin".into(),
+                password: "pass".into(),
+            },
         }
     }
 

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -7882,6 +7882,14 @@ enum ComputeTrayComponent {
   COMPUTE_TRAY_COMPONENT_UNKNOWN = 0;
   COMPUTE_TRAY_COMPONENT_BMC = 1;
   COMPUTE_TRAY_COMPONENT_BIOS = 2;
+  COMPUTE_TRAY_COMPONENT_CEC = 3;
+  COMPUTE_TRAY_COMPONENT_NIC = 4;
+  COMPUTE_TRAY_COMPONENT_CPLD_MB = 5;
+  COMPUTE_TRAY_COMPONENT_CPLD_PDB = 6;
+  COMPUTE_TRAY_COMPONENT_HGX_BMC = 7;
+  COMPUTE_TRAY_COMPONENT_COMBINED_BMC_UEFI = 8;
+  COMPUTE_TRAY_COMPONENT_GPU = 9;
+  COMPUTE_TRAY_COMPONENT_CX7 = 10;
 }
 
 message UpdateComputeTrayFirmwareTarget {
@@ -7941,9 +7949,20 @@ message ListComponentFirmwareVersionsRequest {
   }
 }
 
+// Per-component firmware versions for a compute tray. Since compute trays
+// don't use bundles, each component (BMC, BIOS, etc.) has its own set of
+// available firmware versions.
+message ComputeTrayFirmwareVersions {
+  ComputeTrayComponent component = 1;
+  repeated string versions = 2;
+}
+
 message DeviceFirmwareVersions {
   ComponentResult result = 1;
+  // Firmware Bundle IDs for switches, powershelves, and racks.
   repeated string versions = 2;
+  // Per-component firmware versions for compute trays.
+  repeated ComputeTrayFirmwareVersions compute_fw_versions = 3;
 }
 
 message ListComponentFirmwareVersionsResponse {


### PR DESCRIPTION
## Description

chore: implement list_component_firmware_versions for compute trays

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Component firmware version lookup by machine ID now functions correctly. The API retrieves and displays available firmware versions for each requested machine, returns clear error messages when firmware configurations are unavailable, and provides improved error reporting and diagnostics for database and network endpoint operation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->