### PR TITLE
Mention is_primary_dpu into dpudevice.

### DIFF
--- a/crates/api/src/dpf.rs
+++ b/crates/api/src/dpf.rs
@@ -154,8 +154,8 @@ impl ResourceLabeler for CarbideDPFLabeler {
                 info.host_bmc_ip.clone(),
             ),
             (
-                "carbide.nvidia.com/host-machine-id".to_string(),
-                info.host_machine_id.clone(),
+                "carbide.nvidia.com/is-primary-dpu".to_string(),
+                info.is_primary.to_string(),
             ),
             (
                 "carbide.nvidia.com/dpu-machine-id".to_string(),

--- a/crates/api/src/state_controller/machine/handler/dpf.rs
+++ b/crates/api/src/state_controller/machine/handler/dpf.rs
@@ -171,6 +171,17 @@ async fn handle_dpf_provisioning(
     state: &ManagedHostStateSnapshot,
     dpf_sdk: &dyn DpfOperations,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let primary_dpu_id = state
+        .host_snapshot
+        .interfaces
+        .iter()
+        .find(|iface| iface.primary_interface)
+        .and_then(|iface| iface.attached_dpu_machine_id)
+        .ok_or_else(|| StateHandlerError::MissingData {
+            object_id: state.host_snapshot.id.to_string(),
+            missing: "primary_dpu",
+        })?;
+
     for dpu in &state.dpu_snapshots {
         let serial_number = dpu
             .hardware_info
@@ -183,8 +194,8 @@ async fn handle_dpf_provisioning(
             dpu_bmc_ip: bmc_ip(dpu)?.to_string(),
             host_bmc_ip: bmc_ip(&state.host_snapshot)?.to_string(),
             serial_number: serial_number.to_string(),
-            host_machine_id: state.host_snapshot.id.to_string(),
             dpu_machine_id: dpu.id.to_string(),
+            is_primary: dpu.id == primary_dpu_id,
         };
         dpf_sdk.register_dpu_device(device_info).await?;
     }
@@ -198,7 +209,6 @@ async fn handle_dpf_provisioning(
         node_id: dpf_id(&state.host_snapshot)?,
         host_bmc_ip: bmc_ip(&state.host_snapshot)?.to_string(),
         device_ids,
-        host_machine_id: state.host_snapshot.id.to_string(),
     };
     dpf_sdk.register_dpu_node(node_info).await?;
 

--- a/crates/dpf/src/bin/api_harness.rs
+++ b/crates/dpf/src/bin/api_harness.rs
@@ -722,8 +722,8 @@ async fn run_provisioning_flow(
             dpu_bmc_ip: dpu.dpu_bmc_ip.clone(),
             host_bmc_ip: host_bmc_ip.to_string(),
             serial_number: dpu.serial_number.clone(),
-            host_machine_id: String::new(),
             dpu_machine_id: String::new(),
+            is_primary: true,
         };
         sdk.register_dpu_device(info).await?;
         tracing::info!(device_name = %dpu.device_name, serial = %dpu.serial_number, "Registered device");
@@ -734,7 +734,6 @@ async fn run_provisioning_flow(
         node_id: node_id.to_string(),
         host_bmc_ip: host_bmc_ip.to_string(),
         device_ids: dpus.iter().map(|d| d.device_name.clone()).collect(),
-        host_machine_id: String::new(),
     };
     sdk.register_dpu_node(node_info).await?;
     tracing::info!(dpu_count = dpus.len(), "Node registered");

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -1866,8 +1866,8 @@ mod tests {
             dpu_bmc_ip: "10.0.0.10".to_string(),
             host_bmc_ip: "10.0.0.1".to_string(),
             serial_number: "SN123456".to_string(),
-            host_machine_id: "host-aaa".to_string(),
             dpu_machine_id: "dpu-bbb".to_string(),
+            is_primary: true,
         };
 
         sdk.register_dpu_device(info).await.unwrap();
@@ -1891,7 +1891,6 @@ mod tests {
             node_id: "host-001".to_string(),
             host_bmc_ip: "10.0.0.1".to_string(),
             device_ids: vec!["dpu-001".to_string(), "dpu-002".to_string()],
-            host_machine_id: "host-aaa".to_string(),
         };
 
         sdk.register_dpu_node(info).await.unwrap();
@@ -1917,8 +1916,8 @@ mod tests {
             dpu_bmc_ip: "10.0.0.10".to_string(),
             host_bmc_ip: "10.0.0.1".to_string(),
             serial_number: "SN123456".to_string(),
-            host_machine_id: "host-aaa".to_string(),
             dpu_machine_id: "dpu-bbb".to_string(),
+            is_primary: true,
         };
 
         sdk.register_dpu_device(info).await.unwrap();
@@ -1948,7 +1947,6 @@ mod tests {
             node_id: "host-001".to_string(),
             host_bmc_ip: "10.0.0.1".to_string(),
             device_ids: vec!["dpu-001".to_string()],
-            host_machine_id: "host-aaa".to_string(),
         };
 
         sdk.register_dpu_node(info).await.unwrap();
@@ -1974,10 +1972,6 @@ mod tests {
                 ("test/device".to_string(), "true".to_string()),
                 ("test/host-bmc-ip".to_string(), info.host_bmc_ip.clone()),
                 (
-                    "test/host-machine-id".to_string(),
-                    info.host_machine_id.clone(),
-                ),
-                (
                     "test/dpu-machine-id".to_string(),
                     info.dpu_machine_id.clone(),
                 ),
@@ -1988,11 +1982,8 @@ mod tests {
             BTreeMap::from([("test/node".to_string(), "true".to_string())])
         }
 
-        fn node_context_labels(&self, info: &DpuNodeInfo) -> BTreeMap<String, String> {
-            BTreeMap::from([(
-                "test/host-machine-id".to_string(),
-                info.host_machine_id.clone(),
-            )])
+        fn node_context_labels(&self, _info: &DpuNodeInfo) -> BTreeMap<String, String> {
+            BTreeMap::new()
         }
     }
 
@@ -2010,8 +2001,8 @@ mod tests {
             dpu_bmc_ip: "10.0.0.10".to_string(),
             host_bmc_ip: "10.0.0.1".to_string(),
             serial_number: "SN123456".to_string(),
-            host_machine_id: "host-aaa".to_string(),
             dpu_machine_id: "dpu-bbb".to_string(),
+            is_primary: true,
         };
 
         sdk.register_dpu_device(info).await.unwrap();
@@ -2026,10 +2017,6 @@ mod tests {
         assert_eq!(
             labels.get("test/host-bmc-ip"),
             Some(&"10.0.0.1".to_string())
-        );
-        assert_eq!(
-            labels.get("test/host-machine-id"),
-            Some(&"host-aaa".to_string())
         );
         assert_eq!(
             labels.get("test/dpu-machine-id"),
@@ -2050,8 +2037,8 @@ mod tests {
             dpu_bmc_ip: "10.0.0.10".to_string(),
             host_bmc_ip: "10.0.0.1".to_string(),
             serial_number: "SN123456".to_string(),
-            host_machine_id: "host-aaa".to_string(),
             dpu_machine_id: "dpu-bbb".to_string(),
+            is_primary: true,
         };
 
         sdk.register_dpu_device(info).await.unwrap();
@@ -2076,7 +2063,6 @@ mod tests {
             node_id: "host-001".to_string(),
             host_bmc_ip: "10.0.0.1".to_string(),
             device_ids: vec!["dpu-001".to_string()],
-            host_machine_id: "host-aaa".to_string(),
         };
 
         sdk.register_dpu_node(info).await.unwrap();
@@ -2088,11 +2074,6 @@ mod tests {
         let labels = node.metadata.labels.as_ref().unwrap();
 
         assert_eq!(labels.get("test/node"), Some(&"true".to_string()));
-        assert_eq!(
-            labels.get("test/host-machine-id"),
-            Some(&"host-aaa".to_string()),
-            "contextual label from node_context_labels should be merged"
-        );
     }
 
     #[tokio::test]
@@ -2107,7 +2088,6 @@ mod tests {
             node_id: "host-001".to_string(),
             host_bmc_ip: "10.0.0.1".to_string(),
             device_ids: vec!["dpu-001".to_string()],
-            host_machine_id: "host-aaa".to_string(),
         };
 
         sdk.register_dpu_node(info).await.unwrap();
@@ -2174,8 +2154,8 @@ mod tests {
             dpu_bmc_ip: "10.0.0.10".to_string(),
             host_bmc_ip: "10.0.0.1".to_string(),
             serial_number: "SN123".to_string(),
-            host_machine_id: "host-aaa".to_string(),
             dpu_machine_id: "dpu-bbb".to_string(),
+            is_primary: true,
         };
         sdk.register_dpu_device(device_info).await.unwrap();
 
@@ -2252,8 +2232,8 @@ mod tests {
             dpu_bmc_ip: "10.0.0.10".to_string(),
             host_bmc_ip: "10.0.0.1".to_string(),
             serial_number: "SN111".to_string(),
-            host_machine_id: "host-111".to_string(),
             dpu_machine_id: "dpu-111".to_string(),
+            is_primary: true,
         };
 
         let info2 = DpuDeviceInfo {
@@ -2261,8 +2241,8 @@ mod tests {
             dpu_bmc_ip: "10.0.0.20".to_string(),
             host_bmc_ip: "10.0.0.2".to_string(),
             serial_number: "SN222".to_string(),
-            host_machine_id: "host-222".to_string(),
             dpu_machine_id: "dpu-222".to_string(),
+            is_primary: false,
         };
 
         sdk1.register_dpu_device(info1).await.unwrap();
@@ -2444,8 +2424,8 @@ mod tests {
             dpu_bmc_ip: "10.0.0.10".to_string(),
             host_bmc_ip: "10.0.0.1".to_string(),
             serial_number: "SN123456".to_string(),
-            host_machine_id: "host-aaa".to_string(),
             dpu_machine_id: "dpu-bbb".to_string(),
+            is_primary: true,
         };
         let err = sdk.register_dpu_device(info).await.unwrap_err();
         assert!(
@@ -2489,8 +2469,8 @@ mod tests {
             dpu_bmc_ip: "10.0.0.10".to_string(),
             host_bmc_ip: "10.0.0.1".to_string(),
             serial_number: "SN123456".to_string(),
-            host_machine_id: "host-aaa".to_string(),
             dpu_machine_id: "dpu-bbb".to_string(),
+            is_primary: true,
         };
         sdk.register_dpu_device(info).await.unwrap();
     }
@@ -2527,7 +2507,6 @@ mod tests {
             node_id: "host-001".to_string(),
             host_bmc_ip: "10.0.0.1".to_string(),
             device_ids: vec!["dpu-001".to_string()],
-            host_machine_id: "host-aaa".to_string(),
         };
         let err = sdk.register_dpu_node(info).await.unwrap_err();
         assert!(
@@ -2567,7 +2546,6 @@ mod tests {
             node_id: "host-001".to_string(),
             host_bmc_ip: "10.0.0.1".to_string(),
             device_ids: vec!["dpu-001".to_string()],
-            host_machine_id: "host-aaa".to_string(),
         };
         sdk.register_dpu_node(info).await.unwrap();
     }
@@ -2729,7 +2707,6 @@ mod tests {
             node_id: "host-001".to_string(),
             host_bmc_ip: "10.0.0.1".to_string(),
             device_ids: vec!["dpu-001".to_string()],
-            host_machine_id: "host-aaa".to_string(),
         };
         sdk.register_dpu_node(info).await.unwrap();
 

--- a/crates/dpf/src/test/sdk_device_registration.rs
+++ b/crates/dpf/src/test/sdk_device_registration.rs
@@ -198,8 +198,8 @@ async fn test_register_devices_node_and_force_delete() {
             dpu_bmc_ip: format!("192.168.1.{}", 100 + i),
             host_bmc_ip: "192.168.1.1".to_string(),
             serial_number: format!("SN-{}", i),
-            host_machine_id: "host-001-id".to_string(),
             dpu_machine_id: format!("dpu-{}-id", i),
+            is_primary: true,
         };
         sdk.register_dpu_device(info).await.unwrap();
     }
@@ -209,7 +209,6 @@ async fn test_register_devices_node_and_force_delete() {
         node_id: "host-001".to_string(),
         host_bmc_ip: "192.168.1.1".to_string(),
         device_ids: vec!["dpu-1".to_string(), "dpu-2".to_string()],
-        host_machine_id: "host-001-id".to_string(),
     };
     sdk.register_dpu_node(node_info).await.unwrap();
 

--- a/crates/dpf/src/test/sdk_reboot_annotation.rs
+++ b/crates/dpf/src/test/sdk_reboot_annotation.rs
@@ -147,7 +147,6 @@ async fn test_reboot_annotation_set_check_clear() {
         node_id: "host-001".to_string(),
         host_bmc_ip: "192.168.1.1".to_string(),
         device_ids: vec!["dpu-001".to_string()],
-        host_machine_id: "host-001-id".to_string(),
     };
     sdk.register_dpu_node(node_info).await.unwrap();
 

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -225,12 +225,11 @@ pub struct DpuDeviceInfo {
     pub host_bmc_ip: String,
     /// Serial number of the DPU.
     pub serial_number: String,
-    /// Caller-defined identifier for the host machine.
-    /// Passed through to the labeler for resource labels.
-    pub host_machine_id: String,
     /// Caller-defined identifier for the DPU machine.
     /// Passed through to the labeler for resource labels.
     pub dpu_machine_id: String,
+    /// is _primary dpu?
+    pub is_primary: bool,
 }
 
 /// Information about a DPU node (host with DPUs).
@@ -243,9 +242,6 @@ pub struct DpuNodeInfo {
     pub host_bmc_ip: String,
     /// Identifiers of each device attached to this node.
     pub device_ids: Vec<String>,
-    /// Caller-defined identifier for the host machine.
-    /// Passed through to the labeler for contextual node labels.
-    pub host_machine_id: String,
 }
 
 /// Phase of DPU lifecycle.


### PR DESCRIPTION
## Description
is_primary_dpu is important to identify primary dpu during debugging.
Also, host_machine_id changes after the host provisioning, so not very useful.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

