### PR TITLE
fix(api): validate bmc endpoint IP + check for error instead of parse + unwrap

### DIFF
--- a/crates/api/src/handlers/bmc_endpoint_explorer.rs
+++ b/crates/api/src/handlers/bmc_endpoint_explorer.rs
@@ -849,15 +849,18 @@ pub(crate) async fn validate_and_complete_bmc_endpoint_request(
 ) -> Result<(rpc::BmcEndpointRequest, Option<MachineId>), CarbideError> {
     match (bmc_endpoint_request, machine_id) {
         (Some(bmc_endpoint_request), _) => {
-            let interface = db::machine_interface::find_by_ip(
-                txn,
-                bmc_endpoint_request.ip_address.parse().unwrap(),
-            )
-            .await?
-            .ok_or_else(|| CarbideError::NotFoundError {
-                kind: "machine_interface",
-                id: bmc_endpoint_request.ip_address.clone(),
+            let parsed_ip = bmc_endpoint_request.ip_address.parse().map_err(|e| {
+                CarbideError::InvalidArgument(format!(
+                    "invalid ip_address {:?}: {e}",
+                    bmc_endpoint_request.ip_address
+                ))
             })?;
+            let interface = db::machine_interface::find_by_ip(txn, parsed_ip)
+                .await?
+                .ok_or_else(|| CarbideError::NotFoundError {
+                    kind: "machine_interface",
+                    id: bmc_endpoint_request.ip_address.clone(),
+                })?;
 
             let bmc_mac = match bmc_endpoint_request.mac_address {
                 // No MAC in the request, use the interface MAC

--- a/crates/api/src/tests/explored_endpoint_find.rs
+++ b/crates/api/src/tests/explored_endpoint_find.rs
@@ -304,3 +304,34 @@ async fn test_find_explored_endpoint_firmware_versions(
 
     Ok(())
 }
+
+#[crate::sqlx_test]
+async fn test_admin_bmc_reset_rejects_malformed_ip_address(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    let req = tonic::Request::new(rpc::AdminBmcResetRequest {
+        bmc_endpoint_request: Some(rpc::BmcEndpointRequest {
+            ip_address: "not-an-ip".to_string(),
+            mac_address: None,
+        }),
+        machine_id: None,
+        use_ipmitool: false,
+    });
+
+    let err = env
+        .api
+        .admin_bmc_reset(req)
+        .await
+        .expect_err("expected malformed ip_address to be rejected");
+
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(
+        err.message().contains("invalid ip_address"),
+        "message was: {}",
+        err.message()
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

Making this a little better. We were parsing and unwrapping here instead of returning an error. There are a bunch of handlers that call this (e.g. `admin_bmc_reset`, `disable_secure_boot`, bmc_explore_*`, etc), so it's probably good to be a little more strict here.

Test added.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

