### PR TITLE
chore: Show web-ui health page also for Racks

### DIFF
--- a/crates/api/src/tests/web/machine_health.rs
+++ b/crates/api/src/tests/web/machine_health.rs
@@ -22,6 +22,7 @@ use rpc::forge::AdminForceDeleteMachineRequest;
 use rpc::forge::forge_server::Forge;
 use tower::ServiceExt;
 
+use crate::tests::common::api_fixtures::site_explorer::TestRackDbBuilder;
 use crate::tests::common::api_fixtures::{create_managed_host, create_test_env};
 use crate::tests::web::{make_test_app, web_request_builder};
 
@@ -168,4 +169,124 @@ async fn test_add_remove_health_report_via_web_ui(pool: sqlx::PgPool) {
         .to_bytes();
     let body = String::from_utf8_lossy(&body_bytes);
     assert!(!body.contains("web-health-test"));
+}
+
+#[crate::sqlx_test]
+async fn test_health_of_rack(pool: sqlx::PgPool) {
+    let env = create_test_env(pool.clone()).await;
+    let app = make_test_app(&env);
+
+    let mut txn = pool.acquire().await.unwrap();
+    let rack_id = TestRackDbBuilder::new().persist(&mut txn).await.unwrap();
+    drop(txn);
+
+    let response = app
+        .clone()
+        .oneshot(
+            web_request_builder()
+                .uri(format!("/admin/rack/{rack_id}/health"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body_bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("Empty response body?")
+        .to_bytes();
+    let body = String::from_utf8_lossy(&body_bytes);
+    assert!(body.contains("Rack Health"));
+    assert!(body.contains("Health Report Management"));
+    assert!(body.contains("Health History"));
+
+    let payload = r#"{
+        "mode": "Merge",
+        "health_report": {
+            "source": "web-rack-health-test",
+            "triggered_by": null,
+            "observed_at": null,
+            "successes": [],
+            "alerts": [{
+                "id": "RackWebHealth",
+                "target": null,
+                "in_alert_since": null,
+                "message": "rack web health",
+                "tenant_message": null,
+                "classifications": ["PreventAllocations"]
+            }]
+        }
+    }"#;
+    let response = app
+        .clone()
+        .oneshot(
+            web_request_builder()
+                .method(Method::POST)
+                .uri(format!("/admin/rack/{rack_id}/health/add-report"))
+                .header("Content-Type", "application/json")
+                .body(Body::from(payload))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .clone()
+        .oneshot(
+            web_request_builder()
+                .uri(format!("/admin/rack/{rack_id}/health"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body_bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("Empty response body?")
+        .to_bytes();
+    let body = String::from_utf8_lossy(&body_bytes);
+    assert!(body.contains("web-rack-health-test"));
+    assert!(body.contains("rack web health"));
+
+    let response = app
+        .clone()
+        .oneshot(
+            web_request_builder()
+                .method(Method::POST)
+                .uri(format!("/admin/rack/{rack_id}/health/remove-report"))
+                .header("Content-Type", "application/json")
+                .body(Body::from(r#"{"source":"web-rack-health-test"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .oneshot(
+            web_request_builder()
+                .uri(format!("/admin/rack/{rack_id}/health"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body_bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("Empty response body?")
+        .to_bytes();
+    let body = String::from_utf8_lossy(&body_bytes);
+    assert!(!body.contains("web-rack-health-test"));
 }

--- a/crates/api/src/web/health.rs
+++ b/crates/api/src/web/health.rs
@@ -21,14 +21,15 @@ use std::sync::Arc;
 use askama::Template;
 use axum::extract::{self, Path as AxumPath, State as AxumState};
 use axum::response::{Html, IntoResponse, Response};
-use carbide_uuid::machine::{MachineId, MachineType};
+use carbide_uuid::machine::MachineId;
+use carbide_uuid::rack::RackId;
 use health_report::HealthReport;
 use hyper::http::StatusCode;
-use model::health::HealthReportSources;
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{
-    HealthReportApplyMode, InsertMachineHealthReportRequest, MachinesByIdsRequest,
-    RemoveMachineHealthReportRequest,
+    HealthReportApplyMode, InsertMachineHealthReportRequest, InsertRackHealthReportRequest,
+    ListRackHealthReportsRequest, MachinesByIdsRequest, RacksByIdsRequest,
+    RemoveMachineHealthReportRequest, RemoveRackHealthReportRequest,
 };
 
 use super::filters;
@@ -36,13 +37,16 @@ use crate::api::Api;
 use crate::auth::AuthContext;
 
 #[derive(Template)]
-#[template(path = "machine_health.html")]
-struct MachineHealth {
-    id: MachineId,
-    machine_type: MachineType,
+#[template(path = "health_reports_detail.html")]
+struct HealthPage {
+    id: String,
+    object_label: String,
+    object_detail_url: String,
+    show_machine_templates: bool,
     entries: Vec<HealthReportEntry>,
     aggregate_health: LabeledHealthReport,
-    component_health: Vec<LabeledHealthReport>,
+    health_contributors: Vec<LabeledHealthReport>,
+    history_url: Option<String>,
     history: HealthHistoryTable,
 }
 
@@ -77,8 +81,64 @@ struct LabeledHealthReport {
     report: Option<health_report::HealthReport>,
 }
 
-/// View machine
-pub async fn health(
+#[derive(Clone)]
+enum HealthObject {
+    Machine(MachineId),
+    Rack(RackId),
+}
+
+impl HealthObject {
+    fn id(&self) -> String {
+        match self {
+            HealthObject::Machine(id) => id.to_string(),
+            HealthObject::Rack(id) => id.to_string(),
+        }
+    }
+
+    fn kind(&self) -> &'static str {
+        match self {
+            HealthObject::Machine(_) => "machine",
+            HealthObject::Rack(_) => "rack",
+        }
+    }
+
+    fn label(&self) -> String {
+        match self {
+            HealthObject::Machine(id) => id.machine_type().to_string(),
+            HealthObject::Rack(_) => "Rack".to_string(),
+        }
+    }
+
+    fn detail_url(&self) -> String {
+        format!("/admin/{}/{}", self.kind(), self.id())
+    }
+
+    fn history_url(&self) -> Option<String> {
+        match self {
+            HealthObject::Machine(id) => Some(format!("/admin/machine/{id}/health-history")),
+            HealthObject::Rack(_) => None,
+        }
+    }
+
+    fn show_machine_templates(&self) -> bool {
+        matches!(self, HealthObject::Machine(_))
+    }
+}
+
+struct HealthPageData {
+    entries: Vec<::rpc::forge::HealthReportEntry>,
+    aggregate_health: Option<HealthReport>,
+    health_contributors: Vec<LabeledHealthReport>,
+    history: HealthHistoryTable,
+}
+
+struct MachineHealthSnapshot {
+    aggregate_health: Option<HealthReport>,
+    associated_dpu_machine_ids: Vec<MachineId>,
+}
+
+/// View machine health.
+pub async fn machine_health(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(machine_id): AxumPath<String>,
 ) -> Response {
@@ -93,77 +153,33 @@ pub async fn health(
             .into_response();
     }
 
-    let machine = match state
-        .find_machines_by_ids(tonic::Request::new(rpc::forge::MachinesByIdsRequest {
-            machine_ids: vec![machine_id],
-            include_history: false,
-        }))
-        .await
-        .map(|response| response.into_inner())
-    {
-        Ok(m) if m.machines.is_empty() => None,
-        Ok(m) if m.machines.len() != 1 => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!(
-                    "Machine list for {machine_id} returned {} machines",
-                    m.machines.len()
-                ),
-            )
-                .into_response();
-        }
-        Ok(mut m) => Some(m.machines.remove(0)),
-        Err(err) if err.code() == tonic::Code::NotFound => None,
-        Err(err) => {
-            tracing::error!(%err, %machine_id, "find_machines_by_ids");
-            return (StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response();
-        }
+    let data = match fetch_machine_health_page_data(&state, &machine_id).await {
+        Ok(data) => data,
+        Err(response) => return response,
     };
 
-    let aggregate_health = machine
-        .as_ref()
-        .and_then(|m| m.health.as_ref())
-        .map(|health| health_report_from_rpc_convert_invalid(health.clone()));
-    let associated_dpu_machine_ids = match machine {
-        Some(m) => m.associated_dpu_machine_ids,
-        None => Vec::new(),
+    render_health(HealthObject::Machine(machine_id), data)
+}
+
+/// View rack health.
+pub async fn rack_health(
+    AxumState(state): AxumState<Arc<Api>>,
+    AxumPath(rack_id): AxumPath<String>,
+) -> Response {
+    let Ok(rack_id) = RackId::from_str(&rack_id) else {
+        return (StatusCode::BAD_REQUEST, "invalid rack id").into_response();
     };
 
-    let request = tonic::Request::new(machine_id);
-    let mut listed_entries = match state
-        .list_machine_health_reports(request)
-        .await
-        .map(|response| response.into_inner().health_report_entries)
-    {
-        Ok(m) => m,
-        Err(err) if err.code() == tonic::Code::NotFound => Vec::new(),
-        Err(err) => {
-            tracing::error!(%err, %machine_id, "list_machine_health_reports");
-            return (StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response();
-        }
+    let data = match fetch_rack_health_page_data(&state, &rack_id).await {
+        Ok(data) => data,
+        Err(response) => return response,
     };
-    let mut hardware_health: Option<health_report::HealthReport> = None;
-    let mut entries = Vec::new();
-    for entry in listed_entries.drain(..) {
-        let source = entry
-            .report
-            .as_ref()
-            .map(|report| report.source.as_str())
-            .unwrap_or_default();
-        if HealthReportSources::is_hardware_health_override_source(source) {
-            if let Some(report) = entry.report {
-                let report = health_report_from_rpc_convert_invalid(report);
-                if let Some(aggregated) = hardware_health.as_mut() {
-                    aggregated.merge(&report);
-                } else {
-                    hardware_health = Some(report);
-                }
-            }
-            continue;
-        }
-        entries.push(entry);
-    }
 
+    render_health(HealthObject::Rack(rack_id), data)
+}
+
+fn render_health(object: HealthObject, data: HealthPageData) -> Response {
+    let mut entries = data.entries;
     // Sort by type first and source name second.
     entries.sort_by(|a, b| {
         if a.mode() == HealthReportApplyMode::Replace {
@@ -178,72 +194,219 @@ pub async fn health(
     });
 
     let entries: Vec<HealthReportEntry> = entries
-        .iter()
-        .map(|o| HealthReportEntry::from_rpc_convert_invalid(o.clone()))
+        .into_iter()
+        .map(HealthReportEntry::from_rpc_convert_invalid)
         .collect();
 
-    let mut component_health = Vec::new();
-    component_health.push(LabeledHealthReport {
-        label: "Hardware Health".to_string(),
-        report: hardware_health,
-    });
-
-    if !associated_dpu_machine_ids.is_empty() {
-        let request = tonic::Request::new(MachinesByIdsRequest {
-            machine_ids: associated_dpu_machine_ids,
-            include_history: false,
-        });
-        let dpus = match state
-            .find_machines_by_ids(request)
-            .await
-            .map(|response| response.into_inner())
-        {
-            Ok(m) => m.machines,
-            Err(err) if err.code() == tonic::Code::NotFound => Vec::new(),
-            Err(err) => {
-                tracing::error!(%err, %machine_id, "find_machines_by_ids");
-                return (StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response();
-            }
-        };
-        for dpu in dpus {
-            component_health.push(LabeledHealthReport {
-                label: format!(
-                    "DPU Health {}",
-                    dpu.id.map(|id| id.to_string()).unwrap_or_default()
-                ),
-                report: dpu.health.map(health_report_from_rpc_convert_invalid),
-            })
-        }
-    }
-
-    component_health.extend(entries.iter().map(|o| LabeledHealthReport {
-        label: format!("Health Report {} {}", o.mode, o.health_report.source),
-        report: Some(o.health_report.clone()),
-    }));
-
-    let health_records = match fetch_health_history(&state, &machine_id).await {
-        Ok(records) => records,
-        Err(err) => {
-            tracing::error!(%err, %machine_id, "find_machine_health_histories");
-            return (StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response();
-        }
-    };
-
-    let display = MachineHealth {
-        id: machine_id,
-        machine_type: machine_id.machine_type(),
+    let display = HealthPage {
+        id: object.id(),
+        object_label: object.label(),
+        object_detail_url: object.detail_url(),
+        show_machine_templates: object.show_machine_templates(),
         aggregate_health: LabeledHealthReport {
             label: "Aggregate Health".to_string(),
-            report: aggregate_health,
+            report: data.aggregate_health,
         },
-        component_health,
+        health_contributors: data.health_contributors,
         entries,
-        history: HealthHistoryTable {
-            records: health_records,
-        },
+        history_url: object.history_url(),
+        history: data.history,
     };
 
     (StatusCode::OK, Html(display.render().unwrap())).into_response()
+}
+
+async fn fetch_machine_health_page_data(
+    api: &Api,
+    machine_id: &MachineId,
+) -> Result<HealthPageData, Response> {
+    let snapshot = fetch_machine_health_snapshot(api, machine_id).await?;
+    let entries = match list_machine_health_report_entries(api, machine_id).await {
+        Ok(entries) => entries,
+        Err(err) if err.code() == tonic::Code::NotFound => Vec::new(),
+        Err(err) => {
+            tracing::error!(%err, %machine_id, "list_health_report_entries");
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
+        }
+    };
+    let health_contributors =
+        fetch_dpu_health_contributors(api, machine_id, snapshot.associated_dpu_machine_ids).await?;
+    let history = match fetch_health_history(api, machine_id).await {
+        Ok(records) => HealthHistoryTable { records },
+        Err(err) => {
+            tracing::error!(%err, %machine_id, "find_machine_health_histories");
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
+        }
+    };
+
+    Ok(HealthPageData {
+        entries,
+        aggregate_health: snapshot.aggregate_health,
+        health_contributors,
+        history,
+    })
+}
+
+async fn fetch_rack_health_page_data(
+    api: &Api,
+    rack_id: &RackId,
+) -> Result<HealthPageData, Response> {
+    let aggregate_health = fetch_rack_aggregate_health(api, rack_id).await?;
+    let entries = match list_rack_health_report_entries(api, rack_id).await {
+        Ok(entries) => entries,
+        Err(err) if err.code() == tonic::Code::NotFound => Vec::new(),
+        Err(err) => {
+            tracing::error!(%err, %rack_id, "list_rack_health_report_overrides");
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
+        }
+    };
+
+    Ok(HealthPageData {
+        entries,
+        aggregate_health,
+        health_contributors: Vec::new(),
+        history: HealthHistoryTable {
+            records: Vec::new(),
+        },
+    })
+}
+
+async fn fetch_dpu_health_contributors(
+    api: &Api,
+    host_machine_id: &MachineId,
+    dpu_machine_ids: Vec<MachineId>,
+) -> Result<Vec<LabeledHealthReport>, Response> {
+    if dpu_machine_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let request = tonic::Request::new(MachinesByIdsRequest {
+        machine_ids: dpu_machine_ids,
+        include_history: false,
+    });
+    let dpus = match api
+        .find_machines_by_ids(request)
+        .await
+        .map(|response| response.into_inner())
+    {
+        Ok(m) => m.machines,
+        Err(err) if err.code() == tonic::Code::NotFound => Vec::new(),
+        Err(err) => {
+            tracing::error!(%err, %host_machine_id, "find_dpu_machines_by_ids");
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
+        }
+    };
+
+    Ok(dpus
+        .into_iter()
+        .map(|dpu| LabeledHealthReport {
+            label: format!(
+                "DPU Health {}",
+                dpu.id.map(|id| id.to_string()).unwrap_or_default()
+            ),
+            report: dpu.health.map(health_report_from_rpc_convert_invalid),
+        })
+        .collect())
+}
+
+async fn list_machine_health_report_entries(
+    api: &Api,
+    machine_id: &MachineId,
+) -> Result<Vec<::rpc::forge::HealthReportEntry>, tonic::Status> {
+    Ok(api
+        .list_machine_health_reports(tonic::Request::new(*machine_id))
+        .await?
+        .into_inner()
+        .health_report_entries)
+}
+
+async fn list_rack_health_report_entries(
+    api: &Api,
+    rack_id: &RackId,
+) -> Result<Vec<::rpc::forge::HealthReportEntry>, tonic::Status> {
+    Ok(api
+        .list_rack_health_reports(tonic::Request::new(ListRackHealthReportsRequest {
+            rack_id: Some(rack_id.clone()),
+        }))
+        .await?
+        .into_inner()
+        .health_report_entries)
+}
+
+async fn fetch_machine_health_snapshot(
+    api: &Api,
+    machine_id: &MachineId,
+) -> Result<MachineHealthSnapshot, Response> {
+    let machine = match api
+        .find_machines_by_ids(tonic::Request::new(rpc::forge::MachinesByIdsRequest {
+            machine_ids: vec![*machine_id],
+            include_history: false,
+        }))
+        .await
+        .map(|response| response.into_inner())
+    {
+        Ok(m) if m.machines.is_empty() => None,
+        Ok(m) if m.machines.len() != 1 => {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!(
+                    "Machine list for {machine_id} returned {} machines",
+                    m.machines.len()
+                ),
+            )
+                .into_response());
+        }
+        Ok(mut m) => Some(m.machines.remove(0)),
+        Err(err) if err.code() == tonic::Code::NotFound => None,
+        Err(err) => {
+            tracing::error!(%err, %machine_id, "find_machines_by_ids");
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
+        }
+    };
+
+    Ok(MachineHealthSnapshot {
+        aggregate_health: machine
+            .as_ref()
+            .and_then(|m| m.health.as_ref())
+            .map(|health| health_report_from_rpc_convert_invalid(health.clone())),
+        associated_dpu_machine_ids: machine
+            .map(|m| m.associated_dpu_machine_ids)
+            .unwrap_or_default(),
+    })
+}
+
+async fn fetch_rack_aggregate_health(
+    api: &Api,
+    rack_id: &RackId,
+) -> Result<Option<HealthReport>, Response> {
+    let rack = match api
+        .find_racks_by_ids(tonic::Request::new(RacksByIdsRequest {
+            rack_ids: vec![rack_id.clone()],
+        }))
+        .await
+        .map(|response| response.into_inner())
+    {
+        Ok(r) if r.racks.is_empty() => None,
+        Ok(r) if r.racks.len() != 1 => {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Rack list for {rack_id} returned {} racks", r.racks.len()),
+            )
+                .into_response());
+        }
+        Ok(mut r) => Some(r.racks.remove(0)),
+        Err(err) if err.code() == tonic::Code::NotFound => None,
+        Err(err) => {
+            tracing::error!(%err, %rack_id, "find_racks_by_ids");
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
+        }
+    };
+
+    Ok(rack
+        .as_ref()
+        .and_then(|rack| rack.status.as_ref())
+        .and_then(|status| status.health.as_ref())
+        .map(|health| health_report_from_rpc_convert_invalid(health.clone())))
 }
 
 #[derive(serde::Deserialize, serde::Serialize)]
@@ -298,71 +461,153 @@ pub struct RemoveHealthReport {
     source: String,
 }
 
-pub async fn add_health_report(
+pub async fn add_machine_health_report(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(machine_id): AxumPath<String>,
     auth_context: Option<axum::Extension<AuthContext>>,
     extract::Json(payload): extract::Json<HealthReportEntry>,
-) -> impl IntoResponse {
-    let entry = match ::rpc::forge::HealthReportEntry::try_from(payload) {
-        Ok(entry) => entry,
-        Err(e) => return (StatusCode::BAD_REQUEST, e),
-    };
-
+) -> Response {
     let machine_id = match machine_id.parse::<MachineId>() {
         Ok(id) => id,
-        Err(e) => return (StatusCode::BAD_REQUEST, e.to_string()),
+        Err(e) => return (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
     };
 
-    let mut request = tonic::Request::new(InsertMachineHealthReportRequest {
-        machine_id: Some(machine_id),
-        health_report_entry: Some(entry),
-    });
-    if let Some(axum::Extension(auth_context)) = auth_context {
-        request.extensions_mut().insert(auth_context);
-    }
-    match state
-        .insert_machine_health_report(request)
-        .await
-        .map(|response| response.into_inner())
-    {
+    add_health_report_for(
+        state,
+        HealthObject::Machine(machine_id),
+        auth_context,
+        payload,
+    )
+    .await
+}
+
+pub async fn add_rack_health_report(
+    AxumState(state): AxumState<Arc<Api>>,
+    AxumPath(rack_id): AxumPath<String>,
+    auth_context: Option<axum::Extension<AuthContext>>,
+    extract::Json(payload): extract::Json<HealthReportEntry>,
+) -> Response {
+    let rack_id = match rack_id.parse::<RackId>() {
+        Ok(id) => id,
+        Err(e) => return (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
+    };
+
+    add_health_report_for(state, HealthObject::Rack(rack_id), auth_context, payload).await
+}
+
+async fn add_health_report_for(
+    state: Arc<Api>,
+    object: HealthObject,
+    auth_context: Option<axum::Extension<AuthContext>>,
+    payload: HealthReportEntry,
+) -> Response {
+    let entry = match ::rpc::forge::HealthReportEntry::try_from(payload) {
+        Ok(entry) => entry,
+        Err(e) => return (StatusCode::BAD_REQUEST, e).into_response(),
+    };
+
+    let object_id = object.id();
+    let object_kind = object.kind();
+    let result = match object {
+        HealthObject::Machine(machine_id) => {
+            let mut request = tonic::Request::new(InsertMachineHealthReportRequest {
+                machine_id: Some(machine_id),
+                health_report_entry: Some(entry),
+            });
+            if let Some(axum::Extension(auth_context)) = auth_context {
+                request.extensions_mut().insert(auth_context);
+            }
+            state
+                .insert_machine_health_report(request)
+                .await
+                .map(|response| response.into_inner())
+        }
+        HealthObject::Rack(rack_id) => {
+            let mut request = tonic::Request::new(InsertRackHealthReportRequest {
+                rack_id: Some(rack_id),
+                health_report_entry: Some(entry),
+            });
+            if let Some(axum::Extension(auth_context)) = auth_context {
+                request.extensions_mut().insert(auth_context);
+            }
+            state
+                .insert_rack_health_report(request)
+                .await
+                .map(|response| response.into_inner())
+        }
+    };
+
+    match result {
         Err(err) if err.code() == tonic::Code::NotFound => {
-            (StatusCode::NOT_FOUND, format!("Not found: {machine_id}"))
+            (StatusCode::NOT_FOUND, format!("Not found: {object_id}")).into_response()
         }
         Err(err) => {
-            tracing::error!(%err, %machine_id, "insert_health_report_overrides");
-            (StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
+            tracing::error!(%err, %object_id, object_kind, "insert_health_report");
+            (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
         }
-        Ok(_) => (StatusCode::OK, String::new()),
+        Ok(_) => (StatusCode::OK, String::new()).into_response(),
     }
 }
 
-pub async fn remove_health_report(
+pub async fn remove_machine_health_report(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(machine_id): AxumPath<String>,
     extract::Json(payload): extract::Json<RemoveHealthReport>,
-) -> impl IntoResponse {
+) -> Response {
     let machine_id = match machine_id.parse::<MachineId>() {
         Ok(id) => id,
-        Err(e) => return (StatusCode::BAD_REQUEST, e.to_string()),
+        Err(e) => return (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
     };
-    let request = tonic::Request::new(RemoveMachineHealthReportRequest {
-        machine_id: Some(machine_id),
-        source: payload.source,
-    });
-    match state
-        .remove_machine_health_report(request)
-        .await
-        .map(|response| response.into_inner())
-    {
+
+    remove_health_report_for(state, HealthObject::Machine(machine_id), payload).await
+}
+
+pub async fn remove_rack_health_report(
+    AxumState(state): AxumState<Arc<Api>>,
+    AxumPath(rack_id): AxumPath<String>,
+    extract::Json(payload): extract::Json<RemoveHealthReport>,
+) -> Response {
+    let rack_id = match rack_id.parse::<RackId>() {
+        Ok(id) => id,
+        Err(e) => return (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
+    };
+
+    remove_health_report_for(state, HealthObject::Rack(rack_id), payload).await
+}
+
+async fn remove_health_report_for(
+    state: Arc<Api>,
+    object: HealthObject,
+    payload: RemoveHealthReport,
+) -> Response {
+    let object_id = object.id();
+    let object_kind = object.kind();
+    let result = match object {
+        HealthObject::Machine(machine_id) => state
+            .remove_machine_health_report(tonic::Request::new(RemoveMachineHealthReportRequest {
+                machine_id: Some(machine_id),
+                source: payload.source,
+            }))
+            .await
+            .map(|response| response.into_inner()),
+        HealthObject::Rack(rack_id) => state
+            .remove_rack_health_report(tonic::Request::new(RemoveRackHealthReportRequest {
+                rack_id: Some(rack_id),
+                source: payload.source,
+            }))
+            .await
+            .map(|response| response.into_inner()),
+    };
+
+    match result {
         Err(err) if err.code() == tonic::Code::NotFound => {
-            (StatusCode::NOT_FOUND, format!("Not found: {machine_id}"))
+            (StatusCode::NOT_FOUND, format!("Not found: {object_id}")).into_response()
         }
         Err(err) => {
-            tracing::error!(%err, %machine_id, "remove_health_report_overrides");
-            (StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
+            tracing::error!(%err, %object_id, object_kind, "remove_health_report");
+            (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
         }
-        Ok(_) => (StatusCode::OK, String::new()),
+        Ok(_) => (StatusCode::OK, String::new()).into_response(),
     }
 }
 

--- a/crates/api/src/web/machine.rs
+++ b/crates/api/src/web/machine.rs
@@ -450,8 +450,7 @@ struct MachineDetail<'a> {
     interfaces: Vec<MachineInterfaceDisplay>,
     ib_interfaces: Vec<MachineIbInterfaceDisplay>,
     inventory: Vec<MachineInventorySoftwareComponent>,
-    health: health_report::HealthReport,
-    health_sources: Vec<String>,
+    health_detail: super::HealthDetail,
     bmc_info: Option<rpc::forge::BmcInfo>,
     discovery_info_json: String,
     metadata_detail: super::MetadataDetail,
@@ -637,6 +636,21 @@ impl From<forgerpc::Machine> for MachineDetail<'_> {
         let quarantine_state = m
             .quarantine_state
             .and_then(|q| ManagedHostQuarantineState::try_from(q).ok());
+        let is_host = m.machine_type == forgerpc::MachineType::Host as i32;
+        let host_id = m
+            .associated_host_machine_id
+            .map_or_else(String::default, |id| id.to_string());
+        let health_reports_url = if is_host || host_id.is_empty() {
+            format!("/admin/machine/{machine_id}/health")
+        } else {
+            format!("/admin/machine/{host_id}/health")
+        };
+        let health_detail = super::HealthDetail::new(
+            health_reports_url,
+            "Go to ManagedHost health reports",
+            m.health,
+            m.health_sources,
+        );
 
         MachineDetail {
             id: machine_id.clone(),
@@ -654,7 +668,7 @@ impl From<forgerpc::Machine> for MachineDetail<'_> {
                 metadata_version: m.version,
             },
             machine_type: get_machine_type(&machine_id),
-            is_host: m.machine_type == forgerpc::MachineType::Host as i32,
+            is_host,
             network_config: String::new(), // filled in later
             bmc_info: m.bmc_info,
             history,
@@ -676,17 +690,8 @@ impl From<forgerpc::Machine> for MachineDetail<'_> {
             maintenance_reference: m.maintenance_reference.unwrap_or_default(),
             maintenance_start_time: to_time(m.maintenance_start_time, Some(&machine_id))
                 .unwrap_or_default(),
-            host_id: m
-                .associated_host_machine_id
-                .map_or_else(String::default, |id| id.to_string()),
-            health: m
-                .health
-                .map(|h| {
-                    health_report::HealthReport::try_from(h)
-                        .unwrap_or_else(health_report::HealthReport::malformed_report)
-                })
-                .unwrap_or_else(health_report::HealthReport::missing_report),
-            health_sources: m.health_sources.iter().map(|o| o.source.clone()).collect(),
+            host_id,
+            health_detail,
             discovery_info_json,
             capabilities_json: m
                 .capabilities

--- a/crates/api/src/web/mod.rs
+++ b/crates/api/src/web/mod.rs
@@ -60,6 +60,41 @@ pub(crate) struct MetadataDetail {
     pub metadata_version: String,
 }
 
+/// Reusable template for rendering aggregate health details in entity detail
+/// pages. Render with `{{ health_detail|safe }}`.
+#[derive(Template)]
+#[template(path = "health_detail.html")]
+pub(crate) struct HealthDetail {
+    pub health_reports_url: String,
+    pub health_reports_link_text: &'static str,
+    pub health: health_report::HealthReport,
+    pub health_sources: Vec<String>,
+}
+
+impl HealthDetail {
+    pub(crate) fn new(
+        health_reports_url: String,
+        health_reports_link_text: &'static str,
+        health: Option<rpc::health::HealthReport>,
+        health_sources: Vec<rpc::forge::HealthSourceOrigin>,
+    ) -> Self {
+        HealthDetail {
+            health_reports_url,
+            health_reports_link_text,
+            health: health
+                .map(|health| {
+                    health_report::HealthReport::try_from(health)
+                        .unwrap_or_else(health_report::HealthReport::malformed_report)
+                })
+                .unwrap_or_else(health_report::HealthReport::missing_report),
+            health_sources: health_sources
+                .into_iter()
+                .map(|source| source.source)
+                .collect(),
+        }
+    }
+}
+
 /// Reusable template for rendering a color-coded state bubble.
 /// Render with `{{ state_display|safe }}`.
 #[derive(Template)]
@@ -480,7 +515,7 @@ pub fn routes(api: Arc<Api>) -> eyre::Result<NormalizePath<Router>> {
                 "/machine/{machine_id}/set-dpu-first-boot-order",
                 post(machine::set_dpu_first_boot_order),
             )
-            .route("/machine/{machine_id}/health", get(health::health))
+            .route("/machine/{machine_id}/health", get(health::machine_health))
             .route(
                 "/machine/{machine_id}/health-history",
                 get(health_history::show_health_history),
@@ -511,6 +546,15 @@ pub fn routes(api: Arc<Api>) -> eyre::Result<NormalizePath<Router>> {
             .route("/rack", get(rack::show_html))
             .route("/rack.json", get(rack::show_json))
             .route("/rack/{rack_id}", get(rack::detail))
+            .route("/rack/{rack_id}/health", get(health::rack_health))
+            .route(
+                "/rack/{rack_id}/health/add-report",
+                post(health::add_rack_health_report),
+            )
+            .route(
+                "/rack/{rack_id}/health/remove-report",
+                post(health::remove_rack_health_report),
+            )
             .route(
                 "/rack/{rack_id}/state-history",
                 get(state_history::show_rack_state_history),
@@ -532,11 +576,11 @@ pub fn routes(api: Arc<Api>) -> eyre::Result<NormalizePath<Router>> {
             )
             .route(
                 "/machine/{machine_id}/health/add-report",
-                post(health::add_health_report),
+                post(health::add_machine_health_report),
             )
             .route(
                 "/machine/{machine_id}/health/remove-report",
-                post(health::remove_health_report),
+                post(health::remove_machine_health_report),
             )
             .route(
                 "/machine/{machine_id}/attestation-results",

--- a/crates/api/src/web/rack.rs
+++ b/crates/api/src/web/rack.rs
@@ -41,6 +41,7 @@ struct RackDetail {
     id: String,
     lifecycle_detail: super::LifecycleDetail,
     version: String,
+    health_detail: super::HealthDetail,
     associated_machines: Vec<String>,
     associated_switches: Vec<String>,
     associated_power_shelves: Vec<String>,
@@ -210,12 +211,24 @@ pub async fn detail(
         metadata_version: version.clone(),
     };
 
+    let rack_status = maybe_rack.as_ref().and_then(|rack| rack.status.as_ref());
+    let health_url = format!("/admin/rack/{rack_id}/health");
+    let health_detail = super::HealthDetail::new(
+        health_url,
+        "Go to Rack health reports",
+        rack_status.and_then(|status| status.health.clone()),
+        rack_status
+            .map(|status| status.health_sources.clone())
+            .unwrap_or_default(),
+    );
+
     let history = fetch_rack_state_history(&api, &rack_id).await;
 
     let display = RackDetail {
         id: rack_id.to_string(),
         lifecycle_detail: lifecycle.into(),
         version,
+        health_detail,
         associated_machines,
         associated_switches,
         associated_power_shelves,

--- a/crates/api/templates/health_detail.html
+++ b/crates/api/templates/health_detail.html
@@ -1,0 +1,30 @@
+<h3>Health</h3>
+
+<table class="detailsview">
+	<tr>
+		<th>Health Reports</th>
+		<td><a href="{{ health_reports_url }}">{{ health_reports_link_text }}</a></td>
+	</tr>
+	<tr><th>Report Source</th><td>{{ health.source }}</td></tr>
+	<tr><th>Report Observed At</th><td>{{ health.observed_at|option_fmt }}</td></tr>
+	<tr>
+		<th>Health Probe Alerts</th>
+		<td>
+			<a href="{{ health_reports_url }}">
+				{{ health.alerts|health_alerts_fmt(true, true)|safe }}
+			</a>
+		</td>
+	</tr>
+	<tr>
+		<th>Health Alert Classifications</th>
+		<td>{{ health.alerts|health_alert_classifications_fmt|safe }}</td>
+	</tr>
+	<tr>
+		<th>Health Reports</th>
+		<td>
+			<a href="{{ health_reports_url }}">
+				{{ health_sources|join("\n")|linebreaksbr|safe }}
+			</a>
+		</td>
+	</tr>
+</table>

--- a/crates/api/templates/health_reports_detail.html
+++ b/crates/api/templates/health_reports_detail.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 
-{% block title %}{{ machine_type }} Health {{ id }}{% endblock %}
+{% block title %}{{ object_label }} Health {{ id }}{% endblock %}
 
 {% block content %}
-<h1>{{ machine_type }} Health: <a href="/admin/machine/{{ id }}">{{ id }}</a></h1>
+<h1>{{ object_label }} Health: <a href="{{ object_detail_url }}">{{ id }}</a></h1>
 
 <!-- Main Aggregate Health Status -->
 {{ aggregate_health|safe }}
@@ -56,17 +56,19 @@
 			</p>
 			<div class="button-group horizontal">
 				<button onclick="setHealthReportTextBoxToTemplate(templateHealthReport)">Blank Template</button>
-				<button onclick="setHealthReportTextBoxToTemplate(templateMergeHostUpdateMaintenance)">Host Update</button>
 				<button onclick="setHealthReportTextBoxToTemplate(templateMergeInternalMaintenance)">Internal Maintenance</button>
+				<button onclick="setHealthReportTextBoxToTemplate(templateMergeSuppressExternalAlerting)">Suppress Alerts</button>
+				<button onclick="setHealthReportTextBoxToTemplate(templateMergeSingleAlert)">Merge Alert</button>
+				<button onclick="setHealthReportTextBoxToTemplate(templateReplaceSingleAlert)">Replace Alert</button>
+				<button onclick="setHealthReportTextBoxToTemplate(templateReplaceAsHealthy)">Mark Healthy</button>
+				{% if show_machine_templates %}
+				<button onclick="setHealthReportTextBoxToTemplate(templateMergeHostUpdateMaintenance)">Host Update</button>
 				<button onclick="setHealthReportTextBoxToTemplate(templateStopRebootForRecovery)">Prevent Reboot</button>
 				<button onclick="setHealthReportTextBoxToTemplate(templateMergeOfrMaintenance)">Out for Repair</button>
 				<button onclick="setHealthReportTextBoxToTemplate(templateMergeBreakfix)">Request Repair Automation</button>
 				<button onclick="setHealthReportTextBoxToTemplate(templateMergeDegradedMaintenance)">Degraded</button>
 				<button onclick="setHealthReportTextBoxToTemplate(templateMergeValidationMaintenance)">Validation</button>
-				<button onclick="setHealthReportTextBoxToTemplate(templateMergeSuppressExternalAlerting)">Suppress Alerts</button>
-				<button onclick="setHealthReportTextBoxToTemplate(templateMergeSingleAlert)">Merge Alert</button>
-				<button onclick="setHealthReportTextBoxToTemplate(templateReplaceSingleAlert)">Replace Alert</button>
-				<button onclick="setHealthReportTextBoxToTemplate(templateReplaceAsHealthy)">Mark Healthy</button>
+				{% endif %}
 			</div>
 		</td>
 	</tr>
@@ -82,22 +84,28 @@
 	</tr>
 </table>
 
-<h2>Component Health Details</h2>
+{% if !health_contributors.is_empty() %}
+<h2>Additional Health Contributors</h2>
 <details>
-	<summary>View Detailed Component Health Information</summary>
+	<summary>View Health Information that is contributed besides API managed Health Report Entries</summary>
 	<div style="padding: 1rem 0;">
-		{% for component in component_health %}
+		{% for health_report in health_contributors %}
 		<div style="margin-bottom: 2rem;">
-			{{ component|safe }}
+			{{ health_report|safe }}
 		</div>
 		{%endfor%}
 	</div>
 </details>
+{% endif %}
 
 <h2>Health History</h2>
+{% match history_url %}
+{% when Some with (history_url) %}
 <p style="margin-bottom: 1rem;">
-	<a href="/admin/machine/{{ id }}/health-history">View extended history timeline →</a>
+	<a href="{{ history_url }}">View extended history timeline →</a>
 </p>
+{% when None %}
+{% endmatch %}
 {{ history|safe }}
 
 {% endblock %}
@@ -182,7 +190,7 @@ const templateMergeSuppressExternalAlerting = {
 	health_report: {
 		source: "suppress-paging",
 		successes: [],
-		alerts: [{id: "SuppressExternalAlerting", target: null, message: "Paging is suppressed for this Host", tenant_message: null, classifications: ["SuppressExternalAlerting"]}]
+		alerts: [{id: "SuppressExternalAlerting", target: null, message: "Paging is suppressed for this {{ object_label }}", tenant_message: null, classifications: ["SuppressExternalAlerting"]}]
 	}
 };
 

--- a/crates/api/templates/machine_detail.html
+++ b/crates/api/templates/machine_detail.html
@@ -60,39 +60,8 @@
 <h3>Metadata</h3>
 {{ metadata_detail|safe }}
 
-<h3>Health</h3>
+{{ health_detail|safe }}
 <table class="detailsview">
-	<tr><th>Health Reports</th>
-		<td>
-			{% if !is_host %}
-				<a href="/admin/machine/{{ host_id }}/health">Go to ManagedHost health reports</a>
-			{% else %}
-				<a href="/admin/machine/{{ id }}/health">Go to ManagedHost health reports</a>
-			{% endif %}
-		</td>
-	</tr>
-	<tr><th>Report Source</th><td>{{ health.source }}</td></tr>
-	<tr><th>Report Observed At</th><td>{{ health.observed_at|option_fmt }}</td></tr>
-	<tr>
-		<th>Health Probe Alerts</th>
-		<td>
-			<a href="/admin/machine/{{ id }}/health">
-				{{ health.alerts|health_alerts_fmt(true, true)|safe }}
-			</a>
-		</td>
-	</tr>
-	<tr>
-		<th>Health Alert Classifications</th>
-		<td>{{ health.alerts|health_alert_classifications_fmt|safe }}</td>
-	</tr>
-	<tr>
-		<th>Health Reports</th>
-		<td>
-			<a href="/admin/machine/{{ id }}/health">
-				{{ health_sources|join("\n")|linebreaksbr|safe }}
-			</a>
-		</td>
-	</tr>
 	<tr>
 		<th>Attestation Results</th>
 		<td>

--- a/crates/api/templates/rack_detail.html
+++ b/crates/api/templates/rack_detail.html
@@ -22,6 +22,8 @@
 
 {{ lifecycle_detail|safe }}
 
+{{ health_detail|safe }}
+
 <h2>Metadata</h2>
 {{ metadata_detail|safe }}
 


### PR DESCRIPTION
## Description

Adds a Rack health page in the web UI under /rack/$id/health, with the ability to add and remove health reports as for machines.

The common template was restructured to show all "health entries" only at the top of the page in the "active health reports" table.

The component health section was replaced by an "additional health contributors" section that is populated only for Machines. For these it contains the DPU health reports.

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

