### PR TITLE
refactor(site-explorer): explore endpoint without full last report

### DIFF
--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -132,14 +132,6 @@ pub struct EndpointExplorationReport {
 }
 
 impl EndpointExplorationReport {
-    pub fn cannot_login(&self) -> bool {
-        if let Some(ref e) = self.last_exploration_error {
-            return e.is_unauthorized();
-        }
-
-        false
-    }
-
     /// model does a best effort to find a model name within the report
     pub fn model(&self) -> Option<String> {
         // Prefer Systems, not Chassis; at least for Lenovo, Chassis has what is more of a SKU instead of the actual model name.

--- a/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
@@ -86,7 +86,7 @@ impl EndpointExplorer for MockEndpointExplorer {
         bmc_ip_address: SocketAddr,
         _interface: &MachineInterfaceSnapshot,
         _expected: Option<&ExpectedEntity>,
-        _last_report: Option<&EndpointExplorationReport>,
+        _last_error: Option<&EndpointExplorationError>,
         _boot_interface_mac: Option<MacAddress>,
     ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
         tracing::info!("Endpoint {bmc_ip_address} is getting explored");

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -504,15 +504,13 @@ impl EndpointExplorer for BmcEndpointExplorer {
         bmc_ip_address: SocketAddr,
         interface: &MachineInterfaceSnapshot,
         expected: Option<&ExpectedEntity>,
-        last_report: Option<&EndpointExplorationReport>,
+        last_exploration_error: Option<&EndpointExplorationError>,
         boot_interface_mac: Option<MacAddress>,
     ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
         // If the site explorer was previously unable to login to the root BMC account using
         // the expected credentials, wait for an operator to manually intervene.
         // This will avoid locking us out of BMCs.
-        if let Some(report) = last_report
-            && report.cannot_login()
-        {
+        if last_exploration_error.is_some_and(|e| e.is_unauthorized()) {
             return Err(EndpointExplorationError::AvoidLockout);
         }
 
@@ -590,8 +588,7 @@ impl EndpointExplorer for BmcEndpointExplorer {
                     }) if vendor == RedfishVendor::Hpe => {
                         const MAX_AUTH_RETRIES: u32 = 5;
 
-                        let previous_count = last_report
-                            .and_then(|r| r.last_exploration_error.as_ref())
+                        let previous_count = last_exploration_error
                             .and_then(|e| e.intermittent_unauthorized_count())
                             .unwrap_or(0);
                         let consecutive_count = previous_count + 1;

--- a/crates/site-explorer/src/endpoint_explorer.rs
+++ b/crates/site-explorer/src/endpoint_explorer.rs
@@ -40,7 +40,7 @@ pub trait EndpointExplorer: Send + Sync + 'static {
         address: SocketAddr,
         interface: &MachineInterfaceSnapshot,
         expected: Option<&ExpectedEntity>,
-        last_report: Option<&EndpointExplorationReport>,
+        last_exploration_error: Option<&EndpointExplorationError>,
         boot_interface_mac: Option<MacAddress>,
     ) -> Result<EndpointExplorationReport, EndpointExplorationError>;
 

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -1566,7 +1566,7 @@ impl SiteExplorer {
                             bmc_target_addr,
                             endpoint.iface,
                             endpoint.expected,
-                            endpoint.last_explored.map(|e| &e.report),
+                            endpoint.last_explored.and_then(|e| e.report.last_exploration_error.as_ref()),
                             endpoint.last_explored.and_then(|e| e.boot_interface_mac),
                         )
                         .await;


### PR DESCRIPTION
## Description

The `EndpointExplorer::explore_endpoint` function only uses `last_exploration_error` in its body, so there is no need to pass the full report to it.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

