### PR TITLE
refactor(api-model): remove libredfish dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,7 +1042,6 @@ name = "bmc-vendor"
 version = "0.1.0"
 dependencies = [
  "clap",
- "libredfish",
  "serde",
 ]
 
@@ -1548,7 +1547,6 @@ dependencies = [
  "itertools 0.14.0",
  "lazy_static",
  "libnmxm",
- "libredfish",
  "mac_address",
  "nras",
  "once_cell",
@@ -2426,6 +2424,7 @@ version = "0.0.1"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "bmc-vendor",
  "carbide-api-db",
  "carbide-api-model",
  "carbide-secrets",

--- a/crates/api-model/Cargo.toml
+++ b/crates/api-model/Cargo.toml
@@ -56,7 +56,6 @@ hex = { workspace = true }
 ipnetwork = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
-libredfish = { workspace = true }
 mac_address = { features = ["serde"], workspace = true }
 once_cell = { workspace = true }
 rand = { workspace = true }

--- a/crates/api-model/src/attestation.rs
+++ b/crates/api-model/src/attestation.rs
@@ -53,7 +53,6 @@ pub mod spdm {
 
     use config_version::ConfigVersion;
     use itertools::Itertools;
-    use libredfish::model::component_integrity::{CaCertificate, ComponentIntegrity, Evidence};
     use nras::{NrasError, NrasVerifierClient, ProcessedAttestationOutcome, RawAttestationOutcome};
     use serde::{Deserialize, Serialize};
     use sqlx::Row;
@@ -342,6 +341,33 @@ pub mod spdm {
         pub firmware_version: Option<String>,
     }
 
+    #[derive(Debug, Serialize, Deserialize, Clone)]
+    #[serde(rename_all = "PascalCase")]
+    pub struct CaCertificate {
+        pub certificate_string: String,
+        pub certificate_type: String,
+        pub certificate_usage_types: Vec<String>,
+        pub id: String,
+        pub name: String,
+        #[serde(rename = "SPDM")]
+        pub spdm: SlotInfo,
+    }
+
+    #[derive(Debug, Serialize, Deserialize, Clone)]
+    #[serde(rename_all = "PascalCase")]
+    pub struct Evidence {
+        pub hashing_algorithm: String,
+        pub signed_measurements: String,
+        pub signing_algorithm: String,
+        pub version: String,
+    }
+
+    #[derive(Debug, Serialize, Deserialize, Clone)]
+    #[serde(rename_all = "PascalCase")]
+    pub struct SlotInfo {
+        pub slot_id: u16,
+    }
+
     impl<'r> sqlx::FromRow<'r, PgRow> for SpdmMachineAttestationHistory {
         fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
             let snapshot: sqlx::types::Json<SpdmMachineStateSnapshot> =
@@ -476,38 +502,6 @@ pub mod spdm {
                 update_machine_version: false,
                 update_device_version: false,
             }
-        }
-    }
-
-    pub fn from_component_integrity(
-        integrity: ComponentIntegrity,
-        machine_id: MachineId,
-    ) -> SpdmMachineDeviceAttestation {
-        let ca_certificate_link = integrity
-            .spdm
-            .map(|x| x.identity_authentication)
-            .map(|x| x.component_certificate)
-            .map(|x| x.odata_id);
-
-        let evidence_target =
-            if let Some(Some(data)) = integrity.actions.map(|x| x.get_signed_measurements) {
-                Some(data.target)
-            } else {
-                None
-            };
-
-        SpdmMachineDeviceAttestation {
-            machine_id,
-            device_id: integrity.id,
-            nonce: uuid::Uuid::new_v4(),
-            state: AttestationDeviceState::FetchData(FetchDataDeviceStates::FetchMetadata),
-            state_version: ConfigVersion::initial(),
-            state_outcome: None,
-            metadata: None,
-            ca_certificate_link,
-            ca_certificate: None,
-            evidence_target,
-            evidence: None,
         }
     }
 

--- a/crates/api-model/src/firmware.rs
+++ b/crates/api-model/src/firmware.rs
@@ -131,24 +131,6 @@ pub enum FirmwareComponentType {
     Unknown,
 }
 
-impl From<FirmwareComponentType> for libredfish::model::update_service::ComponentType {
-    fn from(fct: FirmwareComponentType) -> libredfish::model::update_service::ComponentType {
-        use libredfish::model::update_service::ComponentType;
-        match fct {
-            FirmwareComponentType::Bmc => ComponentType::BMC,
-            FirmwareComponentType::Uefi => ComponentType::UEFI,
-            FirmwareComponentType::Cec => ComponentType::Unknown,
-            FirmwareComponentType::Nic => ComponentType::Unknown,
-            FirmwareComponentType::CpldMb => ComponentType::CPLDMB,
-            FirmwareComponentType::CpldPdb => ComponentType::CPLDPDB,
-            FirmwareComponentType::HGXBmc => ComponentType::HGXBMC,
-            FirmwareComponentType::CombinedBmcUefi => ComponentType::Unknown,
-            FirmwareComponentType::Gpu => ComponentType::Unknown,
-            FirmwareComponentType::Unknown => ComponentType::Unknown,
-        }
-    }
-}
-
 impl fmt::Display for FirmwareComponentType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -35,7 +35,6 @@ use config_version::{ConfigVersion, Versioned};
 use duration_str::deserialize_duration_chrono;
 use health_report::HealthReport;
 use json::MachineSnapshotPgJson;
-use libredfish::{PowerState, SystemPowerControl};
 use mac_address::MacAddress;
 use rpc::forge::HealthSourceOrigin;
 use rpc::forge_agent_control_response as fac;
@@ -738,20 +737,6 @@ pub enum MachineLastRebootRequestedMode {
     PowerOff,
     PowerOn,
     GracefulShutdown,
-}
-
-impl From<SystemPowerControl> for MachineLastRebootRequestedMode {
-    fn from(value: SystemPowerControl) -> Self {
-        match value {
-            SystemPowerControl::On => Self::PowerOn,
-            SystemPowerControl::GracefulShutdown => Self::PowerOff,
-            SystemPowerControl::ForceOff => Self::PowerOff,
-            SystemPowerControl::GracefulRestart => Self::Reboot,
-            SystemPowerControl::ForceRestart => Self::Reboot,
-            SystemPowerControl::ACPowercycle => Self::Reboot,
-            SystemPowerControl::PowerCycle => Self::Reboot,
-        }
-    }
 }
 
 impl Display for MachineLastRebootRequestedMode {
@@ -2038,7 +2023,7 @@ pub struct BiosConfigInfo {
     pub retry_count: u32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, EnumIter)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(tag = "state", rename_all = "lowercase")]
 pub enum BiosConfigState {
     WaitForBiosJobScheduled,
@@ -2062,7 +2047,7 @@ pub struct SetBootOrderInfo {
     pub retry_count: u32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, EnumIter)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(tag = "state", rename_all = "lowercase")]
 pub enum SetBootOrderState {
     SetBootOrder,
@@ -2087,7 +2072,7 @@ pub struct SecureEraseBossContext {
     pub secure_erase_boss_state: SecureEraseBossState,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, EnumIter)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(tag = "state", rename_all = "lowercase")]
 pub enum SecureEraseBossState {
     UnlockHost,
@@ -2110,7 +2095,7 @@ pub struct CreateBossVolumeContext {
     pub create_boss_volume_state: CreateBossVolumeState,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, EnumIter)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(tag = "state", rename_all = "lowercase")]
 pub enum CreateBossVolumeState {
     CreateBossVolume,
@@ -2940,6 +2925,25 @@ impl<'r> FromRow<'r, PgRow> for MachineInterfaceSnapshot {
             switch_id: row.try_get("switch_id")?,
             association_type: row.try_get("association_type")?,
         })
+    }
+}
+
+// TODO: reconcile with site_explorer::PowerState. They are almost
+// identical but here we have Reset enum item.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub enum PowerState {
+    Off,
+    On,
+    PoweringOff,
+    PoweringOn,
+    Paused,
+    Reset,
+    Unknown,
+}
+
+impl Display for PowerState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
     }
 }
 

--- a/crates/api-model/src/power_manager.rs
+++ b/crates/api-model/src/power_manager.rs
@@ -24,13 +24,6 @@ use sqlx::{FromRow, Row};
 
 use crate::machine::{DpuInitState, ManagedHostState, ManagedHostStateSnapshot};
 
-// If power state is Paused and Reset, state machine can't take any decision on it.
-// Ignore power manager with a log and moved to state machine.
-pub enum UsablePowerState {
-    Usable(PowerState),
-    NotUsable(libredfish::PowerState),
-}
-
 /// Representing DPU state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, sqlx::Type, Serialize, Deserialize)]
 #[sqlx(rename_all = "snake_case")]

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -29,8 +29,6 @@ use chrono::{DateTime, Utc};
 use config_version::ConfigVersion;
 use itertools::Itertools;
 use lazy_static::lazy_static;
-use libredfish::RedfishError;
-pub use libredfish::model::oem::nvidia_dpu::NicMode;
 use mac_address::MacAddress;
 use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -1430,7 +1428,7 @@ lazy_static! {
 }
 
 impl FromStr for UefiDevicePath {
-    type Err = RedfishError;
+    type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Uefi string is received as PciRoot(0x8)/Pci(0x2,0xa)/Pci(0x0,0x0)/MAC(A088C208545C,0x1)
@@ -1439,12 +1437,9 @@ impl FromStr for UefiDevicePath {
 
         let st = s.rsplit_once("/MAC").map(|x| x.0).unwrap_or(s);
 
-        let captures =
-            UEFI_DEVICE_PATH_REGEX
-                .captures(st)
-                .ok_or_else(|| RedfishError::GenericError {
-                    error: format!("Could not match regex in PCI Device Path {s}."),
-                })?;
+        let captures = UEFI_DEVICE_PATH_REGEX
+            .captures(st)
+            .ok_or_else(|| format!("Could not match regex in PCI Device Path {s}."))?;
 
         let mut pci = vec![];
 
@@ -1456,10 +1451,10 @@ impl FromStr for UefiDevicePath {
             if let Some(capture) = capture {
                 for hex in capture.as_str().split(',') {
                     let hex_int = u32::from_str_radix(&hex.to_lowercase().replace("0x", ""), 16)
-                        .map_err(|e| RedfishError::GenericError {
-                            error: format!(
+                        .map_err(|e| {
+                            format!(
                                 "Can't convert pci address to int {hex}, error: {e} for pci: {s}"
-                            ),
+                            )
                         })?;
                     pci.push(hex_int.to_string());
                 }
@@ -1752,86 +1747,17 @@ impl From<Option<bool>> for MachineExpectation {
     }
 }
 
-impl From<libredfish::PowerState> for PowerState {
-    fn from(state: libredfish::PowerState) -> Self {
-        match state {
-            libredfish::PowerState::Off => PowerState::Off,
-            libredfish::PowerState::On => PowerState::On,
-            libredfish::PowerState::PoweringOff => PowerState::PoweringOff,
-            libredfish::PowerState::PoweringOn => PowerState::PoweringOn,
-            libredfish::PowerState::Paused => PowerState::Paused,
-            libredfish::PowerState::Reset => PowerState::PoweringOn,
-            libredfish::PowerState::Unknown => PowerState::Unknown,
-        }
-    }
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub enum NicMode {
+    #[serde(rename = "DpuMode", alias = "Dpu")]
+    Dpu,
+    #[serde(rename = "NicMode", alias = "Nic")]
+    Nic,
 }
 
-impl From<libredfish::PCIeDevice> for PCIeDevice {
-    fn from(device: libredfish::PCIeDevice) -> Self {
-        PCIeDevice {
-            description: device.description,
-            firmware_version: device.firmware_version,
-            id: device.id,
-            manufacturer: device.manufacturer,
-            name: device.name,
-            part_number: device.part_number,
-            serial_number: device.serial_number,
-            status: device.status.map(|s| s.into()),
-            gpu_vendor: device.gpu_vendor,
-        }
-    }
-}
-impl From<PCIeDevice> for libredfish::PCIeDevice {
-    fn from(device: PCIeDevice) -> Self {
-        libredfish::PCIeDevice {
-            description: device.description,
-            firmware_version: device.firmware_version,
-            id: device.id,
-            manufacturer: device.manufacturer,
-            name: device.name,
-            part_number: device.part_number,
-            serial_number: device.serial_number,
-            status: device.status.map(|s| s.into()),
-            gpu_vendor: device.gpu_vendor,
-            odata: libredfish::OData {
-                odata_id: "odata_id".to_owned(),
-                odata_type: "odata_type".to_owned(),
-                odata_etag: None,
-                odata_context: None,
-            },
-            pcie_functions: None,
-            slot: None,
-        }
-    }
-}
-
-impl From<SystemStatus> for libredfish::model::SystemStatus {
-    fn from(status: SystemStatus) -> Self {
-        libredfish::model::SystemStatus {
-            health: status.health,
-            health_rollup: status.health_rollup,
-            state: Some(status.state),
-        }
-    }
-}
-impl From<libredfish::model::SystemStatus> for SystemStatus {
-    fn from(status: libredfish::model::SystemStatus) -> Self {
-        SystemStatus {
-            health: status.health,
-            health_rollup: status.health_rollup,
-            state: status.state.unwrap_or("".to_string()),
-        }
-    }
-}
-
-impl From<libredfish::model::BootOption> for BootOption {
-    fn from(boot_option: libredfish::model::BootOption) -> Self {
-        BootOption {
-            display_name: boot_option.display_name,
-            id: boot_option.id,
-            boot_option_enabled: boot_option.boot_option_enabled,
-            uefi_device_path: boot_option.uefi_device_path,
-        }
+impl Display for NicMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
     }
 }
 

--- a/crates/api/src/redfish.rs
+++ b/crates/api/src/redfish.rs
@@ -18,6 +18,7 @@
 use std::sync::Arc;
 
 use carbide_redfish::libredfish::RedfishClientPool;
+use carbide_redfish::libredfish::conv::machine_last_reboot_requested_mode;
 use chrono::Utc;
 use libredfish::model::BootProgress;
 use libredfish::{PowerState, Redfish, RedfishError, SystemPowerControl};
@@ -67,7 +68,7 @@ pub async fn host_power_control_with_location(
     ctx.pending_db_writes
         .push(MachineWriteOp::UpdateRebootRequestedTime {
             machine_id: machine.id,
-            mode: action.into(),
+            mode: machine_last_reboot_requested_mode(action),
             time: Utc::now(),
         });
 

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -25,6 +25,9 @@ use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
 use carbide_firmware::{FirmwareConfig, FirmwareConfigSnapshot, FirmwareDownloader};
+use carbide_redfish::libredfish::conv::{
+    IntoLibredfish, IntoModel, machine_last_reboot_requested_mode,
+};
 use carbide_uuid::machine::MachineId;
 use chrono::{DateTime, Duration, Utc};
 use config_version::{ConfigVersion, Versioned};
@@ -41,7 +44,7 @@ use itertools::Itertools;
 use libredfish::model::oem::nvidia_dpu::HostPrivilegeLevel;
 use libredfish::model::task::TaskState;
 use libredfish::model::update_service::TransferProtocolType;
-use libredfish::{Boot, EnabledDisabled, PowerState, Redfish, RedfishError, SystemPowerControl};
+use libredfish::{Boot, EnabledDisabled, Redfish, RedfishError, SystemPowerControl};
 use machine_validation::{handle_machine_validation_requested, handle_machine_validation_state};
 use measured_boot::records::MeasurementMachineState;
 use model::DpuModel;
@@ -68,10 +71,10 @@ use model::machine::{
     InstanceState, LockdownInfo, LockdownState, Machine, MachineLastRebootRequested,
     MachineLastRebootRequestedMode, MachineNextStateResolver, MachineState, ManagedHostState,
     ManagedHostStateSnapshot, MeasuringState, NetworkConfigUpdateState, NextStateBFBSupport,
-    PerformPowerOperation, PowerDrainState, ReprovisionState, RetryInfo, SecureEraseBossContext,
-    SecureEraseBossState, SetBootOrderInfo, SetBootOrderState, SetSecureBootState,
-    StateMachineArea, UefiSetupInfo, UefiSetupState, UnlockHostState, ValidationState,
-    dpf_based_dpu_provisioning_possible, get_display_ids,
+    PerformPowerOperation, PowerDrainState, PowerState, ReprovisionState, RetryInfo,
+    SecureEraseBossContext, SecureEraseBossState, SetBootOrderInfo, SetBootOrderState,
+    SetSecureBootState, StateMachineArea, UefiSetupInfo, UefiSetupState, UnlockHostState,
+    ValidationState, dpf_based_dpu_provisioning_possible, get_display_ids,
 };
 use model::power_manager::PowerHandlingOutcome;
 use model::resource_pool::common::CommonPools;
@@ -7524,12 +7527,7 @@ impl HostUpgradeState {
                         operation: "power off",
                         error: e,
                     })?;
-                let status = redfish_client.get_power_state().await.map_err(|e| {
-                    StateHandlerError::RedfishError {
-                        operation: "get power state",
-                        error: e,
-                    }
-                })?;
+                let status = get_power_state(redfish_client.as_ref()).await?;
                 if status != PowerState::Off {
                     return Err(StateHandlerError::GenericError(eyre!(
                         "Host {} did not turn off when requested",
@@ -7564,12 +7562,7 @@ impl HostUpgradeState {
                         operation: "power on",
                         error: e,
                     })?;
-                let status = redfish_client.get_power_state().await.map_err(|e| {
-                    StateHandlerError::RedfishError {
-                        operation: "get power state",
-                        error: e,
-                    }
-                })?;
+                let status = get_power_state(redfish_client.as_ref()).await?;
                 if status != PowerState::On {
                     return Err(StateHandlerError::GenericError(eyre!(
                         "Host {} did not turn on when requested",
@@ -7685,7 +7678,7 @@ impl HostUpgradeState {
         let redfish_component_type: libredfish::model::update_service::ComponentType =
             match to_install.install_only_specified {
                 false => libredfish::model::update_service::ComponentType::Unknown,
-                true => (*component_type).into(),
+                true => component_type.into_libredfish(),
             };
         let address = address.to_string();
 
@@ -8531,7 +8524,7 @@ fn get_next_state_boss_job_failure(
                     failure,
                     power_state,
                 } => match power_state {
-                    libredfish::PowerState::Off => (
+                    PowerState::Off => (
                         ManagedHostState::WaitingForCleanup {
                             cleanup_state: CleanupState::SecureEraseBoss {
                                 secure_erase_boss_context: SecureEraseBossContext {
@@ -8543,14 +8536,14 @@ fn get_next_state_boss_job_failure(
                                     secure_erase_boss_state:
                                         SecureEraseBossState::HandleJobFailure {
                                             failure: failure.to_string(),
-                                            power_state: libredfish::PowerState::On,
+                                            power_state: PowerState::On,
                                         },
                                 },
                             },
                         },
                         *power_state,
                     ),
-                    libredfish::PowerState::On => (
+                    PowerState::On => (
                         ManagedHostState::WaitingForCleanup {
                             cleanup_state: CleanupState::SecureEraseBoss {
                                 secure_erase_boss_context: SecureEraseBossContext {
@@ -8590,7 +8583,7 @@ fn get_next_state_boss_job_failure(
                     failure,
                     power_state,
                 } => match power_state {
-                    libredfish::PowerState::Off => (
+                    PowerState::Off => (
                         ManagedHostState::WaitingForCleanup {
                             cleanup_state: CleanupState::CreateBossVolume {
                                 create_boss_volume_context: CreateBossVolumeContext {
@@ -8602,14 +8595,14 @@ fn get_next_state_boss_job_failure(
                                     create_boss_volume_state:
                                         CreateBossVolumeState::HandleJobFailure {
                                             failure: failure.to_string(),
-                                            power_state: libredfish::PowerState::On,
+                                            power_state: PowerState::On,
                                         },
                                 },
                             },
                         },
                         *power_state,
                     ),
-                    libredfish::PowerState::On => (
+                    PowerState::On => (
                         ManagedHostState::WaitingForCleanup {
                             cleanup_state: CleanupState::CreateBossVolume {
                                 create_boss_volume_context: CreateBossVolumeContext {
@@ -8704,7 +8697,7 @@ fn handle_boss_controller_job_error(
                 secure_erase_jid: None,
                 secure_erase_boss_state: SecureEraseBossState::HandleJobFailure {
                     failure: err.to_string(),
-                    power_state: libredfish::PowerState::Off,
+                    power_state: PowerState::Off,
                 },
                 iteration: Some(iterations),
             },
@@ -8716,7 +8709,7 @@ fn handle_boss_controller_job_error(
                 create_boss_volume_jid: None,
                 create_boss_volume_state: CreateBossVolumeState::HandleJobFailure {
                     failure: err.to_string(),
-                    power_state: libredfish::PowerState::Off,
+                    power_state: PowerState::Off,
                 },
                 iteration: Some(iterations),
             },
@@ -8941,7 +8934,7 @@ async fn handle_boss_job_failure(
             })?;
 
     match expected_power_state {
-        libredfish::PowerState::Off => {
+        PowerState::Off => {
             if current_power_state != libredfish::PowerState::Off {
                 handler_host_power_control(mh_snapshot, ctx, SystemPowerControl::ForceOff).await?;
 
@@ -8961,7 +8954,7 @@ async fn handle_boss_job_failure(
 
             Ok(StateHandlerOutcome::transition(next_state))
         }
-        libredfish::PowerState::On => {
+        PowerState::On => {
             let basetime = mh_snapshot
                 .host_snapshot
                 .last_reboot_requested
@@ -9081,7 +9074,7 @@ pub async fn handler_host_power_control_with_location(
             ctx.pending_db_writes
                 .push(MachineWriteOp::UpdateRebootRequestedTime {
                     machine_id: dpu_snapshot.id,
-                    mode: action.into(),
+                    mode: machine_last_reboot_requested_mode(action),
                     time: Utc::now(),
                 });
         }
@@ -9176,7 +9169,7 @@ async fn do_ipmi_restart(
     ctx.pending_db_writes
         .push(MachineWriteOp::UpdateRebootRequestedTime {
             machine_id: machine.id,
-            mode: action.into(),
+            mode: machine_last_reboot_requested_mode(action),
             time: Utc::now(),
         });
 
@@ -9454,12 +9447,7 @@ async fn handle_instance_host_platform_config(
             power_on,
             power_on_retry_count,
         } => {
-            let power_state = redfish_client.get_power_state().await.map_err(|e| {
-                StateHandlerError::RedfishError {
-                    operation: "get_power_state",
-                    error: e,
-                }
-            })?;
+            let power_state = get_power_state(redfish_client.as_ref()).await?;
 
             // Phase 1: Power OFF (power_on=false means we need to power off first)
             if !power_on {
@@ -9997,7 +9985,7 @@ fn bios_config_enter_handle_failure(
         bios_job_id: info.bios_job_id.clone(),
         bios_config_state: BiosConfigState::HandleBiosJobFailure {
             failure,
-            power_state: libredfish::PowerState::Off,
+            power_state: PowerState::Off,
         },
         retry_count: info.retry_count + 1,
     })
@@ -10137,7 +10125,7 @@ async fn advance_bios_config_job(
             })?;
 
             match power_state {
-                libredfish::PowerState::Off => {
+                PowerState::Off => {
                     if current_power_state != libredfish::PowerState::Off {
                         handler_host_power_control(mh_snapshot, ctx, SystemPowerControl::ForceOff)
                             .await?;
@@ -10161,12 +10149,12 @@ async fn advance_bios_config_job(
                         bios_job_id: info.bios_job_id.clone(),
                         bios_config_state: BiosConfigState::HandleBiosJobFailure {
                             failure: failure.clone(),
-                            power_state: libredfish::PowerState::On,
+                            power_state: PowerState::On,
                         },
                         retry_count: info.retry_count,
                     }))
                 }
-                libredfish::PowerState::On => {
+                PowerState::On => {
                     if current_power_state != libredfish::PowerState::On {
                         let basetime = mh_snapshot
                             .host_snapshot
@@ -10381,7 +10369,7 @@ async fn set_host_boot_order(
                             set_boot_order_jid: None,
                             set_boot_order_state: SetBootOrderState::HandleJobFailure {
                                 failure: format!("Job {} lookup failed: {}", job_id, e),
-                                power_state: libredfish::PowerState::Off,
+                                power_state: PowerState::Off,
                             },
                             retry_count: set_boot_order_info.retry_count,
                         }));
@@ -10404,7 +10392,7 @@ async fn set_host_boot_order(
                             set_boot_order_jid: None,
                             set_boot_order_state: SetBootOrderState::HandleJobFailure {
                                 failure: format!("Job {} failed: {job_state:#?}", job_id),
-                                power_state: libredfish::PowerState::Off,
+                                power_state: PowerState::Off,
                             },
                             retry_count: set_boot_order_info.retry_count,
                         }));
@@ -10442,7 +10430,7 @@ async fn set_host_boot_order(
             })?;
 
             match power_state {
-                libredfish::PowerState::Off => {
+                PowerState::Off => {
                     if current_power_state != libredfish::PowerState::Off {
                         handler_host_power_control(mh_snapshot, ctx, SystemPowerControl::ForceOff)
                             .await?;
@@ -10472,12 +10460,12 @@ async fn set_host_boot_order(
                         set_boot_order_jid: None,
                         set_boot_order_state: SetBootOrderState::HandleJobFailure {
                             failure: failure.clone(),
-                            power_state: libredfish::PowerState::On,
+                            power_state: PowerState::On,
                         },
                         retry_count: set_boot_order_info.retry_count,
                     }))
                 }
-                libredfish::PowerState::On => {
+                PowerState::On => {
                     // BMC should be back, power the host back on
                     if current_power_state != libredfish::PowerState::On {
                         // Wait for the BMC to come back online after reset before powering on
@@ -10596,6 +10584,17 @@ async fn set_host_boot_order(
             )))
         }
     }
+}
+
+async fn get_power_state(redfish_client: &dyn Redfish) -> Result<PowerState, StateHandlerError> {
+    redfish_client
+        .get_power_state()
+        .await
+        .map_err(|e| StateHandlerError::RedfishError {
+            operation: "get_power_state",
+            error: e,
+        })
+        .map(IntoModel::into_model)
 }
 
 #[cfg(test)]

--- a/crates/api/src/state_controller/machine/handler/power.rs
+++ b/crates/api/src/state_controller/machine/handler/power.rs
@@ -19,8 +19,8 @@ use chrono::Utc;
 use libredfish::SystemPowerControl;
 use model::machine::ManagedHostStateSnapshot;
 use model::power_manager::{
-    PowerHandlingOutcome, PowerOptions, PowerState, UsablePowerState,
-    are_all_dpus_up_after_power_operation, get_updated_power_options_for_desired_on_state_off,
+    PowerHandlingOutcome, PowerOptions, PowerState, are_all_dpus_up_after_power_operation,
+    get_updated_power_options_for_desired_on_state_off,
     update_power_options_for_desired_on_state_on,
 };
 
@@ -29,6 +29,13 @@ use crate::state_controller::machine::handler::{
     PowerOptionConfig, handler_host_power_control, host_power_state,
 };
 use crate::state_controller::state_handler::{StateHandlerContext, StateHandlerError};
+
+// If power state is Paused and Reset, state machine can't take any decision on it.
+// Ignore power manager with a log and moved to state machine.
+pub enum UsablePowerState {
+    Usable(PowerState),
+    NotUsable(libredfish::PowerState),
+}
 
 // Handle power related stuff and return updated power options.
 pub async fn handle_power(

--- a/crates/api/src/state_controller/spdm/handler.rs
+++ b/crates/api/src/state_controller/spdm/handler.rs
@@ -20,6 +20,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use carbide_uuid::machine::MachineId;
+use config_version::ConfigVersion;
 use itertools::Itertools;
 use libredfish::Redfish;
 use libredfish::model::component_integrity::{ComponentIntegrities, ComponentIntegrity};
@@ -29,7 +31,6 @@ use model::attestation::spdm::{
     EvidenceResultAppraisalPolicyDeviceStates, FetchDataDeviceStates, SpdmAttestationStatus,
     SpdmHandlerError, SpdmMachineDeviceAttestation, SpdmMachineDeviceMetadata, SpdmMachineSnapshot,
     SpdmMachineStateSnapshot, SpdmObjectId, VerificationDeviceStates, Verifier,
-    from_component_integrity,
 };
 use model::bmc_info::BmcInfo;
 use nras::{DeviceAttestationInfo, EvidenceCertificate, RawAttestationOutcome, VerifierClient};
@@ -306,7 +307,7 @@ impl StateHandler for SpdmAttestationStateHandler {
                 // Remove existing device list and over-write with this list.
                 let devices = components
                     .into_iter()
-                    .map(|x| from_component_integrity(x.clone(), machine_id))
+                    .map(|x| spdm_attestation_from_component_integrity(x.clone(), machine_id))
                     .collect_vec();
 
                 db::attestation::spdm::insert_devices(&mut txn, &machine_id, devices)
@@ -831,4 +832,36 @@ fn attestation_complete(
         controller_state,
         AttestationDeviceState::AttestationCompleted { status },
     )
+}
+
+pub fn spdm_attestation_from_component_integrity(
+    integrity: libredfish::model::component_integrity::ComponentIntegrity,
+    machine_id: MachineId,
+) -> SpdmMachineDeviceAttestation {
+    let ca_certificate_link = integrity
+        .spdm
+        .map(|x| x.identity_authentication)
+        .map(|x| x.component_certificate)
+        .map(|x| x.odata_id);
+
+    let evidence_target =
+        if let Some(Some(data)) = integrity.actions.map(|x| x.get_signed_measurements) {
+            Some(data.target)
+        } else {
+            None
+        };
+
+    SpdmMachineDeviceAttestation {
+        machine_id,
+        device_id: integrity.id,
+        nonce: uuid::Uuid::new_v4(),
+        state: AttestationDeviceState::FetchData(FetchDataDeviceStates::FetchMetadata),
+        state_version: ConfigVersion::initial(),
+        state_outcome: None,
+        metadata: None,
+        ca_certificate_link,
+        ca_certificate: None,
+        evidence_target,
+        evidence: None,
+    }
 }

--- a/crates/api/src/tests/common/api_fixtures/dpu.rs
+++ b/crates/api/src/tests/common/api_fixtures/dpu.rs
@@ -20,16 +20,16 @@
 use std::net::IpAddr;
 use std::sync::atomic::{AtomicU32, Ordering};
 
+use carbide_redfish::libredfish::conv::IntoModel;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
-use libredfish::model::oem::nvidia_dpu::NicMode;
 use libredfish::{OData, PCIeDevice};
 use mac_address::MacAddress;
 use model::hardware_info::HardwareInfo;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::site_explorer::{
     Chassis, ComputerSystem, ComputerSystemAttributes, EndpointExplorationError,
-    EndpointExplorationReport, EndpointType, EthernetInterface, Inventory, Manager, PowerState,
-    Service, UefiDevicePath,
+    EndpointExplorationReport, EndpointType, EthernetInterface, Inventory, Manager, NicMode,
+    PowerState, Service, UefiDevicePath,
 };
 use rpc::forge::forge_server::Forge;
 use rpc::{DiscoveryData, DiscoveryInfo, MachineDiscoveryInfo};
@@ -180,7 +180,7 @@ impl From<DpuConfig> for EndpointExplorationReport {
                         slot: None,
                         pcie_functions: None,
                     }
-                    .into(),
+                    .into_model(),
                 ],
                 base_mac: Some(value.host_mac_address.into()),
                 power_state: PowerState::On,

--- a/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
@@ -19,13 +19,13 @@ use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, Mutex};
 
 use carbide_site_explorer::{EndpointExplorer, SiteExplorationMetrics};
-use libredfish::model::oem::nvidia_dpu::NicMode;
 use libredfish::{PowerState, RoleId, SystemPowerControl};
 use mac_address::MacAddress;
 use model::expected_entity::ExpectedEntity;
 use model::machine::MachineInterfaceSnapshot;
 use model::site_explorer::{
     EndpointExplorationError, EndpointExplorationReport, InternalLockdownStatus, LockdownStatus,
+    NicMode,
 };
 
 /// EndpointExplorer which returns predefined data

--- a/crates/api/src/tests/common/api_fixtures/managed_host.rs
+++ b/crates/api/src/tests/common/api_fixtures/managed_host.rs
@@ -19,6 +19,7 @@ use std::iter;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU32, Ordering};
 
+use carbide_redfish::libredfish::conv::IntoModel;
 use itertools::Itertools;
 use libredfish::{OData, PCIeDevice};
 use mac_address::MacAddress;
@@ -302,7 +303,10 @@ impl From<ManagedHostConfig> for EndpointExplorationReport {
                 serial_number: Some(value.serial.clone()),
                 ethernet_interfaces: systems_ethernet_interfaces,
                 attributes: ComputerSystemAttributes::default(),
-                pcie_devices: pcie_devices.into_iter().map(Into::into).collect(),
+                pcie_devices: pcie_devices
+                    .into_iter()
+                    .map(IntoModel::into_model)
+                    .collect(),
                 base_mac: None,
                 power_state: PowerState::On,
                 sku: None,

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -4912,8 +4912,8 @@ async fn test_get_machine_position_info_no_endpoint(
 async fn test_site_explorer_auto_corrects_nic_mode_per_expected_machine(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    use libredfish::model::oem::nvidia_dpu::NicMode;
     use model::expected_machine::{DpuMode, ExpectedMachine, ExpectedMachineData};
+    use model::site_explorer::NicMode;
 
     let env = common::api_fixtures::create_test_env(pool).await;
 

--- a/crates/bmc-vendor/Cargo.toml
+++ b/crates/bmc-vendor/Cargo.toml
@@ -23,7 +23,6 @@ authors.workspace = true
 
 [dependencies]
 clap = { workspace = true }
-libredfish = { workspace = true }
 serde = { features = ["derive"], workspace = true }
 
 [lints]

--- a/crates/bmc-vendor/src/lib.rs
+++ b/crates/bmc-vendor/src/lib.rs
@@ -19,8 +19,6 @@
 
 use std::fmt;
 
-use libredfish::model::service_root::RedfishVendor;
-
 #[derive(
     Clone,
     Copy,
@@ -140,25 +138,5 @@ impl BMCVendor {
 
     pub fn is_unknown(&self) -> bool {
         *self == Self::Unknown
-    }
-}
-
-impl From<RedfishVendor> for BMCVendor {
-    fn from(r: RedfishVendor) -> BMCVendor {
-        match r {
-            RedfishVendor::AMI
-            | RedfishVendor::NvidiaDpu
-            | RedfishVendor::NvidiaGBx00
-            | RedfishVendor::NvidiaGH200
-            | RedfishVendor::NvidiaGBSwitch
-            | RedfishVendor::P3809 => BMCVendor::Nvidia,
-            RedfishVendor::Dell => BMCVendor::Dell,
-            RedfishVendor::Hpe => BMCVendor::Hpe,
-            RedfishVendor::Lenovo => BMCVendor::Lenovo,
-            RedfishVendor::LenovoAMI => BMCVendor::LenovoAMI,
-            RedfishVendor::LiteOnPowerShelf => BMCVendor::Liteon,
-            RedfishVendor::Supermicro => BMCVendor::Supermicro,
-            RedfishVendor::Unknown => BMCVendor::Unknown,
-        }
     }
 }

--- a/crates/preingestion-manager/src/lib.rs
+++ b/crates/preingestion-manager/src/lib.rs
@@ -27,6 +27,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use carbide_firmware::FirmwareDownloader;
+use carbide_redfish::libredfish::conv::IntoLibredfish;
 use carbide_redfish::libredfish::{RedfishClientCreationError, RedfishClientPool};
 use carbide_utils::periodic_timer::PeriodicTimer;
 use chrono::{DateTime, Utc};
@@ -2370,7 +2371,7 @@ async fn initiate_update(
     let redfish_component_type: libredfish::model::update_service::ComponentType =
         match to_install.install_only_specified {
             false => libredfish::model::update_service::ComponentType::Unknown,
-            true => (*firmware_type).into(),
+            true => firmware_type.into_libredfish(),
         };
     let task = if to_install.get_filename(firmware_number).ends_with("bfb") {
         let _ = redfish_client

--- a/crates/redfish/Cargo.toml
+++ b/crates/redfish/Cargo.toml
@@ -14,6 +14,7 @@ default = []
 test-support = [ "dep:chrono", "dep:serde_json", "dep:tokio" ]
 
 [dependencies]
+bmc-vendor = { path = "../bmc-vendor" }
 carbide-api-db = { path = "../api-db", default-features = false }
 carbide-api-model = { path = "../api-model", default-features = false }
 carbide-secrets = { path = "../secrets" }

--- a/crates/redfish/src/libredfish/conv.rs
+++ b/crates/redfish/src/libredfish/conv.rs
@@ -1,0 +1,165 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use bmc_vendor::BMCVendor;
+use model::firmware::FirmwareComponentType;
+use model::machine::{MachineLastRebootRequestedMode, PowerState as MachinePowerState};
+use model::site_explorer::{BootOption, NicMode, PCIeDevice, PowerState, SystemStatus};
+
+pub trait IntoLibredfish<T> {
+    fn into_libredfish(self) -> T;
+}
+
+impl IntoLibredfish<libredfish::model::update_service::ComponentType> for FirmwareComponentType {
+    fn into_libredfish(self) -> libredfish::model::update_service::ComponentType {
+        use libredfish::model::update_service::ComponentType;
+        match self {
+            FirmwareComponentType::Bmc => ComponentType::BMC,
+            FirmwareComponentType::Uefi => ComponentType::UEFI,
+            FirmwareComponentType::Cec => ComponentType::Unknown,
+            FirmwareComponentType::Nic => ComponentType::Unknown,
+            FirmwareComponentType::CpldMb => ComponentType::CPLDMB,
+            FirmwareComponentType::CpldPdb => ComponentType::CPLDPDB,
+            FirmwareComponentType::HGXBmc => ComponentType::HGXBMC,
+            FirmwareComponentType::CombinedBmcUefi => ComponentType::Unknown,
+            FirmwareComponentType::Gpu => ComponentType::Unknown,
+            FirmwareComponentType::Unknown => ComponentType::Unknown,
+        }
+    }
+}
+
+pub trait IntoModel<T> {
+    fn into_model(self) -> T;
+}
+
+impl IntoModel<PowerState> for libredfish::PowerState {
+    fn into_model(self) -> PowerState {
+        match self {
+            libredfish::PowerState::Off => PowerState::Off,
+            libredfish::PowerState::On => PowerState::On,
+            libredfish::PowerState::PoweringOff => PowerState::PoweringOff,
+            libredfish::PowerState::PoweringOn => PowerState::PoweringOn,
+            libredfish::PowerState::Paused => PowerState::Paused,
+            libredfish::PowerState::Reset => PowerState::PoweringOn,
+            libredfish::PowerState::Unknown => PowerState::Unknown,
+        }
+    }
+}
+
+impl IntoModel<MachinePowerState> for libredfish::PowerState {
+    fn into_model(self) -> MachinePowerState {
+        match self {
+            libredfish::PowerState::Off => MachinePowerState::Off,
+            libredfish::PowerState::On => MachinePowerState::On,
+            libredfish::PowerState::PoweringOff => MachinePowerState::PoweringOff,
+            libredfish::PowerState::PoweringOn => MachinePowerState::PoweringOn,
+            libredfish::PowerState::Paused => MachinePowerState::Paused,
+            libredfish::PowerState::Reset => MachinePowerState::Reset,
+            libredfish::PowerState::Unknown => MachinePowerState::Unknown,
+        }
+    }
+}
+
+impl IntoModel<PCIeDevice> for libredfish::PCIeDevice {
+    fn into_model(self) -> PCIeDevice {
+        PCIeDevice {
+            description: self.description,
+            firmware_version: self.firmware_version,
+            id: self.id,
+            manufacturer: self.manufacturer,
+            name: self.name,
+            part_number: self.part_number,
+            serial_number: self.serial_number,
+            status: self.status.map(|s| s.into_model()),
+            gpu_vendor: self.gpu_vendor,
+        }
+    }
+}
+
+impl IntoModel<SystemStatus> for libredfish::model::SystemStatus {
+    fn into_model(self) -> SystemStatus {
+        SystemStatus {
+            health: self.health,
+            health_rollup: self.health_rollup,
+            state: self.state.unwrap_or("".to_string()),
+        }
+    }
+}
+
+impl IntoModel<BootOption> for libredfish::model::BootOption {
+    fn into_model(self) -> BootOption {
+        BootOption {
+            display_name: self.display_name,
+            id: self.id,
+            boot_option_enabled: self.boot_option_enabled,
+            uefi_device_path: self.uefi_device_path,
+        }
+    }
+}
+
+impl IntoModel<NicMode> for libredfish::model::oem::nvidia_dpu::NicMode {
+    fn into_model(self) -> NicMode {
+        match self {
+            Self::Dpu => NicMode::Dpu,
+            Self::Nic => NicMode::Nic,
+        }
+    }
+}
+
+impl IntoLibredfish<libredfish::model::oem::nvidia_dpu::NicMode> for NicMode {
+    fn into_libredfish(self) -> libredfish::model::oem::nvidia_dpu::NicMode {
+        match self {
+            Self::Dpu => libredfish::model::oem::nvidia_dpu::NicMode::Dpu,
+            Self::Nic => libredfish::model::oem::nvidia_dpu::NicMode::Nic,
+        }
+    }
+}
+
+pub fn machine_last_reboot_requested_mode(
+    action: libredfish::SystemPowerControl,
+) -> MachineLastRebootRequestedMode {
+    match action {
+        libredfish::SystemPowerControl::On => MachineLastRebootRequestedMode::PowerOn,
+        libredfish::SystemPowerControl::GracefulShutdown => {
+            MachineLastRebootRequestedMode::PowerOff
+        }
+        libredfish::SystemPowerControl::ForceOff => MachineLastRebootRequestedMode::PowerOff,
+        libredfish::SystemPowerControl::GracefulRestart => MachineLastRebootRequestedMode::Reboot,
+        libredfish::SystemPowerControl::ForceRestart => MachineLastRebootRequestedMode::Reboot,
+        libredfish::SystemPowerControl::ACPowercycle => MachineLastRebootRequestedMode::Reboot,
+        libredfish::SystemPowerControl::PowerCycle => MachineLastRebootRequestedMode::Reboot,
+    }
+}
+
+pub fn bmc_vendor(r: libredfish::model::service_root::RedfishVendor) -> BMCVendor {
+    use libredfish::model::service_root::RedfishVendor;
+    match r {
+        RedfishVendor::AMI
+        | RedfishVendor::NvidiaDpu
+        | RedfishVendor::NvidiaGBx00
+        | RedfishVendor::NvidiaGH200
+        | RedfishVendor::NvidiaGBSwitch
+        | RedfishVendor::P3809 => BMCVendor::Nvidia,
+        RedfishVendor::Dell => BMCVendor::Dell,
+        RedfishVendor::Hpe => BMCVendor::Hpe,
+        RedfishVendor::Lenovo => BMCVendor::Lenovo,
+        RedfishVendor::LenovoAMI => BMCVendor::LenovoAMI,
+        RedfishVendor::LiteOnPowerShelf => BMCVendor::Liteon,
+        RedfishVendor::Supermicro => BMCVendor::Supermicro,
+        RedfishVendor::Unknown => BMCVendor::Unknown,
+    }
+}

--- a/crates/redfish/src/libredfish/mod.rs
+++ b/crates/redfish/src/libredfish/mod.rs
@@ -18,6 +18,7 @@
 mod implementation;
 
 pub mod auth;
+pub mod conv;
 pub mod error;
 #[cfg(feature = "test-support")]
 pub mod test_support;

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -22,15 +22,17 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use carbide_ipmi::IPMITool;
 use carbide_redfish::libredfish::RedfishClientPool;
+use carbide_redfish::libredfish::conv::IntoLibredfish;
 use carbide_redfish::nv_redfish::NvRedfishClientPool;
 use forge_secrets::credentials::{CredentialManager, Credentials};
-use libredfish::model::oem::nvidia_dpu::NicMode;
 use libredfish::model::service_root::RedfishVendor;
 use mac_address::MacAddress;
 use model::expected_entity::{BmcCredentialsData, ExpectedEntity};
 use model::expected_switch::ExpectedSwitch;
 use model::machine::MachineInterfaceSnapshot;
-use model::site_explorer::{EndpointExplorationError, EndpointExplorationReport, LockdownStatus};
+use model::site_explorer::{
+    EndpointExplorationError, EndpointExplorationReport, LockdownStatus, NicMode,
+};
 
 use super::EndpointExplorer;
 use super::config::SiteExplorerExploreMode;
@@ -326,7 +328,7 @@ impl BmcEndpointExplorer {
         mode: NicMode,
     ) -> Result<(), EndpointExplorationError> {
         self.redfish_client
-            .set_nic_mode(bmc_ip_address, credentials, mode)
+            .set_nic_mode(bmc_ip_address, credentials, mode.into_libredfish())
             .await
     }
 

--- a/crates/site-explorer/src/endpoint_explorer.rs
+++ b/crates/site-explorer/src/endpoint_explorer.rs
@@ -18,11 +18,12 @@
 use std::net::SocketAddr;
 
 use libredfish::RoleId;
-use libredfish::model::oem::nvidia_dpu::NicMode;
 use mac_address::MacAddress;
 use model::expected_entity::ExpectedEntity;
 use model::machine::MachineInterfaceSnapshot;
-use model::site_explorer::{EndpointExplorationError, EndpointExplorationReport, LockdownStatus};
+use model::site_explorer::{
+    EndpointExplorationError, EndpointExplorationReport, LockdownStatus, NicMode,
+};
 
 use super::metrics::SiteExplorationMetrics;
 

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -28,6 +28,7 @@ use std::time::Instant;
 
 use carbide_firmware::FirmwareConfig;
 use carbide_network::sanitized_mac;
+use carbide_redfish::libredfish::conv::IntoModel;
 use carbide_utils::periodic_timer::PeriodicTimer;
 use carbide_uuid::machine::MachineType;
 use carbide_uuid::power_shelf::{PowerShelfIdSource, PowerShelfType};
@@ -38,7 +39,6 @@ use forge_secrets::credentials::CredentialManager;
 use futures_util::stream::FuturesUnordered;
 use futures_util::{StreamExt, TryFutureExt};
 use itertools::Itertools;
-use libredfish::model::oem::nvidia_dpu::NicMode;
 use librms::RmsApi;
 use mac_address::MacAddress;
 use model::expected_entity::ExpectedEntity;
@@ -49,8 +49,8 @@ use model::power_shelf::{NewPowerShelf, PowerShelfConfig};
 use model::resource_pool::common::CommonPools;
 use model::site_explorer::{
     EndpointExplorationError, EndpointExplorationReport, EndpointType, ExploredDpu,
-    ExploredEndpoint, ExploredManagedHost, ExploredManagedSwitch, MachineExpectation, PowerState,
-    PreingestionState, Service, is_bf3_dpu, is_bf3_supernic, is_bluefield_model,
+    ExploredEndpoint, ExploredManagedHost, ExploredManagedSwitch, MachineExpectation, NicMode,
+    PowerState, PreingestionState, Service, is_bf3_dpu, is_bf3_supernic, is_bluefield_model,
 };
 use sqlx::PgPool;
 use tokio::task::JoinSet;
@@ -2031,7 +2031,7 @@ impl SiteExplorer {
         self.endpoint_explorer
             .redfish_get_power_state(bmc_target_addr, endpoint.iface)
             .await
-            .map(PowerState::from)
+            .map(IntoModel::into_model)
             .map_err(|err| SiteExplorerError::EndpointExplorationError {
                 action: "redfish_get_power_state",
                 err,
@@ -2324,7 +2324,7 @@ impl SiteExplorer {
                         .redfish_get_power_state(bmc_target_addr, interface)
                         .await
                         .ok()
-                        .map(PowerState::from),
+                        .map(IntoModel::into_model),
                     None => None,
                 },
             };

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use carbide_network::deserialize_input_mac_to_address;
+use carbide_redfish::libredfish::conv::{IntoModel, bmc_vendor};
 use carbide_redfish::libredfish::{
     RedfishAuth, RedfishClientCreationError, RedfishClientPool, redact_password,
 };
@@ -271,7 +272,7 @@ impl RedfishClient {
             .map_err(map_redfish_client_creation_error)?;
 
         let service_root = client.get_service_root().await.map_err(map_redfish_error)?;
-        let vendor = service_root.vendor().map(|v| v.into());
+        let vendor = service_root.vendor().map(bmc_vendor);
 
         let manager = fetch_manager(client.as_ref())
             .await
@@ -770,12 +771,12 @@ async fn fetch_system(client: &dyn Redfish) -> Result<ComputerSystem, EndpointEx
         model: system.model,
         serial_number: system.serial_number,
         attributes: ComputerSystemAttributes {
-            nic_mode,
+            nic_mode: nic_mode.map(IntoModel::into_model),
             is_infinite_boot_enabled,
         },
         pcie_devices,
         base_mac,
-        power_state: system.power_state.into(),
+        power_state: system.power_state.into_model(),
         sku: system.sku,
         boot_order,
     })
@@ -842,7 +843,8 @@ async fn fetch_ethernet_interfaces(
         }?;
 
         let uefi_device_path = if let Some(uefi_device_path) = iface.uefi_device_path {
-            let path_as_version_string = UefiDevicePath::from_str(&uefi_device_path)?;
+            let path_as_version_string = UefiDevicePath::from_str(&uefi_device_path)
+                .map_err(|error| RedfishError::GenericError { error })?;
             Some(path_as_version_string)
         } else {
             None
@@ -1062,7 +1064,7 @@ async fn fetch_boot_order(
                 .iter()
                 .find(|opt| opt.boot_option_reference == *ref_id)
                 .cloned()
-                .map(Into::into)
+                .map(IntoModel::into_model)
         })
         .collect();
 
@@ -1083,7 +1085,7 @@ async fn fetch_pcie_devices(client: &dyn Redfish) -> Result<Vec<PCIeDevice>, Red
             name: pci_device.name,
             part_number: pci_device.part_number,
             serial_number: pci_device.serial_number,
-            status: pci_device.status.map(|s| s.into()),
+            status: pci_device.status.map(IntoModel::into_model),
         });
     }
     Ok(pci_devices)


### PR DESCRIPTION
## Description
Move libredfish-specific conversions into carbide-redfish and replace direct model-layer references with local domain types. This decouples carbide-api-model and bmc-vendor from libredfish while preserving Redfish conversion behavior at integration boundaries.

This change speeds up build because more crates can be built in parallel. 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

