### PR TITLE
Move to ResetForNewFirmware after scout based upgrade succeeds

### DIFF
--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1726,8 +1726,10 @@ pub enum HostReprovisionState {
     WaitingForRackFirmwareUpgrade,
     WaitingForScoutUpgrade {
         upgrade_task_id: String,
-        component_type: FirmwareComponentType,
-        target_version: String,
+        firmware_type: FirmwareComponentType,
+        final_version: String,
+        #[serde(default)]
+        power_drains_needed: Option<u32>,
         started_at: DateTime<Utc>,
         /// Absolute deadline; the API declares failure past this time.
         /// Derived from scout's execution/download timeouts plus slack.

--- a/crates/api/src/handlers/host_reprovisioning.rs
+++ b/crates/api/src/handlers/host_reprovisioning.rs
@@ -163,8 +163,9 @@ pub async fn report_scout_firmware_upgrade_status(
         reprovision_state:
             HostReprovisionState::WaitingForScoutUpgrade {
                 upgrade_task_id,
-                component_type,
-                target_version,
+                firmware_type,
+                final_version,
+                power_drains_needed,
                 started_at,
                 deadline,
                 task_json,
@@ -199,8 +200,9 @@ pub async fn report_scout_firmware_upgrade_status(
     let new_state = ManagedHostState::HostReprovision {
         reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
             upgrade_task_id,
-            component_type,
-            target_version,
+            firmware_type,
+            final_version,
+            power_drains_needed,
             started_at,
             deadline,
             task_json,

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -6829,7 +6829,9 @@ impl HostUpgradeState {
                     .await
             }
             HostReprovisionState::WaitingForScoutUpgrade {
-                component_type,
+                firmware_type,
+                final_version,
+                power_drains_needed,
                 deadline,
                 result,
                 ..
@@ -6840,11 +6842,16 @@ impl HostUpgradeState {
                             "Scout firmware upgrade succeeded for {}",
                             state.host_snapshot.id
                         );
+                        let next_reprov_state = HostReprovisionState::ResetForNewFirmware {
+                            final_version: final_version.to_string(),
+                            firmware_type: *firmware_type,
+                            firmware_number: None,
+                            power_drains_needed: *power_drains_needed,
+                            delay_until: None,
+                            last_power_drain_operation: None,
+                        };
                         Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
-                            HostReprovisionState::CheckingFirmwareRepeatV2 {
-                                firmware_type: None,
-                                firmware_number: None,
-                            },
+                            next_reprov_state,
                             state.managed_state.get_host_repro_retry_count(),
                         )))
                     } else {
@@ -6860,7 +6867,7 @@ impl HostUpgradeState {
                         );
                         Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
                             HostReprovisionState::FailedFirmwareUpgrade {
-                                firmware_type: *component_type,
+                                firmware_type: *firmware_type,
                                 report_time: Some(Utc::now()),
                                 reason: Some(reason),
                             },
@@ -6875,7 +6882,7 @@ impl HostUpgradeState {
                     );
                     Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
                         HostReprovisionState::FailedFirmwareUpgrade {
-                            firmware_type: *component_type,
+                            firmware_type: *firmware_type,
                             report_time: Some(Utc::now()),
                             reason: Some(format!(
                                 "Scout firmware upgrade timed out (deadline {deadline})"
@@ -7175,7 +7182,7 @@ impl HostUpgradeState {
                     let task = rpc::forge_agent_control_response::ScoutFirmwareUpgradeTask {
                         upgrade_task_id: upgrade_task_id.clone(),
                         component_type: firmware_type.to_string(),
-                        target_version: to_install.version,
+                        target_version: to_install.version.clone(),
                         script: Some(FileArtifact {
                             url: to_pxe_url(&scout_config.script.filename),
                             sha256: scout_config.script.sha256.clone(),
@@ -7206,8 +7213,9 @@ impl HostUpgradeState {
                         scenario.actual_new_state(
                             HostReprovisionState::WaitingForScoutUpgrade {
                                 upgrade_task_id,
-                                component_type: firmware_type,
-                                target_version: task.target_version.clone(),
+                                firmware_type,
+                                final_version: to_install.version,
+                                power_drains_needed: to_install.power_drains_needed,
                                 started_at,
                                 deadline,
                                 // Safety: The #[derive(Serialize)] impl does not fail

--- a/crates/api/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api/src/tests/host_bmc_firmware_test.rs
@@ -2666,8 +2666,9 @@ async fn test_forge_agent_control_waiting_for_scout_upgrade_returns_typed_and_le
     let waiting_state = ManagedHostState::HostReprovision {
         reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
             upgrade_task_id: upgrade_task_id.clone(),
-            component_type: FirmwareComponentType::Bmc,
-            target_version: "1.2.3".to_string(),
+            firmware_type: FirmwareComponentType::Bmc,
+            final_version: "1.2.3".to_string(),
+            power_drains_needed: None,
             started_at: chrono::Utc::now(),
             deadline: chrono::Utc::now() + chrono::TimeDelta::minutes(60),
             task_json: task_json.clone(),
@@ -2730,8 +2731,9 @@ async fn test_forge_agent_control_invalid_json_falls_back_to_noop(
     let waiting_state = ManagedHostState::HostReprovision {
         reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
             upgrade_task_id: uuid::Uuid::new_v4().to_string(),
-            component_type: FirmwareComponentType::Bmc,
-            target_version: "1.2.3".to_string(),
+            firmware_type: FirmwareComponentType::Bmc,
+            final_version: "1.2.3".to_string(),
+            power_drains_needed: None,
             started_at: chrono::Utc::now(),
             deadline: chrono::Utc::now() + chrono::TimeDelta::minutes(60),
             task_json: task_json.clone(),
@@ -2770,8 +2772,9 @@ async fn test_report_scout_firmware_upgrade_status(pool: sqlx::PgPool) -> Carbid
     let waiting_state = ManagedHostState::HostReprovision {
         reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
             upgrade_task_id: UPGRADE_TASK_ID.to_string(),
-            component_type: FirmwareComponentType::Bmc,
-            target_version: "1.2.3".to_string(),
+            firmware_type: FirmwareComponentType::Bmc,
+            final_version: "1.2.3".to_string(),
+            power_drains_needed: None,
             started_at: chrono::Utc::now(),
             deadline: chrono::Utc::now() + chrono::TimeDelta::minutes(60),
             task_json: String::new(),
@@ -2836,8 +2839,9 @@ async fn test_report_scout_firmware_upgrade_status_failure(
     let waiting_state = ManagedHostState::HostReprovision {
         reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
             upgrade_task_id: UPGRADE_TASK_ID.to_string(),
-            component_type: FirmwareComponentType::Bmc,
-            target_version: "1.2.3".to_string(),
+            firmware_type: FirmwareComponentType::Bmc,
+            final_version: "1.2.3".to_string(),
+            power_drains_needed: None,
             started_at: chrono::Utc::now(),
             deadline: chrono::Utc::now() + chrono::TimeDelta::minutes(60),
             task_json: String::new(),
@@ -2932,8 +2936,9 @@ async fn test_report_scout_firmware_upgrade_status_rejects_stale_task_id(
     let waiting_state = ManagedHostState::HostReprovision {
         reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
             upgrade_task_id: CURRENT_TASK_ID.to_string(),
-            component_type: FirmwareComponentType::Bmc,
-            target_version: "1.2.3".to_string(),
+            firmware_type: FirmwareComponentType::Bmc,
+            final_version: "1.2.3".to_string(),
+            power_drains_needed: None,
             started_at: chrono::Utc::now(),
             deadline: chrono::Utc::now() + chrono::TimeDelta::minutes(60),
             task_json: String::new(),
@@ -3002,8 +3007,9 @@ async fn test_report_scout_firmware_upgrade_status_truncates_output(
     let waiting_state = ManagedHostState::HostReprovision {
         reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
             upgrade_task_id: UPGRADE_TASK_ID.to_string(),
-            component_type: FirmwareComponentType::Bmc,
-            target_version: "1.2.3".to_string(),
+            firmware_type: FirmwareComponentType::Bmc,
+            final_version: "1.2.3".to_string(),
+            power_drains_needed: None,
             started_at: chrono::Utc::now(),
             deadline: chrono::Utc::now() + chrono::TimeDelta::minutes(60),
             task_json: String::new(),
@@ -3059,6 +3065,7 @@ async fn put_in_waiting_for_scout_upgrade(
     env: &common::api_fixtures::TestEnv,
     host: &common::api_fixtures::test_machine::TestMachine,
     deadline: chrono::DateTime<chrono::Utc>,
+    power_drains_needed: Option<u32>,
     result: Option<model::machine::ScoutUpgradeResult>,
 ) {
     let mut txn = env.pool.begin().await.unwrap();
@@ -3066,8 +3073,9 @@ async fn put_in_waiting_for_scout_upgrade(
     let state = ManagedHostState::HostReprovision {
         reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
             upgrade_task_id: "scout-upgrade-task-id".to_string(),
-            component_type: FirmwareComponentType::Bmc,
-            target_version: "1.2.3".to_string(),
+            firmware_type: FirmwareComponentType::Bmc,
+            final_version: "1.2.3".to_string(),
+            power_drains_needed,
             started_at: chrono::Utc::now(),
             deadline,
             task_json: String::new(),
@@ -3082,7 +3090,7 @@ async fn put_in_waiting_for_scout_upgrade(
 }
 
 #[crate::sqlx_test]
-async fn test_waiting_for_scout_upgrade_success_transitions_to_repeat_check(
+async fn test_waiting_for_scout_upgrade_success_transitions_to_reset_for_new_firmware(
     pool: sqlx::PgPool,
 ) -> CarbideResult<()> {
     let env = create_test_env(pool).await;
@@ -3092,6 +3100,7 @@ async fn test_waiting_for_scout_upgrade_success_transitions_to_repeat_check(
         &env,
         &mh.host(),
         chrono::Utc::now() + chrono::TimeDelta::minutes(60),
+        Some(1),
         Some(model::machine::ScoutUpgradeResult {
             success: true,
             exit_code: 0,
@@ -3112,13 +3121,14 @@ async fn test_waiting_for_scout_upgrade_success_transitions_to_repeat_check(
     else {
         panic!("Not in HostReprovision");
     };
-    assert!(
-        matches!(
-            reprovision_state,
-            HostReprovisionState::CheckingFirmwareRepeatV2 { .. }
-        ),
-        "expected CheckingFirmwareRepeatV2, got {reprovision_state:?}",
-    );
+    let HostReprovisionState::ResetForNewFirmware {
+        power_drains_needed,
+        ..
+    } = reprovision_state
+    else {
+        panic!("expected ResetForNewFirmware, got {reprovision_state:?}");
+    };
+    assert_eq!(*power_drains_needed, Some(1));
 
     Ok(())
 }
@@ -3134,6 +3144,7 @@ async fn test_waiting_for_scout_upgrade_failure_uses_error_as_reason(
         &env,
         &mh.host(),
         chrono::Utc::now() + chrono::TimeDelta::minutes(60),
+        None,
         Some(model::machine::ScoutUpgradeResult {
             success: false,
             exit_code: 1,
@@ -3173,6 +3184,7 @@ async fn test_waiting_for_scout_upgrade_failure_without_error_uses_exit_code(
         &env,
         &mh.host(),
         chrono::Utc::now() + chrono::TimeDelta::minutes(60),
+        None,
         Some(model::machine::ScoutUpgradeResult {
             success: false,
             exit_code: 7,
@@ -3216,6 +3228,7 @@ async fn test_waiting_for_scout_upgrade_past_deadline_times_out(
         &mh.host(),
         chrono::Utc::now() - chrono::TimeDelta::minutes(1),
         None,
+        None,
     )
     .await;
 
@@ -3253,6 +3266,7 @@ async fn test_waiting_for_scout_upgrade_before_deadline_waits(
         &env,
         &mh.host(),
         chrono::Utc::now() + chrono::TimeDelta::minutes(60),
+        None,
         None,
     )
     .await;


### PR DESCRIPTION
## Description

I figured the machine should go to `ResetForNewFirmware` after the scout based upgrade succeeds in order for the upgrade to take affect. This is the biggest change of the PR. The rest follows this change.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

