### PR TITLE
chore: test to verify zero-DPU underlay IP visibility on Instance::status

### DIFF
--- a/crates/api/src/tests/instance_allocate.rs
+++ b/crates/api/src/tests/instance_allocate.rs
@@ -975,3 +975,139 @@ async fn test_reject_zero_dpu_instance_with_tenant_network_segment(
 
     Ok(())
 }
+
+// A zero-DPU instance must surface its underlay IP, MAC, and gateway/prefix
+// to the tenant via the standard `Instance::status::network::interfaces`
+// path.
+//
+// This works because, behind the scenes, instance allocation auto-populates
+// `config.network.interfaces` with the host's HostInband segment when the
+// tenant submits no network config (`add_inband_interfaces_to_config`) and
+// allocates IPs into `ip_addrs` (`with_allocated_ips`). When the Instance
+// is read, `InstanceNetworkStatus::from_config_and_observations` sees no
+// DPU observations + `config.is_host_inband()` and falls into
+// `synchronized_from_host_interfaces`, which synthesizes per-interface
+// status from the config. So the same `status.network.interfaces[i]`
+// tenant machines with DPUs read from also carries the underlay IP for
+// zero-DPU tenants.
+#[crate::sqlx_test]
+async fn test_zero_dpu_instance_surfaces_underlay_ip_in_status(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_for_instance_allocation(pool.clone(), None).await;
+    let config = ManagedHostConfig::with_dpus(vec![]);
+    let zero_dpu_host = api_fixtures::site_explorer::new_host(&env, config).await?;
+
+    let host_inband_segment =
+        db::network_segment::find_by_name(env.pool.begin().await?.deref_mut(), "HOST_INBAND")
+            .await?;
+
+    crate::handlers::instance::allocate(
+        env.api.as_ref(),
+        tonic::Request::new(forge::InstanceAllocationRequest {
+            machine_id: Some(zero_dpu_host.host_snapshot.id),
+            instance_type_id: None,
+            config: Some(forge::InstanceConfig {
+                tenant: Some(forge::TenantConfig {
+                    tenant_organization_id: "2829bbe3-c169-4cd9-8b2a-19a8b1618a93".to_string(),
+                    hostname: None,
+                    tenant_keyset_ids: vec![],
+                }),
+                network_security_group_id: None,
+                os: Some(forge::InstanceOperatingSystemConfig {
+                    phone_home_enabled: false,
+                    run_provisioning_instructions_on_every_boot: false,
+                    user_data: None,
+                    variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
+                        forge::InlineIpxe {
+                            ipxe_script: "exit".to_string(),
+                            user_data: None,
+                        },
+                    )),
+                }),
+                // Tenant submits no network config -- server auto-fills with
+                // the HostInband interface for the zero-DPU host.
+                network: None,
+                infiniband: None,
+                dpu_extension_services: None,
+                nvlink: None,
+            }),
+            instance_id: None,
+            metadata: None,
+            allow_unhealthy_machine: false,
+        }),
+    )
+    .await
+    .expect("instance allocation should have succeeded")
+    .into_inner();
+
+    let response = env
+        .api
+        .find_instance_by_machine_id(tonic::Request::new(zero_dpu_host.host_snapshot.id))
+        .await?
+        .into_inner();
+    let instance = response
+        .instances
+        .first()
+        .expect("zero-DPU host should have one allocated instance");
+
+    let status = instance
+        .status
+        .as_ref()
+        .expect("instance.status should be set");
+    let net_status = status
+        .network
+        .as_ref()
+        .expect("status.network should be set");
+
+    assert_eq!(
+        net_status.configs_synced,
+        forge::SyncState::Synced as i32,
+        "host-inband interfaces don't need DPU-agent observations, so the status should be synthesized from config and report Synced immediately"
+    );
+
+    assert_eq!(
+        net_status.interfaces.len(),
+        1,
+        "expected one synthesized interface mirroring the auto-filled HostInband config entry",
+    );
+    let iface = &net_status.interfaces[0];
+    assert!(
+        !iface.addresses.is_empty(),
+        "underlay IP must be visible to the tenant via status.network.interfaces[0].addresses; got: {iface:?}",
+    );
+    assert!(
+        iface.mac_address.is_some(),
+        "underlay MAC must be visible to the tenant via status.network.interfaces[0].mac_address; got: {iface:?}",
+    );
+    assert_eq!(
+        iface.gateways.len(),
+        iface.addresses.len(),
+        "one gateway should be reported per address; got: {iface:?}",
+    );
+    assert_eq!(
+        iface.prefixes.len(),
+        iface.addresses.len(),
+        "one prefix should be reported per address; got: {iface:?}",
+    );
+
+    // The synthesized status should mirror the (auto-filled) config side.
+    let cfg_interfaces = instance
+        .config
+        .as_ref()
+        .and_then(|c| c.network.as_ref())
+        .map(|n| n.interfaces.as_slice())
+        .unwrap_or(&[]);
+    assert_eq!(
+        cfg_interfaces.len(),
+        net_status.interfaces.len(),
+        "config.network.interfaces and status.network.interfaces must have the same length",
+    );
+    assert_eq!(
+        cfg_interfaces[0].network_segment_id,
+        Some(host_inband_segment.id),
+        "auto-filled config interface should be on the HostInband segment",
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

Closes https://github.com/NVIDIA/ncx-infra-controller-core/issues/951.

The issue premise was that, for zero-DPU instances, `Instance::config::network::interfaces` would be empty, leaving the tenant with no way to learn the underlay IP -- the proposal was either letting tenants send empty interface entries (not natural), OR adding a separate field on `Instance::status` (e.g. `underlay_interfaces`).

BUT! ..as it turns out, no work here is needed! **The visibility already exists** via the standard `Instance::status::network::interfaces` field (thanks to pre-existing logic, with no zero-DPU-specific branching needed). Behind the scenes:

1. Instance allocation populates `config.network.interfaces` with the host's `HostInband` segment when the tenant submits no network config (via `add_inband_interfaces_to_config`).
2. IPs (..and MAC, ..and gateway, ..and prefix) are allocated into the auto-filled interface `ip_addrs` (via `with_allocated_ips`).

And when `Instance::status` is rendered, `InstanceNetworkStatus::from_config_and_observations` sees:
- No DPU observations.
- `config.is_host_inband()` is true.

..which THEN falls into `synchronized_from_host_interfaces`, which synthesizes per-interface status directly from the config.

The result is that the tenant reads the underlay IP from the same `status.network.interfaces[i].addresses` field that tenant machines with DPUs use, with one entry, the `HostInband` one.

What was really missing here was some test coverage to actually test the synchronization/synthesization, so this adds a test to allocate a new zero-DPU instance (with no tenant-supplied network config), and asserts that `status.network.interfaces[0]` carries an address, MAC, gateway, prefix, and reports `Synced`.

...so, test added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

