### PR TITLE
Avoid reloading data from DB in get_managed_host_network_config function

### DIFF
--- a/crates/api/src/ethernet_virtualization.rs
+++ b/crates/api/src/ethernet_virtualization.rs
@@ -25,6 +25,7 @@ use db::vpc_peering::get_prefixes_by_vpcs;
 use db::{self, ObjectColumnFilter, network_security_group};
 use ipnetwork::{IpNetwork, Ipv4Network};
 use model::instance::config::network::{InstanceInterfaceConfig, InterfaceFunctionId};
+use model::machine::ManagedHostStateSnapshot;
 use model::network_prefix::NetworkPrefix;
 use model::network_security_group::{
     NetworkSecurityGroup, NetworkSecurityGroupRule, NetworkSecurityGroupRuleNet,
@@ -198,7 +199,7 @@ impl<'a> PrefixPair<'a> {
 
 pub async fn admin_network(
     txn: &mut PgConnection,
-    host_machine_id: &MachineId,
+    snapshot: &ManagedHostStateSnapshot,
     dpu_machine_id: &MachineId,
     fnn_enabled_on_admin: bool,
     common_pools: &CommonPools,
@@ -233,16 +234,10 @@ pub async fn admin_network(
         None => "unknowndomain".to_string(),
     };
 
-    let interfaces =
-        db::machine_interface::find_by_machine_and_segment(txn, host_machine_id, admin_segment.id)
-            .await?;
-
-    let interface = interfaces.into_iter().find(|x| {
-        if let Some(id) = &x.attached_dpu_machine_id {
-            id == dpu_machine_id
-        } else {
-            false
-        }
+    let host_machine_id = snapshot.host_snapshot.id;
+    let interface = snapshot.host_snapshot.interfaces.iter().find(|interface| {
+        interface.segment_id == admin_segment.id
+            && interface.attached_dpu_machine_id.as_ref() == Some(dpu_machine_id)
     });
 
     let Some(interface) = interface else {
@@ -252,18 +247,24 @@ pub async fn admin_network(
         .into());
     };
 
-    let address = db::machine_interface_address::find_ipv4_for_interface(txn, interface.id).await?;
+    let address = interface
+        .addresses
+        .iter()
+        .copied()
+        .find(|address| address.is_ipv4())
+        .ok_or_else(|| {
+            CarbideError::InvalidArgument(format!(
+                "No IPv4 address found on host interface {} for dpu: {dpu_machine_id}",
+                interface.id
+            ))
+        })?;
 
     // On the admin network, the interface_prefix is always
     // just going to be a /32 derived from the machine interface
     // address.
-    let address_prefix =
-        IpNetwork::new(address.address, 32).map_err(|e| CarbideError::Internal {
-            message: format!(
-                "failed to build default admin address prefix for {}/32: {}",
-                address.address, e
-            ),
-        })?;
+    let address_prefix = IpNetwork::new(address, 32).map_err(|e| CarbideError::Internal {
+        message: format!("failed to build default admin address prefix for {address}/32: {e}"),
+    })?;
 
     let svi_ip = if !fnn_enabled_on_admin {
         None
@@ -335,10 +336,10 @@ pub async fn admin_network(
         },
         vpc_vni,
         gateway: prefix.gateway_cidr().unwrap_or_default(),
-        ip: address.address.to_string(),
+        ip: address.to_string(),
         interface_prefix: address_prefix.to_string(),
         vpc_prefixes: if fnn_enabled_on_admin {
-            vec![format!("{}/32", address.address.to_string())]
+            vec![format!("{address}/32")]
         } else {
             vec![]
         },

--- a/crates/api/src/handlers/dpu.rs
+++ b/crates/api/src/handlers/dpu.rs
@@ -195,7 +195,7 @@ pub(crate) async fn get_managed_host_network_config_inner(
 
     let (admin_interface_rpc, host_interface_id) = ethernet_virtualization::admin_network(
         &mut txn,
-        &snapshot.host_snapshot.id,
+        &snapshot,
         &dpu_snapshot.id,
         use_fnn_over_admin_nw,
         &api.common_pools,


### PR DESCRIPTION
## Description

When we call the `admin_network` function, we already have a complete host snapshot available. Despite this, we are reloading various data from the DB. This change removes the 2 DB queries for re-loading the data.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

