### PR TITLE
feat: hw-health leak detector api

### DIFF
--- a/crates/bmc-mock/src/hw/bluefield3.rs
+++ b/crates/bmc-mock/src/hw/bluefield3.rs
@@ -56,7 +56,7 @@ impl Bluefield3<'_> {
             fan: 4,
             power: 3,
             current: 3,
-            leak: 0,
+            voltage: 0,
         }
     }
 

--- a/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
+++ b/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
@@ -45,7 +45,7 @@ impl DellPowerEdgeR750<'_> {
             fan: 10,
             power: 20,
             current: 10,
-            leak: 0,
+            voltage: 0,
         }
     }
 

--- a/crates/bmc-mock/src/hw/lenovo_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/lenovo_gb300_nvl.rs
@@ -237,10 +237,13 @@ impl LenovoGB300Nvl<'_> {
                         redfish::sensor::Layout {
                             temperature: 47,
                             power: 2,
-                            leak: 12, // Leak + Voltage
+                            voltage: 12,
                             fan: 24,
                             current: 0,
                         },
+                    )),
+                    leak_detectors: Some(redfish::leak_detector::generate_chassis_leak_detectors(
+                        4,
                     )),
                     ..redfish::chassis::SingleChassisConfig::defaults()
                 }))

--- a/crates/bmc-mock/src/hw/liteon_power_shelf.rs
+++ b/crates/bmc-mock/src/hw/liteon_power_shelf.rs
@@ -33,7 +33,7 @@ impl LiteOnPowerShelf<'_> {
             fan: 6,
             power: 12,
             current: 12,
-            leak: 0,
+            voltage: 0,
         }
     }
 

--- a/crates/bmc-mock/src/hw/nvidia_dgx_h100.rs
+++ b/crates/bmc-mock/src/hw/nvidia_dgx_h100.rs
@@ -312,16 +312,16 @@ impl NvidiaDgxH100<'_> {
                             fan: 36,              // FAN_*
                             power: 47,            // PWR_*
                             current: 3,           // AMP_*
-                            leak: 17,             // VOLT_*
-                                                  // TOTAL: 223 of 253
-                                                  // Omitted: 29
-                                                  //     ENERGY_* = 12,
-                                                  //     HMCReady,
-                                                  //     OVERT_* = 2,
-                                                  //     RST_GB1_GPU,
-                                                  //     SEL_FULLNESS,
-                                                  //     STATUS_* = 12,
-                                                  //     WATCHDOG2
+                            voltage: 17,
+                            // TOTAL: 223 of 253
+                            // Omitted: 29
+                            //     ENERGY_* = 12,
+                            //     HMCReady,
+                            //     OVERT_* = 2,
+                            //     RST_GB1_GPU,
+                            //     SEL_FULLNESS,
+                            //     STATUS_* = 12,
+                            //     WATCHDOG2
                         },
                     )),
                     ..redfish::chassis::SingleChassisConfig::defaults()
@@ -567,7 +567,7 @@ fn hgx_gpu_sxm_chassis(index: usize, serial: &str) -> redfish::chassis::SingleCh
             redfish::sensor::Layout {
                 temperature: 3,
                 power: 2,
-                leak: 1, // Voltage
+                voltage: 1,
                 ..Default::default()
             },
         )),

--- a/crates/bmc-mock/src/hw/nvidia_gb200.rs
+++ b/crates/bmc-mock/src/hw/nvidia_gb200.rs
@@ -57,7 +57,7 @@ impl BiancaBoard<'_> {
             redfish::sensor::Layout {
                 temperature: 2,
                 power: 3,
-                leak: 2, // Voltage
+                voltage: 2,
                 fan: 0,
                 current: 0,
                 // + 1 Energy
@@ -87,7 +87,7 @@ impl BiancaBoard<'_> {
                 redfish::sensor::Layout {
                     temperature: 3,
                     power: 2,
-                    leak: 1, // Voltage
+                    voltage: 1,
                     fan: 0,
                     current: 0,
                     // + 1 Energy

--- a/crates/bmc-mock/src/hw/nvidia_gb300.rs
+++ b/crates/bmc-mock/src/hw/nvidia_gb300.rs
@@ -30,7 +30,7 @@ impl NvidiaGB300Gpu<'_> {
             redfish::sensor::Layout {
                 temperature: 3,
                 power: 2,
-                leak: 1, // Leak + Voltage
+                voltage: 1,
                 fan: 0,
                 current: 0,
                 // + 1 Energy
@@ -60,7 +60,7 @@ impl NvidiaGB300Cpu<'_> {
             redfish::sensor::Layout {
                 temperature: 2,
                 power: 5,
-                leak: 2, // Voltage
+                voltage: 2,
                 fan: 0,
                 current: 0,
                 // + 1 Energy

--- a/crates/bmc-mock/src/hw/nvidia_switch_nd5200_ld.rs
+++ b/crates/bmc-mock/src/hw/nvidia_switch_nd5200_ld.rs
@@ -121,9 +121,11 @@ impl NvidiaSwitchNd5200Ld<'_> {
                         "MGX_BMC_0",
                         redfish::sensor::Layout {
                             temperature: 1,
-                            voltage: 8,
                             ..Default::default()
                         },
+                    )),
+                    leak_detectors: Some(redfish::leak_detector::generate_chassis_leak_detectors(
+                        8,
                     )),
                     ..redfish::chassis::SingleChassisConfig::defaults()
                 },

--- a/crates/bmc-mock/src/hw/nvidia_switch_nd5200_ld.rs
+++ b/crates/bmc-mock/src/hw/nvidia_switch_nd5200_ld.rs
@@ -121,6 +121,7 @@ impl NvidiaSwitchNd5200Ld<'_> {
                         "MGX_BMC_0",
                         redfish::sensor::Layout {
                             temperature: 1,
+                            voltage: 8,
                             ..Default::default()
                         },
                     )),

--- a/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
+++ b/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
@@ -41,7 +41,7 @@ impl WiwynnGB200Nvl<'_> {
             fan: 10,
             power: 10,
             current: 10,
-            leak: 4,
+            voltage: 4,
         }
     }
 
@@ -183,6 +183,7 @@ impl WiwynnGB200Nvl<'_> {
                     "Chassis_0",
                     Self::sensor_layout(),
                 )),
+                leak_detectors: Some(redfish::leak_detector::generate_chassis_leak_detectors(4)),
                 assembly: Some(
                     redfish::assembly::builder(&redfish::assembly::chassis_resource("Chassis_0"))
                         .add_data(

--- a/crates/bmc-mock/src/redfish/chassis.rs
+++ b/crates/bmc-mock/src/redfish/chassis.rs
@@ -60,6 +60,7 @@ pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
     const PCIE_DEVICE_ID: &str = "{pcie_device_id}";
     const SENSOR_ID: &str = "{sensor_id}";
     const POWER_SUPPLY_ID: &str = "{power_supply_id}";
+    const LEAK_DETECTOR_ID: &str = "{leak_detector_id}";
     r.route(&collection().odata_id, get(get_chassis_collection))
         .route(&resource(CHASSIS_ID).odata_id, get(get_chassis))
         .route(
@@ -116,6 +117,22 @@ pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
             &redfish::power_supply::resource(CHASSIS_ID, POWER_SUPPLY_ID).odata_id,
             get(get_chassis_power_supply),
         )
+        .route(
+            &redfish::thermal_subsystem::resource(CHASSIS_ID).odata_id,
+            get(get_chassis_thermal_subsystem),
+        )
+        .route(
+            &redfish::thermal_subsystem::leak_detection_resource(CHASSIS_ID).odata_id,
+            get(get_chassis_leak_detection),
+        )
+        .route(
+            &redfish::leak_detector::collection(CHASSIS_ID).odata_id,
+            get(get_chassis_leak_detector_collection),
+        )
+        .route(
+            &redfish::leak_detector::resource(CHASSIS_ID, LEAK_DETECTOR_ID).odata_id,
+            get(get_chassis_leak_detector),
+        )
 }
 
 pub struct SingleChassisConfig {
@@ -127,6 +144,7 @@ pub struct SingleChassisConfig {
     pub network_adapters: Option<Vec<redfish::network_adapter::NetworkAdapter>>,
     pub pcie_devices: Option<Vec<redfish::pcie_device::PCIeDevice>>,
     pub sensors: Option<Vec<redfish::sensor::Sensor>>,
+    pub leak_detectors: Option<Vec<redfish::leak_detector::LeakDetector>>,
     pub chassis_type: Cow<'static, str>,
     pub assembly: Option<serde_json::Value>,
     pub power_supplies: Option<Vec<redfish::power_supply::PowerSupply>>,
@@ -147,6 +165,7 @@ impl SingleChassisConfig {
             network_adapters: None,
             pcie_devices: None,
             sensors: None,
+            leak_detectors: None,
             assembly: None,
             power_supplies: None,
             oem: None,
@@ -224,6 +243,21 @@ impl SingleChassisState {
             .as_ref()
             .and_then(|v| v.iter().find(|v| v.id == id))
     }
+
+    fn leak_detectors(&self) -> Vec<redfish::leak_detector::LeakDetector> {
+        self.config.leak_detectors.clone().unwrap_or_default()
+    }
+
+    fn find_leak_detector(&self, id: &str) -> Option<&redfish::leak_detector::LeakDetector> {
+        self.config
+            .leak_detectors
+            .as_ref()
+            .and_then(|leak_detectors| {
+                leak_detectors
+                    .iter()
+                    .find(|detector| detector.id.as_ref() == id)
+            })
+    }
 }
 
 async fn get_chassis_collection(State(state): State<BmcState>) -> Response {
@@ -266,6 +300,11 @@ async fn get_chassis(State(state): State<BmcState>, Path(chassis_id): Path<Strin
         .is_some()
         .then_some(redfish::power_subsystem::resource(&chassis_id));
 
+    let thermal_subsystem = config
+        .leak_detectors
+        .is_some()
+        .then_some(redfish::thermal_subsystem::resource(&chassis_id));
+
     let mut b = builder(&resource(&chassis_id))
         .chassis_type(&config.chassis_type)
         .maybe_with(ChassisBuilder::assembly, &assembly)
@@ -276,6 +315,7 @@ async fn get_chassis(State(state): State<BmcState>, Path(chassis_id): Path<Strin
         .maybe_with(ChassisBuilder::manufacturer, &config.manufacturer)
         .maybe_with(ChassisBuilder::part_number, &config.part_number)
         .maybe_with(ChassisBuilder::power_subsystem, &power_subsystem)
+        .maybe_with(ChassisBuilder::thermal_subsystem, &thermal_subsystem)
         .maybe_with(ChassisBuilder::model, &config.model);
 
     if let Some(oem) = &config.oem {
@@ -509,6 +549,78 @@ async fn get_chassis_power_supply(
         .unwrap_or_else(http::not_found)
 }
 
+async fn get_chassis_thermal_subsystem(
+    State(state): State<BmcState>,
+    Path(chassis_id): Path<String>,
+) -> Response {
+    state
+        .chassis_state
+        .find(&chassis_id)
+        .map(|_| {
+            redfish::thermal_subsystem::builder(&redfish::thermal_subsystem::resource(&chassis_id))
+                .leak_detection(&redfish::thermal_subsystem::leak_detection_resource(
+                    &chassis_id,
+                ))
+                .build()
+                .into_ok_response()
+        })
+        .unwrap_or_else(http::not_found)
+}
+
+async fn get_chassis_leak_detection(
+    State(state): State<BmcState>,
+    Path(chassis_id): Path<String>,
+) -> Response {
+    state
+        .chassis_state
+        .find(&chassis_id)
+        .map(|_| {
+            redfish::thermal_subsystem::leak_detection_builder(
+                &redfish::thermal_subsystem::leak_detection_resource(&chassis_id),
+            )
+            .leak_detectors(&redfish::leak_detector::collection(&chassis_id))
+            .build()
+            .into_ok_response()
+        })
+        .unwrap_or_else(http::not_found)
+}
+
+async fn get_chassis_leak_detector_collection(
+    State(state): State<BmcState>,
+    Path(chassis_id): Path<String>,
+) -> Response {
+    state
+        .chassis_state
+        .find(&chassis_id)
+        .map(SingleChassisState::leak_detectors)
+        .map(|leak_detectors| {
+            leak_detectors
+                .iter()
+                .map(|detector| {
+                    redfish::leak_detector::resource(&chassis_id, &detector.id).entity_ref()
+                })
+                .collect::<Vec<_>>()
+        })
+        .map(|members| {
+            redfish::leak_detector::collection(&chassis_id)
+                .with_members(&members)
+                .into_ok_response()
+        })
+        .unwrap_or_else(http::not_found)
+}
+
+async fn get_chassis_leak_detector(
+    State(state): State<BmcState>,
+    Path((chassis_id, leak_detector_id)): Path<(String, String)>,
+) -> Response {
+    state
+        .chassis_state
+        .find(&chassis_id)
+        .and_then(|chassis_state| chassis_state.find_leak_detector(&leak_detector_id))
+        .map(|detector| detector.to_json(&chassis_id).into_ok_response())
+        .unwrap_or_else(http::not_found)
+}
+
 pub struct ChassisBuilder {
     value: serde_json::Value,
 }
@@ -560,6 +672,10 @@ impl ChassisBuilder {
 
     pub fn power_subsystem(self, v: &redfish::Resource<'_>) -> Self {
         self.apply_patch(v.nav_property("PowerSubsystem"))
+    }
+
+    pub fn thermal_subsystem(self, v: &redfish::Resource<'_>) -> Self {
+        self.apply_patch(v.nav_property("ThermalSubsystem"))
     }
 
     pub fn oem(self, v: &serde_json::Value) -> Self {

--- a/crates/bmc-mock/src/redfish/leak_detector.rs
+++ b/crates/bmc-mock/src/redfish/leak_detector.rs
@@ -1,0 +1,140 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+
+use serde_json::json;
+
+use crate::json::{JsonExt, JsonPatch};
+use crate::redfish;
+use crate::redfish::Builder;
+
+pub fn collection(chassis_id: &str) -> redfish::Collection<'static> {
+    let odata_id = format!(
+        "{}/LeakDetectors",
+        redfish::thermal_subsystem::leak_detection_resource(chassis_id).odata_id
+    );
+    redfish::Collection {
+        odata_id: Cow::Owned(odata_id),
+        odata_type: Cow::Borrowed("#LeakDetectorCollection.LeakDetectorCollection"),
+        name: Cow::Borrowed("Leak Detector Collection"),
+    }
+}
+
+pub fn resource<'a>(chassis_id: &str, leak_detector_id: &'a str) -> redfish::Resource<'a> {
+    let odata_id = format!("{}/{leak_detector_id}", collection(chassis_id).odata_id);
+    redfish::Resource {
+        odata_id: Cow::Owned(odata_id),
+        odata_type: Cow::Borrowed("#LeakDetector.v1_0_0.LeakDetector"),
+        id: Cow::Borrowed(leak_detector_id),
+        name: Cow::Borrowed("Leak Detector"),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LeakDetector {
+    pub id: Cow<'static, str>,
+    pub user_label: Option<Cow<'static, str>>,
+    pub detector_state: DetectorState,
+}
+
+impl LeakDetector {
+    pub fn to_json(&self, chassis_id: &str) -> serde_json::Value {
+        let mut builder = builder(&resource(chassis_id, &self.id))
+            .detector_state(self.detector_state)
+            .leak_detector_type("Moisture");
+        if let Some(user_label) = &self.user_label {
+            builder = builder.user_label(user_label);
+        }
+        builder.build()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum DetectorState {
+    Ok,
+    Warning,
+    Critical,
+}
+
+impl DetectorState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Ok => "OK",
+            Self::Warning => "Warning",
+            Self::Critical => "Critical",
+        }
+    }
+}
+
+pub fn builder(resource: &redfish::Resource) -> LeakDetectorBuilder {
+    LeakDetectorBuilder {
+        value: resource.json_patch().patch(json!({
+            "Status": redfish::resource::Status::Ok.into_json(),
+            "DetectorState": DetectorState::Ok.as_str(),
+            "LeakDetectorType": "Moisture",
+        })),
+    }
+}
+
+pub struct LeakDetectorBuilder {
+    value: serde_json::Value,
+}
+
+impl Builder for LeakDetectorBuilder {
+    fn apply_patch(self, patch: serde_json::Value) -> Self {
+        Self {
+            value: self.value.patch(patch),
+        }
+    }
+}
+
+impl LeakDetectorBuilder {
+    pub fn detector_state(self, detector_state: DetectorState) -> Self {
+        let status = match detector_state {
+            DetectorState::Ok => redfish::resource::Status::Ok,
+            DetectorState::Warning => redfish::resource::Status::Warning,
+            DetectorState::Critical => redfish::resource::Status::Critical,
+        };
+        self.apply_patch(json!({
+            "DetectorState": detector_state.as_str(),
+            "Status": status.into_json(),
+        }))
+    }
+
+    pub fn leak_detector_type(self, value: &str) -> Self {
+        self.add_str_field("LeakDetectorType", value)
+    }
+
+    pub fn user_label(self, value: &str) -> Self {
+        self.add_str_field("UserLabel", value)
+    }
+
+    pub fn build(self) -> serde_json::Value {
+        self.value
+    }
+}
+
+pub fn generate_chassis_leak_detectors(count: usize) -> Vec<LeakDetector> {
+    (1..=count)
+        .map(|index| LeakDetector {
+            id: Cow::Owned(format!("LeakDetector_{index}")),
+            user_label: Some(Cow::Owned(format!("Leak Detector {index}"))),
+            detector_state: DetectorState::Ok,
+        })
+        .collect()
+}

--- a/crates/bmc-mock/src/redfish/mod.rs
+++ b/crates/bmc-mock/src/redfish/mod.rs
@@ -24,6 +24,7 @@ pub mod collection;
 pub mod computer_system;
 pub mod ethernet_interface;
 pub mod host_interface;
+pub mod leak_detector;
 pub mod log_service;
 pub mod manager;
 pub mod manager_network_protocol;
@@ -40,6 +41,7 @@ pub mod service_root;
 pub mod software_inventory;
 pub mod storage;
 pub mod task_service;
+pub mod thermal_subsystem;
 pub mod update_service;
 
 pub mod expander_router;

--- a/crates/bmc-mock/src/redfish/sensor.rs
+++ b/crates/bmc-mock/src/redfish/sensor.rs
@@ -58,12 +58,12 @@ pub struct Layout {
     pub fan: usize,
     pub power: usize,
     pub current: usize,
-    pub leak: usize,
+    pub voltage: usize,
 }
 
 impl Layout {
     pub const fn total(&self) -> usize {
-        self.temperature + self.fan + self.power + self.current + self.leak
+        self.temperature + self.fan + self.power + self.current + self.voltage
     }
 }
 
@@ -307,7 +307,7 @@ enum SensorKind {
     Fan,
     Power,
     Current,
-    LeakDetector,
+    Voltage,
 }
 
 enum SensorReading {
@@ -338,7 +338,7 @@ impl SensorKind {
             "Rotational" => Some(Self::Fan),
             "Power" => Some(Self::Power),
             "Current" => Some(Self::Current),
-            "Voltage" => Some(Self::LeakDetector),
+            "Voltage" => Some(Self::Voltage),
             _ => None,
         }
     }
@@ -349,7 +349,7 @@ impl SensorKind {
             SensorKind::Fan => "Fan",
             SensorKind::Power => "Power",
             SensorKind::Current => "Current",
-            SensorKind::LeakDetector => "LeakDetector",
+            SensorKind::Voltage => "Voltage",
         }
     }
 
@@ -359,7 +359,7 @@ impl SensorKind {
             SensorKind::Fan => "Fan Sensor",
             SensorKind::Power => "Power Sensor",
             SensorKind::Current => "Current Sensor",
-            SensorKind::LeakDetector => "Leak Detector Sensor",
+            SensorKind::Voltage => "Voltage Sensor",
         }
     }
 
@@ -369,7 +369,7 @@ impl SensorKind {
             SensorKind::Fan => "Rotational",
             SensorKind::Power => "Power",
             SensorKind::Current => "Current",
-            SensorKind::LeakDetector => "Voltage",
+            SensorKind::Voltage => "Voltage",
         }
     }
 
@@ -379,7 +379,7 @@ impl SensorKind {
             SensorKind::Fan => "RPM",
             SensorKind::Power => "W",
             SensorKind::Current => "A",
-            SensorKind::LeakDetector => "V",
+            SensorKind::Voltage => "V",
         }
     }
 
@@ -389,7 +389,7 @@ impl SensorKind {
             SensorKind::Fan => "Fan",
             SensorKind::Power => "PowerSupply",
             SensorKind::Current => "SystemBoard",
-            SensorKind::LeakDetector => "SystemBoard",
+            SensorKind::Voltage => "SystemBoard",
         }
     }
 
@@ -399,7 +399,7 @@ impl SensorKind {
             Self::Fan => SensorReading::Unsigned(rng.random_range(0..=9400)),
             Self::Power => SensorReading::Float(random_tenths(rng, 130.0..=780.0)),
             Self::Current => SensorReading::Float(random_tenths(rng, 1.5..=42.0)),
-            Self::LeakDetector => SensorReading::Float(random_tenths(rng, 1.2..=1.85)),
+            Self::Voltage => SensorReading::Float(random_tenths(rng, 1.2..=1.85)),
         }
     }
 
@@ -422,7 +422,7 @@ impl SensorKind {
                 ..Default::default()
             },
             Self::Current => Thresholds::default(),
-            Self::LeakDetector => Thresholds {
+            Self::Voltage => Thresholds {
                 lower_critical: Some(1.5),
                 ..Default::default()
             },
@@ -468,8 +468,8 @@ pub fn generate_chassis_sensors(chassis_id: &str, layout: Layout) -> Vec<Sensor>
     append_sensors(
         &mut sensors,
         chassis_id,
-        layout.leak,
-        SensorKind::LeakDetector,
+        layout.voltage,
+        SensorKind::Voltage,
         &mut rng,
     );
     sensors
@@ -517,7 +517,7 @@ mod tests {
                 fan: 10,
                 power: 20,
                 current: 10,
-                leak: 4,
+                voltage: 4,
             },
         );
         assert_eq!(sensors.len(), 54);
@@ -548,7 +548,7 @@ mod tests {
 
     #[test]
     fn sensor_status_is_ok_when_reading_within_thresholds() {
-        let sensor = builder(&chassis_resource("System.Embedded.1", "LeakDetector_1"))
+        let sensor = builder(&chassis_resource("System.Embedded.1", "Voltage_1"))
             .reading_f64(1.7)
             .thresholds(Thresholds {
                 lower_critical: Some(1.5),
@@ -578,7 +578,7 @@ mod tests {
 
     #[test]
     fn sensor_status_is_critical_when_crossing_critical_threshold() {
-        let sensor = builder(&chassis_resource("System.Embedded.1", "LeakDetector_1"))
+        let sensor = builder(&chassis_resource("System.Embedded.1", "Voltage_1"))
             .reading_f64(1.4)
             .thresholds(Thresholds {
                 lower_critical: Some(1.5),

--- a/crates/bmc-mock/src/redfish/thermal_subsystem.rs
+++ b/crates/bmc-mock/src/redfish/thermal_subsystem.rs
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+
+use crate::json::{JsonExt, JsonPatch};
+use crate::redfish;
+use crate::redfish::Builder;
+
+pub fn resource(chassis_id: &str) -> redfish::Resource<'static> {
+    let odata_id = format!(
+        "{}/ThermalSubsystem",
+        redfish::chassis::resource(chassis_id).odata_id
+    );
+    redfish::Resource {
+        odata_id: Cow::Owned(odata_id),
+        odata_type: Cow::Borrowed("#ThermalSubsystem.v1_4_0.ThermalSubsystem"),
+        id: Cow::Borrowed("ThermalSubsystem"),
+        name: Cow::Borrowed("Thermal Subsystem"),
+    }
+}
+
+pub fn leak_detection_resource(chassis_id: &str) -> redfish::Resource<'static> {
+    let odata_id = format!("{}/LeakDetection", resource(chassis_id).odata_id);
+    redfish::Resource {
+        odata_id: Cow::Owned(odata_id),
+        odata_type: Cow::Borrowed("#LeakDetection.v1_0_0.LeakDetection"),
+        id: Cow::Borrowed("LeakDetection"),
+        name: Cow::Borrowed("Leak Detection"),
+    }
+}
+
+pub fn builder(resource: &redfish::Resource) -> ThermalSubsystemBuilder {
+    ThermalSubsystemBuilder {
+        value: resource.json_patch(),
+    }
+}
+
+pub fn leak_detection_builder(resource: &redfish::Resource) -> LeakDetectionBuilder {
+    LeakDetectionBuilder {
+        value: resource.json_patch(),
+    }
+}
+
+pub struct ThermalSubsystemBuilder {
+    value: serde_json::Value,
+}
+
+impl Builder for ThermalSubsystemBuilder {
+    fn apply_patch(self, patch: serde_json::Value) -> Self {
+        Self {
+            value: self.value.patch(patch),
+        }
+    }
+}
+
+impl ThermalSubsystemBuilder {
+    pub fn leak_detection(self, v: &redfish::Resource<'_>) -> Self {
+        self.apply_patch(v.nav_property("LeakDetection"))
+    }
+
+    pub fn build(self) -> serde_json::Value {
+        self.value
+    }
+}
+
+pub struct LeakDetectionBuilder {
+    value: serde_json::Value,
+}
+
+impl Builder for LeakDetectionBuilder {
+    fn apply_patch(self, patch: serde_json::Value) -> Self {
+        Self {
+            value: self.value.patch(patch),
+        }
+    }
+}
+
+impl LeakDetectionBuilder {
+    pub fn leak_detectors(self, v: &redfish::Collection<'_>) -> Self {
+        self.apply_patch(v.nav_property("LeakDetectors"))
+    }
+
+    pub fn build(self) -> serde_json::Value {
+        self.value
+    }
+}

--- a/crates/health/Cargo.toml
+++ b/crates/health/Cargo.toml
@@ -68,6 +68,7 @@ nv-redfish = { workspace = true, features = [
   "processors",
   "sensors",
   "storages",
+  "thermal",
   "update-service",
   "resource-status",
 ] }

--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -99,6 +99,10 @@ include_sensor_thresholds = true
 [collectors.firmware]
 firmware_refresh_interval = "30m"
 
+[collectors.leak_detector]
+poll_interval = "1m"
+state_refresh_interval = "30m"
+
 [collectors.logs]
 mode = "sse" # "sse" (default, preferred) or "periodic" (fallback)
 

--- a/crates/health/src/collectors/leak_detector.rs
+++ b/crates/health/src/collectors/leak_detector.rs
@@ -1,0 +1,284 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use nv_redfish::ServiceRoot;
+use nv_redfish::core::{Bmc, EntityTypeRef, ODataId, ToSnakeCase};
+use nv_redfish::schema::leak_detector::{DetectorState, LeakDetector};
+
+use crate::HealthError;
+use crate::collectors::{IterationResult, PeriodicCollector};
+use crate::endpoint::BmcEndpoint;
+use crate::sink::{
+    Classification, CollectorEvent, DataSink, EventContext, HealthReport, HealthReportAlert,
+    HealthReportSuccess, Probe, ReportSource,
+};
+
+pub struct LeakDetectorCollectorConfig {
+    pub data_sink: Option<Arc<dyn DataSink>>,
+    pub state_refresh_interval: Duration,
+}
+
+pub struct LeakDetectorCollector<B: Bmc> {
+    bmc: Arc<B>,
+    event_context: EventContext,
+    state: Option<LeakDetectorCollectorState>,
+    data_sink: Option<Arc<dyn DataSink>>,
+    state_refresh_interval: Duration,
+}
+
+struct LeakDetectorCollectorState {
+    detector_ids: Vec<ODataId>,
+    last_detector_refresh: Instant,
+}
+
+impl<B> PeriodicCollector<B> for LeakDetectorCollector<B>
+where
+    B: Bmc + 'static,
+    B::Error: 'static,
+{
+    type Config = LeakDetectorCollectorConfig;
+
+    fn new_runner(
+        bmc: Arc<B>,
+        endpoint: Arc<BmcEndpoint>,
+        config: Self::Config,
+    ) -> Result<Self, HealthError> {
+        let event_context =
+            EventContext::from_endpoint(endpoint.as_ref(), "leak_detector_collector");
+        Ok(Self {
+            bmc,
+            event_context,
+            state: None,
+            data_sink: config.data_sink,
+            state_refresh_interval: config.state_refresh_interval,
+        })
+    }
+
+    async fn run_iteration(&mut self) -> Result<IterationResult, HealthError> {
+        self.run_leak_detector_iteration().await
+    }
+
+    fn collector_type(&self) -> &'static str {
+        "leak_detector_collector"
+    }
+
+    async fn stop(&mut self) {
+        self.emit_event(CollectorEvent::CollectorRemoved);
+    }
+}
+
+impl<B> LeakDetectorCollector<B>
+where
+    B: Bmc + 'static,
+    B::Error: 'static,
+{
+    fn emit_event(&self, event: CollectorEvent) {
+        if let Some(data_sink) = &self.data_sink {
+            data_sink.handle_event(&self.event_context, &event);
+        }
+    }
+
+    async fn run_leak_detector_iteration(&mut self) -> Result<IterationResult, HealthError> {
+        let needs_detector_refresh = self
+            .state
+            .as_ref()
+            .map(|s| s.last_detector_refresh.elapsed() > self.state_refresh_interval)
+            .unwrap_or(true);
+
+        let mut refresh_triggered = false;
+
+        if needs_detector_refresh {
+            match self.discover_leak_detectors().await {
+                Ok(detector_ids) => {
+                    tracing::info!(
+                        detector_count = detector_ids.len(),
+                        "Leak detector discovery complete"
+                    );
+                    self.state = Some(LeakDetectorCollectorState {
+                        detector_ids,
+                        last_detector_refresh: Instant::now(),
+                    });
+                    refresh_triggered = true;
+                }
+                Err(error) => {
+                    tracing::error!(?error, "Failed to discover leak detectors");
+                    if self.state.is_none() {
+                        return Err(error);
+                    }
+                }
+            }
+        }
+
+        let detectors = if let Some(state) = &self.state {
+            self.fetch_leak_detectors(&state.detector_ids).await?
+        } else {
+            Vec::new()
+        };
+        let detector_count = detectors.len();
+        let report = build_health_report(detectors);
+
+        self.emit_event(CollectorEvent::HealthReport(Arc::new(report)));
+
+        Ok(IterationResult {
+            refresh_triggered,
+            entity_count: Some(detector_count),
+            fetch_failures: 0,
+        })
+    }
+
+    async fn discover_leak_detectors(&self) -> Result<Vec<ODataId>, HealthError> {
+        let service_root = ServiceRoot::new(self.bmc.clone()).await?;
+        let Some(chassis_collection) = service_root.chassis().await? else {
+            return Ok(Vec::new());
+        };
+
+        let mut detector_ids = Vec::new();
+        for chassis in chassis_collection.members().await? {
+            // These are optional Redfish navigation properties. Each link must
+            // be fetched before the next one exists, so this stays as an
+            // explicit step-by-step walk instead of an Option chain.
+            let Some(thermal_subsystem_ref) = &chassis.raw().thermal_subsystem else {
+                continue;
+            };
+            let thermal_subsystem = thermal_subsystem_ref
+                .get(self.bmc.as_ref())
+                .await
+                .map_err(|error| HealthError::BmcError(Box::new(error)))?;
+            let Some(leak_detection_ref) = &thermal_subsystem.leak_detection else {
+                continue;
+            };
+            let leak_detection = leak_detection_ref
+                .get(self.bmc.as_ref())
+                .await
+                .map_err(|error| HealthError::BmcError(Box::new(error)))?;
+            let Some(leak_detector_collection_ref) = &leak_detection.leak_detectors else {
+                continue;
+            };
+            let leak_detector_collection = leak_detector_collection_ref
+                .get(self.bmc.as_ref())
+                .await
+                .map_err(|error| HealthError::BmcError(Box::new(error)))?;
+
+            for leak_detector_ref in &leak_detector_collection.members {
+                detector_ids.push(leak_detector_ref.id().clone());
+            }
+        }
+
+        Ok(detector_ids)
+    }
+
+    async fn fetch_leak_detectors(
+        &self,
+        detector_ids: &[ODataId],
+    ) -> Result<Vec<Arc<LeakDetector>>, HealthError> {
+        let mut detectors = Vec::new();
+        for detector_id in detector_ids {
+            detectors.push(
+                self.bmc
+                    .get::<LeakDetector>(detector_id)
+                    .await
+                    .map_err(|error| HealthError::BmcError(Box::new(error)))?,
+            );
+        }
+
+        Ok(detectors)
+    }
+}
+
+fn build_health_report(detectors: Vec<Arc<LeakDetector>>) -> HealthReport {
+    let mut successes = Vec::new();
+    let mut alerts = Vec::new();
+
+    for detector in detectors {
+        let target = detector_target(detector.as_ref());
+        match detector.detector_state.flatten() {
+            Some(DetectorState::Ok) => successes.push(HealthReportSuccess {
+                probe_id: Probe::LeakDetection,
+                target: Some(target),
+            }),
+            Some(DetectorState::Warning) | Some(DetectorState::Critical) => {
+                alerts.push(leak_alert(detector.as_ref(), target));
+            }
+            Some(DetectorState::Unavailable)
+            | Some(DetectorState::Absent)
+            | Some(DetectorState::UnsupportedValue)
+            | None => {
+                tracing::warn!(
+                    detector = %target,
+                    state = ?detector.detector_state.flatten(),
+                    "Leak detector is not reporting an actionable leak state"
+                );
+            }
+        }
+    }
+
+    HealthReport {
+        source: ReportSource::BmcLeakDetectors,
+        observed_at: Some(chrono::Utc::now()),
+        successes,
+        alerts,
+    }
+}
+
+fn detector_target(detector: &LeakDetector) -> String {
+    detector
+        .user_label
+        .clone()
+        .filter(|label| !label.is_empty())
+        .unwrap_or_else(|| detector.odata_id().to_string())
+}
+
+fn leak_alert(detector: &LeakDetector, target: String) -> HealthReportAlert {
+    let state = detector.detector_state.flatten();
+    HealthReportAlert {
+        probe_id: Probe::LeakDetection,
+        target: Some(target.clone()),
+        message: format!(
+            "Leak detector '{}' reports {}",
+            target,
+            state
+                .map(|state| state.to_snake_case())
+                .unwrap_or("unknown")
+        ),
+        classifications: vec![Classification::LeakDetector],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn leak_alerts_are_marked_for_leak_processing() {
+        let alert = HealthReportAlert {
+            probe_id: Probe::LeakDetection,
+            target: Some("LeakDetector_1".to_string()),
+            message: "leak".to_string(),
+            classifications: vec![Classification::LeakDetector],
+        };
+
+        assert!(
+            alert
+                .classifications
+                .iter()
+                .any(|classification| classification == &Classification::LeakDetector)
+        );
+    }
+}

--- a/crates/health/src/collectors/mod.rs
+++ b/crates/health/src/collectors/mod.rs
@@ -16,6 +16,7 @@
  */
 
 mod firmware;
+mod leak_detector;
 mod logs;
 mod nmxt;
 mod nvue;
@@ -23,6 +24,7 @@ mod runtime;
 mod sensors;
 
 pub use firmware::{FirmwareCollector, FirmwareCollectorConfig};
+pub use leak_detector::{LeakDetectorCollector, LeakDetectorCollectorConfig};
 pub use logs::{LogsCollector, LogsCollectorConfig, SseLogCollector, SseLogCollectorConfig};
 pub use nmxt::{NmxtCollector, NmxtCollectorConfig};
 pub use nvue::rest::collector::{NvueRestCollector, NvueRestCollectorConfig};

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -292,6 +292,9 @@ pub struct CollectorsConfig {
     /// Firmware collector configuration (if present, firmware collector is enabled)
     pub firmware: Configurable<FirmwareCollectorConfig>,
 
+    /// Leak detector collector configuration (if present, leak detector collector is enabled)
+    pub leak_detector: Configurable<LeakDetectorCollectorConfig>,
+
     /// Logs collector configuration (if present, logs collector is enabled)
     pub logs: Configurable<LogsCollectorConfig>,
 
@@ -307,6 +310,7 @@ impl Default for CollectorsConfig {
         Self {
             sensors: Configurable::Enabled(SensorCollectorConfig::default()),
             firmware: Configurable::Disabled,
+            leak_detector: Configurable::Enabled(LeakDetectorCollectorConfig::default()),
             logs: Configurable::Disabled,
             nmxt: Configurable::Disabled,
             nvue: Configurable::Disabled,
@@ -410,6 +414,27 @@ impl Default for FirmwareCollectorConfig {
     fn default() -> Self {
         Self {
             firmware_refresh_interval: Duration::from_secs(60 * 60 * 2), // 2 hours
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct LeakDetectorCollectorConfig {
+    /// Interval between thermal subsystem leak detector polls.
+    #[serde(with = "humantime_serde")]
+    pub poll_interval: Duration,
+
+    /// Interval between thermal subsystem leak detector discovery refreshes.
+    #[serde(with = "humantime_serde")]
+    pub state_refresh_interval: Duration,
+}
+
+impl Default for LeakDetectorCollectorConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: Duration::from_secs(60),
+            state_refresh_interval: Duration::from_secs(60 * 30),
         }
     }
 }
@@ -771,6 +796,7 @@ mod tests {
 
         assert!(config.collectors.sensors.is_enabled());
         assert!(config.collectors.firmware.is_enabled());
+        assert!(config.collectors.leak_detector.is_enabled());
         assert!(config.collectors.logs.is_enabled());
         assert!(config.collectors.nvue.is_enabled());
         assert!(!config.sinks.tracing.is_enabled());
@@ -792,6 +818,16 @@ mod tests {
             assert!(logs.validate().is_ok());
         } else {
             panic!("logs empty")
+        }
+
+        if let Configurable::Enabled(ref leak_detector) = config.collectors.leak_detector {
+            assert_eq!(leak_detector.poll_interval, Duration::from_secs(60));
+            assert_eq!(
+                leak_detector.state_refresh_interval,
+                Duration::from_secs(1800)
+            );
+        } else {
+            panic!("leak detector collector is disabled")
         }
 
         if let Configurable::Enabled(ref leak_detection) = config.processors.leak_detection {
@@ -888,6 +924,7 @@ cache_size = 50
         }
 
         assert!(!config.collectors.firmware.is_enabled());
+        assert!(config.collectors.leak_detector.is_enabled());
         assert!(!config.collectors.logs.is_enabled());
         assert!(config.processors.leak_detection.is_enabled());
 
@@ -971,6 +1008,7 @@ cache_size = 50
         assert_eq!(config.metrics.endpoint, "0.0.0.0:9009");
         assert!(config.rate_limit.is_enabled());
         assert!(config.processors.leak_detection.is_enabled());
+        assert!(config.collectors.leak_detector.is_enabled());
         assert!(!config.collectors.nvue.is_enabled());
     }
 

--- a/crates/health/src/discovery/cleanup.rs
+++ b/crates/health/src/discovery/cleanup.rs
@@ -56,6 +56,7 @@ pub(super) fn stop_removed_bmc_collectors(
             remaining_sensors = ctx.collectors.len(CollectorKind::Sensor),
             remaining_collectors = ctx.collectors.len(CollectorKind::Logs),
             remaining_firmware_collectors = ctx.collectors.len(CollectorKind::Firmware),
+            remaining_leak_detector_collectors = ctx.collectors.len(CollectorKind::LeakDetector),
             remaining_nmxt_collectors = ctx.collectors.len(CollectorKind::Nmxt),
             remaining_nvue_rest_collectors = ctx.collectors.len(CollectorKind::NvueRest),
             "Cleaned up removed endpoints"
@@ -81,6 +82,7 @@ mod tests {
             HashMap::from([("b".to_string(), 3), ("c".to_string(), 4)]),
         );
         maps.insert(CollectorKind::Firmware, HashMap::new());
+        maps.insert(CollectorKind::LeakDetector, HashMap::new());
         maps.insert(CollectorKind::Nmxt, HashMap::new());
         maps.insert(CollectorKind::NvueRest, HashMap::new());
 

--- a/crates/health/src/discovery/context.rs
+++ b/crates/health/src/discovery/context.rs
@@ -29,6 +29,7 @@ use crate::bmc::AuthRefreshingBmc;
 use crate::collectors::Collector;
 use crate::config::{
     Config, Configurable, FirmwareCollectorConfig as FirmwareCollectorOptions,
+    LeakDetectorCollectorConfig as LeakDetectorCollectorOptions,
     LogsCollectorConfig as LogsCollectorOptions, NmxtCollectorConfig as NmxtCollectorOptions,
     NvueCollectorConfig as NvueCollectorOptions, SensorCollectorConfig as SensorCollectorOptions,
 };
@@ -42,15 +43,17 @@ pub(super) enum CollectorKind {
     Sensor,
     Logs,
     Firmware,
+    LeakDetector,
     Nmxt,
     NvueRest,
 }
 
 impl CollectorKind {
-    pub(super) const ALL: [CollectorKind; 5] = [
+    pub(super) const ALL: [CollectorKind; 6] = [
         CollectorKind::Sensor,
         CollectorKind::Logs,
         CollectorKind::Firmware,
+        CollectorKind::LeakDetector,
         CollectorKind::Nmxt,
         CollectorKind::NvueRest,
     ];
@@ -60,6 +63,9 @@ impl CollectorKind {
             CollectorKind::Sensor => "Stopping sensor collector for removed BMC endpoint",
             CollectorKind::Logs => "Stopping logs collector for removed BMC endpoint",
             CollectorKind::Firmware => "Stopping firmware collector for removed BMC endpoint",
+            CollectorKind::LeakDetector => {
+                "Stopping leak detector collector for removed BMC endpoint"
+            }
             CollectorKind::Nmxt => "Stopping NMX-T collector for removed BMC endpoint",
             CollectorKind::NvueRest => "Stopping NVUE REST collector for removed BMC endpoint",
         }
@@ -69,6 +75,7 @@ impl CollectorKind {
 pub(super) struct CollectorState {
     sensors: HashMap<Cow<'static, str>, Collector>,
     firmware: HashMap<Cow<'static, str>, Collector>,
+    leak_detector: HashMap<Cow<'static, str>, Collector>,
     logs: HashMap<Cow<'static, str>, Collector>,
     nmxt: HashMap<Cow<'static, str>, Collector>,
     nvue_rest: HashMap<Cow<'static, str>, Collector>,
@@ -79,6 +86,7 @@ impl CollectorState {
         Self {
             sensors: HashMap::new(),
             firmware: HashMap::new(),
+            leak_detector: HashMap::new(),
             logs: HashMap::new(),
             nmxt: HashMap::new(),
             nvue_rest: HashMap::new(),
@@ -90,6 +98,7 @@ impl CollectorState {
             CollectorKind::Sensor => &self.sensors,
             CollectorKind::Logs => &self.logs,
             CollectorKind::Firmware => &self.firmware,
+            CollectorKind::LeakDetector => &self.leak_detector,
             CollectorKind::Nmxt => &self.nmxt,
             CollectorKind::NvueRest => &self.nvue_rest,
         }
@@ -103,6 +112,7 @@ impl CollectorState {
             CollectorKind::Sensor => &mut self.sensors,
             CollectorKind::Logs => &mut self.logs,
             CollectorKind::Firmware => &mut self.firmware,
+            CollectorKind::LeakDetector => &mut self.leak_detector,
             CollectorKind::Nmxt => &mut self.nmxt,
             CollectorKind::NvueRest => &mut self.nvue_rest,
         }
@@ -133,6 +143,7 @@ impl CollectorState {
             .keys()
             .chain(self.logs.keys())
             .chain(self.firmware.keys())
+            .chain(self.leak_detector.keys())
             .chain(self.nmxt.keys())
             .chain(self.nvue_rest.keys())
             .filter(|key| !active_keys.contains(*key))
@@ -152,6 +163,7 @@ pub struct DiscoveryLoopContext {
     pub(crate) sensors_config: Configurable<SensorCollectorOptions>,
     pub(crate) logs_config: Configurable<LogsCollectorOptions>,
     pub(crate) firmware_config: Configurable<FirmwareCollectorOptions>,
+    pub(crate) leak_detector_config: Configurable<LeakDetectorCollectorOptions>,
     pub(crate) nmxt_config: Configurable<NmxtCollectorOptions>,
     pub(crate) nvue_config: Configurable<NvueCollectorOptions>,
 }
@@ -191,6 +203,7 @@ impl DiscoveryLoopContext {
         let sensors_config = config.collectors.sensors.clone();
         let logs_config = config.collectors.logs.clone();
         let firmware_config = config.collectors.firmware.clone();
+        let leak_detector_config = config.collectors.leak_detector.clone();
         let nmxt_config = config.collectors.nmxt.clone();
         let nvue_config = config.collectors.nvue.clone();
 
@@ -205,6 +218,7 @@ impl DiscoveryLoopContext {
             sensors_config,
             logs_config,
             firmware_config,
+            leak_detector_config,
             nmxt_config,
             nvue_config,
         })

--- a/crates/health/src/discovery/spawn.rs
+++ b/crates/health/src/discovery/spawn.rs
@@ -22,9 +22,10 @@ use super::context::{BmcClient, CollectorKind, DiscoveryLoopContext};
 use crate::HealthError;
 use crate::collectors::{
     BackoffConfig, Collector, CollectorStartContext, FirmwareCollector, FirmwareCollectorConfig,
-    LogsCollector, LogsCollectorConfig, NmxtCollector, NmxtCollectorConfig, NvueRestCollector,
-    NvueRestCollectorConfig, SensorCollector, SensorCollectorConfig, SseLogCollector,
-    SseLogCollectorConfig, StreamingCollectorStartContext,
+    LeakDetectorCollector, LeakDetectorCollectorConfig, LogsCollector, LogsCollectorConfig,
+    NmxtCollector, NmxtCollectorConfig, NvueRestCollector, NvueRestCollectorConfig,
+    SensorCollector, SensorCollectorConfig, SseLogCollector, SseLogCollectorConfig,
+    StreamingCollectorStartContext,
 };
 use crate::config::{Configurable, LogCollectionMode};
 use crate::endpoint::{BmcEndpoint, EndpointMetadata};
@@ -206,6 +207,49 @@ pub(super) async fn spawn_collectors_for_endpoint(
         }
     }
 
+    if let Configurable::Enabled(leak_detector_cfg) = &ctx.leak_detector_config
+        && !ctx.collectors.contains(CollectorKind::LeakDetector, &key)
+    {
+        let collector_registry =
+            Arc::new(ctx.metrics_manager.create_collector_registry(
+                format!("leak_detector_collector_{key}"),
+                metrics_prefix,
+            )?);
+        match Collector::start::<LeakDetectorCollector<BmcClient>>(
+            endpoint_arc.clone(),
+            LeakDetectorCollectorConfig {
+                data_sink: data_sink.clone(),
+                state_refresh_interval: leak_detector_cfg.state_refresh_interval,
+            },
+            CollectorStartContext {
+                limiter: ctx.limiter.clone(),
+                iteration_interval: leak_detector_cfg.poll_interval,
+                collector_registry,
+                metrics_manager: ctx.metrics_manager.clone(),
+                client: ctx.client.clone(),
+                health_options: ctx.config.clone(),
+            },
+        ) {
+            Ok(collector) => {
+                ctx.collectors
+                    .insert(CollectorKind::LeakDetector, key.clone(), collector);
+                tracing::info!(
+                    endpoint_key = %key,
+                    total_leak_detector_collectors =
+                        ctx.collectors.len(CollectorKind::LeakDetector),
+                    "Started leak detector collection for BMC endpoint"
+                );
+            }
+            Err(error) => {
+                tracing::error!(
+                    ?error,
+                    "Could not start leak detector collector for: {:?}",
+                    endpoint.addr
+                )
+            }
+        }
+    }
+
     if let Configurable::Enabled(nmxt_cfg) = &ctx.nmxt_config
         && !ctx.collectors.contains(CollectorKind::Nmxt, &key)
         && matches!(endpoint.metadata, Some(EndpointMetadata::Switch(_)))
@@ -359,6 +403,7 @@ mod tests {
         config.collectors.sensors = Configurable::Disabled;
         config.collectors.logs = Configurable::Disabled;
         config.collectors.firmware = Configurable::Disabled;
+        config.collectors.leak_detector = Configurable::Disabled;
         config.collectors.nmxt = Configurable::Disabled;
 
         let limiter: Arc<dyn RateLimiter> = Arc::new(NoopLimiter);
@@ -391,6 +436,7 @@ mod tests {
         assert_eq!(ctx.collectors.len(CollectorKind::Sensor), 0);
         assert_eq!(ctx.collectors.len(CollectorKind::Logs), 0);
         assert_eq!(ctx.collectors.len(CollectorKind::Firmware), 0);
+        assert_eq!(ctx.collectors.len(CollectorKind::LeakDetector), 0);
         assert_eq!(ctx.collectors.len(CollectorKind::Nmxt), 0);
         assert_eq!(ctx.collectors.len(CollectorKind::NvueRest), 0);
     }

--- a/crates/health/src/processor/leak_events.rs
+++ b/crates/health/src/processor/leak_events.rs
@@ -24,8 +24,6 @@ use crate::sink::{
     ReportSource,
 };
 
-const LEAK_DETECTOR_MARKER: &str = Classification::LeakDetector.as_str();
-
 pub struct LeakEventProcessor {
     minimum_alerts_per_report: usize,
 }
@@ -44,9 +42,9 @@ impl LeakEventProcessor {
 
 fn is_leak_detector_alert(alert: &HealthReportAlert) -> bool {
     alert
-        .target
-        .as_deref()
-        .is_some_and(|input| input.contains(LEAK_DETECTOR_MARKER))
+        .classifications
+        .iter()
+        .any(|classification| classification == &Classification::LeakDetector)
 }
 
 fn leak_details(alerts: &[&HealthReportAlert]) -> String {
@@ -75,6 +73,10 @@ impl EventProcessor for LeakEventProcessor {
         let CollectorEvent::HealthReport(report) = event else {
             return Vec::new();
         };
+
+        if report.source != ReportSource::BmcLeakDetectors {
+            return Vec::new();
+        }
 
         let leak_alerts: Vec<&HealthReportAlert> = report
             .alerts
@@ -138,7 +140,7 @@ mod tests {
                 port: Some(443),
                 mac: MacAddress::from_str("42:9e:b1:bd:9d:dd").expect("valid mac"),
             },
-            collector_type: "sensor_collector",
+            collector_type: "leak_detector_collector",
             metadata: None,
             rack_id: None,
         }
@@ -146,7 +148,7 @@ mod tests {
 
     fn leak_alert(target: &str) -> HealthReportAlert {
         HealthReportAlert {
-            probe_id: Probe::Sensor,
+            probe_id: Probe::LeakDetection,
             target: Some(target.to_string()),
             message: "LeakDetector found leak".to_string(),
             classifications: vec![Classification::LeakDetector],
@@ -157,7 +159,7 @@ mod tests {
     fn does_not_emit_alert_when_threshold_not_met() {
         let processor = LeakEventProcessor::new(2);
         let report = HealthReport {
-            source: ReportSource::BmcSensors,
+            source: ReportSource::BmcLeakDetectors,
             observed_at: Some(chrono::Utc::now()),
             successes: Vec::new(),
             alerts: vec![leak_alert("LeakDetector_Probe")],
@@ -180,7 +182,7 @@ mod tests {
     fn emits_derived_leak_report_when_threshold_met() {
         let processor = LeakEventProcessor::new(1);
         let report = HealthReport {
-            source: ReportSource::BmcSensors,
+            source: ReportSource::BmcLeakDetectors,
             observed_at: Some(chrono::Utc::now()),
             successes: Vec::new(),
             alerts: vec![leak_alert("LeakDetector_Probe")],
@@ -220,6 +222,25 @@ mod tests {
             .into(),
         );
         let emitted = processor.process_event(&context(), &metric_event);
+        assert!(emitted.is_empty());
+    }
+
+    #[test]
+    fn ignores_sensor_health_reports() {
+        let processor = LeakEventProcessor::new(1);
+        let report = HealthReport {
+            source: ReportSource::BmcSensors,
+            observed_at: Some(chrono::Utc::now()),
+            successes: vec![HealthReportSuccess {
+                probe_id: Probe::Sensor,
+                target: Some("Voltage_1".to_string()),
+            }],
+            alerts: vec![],
+        };
+
+        let emitted =
+            processor.process_event(&context(), &CollectorEvent::HealthReport(Arc::new(report)));
+
         assert!(emitted.is_empty());
     }
 }

--- a/crates/health/src/sink/events.rs
+++ b/crates/health/src/sink/events.rs
@@ -146,6 +146,7 @@ pub enum CollectorEvent {
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum ReportSource {
     BmcSensors,
+    BmcLeakDetectors,
     TrayLeakDetection,
     RackLeakDetection,
 }
@@ -154,6 +155,7 @@ impl ReportSource {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::BmcSensors => "bmc-sensors",
+            Self::BmcLeakDetectors => "bmc-leak-detectors",
             Self::TrayLeakDetection => "tray-leak-detection",
             Self::RackLeakDetection => "rack-leak-detection",
         }


### PR DESCRIPTION
## Description
Added LeakDetector support for HW-Health, before it used just sensors, but switches does not maps sensors to LeakDetectors. This introducec new collector type for LeakDetector entity.

Also enchance BMC Mock with ThermalSubystem and LeakDetector entities.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

