### PR TITLE
fix: clearer error when set_primary_dpu targets a zero-DPU host

### DIFF
--- a/crates/api/src/handlers/managed_host.rs
+++ b/crates/api/src/handlers/managed_host.rs
@@ -19,6 +19,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 
 use ::rpc::forge as rpc;
+use model::machine::LoadSnapshotOptions;
 use model::machine::machine_search_config::MachineSearchConfig;
 use tonic::{Request, Response, Status};
 
@@ -57,6 +58,24 @@ pub(crate) async fn set_primary_dpu(
     log_machine_id(&host_machine_id);
 
     let mut txn = api.txn_begin().await?;
+
+    // Reject early on a zero-DPU host to provide a better error,
+    // otherwise we'd end up just looping over snapshots below,
+    // and eventually error that it couldn't deetermine the primary
+    // interface ID, which is kind of confusing.
+    let snapshot =
+        db::managed_host::load_snapshot(&mut txn, &host_machine_id, LoadSnapshotOptions::default())
+            .await?
+            .ok_or_else(|| CarbideError::NotFoundError {
+                kind: "Machine",
+                id: host_machine_id.to_string(),
+            })?;
+    if snapshot.is_zero_dpu() {
+        return Err(CarbideError::FailedPrecondition(format!(
+            "Host {host_machine_id} has no DPUs; set-primary-dpu does not apply to zero-DPU hosts."
+        ))
+        .into());
+    }
 
     let interface_map =
         db::machine_interface::find_by_machine_ids(&mut txn, &[host_machine_id]).await?;

--- a/crates/api/src/tests/mod.rs
+++ b/crates/api/src/tests/mod.rs
@@ -104,6 +104,7 @@ mod redfish_actions;
 mod resource_pool;
 mod route_servers;
 mod service_health_metrics;
+mod set_primary_dpu;
 mod site_explorer;
 mod sku;
 mod spdm;

--- a/crates/api/src/tests/set_primary_dpu.rs
+++ b/crates/api/src/tests/set_primary_dpu.rs
@@ -1,0 +1,114 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::machine::{MachineId, MachineIdSource, MachineType};
+use ipnetwork::IpNetwork;
+use rpc::forge;
+use rpc::forge::forge_server::Forge;
+
+use crate::tests::common::api_fixtures;
+use crate::tests::common::api_fixtures::managed_host::ManagedHostConfig;
+use crate::tests::common::api_fixtures::network_segment::{
+    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY, FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY,
+    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY, create_admin_network_segment,
+    create_host_inband_network_segment, create_underlay_network_segment,
+};
+use crate::tests::common::rpc_builder::VpcCreationRequest;
+
+// On a zero-DPU host the handler's interface scan never finds a row with a
+// matching `attached_dpu_machine_id`, which previously bubbled up as a
+// generic "Could not determine old primary interface id..." internal
+// error. Reject up-front with `FailedPrecondition` and a message that
+// names the underlying reason.
+#[crate::sqlx_test]
+async fn test_set_primary_dpu_rejects_zero_dpu_host(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Zero-DPU host ingestion needs a HostInband network segment whose CIDR
+    // covers the relay address; the default test env doesn't define one.
+    let env = api_fixtures::create_test_env_with_overrides(
+        pool,
+        api_fixtures::TestEnvOverrides {
+            allow_zero_dpu_hosts: Some(true),
+            site_prefixes: Some(vec![
+                IpNetwork::new(
+                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+                IpNetwork::new(
+                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+                IpNetwork::new(
+                    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+            ]),
+            create_network_segments: Some(false),
+            ..Default::default()
+        },
+    )
+    .await;
+    let vpc = env
+        .api
+        .create_vpc(
+            VpcCreationRequest::builder("test vpc", "2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                .tonic_request(),
+        )
+        .await?
+        .into_inner();
+    create_underlay_network_segment(&env.api).await;
+    create_admin_network_segment(&env.api).await;
+    create_host_inband_network_segment(&env.api, vpc.id).await;
+    env.run_network_segment_controller_iteration().await;
+    env.run_network_segment_controller_iteration().await;
+
+    let zero_dpu_host =
+        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::with_dpus(vec![])).await?;
+
+    let result = env
+        .api
+        .set_primary_dpu(tonic::Request::new(forge::SetPrimaryDpuRequest {
+            host_machine_id: Some(zero_dpu_host.host_snapshot.id),
+            // Any well-formed DPU id; the handler bails before reading it.
+            dpu_machine_id: Some(MachineId::new(
+                MachineIdSource::ProductBoardChassisSerial,
+                [0u8; 32],
+                MachineType::Dpu,
+            )),
+            reboot: false,
+        }))
+        .await;
+
+    match result {
+        Err(e) if e.code() == tonic::Code::FailedPrecondition => {
+            assert!(
+                e.message().contains("zero-DPU"),
+                "error message should explicitly name zero-DPU as the reason; got: {}",
+                e.message(),
+            );
+        }
+        _ => panic!(
+            "Expected zero-DPU host to reject set_primary_dpu with FailedPrecondition, got: {result:?}"
+        ),
+    };
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

Closes https://github.com/NVIDIA/ncx-infra-controller-core/issues/1244.

The `SetManagedHostPrimaryDpu` API handler scans the host's `machine_interfaces` for one with `attached_dpu_machine_id` matching the requested DPU ID. On a zero-DPU host, no interface ever matches, so the loop falls through and the handler bails with a generic error. Instead, check `is_zero_dpu()`, and return a `FailedPrecondition` with a message that provides a more accurate reason.

Test added! And tbh I don't know if this really needs a test, but for the purpose of zero DPU in general it's probably good to have coverage.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

