### PR TITLE
feat(helm-prereqs): add optional carbide-api K8s auth role for vault

### DIFF
--- a/helm-prereqs/templates/vault-config-job.yaml
+++ b/helm-prereqs/templates/vault-config-job.yaml
@@ -235,6 +235,20 @@ spec:
                 policies=cert-manager-forge-policy \
                 ttl=1h
 
+              {{ if .Values.vault.carbideApiK8sAuth.enabled }}
+              # ---- K8s auth role for carbide-api ----
+              # carbide-api authenticates to in-cluster Vault via its SA JWT
+              # (vault SDK auto-detects /var/run/secrets/kubernetes.io/serviceaccount/token)
+              # and reads BMC credentials from the KV mount (forge-vault-policy
+              # grants read on {{ .Values.vault.kvMount }}/data/*).
+              echo "Creating K8s auth role for carbide-api..."
+              vault write auth/kubernetes/role/{{ .Values.vault.carbideApiK8sAuth.serviceAccountName }} \
+                bound_service_account_names={{ .Values.vault.carbideApiK8sAuth.serviceAccountName }} \
+                bound_service_account_namespaces="{{ .Values.namespace }}" \
+                policies=forge-vault-policy \
+                ttl={{ .Values.vault.carbideApiK8sAuth.tokenTTL }}
+              {{ end }}
+
               # ---- KV v2 + AppRole ----
               echo "Enabling KV v2 at {{ .Values.vault.kvMount }}/..."
               vault secrets enable -path={{ .Values.vault.kvMount }} kv-v2 2>/dev/null || true

--- a/helm-prereqs/values.yaml
+++ b/helm-prereqs/values.yaml
@@ -51,6 +51,12 @@ vault:
     enabled: false
     name: "nico-cli-client"
     organization: ""
+  ## Kubernetes auth role for carbide-api to read from Vault KV
+  ## (e.g., BMC credentials for SiteExplorer).
+  carbideApiK8sAuth:
+    enabled: false
+    serviceAccountName: "carbide-api"
+    tokenTTL: "1h"
   kvMount: "secrets"
 
 certManager:


### PR DESCRIPTION
## Description

Add opt-in Kubernetes auth role for `carbide-api` SA in the `vault-pki-config` Job. Default `enabled: false` (no behavior change).

## Type of Change

- [x] **Add** - New feature or capability

## Related Issues (Optional)

Similar pattern as the existing `nicoCliClientRole` opt-in.

## Breaking Changes

- [ ] This PR contains breaking changes

## Testing

- [x] Manual testing performed

## Additional Notes

**Problem** — on clusters running carbide via dsx-sbom-dev, `carbide-api` pod logs show:

```
ERROR msg="Detected errors in API response: [\"invalid role name \"carbide-api\"\"]"
ERROR msg="SiteExplorer run failed: Internal { message: \"Missing credential machines/bmc/site/root\" }"
```

`carbide-api` auths to in-cluster Vault via its SA JWT and expects a k8s auth role named `carbide-api` (matches legacy stardrive setup on az51-dev3-dh2). This PR makes the chart create that role when enabled.

**Helm template verification**

Default (unchanged):
```
$ helm template test helm-prereqs --namespace forge-system | grep -c 'auth/kubernetes/role/carbide-api'
0
```

With opt-in:
```
$ helm template test helm-prereqs --namespace forge-system \
    --set vault.carbideApiK8sAuth.enabled=true | grep 'auth/kubernetes/role/carbide-api'
              vault write auth/kubernetes/role/carbide-api \
```