### PR TITLE
fix: Don't send DPU into Error phase during force-delete

### DIFF
--- a/crates/api/src/state_controller/machine/handler/dpf.rs
+++ b/crates/api/src/state_controller/machine/handler/dpf.rs
@@ -197,7 +197,21 @@ async fn handle_dpf_provisioning(
             dpu_machine_id: dpu.id.to_string(),
             is_primary: dpu.id == primary_dpu_id,
         };
-        dpf_sdk.register_dpu_device(device_info).await?;
+        if let Err(err) = dpf_sdk.register_dpu_device(device_info).await {
+            return Ok(StateHandlerOutcome::transition(ManagedHostState::Failed {
+                details: FailureDetails {
+                    cause: FailureCause::DpfProvisioning {
+                        err: format!(
+                            "DPUDevice creation failed. Force-delete again to clean old values. Wait until DPU CR are deleted. {err}"
+                        ),
+                    },
+                    failed_at: chrono::Utc::now(),
+                    source: FailureSource::StateMachineArea(StateMachineArea::MainFlow),
+                },
+                machine_id: dpu.id,
+                retry_count: 0,
+            }));
+        }
     }
 
     let device_ids: Vec<String> = state
@@ -210,7 +224,21 @@ async fn handle_dpf_provisioning(
         host_bmc_ip: bmc_ip(&state.host_snapshot)?.to_string(),
         device_ids,
     };
-    dpf_sdk.register_dpu_node(node_info).await?;
+    if let Err(err) = dpf_sdk.register_dpu_node(node_info).await {
+        return Ok(StateHandlerOutcome::transition(ManagedHostState::Failed {
+            details: FailureDetails {
+                cause: FailureCause::DpfProvisioning {
+                    err: format!(
+                        "DPUNode creation failed. Force-delete again to clean old values. Wait until DPU CR are deleted. {err}"
+                    ),
+                },
+                failed_at: chrono::Utc::now(),
+                source: FailureSource::StateMachineArea(StateMachineArea::MainFlow),
+            },
+            machine_id: state.host_snapshot.id,
+            retry_count: 0,
+        }));
+    }
 
     let next =
         transition_all_dpus_to_dpf_state(DpfState::WaitingForReady { phase_detail: None }, state)?;

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -1432,24 +1432,6 @@ impl<R: DpuRepository + DpuNodeRepository + DpuDeviceRepository, L: ResourceLabe
         let node_name = &dpu_node_cr_name(node_id);
         let node = DpuNodeRepository::get(&*self.repo, node_name, &self.namespace).await?;
 
-        for name in dpu_device_names {
-            let dpu_cr_name = dpu_cr_name(name, node_id);
-            let dpu_cr = DpuRepository::get(&*self.repo, &dpu_cr_name, &self.namespace).await?;
-
-            if dpu_cr.is_some() {
-                // Move the DPU to the Error phase so the operator stops reconciling it
-                // before we drop the DPUNode and DPUDevice CRs below. Best-effort: a
-                // failed patch must not block the deletes that follow.
-                let patch = json!({ "status": { "phase": "Error" } });
-                if let Err(e) =
-                    DpuRepository::patch_status(&*self.repo, &dpu_cr_name, &self.namespace, patch)
-                        .await
-                {
-                    tracing::warn!("Failed to patch DPU {} to Error phase: {}", dpu_cr_name, e);
-                }
-            }
-        }
-
         if let Some(node) = node {
             let dpus = node.spec.dpus.unwrap_or_default();
 


### PR DESCRIPTION
## Description
As per DPF team, force-delete should wait until all DPU CRs are deleted and don't force them into Error phase.
Will work on another PR to handle waiting time.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

