### PR TITLE
fix: reject zero-DPU instance allocation with extension services

### DIFF
--- a/crates/api-model/src/instance/status/extension_service.rs
+++ b/crates/api-model/src/instance/status/extension_service.rs
@@ -78,7 +78,10 @@ impl InstanceExtensionServicesStatus {
         let all_dpu_ids: Vec<MachineId> =
             dpu_id_to_device_map.values().flatten().copied().collect();
 
-        // @TODO(Felicity): Zero DPU for this instance? Maybe deny extension service config if no DPUs?
+        // Instance allocation rejects non-empty service_configs on zero-DPU
+        // hosts, so, in practice, we *shouldn't* reach here. BUT, if we do,
+        // assume it's from something like a stale pre-validation instance,
+        // and just report unsynced.
         if all_dpu_ids.is_empty() {
             return Self::unsynced_for_config(&config);
         }

--- a/crates/api/src/instance/mod.rs
+++ b/crates/api/src/instance/mod.rs
@@ -862,6 +862,16 @@ pub async fn batch_allocate_instances(
                     )));
                 }
             }
+
+            // Extension services run on DPU agents; a zero-DPU host has no
+            // place to schedule them. We need to check, otherwise the status
+            // would just report "Unknown" forever.
+            if !request.config.extension_services.service_configs.is_empty() {
+                return Err(CarbideError::InvalidArgument(format!(
+                    "zero-DPU host {} cannot serve extension services; remove `dpu_extension_services` from the instance config.",
+                    mh_snapshot.host_snapshot.id,
+                )));
+            }
         }
 
         processed_requests.push((request, mh_snapshot));

--- a/crates/api/src/tests/instance_allocate.rs
+++ b/crates/api/src/tests/instance_allocate.rs
@@ -1111,3 +1111,66 @@ async fn test_zero_dpu_instance_surfaces_underlay_ip_in_status(
 
     Ok(())
 }
+
+// Extension services run on the DPU agent; on a zero-DPU host there's no DPU
+// to schedule them on, so the allocation should be rejected up front (rather
+// than letting the instance get stuck reporting "Unknown" extension service
+// status forever).
+#[crate::sqlx_test]
+async fn test_reject_zero_dpu_instance_with_extension_services(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_for_instance_allocation(pool.clone(), None).await;
+    let config = ManagedHostConfig::with_dpus(vec![]);
+
+    let zero_dpu_host = api_fixtures::site_explorer::new_host(&env, config).await?;
+
+    let result = crate::handlers::instance::allocate(
+        env.api.as_ref(),
+        tonic::Request::new(forge::InstanceAllocationRequest {
+            machine_id: Some(zero_dpu_host.host_snapshot.id),
+            instance_type_id: None,
+            config: Some(forge::InstanceConfig {
+                tenant: Some(forge::TenantConfig {
+                    tenant_organization_id: "2829bbe3-c169-4cd9-8b2a-19a8b1618a93".to_string(),
+                    hostname: None,
+                    tenant_keyset_ids: vec![],
+                }),
+                network_security_group_id: None,
+                os: Some(forge::InstanceOperatingSystemConfig {
+                    phone_home_enabled: false,
+                    run_provisioning_instructions_on_every_boot: false,
+                    user_data: None,
+                    variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
+                        forge::InlineIpxe {
+                            ipxe_script: "exit".to_string(),
+                            user_data: None,
+                        },
+                    )),
+                }),
+                network: None,
+                infiniband: None,
+                dpu_extension_services: Some(forge::InstanceDpuExtensionServicesConfig {
+                    service_configs: vec![forge::InstanceDpuExtensionServiceConfig {
+                        service_id: "test-service".to_string(),
+                        version: "1.0.0".to_string(),
+                    }],
+                }),
+                nvlink: None,
+            }),
+            instance_id: None,
+            metadata: None,
+            allow_unhealthy_machine: false,
+        }),
+    )
+    .await;
+
+    match result {
+        Err(e) if e.code() == tonic::Code::InvalidArgument => {}
+        _ => panic!(
+            "Expected zero-DPU host to reject instance allocation with dpu_extension_services (no DPU to schedule them on), got: {result:?}"
+        ),
+    };
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

Closes https://github.com/NVIDIA/ncx-infra-controller-core/issues/1243.

Extension services run on the DPU agent, so a zero-DPU host has nowhere to schedule them. Today the allocation silently succeeds, and the status path falls through `all_dpu_ids.is_empty()` to `unsynced_for_config`, leaving `InstanceDpuExtensionServicesStatus` stuck in `Unknown` forever.

Mirroring the pattern from #1027 (zero-DPU + non-inband network segment); this rejects up-front in the `allocate` path with `InvalidArgument` when `.is_zero_dpu()` and the service configs aren't empty. Drops the corresponding `@TODO(Felicity)`.

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

