### PR TITLE
fix(dpf,fmds): Provide arguments to enable phone home on fmds

### DIFF
--- a/bluefield/charts/carbide-fmds/templates/daemonset.yaml
+++ b/bluefield/charts/carbide-fmds/templates/daemonset.yaml
@@ -67,6 +67,9 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           args:
             - "--grpc-address=$(POD_IP):50052"
+            - "--root-ca=/opt/forge/forge_root.pem"
+            - "--client-cert=/opt/forge/machine_cert.pem"
+            - "--client-key=/opt/forge/machine_cert.key"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with toYaml .Values.serviceDaemonSet.resources }}
           resources:


### PR DESCRIPTION
## Description
Right now phone-home was not enabled on feds in the container because of missing command line arguments.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

