### PR TITLE
fix(api): clean up extension services by (service_id, version)

### DIFF
--- a/crates/api-model/src/instance/config/extension_services.rs
+++ b/crates/api-model/src/instance/config/extension_services.rs
@@ -186,16 +186,17 @@ impl InstanceExtensionServicesConfig {
             .collect()
     }
 
-    /// Removes services that have been marked as removed AND have the specified service IDs
-    /// This is used to clean up services that have been fully terminated across all DPUs
+    /// Removes extension service entries that match a fully-terminated `(service_id, version)`.
     pub fn remove_terminated_services(
         &self,
-        service_ids_to_remove: &HashSet<ExtensionServiceId>,
+        keys_to_remove: &[(ExtensionServiceId, ConfigVersion)],
     ) -> Self {
         let mut config = self.clone();
-        config
-            .service_configs
-            .retain(|s| !service_ids_to_remove.contains(&s.service_id));
+        config.service_configs.retain(|s| {
+            !keys_to_remove
+                .iter()
+                .any(|&(id, ver)| id == s.service_id && ver == s.version)
+        });
         config
     }
 }
@@ -225,5 +226,45 @@ impl TryFrom<InstanceExtensionServicesConfig> for rpc::InstanceDpuExtensionServi
                 .map(|config| config.into())
                 .collect(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use carbide_uuid::extension_service::ExtensionServiceId;
+    use chrono::Utc;
+    use config_version::ConfigVersion;
+
+    use super::{InstanceExtensionServiceConfig, InstanceExtensionServicesConfig};
+
+    #[test]
+    fn extension_service_remove_terminated_services() {
+        let sid = ExtensionServiceId::from_str("00000000-0000-0000-0000-000000000001").unwrap();
+        let init_version = ConfigVersion::initial();
+        let second_version = init_version.increment();
+
+        let config = InstanceExtensionServicesConfig {
+            service_configs: vec![
+                InstanceExtensionServiceConfig {
+                    service_id: sid,
+                    version: second_version,
+                    removed: None,
+                },
+                InstanceExtensionServiceConfig {
+                    service_id: sid,
+                    version: init_version,
+                    removed: Some(Utc::now()),
+                },
+            ],
+        };
+
+        let cleaned = config.remove_terminated_services(&[(sid, init_version)]);
+
+        assert_eq!(cleaned.service_configs.len(), 1);
+        assert_eq!(cleaned.service_configs[0].service_id, sid);
+        assert_eq!(cleaned.service_configs[0].version, second_version);
+        assert!(cleaned.service_configs[0].removed.is_none());
     }
 }

--- a/crates/api-model/src/instance/status/extension_service.rs
+++ b/crates/api-model/src/instance/status/extension_service.rs
@@ -247,9 +247,11 @@ impl InstanceExtensionServicesStatus {
         }
     }
 
-    /// Returns the set of service IDs that are marked as removed and have been fully terminated
-    /// across all DPUs (i.e., all DPUs report the service as Terminated)
-    pub fn get_terminated_service_ids(&self) -> std::collections::HashSet<ExtensionServiceId> {
+    /// Returns `(service_id, extension service config version)` for extension services that are
+    /// marked removed and fully `Terminated` on every DPU. Cleanup must use this pair, not
+    /// `service_id` alone, because multiple config versions for the same service can exist during
+    /// rolldown/upgrade.
+    pub fn get_terminated_service_keys(&self) -> Vec<(ExtensionServiceId, ConfigVersion)> {
         self.extension_services
             .iter()
             .filter(|svc| {
@@ -264,7 +266,7 @@ impl InstanceExtensionServicesStatus {
                         )
                     })
             })
-            .map(|svc| svc.service_id)
+            .map(|svc| (svc.service_id, svc.version))
             .collect()
     }
 }
@@ -619,6 +621,8 @@ pub fn is_extension_services_ready(
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
+
+    use chrono::Utc;
 
     use super::*;
     use crate::extension_service::ExtensionServiceType;
@@ -995,5 +999,86 @@ mod tests {
         let overall_status =
             InstanceExtensionServicesStatus::calculate_overall_status(&dpu_statuses);
         assert_eq!(overall_status, ExtensionServiceDeploymentStatus::Unknown);
+    }
+
+    fn create_observation_two_versions(
+        cfg_version: ConfigVersion,
+        v_new: ConfigVersion,
+        new_state: ExtensionServiceDeploymentStatus,
+        v_old: ConfigVersion,
+        old_state: ExtensionServiceDeploymentStatus,
+    ) -> HashMap<MachineId, InstanceExtensionServiceStatusObservation> {
+        let mut observations = HashMap::new();
+        observations.insert(
+            get_test_machine_id(),
+            InstanceExtensionServiceStatusObservation {
+                config_version: cfg_version,
+                instance_config_version: None,
+                extension_service_statuses: vec![
+                    ExtensionServiceStatusObservation {
+                        service_id: get_test_service_id(),
+                        service_type: ExtensionServiceType::KubernetesPod,
+                        service_name: "test-service".to_string(),
+                        version: v_new,
+                        removed: None,
+                        overall_state: new_state,
+                        components: vec![],
+                        message: String::new(),
+                    },
+                    ExtensionServiceStatusObservation {
+                        service_id: get_test_service_id(),
+                        service_type: ExtensionServiceType::KubernetesPod,
+                        service_name: "test-service".to_string(),
+                        version: v_old,
+                        removed: Some(Utc::now().to_rfc3339()),
+                        overall_state: old_state,
+                        components: vec![],
+                        message: String::new(),
+                    },
+                ],
+                observed_at: chrono::Utc::now(),
+            },
+        );
+        observations
+    }
+
+    #[test]
+    fn extension_service_get_terminated_service_keys() {
+        let init_version = ConfigVersion::initial();
+        let second_version = init_version.increment();
+        let config = InstanceExtensionServicesConfig {
+            service_configs: vec![
+                InstanceExtensionServiceConfig {
+                    service_id: get_test_service_id(),
+                    version: second_version,
+                    removed: None,
+                },
+                InstanceExtensionServiceConfig {
+                    service_id: get_test_service_id(),
+                    version: init_version,
+                    removed: Some(Utc::now()),
+                },
+            ],
+        };
+        let config_version = ConfigVersion::initial();
+        let dpu_map = create_dpu_map_with_one_dpu();
+        let observations = create_observation_two_versions(
+            config_version,
+            second_version,
+            ExtensionServiceDeploymentStatus::Running,
+            init_version,
+            ExtensionServiceDeploymentStatus::Terminated,
+        );
+
+        let status = InstanceExtensionServicesStatus::from_config_and_observations(
+            &dpu_map,
+            Versioned::new(&config, config_version),
+            &observations,
+        );
+
+        let keys = status.get_terminated_service_keys();
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].0, get_test_service_id());
+        assert_eq!(keys[0].1, init_version);
     }
 }

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -5395,7 +5395,7 @@ impl StateHandler for InstanceStateHandler {
                         get_extension_services_status(mh_snapshot, instance);
                     let txn = if extension_services_status.configs_synced == SyncState::Synced
                         && !extension_services_status
-                            .get_terminated_service_ids()
+                            .get_terminated_service_keys()
                             .is_empty()
                     {
                         let mut txn = ctx.services.db_pool.begin().await?;
@@ -5496,7 +5496,7 @@ impl StateHandler for InstanceStateHandler {
                             get_extension_services_status(mh_snapshot, instance);
                         if extension_services_status.configs_synced == SyncState::Synced
                             && !extension_services_status
-                                .get_terminated_service_ids()
+                                .get_terminated_service_keys()
                                 .is_empty()
                         {
                             let mut txn = ctx.services.db_pool.begin().await?;
@@ -6192,20 +6192,20 @@ async fn cleanup_terminated_extension_services(
         return Ok(());
     }
 
-    let terminated_service_ids = extension_services_status.get_terminated_service_ids();
-    if terminated_service_ids.is_empty() {
+    let terminated_service_keys = extension_services_status.get_terminated_service_keys();
+    if terminated_service_keys.is_empty() {
         return Ok(());
     }
 
     tracing::info!(
         instance_id = %instance.id,
-        service_ids = ?terminated_service_ids,
+        terminated_extension_services = ?terminated_service_keys,
         "Cleaning up fully terminated extension services from instance config"
     );
     let new_config = instance
         .config
         .extension_services
-        .remove_terminated_services(&terminated_service_ids);
+        .remove_terminated_services(&terminated_service_keys);
 
     db::instance::update_extension_services_config(
         txn,
@@ -6216,9 +6216,11 @@ async fn cleanup_terminated_extension_services(
     )
     .await?;
 
-    extension_services_status
-        .extension_services
-        .retain(|svc| !terminated_service_ids.contains(&svc.service_id));
+    extension_services_status.extension_services.retain(|svc| {
+        !terminated_service_keys
+            .iter()
+            .any(|&(id, ver)| id == svc.service_id && ver == svc.version)
+    });
     Ok(())
 }
 


### PR DESCRIPTION
## Description
Fixes extension service termination cleanup so only the specific fully terminated extension service config version is removed from persisted instance config, not every row sharing the same service id.

Related [bug](https://nvbugspro.nvidia.com/bug/5964187). 

The cause is that when the controller cleaned up terminated extension services, it collected terminated `service_id`s and removed all instance config entries with a matching `service_id`. That is incorrect during version changes: an upgrade or downgrade keeps an older version in the config as removed/terminating until DPUs report it terminated, while a newer version stays active under the same `service_id`. Because cleanup keyed only on id, it could delete every version row for that service—including the active one—leaving the instance with no extension service in config even though the tenant still intended to run the new version.

Therefore, termination cleanup now keys off (ExtensionServiceId, ConfigVersion) (and applies the same rule when updating in-memory status) so only the row that is actually fully terminated is dropped; other versions for the same service id remain.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)


## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

