### PR TITLE
Add support for CX7 Firmware Component

### DIFF
--- a/crates/api-model/src/firmware.rs
+++ b/crates/api-model/src/firmware.rs
@@ -126,6 +126,7 @@ pub enum FirmwareComponentType {
     HGXBmc,
     CombinedBmcUefi,
     Gpu,
+    Cx7,
     #[serde(other)]
     #[default]
     Unknown,
@@ -143,6 +144,7 @@ impl fmt::Display for FirmwareComponentType {
             FirmwareComponentType::Cec => write!(f, "CEC"),
             FirmwareComponentType::Gpu => write!(f, "GPU"),
             FirmwareComponentType::HGXBmc => write!(f, "HGX BMC"),
+            FirmwareComponentType::Cx7 => write!(f, "CX7"),
             FirmwareComponentType::Unknown => write!(f, "Unknown"),
         }
     }

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -1882,19 +1882,26 @@ fn need_host_fw_upgrade(
 ) -> Option<FirmwareEntry> {
     // Determining if we've disabled upgrades for this host is determined in machine_update_manager, not here; if it was disabled, nothing kicks it out of Ready.
 
-    // First, find the current version.
-    let Some(current_version) = endpoint.report.versions.get(&firmware_type) else {
+    // First, find all current versions for this component. Some component types,
+    // such as CX7, have several firmware inventory entries.
+    let current_versions = endpoint.find_all_versions(fw_info, firmware_type);
+    if current_versions.is_empty() {
         // Not listed, so we couldn't do an upgrade
         return None;
-    };
+    }
 
-    // Now find the desired version, if it's not the version that is currently installed
+    // Now find the desired version, if any matching inventory is not already on it.
     fw_info
         .components
         .get(&firmware_type)?
         .known_firmware
         .iter()
-        .find(|x| x.default && x.version != *current_version)
+        .find(|firmware| {
+            firmware.default
+                && current_versions
+                    .iter()
+                    .any(|v| v.as_str() != firmware.version)
+        })
         .cloned()
 }
 
@@ -10601,6 +10608,12 @@ async fn get_power_state(redfish_client: &dyn Redfish) -> Result<PowerState, Sta
 mod tests {
     use std::str::FromStr;
 
+    use model::firmware::FirmwareComponent;
+    use model::site_explorer::{
+        EndpointExplorationReport, EndpointType, Inventory, PreingestionState, Service,
+    };
+    use regex::Regex;
+
     use super::*;
 
     #[test]
@@ -10626,6 +10639,71 @@ mod tests {
         let deadline = scout_firmware_upgrade_deadline(started_at, u32::MAX, u32::MAX, usize::MAX);
 
         assert_eq!(deadline, started_at + Duration::hours(5));
+    }
+
+    #[test]
+    fn need_host_fw_upgrade_checks_all_matching_cx7_inventories() {
+        let firmware_type = FirmwareComponentType::Cx7;
+        let target_version = "28.47.2682";
+        let old_version = "28.46.1000";
+        let fw_info = Firmware {
+            vendor: bmc_vendor::BMCVendor::Nvidia,
+            model: "DGXH100".to_string(),
+            components: HashMap::from([(
+                firmware_type,
+                FirmwareComponent {
+                    current_version_reported_as: Some(Regex::new(r"^CX7_[0-9]+$").unwrap()),
+                    preingest_upgrade_when_below: None,
+                    known_firmware: vec![FirmwareEntry::standard_filename(
+                        target_version,
+                        "/opt/carbide/firmware/cx7.bin",
+                    )],
+                },
+            )]),
+            explicit_start_needed: false,
+            ordering: vec![firmware_type],
+        };
+        let endpoint = ExploredEndpoint {
+            address: "192.0.2.10".parse().unwrap(),
+            report: EndpointExplorationReport {
+                endpoint_type: EndpointType::Bmc,
+                service: vec![Service {
+                    id: "FirmwareInventory".to_string(),
+                    inventories: vec![
+                        Inventory {
+                            id: "CX7_0".to_string(),
+                            description: None,
+                            version: Some(target_version.to_string()),
+                            release_date: None,
+                        },
+                        Inventory {
+                            id: "CX7_1".to_string(),
+                            description: None,
+                            version: Some(old_version.to_string()),
+                            release_date: None,
+                        },
+                    ],
+                }],
+                versions: HashMap::from([(firmware_type, target_version.to_string())]),
+                ..Default::default()
+            },
+            report_version: ConfigVersion::new(1),
+            preingestion_state: PreingestionState::Initial,
+            waiting_for_explorer_refresh: false,
+            exploration_requested: false,
+            last_redfish_bmc_reset: None,
+            last_ipmitool_bmc_reset: None,
+            last_redfish_reboot: None,
+            last_redfish_powercycle: None,
+            pause_ingestion_and_poweron: false,
+            pause_remediation: false,
+            boot_interface_mac: None,
+        };
+
+        let to_install = need_host_fw_upgrade(&endpoint, &fw_info, firmware_type)
+            .expect("stale CX7 inventory should require upgrade");
+
+        assert_eq!(to_install.version, target_version);
     }
 
     /// Verify that `oem_manager_profiles` from the site config is forwarded to `machine_setup`.

--- a/crates/api/src/tests/explored_endpoint_find.rs
+++ b/crates/api/src/tests/explored_endpoint_find.rs
@@ -262,6 +262,7 @@ async fn test_find_explored_endpoint_firmware_versions(
         (FirmwareComponentType::Bmc, "25.06-2_NV_WW_02".to_string()),
         (FirmwareComponentType::Uefi, "00000083".to_string()),
         (FirmwareComponentType::HGXBmc, "97.00.B9.00.76".to_string()),
+        (FirmwareComponentType::Cx7, "28.47.2682".to_string()),
     ]);
 
     let mut txn = env.pool.begin().await?;
@@ -297,10 +298,11 @@ async fn test_find_explored_endpoint_firmware_versions(
 
     let report = endpoint_list.endpoints[0].report.as_ref().unwrap();
     let fw_versions = &report.firmware_versions;
-    assert_eq!(fw_versions.len(), 3);
+    assert_eq!(fw_versions.len(), 4);
     assert_eq!(fw_versions.get("bmc").unwrap(), "25.06-2_NV_WW_02");
     assert_eq!(fw_versions.get("uefi").unwrap(), "00000083");
     assert_eq!(fw_versions.get("hgxbmc").unwrap(), "97.00.B9.00.76");
+    assert_eq!(fw_versions.get("cx7").unwrap(), "28.47.2682");
 
     Ok(())
 }

--- a/crates/firmware/src/tests/config.rs
+++ b/crates/firmware/src/tests/config.rs
@@ -106,3 +106,59 @@ default = true
     );
     Ok(())
 }
+
+#[test]
+fn cx7_component_config_parses_as_first_class_component() -> eyre::Result<()> {
+    let cfg = r#"
+model = "DGXH100"
+vendor = "Nvidia"
+ordering = ["hgxbmc", "combinedbmcuefi", "uefi", "bmc", "cx7"]
+
+[components.cx7]
+current_version_reported_as = "^CX7_[0-9]+$"
+
+[[components.cx7.known_firmware]]
+version = "28.47.2682"
+filename = "/opt/carbide/firmware/nvidia-dgxh100-cx7-28.47.2682/cx7.bin"
+filenames = ["/opt/carbide/firmware/nvidia-dgxh100-cx7-28.47.2682/cx7.bin"]
+default = true
+power_drains_needed = 1
+
+[[components.cx7.known_firmware.files]]
+filename = "/opt/carbide/firmware/nvidia-dgxh100-cx7-28.47.2682/cx7.bin"
+sha256 = "abc123"
+
+[components.cx7.known_firmware.scout]
+execution_timeout_seconds = 1800
+artifact_download_timeout_seconds = 600
+
+[components.cx7.known_firmware.scout.script]
+filename = "/opt/carbide/firmware/nvidia-dgxh100-cx7-28.47.2682/scripts/cx7_upgrade.sh"
+sha256 = "def456"
+"#;
+    let mut config: FirmwareConfig = Default::default();
+    config.add_test_override(cfg.to_string());
+
+    let snapshot = config.create_snapshot();
+    let server = snapshot.data.get("nvidia:dgxh100").unwrap();
+    assert_eq!(
+        server.ordering.last().copied(),
+        Some(FirmwareComponentType::Cx7)
+    );
+
+    let cx7 = server.components.get(&FirmwareComponentType::Cx7).unwrap();
+    assert!(cx7.current_version_reported_as.is_some());
+    let firmware = cx7.known_firmware.first().unwrap();
+    assert_eq!(firmware.version, "28.47.2682");
+    assert_eq!(firmware.power_drains_needed, Some(1));
+    assert_eq!(firmware.files.len(), 1);
+
+    let scout = firmware.scout.as_ref().unwrap();
+    assert_eq!(scout.execution_timeout_seconds, 1800);
+    assert_eq!(scout.artifact_download_timeout_seconds, 600);
+    assert_eq!(
+        scout.script.filename,
+        "/opt/carbide/firmware/nvidia-dgxh100-cx7-28.47.2682/scripts/cx7_upgrade.sh"
+    );
+    Ok(())
+}

--- a/crates/firmware/src/tests/desired_firmware_versions.rs
+++ b/crates/firmware/src/tests/desired_firmware_versions.rs
@@ -54,6 +54,14 @@ pub async fn test_build_versions(pool: sqlx::PgPool) -> Result<(), eyre::Error> 
     version = "7.10.30.00"
     url = "https://urm.nvidia.com/artifactory/sw-ngc-forge-cargo-local/misc/iDRAC-with-Lifecycle-Controller_Firmware_HV310_WN64_7.10.30.00_A00.EXE"
     default = true
+
+    [components.cx7]
+    current_version_reported_as = "^CX7_[0-9]+$"
+
+    [[components.cx7.known_firmware]]
+    version = "28.47.2682"
+    url = "https://urm.nvidia.com/artifactory/sw-ngc-forge-cargo-local/misc/cx7.bin"
+    default = true
         "#;
     config.add_test_override(src_cfg_str.to_string());
 
@@ -111,7 +119,8 @@ current_version_reported_as = "^2$"
     let versions_all: Vec<AsStrings> = sqlx::query_as(query).fetch_all(txn.deref_mut()).await?;
     let versions = versions_all.first().unwrap().versions.clone();
 
-    let expected = r#"{"bmc": "7.10.30.00", "cec": "8.10.30.00", "uefi": "1.13.3"}"#;
+    let expected =
+        r#"{"bmc": "7.10.30.00", "cec": "8.10.30.00", "cx7": "28.47.2682", "uefi": "1.13.3"}"#;
 
     assert_eq!(expected, versions);
 

--- a/crates/redfish/src/libredfish/conv.rs
+++ b/crates/redfish/src/libredfish/conv.rs
@@ -38,6 +38,7 @@ impl IntoLibredfish<libredfish::model::update_service::ComponentType> for Firmwa
             FirmwareComponentType::HGXBmc => ComponentType::HGXBMC,
             FirmwareComponentType::CombinedBmcUefi => ComponentType::Unknown,
             FirmwareComponentType::Gpu => ComponentType::Unknown,
+            FirmwareComponentType::Cx7 => ComponentType::Unknown,
             FirmwareComponentType::Unknown => ComponentType::Unknown,
         }
     }


### PR DESCRIPTION
## Description
The main change is simple: adding support for the CX7 component.

There is another minor change that I want to ship together: changing `need_host_fw_upgrade` so that it checks all the versions rather than just one. There are usually multiple CX7 components in a machine and they all can be in different versions. So we want this function to detect that and send them to the upgrade path.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

