### PR TITLE
bmc-mock: cover factory-default auth in integration path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,6 +697,7 @@ dependencies = [
  "bytes",
  "cookie",
  "futures-util",
+ "headers",
  "http",
  "http-body",
  "http-body-util",
@@ -1016,6 +1017,7 @@ version = "0.1.0"
 dependencies = [
  "arc-swap",
  "axum 0.8.6",
+ "axum-extra",
  "axum-server",
  "bmc-vendor",
  "bytes",
@@ -4939,6 +4941,30 @@ dependencies = [
  "serde",
  "serde_json",
  "uuid",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
 ]
 
 [[package]]

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -313,7 +313,7 @@ pub fn create_ipmi_tool(
         }
         Some("bmc-mock") => {
             tracing::info!("Using HTTP IPMI transport via bmc_proxy");
-            carbide_ipmi::bmc_mock(bmc_proxy)
+            carbide_ipmi::bmc_mock(bmc_proxy, credential_reader)
         }
         _ => {
             tracing::info!("Using lanplus IPMI transport (/usr/bin/ipmitool)");

--- a/crates/bmc-mock/Cargo.toml
+++ b/crates/bmc-mock/Cargo.toml
@@ -29,6 +29,7 @@ carbide-utils = { path = "../utils", default-features = false }
 
 arc-swap = { workspace = true }
 axum = { workspace = true }
+axum-extra = { features = [ "typed-header" ], workspace = true }
 axum-server = { features = ["tls-rustls"], workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }

--- a/crates/bmc-mock/src/auth_router.rs
+++ b/crates/bmc-mock/src/auth_router.rs
@@ -1,0 +1,182 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::http::header::WWW_AUTHENTICATE;
+use axum::http::{HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::any;
+use axum_extra::TypedHeader;
+use axum_extra::headers::Authorization;
+use axum_extra::headers::authorization::Basic;
+use tracing::instrument;
+
+use crate::http::call_router_with_new_request;
+use crate::redfish::account_service::AccountServiceState;
+use crate::redfish::{account_service, service_root};
+
+const WWW_AUTHENTICATE_VALUE: HeaderValue = HeaderValue::from_static("Basic realm=\"bmc-mock\"");
+
+pub fn append(router: Router, authorizer: Authorizer) -> Router {
+    let service_root_path = service_root::resource().odata_id.to_string();
+    let service_root_path_with_trailing_slash = format!("{service_root_path}/");
+    let account_service_path = account_service::resource().odata_id.to_string();
+    let account_service_subtree_path = format!("{account_service_path}/{{*all}}");
+
+    Router::new()
+        .route(&service_root_path, any(process_without_auth))
+        .route(
+            &service_root_path_with_trailing_slash,
+            any(process_without_auth),
+        )
+        .route(&account_service_path, any(process_account_service))
+        .route(&account_service_subtree_path, any(process_account_service))
+        .route("/{*all}", any(process))
+        .with_state(AuthMiddleware {
+            inner: router,
+            authorizer,
+        })
+}
+
+#[instrument(skip_all)]
+async fn process_without_auth(
+    State(mut state): State<AuthMiddleware>,
+    request: Request<Body>,
+) -> Response {
+    state.call_inner_router(request).await
+}
+
+#[instrument(skip_all)]
+async fn process_account_service(
+    State(mut state): State<AuthMiddleware>,
+    authorization: Option<TypedHeader<Authorization<Basic>>>,
+    request: Request<Body>,
+) -> Response {
+    match state.authorizer.authorize(authorization.as_ref(), true) {
+        AuthorizationResult::Authorized => state.call_inner_router(request).await,
+        AuthorizationResult::Unauthorized => {
+            tracing::warn!(
+                method = request.method().as_str(),
+                path = request.uri().path(),
+                "Unauthorized request",
+            );
+            unauthorized_response()
+        }
+        AuthorizationResult::FactoryDefaultPasswordForbidden => {
+            unreachable!("account service authorization does not forbid factory-default passwords")
+        }
+    }
+}
+
+#[instrument(skip_all)]
+async fn process(
+    State(mut state): State<AuthMiddleware>,
+    authorization: Option<TypedHeader<Authorization<Basic>>>,
+    request: Request<Body>,
+) -> Response {
+    match state.authorizer.authorize(authorization.as_ref(), false) {
+        AuthorizationResult::Authorized => state.call_inner_router(request).await,
+        AuthorizationResult::Unauthorized => {
+            tracing::warn!(
+                method = request.method().as_str(),
+                path = request.uri().path(),
+                "Unauthorized request",
+            );
+            unauthorized_response()
+        }
+        AuthorizationResult::FactoryDefaultPasswordForbidden => {
+            tracing::warn!(
+                method = request.method().as_str(),
+                path = request.uri().path(),
+                "Factory-default password must be changed before accessing this resource",
+            );
+            StatusCode::FORBIDDEN.into_response()
+        }
+    }
+}
+
+fn unauthorized_response() -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        [(WWW_AUTHENTICATE, WWW_AUTHENTICATE_VALUE)],
+    )
+        .into_response()
+}
+
+#[derive(Clone)]
+struct AuthMiddleware {
+    inner: Router,
+    authorizer: Authorizer,
+}
+
+impl AuthMiddleware {
+    async fn call_inner_router(&mut self, request: Request<Body>) -> Response {
+        call_router_with_new_request(&mut self.inner, request).await
+    }
+}
+
+#[derive(Clone)]
+pub struct Authorizer {
+    account_service_state: Arc<AccountServiceState>,
+}
+
+impl Authorizer {
+    /// Builds the factory-default authorizer for a mock BMC state.
+    pub fn new(account_service_state: Arc<AccountServiceState>) -> Self {
+        Self {
+            account_service_state,
+        }
+    }
+
+    fn authorize(
+        &self,
+        authorization: Option<&TypedHeader<Authorization<Basic>>>,
+        permit_factory_default: bool,
+    ) -> AuthorizationResult {
+        let Some(authorization) = authorization else {
+            return AuthorizationResult::Unauthorized;
+        };
+        let actual = &authorization.0.0;
+        if self
+            .account_service_state
+            .is_authorized(actual.username(), actual.password())
+        {
+            if !permit_factory_default
+                && self
+                    .account_service_state
+                    .is_factory_default_password(actual.username(), actual.password())
+            {
+                AuthorizationResult::FactoryDefaultPasswordForbidden
+            } else {
+                AuthorizationResult::Authorized
+            }
+        } else {
+            AuthorizationResult::Unauthorized
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AuthorizationResult {
+    Authorized,
+    Unauthorized,
+    FactoryDefaultPasswordForbidden,
+}

--- a/crates/bmc-mock/src/bmc_state.rs
+++ b/crates/bmc-mock/src/bmc_state.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use crate::bug::InjectedBugs;
 use crate::redfish;
+use crate::redfish::account_service::AccountServiceState;
 use crate::redfish::chassis::ChassisState;
 use crate::redfish::computer_system::SystemState;
 use crate::redfish::manager::ManagerState;
@@ -33,6 +34,7 @@ pub struct BmcState {
     pub system_state: Arc<SystemState>,
     pub chassis_state: Arc<ChassisState>,
     pub update_service_state: Arc<UpdateServiceState>,
+    pub account_service_state: Arc<AccountServiceState>,
     pub injected_bugs: Arc<InjectedBugs>,
     pub callbacks: Option<Arc<dyn crate::Callbacks>>,
 }

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 use tokio::time::Instant;
 pub mod ipmi;
 
+mod auth_router;
 mod bmc_state;
 pub mod bug;
 mod combined_server;
@@ -44,6 +45,10 @@ pub use machine_info::{
 pub use mock_machine_router::{
     BmcCommand, SetSystemPowerError, SetSystemPowerResult, machine_router,
 };
+
+pub const DUMMY_FACTORY_USERNAME: &str = "root";
+pub const DUMMY_FACTORY_PASSWORD: &str = "factory_password";
+pub const DUMMY_FACTORY_DPU_PASSWORD: &str = "0penBmc";
 
 #[derive(Default, Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq)]
 pub enum HostHardwareType {

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -24,7 +24,9 @@ use serde::{Deserialize, Serialize};
 use crate::redfish::update_service::UpdateServiceConfig;
 use crate::{hw, redfish};
 static NEXT_MAC_ADDRESS: AtomicU32 = AtomicU32::new(1);
-use crate::HostHardwareType;
+use crate::{
+    DUMMY_FACTORY_DPU_PASSWORD, DUMMY_FACTORY_PASSWORD, DUMMY_FACTORY_USERNAME, HostHardwareType,
+};
 
 /// Represents static information we know ahead of time about a host or DPU (independent of any
 /// state we get from carbide like IP addresses or machine ID's.) Intended to be immutable and
@@ -280,6 +282,19 @@ impl HostMachineInfo {
                 panic!("discovery_info requested for {}", self.hw_type)
             }
         }
+    }
+
+    pub fn factory_default_account(&self) -> redfish::account_service::Account {
+        // TODO: need to be updated for each individual system.
+        let id = match self.hw_type {
+            HostHardwareType::NvidiaDgxH100 => "2",
+            _ => DUMMY_FACTORY_USERNAME,
+        };
+        redfish::account_service::Account::administrator(
+            id,
+            DUMMY_FACTORY_USERNAME,
+            DUMMY_FACTORY_PASSWORD,
+        )
     }
 
     fn dell_poweredge_r750(&self) -> hw::dell_poweredge_r750::DellPowerEdgeR750<'_> {
@@ -586,6 +601,17 @@ impl MachineInfo {
         match self {
             Self::Host(h) => h.discovery_info(),
             Self::Dpu(dpu) => dpu.bluefield3().discovery_info(),
+        }
+    }
+
+    pub fn factory_default_account(&self) -> redfish::account_service::Account {
+        match self {
+            MachineInfo::Host(h) => h.factory_default_account(),
+            MachineInfo::Dpu(_) => redfish::account_service::Account::administrator(
+                "root",
+                DUMMY_FACTORY_USERNAME,
+                DUMMY_FACTORY_DPU_PASSWORD,
+            ),
         }
     }
 }

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -162,6 +162,7 @@ fn default_host_mock() -> Router {
         )),
         callbacks,
         String::default(),
+        false,
     )
     .0
 }

--- a/crates/bmc-mock/src/mock_machine_router.rs
+++ b/crates/bmc-mock/src/mock_machine_router.rs
@@ -23,11 +23,12 @@ use axum::routing::get;
 use axum::{Json, Router};
 use tokio::sync::oneshot;
 
+use crate::auth_router::Authorizer;
 use crate::bmc_state::BmcState;
 use crate::bug::InjectedBugs;
 use crate::json::JsonExt;
 use crate::redfish::manager::ManagerState;
-use crate::{Callbacks, MachineInfo, SystemPowerControl, middleware_router, redfish};
+use crate::{Callbacks, MachineInfo, SystemPowerControl, auth_router, middleware_router, redfish};
 
 #[derive(Debug)]
 pub enum BmcCommand {
@@ -66,6 +67,7 @@ pub fn machine_router(
     machine_info: MachineInfo,
     callbacks: Arc<dyn Callbacks>,
     mat_host_id: String,
+    redfish_auth: bool,
 ) -> (Router, BmcState) {
     let system_config = machine_info.system_config(callbacks.clone());
     let chassis_config = machine_info.chassis_config();
@@ -74,6 +76,7 @@ pub fn machine_router(
     let bmc_product = machine_info.bmc_product();
     let bmc_redfish_version = machine_info.bmc_redfish_version();
     let oem_state = machine_info.oem_state();
+    let factory_default_account = machine_info.factory_default_account();
     let router = Router::new()
         // Couple routes for bug injection.
         .route(
@@ -104,6 +107,9 @@ pub fn machine_router(
     let update_service_state = Arc::new(
         crate::redfish::update_service::UpdateServiceState::from_config(update_service_config),
     );
+    let account_service_state = Arc::new(
+        crate::redfish::account_service::AccountServiceState::new(factory_default_account),
+    );
     let injected_bugs = Arc::new(InjectedBugs::default());
     let state = BmcState {
         bmc_vendor,
@@ -114,15 +120,27 @@ pub fn machine_router(
         system_state,
         chassis_state,
         update_service_state,
+        account_service_state,
         injected_bugs: injected_bugs.clone(),
         callbacks: Some(callbacks.clone()),
     };
-    let router = router.with_state(state.clone());
-    let router_with_expansion = redfish::expander_router::append(router);
-    (
-        middleware_router::append(mat_host_id, router_with_expansion, injected_bugs, callbacks),
-        state,
-    )
+    let account_service_state = state.account_service_state.clone();
+    let router = ([
+        Box::new(redfish::expander_router::append),
+        Box::new(move |router| {
+            if redfish_auth {
+                auth_router::append(router, Authorizer::new(account_service_state))
+            } else {
+                router
+            }
+        }),
+        Box::new(move |router| {
+            middleware_router::append(mat_host_id, router, injected_bugs, callbacks)
+        }),
+    ] as [Box<dyn FnOnce(axum::Router) -> axum::Router>; _])
+        .into_iter()
+        .fold(router.with_state(state.clone()), |router, f| f(router));
+    (router, state)
 }
 
 async fn get_injected_bugs(State(state): State<BmcState>) -> Response {

--- a/crates/bmc-mock/src/redfish/account_service.rs
+++ b/crates/bmc-mock/src/redfish/account_service.rs
@@ -17,11 +17,13 @@
 
 use std::borrow::Cow;
 use std::fmt::Display;
+use std::sync::Mutex;
 
-use axum::Router;
-use axum::extract::Path;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
 use axum::response::Response;
 use axum::routing::get;
+use axum::{Json, Router};
 use serde_json::json;
 
 use crate::bmc_state::BmcState;
@@ -55,6 +57,100 @@ const ACCOUNTS_COLLECTION_RESOURCE: redfish::Collection<'static> = redfish::Coll
     name: Cow::Borrowed("Accounts Collection"),
 };
 
+#[derive(Debug)]
+pub struct AccountServiceState {
+    accounts: Mutex<Vec<Account>>,
+}
+
+impl AccountServiceState {
+    pub fn new(factory_default_account: Account) -> Self {
+        Self {
+            accounts: Mutex::new(vec![factory_default_account]),
+        }
+    }
+
+    pub fn accounts(&self) -> Vec<Account> {
+        self.accounts.lock().expect("mutex poisoned").clone()
+    }
+
+    pub fn find(&self, account_id: &str) -> Option<Account> {
+        self.accounts
+            .lock()
+            .expect("mutex poisoned")
+            .iter()
+            .find(|account| account.id == account_id)
+            .cloned()
+    }
+
+    pub fn is_authorized(&self, username: &str, password: &str) -> bool {
+        self.accounts
+            .lock()
+            .expect("mutex poisoned")
+            .iter()
+            .any(|account| account.matches(username, password))
+    }
+
+    pub fn is_factory_default_password(&self, username: &str, password: &str) -> bool {
+        self.accounts
+            .lock()
+            .expect("mutex poisoned")
+            .iter()
+            .any(|account| account.matches_factory_default_password(username, password))
+    }
+
+    pub fn update_password(&self, account_id: &str, password: impl Into<String>) -> bool {
+        let mut accounts = self.accounts.lock().expect("mutex poisoned");
+        let Some(account) = accounts.iter_mut().find(|account| account.id == account_id) else {
+            return false;
+        };
+        account.password = password.into();
+        true
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Account {
+    id: String,
+    username: String,
+    password: String,
+    factory_default_password: String,
+    role_id: String,
+}
+
+impl Account {
+    pub fn administrator(
+        id: impl Into<String>,
+        username: impl Into<String>,
+        password: impl Into<String>,
+    ) -> Self {
+        let password = password.into();
+        Self {
+            id: id.into(),
+            username: username.into(),
+            password: password.clone(),
+            factory_default_password: password,
+            role_id: "Administrator".into(),
+        }
+    }
+
+    fn matches(&self, username: &str, password: &str) -> bool {
+        self.username == username && self.password == password
+    }
+
+    fn matches_factory_default_password(&self, username: &str, password: &str) -> bool {
+        self.matches(username, password) && self.password == self.factory_default_password
+    }
+
+    fn to_json(&self) -> serde_json::Value {
+        json!({
+            "UserName": self.username,
+            "RoleId": self.role_id,
+            "AccountTypes": ["Redfish"]
+        })
+        .patch(account_resource(&self.id))
+    }
+}
+
 pub async fn get_root() -> Response {
     let service_attrs = json!({
         "AccountLockoutCounterResetAfter": 0,
@@ -84,36 +180,51 @@ pub fn account_resource(id: impl Display) -> redfish::Resource<'static> {
     }
 }
 
-pub async fn get_accounts() -> Response {
-    // This is Dell-specific behavior of Account handling. Fixed slots...
-    let members = (1..16)
-        .map(|v| json!({"@odata.id": format!("{}/{v}", ACCOUNTS_COLLECTION_RESOURCE.odata_id)}))
+pub async fn get_accounts(State(state): State<BmcState>) -> Response {
+    let members = state
+        .account_service_state
+        .accounts()
+        .iter()
+        .map(|account| account_resource(&account.id).entity_ref())
         .collect::<Vec<_>>();
     ACCOUNTS_COLLECTION_RESOURCE
         .with_members(&members)
         .into_ok_response()
 }
 
-pub async fn create_account(Path(_account_id): Path<String>) -> Response {
+pub async fn create_account() -> Response {
     json!({}).into_ok_response()
 }
 
-pub async fn patch_account(Path(_account_id): Path<String>) -> Response {
-    http::ok_no_content()
+pub async fn patch_account(
+    State(state): State<BmcState>,
+    Path(account_id): Path<String>,
+    Json(patch_account): Json<serde_json::Value>,
+) -> Response {
+    let Some(password) = patch_account
+        .get("Password")
+        .and_then(serde_json::Value::as_str)
+    else {
+        return json!("Password must be a string").into_response(StatusCode::BAD_REQUEST);
+    };
+
+    if state
+        .account_service_state
+        .update_password(&account_id, password)
+    {
+        http::ok_no_content()
+    } else {
+        http::not_found()
+    }
 }
 
-pub async fn get_account(Path(account_id): Path<String>) -> Response {
-    // This is Dell behavior must be fixed for other platform.
-    let (username, role_id) = if account_id == "2" {
-        ("root", "Administrator")
-    } else {
-        ("", "")
-    };
-    json!({
-        "UserName": username,
-        "RoleId": role_id,
-        "AccountTypes": ["Redfish"]
-    })
-    .patch(account_resource(account_id))
-    .into_ok_response()
+pub async fn get_account(
+    State(state): State<BmcState>,
+    Path(account_id): Path<String>,
+) -> Response {
+    state
+        .account_service_state
+        .find(&account_id)
+        .map(|account| account.to_json().into_ok_response())
+        .unwrap_or_else(http::not_found)
 }

--- a/crates/bmc-mock/src/redfish/expander_router.rs
+++ b/crates/bmc-mock/src/redfish/expander_router.rs
@@ -263,6 +263,7 @@ mod tests {
             )),
             callbacks,
             String::default(),
+            false,
         )
         .0
     }

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -82,6 +82,7 @@ pub async fn wiwynn_gb200_bmc() -> TestBmcHandle {
         )),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
+        false,
     ))
     .await
 }
@@ -94,6 +95,7 @@ pub async fn liteon_powershelf_bmc() -> TestBmcHandle {
         )),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
+        false,
     ))
     .await
 }
@@ -106,6 +108,7 @@ pub async fn nvidia_switch_nd5200_ld_bmc() -> TestBmcHandle {
         )),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
+        false,
     ))
     .await
 }
@@ -118,6 +121,7 @@ pub async fn dell_poweredge_r750_bmc() -> TestBmcHandle {
         )),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
+        false,
     ))
     .await
 }
@@ -130,6 +134,7 @@ pub async fn dell_poweredge_r750_bluefield3_bmc(settings: DpuSettings) -> TestBm
         )),
         Arc::new(NoopCallbacks),
         "test-dpu-id".to_string(),
+        false,
     ))
     .await
 }
@@ -154,6 +159,7 @@ mod test {
                 )),
                 Arc::new(NoopCallbacks),
                 "test-host-id".to_string(),
+                false,
             )
             .0,
         );

--- a/crates/ipmi/src/bmc_mock.rs
+++ b/crates/ipmi/src/bmc_mock.rs
@@ -23,7 +23,7 @@ use async_trait::async_trait;
 use carbide_utils::HostPortPair;
 use carbide_uuid::machine::MachineId;
 use eyre::eyre;
-use forge_secrets::credentials::CredentialKey;
+use forge_secrets::credentials::{CredentialKey, CredentialReader, Credentials};
 
 use crate::IPMITool;
 
@@ -31,14 +31,26 @@ use crate::IPMITool;
 /// Sends JSON requests to bmc_proxy which routes to appropriate machine.
 pub struct IPMIToolHttpImpl {
     bmc_proxy: Arc<ArcSwap<Option<HostPortPair>>>,
+    credential_reader: Arc<dyn CredentialReader>,
 }
 
 impl IPMIToolHttpImpl {
-    pub fn new(bmc_proxy: Arc<ArcSwap<Option<HostPortPair>>>) -> Self {
-        Self { bmc_proxy }
+    pub fn new(
+        bmc_proxy: Arc<ArcSwap<Option<HostPortPair>>>,
+        credential_reader: Arc<dyn CredentialReader>,
+    ) -> Self {
+        Self {
+            bmc_proxy,
+            credential_reader,
+        }
     }
 
-    async fn execute_action(&self, action: &str, bmc_ip: IpAddr) -> Result<(), eyre::Report> {
+    async fn execute_action(
+        &self,
+        action: &str,
+        bmc_ip: IpAddr,
+        credential_key: &CredentialKey,
+    ) -> Result<(), eyre::Report> {
         let proxy = self.bmc_proxy.load();
 
         // Determine the target URL and headers based on whether a proxy is configured
@@ -61,6 +73,16 @@ impl IPMIToolHttpImpl {
             }
         };
 
+        let credentials = self
+            .credential_reader
+            .get_credentials(credential_key)
+            .await
+            .map_err(|e| {
+                eyre!("Secret engine getting credentials for key {credential_key:#?}: {e:#?}")
+            })?
+            .ok_or_else(|| eyre!("No credentials for key {credential_key:#?} found"))?;
+        let Credentials::UsernamePassword { username, password } = credentials;
+
         let client = reqwest::Client::builder()
             .danger_accept_invalid_certs(true)
             .build()
@@ -68,6 +90,7 @@ impl IPMIToolHttpImpl {
 
         let mut request = client
             .post(&url)
+            .basic_auth(username, Some(password))
             .json(&serde_json::json!({"action": action}));
 
         if let Some(header) = forwarded_header {
@@ -110,9 +133,10 @@ impl IPMITool for IPMIToolHttpImpl {
     async fn bmc_cold_reset(
         &self,
         bmc_ip: IpAddr,
-        _credential_key: &CredentialKey,
+        credential_key: &CredentialKey,
     ) -> Result<(), eyre::Report> {
-        self.execute_action("bmc_cold_reset", bmc_ip).await
+        self.execute_action("bmc_cold_reset", bmc_ip, credential_key)
+            .await
     }
 
     async fn restart(
@@ -120,12 +144,18 @@ impl IPMITool for IPMIToolHttpImpl {
         _machine_id: &MachineId,
         bmc_ip: IpAddr,
         legacy_boot: bool,
-        _credential_key: &CredentialKey,
+        credential_key: &CredentialKey,
     ) -> Result<(), eyre::Report> {
-        if legacy_boot && self.execute_action("dpu_legacy_boot", bmc_ip).await.is_ok() {
+        if legacy_boot
+            && self
+                .execute_action("dpu_legacy_boot", bmc_ip, credential_key)
+                .await
+                .is_ok()
+        {
             return Ok(());
         }
         // Fall through to chassis_power_reset if legacy_boot fails or is false
-        self.execute_action("chassis_power_reset", bmc_ip).await
+        self.execute_action("chassis_power_reset", bmc_ip, credential_key)
+            .await
     }
 }

--- a/crates/ipmi/src/lib.rs
+++ b/crates/ipmi/src/lib.rs
@@ -49,8 +49,14 @@ pub fn tool(cred_provider: Arc<dyn CredentialReader>, attempts: Option<u32>) -> 
     Arc::new(tool::IPMIToolImpl::new(cred_provider, attempts))
 }
 
-pub fn bmc_mock(bmc_proxy: Arc<ArcSwap<Option<HostPortPair>>>) -> Arc<dyn IPMITool> {
-    Arc::new(bmc_mock::IPMIToolHttpImpl::new(bmc_proxy))
+pub fn bmc_mock(
+    bmc_proxy: Arc<ArcSwap<Option<HostPortPair>>>,
+    credential_reader: Arc<dyn CredentialReader>,
+) -> Arc<dyn IPMITool> {
+    Arc::new(bmc_mock::IPMIToolHttpImpl::new(
+        bmc_proxy,
+        credential_reader,
+    ))
 }
 
 pub fn test_support() -> Arc<dyn IPMITool> {

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -17,7 +17,7 @@
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use base64::prelude::*;
-use bmc_mock::MachineInfo;
+use bmc_mock::{DUMMY_FACTORY_PASSWORD, DUMMY_FACTORY_USERNAME, MachineInfo};
 use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use mac_address::MacAddress;
@@ -508,8 +508,8 @@ impl ApiClient {
         self.0
             .add_expected_machine(ExpectedMachine {
                 bmc_mac_address,
-                bmc_username: "root".to_string(),
-                bmc_password: "factory_password".to_string(),
+                bmc_username: DUMMY_FACTORY_USERNAME.to_string(),
+                bmc_password: DUMMY_FACTORY_PASSWORD.to_string(),
                 chassis_serial_number,
                 fallback_dpu_serial_numbers: Vec::new(),
                 metadata: None,

--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -52,7 +52,7 @@ impl BmcMockWrapper {
         host_id: Uuid,
     ) -> Self {
         let (bmc_mock_router, bmc_mock_state) =
-            bmc_mock::machine_router(machine_info.clone(), callbacks, host_id.to_string());
+            bmc_mock::machine_router(machine_info.clone(), callbacks, host_id.to_string(), true);
 
         BmcMockWrapper {
             machine_info,

--- a/crates/redfish/src/nv_redfish/mod.rs
+++ b/crates/redfish/src/nv_redfish/mod.rs
@@ -97,7 +97,7 @@ impl NvRedfishClientPool {
         }
     }
 
-    pub fn cached_root(
+    fn cached_root(
         &self,
         bmc_address: SocketAddr,
         credentials: Credentials,


### PR DESCRIPTION
## Description

Follow up on #1249 / bf980856db, which fixed BMC password rotation by using an uninitialized Redfish client for the initial factory-credential password change.  That regression showed that our tests could miss the real BMC behavior where most resources are inaccessible until the factory-default password has been rotated.

Add AccountService-backed Basic Auth to bmc-mock and enable it for the machine-a-tron bmc-mock integration path.  The mock now allows the Redfish service root without auth, allows AccountService access with the factory-default password so clients can change it, and returns 403 for other authenticated requests until the factory-default password has been changed.

Also pass credentials through the HTTP IPMI bmc-mock transport so IPMI calls use the same authenticated mock BMC behavior.

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
