### PR TITLE
fix: expected_machines.json should use the same interface allocation path

### DIFF
--- a/crates/api-db/src/expected_machine.rs
+++ b/crates/api-db/src/expected_machine.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::net::IpAddr;
 
 use carbide_uuid::machine::MachineId;
@@ -441,32 +441,5 @@ pub async fn update(txn: &mut PgConnection, machine: &ExpectedMachine) -> Databa
             id: target_id,
         });
     }
-    Ok(())
-}
-
-/// fn will insert rows that are not currently present in DB for each expected_machine arg in list,
-/// but will NOT overwrite existing rows matching by MAC addr.
-pub async fn create_missing_from(
-    txn: &mut PgConnection,
-    expected_machines: &[ExpectedMachine],
-) -> DatabaseResult<()> {
-    let existing_machines = find_all(&mut *txn).await?;
-    let existing_map: BTreeMap<String, ExpectedMachine> = existing_machines
-        .into_iter()
-        .map(|machine| (machine.bmc_mac_address.to_string(), machine))
-        .collect();
-
-    for expected_machine in expected_machines {
-        if existing_map.contains_key(&expected_machine.bmc_mac_address.to_string()) {
-            tracing::debug!(
-                "Not overwriting expected-machine with mac_addr: {}",
-                expected_machine.bmc_mac_address.to_string()
-            );
-            continue;
-        }
-
-        create(txn, expected_machine.clone()).await?;
-    }
-
     Ok(())
 }

--- a/crates/api/src/handlers/expected_machine.rs
+++ b/crates/api/src/handlers/expected_machine.rs
@@ -110,30 +110,72 @@ pub(crate) async fn add(
         data: db_data,
     };
 
-    validate_at_most_one_primary_host_nic(&machine.data.host_nics)?;
-
     let mut txn = api.txn_begin().await?;
 
-    // Pre-allocate BMC interface if bmc_ip_address is set.
-    if let Some(bmc_ip) = machine.data.bmc_ip_address {
-        preallocate_machine_interface(&mut txn, machine.bmc_mac_address, bmc_ip).await?;
-    }
-
-    // Pre-allocate machine interfaces for host NICs with fixed IPs.
-    for nic in &machine.data.host_nics {
-        if let Some(ref ip_str) = nic.fixed_ip {
-            let ip: std::net::IpAddr = ip_str.parse().map_err(|_| {
-                CarbideError::InvalidArgument(format!("invalid fixed_ip: {ip_str}"))
-            })?;
-            preallocate_machine_interface(&mut txn, nic.mac_address, ip).await?;
-        }
-    }
-
+    preallocate_interfaces_for(&mut txn, &machine).await?;
     db::expected_machine::create(&mut txn, machine).await?;
 
     txn.commit().await?;
 
     Ok(tonic::Response::new(()))
+}
+
+/// Validate the ExpectedMachine payload and pre-allocate `machine_interfaces`
+/// (and their addresses) for the BMC and any host NICs with a fixed-address
+/// via `fixed_ip`.
+///
+/// Shared between the `add` gRPC handler and `expected_machines.json`.
+pub(crate) async fn preallocate_interfaces_for(
+    txn: &mut sqlx::PgConnection,
+    machine: &ExpectedMachine,
+) -> Result<(), CarbideError> {
+    validate_at_most_one_primary_host_nic(&machine.data.host_nics)?;
+
+    if let Some(bmc_ip) = machine.data.bmc_ip_address {
+        preallocate_machine_interface(txn, machine.bmc_mac_address, bmc_ip).await?;
+    }
+
+    for nic in &machine.data.host_nics {
+        if let Some(ref ip_str) = nic.fixed_ip {
+            let ip: std::net::IpAddr = ip_str.parse().map_err(|_| {
+                CarbideError::InvalidArgument(format!("invalid fixed_ip: {ip_str}"))
+            })?;
+            preallocate_machine_interface(txn, nic.mac_address, ip).await?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Create missing expected_machines that aren't already in the database,
+/// calling `preallocate_interfaces_for` for each new entry. This is currently
+/// purely used by the expected_machines.json import path only, but lives
+/// here so it can re-leverage `preallocate_instances_for` and share the
+/// same allocation codepath as the API handler.
+pub(crate) async fn create_missing_from(
+    txn: &mut sqlx::PgConnection,
+    expected_machines: &[ExpectedMachine],
+) -> Result<(), CarbideError> {
+    let existing_macs: std::collections::HashSet<String> =
+        db::expected_machine::find_all(&mut *txn)
+            .await?
+            .into_iter()
+            .map(|m| m.bmc_mac_address.to_string())
+            .collect();
+
+    for expected_machine in expected_machines {
+        if existing_macs.contains(&expected_machine.bmc_mac_address.to_string()) {
+            tracing::debug!(
+                "Not overwriting expected-machine with mac_addr: {}",
+                expected_machine.bmc_mac_address
+            );
+            continue;
+        }
+        preallocate_interfaces_for(&mut *txn, expected_machine).await?;
+        db::expected_machine::create(&mut *txn, expected_machine.clone()).await?;
+    }
+
+    Ok(())
 }
 
 /// Deletes an expected machine by id or BMC MAC.

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -715,7 +715,7 @@ pub async fn initialize_and_start_controllers(
                 tracing::error!("expected_machines.json file exists, but unable to parse expected_machines file, nothing was written to db, bailing: {err}.");
             })?;
         let mut txn = Transaction::begin(db_pool).await?;
-        db::expected_machine::create_missing_from(&mut txn, &expected_machines)
+        crate::handlers::expected_machine::create_missing_from(&mut txn, &expected_machines)
             .await
             .inspect_err(|err| {
                 tracing::error!(

--- a/crates/api/src/tests/expected_machine.rs
+++ b/crates/api/src/tests/expected_machine.rs
@@ -2542,3 +2542,72 @@ async fn test_dpu_mode_default_value_omitted_on_wire(
 
     Ok(())
 }
+
+/// Make sure expected_machines.json, which uses create_missing_from,
+/// follows the shared codepath for handling interface allocation.
+#[crate::sqlx_test]
+async fn test_create_missing_from_preallocates_interfaces(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "AA:BB:CC:DD:EE:01".parse().unwrap();
+    let nic_mac: MacAddress = "AA:BB:CC:DD:EE:02".parse().unwrap();
+    let bmc_ip: std::net::IpAddr = "192.0.2.240".parse().unwrap();
+    let host_ip: std::net::IpAddr = "192.0.2.241".parse().unwrap();
+
+    let machine = ExpectedMachine {
+        id: None,
+        bmc_mac_address: bmc_mac,
+        data: ExpectedMachineData {
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            serial_number: "EM-JSON-SEED-001".into(),
+            bmc_ip_address: Some(bmc_ip),
+            host_nics: vec![model::expected_machine::ExpectedHostNic {
+                mac_address: nic_mac,
+                nic_type: Some("onboard".into()),
+                fixed_ip: Some(host_ip.to_string()),
+                fixed_mask: None,
+                fixed_gateway: None,
+                primary: Some(true),
+            }],
+            ..Default::default()
+        },
+    };
+
+    let mut txn = env.pool.begin().await?;
+    crate::handlers::expected_machine::create_missing_from(
+        &mut txn,
+        std::slice::from_ref(&machine),
+    )
+    .await?;
+    txn.commit().await?;
+
+    // Both the BMC interface and the host NIC interface should now exist
+    // with their static IPs assigned.
+    let mut txn = env.pool.begin().await?;
+    for (mac, expected_ip) in [(bmc_mac, bmc_ip), (nic_mac, host_ip)] {
+        let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, mac).await?;
+        assert_eq!(
+            interfaces.len(),
+            1,
+            "expected one machine_interface for MAC {mac}"
+        );
+        assert!(
+            interfaces[0].addresses.contains(&expected_ip),
+            "machine_interface for MAC {mac} should carry static IP {expected_ip}, got {:?}",
+            interfaces[0].addresses,
+        );
+    }
+
+    // Re-running with the same input must be a no-op (i.e. idempotent).
+    let mut txn = env.pool.begin().await?;
+    crate::handlers::expected_machine::create_missing_from(
+        &mut txn,
+        std::slice::from_ref(&machine),
+    )
+    .await?;
+    txn.commit().await?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

I was testing out static/fixed-address allocation stuff in my `local-dev` environment, using my `expected_machines.json` input file, and noticed I wasn't getting interface allocation as expected (as it does when you do `admin-cli expected-machines add` aka hits the `AddExpectedMachine` API). Small tweak so that it all flows through the same code path.

Tests added.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

