### PR TITLE
Fix devspace build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,6 +1222,7 @@ dependencies = [
  "blake3",
  "carbide-certs",
  "carbide-dpu-agent-utils",
+ "carbide-dpu-fmds-shared",
  "carbide-dpu-remediation",
  "carbide-health-report",
  "carbide-host-support",
@@ -1292,6 +1293,7 @@ dependencies = [
  "tower 0.5.2",
  "tower-http",
  "tracing",
+ "url",
  "uuid",
  "uzers",
  "version-compare 0.2.1",
@@ -1533,6 +1535,7 @@ dependencies = [
  "carbide-libmlx",
  "carbide-network",
  "carbide-rpc",
+ "carbide-secrets",
  "carbide-sqlx-testing",
  "carbide-utils",
  "carbide-uuid",
@@ -1823,14 +1826,26 @@ name = "carbide-dpu-agent-utils"
 version = "0.0.0"
 dependencies = [
  "carbide-rpc",
- "carbide-tls",
  "eyre",
- "rand 0.9.2",
+]
+
+[[package]]
+name = "carbide-dpu-fmds-shared"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "axum 0.8.6",
+ "carbide-dpu-agent-utils",
+ "carbide-rpc",
+ "governor",
+ "http-body-util",
+ "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "tokio",
  "tonic 0.14.2",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -1937,6 +1952,7 @@ dependencies = [
  "axum 0.8.6",
  "axum-server",
  "carbide-dpu-agent-utils",
+ "carbide-dpu-fmds-shared",
  "carbide-rpc",
  "carbide-tls",
  "carbide-uuid",
@@ -1953,6 +1969,7 @@ dependencies = [
  "netlink-packet-route",
  "nonzero_ext",
  "prost 0.14.1",
+ "reqwest",
  "rtnetlink",
  "tokio",
  "tonic 0.14.2",
@@ -2023,6 +2040,7 @@ name = "carbide-host-support"
 version = "0.0.0"
 dependencies = [
  "base64 0.22.1",
+ "carbide-dpu-agent-utils",
  "carbide-libmlx",
  "carbide-rpc",
  "carbide-tls",
@@ -2035,6 +2053,7 @@ dependencies = [
  "logfmt",
  "procfs",
  "regex",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_with",
@@ -2048,6 +2067,7 @@ dependencies = [
  "tracing-subscriber",
  "tryhard",
  "uname",
+ "url",
  "uuid",
 ]
 


### PR DESCRIPTION
## Description

`devspace deploy -n forge-system` command fails with the following message:

`build:machine-a-tron 0.286 error: the lock file /workspace/Cargo.lock needs to be updated but --locked was passed to prevent this`

### Fix

Refresh `Cargo.lock` by running `cargo update --workspace`, which adds the missing `carbide-dpu-fmds-shared` dependency.


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

