### PR TITLE
chore: Remove depcrecated field `name` from VPCPrefix

### DIFF
--- a/crates/admin-cli/src/devenv/config/apply/cmd.rs
+++ b/crates/admin-cli/src/devenv/config/apply/cmd.rs
@@ -144,7 +144,6 @@ async fn handle_overlay_vpc_prefix_creation(
         let new_prefix = VpcPrefixCreationRequest {
             id: Some(uuid::Uuid::new_v4().into()),
             prefix: String::new(),
-            name: String::new(),
             vpc_id: vpc.id,
             config: Some(rpc::forge::VpcPrefixConfig {
                 prefix: network.to_string(),
@@ -157,11 +156,15 @@ async fn handle_overlay_vpc_prefix_creation(
             }),
         };
         let vpc_prefix = api_client.0.create_vpc_prefix(new_prefix).await?;
-
+        let vpc_prefix_name = vpc_prefix
+            .metadata
+            .as_ref()
+            .map(|x| x.name.as_str())
+            .unwrap_or("");
         println!(
             "Created Vpc prefix {}, name: {} for network {network}.",
             vpc_prefix.id.unwrap(),
-            vpc_prefix.name
+            vpc_prefix_name
         );
     }
     Ok(())

--- a/crates/admin-cli/src/vpc_prefix/create/args.rs
+++ b/crates/admin-cli/src/vpc_prefix/create/args.rs
@@ -96,7 +96,6 @@ impl From<Args> for VpcPrefixCreationRequest {
         VpcPrefixCreationRequest {
             id: args.vpc_prefix_id,
             prefix: String::new(), // Deprecated field
-            name: String::new(),   // Deprecated field
             vpc_id: Some(args.vpc_id),
             config: Some(rpc::forge::VpcPrefixConfig {
                 prefix: args.prefix.to_string(),

--- a/crates/admin-cli/src/vpc_prefix/show/cmd.rs
+++ b/crates/admin-cli/src/vpc_prefix/show/cmd.rs
@@ -137,7 +137,11 @@ impl IntoTable for ShowOutput {
             .map(|id| id.to_string().into())
             .unwrap_or("".into());
         let prefix = row.prefix.as_str();
-        let name = row.name.as_str();
+        let name = row
+            .metadata
+            .as_ref()
+            .map(|x| x.name.as_str())
+            .unwrap_or("<no name>");
         let mut r = vec![vpc_prefix_id, vpc_id, prefix.into(), name.into()];
 
         if let Some(status) = &row.status {

--- a/crates/api-model/src/vpc_prefix.rs
+++ b/crates/api-model/src/vpc_prefix.rs
@@ -112,7 +112,6 @@ impl TryFrom<rpc::forge::VpcPrefixCreationRequest> for NewVpcPrefix {
         let rpc::forge::VpcPrefixCreationRequest {
             id,
             prefix,
-            name,
             vpc_id,
             config,
             metadata,
@@ -120,25 +119,30 @@ impl TryFrom<rpc::forge::VpcPrefixCreationRequest> for NewVpcPrefix {
 
         let id = id.unwrap_or_else(VpcPrefixId::new);
         let vpc_id = vpc_id.ok_or(RpcDataConversionError::MissingArgument("vpc_id"))?;
-        // let id = VpcPrefixId::new();
+
+        let metadata = match metadata {
+            Some(metadata) => metadata.try_into()?,
+            None => Metadata::new_with_default_name(),
+        };
+
+        metadata.validate(true).map_err(|e| {
+            RpcDataConversionError::InvalidArgument(format!(
+                "VPCPrefix metadata is not valid: {}",
+                e
+            ))
+        })?;
+
+        let config = match config {
+            Some(config) => VpcPrefixConfig::try_from(config)?,
+            None => VpcPrefixConfig {
+                prefix: IpNetwork::try_from(prefix.as_str())?,
+            },
+        };
 
         Ok(Self {
             id,
-            config: match config {
-                Some(c) => VpcPrefixConfig::try_from(c)?,
-                // Deprecated fields support
-                None => VpcPrefixConfig {
-                    prefix: IpNetwork::try_from(prefix.as_str())?,
-                },
-            },
-            metadata: match metadata {
-                Some(m) => Metadata::try_from(m)?,
-                // Deprecated fields support
-                None => Metadata {
-                    name,
-                    ..Default::default()
-                },
-            },
+            config,
+            metadata,
             vpc_id,
         })
     }
@@ -165,7 +169,6 @@ impl TryFrom<rpc::forge::VpcPrefixUpdateRequest> for UpdateVpcPrefix {
         let rpc::forge::VpcPrefixUpdateRequest {
             id,
             prefix,
-            name,
             config,
             metadata,
         } = rpc_update_prefix;
@@ -180,24 +183,19 @@ impl TryFrom<rpc::forge::VpcPrefixUpdateRequest> for UpdateVpcPrefix {
                 "Resizing VPC prefixes is currently unsupported".to_owned(),
             ));
         }
-
         let id = id.ok_or(RpcDataConversionError::MissingArgument("id"))?;
 
-        // At least one update field must be set
-        if metadata.is_none() && name.is_none() {
-            return Err(RpcDataConversionError::InvalidArgument(
-                "At least one updated field must be set".to_owned(),
-            ));
-        }
-
         let metadata = match metadata {
-            Some(m) => Metadata::try_from(m)?,
-            // Deprecated field handling
-            None => Metadata {
-                name: name.unwrap_or_default(),
-                ..Default::default()
-            },
+            Some(metadata) => metadata.try_into()?,
+            None => Metadata::new_with_default_name(),
         };
+
+        metadata.validate(true).map_err(|e| {
+            RpcDataConversionError::InvalidArgument(format!(
+                "VPC prefix metadata is not valid: {}",
+                e
+            ))
+        })?;
 
         Ok(Self { id, metadata })
     }
@@ -252,8 +250,7 @@ impl From<VpcPrefix> for rpc::forge::VpcPrefix {
 
         Self {
             id,
-            prefix: prefix.clone(),      // Deprecated
-            name: metadata.name.clone(), // Deprecated
+            prefix: prefix.clone(), // Deprecated
             vpc_id,
             total_31_segments: status.total_31_segments, // Deprecated
             available_31_segments: status.available_31_segments, // Deprecated

--- a/crates/api/src/tests/instance.rs
+++ b/crates/api/src/tests/instance.rs
@@ -3401,7 +3401,6 @@ async fn test_network_details_migration(
         .create_vpc_prefix(tonic::Request::new(rpc::forge::VpcPrefixCreationRequest {
             id: None,
             prefix: String::new(),
-            name: String::new(),
             vpc_id: Some(vpc_id),
             config: Some(rpc::forge::VpcPrefixConfig {
                 prefix: ip_prefix.into(),
@@ -3900,7 +3899,6 @@ async fn test_update_instance_config_vpc_prefix_network_update_delete_vf(
     let new_vpc_prefix = rpc::forge::VpcPrefixCreationRequest {
         id: None,
         prefix: String::new(),
-        name: String::new(),
         vpc_id: Some(vpc_id),
         config: Some(rpc::forge::VpcPrefixConfig {
             prefix: ip_prefix.into(),
@@ -4303,7 +4301,6 @@ async fn test_update_instance_config_vpc_prefix_network_update_state_machine(
     let new_vpc_prefix = rpc::forge::VpcPrefixCreationRequest {
         id: None,
         prefix: String::new(),
-        name: String::new(),
         vpc_id: Some(vpc_id),
         config: Some(rpc::forge::VpcPrefixConfig {
             prefix: ip_prefix.into(),

--- a/crates/api/src/tests/instance_config_update.rs
+++ b/crates/api/src/tests/instance_config_update.rs
@@ -612,7 +612,6 @@ async fn test_update_instance_config_vpc_prefix_no_network_update(
     let new_vpc_prefix = rpc::forge::VpcPrefixCreationRequest {
         id: None,
         prefix: String::new(),
-        name: String::new(),
         vpc_id: Some(vpc_id),
         config: Some(rpc::forge::VpcPrefixConfig {
             prefix: ip_prefix.into(),
@@ -746,7 +745,6 @@ async fn test_update_instance_config_vpc_prefix_network_update(
     let new_vpc_prefix = rpc::forge::VpcPrefixCreationRequest {
         id: None,
         prefix: String::new(),
-        name: String::new(),
         vpc_id: Some(vpc_id),
         config: Some(rpc::forge::VpcPrefixConfig {
             prefix: ip_prefix.into(),
@@ -948,7 +946,6 @@ async fn test_update_instance_config_vpc_prefix_network_update_post_instance_del
     let new_vpc_prefix = rpc::forge::VpcPrefixCreationRequest {
         id: None,
         prefix: String::new(),
-        name: String::new(),
         vpc_id: Some(vpc_id),
         config: Some(rpc::forge::VpcPrefixConfig {
             prefix: ip_prefix.into(),
@@ -1101,7 +1098,6 @@ async fn test_update_instance_config_vpc_prefix_network_update_multidpu(
     let new_vpc_prefix = rpc::forge::VpcPrefixCreationRequest {
         id: None,
         prefix: String::new(),
-        name: String::new(),
         vpc_id: Some(vpc_id),
         config: Some(rpc::forge::VpcPrefixConfig {
             prefix: ip_prefix.into(),
@@ -1267,7 +1263,6 @@ async fn test_update_instance_config_vpc_prefix_network_update_multidpu_differen
     let new_vpc_prefix = rpc::forge::VpcPrefixCreationRequest {
         id: None,
         prefix: String::new(),
-        name: String::new(),
         vpc_id: Some(vpc_id),
         config: Some(rpc::forge::VpcPrefixConfig {
             prefix: ip_prefix.into(),
@@ -1293,7 +1288,6 @@ async fn test_update_instance_config_vpc_prefix_network_update_multidpu_differen
     let new_vpc_prefix1 = rpc::forge::VpcPrefixCreationRequest {
         id: None,
         prefix: String::new(),
-        name: String::new(),
         vpc_id: Some(vpc_id),
         config: Some(rpc::forge::VpcPrefixConfig {
             prefix: ip_prefix1.into(),
@@ -1460,7 +1454,6 @@ async fn test_update_instance_config_vpc_prefix_network_update_different_prefix_
     let new_vpc_prefix = rpc::forge::VpcPrefixCreationRequest {
         id: None,
         prefix: String::new(),
-        name: String::new(),
         vpc_id: Some(vpc_id),
         config: Some(rpc::forge::VpcPrefixConfig {
             prefix: ip_prefix.into(),
@@ -1653,7 +1646,6 @@ async fn test_update_instance_config_vpc_prefix_network_update_different_prefix_
     let new_vpc_prefix1 = rpc::forge::VpcPrefixCreationRequest {
         id: None,
         prefix: String::new(),
-        name: String::new(),
         vpc_id: Some(vpc_id),
         config: Some(rpc::forge::VpcPrefixConfig {
             prefix: ip_prefix1.into(),

--- a/crates/api/src/tests/vpc_prefix.rs
+++ b/crates/api/src/tests/vpc_prefix.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use rpc::Metadata;
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{
     PrefixMatchType, VpcPrefixCreationRequest, VpcPrefixDeletionRequest, VpcPrefixSearchQuery,
@@ -35,7 +36,10 @@ async fn test_create_and_delete_vpc_prefix_deprecated_fields(
     let new_vpc_prefix = VpcPrefixCreationRequest {
         id: None,
         prefix: ip_prefix.into(),
-        name: "Test VPC prefix".into(),
+        metadata: Some(Metadata {
+            name: "Test VPC prefix".to_string(),
+            ..Default::default()
+        }),
         vpc_id: Some(vpc_id),
         ..Default::default()
     };
@@ -70,7 +74,6 @@ async fn test_create_and_delete_vpc_prefix(pool: PgPool) -> Result<(), Box<dyn s
     let new_vpc_prefix = VpcPrefixCreationRequest {
         id: None,
         prefix: String::new(),
-        name: String::new(),
         vpc_id: Some(vpc_id),
         config: Some(rpc::forge::VpcPrefixConfig {
             prefix: ip_prefix.into(),
@@ -118,7 +121,6 @@ async fn test_overlapping_vpc_prefixes(pool: PgPool) -> Result<(), Box<dyn std::
     let new_vpc_prefix = VpcPrefixCreationRequest {
         id: None,
         prefix: String::new(),
-        name: String::new(),
         vpc_id: Some(vpc_id),
         config: Some(rpc::forge::VpcPrefixConfig {
             prefix: ip_prefix.into(),
@@ -139,7 +141,6 @@ async fn test_overlapping_vpc_prefixes(pool: PgPool) -> Result<(), Box<dyn std::
     let overlapping_vpc_prefix = VpcPrefixCreationRequest {
         id: None,
         prefix: String::new(),
-        name: String::new(),
         vpc_id: Some(vpc_id),
         config: Some(rpc::forge::VpcPrefixConfig {
             prefix: overlapping_ip_prefix.into(),
@@ -173,7 +174,6 @@ async fn test_reject_create_with_invalid_metadata(
     let new_vpc_prefix = VpcPrefixCreationRequest {
         id: None,
         prefix: String::new(),
-        name: String::new(),
         vpc_id: Some(vpc_id),
         config: Some(rpc::forge::VpcPrefixConfig {
             prefix: ip_prefix.into(),
@@ -223,7 +223,6 @@ async fn test_invalid_vpc_prefixes(pool: PgPool) -> Result<(), Box<dyn std::erro
         let bad_vpc_prefix = VpcPrefixCreationRequest {
             id: None,
             prefix: String::new(),
-            name: String::new(),
             vpc_id: Some(vpc_id),
 
             config: Some(rpc::forge::VpcPrefixConfig {
@@ -257,7 +256,6 @@ async fn test_vpc_prefix_search(pool: PgPool) -> Result<(), Box<dyn std::error::
     let create_p1 = VpcPrefixCreationRequest {
         id: None,
         prefix: String::new(),
-        name: String::new(),
         vpc_id: Some(vpc_id),
         config: Some(rpc::forge::VpcPrefixConfig { prefix: p1.into() }),
         metadata: Some(rpc::forge::Metadata {
@@ -268,7 +266,6 @@ async fn test_vpc_prefix_search(pool: PgPool) -> Result<(), Box<dyn std::error::
     let create_p2 = VpcPrefixCreationRequest {
         id: None,
         prefix: String::new(),
-        name: String::new(),
         vpc_id: Some(vpc_id),
         config: Some(rpc::forge::VpcPrefixConfig { prefix: p2.into() }),
         metadata: Some(rpc::forge::Metadata {

--- a/crates/api/src/tests/web/vpc.rs
+++ b/crates/api/src/tests/web/vpc.rs
@@ -73,7 +73,6 @@ async fn vpc_pages_show_status_vni(pool: sqlx::PgPool) {
         .create_vpc_prefix(tonic::Request::new(forge::VpcPrefixCreationRequest {
             id: None,
             prefix: String::new(),
-            name: String::new(),
             vpc_id: Some(vpc_id),
             config: Some(forge::VpcPrefixConfig {
                 prefix: "192.0.2.0/25".to_string(),

--- a/crates/api/src/web/ipam.rs
+++ b/crates/api/src/web/ipam.rs
@@ -535,13 +535,6 @@ pub async fn overlay_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
             .metadata
             .as_ref()
             .map(|m| m.name.clone())
-            .or_else(|| {
-                if p.name.is_empty() {
-                    None
-                } else {
-                    Some(p.name.clone())
-                }
-            })
             .unwrap_or_default();
         prefixes_by_vpc
             .entry(vpc_id)
@@ -685,7 +678,7 @@ pub async fn overlay_prefix_html(
         .metadata
         .as_ref()
         .map(|m| m.name.clone())
-        .unwrap_or_else(|| prefix.name.clone());
+        .unwrap_or_else(|| "<no name>".to_string());
     let vpc_id = prefix.vpc_id.map(|id| id.to_string()).unwrap_or_default();
 
     // Fetch the parent VPC for name/VNI.

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1589,7 +1589,7 @@ enum PrefixMatchType {
 message VpcPrefix {
   common.VpcPrefixId id = 1;
   string prefix = 2; // Deprecated, use config instead
-  string name = 3; // Deprecated, use metadata instead
+  reserved 3; // was string name, replaced with metadata instead
   common.VpcId vpc_id = 4;
   reserved 5; // tenant_prefix_id
   uint32 total_31_segments = 6; // Deprecated, use status instead
@@ -1616,7 +1616,7 @@ message VpcPrefixCreationRequest {
   optional common.VpcPrefixId id = 1;
   // IPv4 or IPv6 prefix in CIDR notation
   string prefix = 2; // Deprecated, use config instead
-  string name = 3; // Deprecated, use config instead
+  reserved 3; // was string name, replaced with metadata
   common.VpcId vpc_id = 4;
   reserved 5; // tenant_prefix_id
   VpcPrefixConfig config = 6;
@@ -1654,7 +1654,7 @@ message VpcPrefixUpdateRequest {
   // 2. It is not larger than its containing site prefix.
   // 3. It contains all of its associated network segment prefixes.
   optional string prefix = 2; // Deprecated, use config instead
-  optional string name = 3;  // Deprecated, use metadata instead
+  reserved 3;  // was string name, replaced metadata
   VpcPrefixConfig config = 4;
   Metadata metadata = 5;
 }


### PR DESCRIPTION
  * The infra-controller-rest component already as the changes in place
  1. https://github.com/NVIDIA/infra-controller-rest/blob/main/api/pkg/api/handler/vpcprefix.go#L272
  2. https://github.com/NVIDIA/infra-controller-rest/blob/main/api/pkg/api/handler/vpcprefix.go#L813
  * Updated protobuf definitions
  * Removed references to name in source code and tests

Fixes NVIDIA/infra-controller-core#930


