### PR TITLE
refactor: move RPC conversions out of domain crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,7 +1449,6 @@ dependencies = [
  "base64 0.22.1",
  "carbide-api-model",
  "carbide-health-report",
- "carbide-host-support",
  "carbide-ipxe-renderer",
  "carbide-libmlx",
  "carbide-macros",
@@ -1645,7 +1644,6 @@ dependencies = [
  "hyper-timeout",
  "hyper-util",
  "lazy_static",
- "libredfish",
  "logfmt",
  "metrics-endpoint",
  "opentelemetry",
@@ -2309,7 +2307,6 @@ dependencies = [
 name = "carbide-network"
 version = "0.0.0"
 dependencies = [
- "carbide-rpc",
  "eyre",
  "ipnet",
  "ipnetwork",
@@ -2449,6 +2446,8 @@ dependencies = [
  "async-trait",
  "carbide-health-report",
  "carbide-http-connector",
+ "carbide-network",
+ "carbide-secrets",
  "carbide-tls",
  "carbide-uuid",
  "chrono",
@@ -2539,7 +2538,6 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bmc-vendor",
- "carbide-rpc",
  "carbide-uuid",
  "eyre",
  "figment",

--- a/crates/api-db/Cargo.toml
+++ b/crates/api-db/Cargo.toml
@@ -29,7 +29,6 @@ name = "db"
 # [local-dependencies]
 # DO NOT PUT DEPENDENCIES OTHER THAN LOCAL DEPS HERE, THEY SHOULD ALL HAVE 'path =' IN THEM.
 config-version = { path = "../config-version", features = ["sqlx"] }
-carbide-host-support = { path = "../host-support", default-features = false }
 carbide-libmlx = { path = "../libmlx" }
 carbide-network = { path = "../network", features = ["sqlx"] }
 carbide-version = { path = "../version" }

--- a/crates/api-model/src/vpc.rs
+++ b/crates/api-model/src/vpc.rs
@@ -199,7 +199,7 @@ impl TryFrom<rpc::forge::VpcCreationRequest> for NewVpc {
     fn try_from(value: rpc::forge::VpcCreationRequest) -> Result<Self, Self::Error> {
         let virt_type = match value.network_virtualization_type {
             None => DEFAULT_NETWORK_VIRTUALIZATION_TYPE,
-            Some(v) => v.try_into()?,
+            Some(v) => rpc::network::vpc_virtualization_type_try_from_rpc(v)?,
         };
         let id = value.id.unwrap_or_else(|| uuid::Uuid::new_v4().into());
 
@@ -311,7 +311,7 @@ impl TryFrom<rpc::forge::VpcUpdateVirtualizationRequest> for UpdateVpcVirtualiza
             };
 
         let network_virtualization_type = match value.network_virtualization_type {
-            Some(v) => v.try_into()?,
+            Some(v) => rpc::network::vpc_virtualization_type_try_from_rpc(v)?,
             None => {
                 return Err(RpcDataConversionError::MissingArgument(
                     "network_virtualization_type",

--- a/crates/bmc-proxy/Cargo.toml
+++ b/crates/bmc-proxy/Cargo.toml
@@ -55,7 +55,6 @@ hyper-timeout = { workspace = true }
 hyper-util = { workspace = true }
 hyper = { workspace = true, features = ["full"] }
 lazy_static = { workspace = true }
-libredfish = { workspace = true }
 opentelemetry = { workspace = true, features = ["logs"] }
 opentelemetry-otlp = { workspace = true, features = ["grpc-tonic"] }
 opentelemetry-prometheus.workspace = true

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -49,8 +49,6 @@ sqlx = { workspace = true, features = [
 ], optional = true }
 thiserror = { workspace = true }
 
-carbide-rpc = { path = "../rpc" }
-
 [dev-dependencies]
 serde_json = { workspace = true }
 

--- a/crates/network/src/virtualization.rs
+++ b/crates/network/src/virtualization.rs
@@ -18,8 +18,6 @@
 use std::fmt;
 use std::str::FromStr;
 
-use ::rpc::errors::RpcDataConversionError;
-use ::rpc::forge as rpc;
 #[cfg(feature = "ipnetwork")]
 use ipnetwork::IpNetwork;
 
@@ -142,52 +140,6 @@ impl fmt::Display for VpcVirtualizationType {
     }
 }
 
-impl TryFrom<i32> for VpcVirtualizationType {
-    type Error = RpcDataConversionError;
-    fn try_from(value: i32) -> Result<Self, Self::Error> {
-        Ok(match value {
-            x if x == rpc::VpcVirtualizationType::EthernetVirtualizer as i32 => {
-                Self::EthernetVirtualizer
-            }
-            // If we get proto enum field 2, which is ETHERNET_VIRTUALIZER_WITH_NVUE,
-            // just map it to EthernetVirtualizer.
-            x if x == rpc::VpcVirtualizationType::EthernetVirtualizerWithNvue as i32 => {
-                Self::EthernetVirtualizer
-            }
-            x if x == rpc::VpcVirtualizationType::Fnn as i32 => Self::Fnn,
-            _ => {
-                return Err(RpcDataConversionError::InvalidVpcVirtualizationType(value));
-            }
-        })
-    }
-}
-
-impl From<rpc::VpcVirtualizationType> for VpcVirtualizationType {
-    fn from(v: rpc::VpcVirtualizationType) -> Self {
-        match v {
-            rpc::VpcVirtualizationType::EthernetVirtualizer => Self::EthernetVirtualizer,
-            // ETHERNET_VIRTUALIZER_WITH_NVUE is equivalent to EthernetVirtualizer
-            rpc::VpcVirtualizationType::EthernetVirtualizerWithNvue => Self::EthernetVirtualizer,
-            rpc::VpcVirtualizationType::Fnn => Self::Fnn,
-            // Following are deprecated.
-            rpc::VpcVirtualizationType::FnnClassic => Self::Fnn,
-            rpc::VpcVirtualizationType::FnnL3 => Self::Fnn,
-        }
-    }
-}
-
-impl From<VpcVirtualizationType> for rpc::VpcVirtualizationType {
-    fn from(nvt: VpcVirtualizationType) -> Self {
-        match nvt {
-            VpcVirtualizationType::EthernetVirtualizer
-            | VpcVirtualizationType::EthernetVirtualizerWithNvue => {
-                rpc::VpcVirtualizationType::EthernetVirtualizer
-            }
-            VpcVirtualizationType::Fnn => rpc::VpcVirtualizationType::Fnn,
-        }
-    }
-}
-
 /// Concatenate a required IPv4 value with an optional IPv6 value into a vector.
 /// Empty IPv6 strings are filtered out.
 pub fn build_dual_stack_list(v4: String, v6: Option<String>) -> Vec<String> {
@@ -282,34 +234,6 @@ mod tests {
             "etv".parse::<VpcVirtualizationType>().unwrap(),
             VpcVirtualizationType::EthernetVirtualizer
         );
-    }
-
-    #[test]
-    fn proto_value_2_maps_to_etv() {
-        // Make sure our proto From implementation turns
-        // ETHERNET_VIRTUALIZER_WITH_NVUE into EthernetVirtualizer.
-        let vtype = VpcVirtualizationType::try_from(2).unwrap();
-        assert_eq!(vtype, VpcVirtualizationType::EthernetVirtualizer);
-    }
-
-    #[test]
-    fn proto_value_0_maps_to_etv() {
-        let vtype = VpcVirtualizationType::try_from(0).unwrap();
-        assert_eq!(vtype, VpcVirtualizationType::EthernetVirtualizer);
-    }
-
-    #[test]
-    fn from_rpc_etv_with_nvue_maps_to_etv() {
-        let vtype: VpcVirtualizationType =
-            rpc::VpcVirtualizationType::EthernetVirtualizerWithNvue.into();
-        assert_eq!(vtype, VpcVirtualizationType::EthernetVirtualizer);
-    }
-
-    #[test]
-    fn to_rpc_etv_maps_to_proto_etv() {
-        let rpc_vtype: rpc::VpcVirtualizationType =
-            VpcVirtualizationType::EthernetVirtualizer.into();
-        assert_eq!(rpc_vtype, rpc::VpcVirtualizationType::EthernetVirtualizer);
     }
 
     #[test]

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -34,6 +34,8 @@ cli = ["dep:clap", "dep:prettytable-rs", "dep:serde_yaml", "dep:csv"]
 carbide-http-connector = { path = "../http-connector" }
 carbide-tls = { path = "../tls" }
 carbide-health-report = { path = "../health-report" }
+carbide-secrets = { path = "../secrets" }
+carbide-network = { path = "../network" }
 tonic-client-wrapper = { path = "../tonic-client-wrapper", default-features = false }
 dns-record = { path = "../dns-record" }
 carbide-uuid = { path = "../uuid" }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -62,7 +62,9 @@ pub use crate::protos::{fmds, health, site_explorer};
 
 pub mod errors;
 pub mod forge_tls_client;
+pub mod network;
 pub mod protos;
+pub mod secrets;
 
 #[cfg(feature = "cli")]
 pub mod admin_cli;

--- a/crates/rpc/src/network.rs
+++ b/crates/rpc/src/network.rs
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_network::virtualization::VpcVirtualizationType;
+
+use crate::{RpcDataConversionError, forge as rpc};
+
+impl From<rpc::VpcVirtualizationType> for VpcVirtualizationType {
+    fn from(v: rpc::VpcVirtualizationType) -> Self {
+        match v {
+            rpc::VpcVirtualizationType::EthernetVirtualizer => Self::EthernetVirtualizer,
+            // ETHERNET_VIRTUALIZER_WITH_NVUE is equivalent to EthernetVirtualizer
+            rpc::VpcVirtualizationType::EthernetVirtualizerWithNvue => Self::EthernetVirtualizer,
+            rpc::VpcVirtualizationType::Fnn => Self::Fnn,
+            // Following are deprecated.
+            rpc::VpcVirtualizationType::FnnClassic => Self::Fnn,
+            rpc::VpcVirtualizationType::FnnL3 => Self::Fnn,
+        }
+    }
+}
+
+impl From<VpcVirtualizationType> for rpc::VpcVirtualizationType {
+    fn from(nvt: VpcVirtualizationType) -> Self {
+        match nvt {
+            VpcVirtualizationType::EthernetVirtualizer
+            | VpcVirtualizationType::EthernetVirtualizerWithNvue => {
+                rpc::VpcVirtualizationType::EthernetVirtualizer
+            }
+            VpcVirtualizationType::Fnn => rpc::VpcVirtualizationType::Fnn,
+        }
+    }
+}
+
+pub fn vpc_virtualization_type_try_from_rpc(
+    value: i32,
+) -> Result<VpcVirtualizationType, RpcDataConversionError> {
+    Ok(match value {
+        x if x == rpc::VpcVirtualizationType::EthernetVirtualizer as i32 => {
+            VpcVirtualizationType::EthernetVirtualizer
+        }
+        // If we get proto enum field 2, which is ETHERNET_VIRTUALIZER_WITH_NVUE,
+        // just map it to EthernetVirtualizer.
+        x if x == rpc::VpcVirtualizationType::EthernetVirtualizerWithNvue as i32 => {
+            VpcVirtualizationType::EthernetVirtualizer
+        }
+        x if x == rpc::VpcVirtualizationType::Fnn as i32 => VpcVirtualizationType::Fnn,
+        _ => {
+            return Err(RpcDataConversionError::InvalidVpcVirtualizationType(value));
+        }
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use carbide_network::virtualization::VpcVirtualizationType;
+
+    use super::*;
+
+    #[test]
+    fn from_rpc_etv_with_nvue_maps_to_etv() {
+        let vtype: VpcVirtualizationType =
+            rpc::VpcVirtualizationType::EthernetVirtualizerWithNvue.into();
+        assert_eq!(vtype, VpcVirtualizationType::EthernetVirtualizer);
+    }
+
+    #[test]
+    fn to_rpc_etv_maps_to_proto_etv() {
+        let rpc_vtype: rpc::VpcVirtualizationType =
+            VpcVirtualizationType::EthernetVirtualizer.into();
+        assert_eq!(rpc_vtype, rpc::VpcVirtualizationType::EthernetVirtualizer);
+    }
+
+    #[test]
+    fn proto_value_2_maps_to_etv() {
+        // Make sure our proto From implementation turns
+        // ETHERNET_VIRTUALIZER_WITH_NVUE into EthernetVirtualizer.
+        let vtype = vpc_virtualization_type_try_from_rpc(2).unwrap();
+        assert_eq!(vtype, VpcVirtualizationType::EthernetVirtualizer);
+    }
+
+    #[test]
+    fn proto_value_0_maps_to_etv() {
+        let vtype = vpc_virtualization_type_try_from_rpc(0).unwrap();
+        assert_eq!(vtype, VpcVirtualizationType::EthernetVirtualizer);
+    }
+}

--- a/crates/rpc/src/secrets.rs
+++ b/crates/rpc/src/secrets.rs
@@ -14,23 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use async_trait::async_trait;
 
-use crate::SecretsError;
+use forge_secrets::certificates::Certificate;
 
-#[derive(Debug, Clone, Default)]
-pub struct Certificate {
-    pub issuing_ca: Vec<u8>,
-    pub private_key: Vec<u8>,
-    pub public_key: Vec<u8>,
-}
+use crate::protos::forge::MachineCertificate;
 
-#[async_trait]
-pub trait CertificateProvider: Send + Sync {
-    async fn get_certificate(
-        &self,
-        unique_identifier: &str,
-        alt_names: Option<String>,
-        ttl: Option<String>,
-    ) -> Result<Certificate, SecretsError>;
+impl From<Certificate> for MachineCertificate {
+    fn from(value: Certificate) -> Self {
+        MachineCertificate {
+            issuing_ca: value.issuing_ca,
+            private_key: value.private_key,
+            public_key: value.public_key,
+        }
+    }
 }

--- a/crates/secrets/Cargo.toml
+++ b/crates/secrets/Cargo.toml
@@ -52,7 +52,6 @@ vaultrs = { workspace = true }
 
 # [local-dependencies]
 bmc-vendor = { path = "../bmc-vendor" }
-carbide-rpc = { path = "../rpc" }
 carbide-uuid = { path = "../uuid" }
 
 [dev-dependencies]


### PR DESCRIPTION
## Description

Move protobuf/RPC-specific conversion logic from network and secrets into the rpc crate, so crates that only need network or secrets types do not also pull in RPC dependencies.

This keeps domain crates lighter and avoids forcing RPC/protobuf coupling onto consumers that only need network/security functionality.

Longer term plan is to move RPC conversions from model to RPC as well. 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

