### PR TITLE
fix(helm): grant carbide-api 'get services' RBAC for DPF BFB URL lookup

### DIFF
--- a/helm/charts/carbide-api/templates/rbac.yaml
+++ b/helm/charts/carbide-api/templates/rbac.yaml
@@ -9,6 +9,13 @@ rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificaterequests"]
     verbs: ["create"]
+  # This is needed when DPF v1 is enabled and a static `dpf.bfb_url`
+  # isn't configured (meaning dpf::resolve_bfb_url tries to read the
+  # `carbide-pxe-external` Service IP to build a URL). Without this
+  # rule, carbide-api will fail with a 403 from the k8s apiserver.
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Description

This is needed when DPF v1 is enabled and a static `dpf.bfb_url` isn't configured (meaning dpf::resolve_bfb_url tries to read the `carbide-pxe-external` Service IP to build a URL). Without this rule, carbide-api will fail with a 403 from the k8s apiserver.

Fwiw, it might not even be needed, since this is v1 only (and we're going to be going to v2 now anyway), BUT,  wanted to put a PR up just incase. Happy to close it out if it's useless now!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

