### PR TITLE
feat(dpf): MachineUpdateManager - dpu_firmware_update support for DPF provisioned machines

### DIFF
--- a/crates/api-model/src/dpu_machine_update.rs
+++ b/crates/api-model/src/dpu_machine_update.rs
@@ -109,10 +109,10 @@ impl DpuMachineUpdate {
         unavailable_outdated_dpus
     }
 
-    pub fn find_outdated_dpus(
+    pub fn find_outdated_dpus<'a>(
         dpu_nic_firmware_update_versions: &[String],
-        snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
-    ) -> Vec<OutdatedHost> {
+        snapshots: &'a HashMap<MachineId, ManagedHostStateSnapshot>,
+    ) -> Vec<OutdatedHost<'a>> {
         snapshots
             .iter()
             .filter_map(|(machine_id, managed_host)| {
@@ -148,7 +148,7 @@ impl DpuMachineUpdate {
                 }
 
                 Some(OutdatedHost {
-                    managed_host: managed_host.clone(),
+                    managed_host,
                     outdated_dpus,
                 })
             })
@@ -159,10 +159,10 @@ impl DpuMachineUpdate {
     /// snapshots and produce one [`OutdatedHost`] per host. DPUs that do not
     /// appear in any snapshot are dropped silently — the upstream DPF query
     /// layer is responsible for logging that case.
-    pub fn find_outdated_dpus_dpf(
+    pub fn find_outdated_dpus_dpf<'a>(
         dpf_outdated: &[OutdatedDpfDpu],
-        snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
-    ) -> Vec<OutdatedHost> {
+        snapshots: &'a HashMap<MachineId, ManagedHostStateSnapshot>,
+    ) -> Vec<OutdatedHost<'a>> {
         if dpf_outdated.is_empty() {
             return vec![];
         }
@@ -187,7 +187,7 @@ impl DpuMachineUpdate {
         by_host
             .into_iter()
             .filter_map(|(host_id, outdated_dpus)| {
-                let managed_host = snapshots.get(&host_id)?.clone();
+                let managed_host = snapshots.get(&host_id)?;
                 Some(OutdatedHost {
                     managed_host,
                     outdated_dpus,
@@ -197,12 +197,12 @@ impl DpuMachineUpdate {
     }
 }
 
-pub struct OutdatedHost {
-    pub managed_host: ManagedHostStateSnapshot,
+pub struct OutdatedHost<'a> {
+    pub managed_host: &'a ManagedHostStateSnapshot,
     pub outdated_dpus: Vec<DpuMachineUpdate>,
 }
 
-impl OutdatedHost {
+impl OutdatedHost<'_> {
     pub fn is_available_for_updates(&self) -> bool {
         // Skip any machines that have pending health alerts
         if !self.managed_host.aggregate_health.alerts.is_empty() {

--- a/crates/api-model/src/dpu_machine_update.rs
+++ b/crates/api-model/src/dpu_machine_update.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use carbide_uuid::machine::MachineId;
 use sqlx::FromRow;
 
+use crate::errors::ModelError;
 use crate::machine::{ManagedHostState, ManagedHostStateSnapshot};
 
 #[derive(Debug, FromRow)]
@@ -26,6 +27,18 @@ pub struct DpuMachineUpdate {
     pub host_machine_id: MachineId,
     pub dpu_machine_id: MachineId,
     pub firmware_version: String,
+}
+
+/// A DPU identified via DPF whose installed BFB no longer matches the
+/// expected one. Produced by the DPF query layer and joined to host snapshots
+/// by [`DpuMachineUpdate::find_outdated_dpus_dpf`].
+#[derive(Debug, Clone)]
+pub struct OutdatedDpfDpu {
+    pub dpu_machine_id: MachineId,
+    /// Expected BFB filename (e.g. `dpf-operator-system-bf-bundle-<hash>.bfb`).
+    /// Used as the `firmware_version` field for traceability when this DPU is
+    /// turned into a [`DpuMachineUpdate`].
+    pub target_bfb: String,
 }
 
 impl DpuMachineUpdate {
@@ -44,12 +57,15 @@ impl DpuMachineUpdate {
         limit: Option<i32>,
         dpu_nic_firmware_update_versions: &[String],
         snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
-    ) -> Vec<DpuMachineUpdate> {
+        dpf_outdated: &[OutdatedDpfDpu],
+    ) -> Result<Vec<DpuMachineUpdate>, ModelError> {
         if limit.is_some_and(|l| l <= 0) {
-            return vec![];
+            return Ok(vec![]);
         }
 
-        let outdated_dpus = Self::find_outdated_dpus(dpu_nic_firmware_update_versions, snapshots);
+        let mut outdated_dpus =
+            Self::find_outdated_dpus(dpu_nic_firmware_update_versions, snapshots);
+        outdated_dpus.extend(Self::find_outdated_dpus_dpf(dpf_outdated, snapshots));
 
         let mut scheduled_host_updates = 0;
         let available_outdated_dpus: Vec<DpuMachineUpdate> = outdated_dpus
@@ -70,7 +86,7 @@ impl DpuMachineUpdate {
             .flatten()
             .collect();
 
-        available_outdated_dpus
+        Ok(available_outdated_dpus)
     }
 
     pub fn find_unavailable_outdated_dpus(
@@ -133,6 +149,47 @@ impl DpuMachineUpdate {
 
                 Some(OutdatedHost {
                     managed_host: managed_host.clone(),
+                    outdated_dpus,
+                })
+            })
+            .collect()
+    }
+
+    /// Join DPF-identified outdated DPUs (by `MachineId`) to their owning host
+    /// snapshots and produce one [`OutdatedHost`] per host. DPUs that do not
+    /// appear in any snapshot are dropped silently — the upstream DPF query
+    /// layer is responsible for logging that case.
+    pub fn find_outdated_dpus_dpf(
+        dpf_outdated: &[OutdatedDpfDpu],
+        snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
+    ) -> Vec<OutdatedHost> {
+        if dpf_outdated.is_empty() {
+            return vec![];
+        }
+
+        let dpu_to_host: HashMap<MachineId, MachineId> = snapshots
+            .iter()
+            .flat_map(|(host_id, snap)| snap.dpu_snapshots.iter().map(move |d| (d.id, *host_id)))
+            .collect();
+
+        let mut by_host: HashMap<MachineId, Vec<DpuMachineUpdate>> = HashMap::new();
+        for outdated in dpf_outdated {
+            let Some(&host_id) = dpu_to_host.get(&outdated.dpu_machine_id) else {
+                continue;
+            };
+            by_host.entry(host_id).or_default().push(DpuMachineUpdate {
+                host_machine_id: host_id,
+                dpu_machine_id: outdated.dpu_machine_id,
+                firmware_version: outdated.target_bfb.clone(),
+            });
+        }
+
+        by_host
+            .into_iter()
+            .filter_map(|(host_id, outdated_dpus)| {
+                let managed_host = snapshots.get(&host_id)?.clone();
+                Some(OutdatedHost {
+                    managed_host,
                     outdated_dpus,
                 })
             })

--- a/crates/api/src/dpf.rs
+++ b/crates/api/src/dpf.rs
@@ -21,16 +21,26 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use carbide_dpf::types::{HostDpfSnapshot, ServiceTemplateVersion};
 use carbide_dpf::{
     BmcPasswordProvider, DpfError, DpfSdk, DpuDeviceInfo, DpuNodeInfo, DpuPhase, DpuWatcher,
-    HostDpfSnapshot, KubeRepository, ResourceLabeler, ServiceTemplateVersion,
-    node_id_from_dpu_node_cr_name,
+    KubeRepository, ResourceLabeler, node_id_from_dpu_node_cr_name,
 };
+use carbide_uuid::machine::MachineId;
+use model::dpu_machine_update::OutdatedDpfDpu;
 use sqlx::PgPool;
 use tokio::task::JoinSet;
 
 use crate::state_controller::controller::Enqueuer;
 use crate::state_controller::machine::io::MachineStateControllerIO;
+
+/// Label key used by [`CarbideDPFLabeler`] to stamp the carbide `MachineId` of
+/// the DPU onto its DPUDevice. Propagates to the DPU CR via DPF.
+const DPU_MACHINE_ID_LABEL: &str = "carbide.nvidia.com/dpu-machine-id";
+
+/// Label key used by [`CarbideDPFLabeler`] to mark a DPU device as
+/// carbide-controlled. Propagates to the DPU CR.
+const CONTROLLED_DEVICE_LABEL: &str = "carbide.nvidia.com/controlled.device";
 
 /// Trait for DPF SDK operations used by Carbide.
 ///
@@ -86,6 +96,14 @@ pub trait DpfOperations: Send + Sync + std::fmt::Debug {
     /// CR — used for comparing config vs deployed state.
     async fn list_service_template_versions(&self)
     -> Result<Vec<ServiceTemplateVersion>, DpfError>;
+
+    /// Return DPUs whose installed BFB or `spec.dpuFlavor` does not match
+    /// the namespace's ready DPUDeployment, mapped back to carbide
+    /// `MachineId` via the `carbide.nvidia.com/dpu-machine-id` label. The
+    /// expected BFB and flavor are read from the live DPUDeployment, not
+    /// from carbide config — see [`DpfSdk::find_outdated_dpus_dpf`] for
+    /// details.
+    async fn find_outdated_dpus_dpf(&self) -> Result<Vec<OutdatedDpfDpu>, DpfError>;
 }
 
 /// Applies carbide-specific labels to DPF resources.
@@ -109,10 +127,7 @@ impl CarbideDPFLabeler {
 impl ResourceLabeler for CarbideDPFLabeler {
     fn device_labels(&self, info: &DpuDeviceInfo) -> BTreeMap<String, String> {
         BTreeMap::from([
-            (
-                "carbide.nvidia.com/controlled.device".to_string(),
-                "true".to_string(),
-            ),
+            (CONTROLLED_DEVICE_LABEL.to_string(), "true".to_string()),
             (
                 "carbide.nvidia.com/host-bmc-ip".to_string(),
                 info.host_bmc_ip.clone(),
@@ -122,7 +137,7 @@ impl ResourceLabeler for CarbideDPFLabeler {
                 info.is_primary.to_string(),
             ),
             (
-                "carbide.nvidia.com/dpu-machine-id".to_string(),
+                DPU_MACHINE_ID_LABEL.to_string(),
                 info.dpu_machine_id.clone(),
             ),
         ])
@@ -146,7 +161,7 @@ impl ResourceLabeler for CarbideDPFLabeler {
     }
 
     fn dpu_label_selector(&self) -> Option<String> {
-        Some("carbide.nvidia.com/controlled.device=true".to_string())
+        Some(format!("{CONTROLLED_DEVICE_LABEL}=true"))
     }
 }
 
@@ -389,5 +404,41 @@ impl DpfOperations for DpfSdkOps {
         &self,
     ) -> Result<Vec<ServiceTemplateVersion>, DpfError> {
         self.sdk.list_service_template_versions().await
+    }
+
+    async fn find_outdated_dpus_dpf(&self) -> Result<Vec<OutdatedDpfDpu>, DpfError> {
+        let label_selector = format!("{CONTROLLED_DEVICE_LABEL}=true");
+        let mismatches = self
+            .sdk
+            .find_outdated_dpus_dpf(Some(label_selector.as_str()))
+            .await?;
+
+        let mut out = Vec::with_capacity(mismatches.len());
+        for m in mismatches {
+            let Some(machine_id_str) = m.dpu_labels.get(DPU_MACHINE_ID_LABEL) else {
+                tracing::warn!(
+                    dpu = %m.dpu_cr_name,
+                    "Outdated DPU missing {DPU_MACHINE_ID_LABEL} label; skipping"
+                );
+                continue;
+            };
+            let dpu_machine_id: MachineId = match machine_id_str.parse() {
+                Ok(id) => id,
+                Err(e) => {
+                    tracing::warn!(
+                        dpu = %m.dpu_cr_name,
+                        label_value = %machine_id_str,
+                        error = %e,
+                        "Outdated DPU has invalid {DPU_MACHINE_ID_LABEL} label; skipping"
+                    );
+                    continue;
+                }
+            };
+            out.push(OutdatedDpfDpu {
+                dpu_machine_id,
+                target_bfb: m.target_bfb,
+            });
+        }
+        Ok(out)
     }
 }

--- a/crates/api/src/machine_update_manager/dpu_nic_firmware.rs
+++ b/crates/api/src/machine_update_manager/dpu_nic_firmware.rs
@@ -22,13 +22,14 @@ use std::sync::atomic::Ordering;
 use async_trait::async_trait;
 use carbide_uuid::machine::MachineId;
 use db::dpu_machine_update;
-use model::dpu_machine_update::DpuMachineUpdate;
+use model::dpu_machine_update::{DpuMachineUpdate, OutdatedDpfDpu};
 use model::machine::ManagedHostStateSnapshot;
 use sqlx::PgConnection;
 
 use super::dpu_nic_firmware_metrics::DpuNicFirmwareUpdateMetrics;
 use super::machine_update_module::MachineUpdateModule;
 use crate::cfg::file::CarbideConfig;
+use crate::dpf::DpfOperations;
 use crate::machine_update_manager::MachineUpdateManager;
 use crate::{CarbideResult, DatabaseError};
 
@@ -42,6 +43,9 @@ use crate::{CarbideResult, DatabaseError};
 pub struct DpuNicFirmwareUpdate {
     pub metrics: Option<DpuNicFirmwareUpdateMetrics>,
     pub config: Arc<CarbideConfig>,
+    /// DPF handle for discovering outdated DPF-managed DPUs. `None` when DPF
+    /// is disabled in config; in that case `find_outdated_dpus_dpf` is not called.
+    pub dpf: Option<Arc<dyn DpfOperations>>,
 }
 
 #[async_trait]
@@ -67,13 +71,14 @@ impl MachineUpdateModule for DpuNicFirmwareUpdate {
 
     async fn start_updates(
         &self,
-        txn: &mut PgConnection,
+        pool: &sqlx::Pool<sqlx::Postgres>,
         available_updates: i32,
         updating_host_machines: &HashSet<MachineId>,
         snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
     ) -> CarbideResult<HashSet<MachineId>> {
         let machine_updates: Vec<DpuMachineUpdate> = self
             .check_for_updates(snapshots, available_updates)
+            .await
             .into_iter()
             .filter(|u| updating_host_machines.get(&u.host_machine_id).is_none())
             .collect();
@@ -108,9 +113,14 @@ impl MachineUpdateModule for DpuNicFirmwareUpdate {
             // If the reprovisioning failed to update the database for a
             // given {dpu,host}_machine_id, log it as a warning and don't
             // add it to updates_started.
+
+            let mut txn = db::Transaction::begin(pool).await?;
             if let Err(reprovisioning_err) =
-                dpu_machine_update::trigger_reprovisioning_for_managed_host(txn, &machine_updates)
-                    .await
+                dpu_machine_update::trigger_reprovisioning_for_managed_host(
+                    &mut txn,
+                    &machine_updates,
+                )
+                .await
             {
                 match reprovisioning_err {
                     DatabaseError::NotFoundError { id, .. } => {
@@ -126,6 +136,8 @@ impl MachineUpdateModule for DpuNicFirmwareUpdate {
                     }
                 }
             }
+
+            txn.commit().await?;
 
             updates_started.insert(host_machine_id);
         }
@@ -165,18 +177,24 @@ impl MachineUpdateModule for DpuNicFirmwareUpdate {
 
     async fn update_metrics(
         &self,
-        txn: &mut PgConnection,
+        pool: &sqlx::Pool<sqlx::Postgres>,
         snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
-    ) {
-        let outdated_dpus = DpuMachineUpdate::find_available_outdated_dpus(
+    ) -> CarbideResult<()> {
+        let dpf_outdated = self.fetch_dpf_outdated().await;
+        match DpuMachineUpdate::find_available_outdated_dpus(
             None,
             &self.config.dpu_config.dpu_nic_firmware_update_versions,
             snapshots,
-        );
-        if let Some(metrics) = &self.metrics {
-            metrics
-                .pending_firmware_updates
-                .store(outdated_dpus.len() as u64, Ordering::Relaxed);
+            &dpf_outdated,
+        ) {
+            Ok(outdated_dpus) => {
+                if let Some(metrics) = &self.metrics {
+                    metrics
+                        .pending_firmware_updates
+                        .store(outdated_dpus.len() as u64, Ordering::Relaxed);
+                }
+            }
+            Err(e) => tracing::warn!(error=%e, "Error geting outdated dpus for metrics"),
         }
 
         let outdated_dpus = DpuMachineUpdate::find_unavailable_outdated_dpus(
@@ -189,24 +207,32 @@ impl MachineUpdateModule for DpuNicFirmwareUpdate {
                 .store(outdated_dpus.len() as u64, Ordering::Relaxed);
         }
 
-        match dpu_machine_update::get_fw_updates_running_count(txn).await {
+        let mut txn = db::Transaction::begin(pool).await?;
+        match dpu_machine_update::get_fw_updates_running_count(&mut txn).await {
             Ok(count) => {
                 if let Some(metrics) = &self.metrics {
                     metrics
                         .running_dpu_updates
                         .store(count as u64, Ordering::Relaxed);
                 }
+                txn.commit().await?;
             }
             Err(e) => tracing::warn!(
                 error = %e,
                 "Error getting running upgrade count for metrics",
             ),
         }
+
+        Ok(())
     }
 }
 
 impl DpuNicFirmwareUpdate {
-    pub fn new(config: Arc<CarbideConfig>, meter: opentelemetry::metrics::Meter) -> Option<Self> {
+    pub fn new(
+        config: Arc<CarbideConfig>,
+        meter: opentelemetry::metrics::Meter,
+        dpf: Option<Arc<dyn DpfOperations>>,
+    ) -> Option<Self> {
         if !config
             .dpu_config
             .dpu_nic_firmware_reprovision_update_enabled
@@ -219,19 +245,44 @@ impl DpuNicFirmwareUpdate {
         Some(DpuNicFirmwareUpdate {
             metrics: Some(metrics),
             config,
+            dpf,
         })
     }
 
-    pub fn check_for_updates(
+    pub async fn check_for_updates(
         &self,
         snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
         available_updates: i32,
     ) -> Vec<DpuMachineUpdate> {
-        DpuMachineUpdate::find_available_outdated_dpus(
+        let dpf_outdated = self.fetch_dpf_outdated().await;
+        match DpuMachineUpdate::find_available_outdated_dpus(
             Some(available_updates),
             &self.config.dpu_config.dpu_nic_firmware_update_versions,
             snapshots,
-        )
+            &dpf_outdated,
+        ) {
+            Ok(machine_updates) => machine_updates,
+            Err(e) => {
+                tracing::warn!("Failed to find machines needing updates: {}", e);
+                vec![]
+            }
+        }
+    }
+
+    /// Best-effort fetch of DPF-managed outdated DPUs. Returns an empty vec
+    /// when DPF is disabled or the query fails — callers should treat the
+    /// result as "what we know right now" rather than authoritative.
+    async fn fetch_dpf_outdated(&self) -> Vec<OutdatedDpfDpu> {
+        let Some(dpf) = self.dpf.as_ref() else {
+            return vec![];
+        };
+        match dpf.find_outdated_dpus_dpf().await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to fetch DPF outdated DPUs");
+                vec![]
+            }
+        }
     }
 }
 

--- a/crates/api/src/machine_update_manager/host_firmware.rs
+++ b/crates/api/src/machine_update_manager/host_firmware.rs
@@ -54,11 +54,12 @@ impl MachineUpdateModule for HostFirmwareUpdate {
 
     async fn start_updates(
         &self,
-        txn: &mut PgConnection,
+        pool: &sqlx::Pool<sqlx::Postgres>,
         available_updates: i32,
         updating_host_machines: &HashSet<MachineId>,
         _snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
     ) -> CarbideResult<HashSet<MachineId>> {
+        let mut txn = db::Transaction::begin(pool).await?;
         if let Ok(mut firmware_dir_last_read) = self.firmware_dir_last_read.try_lock() {
             let firmware_dir_mod_time = self.firmware_config.config_update_time();
             if (firmware_dir_mod_time.is_none() && firmware_dir_last_read.is_none()) // Not using an auto firmware directory, one and done
@@ -70,13 +71,13 @@ impl MachineUpdateModule for HostFirmwareUpdate {
                 let fw_config_snapshot = self.firmware_config.create_snapshot();
                 tracing::info!("Firmware config now: {:?}", fw_config_snapshot);
                 let models = fw_config_snapshot.into_values().collect::<Vec<_>>();
-                desired_firmware::snapshot_desired_firmware(txn, &models).await?;
+                desired_firmware::snapshot_desired_firmware(&mut txn, &models).await?;
                 *firmware_dir_last_read =
                     Some(firmware_dir_mod_time.unwrap_or(std::time::SystemTime::now()));
             }
         }
 
-        let machine_updates = self.check_for_updates(txn, available_updates).await?;
+        let machine_updates = self.check_for_updates(&mut txn, available_updates).await?;
         let mut updates_started = HashSet::default();
         self.metrics
             .pending_firmware_updates
@@ -90,7 +91,7 @@ impl MachineUpdateModule for HostFirmwareUpdate {
             tracing::info!("Moving {} to host reprovision", machine_update);
 
             db::host_machine_update::trigger_host_reprovisioning_request(
-                txn,
+                &mut txn,
                 "Automated",
                 machine_update,
             )
@@ -99,6 +100,7 @@ impl MachineUpdateModule for HostFirmwareUpdate {
             updates_started.insert(*machine_update);
         }
 
+        txn.commit().await?;
         Ok(updates_started)
     }
 
@@ -123,11 +125,12 @@ impl MachineUpdateModule for HostFirmwareUpdate {
 
     async fn update_metrics(
         &self,
-        txn: &mut PgConnection,
+        pool: &sqlx::Pool<sqlx::Postgres>,
         _snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
-    ) {
+    ) -> CarbideResult<()> {
+        let mut txn = db::Transaction::begin(pool).await?;
         match db::host_machine_update::find_upgrade_needed(
-            txn,
+            &mut txn,
             self.config.firmware_global.autoupdate,
             self.config.firmware_global.instance_updates_manual_tagging,
         )
@@ -140,7 +143,7 @@ impl MachineUpdateModule for HostFirmwareUpdate {
             }
             Err(e) => tracing::warn!(error=%e, "Error geting host upgrade needed for metrics"),
         };
-        match db::host_machine_update::find_upgrade_in_progress(txn).await {
+        match db::host_machine_update::find_upgrade_in_progress(&mut txn).await {
             Ok(upgrade_in_progress) => {
                 self.metrics
                     .active_firmware_updates
@@ -148,6 +151,8 @@ impl MachineUpdateModule for HostFirmwareUpdate {
             }
             Err(e) => tracing::warn!(error=%e, "Error geting host upgrade in progress for metrics"),
         };
+        txn.commit().await?;
+        Ok(())
     }
 }
 

--- a/crates/api/src/machine_update_manager/machine_update_module.rs
+++ b/crates/api/src/machine_update_manager/machine_update_module.rs
@@ -45,7 +45,7 @@ pub trait MachineUpdateModule: Send + Sync + fmt::Display {
 
     async fn start_updates(
         &self,
-        txn: &mut PgConnection,
+        pool: &sqlx::Pool<sqlx::Postgres>,
         available_updates: i32,
         updating_host_machines: &HashSet<MachineId>,
         snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
@@ -55,9 +55,9 @@ pub trait MachineUpdateModule: Send + Sync + fmt::Display {
 
     async fn update_metrics(
         &self,
-        txn: &mut PgConnection,
+        pool: &sqlx::Pool<sqlx::Postgres>,
         snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
-    );
+    ) -> CarbideResult<()>;
 }
 
 /// Creates a Health override report that indicates that a host update is in progress

--- a/crates/api/src/machine_update_manager/mod.rs
+++ b/crates/api/src/machine_update_manager/mod.rs
@@ -44,6 +44,7 @@ use self::dpu_nic_firmware::DpuNicFirmwareUpdate;
 use self::metrics::MachineUpdateManagerMetrics;
 use crate::CarbideResult;
 use crate::cfg::file::{CarbideConfig, MaxConcurrentUpdates};
+use crate::dpf::DpfOperations;
 
 /// The MachineUpdateManager periodically runs [modules](machine_update_module::MachineUpdateModule) to initiate upgrades of machine components.
 /// On each iteration the MachineUpdateManager will:
@@ -93,10 +94,13 @@ impl MachineUpdateManager {
         config: Arc<CarbideConfig>,
         meter: opentelemetry::metrics::Meter,
         work_lock_manager_handle: WorkLockManagerHandle,
+        dpf: Option<Arc<dyn DpfOperations>>,
     ) -> Self {
         let mut update_modules = vec![];
 
-        if let Some(dpu_nic_firmware) = DpuNicFirmwareUpdate::new(config.clone(), meter.clone()) {
+        if let Some(dpu_nic_firmware) =
+            DpuNicFirmwareUpdate::new(config.clone(), meter.clone(), dpf)
+        {
             update_modules.push(Box::new(dpu_nic_firmware) as Box<dyn MachineUpdateModule>);
         }
 
@@ -223,6 +227,8 @@ impl MachineUpdateManager {
 
         let snapshots = self.get_all_snapshots(&mut txn).await?;
 
+        txn.commit().await?;
+
         let (all_count, unhealthy_count) =
             db::machine::count_healthy_unhealthy_host_machines(&snapshots);
         let max_concurrent_updates = self
@@ -238,7 +244,7 @@ impl MachineUpdateManager {
 
             let updates_started = update_module
                 .start_updates(
-                    &mut txn,
+                    &self.database_connection,
                     available_updates,
                     &current_updating_machines,
                     &snapshots,
@@ -256,13 +262,15 @@ impl MachineUpdateManager {
         let current_updating_count = current_updating_machines.len();
 
         //refresh snapshots for metrics
+        let mut txn = Transaction::begin(&self.database_connection).await?;
         let snapshots = self.get_all_snapshots(&mut txn).await?;
+        txn.commit().await?;
 
         for update_module in self.update_modules.iter() {
-            update_module.update_metrics(&mut txn, &snapshots).await;
+            update_module
+                .update_metrics(&self.database_connection, &snapshots)
+                .await?;
         }
-
-        txn.commit().await?;
 
         if let Some(metrics) = self.metrics.as_ref() {
             metrics

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -1322,6 +1322,7 @@ pub async fn initialize_and_start_controllers<'a>(
         carbide_config.clone(),
         meter.clone(),
         work_lock_manager_handle.clone(),
+        dpf_sdk.clone(),
     )
     .start(join_set, cancel_token.clone())?;
 

--- a/crates/api/src/tests/dpu_machine_update.rs
+++ b/crates/api/src/tests/dpu_machine_update.rs
@@ -116,7 +116,8 @@ async fn test_find_available_outdated_dpus(
         None,
         &env.config.dpu_config.dpu_nic_firmware_update_versions,
         &snapshots,
-    );
+        &[],
+    )?;
 
     assert_eq!(dpus.len(), dpu_count);
     Ok(())
@@ -174,7 +175,8 @@ async fn test_find_available_outdated_dpus_with_unhealthy(
         None,
         &env.config.dpu_config.dpu_nic_firmware_update_versions,
         &snapshots,
-    );
+        &[],
+    )?;
 
     assert_eq!(dpus.len(), 9);
     Ok(())
@@ -190,7 +192,8 @@ async fn test_find_available_outdated_dpus_limit(
         Some(1),
         &env.config.dpu_config.dpu_nic_firmware_update_versions,
         &snapshots,
-    );
+        &[],
+    )?;
 
     assert_eq!(dpus.len(), 1);
     Ok(())
@@ -215,7 +218,8 @@ async fn test_find_available_outdated_dpus_skips_dpf_ingested(
         None,
         &env.config.dpu_config.dpu_nic_firmware_update_versions,
         &snapshots,
-    );
+        &[],
+    )?;
 
     assert_eq!(dpus.len(), 1);
     Ok(())
@@ -297,7 +301,8 @@ async fn test_find_available_outdated_dpus_multidpu(
         None,
         &env.config.dpu_config.dpu_nic_firmware_update_versions,
         &snapshots,
-    );
+        &[],
+    )?;
 
     assert_eq!(dpus.len(), all_dpus.len());
     Ok(())
@@ -341,7 +346,8 @@ async fn test_find_available_outdated_dpus_multidpu_one_under_reprov(
         None,
         &env.config.dpu_config.dpu_nic_firmware_update_versions,
         &snapshots,
-    );
+        &[],
+    )?;
 
     assert!(dpus.is_empty());
 
@@ -404,7 +410,8 @@ async fn test_find_available_outdated_dpus_multidpu_both_under_reprov(
         None,
         &env.config.dpu_config.dpu_nic_firmware_update_versions,
         &snapshots,
-    );
+        &[],
+    )?;
 
     assert!(dpus.is_empty());
 

--- a/crates/api/src/tests/dpu_nic_firmware.rs
+++ b/crates/api/src/tests/dpu_nic_firmware.rs
@@ -41,6 +41,7 @@ async fn test_start_updates(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error
     let dpu_nic_firmware_update = DpuNicFirmwareUpdate {
         metrics: None,
         config: env.config.clone(),
+        dpf: None,
     };
 
     let snapshots = get_all_snapshots(&env).await;
@@ -52,7 +53,7 @@ async fn test_start_updates(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error
         .expect("Failed to create transaction");
 
     let started_count = dpu_nic_firmware_update
-        .start_updates(&mut txn, 10, &HashSet::default(), &snapshots)
+        .start_updates(&env.pool, 10, &HashSet::default(), &snapshots)
         .await?;
 
     assert_eq!(started_count.len(), 1);
@@ -89,6 +90,7 @@ async fn test_start_updates_with_multidpu(
     let dpu_nic_firmware_update = DpuNicFirmwareUpdate {
         metrics: None,
         config: env.config.clone(),
+        dpf: None,
     };
 
     let snapshots = get_all_snapshots(&env).await;
@@ -100,7 +102,7 @@ async fn test_start_updates_with_multidpu(
         .expect("Failed to create transaction");
 
     let dpus_started = dpu_nic_firmware_update
-        .start_updates(&mut txn, 10, &HashSet::default(), &snapshots)
+        .start_updates(&env.pool, 10, &HashSet::default(), &snapshots)
         .await?;
 
     assert_eq!(dpus_started.len(), 1);
@@ -131,6 +133,7 @@ async fn test_get_updates_in_progress(
     let dpu_nic_firmware_update = DpuNicFirmwareUpdate {
         metrics: None,
         config: env.config.clone(),
+        dpf: None,
     };
 
     let snapshots = get_all_snapshots(&env).await;
@@ -148,7 +151,7 @@ async fn test_get_updates_in_progress(
     assert!(updating_count.is_empty());
 
     let started_count = dpu_nic_firmware_update
-        .start_updates(&mut txn, 10, &HashSet::default(), &snapshots)
+        .start_updates(&env.pool, 10, &HashSet::default(), &snapshots)
         .await?;
 
     let updating_count = dpu_nic_firmware_update
@@ -178,6 +181,7 @@ async fn test_check_for_updates(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
     let dpu_nic_firmware_update = DpuNicFirmwareUpdate {
         metrics: None,
         config: env.config.clone(),
+        dpf: None,
     };
 
     let snapshots = machines
@@ -191,7 +195,9 @@ async fn test_check_for_updates(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
         )
         .await;
 
-    let machine_updates = dpu_nic_firmware_update.check_for_updates(&snapshots, 10);
+    let machine_updates = dpu_nic_firmware_update
+        .check_for_updates(&snapshots, 10)
+        .await;
     assert_eq!(machine_updates.len(), 2);
 
     Ok(())
@@ -210,6 +216,7 @@ async fn test_clear_completed_updates(
     let dpu_nic_firmware_update = DpuNicFirmwareUpdate {
         metrics: None,
         config: env.config.clone(),
+        dpf: None,
     };
 
     let snapshots = get_all_snapshots(&env).await;
@@ -221,7 +228,7 @@ async fn test_clear_completed_updates(
         .expect("Failed to create transaction");
 
     let started_count = dpu_nic_firmware_update
-        .start_updates(&mut txn, 10, &HashSet::default(), &snapshots)
+        .start_updates(&env.pool, 10, &HashSet::default(), &snapshots)
         .await?;
 
     assert!(!started_count.contains(&mh.dpu().id));

--- a/crates/api/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api/src/tests/host_bmc_firmware_test.rs
@@ -455,6 +455,7 @@ async fn test_postingestion_bmc_upgrade(pool: sqlx::PgPool) -> CarbideResult<()>
         env.config.clone(),
         env.test_meter.meter(),
         env.api.work_lock_manager_handle.clone(),
+        None,
     );
     // Update manager should notice that the host is underversioned, setting the request to update it
     update_manager.run_single_iteration().await.unwrap();
@@ -777,6 +778,7 @@ async fn test_host_fw_upgrade_enabledisable_global_enabled(
         env.config.clone(),
         env.test_meter.meter(),
         env.api.work_lock_manager_handle.clone(),
+        None,
     );
     update_manager.run_single_iteration().await?;
 
@@ -809,6 +811,7 @@ async fn test_host_fw_upgrade_enabledisable_global_disabled(
         env.config.clone(),
         env.test_meter.meter(),
         env.api.work_lock_manager_handle.clone(),
+        None,
     );
     update_manager.run_single_iteration().await?;
 
@@ -1197,6 +1200,7 @@ async fn test_instance_upgrading_actual(
         env.config.clone(),
         env.test_meter.meter(),
         env.api.work_lock_manager_handle.clone(),
+        None,
     );
 
     // Single iteration now starts it
@@ -1905,6 +1909,7 @@ async fn test_script_upgrade(pool: sqlx::PgPool) -> CarbideResult<()> {
         env.config.clone(),
         env.test_meter.meter(),
         env.api.work_lock_manager_handle.clone(),
+        None,
     );
     // Update manager should notice that the host is underversioned, setting the request to update it
     update_manager.run_single_iteration().await.unwrap();
@@ -2002,6 +2007,7 @@ async fn test_script_upgrade_failure(pool: sqlx::PgPool) -> CarbideResult<()> {
         env.config.clone(),
         env.test_meter.meter(),
         env.api.work_lock_manager_handle.clone(),
+        None,
     );
     // Update manager should notice that the host is underversioned, setting the request to update it
     update_manager.run_single_iteration().await.unwrap();
@@ -2163,6 +2169,7 @@ async fn test_explicit_update(pool: sqlx::PgPool) -> CarbideResult<()> {
         env.config.clone(),
         env.test_meter.meter(),
         env.api.work_lock_manager_handle.clone(),
+        None,
     );
 
     // A tick of the state machine, but we don't start anything yet and it's still in ready
@@ -2584,6 +2591,7 @@ async fn test_manual_firmware_upgrade_workflow(pool: sqlx::PgPool) -> CarbideRes
         env.config.clone(),
         env.test_meter.meter(),
         env.api.work_lock_manager_handle.clone(),
+        None,
     );
     update_manager.run_single_iteration().await?;
 

--- a/crates/api/src/tests/machine_update_manager.rs
+++ b/crates/api/src/tests/machine_update_manager.rs
@@ -63,7 +63,7 @@ impl MachineUpdateModule for TestUpdateModule {
 
     async fn start_updates(
         &self,
-        _txn: &mut PgConnection,
+        _pool: &sqlx::Pool<sqlx::Postgres>,
         _available_updates: i32,
         _updating_machines: &HashSet<MachineId>,
         _snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
@@ -84,9 +84,10 @@ impl MachineUpdateModule for TestUpdateModule {
 
     async fn update_metrics(
         &self,
-        _txn: &mut PgConnection,
+        _pool: &sqlx::Pool<sqlx::Postgres>,
         _snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
-    ) {
+    ) -> CarbideResult<()> {
+        Ok(())
     }
 }
 

--- a/crates/dpf/src/lib.rs
+++ b/crates/dpf/src/lib.rs
@@ -79,11 +79,10 @@ pub use sdk::{
 };
 pub use services::{DEFAULT_DOCA_HELM_REGISTRY, ServiceRegistryConfig};
 pub use types::{
-    BmcPasswordProvider, ConfigPortsServiceType, DpuDeviceInfo, DpuDeviceSummary, DpuErrorEvent,
-    DpuEvent, DpuNodeInfo, DpuNodeSummary, DpuPhase, DpuReadyEvent, DpuSummary, HostDpfSnapshot,
-    InitDpfResourcesConfig, MaintenanceEvent, RebootRequiredEvent, ServiceChainSwitch,
-    ServiceConfigPort, ServiceConfigPortProtocol, ServiceDefinition, ServiceInterface, ServiceNAD,
-    ServiceNADResourceType, ServiceTemplateVersion,
+    BmcPasswordProvider, ConfigPortsServiceType, DpuDeviceInfo, DpuErrorEvent, DpuEvent,
+    DpuMismatch, DpuNodeInfo, DpuPhase, DpuReadyEvent, InitDpfResourcesConfig, MaintenanceEvent,
+    RebootRequiredEvent, ServiceChainSwitch, ServiceConfigPort, ServiceConfigPortProtocol,
+    ServiceDefinition, ServiceInterface, ServiceNAD, ServiceNADResourceType,
 };
 pub use watcher::{DpuWatcher, DpuWatcherBuilder};
 

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -17,7 +17,7 @@
 
 //! DPF SDK - High-level interface for DPF operations.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -76,16 +76,20 @@ use crate::repository::{
 };
 use crate::types::{
     BmcPasswordProvider, ConfigPortsServiceType, DHCP_SERVER_SERVICE_NAME, DOCA_HBN_SERVICE_NAME,
-    DPU_AGENT_SERVICE_NAME, DpuDeviceInfo, DpuDeviceSummary, DpuNodeInfo, DpuNodeSummary, DpuPhase,
-    DpuServiceInterfaceTemplateDefinition, DpuServiceInterfaceTemplateType, DpuSummary,
-    FMDS_SERVICE_NAME, HostDpfSnapshot, InitDpfResourcesConfig, OTEL_COLLECTOR_SERVICE_NAME,
-    ServiceConfigPortProtocol, ServiceDefinition, ServiceNADResourceType, ServiceTemplateVersion,
+    DPU_AGENT_SERVICE_NAME, DpuDeviceInfo, DpuDeviceSummary, DpuMismatch, DpuNodeInfo,
+    DpuNodeSummary, DpuPhase, DpuServiceInterfaceTemplateDefinition,
+    DpuServiceInterfaceTemplateType, DpuSummary, FMDS_SERVICE_NAME, HostDpfSnapshot,
+    InitDpfResourcesConfig, OTEL_COLLECTOR_SERVICE_NAME, ServiceConfigPortProtocol,
+    ServiceDefinition, ServiceNADResourceType, ServiceTemplateVersion,
 };
 use crate::watcher::DpuWatcherBuilder;
 
 const SECRET_NAME: &str = "bmc-shared-password";
 const BFB_NAME_PREFIX: &str = "bf-bundle";
 const DPF_OPERATOR_CONFIG: &str = "dpfoperatorconfig";
+/// Label set by the DPF operator on each DPU CR pointing back to its owning
+/// DPUDeployment. Value format: `<namespace>_<deployment_name>`.
+const DPU_OWNED_BY_DEPLOYMENT_LABEL: &str = "svc.dpu.nvidia.com/owned-by-dpudeployment";
 
 pub(crate) const RESTART_ANNOTATION: &str =
     "provisioning.dpu.nvidia.com/dpunode-external-reboot-required";
@@ -1396,6 +1400,133 @@ impl<R: DpuRepository, L> DpfSdk<R, L> {
         let cr_name = dpu_cr_name(dpu_device_name, dpf_id);
         DpuRepository::delete(&*self.repo, &cr_name, &self.namespace).await
     }
+}
+
+impl<R: DpuDeploymentRepository + DpuRepository, L> DpfSdk<R, L> {
+    /// Find DPUs whose installed BFB or `spec.dpuFlavor` no longer matches
+    /// the values declared on the DPUDeployment that owns them.
+    ///
+    /// Each DPU is expected to carry the
+    /// `svc.dpu.nvidia.com/owned-by-dpudeployment` label (set by the DPF
+    /// operator) whose value is `<namespace>_<deployment_name>`. We use that
+    /// label to look up the owning DPUDeployment and read `spec.dpus.bfb`
+    /// (BFB CR name) and `spec.dpus.flavor` from it for the comparison.
+    ///
+    /// Reading from the deployment — rather than from carbide config —
+    /// keeps the comparison correct when multiple DPUDeployments coexist,
+    /// each pinning their DPUs to a different BFB or flavor.
+    ///
+    /// The DPF operator stores the downloaded BFB on disk as
+    /// `/bfb/<namespace>-<bfb_cr_name>.bfb` and reflects that path in
+    /// `DPU.status.bfbFile`, so the expected filename is just
+    /// `<namespace>-<spec.dpus.bfb>.bfb`.
+    ///
+    /// DPUs are skipped (not flagged) when:
+    /// - the owned-by label is missing or points to an unknown deployment, or
+    /// - the owning DPUDeployment is not currently reconciled
+    ///   (`DPUSetsReconciled=True` with matching `observedGeneration`),
+    ///
+    /// to avoid acting on a partially-reconciled or mislabeled cluster.
+    ///
+    /// `dpu_label_selector` is forwarded to `DpuRepository::list` — pass the
+    /// caller's controlled-device selector to limit the scan to its own DPUs.
+    pub async fn find_outdated_dpus_dpf(
+        &self,
+        dpu_label_selector: Option<&str>,
+    ) -> Result<Vec<DpuMismatch>, DpfError> {
+        let deployments = DpuDeploymentRepository::list(&*self.repo, &self.namespace).await?;
+        let ready_deployments: HashMap<String, &DPUDeployment> = deployments
+            .iter()
+            .filter(|d| dpu_deployment_is_ready(d))
+            .filter_map(|d| {
+                let name = d.metadata.name.as_deref()?;
+                Some((format!("{}_{}", self.namespace, name), d))
+            })
+            .collect();
+
+        if ready_deployments.is_empty() {
+            tracing::debug!(
+                namespace = %self.namespace,
+                deployment_count = deployments.len(),
+                "No DPUDeployment has DPUSetsReconciled=True with current observedGeneration; skipping DPF outdated scan"
+            );
+            return Ok(vec![]);
+        }
+
+        let dpus = DpuRepository::list(&*self.repo, &self.namespace, dpu_label_selector).await?;
+        let mismatches = dpus
+            .into_iter()
+            .filter_map(|dpu| {
+                let cr_name = dpu.metadata.name.clone()?;
+                let owner_label = dpu
+                    .metadata
+                    .labels
+                    .as_ref()
+                    .and_then(|l| l.get(DPU_OWNED_BY_DEPLOYMENT_LABEL));
+                let Some(owner_label) = owner_label else {
+                    tracing::debug!(
+                        dpu = %cr_name,
+                        "DPU is missing {DPU_OWNED_BY_DEPLOYMENT_LABEL} label; skipping"
+                    );
+                    return None;
+                };
+                let Some(deployment) = ready_deployments.get(owner_label.as_str()) else {
+                    tracing::debug!(
+                        dpu = %cr_name,
+                        owner = %owner_label,
+                        "DPU's owning DPUDeployment is not ready or not found; skipping"
+                    );
+                    return None;
+                };
+
+                let expected_bfb_cr_name = deployment.spec.dpus.bfb.as_str();
+                let expected_flavor = deployment.spec.dpus.flavor.as_str();
+                let expected_filename = format!("{}-{}.bfb", self.namespace, expected_bfb_cr_name);
+
+                let current_basename = dpu
+                    .status
+                    .as_ref()
+                    .and_then(|s| s.bfb_file.as_deref())
+                    .map(bfb_file_basename);
+                let bfb_matches = current_basename == Some(expected_filename.as_str());
+                let flavor_matches = dpu.spec.dpu_flavor == expected_flavor;
+                if bfb_matches && flavor_matches {
+                    return None;
+                }
+                Some(DpuMismatch {
+                    dpu_cr_name: cr_name,
+                    dpu_labels: dpu.metadata.labels.clone().unwrap_or_default(),
+                    target_bfb: expected_filename,
+                })
+            })
+            .collect();
+
+        Ok(mismatches)
+    }
+}
+
+/// Extract the trailing filename from a `DPU.status.bfbFile` path
+/// (e.g. `/bfb/dpf-operator-system-bf-bundle-XXX.bfb` → `dpf-operator-system-bf-bundle-XXX.bfb`).
+fn bfb_file_basename(path: &str) -> &str {
+    path.rsplit('/').next().unwrap_or(path)
+}
+
+/// Returns true when `metadata.generation` matches the
+/// `DPUSetsReconciled` condition's `observedGeneration` and its status is `True`.
+fn dpu_deployment_is_ready(d: &DPUDeployment) -> bool {
+    let Some(generation) = d.metadata.generation else {
+        return false;
+    };
+    let Some(status) = d.status.as_ref() else {
+        return false;
+    };
+    let Some(conditions) = status.conditions.as_ref() else {
+        return false;
+    };
+    let Some(cond) = conditions.iter().find(|c| c.type_ == "DPUSetsReconciled") else {
+        return false;
+    };
+    cond.status == "True" && cond.observed_generation == Some(generation)
 }
 
 impl<R: DpuNodeMaintenanceRepository, L> DpfSdk<R, L> {

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -70,6 +70,18 @@ impl Default for InitDpfResourcesConfig {
     }
 }
 
+/// A DPU CR whose installed BFB or `spec.dpuFlavor` does not match the
+/// expected one. Returned by [`crate::DpfSdk::find_outdated_dpus_dpf`]; the
+/// labels map is the DPU CR's `metadata.labels` so callers can map back to
+/// their own identifiers.
+#[derive(Debug, Clone)]
+pub struct DpuMismatch {
+    pub dpu_cr_name: String,
+    pub dpu_labels: std::collections::BTreeMap<String, String>,
+    /// Expected BFB filename (e.g. `<namespace>-bf-bundle-<sha256>.bfb`).
+    pub target_bfb: String,
+}
+
 /// Service type for configPorts (DPUServiceConfiguration).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfigPortsServiceType {


### PR DESCRIPTION
## Description
The DPUs provisioned with DPF should also be checked for the reprovisioning. The logic is different. Instead of checking the firmware version, it is easy to check the BFB URL. This PR performs the same operation.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

