### PR TITLE
chore: Add preingestion.bfb into Dockerfile for localdev

### DIFF
--- a/dev/deployment/localdev/Dockerfile.api.localdev
+++ b/dev/deployment/localdev/Dockerfile.api.localdev
@@ -24,4 +24,5 @@ COPY .skaffold/target/carbide-admin-cli/debug/carbide-admin-cli /opt/carbide/
 RUN ln -s /opt/carbide/carbide-admin-cli /opt/carbide/forge-admin-cli
 COPY crates/api/casbin-policy.csv /opt/carbide/
 COPY pxe/static/blobs/internal/aarch64/secure-boot-pk.pem /forge-boot-artifacts/blobs/internal/aarch64/secure-boot-pk.pem
+COPY pxe/static/blobs/internal/aarch64/preingestion.bfb /forge-boot-artifacts/blobs/internal/aarch64/preingestion.bfb
 ENV CASBIN_POLICY_FILE=/opt/carbide/casbin-policy.csv


### PR DESCRIPTION
## Description
The local-dev kustomization does not include the boot-artifacts-containers component. The only component pulled in is carbide-maintenance-jobs. There's no sidecar populating /forge-boot-artifacts/, and no hostPath volume mounted into carbide-api either (forged/components/boot-artifacts-directory/ exists but isn't referenced by the local-dev overlay).
So in localdev, the carbide-api container's filesystem is the only place the binary can find the BFB. That means we have to bake it into the image at build time.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes: no.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)
