### PR TITLE
Do not use otel agent; configure otel collector to read forge certs directly

### DIFF
--- a/bluefield/charts/carbide-otelcol/files/otel_config.yaml
+++ b/bluefield/charts/carbide-otelcol/files/otel_config.yaml
@@ -357,8 +357,8 @@ exporters:
     endpoint: otel-receiver.forge:443
     tls:
       ca_file: /opt/forge/forge_root.pem
-      cert_file: /etc/ssl/certs/forge-dpu-otel-agent.pem
-      key_file: /etc/ssl/private/forge-dpu-otel-agent.key
+      cert_file: /opt/forge/machine_cert.pem
+      key_file: /opt/forge/machine_cert.key
       reload_interval: 1h
     retry_on_failure:
       enabled: true

--- a/bluefield/charts/carbide-otelcol/templates/daemonset.yaml
+++ b/bluefield/charts/carbide-otelcol/templates/daemonset.yaml
@@ -89,12 +89,6 @@ spec:
             - name: forge-certs
               mountPath: /opt/forge
               readOnly: true
-            - name: ssl-certs
-              mountPath: /etc/ssl/certs
-              readOnly: true
-            - name: ssl-private
-              mountPath: /etc/ssl/private
-              readOnly: true
             - name: machine-id
               mountPath: /run/otelcol-contrib
             - name: cursors
@@ -121,14 +115,6 @@ spec:
         - name: forge-certs
           hostPath:
             path: /opt/forge
-            type: DirectoryOrCreate
-        - name: ssl-certs
-          hostPath:
-            path: /etc/ssl/certs
-            type: DirectoryOrCreate
-        - name: ssl-private
-          hostPath:
-            path: /etc/ssl/private
             type: DirectoryOrCreate
         - name: machine-id
           hostPath:

--- a/bluefield/containers/otelcol-contrib/Dockerfile
+++ b/bluefield/containers/otelcol-contrib/Dockerfile
@@ -63,7 +63,7 @@ COPY --from=builder --chmod=755 /build/ocb-build/otelcol-contrib /usr/bin/otelco
 COPY --from=builder /lib/aarch64-linux-gnu/libudev.so.1 /lib/aarch64-linux-gnu/libudev.so.1
 # Wrapper scripts
 COPY bluefield/otel/otelcol-wrapper /etc/otelcol-contrib/otelcol-wrapper
-COPY bluefield/otel/otelcol-wrapper-imports /etc/otelcol-contrib/otelcol-wrapper-imports
+COPY bluefield/otel/otelcol-wrapper-imports-dpf /etc/otelcol-contrib/otelcol-wrapper-imports
 COPY bluefield/otel/otelcol-wrapper-validate /etc/otelcol-contrib/otelcol-wrapper-validate
 RUN chmod +x /etc/otelcol-contrib/otelcol-wrapper \
              /etc/otelcol-contrib/otelcol-wrapper-imports \

--- a/bluefield/otel/otelcol-wrapper
+++ b/bluefield/otel/otelcol-wrapper
@@ -1,7 +1,7 @@
 #!/bin/bash -p
 
 
-$HOSTNAME=$(hostname)
+HOSTNAME=$(hostname)
 
 if [[ "$HOSTNAME" == "localhost" ]]; then
     echo "hostname cannot be 'localhost'"

--- a/bluefield/otel/otelcol-wrapper-imports-dpf
+++ b/bluefield/otel/otelcol-wrapper-imports-dpf
@@ -1,0 +1,33 @@
+#!/bin/bash -p
+
+CERT_PATH=/opt/forge/machine_cert.pem
+KEY_PATH=/opt/forge/machine_cert.key
+MAX_INTERVAL=30
+MAX_INTERVAL_REPEATED_COUNT=5
+
+CONFIG_FRAGMENTS_DIR=/etc/otelcol-contrib/config-fragments
+ADDITIONAL_CONFIGS=$(ls ${CONFIG_FRAGMENTS_DIR}/*.yaml 2>/dev/null | awk 'FNR==1 {printf " --config="$1} FNR>1 {printf " --config="$1}')
+
+interval=1
+interval_repeated_count=0
+max_interval_reached=false
+
+while [[ ! -f "$CERT_PATH" || ! -f "$KEY_PATH" ]]; do
+    echo "Certs not found. Try again in ${interval}s."
+
+    sleep $interval
+
+    if [[ $max_interval_reached == "true" ]]; then
+        : # leave max interval unchanged
+    elif [[ $interval -ge $MAX_INTERVAL ]]; then
+        echo "Maximum interval reached. Continue to try every ${MAX_INTERVAL}s."
+        max_interval_reached=true
+    elif [[ $interval_repeated_count -ge $MAX_INTERVAL_REPEATED_COUNT ]]; then
+        interval=$(( (interval * 3 + 1) / 2 )) # backoff factor 1.5 rounded up
+        interval=$(( interval < MAX_INTERVAL ? interval : MAX_INTERVAL ))
+        interval_repeated_count=0
+    else
+        interval_repeated_count=$(( $interval_repeated_count + 1 ))
+    fi
+done
+

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -727,7 +727,7 @@ pub struct DpfMandatoryServicesConfig {
     pub fmds: DpfServiceConfig,
     #[serde(default = "crate::dpf_services::default_otelcol_service")]
     pub otel: DpfServiceConfig,
-    #[serde(default = "crate::dpf_services::default_otel_agent_service")]
+    #[serde(default)]
     pub otel_agent: DpfServiceConfig,
 }
 
@@ -740,7 +740,7 @@ impl Default for DpfMandatoryServicesConfig {
             dhcp_server: crate::dpf_services::default_dhcp_server_service(),
             fmds: crate::dpf_services::default_fmds_service(),
             otel: crate::dpf_services::default_otelcol_service(),
-            otel_agent: crate::dpf_services::default_otel_agent_service(),
+            otel_agent: DpfServiceConfig::default(),
         }
     }
 }

--- a/crates/api/src/dpf_services.rs
+++ b/crates/api/src/dpf_services.rs
@@ -75,11 +75,6 @@ pub const OTEL_COLLECTOR_SERVICE_NAME: &str = "carbide-otelcol";
 pub const OTEL_COLLECTOR_SERVICE_HELM_NAME: &str = "carbide-otelcol";
 pub const OTEL_COLLECTOR_SERVICE_IMAGE_NAME: &str = "otelcol-contrib";
 
-/// OTel Agent Service Definitions
-pub const OTEL_SERVICE_NAME: &str = "forge-dpu-otel-agent";
-pub const OTEL_SERVICE_HELM_NAME: &str = "forge-dpu-otel-agent";
-pub const OTEL_SERVICE_IMAGE_NAME: &str = "forge-dpu-otel-agent";
-
 /// Compile-time helm version (set by CI via VERSION env var). Empty on PR/fork builds.
 pub(crate) const COMPILE_TIME_HELM_VERSION: &str = match option_env!("CARBIDE_BUILD_HELM_VERSION") {
     Some(v) => v,
@@ -209,17 +204,6 @@ pub(crate) fn default_otelcol_service() -> DpfServiceConfig {
         docker_repo_url: format!(
             "{DEFAULT_CARBIDE_IMAGE_REGISTRY}/{OTEL_COLLECTOR_SERVICE_IMAGE_NAME}"
         ),
-        docker_image_tag: COMPILE_TIME_IMAGE_TAG.to_string(),
-    }
-}
-
-pub(crate) fn default_otel_agent_service() -> DpfServiceConfig {
-    DpfServiceConfig {
-        name: OTEL_SERVICE_NAME.to_string(),
-        helm_repo_url: DEFAULT_CARBIDE_HELM_REGISTRY.to_string(),
-        helm_chart: OTEL_SERVICE_HELM_NAME.to_string(),
-        helm_version: COMPILE_TIME_HELM_VERSION.to_string(),
-        docker_repo_url: format!("{DEFAULT_CARBIDE_IMAGE_REGISTRY}/{OTEL_SERVICE_IMAGE_NAME}"),
         docker_image_tag: COMPILE_TIME_IMAGE_TAG.to_string(),
     }
 }

--- a/crates/api/src/dpf_services.rs
+++ b/crates/api/src/dpf_services.rs
@@ -422,33 +422,6 @@ pub fn otelcol_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
     }
 }
 
-/// OTel service definition.
-pub fn otel_agent_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
-    ServiceDefinition {
-        helm_values: Some(serde_json::json!({
-            "image": {
-                "repository": cfg.docker_repo_url,
-                "tag": cfg.docker_image_tag,
-            },
-            "imagePullSecrets": [
-                {
-                    "name": "dpf-pull-secret"
-                }
-            ]
-        })),
-        service_daemon_set_annotations: Some(BTreeMap::new()),
-
-        config_ports: None,
-        config_ports_service_type: Some(ConfigPortsServiceType::None),
-        ..ServiceDefinition::new(
-            &cfg.name,
-            &cfg.helm_repo_url,
-            &cfg.helm_chart,
-            &cfg.helm_version,
-        )
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use carbide_dpf::build_service_interface;

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -536,7 +536,6 @@ pub async fn start_api(
             crate::dpf_services::dpu_agent_service(&mandatory_services.dpu_agent),
             crate::dpf_services::fmds_service(&mandatory_services.fmds),
             crate::dpf_services::otelcol_service(&mandatory_services.otel),
-            crate::dpf_services::otel_agent_service(&mandatory_services.otel_agent),
         ];
 
         // This is just temparary code until we make v2 only option. (just 2 weeks)


### PR DESCRIPTION
This changes otel to use the certs in /opt/forge instead of from /etc/ssl.  This removes the need to run the otel-agent that renews certs.  dpu agent will renew the certs in /opt/forge

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

