### PR TITLE
refactor(model): remove dependency on host-support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.12.1"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5136e6c5e7e7978fe23e9876fb924af2c0f84c72127ac6ac17e7c46f457d362c"
+checksum = "be44683b41ccb9ab2d23a5230015c9c3c55be97a25e4428366de8873103f7970"
 dependencies = [
  "axum 0.8.9",
  "axum-core 0.5.5",
@@ -1419,11 +1419,11 @@ dependencies = [
  "bmc-vendor",
  "carbide-dpf",
  "carbide-health-report",
- "carbide-host-support",
  "carbide-ipxe-renderer",
  "carbide-libmlx",
  "carbide-network",
  "carbide-rpc",
+ "carbide-rpc-utils",
  "carbide-secrets",
  "carbide-sqlx-testing",
  "carbide-utils",
@@ -1940,6 +1940,7 @@ dependencies = [
  "carbide-dpu-agent-utils",
  "carbide-libmlx",
  "carbide-rpc",
+ "carbide-rpc-utils",
  "carbide-tls",
  "carbide-utils",
  "carbide-uuid",

--- a/crates/api-model/Cargo.toml
+++ b/crates/api-model/Cargo.toml
@@ -31,7 +31,6 @@ name = "model"
 bmc-vendor = { path = "../bmc-vendor" }
 carbide-dpf = { path = "../dpf" }
 config-version = { path = "../config-version", features = ["sqlx"] }
-carbide-host-support = { path = "../host-support", default-features = false }
 carbide-libmlx = { path = "../libmlx" }
 carbide-network = { path = "../network", features = ["sqlx"] }
 carbide-version = { path = "../version" }
@@ -40,6 +39,7 @@ carbide-ipxe-renderer = { path = "../ipxe-renderer" }
 carbide-rpc = { path = "../rpc", features = ["sqlx"] }
 carbide-secrets = { path = "../secrets" }
 carbide-utils = { path = "../utils", features = ["sqlx"] }
+carbide-rpc-utils = { path = "../rpc-utils" }
 carbide-uuid = { path = "../uuid", features = ["sqlx"] }
 dns-record = { path = "../dns-record" }
 libnmxm = { path = "../libnmxm" }

--- a/crates/api-model/src/hardware_info.rs
+++ b/crates/api-model/src/hardware_info.rs
@@ -23,8 +23,8 @@ use std::str::FromStr;
 
 use ::rpc::errors::RpcDataConversionError;
 use base64::prelude::*;
-use carbide_host_support::cpu::aggregate_cpus;
 use carbide_network::{MELLANOX_SF_VF_MAC_ADDRESS_IN, MELLANOX_SF_VF_MAC_ADDRESS_OUT};
+use carbide_rpc_utils::machine_discovery::aggregate_cpus;
 use carbide_utils::arch::CpuArchitecture;
 use carbide_uuid::nvlink::NvLinkDomainId;
 use mac_address::{MacAddress, MacParseError};

--- a/crates/host-support/Cargo.toml
+++ b/crates/host-support/Cargo.toml
@@ -35,6 +35,7 @@ carbide-tls = { path = "../tls" }
 carbide-libmlx = { path = "../libmlx" }
 logfmt = { path = "../logfmt" }
 carbide-rpc = { path = "../rpc" }
+carbide-rpc-utils = { path = "../rpc-utils" }
 carbide-utils = { path = "../utils" }
 carbide-uuid = { path = "../uuid" }
 

--- a/crates/host-support/src/hardware_enumeration.rs
+++ b/crates/host-support/src/hardware_enumeration.rs
@@ -23,6 +23,7 @@ use std::path::Path;
 use std::process::Command;
 use std::str::Utf8Error;
 
+use ::carbide_rpc_utils::machine_discovery::aggregate_cpus;
 use ::carbide_utils::arch::{CpuArchitecture, UnsupportedCpuArchitecture};
 use ::carbide_utils::cmd::CmdError;
 use ::rpc::machine_discovery as rpc_discovery;
@@ -33,8 +34,6 @@ use procfs::{CpuInfo, FromRead};
 use rpc::machine_discovery::MemoryDevice;
 use tracing::warn;
 use uname::uname;
-
-use crate::cpu::aggregate_cpus;
 
 pub mod dpu;
 mod gpu;

--- a/crates/host-support/src/lib.rs
+++ b/crates/host-support/src/lib.rs
@@ -26,7 +26,6 @@ use tracing_subscriber::prelude::*;
 use tracing_subscriber::util::SubscriberInitExt;
 
 pub mod agent_config;
-pub mod cpu;
 pub mod dpa_cmds;
 #[cfg(feature = "linux-build")]
 pub mod hardware_enumeration;

--- a/crates/rpc-utils/src/lib.rs
+++ b/crates/rpc-utils/src/lib.rs
@@ -16,6 +16,7 @@
  */
 
 pub mod dhcp;
+pub mod machine_discovery;
 pub mod managed_host_display;
 
 pub use managed_host_display::{ManagedHostMetadata, ManagedHostOutput, get_managed_host_output};

--- a/crates/rpc-utils/src/machine_discovery.rs
+++ b/crates/rpc-utils/src/machine_discovery.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 use std::collections::{HashMap, HashSet};
 
 use ::rpc::machine_discovery as rpc_discovery;
@@ -83,12 +84,12 @@ pub fn aggregate_cpus(cpus: &[rpc_discovery::Cpu]) -> Vec<rpc_discovery::CpuInfo
 }
 
 // Same as rpc_discovery::CpuInfo but with total thread count before computing threads per socket
-pub(crate) struct CpuAccumulator {
-    model: String,
-    vendor: String,
-    sockets: u32,
-    cores: u32,
-    threads: u32,
+pub struct CpuAccumulator {
+    pub model: String,
+    pub vendor: String,
+    pub sockets: u32,
+    pub cores: u32,
+    pub threads: u32,
 }
 
 impl From<&CpuAccumulator> for rpc_discovery::CpuInfo {


### PR DESCRIPTION
## Description

The host-support crate is initially designed as a set of helpers that run on hosts/DPUs. Therefore, having the carbide model depend on this crate is architecturally unsound.

This change moves shared data types to rpc-utils.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

