### PR TITLE
fix: Don't check client cert expiry in non-TLS mode

### DIFF
--- a/crates/rpc/src/forge_tls_client.rs
+++ b/crates/rpc/src/forge_tls_client.rs
@@ -561,7 +561,8 @@ impl<'a> ForgeTlsClient<'a> {
             error: e,
         })?;
 
-        // only check for the root cert if the uri we were given is actually HTTPS.  That lets tests function properly.
+        // Only check the root and client certs if the uri we were given is actually HTTPS.
+        // That lets tests and plaintext-HTTP environments function properly.
         if let Some(scheme) = uri.scheme()
             && scheme == &tonic::codegen::http::uri::Scheme::HTTPS
         {
@@ -579,6 +580,25 @@ impl<'a> ForgeTlsClient<'a> {
                         path: self.forge_client_config.root_ca_path.clone(),
                         error,
                     }
+                    .into());
+                }
+            }
+
+            if let Some(cert_expiry) = self.forge_client_config.client_cert_expiry() {
+                let start = SystemTime::now();
+                let current_time = start
+                    .duration_since(UNIX_EPOCH)
+                    .expect("Time went backwards");
+                if u64::try_from(cert_expiry)
+                    .ok()
+                    .is_none_or(|v| current_time.as_secs() > v)
+                {
+                    tracing::error!(
+                        "Client certificate is expired, perhaps you need to regenerate your cert?"
+                    );
+                    return Err(ConfigurationError::InvalidClientCert(
+                        rustls::Error::InvalidCertificate(rustls::CertificateError::Expired),
+                    )
                     .into());
                 }
             }
@@ -604,25 +624,6 @@ impl<'a> ForgeTlsClient<'a> {
                         ))
                 }
             };
-
-            if let Some(cert_expiry) = self.forge_client_config.client_cert_expiry() {
-                let start = SystemTime::now();
-                let current_time = start
-                    .duration_since(UNIX_EPOCH)
-                    .expect("Time went backwards");
-                if u64::try_from(cert_expiry)
-                    .ok()
-                    .is_none_or(|v| current_time.as_secs() > v)
-                {
-                    tracing::error!(
-                        "Client certificate is expired, perhaps you need to regenerate your cert?"
-                    );
-                    return Err(ConfigurationError::InvalidClientCert(
-                        rustls::Error::InvalidCertificate(rustls::CertificateError::Expired),
-                    )
-                    .into());
-                }
-            }
 
             if let Some((certs, key)) = self.forge_client_config.read_client_cert() {
                 builder()


### PR DESCRIPTION
## Description
Currently when given a http (not https) url, we skip checking the root cert but still check the client cert. We shouldn't be doing either as they are unused and needing valid but unused values makes development/testing environments harder.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

