### PR TITLE
fix: admin-cli: accept full ExpectedHostNic JSON

### DIFF
--- a/crates/admin-cli/src/expected_machines/add/args.rs
+++ b/crates/admin-cli/src/expected_machines/add/args.rs
@@ -22,7 +22,7 @@ use carbide_uuid::rack::RackId;
 use clap::Parser;
 use mac_address::MacAddress;
 use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
-use rpc::forge::DpuMode;
+use rpc::forge::{DpuMode, ExpectedHostNic};
 use serde::{Deserialize, Serialize};
 
 /// `forge-admin-cli expected-machine add` — mirrors expected switch flags; optional
@@ -89,7 +89,7 @@ pub struct Args {
     #[clap(
         long = "host_nics",
         value_name = "HOST_NICS",
-        help = "Host NICs MAC addresses as JSON",
+        help = "Host NICs as a JSON array of ExpectedHostNic objects (fields: mac_address, nic_type, fixed_ip, fixed_mask, fixed_gateway, primary)",
         action = clap::ArgAction::Append
     )]
     pub host_nics: Option<String>,
@@ -167,19 +167,9 @@ impl TryFrom<Args> for rpc::forge::ExpectedMachine {
 
         let host_nics = value
             .host_nics
-            .map(|s| serde_json::from_str::<Vec<MacAddress>>(&s))
+            .map(|s| serde_json::from_str::<Vec<ExpectedHostNic>>(&s))
             .transpose()?
-            .unwrap_or_default()
-            .into_iter()
-            .map(|mac| rpc::forge::ExpectedHostNic {
-                mac_address: mac.to_string(),
-                nic_type: None,
-                fixed_ip: None,
-                fixed_mask: None,
-                fixed_gateway: None,
-                primary: None,
-            })
-            .collect();
+            .unwrap_or_default();
 
         Ok(rpc::forge::ExpectedMachine {
             bmc_mac_address: value.bmc_mac_address.to_string(),


### PR DESCRIPTION
Parse  directly as a JSON array of  objects
instead of bare MAC strings, so callers can specify nic_type, fixed_ip, fixed_mask, fixed_gateway, and primary alongside the MAC.

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

