### PR TITLE
perf: use line-tables-only debug info for local dev builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,7 +262,7 @@ k8s-openapi = "0.27.0"
 tower-test = "0.4"
 
 [profile.release]
-debug = true            # Enable debuginfo
+debug = "line-tables-only"
 debug-assertions = true # Add some extra assurance during development
 overflow-checks = true  # Add some extra assurance during development
 

--- a/dev/docker/Dockerfile.release-container-aarch64
+++ b/dev/docker/Dockerfile.release-container-aarch64
@@ -39,6 +39,7 @@ RUN --mount=type=cache,id=sccache-aarch64,target=/sccache \
   export DATABASE_URL="postgresql://%2Fvar%2Frun%2Fpostgresql" && \
   export SCCACHE_DIR=/sccache && \
   export RUSTC_WRAPPER=sccache && \
+  export CARGO_PROFILE_RELEASE_DEBUG=true && \
   /etc/init.d/postgresql start && \
   sudo -u postgres psql -c "ALTER USER root WITH SUPERUSER;" && \
   createdb root && \

--- a/dev/docker/Dockerfile.release-container-sa-x86_64
+++ b/dev/docker/Dockerfile.release-container-sa-x86_64
@@ -40,6 +40,7 @@ RUN --mount=type=cache,id=sccache-x86_64,target=/sccache \
   export DATABASE_URL="postgresql://%2Fvar%2Frun%2Fpostgresql" && \
   export SCCACHE_DIR=/sccache && \
   export RUSTC_WRAPPER=sccache && \
+  export CARGO_PROFILE_RELEASE_DEBUG=true && \
   /etc/init.d/postgresql start && \
   sudo -u postgres psql -c "ALTER USER root WITH SUPERUSER;" && \
   createdb root && \

--- a/dev/docker/Dockerfile.release-container-x86_64
+++ b/dev/docker/Dockerfile.release-container-x86_64
@@ -39,6 +39,7 @@ RUN --mount=type=cache,id=sccache-x86_64,target=/sccache \
   export DATABASE_URL="postgresql://%2Fvar%2Frun%2Fpostgresql" && \
   export SCCACHE_DIR=/sccache && \
   export RUSTC_WRAPPER=sccache && \
+  export CARGO_PROFILE_RELEASE_DEBUG=true && \
   /etc/init.d/postgresql start && \
   sudo -u postgres psql -c "ALTER USER root WITH SUPERUSER;" && \
   createdb root && \

--- a/dev/docker/Dockerfile.release-forge-cli
+++ b/dev/docker/Dockerfile.release-forge-cli
@@ -29,6 +29,7 @@ RUN --mount=type=cache,id=sccache-x86_64,target=/sccache \
   cd /carbide && \
   export SCCACHE_DIR=/sccache && \
   export RUSTC_WRAPPER=sccache && \
+  export CARGO_PROFILE_RELEASE_DEBUG=true && \
   cargo build --release -p carbide-admin-cli
 
 FROM debian:12-slim


### PR DESCRIPTION
## Description
Change the default release profile to `debug = "line-tables-only"`, reducing local dev binary size and build time. Release container builds override back to full debug info (`CARGO_PROFILE_RELEASE_DEBUG=true`) so shipped images retain full debugger support for post-mortem analysis.

## Type of Change
- [x] **Change** - Changes in existing functionality

## Related Issues
Fixes #1363

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
This PR touches the same four Dockerfiles as #945 and #947. It should land after those to avoid merge conflicts.