### PR TITLE
chore(api): compare dpu network config version against host version

### DIFF
--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -569,14 +569,12 @@ impl ManagedHostStateSnapshot {
     /// Returns true if the desired managedhost networking configuration had been synced
     /// to **all** DPUs.
     ///
-    /// Each DPU's check compares its own `network_config.version` against its
-    /// reported observation; per-DPU versions are kept equal to the host's via
-    /// its "machine group" (and `try_update_network_config`), so a change
-    /// anywhere in the machine group flips all per-DPU sync states to out of
-    /// sync until each agent has polled + re-sent an observation.
+    /// Each DPU's check compares the host-level `network_config.version`
+    /// against the version that DPU agent reported observing.
     pub fn managed_host_network_config_version_synced(&self) -> bool {
+        let host_version = self.host_snapshot.network_config.version;
         for dpu_snapshot in self.dpu_snapshots.iter() {
-            if !dpu_snapshot.managed_host_network_config_version_synced() {
+            if !dpu_snapshot.managed_host_network_config_version_synced(host_version) {
                 return false;
             }
         }
@@ -1076,10 +1074,11 @@ impl Machine {
             .map(|ip| SocketAddr::new(ip, self.bmc_info.port.unwrap_or(443)))
     }
 
-    /// If this machine is a DPU, then this returns whether the desired ManagedHost
-    /// network configuration had been applied by forge-dpu-agent
-    pub fn managed_host_network_config_version_synced(&self) -> bool {
-        let dpu_expected_version = self.network_config.version;
+    /// If this machine is a DPU, returns whether the version of the
+    /// given ManagedHostNetworkConfig (which is a host-level versioned
+    /// config that is kept in sync across all DPUs on a host) has been
+    /// applied + reported back as same by the carbide-dpu-agent.
+    pub fn managed_host_network_config_version_synced(&self, host_version: ConfigVersion) -> bool {
         let dpu_observation = self.network_status_observation.as_ref();
 
         let dpu_observed_version: ConfigVersion = match dpu_observation {
@@ -1094,11 +1093,7 @@ impl Machine {
             },
         };
 
-        if dpu_expected_version != dpu_observed_version {
-            return false;
-        }
-
-        true
+        host_version == dpu_observed_version
     }
 
     pub fn instance_network_restrictions(&self) -> rpc::forge::InstanceNetworkRestrictions {

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -2803,7 +2803,10 @@ async fn handle_dpu_reprovision(
                     )));
                 }
 
-                if !managed_host_network_config_version_synced_and_dpu_healthy(dsnapshot) {
+                if !managed_host_network_config_version_synced_and_dpu_healthy(
+                    dsnapshot,
+                    state.host_snapshot.network_config.version,
+                ) {
                     tracing::warn!("Waiting for network to be ready for DPU {}", dsnapshot.id);
 
                     // we requested a DPU reboot in ReprovisionState::WaitingForNetworkInstall
@@ -3715,7 +3718,10 @@ impl DpuMachineStateHandler {
                 // is_network_ready is syncing over all DPUs.
                 // The code will move only when all DPUs returns network_ready signal.
                 for dsnapshot in &state.dpu_snapshots {
-                    if !managed_host_network_config_version_synced_and_dpu_healthy(dsnapshot) {
+                    if !managed_host_network_config_version_synced_and_dpu_healthy(
+                        dsnapshot,
+                        state.host_snapshot.network_config.version,
+                    ) {
                         let mut reboot_status = None;
                         // Only reboot the DPU which is targeted in this event loop.
                         if dsnapshot.id == dpu_snapshot.id {
@@ -4438,8 +4444,11 @@ impl HostMachineStateHandler {
     }
 }
 
-fn managed_host_network_config_version_synced_and_dpu_healthy(dpu_snapshot: &Machine) -> bool {
-    if !dpu_snapshot.managed_host_network_config_version_synced() {
+fn managed_host_network_config_version_synced_and_dpu_healthy(
+    dpu_snapshot: &Machine,
+    host_version: ConfigVersion,
+) -> bool {
+    if !dpu_snapshot.managed_host_network_config_version_synced(host_version) {
         return false;
     }
 

--- a/crates/api/src/tests/machine_states.rs
+++ b/crates/api/src/tests/machine_states.rs
@@ -171,6 +171,63 @@ async fn test_managed_host_network_config_group_sync(pool: sqlx::PgPool) {
     );
 }
 
+// Per-DPU network-config sync is rooted in the host-level
+// `network_config.version`, not the DPU's own row version.
+// carbide-api serves `host.version` to carbide-dpu-agent as
+// `managed_host_config_version`, and the agent echoes it back
+// as its observation; this just makes sure the host-level
+// verison is looked at, and the DPU-level version is ignored.
+#[crate::sqlx_test]
+async fn test_managed_host_network_config_sync_host_version(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+
+    // Do a baseline check that the initial ingestion
+    // `network_configured` brought DPU observations up
+    // to host.version, meaning things shold be in sync.
+    let mut txn = env.db_txn().await;
+    let snapshot = mh.snapshot(&mut txn).await;
+    assert!(
+        snapshot.managed_host_network_config_version_synced(),
+        "sync should be true after ingestion"
+    );
+
+    // Now, bump just the DPU row's `network_config_version` via
+    // a direct raw UPDATE (and bypassing `try_update_network_config`).
+    // The idea is this shouldn't matter, since we're looking at the
+    // host-level version.
+    let dpu_before = mh.dpu().db_machine(&mut txn).await;
+    let host_before = mh.host().db_machine(&mut txn).await;
+    let drifted_dpu_version = dpu_before.network_config.version.increment();
+    sqlx::query("UPDATE machines SET network_config_version = $1 WHERE id = $2")
+        .bind(drifted_dpu_version)
+        .bind(dpu_before.id)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    let mut txn = env.db_txn().await;
+    let host_after = mh.host().db_machine(&mut txn).await;
+    let dpu_after = mh.dpu().db_machine(&mut txn).await;
+    assert_eq!(
+        host_after.network_config.version, host_before.network_config.version,
+        "raw DPU update should leave host.version untouched"
+    );
+    assert_ne!(
+        dpu_after.network_config.version, host_after.network_config.version,
+        "dpu.row.version is now ahead of host.version"
+    );
+
+    // The observation version should still equal the host.version,
+    // so things should still be in sync!
+    let snapshot = mh.snapshot(&mut txn).await;
+    assert!(
+        snapshot.managed_host_network_config_version_synced(),
+        "sync should be true because observation == host.version, even though dpu.row.version is ahead"
+    );
+}
+
 // A freshly-created host defaults to admin (`use_admin_network` = true);
 // flipping the host-level `network_config.use_admin_network` to false
 // must be reflected by `ManagedHostStateSnapshot::use_admin_network()`.


### PR DESCRIPTION
## Description

Per #1180, we now use the host-level `ConfigVersion` of a `ManagedHostNetworkConfig` as the authoritative version to control DPU-level version syncs. While a Postgres function does exist for keeping a "machine group" in sync, which would theoretically make it so we can look at the DPU version, we shouldn't. Directly compare against the host version.

Added a test that bumps the DPU version on the side to verify that we are indeed looking at the host version.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

