### PR TITLE
feat(api): Allow multiple admin network segments

### DIFF
--- a/crates/api-db/migrations/20260508120000_allow_multiple_admin_network_segments.sql
+++ b/crates/api-db/migrations/20260508120000_allow_multiple_admin_network_segments.sql
@@ -1,0 +1,5 @@
+-- Admin networks may now be represented by multiple network segments.
+-- Prefix exclusion constraints still prevent overlapping managed prefixes,
+-- but network_segment_type='admin' is no longer globally unique.
+DROP INDEX IF EXISTS only_one_admin_network_segment;
+

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -26,6 +26,7 @@ use carbide_uuid::power_shelf::PowerShelfId;
 use carbide_uuid::switch::SwitchId;
 use chrono::{DateTime, Utc};
 use ipnetwork::IpNetwork;
+use itertools::Itertools;
 use lazy_static::lazy_static;
 use mac_address::MacAddress;
 use model::address_selection_strategy::AddressSelectionStrategy;
@@ -302,23 +303,27 @@ pub async fn find_or_create_machine_interface(
     txn: &mut PgConnection,
     machine_id: Option<MachineId>,
     mac_address: MacAddress,
-    relay: IpAddr,
+    relays: &[IpAddr],
     host_nic: Option<ExpectedHostNic>,
     is_primary: Option<bool>,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
+    let relaystr = relays
+        .iter()
+        .map(|v| v.to_string())
+        .collect::<Vec<String>>()
+        .join(", ");
     match machine_id {
         None => {
             tracing::info!(
                 %mac_address,
-                %relay,
-                "Found no existing machine with mac address {mac_address} using network with relay {relay}",
+                "Found no existing machine with mac address {mac_address} using networks with relays {relaystr}",
             );
             // validate_existing_mac_and_create hardcodes primary_interface: true
             // at creation. If the caller has explicitly declared a *different*
             // NIC as this machine's primary (i.e. is_primary == false), override the
             // true/default here.
             let mut interface =
-                validate_existing_mac_and_create(&mut *txn, mac_address, relay, host_nic).await?;
+                validate_existing_mac_and_create(&mut *txn, mac_address, relays, host_nic).await?;
             if is_primary == Some(false) && interface.primary_interface {
                 set_primary_interface(&interface.id, false, &mut *txn).await?;
                 interface.primary_interface = false;
@@ -332,7 +337,7 @@ pub async fn find_or_create_machine_interface(
                 n => {
                     tracing::warn!(
                         %mac_address,
-                        relay_ip = %relay,
+                        relay_ips = %relaystr,
                         num_mac_address = n,
                         "Duplicate mac address for network segment",
                     );
@@ -349,7 +354,7 @@ pub async fn find_or_create_machine_interface(
 pub async fn validate_existing_mac_and_create(
     txn: &mut PgConnection,
     mac_address: MacAddress,
-    relay: IpAddr,
+    relays: &[IpAddr],
     host_nic: Option<ExpectedHostNic>,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
     let mut interface_snapshot = find_by_mac_address(&mut *txn, mac_address).await?;
@@ -377,22 +382,24 @@ pub async fn validate_existing_mac_and_create(
                 None
             };
 
-            let network_segment = if let Some(network_segment_type) = segment_type {
+            let network_segments = if let Some(network_segment_type) = segment_type {
                 // only if forcing a segment type
-                db_network_segment::for_segment_type(txn, relay, network_segment_type).await?
+                db_network_segment::for_segment_type_all(txn, relays, network_segment_type).await?
             } else {
-                db_network_segment::for_relay(txn, relay).await?
+                db_network_segment::for_relay_all(txn, relays).await?
             };
 
-            if let Some(segment) = network_segment {
+            if !network_segments.is_empty() {
                 // If the segment only allows static reservations, reject
                 // dynamic allocation. The device must have a pre-existing
                 // static reservation to get an IP on this segment.
-                if segment.allocation_strategy == AllocationStrategy::Reserved {
-                    return Err(DatabaseError::internal(format!(
-                        "segment {} configured for static DHCP leases only; no static reservation for MAC {mac_address}",
-                        segment.name,
-                    )));
+                for segment in network_segments.iter() {
+                    if segment.allocation_strategy == AllocationStrategy::Reserved {
+                        return Err(DatabaseError::internal(format!(
+                            "segment {} configured for static DHCP leases only; no static reservation for MAC {mac_address}",
+                            segment.name,
+                        )));
+                    }
                 }
 
                 // If a fixed IP is specified for this NIC, use static
@@ -410,19 +417,12 @@ pub async fn validate_existing_mac_and_create(
                     AddressSelectionStrategy::NextAvailableIp
                 };
 
-                let v = create(
-                    txn,
-                    &segment,
-                    &mac_address,
-                    segment.subdomain_id,
-                    true,
-                    strategy,
-                )
-                .await?;
+                let v = create(txn, &network_segments, &mac_address, true, strategy).await?;
                 Ok(v)
             } else {
                 Err(DatabaseError::internal(format!(
-                    "No network segment defined for relay address: {relay}"
+                    "No network segment defined for relay addresses: {:?}",
+                    relays
                 )))
             }
         }
@@ -431,18 +431,19 @@ pub async fn validate_existing_mac_and_create(
                 %mac_address,
                 "Mac address exists, validating the relay and returning it",
             );
+
             // TODO(chet): I don't like that it's mut here, but this seems to be
             // a pattern in this module in general, especially since we may or may
             // not update the interface. Consider having reconcile_interface_segment
             // just return the interface, which would probably look a lot better.
             let mut existing_interface = interface_snapshot.remove(0);
-            reconcile_interface_segment(txn, &mut existing_interface, relay).await?;
+            reconcile_interface_segment(txn, &mut existing_interface, relays).await?;
             Ok(existing_interface)
         }
         _ => {
             tracing::warn!(
                 %mac_address,
-                %relay,
+                // A MAC address should identify a single machine interface within a segment.
                 "More than one existing mac address for network segment",
             );
             Err(DatabaseError::NetworkSegmentDuplicateMacAddress(
@@ -454,29 +455,28 @@ pub async fn validate_existing_mac_and_create(
 
 pub async fn create(
     txn: &mut PgConnection,
-    segment: &NetworkSegment,
+    segments: &[NetworkSegment],
     macaddr: &MacAddress,
-    domain_id: Option<DomainId>,
     primary_interface: bool,
     address_strategy: AddressSelectionStrategy,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
     match address_strategy {
         AddressSelectionStrategy::NextAvailableIp | AddressSelectionStrategy::Automatic => {
-            create_fast_path(txn, segment, macaddr, domain_id, primary_interface).await
+            create_fast_path(txn, segments, macaddr, primary_interface).await
         }
         AddressSelectionStrategy::StaticAddress(addr) => {
-            create_static_path(txn, segment, macaddr, domain_id, primary_interface, addr).await
+            create_static_path(txn, segments, macaddr, primary_interface, addr).await
         }
+        //
         AddressSelectionStrategy::NextAvailablePrefix(_) => {
-            create_slow_path(
-                txn,
-                segment,
-                macaddr,
-                domain_id,
-                primary_interface,
-                address_strategy,
-            )
-            .await
+            let [segment] = segments else {
+                return Err(DatabaseError::InvalidArgument(
+                    "NextAvailablePrefix allocation requires exactly one candidate segment"
+                        .to_string(),
+                ));
+            };
+
+            create_slow_path(txn, segment, macaddr, primary_interface, address_strategy).await
         }
     }
 }
@@ -484,57 +484,69 @@ pub async fn create(
 #[allow(txn_held_across_await)]
 async fn create_fast_path(
     txn: &mut PgConnection,
-    segment: &NetworkSegment,
+    segments: &[NetworkSegment],
     macaddr: &MacAddress,
-    domain_id: Option<DomainId>,
     primary_interface: bool,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
-    for _ in 0..FAST_PATH_MAX_RETRIES {
-        let mut fast_txn = Transaction::begin_inner(txn).await?;
+    for segments_idx in 0..segments.len() {
+        let segment = &segments[segments_idx];
+        for _ in 0..FAST_PATH_MAX_RETRIES {
+            let mut fast_txn = Transaction::begin_inner(txn).await?;
 
-        // Make sure we're mutually exclusive with the slow path: a shared lock means many fast-path
-        // allocations can happen concurrently, but the slow path will hold this exclusively
-        // (waiting on any shared locks to complete)
-        lock_network_segment_shared(&mut fast_txn, segment).await?;
+            // Make sure we're mutually exclusive with the slow path: a shared lock means many fast-path
+            // allocations can happen concurrently, but the slow path will hold this exclusively
+            // (waiting on any shared locks to complete)
+            lock_network_segment_shared(&mut fast_txn, segment).await?;
 
-        match try_create_fast_path(
-            &mut fast_txn,
-            segment,
-            macaddr,
-            domain_id,
-            primary_interface,
-        )
-        .await
-        {
-            Ok(interface_id) => {
-                fast_txn.commit().await?;
-                return Ok(
-                    find_by(txn, ObjectColumnFilter::One(IdColumn, &interface_id))
-                        .await?
-                        .remove(0),
-                );
-            }
-            Err(err) if err.is_fqdn_conflict() => {
-                // Another simultaneous create got the same FQDN, try again.
-            }
-            Err(DatabaseError::TryAgain) => {
-                // All the IP's in the batch we grabbed from the database got taken by other
-                // concurrent calls to create_fast_path. Try again.
-            }
-            Err(err) => {
-                // Some other error, roll back the inner transaction
-                fast_txn.rollback().await?;
-                return Err(err);
+            let segment_exhausted = match try_create_fast_path(
+                &mut fast_txn,
+                segment,
+                macaddr,
+                primary_interface,
+            )
+            .await
+            {
+                Ok(interface_id) => {
+                    fast_txn.commit().await?;
+                    return Ok(
+                        find_by(txn, ObjectColumnFilter::One(IdColumn, &interface_id))
+                            .await?
+                            .remove(0),
+                    );
+                }
+                Err(err) if err.is_fqdn_conflict() => {
+                    // Another simultaneous create got the same FQDN, try again.
+                    false
+                }
+                Err(DatabaseError::TryAgain) => {
+                    // All the IP's in the batch we grabbed from the database got taken by other
+                    // concurrent calls to create_fast_path. Try again.
+                    false
+                }
+                Err(DatabaseError::ResourceExhausted(_)) if segments_idx < segments.len() - 1 => {
+                    // If there are more segments to check, we just need to signal that this one was exhausted.
+                    true
+                }
+                Err(err) => {
+                    // Some other error, roll back the inner transaction
+                    fast_txn.rollback().await?;
+                    return Err(err);
+                }
+            };
+
+            fast_txn.rollback().await?;
+            tokio::task::yield_now().await;
+
+            // If this segment is exhausted, go to the next segment.
+            if segment_exhausted {
+                break;
             }
         }
-
-        fast_txn.rollback().await?;
-        tokio::task::yield_now().await;
     }
 
     Err(DatabaseError::internal(format!(
-        "unable to create machine interface in fast path for segment {} after {} retries",
-        segment.id, FAST_PATH_MAX_RETRIES
+        "unable to create machine interface in fast path out of segments {:?} after {} retries",
+        segments, FAST_PATH_MAX_RETRIES
     )))
 }
 
@@ -542,17 +554,34 @@ async fn create_fast_path(
 /// A perfect compliment to create_fast_path and create_slow_path.
 async fn create_static_path(
     txn: &mut PgConnection,
-    segment: &NetworkSegment,
+    segments: &[NetworkSegment],
     macaddr: &MacAddress,
-    domain_id: Option<DomainId>,
     primary_interface: bool,
     address: IpAddr,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
+    // For the staic path, we need to be a little forgiving since
+    // we expect to allow static assignment even if the requested
+    // assignment is outside any network segment as long as
+    // there is a "static assignment segment".
+    // To identify the owning segment:
+    //  - pick a segment whose prefix contains the static IP (we guard against overlap so there could be at most 1)
+    //  - otherwise allow the special static-assignments segment
+    //  - otherwise return an error
+    let segment = segments
+                .iter()
+                .find(|s| s.prefixes.iter().any(|p| p.prefix.contains(address)))
+                .or_else(|| segments.iter().find(|s| s.name == crate::network_segment::STATIC_ASSIGNMENTS_SEGMENT_NAME))
+                .ok_or_else(|| DatabaseError::internal(format!(
+                    "unable to find network segment that contains requested IP {address} in network segments: {}",
+                    segments.iter().map(|s| s.id.to_string()).join(", "),
+                ))
+    )?;
+
     let interface_id = create_inner(
         txn,
         segment,
         macaddr,
-        domain_id,
+        segment.subdomain_id,
         primary_interface,
         &[address],
         AllocationType::Static,
@@ -578,7 +607,6 @@ pub async fn create_slow_path(
     txn: &mut PgConnection,
     segment: &NetworkSegment,
     macaddr: &MacAddress,
-    domain_id: Option<DomainId>,
     primary_interface: bool,
     address_strategy: AddressSelectionStrategy,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
@@ -623,7 +651,7 @@ pub async fn create_slow_path(
         inner_txn.as_pgconn(),
         segment,
         macaddr,
-        domain_id,
+        segment.subdomain_id,
         primary_interface,
         &allocated_addresses,
         AllocationType::Dhcp,
@@ -647,7 +675,6 @@ async fn try_create_fast_path(
     txn: &mut PgTransaction<'_>,
     segment: &NetworkSegment,
     macaddr: &MacAddress,
-    domain_id: Option<DomainId>,
     primary_interface: bool,
 ) -> DatabaseResult<MachineInterfaceId> {
     let allocated_addresses = allocate_addresses_from_segment(txn, segment).await?;
@@ -656,7 +683,7 @@ async fn try_create_fast_path(
         txn,
         segment,
         macaddr,
-        domain_id,
+        segment.subdomain_id,
         primary_interface,
         &allocated_addresses,
         AllocationType::Dhcp,
@@ -1078,9 +1105,8 @@ pub async fn move_predicted_machine_interface_to_machine(
             // This host has never DHCP'd before, create a new machine_interface for it
             let machine_interface = create(
                 txn,
-                &network_segment,
+                &[network_segment],
                 &predicted_machine_interface.mac_address,
-                network_segment.subdomain_id,
                 false,
                 AddressSelectionStrategy::NextAvailableIp,
             )
@@ -1112,18 +1138,22 @@ pub async fn create_host_machine_dpu_interface_proactively(
     hardware_info: Option<&HardwareInfo>,
     dpu_id: &MachineId,
 ) -> Result<MachineInterfaceSnapshot, DatabaseError> {
-    let admin_network = crate::network_segment::admin(txn).await?;
+    let admin_networks = crate::network_segment::admin(txn).await?;
 
     // Using gateway IP as relay IP. This is just to enable next algorithm to find related network
     // segment.
-    let prefix = admin_network
-        .prefixes
-        .iter()
-        .filter(|x| x.prefix.is_ipv4())
-        .next_back()
-        .ok_or(DatabaseError::AdminNetworkNotConfigured)?;
+    let mut gateways = vec![];
+    let mut existing_machine = None;
 
-    let Some(gateway) = prefix.gateway else {
+    for admin_network in admin_networks {
+        for prefix in admin_network.prefixes {
+            if let Some(gateway) = prefix.gateway {
+                gateways.push(gateway);
+            }
+        }
+    }
+
+    if gateways.is_empty() {
         return Err(DatabaseError::AdminNetworkNotConfigured);
     };
 
@@ -1135,10 +1165,16 @@ pub async fn create_host_machine_dpu_interface_proactively(
             id: dpu_id.to_string(),
         })??;
 
-    let existing_machine = crate::machine::find_existing_machine(txn, host_mac, gateway).await?;
+    for gateway in gateways.iter() {
+        existing_machine =
+            crate::machine::find_existing_machine(txn, host_mac, gateway.to_owned()).await?;
+        if existing_machine.is_some() {
+            break;
+        }
+    }
 
     let machine_interface =
-        find_or_create_machine_interface(txn, existing_machine, host_mac, gateway, None, None)
+        find_or_create_machine_interface(txn, existing_machine, host_mac, &gateways, None, None)
             .await?;
     associate_interface_with_dpu_machine(&machine_interface.id, dpu_id, txn).await?;
 
@@ -1197,19 +1233,23 @@ pub async fn update_segment_id(
 async fn reconcile_interface_segment(
     txn: &mut PgConnection,
     existing_interface: &mut MachineInterfaceSnapshot,
-    relay: IpAddr,
+    relays: &[IpAddr],
 ) -> DatabaseResult<()> {
-    let relay_segment = crate::network_segment::for_relay(txn, relay)
-        .await?
-        .ok_or_else(|| {
-            DatabaseError::internal(format!(
-                "No network segment defined for DHCP relay address: {relay}"
-            ))
-        })?;
+    let relay_segments = crate::network_segment::for_relay_all(txn, relays).await?;
 
-    // If it's the same segment, then we're good! Nothing
-    // to do here.
-    if relay_segment.id == existing_interface.segment_id {
+    if relay_segments.is_empty() {
+        return Err(DatabaseError::internal(format!(
+            "No network segment defined for DHCP relay addresses: {}",
+            relays.iter().join(", ")
+        )));
+    };
+
+    // If the existing interface belongs to any candidate segment, it is valid.
+    // This handles proactive DPU ingestion where all admin gateways are candidates.
+    if relay_segments
+        .iter()
+        .any(|n| n.id == existing_interface.segment_id)
+    {
         return Ok(());
     }
 
@@ -1225,6 +1265,13 @@ async fn reconcile_interface_segment(
     // removed the static allocation on purpose, and now we're waiting for
     // the device to DHCP so we can see what segment it's coming in on.
     if on_static_assignments && existing_interface.addresses.is_empty() {
+        let [relay_segment] = relay_segments.as_slice() else {
+            return Err(DatabaseError::internal(format!(
+                "Cannot move interface from static-assignments with multiple candidate relays: {} ",
+                relays.iter().join(", ")
+            )));
+        };
+
         tracing::info!(
             mac_address = %existing_interface.mac_address,
             old_segment_id = %existing_interface.segment_id,
@@ -1253,7 +1300,13 @@ async fn reconcile_interface_segment(
         // integration.
         return Err(DatabaseError::internal(format!(
             "Network segment mismatch for existing MAC address: {} expected: {} actual from network switch: {}",
-            existing_interface.mac_address, existing_interface.segment_id, relay_segment.id,
+            existing_interface.mac_address,
+            existing_interface.segment_id,
+            relay_segments
+                .iter()
+                .map(|ns| ns.id.to_string())
+                .collect::<Vec<String>>()
+                .join(", "),
         )));
     }
 

--- a/crates/api-db/src/network_segment.rs
+++ b/crates/api-db/src/network_segment.rs
@@ -186,19 +186,7 @@ pub async fn for_relay(
     txn: &mut PgConnection,
     relay: IpAddr,
 ) -> DatabaseResult<Option<NetworkSegment>> {
-    lazy_static! {
-        static ref query: String = format!(
-            r#"{}
-                INNER JOIN network_prefixes ON network_prefixes.segment_id = ns.id
-                WHERE $1::inet <<= network_prefixes.prefix"#,
-            NETWORK_SEGMENT_SNAPSHOT_QUERY.deref()
-        );
-    }
-    let mut results = sqlx::query_as(&query)
-        .bind(IpNetwork::from(relay))
-        .fetch_all(txn)
-        .await
-        .map_err(|e| DatabaseError::query(&query, e))?;
+    let mut results = for_relay_all(txn, std::slice::from_ref(&relay)).await?;
 
     match results.len() {
         0 | 1 => Ok(results.pop()),
@@ -208,28 +196,87 @@ pub async fn for_relay(
     }
 }
 
-pub async fn for_segment_type(
+/// Returns all network segments that contain at least one relay/gateway IP.
+pub async fn for_relay_all(
     txn: &mut PgConnection,
-    relay: IpAddr,
-    segment_type: NetworkSegmentType,
-) -> DatabaseResult<Option<NetworkSegment>> {
+    relays: &[IpAddr],
+) -> DatabaseResult<Vec<NetworkSegment>> {
     lazy_static! {
         static ref query: String = format!(
             r#"{}
-                INNER JOIN network_prefixes ON network_prefixes.segment_id = ns.id
-                WHERE $1::inet <<= network_prefixes.prefix
-                AND $2 = ns.network_segment_type
-                "#,
+                WHERE EXISTS (
+                    SELECT 1
+                    FROM network_prefixes
+                    WHERE network_prefixes.segment_id = ns.id
+                    AND EXISTS (
+                        SELECT 1 FROM unnest($1::inet[]) AS ip
+                        WHERE ip <<= network_prefixes.prefix
+                    )
+                )
+                ORDER BY ns.id"#,
             NETWORK_SEGMENT_SNAPSHOT_QUERY.deref()
         );
     }
-    let mut results = sqlx::query_as(&query)
-        .bind(IpNetwork::from(relay))
+    let results = sqlx::query_as(&query)
+        .bind(
+            relays
+                .iter()
+                .map(|v| IpNetwork::from(v.to_owned()))
+                .collect::<Vec<IpNetwork>>(),
+        )
+        .fetch_all(txn)
+        .await
+        .map_err(|e| DatabaseError::query(&query, e))?;
+
+    Ok(results)
+}
+
+/// Accepts a set of relay/gateway IPs and a segment type and returns
+/// all network segments that match.
+pub async fn for_segment_type_all(
+    txn: &mut PgConnection,
+    relays: &[IpAddr],
+    segment_type: NetworkSegmentType,
+) -> DatabaseResult<Vec<NetworkSegment>> {
+    lazy_static! {
+        static ref query: String = format!(
+            r#"{}
+                WHERE EXISTS (
+                    SELECT 1
+                    FROM network_prefixes
+                    WHERE network_prefixes.segment_id = ns.id
+                    AND EXISTS (
+                        SELECT 1 FROM unnest($1::inet[]) AS ip
+                        WHERE ip <<= network_prefixes.prefix
+                    )
+                )
+                AND $2 = ns.network_segment_type
+                ORDER BY ns.id"#,
+            NETWORK_SEGMENT_SNAPSHOT_QUERY.deref()
+        );
+    }
+
+    let results = sqlx::query_as(&query)
+        .bind(
+            relays
+                .iter()
+                .map(|v| IpNetwork::from(v.to_owned()))
+                .collect::<Vec<IpNetwork>>(),
+        )
         .bind(segment_type)
         .fetch_all(txn)
         .await
         .map_err(|e| DatabaseError::new(&query, e))?;
 
+    Ok(results)
+}
+
+pub async fn for_segment_type(
+    txn: &mut PgConnection,
+    relay: IpAddr,
+    segment_type: NetworkSegmentType,
+) -> DatabaseResult<Option<NetworkSegment>> {
+    let mut results = for_segment_type_all(txn, std::slice::from_ref(&relay), segment_type).await?;
     if results.len() > 1 {
         tracing::trace!(
             "Multiple network segments defined for segment_type {} and relay address {}",
@@ -583,15 +630,15 @@ pub async fn static_assignments(txn: &mut PgConnection) -> Result<NetworkSegment
     find_by_name(txn, STATIC_ASSIGNMENTS_SEGMENT_NAME).await
 }
 
-/// This method returns Admin network segment.
-pub async fn admin(txn: &mut PgConnection) -> Result<NetworkSegment, DatabaseError> {
+/// Returns all admin network segments.
+pub async fn admin(txn: &mut PgConnection) -> Result<Vec<NetworkSegment>, DatabaseError> {
     lazy_static! {
         static ref query: String = format!(
-            "{} WHERE network_segment_type = 'admin'",
+            "{} WHERE network_segment_type = 'admin' ORDER BY ns.id",
             NETWORK_SEGMENT_SNAPSHOT_QUERY.deref()
         );
     }
-    let mut segments: Vec<NetworkSegment> = sqlx::query_as(&query)
+    let segments: Vec<NetworkSegment> = sqlx::query_as(&query)
         .fetch_all(txn)
         .await
         .map_err(|e| DatabaseError::query(&query, e))?;
@@ -600,7 +647,7 @@ pub async fn admin(txn: &mut PgConnection) -> Result<NetworkSegment, DatabaseErr
         return Err(DatabaseError::query(&query, sqlx::Error::RowNotFound));
     }
 
-    Ok(segments.remove(0))
+    Ok(segments)
 }
 
 /// Are queried segment in ready state?

--- a/crates/api-db/src/vpc_dpu_loopback.rs
+++ b/crates/api-db/src/vpc_dpu_loopback.rs
@@ -44,30 +44,41 @@ pub async fn delete_and_deallocate(
     txn: &mut PgConnection,
     delete_admin_loopback_also: bool,
 ) -> Result<(), DatabaseError> {
-    let mut admin_vpc = None;
-    let query = if !delete_admin_loopback_also {
-        let admin_segment = crate::network_segment::admin(txn).await?;
-        admin_vpc = admin_segment.vpc_id;
-        if admin_vpc.is_some() {
-            "DELETE FROM vpc_dpu_loopbacks WHERE dpu_id=$1 AND vpc_id != $2 RETURNING *"
+    let mut query = sqlx::QueryBuilder::new("DELETE FROM vpc_dpu_loopbacks WHERE TRUE ");
+
+    query.push(" AND dpu_id= ");
+    query.push_bind(dpu_id);
+
+    if !delete_admin_loopback_also {
+        let admin_segments = crate::network_segment::admin(txn).await?;
+        let admin_vpcs = admin_segments
+            .iter()
+            .filter_map(|s| s.vpc_id)
+            .collect::<Vec<VpcId>>();
+
+        if admin_vpcs.is_empty() {
+            tracing::warn!(
+                "No VPC attached to one or more admin segments: {:?}.",
+                admin_segments
+            );
         } else {
-            tracing::warn!("No VPC is attached to admin segment {}.", admin_segment.id);
-            "DELETE FROM vpc_dpu_loopbacks WHERE dpu_id=$1 RETURNING *"
+            // We only allow a single admin VPC, so it seems this could easily be
+            // vpc_id != admin_vpc_id, but the ALL seems cheap enough based on that
+            // and would ensure we don't have to worry later if we introduce multiple
+            // admin VPCs.
+            query.push(" AND vpc_id != ALL( ");
+            query.push_bind(admin_vpcs);
+            query.push(" )");
         }
-    } else {
-        "DELETE FROM vpc_dpu_loopbacks WHERE dpu_id=$1 RETURNING *"
     };
 
-    let mut sqlx_query = sqlx::query_as::<_, VpcDpuLoopback>(query).bind(dpu_id);
+    query.push("  RETURNING * ");
 
-    if let Some(admin_vpc) = admin_vpc {
-        sqlx_query = sqlx_query.bind(admin_vpc);
-    }
-
-    let deleted_loopbacks = sqlx_query
+    let deleted_loopbacks: Vec<VpcDpuLoopback> = query
+        .build_query_as()
         .fetch_all(&mut *txn)
         .await
-        .map_err(|e| DatabaseError::query(query, e))?;
+        .map_err(|e| DatabaseError::query(query.sql(), e))?;
 
     for value in deleted_loopbacks {
         // We deleted a IP from vpc_dpu_loopback table. Deallocate this IP from common pool.

--- a/crates/api/src/db_init.rs
+++ b/crates/api/src/db_init.rs
@@ -246,29 +246,34 @@ pub(crate) async fn create_admin_vpc(
 
     let mut txn = Transaction::begin(db_pool).await?;
 
-    let admin_segment = db::network_segment::admin(&mut txn).await?;
+    let admin_segments = db::network_segment::admin(&mut txn).await?;
     let existing_vpc = db::vpc::find_by_vni(&mut txn, vpc_vni as i32).await?;
-    if let Some(existing_vpc) = existing_vpc.first() {
-        if let Some(vpc_id) = admin_segment.vpc_id {
-            if vpc_id != existing_vpc.id {
-                return Err(CarbideError::internal(format!(
-                    "Mismatch found in admin vpc id {} and admin network segment's attached vpc id {vpc_id}.",
-                    existing_vpc.id
-                )));
-            }
 
-            // All good here. We have valid admin vpc and it is attached to valid segment.
-            return Ok(());
-        } else {
-            // Somehow vni field is not updated in network segment table. do it now.
-            db::network_segment::set_vpc_id_and_can_stretch(
-                &admin_segment,
-                &mut txn,
-                existing_vpc.id,
-            )
-            .await?;
-            return Ok(());
+    if let Some(existing_vpc) = existing_vpc.first() {
+        for admin_segment in admin_segments {
+            if let Some(vpc_id) = admin_segment.vpc_id {
+                if vpc_id != existing_vpc.id {
+                    return Err(CarbideError::internal(format!(
+                        "Mismatch found in admin vpc id {} and admin network segment's attached vpc id {vpc_id}.",
+                        existing_vpc.id
+                    )));
+                }
+
+                // All good here. We have valid admin vpc and it is attached to valid segment.
+            } else {
+                // Somehow vni field is not updated in network segment table. do it now.
+                db::network_segment::set_vpc_id_and_can_stretch(
+                    &admin_segment,
+                    &mut txn,
+                    existing_vpc.id,
+                )
+                .await?;
+            }
         }
+
+        txn.commit().await?;
+
+        return Ok(());
     }
 
     // Let's create admin vpc.
@@ -297,8 +302,10 @@ pub(crate) async fn create_admin_vpc(
     )
     .await?;
 
-    // Attach it to admin network segment.
-    db::network_segment::set_vpc_id_and_can_stretch(&admin_segment, &mut txn, vpc.id).await?;
+    // Attach it to admin network segments.
+    for admin_segment in admin_segments {
+        db::network_segment::set_vpc_id_and_can_stretch(&admin_segment, &mut txn, vpc.id).await?;
+    }
 
     txn.commit().await?;
 

--- a/crates/api/src/dhcp/discover.rs
+++ b/crates/api/src/dhcp/discover.rs
@@ -268,7 +268,7 @@ pub async fn discover_dhcp(
         &mut txn,
         existing_machine_id,
         parsed_mac,
-        parsed_relay,
+        std::slice::from_ref(&parsed_relay),
         host_nic,
         is_primary_nic,
     )

--- a/crates/api/src/ethernet_virtualization.rs
+++ b/crates/api/src/ethernet_virtualization.rs
@@ -20,6 +20,7 @@ use ::rpc::forge as rpc;
 use carbide_network::virtualization::{VpcVirtualizationType, get_svi_ip};
 use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
+use carbide_uuid::network::NetworkSegmentId;
 use db::vpc::{self};
 use db::vpc_peering::get_prefixes_by_vpcs;
 use db::{self, ObjectColumnFilter, network_security_group};
@@ -205,7 +206,38 @@ pub async fn admin_network(
     common_pools: &CommonPools,
     booturl: &Option<String>,
 ) -> Result<(rpc::FlatInterfaceConfig, MachineInterfaceId), tonic::Status> {
-    let admin_segment = db::network_segment::admin(txn).await?;
+    let admin_segments = db::network_segment::admin(txn).await?;
+    let admin_segment_ids = admin_segments
+        .iter()
+        .map(|s| s.id)
+        .collect::<Vec<NetworkSegmentId>>();
+
+    // Admin network interfaces are machine_interfaces records where the machine_id
+    // is a host machine ID and attached_dpu_machine_id is a DPU ID.
+    // If we loop through the machine interfaces for the host snapshot and look for
+    // that combo, the segment_id of that interface should be the network segment we want,
+    // but checking against known admin segments adds a little bit of defense.
+    let interface = snapshot.host_snapshot.interfaces.iter().find(|interface| {
+        interface.attached_dpu_machine_id.as_ref() == Some(dpu_machine_id)
+            && admin_segment_ids.contains(&interface.segment_id)
+    });
+
+    let host_machine_id = snapshot.host_snapshot.id;
+    let Some(interface) = interface else {
+        return Err(CarbideError::InvalidArgument(format!(
+            "No admin interface found attached on host: {host_machine_id} with dpu: {dpu_machine_id}"
+        ))
+        .into());
+    };
+
+    let admin_segment = admin_segments.iter().find(|v| v.id == interface.segment_id);
+
+    let Some(admin_segment) = admin_segment else {
+        return Err(CarbideError::internal(format!(
+            "Unknown admin segment `{}` attached on host: {host_machine_id} with dpu: {dpu_machine_id}", interface.segment_id
+        ))
+        .into());
+    };
 
     let prefix = match admin_segment.prefixes.first() {
         Some(p) => p,
@@ -232,19 +264,6 @@ pub async fn admin_network(
                 .name
         }
         None => "unknowndomain".to_string(),
-    };
-
-    let host_machine_id = snapshot.host_snapshot.id;
-    let interface = snapshot.host_snapshot.interfaces.iter().find(|interface| {
-        interface.segment_id == admin_segment.id
-            && interface.attached_dpu_machine_id.as_ref() == Some(dpu_machine_id)
-    });
-
-    let Some(interface) = interface else {
-        return Err(CarbideError::InvalidArgument(format!(
-            "No interface found attached on host: {host_machine_id} with dpu: {dpu_machine_id}"
-        ))
-        .into());
     };
 
     let address = interface

--- a/crates/api/src/handlers/machine_interface_address.rs
+++ b/crates/api/src/handlers/machine_interface_address.rs
@@ -75,9 +75,8 @@ pub async fn preallocate_machine_interface(
 
     db::machine_interface::create(
         txn,
-        &segment,
+        std::slice::from_ref(&segment),
         &bmc_mac_address,
-        segment.subdomain_id,
         true,
         AddressSelectionStrategy::StaticAddress(bmc_ip),
     )
@@ -150,9 +149,8 @@ pub async fn update_preallocated_machine_interface(
 
         db::machine_interface::create(
             txn,
-            &segment,
+            std::slice::from_ref(&segment),
             &bmc_mac_address,
-            segment.subdomain_id,
             true,
             AddressSelectionStrategy::StaticAddress(bmc_ip),
         )

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -364,7 +364,7 @@ pub struct TestEnv {
     pub site_explorer: SiteExplorer,
     pub nmxm_sim: Arc<dyn NmxmClientPool>,
     pub endpoint_explorer: MockEndpointExplorer,
-    pub admin_segment: Option<NetworkSegmentId>,
+    pub admin_segments: Vec<NetworkSegmentId>,
     pub underlay_segment: Option<NetworkSegmentId>,
     pub domain: uuid::Uuid,
     pub nvl_partition_monitor: Arc<Mutex<NvlPartitionMonitor>>,
@@ -376,6 +376,21 @@ pub struct TestEnv {
 }
 
 impl TestEnv {
+    /// Returns the default admin network segment used by most tests.
+    pub fn admin_segment(&self) -> NetworkSegmentId {
+        *self
+            .admin_segments
+            .first()
+            .expect("test env should have an admin segment")
+    }
+
+    /// Returns a reference to the default admin network segment used by most tests.
+    pub fn admin_segment_ref(&self) -> &NetworkSegmentId {
+        self.admin_segments
+            .first()
+            .expect("test env should have an admin segment")
+    }
+
     /// Creates an instance of CommonStateHandlerServices that are suitable for this
     /// test environment
     pub fn state_handler_services(&self) -> CommonStateHandlerServices {
@@ -1809,9 +1824,9 @@ pub async fn create_test_env_with_overrides(
         .unwrap()
         .unwrap();
 
-    let (admin_segment, underlay_segment) = if overrides.create_network_segments.unwrap_or(true) {
+    let (admin_segments, underlay_segment) = if overrides.create_network_segments.unwrap_or(true) {
         // Create admin network
-        let admin = Some(create_admin_network_segment(&api).await);
+        let admin_segments = vec![create_admin_network_segment(&api).await];
         network_controller.run_single_iteration().await;
         network_controller.run_single_iteration().await;
 
@@ -1827,9 +1842,9 @@ pub async fn create_test_env_with_overrides(
         network_controller.run_single_iteration().await;
         network_controller.run_single_iteration().await;
 
-        (admin, underlay)
+        (admin_segments, underlay)
     } else {
-        (None, None)
+        (Vec::new(), None)
     };
 
     TestEnv {
@@ -1854,7 +1869,7 @@ pub async fn create_test_env_with_overrides(
         site_explorer,
         nmxm_sim,
         endpoint_explorer: fake_endpoint_explorer,
-        admin_segment,
+        admin_segments,
         underlay_segment,
         domain: domain.into(),
         nvl_partition_monitor: Arc::new(Mutex::new(nvl_partition_monitor)),

--- a/crates/api/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/site_explorer.rs
@@ -1848,7 +1848,7 @@ pub async fn create_expected_switches(
             .await
             .expect("unable to create expected switch");
 
-        let network_segment = db::network_segment::admin(txn)
+        let network_segments = db::network_segment::admin(txn)
             .await
             .map_err(|e| eyre::eyre!("Failed to get admin network segment: {:?}", e))
             .unwrap();
@@ -1856,9 +1856,8 @@ pub async fn create_expected_switches(
         for nvos_mac in &result.nvos_mac_addresses.clone() {
             db::machine_interface::create(
                 txn,
-                &network_segment,
+                &network_segments,
                 nvos_mac,
-                network_segment.subdomain_id,
                 false,
                 AddressSelectionStrategy::NextAvailableIp,
             )
@@ -1873,9 +1872,8 @@ pub async fn create_expected_switches(
 
         db::machine_interface::create(
             txn,
-            &overlay_network_segment,
+            std::slice::from_ref(&overlay_network_segment),
             &result.bmc_mac_address.clone(),
-            overlay_network_segment.subdomain_id,
             false,
             AddressSelectionStrategy::NextAvailableIp,
         )

--- a/crates/api/src/tests/dhcp_lease_expiration.rs
+++ b/crates/api/src/tests/dhcp_lease_expiration.rs
@@ -40,7 +40,7 @@ async fn test_expire_releases_allocation(
     let interface = db::machine_interface::validate_existing_mac_and_create(
         &mut txn,
         MacAddress::from_str("aa:bb:cc:dd:ee:01").unwrap(),
-        relay,
+        std::slice::from_ref(&relay),
         None,
     )
     .await?;
@@ -197,12 +197,15 @@ async fn test_expire_does_not_delete_static_allocation(
 
     // Create an interface with a static IP via the proper create path.
     let mut txn = env.pool.begin().await?;
-    let segment = db::network_segment::admin(&mut txn).await?;
+    let segment = db::network_segment::admin(&mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .unwrap();
     let interface = db::machine_interface::create(
         &mut txn,
-        &segment,
+        std::slice::from_ref(&segment),
         &MacAddress::from_str("aa:bb:cc:dd:ee:08").unwrap(),
-        segment.subdomain_id,
         true,
         AddressSelectionStrategy::StaticAddress(static_ip),
     )
@@ -244,12 +247,15 @@ async fn test_static_address_survives_expiration_and_rediscover(
 
     // Create an interface with a static IP via the proper create path.
     let mut txn = env.pool.begin().await?;
-    let segment = db::network_segment::admin(&mut txn).await?;
+    let segment = db::network_segment::admin(&mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .unwrap();
     let interface = db::machine_interface::create(
         &mut txn,
-        &segment,
+        std::slice::from_ref(&segment),
         &mac,
-        segment.subdomain_id,
         true,
         AddressSelectionStrategy::StaticAddress(static_ip),
     )

--- a/crates/api/src/tests/expected_power_shelf.rs
+++ b/crates/api/src/tests/expected_power_shelf.rs
@@ -1045,7 +1045,13 @@ async fn test_add_with_bmc_ip_rejects_if_interface_exists(
 
     // Create an interface via DHCP (simulating the device already being on the network).
     let mut txn = env.pool.begin().await?;
-    db::machine_interface::validate_existing_mac_and_create(&mut txn, bmc_mac, relay, None).await?;
+    db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        bmc_mac,
+        std::slice::from_ref(&relay),
+        None,
+    )
+    .await?;
     txn.commit().await?;
 
     // Now try to add an expected power shelf with the same MAC -- should fail.
@@ -1130,7 +1136,7 @@ async fn test_add_with_bmc_ip_rejects_if_ip_already_allocated(
     let existing = db::machine_interface::validate_existing_mac_and_create(
         &mut txn,
         "6A:6B:6C:6D:6E:87".parse().unwrap(),
-        relay,
+        std::slice::from_ref(&relay),
         None,
     )
     .await?;
@@ -1276,9 +1282,13 @@ async fn test_update_with_bmc_ip_assigns_to_empty_interface(
 
     // Create interface via DHCP, then remove its address.
     let mut txn = env.pool.begin().await?;
-    let iface =
-        db::machine_interface::validate_existing_mac_and_create(&mut txn, bmc_mac, relay, None)
-            .await?;
+    let iface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        bmc_mac,
+        std::slice::from_ref(&relay),
+        None,
+    )
+    .await?;
     db::machine_interface_address::delete(&mut txn, &iface.id).await?;
     txn.commit().await?;
 

--- a/crates/api/src/tests/ip_allocator.rs
+++ b/crates/api/src/tests/ip_allocator.rs
@@ -21,10 +21,12 @@ use mac_address::MacAddress;
 use model::address_selection_strategy::AddressSelectionStrategy;
 use model::network_prefix::NewNetworkPrefix;
 use model::network_segment::{
-    NetworkSegmentControllerState, NetworkSegmentType, NewNetworkSegment,
+    AllocationStrategy, NetworkSegmentControllerState, NetworkSegmentType, NewNetworkSegment,
 };
 
-use crate::tests::common::api_fixtures::create_test_env;
+use crate::tests::common::api_fixtures::{
+    TestEnvOverrides, create_test_env, create_test_env_with_overrides,
+};
 
 /// Test that machine_interface::create allocates the correct IPv4 address
 /// from the admin segment (192.0.2.0/24 with num_reserved=3, gateway=.1).
@@ -35,7 +37,11 @@ async fn test_machine_interface_create_with_ipv4_prefix(
     let env = create_test_env(pool).await;
     let mut txn = env.pool.begin().await?;
 
-    let network_segment = db::network_segment::admin(&mut txn).await?;
+    let network_segment = db::network_segment::admin(&mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .unwrap();
     let network_prefix = network_segment
         .prefixes
         .first()
@@ -60,9 +66,8 @@ async fn test_machine_interface_create_with_ipv4_prefix(
 
     let interface = db::machine_interface::create(
         &mut txn,
-        &network_segment,
+        std::slice::from_ref(&network_segment),
         MacAddress::from_str("ff:ff:ff:ff:ff:ff").as_ref().unwrap(),
-        Some(env.domain.into()),
         true,
         AddressSelectionStrategy::NextAvailableIp,
     )
@@ -82,9 +87,8 @@ async fn test_machine_interface_create_with_ipv4_prefix(
     // Allocate a second interface and verify it gets a different address
     let interface2 = db::machine_interface::create(
         &mut txn,
-        &network_segment,
+        std::slice::from_ref(&network_segment),
         &MacAddress::from_str("ff:ff:ff:ff:ff:fe").unwrap(),
-        Some(env.domain.into()),
         false,
         AddressSelectionStrategy::NextAvailableIp,
     )
@@ -99,6 +103,89 @@ async fn test_machine_interface_create_with_ipv4_prefix(
     Ok(())
 }
 
+/// Verify that machine_interface::create falls through to a later candidate
+/// admin segment when the first candidate is exhausted.
+#[crate::sqlx_test]
+async fn test_machine_interface_create_falls_through_admin_segments(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(pool, TestEnvOverrides::no_network_segments()).await;
+    let mut txn = env.pool.begin().await?;
+
+    let admin_segment = |name: &str, prefix: &str, gateway: &str| NewNetworkSegment {
+        name: name.to_string(),
+        subdomain_id: None,
+        vpc_id: None,
+        mtu: 1500,
+        prefixes: vec![NewNetworkPrefix {
+            prefix: prefix.parse().unwrap(),
+            gateway: Some(gateway.parse().unwrap()),
+            num_reserved: 2,
+        }],
+        vlan_id: None,
+        vni: None,
+        segment_type: NetworkSegmentType::Admin,
+        id: uuid::Uuid::new_v4().into(),
+        can_stretch: None,
+        allocation_strategy: AllocationStrategy::Dynamic,
+    };
+
+    // Create two tiny admin segments with one allocatable address each.
+    let first_segment = db::network_segment::persist(
+        admin_segment("ADMIN_TINY_1", "192.0.20.0/30", "192.0.20.1"),
+        &mut txn,
+        NetworkSegmentControllerState::Ready,
+    )
+    .await?;
+    let second_segment = db::network_segment::persist(
+        admin_segment("ADMIN_TINY_2", "192.0.21.0/30", "192.0.21.1"),
+        &mut txn,
+        NetworkSegmentControllerState::Ready,
+    )
+    .await?;
+    let candidate_segments = [first_segment.clone(), second_segment.clone()];
+
+    // Allocate the only usable address from the first candidate segment.
+    let first_interface = db::machine_interface::create(
+        &mut txn,
+        &candidate_segments,
+        &MacAddress::from_str("aa:bb:cc:dd:ee:10").unwrap(),
+        true,
+        AddressSelectionStrategy::NextAvailableIp,
+    )
+    .await?;
+    assert_eq!(first_interface.segment_id, first_segment.id);
+    assert_eq!(
+        first_interface.addresses,
+        vec![IpAddr::V4("192.0.20.2".parse()?)]
+    );
+
+    // Allocate again with the same candidates and verify it falls through.
+    let second_interface = db::machine_interface::create(
+        &mut txn,
+        &candidate_segments,
+        &MacAddress::from_str("aa:bb:cc:dd:ee:11").unwrap(),
+        false,
+        AddressSelectionStrategy::NextAvailableIp,
+    )
+    .await?;
+
+    let second_interface_id = second_interface.id;
+    txn.commit().await?;
+
+    // Re-read the second interface to verify the persisted segment and address.
+    let mut txn = env.pool.begin().await?;
+    let persisted_interface =
+        db::machine_interface::find_one(txn.as_mut(), second_interface_id).await?;
+    assert_eq!(persisted_interface.segment_id, second_segment.id);
+    assert_eq!(
+        persisted_interface.addresses,
+        vec![IpAddr::V4("192.0.21.2".parse()?)]
+    );
+
+    Ok(())
+}
+
 /// Verify that machine_interface::create allocates from an IPv6-only segment.
 #[crate::sqlx_test]
 async fn test_machine_interface_create_with_ipv6_prefix(
@@ -107,7 +194,7 @@ async fn test_machine_interface_create_with_ipv6_prefix(
     let env = create_test_env(pool).await;
     let mut txn = env.pool.begin().await?;
 
-    let domain = db::dns::domain::find_by_name(&mut txn, "dwrt1.com")
+    let domain = db::dns::domain::find_by_name(txn.as_mut(), "dwrt1.com")
         .await?
         .into_iter()
         .next()
@@ -129,6 +216,7 @@ async fn test_machine_interface_create_with_ipv6_prefix(
         segment_type: NetworkSegmentType::Underlay,
         id: uuid::Uuid::new_v4().into(),
         can_stretch: None,
+        allocation_strategy: AllocationStrategy::Dynamic,
     };
     let network_segment =
         db::network_segment::persist(new_ns, &mut txn, NetworkSegmentControllerState::Ready)
@@ -136,9 +224,8 @@ async fn test_machine_interface_create_with_ipv6_prefix(
 
     let interface = db::machine_interface::create(
         &mut txn,
-        &network_segment,
+        std::slice::from_ref(&network_segment),
         &MacAddress::from_str("aa:bb:cc:dd:ee:01").unwrap(),
-        Some(domain.id),
         true,
         AddressSelectionStrategy::NextAvailableIp,
     )
@@ -158,9 +245,8 @@ async fn test_machine_interface_create_with_ipv6_prefix(
     // Allocate a second interface to verify sequential allocation works
     let interface2 = db::machine_interface::create(
         &mut txn,
-        &network_segment,
+        std::slice::from_ref(&network_segment),
         &MacAddress::from_str("aa:bb:cc:dd:ee:02").unwrap(),
-        Some(domain.id),
         false,
         AddressSelectionStrategy::NextAvailableIp,
     )
@@ -189,7 +275,7 @@ async fn test_machine_interface_create_dual_stack(
     let env = create_test_env(pool).await;
     let mut txn = env.pool.begin().await?;
 
-    let domain = db::dns::domain::find_by_name(&mut txn, "dwrt1.com")
+    let domain = db::dns::domain::find_by_name(txn.as_mut(), "dwrt1.com")
         .await?
         .into_iter()
         .next()
@@ -217,6 +303,7 @@ async fn test_machine_interface_create_dual_stack(
         segment_type: NetworkSegmentType::Underlay,
         id: uuid::Uuid::new_v4().into(),
         can_stretch: None,
+        allocation_strategy: AllocationStrategy::Dynamic,
     };
     let network_segment =
         db::network_segment::persist(new_ns, &mut txn, NetworkSegmentControllerState::Ready)
@@ -224,9 +311,8 @@ async fn test_machine_interface_create_dual_stack(
 
     let interface = db::machine_interface::create(
         &mut txn,
-        &network_segment,
+        std::slice::from_ref(&network_segment),
         &MacAddress::from_str("aa:bb:cc:00:00:01").unwrap(),
-        Some(domain.id),
         true,
         AddressSelectionStrategy::NextAvailableIp,
     )
@@ -260,9 +346,8 @@ async fn test_machine_interface_create_dual_stack(
     // Allocate a second interface and verify both families get new addresses
     let interface2 = db::machine_interface::create(
         &mut txn,
-        &network_segment,
+        std::slice::from_ref(&network_segment),
         &MacAddress::from_str("aa:bb:cc:00:00:02").unwrap(),
-        Some(domain.id),
         false,
         AddressSelectionStrategy::NextAvailableIp,
     )

--- a/crates/api/src/tests/machine_dhcp.rs
+++ b/crates/api/src/tests/machine_dhcp.rs
@@ -23,11 +23,12 @@ use carbide_uuid::machine::MachineInterfaceId;
 use common::api_fixtures::managed_host::ManagedHostConfig;
 use common::api_fixtures::network_segment::{
     FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY, FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY,
-    create_host_inband_network_segment,
+    create_host_inband_network_segment, create_network_segment,
 };
 use common::api_fixtures::{
     FIXTURE_DHCP_RELAY_ADDRESS, TestEnv, TestEnvOverrides, create_managed_host,
     create_managed_host_with_config, create_test_env, create_test_env_with_overrides, dpu,
+    get_config,
 };
 use db::{self, ObjectColumnFilter, dhcp_entry};
 use ipnetwork::IpNetwork;
@@ -51,7 +52,7 @@ async fn test_machine_dhcp(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error:
     db::machine_interface::validate_existing_mac_and_create(
         &mut txn,
         test_mac_address,
-        test_gateway_address,
+        std::slice::from_ref(&test_gateway_address),
         None,
     )
     .await?;
@@ -74,7 +75,7 @@ async fn test_machine_dhcp_from_wrong_vlan_fails(
     db::machine_interface::validate_existing_mac_and_create(
         &mut txn,
         test_mac_address,
-        test_gateway_address,
+        std::slice::from_ref(&test_gateway_address),
         None,
     )
     .await?;
@@ -83,7 +84,7 @@ async fn test_machine_dhcp_from_wrong_vlan_fails(
     db::machine_interface::validate_existing_mac_and_create(
         &mut txn,
         test_mac_address,
-        test_gateway_address,
+        std::slice::from_ref(&test_gateway_address),
         None,
     )
     .await?;
@@ -92,7 +93,7 @@ async fn test_machine_dhcp_from_wrong_vlan_fails(
     let output = db::machine_interface::validate_existing_mac_and_create(
         &mut txn,
         test_mac_address,
-        "192.0.1.1".parse().unwrap(),
+        &["192.0.1.1".parse().unwrap()],
         None,
     )
     .await;
@@ -113,7 +114,7 @@ async fn test_machine_dhcp_with_api(pool: sqlx::PgPool) -> Result<(), Box<dyn st
     // Inititially 0 addresses are allocated on the segment
     let mut txn = env.pool.begin().await?;
     assert_eq!(
-        db::machine_interface::count_by_segment_id(&mut txn, &env.admin_segment.unwrap())
+        db::machine_interface::count_by_segment_id(&mut txn, env.admin_segment_ref())
             .await
             .unwrap(),
         0
@@ -130,7 +131,7 @@ async fn test_machine_dhcp_with_api(pool: sqlx::PgPool) -> Result<(), Box<dyn st
         .unwrap()
         .into_inner();
 
-    assert_eq!(response.segment_id.unwrap(), (env.admin_segment.unwrap()));
+    assert_eq!(response.segment_id.unwrap(), (env.admin_segment()));
 
     assert_eq!(response.mac_address, mac_address);
     assert_eq!(response.subdomain_id.unwrap(), env.domain.into());
@@ -141,7 +142,7 @@ async fn test_machine_dhcp_with_api(pool: sqlx::PgPool) -> Result<(), Box<dyn st
     // After DHCP, 1 address is allocated on the segment
     let mut txn = pool.begin().await?;
     assert_eq!(
-        db::machine_interface::count_by_segment_id(&mut txn, &env.admin_segment.unwrap())
+        db::machine_interface::count_by_segment_id(&mut txn, env.admin_segment_ref())
             .await
             .unwrap(),
         1
@@ -159,7 +160,7 @@ async fn test_multiple_machines_dhcp_with_api(
     // Inititially 0 addresses are allocated on the segment
     let mut txn = pool.begin().await?;
     assert_eq!(
-        db::machine_interface::count_by_segment_id(&mut txn, &env.admin_segment.unwrap())
+        db::machine_interface::count_by_segment_id(&mut txn, env.admin_segment_ref())
             .await
             .unwrap(),
         0
@@ -178,7 +179,7 @@ async fn test_multiple_machines_dhcp_with_api(
             .unwrap()
             .into_inner();
 
-        assert_eq!(response.segment_id.unwrap(), (env.admin_segment.unwrap()));
+        assert_eq!(response.segment_id.unwrap(), (env.admin_segment()));
 
         assert_eq!(response.mac_address, mac);
         assert_eq!(response.subdomain_id.unwrap(), env.domain.into());
@@ -189,12 +190,84 @@ async fn test_multiple_machines_dhcp_with_api(
 
     let mut txn = pool.begin().await?;
     assert_eq!(
-        db::machine_interface::count_by_segment_id(&mut txn, &env.admin_segment.unwrap())
+        db::machine_interface::count_by_segment_id(&mut txn, env.admin_segment_ref())
             .await
             .unwrap(),
         NUM_MACHINES
     );
     txn.commit().await.unwrap();
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_machine_dhcp_declared_admin_nic_allocates_from_relay_admin_segment(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = get_config();
+    config.rack_management_enabled = true;
+    let env = create_test_env_with_overrides(pool, TestEnvOverrides::with_config(config)).await;
+
+    // Create a second admin segment so the relay determines which admin segment is used.
+    let second_admin_segment = create_network_segment(
+        &env.api,
+        "ADMIN_2",
+        "192.0.12.0/24",
+        "192.0.12.1",
+        rpc::forge::NetworkSegmentType::Admin,
+        None,
+        true,
+    )
+    .await;
+
+    // Register an expected host NIC declared as an admin-network NIC.
+    let bmc_mac: MacAddress = "7a:7b:7c:7d:7e:10".parse().unwrap();
+    let admin_nic_mac: MacAddress = "7a:7b:7c:7d:7e:11".parse().unwrap();
+    env.api
+        .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+            id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: "EM-ADMIN-RELAY-001".into(),
+            host_nics: vec![rpc::forge::ExpectedHostNic {
+                mac_address: admin_nic_mac.to_string(),
+                nic_type: Some("onboard".into()),
+                fixed_ip: None,
+                fixed_mask: None,
+                fixed_gateway: None,
+                primary: Some(true),
+            }],
+            ..Default::default()
+        }))
+        .await?;
+
+    // DHCP through the second admin relay should allocate from that segment.
+    let response = env
+        .api
+        .discover_dhcp(DhcpDiscovery::builder(admin_nic_mac, "192.0.12.1").tonic_request())
+        .await?
+        .into_inner();
+
+    let expected_address: IpAddr = "192.0.12.3".parse().unwrap();
+    assert_eq!(response.segment_id.unwrap(), second_admin_segment);
+    assert_eq!(response.mac_address, admin_nic_mac.to_string());
+    assert_eq!(response.subdomain_id.unwrap(), env.domain.into());
+    assert_eq!(response.address, expected_address.to_string());
+    assert_eq!(response.prefix, "192.0.12.0/24");
+    assert_eq!(response.gateway.unwrap(), "192.0.12.1");
+
+    // Verify the persisted interface matches the DHCP response.
+    let interface_id = response
+        .machine_interface_id
+        .expect("DHCP response should include machine_interface_id");
+    let mut txn = env.pool.begin().await?;
+    let persisted_interface = db::machine_interface::find_one(txn.as_mut(), interface_id).await?;
+    assert_eq!(persisted_interface.segment_id, second_admin_segment);
+    assert_eq!(persisted_interface.mac_address, admin_nic_mac);
+    assert_eq!(persisted_interface.domain_id, Some(env.domain.into()));
+    assert!(persisted_interface.primary_interface);
+    assert_eq!(persisted_interface.addresses, vec![expected_address]);
+
     Ok(())
 }
 

--- a/crates/api/src/tests/machine_discovery.rs
+++ b/crates/api/src/tests/machine_discovery.rs
@@ -38,7 +38,7 @@ async fn test_machine_discovery_no_domain(
     let machine_interface = db::machine_interface::validate_existing_mac_and_create(
         &mut txn,
         MacAddress::from_str("ff:ff:ff:ff:ff:ff").unwrap(),
-        FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap(),
+        std::slice::from_ref(&FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap()),
         None,
     )
     .await
@@ -75,7 +75,7 @@ async fn test_machine_discovery_with_domain(
     let machine_interface = db::machine_interface::validate_existing_mac_and_create(
         &mut txn,
         MacAddress::from_str("ff:ff:ff:ff:ff:ff").unwrap(),
-        FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap(),
+        std::slice::from_ref(&FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap()),
         None,
     )
     .await

--- a/crates/api/src/tests/machine_interface_addresses.rs
+++ b/crates/api/src/tests/machine_interface_addresses.rs
@@ -62,9 +62,8 @@ async fn find_by_address_bmc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::erro
     // An interface that isn't attached to a Machine. This is what BMC interfaces are.
     let interface = db::machine_interface::create(
         &mut txn,
-        &network_segment,
+        std::slice::from_ref(&network_segment),
         &MacAddress::from_str("ff:ff:ff:ff:ff:ff").unwrap(),
-        Some(domain.id),
         true,
         AddressSelectionStrategy::NextAvailableIp,
     )

--- a/crates/api/src/tests/machine_interfaces.rs
+++ b/crates/api/src/tests/machine_interfaces.rs
@@ -21,7 +21,7 @@ use std::str::FromStr;
 
 use common::api_fixtures::{FIXTURE_DHCP_RELAY_ADDRESS, create_test_env};
 use db::dhcp_entry::DhcpEntry;
-use db::{self, ObjectColumnFilter};
+use db::{self};
 use itertools::Itertools;
 use mac_address::MacAddress;
 use model::address_selection_strategy::AddressSelectionStrategy;
@@ -49,13 +49,16 @@ async fn only_one_primary_interface_per_machine(
 
     let mut txn = env.pool.begin().await?;
 
-    let network_segment = db::network_segment::admin(&mut txn).await?;
+    let network_segment = db::network_segment::admin(&mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .unwrap();
 
     let new_interface = db::machine_interface::create(
         &mut txn,
-        &network_segment,
+        std::slice::from_ref(&network_segment),
         &dpu.oob_mac_address,
-        None,
         true,
         AddressSelectionStrategy::NextAvailableIp,
     )
@@ -72,9 +75,8 @@ async fn only_one_primary_interface_per_machine(
 
     let should_failed_machine_interface = db::machine_interface::create(
         &mut txn,
-        &network_segment,
+        std::slice::from_ref(&network_segment),
         &other_dpu.oob_mac_address,
-        None,
         true,
         AddressSelectionStrategy::NextAvailableIp,
     )
@@ -100,13 +102,16 @@ async fn many_non_primary_interfaces_per_machine(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env(pool).await;
     let mut txn = env.pool.begin().await?;
-    let network_segment = db::network_segment::admin(&mut txn).await?;
+    let network_segment = db::network_segment::admin(&mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .unwrap();
 
     db::machine_interface::create(
         &mut txn,
-        &network_segment,
+        std::slice::from_ref(&network_segment),
         MacAddress::from_str("ff:ff:ff:ff:ff:ff").as_ref().unwrap(),
-        None,
         true,
         AddressSelectionStrategy::NextAvailableIp,
     )
@@ -118,9 +123,8 @@ async fn many_non_primary_interfaces_per_machine(
 
     let should_be_ok_interface = db::machine_interface::create(
         &mut txn,
-        &network_segment,
+        std::slice::from_ref(&network_segment),
         MacAddress::from_str("ff:ff:ff:ff:ff:ef").as_ref().unwrap(),
-        None,
         false,
         AddressSelectionStrategy::NextAvailableIp,
     )
@@ -148,7 +152,7 @@ async fn return_existing_machine_interface_on_rediscover(
     let new_machine = db::machine_interface::validate_existing_mac_and_create(
         &mut txn,
         test_mac,
-        FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap(),
+        std::slice::from_ref(&FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap()),
         None,
     )
     .await?;
@@ -156,7 +160,7 @@ async fn return_existing_machine_interface_on_rediscover(
     let existing_machine = db::machine_interface::validate_existing_mac_and_create(
         &mut txn,
         test_mac,
-        FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap(),
+        std::slice::from_ref(&FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap()),
         None,
     )
     .await?;
@@ -174,23 +178,21 @@ async fn find_all_interfaces_test_cases(
 
     let mut txn = env.pool.begin().await?;
 
-    let network_segment = db::network_segment::admin(&mut txn).await?;
-    let domain_ids = db::dns::domain::find_by(
-        txn.as_mut(),
-        ObjectColumnFilter::<db::dns::domain::IdColumn>::All,
-    )
-    .await?;
-    let domain_id = domain_ids[0].id;
+    let network_segment = db::network_segment::admin(&mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .unwrap();
+
     let mut interfaces: Vec<MachineInterfaceSnapshot> = Vec::new();
     for i in 0..2 {
         let mut txn = env.pool.begin().await?;
         let interface = db::machine_interface::create(
             &mut txn,
-            &network_segment,
+            std::slice::from_ref(&network_segment),
             MacAddress::from_str(format!("ff:ff:ff:ff:ff:0{i}").as_str())
                 .as_ref()
                 .unwrap(),
-            Some(domain_id),
             true,
             AddressSelectionStrategy::NextAvailableIp,
         )
@@ -256,18 +258,16 @@ async fn find_interfaces_test_cases(pool: sqlx::PgPool) -> Result<(), Box<dyn st
 
     let mut txn = env.pool.begin().await?;
 
-    let network_segment = db::network_segment::admin(&mut txn).await?;
-    let domain_ids = db::dns::domain::find_by(
-        txn.as_mut(),
-        ObjectColumnFilter::<db::dns::domain::IdColumn>::All,
-    )
-    .await?;
-    let domain_id = domain_ids[0].id;
+    let network_segment = db::network_segment::admin(&mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .unwrap();
+
     let new_interface = db::machine_interface::create(
         &mut txn,
-        &network_segment,
+        std::slice::from_ref(&network_segment),
         &dpu.oob_mac_address,
-        Some(domain_id),
         true,
         AddressSelectionStrategy::NextAvailableIp,
     )
@@ -327,7 +327,11 @@ async fn find_interfaces_test_cases(pool: sqlx::PgPool) -> Result<(), Box<dyn st
 async fn create_parallel_mi(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env(pool).await;
     let mut txn = env.pool.begin().await?;
-    let network = db::network_segment::admin(&mut txn).await?;
+    let network = db::network_segment::admin(&mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .unwrap();
     txn.commit().await.unwrap();
 
     let (tx, _rx1) = broadcast::channel(10);
@@ -344,9 +348,8 @@ async fn create_parallel_mi(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error
             let mut txn = db_pool.begin().await.unwrap();
             db::machine_interface::create(
                 &mut txn,
-                &n,
+                std::slice::from_ref(&n),
                 &MacAddress::from_str(&mac).unwrap(),
-                Some(env.domain.into()),
                 true,
                 AddressSelectionStrategy::NextAvailableIp,
             )
@@ -385,12 +388,15 @@ async fn test_find_by_ip_or_id(pool: sqlx::PgPool) -> Result<(), Box<dyn std::er
     let env = create_test_env(pool).await;
     let mut txn = env.pool.begin().await?;
 
-    let network_segment = db::network_segment::admin(&mut txn).await?;
+    let network_segment = db::network_segment::admin(&mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .unwrap();
     let interface = db::machine_interface::create(
         &mut txn,
-        &network_segment,
+        std::slice::from_ref(&network_segment),
         MacAddress::from_str("ff:ff:ff:ff:ff:ff").as_ref().unwrap(),
-        Some(env.domain.into()),
         true,
         AddressSelectionStrategy::NextAvailableIp,
     )
@@ -586,12 +592,15 @@ async fn test_hostname_equals_ip(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
     let env = create_test_env(pool).await;
     let mut txn = env.pool.begin().await?;
 
-    let network_segment = db::network_segment::admin(&mut txn).await?;
+    let network_segment = db::network_segment::admin(&mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .unwrap();
     let interface = db::machine_interface::create(
         &mut txn,
-        &network_segment,
+        std::slice::from_ref(&network_segment),
         MacAddress::from_str("ff:ff:ff:ff:ff:ff").as_ref().unwrap(),
-        Some(env.domain.into()),
         true,
         AddressSelectionStrategy::NextAvailableIp,
     )
@@ -623,12 +632,15 @@ async fn test_max_one_interface_association(
     let env = create_test_env(pool).await;
     let mut txn = env.pool.begin().await?;
 
-    let network_segment = db::network_segment::admin(&mut txn).await?;
+    let network_segment = db::network_segment::admin(&mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .unwrap();
     let interface = db::machine_interface::create(
         &mut txn,
-        &network_segment,
+        std::slice::from_ref(&network_segment),
         MacAddress::from_str("ff:ff:ff:ff:ff:ff").as_ref().unwrap(),
-        Some(env.domain.into()),
         true,
         AddressSelectionStrategy::NextAvailableIp,
     )
@@ -699,12 +711,15 @@ async fn test_power_shelf_association(
     let env = create_test_env(pool).await;
     let mut txn = env.pool.begin().await?;
 
-    let network_segment = db::network_segment::admin(&mut txn).await?;
+    let network_segment = db::network_segment::admin(&mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .unwrap();
     let interface = db::machine_interface::create(
         &mut txn,
-        &network_segment,
+        std::slice::from_ref(&network_segment),
         MacAddress::from_str("ff:ff:ff:ff:ff:ff").as_ref().unwrap(),
-        Some(env.domain.into()),
         true,
         AddressSelectionStrategy::NextAvailableIp,
     )
@@ -748,12 +763,15 @@ async fn test_switch_association(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
     let env = create_test_env(pool).await;
     let mut txn = env.pool.begin().await?;
 
-    let network_segment = db::network_segment::admin(&mut txn).await?;
+    let network_segment = db::network_segment::admin(&mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .unwrap();
     let interface = db::machine_interface::create(
         &mut txn,
-        &network_segment,
+        std::slice::from_ref(&network_segment),
         MacAddress::from_str("ff:ff:ff:ff:ff:ff").as_ref().unwrap(),
-        Some(env.domain.into()),
         true,
         AddressSelectionStrategy::NextAvailableIp,
     )

--- a/crates/api/src/tests/machine_network.rs
+++ b/crates/api/src/tests/machine_network.rs
@@ -23,6 +23,7 @@ use ::rpc::forge::{
     InstanceDpuExtensionServiceConfig, InstanceDpuExtensionServicesConfig,
     ManagedHostNetworkConfigRequest, ManagedHostNetworkStatusRequest,
 };
+use common::api_fixtures::network_segment::create_network_segment;
 use common::api_fixtures::{self, create_managed_host, dpu, network_configured_with_health};
 use forge_secrets::credentials::{BgpCredentialType, CredentialKey, Credentials};
 use model::machine::network::ManagedHostQuarantineMode;
@@ -243,12 +244,26 @@ async fn test_managed_host_network_config_errors_when_sitewide_bgp_password_miss
 
 #[crate::sqlx_test]
 async fn test_managed_host_network_config_multi_dpu(pool: sqlx::PgPool) {
-    // Given: A managed host with 2 DPUs
     let env = api_fixtures::create_test_env(pool).await;
+
+    // Given: A managed host with 2 DPUs.
     let mh = api_fixtures::create_managed_host_multi_dpu(&env, 2).await;
+
     let host_machine = mh.host().rpc_machine().await;
     let dpu_1_id = host_machine.associated_dpu_machine_ids[0];
     let dpu_2_id = host_machine.associated_dpu_machine_ids[1];
+
+    // And: Multiple admin segments exist when the DPU network config is rendered.
+    let _second_admin_segment = create_network_segment(
+        &env.api,
+        "ADMIN_2",
+        "192.0.12.0/24",
+        "192.0.12.1",
+        rpc::forge::NetworkSegmentType::Admin,
+        None,
+        true,
+    )
+    .await;
 
     // Then: Get the managed host network config version via DPU 1's ID and DPU 2's ID
     let dpu_1_network_config = env
@@ -267,6 +282,24 @@ async fn test_managed_host_network_config_multi_dpu(pool: sqlx::PgPool) {
         .await
         .expect("Error getting DPU1 network config")
         .into_inner();
+
+    let configs = [&dpu_1_network_config, &dpu_2_network_config];
+
+    // Assert: Both DPUs are still on the singular admin-interface path.
+    for config in configs {
+        assert!(config.use_admin_network);
+        assert!(config.admin_interface.is_some());
+        assert!(config.tenant_interfaces.is_empty());
+    }
+
+    // Assert: Only the primary DPU is active on the admin network.
+    assert_eq!(
+        configs
+            .iter()
+            .filter(|config| config.is_primary_dpu)
+            .count(),
+        1,
+    );
 
     // Assert: Both DPUs report the same managed_host_config_version, because
     // it's the host's network_config_version and group-sync keeps every member

--- a/crates/api/src/tests/machine_topology.rs
+++ b/crates/api/src/tests/machine_topology.rs
@@ -64,7 +64,7 @@ async fn test_crud_machine_topology(pool: sqlx::PgPool) -> Result<(), Box<dyn st
     let mut txn = env.pool.begin().await?;
     let segment = db::network_segment::find_by(
         txn.as_mut(),
-        ObjectColumnFilter::One(network_segment::IdColumn, &env.admin_segment.unwrap()),
+        ObjectColumnFilter::One(network_segment::IdColumn, env.admin_segment_ref()),
         model::network_segment::NetworkSegmentSearchConfig::default(),
     )
     .await
@@ -73,9 +73,8 @@ async fn test_crud_machine_topology(pool: sqlx::PgPool) -> Result<(), Box<dyn st
 
     let iface = db::machine_interface::create(
         &mut txn,
-        &segment,
+        std::slice::from_ref(&segment),
         &dpu.host_mac_address,
-        Some(env.domain.into()),
         true,
         model::address_selection_strategy::AddressSelectionStrategy::NextAvailableIp,
     )
@@ -216,7 +215,7 @@ async fn test_v1_cpu_topology(pool: sqlx::PgPool) -> Result<(), Box<dyn std::err
     let mut txn = env.pool.begin().await?;
     let segment = db::network_segment::find_by(
         txn.as_mut(),
-        ObjectColumnFilter::One(network_segment::IdColumn, &env.admin_segment.unwrap()),
+        ObjectColumnFilter::One(network_segment::IdColumn, env.admin_segment_ref()),
         model::network_segment::NetworkSegmentSearchConfig::default(),
     )
     .await
@@ -225,9 +224,8 @@ async fn test_v1_cpu_topology(pool: sqlx::PgPool) -> Result<(), Box<dyn std::err
 
     let iface = db::machine_interface::create(
         &mut txn,
-        &segment,
+        std::slice::from_ref(&segment),
         &dpu.host_mac_address,
-        Some(env.domain.into()),
         true,
         model::address_selection_strategy::AddressSelectionStrategy::NextAvailableIp,
     )

--- a/crates/api/src/tests/mod.rs
+++ b/crates/api/src/tests/mod.rs
@@ -55,6 +55,7 @@ mod instance_find;
 mod instance_ipxe_behaviors;
 mod instance_os;
 mod instance_type;
+mod ip_allocator;
 mod ipxe;
 mod level_filter;
 mod lldp;

--- a/crates/api/src/tests/network_segment.rs
+++ b/crates/api/src/tests/network_segment.rs
@@ -156,9 +156,8 @@ async fn test_network_segment_delete_fails_with_associated_machine_interface(
 
     db::machine_interface::create(
         &mut txn,
-        &db_segment,
+        std::slice::from_ref(&db_segment),
         MacAddress::from_str("ff:ff:ff:ff:ff:ff").as_ref().unwrap(),
-        None,
         true,
         AddressSelectionStrategy::NextAvailableIp,
     )
@@ -1012,21 +1011,28 @@ async fn test_update_svi_ip_admin_segment(
     db_init::create_admin_vpc(&env.pool, Some(10600)).await?;
 
     let mut txn = env.pool.begin().await?;
-    let admin_segment = db::network_segment::admin(&mut txn).await?;
-    assert!(admin_segment.vpc_id.is_some());
-    let admin_vpc = db::vpc::find_by(
-        txn.as_mut(),
-        ObjectColumnFilter::One(IdColumn, &admin_segment.vpc_id.unwrap()),
-    )
-    .await?;
-    assert_eq!(
-        admin_vpc[0].network_virtualization_type,
-        VpcVirtualizationType::Fnn
-    );
+    let admin_segments = db::network_segment::admin(&mut txn).await?;
+
+    for admin_segment in admin_segments {
+        assert!(admin_segment.vpc_id.is_some());
+        let admin_vpc = db::vpc::find_by(
+            txn.as_mut(),
+            ObjectColumnFilter::One(IdColumn, &admin_segment.vpc_id.unwrap()),
+        )
+        .await?;
+        assert_eq!(
+            admin_vpc[0].network_virtualization_type,
+            VpcVirtualizationType::Fnn
+        );
+    }
+
     db_init::update_network_segments_svi_ip(&env.pool).await?;
-    let admin_segment = db::network_segment::admin(&mut txn).await?;
-    for prefix in admin_segment.prefixes {
-        assert!(prefix.svi_ip.is_some());
+    let admin_segments = db::network_segment::admin(&mut txn).await?;
+
+    for admin_segment in admin_segments {
+        for prefix in admin_segment.prefixes {
+            assert!(prefix.svi_ip.is_some());
+        }
     }
     Ok(())
 }

--- a/crates/api/src/tests/network_segment_lifecycle.rs
+++ b/crates/api/src/tests/network_segment_lifecycle.rs
@@ -18,6 +18,7 @@
 use std::time::Duration;
 
 use carbide_uuid::network::NetworkSegmentId;
+use common::api_fixtures::network_segment::create_network_segment;
 use common::api_fixtures::{TestEnvOverrides, create_test_env, create_test_env_with_overrides};
 use common::network_segment::{create_network_segment_with_api, get_segment_state, text_history};
 use rpc::forge::forge_server::Forge;
@@ -216,7 +217,60 @@ async fn test_admin_network_exists(pool: sqlx::PgPool) -> Result<(), Box<dyn std
 
     let segments = db::network_segment::admin(&mut txn).await?;
 
-    assert_eq!(segments.id, env.admin_segment.unwrap());
+    assert_eq!(segments[0].id, env.admin_segment());
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_multiple_admin_network_segments_exist(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let first_admin_segment = env.admin_segment();
+
+    // Create a second admin segment through the same API path operators use.
+    let second_admin_segment = create_network_segment(
+        &env.api,
+        "ADMIN_2",
+        "192.0.12.0/24",
+        "192.0.12.1",
+        rpc::forge::NetworkSegmentType::Admin,
+        None,
+        true,
+    )
+    .await;
+
+    // Verify both admin segments can be found through the RPC find-by-ids path.
+    let segments = env
+        .api
+        .find_network_segments_by_ids(Request::new(rpc::forge::NetworkSegmentsByIdsRequest {
+            network_segments_ids: vec![first_admin_segment, second_admin_segment],
+            include_history: false,
+            include_num_free_ips: false,
+        }))
+        .await?
+        .into_inner()
+        .network_segments;
+
+    let segment_ids = segments
+        .iter()
+        .map(|segment| segment.id.unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(segment_ids.len(), 2);
+    assert!(segment_ids.contains(&first_admin_segment));
+    assert!(segment_ids.contains(&second_admin_segment));
+
+    // Verify the DB admin lookup returns both admin segments as candidates.
+    let mut txn = env.pool.begin().await?;
+    let admin_segments = db::network_segment::admin(&mut txn).await?;
+    let admin_segment_ids = admin_segments
+        .iter()
+        .map(|segment| segment.id)
+        .collect::<Vec<_>>();
+    assert_eq!(admin_segment_ids.len(), 2);
+    assert!(admin_segment_ids.contains(&first_admin_segment));
+    assert!(admin_segment_ids.contains(&second_admin_segment));
 
     Ok(())
 }

--- a/crates/api/src/tests/prevent_duplicate_mac_addresses.rs
+++ b/crates/api/src/tests/prevent_duplicate_mac_addresses.rs
@@ -33,7 +33,7 @@ async fn prevent_duplicate_mac_addresses(
 
     let network_segment = db::network_segment::find_by(
         txn.as_mut(),
-        ObjectColumnFilter::One(network_segment::IdColumn, &env.admin_segment.unwrap()),
+        ObjectColumnFilter::One(network_segment::IdColumn, env.admin_segment_ref()),
         model::network_segment::NetworkSegmentSearchConfig::default(),
     )
     .await?
@@ -42,9 +42,8 @@ async fn prevent_duplicate_mac_addresses(
 
     let new_interface = db::machine_interface::create(
         &mut txn,
-        &network_segment,
+        std::slice::from_ref(&network_segment),
         &dpu.oob_mac_address,
-        None,
         true,
         AddressSelectionStrategy::NextAvailableIp,
     )
@@ -55,9 +54,8 @@ async fn prevent_duplicate_mac_addresses(
 
     let duplicate_interface = db::machine_interface::create(
         &mut txn,
-        &network_segment,
+        std::slice::from_ref(&network_segment),
         &dpu.oob_mac_address,
-        None,
         true,
         AddressSelectionStrategy::NextAvailableIp,
     )

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -72,11 +72,11 @@ struct FakeMachine {
 }
 
 impl FakeMachine {
-    fn new(mac: &str, vendor: &str, segment: &Option<NetworkSegmentId>) -> Self {
+    fn new(mac: &str, vendor: &str, segment: NetworkSegmentId) -> Self {
         Self {
             mac: mac.parse().unwrap(),
             dhcp_vendor: vendor.to_string(),
-            segment: segment.unwrap(),
+            segment,
             ip: String::new(),
         }
     }
@@ -200,7 +200,7 @@ async fn test_site_explorer_default_pause_ingestion_and_poweron(
     let mut machines = vec![FakeMachine::new(
         "6a:6b:6c:6d:6e:6f",
         "Vendor1",
-        &env.underlay_segment,
+        env.underlay_segment.unwrap(),
     )];
     machines.discover_dhcp(&env).await?;
 
@@ -350,7 +350,11 @@ async fn test_handle_redfish_error_powers_on_machine(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = common::api_fixtures::create_test_env(pool.clone()).await;
 
-    let mut machine = FakeMachine::new("6a:6b:6c:6d:6e:70", "Vendor1", &env.underlay_segment);
+    let mut machine = FakeMachine::new(
+        "6a:6b:6c:6d:6e:70",
+        "Vendor1",
+        env.underlay_segment.unwrap(),
+    );
     machine.discover_dhcp(&env).await?;
     let bmc_ip: IpAddr = machine.ip.parse()?;
 
@@ -439,16 +443,28 @@ async fn test_site_explorer_main(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
     // to a panic if the machine is queried
     let mut machines = vec![
         // machines[0] is a DPU belonging to machines[1]
-        FakeMachine::new("B8:3F:D2:90:97:A6", "Vendor1", &env.underlay_segment),
+        FakeMachine::new(
+            "B8:3F:D2:90:97:A6",
+            "Vendor1",
+            env.underlay_segment.unwrap(),
+        ),
         // machines[1] has 1 dpu (machines[0])
-        FakeMachine::new("AA:AB:AC:AD:AA:02", "Vendor2", &env.underlay_segment),
+        FakeMachine::new(
+            "AA:AB:AC:AD:AA:02",
+            "Vendor2",
+            env.underlay_segment.unwrap(),
+        ),
         // machines[2] has no DPUs
-        FakeMachine::new("AA:AB:AC:AD:AA:03", "Vendor3", &env.underlay_segment),
+        FakeMachine::new(
+            "AA:AB:AC:AD:AA:03",
+            "Vendor3",
+            env.underlay_segment.unwrap(),
+        ),
         // machines[3] is not on the underlay network and should not be searched.
         FakeMachine::new(
             "AA:AB:AC:AD:BB:01",
             "VendorInvalidSegment",
-            &env.admin_segment,
+            env.admin_segment(),
         ),
     ];
     machines.discover_dhcp(&env).await?;
@@ -461,7 +477,7 @@ async fn test_site_explorer_main(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
         3
     );
     assert_eq!(
-        db::machine_interface::count_by_segment_id(&mut txn, &env.admin_segment.unwrap())
+        db::machine_interface::count_by_segment_id(&mut txn, env.admin_segment_ref())
             .await
             .unwrap(),
         1
@@ -808,20 +824,48 @@ async fn test_site_explorer_audit_exploration_results(
         // This will be our expected DPU, and it will have the
         // expected serial number, but we assume no DPUs are expected,
         // should it still shouldn't be counted as `expected`        .
-        FakeMachine::new("5a:5b:5c:5d:5e:5f", "Vendor1", &env.underlay_segment),
+        FakeMachine::new(
+            "5a:5b:5c:5d:5e:5f",
+            "Vendor1",
+            env.underlay_segment.unwrap(),
+        ),
         // This will be expected but unauthorized, and the serial is mismatched
-        FakeMachine::new("0a:0b:0c:0d:0e:0f", "Vendor3", &env.underlay_segment),
+        FakeMachine::new(
+            "0a:0b:0c:0d:0e:0f",
+            "Vendor3",
+            env.underlay_segment.unwrap(),
+        ),
         // This host will be expected but missing credentials, and the serial is mismatched
-        FakeMachine::new("1a:1b:1c:1d:1e:1f", "Vendor3", &env.underlay_segment),
+        FakeMachine::new(
+            "1a:1b:1c:1d:1e:1f",
+            "Vendor3",
+            env.underlay_segment.unwrap(),
+        ),
         // This host will be expected, but the serial number will be mismatched.
-        FakeMachine::new("2a:2b:2c:2d:2e:2f", "Vendor3", &env.underlay_segment),
+        FakeMachine::new(
+            "2a:2b:2c:2d:2e:2f",
+            "Vendor3",
+            env.underlay_segment.unwrap(),
+        ),
         // This will be expected, with a good serial number.
         // It will also have associated DPUs and should get a managed host.
-        FakeMachine::new("3a:3b:3c:3d:3e:3f", "Vendor3", &env.underlay_segment),
+        FakeMachine::new(
+            "3a:3b:3c:3d:3e:3f",
+            "Vendor3",
+            env.underlay_segment.unwrap(),
+        ),
         // This host is not expected.
-        FakeMachine::new("ab:cd:ef:ab:cd:ef", "Vendor3", &env.underlay_segment),
+        FakeMachine::new(
+            "ab:cd:ef:ab:cd:ef",
+            "Vendor3",
+            env.underlay_segment.unwrap(),
+        ),
         // This DPU is really not expected. (i.e. no DB entry)
-        FakeMachine::new("ef:cd:ab:ef:cd:ab", "Vendor3", &env.underlay_segment),
+        FakeMachine::new(
+            "ef:cd:ab:ef:cd:ab",
+            "Vendor3",
+            env.underlay_segment.unwrap(),
+        ),
     ];
 
     machines.discover_dhcp(&env).await?;
@@ -1154,8 +1198,16 @@ async fn test_site_explorer_reexplore(
     let env = common::api_fixtures::create_test_env(pool.clone()).await;
 
     let mut machines = vec![
-        FakeMachine::new("B8:3F:D2:90:97:A6", "Vendor1", &env.underlay_segment),
-        FakeMachine::new("AA:AB:AC:AD:AA:02", "Vendor2", &env.underlay_segment),
+        FakeMachine::new(
+            "B8:3F:D2:90:97:A6",
+            "Vendor1",
+            env.underlay_segment.unwrap(),
+        ),
+        FakeMachine::new(
+            "AA:AB:AC:AD:AA:02",
+            "Vendor2",
+            env.underlay_segment.unwrap(),
+        ),
     ];
 
     machines.discover_dhcp(&env).await?;
@@ -1431,9 +1483,9 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
     const HOST1_MAC: &str = "AA:AB:AC:AD:AA:02";
     const HOST1_DPU_SERIAL_NUMBER: &str = "host1_dpu_serial_number";
 
-    let mut host1_dpu = FakeMachine::new(HOST1_DPU_MAC, "Vendor1", &env.underlay_segment);
+    let mut host1_dpu = FakeMachine::new(HOST1_DPU_MAC, "Vendor1", env.underlay_segment.unwrap());
 
-    let mut host1 = FakeMachine::new(HOST1_MAC, "Vendor2", &env.underlay_segment);
+    let mut host1 = FakeMachine::new(HOST1_MAC, "Vendor2", env.underlay_segment.unwrap());
 
     // Create dhcp entries and machine_interface entries for the machines
     for machine in [&mut host1_dpu, &mut host1] {
@@ -2236,7 +2288,11 @@ async fn test_site_explorer_unknown_vendor(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = common::api_fixtures::create_test_env(pool.clone()).await;
 
-    let mut machine = FakeMachine::new("B8:3F:D2:90:97:A7", "Vendor1", &env.underlay_segment);
+    let mut machine = FakeMachine::new(
+        "B8:3F:D2:90:97:A7",
+        "Vendor1",
+        env.underlay_segment.unwrap(),
+    );
     machine.discover_dhcp(&env).await?;
 
     let mut txn = env.pool.begin().await?;
@@ -2453,9 +2509,9 @@ async fn test_machine_creation_with_sku(
     const HOST1_MAC: &str = "AA:AB:AC:AD:AA:02";
     const HOST1_DPU_SERIAL_NUMBER: &str = "host1_dpu_serial_number";
 
-    let mut host1_dpu = FakeMachine::new(HOST1_DPU_MAC, "Vendor1", &env.underlay_segment);
+    let mut host1_dpu = FakeMachine::new(HOST1_DPU_MAC, "Vendor1", env.underlay_segment.unwrap());
 
-    let mut host1 = FakeMachine::new(HOST1_MAC, "Vendor2", &env.underlay_segment);
+    let mut host1 = FakeMachine::new(HOST1_MAC, "Vendor2", env.underlay_segment.unwrap());
 
     // Create dhcp entries and machine_interface entries for the machines
     for machine in [&mut host1_dpu, &mut host1] {
@@ -2610,9 +2666,21 @@ async fn test_expected_machine_device_type_metrics(
 
     // Create fake machines with network interfaces so they can be discovered
     let mut machines = vec![
-        FakeMachine::new(EXPECTED_MACHINE_1_MAC, "Vendor1", &env.underlay_segment),
-        FakeMachine::new(EXPECTED_MACHINE_2_MAC, "Vendor2", &env.underlay_segment),
-        FakeMachine::new(EXPECTED_MACHINE_3_MAC, "Vendor3", &env.underlay_segment),
+        FakeMachine::new(
+            EXPECTED_MACHINE_1_MAC,
+            "Vendor1",
+            env.underlay_segment.unwrap(),
+        ),
+        FakeMachine::new(
+            EXPECTED_MACHINE_2_MAC,
+            "Vendor2",
+            env.underlay_segment.unwrap(),
+        ),
+        FakeMachine::new(
+            EXPECTED_MACHINE_3_MAC,
+            "Vendor3",
+            env.underlay_segment.unwrap(),
+        ),
     ];
     machines.discover_dhcp(&env).await?;
 

--- a/crates/api/src/tests/static_address_management.rs
+++ b/crates/api/src/tests/static_address_management.rs
@@ -39,7 +39,7 @@ async fn test_assign_static_address(pool: sqlx::PgPool) -> Result<(), Box<dyn st
     let interface = db::machine_interface::validate_existing_mac_and_create(
         &mut txn,
         MacAddress::from_str("aa:bb:cc:dd:ee:10").unwrap(),
-        relay,
+        std::slice::from_ref(&relay),
         None,
     )
     .await?;
@@ -74,7 +74,7 @@ async fn test_assign_replaces_existing_static(
     let interface = db::machine_interface::validate_existing_mac_and_create(
         &mut txn,
         MacAddress::from_str("aa:bb:cc:dd:ee:11").unwrap(),
-        relay,
+        std::slice::from_ref(&relay),
         None,
     )
     .await?;
@@ -131,7 +131,7 @@ async fn test_assign_takes_over_dhcp_allocation(
     let interface = db::machine_interface::validate_existing_mac_and_create(
         &mut txn,
         MacAddress::from_str("aa:bb:cc:dd:ee:12").unwrap(),
-        relay,
+        std::slice::from_ref(&relay),
         None,
     )
     .await?;
@@ -182,7 +182,7 @@ async fn test_remove_static_address(pool: sqlx::PgPool) -> Result<(), Box<dyn st
     let interface = db::machine_interface::validate_existing_mac_and_create(
         &mut txn,
         MacAddress::from_str("aa:bb:cc:dd:ee:13").unwrap(),
-        relay,
+        std::slice::from_ref(&relay),
         None,
     )
     .await?;
@@ -233,7 +233,7 @@ async fn test_remove_nonexistent_returns_not_found(
     let interface = db::machine_interface::validate_existing_mac_and_create(
         &mut txn,
         MacAddress::from_str("aa:bb:cc:dd:ee:14").unwrap(),
-        relay,
+        std::slice::from_ref(&relay),
         None,
     )
     .await?;
@@ -268,7 +268,7 @@ async fn test_remove_dhcp_address_returns_not_found(
     let interface = db::machine_interface::validate_existing_mac_and_create(
         &mut txn,
         MacAddress::from_str("aa:bb:cc:dd:ee:25").unwrap(),
-        relay,
+        std::slice::from_ref(&relay),
         None,
     )
     .await?;
@@ -313,7 +313,7 @@ async fn test_find_interface_addresses_shows_types(
     let interface = db::machine_interface::validate_existing_mac_and_create(
         &mut txn,
         MacAddress::from_str("aa:bb:cc:dd:ee:15").unwrap(),
-        relay,
+        std::slice::from_ref(&relay),
         None,
     )
     .await?;
@@ -345,8 +345,13 @@ async fn test_assign_remove_then_dhcp_reallocates(
     // First, create the interface, clear its DHCP address, and
     // a assign static one.
     let mut txn = env.pool.begin().await?;
-    let interface =
-        db::machine_interface::validate_existing_mac_and_create(&mut txn, mac, relay, None).await?;
+    let interface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        mac,
+        std::slice::from_ref(&relay),
+        None,
+    )
+    .await?;
     db::machine_interface_address::delete(&mut txn, &interface.id).await?;
     txn.commit().await?;
 
@@ -421,7 +426,7 @@ async fn test_assign_moves_interface_to_correct_segment(
     let interface = db::machine_interface::validate_existing_mac_and_create(
         &mut txn,
         MacAddress::from_str("aa:bb:cc:dd:ee:20").unwrap(),
-        relay,
+        std::slice::from_ref(&relay),
         None,
     )
     .await?;
@@ -429,7 +434,7 @@ async fn test_assign_moves_interface_to_correct_segment(
     txn.commit().await?;
 
     // Interface is on the admin segment (192.0.2.0/24).
-    assert_eq!(interface.segment_id, env.admin_segment.unwrap());
+    assert_eq!(interface.segment_id, env.admin_segment());
 
     // Assign a static IP in the underlay segment's range (192.0.1.0/24).
     env.api
@@ -465,14 +470,14 @@ async fn test_assign_external_ip_moves_to_static_assignments(
     let interface = db::machine_interface::validate_existing_mac_and_create(
         &mut txn,
         MacAddress::from_str("aa:bb:cc:dd:ee:21").unwrap(),
-        relay,
+        std::slice::from_ref(&relay),
         None,
     )
     .await?;
     db::machine_interface_address::delete(&mut txn, &interface.id).await?;
     txn.commit().await?;
 
-    assert_eq!(interface.segment_id, env.admin_segment.unwrap());
+    assert_eq!(interface.segment_id, env.admin_segment());
 
     // Assign an external IP (not in any managed segment).
     env.api
@@ -512,7 +517,7 @@ async fn test_assign_within_same_segment_no_move(
     let interface = db::machine_interface::validate_existing_mac_and_create(
         &mut txn,
         MacAddress::from_str("aa:bb:cc:dd:ee:22").unwrap(),
-        relay,
+        std::slice::from_ref(&relay),
         None,
     )
     .await?;
@@ -614,7 +619,7 @@ async fn test_dhcp_moves_interface_back_from_static_assignments(
     let updated = db::machine_interface::find_one(&mut *txn, interface_id).await?;
     assert_eq!(
         updated.segment_id,
-        env.admin_segment.unwrap(),
+        env.admin_segment(),
         "interface should have moved back to admin segment from static-assignments"
     );
     assert!(
@@ -716,19 +721,22 @@ async fn test_reserved_segment_serves_static_reservation(
     // Set the admin segment to reserved allocation strategy.
     let mut txn = env.pool.begin().await?;
     sqlx::query("UPDATE network_segments SET allocation_strategy = 'reserved' WHERE id = $1")
-        .bind(env.admin_segment.unwrap())
+        .bind(env.admin_segment())
         .execute(&mut *txn)
         .await?;
     txn.commit().await?;
 
     // Create a static reservation for this MAC on the admin segment.
     let mut txn = env.pool.begin().await?;
-    let admin_seg = db::network_segment::admin(&mut txn).await?;
+    let admin_seg = db::network_segment::admin(&mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .unwrap();
     db::machine_interface::create(
         &mut txn,
-        &admin_seg,
+        std::slice::from_ref(&admin_seg),
         &bmc_mac,
-        admin_seg.subdomain_id,
         true,
         model::address_selection_strategy::AddressSelectionStrategy::StaticAddress(reserved_ip),
     )
@@ -766,7 +774,7 @@ async fn test_reserved_segment_rejects_unknown_mac(
     // Set the admin segment to reserved allocation strategy.
     let mut txn = env.pool.begin().await?;
     sqlx::query("UPDATE network_segments SET allocation_strategy = 'reserved' WHERE id = $1")
-        .bind(env.admin_segment.unwrap())
+        .bind(env.admin_segment())
         .execute(&mut *txn)
         .await?;
     txn.commit().await?;

--- a/crates/api/src/tests/tpm_ca.rs
+++ b/crates/api/src/tests/tpm_ca.rs
@@ -69,7 +69,7 @@ pub mod tests {
 
         let segment = db::network_segment::find_by(
             txn.as_mut(),
-            ObjectColumnFilter::One(db::network_segment::IdColumn, &env.admin_segment.unwrap()),
+            ObjectColumnFilter::One(db::network_segment::IdColumn, env.admin_segment_ref()),
             network_segment::NetworkSegmentSearchConfig::default(),
         )
         .await
@@ -78,9 +78,8 @@ pub mod tests {
 
         let iface = db::machine_interface::create(
             &mut txn,
-            &segment,
+            std::slice::from_ref(&segment),
             &dpu.host_mac_address,
-            Some(env.domain.into()),
             true,
             model::address_selection_strategy::AddressSelectionStrategy::NextAvailableIp,
         )
@@ -120,7 +119,7 @@ pub mod tests {
 
         let segment = db::network_segment::find_by(
             txn.as_mut(),
-            ObjectColumnFilter::One(db::network_segment::IdColumn, &env.admin_segment.unwrap()),
+            ObjectColumnFilter::One(db::network_segment::IdColumn, env.admin_segment_ref()),
             network_segment::NetworkSegmentSearchConfig::default(),
         )
         .await
@@ -129,9 +128,8 @@ pub mod tests {
 
         let iface = db::machine_interface::create(
             &mut txn,
-            &segment,
+            std::slice::from_ref(&segment),
             &dpu.host_mac_address,
-            Some(env.domain.into()),
             true,
             model::address_selection_strategy::AddressSelectionStrategy::NextAvailableIp,
         )
@@ -1183,7 +1181,7 @@ pub mod tests {
 
         let segment = db::network_segment::find_by(
             txn.as_mut(),
-            ObjectColumnFilter::One(db::network_segment::IdColumn, &env.admin_segment.unwrap()),
+            ObjectColumnFilter::One(db::network_segment::IdColumn, env.admin_segment_ref()),
             network_segment::NetworkSegmentSearchConfig::default(),
         )
         .await
@@ -1192,9 +1190,8 @@ pub mod tests {
 
         let iface = db::machine_interface::create(
             &mut txn,
-            &segment,
+            std::slice::from_ref(&segment),
             &dpu.host_mac_address,
-            Some(env.domain.into()),
             true,
             model::address_selection_strategy::AddressSelectionStrategy::NextAvailableIp,
         )

--- a/crates/api/src/tests/vpc.rs
+++ b/crates/api/src/tests/vpc.rs
@@ -853,9 +853,11 @@ async fn create_admin_vpc(pool: sqlx::PgPool) -> Result<(), eyre::Report> {
         VpcVirtualizationType::Fnn
     );
 
-    let admin_segment = db::network_segment::admin(&mut txn).await?;
+    let admin_segments = db::network_segment::admin(&mut txn).await?;
 
-    assert_eq!(admin_vpc.id, admin_segment.vpc_id.unwrap());
+    for admin_segment in admin_segments {
+        assert_eq!(admin_vpc.id, admin_segment.vpc_id.unwrap());
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Description
Up to now, we've only permitted config for a single admin network-segment.  This PR opens things up to allow multiple segments.  I was tempted to restrict this to only FNN, but there's no reason this should be blocked on sites using legacy admin VPC settings.

This does NOT mean multiple admin network interfaces, only multiple sources to choose from when selecting the admin IP of a host.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

