### PR TITLE
feat: try site-wide password on initial exploration

### DIFF
--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -256,11 +256,10 @@ impl BmcEndpointExplorer {
         &self,
         bmc_ip_address: SocketAddr,
         bmc_mac_address: MacAddress,
-        vendor: RedfishVendor,
         username: &str,
-    ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
+    ) -> Result<Credentials, EndpointExplorationError> {
         tracing::info!(
-            %bmc_ip_address, %bmc_mac_address, %vendor, %username,
+            %bmc_ip_address, %bmc_mac_address,
             "Attempting sitewide BMC root credentials fallback for possible reingested hardware"
         );
 
@@ -287,15 +286,11 @@ impl BmcEndpointExplorer {
             .await?;
 
         tracing::info!(
-            %bmc_ip_address, %bmc_mac_address, %vendor,
+            %bmc_ip_address, %bmc_mac_address,
             "Sitewide BMC root credentials succeeded - stored per-BMC vault entry"
         );
 
-        let report = self
-            .generate_exploration_report(bmc_ip_address, credentials, None, Some(vendor))
-            .await?;
-
-        Ok(report)
+        Ok(credentials)
     }
 
     // Handle switch NVOS admin credentials setup
@@ -688,11 +683,18 @@ impl EndpointExplorer for BmcEndpointExplorer {
                         .await?
                     }
                     Err(EndpointExplorationError::Unauthorized { .. }) => {
-                        self.try_sitewide_bmc_root_credentials(
+                        let bmc_credentials = self
+                            .try_sitewide_bmc_root_credentials(
+                                bmc_ip_address,
+                                bmc_mac_address,
+                                bmc_cred_data.username,
+                            )
+                            .await?;
+                        self.generate_exploration_report(
                             bmc_ip_address,
-                            bmc_mac_address,
-                            vendor,
-                            bmc_cred_data.username,
+                            bmc_credentials,
+                            None,
+                            Some(vendor),
                         )
                         .await?
                     }

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -39,6 +39,8 @@ use super::credentials::{CredentialClient, get_bmc_root_credential_key};
 use super::metrics::SiteExplorationMetrics;
 use super::redfish::RedfishClient;
 
+const BMC_AUTH_RETRY_DURATION: Duration = Duration::from_secs(3);
+
 /// An `EndpointExplorer` which uses redfish APIs to query the endpoint
 pub struct BmcEndpointExplorer {
     redfish_client: RedfishClient,
@@ -276,7 +278,7 @@ impl BmcEndpointExplorer {
         // Some BMCs (notably HPE iLO) enforce a brief auth-failure throttle
         // after an attempt fails. Wait long enough to clear it
         // before validating with the sitewide credentials.
-        tokio::time::sleep(Duration::from_secs(3)).await;
+        tokio::time::sleep(BMC_AUTH_RETRY_DURATION).await;
 
         self.redfish_client
             .validate_bmc_credentials(bmc_ip_address, credentials.clone())

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use carbide_ipmi::IPMITool;
 use carbide_redfish::libredfish::RedfishClientPool;
@@ -246,6 +247,55 @@ impl BmcEndpointExplorer {
             .await?;
 
         Ok(bmc_credentials)
+    }
+
+    /// Fallback for reingested hardware: try the configured sitewide BMC root
+    /// password with the expected/factory username. If the BMC is already on
+    /// the sitewide password, we just need to re-populate the per-BMC vault entry.
+    async fn try_sitewide_bmc_root_credentials(
+        &self,
+        bmc_ip_address: SocketAddr,
+        bmc_mac_address: MacAddress,
+        vendor: RedfishVendor,
+        username: &str,
+    ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
+        tracing::info!(
+            %bmc_ip_address, %bmc_mac_address, %vendor, %username,
+            "Attempting sitewide BMC root credentials fallback for possible reingested hardware"
+        );
+
+        let sitewide_credentials = self
+            .credential_client
+            .get_sitewide_bmc_root_credentials()
+            .await?;
+        let Credentials::UsernamePassword { password, .. } = sitewide_credentials;
+        let credentials = Credentials::UsernamePassword {
+            username: username.to_string(),
+            password,
+        };
+
+        // Some BMCs (notably HPE iLO) enforce a brief auth-failure throttle
+        // after an attempt fails. Wait long enough to clear it
+        // before validating with the sitewide credentials.
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        self.redfish_client
+            .validate_bmc_credentials(bmc_ip_address, credentials.clone())
+            .await?;
+
+        self.set_bmc_root_credentials(bmc_mac_address, &credentials)
+            .await?;
+
+        tracing::info!(
+            %bmc_ip_address, %bmc_mac_address, %vendor,
+            "Sitewide BMC root credentials succeeded - stored per-BMC vault entry"
+        );
+
+        let report = self
+            .generate_exploration_report(bmc_ip_address, credentials, None, Some(vendor))
+            .await?;
+
+        Ok(report)
     }
 
     // Handle switch NVOS admin credentials setup
@@ -575,11 +625,16 @@ impl EndpointExplorer for BmcEndpointExplorer {
             }
 
             Err(EndpointExplorationError::MissingCredentials { .. }) => {
-                // The machine's BMC root password has not been set to the Forge Sitewide BMC root password
-                // 1) Try to login to the machine's BMC root account
-                // 2) Set the machine's BMC root password to the Forge Sitewide BMC root password
-                // 3) Set the password policy for the machine's BMC
-                // 4) Generate the report
+                // No per-BMC vault entry exists. Now try to:
+                //   1) Login with expected/factory credentials
+                //   2) Rotate the BMC root password to the sitewide root password
+                //   3) Store the per-BMC vault entry
+                //   4) Generate the report
+                //
+                // If the expected/factory credentials fail (Unauthorized), fall
+                // back to the configured sitewide root password without rotation.
+                // This covers reingested hardware whose per-BMC vault entry was
+                // lost but whose BMC is already set to the sitewide password.
 
                 tracing::info!(
                     %bmc_ip_address,
@@ -613,22 +668,36 @@ impl EndpointExplorer for BmcEndpointExplorer {
                         }
                     }
                 };
-                let bmc_credentials = self
+
+                match self
                     .set_sitewide_bmc_root_password(
                         bmc_ip_address,
                         bmc_mac_address,
                         vendor,
                         bmc_cred_data,
                     )
-                    .await?;
-
-                self.generate_exploration_report(
-                    bmc_ip_address,
-                    bmc_credentials,
-                    None,
-                    Some(vendor),
-                )
-                .await?
+                    .await
+                {
+                    Ok(bmc_credentials) => {
+                        self.generate_exploration_report(
+                            bmc_ip_address,
+                            bmc_credentials,
+                            None,
+                            Some(vendor),
+                        )
+                        .await?
+                    }
+                    Err(EndpointExplorationError::Unauthorized { .. }) => {
+                        self.try_sitewide_bmc_root_credentials(
+                            bmc_ip_address,
+                            bmc_mac_address,
+                            vendor,
+                            bmc_cred_data.username,
+                        )
+                        .await?
+                    }
+                    Err(e) => return Err(e),
+                }
             }
             Err(e) => {
                 return Err(e);

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -135,6 +135,21 @@ impl RedfishClient {
         Ok(vendor)
     }
 
+    pub async fn validate_bmc_credentials(
+        &self,
+        bmc_ip_address: SocketAddr,
+        credentials: Credentials,
+    ) -> Result<(), EndpointExplorationError> {
+        let client = self
+            .create_direct_redfish_client(bmc_ip_address, credentials, Some(RedfishVendor::Unknown))
+            .await
+            .map_err(map_redfish_client_creation_error)?;
+
+        client.get_systems().await.map_err(map_redfish_error)?;
+
+        Ok(())
+    }
+
     pub async fn set_bmc_root_password(
         &self,
         bmc_ip_address: SocketAddr,


### PR DESCRIPTION
## Description

When an endpoint has no per-BMC credentials in vault upon initial exploration, site explorer tries the expected/factory credentials and then rotates to the sitewide BMC root password. Reingested hardware often still has the sitewide password from before, so the factory attempt fails with 401 even though sitewide auth would work.

Now, if factory/default login fails with `Unauthorized`, site explorer retries using the configured sitewide BMC root password, and if it succeeds, writes the per-BMC Vault entry, and continues exploration. 

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
https://github.com/NVIDIA/infra-controller-core/issues/1294

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

