### PR TITLE
change: auth refresh for sensors fetch

### DIFF
--- a/crates/health/example/config.bmc-mock.toml
+++ b/crates/health/example/config.bmc-mock.toml
@@ -22,7 +22,7 @@ port = 1266
 mac = "aa:bb:cc:dd:ee:ff"
 username = "admin"
 password = "secret"
-rack_id = "RACK-1"
+rack_id = "RACK_1"
 
 [endpoint_sources.carbide_api]
 enabled = false

--- a/crates/health/src/bmc.rs
+++ b/crates/health/src/bmc.rs
@@ -31,7 +31,7 @@ use tokio::sync::Mutex;
 use crate::HealthError;
 use crate::endpoint::BmcEndpoint;
 
-/// BMC client wrapper that refreshes endpoint credentials and retries once on auth failures.
+/// BMC client wrapper that refreshes endpoint credentials after auth failures.
 pub struct AuthRefreshingBmc {
     inner: HttpBmc<ReqwestClient>,
     endpoint: Arc<BmcEndpoint>,
@@ -64,7 +64,7 @@ impl AuthRefreshingBmc {
         tracing::warn!(
             error = ?error,
             endpoint = ?self.endpoint.addr,
-            "Authentication failed, refreshing BMC credentials and retrying once"
+            "Authentication failed, refreshing BMC credentials"
         );
 
         let credentials = self.endpoint.refresh().await.map_err(|refresh_error| {
@@ -77,17 +77,25 @@ impl AuthRefreshingBmc {
         Ok(())
     }
 
-    async fn refresh_if_auth(
+    async fn refresh_auth_if_needed(
         &self,
         error: HealthError,
         observed_generation: u64,
-    ) -> Result<(), HealthError> {
-        if is_auth_error(&error) {
-            self.refresh_credentials(&error, Some(observed_generation))
+    ) -> HealthError {
+        if is_auth_error(&error)
+            && let Err(refresh_error) = self
+                .refresh_credentials(&error, Some(observed_generation))
                 .await
-        } else {
-            Err(error)
+        {
+            tracing::error!(
+                error = ?refresh_error,
+                original_error = ?error,
+                endpoint = ?self.endpoint.addr,
+                "Failed to refresh BMC credentials after authentication error"
+            );
         }
+
+        error
     }
 }
 
@@ -102,18 +110,14 @@ impl Bmc for AuthRefreshingBmc {
         let credential_generation = self.credential_generation.load(Ordering::Acquire);
         match self
             .inner
-            .expand(id, query.clone())
+            .expand(id, query)
             .await
             .map_err(HealthError::from)
         {
             Ok(value) => Ok(value),
-            Err(error) => {
-                self.refresh_if_auth(error, credential_generation).await?;
-                self.inner
-                    .expand(id, query)
-                    .await
-                    .map_err(HealthError::from)
-            }
+            Err(error) => Err(self
+                .refresh_auth_if_needed(error, credential_generation)
+                .await),
         }
     }
 
@@ -124,10 +128,9 @@ impl Bmc for AuthRefreshingBmc {
         let credential_generation = self.credential_generation.load(Ordering::Acquire);
         match self.inner.get(id).await.map_err(HealthError::from) {
             Ok(value) => Ok(value),
-            Err(error) => {
-                self.refresh_if_auth(error, credential_generation).await?;
-                self.inner.get(id).await.map_err(HealthError::from)
-            }
+            Err(error) => Err(self
+                .refresh_auth_if_needed(error, credential_generation)
+                .await),
         }
     }
 
@@ -139,18 +142,14 @@ impl Bmc for AuthRefreshingBmc {
         let credential_generation = self.credential_generation.load(Ordering::Acquire);
         match self
             .inner
-            .filter(id, query.clone())
+            .filter(id, query)
             .await
             .map_err(HealthError::from)
         {
             Ok(value) => Ok(value),
-            Err(error) => {
-                self.refresh_if_auth(error, credential_generation).await?;
-                self.inner
-                    .filter(id, query)
-                    .await
-                    .map_err(HealthError::from)
-            }
+            Err(error) => Err(self
+                .refresh_auth_if_needed(error, credential_generation)
+                .await),
         }
     }
 
@@ -206,15 +205,12 @@ impl Bmc for AuthRefreshingBmc {
         uri: &str,
     ) -> Result<BoxTryStream<T, Self::Error>, Self::Error> {
         let credential_generation = self.credential_generation.load(Ordering::Acquire);
-        let stream = match self.inner.stream(uri).await.map_err(HealthError::from) {
-            Ok(stream) => stream,
-            Err(error) => {
-                self.refresh_if_auth(error, credential_generation).await?;
-                self.inner.stream(uri).await.map_err(HealthError::from)?
-            }
-        };
-
-        Ok(Box::pin(stream.map_err(HealthError::from)))
+        match self.inner.stream(uri).await.map_err(HealthError::from) {
+            Ok(stream) => Ok(Box::pin(stream.map_err(HealthError::from))),
+            Err(error) => Err(self
+                .refresh_auth_if_needed(error, credential_generation)
+                .await),
+        }
     }
 }
 

--- a/crates/health/src/bmc.rs
+++ b/crates/health/src/bmc.rs
@@ -1,0 +1,287 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use futures::TryStreamExt;
+use nv_redfish::bmc_http::HttpBmc;
+use nv_redfish::bmc_http::reqwest::{BmcError, Client as ReqwestClient};
+use nv_redfish::core::query::{ExpandQuery, FilterQuery};
+use nv_redfish::core::{
+    Action, Bmc, BoxTryStream, EntityTypeRef, Expandable, ModificationResponse, ODataETag, ODataId,
+};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+use crate::HealthError;
+use crate::endpoint::BmcEndpoint;
+
+/// BMC client wrapper that refreshes endpoint credentials and retries once on auth failures.
+pub struct AuthRefreshingBmc {
+    inner: HttpBmc<ReqwestClient>,
+    endpoint: Arc<BmcEndpoint>,
+    credential_generation: AtomicU64,
+    refresh_lock: Mutex<()>,
+}
+
+impl AuthRefreshingBmc {
+    pub(crate) fn new(inner: HttpBmc<ReqwestClient>, endpoint: Arc<BmcEndpoint>) -> Self {
+        Self {
+            inner,
+            endpoint,
+            credential_generation: AtomicU64::new(0),
+            refresh_lock: Mutex::new(()),
+        }
+    }
+
+    async fn refresh_credentials(
+        &self,
+        error: &HealthError,
+        observed_generation: Option<u64>,
+    ) -> Result<(), HealthError> {
+        let _guard = self.refresh_lock.lock().await;
+        if observed_generation.is_some_and(|generation| {
+            generation != self.credential_generation.load(Ordering::Acquire)
+        }) {
+            return Ok(());
+        }
+
+        tracing::warn!(
+            error = ?error,
+            endpoint = ?self.endpoint.addr,
+            "Authentication failed, refreshing BMC credentials and retrying once"
+        );
+
+        let credentials = self.endpoint.refresh().await.map_err(|refresh_error| {
+            HealthError::GenericError(format!(
+                "Failed to refresh credentials after auth error {error}: {refresh_error}"
+            ))
+        })?;
+        self.inner.set_credentials(credentials.into());
+        self.credential_generation.fetch_add(1, Ordering::AcqRel);
+        Ok(())
+    }
+
+    async fn refresh_if_auth(
+        &self,
+        error: HealthError,
+        observed_generation: u64,
+    ) -> Result<(), HealthError> {
+        if is_auth_error(&error) {
+            self.refresh_credentials(&error, Some(observed_generation))
+                .await
+        } else {
+            Err(error)
+        }
+    }
+}
+
+impl Bmc for AuthRefreshingBmc {
+    type Error = HealthError;
+
+    async fn expand<T: Expandable>(
+        &self,
+        id: &ODataId,
+        query: ExpandQuery,
+    ) -> Result<Arc<T>, Self::Error> {
+        let credential_generation = self.credential_generation.load(Ordering::Acquire);
+        match self
+            .inner
+            .expand(id, query.clone())
+            .await
+            .map_err(HealthError::from)
+        {
+            Ok(value) => Ok(value),
+            Err(error) => {
+                self.refresh_if_auth(error, credential_generation).await?;
+                self.inner
+                    .expand(id, query)
+                    .await
+                    .map_err(HealthError::from)
+            }
+        }
+    }
+
+    async fn get<T: EntityTypeRef + for<'de> Deserialize<'de> + 'static>(
+        &self,
+        id: &ODataId,
+    ) -> Result<Arc<T>, Self::Error> {
+        let credential_generation = self.credential_generation.load(Ordering::Acquire);
+        match self.inner.get(id).await.map_err(HealthError::from) {
+            Ok(value) => Ok(value),
+            Err(error) => {
+                self.refresh_if_auth(error, credential_generation).await?;
+                self.inner.get(id).await.map_err(HealthError::from)
+            }
+        }
+    }
+
+    async fn filter<T: EntityTypeRef + for<'de> Deserialize<'de> + 'static>(
+        &self,
+        id: &ODataId,
+        query: FilterQuery,
+    ) -> Result<Arc<T>, Self::Error> {
+        let credential_generation = self.credential_generation.load(Ordering::Acquire);
+        match self
+            .inner
+            .filter(id, query.clone())
+            .await
+            .map_err(HealthError::from)
+        {
+            Ok(value) => Ok(value),
+            Err(error) => {
+                self.refresh_if_auth(error, credential_generation).await?;
+                self.inner
+                    .filter(id, query)
+                    .await
+                    .map_err(HealthError::from)
+            }
+        }
+    }
+
+    async fn create<V: Send + Sync + Serialize, R: Send + Sync + for<'de> Deserialize<'de>>(
+        &self,
+        id: &ODataId,
+        query: &V,
+    ) -> Result<ModificationResponse<R>, Self::Error> {
+        self.inner
+            .create(id, query)
+            .await
+            .map_err(HealthError::from)
+    }
+
+    async fn update<
+        V: Sync + Send + Serialize,
+        R: Send + Sync + Sized + for<'de> Deserialize<'de>,
+    >(
+        &self,
+        id: &ODataId,
+        etag: Option<&ODataETag>,
+        update: &V,
+    ) -> Result<ModificationResponse<R>, Self::Error> {
+        self.inner
+            .update(id, etag, update)
+            .await
+            .map_err(HealthError::from)
+    }
+
+    async fn delete<R: EntityTypeRef + for<'de> Deserialize<'de>>(
+        &self,
+        id: &ODataId,
+    ) -> Result<ModificationResponse<R>, Self::Error> {
+        self.inner.delete(id).await.map_err(HealthError::from)
+    }
+
+    async fn action<
+        T: Send + Sync + Serialize,
+        R: Send + Sync + Sized + for<'de> Deserialize<'de>,
+    >(
+        &self,
+        action: &Action<T, R>,
+        params: &T,
+    ) -> Result<ModificationResponse<R>, Self::Error> {
+        self.inner
+            .action(action, params)
+            .await
+            .map_err(HealthError::from)
+    }
+
+    async fn stream<T: Sized + for<'de> Deserialize<'de> + Send + 'static>(
+        &self,
+        uri: &str,
+    ) -> Result<BoxTryStream<T, Self::Error>, Self::Error> {
+        let credential_generation = self.credential_generation.load(Ordering::Acquire);
+        let stream = match self.inner.stream(uri).await.map_err(HealthError::from) {
+            Ok(stream) => stream,
+            Err(error) => {
+                self.refresh_if_auth(error, credential_generation).await?;
+                self.inner.stream(uri).await.map_err(HealthError::from)?
+            }
+        };
+
+        Ok(Box::pin(stream.map_err(HealthError::from)))
+    }
+}
+
+pub(crate) fn is_auth_error(error: &HealthError) -> bool {
+    match error {
+        HealthError::HttpError(message) => {
+            message.contains("HTTP 401") || message.contains("HTTP 403")
+        }
+        HealthError::BmcError(inner) => is_auth_bmc_source_error(inner.as_ref()),
+        _ => false,
+    }
+}
+
+pub(crate) fn is_auth_bmc_source_error(error: &(dyn std::error::Error + 'static)) -> bool {
+    error
+        .downcast_ref::<BmcError>()
+        .is_some_and(is_auth_bmc_error)
+        || error
+            .downcast_ref::<HealthError>()
+            .is_some_and(is_auth_error)
+}
+
+fn is_auth_bmc_error(error: &BmcError) -> bool {
+    matches!(
+        error,
+        BmcError::InvalidResponse { status, .. }
+            if *status == http::StatusCode::UNAUTHORIZED || *status == http::StatusCode::FORBIDDEN
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use url::Url;
+
+    use super::*;
+
+    fn bmc_status_error(status: http::StatusCode) -> BmcError {
+        BmcError::InvalidResponse {
+            url: Url::parse("https://127.0.0.1/redfish/v1").expect("valid url"),
+            status,
+            text: String::new(),
+        }
+    }
+
+    #[test]
+    fn detects_auth_bmc_errors() {
+        assert!(is_auth_bmc_error(&bmc_status_error(
+            http::StatusCode::UNAUTHORIZED
+        )));
+        assert!(is_auth_bmc_error(&bmc_status_error(
+            http::StatusCode::FORBIDDEN
+        )));
+        assert!(!is_auth_bmc_error(&bmc_status_error(
+            http::StatusCode::NOT_FOUND
+        )));
+    }
+
+    #[test]
+    fn detects_auth_health_errors() {
+        assert!(is_auth_error(&HealthError::BmcError(Box::new(
+            bmc_status_error(http::StatusCode::UNAUTHORIZED),
+        ))));
+        assert!(is_auth_error(&HealthError::HttpError(
+            "request failed with HTTP 403".to_string(),
+        )));
+        assert!(!is_auth_error(&HealthError::HttpError(
+            "request failed with HTTP 404".to_string(),
+        )));
+    }
+}

--- a/crates/health/src/collectors/runtime.rs
+++ b/crates/health/src/collectors/runtime.rs
@@ -24,9 +24,9 @@ use async_trait::async_trait;
 use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
 use http::header::InvalidHeaderValue;
-use http::{HeaderMap, StatusCode, header};
+use http::{HeaderMap, header};
 use nv_redfish::ServiceRoot;
-use nv_redfish::bmc_http::reqwest::{BmcError, Client as ReqwestClient};
+use nv_redfish::bmc_http::reqwest::Client as ReqwestClient;
 use nv_redfish::bmc_http::{CacheSettings, HttpBmc};
 use nv_redfish::core::Bmc;
 use nv_redfish::event_service::EventStreamPayload;
@@ -36,6 +36,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use crate::HealthError;
+use crate::bmc::AuthRefreshingBmc;
 use crate::config::Config as AppConfig;
 use crate::discovery::BmcClient;
 use crate::endpoint::BmcEndpoint;
@@ -258,7 +259,7 @@ pub struct Collector {
 
 fn create_bmc(
     client: ReqwestClient,
-    endpoint: &BmcEndpoint,
+    endpoint: Arc<BmcEndpoint>,
     health_options: &AppConfig,
 ) -> Result<Arc<BmcClient>, HealthError> {
     let bmc_url = match &health_options.bmc_proxy_url {
@@ -283,13 +284,15 @@ fn create_bmc(
     };
 
     let initial_credentials = endpoint.credentials();
-    Ok(Arc::new(HttpBmc::with_custom_headers(
+    let inner = HttpBmc::with_custom_headers(
         client,
         bmc_url,
         initial_credentials.into(),
         CacheSettings::with_capacity(health_options.cache_size),
         headers,
-    )))
+    );
+
+    Ok(Arc::new(AuthRefreshingBmc::new(inner, endpoint)))
 }
 
 pub struct CollectorStartContext {
@@ -326,9 +329,9 @@ impl Collector {
         let cancel_token = CancellationToken::new();
         let cancel_token_clone = cancel_token.clone();
 
-        let bmc = create_bmc(client, &endpoint, &health_options)?;
+        let bmc = create_bmc(client, Arc::clone(&endpoint), &health_options)?;
 
-        let mut runner = C::new_runner(bmc.clone(), endpoint.clone(), config)?;
+        let mut runner = C::new_runner(bmc, endpoint.clone(), config)?;
 
         let endpoint_key = endpoint.hash_key().to_string();
         let const_labels = HashMap::from([
@@ -400,11 +403,7 @@ impl Collector {
                         limiter.acquire().await;
 
                         let start = Instant::now();
-                        let iteration_result = run_iteration_with_auth_refresh(
-                            &mut runner,
-                            &endpoint,
-                            &bmc,
-                        ).await;
+                        let iteration_result = runner.run_iteration().await;
                         let duration = start.elapsed();
 
                         iteration_histogram.observe(duration.as_secs_f64());
@@ -469,9 +468,9 @@ impl Collector {
         let cancel_token = CancellationToken::new();
         let cancel_clone = cancel_token.clone();
 
-        let bmc = create_bmc(client, &endpoint, &health_options)?;
+        let bmc = create_bmc(client, Arc::clone(&endpoint), &health_options)?;
 
-        let mut collector = S::new_runner(bmc, endpoint.clone(), config)?;
+        let mut collector = S::new_runner(Arc::clone(&bmc), endpoint.clone(), config)?;
         let event_context = EventContext::from_endpoint(&endpoint, collector.collector_type());
 
         let endpoint_key = endpoint.hash_key().to_string();
@@ -586,60 +585,4 @@ impl Collector {
         self.cancel_token.cancel();
         let _ = self.handle.await;
     }
-}
-
-async fn run_iteration_with_auth_refresh<C: PeriodicCollector<BmcClient>>(
-    runner: &mut C,
-    endpoint: &Arc<BmcEndpoint>,
-    bmc: &Arc<BmcClient>,
-) -> Result<IterationResult, HealthError> {
-    match runner.run_iteration().await {
-        Ok(result) => Ok(result),
-        Err(error) if is_auth_error(&error) => {
-            tracing::warn!(
-                error = ?error,
-                endpoint = ?endpoint.addr,
-                "Authentication failed, refreshing BMC credentials and retrying once"
-            );
-
-            let credentials = endpoint.refresh().await.map_err(|refresh_error| {
-                HealthError::GenericError(format!(
-                    "Failed to refresh credentials after auth error: {refresh_error}"
-                ))
-            })?;
-
-            // We set credentials and wait till next iteration, to avoid credential fetch loop.
-            bmc.set_credentials(credentials.into());
-            Err(error)
-        }
-        Err(error) => Err(error),
-    }
-}
-
-fn is_auth_error(error: &HealthError) -> bool {
-    match error {
-        HealthError::HttpError(message) => {
-            message.contains("HTTP 401") || message.contains("HTTP 403")
-        }
-        HealthError::BmcError(inner) => {
-            inner
-                .downcast_ref::<BmcError>()
-                .is_some_and(is_auth_bmc_error)
-                || inner
-                    .downcast_ref::<nv_redfish::Error<BmcClient>>()
-                    .is_some_and(|err| match err {
-                        nv_redfish::Error::Bmc(bmc_error) => is_auth_bmc_error(bmc_error),
-                        _ => false,
-                    })
-        }
-        _ => false,
-    }
-}
-
-fn is_auth_bmc_error(error: &BmcError) -> bool {
-    matches!(
-        error,
-        BmcError::InvalidResponse { status, .. }
-            if *status == StatusCode::UNAUTHORIZED || *status == StatusCode::FORBIDDEN
-    )
 }

--- a/crates/health/src/discovery/context.rs
+++ b/crates/health/src/discovery/context.rs
@@ -19,13 +19,13 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use nv_redfish::bmc_http::HttpBmc;
 use nv_redfish::bmc_http::reqwest::{
     BmcError, Client as ReqwestClient, ClientParams as ReqwestClientParams,
 };
 use prometheus::{Histogram, HistogramOpts};
 
 use crate::HealthError;
+use crate::bmc::AuthRefreshingBmc;
 use crate::collectors::Collector;
 use crate::config::{
     Config, Configurable, FirmwareCollectorConfig as FirmwareCollectorOptions,
@@ -35,7 +35,7 @@ use crate::config::{
 use crate::limiter::RateLimiter;
 use crate::metrics::{MetricsManager, operation_duration_buckets_seconds};
 
-pub(crate) type BmcClient = HttpBmc<ReqwestClient>;
+pub(crate) type BmcClient = AuthRefreshingBmc;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub(super) enum CollectorKind {

--- a/crates/health/src/lib.rs
+++ b/crates/health/src/lib.rs
@@ -22,6 +22,7 @@ use nv_redfish::bmc_http::reqwest::BmcError;
 use prometheus::{Gauge, GaugeVec, Opts};
 
 pub mod api_client;
+pub mod bmc;
 pub mod collectors;
 pub mod config;
 pub mod discovery;


### PR DESCRIPTION
## Description
Better handling of all auth errors, created wrapper for nv-redfish BMC, which automaticly refreshes creds on auth errors. Before it was only working for interation, which would miss streaming collector and will delay creds refresh response.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
https://github.com/NVIDIA/infra-controller-core/issues/1292

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

