### PR TITLE
refactor(site-explorer): update exploration failure fields in place

### DIFF
--- a/crates/api-db/src/explored_endpoints.rs
+++ b/crates/api-db/src/explored_endpoints.rs
@@ -259,6 +259,41 @@ WHERE address=$4 AND version=$5";
     Ok(query_result.rows_affected() > 0)
 }
 
+/// Updates only the last exploration error and latency in an endpoint's report.
+///
+/// This preserves the rest of the last successful exploration report while recording
+/// an exploration failure. Returns `Ok(false)` if the entry had been deleted in the
+/// meantime or otherwise modified. It will not fail for version mismatches.
+pub async fn try_update_last_exploration_error(
+    address: IpAddr,
+    old_version: ConfigVersion,
+    error: &model::site_explorer::EndpointExplorationError,
+    latency: std::time::Duration,
+    txn: &mut PgConnection,
+) -> Result<bool, DatabaseError> {
+    let new_version = old_version.increment();
+    let query = "UPDATE explored_endpoints
+SET version=$1,
+    exploration_report=jsonb_set(
+        jsonb_set(exploration_report, '{LastExplorationError}', $2::jsonb, true),
+        '{LastExplorationLatency}', $3::jsonb, true
+    ),
+    waiting_for_explorer_refresh=true,
+    exploration_requested=false
+WHERE address=$4 AND version=$5";
+    let query_result = sqlx::query(query)
+        .bind(new_version)
+        .bind(sqlx::types::Json(error))
+        .bind(sqlx::types::Json(&latency))
+        .bind(address)
+        .bind(old_version)
+        .execute(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    Ok(query_result.rows_affected() > 0)
+}
+
 /// clear_last_known_error clears the last known error in explored_endpoints for the BMC identified by IP
 pub async fn clear_last_known_error(
     address: IpAddr,

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -708,7 +708,8 @@ async fn test_site_explorer_main(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
         assert_eq!(report.report.endpoint_type, EndpointType::Bmc);
         match report.address.to_string() {
             a if a == machines[0].ip => {
-                // The original report is retained. But the error gets stored
+                // The original successful report is retained, while only the latest
+                // exploration failure details are updated.
                 assert_eq!(report.report.vendor, Some(bmc_vendor::BMCVendor::Nvidia));
                 assert_eq!(
                     report.report.last_exploration_error.clone().unwrap(),
@@ -716,6 +717,7 @@ async fn test_site_explorer_main(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
                         details: Some("test_unreachable_detail".to_string())
                     }
                 );
+                assert!(report.report.last_exploration_latency.is_some());
             }
             a if a == machines[1].ip => {
                 assert_eq!(report.report.vendor, Some(bmc_vendor::BMCVendor::Dell));

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -1697,14 +1697,11 @@ impl SiteExplorer {
                         Err(e) => {
                             // If an endpoint can not be explored we don't delete the known information, since it's
                             // still helpful. The failure might just be intermittent.
-                            let mut old_report = old_report.clone();
-                            old_report.last_exploration_error = Some(e);
-                            old_report.last_exploration_latency = Some(exploration_duration);
-                            db::explored_endpoints::try_update(
+                            db::explored_endpoints::try_update_last_exploration_error(
                                 address,
                                 old_version,
-                                &old_report,
-                                true,
+                                &e,
+                                exploration_duration,
                                 &mut txn,
                             )
                             .await?;


### PR DESCRIPTION
## Description

Avoid cloning the existing endpoint exploration report just to update the latest failure details. Add a DB helper that updates only `LastExplorationError` and `LastExplorationLatency` in the stored JSON report.

This preserves the existing behavior while making the update narrower and more explicit. Extend site explorer coverage to verify the retained report data and updated failure latency.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
