### PR TITLE
feat(pxe): default to client IP when DHCP option 43.70 is unset

### DIFF
--- a/crates/api/src/handlers/pxe.rs
+++ b/crates/api/src/handlers/pxe.rs
@@ -34,7 +34,36 @@ pub(crate) async fn get_pxe_instructions(
 
     let mut txn = api.txn_begin().await?;
 
-    let target: model::pxe::PxeInstructionRequest = request.into_inner().try_into()?;
+    // interface_id is sent when carbide-dhcp (or a carbide-api integrated
+    // DHCP service) populates DHCP option 43.70. client_ip is sent when
+    // it didn't -- carbide-pxe forwards the client IP it observed (XFF if
+    // proxied, TCP socket peer otherwise). interface_id wins when both
+    // are present (it's already resolved -- saves a lookup). When only
+    // client_ip is present, resolve it to interface_id here so the rest
+    // of the model can take the same path.
+    let mut rpc_request = request.into_inner();
+    if rpc_request.interface_id.is_none() {
+        let ip_str = rpc_request.client_ip.as_deref().ok_or_else(|| {
+            CarbideError::InvalidArgument(
+                "PxeInstructionRequest requires either interface_id or client_ip".to_string(),
+            )
+        })?;
+        let ip: IpAddr = ip_str.parse().map_err(|e| {
+            CarbideError::InvalidArgument(format!("Failed parsing client_ip '{ip_str}': {e}"))
+        })?;
+        let iface = db::machine_interface::find_by_ip(txn.as_pgconn(), ip)
+            .await?
+            .ok_or_else(|| CarbideError::NotFoundError {
+                kind: "MachineInterface",
+                id: ip.to_string(),
+            })?;
+        rpc_request.interface_id = Some(iface.id);
+    }
+
+    // And now we can naturally continue, whether the request came in
+    // with DHCP option 43.70 (interface_id) or the client-IP (and the
+    // client_ip resolved to interface_id just above).
+    let target: model::pxe::PxeInstructionRequest = rpc_request.try_into()?;
     let interface_id = target.interface_id;
     let pxe_script = PxeInstructions::get_pxe_instructions(&mut txn, target).await?;
 

--- a/crates/api/src/tests/common/api_fixtures/test_machine/interface.rs
+++ b/crates/api/src/tests/common/api_fixtures/test_machine/interface.rs
@@ -39,6 +39,7 @@ impl TestMachineInterface {
                 arch: arch as i32,
                 interface_id: Some(self.id),
                 product: None,
+                client_ip: None,
             }))
             .await
             .unwrap()

--- a/crates/api/src/tests/ipxe.rs
+++ b/crates/api/src/tests/ipxe.rs
@@ -70,6 +70,7 @@ async fn get_pxe_instructions(
             arch: arch as i32,
             interface_id: Some(interface_id),
             product,
+            client_ip: None,
         }))
         .await
         .unwrap()
@@ -648,4 +649,109 @@ async fn test_cloud_init_url_overrides_none_for_internal_host(pool: sqlx::PgPool
         cloud_init.pxe_url_override, None,
         "internal host should not get pxe_url_override"
     );
+}
+
+// When the DHCP server (carbide-dhcp or another DHCP server that happens to
+// be integrated with carbide-api) didn't populate option 43.70, the iPXE chain
+// script falls through to the client-IP path. carbide-pxe observes the client
+// IP (X-Forwarded-For if proxied, TCP socket peer otherwise) and forwards it
+// to carbide-api as PxeInstructionRequest.client_ip (with interface_id unset);
+// this makes sure the API resolves the IP to the same interface_id and returns
+// the same script as the uuid path.
+#[crate::sqlx_test]
+async fn test_pxe_instructions_resolves_client_ip_to_interface_id(pool: sqlx::PgPool) {
+    let env = create_env_with_external_urls(pool).await;
+
+    let ip = "10.99.0.60";
+    let (interface_id, _ip) = preallocate_external_interface(&env, "AA:BB:CC:DD:EE:10", ip).await;
+
+    let by_uuid = get_pxe_instructions(
+        &env,
+        interface_id,
+        rpc::forge::MachineArchitecture::X86,
+        None,
+    )
+    .await;
+
+    let by_client_ip = env
+        .api
+        .get_pxe_instructions(tonic::Request::new(rpc::forge::PxeInstructionRequest {
+            arch: rpc::forge::MachineArchitecture::X86 as i32,
+            interface_id: None,
+            product: None,
+            client_ip: Some(ip.to_string()),
+        }))
+        .await
+        .expect("client_ip-based get_pxe_instructions returned an error")
+        .into_inner();
+
+    assert_eq!(
+        by_client_ip.pxe_script, by_uuid.pxe_script,
+        "client_ip fallback should resolve to the same pxe_script as the uuid path"
+    );
+    assert_eq!(by_client_ip.api_url_override, by_uuid.api_url_override);
+    assert_eq!(by_client_ip.pxe_url_override, by_uuid.pxe_url_override);
+    assert_eq!(
+        by_client_ip.static_pxe_url_override,
+        by_uuid.static_pxe_url_override
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_pxe_instructions_unknown_client_ip_returns_not_found(pool: sqlx::PgPool) {
+    let env = create_env_with_external_urls(pool).await;
+
+    let result = env
+        .api
+        .get_pxe_instructions(tonic::Request::new(rpc::forge::PxeInstructionRequest {
+            arch: rpc::forge::MachineArchitecture::X86 as i32,
+            interface_id: None,
+            product: None,
+            client_ip: Some("203.0.113.99".to_string()),
+        }))
+        .await;
+
+    let status = result.expect_err("expected NotFound for unknown client_ip");
+    assert_eq!(status.code(), tonic::Code::NotFound, "got: {status:?}");
+}
+
+// interface_id is sent when carbide-dhcp populates DHCP option 43.70;
+// client_ip is sent on the client-IP path (when 43.70 is not present).
+// interface_id takes priority when both are present -- as in we use
+// the "pre-resolved" ID and ignore the client_ip, even if the IP would
+// have resolved to a different interface (or no interface at all). Send
+// a deliberately "unknown" IP alongside a valid machine interface ID to
+// prove the handler is actually ignoring the `client_ip` field, and not
+// coincidentally agreeing with it.
+#[crate::sqlx_test]
+async fn test_pxe_instructions_prefers_interface_id_when_both_set(pool: sqlx::PgPool) {
+    let env = create_env_with_external_urls(pool).await;
+
+    let (interface_id, _ip) =
+        preallocate_external_interface(&env, "AA:BB:CC:DD:EE:11", "10.99.0.61").await;
+
+    let by_uuid_only = get_pxe_instructions(
+        &env,
+        interface_id,
+        rpc::forge::MachineArchitecture::X86,
+        None,
+    )
+    .await;
+
+    let with_unknown_client_ip = env
+        .api
+        .get_pxe_instructions(tonic::Request::new(rpc::forge::PxeInstructionRequest {
+            arch: rpc::forge::MachineArchitecture::X86 as i32,
+            interface_id: Some(interface_id),
+            product: None,
+            // Deliberately-unknown IP. If the handler weren't preferring
+            // interface_id, this would NotFound. Instead, the client_ip
+            // is ignored and the script comes from the uuid lookup.
+            client_ip: Some("203.0.113.99".to_string()),
+        }))
+        .await
+        .expect("uuid wins; unknown client_ip should be ignored, not validated")
+        .into_inner();
+
+    assert_eq!(with_unknown_client_ip.pxe_script, by_uuid_only.pxe_script);
 }

--- a/crates/api/src/tests/machine_states.rs
+++ b/crates/api/src/tests/machine_states.rs
@@ -939,6 +939,7 @@ async fn test_failed_state_host_discovery_recovery(pool: sqlx::PgPool) {
             arch: rpc::forge::MachineArchitecture::X86 as i32,
             interface_id: Some(host.interfaces[0].id),
             product: None,
+            client_ip: None,
         }))
         .await
         .unwrap()

--- a/crates/ipxe-renderer/templates.yaml
+++ b/crates/ipxe-renderer/templates.yaml
@@ -346,12 +346,31 @@ templates:
       
       :whoami
       ifconf -c dhcp
-      isset ${43.70} && time chain --autofree http://${next-server}:8080/api/v0/pxe/whoami?uuid=${43.70}
+      # When a DHCP server (carbide-dhcp or API-integrated DHCP server) populates
+      # option 43.70 with the machine_interface_id, use that as the identifier.
+      # Otherwise, just rely on the client IP -- carbide-pxe will resolve it via
+      # X-Forwarded-For (when proxied) or the TCP socket peer (when direct), then
+      # look up the interface by IP. iPXE itself doesn't need to put the IP in
+      # the URL since the network layer carries it.
+      isset ${43.70} && goto whoami_uuid || goto whoami_sourceip
+
+      :whoami_uuid
+      time chain --autofree http://${next-server}:8080/api/v0/pxe/whoami?uuid=${43.70}
       goto carbide_menu
-      
+
+      :whoami_sourceip
+      time chain --autofree http://${next-server}:8080/api/v0/pxe/whoami
+      goto carbide_menu
+
       :carbide
       ifconf -c dhcp
-      isset ${43.70} && time chain --autofree http://${next-server}:8080/api/v0/pxe/boot?uuid=${43.70}&buildarch=${buildarch}&platform=${platform}&manufacturer=${manufacturer}&product=${product}&serial=${serial} && exit 1 || goto error_handler
+      isset ${43.70} && goto carbide_uuid || goto carbide_sourceip
+
+      :carbide_uuid
+      time chain --autofree http://${next-server}:8080/api/v0/pxe/boot?uuid=${43.70}&buildarch=${buildarch}&platform=${platform}&manufacturer=${manufacturer}&product=${product}&serial=${serial} && exit 1 || goto error_handler
+
+      :carbide_sourceip
+      time chain --autofree http://${next-server}:8080/api/v0/pxe/boot?buildarch=${buildarch}&platform=${platform}&manufacturer=${manufacturer}&product=${product}&serial=${serial} && exit 1 || goto error_handler
       
       :carbide_menu
       menu Carbide - ${hostname}

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -482,6 +482,7 @@ impl ApiClient {
                 arch: arch.into(),
                 interface_id: Some(interface_id),
                 product,
+                client_ip: None,
             })
             .await
             .map_err(ClientApiError::InvocationError)

--- a/crates/pxe/src/common.rs
+++ b/crates/pxe/src/common.rs
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::net::IpAddr;
+
 use axum_template::engine::Engine;
 use carbide_uuid::machine::MachineInterfaceId;
 use metrics_exporter_prometheus::PrometheusHandle;
@@ -30,10 +32,23 @@ pub(crate) struct Machine {
     pub instructions: CloudInitInstructions,
 }
 
+/// MachineLookup defines how the booting machine identified itself.
+/// The `uuid` query param (which comes from DHCP option 43.70, populated
+/// by carbide-dhcp or another API-integrated DHCP server) yields
+/// `InterfaceId`.
+/// When DHCP option 43.70 isn't set, carbide-pxe falls back to the
+/// observed source IP (`X-Forwarded-For` if proxied, TCP socket peer
+/// otherwise), populating `SourceIp`.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) enum MachineLookup {
+    InterfaceId(MachineInterfaceId),
+    SourceIp(IpAddr),
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct MachineInterface {
     pub architecture: Option<machine_architecture::MachineArchitecture>,
-    pub interface_id: MachineInterfaceId,
+    pub lookup: MachineLookup,
     pub platform: Option<String>,
     pub manufacturer: Option<String>,
     pub product: Option<String>,

--- a/crates/pxe/src/extractors/machine_interface.rs
+++ b/crates/pxe/src/extractors/machine_interface.rs
@@ -18,10 +18,11 @@ use std::collections::HashMap;
 
 use axum::extract::{FromRequestParts, Path, Query};
 use axum::http::request::Parts;
+use axum_client_ip::ClientIp;
 use carbide_uuid::machine::MachineInterfaceId;
 use serde::{Deserialize, Serialize};
 
-use crate::common::MachineInterface;
+use crate::common::{MachineInterface, MachineLookup};
 use crate::extractors::machine_architecture::MachineArchitecture;
 use crate::rpc_error::PxeRequestError;
 
@@ -45,35 +46,6 @@ struct MaybeMachineInterface {
     asset: Option<String>,
 }
 
-impl TryFrom<MaybeMachineInterface> for MachineInterface {
-    type Error = PxeRequestError;
-
-    fn try_from(value: MaybeMachineInterface) -> Result<Self, Self::Error> {
-        let build_architecture = MachineArchitecture::try_from(value.build_architecture.as_str())?;
-
-        let uuid = match (value.uuid, value.uuid_as_param) {
-            (Some(uuid), _) => Ok(uuid),
-            (None, Some(uuid)) => {
-                uuid.parse()
-                    .map_err(|e: carbide_uuid::typed_uuids::UuidError| {
-                        PxeRequestError::UuidConversion(e.into())
-                    })
-            }
-            _ => Err(PxeRequestError::MissingMachineId),
-        }?;
-
-        Ok(MachineInterface {
-            architecture: Some(build_architecture),
-            interface_id: uuid,
-            platform: value.platform,
-            manufacturer: value.manufacturer,
-            product: value.product,
-            serial: value.serial,
-            asset: value.asset,
-        })
-    }
-}
-
 impl<S> FromRequestParts<S> for MachineInterface
 where
     S: Send + Sync,
@@ -81,17 +53,46 @@ where
     type Rejection = PxeRequestError;
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        if let Ok(maybe) = Query::<MaybeMachineInterface>::from_request_parts(parts, state).await {
-            let mut maybe_machine_interface = maybe.0;
-            maybe_machine_interface.uuid_as_param =
-                Path::<HashMap<String, String>>::from_request_parts(parts, state)
+        let Ok(maybe) = Query::<MaybeMachineInterface>::from_request_parts(parts, state).await
+        else {
+            // Query parsing only fails on the required build_architecture
+            // field; everything else is optional.
+            return Err(PxeRequestError::InvalidBuildArch);
+        };
+        let mut maybe = maybe.0;
+        maybe.uuid_as_param = Path::<HashMap<String, String>>::from_request_parts(parts, state)
+            .await
+            .ok()
+            .and_then(|params| params.0.get("uuid").cloned());
+
+        let build_architecture = MachineArchitecture::try_from(maybe.build_architecture.as_str())?;
+
+        // Prefer interface_id (DHCP option 43.70 path) when present.
+        // Otherwise fall back to the source IP -- ClientIp uses
+        // X-Forwarded-For when a proxy injects it, and the TCP socket
+        // peer otherwise.
+        let lookup = match (maybe.uuid, maybe.uuid_as_param) {
+            (Some(uuid), _) => MachineLookup::InterfaceId(uuid),
+            (None, Some(uuid)) => MachineLookup::InterfaceId(uuid.parse().map_err(
+                |e: carbide_uuid::typed_uuids::UuidError| PxeRequestError::UuidConversion(e.into()),
+            )?),
+            (None, None) => {
+                let client_ip = ClientIp::from_request_parts(parts, state)
                     .await
-                    .ok()
-                    .and_then(|params| params.0.get("uuid").cloned());
-            maybe_machine_interface.try_into()
-        } else {
-            // it can only fail to parse because of missing build arch, the other fields are optional.
-            Err(PxeRequestError::InvalidBuildArch)
-        }
+                    .map_err(PxeRequestError::MissingIp)?
+                    .0;
+                MachineLookup::SourceIp(client_ip)
+            }
+        };
+
+        Ok(MachineInterface {
+            architecture: Some(build_architecture),
+            lookup,
+            platform: maybe.platform,
+            manufacturer: maybe.manufacturer,
+            product: maybe.product,
+            serial: maybe.serial,
+            asset: maybe.asset,
+        })
     }
 }

--- a/crates/pxe/src/routes/ipxe.rs
+++ b/crates/pxe/src/routes/ipxe.rs
@@ -83,12 +83,14 @@ pub async fn whoami(machine: Machine, state: State<AppState>) -> impl IntoRespon
 }
 
 pub async fn boot(contents: MachineInterface, state: State<AppState>) -> impl IntoResponse {
-    let machine_interface_id = contents.interface_id;
-
     let (template_key, template_data) = match contents.architecture {
         Some(arch) => {
+            // The wrapping `pxe` Tera template (pxe/templates/pxe) consumes:
+            //   - {{ pxe_url }}        -- carbide-pxe URL for cloud-init.
+            //   - {{ static_pxe_url }} -- carbide-pxe URL for /public/blobs.
+            //   - {{ ipxe }}           -- the OS-specific iPXE script body
+            //                             returned by carbide-api.
             let mut template_data = HashMap::new();
-            template_data.insert("interface_id".to_string(), machine_interface_id.to_string());
             template_data.insert("pxe_url".to_string(), state.runtime_config.pxe_url.clone());
 
             if !state.runtime_config.static_pxe_url.is_empty() {
@@ -100,7 +102,7 @@ pub async fn boot(contents: MachineInterface, state: State<AppState>) -> impl In
 
             let pxe_response = RpcContext::get_pxe_instructions(
                 arch.into(),
-                machine_interface_id,
+                &contents.lookup,
                 contents.product,
                 &state.runtime_config.internal_api_url,
                 &ForgeClientConfig::new(

--- a/crates/pxe/src/routes/mod.rs
+++ b/crates/pxe/src/routes/mod.rs
@@ -16,7 +16,8 @@
  */
 use ::rpc::forge as rpc;
 use ::rpc::forge_tls_client::{self, ApiConfig, ForgeClientConfig};
-use carbide_uuid::machine::MachineInterfaceId;
+
+use crate::common::MachineLookup;
 
 pub(crate) mod cloud_init;
 pub(crate) mod ipxe;
@@ -28,7 +29,7 @@ pub struct RpcContext;
 impl RpcContext {
     async fn get_pxe_instructions(
         arch: rpc::MachineArchitecture,
-        interface_id: MachineInterfaceId,
+        lookup: &MachineLookup,
         product: Option<String>,
         url: &str,
         client_config: &ForgeClientConfig,
@@ -37,19 +38,22 @@ impl RpcContext {
         let mut client = forge_tls_client::ForgeTlsClient::retry_build(&api_config)
             .await
             .map_err(|err| err.to_string())?;
+        let (interface_id, client_ip) = match lookup {
+            MachineLookup::InterfaceId(id) => (Some(*id), None),
+            MachineLookup::SourceIp(ip) => (None, Some(ip.to_string())),
+        };
         let request = tonic::Request::new(rpc::PxeInstructionRequest {
             arch: arch as i32,
-            interface_id: Some(interface_id),
+            interface_id,
             product,
+            client_ip,
         });
         client
             .get_pxe_instructions(request)
             .await
             .map(|response| response.into_inner())
             .map_err(|error| {
-                format!(
-                    "Error in updating build needed flag for instance for machine {interface_id:?}; Error: {error}."
-                )
+                format!("Error fetching PXE instructions for {lookup:?}; Error: {error}.")
             })
     }
 }

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -4524,8 +4524,21 @@ message ForgeScoutErrorReportResult {
 
 message PxeInstructionRequest {
   MachineArchitecture arch = 1;
+  // interface_id is populated via DHCP option 43.70, either by
+  // carbide-dhcp or an operator DHCP server that integrates with
+  // carbide-api. If unset, we fall back to identifying the booting
+  // machine by its source IP (see client_ip below).
   common.MachineInterfaceId interface_id = 2;
   optional string product = 3;
+  // client_ip is the IP carbide-pxe observed for the booting machine
+  // -- read from X-Forwarded-For when carbide-pxe is fronted by a
+  // proxy, or the TCP socket peer when reached directly.
+  // Used as the machine identifier when DHCP option 43.70 wasn't
+  // populated (and interface_id above isn't set). Resolved here via
+  // find_by_ip on machine_interface_addresses to fetch the matching
+  // interface_id. At least one of interface_id or client_ip must be
+  // set; interface_id wins if both are present.
+  optional string client_ip = 4;
 }
 
 message PxeInstructions {

--- a/pxe/ipxe/local/embed.ipxe
+++ b/pxe/ipxe/local/embed.ipxe
@@ -15,12 +15,31 @@ prompt --key p --timeout 4000 Hit the ${bold}p${boldoff} key to open carbide men
 
 :whoami
 ifconf -c dhcp
-isset ${43.70} && time chain --autofree http://${next-server}:8080/api/v0/pxe/whoami?uuid=${43.70}
+# When a DHCP server (carbide-dhcp or API-integrated DHCP server) populates
+# option 43.70 with the machine_interface_id, use that as the identifier.
+# Otherwise, just rely on the client IP -- carbide-pxe will resolve it via
+# X-Forwarded-For (when proxied) or the TCP socket peer (when direct), then
+# look up the interface by IP. iPXE itself doesn't need to put the IP in
+# the URL since the network layer carries it.
+isset ${43.70} && goto whoami_uuid || goto whoami_sourceip
+
+:whoami_uuid
+time chain --autofree http://${next-server}:8080/api/v0/pxe/whoami?uuid=${43.70}
+goto carbide_menu
+
+:whoami_sourceip
+time chain --autofree http://${next-server}:8080/api/v0/pxe/whoami
 goto carbide_menu
 
 :carbide
 ifconf -c dhcp
-isset ${43.70} && time chain --autofree http://${next-server}:8080/api/v0/pxe/boot?uuid=${43.70}&buildarch=${buildarch}&platform=${platform}&manufacturer=${manufacturer}&product=${product}&serial=${serial} && exit 1 || goto error_handler
+isset ${43.70} && goto carbide_uuid || goto carbide_sourceip
+
+:carbide_uuid
+time chain --autofree http://${next-server}:8080/api/v0/pxe/boot?uuid=${43.70}&buildarch=${buildarch}&platform=${platform}&manufacturer=${manufacturer}&product=${product}&serial=${serial} && exit 1 || goto error_handler
+
+:carbide_sourceip
+time chain --autofree http://${next-server}:8080/api/v0/pxe/boot?buildarch=${buildarch}&platform=${platform}&manufacturer=${manufacturer}&product=${product}&serial=${serial} && exit 1 || goto error_handler
 
 :carbide_menu
 menu Carbide - ${hostname}


### PR DESCRIPTION
## Description

This closes https://github.com/NVIDIA/infra-controller-core/issues/1562.

We use client IP already for `whoami` and `cloud-init` (`user-data` and `meta-data`) calls, do the same for `boot`.

This introduces a new `chain` where, if `43.70` is NOT set, we just pass through a URL to `carbide-pxe` that excludes it, and then `carbide-pxe` pulls out the client IP (prioritizing `X-Forwarded-For` if it exists), and then calling back to `find_by_ip` to get the corresponding `machine_interface_id` (the same one that would have been populated by `43.70`).

The flow is:
- *iPXE boots*, runs `embed.ipxe`.
- `:carbide` checks `isset ${43.70}`.
  - If yes, chain with `?uuid=${43.70}` (existing path).
  - If no, chain without it.
- `carbide-pxe` accepts either `uuid` as a query param (or plucks an `ip_address`), plumbs it through to `carbide-api` via `PxeInstructionRequest`.
- `carbide-api` either:
  - Sees `uuid` and uses that as `interface_id`.
  - Sees `ip_address` and uses that to call `find_by_ip` to resolve the `interface_id`.
- Identical flow from here on

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

