### PR TITLE
fix VPC version increments and flaky tests

### DIFF
--- a/crates/api-db/src/vpc.rs
+++ b/crates/api-db/src/vpc.rs
@@ -358,30 +358,25 @@ pub async fn update_virtualization(
 pub async fn increment_vpc_version(
     txn: &mut PgConnection,
     id: VpcId,
+    expected_version: ConfigVersion,
 ) -> Result<ConfigVersion, DatabaseError> {
-    let read_query = "SELECT version FROM vpcs WHERE id=$1";
-    let current_version: ConfigVersion = sqlx::query_as(read_query)
-        .bind(id)
-        .fetch_one(&mut *txn)
-        .await
-        .map_err(|e| DatabaseError::query(read_query, e))?;
-
-    let new_version = current_version.increment();
+    let next_version = expected_version.increment();
 
     let update_query =
         "UPDATE vpcs SET version = $1 WHERE id = $2 AND version = $3 RETURNING version";
-    let updated: Option<(ConfigVersion,)> = sqlx::query_as(update_query)
-        .bind(new_version)
+    let updated: Result<(ConfigVersion,), _> = sqlx::query_as(update_query)
+        .bind(next_version)
         .bind(id)
-        .bind(current_version)
-        .fetch_optional(&mut *txn)
-        .await
-        .map_err(|e| DatabaseError::query(update_query, e))?;
+        .bind(expected_version)
+        .fetch_one(&mut *txn)
+        .await;
 
-    updated
-        .map(|(v,)| v)
-        .ok_or(DatabaseError::ConcurrentModificationError(
+    match updated {
+        Ok((version,)) => Ok(version),
+        Err(sqlx::Error::RowNotFound) => Err(DatabaseError::ConcurrentModificationError(
             "vpc",
-            current_version.to_string(),
-        ))
+            expected_version.to_string(),
+        )),
+        Err(e) => Err(DatabaseError::query(update_query, e)),
+    }
 }

--- a/crates/api-db/src/vpc_prefix.rs
+++ b/crates/api-db/src/vpc_prefix.rs
@@ -16,6 +16,7 @@
  */
 
 pub use carbide_uuid::vpc::{VpcId, VpcPrefixId};
+use config_version::ConfigVersion;
 use ipnetwork::IpNetwork;
 use itertools::Itertools;
 use model::network_prefix::NetworkPrefix;
@@ -234,6 +235,7 @@ impl ColumnInfo<'_> for IdColumn {
 
 pub async fn persist(
     value: NewVpcPrefix,
+    expected_vpc_version: ConfigVersion,
     txn: &mut PgConnection,
 ) -> Result<VpcPrefix, DatabaseError> {
     let insert_query = "INSERT INTO network_vpc_prefixes (id, prefix, name, labels, description, vpc_id) VALUES ($1, $2, $3, $4::json, $5, $6) RETURNING *";
@@ -248,7 +250,7 @@ pub async fn persist(
         .await
         .map_err(|e| DatabaseError::query(insert_query, e))?;
 
-    increment_vpc_version(txn, value.vpc_id).await?;
+    increment_vpc_version(txn, value.vpc_id, expected_vpc_version).await?;
 
     Ok(vpc_prefix)
 }
@@ -310,6 +312,7 @@ pub async fn update(
 
 pub async fn delete(
     value: &DeleteVpcPrefix,
+    expected_vpc_version: ConfigVersion,
     txn: &mut PgConnection,
 ) -> Result<VpcPrefixId, DatabaseError> {
     let query = "DELETE FROM network_vpc_prefixes WHERE id=$1 RETURNING *";
@@ -319,7 +322,7 @@ pub async fn delete(
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
 
-    increment_vpc_version(txn, deleted_prefix.vpc_id).await?;
+    increment_vpc_version(txn, deleted_prefix.vpc_id, expected_vpc_version).await?;
 
     Ok(deleted_prefix.id)
 }

--- a/crates/api/src/handlers/vpc_prefix.rs
+++ b/crates/api/src/handlers/vpc_prefix.rs
@@ -63,23 +63,26 @@ pub async fn create(
 
     let mut txn = api.txn_begin().await?;
 
+    let vpcs = ::db::vpc::find_by(
+        &mut txn,
+        ObjectColumnFilter::One(::db::vpc::IdColumn, &new_prefix.vpc_id),
+    )
+    .await?;
+    let vpc = vpcs.first().ok_or_else(|| CarbideError::NotFoundError {
+        kind: "vpc",
+        id: new_prefix.vpc_id.to_string(),
+    })?;
+
     // IPv6 VPC prefixes are only supported for FNN VPCs.
-    if new_prefix.config.prefix.is_ipv6() {
-        let vpcs = ::db::vpc::find_by(
-            &mut txn,
-            ObjectColumnFilter::One(::db::vpc::IdColumn, &new_prefix.vpc_id),
+    if new_prefix.config.prefix.is_ipv6()
+        && vpc.network_virtualization_type != VpcVirtualizationType::Fnn
+    {
+        return Err(CarbideError::InvalidArgument(
+            "IPv6 VPC prefixes are only supported for FNN VPCs".to_string(),
         )
-        .await?;
-        let vpc = vpcs.first().ok_or_else(|| {
-            CarbideError::internal(format!("VPC ID: {} not found", new_prefix.vpc_id))
-        })?;
-        if vpc.network_virtualization_type != VpcVirtualizationType::Fnn {
-            return Err(CarbideError::InvalidArgument(
-                "IPv6 VPC prefixes are only supported for FNN VPCs".to_string(),
-            )
-            .into());
-        }
+        .into());
     }
+    let expected_vpc_version = vpc.version;
 
     let conflicting_vpc_prefixes = db::probe(new_prefix.config.prefix, &mut txn).await?;
     if !conflicting_vpc_prefixes.is_empty() {
@@ -164,7 +167,7 @@ pub async fn create(
         .validate(true)
         .map_err(CarbideError::from)?;
 
-    let vpc_prefix = db::persist(new_prefix, &mut txn).await?;
+    let vpc_prefix = db::persist(new_prefix, expected_vpc_version, &mut txn).await?;
 
     // Associate all of the network segment prefixes with the new VPC prefix.
     for mut segment_prefix in segment_prefixes {
@@ -305,7 +308,29 @@ pub async fn delete(
     // whatever else might be pointing at them. For now we're just relying on
     // the DB constraints and returning whatever error that results in.
 
-    db::delete(&delete_prefix, &mut txn).await?;
+    let vpc_prefixes = db::get_by_id(
+        &mut txn,
+        ObjectColumnFilter::One(db::IdColumn, &delete_prefix.id),
+    )
+    .await?;
+    let vpc_prefix = vpc_prefixes
+        .first()
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "vpc_prefix",
+            id: delete_prefix.id.to_string(),
+        })?;
+
+    let vpcs = ::db::vpc::find_by(
+        &mut txn,
+        ObjectColumnFilter::One(::db::vpc::IdColumn, &vpc_prefix.vpc_id),
+    )
+    .await?;
+    let vpc = vpcs.first().ok_or_else(|| CarbideError::NotFoundError {
+        kind: "vpc",
+        id: vpc_prefix.vpc_id.to_string(),
+    })?;
+
+    db::delete(&delete_prefix, vpc.version, &mut txn).await?;
 
     txn.commit().await?;
 

--- a/crates/api/src/tests/instance.rs
+++ b/crates/api/src/tests/instance.rs
@@ -2872,6 +2872,14 @@ async fn create_tenant_overlay_prefix(
     vpc_id: carbide_uuid::vpc::VpcId,
 ) -> VpcPrefixId {
     let mut txn = env.db_txn().await;
+    let vpcs = db::vpc::find_by(
+        txn.as_mut(),
+        ObjectColumnFilter::One(db::vpc::IdColumn, &vpc_id),
+    )
+    .await
+    .unwrap();
+    let expected_vpc_version = vpcs[0].version;
+
     let vpc_prefix_id = db::vpc_prefix::persist(
         model::vpc_prefix::NewVpcPrefix {
             id: uuid::Uuid::new_v4().into(),
@@ -2887,6 +2895,7 @@ async fn create_tenant_overlay_prefix(
                 labels: HashMap::new(),
             },
         },
+        expected_vpc_version,
         &mut txn,
     )
     .await

--- a/crates/api/src/tests/vpc.rs
+++ b/crates/api/src/tests/vpc.rs
@@ -990,19 +990,20 @@ async fn test_increment_vpc_version_detects_concurrent_writes(
         .id
         .unwrap();
 
-    let initial_version_nr = {
+    let initial_version = {
         let vpcs =
             db::vpc::find_by(&pool, ObjectColumnFilter::One(db::vpc::IdColumn, &vpc_id)).await?;
-        vpcs[0].version.version_nr()
+        vpcs[0].version
     };
+    let initial_version_nr = initial_version.version_nr();
 
-    // Open two transactions, have both read the current version, then race!
+    // Open two transactions, have both use the same expected version, then race!
     let pool_a = pool.clone();
     let pool_b = pool.clone();
     let (a, b) = tokio::join!(
         tokio::spawn(async move {
             let mut txn = pool_a.begin().await.unwrap();
-            let result = db::vpc::increment_vpc_version(&mut txn, vpc_id).await;
+            let result = db::vpc::increment_vpc_version(&mut txn, vpc_id, initial_version).await;
             if result.is_ok() {
                 txn.commit().await.unwrap();
             } else {
@@ -1012,7 +1013,7 @@ async fn test_increment_vpc_version_detects_concurrent_writes(
         }),
         tokio::spawn(async move {
             let mut txn = pool_b.begin().await.unwrap();
-            let result = db::vpc::increment_vpc_version(&mut txn, vpc_id).await;
+            let result = db::vpc::increment_vpc_version(&mut txn, vpc_id, initial_version).await;
             if result.is_ok() {
                 txn.commit().await.unwrap();
             } else {


### PR DESCRIPTION
## Description

Fixes the flaky `test_increment_vpc_version_detects_concurrent_writes` test by splitting reading the VPC version and updating the VPC version into separate methods.

This also fixes sending a proper "NotFoundError" in case a user specifies an invalid VPC ID in the affected VpcPrefix APIs.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

