### PR TITLE
chore: Remove name field from Vpc object

### DIFF
--- a/crates/admin-cli/src/instance/show/cmd.rs
+++ b/crates/admin-cli/src/instance/show/cmd.rs
@@ -256,7 +256,8 @@ async fn convert_instance_to_nice_format(
                 (
                     "VPC NAME",
                     vpc.as_ref()
-                        .map(|v| v.name.as_str().into())
+                        .and_then(|v| v.metadata.as_ref())
+                        .map(|v| Cow::Borrowed(v.name.as_str()))
                         .unwrap_or("<not found>".into()),
                 ),
             ];

--- a/crates/admin-cli/src/network_security_group/attach/cmd.rs
+++ b/crates/admin-cli/src/network_security_group/attach/cmd.rs
@@ -80,13 +80,7 @@ pub async fn attach(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> 
         // Submit the VPC details back to the system but change the
         // NSG ID value.
         let _vpc = api_client
-            .update_vpc_config(
-                v,
-                vpc.version,
-                vpc.name,
-                vpc.metadata,
-                Some(args.id.clone()),
-            )
+            .update_vpc_config(v, vpc.version, vpc.metadata, Some(args.id.clone()))
             .await?;
 
         println!(

--- a/crates/admin-cli/src/network_security_group/detach/cmd.rs
+++ b/crates/admin-cli/src/network_security_group/detach/cmd.rs
@@ -77,7 +77,7 @@ pub async fn detach(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> 
         // VPC details we just grabbed and only clear
         // the NSG ID field.
         let _vpc = api_client
-            .update_vpc_config(v, vpc.version, vpc.name, vpc.metadata, None)
+            .update_vpc_config(v, vpc.version, vpc.metadata, None)
             .await?;
 
         println!("Network security group successfully detached from VPC {v}");

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -898,7 +898,6 @@ impl ApiClient {
         let vpc = match self
             .0
             .create_vpc(VpcCreationRequest {
-                name: name.to_string(),
                 vni: None,
                 routing_profile_type: None,
                 tenant_organization_id: "devenv_test_org".to_string(),
@@ -1668,12 +1667,10 @@ impl ApiClient {
         &self,
         vpc_id: VpcId,
         version: String,
-        name: String,
         metadata: Option<rpc::Metadata>,
         network_security_group_id: Option<String>,
     ) -> CarbideCliResult<rpc::Vpc> {
         let request = rpc::VpcUpdateRequest {
-            name,
             id: Some(vpc_id),
             if_version_match: Some(version),
             metadata,

--- a/crates/admin-cli/src/vpc/show/cmd.rs
+++ b/crates/admin-cli/src/vpc/show/cmd.rs
@@ -123,7 +123,7 @@ fn convert_vpcs_to_nice_table(vpcs: forgerpc::VpcList) -> Box<Table> {
 
         table.add_row(row![
             vpc.id.unwrap_or_default(),
-            vpc.name,
+            metadata.name,
             vpc.tenant_organization_id,
             vpc.network_security_group_id.unwrap_or_default(),
             vpc.version,
@@ -149,9 +149,15 @@ fn convert_vpc_to_nice_format(vpc: &forgerpc::Vpc) -> CarbideCliResult<String> {
     let width = 25;
     let mut lines = String::new();
 
+    let vpc_name = vpc
+        .metadata
+        .as_ref()
+        .map(|x| Cow::Borrowed(x.name.as_str()))
+        .unwrap_or("<no name>".into());
+
     let data: Vec<(&'static str, Cow<str>)> = vec![
         ("ID", vpc.id.unwrap_or_default().to_string().into()),
-        ("NAME", vpc.name.as_str().into()),
+        ("NAME", vpc_name),
         ("TENANT ORG", vpc.tenant_organization_id.as_str().into()),
         (
             "NETWORK SECURITY GROUP",

--- a/crates/api-model/src/vpc.rs
+++ b/crates/api-model/src/vpc.rs
@@ -144,7 +144,6 @@ impl From<Vpc> for rpc::forge::Vpc {
         rpc::forge::Vpc {
             id: Some(src.id),
             version: src.version.version_string(),
-            name: src.metadata.name.clone(),
             tenant_organization_id: src.tenant_organization_id,
             network_security_group_id: src
                 .network_security_group_id
@@ -203,20 +202,10 @@ impl TryFrom<rpc::forge::VpcCreationRequest> for NewVpc {
         };
         let id = value.id.unwrap_or_else(|| uuid::Uuid::new_v4().into());
 
-        // If Metadata isn't passed or empty, then use the old name field
-        let use_legacy_name = if let Some(metadata) = &value.metadata {
-            metadata.name.is_empty()
-        } else {
-            true
-        };
-
-        let mut metadata = match value.metadata {
+        let metadata = match value.metadata {
             Some(metadata) => metadata.try_into()?,
             None => Metadata::new_with_default_name(),
         };
-        if use_legacy_name {
-            metadata.name = value.name;
-        }
 
         metadata.validate(true).map_err(|e| {
             RpcDataConversionError::InvalidArgument(format!("VPC metadata is not valid: {e}"))
@@ -262,20 +251,10 @@ impl TryFrom<rpc::forge::VpcUpdateRequest> for UpdateVpc {
                 None => None,
             };
 
-        // If Metadata isn't passed or empty, then use the old name field
-        let use_legacy_name = if let Some(metadata) = &value.metadata {
-            metadata.name.is_empty()
-        } else {
-            true
-        };
-
-        let mut metadata = match value.metadata {
+        let metadata = match value.metadata {
             Some(metadata) => metadata.try_into()?,
             None => Metadata::new_with_default_name(),
         };
-        if use_legacy_name {
-            metadata.name = value.name;
-        }
 
         metadata.validate(true).map_err(|e| {
             RpcDataConversionError::InvalidArgument(format!("VPC metadata is not valid: {e}"))

--- a/crates/api-test-helper/src/vpc.rs
+++ b/crates/api-test-helper/src/vpc.rs
@@ -23,7 +23,7 @@ pub async fn create(carbide_api_addrs: &[SocketAddr], tenant_org_id: &str) -> ey
     tracing::info!("Creating VPC");
 
     let data = serde_json::json!({
-        "name": "tenant_vpc",
+        "metadata": { "name": "tenant_vpc" },
         "tenantOrganizationId": tenant_org_id,
         "routing_profile_type": "EXTERNAL".to_string(),
     });
@@ -39,7 +39,7 @@ pub async fn create_fnn(
     tracing::info!("Creating FNN VPC");
 
     let data = serde_json::json!({
-        "name": "tenant_vpc_fnn",
+        "metadata": { "name": "tenant_vpc_fnn" },
         "tenantOrganizationId": tenant_org_id,
         "routing_profile_type": "EXTERNAL".to_string(),
         "network_virtualization_type": 5, // FNN

--- a/crates/api/src/handlers/vpc.rs
+++ b/crates/api/src/handlers/vpc.rs
@@ -37,16 +37,6 @@ pub(crate) async fn create(
     log_request_data(&request);
     let vpc_creation_request = request.get_ref();
 
-    if let Some(metadata) = &vpc_creation_request.metadata
-        && !vpc_creation_request.name.is_empty()
-        && metadata.name != vpc_creation_request.name
-    {
-        return Err(CarbideError::InvalidArgument(
-            "VPC name must be specified under metadata only.".to_string(),
-        )
-        .into());
-    }
-
     let mut txn = api.txn_begin().await?;
 
     // Grab the tenant details and a row-lock if found so we can coordinate around the tenant record.

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -847,10 +847,14 @@ impl TestEnv {
         Option<u32>,
         NetworkSegmentId,
     ) {
-        let vpc_details =
-            VpcCreationRequest::builder("test vpc", "2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
-                .network_virtualization_type(vtype1)
-                .tonic_request();
+        let vpc_details = VpcCreationRequest::builder("2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+            .metadata(Metadata {
+                name: "test vpc".to_string(),
+                description: "".to_string(),
+                labels: Default::default(),
+            })
+            .network_virtualization_type(vtype1)
+            .tonic_request();
 
         let vpc = self.api.create_vpc(vpc_details).await.unwrap().into_inner();
 
@@ -867,10 +871,13 @@ impl TestEnv {
         self.run_network_segment_controller_iteration().await;
         self.run_network_segment_controller_iteration().await;
 
-        let peer_vpc_details =
-            VpcCreationRequest::builder("test peer vpc", "e65a9d69-39d2-4872-a53e-e5cb87c84e75")
-                .network_virtualization_type(vtype2)
-                .tonic_request();
+        let peer_vpc_details = VpcCreationRequest::builder("e65a9d69-39d2-4872-a53e-e5cb87c84e75")
+            .metadata(Metadata {
+                name: "test peer vpc".to_string(),
+                ..Default::default()
+            })
+            .network_virtualization_type(vtype2)
+            .tonic_request();
 
         let peer_vpc = self
             .api
@@ -904,7 +911,12 @@ impl TestEnv {
 
     pub async fn create_vpc_and_tenant_segment(&self) -> NetworkSegmentId {
         self.create_vpc_and_tenant_segment_with_vpc_details(
-            VpcCreationRequest::builder("test vpc 1", "2829bbe3-c169-4cd9-8b2a-19a8b1618a93").rpc(),
+            VpcCreationRequest::builder("2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                .metadata(Metadata {
+                    name: "test vpc 1".to_string(),
+                    ..Default::default()
+                })
+                .rpc(),
         )
         .await
     }
@@ -914,7 +926,12 @@ impl TestEnv {
         segment_count: usize,
     ) -> Vec<NetworkSegmentId> {
         self.create_vpc_and_tenant_segments_with_vpc_details(
-            VpcCreationRequest::builder("test vpc 1", "2829bbe3-c169-4cd9-8b2a-19a8b1618a93").rpc(),
+            VpcCreationRequest::builder("2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                .metadata(Metadata {
+                    name: "test vpc 1".to_string(),
+                    ..Default::default()
+                })
+                .rpc(),
             segment_count,
         )
         .await
@@ -924,7 +941,11 @@ impl TestEnv {
         let vpc = self
             .api
             .create_vpc(
-                VpcCreationRequest::builder("test vpc 1", "2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                VpcCreationRequest::builder("2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                    .metadata(Metadata {
+                        name: "test vpc 1".to_string(),
+                        ..Default::default()
+                    })
                     .tonic_request(),
             )
             .await

--- a/crates/api/src/tests/common/api_fixtures/vpc.rs
+++ b/crates/api/src/tests/common/api_fixtures/vpc.rs
@@ -32,21 +32,19 @@ pub async fn create_vpc(
     let tenant_config = default_tenant_config();
 
     let vpc_id = VpcId::new();
-    let request = VpcCreationRequest::builder(
-        "",
-        tenant_org_id.unwrap_or(tenant_config.tenant_organization_id),
-    )
-    .id(vpc_id)
-    .metadata(rpc::Metadata {
-        name,
-        description: vpc_metadata
-            .as_ref()
-            .map_or("".to_string(), |s| s.description.clone()),
-        labels: vpc_metadata
-            .as_ref()
-            .map_or(Vec::new(), |s| s.labels.clone()),
-    })
-    .tonic_request();
+    let request =
+        VpcCreationRequest::builder(tenant_org_id.unwrap_or(tenant_config.tenant_organization_id))
+            .id(vpc_id)
+            .metadata(rpc::Metadata {
+                name,
+                description: vpc_metadata
+                    .as_ref()
+                    .map_or("".to_string(), |s| s.description.clone()),
+                labels: vpc_metadata
+                    .as_ref()
+                    .map_or(Vec::new(), |s| s.labels.clone()),
+            })
+            .tonic_request();
 
     let response = env.api.create_vpc(request).await;
     let vpc = response.unwrap().into_inner();

--- a/crates/api/src/tests/common/network_segment.rs
+++ b/crates/api/src/tests/common/network_segment.rs
@@ -70,8 +70,7 @@ pub async fn create_network_segment_with_api(
     let vpc_id = if use_vpc {
         env.api
             .create_vpc(
-                VpcCreationRequest::builder("test vpc 1", "2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
-                    .tonic_request(),
+                VpcCreationRequest::builder("2829bbe3-c169-4cd9-8b2a-19a8b1618a93").tonic_request(),
             )
             .await
             .unwrap()

--- a/crates/api/src/tests/common/rpc_builder.rs
+++ b/crates/api/src/tests/common/rpc_builder.rs
@@ -38,7 +38,6 @@ pub struct DhcpDiscovery {
 // produce error on carbide_prost_builder::Builder derivation.
 #[derive(carbide_prost_builder::Builder)]
 pub struct VpcCreationRequest {
-    pub name: ::prost::alloc::string::String,
     pub tenant_organization_id: ::prost::alloc::string::String,
     pub tenant_keyset_id: ::core::option::Option<::prost::alloc::string::String>,
     pub network_virtualization_type: ::core::option::Option<i32>,
@@ -58,7 +57,6 @@ pub struct VpcCreationRequest {
 pub struct VpcUpdateRequest {
     pub id: ::core::option::Option<::carbide_uuid::vpc::VpcId>,
     pub if_version_match: ::core::option::Option<::prost::alloc::string::String>,
-    pub name: ::prost::alloc::string::String,
     pub metadata: ::core::option::Option<::rpc::forge::Metadata>,
     pub network_security_group_id: ::core::option::Option<::prost::alloc::string::String>,
     pub default_nvlink_logical_partition_id:

--- a/crates/api/src/tests/instance.rs
+++ b/crates/api/src/tests/instance.rs
@@ -2703,7 +2703,11 @@ async fn test_vpc_prefix_handling(pool: PgPool) {
     let vpc = env
         .api
         .create_vpc(
-            VpcCreationRequest::builder("test vpc 1", "2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+            VpcCreationRequest::builder("2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                .metadata(Metadata {
+                    name: "test vpc 1".to_string(),
+                    ..Default::default()
+                })
                 .tonic_request(),
         )
         .await

--- a/crates/api/src/tests/instance_allocate.rs
+++ b/crates/api/src/tests/instance_allocate.rs
@@ -22,7 +22,7 @@ use forge::forge_server::Forge;
 use ipnetwork::IpNetwork;
 use itertools::Itertools;
 use model::machine::{ManagedHostState, ManagedHostStateSnapshot};
-use rpc::forge;
+use rpc::{Metadata, forge};
 
 use crate::tests::common;
 use crate::tests::common::api_fixtures;
@@ -101,7 +101,11 @@ async fn create_test_env_for_instance_allocation(
     let vpc_1 = env
         .api
         .create_vpc(
-            VpcCreationRequest::builder("test vpc 1", "2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+            VpcCreationRequest::builder("2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                .metadata(Metadata {
+                    name: "test vpc 1".to_string(),
+                    ..Default::default()
+                })
                 .tonic_request(),
         )
         .await
@@ -111,7 +115,11 @@ async fn create_test_env_for_instance_allocation(
     let vpc_2 = env
         .api
         .create_vpc(
-            VpcCreationRequest::builder("test vpc 2", "2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+            VpcCreationRequest::builder("2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                .metadata(Metadata {
+                    name: "test vpc 2".to_string(),
+                    ..Default::default()
+                })
                 .tonic_request(),
         )
         .await

--- a/crates/api/src/tests/machine_network.rs
+++ b/crates/api/src/tests/machine_network.rs
@@ -26,6 +26,7 @@ use ::rpc::forge::{
 use common::api_fixtures::{self, create_managed_host, dpu, network_configured_with_health};
 use forge_secrets::credentials::{BgpCredentialType, CredentialKey, Credentials};
 use model::machine::network::ManagedHostQuarantineMode;
+use rpc::Metadata;
 use rpc::forge::forge_server::Forge;
 
 use crate::cfg::file::{FnnConfig, FnnRoutingProfileConfig, PrefixFilterPolicyEntry};
@@ -149,7 +150,11 @@ async fn test_managed_host_network_config_includes_routing_profile_accepted_leak
 
     let segment_id = env
         .create_vpc_and_tenant_segment_with_vpc_details(
-            VpcCreationRequest::builder("route leak vpc", tenant.organization_id.as_str())
+            VpcCreationRequest::builder(tenant.organization_id.as_str())
+                .metadata(Metadata {
+                    name: "route leak vpc".to_string(),
+                    ..Default::default()
+                })
                 .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
                 .routing_profile_type(profile_type.to_string())
                 .rpc(),

--- a/crates/api/src/tests/network_security_group.rs
+++ b/crates/api/src/tests/network_security_group.rs
@@ -889,7 +889,7 @@ async fn test_network_security_group_delete(
     let vpc = env
         .api
         .create_vpc(
-            VpcCreationRequest::builder("", default_tenant_org)
+            VpcCreationRequest::builder(default_tenant_org)
                 .network_security_group_id(good_network_security_group_id)
                 .metadata(Metadata::new_with_default_name())
                 .tonic_request(),
@@ -1159,8 +1159,9 @@ async fn test_network_security_group_propagation_impl(
 
     let segment_ids = env
         .create_vpc_and_tenant_segments_with_vpc_details(
-            VpcCreationRequest::builder("Tenant1", default_tenant_org)
+            VpcCreationRequest::builder(default_tenant_org)
                 .id(vpc_id)
+                .metadata(Metadata::new_with_default_name())
                 .network_security_group_id(good_network_security_group_id)
                 .rpc(),
             dpu_count,
@@ -1785,8 +1786,12 @@ async fn test_network_security_group_get_attachments(
     // Create a VPC
     let segment_id = env
         .create_vpc_and_tenant_segment_with_vpc_details(
-            VpcCreationRequest::builder("Tenant1", default_tenant_org)
+            VpcCreationRequest::builder(default_tenant_org)
                 .id(vpc_id)
+                .metadata(Metadata {
+                    name: "test vpc 1".to_string(),
+                    ..Default::default()
+                })
                 .network_security_group_id(good_network_security_group_id)
                 .rpc(),
         )

--- a/crates/api/src/tests/network_segment.rs
+++ b/crates/api/src/tests/network_segment.rs
@@ -41,6 +41,7 @@ use model::resource_pool::common::VLANID;
 use model::resource_pool::{ResourcePool, ResourcePoolStats, ValueType};
 use model::vpc::UpdateVpcVirtualization;
 use prometheus_text_parser::ParsedPrometheusMetrics;
+use rpc::Metadata;
 use rpc::forge::forge_server::Forge;
 use tonic::Request;
 
@@ -64,7 +65,11 @@ async fn test_advance_network_prefix_state(
     let vpc = env
         .api
         .create_vpc(
-            VpcCreationRequest::builder("test vpc 1", "2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+            VpcCreationRequest::builder("2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                .metadata(rpc::forge::Metadata {
+                    name: "test vpc 1".to_string(),
+                    ..Default::default()
+                })
                 .tonic_request(),
         )
         .await
@@ -1169,7 +1174,11 @@ async fn test_create_dual_stack_tenant_segment(pool: sqlx::PgPool) -> Result<(),
     let vpc = env
         .api
         .create_vpc(
-            VpcCreationRequest::builder("dual-stack vpc", "2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+            VpcCreationRequest::builder("2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                .metadata(Metadata {
+                    name: "dual-stack vpc".to_string(),
+                    ..Default::default()
+                })
                 .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
                 .tonic_request(),
         )
@@ -1250,12 +1259,14 @@ async fn test_ipv6_tenant_prefix_rejected_when_not_in_site_fabric(
     let vpc = env
         .api
         .create_vpc(
-            VpcCreationRequest::builder(
-                "uncontained-ipv6-vpc",
-                "2829bbe3-c169-4cd9-8b2a-19a8b1618a93",
-            )
-            .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
-            .tonic_request(),
+            VpcCreationRequest::builder("2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                .metadata(Metadata {
+                    name: "uncontained-ipv6-vpc".to_string(),
+                    description: "".to_string(),
+                    labels: vec![],
+                })
+                .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
+                .tonic_request(),
         )
         .await?
         .into_inner();

--- a/crates/api/src/tests/resource_pool.rs
+++ b/crates/api/src/tests/resource_pool.rs
@@ -24,6 +24,7 @@ use model::resource_pool::common::VPC_VNI;
 use model::resource_pool::{
     OwnerType, ResourcePool, ResourcePoolError, ResourcePoolStats as St, ValueType,
 };
+use rpc::Metadata;
 use rpc::forge::forge_server::Forge;
 use sqlx::migrate::MigrateDatabase;
 
@@ -387,7 +388,11 @@ async fn test_vpc_assign_after_delete(db_pool: sqlx::PgPool) -> Result<(), eyre:
     txn.commit().await?;
 
     // CreateVpc rpc call
-    let vpc_req = VpcCreationRequest::builder("test_vpc_assign_after_delete_1", "test")
+    let vpc_req = VpcCreationRequest::builder("test")
+        .metadata(Metadata {
+            name: "test_vpc_assign_after_delete_1".to_string(),
+            ..Default::default()
+        })
         .network_virtualization_type(rpc::forge::VpcVirtualizationType::EthernetVirtualizer)
         .tonic_request();
     let vpc1 = env.api.create_vpc(vpc_req).await.unwrap().into_inner();
@@ -430,7 +435,12 @@ async fn test_vpc_assign_after_delete(db_pool: sqlx::PgPool) -> Result<(), eyre:
     txn.commit().await?;
 
     // CreateVpc
-    let vpc_req = VpcCreationRequest::builder("test_vpc_assign_after_delete_2", "test")
+    let vpc_req = VpcCreationRequest::builder("test")
+        .metadata(Metadata {
+            name: "test_vpc_assign_after_delete_2".to_string(),
+            description: "".to_string(),
+            labels: vec![],
+        })
         .network_virtualization_type(rpc::forge::VpcVirtualizationType::EthernetVirtualizer)
         .tonic_request();
     let vpc2 = env.api.create_vpc(vpc_req).await.unwrap().into_inner();

--- a/crates/api/src/tests/set_primary_dpu.rs
+++ b/crates/api/src/tests/set_primary_dpu.rs
@@ -17,6 +17,7 @@
 
 use carbide_uuid::machine::{MachineId, MachineIdSource, MachineType};
 use ipnetwork::IpNetwork;
+use model::metadata::Metadata;
 use rpc::forge;
 use rpc::forge::forge_server::Forge;
 
@@ -69,7 +70,8 @@ async fn test_set_primary_dpu_rejects_zero_dpu_host(
     let vpc = env
         .api
         .create_vpc(
-            VpcCreationRequest::builder("test vpc", "2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+            VpcCreationRequest::builder("2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                .metadata(Metadata::new_with_default_name())
                 .tonic_request(),
         )
         .await?

--- a/crates/api/src/tests/tenants.rs
+++ b/crates/api/src/tests/tenants.rs
@@ -224,7 +224,7 @@ async fn test_tenant(pool: sqlx::PgPool) {
     let new_vpc = env
         .api
         .create_vpc(
-            common::rpc_builder::VpcCreationRequest::builder("", tenant_org)
+            common::rpc_builder::VpcCreationRequest::builder(tenant_org)
                 .metadata(rpc::forge::Metadata {
                     name: "Forge".to_string(),
                     description: "".to_string(),

--- a/crates/api/src/tests/vpc.rs
+++ b/crates/api/src/tests/vpc.rs
@@ -61,11 +61,10 @@ async fn create_vpc_for_tenant_without_profile(
     assert!(
         env.api
             .create_vpc(
-                VpcCreationRequest::builder("", "")
+                VpcCreationRequest::builder("")
                     .metadata(rpc::forge::Metadata {
                         name: "Forge".to_string(),
-                        description: "".to_string(),
-                        labels: Vec::new(),
+                        ..Default::default()
                     })
                     .routing_profile_type("PRIVILEGED_INTERNAL".to_string())
                     .tonic_request(),
@@ -80,11 +79,10 @@ async fn create_vpc_for_tenant_without_profile(
     assert!(
         env.api
             .create_vpc(
-                VpcCreationRequest::builder("", tenant.organization_id)
+                VpcCreationRequest::builder(tenant.organization_id)
                     .metadata(rpc::forge::Metadata {
                         name: "Forge".to_string(),
-                        description: "".to_string(),
-                        labels: Vec::new(),
+                        ..Default::default()
                     })
                     .routing_profile_type("PRIVILEGED_INTERNAL".to_string())
                     .tonic_request(),
@@ -166,11 +164,10 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
     assert!(
         env.api
             .create_vpc(
-                VpcCreationRequest::builder("", &tenant.organization_id)
+                VpcCreationRequest::builder(&tenant.organization_id)
                     .metadata(rpc::forge::Metadata {
                         name: "Forge".to_string(),
-                        description: "".to_string(),
-                        labels: Vec::new(),
+                        ..Default::default()
                     })
                     .vni(100u32)
                     .tonic_request(),
@@ -186,11 +183,10 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
     assert!(
         env.api
             .create_vpc(
-                VpcCreationRequest::builder("", &tenant.organization_id)
+                VpcCreationRequest::builder(&tenant.organization_id)
                     .metadata(rpc::forge::Metadata {
                         name: "Forge".to_string(),
-                        description: "".to_string(),
-                        labels: Vec::new(),
+                        ..Default::default()
                     })
                     .vni(20002u32)
                     .tonic_request(),
@@ -224,11 +220,10 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
     assert!(
         env.api
             .create_vpc(
-                VpcCreationRequest::builder("", &tenant.organization_id)
+                VpcCreationRequest::builder(&tenant.organization_id)
                     .metadata(rpc::forge::Metadata {
                         name: "Forge".to_string(),
-                        description: "".to_string(),
-                        labels: Vec::new(),
+                        ..Default::default()
                     })
                     .routing_profile_type("PRIVILEGED_INTERNAL".to_string())
                     .tonic_request(),
@@ -244,12 +239,11 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
     let forge_vpc = env
         .api
         .create_vpc(
-            VpcCreationRequest::builder("", &tenant.organization_id)
+            VpcCreationRequest::builder(&tenant.organization_id)
                 .vni(60001u32)
                 .metadata(rpc::forge::Metadata {
                     name: "Forge_with_vni".to_string(),
-                    description: "".to_string(),
-                    labels: Vec::new(),
+                    ..Default::default()
                 })
                 .tonic_request(),
         )
@@ -267,12 +261,11 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
     let _ = env
         .api
         .create_vpc(
-            VpcCreationRequest::builder("", &tenant.organization_id)
+            VpcCreationRequest::builder(&tenant.organization_id)
                 .vni(60001u32)
                 .metadata(rpc::forge::Metadata {
                     name: "Forge_with_vni_dupe".to_string(),
-                    description: "".to_string(),
-                    labels: Vec::new(),
+                    ..Default::default()
                 })
                 .tonic_request(),
         )
@@ -294,11 +287,10 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
     let forge_vpc = env
         .api
         .create_vpc(
-            VpcCreationRequest::builder("", &tenant.organization_id)
+            VpcCreationRequest::builder(&tenant.organization_id)
                 .metadata(rpc::forge::Metadata {
                     name: "Forge".to_string(),
-                    description: "".to_string(),
-                    labels: Vec::new(),
+                    ..Default::default()
                 })
                 .tonic_request(),
         )
@@ -318,7 +310,7 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
     let no_org_vpc = env
         .api
         .create_vpc(
-            VpcCreationRequest::builder("", &tenant.organization_id)
+            VpcCreationRequest::builder(&tenant.organization_id)
                 .network_virtualization_type(rpc::forge::VpcVirtualizationType::from(
                     VpcVirtualizationType::EthernetVirtualizer,
                 ))
@@ -350,7 +342,6 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
         let invalid_updated_vpc = env
             .api
             .update_vpc(tonic::Request::new(rpc::forge::VpcUpdateRequest {
-                name: "".to_string(),
                 id: Some(no_org_vpc_id),
                 if_version_match: None,
                 metadata: Some(invalid_metadata.clone()),
@@ -567,11 +558,10 @@ async fn create_vpc_without_fnn_rejects_explicit_routing_profile(
     assert!(
         env.api
             .create_vpc(
-                VpcCreationRequest::builder("", &tenant_organization_id)
+                VpcCreationRequest::builder(&tenant_organization_id)
                     .metadata(rpc::forge::Metadata {
                         name: "Forge".to_string(),
-                        description: "".to_string(),
-                        labels: Vec::new(),
+                        ..Default::default()
                     })
                     .routing_profile_type("PRIVILEGED_INTERNAL".to_string())
                     .tonic_request(),
@@ -592,7 +582,7 @@ async fn create_vpc_with_labels(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
     let forge_vpc = env
         .api
         .create_vpc(
-            VpcCreationRequest::builder("", "Forge_unit_tests")
+            VpcCreationRequest::builder("Forge_unit_tests")
                 .metadata(Metadata {
                     name: "test_VPC_with_labels".to_string(),
                     description: "this VPC must have labels.".to_string(),
@@ -704,7 +694,7 @@ async fn create_vpc_with_invalid_metadata(
         let result = env
             .api
             .create_vpc(
-                VpcCreationRequest::builder("", "Forge_unit_tests")
+                VpcCreationRequest::builder("Forge_unit_tests")
                     .metadata(invalid_metadata.clone())
                     .tonic_request(),
             )
@@ -722,60 +712,6 @@ async fn create_vpc_with_invalid_metadata(
             expected_err
         )
     }
-
-    Ok(())
-}
-
-#[crate::sqlx_test]
-async fn prevent_vpc_with_two_names(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool).await;
-
-    let forge_vpc1 = env
-        .api
-        .create_vpc(
-            VpcCreationRequest::builder("vpc_name", "Forge_unit_tests")
-                .metadata(Metadata {
-                    name: "vpc_another_name".to_string(),
-                    description: "No description.".to_string(),
-                    ..Default::default()
-                })
-                .tonic_request(),
-        )
-        .await;
-
-    match forge_vpc1 {
-        Ok(..) => panic!("Expected VPC creation failure when two names are passed."),
-        Err(e) => {
-            assert_eq!(
-                e.message(),
-                "VPC name must be specified under metadata only."
-            );
-        }
-    };
-
-    let forge_vpc2 = env
-        .api
-        .create_vpc(
-            VpcCreationRequest::builder("vpc_name", "Forge_unit_tests")
-                .metadata(Metadata {
-                    description: "No description.".to_string(),
-                    ..Default::default()
-                })
-                .tonic_request(),
-        )
-        .await;
-
-    match forge_vpc2 {
-        Ok(..) => {
-            panic!("Expected VPC creation failure when metadata exists but vpc.name is not empty.")
-        }
-        Err(e) => {
-            assert_eq!(
-                e.message(),
-                "VPC name must be specified under metadata only."
-            );
-        }
-    };
 
     Ok(())
 }
@@ -811,7 +747,7 @@ async fn test_vpc_with_id(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::
     let forge_vpc = env
         .api
         .create_vpc(
-            VpcCreationRequest::builder("", "")
+            VpcCreationRequest::builder("")
                 .id(id)
                 .metadata(Metadata {
                     name: "Forge".to_string(),
@@ -831,7 +767,7 @@ async fn test_vpc_with_id(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::
 async fn vpc_deletion_is_idempotent(pool: sqlx::PgPool) -> Result<(), eyre::Report> {
     let env = create_test_env(pool).await;
 
-    let vpc_req = VpcCreationRequest::builder("", "test")
+    let vpc_req = VpcCreationRequest::builder("test")
         .metadata(Metadata {
             name: "test_vpc".to_string(),
             ..Default::default()
@@ -840,7 +776,7 @@ async fn vpc_deletion_is_idempotent(pool: sqlx::PgPool) -> Result<(), eyre::Repo
     let resp = env.api.create_vpc(vpc_req).await.unwrap().into_inner();
 
     let vpc_id = resp.id.unwrap();
-    assert_eq!(resp.name, "test_vpc");
+    assert_eq!(resp.metadata.unwrap().name, "test_vpc");
 
     let vpc_list = env
         .api
@@ -850,9 +786,12 @@ async fn vpc_deletion_is_idempotent(pool: sqlx::PgPool) -> Result<(), eyre::Repo
         .await
         .unwrap()
         .into_inner();
+
+    let vpc_name = vpc_list.vpcs[0].metadata.as_ref().unwrap().name.clone();
+
     assert_eq!(vpc_list.vpcs.len(), 1);
     assert_eq!(vpc_list.vpcs[0].id, Some(vpc_id));
-    assert_eq!(vpc_list.vpcs[0].name, "test_vpc");
+    assert_eq!(vpc_name, "test_vpc");
 
     // Delete the first time. Queries should now yield no results
     env.api
@@ -939,7 +878,7 @@ async fn create_update_network_security_group_for_vpc(
     let _ = env
         .api
         .create_vpc(
-            VpcCreationRequest::builder("", default_tenant_org)
+            VpcCreationRequest::builder(default_tenant_org)
                 .network_security_group_id(bad_network_security_group_id)
                 .metadata(Metadata::new_with_default_name())
                 .tonic_request(),
@@ -951,7 +890,7 @@ async fn create_update_network_security_group_for_vpc(
     let vpc = env
         .api
         .create_vpc(
-            VpcCreationRequest::builder("", default_tenant_org)
+            VpcCreationRequest::builder(default_tenant_org)
                 .network_security_group_id(good_network_security_group_id)
                 .metadata(Metadata::new_with_default_name())
                 .tonic_request(),
@@ -974,7 +913,7 @@ async fn create_update_network_security_group_for_vpc(
     let _ = env
         .api
         .update_vpc(
-            VpcUpdateRequest::builder("")
+            VpcUpdateRequest::builder()
                 .set_id(vpc_id)
                 .network_security_group_id(bad_network_security_group_id)
                 .metadata(Metadata::new_with_default_name())
@@ -987,7 +926,7 @@ async fn create_update_network_security_group_for_vpc(
     let vpc = env
         .api
         .update_vpc(
-            VpcUpdateRequest::builder("")
+            VpcUpdateRequest::builder()
                 .set_id(vpc_id)
                 .network_security_group_id(good_network_security_group_id)
                 .metadata(Metadata::new_with_default_name())
@@ -1009,7 +948,7 @@ async fn create_update_network_security_group_for_vpc(
     let vpc = env
         .api
         .update_vpc(
-            VpcUpdateRequest::builder("")
+            VpcUpdateRequest::builder()
                 .set_id(vpc_id)
                 .metadata(Metadata::new_with_default_name())
                 .tonic_request(),
@@ -1038,7 +977,11 @@ async fn test_increment_vpc_version_detects_concurrent_writes(
     let vpc_id: VpcId = env
         .api
         .create_vpc(
-            VpcCreationRequest::builder("vpc-bump", "2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+            VpcCreationRequest::builder("2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                .metadata(Metadata {
+                    name: "vpc-bump".to_string(),
+                    ..Default::default()
+                })
                 .tonic_request(),
         )
         .await

--- a/crates/api/src/tests/vpc_find.rs
+++ b/crates/api/src/tests/vpc_find.rs
@@ -238,7 +238,7 @@ async fn test_vpc_search_based_on_labels(pool: sqlx::PgPool) {
     for i in 0..=3 {
         env.api
             .create_vpc(
-                VpcCreationRequest::builder("", "Forge_unit_tests")
+                VpcCreationRequest::builder("")
                     .metadata(rpc::Metadata {
                         name: format!("VPC_{i}{i}{i}").to_string(),
                         description: format!("VPC_{i}{i}{i} have labels").to_string(),

--- a/crates/api/src/tests/vpc_peering.rs
+++ b/crates/api/src/tests/vpc_peering.rs
@@ -48,7 +48,7 @@ async fn create_test_vpcs(
             Some(vtype) => env
                 .api
                 .create_vpc(
-                    VpcCreationRequest::builder(&name, "")
+                    VpcCreationRequest::builder("")
                         .metadata(Metadata {
                             name,
                             ..Default::default()
@@ -62,7 +62,7 @@ async fn create_test_vpcs(
             None => env
                 .api
                 .create_vpc(
-                    VpcCreationRequest::builder(&name, "")
+                    VpcCreationRequest::builder("")
                         .metadata(Metadata {
                             name,
                             ..Default::default()

--- a/crates/api/src/web/instance.rs
+++ b/crates/api/src/web/instance.rs
@@ -543,7 +543,12 @@ async fn get_interfaces_for_instance_detail(
             && let Some(vpc) = vpc_map.get(&vpc_id_val)
         {
             vpc_id = vpc.id.map(|id| id.to_string()).unwrap_or_default();
-            vpc_name = vpc.name.clone();
+            vpc_name = vpc
+                .metadata
+                .as_ref()
+                .map(|x| x.name.as_str())
+                .unwrap_or("<no name>")
+                .to_string();
         }
 
         let status = &if_status[i];

--- a/crates/api/src/web/ipam.rs
+++ b/crates/api/src/web/ipam.rs
@@ -601,7 +601,19 @@ async fn fetch_vpcs(api: Arc<Api>) -> Result<Vec<forgerpc::Vpc>, tonic::Status> 
         offset += page_size;
     }
 
-    vpcs.sort_unstable_by(|a, b| a.name.cmp(&b.name));
+    vpcs.sort_unstable_by(|a, b| {
+        let vpc1_name = a
+            .metadata
+            .as_ref()
+            .map(|x| x.name.as_str())
+            .unwrap_or("<no name>");
+        let vpc2_name = b
+            .metadata
+            .as_ref()
+            .map(|x| x.name.as_str())
+            .unwrap_or("<no name>");
+        vpc1_name.cmp(vpc2_name)
+    });
     Ok(vpcs)
 }
 

--- a/crates/api/src/web/vpc.rs
+++ b/crates/api/src/web/vpc.rs
@@ -116,7 +116,18 @@ async fn fetch_vpcs(api: Arc<Api>) -> Result<Vec<forgerpc::Vpc>, tonic::Status> 
 
     vpcs.sort_unstable_by(|vpc1, vpc2| {
         // Order by name first, and ID second
-        let ord = vpc1.name.cmp(&vpc2.name);
+        let vpc1_name = vpc1
+            .metadata
+            .as_ref()
+            .map(|x| x.name.as_str())
+            .unwrap_or_default();
+        let vpc2_name = vpc2
+            .metadata
+            .as_ref()
+            .map(|x| x.name.as_str())
+            .unwrap_or_default();
+        let ord = vpc1_name.cmp(vpc2_name);
+
         if !ord.is_eq() {
             return ord;
         }

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -406,7 +406,6 @@ impl ApiClient {
         self.0
             .create_vpc(rpc::forge::VpcCreationRequest {
                 id: None,
-                name: "".to_string(),
                 tenant_organization_id: "Forge-simulation-tenant".to_string(),
                 tenant_keyset_id: None,
                 network_security_group_id: None,

--- a/crates/machine-a-tron/src/subnet.rs
+++ b/crates/machine-a-tron/src/subnet.rs
@@ -45,7 +45,7 @@ impl Subnet {
     ) -> Result<Subnet, Status> {
         let network_segment = app_context
             .api_client()
-            .create_network_segment(&vpc.vpc_name, vpc.network_virtualization_type)
+            .create_network_segment(&vpc.metadata.name, vpc.network_virtualization_type)
             .await
             .map_err(|e| {
                 tracing::error!("Error creating network segment: {}", e);

--- a/crates/machine-a-tron/src/tui.rs
+++ b/crates/machine-a-tron/src/tui.rs
@@ -50,7 +50,7 @@ impl From<&Vpc> for VpcDetails {
     fn from(value: &Vpc) -> Self {
         Self {
             vpc_id: value.vpc_id,
-            vpc_name: Some(value.vpc_name.clone()),
+            vpc_name: Some(value.metadata.name.clone()),
         }
     }
 }

--- a/crates/machine-a-tron/src/vpc.rs
+++ b/crates/machine-a-tron/src/vpc.rs
@@ -18,7 +18,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use ::rpc::Timestamp;
-use ::rpc::forge::VpcVirtualizationType;
+use ::rpc::forge::{Metadata, VpcVirtualizationType};
 use carbide_uuid::vpc::VpcId;
 
 use crate::config::MachineATronContext;
@@ -29,7 +29,7 @@ pub struct Vpc {
     pub vpc_id: VpcId,
     pub app_context: Arc<MachineATronContext>,
 
-    pub vpc_name: String,
+    pub metadata: Metadata,
     pub network_virtualization_type: Option<VpcVirtualizationType>,
 
     pub logs: Vec<String>,
@@ -53,7 +53,7 @@ impl Vpc {
         let new_vpc = Vpc {
             vpc_id: vpc.id.expect("VPC must have an ID."),
             app_context,
-            vpc_name: vpc.name,
+            metadata: vpc.metadata.expect("VPC must contain metadata.name"),
             network_virtualization_type,
             logs: Vec::default(),
             _created: vpc.created,

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1422,7 +1422,7 @@ message VpcStatus {
 
 message Vpc {
   common.VpcId id = 1;
-  string name = 2;
+  reserved 2;  // was: string name, replaced with metadata.name
   string tenantOrganizationId = 3; // protolint:disable:this FIELD_NAMES_LOWER_SNAKE_CASE
 
   string version = 99;
@@ -1463,8 +1463,7 @@ message Vpc {
 }
 
 message VpcCreationRequest {
-  // TODO: Remove the name field as soon as cloud codes gets updated to using metadata.name.
-  string name = 2;
+  reserved 2;  // was: string name, replaced with metadata.name
   string tenantOrganizationId = 3; // protolint:disable:this FIELD_NAMES_LOWER_SNAKE_CASE
   // this keyset will enable any key contained within it to access any instance associated with this VPC.
   optional string tenantKeysetId = 4; // protolint:disable:this FIELD_NAMES_LOWER_SNAKE_CASE
@@ -1525,8 +1524,7 @@ message VpcUpdateRequest {
   // a `message VpcConfig/VpcSettings`. However I don't feel like this would add
   // a lot for primitive types like Vpc.
 
-  // TODO: Remove the name field as soon as cloud codes gets updated to using metadata.name.
-  string name = 3;
+  reserved 3; // was string name, replaced with metadata.name
   reserved 4; // was tenantOrganizationId
   reserved 5; // was tenantKeysetId
 


### PR DESCRIPTION
 * Changes are already applied to infra-controller-rest
   1. https://github.com/NVIDIA/infra-controller-rest/blob/main/api/pkg/api/handler/vpc.go#L419
   2. https://github.com/NVIDIA/infra-controller-rest/blob/main/api/pkg/api/handler/vpc.go#L880
 * Update VPC related tests to pass `Metadata.name` rather than `Vpc.name`
 * Mark field as deprecated in protobuf

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ X] Unit tests added/updated
- [ X] Integration tests added/updated  
- [ X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

Fixes https://github.com/NVIDIA/infra-controller-core/issues/927