### PR TITLE
feat: In-memory credential store for vault-less dev environments

### DIFF
--- a/crates/api/src/run.rs
+++ b/crates/api/src/run.rs
@@ -19,8 +19,10 @@ use std::sync::Arc;
 
 use carbide_utils::HostPortPair;
 use eyre::WrapErr;
-use forge_secrets::credentials::{CredentialReader, CredentialWriter};
-use forge_secrets::{CredentialConfig, create_credential_manager_from, create_vault_client};
+use forge_secrets::credentials::{CredentialManager, CredentialReader};
+use forge_secrets::{
+    CredentialConfig, MemoryCredentialStore, create_credential_manager_from, create_vault_client,
+};
 use tokio::sync::oneshot::Sender;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
@@ -148,6 +150,24 @@ pub async fn run(
     let certificate_provider =
         create_vault_client(&credential_config.vault, metrics.meter.clone())?;
 
+    // Pick a credential store based on CARBIDE_CREDENTIAL_STORE (default: "vault").
+    // Set to "memory" to use an in-memory store with no persistence or shared state between
+    // processes. This is only suitable for development and testing.
+    let credential_store: Arc<dyn CredentialManager> = match std::env::var(
+        "CARBIDE_CREDENTIAL_STORE",
+    )
+    .as_deref()
+    .unwrap_or("vault")
+    {
+        "vault" => create_vault_client(&credential_config.vault, metrics.meter.clone())?,
+        "memory" => Arc::new(MemoryCredentialStore::default()),
+        other => {
+            return Err(eyre::eyre!(
+                "Invalid CARBIDE_CREDENTIAL_STORE value {other:?}: expected \"vault\" or \"memory\""
+            ));
+        }
+    };
+
     // Build credential reader chain. The idea is this chain
     // can be flexible, to allow us to introduce an ordered
     // list of readers, which we build on-demand based on
@@ -175,17 +195,12 @@ pub async fn run(
         ));
     }
 
-    // Last, we tack on the VaultClient to the end.
-    let vault_client = create_vault_client(&credential_config.vault, metrics.meter.clone())?;
-    readers.push(Box::new(vault_client.clone()));
-
-    // And our vault_client is also implemented as the writer.
-    let writer: Arc<dyn CredentialWriter> = vault_client;
+    // Last, we tack on the credential store to the end.
+    readers.push(Box::new(credential_store.clone()));
 
     // And now we create our new composite credential manager
-    // from the list of readers we just built, plus the Vault
-    // client.
-    let credential_manager = create_credential_manager_from(writer, readers);
+    // from the list of readers we just built, plus the credential store as writer.
+    let credential_manager = create_credential_manager_from(credential_store, readers);
 
     let redfish_pool = {
         let rf_pool = libredfish::RedfishClientPool::builder()

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -34,11 +34,13 @@ pub mod credentials;
 pub mod forge_vault;
 pub mod key_encryption;
 pub mod local_credentials;
+pub mod memory_credentials;
 
 use credentials::{
     CompositeCredentialManager, CredentialManager, CredentialReader, CredentialWriter,
 };
 use local_credentials::{EnvCredentials, FileCredentialsWatcher};
+pub use memory_credentials::MemoryCredentialStore;
 
 #[derive(Default, Debug, Clone)]
 pub struct CredentialConfig {

--- a/crates/secrets/src/memory_credentials.rs
+++ b/crates/secrets/src/memory_credentials.rs
@@ -1,0 +1,182 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use tokio::sync::RwLock;
+
+use crate::SecretsError;
+use crate::credentials::{
+    CredentialKey, CredentialManager, CredentialReader, CredentialWriter, Credentials,
+};
+
+/// An in-memory credential store that implements both reading and writing.
+///
+/// Useful in dev/test environments where vault is unavailable. Credentials are
+/// held in process memory and lost when the process exits.
+#[derive(Default)]
+pub struct MemoryCredentialStore {
+    store: RwLock<HashMap<String, Credentials>>,
+}
+
+#[async_trait]
+impl CredentialReader for MemoryCredentialStore {
+    async fn get_credentials(
+        &self,
+        key: &CredentialKey,
+    ) -> Result<Option<Credentials>, SecretsError> {
+        let store = self.store.read().await;
+        Ok(store.get(key.to_key_str().as_ref()).cloned())
+    }
+}
+
+#[async_trait]
+impl CredentialWriter for MemoryCredentialStore {
+    async fn set_credentials(
+        &self,
+        key: &CredentialKey,
+        credentials: &Credentials,
+    ) -> Result<(), SecretsError> {
+        let mut store = self.store.write().await;
+        store.insert(key.to_key_str().into_owned(), credentials.clone());
+        Ok(())
+    }
+
+    async fn create_credentials(
+        &self,
+        key: &CredentialKey,
+        credentials: &Credentials,
+    ) -> Result<(), SecretsError> {
+        let mut store = self.store.write().await;
+        let key_str = key.to_key_str().into_owned();
+        if store.contains_key(&key_str) {
+            return Err(SecretsError::GenericError(eyre::eyre!(
+                "credential already exists at {key_str}"
+            )));
+        }
+        store.insert(key_str, credentials.clone());
+        Ok(())
+    }
+
+    async fn delete_credentials(&self, key: &CredentialKey) -> Result<(), SecretsError> {
+        let mut store = self.store.write().await;
+        store.remove(key.to_key_str().as_ref());
+        Ok(())
+    }
+}
+
+impl CredentialManager for MemoryCredentialStore {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::credentials::CredentialKey;
+
+    fn cred(username: &str, password: &str) -> Credentials {
+        Credentials::UsernamePassword {
+            username: username.to_string(),
+            password: password.to_string(),
+        }
+    }
+
+    fn key(fabric: &str) -> CredentialKey {
+        CredentialKey::UfmAuth {
+            fabric: fabric.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_returns_none_when_empty() {
+        let store = MemoryCredentialStore::default();
+        let result = store.get_credentials(&key("fabric")).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn set_and_get_roundtrip() {
+        let store = MemoryCredentialStore::default();
+        let k = key("fabric");
+        let c = cred("user", "pass");
+        store.set_credentials(&k, &c).await.unwrap();
+        let result = store.get_credentials(&k).await.unwrap();
+        assert_eq!(result, Some(c));
+    }
+
+    #[tokio::test]
+    async fn set_overwrites_existing() {
+        let store = MemoryCredentialStore::default();
+        let k = key("fabric");
+        store.set_credentials(&k, &cred("u1", "p1")).await.unwrap();
+        store.set_credentials(&k, &cred("u2", "p2")).await.unwrap();
+        let result = store.get_credentials(&k).await.unwrap();
+        assert_eq!(result, Some(cred("u2", "p2")));
+    }
+
+    #[tokio::test]
+    async fn create_inserts_new_credential() {
+        let store = MemoryCredentialStore::default();
+        let k = key("fabric");
+        let c = cred("user", "pass");
+        store.create_credentials(&k, &c).await.unwrap();
+        let result = store.get_credentials(&k).await.unwrap();
+        assert_eq!(result, Some(c));
+    }
+
+    #[tokio::test]
+    async fn create_rejects_duplicate() {
+        let store = MemoryCredentialStore::default();
+        let k = key("fabric");
+        let c = cred("user", "pass");
+        store.create_credentials(&k, &c).await.unwrap();
+        let result = store.create_credentials(&k, &c).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn delete_removes_credential() {
+        let store = MemoryCredentialStore::default();
+        let k = key("fabric");
+        store
+            .set_credentials(&k, &cred("user", "pass"))
+            .await
+            .unwrap();
+        store.delete_credentials(&k).await.unwrap();
+        let result = store.get_credentials(&k).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_is_idempotent() {
+        let store = MemoryCredentialStore::default();
+        let k = key("fabric");
+        // Deleting a non-existent key should not error.
+        store.delete_credentials(&k).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn different_keys_are_independent() {
+        let store = MemoryCredentialStore::default();
+        let k1 = key("fabric-a");
+        let k2 = key("fabric-b");
+        let c1 = cred("u1", "p1");
+        let c2 = cred("u2", "p2");
+        store.set_credentials(&k1, &c1).await.unwrap();
+        store.set_credentials(&k2, &c2).await.unwrap();
+        assert_eq!(store.get_credentials(&k1).await.unwrap(), Some(c1));
+        assert_eq!(store.get_credentials(&k2).await.unwrap(), Some(c2));
+    }
+}


### PR DESCRIPTION
## Description
By setting `CARBIDE_CREDENTIAL_STORE=memory`, we replace Vault with an ephemeral in-memory credential store. This is not suitable for production but helpful in development and testing environments.

This was my quick and dirty solution to the problem to get a dev environment working without Vault. https://github.com/NVIDIA/infra-controller-core/issues/195 is related, but describes a production-ready solution of storing in postgres along with security considerations.
The `CARBIDE_CREDENTIAL_STORE` env var can be later extended to switch to postgres etc. A simple in-memory store will still remain useful for testing.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
- https://github.com/NVIDIA/infra-controller-core/issues/195

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

