### PR TITLE
feat(secrets): BMC side wide root credentials via env var

### DIFF
--- a/crates/secrets/src/local_credentials/mod.rs
+++ b/crates/secrets/src/local_credentials/mod.rs
@@ -21,7 +21,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::SecretsError;
 use crate::credentials::{
-    CredentialKey, CredentialReader, CredentialType, Credentials, MqttCredentialType,
+    BmcCredentialType, CredentialKey, CredentialReader, CredentialType, Credentials,
+    MqttCredentialType,
 };
 
 mod env;
@@ -80,6 +81,7 @@ pub struct CredentialSnapshot {
     pub nmxm_auth_by_id: HashMap<String, UsernamePassword>,
     pub mqtt_auth_by_credential_type: HashMap<MqttCredentialType, UsernamePassword>,
     pub machine_identity: Option<MachineIdentityConfig>,
+    pub bmc_site_wide_root: Option<UsernamePassword>,
 }
 
 impl CredentialSnapshot {
@@ -134,6 +136,9 @@ impl CredentialSnapshot {
                     username: key_id.clone(),
                     password: secret,
                 }),
+            CredentialKey::BmcCredentials {
+                credential_type: BmcCredentialType::SiteWideRoot,
+            } => self.bmc_site_wide_root.clone().map(Into::into),
             _ => None,
         }
     }
@@ -152,7 +157,6 @@ impl CredentialReader for CredentialSnapshot {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::credentials::BmcCredentialType;
 
     fn up(user: &str, pass: &str) -> UsernamePassword {
         UsernamePassword {
@@ -193,6 +197,7 @@ mod tests {
                 up("mqtt-u", "mqtt-p"),
             )]),
             machine_identity: None,
+            bmc_site_wide_root: None,
         }
     }
 
@@ -313,12 +318,21 @@ mod tests {
     }
 
     #[test]
+    fn snapshot_bmc_site_wide_root() {
+        let snap = CredentialSnapshot {
+            bmc_site_wide_root: Some(up("bmc-u", "bmc-p")),
+            ..Default::default()
+        };
+        let key = CredentialKey::BmcCredentials {
+            credential_type: BmcCredentialType::SiteWideRoot,
+        };
+        assert_eq!(snap.get_credentials(&key), Some(cred("bmc-u", "bmc-p")));
+    }
+
+    #[test]
     fn snapshot_unsupported_keys_return_none() {
         let snap = populated_snapshot();
         let keys: Vec<CredentialKey> = vec![
-            CredentialKey::BmcCredentials {
-                credential_type: BmcCredentialType::SiteWideRoot,
-            },
             CredentialKey::ExtensionService {
                 service_id: "svc".to_string(),
                 version: "1".to_string(),


### PR DESCRIPTION
## Description
Allows reading static side wide root BMC credentials via:
- `CARBIDE_STATIC_CREDENTIAL__BMC_SITE_WIDE_ROOT__USERNAME`
- `CARBIDE_STATIC_CREDENTIAL__BMC_SITE_WIDE_ROOT__PASSWORD`
similarly to other env var secrets.

This provides some flexibility for providing this credential via k8s Secret or other method, and is needed to enable running without vault (for development/testing purposes).

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

