### PR TITLE
Update "Publish Fern Docs" workflow path triggers

### DIFF
--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -13,10 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Publishes the Fern documentation site when a docs tag is pushed or manually triggered.
-#
-# To publish:  git tag docs/v1.2.0 && git push origin docs/v1.2.0
-# Or use the "Run workflow" button in the Actions tab.
+# Publishes the Fern documentation site on push to main when fern/, docs/, or this
+# workflow file changes, or when manually triggered from the Actions tab.
 #
 # Required configuration:
 # - Organization secret: DOCS_FERN_TOKEN (from `fern token` for the nvidia Fern org)
@@ -29,6 +27,7 @@ on:
       - main
     paths:
       - 'fern/**'
+      - 'docs/**'
       - '.github/workflows/publish-fern-docs.yml'
   workflow_dispatch: {}
 


### PR DESCRIPTION
Modifies the workflow to run when "docs/" is touched, not just "fern/".
-e

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

