### PR TITLE
feat: emit metrics for switch/ps/racks health alerts

### DIFF
--- a/crates/api-model/src/power_shelf/mod.rs
+++ b/crates/api-model/src/power_shelf/mod.rs
@@ -157,7 +157,7 @@ impl TryFrom<rpc::PowerShelfConfig> for PowerShelfConfig {
     }
 }
 
-fn derive_power_shelf_aggregate_health(
+pub fn derive_power_shelf_aggregate_health(
     sources: &HealthReportSources,
 ) -> health_report::HealthReport {
     if let Some(replace) = &sources.replace {

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -329,7 +329,7 @@ impl From<rpc::forge::RackSearchFilter> for RackSearchFilter {
     }
 }
 
-fn derive_rack_aggregate_health(sources: &HealthReportSources) -> health_report::HealthReport {
+pub fn derive_rack_aggregate_health(sources: &HealthReportSources) -> health_report::HealthReport {
     if let Some(replace) = &sources.replace {
         return replace.clone();
     }

--- a/crates/api-model/src/switch/mod.rs
+++ b/crates/api-model/src/switch/mod.rs
@@ -271,7 +271,9 @@ impl TryFrom<rpc::SwitchConfig> for SwitchConfig {
     }
 }
 
-fn derive_switch_aggregate_health(sources: &HealthReportSources) -> health_report::HealthReport {
+pub fn derive_switch_aggregate_health(
+    sources: &HealthReportSources,
+) -> health_report::HealthReport {
     if let Some(replace) = &sources.replace {
         return replace.clone();
     }

--- a/crates/api/src/state_controller/health_metrics.rs
+++ b/crates/api/src/state_controller/health_metrics.rs
@@ -30,11 +30,17 @@ pub trait HealthMetricDimension:
     Hash + Eq + Clone + Default + Debug + Send + Sync + 'static
 {
     fn key_values(&self) -> Vec<KeyValue>;
+
+    fn all_values() -> Vec<Self>;
 }
 
 impl HealthMetricDimension for () {
     fn key_values(&self) -> Vec<KeyValue> {
         Vec::new()
+    }
+
+    fn all_values() -> Vec<Self> {
+        vec![()]
     }
 }
 
@@ -146,10 +152,17 @@ pub fn register_health_gauges<T, D, F>(
             .with_callback(move |observer| {
                 metrics.if_available(|metrics, attrs| {
                     let health = project(metrics);
-                    for ((healthy, dimension), count) in &health.healthy {
-                        let mut labels = vec![KeyValue::new("healthy", healthy.to_string())];
-                        labels.extend(dimension.key_values());
-                        observer.observe(*count as u64, &[attrs, &labels].concat());
+                    for healthy in [true, false] {
+                        for dimension in D::all_values() {
+                            let count = health
+                                .healthy
+                                .get(&(healthy, dimension.clone()))
+                                .copied()
+                                .unwrap_or_default();
+                            let mut labels = vec![KeyValue::new("healthy", healthy.to_string())];
+                            labels.extend(dimension.key_values());
+                            observer.observe(count as u64, &[attrs, &labels].concat());
+                        }
                     }
                 })
             })
@@ -166,11 +179,18 @@ pub fn register_health_gauges<T, D, F>(
             .with_callback(move |observer| {
                 metrics.if_available(|metrics, attrs| {
                     let health = project(metrics);
-                    for ((override_type, dimension), count) in &health.num_overrides {
-                        let mut labels =
-                            vec![KeyValue::new("override_type", override_type.to_string())];
-                        labels.extend(dimension.key_values());
-                        observer.observe(*count as u64, &[attrs, &labels].concat());
+                    for override_type in ["merge", "replace"] {
+                        for dimension in D::all_values() {
+                            let count = health
+                                .num_overrides
+                                .get(&(override_type, dimension.clone()))
+                                .copied()
+                                .unwrap_or_default();
+                            let mut labels =
+                                vec![KeyValue::new("override_type", override_type.to_string())];
+                            labels.extend(dimension.key_values());
+                            observer.observe(count as u64, &[attrs, &labels].concat());
+                        }
                     }
                 })
             })
@@ -226,30 +246,45 @@ pub fn register_health_gauges<T, D, F>(
     }
 
     // {prefix}_alerts_suppressed_count
-    {
-        let metrics = shared;
-        meter
-            .u64_observable_gauge(format!("{metric_prefix}_alerts_suppressed_count"))
-            .with_description(
-                "Whether external metrics based alerting is suppressed for a specific object",
-            )
-            .with_callback(move |observer| {
-                metrics.if_available(|metrics, attrs| {
-                    let health = project(metrics);
-                    for object_id in &health.alerts_suppressed_by_object_id {
-                        observer.observe(
-                            1u64,
-                            &[
-                                attrs,
-                                &[KeyValue::new(suppressed_label_key, object_id.clone())],
-                            ]
-                            .concat(),
-                        );
-                    }
-                })
+    register_alerts_suppressed_gauge(
+        &format!("{metric_prefix}_alerts_suppressed_count"),
+        suppressed_label_key,
+        meter,
+        shared,
+        move |m| &project(m).alerts_suppressed_by_object_id,
+    );
+}
+
+pub fn register_alerts_suppressed_gauge<T, F>(
+    metric_name: &str,
+    suppressed_label_key: &'static str,
+    meter: &Meter,
+    shared: SharedMetricsHolder<T>,
+    project: F,
+) where
+    T: Debug + Send + Sync + 'static,
+    F: Fn(&T) -> &HashSet<String> + Send + Sync + 'static,
+{
+    meter
+        .u64_observable_gauge(metric_name.to_string())
+        .with_description(
+            "Whether external metrics based alerting is suppressed for a specific object",
+        )
+        .with_callback(move |observer| {
+            shared.if_available(|metrics, attrs| {
+                for object_id in project(metrics) {
+                    observer.observe(
+                        1u64,
+                        &[
+                            attrs,
+                            &[KeyValue::new(suppressed_label_key, object_id.clone())],
+                        ]
+                        .concat(),
+                    );
+                }
             })
-            .build();
-    }
+        })
+        .build();
 }
 
 #[cfg(test)]

--- a/crates/api/src/state_controller/health_metrics.rs
+++ b/crates/api/src/state_controller/health_metrics.rs
@@ -1,0 +1,363 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::{HashMap, HashSet};
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::sync::Arc;
+
+use carbide_utils::metrics::SharedMetricsHolder;
+use health_report::{HealthAlertClassification, HealthProbeId, HealthReport};
+use model::health::HealthReportSources;
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::Meter;
+
+pub trait HealthMetricDimension:
+    Hash + Eq + Clone + Default + Debug + Send + Sync + 'static
+{
+    fn key_values(&self) -> Vec<KeyValue>;
+}
+
+impl HealthMetricDimension for () {
+    fn key_values(&self) -> Vec<KeyValue> {
+        Vec::new()
+    }
+}
+
+/// Per object snapshot of the health-related signals
+#[derive(Debug, Default, Clone)]
+pub struct HealthObjectMetrics {
+    pub object_id: String,
+    pub health_probe_alerts: HashSet<(HealthProbeId, Option<String>)>,
+    pub health_alert_classifications: HashSet<HealthAlertClassification>,
+    pub alerts_suppressed: bool,
+    pub num_merge_overrides: usize,
+    pub replace_override_enabled: bool,
+}
+
+impl HealthObjectMetrics {
+    pub fn populate(
+        &mut self,
+        object_id: String,
+        aggregate_health: &HealthReport,
+        sources: &HealthReportSources,
+    ) {
+        self.object_id = object_id;
+
+        let suppress_alerts = HealthAlertClassification::suppress_external_alerting();
+        for alert in aggregate_health.alerts.iter() {
+            self.health_probe_alerts
+                .insert((alert.id.clone(), alert.target.clone()));
+            for c in alert.classifications.iter() {
+                self.health_alert_classifications.insert(c.clone());
+                if *c == suppress_alerts {
+                    self.alerts_suppressed = true;
+                }
+            }
+        }
+
+        self.num_merge_overrides = sources.merges.len();
+        self.replace_override_enabled = sources.replace.is_some();
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct HealthIterationMetrics<D: HealthMetricDimension> {
+    pub healthy: HashMap<(bool, D), usize>,
+    pub unhealthy_by_probe_id: HashMap<(String, Option<String>, D), usize>,
+    pub unhealthy_by_classification_id: HashMap<(String, D), usize>,
+    pub alerts_suppressed_by_object_id: HashSet<String>,
+    pub num_overrides: HashMap<(&'static str, D), usize>,
+}
+
+impl<D: HealthMetricDimension> HealthIterationMetrics<D> {
+    pub fn merge(&mut self, dimension: D, object: &HealthObjectMetrics) {
+        let is_healthy = object.health_probe_alerts.is_empty();
+        *self
+            .healthy
+            .entry((is_healthy, dimension.clone()))
+            .or_default() += 1;
+
+        for (probe_id, target) in &object.health_probe_alerts {
+            *self
+                .unhealthy_by_probe_id
+                .entry((probe_id.to_string(), target.clone(), dimension.clone()))
+                .or_default() += 1;
+        }
+        for classification in &object.health_alert_classifications {
+            *self
+                .unhealthy_by_classification_id
+                .entry((classification.to_string(), dimension.clone()))
+                .or_default() += 1;
+        }
+        if object.alerts_suppressed {
+            self.alerts_suppressed_by_object_id
+                .insert(object.object_id.clone());
+        }
+        *self
+            .num_overrides
+            .entry(("merge", dimension.clone()))
+            .or_default() += object.num_merge_overrides;
+        if object.replace_override_enabled {
+            *self
+                .num_overrides
+                .entry(("replace", dimension))
+                .or_default() += 1;
+        }
+    }
+}
+
+pub fn register_health_gauges<T, D, F>(
+    metric_prefix: &str,
+    suppressed_label_key: &'static str,
+    meter: &Meter,
+    shared: SharedMetricsHolder<T>,
+    project: F,
+) where
+    T: Debug + Send + Sync + 'static,
+    D: HealthMetricDimension,
+    F: Fn(&T) -> &HealthIterationMetrics<D> + Send + Sync + 'static,
+{
+    let project = Arc::new(project);
+
+    // {prefix}_health_status_count
+    {
+        let metrics = shared.clone();
+        let project = project.clone();
+        meter
+            .u64_observable_gauge(format!("{metric_prefix}_health_status_count"))
+            .with_description(
+                "The total number of objects in the system that have reported either a healthy or not healthy status - based on the presence of health probe alerts",
+            )
+            .with_callback(move |observer| {
+                metrics.if_available(|metrics, attrs| {
+                    let health = project(metrics);
+                    for ((healthy, dimension), count) in &health.healthy {
+                        let mut labels = vec![KeyValue::new("healthy", healthy.to_string())];
+                        labels.extend(dimension.key_values());
+                        observer.observe(*count as u64, &[attrs, &labels].concat());
+                    }
+                })
+            })
+            .build();
+    }
+
+    // {prefix}_health_overrides_count
+    {
+        let metrics = shared.clone();
+        let project = project.clone();
+        meter
+            .u64_observable_gauge(format!("{metric_prefix}_health_overrides_count"))
+            .with_description("The amount of health overrides that are configured in the site")
+            .with_callback(move |observer| {
+                metrics.if_available(|metrics, attrs| {
+                    let health = project(metrics);
+                    for ((override_type, dimension), count) in &health.num_overrides {
+                        let mut labels =
+                            vec![KeyValue::new("override_type", override_type.to_string())];
+                        labels.extend(dimension.key_values());
+                        observer.observe(*count as u64, &[attrs, &labels].concat());
+                    }
+                })
+            })
+            .build();
+    }
+
+    // {prefix}_unhealthy_by_probe_id_count
+    {
+        let metrics = shared.clone();
+        let project = project.clone();
+        meter
+            .u64_observable_gauge(format!("{metric_prefix}_unhealthy_by_probe_id_count"))
+            .with_description("The amount of objects which reported a certain Health Probe Alert")
+            .with_callback(move |observer| {
+                metrics.if_available(|metrics, attrs| {
+                    let health = project(metrics);
+                    for ((probe, target, dimension), count) in &health.unhealthy_by_probe_id {
+                        let mut labels = vec![
+                            KeyValue::new("probe_id", probe.clone()),
+                            KeyValue::new("probe_target", target.clone().unwrap_or_default()),
+                        ];
+                        labels.extend(dimension.key_values());
+                        observer.observe(*count as u64, &[attrs, &labels].concat());
+                    }
+                })
+            })
+            .build();
+    }
+
+    // {prefix}_unhealthy_by_classification_count
+    {
+        let metrics = shared.clone();
+        let project = project.clone();
+        meter
+            .u64_observable_gauge(format!("{metric_prefix}_unhealthy_by_classification_count"))
+            .with_description(
+                "The amount of objects which are marked with a certain classification due to being unhealthy",
+            )
+            .with_callback(move |observer| {
+                metrics.if_available(|metrics, attrs| {
+                    let health = project(metrics);
+                    for ((classification, dimension), count) in
+                        &health.unhealthy_by_classification_id
+                    {
+                        let mut labels =
+                            vec![KeyValue::new("classification", classification.clone())];
+                        labels.extend(dimension.key_values());
+                        observer.observe(*count as u64, &[attrs, &labels].concat());
+                    }
+                })
+            })
+            .build();
+    }
+
+    // {prefix}_alerts_suppressed_count
+    {
+        let metrics = shared;
+        meter
+            .u64_observable_gauge(format!("{metric_prefix}_alerts_suppressed_count"))
+            .with_description(
+                "Whether external metrics based alerting is suppressed for a specific object",
+            )
+            .with_callback(move |observer| {
+                metrics.if_available(|metrics, attrs| {
+                    let health = project(metrics);
+                    for object_id in &health.alerts_suppressed_by_object_id {
+                        observer.observe(
+                            1u64,
+                            &[
+                                attrs,
+                                &[KeyValue::new(suppressed_label_key, object_id.clone())],
+                            ]
+                            .concat(),
+                        );
+                    }
+                })
+            })
+            .build();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use health_report::{HealthProbeAlert, HealthReport};
+
+    use super::*;
+
+    fn alert(id: &str, target: Option<&str>, classifications: Vec<&str>) -> HealthProbeAlert {
+        HealthProbeAlert {
+            id: id.parse().unwrap(),
+            target: target.map(str::to_string),
+            in_alert_since: None,
+            message: String::new(),
+            tenant_message: None,
+            classifications: classifications
+                .into_iter()
+                .map(|c| c.parse().unwrap())
+                .collect(),
+        }
+    }
+
+    fn report_with(alerts: Vec<HealthProbeAlert>) -> HealthReport {
+        HealthReport {
+            source: "test".to_string(),
+            triggered_by: None,
+            observed_at: None,
+            successes: vec![],
+            alerts,
+        }
+    }
+
+    #[test]
+    fn populate_from_aggregate_health() {
+        let mut object = HealthObjectMetrics::default();
+        let aggregate = report_with(vec![
+            alert("BgpStats", None, vec!["Class1", "SuppressExternalAlerting"]),
+            alert("FileExists", Some("abc"), vec!["Class2"]),
+        ]);
+        let sources = HealthReportSources {
+            replace: Some(report_with(vec![])),
+            merges: BTreeMap::from_iter([
+                ("a".to_string(), report_with(vec![])),
+                ("b".to_string(), report_with(vec![])),
+            ]),
+        };
+
+        object.populate("obj-1".to_string(), &aggregate, &sources);
+
+        assert_eq!(object.object_id, "obj-1");
+        assert_eq!(object.health_probe_alerts.len(), 2);
+        assert!(object.alerts_suppressed);
+        assert_eq!(object.health_alert_classifications.len(), 3);
+        assert_eq!(object.num_merge_overrides, 2);
+        assert!(object.replace_override_enabled);
+    }
+
+    #[test]
+    fn merge_no_dimension_aggregates_across_objects() {
+        let mut iteration = HealthIterationMetrics::<()>::default();
+
+        let mut healthy = HealthObjectMetrics::default();
+        healthy.populate(
+            "switch-a".to_string(),
+            &report_with(vec![]),
+            &HealthReportSources::default(),
+        );
+        let mut unhealthy_suppressed = HealthObjectMetrics::default();
+        unhealthy_suppressed.populate(
+            "switch-b".to_string(),
+            &report_with(vec![alert(
+                "BgpStats",
+                None,
+                vec!["Class1", "SuppressExternalAlerting"],
+            )]),
+            &HealthReportSources {
+                replace: Some(report_with(vec![])),
+                merges: BTreeMap::from_iter([("a".to_string(), report_with(vec![]))]),
+            },
+        );
+
+        iteration.merge((), &healthy);
+        iteration.merge((), &unhealthy_suppressed);
+
+        assert_eq!(
+            iteration.healthy,
+            HashMap::from_iter([((true, ()), 1), ((false, ()), 1)])
+        );
+        assert_eq!(
+            iteration.unhealthy_by_probe_id,
+            HashMap::from_iter([(("BgpStats".to_string(), None, ()), 1)])
+        );
+        assert_eq!(
+            iteration.unhealthy_by_classification_id,
+            HashMap::from_iter([
+                (("Class1".to_string(), ()), 1),
+                (("SuppressExternalAlerting".to_string(), ()), 1),
+            ])
+        );
+        assert_eq!(
+            iteration.alerts_suppressed_by_object_id,
+            HashSet::from_iter(["switch-b".to_string()])
+        );
+        assert_eq!(
+            iteration.num_overrides,
+            HashMap::from_iter([(("merge", ()), 1), (("replace", ()), 1)])
+        );
+    }
+}

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -520,7 +520,6 @@ impl MachineStateHandler {
             }
         }
 
-        ctx.metrics.machine_id = state.host_snapshot.id.to_string();
         ctx.metrics.is_usable_as_instance = state.is_usable_as_instance(false).is_ok();
         ctx.metrics.num_gpus = state
             .host_snapshot
@@ -538,22 +537,11 @@ impl MachineStateHandler {
         ctx.metrics.sku_device_type = state.host_snapshot.hw_sku_device_type.clone();
 
         // Note that DPU alerts may be suppressed (classifications removed) in the aggregate health report.
-        let suppress_alerts =
-            health_report::HealthAlertClassification::suppress_external_alerting();
-        for alert in state.aggregate_health.alerts.iter() {
-            ctx.metrics
-                .health_probe_alerts
-                .insert((alert.id.clone(), alert.target.clone()));
-            for c in alert.classifications.iter() {
-                ctx.metrics.health_alert_classifications.insert(c.clone());
-                if *c == suppress_alerts {
-                    ctx.metrics.alerts_suppressed = true;
-                }
-            }
-        }
-
-        ctx.metrics.num_merge_overrides = state.host_snapshot.health_reports.merges.len();
-        ctx.metrics.replace_override_enabled = state.host_snapshot.health_reports.replace.is_some();
+        ctx.metrics.health.populate(
+            state.host_snapshot.id.to_string(),
+            &state.aggregate_health,
+            &state.host_snapshot.health_reports,
+        );
     }
 
     fn record_health_history(

--- a/crates/api/src/state_controller/machine/metrics.rs
+++ b/crates/api/src/state_controller/machine/metrics.rs
@@ -25,12 +25,14 @@ use model::tenant::TenantOrganizationId;
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Histogram, Meter};
 
+use crate::state_controller::health_metrics::{
+    HealthIterationMetrics, HealthMetricDimension, HealthObjectMetrics, register_health_gauges,
+};
 use crate::state_controller::metrics::MetricsEmitter;
 
 #[derive(Debug, Default)]
 pub struct MachineMetrics {
     pub agent_versions: HashMap<String, usize>,
-    pub alerts_suppressed: bool,
     pub dpus_up: usize,
     pub dpus_healthy: usize,
     /// DPU probe alerts by Probe ID and Target
@@ -43,14 +45,8 @@ pub struct MachineMetrics {
     pub machine_reboot_attempts_in_failed_during_discovery: Option<u64>,
     pub num_gpus: usize,
     pub in_use_by_tenant: Option<TenantOrganizationId>,
-    /// Health probe alerts for the aggregate host by Probe ID and Target
-    pub health_probe_alerts: HashSet<(health_report::HealthProbeId, Option<String>)>,
-    pub health_alert_classifications: HashSet<health_report::HealthAlertClassification>,
-    pub machine_id: String,
-    /// The amount of configured `merge` overrides
-    pub num_merge_overrides: usize,
-    /// Whether an override of type `replace` is configured
-    pub replace_override_enabled: bool,
+    /// Health related signals that are common across all entity types, e.g switch/host/rack.
+    pub health: HealthObjectMetrics,
     /// The SKU that is assigned to the host
     pub sku: Option<String>,
     pub sku_device_type: Option<String>,
@@ -86,16 +82,9 @@ pub struct MachineStateControllerIterationMetrics {
     pub hosts_in_use_by_tenant: HashMap<TenantOrganizationId, usize>,
     pub hosts_usable: usize,
     pub hosts_total: usize,
-    /// The amount of hosts by Health status (healthy==true) and assignment status
-    pub hosts_healthy: HashMap<(bool, IsInUseByTenant), usize>,
-    /// The amount of unhealthy hosts by Probe ID, Probe Target and assignment status
-    pub unhealthy_hosts_by_probe_id: HashMap<(String, Option<String>, IsInUseByTenant), usize>,
-    /// The amount of unhealthy hosts by Alert classification and assignment status
-    pub unhealthy_hosts_by_classification_id: HashMap<(String, IsInUseByTenant), usize>,
-    /// The set of machines (by machine_id) whose external, metrics-based alerting is suppressed
-    pub host_alerts_suppressed_by_machine_id: HashSet<String>,
-    /// The amount of configured overrides by type (merge vs replace) and assignment status
-    pub num_overrides: HashMap<(&'static str, IsInUseByTenant), usize>,
+    /// Aggregate health-related metrics for all hosts, keyed by tenant
+    /// assignment status.
+    pub health: HealthIterationMetrics<IsInUseByTenant>,
     /// Mapping from SKU ID to the amount of hosts which have the SKU configured
     pub hosts_by_sku: HashMap<(String, String), usize>,
     pub hosts_with_bios_password_set: usize,
@@ -103,8 +92,14 @@ pub struct MachineStateControllerIterationMetrics {
     pub hosts_with_scout_heartbeat_timeout: HashSet<String>,
 }
 
-#[derive(Copy, Clone, Hash, PartialEq, Eq, Debug)]
-pub struct IsInUseByTenant(bool);
+#[derive(Copy, Clone, Hash, PartialEq, Eq, Debug, Default)]
+pub struct IsInUseByTenant(pub bool);
+
+impl HealthMetricDimension for IsInUseByTenant {
+    fn key_values(&self) -> Vec<KeyValue> {
+        vec![KeyValue::new("in_use", self.0.to_string())]
+    }
+}
 
 #[derive(Debug)]
 pub struct MachineMetricsEmitter {
@@ -264,70 +259,13 @@ impl MetricsEmitter for MachineMetricsEmitter {
                 })
                 .build()
         };
-        {
-            let metrics = shared_metrics.clone();
-            meter
-                .u64_observable_gauge("carbide_hosts_health_status_count")
-                .with_description("The total number of Managed Hosts in the system that have reported either a healthy or not healthy status - based on the presence of health probe alerts")
-                .with_callback(move |observer| {
-                    metrics.if_available(|metrics, attrs| {
-                        for healthy in [true, false] {
-                            for in_use in [true, false] {
-                                let count = metrics
-                                    .hosts_healthy
-                                    .get(&(healthy, IsInUseByTenant(in_use)))
-                                    .copied()
-                                    .unwrap_or_default();
-                                observer.observe(
-                                    count as u64,
-                                    &[attrs, &[
-                                        KeyValue::new("healthy", healthy.to_string()),
-                                        KeyValue::new("in_use", in_use.to_string()),
-                                    ]].concat(),
-                                );
-                            }
-                        }
-                    })
-                })
-                .build()
-        };
-        {
-            let metrics = shared_metrics.clone();
-            meter
-                .u64_observable_gauge("carbide_hosts_health_overrides_count")
-                .with_description("The amount of health overrides that are configured in the site")
-                .with_callback(move |observer| {
-                    metrics.if_available(|metrics, attrs| {
-                        // The HashMap access is used here instead of iterating order to make sure that
-                        // all 4 combinations always emit metrics. No metric will be absent in case
-                        // no host falls into that category
-                        for override_type in ["merge", "replace"] {
-                            for in_use in [true, false] {
-                                let count = metrics
-                                    .num_overrides
-                                    .get(&(override_type, IsInUseByTenant(in_use)))
-                                    .copied()
-                                    .unwrap_or_default();
-                                observer.observe(
-                                    count as u64,
-                                    &[
-                                        attrs,
-                                        &[
-                                            KeyValue::new(
-                                                "override_type",
-                                                override_type.to_string(),
-                                            ),
-                                            KeyValue::new("in_use", in_use.to_string()),
-                                        ],
-                                    ]
-                                    .concat(),
-                                );
-                            }
-                        }
-                    })
-                })
-                .build()
-        };
+        register_health_gauges::<_, IsInUseByTenant, _>(
+            "carbide_hosts",
+            "machine_id",
+            meter,
+            shared_metrics.clone(),
+            |m| &m.health,
+        );
 
         {
             let metrics = shared_metrics.clone();
@@ -357,84 +295,6 @@ impl MetricsEmitter for MachineMetricsEmitter {
                                     ],
                                 ]
                                 .concat(),
-                            );
-                        }
-                    })
-                })
-                .build()
-        };
-
-        {
-            let metrics = shared_metrics.clone();
-            meter
-                .u64_observable_gauge("carbide_hosts_unhealthy_by_probe_id_count")
-                .with_description(
-                    "The amount of ManagedHosts which reported a certain Health Probe Alert",
-                )
-                .with_callback(move |observer| {
-                    metrics.if_available(|metrics, attrs| {
-                        for ((probe, target, in_use), count) in &metrics.unhealthy_hosts_by_probe_id
-                        {
-                            observer.observe(
-                                *count as u64,
-                                &[
-                                    attrs,
-                                    &[
-                                        KeyValue::new("probe_id", probe.clone()),
-                                        KeyValue::new(
-                                            "probe_target",
-                                            target.clone().unwrap_or_default(),
-                                        ),
-                                        KeyValue::new("in_use", in_use.0.to_string()),
-                                    ],
-                                ]
-                                .concat(),
-                            );
-                        }
-                    })
-                })
-                .build()
-        };
-
-        {
-            let metrics = shared_metrics.clone();
-            meter
-                .u64_observable_gauge("carbide_hosts_unhealthy_by_classification_count")
-                .with_description(
-                    "The amount of ManagedHosts which are marked with a certain classification due to being unhealthy",
-                )
-                .with_callback(move |observer| {
-                    metrics.if_available(|metrics, attrs| {
-                        for ((classification, in_use), count) in
-                            &metrics.unhealthy_hosts_by_classification_id
-                        {
-                            observer.observe(
-                                *count as u64,
-                                &[attrs, &[
-                                    KeyValue::new("classification", classification.clone()),
-                                    KeyValue::new("in_use", in_use.0.to_string()),
-                                ]].concat(),
-                            );
-                        }
-                    })
-                })
-                .build()
-        };
-
-        {
-            let metrics = shared_metrics.clone();
-            meter
-                .u64_observable_gauge("carbide_alerts_suppressed_count")
-                .with_description(
-                    "Whether external metrics based alerting is suppressed for a specific host",
-                )
-                .with_callback(move |observer| {
-                    metrics.if_available(|metrics, attrs| {
-                        for machine_id in &metrics.host_alerts_suppressed_by_machine_id {
-                            observer.observe(
-                                1u64,
-                                &[attrs, &[KeyValue::new("machine_id", machine_id.clone())]]
-                                    .concat(),
                             );
                         }
                     })
@@ -647,12 +507,10 @@ impl MetricsEmitter for MachineMetricsEmitter {
         iteration_metrics.dpus_up += object_metrics.dpus_up;
         iteration_metrics.dpus_healthy += object_metrics.dpus_healthy;
 
-        let is_healthy = object_metrics.health_probe_alerts.is_empty();
         let is_assigned = IsInUseByTenant(object_metrics.in_use_by_tenant.is_some());
-        *iteration_metrics
-            .hosts_healthy
-            .entry((is_healthy, is_assigned))
-            .or_default() += 1;
+        iteration_metrics
+            .health
+            .merge(is_assigned, &object_metrics.health);
 
         iteration_metrics.gpus_total += object_metrics.num_gpus;
         if object_metrics.is_usable_as_instance {
@@ -686,34 +544,6 @@ impl MetricsEmitter for MachineMetricsEmitter {
                 .unhealthy_dpus_by_probe_id
                 .entry((probe_id.to_string(), target.clone()))
                 .or_default() += count;
-        }
-
-        for (probe_id, target) in &object_metrics.health_probe_alerts {
-            *iteration_metrics
-                .unhealthy_hosts_by_probe_id
-                .entry((probe_id.to_string(), target.clone(), is_assigned))
-                .or_default() += 1;
-        }
-        for classification in &object_metrics.health_alert_classifications {
-            *iteration_metrics
-                .unhealthy_hosts_by_classification_id
-                .entry((classification.to_string(), is_assigned))
-                .or_default() += 1;
-        }
-        if object_metrics.alerts_suppressed {
-            iteration_metrics
-                .host_alerts_suppressed_by_machine_id
-                .insert(object_metrics.machine_id.to_string());
-        }
-        *iteration_metrics
-            .num_overrides
-            .entry(("merge", is_assigned))
-            .or_default() += object_metrics.num_merge_overrides;
-        if object_metrics.replace_override_enabled {
-            *iteration_metrics
-                .num_overrides
-                .entry(("replace", is_assigned))
-                .or_default() += 1;
         }
 
         // Record SKU information for all hosts, using "unknown" for hosts without SKU
@@ -808,15 +638,17 @@ mod tests {
                 client_certificate_expiry: HashMap::from_iter([("machine a".to_string(), Some(1))]),
                 machine_reboot_attempts_in_booting_with_discovery_image: None,
                 machine_reboot_attempts_in_failed_during_discovery: None,
-                health_probe_alerts: HashSet::from_iter([(
-                    "FileExists".parse().unwrap(),
-                    Some("def.txt".to_string()),
-                )]),
-                health_alert_classifications: HashSet::new(),
-                alerts_suppressed: false,
-                machine_id: "".to_string(),
-                num_merge_overrides: 0,
-                replace_override_enabled: false,
+                health: HealthObjectMetrics {
+                    object_id: "".to_string(),
+                    health_probe_alerts: HashSet::from_iter([(
+                        "FileExists".parse().unwrap(),
+                        Some("def.txt".to_string()),
+                    )]),
+                    health_alert_classifications: HashSet::new(),
+                    alerts_suppressed: false,
+                    num_merge_overrides: 0,
+                    replace_override_enabled: false,
+                },
                 is_usable_as_instance: true,
                 is_host_bios_password_set: true,
                 last_machine_validation_list: HashMap::new(),
@@ -854,22 +686,24 @@ mod tests {
                 client_certificate_expiry: HashMap::from_iter([("machine a".to_string(), Some(2))]),
                 machine_reboot_attempts_in_booting_with_discovery_image: Some(0),
                 machine_reboot_attempts_in_failed_during_discovery: Some(0),
-                health_probe_alerts: HashSet::from_iter([
-                    ("bgp".parse().unwrap(), None),
-                    ("ntp".parse().unwrap(), None),
-                    ("FileExists".parse().unwrap(), Some("def.txt".to_string())),
-                    ("FileExists".parse().unwrap(), Some("abc.txt".to_string())),
-                ]),
-                health_alert_classifications: [
-                    "Class1".parse().unwrap(),
-                    "Class3".parse().unwrap(),
-                ]
-                .into_iter()
-                .collect(),
-                alerts_suppressed: false,
-                machine_id: "".to_string(),
-                num_merge_overrides: 0,
-                replace_override_enabled: false,
+                health: HealthObjectMetrics {
+                    object_id: "".to_string(),
+                    health_probe_alerts: HashSet::from_iter([
+                        ("bgp".parse().unwrap(), None),
+                        ("ntp".parse().unwrap(), None),
+                        ("FileExists".parse().unwrap(), Some("def.txt".to_string())),
+                        ("FileExists".parse().unwrap(), Some("abc.txt".to_string())),
+                    ]),
+                    health_alert_classifications: [
+                        "Class1".parse().unwrap(),
+                        "Class3".parse().unwrap(),
+                    ]
+                    .into_iter()
+                    .collect(),
+                    alerts_suppressed: false,
+                    num_merge_overrides: 0,
+                    replace_override_enabled: false,
+                },
                 is_usable_as_instance: true,
                 is_host_bios_password_set: true,
                 last_machine_validation_list: HashMap::from_iter([(
@@ -899,12 +733,14 @@ mod tests {
                 client_certificate_expiry: HashMap::from_iter([("machine b".to_string(), Some(3))]),
                 machine_reboot_attempts_in_booting_with_discovery_image: Some(1),
                 machine_reboot_attempts_in_failed_during_discovery: Some(1),
-                health_probe_alerts: HashSet::new(),
-                health_alert_classifications: HashSet::new(),
-                alerts_suppressed: false,
-                machine_id: "".to_string(),
-                num_merge_overrides: 1,
-                replace_override_enabled: true,
+                health: HealthObjectMetrics {
+                    object_id: "".to_string(),
+                    health_probe_alerts: HashSet::new(),
+                    health_alert_classifications: HashSet::new(),
+                    alerts_suppressed: false,
+                    num_merge_overrides: 1,
+                    replace_override_enabled: true,
+                },
                 is_usable_as_instance: false,
                 is_host_bios_password_set: true,
                 last_machine_validation_list: HashMap::new(),
@@ -941,12 +777,14 @@ mod tests {
                 client_certificate_expiry: HashMap::from_iter([("machine b".to_string(), None)]),
                 machine_reboot_attempts_in_booting_with_discovery_image: Some(2),
                 machine_reboot_attempts_in_failed_during_discovery: Some(2),
-                health_probe_alerts: HashSet::new(),
-                health_alert_classifications: HashSet::new(),
-                alerts_suppressed: false,
-                machine_id: "".to_string(),
-                num_merge_overrides: 0,
-                replace_override_enabled: false,
+                health: HealthObjectMetrics {
+                    object_id: "".to_string(),
+                    health_probe_alerts: HashSet::new(),
+                    health_alert_classifications: HashSet::new(),
+                    alerts_suppressed: false,
+                    num_merge_overrides: 0,
+                    replace_override_enabled: false,
+                },
                 is_usable_as_instance: true,
                 is_host_bios_password_set: true,
                 last_machine_validation_list: HashMap::new(),
@@ -994,25 +832,27 @@ mod tests {
                 client_certificate_expiry: HashMap::default(),
                 machine_reboot_attempts_in_booting_with_discovery_image: None,
                 machine_reboot_attempts_in_failed_during_discovery: None,
-                health_probe_alerts: [
-                    ("BgpStats".parse().unwrap(), None),
-                    (
-                        "HeartbeatTimeout".parse().unwrap(),
-                        Some("forge-dpu-agent".to_string()),
-                    ),
-                ]
-                .into_iter()
-                .collect(),
-                health_alert_classifications: [
-                    "Class1".parse().unwrap(),
-                    "Class2".parse().unwrap(),
-                ]
-                .into_iter()
-                .collect(),
-                alerts_suppressed: false,
-                machine_id: "".to_string(),
-                num_merge_overrides: 1,
-                replace_override_enabled: false,
+                health: HealthObjectMetrics {
+                    object_id: "".to_string(),
+                    health_probe_alerts: [
+                        ("BgpStats".parse().unwrap(), None),
+                        (
+                            "HeartbeatTimeout".parse().unwrap(),
+                            Some("forge-dpu-agent".to_string()),
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                    health_alert_classifications: [
+                        "Class1".parse().unwrap(),
+                        "Class2".parse().unwrap(),
+                    ]
+                    .into_iter()
+                    .collect(),
+                    alerts_suppressed: false,
+                    num_merge_overrides: 1,
+                    replace_override_enabled: false,
+                },
                 is_usable_as_instance: false,
                 is_host_bios_password_set: true,
                 last_machine_validation_list: HashMap::new(),
@@ -1055,17 +895,21 @@ mod tests {
                 client_certificate_expiry: HashMap::default(),
                 machine_reboot_attempts_in_booting_with_discovery_image: None,
                 machine_reboot_attempts_in_failed_during_discovery: None,
-                health_probe_alerts: [("BgpStats".parse().unwrap(), None)].into_iter().collect(),
-                health_alert_classifications: [
-                    "Class1".parse().unwrap(),
-                    "Class2".parse().unwrap(),
-                ]
-                .into_iter()
-                .collect(),
-                alerts_suppressed: false,
-                machine_id: "".to_string(),
-                num_merge_overrides: 0,
-                replace_override_enabled: true,
+                health: HealthObjectMetrics {
+                    object_id: "".to_string(),
+                    health_probe_alerts: [("BgpStats".parse().unwrap(), None)]
+                        .into_iter()
+                        .collect(),
+                    health_alert_classifications: [
+                        "Class1".parse().unwrap(),
+                        "Class2".parse().unwrap(),
+                    ]
+                    .into_iter()
+                    .collect(),
+                    alerts_suppressed: false,
+                    num_merge_overrides: 0,
+                    replace_override_enabled: true,
+                },
                 is_usable_as_instance: false,
                 is_host_bios_password_set: false,
                 last_machine_validation_list: HashMap::new(),
@@ -1147,7 +991,7 @@ mod tests {
 
         assert_eq!(iteration_metrics.hosts_total, 6);
         assert_eq!(
-            iteration_metrics.hosts_healthy,
+            iteration_metrics.health.healthy,
             HashMap::from_iter([
                 ((true, IsInUseByTenant(true)), 1),
                 ((false, IsInUseByTenant(true)), 2),
@@ -1156,7 +1000,7 @@ mod tests {
             ])
         );
         assert_eq!(
-            iteration_metrics.unhealthy_hosts_by_probe_id,
+            iteration_metrics.health.unhealthy_by_probe_id,
             HashMap::from_iter([
                 (
                     ("BgpStats".parse().unwrap(), None, IsInUseByTenant(false)),
@@ -1191,7 +1035,7 @@ mod tests {
             ])
         );
         assert_eq!(
-            iteration_metrics.unhealthy_hosts_by_classification_id,
+            iteration_metrics.health.unhealthy_by_classification_id,
             HashMap::from_iter([
                 (("Class1".parse().unwrap(), IsInUseByTenant(true)), 1),
                 (("Class1".parse().unwrap(), IsInUseByTenant(false)), 2),
@@ -1200,7 +1044,7 @@ mod tests {
             ])
         );
         assert_eq!(
-            iteration_metrics.num_overrides,
+            iteration_metrics.health.num_overrides,
             HashMap::from_iter([
                 (("merge", IsInUseByTenant(true)), 0),
                 (("merge", IsInUseByTenant(false)), 2),

--- a/crates/api/src/state_controller/machine/metrics.rs
+++ b/crates/api/src/state_controller/machine/metrics.rs
@@ -26,7 +26,8 @@ use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Histogram, Meter};
 
 use crate::state_controller::health_metrics::{
-    HealthIterationMetrics, HealthMetricDimension, HealthObjectMetrics, register_health_gauges,
+    HealthIterationMetrics, HealthMetricDimension, HealthObjectMetrics,
+    register_alerts_suppressed_gauge, register_health_gauges,
 };
 use crate::state_controller::metrics::MetricsEmitter;
 
@@ -98,6 +99,10 @@ pub struct IsInUseByTenant(pub bool);
 impl HealthMetricDimension for IsInUseByTenant {
     fn key_values(&self) -> Vec<KeyValue> {
         vec![KeyValue::new("in_use", self.0.to_string())]
+    }
+
+    fn all_values() -> Vec<Self> {
+        vec![IsInUseByTenant(true), IsInUseByTenant(false)]
     }
 }
 
@@ -265,6 +270,18 @@ impl MetricsEmitter for MachineMetricsEmitter {
             meter,
             shared_metrics.clone(),
             |m| &m.health,
+        );
+
+        // Deprecation warning:
+        // `carbide_alerts_suppressed_count` before the metric was renamed to
+        // `carbide_hosts_alerts_suppressed_count`.
+        // Will be remvoed in future
+        register_alerts_suppressed_gauge(
+            "carbide_alerts_suppressed_count",
+            "machine_id",
+            meter,
+            shared_metrics.clone(),
+            |m| &m.health.alerts_suppressed_by_object_id,
         );
 
         {

--- a/crates/api/src/state_controller/mod.rs
+++ b/crates/api/src/state_controller/mod.rs
@@ -18,6 +18,7 @@
 pub mod common_services;
 pub mod dpa_interface;
 pub(crate) mod external_service_error;
+pub mod health_metrics;
 pub mod ib_partition;
 pub mod machine;
 pub mod network_segment;

--- a/crates/api/src/state_controller/power_shelf/context.rs
+++ b/crates/api/src/state_controller/power_shelf/context.rs
@@ -16,11 +16,12 @@
  */
 
 use crate::state_controller::common_services::CommonStateHandlerServices;
+use crate::state_controller::power_shelf::metrics::PowerShelfMetrics;
 use crate::state_controller::state_handler::StateHandlerContextObjects;
 
 pub struct PowerShelfStateHandlerContextObjects {}
 
 impl StateHandlerContextObjects for PowerShelfStateHandlerContextObjects {
-    type ObjectMetrics = ();
+    type ObjectMetrics = PowerShelfMetrics;
     type Services = CommonStateHandlerServices;
 }

--- a/crates/api/src/state_controller/power_shelf/handler.rs
+++ b/crates/api/src/state_controller/power_shelf/handler.rs
@@ -16,7 +16,9 @@
  */
 use carbide_uuid::power_shelf::PowerShelfId;
 use db::power_shelf as db_power_shelf;
-use model::power_shelf::{PowerShelf, PowerShelfControllerState};
+use model::power_shelf::{
+    PowerShelf, PowerShelfControllerState, derive_power_shelf_aggregate_health,
+};
 
 use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
 use crate::state_controller::state_handler::{
@@ -26,6 +28,21 @@ use crate::state_controller::state_handler::{
 /// The actual PowerShelf State handler
 #[derive(Debug, Default, Clone)]
 pub struct PowerShelfStateHandler {}
+
+impl PowerShelfStateHandler {
+    fn record_metrics(
+        &self,
+        state: &PowerShelf,
+        ctx: &mut StateHandlerContext<'_, PowerShelfStateHandlerContextObjects>,
+    ) {
+        let aggregate_health = derive_power_shelf_aggregate_health(&state.health_reports);
+        ctx.metrics.health.populate(
+            state.id.to_string(),
+            &aggregate_health,
+            &state.health_reports,
+        );
+    }
+}
 
 #[async_trait::async_trait]
 impl StateHandler for PowerShelfStateHandler {
@@ -41,6 +58,7 @@ impl StateHandler for PowerShelfStateHandler {
         controller_state: &Self::ControllerState,
         ctx: &mut StateHandlerContext<Self::ContextObjects>,
     ) -> Result<StateHandlerOutcome<PowerShelfControllerState>, StateHandlerError> {
+        self.record_metrics(state, ctx);
         match controller_state {
             PowerShelfControllerState::Initializing => {
                 // TODO: Implement PowerShelf initialization logic

--- a/crates/api/src/state_controller/power_shelf/io.rs
+++ b/crates/api/src/state_controller/power_shelf/io.rs
@@ -28,8 +28,8 @@ use model::{DeletedFilter, StateSla};
 use sqlx::PgConnection;
 
 use crate::state_controller::io::StateControllerIO;
-use crate::state_controller::metrics::NoopMetricsEmitter;
 use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
+use crate::state_controller::power_shelf::metrics::PowerShelfMetricsEmitter;
 
 /// State Controller IO implementation for PowerShelves
 #[derive(Default, Debug)]
@@ -40,7 +40,7 @@ impl StateControllerIO for PowerShelfStateControllerIO {
     type ObjectId = PowerShelfId;
     type State = PowerShelf;
     type ControllerState = PowerShelfControllerState;
-    type MetricsEmitter = NoopMetricsEmitter;
+    type MetricsEmitter = PowerShelfMetricsEmitter;
     type ContextObjects = PowerShelfStateHandlerContextObjects;
 
     const DB_ITERATION_ID_TABLE_NAME: &'static str = "power_shelf_controller_iteration_ids";

--- a/crates/api/src/state_controller/power_shelf/metrics.rs
+++ b/crates/api/src/state_controller/power_shelf/metrics.rs
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_utils::metrics::SharedMetricsHolder;
+use opentelemetry::metrics::Meter;
+
+use crate::state_controller::health_metrics::{
+    HealthIterationMetrics, HealthObjectMetrics, register_health_gauges,
+};
+use crate::state_controller::metrics::MetricsEmitter;
+
+#[derive(Debug, Default)]
+pub struct PowerShelfMetrics {
+    pub health: HealthObjectMetrics,
+}
+
+#[derive(Debug, Default)]
+pub struct PowerShelfStateControllerIterationMetrics {
+    pub health: HealthIterationMetrics<()>,
+}
+
+#[derive(Debug)]
+pub struct PowerShelfMetricsEmitter {}
+
+impl MetricsEmitter for PowerShelfMetricsEmitter {
+    type ObjectMetrics = PowerShelfMetrics;
+    type IterationMetrics = PowerShelfStateControllerIterationMetrics;
+
+    fn new(
+        _object_type: &str,
+        meter: &Meter,
+        shared_metrics: SharedMetricsHolder<Self::IterationMetrics>,
+    ) -> Self {
+        register_health_gauges::<_, (), _>(
+            "carbide_power_shelves",
+            "power_shelf_id",
+            meter,
+            shared_metrics,
+            |m| &m.health,
+        );
+        Self {}
+    }
+
+    fn merge_object_handling_metrics(
+        iteration_metrics: &mut Self::IterationMetrics,
+        object_metrics: &Self::ObjectMetrics,
+    ) {
+        iteration_metrics.health.merge((), &object_metrics.health);
+    }
+
+    fn emit_object_counters_and_histograms(&self, _object_metrics: &Self::ObjectMetrics) {}
+}

--- a/crates/api/src/state_controller/power_shelf/mod.rs
+++ b/crates/api/src/state_controller/power_shelf/mod.rs
@@ -20,3 +20,4 @@
 pub mod context;
 pub mod handler;
 pub mod io;
+pub mod metrics;

--- a/crates/api/src/state_controller/rack/context.rs
+++ b/crates/api/src/state_controller/rack/context.rs
@@ -16,11 +16,12 @@
  */
 
 use crate::state_controller::common_services::CommonStateHandlerServices;
+use crate::state_controller::rack::metrics::RackMetrics;
 use crate::state_controller::state_handler::StateHandlerContextObjects;
 
 pub struct RackStateHandlerContextObjects {}
 
 impl StateHandlerContextObjects for RackStateHandlerContextObjects {
-    type ObjectMetrics = ();
+    type ObjectMetrics = RackMetrics;
     type Services = CommonStateHandlerServices;
 }

--- a/crates/api/src/state_controller/rack/handler.rs
+++ b/crates/api/src/state_controller/rack/handler.rs
@@ -18,7 +18,7 @@
 //! State Handler implementation for Racks.
 
 use carbide_uuid::rack::RackId;
-use model::rack::{Rack, RackState};
+use model::rack::{Rack, RackState, derive_rack_aggregate_health};
 
 use crate::state_controller::rack::context::RackStateHandlerContextObjects;
 use crate::state_controller::rack::created::handle_created;
@@ -40,6 +40,19 @@ use crate::state_controller::state_handler::{
 pub struct RackStateHandler {}
 
 impl RackStateHandler {
+    fn record_metrics(
+        &self,
+        state: &Rack,
+        ctx: &mut StateHandlerContext<'_, RackStateHandlerContextObjects>,
+    ) {
+        let aggregate_health = derive_rack_aggregate_health(&state.health_reports);
+        ctx.metrics.health.populate(
+            state.id.to_string(),
+            &aggregate_health,
+            &state.health_reports,
+        );
+    }
+
     async fn attempt_state_transition(
         &self,
         id: &RackId,
@@ -82,6 +95,8 @@ impl StateHandler for RackStateHandler {
         ctx: &mut StateHandlerContext<Self::ContextObjects>,
     ) -> Result<StateHandlerOutcome<RackState>, StateHandlerError> {
         tracing::info!("Rack {} is in state {}", id, controller_state.to_string());
+
+        self.record_metrics(state, ctx);
 
         if state.deleted.is_some() && !matches!(controller_state, RackState::Deleting) {
             tracing::info!(

--- a/crates/api/src/state_controller/rack/io.rs
+++ b/crates/api/src/state_controller/rack/io.rs
@@ -29,8 +29,8 @@ use model::rack::{
 use sqlx::PgConnection;
 
 use crate::state_controller::io::StateControllerIO;
-use crate::state_controller::metrics::NoopMetricsEmitter;
 use crate::state_controller::rack::context::RackStateHandlerContextObjects;
+use crate::state_controller::rack::metrics::RackMetricsEmitter;
 
 /// State Controller IO implementation for Racks
 #[derive(Default, Debug)]
@@ -41,7 +41,7 @@ impl StateControllerIO for RackStateControllerIO {
     type ObjectId = RackId;
     type State = Rack;
     type ControllerState = RackState;
-    type MetricsEmitter = NoopMetricsEmitter;
+    type MetricsEmitter = RackMetricsEmitter;
     type ContextObjects = RackStateHandlerContextObjects;
 
     const DB_ITERATION_ID_TABLE_NAME: &'static str = "rack_controller_iteration_ids";

--- a/crates/api/src/state_controller/rack/metrics.rs
+++ b/crates/api/src/state_controller/rack/metrics.rs
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_utils::metrics::SharedMetricsHolder;
+use opentelemetry::metrics::Meter;
+
+use crate::state_controller::health_metrics::{
+    HealthIterationMetrics, HealthObjectMetrics, register_health_gauges,
+};
+use crate::state_controller::metrics::MetricsEmitter;
+
+#[derive(Debug, Default)]
+pub struct RackMetrics {
+    pub health: HealthObjectMetrics,
+}
+
+#[derive(Debug, Default)]
+pub struct RackStateControllerIterationMetrics {
+    pub health: HealthIterationMetrics<()>,
+}
+
+#[derive(Debug)]
+pub struct RackMetricsEmitter {}
+
+impl MetricsEmitter for RackMetricsEmitter {
+    type ObjectMetrics = RackMetrics;
+    type IterationMetrics = RackStateControllerIterationMetrics;
+
+    fn new(
+        _object_type: &str,
+        meter: &Meter,
+        shared_metrics: SharedMetricsHolder<Self::IterationMetrics>,
+    ) -> Self {
+        register_health_gauges::<_, (), _>(
+            "carbide_racks",
+            "rack_id",
+            meter,
+            shared_metrics,
+            |m| &m.health,
+        );
+        Self {}
+    }
+
+    fn merge_object_handling_metrics(
+        iteration_metrics: &mut Self::IterationMetrics,
+        object_metrics: &Self::ObjectMetrics,
+    ) {
+        iteration_metrics.health.merge((), &object_metrics.health);
+    }
+
+    fn emit_object_counters_and_histograms(&self, _object_metrics: &Self::ObjectMetrics) {}
+}

--- a/crates/api/src/state_controller/rack/mod.rs
+++ b/crates/api/src/state_controller/rack/mod.rs
@@ -37,6 +37,7 @@ pub mod fabric_manager;
 pub mod handler;
 pub mod io;
 pub mod maintenance;
+pub mod metrics;
 pub mod ready;
 pub mod validating;
 

--- a/crates/api/src/state_controller/switch/context.rs
+++ b/crates/api/src/state_controller/switch/context.rs
@@ -17,10 +17,11 @@
 
 use crate::state_controller::common_services::CommonStateHandlerServices;
 use crate::state_controller::state_handler::StateHandlerContextObjects;
+use crate::state_controller::switch::metrics::SwitchMetrics;
 
 pub struct SwitchStateHandlerContextObjects {}
 
 impl StateHandlerContextObjects for SwitchStateHandlerContextObjects {
-    type ObjectMetrics = ();
+    type ObjectMetrics = SwitchMetrics;
     type Services = CommonStateHandlerServices;
 }

--- a/crates/api/src/state_controller/switch/handler.rs
+++ b/crates/api/src/state_controller/switch/handler.rs
@@ -18,7 +18,7 @@
 //! State Handler implementation for Switches (mirrors Machine state handler structure).
 
 use carbide_uuid::switch::SwitchId;
-use model::switch::{Switch, SwitchControllerState};
+use model::switch::{Switch, SwitchControllerState, derive_switch_aggregate_health};
 use tracing::instrument;
 
 use crate::state_controller::state_handler::{
@@ -40,13 +40,17 @@ use crate::state_controller::switch::validating::handle_validating;
 pub struct SwitchStateHandler {}
 
 impl SwitchStateHandler {
-    /// Records metrics for the switch. Stub for now; extend when switch metrics are defined.
     fn record_metrics(
         &self,
-        _state: &Switch,
-        _ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
+        state: &Switch,
+        ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
     ) {
-        // TODO: Populate when SwitchMetrics has fields (e.g. health, version, etc.)
+        let aggregate_health = derive_switch_aggregate_health(&state.health_reports);
+        ctx.metrics.health.populate(
+            state.id.to_string(),
+            &aggregate_health,
+            &state.health_reports,
+        );
     }
 
     /// Attempts a state transition by delegating to the appropriate state handler.

--- a/crates/api/src/state_controller/switch/io.rs
+++ b/crates/api/src/state_controller/switch/io.rs
@@ -26,8 +26,8 @@ use model::switch::{Switch, SwitchControllerState, SwitchSearchFilter, state_sla
 use sqlx::PgConnection;
 
 use crate::state_controller::io::StateControllerIO;
-use crate::state_controller::metrics::NoopMetricsEmitter;
 use crate::state_controller::switch::context::SwitchStateHandlerContextObjects;
+use crate::state_controller::switch::metrics::SwitchMetricsEmitter;
 
 /// State Controller IO implementation for Switches
 #[derive(Default, Debug)]
@@ -38,7 +38,7 @@ impl StateControllerIO for SwitchStateControllerIO {
     type ObjectId = SwitchId;
     type State = Switch;
     type ControllerState = SwitchControllerState;
-    type MetricsEmitter = NoopMetricsEmitter;
+    type MetricsEmitter = SwitchMetricsEmitter;
     type ContextObjects = SwitchStateHandlerContextObjects;
 
     const DB_ITERATION_ID_TABLE_NAME: &'static str = "switch_controller_iteration_ids";

--- a/crates/api/src/state_controller/switch/metrics.rs
+++ b/crates/api/src/state_controller/switch/metrics.rs
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_utils::metrics::SharedMetricsHolder;
+use opentelemetry::metrics::Meter;
+
+use crate::state_controller::health_metrics::{
+    HealthIterationMetrics, HealthObjectMetrics, register_health_gauges,
+};
+use crate::state_controller::metrics::MetricsEmitter;
+
+#[derive(Debug, Default)]
+pub struct SwitchMetrics {
+    pub health: HealthObjectMetrics,
+}
+
+#[derive(Debug, Default)]
+pub struct SwitchStateControllerIterationMetrics {
+    pub health: HealthIterationMetrics<()>,
+}
+
+#[derive(Debug)]
+pub struct SwitchMetricsEmitter {}
+
+impl MetricsEmitter for SwitchMetricsEmitter {
+    type ObjectMetrics = SwitchMetrics;
+    type IterationMetrics = SwitchStateControllerIterationMetrics;
+
+    fn new(
+        _object_type: &str,
+        meter: &Meter,
+        shared_metrics: SharedMetricsHolder<Self::IterationMetrics>,
+    ) -> Self {
+        register_health_gauges::<_, (), _>(
+            "carbide_switches",
+            "switch_id",
+            meter,
+            shared_metrics,
+            |m| &m.health,
+        );
+        Self {}
+    }
+
+    fn merge_object_handling_metrics(
+        iteration_metrics: &mut Self::IterationMetrics,
+        object_metrics: &Self::ObjectMetrics,
+    ) {
+        iteration_metrics.health.merge((), &object_metrics.health);
+    }
+
+    fn emit_object_counters_and_histograms(&self, _object_metrics: &Self::ObjectMetrics) {}
+}

--- a/crates/api/src/state_controller/switch/mod.rs
+++ b/crates/api/src/state_controller/switch/mod.rs
@@ -26,6 +26,7 @@ pub mod error_state;
 pub mod handler;
 pub mod initializing;
 pub mod io;
+pub mod metrics;
 pub mod ready;
 pub mod reprovisioning;
 pub mod validating;

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -124,6 +124,8 @@ use crate::state_controller::network_segment::handler::NetworkSegmentStateHandle
 use crate::state_controller::network_segment::io::NetworkSegmentStateControllerIO;
 use crate::state_controller::power_shelf::handler::PowerShelfStateHandler;
 use crate::state_controller::power_shelf::io::PowerShelfStateControllerIO;
+use crate::state_controller::rack::handler::RackStateHandler;
+use crate::state_controller::rack::io::RackStateControllerIO;
 use crate::state_controller::spdm::handler::SpdmAttestationStateHandler;
 use crate::state_controller::spdm::io::SpdmStateControllerIO;
 use crate::state_controller::state_handler::{
@@ -357,6 +359,7 @@ pub struct TestEnv {
     network_segment_controller: Arc<Mutex<StateController<NetworkSegmentStateControllerIO>>>,
     ib_partition_controller: Arc<Mutex<StateController<IBPartitionStateControllerIO>>>,
     power_shelf_controller: Arc<Mutex<StateController<PowerShelfStateControllerIO>>>,
+    rack_controller: Arc<Mutex<StateController<RackStateControllerIO>>>,
     switch_controller: Arc<Mutex<StateController<SwitchStateControllerIO>>>,
     pub reachability_params: ReachabilityParams,
     pub test_meter: TestMeter,
@@ -633,6 +636,17 @@ impl TestEnv {
     #[allow(clippy::await_holding_refcell_ref)]
     pub async fn run_switch_controller_iteration(&self) {
         self.switch_controller
+            .lock()
+            .await
+            .run_single_iteration()
+            .await;
+    }
+
+    /// Runs one iteration of the rack state controller handler with the services
+    /// in this test environment
+    #[allow(clippy::await_holding_refcell_ref)]
+    pub async fn run_rack_controller_iteration(&self) {
+        self.rack_controller
             .lock()
             .await
             .run_single_iteration()
@@ -1721,6 +1735,15 @@ pub async fn create_test_env_with_overrides(
         .build_for_manual_iterations(cancel_token.clone())
         .expect("Unable to build state controller");
 
+    let rack_controller = StateController::builder()
+        .database(db_pool.clone(), work_lock_manager_handle.clone())
+        .meter("carbide_racks", test_meter.meter())
+        .processor_id(state_controller_id.clone())
+        .services(handler_services.clone())
+        .state_handler(Arc::new(RackStateHandler::default()))
+        .build_for_manual_iterations(cancel_token.clone())
+        .expect("Unable to build RackStateController");
+
     let fake_endpoint_explorer = MockEndpointExplorer {
         reports: Arc::new(std::sync::Mutex::new(Default::default())),
         power_states: Arc::new(std::sync::Mutex::new(Default::default())),
@@ -1848,6 +1871,7 @@ pub async fn create_test_env_with_overrides(
         switch_controller: Arc::new(Mutex::new(switch_controller)),
         network_segment_controller: Arc::new(Mutex::new(network_controller)),
         power_shelf_controller: Arc::new(Mutex::new(power_shelf_controller)),
+        rack_controller: Arc::new(Mutex::new(rack_controller)),
         reachability_params,
         attestation_enabled,
         test_meter,

--- a/crates/api/src/tests/power_shelf_health.rs
+++ b/crates/api/src/tests/power_shelf_health.rs
@@ -329,3 +329,123 @@ async fn test_health_visible_in_find_power_shelves(
 
     Ok(())
 }
+
+#[crate::sqlx_test]
+async fn test_power_shelf_health_aggregation(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env =
+        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
+            .await;
+
+    let power_shelf_id = new_power_shelf(&env, None, None, None, None).await?;
+
+    env.run_power_shelf_controller_iteration().await;
+
+    let mut override_metrics = env
+        .test_meter
+        .formatted_metrics("carbide_power_shelves_health_overrides_count");
+    override_metrics.sort();
+    assert_eq!(
+        override_metrics,
+        vec![
+            "{fresh=\"true\",override_type=\"merge\"} 0".to_string(),
+            "{fresh=\"true\",override_type=\"replace\"} 0".to_string(),
+        ]
+    );
+
+    let mut status_metrics = env
+        .test_meter
+        .formatted_metrics("carbide_power_shelves_health_status_count");
+    status_metrics.sort();
+    assert_eq!(
+        status_metrics,
+        vec![
+            "{fresh=\"true\",healthy=\"false\"} 0".to_string(),
+            "{fresh=\"true\",healthy=\"true\"} 1".to_string(),
+        ]
+    );
+
+    env.api
+        .insert_power_shelf_health_report(Request::new(
+            rpc_forge::InsertPowerShelfHealthReportRequest {
+                power_shelf_id: Some(power_shelf_id),
+                health_report_entry: Some(rpc_forge::HealthReportEntry {
+                    report: Some(alert_report("external-monitor").into()),
+                    mode: rpc_forge::HealthReportApplyMode::Merge as i32,
+                }),
+            },
+        ))
+        .await?;
+    env.run_power_shelf_controller_iteration().await;
+
+    let mut override_metrics = env
+        .test_meter
+        .formatted_metrics("carbide_power_shelves_health_overrides_count");
+    override_metrics.sort();
+    assert_eq!(
+        override_metrics,
+        vec![
+            "{fresh=\"true\",override_type=\"merge\"} 1".to_string(),
+            "{fresh=\"true\",override_type=\"replace\"} 0".to_string(),
+        ]
+    );
+
+    let mut status_metrics = env
+        .test_meter
+        .formatted_metrics("carbide_power_shelves_health_status_count");
+    status_metrics.sort();
+    assert_eq!(
+        status_metrics,
+        vec![
+            "{fresh=\"true\",healthy=\"false\"} 1".to_string(),
+            "{fresh=\"true\",healthy=\"true\"} 0".to_string(),
+        ]
+    );
+
+    env.api
+        .insert_power_shelf_health_report(Request::new(
+            rpc_forge::InsertPowerShelfHealthReportRequest {
+                power_shelf_id: Some(power_shelf_id),
+                health_report_entry: Some(rpc_forge::HealthReportEntry {
+                    report: Some(empty_healthy_report("admin-override").into()),
+                    mode: rpc_forge::HealthReportApplyMode::Replace as i32,
+                }),
+            },
+        ))
+        .await?;
+    env.run_power_shelf_controller_iteration().await;
+
+    let mut override_metrics = env
+        .test_meter
+        .formatted_metrics("carbide_power_shelves_health_overrides_count");
+    override_metrics.sort();
+    assert_eq!(
+        override_metrics,
+        vec![
+            "{fresh=\"true\",override_type=\"merge\"} 1".to_string(),
+            "{fresh=\"true\",override_type=\"replace\"} 1".to_string(),
+        ]
+    );
+
+    let mut status_metrics = env
+        .test_meter
+        .formatted_metrics("carbide_power_shelves_health_status_count");
+    status_metrics.sort();
+    assert_eq!(
+        status_metrics,
+        vec![
+            "{fresh=\"true\",healthy=\"false\"} 0".to_string(),
+            "{fresh=\"true\",healthy=\"true\"} 1".to_string(),
+        ]
+    );
+
+    assert!(
+        env.test_meter
+            .formatted_metrics("carbide_alerts_suppressed_count")
+            .is_empty(),
+        "power shelves should not emit the legacy alerts_suppressed alias"
+    );
+
+    Ok(())
+}

--- a/crates/api/src/tests/rack_health.rs
+++ b/crates/api/src/tests/rack_health.rs
@@ -574,3 +574,121 @@ async fn test_rack_health_visible_in_find_racks_by_ids(
 
     Ok(())
 }
+
+#[crate::sqlx_test]
+async fn test_rack_health_aggregation(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env =
+        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
+            .await;
+
+    let mut txn = pool.acquire().await?;
+    let rack_id = TestRackDbBuilder::new().persist(&mut txn).await?;
+    drop(txn);
+
+    env.run_rack_controller_iteration().await;
+
+    let mut override_metrics = env
+        .test_meter
+        .formatted_metrics("carbide_racks_health_overrides_count");
+    override_metrics.sort();
+    assert_eq!(
+        override_metrics,
+        vec![
+            "{fresh=\"true\",override_type=\"merge\"} 0".to_string(),
+            "{fresh=\"true\",override_type=\"replace\"} 0".to_string(),
+        ]
+    );
+
+    let mut status_metrics = env
+        .test_meter
+        .formatted_metrics("carbide_racks_health_status_count");
+    status_metrics.sort();
+    assert_eq!(
+        status_metrics,
+        vec![
+            "{fresh=\"true\",healthy=\"false\"} 0".to_string(),
+            "{fresh=\"true\",healthy=\"true\"} 1".to_string(),
+        ]
+    );
+
+    env.api
+        .insert_rack_health_report(Request::new(rpc_forge::InsertRackHealthReportRequest {
+            rack_id: Some(rack_id.clone()),
+            health_report_entry: Some(rpc_forge::HealthReportEntry {
+                report: Some(leak_alert_report("dsx-exchange-consumer").into()),
+                mode: rpc_forge::HealthReportApplyMode::Merge as i32,
+            }),
+        }))
+        .await?;
+    env.run_rack_controller_iteration().await;
+
+    let mut override_metrics = env
+        .test_meter
+        .formatted_metrics("carbide_racks_health_overrides_count");
+    override_metrics.sort();
+    assert_eq!(
+        override_metrics,
+        vec![
+            "{fresh=\"true\",override_type=\"merge\"} 1".to_string(),
+            "{fresh=\"true\",override_type=\"replace\"} 0".to_string(),
+        ]
+    );
+
+    let mut status_metrics = env
+        .test_meter
+        .formatted_metrics("carbide_racks_health_status_count");
+    status_metrics.sort();
+    assert_eq!(
+        status_metrics,
+        vec![
+            "{fresh=\"true\",healthy=\"false\"} 1".to_string(),
+            "{fresh=\"true\",healthy=\"true\"} 0".to_string(),
+        ]
+    );
+
+    env.api
+        .insert_rack_health_report(Request::new(rpc_forge::InsertRackHealthReportRequest {
+            rack_id: Some(rack_id.clone()),
+            health_report_entry: Some(rpc_forge::HealthReportEntry {
+                report: Some(empty_healthy_report("admin-override").into()),
+                mode: rpc_forge::HealthReportApplyMode::Replace as i32,
+            }),
+        }))
+        .await?;
+    env.run_rack_controller_iteration().await;
+
+    let mut override_metrics = env
+        .test_meter
+        .formatted_metrics("carbide_racks_health_overrides_count");
+    override_metrics.sort();
+    assert_eq!(
+        override_metrics,
+        vec![
+            "{fresh=\"true\",override_type=\"merge\"} 1".to_string(),
+            "{fresh=\"true\",override_type=\"replace\"} 1".to_string(),
+        ]
+    );
+
+    let mut status_metrics = env
+        .test_meter
+        .formatted_metrics("carbide_racks_health_status_count");
+    status_metrics.sort();
+    assert_eq!(
+        status_metrics,
+        vec![
+            "{fresh=\"true\",healthy=\"false\"} 0".to_string(),
+            "{fresh=\"true\",healthy=\"true\"} 1".to_string(),
+        ]
+    );
+
+    assert!(
+        env.test_meter
+            .formatted_metrics("carbide_alerts_suppressed_count")
+            .is_empty(),
+        "racks should not emit the legacy alerts_suppressed alias"
+    );
+
+    Ok(())
+}

--- a/crates/api/src/tests/rack_state_controller/handler.rs
+++ b/crates/api/src/tests/rack_state_controller/handler.rs
@@ -43,6 +43,7 @@ use crate::state_controller::db_write_batch::DbWriteBatch;
 use crate::state_controller::rack::context::RackStateHandlerContextObjects;
 use crate::state_controller::rack::handler::RackStateHandler;
 use crate::state_controller::rack::maintenance::apply_nvos_job_status_response;
+use crate::state_controller::rack::metrics::RackMetrics;
 use crate::state_controller::state_handler::{
     StateHandler, StateHandlerContext, StateHandlerOutcome,
 };
@@ -620,7 +621,7 @@ async fn test_expected_no_definition_stays_parked(
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -760,7 +761,7 @@ async fn test_expected_incomplete_device_counts_stays(
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -818,7 +819,7 @@ async fn test_expected_counts_match_but_not_linked_stays(
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -887,7 +888,7 @@ async fn test_expected_zero_topology_transitions_to_discovering(
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -956,7 +957,7 @@ async fn test_expected_more_discovered_than_expected_transitions(
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -1020,7 +1021,7 @@ async fn test_discovering_waits_for_compute_ready(
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -1075,7 +1076,7 @@ async fn test_discovering_empty_rack_transitions_to_maintenance(
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -1126,7 +1127,7 @@ async fn test_error_state_does_nothing(
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -1172,7 +1173,7 @@ async fn test_maintenance_completed_transitions_to_validation(
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -1232,7 +1233,7 @@ async fn test_ready_with_no_labels_stays_ready(
 
     let handler = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -1278,7 +1279,7 @@ async fn test_firmware_upgrade_start_without_default_advances_to_nvos_update(
 
     let handler_instance = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -1362,7 +1363,7 @@ async fn test_firmware_upgrade_start_with_unavailable_default_advances_to_nvos_u
 
     let handler_instance = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -1471,7 +1472,7 @@ async fn test_firmware_upgrade_start_transitions_to_wait_for_complete(
 
     let handler_instance = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -1603,7 +1604,7 @@ async fn test_firmware_upgrade_wait_for_complete_waits_while_jobs_running(
 
     let handler_instance = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -1692,7 +1693,7 @@ async fn test_firmware_upgrade_wait_for_complete_transitions_to_error_on_job_fai
 
     let handler_instance = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -1816,7 +1817,7 @@ async fn test_firmware_upgrade_wait_for_complete_waits_for_all_nodes_to_be_termi
 
     let handler_instance = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -1970,7 +1971,7 @@ async fn test_firmware_upgrade_wait_for_complete_retries_when_job_lookup_fails(
 
     let handler_instance = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -2049,7 +2050,7 @@ async fn test_firmware_upgrade_wait_for_complete_retries_on_transient_poll_error
 
     let handler_instance = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -2140,7 +2141,7 @@ async fn test_nvos_update_start_transitions_to_wait_for_complete(
 
     let handler_instance = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -2223,7 +2224,7 @@ async fn test_configure_nmx_cluster_transitions_to_completed(
 
     let handler_instance = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -2291,7 +2292,7 @@ async fn test_ready_topology_changed_transitions_to_discovering(
 
     let handler_instance = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -2349,7 +2350,7 @@ async fn test_ready_reprovision_requested_transitions_to_maintenance(
 
     let handler_instance = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,
@@ -2401,7 +2402,7 @@ async fn test_validation_failed_transitions_to_error(
 
     let handler_instance = RackStateHandler::default();
     let mut services = env.state_handler_services();
-    let mut metrics = ();
+    let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
         services: &mut services,

--- a/crates/api/src/tests/switch_health.rs
+++ b/crates/api/src/tests/switch_health.rs
@@ -301,3 +301,119 @@ async fn test_switch_health_visible_in_find_switches(
 
     Ok(())
 }
+
+#[crate::sqlx_test]
+async fn test_switch_health_aggregation(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env =
+        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
+            .await;
+
+    let switch_id = new_switch(&env, None, None).await?;
+
+    env.run_switch_controller_iteration().await;
+
+    let mut override_metrics = env
+        .test_meter
+        .formatted_metrics("carbide_switches_health_overrides_count");
+    override_metrics.sort();
+    assert_eq!(
+        override_metrics,
+        vec![
+            "{fresh=\"true\",override_type=\"merge\"} 0".to_string(),
+            "{fresh=\"true\",override_type=\"replace\"} 0".to_string(),
+        ]
+    );
+
+    let mut status_metrics = env
+        .test_meter
+        .formatted_metrics("carbide_switches_health_status_count");
+    status_metrics.sort();
+    assert_eq!(
+        status_metrics,
+        vec![
+            "{fresh=\"true\",healthy=\"false\"} 0".to_string(),
+            "{fresh=\"true\",healthy=\"true\"} 1".to_string(),
+        ]
+    );
+
+    env.api
+        .insert_switch_health_report(Request::new(rpc_forge::InsertSwitchHealthReportRequest {
+            switch_id: Some(switch_id),
+            health_report_entry: Some(rpc_forge::HealthReportEntry {
+                report: Some(alert_report("external-monitor").into()),
+                mode: rpc_forge::HealthReportApplyMode::Merge as i32,
+            }),
+        }))
+        .await?;
+    env.run_switch_controller_iteration().await;
+
+    let mut override_metrics = env
+        .test_meter
+        .formatted_metrics("carbide_switches_health_overrides_count");
+    override_metrics.sort();
+    assert_eq!(
+        override_metrics,
+        vec![
+            "{fresh=\"true\",override_type=\"merge\"} 1".to_string(),
+            "{fresh=\"true\",override_type=\"replace\"} 0".to_string(),
+        ]
+    );
+
+    let mut status_metrics = env
+        .test_meter
+        .formatted_metrics("carbide_switches_health_status_count");
+    status_metrics.sort();
+    assert_eq!(
+        status_metrics,
+        vec![
+            "{fresh=\"true\",healthy=\"false\"} 1".to_string(),
+            "{fresh=\"true\",healthy=\"true\"} 0".to_string(),
+        ]
+    );
+
+    env.api
+        .insert_switch_health_report(Request::new(rpc_forge::InsertSwitchHealthReportRequest {
+            switch_id: Some(switch_id),
+            health_report_entry: Some(rpc_forge::HealthReportEntry {
+                report: Some(empty_healthy_report("admin-override").into()),
+                mode: rpc_forge::HealthReportApplyMode::Replace as i32,
+            }),
+        }))
+        .await?;
+    env.run_switch_controller_iteration().await;
+
+    let mut override_metrics = env
+        .test_meter
+        .formatted_metrics("carbide_switches_health_overrides_count");
+    override_metrics.sort();
+    assert_eq!(
+        override_metrics,
+        vec![
+            "{fresh=\"true\",override_type=\"merge\"} 1".to_string(),
+            "{fresh=\"true\",override_type=\"replace\"} 1".to_string(),
+        ]
+    );
+
+    let mut status_metrics = env
+        .test_meter
+        .formatted_metrics("carbide_switches_health_status_count");
+    status_metrics.sort();
+    assert_eq!(
+        status_metrics,
+        vec![
+            "{fresh=\"true\",healthy=\"false\"} 0".to_string(),
+            "{fresh=\"true\",healthy=\"true\"} 1".to_string(),
+        ]
+    );
+
+    assert!(
+        env.test_meter
+            .formatted_metrics("carbide_alerts_suppressed_count")
+            .is_empty(),
+        "switches should not emit the legacy alerts_suppressed alias"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Description
Moved common health alert related metrics into separate file, tried to reuse it across all entities which has health alerts.

Current behavior for machine alerts should stay the same (including names).

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
Closes
#1380 #1381 #1382

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

