### PR TITLE
Consistently render state and state history in web-ui

### DIFF
--- a/crates/api/src/web/filters.rs
+++ b/crates/api/src/web/filters.rs
@@ -229,10 +229,6 @@ pub fn option_fmt_or(value: &Option<impl Display>, default: &str) -> askama::Res
     })
 }
 
-pub(crate) fn normalize_state_label(state: impl Display) -> String {
-    state_and_substate_labels(state).0
-}
-
 pub(crate) fn state_and_substate_labels(state_json: impl Display) -> (String, String) {
     let state_json = state_json.to_string();
     let Ok(value) = serde_json::from_str::<serde_json::Value>(&state_json) else {

--- a/crates/api/src/web/machine.rs
+++ b/crates/api/src/web/machine.rs
@@ -47,9 +47,7 @@ struct MachineShow {
 struct MachineRowDisplay {
     id: String,
     hostname: String,
-    state: String,
-    time_in_state: String,
-    time_in_state_above_sla: bool,
+    state_display: super::StateDisplay,
     associated_dpu_ids: Vec<String>,
     associated_host_id: String,
     sys_vendor: String,
@@ -130,16 +128,20 @@ impl MachineRowDisplay {
             })
             .unwrap_or_else(health_report::HealthReport::missing_report);
 
+        let time_in_state_above_sla = m
+            .state_sla
+            .as_ref()
+            .map(|sla| sla.time_in_state_above_sla)
+            .unwrap_or_default();
+        let state_display = super::StateDisplay {
+            state: m.state,
+            time_in_state_above_sla,
+        };
+
         MachineRowDisplay {
             hostname,
             id: m.id.map(|id| id.to_string()).unwrap_or_default(),
-            state: m.state,
-            time_in_state: config_version::since_state_change_humanized(&m.state_version),
-            time_in_state_above_sla: m
-                .state_sla
-                .as_ref()
-                .map(|sla| sla.time_in_state_above_sla)
-                .unwrap_or_default(),
+            state_display,
             ip_address,
             mac_address,
             is_host: m.machine_type == forgerpc::MachineType::Host as i32,

--- a/crates/api/src/web/mod.rs
+++ b/crates/api/src/web/mod.rs
@@ -121,11 +121,29 @@ impl HealthDetail {
 
 /// Reusable template for rendering a color-coded state bubble.
 /// Render with `{{ state_display|safe }}`.
-#[derive(Template)]
+#[derive(Debug, Clone, PartialEq, Eq, Template)]
 #[template(path = "state_display.html")]
 pub(crate) struct StateDisplay {
     pub state: String,
     pub time_in_state_above_sla: bool,
+}
+
+impl StateDisplay {
+    pub fn from_lifecycle(lifecycle: Option<&forgerpc::LifecycleStatus>) -> Self {
+        let state = lifecycle
+            .map(|lifecycle| lifecycle.state.clone())
+            .filter(|state| !state.is_empty())
+            .unwrap_or_else(|| r#"{ "state": "unknown" }"#.to_string());
+        let time_in_state_above_sla = lifecycle
+            .and_then(|lifecycle| lifecycle.sla.as_ref())
+            .map(|sla| sla.time_in_state_above_sla)
+            .unwrap_or(false);
+
+        Self {
+            state,
+            time_in_state_above_sla,
+        }
+    }
 }
 
 /// Reusable template for rendering State SLA, time-in-state-above-SLA, and

--- a/crates/api/src/web/power_shelf.rs
+++ b/crates/api/src/web/power_shelf.rs
@@ -26,16 +26,9 @@ use carbide_uuid::power_shelf::PowerShelfId;
 use hyper::http::StatusCode;
 use rpc::forge::forge_server::Forge;
 
+use super::state_history::StateHistoryTable;
 use super::{Base, filters};
 use crate::api::Api;
-
-fn capitalize(s: &str) -> String {
-    let mut c = s.chars();
-    match c.next() {
-        None => String::new(),
-        Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
-    }
-}
 
 #[derive(Template)]
 #[template(path = "power_shelf_show.html")]
@@ -43,11 +36,11 @@ struct PowerShelfShow {
     power_shelves: Vec<PowerShelfRecord>,
 }
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug)]
 struct PowerShelfRecord {
     id: String,
     name: String,
-    state: String,
+    state_display: super::StateDisplay,
     capacity: String,
     voltage: String,
 }
@@ -70,18 +63,15 @@ pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
         .power_shelves
         .into_iter()
         .map(|shelf| {
-            let state = shelf
-                .status
-                .as_ref()
-                .and_then(|s| s.controller_state.clone())
-                .map(|s| capitalize(&s))
-                .unwrap_or_else(|| "Unknown".to_string());
+            let status = shelf.status.as_ref();
+            let lifecycle = status.and_then(|status| status.lifecycle.as_ref());
+            let state_display = super::StateDisplay::from_lifecycle(lifecycle);
 
             let config = shelf.config.unwrap_or_default();
             PowerShelfRecord {
                 id: shelf.id.map(|id| id.to_string()).unwrap_or_default(),
                 name: config.name,
-                state,
+                state_display,
                 capacity: config
                     .capacity
                     .map(|c| c.to_string())
@@ -128,10 +118,11 @@ struct PowerShelfDetail {
     bmc_info: Option<rpc::forge::BmcInfo>,
     metadata_detail: super::MetadataDetail,
     health_detail: super::HealthDetail,
+    history: StateHistoryTable,
 }
 
 impl PowerShelfDetail {
-    fn new(shelf: rpc::forge::PowerShelf) -> Self {
+    fn new(shelf: rpc::forge::PowerShelf, history: StateHistoryTable) -> Self {
         let id = shelf
             .id
             .as_ref()
@@ -175,6 +166,7 @@ impl PowerShelfDetail {
             bmc_info: shelf.bmc_info,
             metadata_detail,
             health_detail,
+            history,
         }
     }
 }
@@ -201,7 +193,22 @@ pub async fn detail(
         return (StatusCode::OK, Json(shelf)).into_response();
     }
 
-    let detail = PowerShelfDetail::new(shelf);
+    let history = match super::state_history::fetch_power_shelf_state_history_records(
+        &api,
+        &power_shelf_id,
+    )
+    .await
+    {
+        Ok((_power_shelf_id, records)) => StateHistoryTable {
+            records: records.into_iter().map(Into::into).collect(),
+        },
+        Err((code, err)) => {
+            tracing::error!(%code, %err, %power_shelf_id, "fetch_power_shelf_state_history_records");
+            StateHistoryTable { records: vec![] }
+        }
+    };
+
+    let detail = PowerShelfDetail::new(shelf, history);
     (StatusCode::OK, Html(detail.render().unwrap())).into_response()
 }
 

--- a/crates/api/src/web/rack.rs
+++ b/crates/api/src/web/rack.rs
@@ -26,13 +26,45 @@ use carbide_uuid::rack::RackId;
 use hyper::http::StatusCode;
 use rpc::forge::forge_server::Forge;
 
+use super::state_history::StateHistoryTable;
 use super::{Base, filters};
 use crate::api::Api;
 
 #[derive(Template)]
 #[template(path = "rack_show.html")]
 struct Racks {
-    racks: Vec<rpc::forge::Rack>,
+    racks: Vec<RackRecord>,
+}
+
+struct RackRecord {
+    id: String,
+    state_display: super::StateDisplay,
+    compute_trays_count: usize,
+    expected_compute_trays_count: usize,
+    power_shelves_count: usize,
+    expected_power_shelves_count: usize,
+    switches_count: usize,
+    expected_nvlink_switches_count: usize,
+}
+
+impl From<rpc::forge::Rack> for RackRecord {
+    fn from(rack: rpc::forge::Rack) -> Self {
+        let lifecycle = rack
+            .status
+            .as_ref()
+            .and_then(|status| status.lifecycle.as_ref());
+
+        Self {
+            id: rack.id.map(|id| id.to_string()).unwrap_or_default(),
+            state_display: super::StateDisplay::from_lifecycle(lifecycle),
+            compute_trays_count: rack.compute_trays.len(),
+            expected_compute_trays_count: rack.expected_compute_trays.len(),
+            power_shelves_count: rack.power_shelves.len(),
+            expected_power_shelves_count: rack.expected_power_shelves.len(),
+            switches_count: rack.switches.len(),
+            expected_nvlink_switches_count: rack.expected_nvlink_switches.len(),
+        }
+    }
 }
 
 #[derive(Template)]
@@ -46,14 +78,7 @@ struct RackDetail {
     associated_switches: Vec<String>,
     associated_power_shelves: Vec<String>,
     metadata_detail: super::MetadataDetail,
-    history: Vec<RackStateHistoryRecord>,
-}
-
-#[derive(Debug)]
-struct RackStateHistoryRecord {
-    state: String,
-    version: String,
-    time: String,
+    history: StateHistoryTable,
 }
 
 /// Show all racks
@@ -66,7 +91,9 @@ pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
         }
     };
 
-    let display = Racks { racks: racks.racks };
+    let display = Racks {
+        racks: racks.racks.into_iter().map(Into::into).collect(),
+    };
     (StatusCode::OK, Html(display.render().unwrap())).into_response()
 }
 
@@ -222,7 +249,20 @@ pub async fn detail(
             .unwrap_or_default(),
     );
 
-    let history = fetch_rack_state_history(&api, &rack_id).await;
+    let history = match super::state_history::fetch_rack_state_history_records(
+        &api,
+        rack_id.as_ref(),
+    )
+    .await
+    {
+        Ok((_rack_id, records)) => StateHistoryTable {
+            records: records.into_iter().map(Into::into).collect(),
+        },
+        Err((code, err)) => {
+            tracing::error!(%code, %err, %rack_id, "fetch_rack_state_history_records");
+            StateHistoryTable { records: vec![] }
+        }
+    };
 
     let display = RackDetail {
         id: rack_id.to_string(),
@@ -289,38 +329,6 @@ async fn fetch_power_shelf_ids(api: &Api, rack_id: &RackId) -> Result<Vec<String
         .into_iter()
         .map(|id| id.to_string())
         .collect())
-}
-
-async fn fetch_rack_state_history(api: &Api, rack_id: &RackId) -> Vec<RackStateHistoryRecord> {
-    let request = tonic::Request::new(rpc::forge::RackStateHistoriesRequest {
-        rack_ids: vec![rack_id.clone()],
-    });
-
-    match api.find_rack_state_histories(request).await {
-        Ok(response) => {
-            let mut histories = response.into_inner().histories;
-            let mut records = histories
-                .remove(&rack_id.to_string())
-                .unwrap_or_default()
-                .records;
-            records.reverse();
-            records
-                .into_iter()
-                .map(|r| RackStateHistoryRecord {
-                    state: r.state,
-                    version: r.version,
-                    time: r
-                        .time
-                        .map(|t| t.to_string())
-                        .unwrap_or_else(|| "N/A".to_string()),
-                })
-                .collect()
-        }
-        Err(err) => {
-            tracing::error!(%err, "fetch_rack_state_history");
-            vec![]
-        }
-    }
 }
 
 impl super::Base for Racks {}

--- a/crates/api/src/web/switch.rs
+++ b/crates/api/src/web/switch.rs
@@ -26,6 +26,7 @@ use carbide_uuid::switch::SwitchId;
 use hyper::http::StatusCode;
 use rpc::forge::forge_server::Forge;
 
+use super::state_history::StateHistoryTable;
 use super::{Base, filters};
 use crate::api::Api;
 
@@ -35,11 +36,11 @@ struct SwitchShow {
     switches: Vec<SwitchRecord>,
 }
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug)]
 struct SwitchRecord {
     id: String,
     name: String,
-    state: String,
+    state_display: super::StateDisplay,
     slot_number: String,
     tray_index: String,
 }
@@ -58,18 +59,15 @@ pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
         .switches
         .into_iter()
         .map(|switch| {
-            let state = switch
-                .status
-                .as_ref()
-                .and_then(|status| status.lifecycle.as_ref())
-                .map(|lifecycle| super::filters::normalize_state_label(&lifecycle.state))
-                .unwrap_or_else(|| "Unknown".to_string());
+            let status = switch.status.as_ref();
+            let lifecycle = status.and_then(|status| status.lifecycle.as_ref());
+            let state_display = super::StateDisplay::from_lifecycle(lifecycle);
 
             let config = switch.config.unwrap_or_default();
             SwitchRecord {
                 id: switch.id.map(|id| id.to_string()).unwrap_or_default(),
                 name: config.name,
-                state,
+                state_display,
                 slot_number: switch
                     .placement_in_rack
                     .as_ref()
@@ -152,10 +150,11 @@ struct SwitchDetail {
     bmc_info: Option<rpc::forge::BmcInfo>,
     metadata_detail: super::MetadataDetail,
     health_detail: super::HealthDetail,
+    history: StateHistoryTable,
 }
 
 impl SwitchDetail {
-    fn new(switch: rpc::forge::Switch) -> Self {
+    fn new(switch: rpc::forge::Switch, history: StateHistoryTable) -> Self {
         let id = switch
             .id
             .as_ref()
@@ -199,6 +198,7 @@ impl SwitchDetail {
             bmc_info: switch.bmc_info,
             metadata_detail,
             health_detail,
+            history,
         }
     }
 }
@@ -225,7 +225,18 @@ pub async fn detail(
         return (StatusCode::OK, Json(switch)).into_response();
     }
 
-    let detail = SwitchDetail::new(switch);
+    let history =
+        match super::state_history::fetch_switch_state_history_records(&api, &switch_id).await {
+            Ok((_switch_id, records)) => StateHistoryTable {
+                records: records.into_iter().map(Into::into).collect(),
+            },
+            Err((code, err)) => {
+                tracing::error!(%code, %err, %switch_id, "fetch_switch_state_history_records");
+                StateHistoryTable { records: vec![] }
+            }
+        };
+
+    let detail = SwitchDetail::new(switch, history);
     (StatusCode::OK, Html(detail.render().unwrap())).into_response()
 }
 

--- a/crates/api/templates/machine_detail.html
+++ b/crates/api/templates/machine_detail.html
@@ -417,7 +417,7 @@ Missing BMC Data
 
 
 <h3>History</h3>
-<a href="/admin/machine/{{ id }}/state-history">Open History on separate page</a>
+<a href="/admin/machine/{{ id }}/state-history">Open State History on separate page</a>
 {{ history|safe }}
 
 <script>

--- a/crates/api/templates/machine_show.html
+++ b/crates/api/templates/machine_show.html
@@ -35,30 +35,7 @@
 		<tr>
 			<td>{{ loop.index }}</td> 
 			<td>{{ m.id|machine_id_link|safe }}</td>
-			<td>
-				{% if m.state.to_lowercase().contains("failed") %}
-					<span class="bubble error">
-						{{ m.state }}
-						{% if !m.state.contains("Ready") %}({{ m.time_in_state }}){% endif %}
-						{% if m.time_in_state_above_sla %}⏱️{% endif %}
-					</span>
-				{% else if m.time_in_state_above_sla %}
-					<span class="bubble warning">
-						{{ m.state }}
-						{% if !m.state.contains("Ready") %}({{ m.time_in_state }}){% endif %}
-						⏱️
-					</span>
-				{% else if m.state == "Ready" || m.state == "Assigned/Ready" %}
-					<span class="bubble success">
-						{{ m.state }}
-					</span>
-				{% else %}
-					<span class="bubble">
-						{{ m.state }}
-						{% if !m.state.contains("Ready") %}({{ m.time_in_state }}){% endif %}
-					</span>
-				{% endif %}
-			</td>
+			<td>{{ m.state_display|safe }}</td>
 			<td>
 				<a href="/admin/machine/{{ m.id }}/health">
 					{{ m.health_probe_alerts|health_alerts_fmt(false, false)|safe }}

--- a/crates/api/templates/power_shelf_detail.html
+++ b/crates/api/templates/power_shelf_detail.html
@@ -85,6 +85,7 @@
 </table>
 
 <h2>History</h2>
-<a href="/admin/power-shelf/{{ id }}/state-history">Open State History</a>
+<a href="/admin/power-shelf/{{ id }}/state-history">Open State History on separate page</a>
+{{ history|safe }}
 
 {% endblock %}

--- a/crates/api/templates/power_shelf_show.html
+++ b/crates/api/templates/power_shelf_show.html
@@ -35,7 +35,7 @@
                             <tr>
                                 <td>{{ shelf.id|power_shelf_id_link|safe }}</td>
                                 <td>{{ shelf.name }}</td>
-                                <td>{{ shelf.state }}</td>
+                                <td>{{ shelf.state_display|safe }}</td>
                                 <td>{{ shelf.capacity }}</td>
                                 <td>{{ shelf.voltage }}</td>
                                 <td>

--- a/crates/api/templates/rack_detail.html
+++ b/crates/api/templates/rack_detail.html
@@ -78,29 +78,7 @@
 </table>
 
 <h2>History</h2>
-{% if !history.is_empty() %}
-<div class="table-responsive">
-	<table class="table table-striped">
-		<thead>
-		<tr>
-			<th>State</th>
-			<th>Version</th>
-			<th>Time</th>
-		</tr>
-		</thead>
-		<tbody>
-		{% for record in history %}
-		<tr>
-			<td>{{ record.state }}</td>
-			<td>{{ record.version }}</td>
-			<td>{{ record.time }}</td>
-		</tr>
-		{% endfor %}
-		</tbody>
-	</table>
-</div>
-{% else %}
-<p class="text-muted">No state history available.</p>
-{% endif %}
+<a href="/admin/rack/{{ id }}/state-history">Open State History on separate page</a>
+{{ history|safe }}
 
 {% endblock %}

--- a/crates/api/templates/rack_show.html
+++ b/crates/api/templates/rack_show.html
@@ -32,11 +32,11 @@
                             <tbody>
                             {% for rack in racks %}
                             <tr>
-                                <td>{{ rack.id|option_fmt|rack_id_link|safe }}</td>
-                                <td>{{ rack.rack_state }}</td>
-                                <td>{{ rack.compute_trays.len() }} / {{ rack.expected_compute_trays.len() }}</td>
-                                <td>{{ rack.power_shelves.len() }} / {{ rack.expected_power_shelves.len() }}</td>
-                                <td>{{ rack.switches.len() }} / {{ rack.expected_nvlink_switches.len() }}</td>
+                                <td>{{ rack.id|rack_id_link|safe }}</td>
+                                <td>{{ rack.state_display|safe }}</td>
+                                <td>{{ rack.compute_trays_count }} / {{ rack.expected_compute_trays_count }}</td>
+                                <td>{{ rack.power_shelves_count }} / {{ rack.expected_power_shelves_count }}</td>
+                                <td>{{ rack.switches_count }} / {{ rack.expected_nvlink_switches_count }}</td>
                             </tr>
                             {% endfor %}
                             </tbody>

--- a/crates/api/templates/state_display.html
+++ b/crates/api/templates/state_display.html
@@ -1,5 +1,5 @@
 {% set display_state = state|state_with_substate_label %}
-{% if display_state.to_lowercase().contains("failed") %}
+{% if display_state.to_lowercase().contains("failed") || display_state.to_lowercase().contains("error") %}
 	<span class="bubble error">{{ display_state }}{% if time_in_state_above_sla %} ⏱️{% endif %}</span>
 {% else if time_in_state_above_sla %}
 	<span class="bubble warning">{{ display_state }} ⏱️</span>

--- a/crates/api/templates/switch_detail.html
+++ b/crates/api/templates/switch_detail.html
@@ -115,6 +115,7 @@
 <p>TBD</p>
 
 <h2>History</h2>
-<a href="/admin/switch/{{ id }}/state-history">Open State History</a>
+<a href="/admin/switch/{{ id }}/state-history">Open State History on separate page</a>
+{{ history|safe }}
 
 {% endblock %}

--- a/crates/api/templates/switch_show.html
+++ b/crates/api/templates/switch_show.html
@@ -35,15 +35,7 @@
                             <tr>
                                 <td>{{ switch.id|switch_id_link|safe }}</td>
                                 <td>{{ switch.name }}</td>
-                                <td>
-                                    {% if switch.state == "Ready" %}
-                                        <span class="bubble success">{{ switch.state }}</span>
-                                    {% else if switch.state.to_lowercase().contains("error") || switch.state.to_lowercase().contains("failed") %}
-                                        <span class="bubble error">{{ switch.state }}</span>
-                                    {% else %}
-                                        <span class="bubble">{{ switch.state }}</span>
-                                    {% endif %}
-                                </td>
+                                <td>{{ switch.state_display|safe }}</td>
                                 <td>{{ switch.slot_number }}</td>
                                 <td>{{ switch.tray_index }}</td>
                                 <td>


### PR DESCRIPTION
## Description

Renders the state bubbles on more machine, rack, switch and powershelf pages in consistent fashion. Thereby drops the "time in state" indicator on the machine page (but the info is still available on the details pages).

Also adds inline state history on the details pages of switches and powershelves, and applies changes to render the inline state histories and links to separate state history pages consistently.

## Type of Change

- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

