### PR TITLE
refactor(api-db): remove libredfish dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,7 +1472,6 @@ dependencies = [
  "ipnetwork",
  "itertools 0.14.0",
  "lazy_static",
- "libredfish",
  "mac_address",
  "names",
  "octseq",

--- a/crates/api-db/Cargo.toml
+++ b/crates/api-db/Cargo.toml
@@ -52,7 +52,6 @@ futures-util = { workspace = true }
 ipnetwork = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
-libredfish = { workspace = true }
 mac_address = { workspace = true }
 names = { default-features = false, workspace = true }
 octseq = { workspace = true }

--- a/crates/api-db/src/attestation/spdm.rs
+++ b/crates/api-db/src/attestation/spdm.rs
@@ -18,11 +18,10 @@
 use carbide_uuid::machine::MachineId;
 use config_version::ConfigVersion;
 use itertools::Itertools;
-use libredfish::model::component_integrity::{CaCertificate, Evidence};
 use model::attestation::spdm::{
-    AttestationState, SpdmAttestationStatus, SpdmMachineAttestation, SpdmMachineDetails,
-    SpdmMachineDeviceAttestation, SpdmMachineDeviceMetadata, SpdmMachineSnapshot,
-    SpdmMachineStateSnapshot, SpdmObjectId, SpdmObjectId_,
+    AttestationState, CaCertificate, Evidence, SpdmAttestationStatus, SpdmMachineAttestation,
+    SpdmMachineDetails, SpdmMachineDeviceAttestation, SpdmMachineDeviceMetadata,
+    SpdmMachineSnapshot, SpdmMachineStateSnapshot, SpdmObjectId, SpdmObjectId_,
 };
 use model::controller_outcome::PersistentStateHandlerOutcome;
 use sqlx::PgConnection;

--- a/crates/api/src/state_controller/spdm/handler.rs
+++ b/crates/api/src/state_controller/spdm/handler.rs
@@ -20,6 +20,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use carbide_redfish::libredfish::conv::IntoModel;
 use carbide_uuid::machine::MachineId;
 use config_version::ConfigVersion;
 use itertools::Itertools;
@@ -515,7 +516,7 @@ impl StateHandler for SpdmAttestationDeviceStateHandler {
                             &mut txn,
                             &object_id.0,
                             device_id,
-                            &ca_certificate,
+                            &ca_certificate.into_model(),
                         )
                         .await?;
                         Ok(StateHandlerOutcome::transition(get_device_state_snapshot(
@@ -645,7 +646,7 @@ impl StateHandler for SpdmAttestationDeviceStateHandler {
                             &mut txn,
                             &object_id.0,
                             device_id,
-                            &evidence,
+                            &evidence.into_model(),
                         )
                         .await?;
                         Ok(StateHandlerOutcome::transition(get_device_state_snapshot(

--- a/crates/redfish/src/libredfish/conv.rs
+++ b/crates/redfish/src/libredfish/conv.rs
@@ -16,6 +16,7 @@
  */
 
 use bmc_vendor::BMCVendor;
+use model::attestation::spdm::{CaCertificate, Evidence};
 use model::firmware::FirmwareComponentType;
 use model::machine::{MachineLastRebootRequestedMode, PowerState as MachinePowerState};
 use model::site_explorer::{BootOption, NicMode, PCIeDevice, PowerState, SystemStatus};
@@ -161,5 +162,31 @@ pub fn bmc_vendor(r: libredfish::model::service_root::RedfishVendor) -> BMCVendo
         RedfishVendor::LiteOnPowerShelf => BMCVendor::Liteon,
         RedfishVendor::Supermicro => BMCVendor::Supermicro,
         RedfishVendor::Unknown => BMCVendor::Unknown,
+    }
+}
+
+impl IntoModel<CaCertificate> for libredfish::model::component_integrity::CaCertificate {
+    fn into_model(self) -> CaCertificate {
+        CaCertificate {
+            certificate_string: self.certificate_string,
+            certificate_type: self.certificate_type,
+            certificate_usage_types: self.certificate_usage_types,
+            id: self.id,
+            name: self.name,
+            spdm: model::attestation::spdm::SlotInfo {
+                slot_id: self.spdm.slot_id,
+            },
+        }
+    }
+}
+
+impl IntoModel<Evidence> for libredfish::model::component_integrity::Evidence {
+    fn into_model(self) -> Evidence {
+        Evidence {
+            hashing_algorithm: self.hashing_algorithm,
+            signed_measurements: self.signed_measurements,
+            signing_algorithm: self.signing_algorithm,
+            version: self.version,
+        }
     }
 }


### PR DESCRIPTION
## Description

Move SPDM Redfish-to-model conversions into carbide-redfish and store model-owned attestation types in api-db. This decouples carbide-api-db from libredfish while keeping libredfish-specific mapping at the Redfish integration boundary.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

