### PR TITLE
chore: Update axum-server to 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.6"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core 0.5.5",
  "axum-macros",
@@ -638,11 +638,11 @@ dependencies = [
 
 [[package]]
 name = "axum-client-ip"
-version = "1.1.3"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f08a543641554404b42acd0d2494df12ca2be034d7b8ee4dbbf7446f940a2ef"
+checksum = "a8ba1af5b620232acf37f2eb6d22151ea465491e0b4c25f552d1990f64ec5a67"
 dependencies = [
- "axum 0.8.6",
+ "axum 0.8.9",
  "client-ip",
  "serde",
 ]
@@ -688,14 +688,15 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.10.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
+checksum = "5136e6c5e7e7978fe23e9876fb924af2c0f84c72127ac6ac17e7c46f457d362c"
 dependencies = [
- "axum 0.8.6",
+ "axum 0.8.9",
  "axum-core 0.5.5",
  "bytes",
  "cookie",
+ "futures-core",
  "futures-util",
  "headers",
  "http",
@@ -703,8 +704,6 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
- "serde_core",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -712,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -723,12 +722,13 @@ dependencies = [
 
 [[package]]
 name = "axum-server"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495c05f60d6df0093e8fb6e74aa5846a0ad06abaf96d76166283720bf740f8ab"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
 dependencies = [
  "arc-swap",
  "bytes",
+ "either",
  "fs-err",
  "http",
  "http-body",
@@ -736,7 +736,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls 0.23.34",
- "rustls-pemfile",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -749,7 +748,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3df50f7d669bfc3a8c348f08f536fe37e7acfbeded3cfdffd2ad3d76725fc40c"
 dependencies = [
- "axum 0.8.6",
+ "axum 0.8.9",
  "serde",
  "tera",
  "thiserror 2.0.17",
@@ -974,7 +973,7 @@ dependencies = [
 name = "bmc-explorer"
 version = "0.1.0"
 dependencies = [
- "axum 0.8.6",
+ "axum 0.8.9",
  "bmc-mock",
  "bmc-vendor",
  "carbide-api-model",
@@ -1010,7 +1009,7 @@ name = "bmc-mock"
 version = "0.1.0"
 dependencies = [
  "arc-swap",
- "axum 0.8.6",
+ "axum 0.8.9",
  "axum-extra",
  "axum-server",
  "bmc-vendor",
@@ -1225,7 +1224,7 @@ version = "0.1.0"
 dependencies = [
  "arc-swap",
  "async-trait",
- "axum 0.8.6",
+ "axum 0.8.9",
  "axum-server",
  "backon",
  "blake3",
@@ -1319,7 +1318,7 @@ dependencies = [
  "askama_escape",
  "asn1-rs",
  "async-trait",
- "axum 0.8.6",
+ "axum 0.8.9",
  "axum-extra",
  "base64 0.22.1",
  "bmc-explorer",
@@ -1640,7 +1639,7 @@ dependencies = [
 name = "carbide-bmc-proxy"
 version = "0.0.0"
 dependencies = [
- "axum 0.8.6",
+ "axum 0.8.9",
  "axum-extra",
  "bytes",
  "carbide-api-db",
@@ -1846,7 +1845,7 @@ name = "carbide-dpu-fmds-shared"
 version = "0.0.0"
 dependencies = [
  "async-trait",
- "axum 0.8.6",
+ "axum 0.8.9",
  "carbide-dpu-agent-utils",
  "carbide-rpc",
  "governor",
@@ -1962,7 +1961,7 @@ version = "0.0.1"
 dependencies = [
  "arc-swap",
  "async-trait",
- "axum 0.8.6",
+ "axum 0.8.9",
  "axum-server",
  "carbide-dpu-agent-utils",
  "carbide-dpu-fmds-shared",
@@ -2241,7 +2240,7 @@ dependencies = [
 name = "carbide-machine-a-tron"
 version = "0.0.0"
 dependencies = [
- "axum 0.8.6",
+ "axum 0.8.9",
  "base64 0.22.1",
  "bmc-mock",
  "carbide-network",
@@ -2422,7 +2421,7 @@ dependencies = [
 name = "carbide-pxe"
 version = "0.0.1"
 dependencies = [
- "axum 0.8.6",
+ "axum 0.8.9",
  "axum-client-ip",
  "axum-template",
  "base64 0.22.1",
@@ -2551,7 +2550,7 @@ dependencies = [
 name = "carbide-scout"
 version = "0.0.1"
 dependencies = [
- "axum 0.8.6",
+ "axum 0.8.9",
  "carbide-host-support",
  "carbide-libmlx",
  "carbide-machine-validation",
@@ -3086,9 +3085,9 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "client-ip"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31211fc26899744f5b22521fdc971e5f3875991d8880537537470685a0e9552d"
+checksum = "39d2056bf065c8b4bce5a8898d40e175211ff4410add2a84d695845d3937c729"
 dependencies = [
  "http",
 ]
@@ -5243,9 +5242,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5258,7 +5257,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -5298,14 +5296,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -10663,7 +10660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
 dependencies = [
  "async-trait",
- "axum 0.8.6",
+ "axum 0.8.9",
  "base64 0.22.1",
  "bytes",
  "h2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,14 +70,6 @@ nv-redfish = { version = "0.8.1" }
 # newer sqlx version.
 ipnetwork = "0.20.0"
 
-# pinning axum:
-# Tonic does not support axum 0.8 or later. Until it does, pin axum to 0.7 and the related crates to the corresponding
-# (working) versions.
-axum = "0.8.4"
-axum-extra = "0.10"                 # Pin this until we can update axum
-axum-client-ip = "1.1.3"
-axum-template = { version = "3.0" }
-
 ########
 # MARK: - Versions common for the rest of the codebase
 ########
@@ -90,8 +82,12 @@ askama_escape = "0.10"
 asn1-rs = "0.7.0"
 async-ssh2-tokio = "0.12.0"
 async-trait = "0.1.88"
+axum = "0.8.9"
+axum-client-ip = "1.3.1"
+axum-extra = "0.12"
 axum-response-cache = "0.4"
-axum-server = "0.7"
+axum-server = "0.8"
+axum-template = { version = "3.0" }
 backon = "1.5.2"
 base64 = "0.22.1"
 blake3 = "1.4"

--- a/crates/agent/src/instance_metadata_endpoint.rs
+++ b/crates/agent/src/instance_metadata_endpoint.rs
@@ -605,7 +605,10 @@ mod tests {
         let std_listener = listener.into_std().unwrap();
 
         let server = tokio::spawn(async move {
-            axum_server::Server::from_tcp(std_listener)
+            axum_server::from_tcp(std_listener)
+                // Safety: This only fails if the socket is blocking, but it started as a tokio
+                // TcpListener which sets non-blocking by default.
+                .expect("BUG: Could not bind to listener")
                 .serve(router.into_make_service())
                 .await
                 .unwrap();

--- a/crates/agent/src/tests/common/mod.rs
+++ b/crates/agent/src/tests/common/mod.rs
@@ -128,11 +128,14 @@ pub async fn run_grpc_server(
     app: axum::Router<()>,
 ) -> eyre::Result<(SocketAddr, tokio::task::JoinHandle<()>)> {
     let listener = TcpListener::bind("127.0.0.1:0")?; // 0 let OS choose available port
+    listener.set_nonblocking(true)?;
     let addr = listener.local_addr()?;
     let server_config = make_rustls_server_config()?;
     let join_handle = tokio::spawn(async move {
         let config = RustlsConfig::from_config(Arc::new(server_config));
         axum_server::from_tcp_rustls(listener, config)
+            // Safety: This only happens if the socket is nonblocking, and we already did set_nonblocking above.
+            .expect("BUG: Could not bind to listener")
             .serve(app.into_make_service())
             .await
             .unwrap();

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -80,7 +80,7 @@ askama_escape = { workspace = true }
 asn1-rs = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true, features = ["http2"] }
-axum-extra = { workspace = true, features = ["cookie", "cookie-private"] }
+axum-extra = { workspace = true, features = ["cookie", "cookie-private", "typed-header"] }
 base64 = { workspace = true }
 byteorder = { workspace = true }
 bytes = { workspace = true }
@@ -214,8 +214,8 @@ rcgen = { workspace = true }
 carbide-macros = { path = "../macros" }
 carbide-sqlx-testing = { path = "../sqlx-testing", default-features = false }
 carbide-prost-builder = { path = "../prost-builder" }
-carbide-nvlink-manager = { path = "../nvlink-manager", features = [ "test-support" ] }
-carbide-redfish = { path = "../redfish", features = [ "test-support" ] }
+carbide-nvlink-manager = { path = "../nvlink-manager", features = ["test-support"] }
+carbide-redfish = { path = "../redfish", features = ["test-support"] }
 carbide-utils = { path = "../utils", features = ["test-support"] }
 state-controller = { path = "../state-controller", features = ["test-support"] }
 carbide-ib-fabric = { path = "../ib-fabric", features = ["test-support"] }

--- a/crates/api/src/web/auth.rs
+++ b/crates/api/src/web/auth.rs
@@ -23,8 +23,9 @@ use axum::Extension;
 use axum::extract::{Query, State as AxumState};
 use axum::http::{HeaderValue, Method, StatusCode, header};
 use axum::response::{IntoResponse, Redirect, Response};
-use axum_extra::extract::Host;
+use axum_extra::TypedHeader;
 use axum_extra::extract::cookie::{Cookie, PrivateCookieJar};
+use axum_extra::headers::Host;
 use base64::Engine;
 use base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use http::HeaderMap;
@@ -57,12 +58,13 @@ pub struct AuthRequest {
 
 pub async fn callback(
     AxumState(_state): AxumState<Arc<Api>>,
-    Host(hostname): Host,
+    TypedHeader::<Host>(hostname): TypedHeader<Host>,
     request_headers: HeaderMap,
     Query(query): Query<AuthRequest>,
     Extension(oauth2_layer): Extension<Option<Oauth2Layer>>,
 ) -> AuthCallbackResponse {
     use AuthCallbackError::*;
+    let hostname = hostname.hostname().to_owned();
 
     let Some(oauth2_layer) = oauth2_layer else {
         return EmptyOauth2Layer.into();

--- a/crates/api/src/web/auth.rs
+++ b/crates/api/src/web/auth.rs
@@ -23,9 +23,7 @@ use axum::Extension;
 use axum::extract::{Query, State as AxumState};
 use axum::http::{HeaderValue, Method, StatusCode, header};
 use axum::response::{IntoResponse, Redirect, Response};
-use axum_extra::TypedHeader;
 use axum_extra::extract::cookie::{Cookie, PrivateCookieJar};
-use axum_extra::headers::Host;
 use base64::Engine;
 use base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use http::HeaderMap;
@@ -58,14 +56,11 @@ pub struct AuthRequest {
 
 pub async fn callback(
     AxumState(_state): AxumState<Arc<Api>>,
-    TypedHeader::<Host>(hostname): TypedHeader<Host>,
     request_headers: HeaderMap,
     Query(query): Query<AuthRequest>,
     Extension(oauth2_layer): Extension<Option<Oauth2Layer>>,
 ) -> AuthCallbackResponse {
     use AuthCallbackError::*;
-    let hostname = hostname.hostname().to_owned();
-
     let Some(oauth2_layer) = oauth2_layer else {
         return EmptyOauth2Layer.into();
     };
@@ -74,30 +69,6 @@ pub async fn callback(
         &request_headers,
         oauth2_layer.private_cookiejar_key.clone(),
     );
-
-    // Cookies with domain `localhost:1079` might not be attached to browser requests
-    // to the hostname `localhost:1079` (tested on Firefox).
-    //
-    // This isn't a problem when going through Kubernetes, which strips the port before
-    // a request reaches carbide-api. It is a problem for local development outside of
-    // Kubernetes.
-    //
-    // https://stackoverflow.com/a/16328399 references https://www.rfc-editor.org/rfc/rfc6265#section-8.5
-    // which states that cookies are not necessarily isolated by port.
-    #[cfg(not(feature = "linux-build"))]
-    let Some(stripped_hostname) = http::Uri::try_from(hostname.clone())
-        .ok()
-        .and_then(|uri| uri.host().map(|host| host.to_owned()))
-    else {
-        return MissingHost.into();
-    };
-    // Extra gating of the override.
-    #[cfg(not(feature = "linux-build"))]
-    let hostname = if hostname.starts_with("localhost") {
-        stripped_hostname
-    } else {
-        hostname
-    };
 
     // See if the caller is really some other app/script
     // calling in with a secret we assigned to it.
@@ -140,7 +111,6 @@ pub async fn callback(
                 now_seconds + CLIENT_CREDENTIALS_FLOW_SESSION_EXPIRATION_SECONDS as u64
             ),
         ))
-        .domain(hostname.clone())
         .path("/")
         .secure(true)
         .http_only(true)
@@ -346,21 +316,18 @@ pub async fn callback(
     //
     // TODO: figure out what to do if no identity provider (e.g. when using admin + local dev password)
     let sid_cookie = Cookie::build(("sid", format!("{}", now_seconds + exp_secs)))
-        .domain(hostname.clone())
         .path("/")
         .secure(true)
         .http_only(true)
         .max_age(Duration::seconds(secs))
         .build();
     let name_cookie = Cookie::build(("name", user.name))
-        .domain(hostname.clone())
         .path("/")
         .secure(true)
         .http_only(true)
         .max_age(Duration::seconds(secs))
         .build();
     let group_cookie = Cookie::build(("group_name", group_name.to_string()))
-        .domain(hostname.clone())
         .path("/")
         .secure(true)
         .http_only(true)
@@ -375,7 +342,6 @@ pub async fn callback(
             .unwrap_or(&user.unique_name)
             .to_owned(),
     ))
-    .domain(hostname.clone())
     .path("/")
     .secure(true)
     .http_only(true)
@@ -416,9 +382,6 @@ pub enum AuthCallbackResponse {
 pub enum AuthCallbackError {
     #[error("expected oauth2 extension layer is empty")]
     EmptyOauth2Layer,
-    #[cfg(not(feature = "linux-build"))]
-    #[error("invalid hostname missing host")]
-    MissingHost,
     #[error(
         "bad token response from external auth service when exchanging client credentials: {0}"
     )]

--- a/crates/api/src/web/mod.rs
+++ b/crates/api/src/web/mod.rs
@@ -27,8 +27,9 @@ use axum::extract::{Path as AxumPath, State as AxumState};
 use axum::middleware::Next;
 use axum::response::{Html, IntoResponse, Redirect, Response};
 use axum::routing::{Router, get, post};
-use axum_extra::extract::Host;
+use axum_extra::TypedHeader;
 use axum_extra::extract::cookie::{Cookie, Key, PrivateCookieJar};
+use axum_extra::headers::Host;
 use carbide_authn::middleware::Principal;
 use http::header::CONTENT_TYPE;
 use http::{HeaderMap, Request, StatusCode, Uri};
@@ -759,7 +760,7 @@ pub fn routes(api: Arc<Api>) -> eyre::Result<NormalizePath<Router>> {
 }
 
 pub async fn auth_oauth2(
-    Host(hostname): Host,
+    TypedHeader::<Host>(hostname): TypedHeader<Host>,
     headers: HeaderMap,
     mut req: Request<AxumBody>,
     next: Next,
@@ -768,7 +769,7 @@ pub async fn auth_oauth2(
     // does not apply for the a page hosted on localhost:1079. Instead the cookie
     // must be for localhost.
 
-    let Some(hostname) = Uri::try_from(hostname)
+    let Some(hostname) = Uri::try_from(hostname.hostname())
         .ok()
         .and_then(|uri| uri.host().map(|host| host.to_owned()))
     else {

--- a/crates/api/src/web/mod.rs
+++ b/crates/api/src/web/mod.rs
@@ -27,12 +27,10 @@ use axum::extract::{Path as AxumPath, State as AxumState};
 use axum::middleware::Next;
 use axum::response::{Html, IntoResponse, Redirect, Response};
 use axum::routing::{Router, get, post};
-use axum_extra::TypedHeader;
 use axum_extra::extract::cookie::{Cookie, Key, PrivateCookieJar};
-use axum_extra::headers::Host;
 use carbide_authn::middleware::Principal;
 use http::header::CONTENT_TYPE;
-use http::{HeaderMap, Request, StatusCode, Uri};
+use http::{HeaderMap, Request, StatusCode};
 use itertools::Itertools;
 use oauth2::basic::{
     BasicClient, BasicErrorResponse, BasicRevocationErrorResponse, BasicTokenIntrospectionResponse,
@@ -760,22 +758,10 @@ pub fn routes(api: Arc<Api>) -> eyre::Result<NormalizePath<Router>> {
 }
 
 pub async fn auth_oauth2(
-    TypedHeader::<Host>(hostname): TypedHeader<Host>,
     headers: HeaderMap,
     mut req: Request<AxumBody>,
     next: Next,
 ) -> Result<Response, StatusCode> {
-    // Remove the port (this matters on localhost) since a cookie for localhost:1079
-    // does not apply for the a page hosted on localhost:1079. Instead the cookie
-    // must be for localhost.
-
-    let Some(hostname) = Uri::try_from(hostname.hostname())
-        .ok()
-        .and_then(|uri| uri.host().map(|host| host.to_owned()))
-    else {
-        return Err(StatusCode::INTERNAL_SERVER_ERROR);
-    };
-
     let oauth_extension_layer = match req.extensions().get::<Option<Oauth2Layer>>() {
         None => {
             tracing::error!("failed to find oauth2 extension layer");
@@ -849,7 +835,6 @@ pub async fn auth_oauth2(
     // during code exchange when they hit our callback URL.
     // Using this with a cookie is a little weird, but it'll be encrypted.
     let pkce_cookie = Cookie::build(("pkce_verifier", pkce_verifier.secret().to_owned()))
-        .domain(hostname.clone())
         .path("/")
         .secure(true)
         .http_only(true)
@@ -858,7 +843,6 @@ pub async fn auth_oauth2(
     // Store the csrf state so we can compare the state we get back from Azure
     // when they hit our callback URL.
     let csrf_cookie = Cookie::build(("csrf_state", csrf_state.secret().to_owned()))
-        .domain(hostname.clone())
         .path("/")
         .secure(true)
         .http_only(true)
@@ -873,7 +857,6 @@ pub async fn auth_oauth2(
             .unwrap_or_else(|| req.uri().path())
             .to_string(),
     ))
-    .domain(hostname)
     .path("/")
     .secure(true)
     .http_only(true)

--- a/crates/bmc-mock/src/combined_server.rs
+++ b/crates/bmc-mock/src/combined_server.rs
@@ -52,7 +52,7 @@ impl ListenerOrAddress {
 #[derive(Debug)]
 pub struct CombinedServer {
     join_handle: Option<JoinHandle<std::io::Result<()>>>,
-    axum_handle: axum_server::Handle,
+    axum_handle: axum_server::Handle<SocketAddr>,
     pub address: SocketAddr,
 }
 
@@ -84,10 +84,15 @@ impl CombinedServer {
                 addr,
                 axum_server::bind_rustls(addr, config).handle(axum_handle.clone()),
             ),
-            Some(ListenerOrAddress::Listener(listener)) => (
-                listener.local_addr().unwrap(),
-                axum_server::from_tcp_rustls(listener, config).handle(axum_handle.clone()),
-            ),
+            Some(ListenerOrAddress::Listener(listener)) => {
+                listener.set_nonblocking(true).ok();
+                (
+                    listener.local_addr().unwrap(),
+                    // Note: This only fails if the listener is not configured as non-blocking. If
+                    // we couldn't configure it as such, it was likely in use.
+                    axum_server::from_tcp_rustls(listener, config).expect("BUG: Failure confguring rustls listner: Socket could not be configured as nonblocking. Maybe already in use?").handle(axum_handle.clone()),
+                )
+            }
             None => {
                 let addr = SocketAddr::from(([0, 0, 0, 0], 1266));
                 (

--- a/crates/fmds/src/rest_server.rs
+++ b/crates/fmds/src/rest_server.rs
@@ -357,6 +357,8 @@ async fn post_phone_home(State(state): State<Arc<FmdsState>>) -> (StatusCode, St
 
 #[cfg(test)]
 mod tests {
+    use std::net::SocketAddr;
+
     use axum::http;
     use forge_dpu_fmds_shared::machine_identity::MachineIdentityParams;
     use http_body_util::{BodyExt, Full};
@@ -393,10 +395,9 @@ mod tests {
         let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 0));
         let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
         let server_port = listener.local_addr().unwrap().port();
-        let std_listener = listener.into_std().unwrap();
 
         let server = tokio::spawn(async move {
-            axum_server::Server::from_tcp(std_listener)
+            axum_server::Server::<SocketAddr>::from_listener(listener)
                 .serve(router.into_make_service())
                 .await
                 .unwrap();


### PR DESCRIPTION
## Description

This is part of a series of PR's to update all "breaking" dependencies that require code changes on our part. Once they are all merged, we will do a final cargo update and be on the latest versions of all dependencies.

Important to note here, axum removed the Host and Scheme extractors from axum-extra: https://github.com/tokio-rs/axum/issues/3442

This is because the old extractors were trusting X-Forwarded-For, which is spoofable and can be a security risk. But it turns out we're only using them for setting the `domain` field for the auth cookie we send the user. But we can just skip that: Cookies without a domain are implicitly scoped to the host they were given by, so we don't need the host extractor at all.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

