### PR TITLE
Fix adding and removing health reports via web-ui

### DIFF
--- a/crates/api/src/tests/web/machine_health.rs
+++ b/crates/api/src/tests/web/machine_health.rs
@@ -17,7 +17,7 @@
 
 use axum::body::Body;
 use http_body_util::BodyExt;
-use hyper::http::StatusCode;
+use hyper::http::{Method, StatusCode};
 use rpc::forge::AdminForceDeleteMachineRequest;
 use rpc::forge::forge_server::Forge;
 use tower::ServiceExt;
@@ -77,4 +77,95 @@ async fn test_health_of_nonexisting_machine(pool: sqlx::PgPool) {
     assert!(env.find_machine(host_machine_id).await.is_empty());
 
     verify_history(&app, host_machine_id.to_string()).await;
+}
+
+#[crate::sqlx_test]
+async fn test_add_remove_health_report_via_web_ui(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let app = make_test_app(&env);
+    let (host_machine_id, _dpu_machine_id) = create_managed_host(&env).await.into();
+
+    let payload = r#"{
+        "mode": "Merge",
+        "health_report": {
+            "source": "web-health-test",
+            "triggered_by": null,
+            "observed_at": null,
+            "successes": [],
+            "alerts": []
+        }
+    }"#;
+
+    let response = app
+        .clone()
+        .oneshot(
+            web_request_builder()
+                .method(Method::POST)
+                .uri(format!(
+                    "/admin/machine/{host_machine_id}/health/add-report"
+                ))
+                .header("Content-Type", "application/json")
+                .body(Body::from(payload))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .clone()
+        .oneshot(
+            web_request_builder()
+                .uri(format!("/admin/machine/{host_machine_id}/health"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body_bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("Empty response body?")
+        .to_bytes();
+    let body = String::from_utf8_lossy(&body_bytes);
+    assert!(body.contains("web-health-test"));
+
+    let response = app
+        .clone()
+        .oneshot(
+            web_request_builder()
+                .method(Method::POST)
+                .uri(format!(
+                    "/admin/machine/{host_machine_id}/health/remove-report"
+                ))
+                .header("Content-Type", "application/json")
+                .body(Body::from(r#"{"source":"web-health-test"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .oneshot(
+            web_request_builder()
+                .uri(format!("/admin/machine/{host_machine_id}/health"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body_bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("Empty response body?")
+        .to_bytes();
+    let body = String::from_utf8_lossy(&body_bytes);
+    assert!(!body.contains("web-health-test"));
 }

--- a/crates/api/src/web/mod.rs
+++ b/crates/api/src/web/mod.rs
@@ -531,11 +531,11 @@ pub fn routes(api: Arc<Api>) -> eyre::Result<NormalizePath<Router>> {
                 get(state_history::show_switch_state_history_json),
             )
             .route(
-                "/machine/{machine_id}/health-report/add",
+                "/machine/{machine_id}/health/add-report",
                 post(health::add_health_report),
             )
             .route(
-                "/machine/{machine_id}/health-report/remove",
+                "/machine/{machine_id}/health/remove-report",
                 post(health::remove_health_report),
             )
             .route(

--- a/crates/api/templates/machine_health.html
+++ b/crates/api/templates/machine_health.html
@@ -245,12 +245,12 @@ function setHealthReportTextBoxToTemplate(template) {
 document.addEventListener("DOMContentLoaded", function (event) {
 	setHealthReportTextBoxToTemplate(templateHealthReport);
 	for (const item of [
-		["submit_add", "/health-report/add", () => document.getElementById("health-report").value],
+		["submit_add", "/add-report", () => document.getElementById("health-report").value],
 	]) {
 		add_click_listener(item);
 	}
 	{% for entry in entries %}
-	add_click_listener(["remove-health-report-{{ entry.health_report.source }}", "/health-report/remove", () => JSON.stringify({source: "{{ entry.health_report.source }}"})]);
+	add_click_listener(["remove-health-report-{{ entry.health_report.source }}", "/remove-report", () => JSON.stringify({source: "{{ entry.health_report.source }}"})]);
 	{% endfor %}
 });
 


### PR DESCRIPTION
## Description

Commit 696f99d introduced a change where the router path for adding and removing health reports changed in a different fashion than the click listener. The click listener would send a health report to `/machine/{machine_id}/health/health-report/add`, while the router expected `/machine/{machine_id}/health-report/add`.

This change fixes the mismatch, and lets both sides use a more flattened path of `/machine/{machine_id}/health/add-report`. It also adds a unit-test for the behavior.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

