### PR TITLE
chore: Update to prost 0.14.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1295,7 +1295,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "prometheus",
- "prost 0.14.1",
+ "prost 0.14.3",
  "rand 0.9.2",
  "regex",
  "reqwest",
@@ -1424,8 +1424,8 @@ dependencies = [
  "pkcs1 0.7.5",
  "prometheus",
  "prometheus-text-parser",
- "prost 0.14.1",
- "prost-types 0.14.1",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
  "rand 0.9.2",
  "rcgen",
  "regex",
@@ -1580,7 +1580,7 @@ dependencies = [
  "mac_address",
  "nras",
  "once_cell",
- "prost 0.14.1",
+ "prost 0.14.3",
  "rand 0.9.2",
  "regex",
  "serde",
@@ -1743,7 +1743,7 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "prometheus",
- "prost 0.14.1",
+ "prost 0.14.3",
  "serde_json",
  "tempfile",
  "test-cdylib",
@@ -1767,7 +1767,7 @@ dependencies = [
  "ipnetwork",
  "logfmt",
  "lru 0.16.3",
- "prost 0.14.1",
+ "prost 0.14.3",
  "serde",
  "serde_yaml",
  "socket2 0.6.1",
@@ -1888,7 +1888,7 @@ dependencies = [
  "ctor",
  "eyre",
  "humantime",
- "prost 0.14.1",
+ "prost 0.14.3",
  "rand 0.9.2",
  "reqwest",
  "rustls-pemfile",
@@ -1996,7 +1996,7 @@ dependencies = [
  "logfmt",
  "netlink-packet-route 0.19.0",
  "nonzero_ext",
- "prost 0.14.1",
+ "prost 0.14.3",
  "reqwest",
  "rtnetlink",
  "tokio",
@@ -2034,8 +2034,8 @@ dependencies = [
  "mac_address",
  "nv-redfish",
  "prometheus",
- "prost 0.14.1",
- "prost-types 0.14.1",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
  "rand 0.9.2",
  "reqwest",
  "serde",
@@ -2216,7 +2216,7 @@ dependencies = [
  "mac_address",
  "once_cell",
  "prettytable-rs",
- "prost-types 0.14.1",
+ "prost-types 0.14.3",
  "quick-xml 0.31.0",
  "regex",
  "reqwest",
@@ -2346,8 +2346,8 @@ dependencies = [
  "chrono",
  "clap",
  "mqttea",
- "prost 0.14.1",
- "prost-build 0.14.1",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
  "rumqttc",
  "serde",
  "serde_json",
@@ -2520,8 +2520,8 @@ dependencies = [
  "mac_address",
  "nonempty",
  "prettytable-rs",
- "prost 0.14.1",
- "prost-types 0.14.1",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
  "resolv-conf",
  "rustls 0.23.34",
  "rustls-pemfile",
@@ -2762,8 +2762,8 @@ dependencies = [
  "carbide-uuid",
  "carbide-version",
  "eyre",
- "prost 0.14.1",
- "prost-types 0.14.1",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
  "rustls 0.23.34",
  "rustls-pemfile",
  "tokio",
@@ -2818,7 +2818,7 @@ version = "0.0.0"
 dependencies = [
  "data-encoding",
  "eyre",
- "prost 0.14.1",
+ "prost 0.14.3",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -2981,7 +2981,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3217,8 +3217,8 @@ dependencies = [
  "chrono",
  "librms",
  "mac_address",
- "prost 0.14.1",
- "prost-types 0.14.1",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
  "serde",
  "sqlx",
  "thiserror 2.0.18",
@@ -5344,7 +5344,7 @@ checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -5531,7 +5531,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.59.0",
+ "windows-core",
 ]
 
 [[package]]
@@ -5970,7 +5970,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.18",
  "walkdir",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -6373,7 +6373,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-timeout",
  "hyper-util",
- "prost 0.14.1",
+ "prost 0.14.3",
  "rustls 0.23.34",
  "rustls-pemfile",
  "serde",
@@ -6853,9 +6853,9 @@ dependencies = [
  "chrono",
  "clap",
  "oauth2",
- "prost 0.14.1",
- "prost-build 0.14.1",
- "prost-types 0.14.1",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
  "regex",
  "reqwest",
  "rumqttc",
@@ -6876,8 +6876,8 @@ dependencies = [
  "chrono",
  "clap",
  "mqttea",
- "prost 0.14.1",
- "prost-build 0.14.1",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
  "rumqttc",
  "serde",
  "serde_json",
@@ -7628,7 +7628,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "windows",
- "windows-strings 0.5.1",
+ "windows-strings",
 ]
 
 [[package]]
@@ -7657,7 +7657,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -7846,6 +7846,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset 0.5.7",
+ "indexmap 2.12.0",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.5",
  "indexmap 2.12.0",
 ]
 
@@ -8401,12 +8412,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive 0.14.1",
+ "prost-derive 0.14.3",
 ]
 
 [[package]]
@@ -8431,19 +8442,18 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
- "once_cell",
- "petgraph 0.7.1",
+ "petgraph 0.8.3",
  "prettyplease",
- "prost 0.14.1",
- "prost-types 0.14.1",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
@@ -8466,9 +8476,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -8488,11 +8498,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost 0.14.1",
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -8550,9 +8560,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "21.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5b6a0769a491a08b31ea5c62494a8f144ee0987d86d670a8af4df1e1b7cde75"
+checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
 dependencies = [
  "pulldown-cmark",
 ]
@@ -11282,7 +11292,7 @@ dependencies = [
  "lazy_static",
  "prettyplease",
  "proc-macro2",
- "prost-types 0.14.1",
+ "prost-types 0.14.3",
  "quote",
  "syn 2.0.117",
  "temp-dir",
@@ -11301,7 +11311,7 @@ dependencies = [
  "lazy_static",
  "prettyplease",
  "proc-macro2",
- "prost-types 0.14.1",
+ "prost-types 0.14.3",
  "quote",
  "syn 2.0.117",
  "thiserror 2.0.18",
@@ -11316,7 +11326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
 dependencies = [
  "bytes",
- "prost 0.14.1",
+ "prost 0.14.3",
  "tonic 0.14.2",
 ]
 
@@ -11328,8 +11338,8 @@ checksum = "a4556786613791cfef4ed134aa670b61a85cfcacf71543ef33e8d801abae988f"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build 0.14.1",
- "prost-types 0.14.1",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
  "quote",
  "syn 2.0.117",
  "tempfile",
@@ -12278,7 +12288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.2",
+ "windows-core",
  "windows-future",
  "windows-numerics",
 ]
@@ -12289,20 +12299,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
-dependencies = [
- "windows-implement 0.59.0",
- "windows-interface",
- "windows-result 0.3.4",
- "windows-strings 0.3.1",
- "windows-targets 0.53.5",
+ "windows-core",
 ]
 
 [[package]]
@@ -12311,11 +12308,11 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
+ "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -12324,20 +12321,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
+ "windows-core",
+ "windows-link",
  "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -12364,12 +12350,6 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
@@ -12380,17 +12360,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -12399,16 +12370,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -12417,7 +12379,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -12462,7 +12424,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -12502,7 +12464,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -12519,7 +12481,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,9 +174,9 @@ prettytable-rs = { default-features = false, version = "0.10" }
 procfs = "0.17"
 proc-macro2 = { default-features = false, version = "1.0.92" }
 prometheus = "0.13.4"
-prost = "0.14.1"
-prost-build = "0.14"
-prost-types = "0.14.1"
+prost = "0.14.3"
+prost-build = "0.14.3"
+prost-types = "0.14.3"
 pwhash = "1.0.0"
 quick-xml = "0.31"
 quote = { default-features = false, version = "1.0" }

--- a/crates/machine-a-tron/src/machine_a_tron.rs
+++ b/crates/machine-a-tron/src/machine_a_tron.rs
@@ -304,6 +304,7 @@ impl MachineATron {
 fn parse_network_virtualization_type(s: Option<&str>) -> Option<VpcVirtualizationType> {
     match s {
         Some("etv") => Some(VpcVirtualizationType::EthernetVirtualizer),
+        #[allow(deprecated)]
         Some("etv_nvue") => Some(VpcVirtualizationType::EthernetVirtualizerWithNvue),
         Some("fnn") => Some(VpcVirtualizationType::Fnn),
         Some(other) => {

--- a/crates/mqttea/tests/errors.rs
+++ b/crates/mqttea/tests/errors.rs
@@ -30,6 +30,9 @@ fn create_test_connection_error() -> ClientError {
 }
 
 fn create_test_decode_error() -> DecodeError {
+    // Deprecation: if they remove DecodeError::new, they hopefully will provide some other way
+    // to impl prost::Message.
+    #[allow(deprecated)]
     DecodeError::new("Test protobuf decode error")
 }
 

--- a/crates/rpc/src/network.rs
+++ b/crates/rpc/src/network.rs
@@ -24,6 +24,7 @@ impl From<rpc::VpcVirtualizationType> for VpcVirtualizationType {
         match v {
             rpc::VpcVirtualizationType::EthernetVirtualizer => Self::EthernetVirtualizer,
             // ETHERNET_VIRTUALIZER_WITH_NVUE is equivalent to EthernetVirtualizer
+            #[allow(deprecated)]
             rpc::VpcVirtualizationType::EthernetVirtualizerWithNvue => Self::EthernetVirtualizer,
             rpc::VpcVirtualizationType::Fnn => Self::Fnn,
             // Following are deprecated.
@@ -54,6 +55,7 @@ pub fn vpc_virtualization_type_try_from_rpc(
         }
         // If we get proto enum field 2, which is ETHERNET_VIRTUALIZER_WITH_NVUE,
         // just map it to EthernetVirtualizer.
+        #[allow(deprecated)]
         x if x == rpc::VpcVirtualizationType::EthernetVirtualizerWithNvue as i32 => {
             VpcVirtualizationType::EthernetVirtualizer
         }
@@ -72,6 +74,7 @@ mod test {
 
     #[test]
     fn from_rpc_etv_with_nvue_maps_to_etv() {
+        #[allow(deprecated)]
         let vtype: VpcVirtualizationType =
             rpc::VpcVirtualizationType::EthernetVirtualizerWithNvue.into();
         assert_eq!(vtype, VpcVirtualizationType::EthernetVirtualizer);

--- a/crates/uuid/src/machine/mod.rs
+++ b/crates/uuid/src/machine/mod.rs
@@ -117,8 +117,12 @@ impl prost::Message for MachineId {
     {
         let mut legacy_message = legacy_rpc::MachineId::from(*self);
         legacy_message.merge_field(tag, wire_type, buf, ctx)?;
-        *self = MachineId::from_str(&legacy_message.id)
-            .map_err(|_| DecodeError::new(format!("Invalid machine id: {}", legacy_message.id)))?;
+        *self = MachineId::from_str(&legacy_message.id).map_err(|_| {
+            // Deprecation: if they remove DecodeError::new, they hopefully will provide some other way
+            // to impl prost::Message.
+            #[allow(deprecated)]
+            DecodeError::new(format!("Invalid machine id: {}", legacy_message.id))
+        })?;
         Ok(())
     }
 

--- a/crates/uuid/src/power_shelf/mod.rs
+++ b/crates/uuid/src/power_shelf/mod.rs
@@ -431,6 +431,9 @@ impl prost::Message for PowerShelfId {
         let mut legacy_message = legacy_rpc::PowerShelfId::from(*self);
         legacy_message.merge_field(tag, wire_type, buf, ctx)?;
         *self = PowerShelfId::from_str(&legacy_message.id).map_err(|_| {
+            // Deprecation: if they remove DecodeError::new, they hopefully will provide some other way
+            // to impl prost::Message.
+            #[allow(deprecated)]
             DecodeError::new(format!("Invalid power shelf id: {}", legacy_message.id))
         })?;
         Ok(())

--- a/crates/uuid/src/switch/mod.rs
+++ b/crates/uuid/src/switch/mod.rs
@@ -413,6 +413,9 @@ impl prost::Message for SwitchId {
         let mut legacy_message = legacy_rpc::SwitchId::from(*self);
         legacy_message.merge_field(tag, wire_type, buf, ctx)?;
         *self = SwitchId::from_str(&legacy_message.id).map_err(|_| {
+            // Deprecation: if they remove DecodeError::new, they hopefully will provide some other way
+            // to impl prost::Message.
+            #[allow(deprecated)]
             DecodeError::new(format!("Invalid power shelf id: {}", legacy_message.id))
         })?;
         Ok(())

--- a/crates/uuid/src/typed_uuids.rs
+++ b/crates/uuid/src/typed_uuids.rs
@@ -66,6 +66,9 @@ impl<T: UuidSubtype + Send + Sync> prost::Message for TypedUuid<T> {
         // Decode through the shim type, which has the identical wire layout.
         let mut tmp = crate::CommonUuidPlaceholder::default();
         prost::Message::merge_field(&mut tmp, tag, wire_type, buf, ctx)?;
+        // Deprecation: if they remove DecodeError::new, they hopefully will provide some other way
+        // to impl prost::Message.
+        #[allow(deprecated)]
         let parsed = uuid::Uuid::parse_str(&tmp.value)
             .map_err(|_| prost::DecodeError::new(format!("invalid UUID: {}", tmp.value)))?;
         *self = parsed.into();


### PR DESCRIPTION
## Description
This is part of a series of PR's to update all "breaking" dependencies that require code changes on our part. Once they are all merged, we will do a final cargo update and be on the latest versions of all dependencies.

For the prost crate, they've deprecated DecodeError::new, which is a bit scary: We have custom impl's of the prost::Message trait, and the trait requires methods to return a DecodeError. But without DecodeError::new there is no way to produce this error... hopefully by the time they actually mark that function private, they'll change the Message trait to be able to return custom errors.

The newer prost also takes any protobuf fields that are marked deprecated, and marks their corresponding Rust fields as deprecated as well, which means we need some #[allow(deprecated)] fields in the places where we're supporting older enum variants.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes

