### PR TITLE
fix(api,agent): Added additional route-leaking controls

### DIFF
--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -465,6 +465,11 @@ pub async fn update_nvue(
                         vni: rt.vni,
                     })
                     .collect(),
+                accepted_leaks_from_underlay: rp
+                    .accepted_leaks_from_underlay
+                    .iter()
+                    .map(|l| l.prefix.to_owned())
+                    .collect(),
             })
         },
         bgp_leaf_session_password: nc.bgp_leaf_session_password.clone(),
@@ -2575,6 +2580,13 @@ mod tests {
                 leak_default_route_from_underlay: include_network_host_route_and_default_leaking,
                 leak_tenant_host_routes_to_underlay: include_network_host_route_and_default_leaking,
                 tenant_leak_communities_accepted: include_network_host_route_and_default_leaking,
+                accepted_leaks_from_underlay: if include_network_host_route_and_default_leaking {
+                    vec![rpc::PrefixFilterPolicyEntry {
+                        prefix: "10.255.0.0/24".to_string(),
+                    }]
+                } else {
+                    vec![]
+                },
                 route_target_imports: vec![rpc_common::RouteTarget {
                     asn: 44444,
                     vni: 55555,
@@ -2828,6 +2840,7 @@ mod tests {
                 tenant_leak_communities_accepted: false,
                 leak_default_route_from_underlay: false,
                 leak_tenant_host_routes_to_underlay: false,
+                accepted_leaks_from_underlay: vec![],
                 route_target_imports: vec![nvue::RouteTargetConfig {
                     asn: 44444,
                     vni: 55555,
@@ -3062,6 +3075,7 @@ mod tests {
                 tenant_leak_communities_accepted: false,
                 leak_default_route_from_underlay: false,
                 leak_tenant_host_routes_to_underlay: false,
+                accepted_leaks_from_underlay: vec![],
                 route_target_imports: vec![rpc_common::RouteTarget {
                     asn: 44444,
                     vni: 55555,

--- a/crates/agent/src/nvue.rs
+++ b/crates/agent/src/nvue.rs
@@ -71,6 +71,9 @@ const NETWORK_SECURITY_GROUP_RULE_COUNT_MAX: usize = 10000;
 /// into IPv4 and IPv6 buckets. Each bucket gets sequential indices
 /// starting at `start_index`. Unparseable prefixes are warned and
 /// dropped (because NVUE would fail on invalid addresses anyway).
+///
+/// start_index should usually be set to 1 to avoid nvue config complaints when
+/// using the output as part of policy generation.
 fn split_prefixes_by_family(prefixes: &[String], start_index: usize) -> (Vec<Prefix>, Vec<Prefix>) {
     let valid: Vec<_> = prefixes
         .iter()
@@ -122,13 +125,15 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
     // profiles into FlatInterfaceConfig could change that.
     // For now, we clone later so that we can put this into each TmplVpc
     // and make a later transition easier.
-    let routing_profile = conf
-        .ct_routing_profile
-        .as_ref()
-        .map(|rt| TmplRoutingProfile {
+    let routing_profile = conf.ct_routing_profile.as_ref().map(|rt| {
+        let (v4leaks, v6leaks) = split_prefixes_by_family(&rt.accepted_leaks_from_underlay, 1);
+
+        TmplRoutingProfile {
             TenantLeakCommunitiesAccepted: rt.tenant_leak_communities_accepted,
             LeakDefaultRouteFromUnderlay: rt.leak_default_route_from_underlay,
             LeakTenantHostRoutesToUnderlay: rt.leak_tenant_host_routes_to_underlay,
+            AcceptedLeaksFromUnderlayIpv4: v4leaks,
+            AcceptedLeaksFromUnderlayIpv6: v6leaks,
             RouteTargetImports: rt
                 .route_target_imports
                 .iter()
@@ -145,7 +150,8 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
                     VNI: rt.vni,
                 })
                 .collect(),
-        });
+        }
+    });
 
     // There are two assumptions about pre-FNN...
     // 1 - ManagedHostNetworkConfigResponse only has rules inherited either from VPC or Instance,
@@ -338,6 +344,20 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
                 RoutingProfile: routing_profile.clone(),
                 PortPrefixes: port.VpcPrefixes.clone(),
                 PortPrefixesIpv6: port.VpcPrefixesIpv6.clone(),
+                HasLeaksFromUnderlayIpv4: routing_profile
+                    .as_ref()
+                    .map(|p| {
+                        p.LeakDefaultRouteFromUnderlay
+                            || !p.AcceptedLeaksFromUnderlayIpv4.is_empty()
+                    })
+                    .unwrap_or_default(),
+                HasLeaksFromUnderlayIpv6: routing_profile
+                    .as_ref()
+                    .map(|p| {
+                        p.LeakDefaultRouteFromUnderlay
+                            || !p.AcceptedLeaksFromUnderlayIpv6.is_empty()
+                    })
+                    .unwrap_or_default(),
             });
 
         port_configs.push(port);
@@ -981,6 +1001,7 @@ pub struct RoutingProfile {
     pub route_target_imports: Vec<RouteTargetConfig>,
     pub route_targets_on_exports: Vec<RouteTargetConfig>,
     pub tenant_leak_communities_accepted: bool,
+    pub accepted_leaks_from_underlay: Vec<String>,
 }
 
 #[derive(Clone, Deserialize, Debug)]
@@ -1265,6 +1286,8 @@ struct TmplRoutingProfile {
     RouteTargetImports: Vec<TmplRouteTargetConfig>,
     RouteTargetsOnExports: Vec<TmplRouteTargetConfig>,
     TenantLeakCommunitiesAccepted: bool,
+    AcceptedLeaksFromUnderlayIpv4: Vec<Prefix>,
+    AcceptedLeaksFromUnderlayIpv6: Vec<Prefix>,
 }
 
 #[allow(non_snake_case)]
@@ -1358,6 +1381,11 @@ struct TmplVpc {
     VpcPeerPrefixes: Vec<Prefix>,
     HasVpcPeerPrefixesIpv6: bool,
     VpcPeerPrefixesIpv6: Vec<Prefix>,
+
+    /// Whether there are _any_ leaks from the default
+    /// VRF into the tenant VRF being used.
+    HasLeaksFromUnderlayIpv4: bool,
+    HasLeaksFromUnderlayIpv6: bool,
 
     // The relationship between interface:VPC is 1:1 but VPC:interface is 1:M.
     // So, a single VPC could have multiple, per-port, VpcPrefixes.  We can
@@ -1678,6 +1706,7 @@ mod tests {
             leak_tenant_host_routes_to_underlay: false,
             route_target_imports: vec![],
             route_targets_on_exports: vec![],
+            accepted_leaks_from_underlay: vec![],
         });
         conf.ct_port_configs = vec![PortConfig {
             interface_name: "pf0vf0_if".into(),
@@ -1758,6 +1787,7 @@ mod tests {
 
             route_target_imports: vec![],
             route_targets_on_exports: vec![],
+            accepted_leaks_from_underlay: vec![],
         });
         conf.ct_port_configs = vec![PortConfig {
             interface_name: "pf0vf0_if".into(),
@@ -1841,6 +1871,7 @@ mod tests {
             leak_tenant_host_routes_to_underlay: false,
             route_target_imports: vec![],
             route_targets_on_exports: vec![],
+            accepted_leaks_from_underlay: vec![],
         });
         conf.ct_port_configs = vec![
             PortConfig {
@@ -1911,6 +1942,7 @@ mod tests {
             tenant_leak_communities_accepted: false,
             route_target_imports: vec![],
             route_targets_on_exports: vec![],
+            accepted_leaks_from_underlay: vec![],
         });
         conf.ct_port_configs = vec![PortConfig {
             interface_name: "pf0vf0_if".into(),
@@ -2072,6 +2104,7 @@ mod tests {
             leak_tenant_host_routes_to_underlay: false,
             route_target_imports: vec![],
             route_targets_on_exports: vec![],
+            accepted_leaks_from_underlay: vec![],
         }
     }
 

--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -838,6 +838,7 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
             tenant_leak_communities_accepted: false,
             leak_default_route_from_underlay: false,
             leak_tenant_host_routes_to_underlay: false,
+            accepted_leaks_from_underlay: vec![],
             route_target_imports: vec![rpc_common::RouteTarget {
                 asn: 44444,
                 vni: 55555,

--- a/crates/agent/templates/nvue_startup_fnn.conf
+++ b/crates/agent/templates/nvue_startup_fnn.conf
@@ -296,24 +296,42 @@
                 match:
                   any: {}
           {{- range $vpc := $tenant.Vpcs }}
-              {{- if $vpc.RoutingProfile.LeakDefaultRouteFromUnderlay }}
+              {{- if $vpc.HasLeaksFromUnderlayIpv4 }}
           FROM_DEFAULT_VRF_TO_{{ $vpc.VrfName }}_PREFIX_LIST:
             rule:
+                {{- range $leak := $vpc.RoutingProfile.AcceptedLeaksFromUnderlayIpv4 }}
+              '{{ $leak.Index }}':
+                action: permit
+                match:
+                  '{{ $leak.Prefix }}':
+                    max-prefix-len: 32{{/* Any */}}
+                {{- end }}
+                {{- if $vpc.RoutingProfile.LeakDefaultRouteFromUnderlay }}
               '65534':
                 action: permit
                 match:
                   0.0.0.0/0: {}{{/* Exact match */}}
+                {{- end }}
               {{- end }}
           {{- end }}
           {{- range $vpc := $tenant.Vpcs }}
-              {{- if $vpc.RoutingProfile.LeakDefaultRouteFromUnderlay }}
+              {{- if $vpc.HasLeaksFromUnderlayIpv6 }}
           FROM_DEFAULT_VRF_TO_{{ $vpc.VrfName }}_PREFIX_LIST_IPV6:
             type: ipv6
             rule:
+                {{- range $leak := $vpc.RoutingProfile.AcceptedLeaksFromUnderlayIpv6 }}
+              '{{ $leak.Index }}':
+                action: permit
+                match:
+                  '{{ $leak.Prefix }}':
+                    max-prefix-len: 128{{/* Any */}}
+                {{- end }}
+                {{- if $vpc.RoutingProfile.LeakDefaultRouteFromUnderlay }}
               '65534':
                 action: permit
                 match:
                   '::/0': {}{{/* Exact match */}}
+                {{- end }}
               {{- end }}
           {{- end }}
         route-map:
@@ -544,7 +562,7 @@
                 action:
                   deny: {}
           {{- range $vpc := $tenant.Vpcs }}
-            {{- if $vpc.RoutingProfile.LeakDefaultRouteFromUnderlay }}
+            {{- if $vpc.HasLeaksFromUnderlayIpv4 }}
           FROM_DEFAULT_VRF_TO_{{ $vpc.VrfName }}_MAP:
             rule:
               '10':
@@ -556,8 +574,8 @@
             {{- end }}
           {{- end }}
           {{- range $vpc := $tenant.Vpcs }}
-            {{- if $vpc.RoutingProfile.LeakDefaultRouteFromUnderlay }}
-          FROM_DEFAULT_VRF_TO_{{ $vpc.VrfName }}_MAP_IPV6:
+            {{- if $vpc.HasLeaksFromUnderlayIpv6 }}
+          FROM_DEFAULT_VRF_TO_{{ $vpc.VrfName }}_MAP_V6:
             rule:
               '10':
                 action:
@@ -773,13 +791,13 @@
                 route-export:
                   to-evpn:
                     enable: on
-                {{- if $vpc.RoutingProfile.LeakDefaultRouteFromUnderlay }}
+                {{- if $vpc.HasLeaksFromUnderlayIpv4 }}
                 route-import:
                   from-vrf:
                     route-map: FROM_DEFAULT_VRF_TO_{{ $vpc.VrfName }}_MAP
                     enable: on
                     list:
-                      default: {}              
+                      default: {}
                 {{- end}}
               ipv6-unicast:
                 enable: on
@@ -789,6 +807,14 @@
                 route-export:
                   to-evpn:
                     enable: on
+                {{- if $vpc.HasLeaksFromUnderlayIpv6 }}
+                route-import:
+                  from-vrf:
+                    route-map: FROM_DEFAULT_VRF_TO_{{ $vpc.VrfName }}_MAP_V6
+                    enable: on
+                    list:
+                      default: {}
+                {{- end}}
             enable: on
             neighbor:
   {{- range $vpc.HostInterfaces}}

--- a/crates/agent/templates/tests/nvue_startup_fnn_with_leaks.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_with_leaks.yaml.expected
@@ -180,12 +180,22 @@
                   any: {}
           FROM_DEFAULT_VRF_TO_vpc_1025186_PREFIX_LIST:
             rule:
+              '1':
+                action: permit
+                match:
+                  '10.255.0.0/24':
+                    max-prefix-len: 32
               '65534':
                 action: permit
                 match:
                   0.0.0.0/0: {}
           FROM_DEFAULT_VRF_TO_vpc_1025197_PREFIX_LIST:
             rule:
+              '1':
+                action: permit
+                match:
+                  '10.255.0.0/24':
+                    max-prefix-len: 32
               '65534':
                 action: permit
                 match:
@@ -527,7 +537,7 @@
                 match:
                   ip-prefix-list: FROM_DEFAULT_VRF_TO_vpc_1025197_PREFIX_LIST
                   type: ipv4
-          FROM_DEFAULT_VRF_TO_vpc_1025186_MAP_IPV6:
+          FROM_DEFAULT_VRF_TO_vpc_1025186_MAP_V6:
             rule:
               '10':
                 action:
@@ -535,7 +545,7 @@
                 match:
                   ip-prefix-list: FROM_DEFAULT_VRF_TO_vpc_1025186_PREFIX_LIST_IPV6
                   type: ipv6
-          FROM_DEFAULT_VRF_TO_vpc_1025197_MAP_IPV6:
+          FROM_DEFAULT_VRF_TO_vpc_1025197_MAP_V6:
             rule:
               '10':
                 action:
@@ -709,6 +719,12 @@
                 route-export:
                   to-evpn:
                     enable: on
+                route-import:
+                  from-vrf:
+                    route-map: FROM_DEFAULT_VRF_TO_vpc_1025186_MAP_V6
+                    enable: on
+                    list:
+                      default: {}
             enable: on
             neighbor:
               10.217.5.170:
@@ -818,6 +834,12 @@
                 route-export:
                   to-evpn:
                     enable: on
+                route-import:
+                  from-vrf:
+                    route-map: FROM_DEFAULT_VRF_TO_vpc_1025197_MAP_V6
+                    enable: on
+                    list:
+                      default: {}
             enable: on
             neighbor:
               10.217.5.170:

--- a/crates/api/src/cfg/README.md
+++ b/crates/api/src/cfg/README.md
@@ -260,7 +260,26 @@ Extends `StateControllerConfig` with:
 | `admin_vpc` | `Option<AdminFnnConfig>` | — | FNN configuration for the admin network VPC. |
 | `common_internal_route_target` | `Option<RouteTargetConfig>` | — | Double-tag for internal tenant routes (consumed by the network infrastructure). |
 | `additional_route_target_imports` | `Vec<RouteTargetConfig>` | `[]` | Extra route targets imported on DPU VRFs. |
-| `routing_profiles` | `HashMap<String, FnnRoutingProfileConfig>` | `{}` | Named per-VPC routing profiles. |
+| `routing_profiles` | `HashMap<String, FnnRoutingProfileConfig>` | `{}` | Named per-VPC routing profiles (see [FnnRoutingProfileConfig](#fnnroutingprofileconfig)). |
+
+### `FnnRoutingProfileConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `route_target_imports` | `Vec<RouteTargetConfig>` | `[]` | Route targets imported into DPU VRFs for VPC routes. |
+| `route_targets_on_exports` | `Vec<RouteTargetConfig>` | `[]` | Route targets added to routes exported by the DPU. |
+| `internal` | `bool` | `false` | Whether the profile uses internal VNI allocation. |
+| `leak_default_route_from_underlay` | `bool` | `false` | Leak the default route from the underlay/default VRF into tenant VRFs. |
+| `leak_tenant_host_routes_to_underlay` | `bool` | `false` | Leak tenant host routes into the underlay/default VRF. |
+| `tenant_leak_communities_accepted` | `bool` | `false` | Honor route-leak communities sent by the tenant host OS. |
+| `accepted_leaks_from_underlay` | `Vec<PrefixFilterPolicyEntry>` | `[]` | Specific underlay/default VRF prefixes allowed to leak into tenant VRFs. Routing only; does not affect ACLs. |
+| `access_tier` | `u32` | `0` | Routing profile access tier. Lower values grant broader access. |
+
+### `PrefixFilterPolicyEntry`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `prefix` | `IpNetwork` | **required** | IPv4 or IPv6 CIDR prefix accepted by a prefix-list policy. |
 
 ### `DpaConfig`
 

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -985,6 +985,15 @@ pub struct FnnRoutingProfileConfig {
     #[serde(default)]
     pub tenant_leak_communities_accepted: bool,
 
+    /// An explicit/granular list of prefixes that should
+    /// be allowed to leak from the default VRF into the tenant
+    /// VRF.
+    ///
+    /// These are purely for routing purposes and will not have any
+    /// impact on ACLs.
+    #[serde(default)]
+    pub accepted_leaks_from_underlay: Vec<PrefixFilterPolicyEntry>,
+
     /// Currently controls which profiles a tenant can use
     /// when creating VPCs.  Lower value means broader access.
     /// A tenant can create a VPC with a routing profile of the same or broader access.
@@ -996,6 +1005,15 @@ pub struct FnnRoutingProfileConfig {
     /// - A tenant with INTERNAL could only create INTERNAL VPCs.
     #[serde(default)]
     pub access_tier: u32,
+}
+
+/// Entries used for prefix-list policies on the DPUS.
+/// Default behavior is max-len lte 32
+/// We can change that with additional fields on this struct
+/// if necessary in the future.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct PrefixFilterPolicyEntry {
+    pub prefix: IpNetwork,
 }
 
 /// FNN configuration specific to the admin network.

--- a/crates/api/src/handlers/dpu.rs
+++ b/crates/api/src/handlers/dpu.rs
@@ -674,6 +674,13 @@ pub(crate) async fn get_managed_host_network_config_inner(
             tenant_leak_communities_accepted: p.tenant_leak_communities_accepted,
             leak_default_route_from_underlay: p.leak_default_route_from_underlay,
             leak_tenant_host_routes_to_underlay: p.leak_tenant_host_routes_to_underlay,
+            accepted_leaks_from_underlay: p
+                .accepted_leaks_from_underlay
+                .iter()
+                .map(|l| rpc::PrefixFilterPolicyEntry {
+                    prefix: l.prefix.to_string(),
+                })
+                .collect(),
             route_target_imports: p
                 .route_target_imports
                 .iter()

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -298,6 +298,7 @@ impl TestEnvOverrides {
                             leak_default_route_from_underlay: false,
                             leak_tenant_host_routes_to_underlay: false,
                             tenant_leak_communities_accepted: false,
+                            accepted_leaks_from_underlay: vec![],
                         },
                     ),
                     (
@@ -310,6 +311,7 @@ impl TestEnvOverrides {
                             leak_default_route_from_underlay: false,
                             leak_tenant_host_routes_to_underlay: false,
                             tenant_leak_communities_accepted: false,
+                            accepted_leaks_from_underlay: vec![],
                         },
                     ),
                 ]),

--- a/crates/api/src/tests/machine_network.rs
+++ b/crates/api/src/tests/machine_network.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::collections::HashMap;
 use std::ops::DerefMut;
 use std::time::SystemTime;
 
@@ -27,9 +28,11 @@ use forge_secrets::credentials::{BgpCredentialType, CredentialKey, Credentials};
 use model::machine::network::ManagedHostQuarantineMode;
 use rpc::forge::forge_server::Forge;
 
+use crate::cfg::file::{FnnConfig, FnnRoutingProfileConfig, PrefixFilterPolicyEntry};
 use crate::tests::common;
 use crate::tests::common::api_fixtures::TestEnvOverrides;
 use crate::tests::common::api_fixtures::site_explorer::MockExploredHost;
+use crate::tests::common::rpc_builder::VpcCreationRequest;
 
 #[crate::sqlx_test]
 async fn test_managed_host_network_config(pool: sqlx::PgPool) {
@@ -92,6 +95,93 @@ async fn test_managed_host_network_config_with_sitewide_bgp_password(pool: sqlx:
         response.bgp_leaf_session_password,
         Some("test-bgp-password".to_string())
     );
+}
+
+#[crate::sqlx_test]
+async fn test_managed_host_network_config_includes_routing_profile_accepted_leaks(
+    pool: sqlx::PgPool,
+) {
+    let profile_type = "ROUTE_LEAK_TEST";
+    let expected_leaks = vec!["10.42.0.0/24".to_string(), "2001:db8:42::/64".to_string()];
+
+    // Configure an FNN routing profile with explicit accepted underlay leaks.
+    let env = api_fixtures::create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides::default().with_fnn_config(Some(FnnConfig {
+            admin_vpc: None,
+            common_internal_route_target: None,
+            additional_route_target_imports: vec![],
+            routing_profiles: HashMap::from([(
+                profile_type.to_string(),
+                FnnRoutingProfileConfig {
+                    internal: true,
+                    access_tier: 0,
+                    accepted_leaks_from_underlay: expected_leaks
+                        .iter()
+                        .map(|prefix| PrefixFilterPolicyEntry {
+                            prefix: prefix.parse().unwrap(),
+                        })
+                        .collect(),
+                    ..Default::default()
+                },
+            )]),
+        })),
+    )
+    .await;
+
+    // Create a tenant and FNN VPC using that routing profile.
+    let tenant = env
+        .api
+        .create_tenant(tonic::Request::new(rpc::forge::CreateTenantRequest {
+            organization_id: "route-leak-test".to_string(),
+            routing_profile_type: Some(profile_type.to_string()),
+            metadata: Some(rpc::forge::Metadata {
+                name: "route-leak-test".to_string(),
+                description: "".to_string(),
+                labels: vec![],
+            }),
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .tenant
+        .unwrap();
+
+    let segment_id = env
+        .create_vpc_and_tenant_segment_with_vpc_details(
+            VpcCreationRequest::builder("route leak vpc", tenant.organization_id.as_str())
+                .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
+                .routing_profile_type(profile_type.to_string())
+                .rpc(),
+        )
+        .await;
+
+    // Allocate an instance on the VPC so the DPU receives tenant network config.
+    let mh = create_managed_host(&env).await;
+    mh.instance_builer(&env)
+        .tenant_org(tenant.organization_id)
+        .single_interface_network_config(segment_id)
+        .build()
+        .await;
+
+    // Fetch the DPU network config and extract its routing profile.
+    let response = env
+        .api
+        .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
+            dpu_machine_id: Some(mh.dpu().id),
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    let routing_profile = response.routing_profile.unwrap();
+
+    // Verify the configured leak prefixes are preserved in the gRPC response.
+    let actual_leaks: Vec<_> = routing_profile
+        .accepted_leaks_from_underlay
+        .into_iter()
+        .map(|leak| leak.prefix)
+        .collect();
+    assert_eq!(actual_leaks, expected_leaks);
 }
 
 #[crate::sqlx_test]

--- a/crates/api/src/tests/vpc.rs
+++ b/crates/api/src/tests/vpc.rs
@@ -122,6 +122,7 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
                         leak_tenant_host_routes_to_underlay: false,
                         tenant_leak_communities_accepted: false,
                         access_tier: 1,
+                        accepted_leaks_from_underlay: vec![],
                     },
                 ),
                 (
@@ -134,6 +135,7 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
                         leak_tenant_host_routes_to_underlay: false,
                         tenant_leak_communities_accepted: false,
                         access_tier: 0,
+                        accepted_leaks_from_underlay: vec![],
                     },
                 ),
             ]),

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -285,6 +285,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "forge.RoutingProfile",
             "#[derive(serde::Serialize)]",
         )
+        .type_attribute(
+            "forge.PrefixFilterPolicyEntry",
+            "#[derive(serde::Serialize)]",
+        )
         .type_attribute("forge.TrafficInterceptConfig", "#[derive(serde::Serialize)]")
         .type_attribute("forge.TrafficInterceptBridging", "#[derive(serde::Serialize)]")
         .type_attribute("forge.NetworkPrefix", "#[derive(serde::Serialize)]")

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -7539,16 +7539,31 @@ enum ScoutStreamErrorStatus {
   SCOUT_STREAM_ERROR_STATUS_INTERNAL = 0;
 }
 
+// Entries used for prefix-list policies on the DPUS.
+// Default behavior is max-len lte 32
+// We can change that with additional fields on this struct
+// if necessary in the future.
+message PrefixFilterPolicyEntry {
+  string prefix = 1;
+}
+
 message RoutingProfile {
-  repeated common.RouteTarget route_target_imports     = 1;
-  repeated common.RouteTarget route_targets_on_exports = 2;
-  bool leak_default_route_from_underlay                = 3;
-  bool leak_tenant_host_routes_to_underlay             = 4;
+  repeated common.RouteTarget route_target_imports             = 1;
+  repeated common.RouteTarget route_targets_on_exports         = 2;
+  bool leak_default_route_from_underlay                        = 3;
+  bool leak_tenant_host_routes_to_underlay                     = 4;
 
   // Are route-leak communities sent by the host OS honored by the DPU for allowing
   // routes advertised by the host OS to be leaked into the underlay?
-  bool tenant_leak_communities_accepted                = 5;
+  bool tenant_leak_communities_accepted                        = 5;
 
+  // An explicit/granular list of prefixes that should
+  // be allowed to leak from the default VRF into the tenant
+  // VRF.
+  //
+  // These are purely for routing purposes and will not have any
+  // impact on ACLs.
+  repeated PrefixFilterPolicyEntry accepted_leaks_from_underlay = 6;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Description

Adds granular route-leaking option to VPC profiles so that deployment can configure certain VPCs to leak more than just default-route from the underlay into the VPC VRF.

There are user-friendly options for leaking tenant routes to the underlay and for leaking a default-route from the underlay into tenant overlays, but some use-cases need more control over leaking from default VRF to tenant VRF.

Specifically, users who plan to run a very large number of number of anycast announcements for a single IP might exceed the limits of ECMP groups in HBN and even cumulus.

The work-around is leaking those routes to the underlay and allowing the ingress path to such VIPs to take the underlay. On the "client" side, those VIPs routes would need to be leaked into the tenant VRF from the default VRF to prevent the client traffic from taking a default route in the overlay and hair-pinning at a border device VRF, or possibly getting dropped completely.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
Satisfies https://github.com/NVIDIA/infra-controller-core/issues/1313

