### PR TITLE
Copy initial certs from /opt/forge for otel

### DIFF
--- a/bluefield/charts/carbide-dpu-otel-agent/templates/daemonset.yaml
+++ b/bluefield/charts/carbide-dpu-otel-agent/templates/daemonset.yaml
@@ -51,9 +51,6 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args:
-            - "--config-path=/etc/forge-dpu-otel-agent/config.toml"
-            - "run"
           {{- with toYaml .Values.serviceDaemonSet.resources }}
           resources:
             limits:
@@ -74,6 +71,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: OTEL_COPY_CERTS_DST_CA
+              value: /etc/ssl/certs/forge-dpu-otel-ca.pem
+            - name: OTEL_COPY_CERTS_DST_CERT
+              value: /etc/ssl/certs/forge-dpu-otel-agent.pem
+            - name: OTEL_COPY_CERTS_DST_KEY
+              value: /etc/ssl/private/forge-dpu-otel-agent.key
           volumeMounts:
             - name: config
               mountPath: /etc/forge-dpu-otel-agent/config.toml

--- a/bluefield/containers/forge-dpu-otel-agent/Dockerfile
+++ b/bluefield/containers/forge-dpu-otel-agent/Dockerfile
@@ -10,16 +10,30 @@ ARG IMG=nvcr.io/nvidia/distroless/cc
 ARG DEBUG_DISTROLESS=true
 ARG DISTROLESS_DEBUG_TAG=${DEBUG_DISTROLESS:+"dev"} # 'dev' provides a busybox shell
 
-FROM debian:12-slim AS udev
+FROM --platform=linux/arm64 debian:bookworm-slim AS runtime-deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libudev1
+    bash \
+    coreutils \
+    libudev1 \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN bins="/bin/bash /bin/mv /bin/date /bin/rm /usr/bin/env /usr/bin/stat /usr/bin/install" \
+ && mkdir -p /rootfs \
+ && for bin in $bins; do \
+      install -D "$bin" "/rootfs$bin"; \
+      ldd "$bin" | grep "=> /" | awk '{print $3}' | while read -r lib; do \
+        install -D "$lib" "/rootfs$lib"; \
+      done; \
+    done \
+ && install -D /lib/aarch64-linux-gnu/libudev.so.1 /rootfs/lib/aarch64-linux-gnu/libudev.so.1
 
 # NVIDIA Distroless Container
-FROM ${IMG}:${TAG}-${DISTROLESS_DEBUG_TAG}
+FROM --platform=linux/arm64 ${IMG}:${TAG}-${DISTROLESS_DEBUG_TAG}
+
+COPY --from=runtime-deps /rootfs/ /
 
 COPY --chmod=755 target/aarch64-unknown-linux-gnu/release/forge-dpu-otel-agent /usr/bin/forge-dpu-otel-agent
+COPY --chmod=755 bluefield/otel/scripts/otel_copy_certs.sh /usr/local/sbin/otel_copy_certs.sh
+COPY --chmod=755 bluefield/otel/otel-agent /otel/otel-agent
 
-COPY --from=udev /lib/aarch64-linux-gnu/libudev.so.1 /lib/aarch64-linux-gnu/libudev.so.1
-
-ENTRYPOINT ["/usr/bin/forge-dpu-otel-agent"]
-CMD ["--config-path=/etc/forge-dpu-otel-agent/config.toml", "run" ]
+ENTRYPOINT ["/otel/otel-agent"]

--- a/bluefield/otel/scripts/otel_copy_certs.sh
+++ b/bluefield/otel/scripts/otel_copy_certs.sh
@@ -12,9 +12,10 @@ SRC_CA="/opt/forge/forge_root.pem"
 SRC_CERT="/opt/forge/machine_cert.pem"
 SRC_KEY="/opt/forge/machine_cert.key"
 
-DST_CA="/etc/otelcol-contrib/certs/ca.pem"
-DST_CERT="/etc/otelcol-contrib/certs/otel-cert.pem"
-DST_KEY="/etc/otelcol-contrib/certs/private/otel-key.pem"
+# Override for layouts that store OTEL mTLS material elsewhere (e.g. Helm uses host /etc/ssl).
+DST_CA="${OTEL_COPY_CERTS_DST_CA:-/etc/otelcol-contrib/certs/ca.pem}"
+DST_CERT="${OTEL_COPY_CERTS_DST_CERT:-/etc/otelcol-contrib/certs/otel-cert.pem}"
+DST_KEY="${OTEL_COPY_CERTS_DST_KEY:-/etc/otelcol-contrib/certs/private/otel-key.pem}"
 
 # Get modification time of a file in seconds since epoch
 file_mtime() {


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
adds the otel_copy_certs script into the otel agent container to populate otel's initial certs.  In the non-containerized flow this is done on service startup.

potential future optimization: have otel use the certs that forge-dpu-agent uses and updates and remove forge-dpu-otel-agent altogether 

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [X] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

