### PR TITLE
fix(ondeman-nvosupdate): Fix on-demand firmware-only switch reprovisioning flow 

### DIFF
--- a/crates/api-db/src/switch.rs
+++ b/crates/api-db/src/switch.rs
@@ -265,9 +265,20 @@ pub async fn set_switch_reprovisioning_requested(
     switch_id: SwitchId,
     initiator: &str,
 ) -> DatabaseResult<()> {
+    set_switch_reprovisioning_requested_with_firmware_continuation(txn, switch_id, initiator, true)
+        .await
+}
+
+pub async fn set_switch_reprovisioning_requested_with_firmware_continuation(
+    txn: &mut PgConnection,
+    switch_id: SwitchId,
+    initiator: &str,
+    continue_after_firmware_upgrade: bool,
+) -> DatabaseResult<()> {
     let req = SwitchReprovisionRequest {
         requested_at: Utc::now(),
         initiator: initiator.to_string(),
+        continue_after_firmware_upgrade,
     };
     let query =
         "UPDATE switches SET switch_reprovisioning_requested = $1 WHERE id = $2 RETURNING id";

--- a/crates/api-model/src/switch/mod.rs
+++ b/crates/api-model/src/switch/mod.rs
@@ -107,12 +107,19 @@ pub struct SwitchStatus {
     pub health_status: String, // "ok", "warning", "critical"
 }
 
+fn default_continue_after_firmware_upgrade() -> bool {
+    true
+}
+
 /// Set by an external entity to request switch reprovisioning. When the switch is in Ready state,
 /// the state controller checks this flag and transitions to ReProvisioning::Start.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SwitchReprovisionRequest {
     pub requested_at: DateTime<Utc>,
     pub initiator: String,
+    /// Continue through rack-managed post-firmware phases such as NVOS/NMXC.
+    #[serde(default = "default_continue_after_firmware_upgrade")]
+    pub continue_after_firmware_upgrade: bool,
 }
 
 pub use crate::rack::{

--- a/crates/api/src/state_controller/rack/maintenance.rs
+++ b/crates/api/src/state_controller/rack/maintenance.rs
@@ -82,6 +82,7 @@ async fn trigger_rack_firmware_reprovisioning_requests(
     rack_id: &RackId,
     machine_ids: &[carbide_uuid::machine::MachineId],
     switch_ids: &[carbide_uuid::switch::SwitchId],
+    continue_after_firmware_upgrade: bool,
 ) -> Result<(), StateHandlerError> {
     for machine_id in machine_ids {
         db_host_machine_update::trigger_host_reprovisioning_request(
@@ -92,10 +93,11 @@ async fn trigger_rack_firmware_reprovisioning_requests(
         .await?;
     }
     for switch_id in switch_ids {
-        db_switch::set_switch_reprovisioning_requested(
+        db_switch::set_switch_reprovisioning_requested_with_firmware_continuation(
             txn,
             *switch_id,
             &format!("rack-{}", rack_id),
+            continue_after_firmware_upgrade,
         )
         .await?;
     }
@@ -1212,11 +1214,16 @@ pub async fn handle_maintenance(
                     rms_start_firmware_upgrade(rms_client.as_ref(), &firmware.id, batches).await;
 
                 let mut txn = ctx.services.db_pool.begin().await?;
+                let continue_after_firmware_upgrade =
+                    scope.should_run(&MaintenanceActivity::NvosUpdate {
+                        rack_firmware_id: None,
+                    });
                 trigger_rack_firmware_reprovisioning_requests(
                     txn.as_mut(),
                     id,
                     &inventory.machine_ids,
                     &inventory.switch_ids,
+                    continue_after_firmware_upgrade,
                 )
                 .await?;
                 clear_rack_firmware_device_statuses(

--- a/crates/api/src/state_controller/switch/reprovisioning.rs
+++ b/crates/api/src/state_controller/switch/reprovisioning.rs
@@ -41,11 +41,12 @@ pub async fn handle_reprovisioning(
 
     match reprovisioning_state {
         ReProvisioningState::WaitingForRackFirmwareUpgrade => {
-            let requested_at = state
+            let request = state
                 .switch_reprovisioning_requested
                 .as_ref()
-                .map(|request| request.requested_at)
                 .expect("WaitingForRackFirmwareUpgrade requires a rack reprovision request");
+            let requested_at = request.requested_at;
+            let continue_after_firmware_upgrade = request.continue_after_firmware_upgrade;
             let Some(firmware_upgrade_status) = state.firmware_upgrade_status.as_ref() else {
                 return Ok(StateHandlerOutcome::wait(
                     "waiting for switch firmware upgrade status".into(),
@@ -63,11 +64,20 @@ pub async fn handle_reprovisioning(
             }
 
             match &firmware_upgrade_status.status {
-                model::rack::RackFirmwareUpgradeState::Completed => Ok(
-                    StateHandlerOutcome::transition(SwitchControllerState::ReProvisioning {
-                        reprovisioning_state: ReProvisioningState::WaitingForNVOSUpgrade,
-                    }),
-                ),
+                model::rack::RackFirmwareUpgradeState::Completed => {
+                    if continue_after_firmware_upgrade {
+                        return Ok(StateHandlerOutcome::transition(
+                            SwitchControllerState::ReProvisioning {
+                                reprovisioning_state: ReProvisioningState::WaitingForNVOSUpgrade,
+                            },
+                        ));
+                    }
+
+                    let mut txn = ctx.services.db_pool.begin().await?;
+                    db_switch::clear_switch_reprovisioning_requested(txn.as_mut(), *switch_id)
+                        .await?;
+                    Ok(StateHandlerOutcome::transition(SwitchControllerState::Ready).with_txn(txn))
+                }
                 model::rack::RackFirmwareUpgradeState::Failed { cause } => {
                     let mut txn = ctx.services.db_pool.begin().await?;
                     db_switch::clear_switch_reprovisioning_requested(txn.as_mut(), *switch_id)

--- a/crates/api/src/tests/rack_state_controller/handler.rs
+++ b/crates/api/src/tests/rack_state_controller/handler.rs
@@ -482,6 +482,48 @@ async fn test_on_demand_rack_maintenance_schedules_nvos_only_scope(
 }
 
 #[crate::sqlx_test]
+async fn test_on_demand_rack_maintenance_schedules_configure_nmx_cluster_only_scope(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(pool.clone(), TestEnvOverrides::default()).await;
+    let (rack_id, switch_id) = create_ready_rack_with_switch(&env, &pool).await?;
+
+    crate::handlers::rack::on_demand_rack_maintenance(
+        env.api.as_ref(),
+        Request::new(rpc::forge::RackMaintenanceOnDemandRequest {
+            rack_id: Some(rack_id.clone()),
+            scope: Some(rpc::forge::RackMaintenanceScope {
+                machine_ids: vec![],
+                switch_ids: vec![switch_id.to_string()],
+                power_shelf_ids: vec![],
+                activities: vec![rpc::forge::MaintenanceActivityConfig {
+                    activity: Some(
+                        rpc::forge::maintenance_activity_config::Activity::ConfigureNmxCluster(
+                            rpc::forge::ConfigureNmxClusterActivity {},
+                        ),
+                    ),
+                }],
+            }),
+        }),
+    )
+    .await?;
+
+    let rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
+    let scope = rack
+        .config
+        .maintenance_requested
+        .expect("maintenance should be scheduled");
+    assert_eq!(scope.switch_ids, vec![switch_id]);
+    assert_eq!(scope.activities.len(), 1);
+    assert!(matches!(
+        &scope.activities[0],
+        MaintenanceActivity::ConfigureNmxCluster
+    ));
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
 async fn test_on_demand_rack_maintenance_schedules_firmware_and_nvos_scope(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/api/src/tests/switch_state_controller/mod.rs
+++ b/crates/api/src/tests/switch_state_controller/mod.rs
@@ -359,6 +359,67 @@ async fn test_switch_waiting_for_rack_firmware_upgrade_transitions_to_waiting_fo
 }
 
 #[crate::sqlx_test]
+async fn test_switch_waiting_for_rack_firmware_upgrade_returns_ready_for_firmware_only_request(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let switch_id = common::api_fixtures::site_explorer::new_switch(&env, None, None).await?;
+
+    let mut txn = pool.begin().await?;
+    db_switch::set_switch_reprovisioning_requested_with_firmware_continuation(
+        txn.as_mut(),
+        switch_id,
+        "rack-test",
+        false,
+    )
+    .await?;
+    let switch = db_switch::find_by_id(txn.as_mut(), &switch_id)
+        .await?
+        .expect("switch should exist");
+    let requested_at = switch
+        .switch_reprovisioning_requested
+        .as_ref()
+        .expect("switch reprovision request should exist")
+        .requested_at;
+    db_switch::try_update_controller_state(
+        txn.as_mut(),
+        switch_id,
+        switch.controller_state.version,
+        switch.controller_state.version.increment(),
+        &SwitchControllerState::ReProvisioning {
+            reprovisioning_state: model::switch::ReProvisioningState::WaitingForRackFirmwareUpgrade,
+        },
+    )
+    .await?;
+    db_switch::update_firmware_upgrade_status(
+        txn.as_mut(),
+        switch_id,
+        Some(&model::rack::RackFirmwareUpgradeStatus {
+            task_id: "rack-job".to_string(),
+            status: model::rack::RackFirmwareUpgradeState::Completed,
+            started_at: Some(requested_at),
+            ended_at: Some(chrono::Utc::now()),
+        }),
+    )
+    .await?;
+    txn.commit().await?;
+
+    env.run_switch_controller_iteration().await;
+
+    let mut txn = pool.acquire().await?;
+    let switch = db_switch::find_by_id(&mut txn, &switch_id)
+        .await?
+        .expect("switch should exist");
+    assert!(matches!(
+        switch.controller_state.value,
+        SwitchControllerState::Ready,
+    ));
+    assert!(switch.switch_reprovisioning_requested.is_none());
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
 async fn test_switch_waiting_for_rack_firmware_upgrade_accepts_completion_when_only_ended_at_is_current(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Description

Fixes on-demand/component-manager firmware-only upgrade flow so switches return to Ready after firmware completion.
Preserves full rack maintenance behavior where firmware upgrade continues into NVOS and NMXC phases.
Adds continue_after_firmware_upgrade to the switch reprovision request to distinguish firmware-only from full maintenance.
Adds targeted tests for firmware-only switch completion and on-demand NMX configure-only scheduling.

## Issue with current Flow
- Rack starts firmware upgrade.
- Switch enters WaitingForRackFirmwareUpgrade.
- Firmware finishes.
- Rack skips NVOS, correctly.
- Switch still moves to WaitingForNVOSUpgrade.
- No NVOS status is ever written because rack intentionally skipped NVOS.
- Switch stays stuck forever in:

## Fixed ondemand sequence flow

```mermaid
flowchart TD
    CM[Component Manager<br/>update-firmware rack] -->|activities = FirmwareUpgrade only| RackReq[RackMaintenanceOnDemandRequest]
    CLI_FW[On-demand firmware-only] -->|activities = FirmwareUpgrade only| RackReq
    CLI_NVOS[On-demand NVOS-only] -->|activities = NvosUpdate only| RackReq
    CLI_NMX[On-demand NMX configure-only] -->|activities = ConfigureNmxCluster only| RackReq
    FullRack[Full rack maintenance] -->|activities empty = all activities| RackReq

    RackReq --> RackConfig[Rack.config.maintenance_requested]
    RackConfig --> RackSM[Rack Maintenance State Machine]

    RackSM --> Scope{Requested activity}

    Scope -->|FirmwareUpgrade| FWStart[FirmwareUpgrade::Start]
    Scope -->|NvosUpdate only| NVOSStart[NVOSUpdate::Start]
    Scope -->|ConfigureNmxCluster only| NMXStart[ConfigureNmxCluster::Start]

    FWStart --> FlagDecision{Should continue after firmware?}
    FlagDecision -->|Full rack / scope includes NVOS| ContinueTrue[continue_after_firmware_upgrade = true]
    FlagDecision -->|Firmware-only on-demand| ContinueFalse[continue_after_firmware_upgrade = false]

    ContinueTrue --> SwitchReq1[Persist switch_reprovisioning_requested<br/>initiator = rack-id<br/>continue_after_firmware_upgrade = true]
    ContinueFalse --> SwitchReq2[Persist switch_reprovisioning_requested<br/>initiator = rack-id<br/>continue_after_firmware_upgrade = false]

    SwitchReq1 --> SwitchReady[Switch Ready State]
    SwitchReq2 --> SwitchReady

    SwitchReady -->|rack initiator detected| WaitFW[Switch ReProvisioning<br/>WaitingForRackFirmwareUpgrade]

    WaitFW -->|firmware still running| WaitFW
    WaitFW -->|firmware failed| SwitchError[Switch Error<br/>clear reprovision request]

    WaitFW -->|firmware completed + continue=true| WaitNVOS[WaitingForNVOSUpgrade]
    WaitFW -->|firmware completed + continue=false| SwitchDone[Clear reprovision request<br/>Switch Ready]

    WaitNVOS -->|NVOS completed| WaitNMX[WaitingForNMXCConfigure]
    WaitNVOS -->|NVOS failed| SwitchError

    WaitNMX -->|Fabric Manager running / terminal| SwitchDone

    NVOSStart --> RackNVOS[Rack owns NVOS update<br/>updates switch.nvos_update_status]
    NMXStart --> RackNMX[Rack owns NMX configure<br/>updates switch.fabric_manager_status]

    RackNVOS --> RackComplete[Rack maintenance continues/completes]
    RackNMX --> RackComplete
    SwitchDone --> RackComplete
```

## Type of Change
- [ ] **Fix** - SwitchStateMachine stuck in WaitingForNVOSUpgrade for firmware only upgrade

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing TBD


## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

