### PR TITLE
Support health overrides for DPU Machines

### DIFF
--- a/crates/admin-cli/src/dpu/health_report/args.rs
+++ b/crates/admin-cli/src/dpu/health_report/args.rs
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::machine::MachineId;
+use clap::{ArgGroup, Parser};
+
+use crate::machine::HealthReportTemplates;
+
+#[derive(Parser, Debug)]
+pub enum Args {
+    #[clap(about = "List health report sources for a DPU")]
+    Show { dpu_id: MachineId },
+    #[clap(about = "Insert a health report source for a DPU")]
+    Add(HealthAddOptions),
+    #[clap(about = "Print an empty health report template")]
+    PrintEmptyTemplate,
+    #[clap(about = "Remove a health report source from a DPU")]
+    Remove {
+        dpu_id: MachineId,
+        report_source: String,
+    },
+}
+
+#[derive(Parser, Debug)]
+#[clap(group(ArgGroup::new("health_report_source").required(true).args(&["health_report", "template"])))]
+pub struct HealthAddOptions {
+    pub dpu_id: MachineId,
+    #[clap(long, help = "New health report as json")]
+    pub health_report: Option<String>,
+    #[clap(long, help = "Predefined Template name")]
+    pub template: Option<HealthReportTemplates>,
+    #[clap(long, help = "Message to be filled in template.")]
+    pub message: Option<String>,
+    #[clap(long, help = "Replace the DPU health contribution with this source")]
+    pub replace: bool,
+    #[clap(long, help = "Print the template that is going to be sent to carbide")]
+    pub print_only: bool,
+}

--- a/crates/admin-cli/src/dpu/health_report/cmd.rs
+++ b/crates/admin-cli/src/dpu/health_report/cmd.rs
@@ -1,0 +1,82 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use carbide_uuid::machine::MachineId;
+
+use super::args::Args;
+use crate::health_utils;
+use crate::rpc::ApiClient;
+
+pub async fn handle_health_report(
+    command: Args,
+    output_format: OutputFormat,
+    api_client: &ApiClient,
+) -> CarbideCliResult<()> {
+    match command {
+        Args::Show { dpu_id } => {
+            ensure_dpu_id(dpu_id)?;
+            let response = api_client.machine_list_health_reports(dpu_id).await?;
+            health_utils::display_health_reports(response.health_report_entries, output_format)?;
+        }
+        Args::Add(options) => {
+            ensure_dpu_id(options.dpu_id)?;
+            let report = health_utils::resolve_health_report(
+                options.template,
+                options.health_report,
+                options.message,
+            )?;
+
+            if options.print_only {
+                println!("{}", serde_json::to_string_pretty(&report).unwrap());
+                return Ok(());
+            }
+
+            api_client
+                .machine_insert_health_report_override(
+                    options.dpu_id,
+                    report.into(),
+                    options.replace,
+                )
+                .await?;
+        }
+        Args::Remove {
+            dpu_id,
+            report_source,
+        } => {
+            ensure_dpu_id(dpu_id)?;
+            api_client
+                .machine_remove_health_report(dpu_id, report_source)
+                .await?;
+        }
+        Args::PrintEmptyTemplate => {
+            health_utils::print_empty_template();
+        }
+    }
+
+    Ok(())
+}
+
+fn ensure_dpu_id(dpu_id: MachineId) -> CarbideCliResult<()> {
+    if dpu_id.machine_type().is_dpu() {
+        Ok(())
+    } else {
+        Err(CarbideCliError::GenericError(format!(
+            "{dpu_id} is not a DPU machine ID"
+        )))
+    }
+}

--- a/crates/admin-cli/src/dpu/health_report/mod.rs
+++ b/crates/admin-cli/src/dpu/health_report/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::handle_health_report(self, ctx.config.format, &ctx.api_client).await
+    }
+}

--- a/crates/admin-cli/src/dpu/mod.rs
+++ b/crates/admin-cli/src/dpu/mod.rs
@@ -16,6 +16,7 @@
  */
 
 mod agent_upgrade_policy;
+mod health_report;
 mod network;
 mod reprovision;
 mod status;
@@ -43,4 +44,10 @@ pub enum Cmd {
     Status(status::Args),
     #[clap(subcommand, about = "Networking information")]
     Network(network::Args),
+    #[clap(
+        about = "Manage DPU health report sources",
+        subcommand,
+        visible_alias = "hr"
+    )]
+    HealthReport(health_report::Args),
 }

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -442,12 +442,21 @@ impl ManagedHostStateSnapshot {
                 }
             };
 
-        let mut has_hardware_health = false;
-
         // Merge DPU's alerts.  If DPU alerts should be suppressed, than remove the classification from the
         // alert so that metrics won't show a critical issue.
         let suppress_dpu_alerts = self.managed_state.suppress_dpu_alerts();
         for snapshot in self.dpu_snapshots.iter_mut() {
+            if let Some(over) = snapshot.health_reports.replace.as_mut() {
+                let source = over.source.clone();
+                Self::merge_override_report_with_hw_health(
+                    &mut output,
+                    &source,
+                    over,
+                    host_health_config.hardware_health_reports,
+                );
+                continue;
+            }
+
             let health_report = if suppress_dpu_alerts {
                 let mut health_report = snapshot.dpu_agent_health_report().cloned();
 
@@ -479,16 +488,16 @@ impl ManagedHostStateSnapshot {
                 .iter_mut()
                 .filter(|(source, _)| source.as_str() != HealthReport::DPU_AGENT_SOURCE)
             {
-                let merged_hardware = Self::merge_override_report_with_hw_health(
+                Self::merge_override_report_with_hw_health(
                     &mut output,
                     source,
                     over,
                     host_health_config.hardware_health_reports,
                 );
-                has_hardware_health |= merged_hardware;
             }
         }
 
+        let mut has_host_hardware_health = false;
         for (source, over) in self.host_snapshot.health_reports.merges.iter_mut() {
             let merged_hardware = Self::merge_override_report_with_hw_health(
                 &mut output,
@@ -496,11 +505,11 @@ impl ManagedHostStateSnapshot {
                 over,
                 host_health_config.hardware_health_reports,
             );
-            has_hardware_health |= merged_hardware;
+            has_host_hardware_health |= merged_hardware;
         }
 
         if host_health_config.hardware_health_reports == HardwareHealthReportsConfig::Enabled
-            && !has_hardware_health
+            && !has_host_hardware_health
         {
             merge_or_timeout(&mut output, &None, "hardware-health".to_string());
         }

--- a/crates/api/src/handlers/health.rs
+++ b/crates/api/src/handlers/health.rs
@@ -35,7 +35,7 @@ pub async fn list_machine_health_reports(
 
     let machine_id = convert_and_log_machine_id(Some(&machine_id.into_inner()))?;
 
-    let host_machine = db::machine::find_one(&mut txn, &machine_id, MachineSearchConfig::default())
+    let machine = db::machine::find_one(&mut txn, &machine_id, MachineSearchConfig::default())
         .await?
         .ok_or_else(|| CarbideError::NotFoundError {
             kind: "machine",
@@ -45,7 +45,7 @@ pub async fn list_machine_health_reports(
     txn.commit().await?;
 
     Ok(Response::new(rpc::ListHealthReportResponse {
-        health_report_entries: host_machine
+        health_report_entries: machine
             .health_reports
             .clone()
             .into_iter()
@@ -62,7 +62,7 @@ async fn remove_by_source(
     machine_id: MachineId,
     source: String,
 ) -> Result<(), CarbideError> {
-    let host_machine = db::machine::find_one(
+    let machine = db::machine::find_one(
         &mut *txn,
         &machine_id,
         MachineSearchConfig {
@@ -79,15 +79,9 @@ async fn remove_by_source(
     })?;
 
     // Ensure this source already exists in override list
-    let mode = if host_machine
-        .health_reports
-        .replace
-        .as_ref()
-        .map(|o| &o.source)
-        == Some(&source)
-    {
+    let mode = if machine.health_reports.replace.as_ref().map(|o| &o.source) == Some(&source) {
         HealthReportApplyMode::Replace
-    } else if host_machine.health_reports.merges.contains_key(&source) {
+    } else if machine.health_reports.merges.contains_key(&source) {
         HealthReportApplyMode::Merge
     } else {
         return Err(CarbideError::NotFoundError {
@@ -116,7 +110,7 @@ pub async fn insert_machine_health_report(
         health_report_entry: Some(rpc::HealthReportEntry { report, mode }),
     } = request.into_inner()
     else {
-        return Err(CarbideError::MissingArgument("override").into());
+        return Err(CarbideError::MissingArgument("health_report_entry").into());
     };
     let machine_id = convert_and_log_machine_id(machine_id.as_ref())?;
     let Some(report) = report else {
@@ -126,13 +120,13 @@ pub async fn insert_machine_health_report(
         return Err(CarbideError::InvalidArgument("mode".to_string()).into());
     };
     let mode: HealthReportApplyMode = mode.into();
-    if machine_id.machine_type().is_dpu() && mode == HealthReportApplyMode::Replace {
-        return Err(CarbideError::InvalidArgument(
-            "DPU's cannot have HealthReportApplyMode::Replace health report overrides".to_string(),
-        )
-        .into());
-    }
     let mut txn = api.txn_begin().await?;
+    let _machine = db::machine::find_one(&mut txn, &machine_id, MachineSearchConfig::default())
+        .await?
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "machine",
+            id: machine_id.to_string(),
+        })?;
 
     let mut report = health_report::HealthReport::try_from(report.clone())
         .map_err(|e| CarbideError::internal(e.to_string()))?;

--- a/crates/api/src/tests/machine_health.rs
+++ b/crates/api/src/tests/machine_health.rs
@@ -535,23 +535,152 @@ async fn test_machine_health_history(pool: sqlx::PgPool) -> Result<(), Box<dyn s
 }
 
 #[crate::sqlx_test]
-async fn test_attempt_dpu_override(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
+async fn test_dpu_replace_override_replaces_dpu_health_contribution(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_env(pool).await;
 
-    let (_, dpu_machine_id) = create_managed_host(&env).await.into();
-    use rpc::forge::forge_server::Forge;
-    use tonic::Request;
-    let _ = env
-        .api
-        .insert_machine_health_report(Request::new(rpc::forge::InsertMachineHealthReportRequest {
-            machine_id: Some(dpu_machine_id),
-            health_report_entry: Some(rpc::forge::HealthReportEntry {
-                report: Some(health_report::HealthReport::empty("".to_string()).into()),
-                mode: health_report::HealthReportApplyMode::Replace as i32,
-            }),
-        }))
+    let (host_machine_id, dpu_machine_id) = create_managed_host(&env).await.into();
+    let merge_report = hr(
+        "manual-dpu-merge",
+        vec![],
+        vec![("ManualDpuMerge", Some("DPU"), "Manual DPU merge alert")],
+    );
+    send_health_report_entry(
+        &env,
+        &dpu_machine_id,
+        (merge_report, HealthReportApplyMode::Merge),
+    )
+    .await;
+
+    let host_health = load_health_via_find_machines_by_ids(&env, &host_machine_id)
         .await
-        .expect_err("Should not be able to add HealthReportApplyMode::Replace on dpu");
+        .unwrap();
+    assert!(
+        host_health
+            .alerts
+            .iter()
+            .any(|alert| alert.id.as_str() == "ManualDpuMerge")
+    );
+
+    let replace_report = hr(
+        "manual-dpu-replace",
+        vec![],
+        vec![("ManualDpuReplace", Some("DPU"), "Manual DPU replace alert")],
+    );
+    send_health_report_entry(
+        &env,
+        &dpu_machine_id,
+        (replace_report, HealthReportApplyMode::Replace),
+    )
+    .await;
+
+    let dpu_health = load_health_via_find_machines_by_ids(&env, &dpu_machine_id)
+        .await
+        .unwrap();
+    assert!(
+        dpu_health
+            .alerts
+            .iter()
+            .any(|alert| alert.id.as_str() == "ManualDpuReplace")
+    );
+    assert!(
+        !dpu_health
+            .alerts
+            .iter()
+            .any(|alert| alert.id.as_str() == "ManualDpuMerge")
+    );
+
+    let host_health = load_health_via_find_machines_by_ids(&env, &host_machine_id)
+        .await
+        .unwrap();
+    assert!(
+        host_health
+            .alerts
+            .iter()
+            .any(|alert| alert.id.as_str() == "ManualDpuReplace")
+    );
+    assert!(
+        !host_health
+            .alerts
+            .iter()
+            .any(|alert| alert.id.as_str() == "ManualDpuMerge")
+    );
+
+    remove_health_report_entry(&env, &dpu_machine_id, "manual-dpu-replace".to_string()).await;
+
+    let host_health = load_health_via_find_machines_by_ids(&env, &host_machine_id)
+        .await
+        .unwrap();
+    assert!(
+        host_health
+            .alerts
+            .iter()
+            .any(|alert| alert.id.as_str() == "ManualDpuMerge")
+    );
+    assert!(
+        !host_health
+            .alerts
+            .iter()
+            .any(|alert| alert.id.as_str() == "ManualDpuReplace")
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_can_manage_dpu_merge_health_report(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_env(pool).await;
+
+    let (host_machine_id, dpu_machine_id) = create_managed_host(&env).await.into();
+    let report = hr(
+        "manual-dpu-alert",
+        vec![],
+        vec![("ManualDpuAlert", Some("DPU"), "Manual DPU alert")],
+    );
+
+    send_health_report_entry(
+        &env,
+        &dpu_machine_id,
+        (report, HealthReportApplyMode::Merge),
+    )
+    .await;
+
+    let dpu = find_machine(&env, &dpu_machine_id).await;
+    assert!(dpu.health_sources.iter().any(|source| {
+        source.mode == HealthReportApplyMode::Merge as i32 && source.source == "manual-dpu-alert"
+    }));
+
+    let host_health = load_health_via_find_machines_by_ids(&env, &host_machine_id)
+        .await
+        .unwrap();
+    assert!(
+        host_health
+            .alerts
+            .iter()
+            .any(|alert| alert.id.as_str() == "ManualDpuAlert")
+    );
+
+    remove_health_report_entry(&env, &dpu_machine_id, "manual-dpu-alert".to_string()).await;
+
+    let dpu = find_machine(&env, &dpu_machine_id).await;
+    assert!(
+        !dpu.health_sources
+            .iter()
+            .any(|source| source.source == "manual-dpu-alert")
+    );
+
+    let host_health = load_health_via_find_machines_by_ids(&env, &host_machine_id)
+        .await
+        .unwrap();
+    assert!(
+        !host_health
+            .alerts
+            .iter()
+            .any(|alert| alert.id.as_str() == "ManualDpuAlert")
+    );
 
     Ok(())
 }

--- a/crates/api/src/tests/web/health.rs
+++ b/crates/api/src/tests/web/health.rs
@@ -99,78 +99,140 @@ async fn test_add_remove_health_report_via_web_ui(pool: sqlx::PgPool) {
         }
     }"#;
 
-    let response = app
-        .clone()
-        .oneshot(
-            web_request_builder()
-                .method(Method::POST)
-                .uri(format!(
-                    "/admin/machine/{host_machine_id}/health/add-report"
-                ))
-                .header("Content-Type", "application/json")
-                .body(Body::from(payload))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
+    post_machine_health_report(&app, &host_machine_id.to_string(), "add-report", payload).await;
 
-    let response = app
-        .clone()
-        .oneshot(
-            web_request_builder()
-                .uri(format!("/admin/machine/{host_machine_id}/health"))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
-
-    let body_bytes = response
-        .into_body()
-        .collect()
-        .await
-        .expect("Empty response body?")
-        .to_bytes();
-    let body = String::from_utf8_lossy(&body_bytes);
+    let body = get_machine_health_page(&app, &host_machine_id.to_string()).await;
     assert!(body.contains("web-health-test"));
 
-    let response = app
-        .clone()
-        .oneshot(
-            web_request_builder()
-                .method(Method::POST)
-                .uri(format!(
-                    "/admin/machine/{host_machine_id}/health/remove-report"
-                ))
-                .header("Content-Type", "application/json")
-                .body(Body::from(r#"{"source":"web-health-test"}"#))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
+    post_machine_health_report(
+        &app,
+        &host_machine_id.to_string(),
+        "remove-report",
+        r#"{"source":"web-health-test"}"#,
+    )
+    .await;
 
-    let response = app
-        .oneshot(
-            web_request_builder()
-                .uri(format!("/admin/machine/{host_machine_id}/health"))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
-
-    let body_bytes = response
-        .into_body()
-        .collect()
-        .await
-        .expect("Empty response body?")
-        .to_bytes();
-    let body = String::from_utf8_lossy(&body_bytes);
+    let body = get_machine_health_page(&app, &host_machine_id.to_string()).await;
     assert!(!body.contains("web-health-test"));
+}
+
+#[crate::sqlx_test]
+async fn test_add_replace_remove_dpu_health_report_via_web_ui(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let app = make_test_app(&env);
+    let (host_machine_id, dpu_machine_id) = create_managed_host(&env).await.into();
+
+    let merge_payload = r#"{
+        "mode": "Merge",
+        "health_report": {
+            "source": "web-dpu-merge-health-test",
+            "triggered_by": null,
+            "observed_at": null,
+            "successes": [],
+            "alerts": [{
+                "id": "DpuMergeWebHealth",
+                "target": null,
+                "in_alert_since": null,
+                "message": "dpu merge web health",
+                "tenant_message": null,
+                "classifications": ["PreventAllocations"]
+            }]
+        }
+    }"#;
+    post_machine_health_report(
+        &app,
+        &dpu_machine_id.to_string(),
+        "add-report",
+        merge_payload,
+    )
+    .await;
+
+    let dpu_health = get_machine_health_page(&app, &dpu_machine_id.to_string()).await;
+    let dpu_aggregate_health = aggregate_health_section(&dpu_health);
+    assert!(dpu_aggregate_health.contains("DpuMergeWebHealth"));
+    assert!(dpu_aggregate_health.contains("dpu merge web health"));
+
+    let host_health = get_machine_health_page(&app, &host_machine_id.to_string()).await;
+    let host_aggregate_health = aggregate_health_section(&host_health);
+    assert!(host_aggregate_health.contains("DpuMergeWebHealth"));
+    assert!(host_aggregate_health.contains("dpu merge web health"));
+
+    let replace_payload = r#"{
+        "mode": "Replace",
+        "health_report": {
+            "source": "web-dpu-replace-health-test",
+            "triggered_by": null,
+            "observed_at": null,
+            "successes": [],
+            "alerts": [{
+                "id": "DpuReplaceWebHealth",
+                "target": null,
+                "in_alert_since": null,
+                "message": "dpu replace web health",
+                "tenant_message": null,
+                "classifications": ["PreventAllocations"]
+            }]
+        }
+    }"#;
+    post_machine_health_report(
+        &app,
+        &dpu_machine_id.to_string(),
+        "add-report",
+        replace_payload,
+    )
+    .await;
+
+    let dpu_health = get_machine_health_page(&app, &dpu_machine_id.to_string()).await;
+    let dpu_aggregate_health = aggregate_health_section(&dpu_health);
+    assert!(dpu_aggregate_health.contains("DpuReplaceWebHealth"));
+    assert!(dpu_aggregate_health.contains("dpu replace web health"));
+    assert!(!dpu_aggregate_health.contains("DpuMergeWebHealth"));
+    assert!(!dpu_aggregate_health.contains("dpu merge web health"));
+
+    let host_health = get_machine_health_page(&app, &host_machine_id.to_string()).await;
+    let host_aggregate_health = aggregate_health_section(&host_health);
+    assert!(host_aggregate_health.contains("DpuReplaceWebHealth"));
+    assert!(host_aggregate_health.contains("dpu replace web health"));
+    assert!(!host_aggregate_health.contains("DpuMergeWebHealth"));
+    assert!(!host_aggregate_health.contains("dpu merge web health"));
+
+    post_machine_health_report(
+        &app,
+        &dpu_machine_id.to_string(),
+        "remove-report",
+        r#"{"source":"web-dpu-replace-health-test"}"#,
+    )
+    .await;
+
+    let dpu_health = get_machine_health_page(&app, &dpu_machine_id.to_string()).await;
+    let dpu_aggregate_health = aggregate_health_section(&dpu_health);
+    assert!(dpu_aggregate_health.contains("DpuMergeWebHealth"));
+    assert!(!dpu_aggregate_health.contains("DpuReplaceWebHealth"));
+
+    let host_health = get_machine_health_page(&app, &host_machine_id.to_string()).await;
+    let host_aggregate_health = aggregate_health_section(&host_health);
+    assert!(host_aggregate_health.contains("DpuMergeWebHealth"));
+    assert!(!host_aggregate_health.contains("DpuReplaceWebHealth"));
+
+    post_machine_health_report(
+        &app,
+        &dpu_machine_id.to_string(),
+        "remove-report",
+        r#"{"source":"web-dpu-merge-health-test"}"#,
+    )
+    .await;
+
+    let dpu_health = get_machine_health_page(&app, &dpu_machine_id.to_string()).await;
+    let dpu_aggregate_health = aggregate_health_section(&dpu_health);
+    assert!(!dpu_aggregate_health.contains("DpuMergeWebHealth"));
+    assert!(!dpu_aggregate_health.contains("DpuReplaceWebHealth"));
+    assert!(!dpu_health.contains("web-dpu-merge-health-test"));
+    assert!(!dpu_health.contains("web-dpu-replace-health-test"));
+
+    let host_health = get_machine_health_page(&app, &host_machine_id.to_string()).await;
+    let host_aggregate_health = aggregate_health_section(&host_health);
+    assert!(!host_aggregate_health.contains("DpuMergeWebHealth"));
+    assert!(!host_aggregate_health.contains("DpuReplaceWebHealth"));
 }
 
 #[crate::sqlx_test]
@@ -529,4 +591,58 @@ async fn test_health_of_power_shelf(pool: sqlx::PgPool) {
         .to_bytes();
     let body = String::from_utf8_lossy(&body_bytes);
     assert!(!body.contains("web-power-shelf-health-test"));
+}
+
+async fn post_machine_health_report(
+    app: &axum::Router,
+    machine_id: &str,
+    action: &str,
+    payload: &str,
+) {
+    let response = app
+        .clone()
+        .oneshot(
+            web_request_builder()
+                .method(Method::POST)
+                .uri(format!("/admin/machine/{machine_id}/health/{action}"))
+                .header("Content-Type", "application/json")
+                .body(Body::from(payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+async fn get_machine_health_page(app: &axum::Router, machine_id: &str) -> String {
+    let response = app
+        .clone()
+        .oneshot(
+            web_request_builder()
+                .uri(format!("/admin/machine/{machine_id}/health"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body_bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("Empty response body?")
+        .to_bytes();
+    String::from_utf8_lossy(&body_bytes).into_owned()
+}
+
+fn aggregate_health_section(body: &str) -> &str {
+    let active_reports_start = body
+        .find("<h2>Active Health Reports</h2>")
+        .unwrap_or(usize::MAX);
+    let management_start = body
+        .find("<h2>Health Report Management</h2>")
+        .unwrap_or(usize::MAX);
+    let end = active_reports_start.min(management_start).min(body.len());
+    &body[..end]
 }

--- a/crates/api/src/web/health.rs
+++ b/crates/api/src/web/health.rs
@@ -136,7 +136,11 @@ impl HealthObject {
     }
 
     fn show_machine_templates(&self) -> bool {
-        matches!(self, HealthObject::Machine(_))
+        matches!(
+            self,
+            HealthObject::Machine(id)
+                if id.machine_type().is_host() || id.machine_type().is_predicted_host()
+        )
     }
 }
 
@@ -160,13 +164,6 @@ pub async fn machine_health(
     let Ok(machine_id) = MachineId::from_str(&machine_id) else {
         return (StatusCode::BAD_REQUEST, "invalid machine id").into_response();
     };
-    if machine_id.machine_type().is_dpu() {
-        return (
-            StatusCode::NOT_FOUND,
-            "no health for dpu. see host machine instead",
-        )
-            .into_response();
-    }
 
     let data = match fetch_machine_health_page_data(&state, &machine_id).await {
         Ok(data) => data,

--- a/crates/api/src/web/health_history.rs
+++ b/crates/api/src/web/health_history.rs
@@ -72,12 +72,6 @@ pub async fn fetch_health_records(
     let Ok(machine_id) = MachineId::from_str(machine_id) else {
         return Err((StatusCode::BAD_REQUEST, "invalid machine id".to_string()));
     };
-    if machine_id.machine_type().is_dpu() {
-        return Err((
-            StatusCode::NOT_FOUND,
-            "no health for dpu. see host machine instead".to_string(),
-        ));
-    }
 
     let health_records = match fetch_health_history(api, &machine_id).await {
         Ok(records) => records,

--- a/crates/api/src/web/machine.rs
+++ b/crates/api/src/web/machine.rs
@@ -642,14 +642,14 @@ impl From<forgerpc::Machine> for MachineDetail<'_> {
         let host_id = m
             .associated_host_machine_id
             .map_or_else(String::default, |id| id.to_string());
-        let health_reports_url = if is_host || host_id.is_empty() {
-            format!("/admin/machine/{machine_id}/health")
+        let health_reports_link_text = if is_host {
+            "Go to Host health reports"
         } else {
-            format!("/admin/machine/{host_id}/health")
+            "Go to DPU health reports"
         };
         let health_detail = super::HealthDetail::new(
-            health_reports_url,
-            "Go to ManagedHost health reports",
+            format!("/admin/machine/{machine_id}/health"),
+            health_reports_link_text,
             m.health,
             m.health_sources,
         );

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -4674,7 +4674,7 @@ message HealthReportEntry {
   HealthReportApplyMode mode = 2;
 }
 
-// Request to insert a health report source for a Machine.
+// Request to insert a health report source for a Host or DPU Machine.
 message InsertMachineHealthReportRequest {
   common.MachineId machine_id = 1;
   HealthReportEntry health_report_entry = 2;
@@ -4735,7 +4735,7 @@ message ListHealthReportResponse {
   repeated HealthReportEntry health_report_entries = 1;
 }
 
-// Request to remove a health report source for a Machine.
+// Request to remove a health report source from a host or DPU Machine.
 message RemoveMachineHealthReportRequest {
   common.MachineId machine_id = 1;
   string source = 2;


### PR DESCRIPTION
## Description

Allow machine health report APIs to manage DPU health reports, including replace reports. When a DPU replace report is set, use it as that DPU's sole contribution to managed host aggregate health; otherwise continue merging the DPU merge reports.

Add DPU health-report commands to the admin CLI and expose DPU health management in the admin web UI. Update web/API tests for DPU merge, replace, and removal behavior.

Fix an issue where derive_aggregate_health considered any hw-health report (host or DPU) as a valid hw-health report which prevented seeing "heartbeat-timeout" on for hw-health on hosts. Now only the actual host health report is considered.

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)>

JIRA FORGE-6662

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

