### PR TITLE
chore: update kea compilation to use pkg-config

### DIFF
--- a/.github/workflows/build-boot-artifacts.yml
+++ b/.github/workflows/build-boot-artifacts.yml
@@ -306,8 +306,6 @@ jobs:
           ENV_ARGS="$ENV_ARGS -e CACHE_DIRECTORY=/workspace/cache"
           ENV_ARGS="$ENV_ARGS -e APT_CACHE_DIR=/workspace/apt"
           ENV_ARGS="$ENV_ARGS -e LOGNAME=root"
-          ENV_ARGS="$ENV_ARGS -e KEA_BIN_PATH=/usr/bin"
-          ENV_ARGS="$ENV_ARGS -e KEA_INCLUDE_PATH=/usr/include/kea"
           ENV_ARGS="$ENV_ARGS -e REPO_ROOT=/workspace"
           ENV_ARGS="$ENV_ARGS -e VERSION=${{ inputs.version }}"
           ENV_ARGS="$ENV_ARGS -e FORGE_CA=prod"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1715,6 +1715,7 @@ dependencies = [
  "metrics-endpoint",
  "once_cell",
  "opentelemetry",
+ "pkg-config",
  "prometheus",
  "prost 0.14.1",
  "serde_json",

--- a/crates/dhcp/Cargo.toml
+++ b/crates/dhcp/Cargo.toml
@@ -46,6 +46,7 @@ prometheus = { workspace = true }
 [build-dependencies]
 cbindgen = "*"
 cc = "1.0"
+pkg-config = "0.3"
 
 [lints]
 workspace = true

--- a/crates/dhcp/build.rs
+++ b/crates/dhcp/build.rs
@@ -18,20 +18,18 @@
 // dhcp package is built for x86_64 and aarch64 architectures
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 fn main() {
-    use std::env;
-
-    let kea_include_path =
-        env::var("KEA_INCLUDE_PATH").unwrap_or_else(|_| "/usr/include/kea".to_string());
-
-    #[cfg(target_arch = "x86_64")]
-    let default_kea_lib_path = "/usr/lib/x86_64-linux-gnu/kea";
-    #[cfg(target_arch = "aarch64")]
-    let default_kea_lib_path = "/usr/lib/aarch64-linux-gnu/kea";
-
-    let kea_lib_path =
-        env::var("KEA_LIB_PATH").unwrap_or_else(|_| default_kea_lib_path.to_string());
-
     let kea_shim_root = format!("{}/src/kea", env!("CARGO_MANIFEST_DIR"));
+
+    let kea = pkg_config::Config::new()
+        .cargo_metadata(true)
+        .probe("kea")
+        .expect("kea pkg-config not found");
+
+    let kea_include_path = kea
+        .include_paths
+        .first()
+        .map(|p| p.to_string_lossy().into_owned())
+        .expect("kea pkg-config returned no include paths");
 
     cbindgen::Builder::new()
         .with_crate(env!("CARGO_MANIFEST_DIR"))
@@ -58,16 +56,8 @@ fn main() {
     println!("cargo:rerun-if-changed=src/kea/carbide_logger.cc");
     println!("cargo:rerun-if-changed=src/kea/carbide_logger.h");
 
-    println!("cargo:rustc-link-search={kea_lib_path}");
     println!("cargo:rustc-link-lib=keashim");
     println!("cargo:rustc-link-lib=stdc++");
-    println!("cargo:rustc-link-lib=kea-asiolink");
-    println!("cargo:rustc-link-lib=kea-dhcpsrv");
-    println!("cargo:rustc-link-lib=kea-dhcp++");
-    println!("cargo:rustc-link-lib=kea-hooks");
-    println!("cargo:rustc-link-lib=kea-log");
-    println!("cargo:rustc-link-lib=kea-util");
-    println!("cargo:rustc-link-lib=kea-exceptions");
 }
 
 #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]


### PR DESCRIPTION
## Description

Kea, at some version changed from `-lkea-dhcp++` to just `-lkea-dhcp`, but rather than try to do version detection and alter based on that just use pkg-config as is standard.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)
