### PR TITLE
Send filepaths as args to firmware script

### DIFF
--- a/crates/scout/src/firmware_upgrade.rs
+++ b/crates/scout/src/firmware_upgrade.rs
@@ -102,6 +102,7 @@ async fn run_firmware_upgrade(
     // Download file artifacts and verify checksums.
     let download_dir = work_dir.path().join("downloads");
     tokio::fs::create_dir_all(&download_dir).await?;
+    let mut downloaded_artifacts = Vec::with_capacity(task.file_artifacts.len());
     for artifact in &task.file_artifacts {
         let dest = tokio::time::timeout(
             download_timeout,
@@ -123,6 +124,7 @@ async fn run_firmware_upgrade(
             .into());
         }
         tracing::info!("[firmware_upgrade] checksum verified for {}", artifact.url);
+        downloaded_artifacts.push(dest);
     }
 
     tracing::info!(
@@ -133,11 +135,15 @@ async fn run_firmware_upgrade(
     // Execute the script with env vars for context.
     // kill_on_drop ensures the child process is terminated if the timeout fires,
     // preventing orphaned processes and races with tempdir cleanup.
-    let child = tokio::process::Command::new("sh")
+    let mut command = tokio::process::Command::new("sh");
+    command
         .arg(&script_path)
+        .args(&downloaded_artifacts)
         .env("DOWNLOAD_DIR", &download_dir)
         .env("COMPONENT_TYPE", &task.component_type)
-        .env("TARGET_VERSION", &task.target_version)
+        .env("TARGET_VERSION", &task.target_version);
+
+    let child = command
         .current_dir(work_dir.path())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
@@ -391,6 +397,54 @@ mod tests {
         assert!(result.stdout.contains("comp=cpldmb"));
         assert!(result.stdout.contains("ver=3.4.5"));
         assert!(result.stdout.contains("dir="));
+    }
+
+    #[tokio::test]
+    async fn test_script_receives_artifacts_as_args_in_order() {
+        let script = r#"#!/bin/sh
+echo "argc=$#"
+echo "arg1=$(basename "$1")"
+echo "arg2=$(basename "$2")"
+test "$#" = "2"
+test -f "$1"
+test -f "$2"
+test "$(basename "$1")" = "first.bin"
+test "$(basename "$2")" = "second.bin"
+"#;
+        let first_content = "first-binary-data";
+        let second_content = "second-binary-data";
+        let base = start_file_server(vec![
+            ("/scripts/env.sh", script),
+            ("/firmware/first.bin", first_content),
+            ("/firmware/second.bin", second_content),
+        ])
+        .await;
+
+        let task = FirmwareUpgradeTask {
+            upgrade_task_id: "test-upgrade-task-id".into(),
+            component_type: "cpldmb".into(),
+            target_version: "3.4.5".into(),
+            script: Some(script_artifact(&base, "/scripts/env.sh", script)),
+            execution_timeout_seconds: 30,
+            artifact_download_timeout_seconds: 30,
+            file_artifacts: vec![
+                FileArtifact {
+                    url: format!("{base}/firmware/first.bin"),
+                    sha256: sha256_hex(first_content),
+                },
+                FileArtifact {
+                    url: format!("{base}/firmware/second.bin"),
+                    sha256: sha256_hex(second_content),
+                },
+            ],
+        };
+
+        let result = handle_firmware_upgrade(&reqwest::Client::new(), &task).await;
+
+        assert!(result.success, "error: {}", result.error);
+        assert!(result.stdout.contains("argc=2"));
+        assert!(result.stdout.contains("arg1=first.bin"));
+        assert!(result.stdout.contains("arg2=second.bin"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description
Sending downloaded files as positional arguments to the script. Cleaner/simpler than each script finding the files from the download directory.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

