### PR TITLE
fix: implement automatic power-on for machines in site-explorer remediation

### DIFF
--- a/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
@@ -19,8 +19,8 @@ use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, Mutex};
 
 use carbide_site_explorer::{EndpointExplorer, SiteExplorationMetrics};
-use libredfish::RoleId;
 use libredfish::model::oem::nvidia_dpu::NicMode;
+use libredfish::{PowerState, RoleId, SystemPowerControl};
 use mac_address::MacAddress;
 use model::expected_entity::ExpectedEntity;
 use model::machine::MachineInterfaceSnapshot;
@@ -33,6 +33,8 @@ use model::site_explorer::{
 pub struct MockEndpointExplorer {
     pub reports:
         Arc<Mutex<HashMap<IpAddr, Result<EndpointExplorationReport, EndpointExplorationError>>>>,
+    pub power_states: Arc<Mutex<HashMap<IpAddr, PowerState>>>,
+    pub redfish_power_control_calls: Arc<Mutex<Vec<(SocketAddr, SystemPowerControl)>>>,
     /// Records every call to `set_nic_mode` (BMC address + requested target
     /// mode) so tests can assert the auto-correct path fired with the
     /// right arguments. Cleared on each `insert_endpoints` reset.
@@ -111,18 +113,28 @@ impl EndpointExplorer for MockEndpointExplorer {
 
     async fn redfish_get_power_state(
         &self,
-        _address: SocketAddr,
+        address: SocketAddr,
         _interface: &MachineInterfaceSnapshot,
     ) -> Result<libredfish::PowerState, EndpointExplorationError> {
-        Ok(libredfish::PowerState::On)
+        Ok(self
+            .power_states
+            .lock()
+            .unwrap()
+            .get(&address.ip())
+            .cloned()
+            .unwrap_or(PowerState::On))
     }
 
     async fn redfish_power_control(
         &self,
-        _address: SocketAddr,
+        address: SocketAddr,
         _interface: &MachineInterfaceSnapshot,
-        _action: libredfish::SystemPowerControl,
+        action: libredfish::SystemPowerControl,
     ) -> Result<(), EndpointExplorationError> {
+        self.redfish_power_control_calls
+            .lock()
+            .unwrap()
+            .push((address, action));
         Ok(())
     }
 

--- a/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
@@ -121,7 +121,7 @@ impl EndpointExplorer for MockEndpointExplorer {
             .lock()
             .unwrap()
             .get(&address.ip())
-            .cloned()
+            .copied()
             .unwrap_or(PowerState::On))
     }
 

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -1659,6 +1659,8 @@ pub async fn create_test_env_with_overrides(
 
     let fake_endpoint_explorer = MockEndpointExplorer {
         reports: Arc::new(std::sync::Mutex::new(Default::default())),
+        power_states: Arc::new(std::sync::Mutex::new(Default::default())),
+        redfish_power_control_calls: Arc::new(std::sync::Mutex::new(Default::default())),
         set_nic_mode_calls: Arc::new(std::sync::Mutex::new(Default::default())),
     };
 

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -429,11 +429,6 @@ async fn test_handle_redfish_error_powers_on_machine(
     let endpoint = endpoints
         .first()
         .expect("expected explored endpoint to be inserted");
-    assert!(
-        endpoint.exploration_requested,
-        "power-on remediation should request a follow-up exploration"
-    );
-
     Ok(())
 }
 

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -408,17 +408,19 @@ async fn test_handle_redfish_error_powers_on_machine(
 
     explorer.run_single_iteration().await?;
 
-    let calls = endpoint_explorer
-        .redfish_power_control_calls
-        .lock()
-        .unwrap();
-    assert_eq!(
-        calls.as_slice(),
-        &[(
-            std::net::SocketAddr::new(bmc_ip, 443),
-            libredfish::SystemPowerControl::On
-        )]
-    );
+    {
+        let calls = endpoint_explorer
+            .redfish_power_control_calls
+            .lock()
+            .unwrap();
+        assert_eq!(
+            calls.as_slice(),
+            &[(
+                std::net::SocketAddr::new(bmc_ip, 443),
+                libredfish::SystemPowerControl::On
+            )]
+        );
+    }
 
     let mut txn = env.pool.begin().await?;
     let endpoints = db::explored_endpoints::find_all_by_ip(bmc_ip, &mut txn).await?;

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -426,9 +426,6 @@ async fn test_handle_redfish_error_powers_on_machine(
     let endpoints = db::explored_endpoints::find_all_by_ip(bmc_ip, &mut txn).await?;
     txn.commit().await?;
     assert_eq!(endpoints.len(), 1, "expected one explored endpoint");
-    let endpoint = endpoints
-        .first()
-        .expect("expected explored endpoint to be inserted");
     Ok(())
 }
 

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -345,6 +345,97 @@ async fn test_site_explorer_default_pause_ingestion_and_poweron(
 }
 
 #[crate::sqlx_test]
+async fn test_handle_redfish_error_powers_on_machine(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+
+    let mut machine = FakeMachine::new("6a:6b:6c:6d:6e:70", "Vendor1", &env.underlay_segment);
+    machine.discover_dhcp(&env).await?;
+    let bmc_ip: IpAddr = machine.ip.parse()?;
+
+    let mut txn = env.pool.begin().await?;
+    db::expected_machine::create(
+        &mut txn,
+        ExpectedMachine {
+            id: None,
+            bmc_mac_address: machine.mac,
+            data: ExpectedMachineData {
+                serial_number: "host-needs-power-on".to_string(),
+                ..Default::default()
+            },
+        },
+    )
+    .await?;
+    txn.commit().await?;
+
+    let endpoint_explorer = Arc::new(MockEndpointExplorer::default());
+    endpoint_explorer.insert_endpoint_result(
+        bmc_ip,
+        Err(EndpointExplorationError::RedfishError {
+            details: "transient redfish failure".to_string(),
+            response_body: None,
+            response_code: Some(500),
+        }),
+    );
+    endpoint_explorer
+        .power_states
+        .lock()
+        .unwrap()
+        .insert(bmc_ip, libredfish::PowerState::Off);
+
+    let explorer_config = SiteExplorerConfig {
+        enabled: Arc::new(true.into()),
+        explorations_per_run: 1,
+        concurrent_explorations: 1,
+        run_interval: std::time::Duration::from_secs(1),
+        create_machines: Arc::new(true.into()),
+        allow_zero_dpu_hosts: true,
+        ..Default::default()
+    };
+    let test_meter = TestMeter::default();
+    let explorer = SiteExplorer::new(
+        env.pool.clone(),
+        explorer_config,
+        test_meter.meter(),
+        endpoint_explorer.clone(),
+        Arc::new(env.config.get_firmware_config()),
+        env.common_pools.clone(),
+        env.api.work_lock_manager_handle.clone(),
+        env.rms_sim.as_rms_client(),
+        env.test_credential_manager.clone(),
+    );
+
+    explorer.run_single_iteration().await?;
+
+    let calls = endpoint_explorer
+        .redfish_power_control_calls
+        .lock()
+        .unwrap();
+    assert_eq!(
+        calls.as_slice(),
+        &[(
+            std::net::SocketAddr::new(bmc_ip, 443),
+            libredfish::SystemPowerControl::On
+        )]
+    );
+
+    let mut txn = env.pool.begin().await?;
+    let endpoints = db::explored_endpoints::find_all_by_ip(bmc_ip, &mut txn).await?;
+    txn.commit().await?;
+    assert_eq!(endpoints.len(), 1, "expected one explored endpoint");
+    let endpoint = endpoints
+        .first()
+        .expect("expected explored endpoint to be inserted");
+    assert!(
+        endpoint.exploration_requested,
+        "power-on remediation should request a follow-up exploration"
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
 async fn test_site_explorer_main(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
     let env = common::api_fixtures::create_test_env(pool.clone()).await;
 

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -186,6 +186,8 @@ pub struct Endpoint<'a> {
     last_redfish_reboot: Option<chrono::DateTime<chrono::Utc>>,
     old_report: Option<(ConfigVersion, &'a EndpointExplorationReport)>,
     pub(crate) expected: Option<&'a ExpectedEntity>,
+    preingestion_state: PreingestionState,
+    pause_ingestion_and_poweron: bool,
     pause_remediation: bool,
     boot_interface_mac: Option<MacAddress>,
 }
@@ -1454,6 +1456,8 @@ impl SiteExplorer {
                 last_redfish_reboot: endpoint.last_redfish_reboot,
                 old_report: Some((endpoint.report_version, &endpoint.report)),
                 pause_remediation: endpoint.pause_remediation,
+                preingestion_state: endpoint.preingestion_state.clone(),
+                pause_ingestion_and_poweron: endpoint.pause_ingestion_and_poweron,
                 boot_interface_mac: endpoint.boot_interface_mac,
                 expected: index.matched_expected(&address),
             });
@@ -1465,6 +1469,8 @@ impl SiteExplorer {
             .iter()
             .take(remaining_explore_endpoints)
         {
+            let pause_ingestion_and_poweron =
+                pause_ingestion_and_poweron(index.expected(), &iface.mac_address);
             explore_endpoint_data.push(Endpoint {
                 address: *address,
                 iface,
@@ -1473,6 +1479,8 @@ impl SiteExplorer {
                 last_redfish_reboot: None,
                 old_report: None,
                 pause_remediation: false, // New endpoints haven't been explored yet, so pause_remediation defaults to false
+                preingestion_state: PreingestionState::Initial,
+                pause_ingestion_and_poweron,
                 boot_interface_mac: None, // boot_interface_mac not yet discovered for new endpoints
                 expected: index.matched_expected(address),
             });
@@ -1497,6 +1505,8 @@ impl SiteExplorer {
                     last_redfish_reboot: endpoint.last_redfish_reboot,
                     old_report: Some((endpoint.report_version, &endpoint.report)),
                     pause_remediation: endpoint.pause_remediation,
+                    preingestion_state: endpoint.preingestion_state.clone(),
+                    pause_ingestion_and_poweron: endpoint.pause_ingestion_and_poweron,
                     boot_interface_mac: endpoint.boot_interface_mac,
                     expected: index.matched_expected(&address),
                 });
@@ -1773,6 +1783,17 @@ impl SiteExplorer {
             return;
         }
 
+        if !matches!(
+            &endpoint.preingestion_state,
+            PreingestionState::Initial | PreingestionState::Complete
+        ) {
+            tracing::info!(
+                "Site explorer will not remediate error for {endpoint} because endpoint is in preingestion state {:?}: {error}",
+                endpoint.preingestion_state,
+            );
+            return;
+        }
+
         match self
             .is_managed_host_created_for_endpoint(endpoint.address)
             .await
@@ -1790,6 +1811,39 @@ impl SiteExplorer {
                 return;
             }
         };
+
+        // Power on machine endpoints in the initial preingestion state automatically unless ingestion was explicitly paused.
+        if matches!(&endpoint.preingestion_state, PreingestionState::Initial)
+            && matches!(endpoint.expected, Some(ExpectedEntity::Machine(_)))
+            && !endpoint.pause_ingestion_and_poweron
+            && let Ok(power_state) = self.redfish_get_power_state(endpoint).await
+            && !matches!(power_state, PowerState::On)
+        {
+            tracing::warn!(
+                "Site Explorer found a host (bmc_ip_address: {}) that isnt on. Turning it on now.",
+                endpoint.address,
+            );
+
+            if self
+                .redfish_power(endpoint, libredfish::SystemPowerControl::On)
+                .await
+                .inspect_err(|err| {
+                    tracing::error!(%err, "Site Explorer failed to power on host through Redfish")
+                })
+                .is_ok()
+            {
+                if let Ok(mut txn) = self.txn_begin().await {
+                    db::explored_endpoints::request_exploration_for_addresses(
+                        &[endpoint.address],
+                        &mut txn,
+                    )
+                    .await
+                    .ok();
+                    txn.commit().await.ok();
+                }
+                return;
+            }
+        }
 
         // Dont let site explorer issue either a force-restart or bmc-reset more than the rate limit.
         let reset_rate_limit = self.config.reset_rate_limit;
@@ -1826,7 +1880,7 @@ impl SiteExplorer {
         if (error.is_dpu_redfish_bios_response_invalid())
             && time_since_redfish_reboot > reset_rate_limit
             && self
-                .force_restart(endpoint)
+                .redfish_power(endpoint, libredfish::SystemPowerControl::ForceRestart)
                 .await
                 .map_err(|err| {
                     tracing::error!(
@@ -1948,6 +2002,49 @@ impl SiteExplorer {
         }
     }
 
+    async fn redfish_get_power_state(
+        &self,
+        endpoint: &Endpoint<'_>,
+    ) -> SiteExplorerResult<PowerState> {
+        let bmc_target_port = self.config.override_target_port.unwrap_or(443);
+        let bmc_target_addr = SocketAddr::new(endpoint.address, bmc_target_port);
+
+        self.endpoint_explorer
+            .redfish_get_power_state(bmc_target_addr, endpoint.iface)
+            .await
+            .map(PowerState::from)
+            .map_err(|err| SiteExplorerError::EndpointExplorationError {
+                action: "redfish_get_power_state",
+                err,
+            })
+    }
+
+    async fn redfish_power(
+        &self,
+        endpoint: &Endpoint<'_>,
+        action: libredfish::SystemPowerControl,
+    ) -> SiteExplorerResult<()> {
+        let is_reboot = matches!(&action, libredfish::SystemPowerControl::ForceRestart);
+        let bmc_target_port = self.config.override_target_port.unwrap_or(443);
+        let bmc_target_addr = SocketAddr::new(endpoint.address, bmc_target_port);
+
+        self.endpoint_explorer
+            .redfish_power_control(bmc_target_addr, endpoint.iface, action)
+            .await
+            .map_err(|err| SiteExplorerError::EndpointExplorationError {
+                action: "redfish_power",
+                err,
+            })?;
+
+        if is_reboot {
+            let mut txn = self.txn_begin().await?;
+            db::explored_endpoints::set_last_redfish_reboot(endpoint.address, &mut txn).await?;
+            txn.commit().await?;
+        }
+
+        Ok(())
+    }
+
     pub async fn is_viking_bmc(&self, endpoint: &Endpoint<'_>) -> bool {
         let bmc_target_port = self.config.override_target_port.unwrap_or(443);
         let bmc_target_addr = SocketAddr::new(endpoint.address, bmc_target_port);
@@ -1981,39 +2078,8 @@ impl SiteExplorer {
                 ))
             })?;
 
-        self.force_restart(endpoint).await
-    }
-
-    pub async fn force_restart(&self, endpoint: &Endpoint<'_>) -> SiteExplorerResult<()> {
-        tracing::info!(
-            "SiteExplorer is initiating a reboot through Redfish to IP {}",
-            endpoint.address
-        );
-        let bmc_target_port = self.config.override_target_port.unwrap_or(443);
-        let bmc_target_addr = SocketAddr::new(endpoint.address, bmc_target_port);
-        match self
-            .endpoint_explorer
-            .redfish_power_control(
-                bmc_target_addr,
-                endpoint.iface,
-                libredfish::SystemPowerControl::ForceRestart,
-            )
+        self.redfish_power(endpoint, libredfish::SystemPowerControl::ForceRestart)
             .await
-        {
-            Ok(()) => {
-                let mut txn = self.txn_begin().await?;
-
-                db::explored_endpoints::set_last_redfish_reboot(endpoint.address, &mut txn).await?;
-
-                txn.commit().await?;
-
-                Ok(())
-            }
-            Err(e) => Err(SiteExplorerError::internal(format!(
-                "site-explorer failed to reboot {}: {:#?}",
-                endpoint.address, e
-            ))),
-        }
     }
 
     async fn is_managed_host_created_for_endpoint(

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -1824,24 +1824,14 @@ impl SiteExplorer {
                 endpoint.address,
             );
 
-            if self
+            match self
                 .redfish_power(endpoint, libredfish::SystemPowerControl::On)
                 .await
-                .inspect_err(|err| {
-                    tracing::error!(%err, "Site Explorer failed to power on host through Redfish")
-                })
-                .is_ok()
             {
-                if let Ok(mut txn) = self.txn_begin().await {
-                    db::explored_endpoints::request_exploration_for_addresses(
-                        &[endpoint.address],
-                        &mut txn,
-                    )
-                    .await
-                    .ok();
-                    txn.commit().await.ok();
+                Ok(()) => return,
+                Err(err) => {
+                    tracing::error!(%err, "Site Explorer failed to power on host through Redfish");
                 }
-                return;
             }
         }
 


### PR DESCRIPTION
## Description
This PR fixes a preingestion deadlock where a host endpoint that is powered off can return redfish exploration errors, preventing site explorer from successfully exploring it and moving the endpoint past `Initial` preingestion.

Now, when site explorer sees a redfish error for a host endpoint in `PreingestionState::Initial`, it checks live power state, powers the host on unless power-on is paused.

This PR also prevents site explorer from remediating redfish errors if the preingestion state is **not** `Initial` or `Complete`.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
NVBug-6101260

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

