### PR TITLE
Add UI health management for switches and powershelves

### DIFF
--- a/crates/api/src/tests/web/health.rs
+++ b/crates/api/src/tests/web/health.rs
@@ -22,7 +22,9 @@ use rpc::forge::AdminForceDeleteMachineRequest;
 use rpc::forge::forge_server::Forge;
 use tower::ServiceExt;
 
-use crate::tests::common::api_fixtures::site_explorer::TestRackDbBuilder;
+use crate::tests::common::api_fixtures::site_explorer::{
+    TestRackDbBuilder, new_power_shelf, new_switch,
+};
 use crate::tests::common::api_fixtures::{create_managed_host, create_test_env};
 use crate::tests::web::{make_test_app, web_request_builder};
 
@@ -289,4 +291,242 @@ async fn test_health_of_rack(pool: sqlx::PgPool) {
         .to_bytes();
     let body = String::from_utf8_lossy(&body_bytes);
     assert!(!body.contains("web-rack-health-test"));
+}
+
+#[crate::sqlx_test]
+async fn test_health_of_switch(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let app = make_test_app(&env);
+    let switch_id = new_switch(&env, None, None).await.unwrap();
+
+    let response = app
+        .clone()
+        .oneshot(
+            web_request_builder()
+                .uri(format!("/admin/switch/{switch_id}/health"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body_bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("Empty response body?")
+        .to_bytes();
+    let body = String::from_utf8_lossy(&body_bytes);
+    assert!(body.contains("Switch Health"));
+    assert!(body.contains("Health Report Management"));
+    assert!(body.contains("Health History"));
+
+    let payload = r#"{
+        "mode": "Merge",
+        "health_report": {
+            "source": "web-switch-health-test",
+            "triggered_by": null,
+            "observed_at": null,
+            "successes": [],
+            "alerts": [{
+                "id": "SwitchWebHealth",
+                "target": null,
+                "in_alert_since": null,
+                "message": "switch web health",
+                "tenant_message": null,
+                "classifications": ["PreventAllocations"]
+            }]
+        }
+    }"#;
+    let response = app
+        .clone()
+        .oneshot(
+            web_request_builder()
+                .method(Method::POST)
+                .uri(format!("/admin/switch/{switch_id}/health/add-report"))
+                .header("Content-Type", "application/json")
+                .body(Body::from(payload))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .clone()
+        .oneshot(
+            web_request_builder()
+                .uri(format!("/admin/switch/{switch_id}/health"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body_bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("Empty response body?")
+        .to_bytes();
+    let body = String::from_utf8_lossy(&body_bytes);
+    assert!(body.contains("web-switch-health-test"));
+    assert!(body.contains("switch web health"));
+
+    let response = app
+        .clone()
+        .oneshot(
+            web_request_builder()
+                .method(Method::POST)
+                .uri(format!("/admin/switch/{switch_id}/health/remove-report"))
+                .header("Content-Type", "application/json")
+                .body(Body::from(r#"{"source":"web-switch-health-test"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .oneshot(
+            web_request_builder()
+                .uri(format!("/admin/switch/{switch_id}/health"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body_bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("Empty response body?")
+        .to_bytes();
+    let body = String::from_utf8_lossy(&body_bytes);
+    assert!(!body.contains("web-switch-health-test"));
+}
+
+#[crate::sqlx_test]
+async fn test_health_of_power_shelf(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let app = make_test_app(&env);
+    let power_shelf_id = new_power_shelf(&env, None, None, None, None).await.unwrap();
+
+    let response = app
+        .clone()
+        .oneshot(
+            web_request_builder()
+                .uri(format!("/admin/power-shelf/{power_shelf_id}/health"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body_bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("Empty response body?")
+        .to_bytes();
+    let body = String::from_utf8_lossy(&body_bytes);
+    assert!(body.contains("Power Shelf Health"));
+    assert!(body.contains("Health Report Management"));
+    assert!(body.contains("Health History"));
+
+    let payload = r#"{
+        "mode": "Merge",
+        "health_report": {
+            "source": "web-power-shelf-health-test",
+            "triggered_by": null,
+            "observed_at": null,
+            "successes": [],
+            "alerts": [{
+                "id": "PowerShelfWebHealth",
+                "target": null,
+                "in_alert_since": null,
+                "message": "power shelf web health",
+                "tenant_message": null,
+                "classifications": ["PreventAllocations"]
+            }]
+        }
+    }"#;
+    let response = app
+        .clone()
+        .oneshot(
+            web_request_builder()
+                .method(Method::POST)
+                .uri(format!(
+                    "/admin/power-shelf/{power_shelf_id}/health/add-report"
+                ))
+                .header("Content-Type", "application/json")
+                .body(Body::from(payload))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .clone()
+        .oneshot(
+            web_request_builder()
+                .uri(format!("/admin/power-shelf/{power_shelf_id}/health"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body_bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("Empty response body?")
+        .to_bytes();
+    let body = String::from_utf8_lossy(&body_bytes);
+    assert!(body.contains("web-power-shelf-health-test"));
+    assert!(body.contains("power shelf web health"));
+
+    let response = app
+        .clone()
+        .oneshot(
+            web_request_builder()
+                .method(Method::POST)
+                .uri(format!(
+                    "/admin/power-shelf/{power_shelf_id}/health/remove-report"
+                ))
+                .header("Content-Type", "application/json")
+                .body(Body::from(r#"{"source":"web-power-shelf-health-test"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .oneshot(
+            web_request_builder()
+                .uri(format!("/admin/power-shelf/{power_shelf_id}/health"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body_bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("Empty response body?")
+        .to_bytes();
+    let body = String::from_utf8_lossy(&body_bytes);
+    assert!(!body.contains("web-power-shelf-health-test"));
 }

--- a/crates/api/src/tests/web/mod.rs
+++ b/crates/api/src/tests/web/mod.rs
@@ -21,7 +21,7 @@ use hyper::http::request::Builder;
 
 use crate::tests::common;
 use crate::web::routes;
-mod machine_health;
+mod health;
 mod managed_host;
 mod vpc;
 

--- a/crates/api/src/web/health.rs
+++ b/crates/api/src/web/health.rs
@@ -22,14 +22,19 @@ use askama::Template;
 use axum::extract::{self, Path as AxumPath, State as AxumState};
 use axum::response::{Html, IntoResponse, Response};
 use carbide_uuid::machine::MachineId;
+use carbide_uuid::power_shelf::PowerShelfId;
 use carbide_uuid::rack::RackId;
+use carbide_uuid::switch::SwitchId;
 use health_report::HealthReport;
 use hyper::http::StatusCode;
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{
-    HealthReportApplyMode, InsertMachineHealthReportRequest, InsertRackHealthReportRequest,
-    ListRackHealthReportsRequest, MachinesByIdsRequest, RacksByIdsRequest,
-    RemoveMachineHealthReportRequest, RemoveRackHealthReportRequest,
+    HealthReportApplyMode, InsertMachineHealthReportRequest, InsertPowerShelfHealthReportRequest,
+    InsertRackHealthReportRequest, InsertSwitchHealthReportRequest,
+    ListPowerShelfHealthReportsRequest, ListRackHealthReportsRequest,
+    ListSwitchHealthReportsRequest, MachinesByIdsRequest, PowerShelvesByIdsRequest,
+    RacksByIdsRequest, RemoveMachineHealthReportRequest, RemovePowerShelfHealthReportRequest,
+    RemoveRackHealthReportRequest, RemoveSwitchHealthReportRequest, SwitchesByIdsRequest,
 };
 
 use super::{Base, filters};
@@ -84,28 +89,36 @@ struct LabeledHealthReport {
 #[derive(Clone)]
 enum HealthObject {
     Machine(MachineId),
+    PowerShelf(PowerShelfId),
     Rack(RackId),
+    Switch(SwitchId),
 }
 
 impl HealthObject {
     fn id(&self) -> String {
         match self {
             HealthObject::Machine(id) => id.to_string(),
+            HealthObject::PowerShelf(id) => id.to_string(),
             HealthObject::Rack(id) => id.to_string(),
+            HealthObject::Switch(id) => id.to_string(),
         }
     }
 
     fn kind(&self) -> &'static str {
         match self {
             HealthObject::Machine(_) => "machine",
+            HealthObject::PowerShelf(_) => "power-shelf",
             HealthObject::Rack(_) => "rack",
+            HealthObject::Switch(_) => "switch",
         }
     }
 
     fn label(&self) -> String {
         match self {
             HealthObject::Machine(id) => id.machine_type().to_string(),
+            HealthObject::PowerShelf(_) => "Power Shelf".to_string(),
             HealthObject::Rack(_) => "Rack".to_string(),
+            HealthObject::Switch(_) => "Switch".to_string(),
         }
     }
 
@@ -116,7 +129,9 @@ impl HealthObject {
     fn history_url(&self) -> Option<String> {
         match self {
             HealthObject::Machine(id) => Some(format!("/admin/machine/{id}/health-history")),
+            HealthObject::PowerShelf(_) => None,
             HealthObject::Rack(_) => None,
+            HealthObject::Switch(_) => None,
         }
     }
 
@@ -176,6 +191,40 @@ pub async fn rack_health(
     };
 
     render_health(HealthObject::Rack(rack_id), data)
+}
+
+/// View power shelf health.
+pub async fn power_shelf_health(
+    AxumState(state): AxumState<Arc<Api>>,
+    AxumPath(power_shelf_id): AxumPath<String>,
+) -> Response {
+    let Ok(power_shelf_id) = PowerShelfId::from_str(&power_shelf_id) else {
+        return (StatusCode::BAD_REQUEST, "invalid power shelf id").into_response();
+    };
+
+    let data = match fetch_power_shelf_health_page_data(&state, &power_shelf_id).await {
+        Ok(data) => data,
+        Err(response) => return response,
+    };
+
+    render_health(HealthObject::PowerShelf(power_shelf_id), data)
+}
+
+/// View switch health.
+pub async fn switch_health(
+    AxumState(state): AxumState<Arc<Api>>,
+    AxumPath(switch_id): AxumPath<String>,
+) -> Response {
+    let Ok(switch_id) = SwitchId::from_str(&switch_id) else {
+        return (StatusCode::BAD_REQUEST, "invalid switch id").into_response();
+    };
+
+    let data = match fetch_switch_health_page_data(&state, &switch_id).await {
+        Ok(data) => data,
+        Err(response) => return response,
+    };
+
+    render_health(HealthObject::Switch(switch_id), data)
 }
 
 fn render_health(object: HealthObject, data: HealthPageData) -> Response {
@@ -271,6 +320,54 @@ async fn fetch_rack_health_page_data(
     })
 }
 
+async fn fetch_power_shelf_health_page_data(
+    api: &Api,
+    power_shelf_id: &PowerShelfId,
+) -> Result<HealthPageData, Response> {
+    let aggregate_health = fetch_power_shelf_aggregate_health(api, power_shelf_id).await?;
+    let entries = match list_power_shelf_health_report_entries(api, power_shelf_id).await {
+        Ok(entries) => entries,
+        Err(err) if err.code() == tonic::Code::NotFound => Vec::new(),
+        Err(err) => {
+            tracing::error!(%err, %power_shelf_id, "list_power_shelf_health_reports");
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
+        }
+    };
+
+    Ok(HealthPageData {
+        entries,
+        aggregate_health,
+        health_contributors: Vec::new(),
+        history: HealthHistoryTable {
+            records: Vec::new(),
+        },
+    })
+}
+
+async fn fetch_switch_health_page_data(
+    api: &Api,
+    switch_id: &SwitchId,
+) -> Result<HealthPageData, Response> {
+    let aggregate_health = fetch_switch_aggregate_health(api, switch_id).await?;
+    let entries = match list_switch_health_report_entries(api, switch_id).await {
+        Ok(entries) => entries,
+        Err(err) if err.code() == tonic::Code::NotFound => Vec::new(),
+        Err(err) => {
+            tracing::error!(%err, %switch_id, "list_switch_health_reports");
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
+        }
+    };
+
+    Ok(HealthPageData {
+        entries,
+        aggregate_health,
+        health_contributors: Vec::new(),
+        history: HealthHistoryTable {
+            records: Vec::new(),
+        },
+    })
+}
+
 async fn fetch_dpu_health_contributors(
     api: &Api,
     host_machine_id: &MachineId,
@@ -327,6 +424,32 @@ async fn list_rack_health_report_entries(
     Ok(api
         .list_rack_health_reports(tonic::Request::new(ListRackHealthReportsRequest {
             rack_id: Some(rack_id.clone()),
+        }))
+        .await?
+        .into_inner()
+        .health_report_entries)
+}
+
+async fn list_power_shelf_health_report_entries(
+    api: &Api,
+    power_shelf_id: &PowerShelfId,
+) -> Result<Vec<::rpc::forge::HealthReportEntry>, tonic::Status> {
+    Ok(api
+        .list_power_shelf_health_reports(tonic::Request::new(ListPowerShelfHealthReportsRequest {
+            power_shelf_id: Some(*power_shelf_id),
+        }))
+        .await?
+        .into_inner()
+        .health_report_entries)
+}
+
+async fn list_switch_health_report_entries(
+    api: &Api,
+    switch_id: &SwitchId,
+) -> Result<Vec<::rpc::forge::HealthReportEntry>, tonic::Status> {
+    Ok(api
+        .list_switch_health_reports(tonic::Request::new(ListSwitchHealthReportsRequest {
+            switch_id: Some(*switch_id),
         }))
         .await?
         .into_inner()
@@ -405,6 +528,80 @@ async fn fetch_rack_aggregate_health(
     Ok(rack
         .as_ref()
         .and_then(|rack| rack.status.as_ref())
+        .and_then(|status| status.health.as_ref())
+        .map(|health| health_report_from_rpc_convert_invalid(health.clone())))
+}
+
+async fn fetch_power_shelf_aggregate_health(
+    api: &Api,
+    power_shelf_id: &PowerShelfId,
+) -> Result<Option<HealthReport>, Response> {
+    let power_shelf = match api
+        .find_power_shelves_by_ids(tonic::Request::new(PowerShelvesByIdsRequest {
+            power_shelf_ids: vec![*power_shelf_id],
+        }))
+        .await
+        .map(|response| response.into_inner())
+    {
+        Ok(r) if r.power_shelves.is_empty() => None,
+        Ok(r) if r.power_shelves.len() != 1 => {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!(
+                    "Power shelf list for {power_shelf_id} returned {} power shelves",
+                    r.power_shelves.len()
+                ),
+            )
+                .into_response());
+        }
+        Ok(mut r) => Some(r.power_shelves.remove(0)),
+        Err(err) if err.code() == tonic::Code::NotFound => None,
+        Err(err) => {
+            tracing::error!(%err, %power_shelf_id, "find_power_shelves_by_ids");
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
+        }
+    };
+
+    Ok(power_shelf
+        .as_ref()
+        .and_then(|power_shelf| power_shelf.status.as_ref())
+        .and_then(|status| status.health.as_ref())
+        .map(|health| health_report_from_rpc_convert_invalid(health.clone())))
+}
+
+async fn fetch_switch_aggregate_health(
+    api: &Api,
+    switch_id: &SwitchId,
+) -> Result<Option<HealthReport>, Response> {
+    let switch = match api
+        .find_switches_by_ids(tonic::Request::new(SwitchesByIdsRequest {
+            switch_ids: vec![*switch_id],
+        }))
+        .await
+        .map(|response| response.into_inner())
+    {
+        Ok(r) if r.switches.is_empty() => None,
+        Ok(r) if r.switches.len() != 1 => {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!(
+                    "Switch list for {switch_id} returned {} switches",
+                    r.switches.len()
+                ),
+            )
+                .into_response());
+        }
+        Ok(mut r) => Some(r.switches.remove(0)),
+        Err(err) if err.code() == tonic::Code::NotFound => None,
+        Err(err) => {
+            tracing::error!(%err, %switch_id, "find_switches_by_ids");
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
+        }
+    };
+
+    Ok(switch
+        .as_ref()
+        .and_then(|switch| switch.status.as_ref())
         .and_then(|status| status.health.as_ref())
         .map(|health| health_report_from_rpc_convert_invalid(health.clone())))
 }
@@ -495,6 +692,46 @@ pub async fn add_rack_health_report(
     add_health_report_for(state, HealthObject::Rack(rack_id), auth_context, payload).await
 }
 
+pub async fn add_power_shelf_health_report(
+    AxumState(state): AxumState<Arc<Api>>,
+    AxumPath(power_shelf_id): AxumPath<String>,
+    auth_context: Option<axum::Extension<AuthContext>>,
+    extract::Json(payload): extract::Json<HealthReportEntry>,
+) -> Response {
+    let power_shelf_id = match power_shelf_id.parse::<PowerShelfId>() {
+        Ok(id) => id,
+        Err(e) => return (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
+    };
+
+    add_health_report_for(
+        state,
+        HealthObject::PowerShelf(power_shelf_id),
+        auth_context,
+        payload,
+    )
+    .await
+}
+
+pub async fn add_switch_health_report(
+    AxumState(state): AxumState<Arc<Api>>,
+    AxumPath(switch_id): AxumPath<String>,
+    auth_context: Option<axum::Extension<AuthContext>>,
+    extract::Json(payload): extract::Json<HealthReportEntry>,
+) -> Response {
+    let switch_id = match switch_id.parse::<SwitchId>() {
+        Ok(id) => id,
+        Err(e) => return (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
+    };
+
+    add_health_report_for(
+        state,
+        HealthObject::Switch(switch_id),
+        auth_context,
+        payload,
+    )
+    .await
+}
+
 async fn add_health_report_for(
     state: Arc<Api>,
     object: HealthObject,
@@ -522,6 +759,19 @@ async fn add_health_report_for(
                 .await
                 .map(|response| response.into_inner())
         }
+        HealthObject::PowerShelf(power_shelf_id) => {
+            let mut request = tonic::Request::new(InsertPowerShelfHealthReportRequest {
+                power_shelf_id: Some(power_shelf_id),
+                health_report_entry: Some(entry),
+            });
+            if let Some(axum::Extension(auth_context)) = auth_context {
+                request.extensions_mut().insert(auth_context);
+            }
+            state
+                .insert_power_shelf_health_report(request)
+                .await
+                .map(|response| response.into_inner())
+        }
         HealthObject::Rack(rack_id) => {
             let mut request = tonic::Request::new(InsertRackHealthReportRequest {
                 rack_id: Some(rack_id),
@@ -532,6 +782,19 @@ async fn add_health_report_for(
             }
             state
                 .insert_rack_health_report(request)
+                .await
+                .map(|response| response.into_inner())
+        }
+        HealthObject::Switch(switch_id) => {
+            let mut request = tonic::Request::new(InsertSwitchHealthReportRequest {
+                switch_id: Some(switch_id),
+                health_report_entry: Some(entry),
+            });
+            if let Some(axum::Extension(auth_context)) = auth_context {
+                request.extensions_mut().insert(auth_context);
+            }
+            state
+                .insert_switch_health_report(request)
                 .await
                 .map(|response| response.into_inner())
         }
@@ -575,6 +838,32 @@ pub async fn remove_rack_health_report(
     remove_health_report_for(state, HealthObject::Rack(rack_id), payload).await
 }
 
+pub async fn remove_power_shelf_health_report(
+    AxumState(state): AxumState<Arc<Api>>,
+    AxumPath(power_shelf_id): AxumPath<String>,
+    extract::Json(payload): extract::Json<RemoveHealthReport>,
+) -> Response {
+    let power_shelf_id = match power_shelf_id.parse::<PowerShelfId>() {
+        Ok(id) => id,
+        Err(e) => return (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
+    };
+
+    remove_health_report_for(state, HealthObject::PowerShelf(power_shelf_id), payload).await
+}
+
+pub async fn remove_switch_health_report(
+    AxumState(state): AxumState<Arc<Api>>,
+    AxumPath(switch_id): AxumPath<String>,
+    extract::Json(payload): extract::Json<RemoveHealthReport>,
+) -> Response {
+    let switch_id = match switch_id.parse::<SwitchId>() {
+        Ok(id) => id,
+        Err(e) => return (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
+    };
+
+    remove_health_report_for(state, HealthObject::Switch(switch_id), payload).await
+}
+
 async fn remove_health_report_for(
     state: Arc<Api>,
     object: HealthObject,
@@ -590,9 +879,25 @@ async fn remove_health_report_for(
             }))
             .await
             .map(|response| response.into_inner()),
+        HealthObject::PowerShelf(power_shelf_id) => state
+            .remove_power_shelf_health_report(tonic::Request::new(
+                RemovePowerShelfHealthReportRequest {
+                    power_shelf_id: Some(power_shelf_id),
+                    source: payload.source,
+                },
+            ))
+            .await
+            .map(|response| response.into_inner()),
         HealthObject::Rack(rack_id) => state
             .remove_rack_health_report(tonic::Request::new(RemoveRackHealthReportRequest {
                 rack_id: Some(rack_id),
+                source: payload.source,
+            }))
+            .await
+            .map(|response| response.into_inner()),
+        HealthObject::Switch(switch_id) => state
+            .remove_switch_health_report(tonic::Request::new(RemoveSwitchHealthReportRequest {
+                switch_id: Some(switch_id),
                 source: payload.source,
             }))
             .await

--- a/crates/api/src/web/mod.rs
+++ b/crates/api/src/web/mod.rs
@@ -560,6 +560,18 @@ pub fn routes(api: Arc<Api>) -> eyre::Result<NormalizePath<Router>> {
             .route("/power-shelf.json", get(power_shelf::show_json))
             .route("/power-shelf/{power_shelf_id}", get(power_shelf::detail))
             .route(
+                "/power-shelf/{power_shelf_id}/health",
+                get(health::power_shelf_health),
+            )
+            .route(
+                "/power-shelf/{power_shelf_id}/health/add-report",
+                post(health::add_power_shelf_health_report),
+            )
+            .route(
+                "/power-shelf/{power_shelf_id}/health/remove-report",
+                post(health::remove_power_shelf_health_report),
+            )
+            .route(
                 "/power-shelf/{power_shelf_id}/state-history",
                 get(state_history::show_power_shelf_state_history),
             )
@@ -590,6 +602,15 @@ pub fn routes(api: Arc<Api>) -> eyre::Result<NormalizePath<Router>> {
             .route("/switch", get(switch::show_html))
             .route("/switch.json", get(switch::show_json))
             .route("/switch/{switch_id}", get(switch::detail))
+            .route("/switch/{switch_id}/health", get(health::switch_health))
+            .route(
+                "/switch/{switch_id}/health/add-report",
+                post(health::add_switch_health_report),
+            )
+            .route(
+                "/switch/{switch_id}/health/remove-report",
+                post(health::remove_switch_health_report),
+            )
             .route(
                 "/switch/{switch_id}/state-history",
                 get(state_history::show_switch_state_history),

--- a/crates/api/src/web/power_shelf.rs
+++ b/crates/api/src/web/power_shelf.rs
@@ -127,6 +127,7 @@ struct PowerShelfDetail {
     voltage: String,
     bmc_info: Option<rpc::forge::BmcInfo>,
     metadata_detail: super::MetadataDetail,
+    health_detail: super::HealthDetail,
 }
 
 impl PowerShelfDetail {
@@ -143,6 +144,16 @@ impl PowerShelfDetail {
             .and_then(|s| s.lifecycle.clone())
             .unwrap_or_default();
         let power_state = shelf.status.as_ref().and_then(|s| s.power_state.clone());
+        let health_detail = super::HealthDetail::new(
+            format!("/admin/power-shelf/{id}/health"),
+            "Go to Power Shelf health reports",
+            shelf.status.as_ref().and_then(|s| s.health.clone()),
+            shelf
+                .status
+                .as_ref()
+                .map(|s| s.health_sources.clone())
+                .unwrap_or_default(),
+        );
         let metadata_detail = super::MetadataDetail {
             metadata: shelf.metadata.unwrap_or_default(),
             metadata_version: shelf.version,
@@ -163,6 +174,7 @@ impl PowerShelfDetail {
                 .unwrap_or_else(|| "N/A".to_string()),
             bmc_info: shelf.bmc_info,
             metadata_detail,
+            health_detail,
         }
     }
 }

--- a/crates/api/src/web/switch.rs
+++ b/crates/api/src/web/switch.rs
@@ -151,6 +151,7 @@ struct SwitchDetail {
     health_status: Option<String>,
     bmc_info: Option<rpc::forge::BmcInfo>,
     metadata_detail: super::MetadataDetail,
+    health_detail: super::HealthDetail,
 }
 
 impl SwitchDetail {
@@ -161,13 +162,16 @@ impl SwitchDetail {
             .map(|id| id.to_string())
             .unwrap_or_default();
         let config = switch.config.unwrap_or_default();
-        let lifecycle = switch
-            .status
-            .as_ref()
-            .and_then(|s| s.lifecycle.clone())
-            .unwrap_or_default();
-        let power_state = switch.status.as_ref().and_then(|s| s.power_state.clone());
-        let health_status = switch.status.as_ref().and_then(|s| s.health_status.clone());
+        let status = switch.status.as_ref();
+        let lifecycle = status.and_then(|s| s.lifecycle.clone()).unwrap_or_default();
+        let power_state = status.and_then(|s| s.power_state.clone());
+        let health_status = status.and_then(|s| s.health_status.clone());
+        let health_detail = super::HealthDetail::new(
+            format!("/admin/switch/{id}/health"),
+            "Go to Switch health reports",
+            status.and_then(|s| s.health.clone()),
+            status.map(|s| s.health_sources.clone()).unwrap_or_default(),
+        );
         let metadata_detail = super::MetadataDetail {
             metadata: switch.metadata.unwrap_or_default(),
             metadata_version: switch.version,
@@ -194,6 +198,7 @@ impl SwitchDetail {
             health_status,
             bmc_info: switch.bmc_info,
             metadata_detail,
+            health_detail,
         }
     }
 }

--- a/crates/api/templates/power_shelf_detail.html
+++ b/crates/api/templates/power_shelf_detail.html
@@ -15,15 +15,14 @@
 		<td>{{ id }}</td>
 	</tr>
 	<tr><th>Rack ID</th><td>{{ rack_id|rack_id_link|safe }}</td></tr>
-	{% if let Some(power_state) = power_state %}
-	<tr>
-		<th>Power State</th>
-		<td>{{ power_state }}</td>
-	</tr>
-	{% endif %}
 </table>
 
 {{ lifecycle_detail|safe }}
+
+<h2>Metadata</h2>
+{{ metadata_detail|safe }}
+
+{{ health_detail|safe }}
 
 <h2>Configuration</h2>
 <table class="detailsview">
@@ -41,8 +40,15 @@
 	</tr>
 </table>
 
-<h2>Metadata</h2>
-{{ metadata_detail|safe }}
+<h2>Status</h2>
+<table class="detailsview">
+	{% if let Some(power_state) = power_state %}
+	<tr>
+		<th>Power State</th>
+		<td>{{ power_state }}</td>
+	</tr>
+	{% endif %}
+</table>
 
 <h2>BMC</h2>
 <table class="detailsview">

--- a/crates/api/templates/rack_detail.html
+++ b/crates/api/templates/rack_detail.html
@@ -22,10 +22,10 @@
 
 {{ lifecycle_detail|safe }}
 
-{{ health_detail|safe }}
-
 <h2>Metadata</h2>
 {{ metadata_detail|safe }}
+
+{{ health_detail|safe }}
 
 <h2>Managed Rack Components</h2>
 

--- a/crates/api/templates/switch_detail.html
+++ b/crates/api/templates/switch_detail.html
@@ -15,29 +15,14 @@
 		<td>{{ id }}</td>
 	</tr>
 	<tr><th>Rack ID</th><td>{{ rack_id|rack_id_link|safe }}</td></tr>
-	{% if let Some(power_state) = power_state %}
-	<tr>
-		<th>Power State</th>
-		<td>{{ power_state }}</td>
-	</tr>
-	{% endif %}
-	{% if let Some(health_status) = health_status %}
-	<tr>
-		<th>Health Status</th>
-		<td>
-			{% if health_status == "ok" || health_status == "OK" %}
-				<span class="bubble success">{{ health_status }}</span>
-			{% else if health_status == "critical" || health_status == "Critical" %}
-				<span class="bubble error">{{ health_status }}</span>
-			{% else %}
-				<span class="bubble warning">{{ health_status }}</span>
-			{% endif %}
-		</td>
-	</tr>
-	{% endif %}
 </table>
 
 {{ lifecycle_detail|safe }}
+
+<h2>Metadata</h2>
+{{ metadata_detail|safe }}
+
+{{ health_detail|safe }}
 
 <h2>Configuration</h2>
 <table class="detailsview">
@@ -59,25 +44,29 @@
 	</tr>
 </table>
 
-<h2>Metadata</h2>
-{{ metadata_detail|safe }}
-
-<h2>Health</h2>
+<h2>Status</h2>
 <table class="detailsview">
+	{% if let Some(power_state) = power_state %}
+	<tr>
+		<th>Power State</th>
+		<td>{{ power_state }}</td>
+	</tr>
+	{% endif %}
 	{% if let Some(health_status) = health_status %}
 	<tr>
 		<th>Health Status</th>
-		<td>{{ health_status }}</td>
-	</tr>
-	{% else %}
-	<tr>
-		<td colspan="2" class="text-muted">No health data available.</td>
+		<td>
+			{% if health_status == "ok" || health_status == "OK" %}
+				<span class="bubble success">{{ health_status }}</span>
+			{% else if health_status == "critical" || health_status == "Critical" %}
+				<span class="bubble error">{{ health_status }}</span>
+			{% else %}
+				<span class="bubble warning">{{ health_status }}</span>
+			{% endif %}
+		</td>
 	</tr>
 	{% endif %}
 </table>
-
-<h2>Maintenance and Quarantine</h2>
-<p>TBD</p>
 
 <h2>BMC</h2>
 <table class="detailsview">


### PR DESCRIPTION
## Description

Adds web-ui health management endpoints for powershelves and switches.

Rearranges their details pages to show information in the same order as Machine pages do.

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

#243 

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

