### PR TITLE
fix(agent): Retry hardware enumeration in case of init-container

### DIFF
--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -201,7 +201,7 @@ pub async fn start(cmdline: command_line::Options) -> eyre::Result<()> {
         // Output path is fixed (HW_CACHE_PATH) so the main container can always find it.
         Some(AgentCommand::InitContainer) => {
             download_cert().await?;
-            enumerate_and_save_hardware()?;
+            enumerate_and_save_hardware().await?;
             util::save_host_nameservers()?;
         }
 

--- a/crates/host-support/src/hardware_enumeration.rs
+++ b/crates/host-support/src/hardware_enumeration.rs
@@ -868,6 +868,23 @@ const INIT_CPU_INFO_PATH: &str = "/host-cpu-info";
 /// Path where the host's `/proc/meminfo` is bind-mounted inside the init container.
 const INIT_MEM_INFO_PATH: &str = "/host-mem-info";
 
+/// Validate that an enumerated [`rpc_discovery::DiscoveryInfo`] is complete
+/// enough for downstream use. Returns `Err` describing the missing piece so
+/// the caller can retry the probe.
+///
+/// Today the only required field is `dpu_info` — DPU VPD probing can race
+/// with device init and produce a `None` if read too early.
+fn validate_enumerated(
+    info: &rpc_discovery::DiscoveryInfo,
+) -> Result<(), HardwareEnumerationError> {
+    if info.dpu_info.is_none() {
+        return Err(HardwareEnumerationError::GenericError(
+            "Hardware enumeration is missing dpu_info".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 /// Enumerate hardware and save the result as JSON to [`HW_CACHE_PATH`].
 ///
 /// Used by the init container to snapshot host hardware info so the containerized agent can
@@ -875,11 +892,49 @@ const INIT_MEM_INFO_PATH: &str = "/host-mem-info";
 ///
 /// Reads CPU info from [`INIT_CPU_INFO_PATH`] (`/host-cpu-info`) where the init container
 /// bind-mounts the host's `/proc/cpuinfo`.
-pub fn enumerate_and_save_hardware()
+pub async fn enumerate_and_save_hardware()
 -> Result<rpc_discovery::DiscoveryInfo, HardwareEnumerationError> {
-    let info = enumerate_hardware_inner(INIT_CPU_INFO_PATH, INIT_MEM_INFO_PATH)?;
-    save_hardware_to(&info, HW_CACHE_PATH)?;
-    Ok(info)
+    let mut last_err = String::new();
+
+    macro_rules! try_or_retry {
+        ($expr:expr, $msg:literal, $attempt:expr) => {
+            match $expr {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(attempt = $attempt, error = %e, $msg);
+                    last_err = e.to_string();
+                    tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+                    continue;
+                }
+            }
+        };
+    }
+
+    for attempt in 1..10 {
+        let info = try_or_retry!(
+            enumerate_hardware_inner(INIT_CPU_INFO_PATH, INIT_MEM_INFO_PATH),
+            "Hardware enumeration failed; retrying in 10s",
+            attempt
+        );
+        try_or_retry!(
+            validate_enumerated(&info),
+            "Hardware enumeration incomplete; retrying in 10s",
+            attempt
+        );
+        try_or_retry!(
+            save_hardware_to(&info, HW_CACHE_PATH),
+            "Failed to save hardware cache; retrying in 10s",
+            attempt
+        );
+        return Ok(info);
+    }
+
+    tracing::error!(
+        last_error = %last_err,
+        "Init container failed to generate hardware info. Try to delete the pod to recover."
+    );
+
+    Err(HardwareEnumerationError::GenericError(last_err))
 }
 
 /// Load the hardware snapshot from [`HW_CACHE_PATH`] written by the init container.


### PR DESCRIPTION
## Description
It seems dpu-agent can come up before fw init is done. A retry is introduced if dpu_info is none. Also return error if retries failed, so that tube system can enforce init retry as well.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

