### PR TITLE
feat(dpf): route fmds metadata via tenant VLAN SVI in Container mode

### DIFF
--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -339,8 +339,18 @@ pub async fn update_nvue(
     };
 
     let hostname = hostname().wrap_err("gethostname error")?;
+    let is_dpu_os = matches!(update_flavor, NvueUpdateFlavor::StartupFile { .. });
     let conf = nvue::NvueConfig {
         is_fnn: false,
+        is_dpu_os,
+        fmds_gateway_vlan: if !is_dpu_os {
+            nc.tenant_interfaces
+                .iter()
+                .find(|i| i.function_type == rpc::InterfaceFunctionType::Physical as i32)
+                .map(|i| i.vlan_id as u16)
+        } else {
+            None
+        },
         vpc_virtualization_type,
         site_global_vpc_vni: nc.site_global_vpc_vni,
         use_admin_network: nc.use_admin_network,
@@ -2849,6 +2859,8 @@ mod tests {
             ct_vrf_loopback: "FNN".to_string(),
             l3_domains: vec![],
             network_security_groups,
+            is_dpu_os: true,
+            fmds_gateway_vlan: None,
         };
         let startup_yaml = nvue::build(conf)?;
 

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -411,6 +411,8 @@ pub async fn start(cmdline: command_line::Options) -> eyre::Result<()> {
                         .transpose()?,
                     network_security_groups,
                     bgp_leaf_session_password: opts.bgp_leaf_session_password,
+                    is_dpu_os: true,
+                    fmds_gateway_vlan: None,
                 };
                 let contents = nvue::build(conf)?;
                 std::fs::write(&opts.path, contents)?;

--- a/crates/agent/src/nvue.rs
+++ b/crates/agent/src/nvue.rs
@@ -103,6 +103,8 @@ fn split_prefixes_by_family(prefixes: &[String], start_index: usize) -> (Vec<Pre
 
 pub fn build(conf: NvueConfig) -> eyre::Result<String> {
     let template = template_for(conf.vpc_virtualization_type)?;
+    let is_dpu_os = conf.is_dpu_os;
+    let fmds_gateway_vlan = conf.fmds_gateway_vlan;
     let host_interfaces: Vec<TmplHostInterfaces> = conf
         .ct_access_vlans
         .into_iter()
@@ -233,6 +235,7 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
     }
 
     let mut has_any_vpc_tenant_host_leak_to_underlay = false;
+    let mut fmds_gateway_matched = false;
 
     for (base_i, network) in conf.ct_port_configs.into_iter().enumerate() {
         let svi_mac = vni_to_svi_mac(network.vni.unwrap_or(0))?.to_string();
@@ -291,7 +294,11 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
                     })
                 })
                 .transpose()?,
+            HasFmdsGateway: !is_dpu_os && (fmds_gateway_vlan == Some(network.vlan)),
         };
+        if port.HasFmdsGateway {
+            fmds_gateway_matched = true;
+        }
 
         has_any_vpc_tenant_host_leak_to_underlay = has_any_vpc_tenant_host_leak_to_underlay
             || routing_profile
@@ -334,6 +341,15 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
             });
 
         port_configs.push(port);
+    }
+
+    if let Some(vlan) = fmds_gateway_vlan
+        && !fmds_gateway_matched
+    {
+        tracing::error!(
+            vlan,
+            "fmds_gateway_vlan not found in any port config; FMDS gateway address will not be configured"
+        );
     }
 
     let include_bridge = !port_configs.is_empty() && port_configs.iter().all(|b| b.IsL2Segment);
@@ -519,6 +535,7 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
         StorageLoopback: "127.8.8.8".to_string(), // XXX (Classic, L3)
         DPUstorageprefix: "127.7.7.7/32".to_string(),
         IncludeBridge: include_bridge,
+        IsDpuOs: is_dpu_os,
     };
 
     gtmpl::template(template, params).map_err(|e| {
@@ -900,6 +917,10 @@ pub struct RouteTargetConfig {
 // What we need to configure NVUE
 pub struct NvueConfig {
     pub is_fnn: bool,
+    pub is_dpu_os: bool,
+    /// In containerized mode, the vlan ID of the pf0hpf-facing SVI that should
+    /// carry 169.254.169.253/30 as the FMDS gateway address.
+    pub fmds_gateway_vlan: Option<u16>,
     pub vpc_virtualization_type: VpcVirtualizationType,
     pub use_admin_network: bool,
     pub tenancy_enabled: bool,
@@ -1196,6 +1217,7 @@ struct TmplNvue {
     StorageLoopback: String,  // XXX (Classic, L3)
     DPUstorageprefix: String, // XXX (Classic, L3)
     IncludeBridge: bool,
+    IsDpuOs: bool,
 
     HasBgpLeafSessionPassword: bool,
     /// A password to use for the BGP session with the
@@ -1422,6 +1444,7 @@ struct TmplConfigPort {
 
     HasNetworkSecurityGroup: bool,
     NetworkSecurityGroupIndex: Option<u16>,
+    HasFmdsGateway: bool,
 }
 
 #[allow(non_snake_case)]
@@ -1527,6 +1550,8 @@ mod tests {
         NvueConfig {
             bgp_leaf_session_password: None,
             is_fnn: false,
+            is_dpu_os: true,
+            fmds_gateway_vlan: None,
             vpc_virtualization_type: VpcVirtualizationType::EthernetVirtualizer,
             use_admin_network: false,
             tenancy_enabled: true,
@@ -1956,6 +1981,130 @@ mod tests {
         assert!(
             !has_null_leaf(&parsed),
             "rendered YAML contains a null leaf:\n\n{output}"
+        );
+    }
+
+    fn phy_port_config(vlan: u16) -> PortConfig {
+        PortConfig {
+            interface_name: "pf0hpf_if".into(),
+            vlan,
+            vni: Some(1000),
+            l3_vni: Some(100),
+            gateway_cidr: "10.0.1.1/24".into(),
+            vpc_prefixes: vec![],
+            vpc_peer_prefixes: vec![],
+            vpc_peer_vnis: vec![],
+            svi_ip: Some("10.0.1.2".into()),
+            tenant_vrf_loopback_ip: None,
+            is_l2_segment: true,
+            is_phy: true,
+            network_security_group_id: None,
+            ipv6_port_config: None,
+        }
+    }
+
+    // In container mode with fmds_gateway_vlan matching the phy port vlan, the
+    // FMDS gateway address should appear in the rendered output.
+    #[test]
+    fn test_fmds_gateway_etv_container_mode_emits_address() {
+        let mut conf = minimal_nvue_config();
+        conf.is_dpu_os = false;
+        conf.fmds_gateway_vlan = Some(274);
+        conf.ct_port_configs = vec![phy_port_config(274)];
+        let output = build(conf).expect("build should succeed");
+        assert!(
+            output.contains("169.254.169.253/30"),
+            "expected FMDS gateway address in output:\n{output}"
+        );
+    }
+
+    // In DPU-OS mode the FMDS gateway address must NOT appear on the vlan SVI
+    // (it lives on pf0dpu1_if instead, managed by the startup template).
+    #[test]
+    fn test_fmds_gateway_etv_dpu_os_mode_suppressed() {
+        let mut conf = minimal_nvue_config();
+        conf.is_dpu_os = true;
+        // Even if fmds_gateway_vlan is accidentally set, DPU-OS mode must ignore it.
+        conf.fmds_gateway_vlan = Some(274);
+        conf.ct_port_configs = vec![phy_port_config(274)];
+        let output = build(conf).expect("build should succeed");
+        // The ETV template uses pf0dpu1_if for the gateway in DPU-OS mode, not the vlan SVI.
+        assert!(
+            !output.contains("169.254.169.253/30") || output.contains("pf0dpu1_if"),
+            "DPU-OS mode should not put 169.254.169.253/30 on the vlan SVI"
+        );
+    }
+
+    // fmds_gateway_vlan pointing at a vlan that does not exist in ct_port_configs
+    // should log an error but still return a valid (if incomplete) config.
+    #[test]
+    fn test_fmds_gateway_vlan_not_in_port_configs_still_builds() {
+        let mut conf = minimal_nvue_config();
+        conf.is_dpu_os = false;
+        conf.fmds_gateway_vlan = Some(999); // no port has vlan 999
+        conf.ct_port_configs = vec![phy_port_config(274)];
+        // Should succeed (just logs an error, does not fail the build).
+        let output = build(conf).expect("build should succeed even when vlan is missing");
+        assert!(
+            !output.contains("169.254.169.253/30"),
+            "mismatched vlan should not produce FMDS address in output"
+        );
+    }
+
+    // fmds_gateway_vlan=None should never emit the FMDS gateway address.
+    #[test]
+    fn test_fmds_gateway_none_emits_no_address() {
+        let mut conf = minimal_nvue_config();
+        conf.is_dpu_os = false;
+        conf.fmds_gateway_vlan = None;
+        conf.ct_port_configs = vec![phy_port_config(274)];
+        let output = build(conf).expect("build should succeed");
+        assert!(
+            !output.contains("169.254.169.253/30"),
+            "no fmds_gateway_vlan should not produce FMDS address in output"
+        );
+    }
+
+    fn minimal_fnn_routing_profile() -> RoutingProfile {
+        RoutingProfile {
+            tenant_leak_communities_accepted: false,
+            leak_default_route_from_underlay: false,
+            leak_tenant_host_routes_to_underlay: false,
+            route_target_imports: vec![],
+            route_targets_on_exports: vec![],
+        }
+    }
+
+    // Same checks for FNN template.
+    #[test]
+    fn test_fmds_gateway_fnn_container_mode_emits_address() {
+        let mut conf = minimal_nvue_config();
+        conf.is_fnn = true;
+        conf.vpc_virtualization_type = VpcVirtualizationType::Fnn;
+        conf.is_dpu_os = false;
+        conf.fmds_gateway_vlan = Some(274);
+        conf.ct_routing_profile = Some(minimal_fnn_routing_profile());
+        conf.ct_port_configs = vec![phy_port_config(274)];
+        let output = build(conf).expect("build should succeed");
+        assert!(
+            output.contains("169.254.169.253/30"),
+            "expected FMDS gateway address in FNN output:\n{output}"
+        );
+    }
+
+    #[test]
+    fn test_fmds_gateway_fnn_dpu_os_mode_suppressed() {
+        let mut conf = minimal_nvue_config();
+        conf.is_fnn = true;
+        conf.vpc_virtualization_type = VpcVirtualizationType::Fnn;
+        conf.is_dpu_os = true;
+        conf.fmds_gateway_vlan = Some(274);
+        conf.ct_routing_profile = Some(minimal_fnn_routing_profile());
+        conf.ct_port_configs = vec![phy_port_config(274)];
+        let output = build(conf).expect("build should succeed");
+        assert!(
+            !output.contains("169.254.169.253/30") || output.contains("pf0dpu1_if"),
+            "DPU-OS mode should not put 169.254.169.253/30 on the vlan SVI in FNN"
         );
     }
 }

--- a/crates/agent/templates/nvue_startup_etv.conf
+++ b/crates/agent/templates/nvue_startup_etv.conf
@@ -29,7 +29,7 @@
             {{ .LoopbackIP }}/32: {}
         type: loopback
 {{- if .HbnVersion }}
-  {{- if (ge .HbnVersion "1.5.0-doca2.2.0" )}}
+  {{- if and .IsDpuOs (ge .HbnVersion "1.5.0-doca2.2.0" )}}
     {{- if (ge .HbnVersion "2.3.0-doca2.8.0" )}}
       pf0dpu1_if:
     {{- else }}
@@ -116,11 +116,14 @@
       vlan{{ .VlanID }}:
         type: svi
         vlan: {{ .VlanID }}
-  {{- if gt (len .IPs) 0 }}
+  {{- if or (gt (len .IPs) 0) .HasFmdsGateway }}
         ip:
           address:
           {{- range .IPs }}
             {{ . }}: {}
+          {{- end }}
+          {{- if .HasFmdsGateway }}
+            169.254.169.253/30: {}
           {{- end }}
   {{- end }}
 {{- end }}

--- a/crates/agent/templates/nvue_startup_fnn.conf
+++ b/crates/agent/templates/nvue_startup_fnn.conf
@@ -27,6 +27,7 @@
           address:
             {{ .LoopbackIP }}/32: {}
         type: loopback
+{{- if $nvueConfig.IsDpuOs }}
 {{- range $portConfig := $tenant.PortConfigs }}
   {{- if $portConfig.IsPhy }}
       pf0dpu1_if:
@@ -34,8 +35,9 @@
           address:
             169.254.169.253/30: {}
           vrf: {{ $portConfig.VrfName }}
-  {{- end }}          
-{{- end }}          
+  {{- end }}
+{{- end }}
+{{- end }}
 {{- if .IsStorageClient }} {{/* New variable to be created to define if a node is a storage client and the interface should be created */}}
       pf0dpu3_if:
         ip:
@@ -136,6 +138,9 @@
           address:
           {{- range $portConfig.SviIPs }}
             {{ . }}: {} {{/* The SviIP is a _different_ ip from the same subnet than the gateway. Typically the second IP in the subnet */}}
+          {{- end }}
+          {{- if $portConfig.HasFmdsGateway }}
+            169.254.169.253/30: {}
           {{- end }}
           vrf: {{ $portConfig.VrfName }} {{/* The name of the VRF (VPC) this interface should be in */}}
           vrr:

--- a/crates/fmds/src/main.rs
+++ b/crates/fmds/src/main.rs
@@ -43,6 +43,7 @@ async fn main() -> eyre::Result<()> {
 
     let interface_cidr: ipnetwork::IpNetwork = options.interface_cidr.parse()?;
     nic_init::assign_address(&options.interface_name, interface_cidr).await?;
+    nic_init::setup_metadata_routing(&options.interface_name, interface_cidr).await?;
 
     // Build ForgeClientConfig for phone_home if cert paths are provided
     let forge_client_config = match (&options.root_ca, &options.client_cert, &options.client_key) {

--- a/crates/fmds/src/nic_init.rs
+++ b/crates/fmds/src/nic_init.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use std::net::Ipv4Addr;
 use std::time::Duration;
 
 use eyre::eyre;
@@ -22,6 +23,7 @@ use futures_util::TryStreamExt;
 use ipnetwork::IpNetwork;
 use netlink_packet_route::address::AddressAttribute;
 use rtnetlink::Handle;
+use tokio::process::Command as TokioCommand;
 
 const LINK_LOOKUP_RETRIES: u32 = 15;
 const LINK_LOOKUP_BACKOFF: Duration = Duration::from_secs(2);
@@ -48,6 +50,53 @@ pub async fn assign_address(name: &str, cidr: IpNetwork) -> eyre::Result<()> {
     }
 
     handle.link().set(index).up().execute().await?;
+    Ok(())
+}
+
+/// Set up policy routing so replies from 169.254.169.254 egress via the metadata interface.
+/// Computes the gateway as the first host in the /30 (e.g. 169.254.169.253 for 169.254.169.254/30).
+pub async fn setup_metadata_routing(interface_name: &str, cidr: IpNetwork) -> eyre::Result<()> {
+    let IpNetwork::V4(net) = cidr else {
+        return Ok(());
+    };
+
+    let src_ip = net.ip();
+    let gateway = Ipv4Addr::from(u32::from(net.network()) + 1);
+
+    let rule = TokioCommand::new("ip")
+        .args(["rule", "add", "from", &src_ip.to_string(), "lookup", "100"])
+        .output()
+        .await?;
+    if !rule.status.success() {
+        let stderr = String::from_utf8_lossy(&rule.stderr);
+        if !stderr.contains("File exists") {
+            eyre::bail!("ip rule add failed: {stderr}");
+        }
+    }
+    tracing::info!(src = %src_ip, "policy rule: from {src_ip} lookup 100");
+
+    let route = TokioCommand::new("ip")
+        .args([
+            "route",
+            "add",
+            "default",
+            "via",
+            &gateway.to_string(),
+            "dev",
+            interface_name,
+            "table",
+            "100",
+        ])
+        .output()
+        .await?;
+    if !route.status.success() {
+        let stderr = String::from_utf8_lossy(&route.stderr);
+        if !stderr.contains("File exists") {
+            eyre::bail!("ip route add failed: {stderr}");
+        }
+    }
+    tracing::info!(gateway = %gateway, interface = interface_name, "policy route: default via {gateway} dev {interface_name} table 100");
+
     Ok(())
 }
 

--- a/crates/nvue-client/src/client.rs
+++ b/crates/nvue-client/src/client.rs
@@ -134,13 +134,10 @@ impl NvueClient {
         // If the config is a top-level array but has no "set" entry that is a
         // schema error — surface it now rather than letting the API reject it
         // with a cryptic response.
-        let mut config = match config.extract_set_payload()? {
+        let config = match config.extract_set_payload()? {
             Some(inner) => inner,
             None => config,
         };
-        // pf0dpu* interfaces lack a `type` field and are rejected by the REST API;
-        // skip them for now.
-        config.remove_pf0dpu_interfaces();
         let builder = builder.json(&config);
         let request = builder.build()?;
         let _response = self.execute(request).await?;

--- a/crates/nvue-client/src/config.rs
+++ b/crates/nvue-client/src/config.rs
@@ -50,17 +50,6 @@ impl NvueConfig {
             Ok(None)
         }
     }
-
-    /// Remove any interfaces whose names start with `pf0dpu` from the config.
-    /// These interfaces lack a `type` field, which the NVUE REST API rejects;
-    /// they are left to be configured by other means.
-    pub fn remove_pf0dpu_interfaces(&mut self) {
-        if let serde_json::Value::Object(root) = &mut self.config_json
-            && let Some(serde_json::Value::Object(ifaces)) = root.get_mut("interface")
-        {
-            ifaces.retain(|key, _| !key.starts_with("pf0dpu"));
-        }
-    }
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]


### PR DESCRIPTION
## Description
wires up cloud-metadata reachability at 169.254.169.254, with FMDS handling the host side and NVUE the fabric side.

Routing on the host (FMDS): FMDS owns 169.254.169.254/30 — a 4-address link-local subnet whose only other usable host (…253) is the switch SVI one L2 hop away. When a workload queries the metadata IP, FMDS replies with source 169.254.169.254; without intervention, the kernel would route that reply via the main table's default gateway and it would exit the wrong interface. So FMDS installs source-based policy routing:
- ip rule from 169.254.169.254 lookup 100 — packets sourced from the metadata IP consult table 100 instead of main.
- ip route add default via 169.254.169.253 dev <iface> table 100 — table 100's default points back at the switch SVI on the metadata interface.

This pins return traffic to the metadata interface so replies hairpin through the fabric back to the requester.

Routing on the fabric (NVUE): the peer /30 address 169.254.169.253 must live on whichever tenant VLAN the host's metadata interface sits on. DPU-OS mode kept it on pf0dpu1_if; containerized mode now puts it on the tenant VLAN's SVI (selected via fmds_gateway_vlan), so the switch ARPs for the gateway and forwards metadata traffic at L2/L3 into the VPC.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

