### PR TITLE
feat(dpf): Move DPU CR into Error phase before force deleting the node and devices.

### DIFF
--- a/crates/api/src/dpf.rs
+++ b/crates/api/src/dpf.rs
@@ -102,7 +102,7 @@ pub trait DpfOperations: Send + Sync + std::fmt::Debug {
     /// Force delete a host and all its DPU resources.
     async fn force_delete_host(
         &self,
-        node_name: &str,
+        node_id: &str,
         dpu_device_names: &[String],
     ) -> Result<(), DpfError>;
 
@@ -383,12 +383,10 @@ impl DpfOperations for DpfSdkOps {
 
     async fn force_delete_host(
         &self,
-        node_name: &str,
+        node_id: &str,
         dpu_device_names: &[String],
     ) -> Result<(), DpfError> {
-        self.sdk
-            .force_delete_host(node_name, dpu_device_names)
-            .await
+        self.sdk.force_delete_host(node_id, dpu_device_names).await
     }
 
     async fn reprovision_dpu(

--- a/crates/api/src/handlers/machine.rs
+++ b/crates/api/src/handlers/machine.rs
@@ -549,7 +549,6 @@ pub(crate) async fn admin_force_delete_machine(
             let host_dpf_id = machine
                 .dpf_id()
                 .ok_or_else(|| CarbideError::internal("BMC MAC not set for host".to_string()))?;
-            let node_name = carbide_dpf::dpu_node_cr_name(&host_dpf_id);
             let dpu_device_names: Vec<String> = dpu_machines
                 .iter()
                 .map(|d| {
@@ -558,7 +557,7 @@ pub(crate) async fn admin_force_delete_machine(
                     })
                 })
                 .collect::<Result<_, _>>()?;
-            ops.force_delete_host(&node_name, &dpu_device_names)
+            ops.force_delete_host(&host_dpf_id, &dpu_device_names)
                 .await
                 .map_err(CarbideError::DpfError)?;
         }

--- a/crates/api/src/tests/machine_admin_force_delete.rs
+++ b/crates/api/src/tests/machine_admin_force_delete.rs
@@ -733,9 +733,10 @@ async fn test_admin_force_delete_with_instance_type(pool: sqlx::PgPool) {
     _ = force_delete(&env, &tmp_machine_id);
 }
 
-/// Force delete with DPF: the node_name and dpu_device_names passed to
-/// force_delete_host must use BMC MAC addresses, not 64-char MachineIds,
-/// so that the resulting K8s resource names stay within the 48-char limit.
+/// Force delete with DPF: the node_id and dpu_device_names passed to
+/// force_delete_host must be BMC MAC-derived ids, not 64-char MachineIds,
+/// so that the resulting K8s resource names stay within the 48-char limit
+/// after the SDK adds the `node-` / `device-` CR prefixes.
 #[crate::sqlx_test]
 async fn test_admin_force_delete_with_dpf_uses_bmc_mac(pool: sqlx::PgPool) {
     type DpfCallLog = Vec<(String, Vec<String>)>;
@@ -798,27 +799,31 @@ async fn test_admin_force_delete_with_dpf_uses_bmc_mac(pool: sqlx::PgPool) {
         "force_delete_host should have been called exactly once, got: {calls:?}"
     );
 
-    let (node_name, device_names) = &calls[0];
+    let (node_id, device_ids) = &calls[0];
 
+    // BMC MAC -> dpf_id formats as `xx-xx-xx-xx-xx-xx` (17 chars). The SDK adds
+    // a `node-` prefix to form the CR name, so the id itself must leave room
+    // for that prefix within the 48-char DPUNode CRD limit.
+    let mac_re = regex::Regex::new(r"^[0-9a-f]{2}(-[0-9a-f]{2}){5}$").unwrap();
     assert!(
-        node_name.starts_with("node-"),
-        "node_name should start with 'node-', got: {node_name}",
+        mac_re.is_match(node_id),
+        "node_id should be a BMC MAC-derived id (xx-xx-xx-xx-xx-xx), got: {node_id}",
     );
     assert!(
-        node_name.len() <= 48,
-        "node_name must be <= 48 chars for DPUNode CRD, got {} chars: {node_name}",
-        node_name.len(),
+        format!("node-{node_id}").len() <= 48,
+        "node CR name must be <= 48 chars for DPUNode CRD, got {} chars",
+        format!("node-{node_id}").len(),
     );
 
-    for name in device_names {
+    for id in device_ids {
         assert!(
-            name.len() <= 48,
-            "dpu device name must be <= 48 chars, got {} chars: {name}",
-            name.len(),
+            mac_re.is_match(id),
+            "dpu device id should be a MAC-derived id (xx-xx-xx-xx-xx-xx), got: {id}",
         );
         assert!(
-            name.contains('-'),
-            "dpu device name should be a MAC-derived id (contain hyphens), got: {name}",
+            format!("device-{id}").len() <= 48,
+            "device CR name must be <= 48 chars, got {} chars",
+            format!("device-{id}").len(),
         );
     }
 }

--- a/crates/dpf/src/bin/api_harness.rs
+++ b/crates/dpf/src/bin/api_harness.rs
@@ -897,15 +897,14 @@ async fn run_cleanup(
         .map(|s| s.trim().to_string())
         .collect();
 
-    let node_name = device_names
+    let node_id = device_names
         .first()
-        .map(|id| dpu_node_cr_name(id))
         .ok_or("dpu_device_names must not be empty")?;
 
     tracing::info!("=== DPF Cleanup ===");
-    tracing::info!(node = %node_name, device_names = ?device_names, "Starting cleanup");
+    tracing::info!(node = %node_id, device_names = ?device_names, "Starting cleanup");
 
-    sdk.force_delete_host(&node_name, &device_names).await?;
+    sdk.force_delete_host(node_id, &device_names).await?;
 
     tracing::info!("Cleanup complete");
     Ok(())

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -1433,10 +1433,29 @@ impl<R: DpuRepository + DpuNodeRepository + DpuDeviceRepository, L: ResourceLabe
     /// `dpu_device_names` contains raw device IDs (without the `device-` CR prefix).
     pub async fn force_delete_host(
         &self,
-        node_name: &str,
+        node_id: &str,
         dpu_device_names: &[String],
     ) -> Result<(), DpfError> {
+        let node_name = &dpu_node_cr_name(node_id);
         let node = DpuNodeRepository::get(&*self.repo, node_name, &self.namespace).await?;
+
+        for name in dpu_device_names {
+            let dpu_cr_name = dpu_cr_name(name, node_id);
+            let dpu_cr = DpuRepository::get(&*self.repo, &dpu_cr_name, &self.namespace).await?;
+
+            if dpu_cr.is_some() {
+                // Move the DPU to the Error phase so the operator stops reconciling it
+                // before we drop the DPUNode and DPUDevice CRs below. Best-effort: a
+                // failed patch must not block the deletes that follow.
+                let patch = json!({ "status": { "phase": "Error" } });
+                if let Err(e) =
+                    DpuRepository::patch_status(&*self.repo, &dpu_cr_name, &self.namespace, patch)
+                        .await
+                {
+                    tracing::warn!("Failed to patch DPU {} to Error phase: {}", dpu_cr_name, e);
+                }
+            }
+        }
 
         if let Some(node) = node {
             let dpus = node.spec.dpus.unwrap_or_default();

--- a/crates/dpf/src/test/sdk_device_registration.rs
+++ b/crates/dpf/src/test/sdk_device_registration.rs
@@ -227,9 +227,7 @@ async fn test_register_devices_node_and_force_delete() {
 
     // Force delete
     let dpu_ids = vec!["dpu-1".to_string(), "dpu-2".to_string()];
-    sdk.force_delete_host("node-host-001", &dpu_ids)
-        .await
-        .unwrap();
+    sdk.force_delete_host("host-001", &dpu_ids).await.unwrap();
 
     assert_eq!(
         DpuDeviceRepository::list(&mock, TEST_NS)


### PR DESCRIPTION
## Description
DPUNode and DPUDevice CR might stuck in reconciliation if DPU CR are not in either Ready or Error phase. It is better to patch DPU CR with Error so that DPF stops reconciliation and don't set any further `finalizers`.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

