### PR TITLE
chore(pxe): use client IP as the machine boot identifier

### DIFF
--- a/crates/api-model/src/pxe.rs
+++ b/crates/api-model/src/pxe.rs
@@ -15,38 +15,55 @@
  * limitations under the License.
  */
 
+use std::net::IpAddr;
+
 use carbide_uuid::machine::MachineInterfaceId;
 use rpc::forge::MachineArchitecture;
 
 pub struct PxeInstructionRequest {
-    pub interface_id: MachineInterfaceId,
     pub arch: MachineArchitecture,
     pub product: Option<String>,
+    pub client_ip: IpAddr,
 }
 
 impl TryFrom<rpc::forge::PxeInstructionRequest> for PxeInstructionRequest {
     type Error = rpc::errors::RpcDataConversionError;
 
     fn try_from(value: rpc::forge::PxeInstructionRequest) -> Result<Self, Self::Error> {
-        let interface_id =
-            value
-                .interface_id
-                .ok_or(rpc::errors::RpcDataConversionError::MissingArgument(
-                    "Interface ID",
-                ))?;
-
         let arch = rpc::forge::MachineArchitecture::try_from(value.arch).map_err(|_| {
             rpc::errors::RpcDataConversionError::InvalidArgument(
                 "Unknown arch received.".to_string(),
             )
         })?;
 
+        let client_ip_str =
+            value
+                .client_ip
+                .ok_or(rpc::errors::RpcDataConversionError::MissingArgument(
+                    "client_ip",
+                ))?;
+        let client_ip: IpAddr = client_ip_str.parse().map_err(|e| {
+            rpc::errors::RpcDataConversionError::InvalidArgument(format!(
+                "Failed parsing client_ip '{client_ip_str}': {e}"
+            ))
+        })?;
+
         let product = value.product;
 
         Ok(PxeInstructionRequest {
-            interface_id,
             arch,
             product,
+            client_ip,
         })
     }
+}
+
+/// Input provided to `PxeInstructions::get_pxe_instructions`.
+/// The PxeInstructionsRequest model contains the client_ip
+/// as determined by carbide-pxe, whereas PxeInstructionsInput
+/// contains the resolved machine_interface_id.
+pub struct PxeInstructionsInput {
+    pub interface_id: MachineInterfaceId,
+    pub arch: MachineArchitecture,
+    pub product: Option<String>,
 }

--- a/crates/api/src/handlers/client_resolution.rs
+++ b/crates/api/src/handlers/client_resolution.rs
@@ -1,0 +1,255 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::HashSet;
+use std::net::IpAddr;
+
+use ::rpc::forge as rpc;
+use db;
+use model::instance::snapshot::InstanceSnapshot;
+use model::machine::MachineInterfaceSnapshot;
+use sqlx::PgConnection;
+
+use crate::CarbideError;
+use crate::api::Api;
+
+/// What `resolve_client_ip` returned. Either the IP belongs directly
+/// to a `machine_interface` (admin / host case), or it belongs to a
+/// tenant-allocated `instance_address` (instance case).
+#[allow(clippy::large_enum_variant)]
+enum ResolvedClient {
+    Interface(MachineInterfaceSnapshot),
+    Instance(InstanceSnapshot),
+}
+
+/// This is a shared two-table lookup that both cloud-init and pxe boot
+/// flows use for resolving a client IP . Check `machine_interface_addresses`
+/// first (the common admin path), then fall back to `instance_address`.
+async fn resolve_client_ip(
+    conn: &mut PgConnection,
+    client_ip: IpAddr,
+) -> Result<ResolvedClient, CarbideError> {
+    if let Some(iface) = db::machine_interface::find_by_ip(&mut *conn, client_ip).await? {
+        return Ok(ResolvedClient::Interface(iface));
+    }
+
+    let instance_address = db::instance_address::find_by_address(&mut *conn, client_ip)
+        .await?
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "Client",
+            id: client_ip.to_string(),
+        })?;
+
+    let instance = db::instance::find_by_id(&mut *conn, instance_address.instance_id)
+        .await?
+        .ok_or_else(|| {
+            CarbideError::internal(format!(
+                "instance_address {client_ip} references missing instance {}",
+                instance_address.instance_id,
+            ))
+        })?;
+
+    Ok(ResolvedClient::Instance(instance))
+}
+
+/// Resolve a client IP to the host's `machine_interface` for PXE-script
+/// generation. For direct-interface IPs this returns the matching
+/// interface; for tenant-allocated IPs it resolves through the instance
+/// to the host's machine_interfaces, and prefers an admin-segment one.
+pub(crate) async fn resolve_machine_interface(
+    conn: &mut PgConnection,
+    client_ip: IpAddr,
+) -> Result<MachineInterfaceSnapshot, CarbideError> {
+    match resolve_client_ip(conn, client_ip).await? {
+        ResolvedClient::Interface(iface) => Ok(iface),
+        ResolvedClient::Instance(instance) => {
+            let interfaces_by_machine =
+                db::machine_interface::find_by_machine_ids(&mut *conn, &[instance.machine_id])
+                    .await?;
+            let host_interfaces =
+                interfaces_by_machine
+                    .get(&instance.machine_id)
+                    .ok_or_else(|| {
+                        CarbideError::internal(format!(
+                            "no machine_interfaces for host {}",
+                            instance.machine_id,
+                        ))
+                    })?;
+
+            let admin_segment_ids: HashSet<_> = db::network_segment::admin(&mut *conn)
+                .await?
+                .into_iter()
+                .map(|s| s.id)
+                .collect();
+
+            host_interfaces
+                .iter()
+                .find(|i| admin_segment_ids.contains(&i.segment_id))
+                .or_else(|| host_interfaces.first())
+                .cloned()
+                .ok_or_else(|| {
+                    CarbideError::internal(format!(
+                        "host {} has no machine_interfaces",
+                        instance.machine_id,
+                    ))
+                })
+        }
+    }
+}
+
+/// Resolve a client IP to its `CloudInitInstructions` response. The
+/// interface arm produces a discovery-instructions response (for
+/// unassigned hosts running scout, etc.); the instance arm produces an
+/// instance-specific response with the tenant-provided user_data.
+pub(crate) async fn resolve_cloud_init_instructions(
+    api: &Api,
+    conn: &mut PgConnection,
+    client_ip: IpAddr,
+) -> Result<rpc::CloudInitInstructions, CarbideError> {
+    let cloud_name = "nvidia".to_string();
+    let platform = "forge".to_string();
+
+    match resolve_client_ip(conn, client_ip).await? {
+        ResolvedClient::Instance(instance) => Ok(rpc::CloudInitInstructions {
+            custom_cloud_init: instance.config.os.user_data,
+            discovery_instructions: None,
+            metadata: Some(rpc::CloudInitMetaData {
+                instance_id: instance.id.to_string(),
+                cloud_name,
+                platform,
+            }),
+            api_url_override: None,
+            pxe_url_override: None,
+        }),
+        ResolvedClient::Interface(machine_interface) => {
+            let domain_id = machine_interface.domain_id.ok_or_else(|| {
+                CarbideError::internal(format!(
+                    "Machine Interface did not have an associated domain {}",
+                    machine_interface.id
+                ))
+            })?;
+
+            let domain = db::dns::domain::find_by_uuid(&mut *conn, domain_id)
+                .await
+                .map_err(CarbideError::from)?
+                .ok_or_else(|| {
+                    CarbideError::internal(format!("Could not find domain with id {domain_id}"))
+                })?
+                .to_owned();
+
+            // This custom pxe is different from a customer instance of pxe. It is more for testing
+            // one off changes until a real dev env is established and we can just override our
+            // existing code to test. It is possible for the user data to be null if we are only
+            // trying to test the pxe, and this will follow the same code path and retrieve the
+            // non custom user data.
+            let custom_cloud_init =
+                match db::machine_boot_override::find_optional(&mut *conn, machine_interface.id)
+                    .await?
+                {
+                    Some(machine_boot_override) => machine_boot_override.custom_user_data,
+                    None => None,
+                };
+
+            let metadata: Option<rpc::CloudInitMetaData> = machine_interface
+                .machine_id
+                .as_ref()
+                .map(|machine_id| rpc::CloudInitMetaData {
+                    instance_id: machine_id.to_string(),
+                    cloud_name,
+                    platform,
+                });
+
+            // For interfaces on the static-assignments segment, include
+            // hostname or IP-based URL overrides so external hosts can
+            // reach carbide-api and carbide-pxe services. Just to reiterate,
+            // these can be either routable IPs, or externally resolvable
+            // hostnames to routable IPs.
+            let is_external = machine_interface.segment_id
+                == db::network_segment::static_assignments(&mut *conn)
+                    .await
+                    .map(|s| s.id)
+                    .unwrap_or_default();
+
+            let (api_url_override, pxe_url_override) = if is_external {
+                (
+                    api.runtime_config.external_api_url.clone(),
+                    api.runtime_config.external_pxe_url.clone(),
+                )
+            } else {
+                (None, None)
+            };
+
+            Ok(rpc::CloudInitInstructions {
+                custom_cloud_init,
+                discovery_instructions: Some(rpc::CloudInitDiscoveryInstructions {
+                    machine_interface: Some(machine_interface.into()),
+                    domain: Some(rpc::PxeDomain {
+                        domain: Some(rpc::pxe_domain::Domain::NewDomain(domain.into())),
+                    }),
+                    hbn_reps: api
+                        .runtime_config
+                        .vmaas_config
+                        .as_ref()
+                        .and_then(|vc| vc.hbn_reps.clone()),
+                    hbn_sfs: api
+                        .runtime_config
+                        .vmaas_config
+                        .as_ref()
+                        .and_then(|vc| vc.hbn_sfs.clone()),
+                    vf_intercept_bridge_name: api.runtime_config.vmaas_config.as_ref().and_then(
+                        |vc| {
+                            vc.bridging
+                                .as_ref()
+                                .map(|b| b.vf_intercept_bridge_name.clone())
+                        },
+                    ),
+                    host_intercept_bridge_name: api.runtime_config.vmaas_config.as_ref().and_then(
+                        |vc| {
+                            vc.bridging
+                                .as_ref()
+                                .map(|b| b.host_intercept_bridge_name.clone())
+                        },
+                    ),
+                    host_intercept_bridge_port: api.runtime_config.vmaas_config.as_ref().and_then(
+                        |vc| {
+                            vc.bridging
+                                .as_ref()
+                                .map(|b| b.host_intercept_bridge_port.clone())
+                        },
+                    ),
+                    vf_intercept_bridge_port: api.runtime_config.vmaas_config.as_ref().and_then(
+                        |vc| {
+                            vc.bridging
+                                .as_ref()
+                                .map(|b| b.vf_intercept_bridge_port.clone())
+                        },
+                    ),
+                    vf_intercept_bridge_sf: api.runtime_config.vmaas_config.as_ref().and_then(
+                        |vc| {
+                            vc.bridging
+                                .as_ref()
+                                .map(|b| b.vf_intercept_bridge_sf.clone())
+                        },
+                    ),
+                }),
+                metadata,
+                api_url_override,
+                pxe_url_override,
+            })
+        }
+    }
+}

--- a/crates/api/src/handlers/mod.rs
+++ b/crates/api/src/handlers/mod.rs
@@ -20,6 +20,7 @@ pub mod attestation;
 pub mod bmc_endpoint_explorer;
 pub mod bmc_metadata;
 pub mod boot_override;
+pub mod client_resolution;
 pub mod component_manager;
 pub mod compute_allocation;
 pub mod credential;

--- a/crates/api/src/handlers/pxe.rs
+++ b/crates/api/src/handlers/pxe.rs
@@ -23,6 +23,9 @@ use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
 use crate::api::{Api, log_request_data};
+use crate::handlers::client_resolution::{
+    resolve_cloud_init_instructions, resolve_machine_interface,
+};
 use crate::ipxe::PxeInstructions;
 
 // The carbide pxe server makes this RPC call
@@ -34,45 +37,25 @@ pub(crate) async fn get_pxe_instructions(
 
     let mut txn = api.txn_begin().await?;
 
-    // interface_id is sent when carbide-dhcp (or a carbide-api integrated
-    // DHCP service) populates DHCP option 43.70. client_ip is sent when
-    // it didn't -- carbide-pxe forwards the client IP it observed (XFF if
-    // proxied, TCP socket peer otherwise). interface_id wins when both
-    // are present (it's already resolved -- saves a lookup). When only
-    // client_ip is present, resolve it to interface_id here so the rest
-    // of the model can take the same path.
-    let mut rpc_request = request.into_inner();
-    if rpc_request.interface_id.is_none() {
-        let ip_str = rpc_request.client_ip.as_deref().ok_or_else(|| {
-            CarbideError::InvalidArgument(
-                "PxeInstructionRequest requires either interface_id or client_ip".to_string(),
-            )
-        })?;
-        let ip: IpAddr = ip_str.parse().map_err(|e| {
-            CarbideError::InvalidArgument(format!("Failed parsing client_ip '{ip_str}': {e}"))
-        })?;
-        let iface = db::machine_interface::find_by_ip(txn.as_pgconn(), ip)
-            .await?
-            .ok_or_else(|| CarbideError::NotFoundError {
-                kind: "MachineInterface",
-                id: ip.to_string(),
-            })?;
-        rpc_request.interface_id = Some(iface.id);
-    }
+    let pxe_request: model::pxe::PxeInstructionRequest = request.into_inner().try_into()?;
 
-    // And now we can naturally continue, whether the request came in
-    // with DHCP option 43.70 (interface_id) or the client-IP (and the
-    // client_ip resolved to interface_id just above).
-    let target: model::pxe::PxeInstructionRequest = rpc_request.try_into()?;
-    let interface_id = target.interface_id;
-    let pxe_script = PxeInstructions::get_pxe_instructions(&mut txn, target).await?;
+    // Resolve the client_ip carbide-pxe observed (XFF or TCP peer) to
+    // a host machine_interface, either via direct machine_interface_addresses
+    // lookup or via instance_address for tenant-allocated machines.
+    let iface = resolve_machine_interface(txn.as_pgconn(), pxe_request.client_ip).await?;
+
+    let input = model::pxe::PxeInstructionsInput {
+        interface_id: iface.id,
+        arch: pxe_request.arch,
+        product: pxe_request.product,
+    };
+    let pxe_script = PxeInstructions::get_pxe_instructions(&mut txn, input).await?;
 
     // For interfaces on the static-assignments segment, include
     // URL overrides so external hosts can reach services via an
     // alternate hostname or IP they can resolve and/or connect
     // to for carbide-pxe and carbide-api.
     let (api_url_override, pxe_url_override, static_pxe_url_override) = {
-        let iface = db::machine_interface::find_one(txn.as_pgconn(), interface_id).await?;
         let is_external = iface.segment_id
             == db::network_segment::static_assignments(txn.as_pgconn())
                 .await
@@ -108,10 +91,6 @@ pub(crate) async fn get_cloud_init_instructions(
     request: Request<rpc::CloudInitInstructionsRequest>,
 ) -> Result<Response<rpc::CloudInitInstructions>, Status> {
     log_request_data(&request);
-    let cloud_name = "nvidia".to_string();
-    let platform = "forge".to_string();
-
-    let db = &api.database_connection;
 
     let ip_str = &request.into_inner().ip;
     let ip: IpAddr = ip_str
@@ -125,158 +104,10 @@ pub(crate) async fn get_cloud_init_instructions(
     // prefix, network segment, and IP allocators behind the scenes for supporting
     // dual stacking interfaces, none of that means much until DHCPv6 is working
     // to actually hand those addresses out.
-    let instructions = match db::instance_address::find_by_address(db, ip).await? {
-        None => {
-            // assume there is no instance associated with this IP and check if there is an interface associated with it
-            let machine_interface = db::machine_interface::find_by_ip(db, ip)
-                .await?
-                .ok_or_else(|| {
-                    CarbideError::internal(format!("No machine interface with IP {ip} was found"))
-                })?;
-
-            let domain_id = machine_interface.domain_id.ok_or_else(|| {
-                CarbideError::internal(format!(
-                    "Machine Interface did not have an associated domain {}",
-                    machine_interface.id
-                ))
-            })?;
-
-            let domain = db::dns::domain::find_by_uuid(db, domain_id)
-                .await
-                .map_err(CarbideError::from)?
-                .ok_or_else(|| {
-                    CarbideError::internal(format!("Could not find domain with id {domain_id}"))
-                })?
-                .to_owned();
-
-            // This custom pxe is different from a customer instance of pxe. It is more for testing one off
-            // changes until a real dev env is established and we can just override our existing code to test
-            // It is possible for the user data to be null if we are only trying to test the pxe, and this will
-            // follow the same code path and retrieve the non custom user data
-            let custom_cloud_init =
-                match db::machine_boot_override::find_optional(db, machine_interface.id).await? {
-                    Some(machine_boot_override) => machine_boot_override.custom_user_data,
-                    None => None,
-                };
-
-            let metadata: Option<rpc::CloudInitMetaData> = machine_interface
-                .machine_id
-                .as_ref()
-                .map(|machine_id| rpc::CloudInitMetaData {
-                    instance_id: machine_id.to_string(),
-                    cloud_name,
-                    platform,
-                });
-
-            // For interfaces on the static-assignments segment, include
-            // hostname or IP-based URL overrides so external hosts can
-            // reach carbide-api and carbide-pxe services. Just to reiterate,
-            // these can be either routable IPs, or externally resolvable
-            // hostnames to routable IPs.
-            let is_external = {
-                let mut conn = db.acquire().await.map_err(|e| {
-                    CarbideError::internal(format!("Failed to acquire database connection: {e}"))
-                })?;
-                machine_interface.segment_id
-                    == db::network_segment::static_assignments(&mut conn)
-                        .await
-                        .map(|s| s.id)
-                        .unwrap_or_default()
-            };
-
-            let (api_url_override, pxe_url_override) = if is_external {
-                (
-                    api.runtime_config.external_api_url.clone(),
-                    api.runtime_config.external_pxe_url.clone(),
-                )
-            } else {
-                (None, None)
-            };
-
-            rpc::CloudInitInstructions {
-                custom_cloud_init,
-                discovery_instructions: Some(rpc::CloudInitDiscoveryInstructions {
-                    machine_interface: Some(machine_interface.into()),
-                    domain: Some(rpc::PxeDomain {
-                        domain: Some(rpc::pxe_domain::Domain::NewDomain(domain.into())),
-                    }),
-                    hbn_reps: api
-                        .runtime_config
-                        .vmaas_config
-                        .as_ref()
-                        .and_then(|vc| vc.hbn_reps.clone()),
-                    hbn_sfs: api
-                        .runtime_config
-                        .vmaas_config
-                        .as_ref()
-                        .and_then(|vc| vc.hbn_sfs.clone()),
-                    vf_intercept_bridge_name: api.runtime_config.vmaas_config.as_ref().and_then(
-                        |vc| {
-                            vc.bridging
-                                .as_ref()
-                                .map(|b| b.vf_intercept_bridge_name.clone())
-                        },
-                    ),
-                    host_intercept_bridge_name: api.runtime_config.vmaas_config.as_ref().and_then(
-                        |vc| {
-                            vc.bridging
-                                .as_ref()
-                                .map(|b| b.host_intercept_bridge_name.clone())
-                        },
-                    ),
-                    host_intercept_bridge_port: api.runtime_config.vmaas_config.as_ref().and_then(
-                        |vc| {
-                            vc.bridging
-                                .as_ref()
-                                .map(|b| b.host_intercept_bridge_port.clone())
-                        },
-                    ),
-                    vf_intercept_bridge_port: api.runtime_config.vmaas_config.as_ref().and_then(
-                        |vc| {
-                            vc.bridging
-                                .as_ref()
-                                .map(|b| b.vf_intercept_bridge_port.clone())
-                        },
-                    ),
-                    vf_intercept_bridge_sf: api.runtime_config.vmaas_config.as_ref().and_then(
-                        |vc| {
-                            vc.bridging
-                                .as_ref()
-                                .map(|b| b.vf_intercept_bridge_sf.clone())
-                        },
-                    ),
-                }),
-                metadata,
-                api_url_override,
-                pxe_url_override,
-            }
-        }
-
-        Some(instance_address) => {
-            let instance = db::instance::find_by_id(db, instance_address.instance_id)
-                .await?
-                .ok_or_else(|| {
-                    // Note that this isn't a NotFound error since it indicates an
-                    // inconsistent data model
-                    CarbideError::internal(format!(
-                        "Could not find an instance for {}",
-                        instance_address.instance_id
-                    ))
-                })?;
-
-            rpc::CloudInitInstructions {
-                custom_cloud_init: instance.config.os.user_data,
-                discovery_instructions: None,
-                metadata: Some(rpc::CloudInitMetaData {
-                    instance_id: instance.id.to_string(),
-                    cloud_name,
-                    platform,
-                }),
-                api_url_override: None,
-                pxe_url_override: None,
-            }
-        }
-    };
+    let mut conn = api.database_connection.acquire().await.map_err(|e| {
+        CarbideError::internal(format!("Failed to acquire database connection: {e}"))
+    })?;
+    let instructions = resolve_cloud_init_instructions(api, &mut conn, ip).await?;
 
     Ok(Response::new(instructions))
 }

--- a/crates/api/src/ipxe.rs
+++ b/crates/api/src/ipxe.rs
@@ -27,7 +27,7 @@ use model::machine::{
     DpuInitState, FailureCause, FailureDetails, HostReprovisionState, InstanceState,
     ManagedHostState, MeasuringState, ReprovisionState, ValidationState,
 };
-use model::pxe::PxeInstructionRequest;
+use model::pxe::PxeInstructionsInput;
 use sqlx::PgConnection;
 
 use crate::CarbideError;
@@ -230,7 +230,7 @@ impl PxeInstructions {
 
     pub async fn get_pxe_instructions(
         txn: &mut PgConnection,
-        target: PxeInstructionRequest,
+        target: PxeInstructionsInput,
     ) -> Result<String, CarbideError> {
         let error_instructions = |machine_id: MachineId,
                                   interface_id: MachineInterfaceId,

--- a/crates/api/src/tests/client_resolution.rs
+++ b/crates/api/src/tests/client_resolution.rs
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use common::api_fixtures::{create_managed_host, create_test_env};
+
+use crate::CarbideError;
+use crate::handlers::client_resolution::resolve_machine_interface;
+use crate::tests::common;
+use crate::tests::common::api_fixtures::instance::{
+    default_os_config, default_tenant_config, single_interface_network_config,
+};
+
+// A client_ip that matches a row in machine_interface_addresses (the
+// common admin/host case) should resolve directly to that interface.
+#[crate::sqlx_test]
+async fn test_resolve_machine_interface_via_direct_admin_ip(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let interfaces = db::machine_interface::find_by_machine_ids(txn.as_mut(), &[mh.host().id])
+        .await
+        .unwrap();
+    let host_iface = &interfaces[&mh.host().id][0];
+    let admin_ip = host_iface.addresses[0];
+    let expected_interface_id = host_iface.id;
+    txn.rollback().await.unwrap();
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let resolved = resolve_machine_interface(txn.as_mut(), admin_ip)
+        .await
+        .expect("admin IP should resolve to its machine_interface");
+    txn.rollback().await.unwrap();
+
+    assert_eq!(resolved.id, expected_interface_id);
+}
+
+// A client_ip that maps to a tenant-allocated instance_address (rather
+// than a machine_interface_addresses entry) should resolve to the
+// host's admin machine_interface via instance -> host_machine_id ->
+// host_interfaces. This is the "PXE-booting an assigned host over its
+// tenant network" path that the find_by_ip fallback was added for.
+#[crate::sqlx_test]
+async fn test_resolve_machine_interface_via_instance_address(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+    let mh = create_managed_host(&env).await;
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let interfaces = db::machine_interface::find_by_machine_ids(txn.as_mut(), &[mh.host().id])
+        .await
+        .unwrap();
+    let expected_interface_id = interfaces[&mh.host().id][0].id;
+    txn.rollback().await.unwrap();
+
+    let config = rpc::InstanceConfig {
+        tenant: Some(default_tenant_config()),
+        os: Some(default_os_config()),
+        network: Some(single_interface_network_config(segment_id)),
+        infiniband: None,
+        network_security_group_id: None,
+        dpu_extension_services: None,
+        nvlink: None,
+    };
+    let tinstance = mh.instance_builer(&env).config(config).build().await;
+
+    // Look up the tenant IP carbide-api allocated to the instance.
+    let mut txn = env.pool.begin().await.unwrap();
+    let inst_addr = db::instance_address::find_by_instance_id_and_segment_id(
+        txn.as_mut(),
+        &tinstance.id,
+        &segment_id,
+    )
+    .await
+    .unwrap()
+    .expect("instance should have a tenant address on the segment");
+    let tenant_ip = inst_addr.address;
+
+    let resolved = resolve_machine_interface(txn.as_mut(), tenant_ip)
+        .await
+        .expect("tenant IP should resolve to the host's admin machine_interface");
+    txn.rollback().await.unwrap();
+
+    // The resolved interface is the host's admin interface -- the same one
+    // we'd have hit if the request had come in on the admin IP directly.
+    assert_eq!(resolved.id, expected_interface_id);
+}
+
+// A client_ip that isn't in either table should NotFound cleanly.
+#[crate::sqlx_test]
+async fn test_resolve_machine_interface_unknown_ip_returns_not_found(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let result = resolve_machine_interface(txn.as_mut(), "203.0.113.99".parse().unwrap()).await;
+    txn.rollback().await.unwrap();
+
+    let err = result.expect_err("expected NotFound for unknown client IP");
+    match err {
+        CarbideError::NotFoundError { kind, .. } => {
+            assert_eq!(kind, "Client", "expected NotFound kind=Client, got {kind}")
+        }
+        other => panic!("expected NotFoundError, got {other:?}"),
+    }
+}

--- a/crates/api/src/tests/common/api_fixtures/test_machine/interface.rs
+++ b/crates/api/src/tests/common/api_fixtures/test_machine/interface.rs
@@ -34,12 +34,23 @@ impl TestMachineInterface {
     }
 
     pub async fn get_pxe_instructions(&self, arch: MachineArchitecture) -> PxeInstructions {
+        let mut txn = self.api.txn_begin().await.unwrap();
+        let iface = db::machine_interface::find_one(txn.as_pgconn(), self.id)
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+        let client_ip = iface
+            .addresses
+            .first()
+            .expect("interface must have at least one address to PXE boot")
+            .to_string();
+
         self.api
             .get_pxe_instructions(tonic::Request::new(rpc::forge::PxeInstructionRequest {
                 arch: arch as i32,
-                interface_id: Some(self.id),
                 product: None,
-                client_ip: None,
+                client_ip: Some(client_ip),
+                ..Default::default()
             }))
             .await
             .unwrap()

--- a/crates/api/src/tests/ipxe.rs
+++ b/crates/api/src/tests/ipxe.rs
@@ -65,12 +65,23 @@ async fn get_pxe_instructions(
     arch: rpc::forge::MachineArchitecture,
     product: Option<String>,
 ) -> rpc::forge::PxeInstructions {
+    let mut txn = env.pool.begin().await.unwrap();
+    let iface = db::machine_interface::find_one(txn.as_mut(), interface_id)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+    let client_ip = iface
+        .addresses
+        .first()
+        .expect("interface must have at least one address to PXE boot")
+        .to_string();
+
     env.api
         .get_pxe_instructions(tonic::Request::new(rpc::forge::PxeInstructionRequest {
             arch: arch as i32,
-            interface_id: Some(interface_id),
             product,
-            client_ip: None,
+            client_ip: Some(client_ip),
+            ..Default::default()
         }))
         .await
         .unwrap()
@@ -651,52 +662,12 @@ async fn test_cloud_init_url_overrides_none_for_internal_host(pool: sqlx::PgPool
     );
 }
 
-// When the DHCP server (carbide-dhcp or another DHCP server that happens to
-// be integrated with carbide-api) didn't populate option 43.70, the iPXE chain
-// script falls through to the client-IP path. carbide-pxe observes the client
-// IP (X-Forwarded-For if proxied, TCP socket peer otherwise) and forwards it
-// to carbide-api as PxeInstructionRequest.client_ip (with interface_id unset);
-// this makes sure the API resolves the IP to the same interface_id and returns
-// the same script as the uuid path.
-#[crate::sqlx_test]
-async fn test_pxe_instructions_resolves_client_ip_to_interface_id(pool: sqlx::PgPool) {
-    let env = create_env_with_external_urls(pool).await;
-
-    let ip = "10.99.0.60";
-    let (interface_id, _ip) = preallocate_external_interface(&env, "AA:BB:CC:DD:EE:10", ip).await;
-
-    let by_uuid = get_pxe_instructions(
-        &env,
-        interface_id,
-        rpc::forge::MachineArchitecture::X86,
-        None,
-    )
-    .await;
-
-    let by_client_ip = env
-        .api
-        .get_pxe_instructions(tonic::Request::new(rpc::forge::PxeInstructionRequest {
-            arch: rpc::forge::MachineArchitecture::X86 as i32,
-            interface_id: None,
-            product: None,
-            client_ip: Some(ip.to_string()),
-        }))
-        .await
-        .expect("client_ip-based get_pxe_instructions returned an error")
-        .into_inner();
-
-    assert_eq!(
-        by_client_ip.pxe_script, by_uuid.pxe_script,
-        "client_ip fallback should resolve to the same pxe_script as the uuid path"
-    );
-    assert_eq!(by_client_ip.api_url_override, by_uuid.api_url_override);
-    assert_eq!(by_client_ip.pxe_url_override, by_uuid.pxe_url_override);
-    assert_eq!(
-        by_client_ip.static_pxe_url_override,
-        by_uuid.static_pxe_url_override
-    );
-}
-
+// carbide-pxe identifies the booting machine by the client IP it observed
+// and forwards it to carbide-api. An IP that doesn't map to any interface
+// in machine_interface_addresses should NotFound cleanly. (The happy path
+// -- known IP resolves to the right interface -- is exercised by every
+// other test in this module that calls get_pxe_instructions, since the
+// helper now goes through the client_ip lookup.)
 #[crate::sqlx_test]
 async fn test_pxe_instructions_unknown_client_ip_returns_not_found(pool: sqlx::PgPool) {
     let env = create_env_with_external_urls(pool).await;
@@ -705,53 +676,12 @@ async fn test_pxe_instructions_unknown_client_ip_returns_not_found(pool: sqlx::P
         .api
         .get_pxe_instructions(tonic::Request::new(rpc::forge::PxeInstructionRequest {
             arch: rpc::forge::MachineArchitecture::X86 as i32,
-            interface_id: None,
             product: None,
             client_ip: Some("203.0.113.99".to_string()),
+            ..Default::default()
         }))
         .await;
 
     let status = result.expect_err("expected NotFound for unknown client_ip");
     assert_eq!(status.code(), tonic::Code::NotFound, "got: {status:?}");
-}
-
-// interface_id is sent when carbide-dhcp populates DHCP option 43.70;
-// client_ip is sent on the client-IP path (when 43.70 is not present).
-// interface_id takes priority when both are present -- as in we use
-// the "pre-resolved" ID and ignore the client_ip, even if the IP would
-// have resolved to a different interface (or no interface at all). Send
-// a deliberately "unknown" IP alongside a valid machine interface ID to
-// prove the handler is actually ignoring the `client_ip` field, and not
-// coincidentally agreeing with it.
-#[crate::sqlx_test]
-async fn test_pxe_instructions_prefers_interface_id_when_both_set(pool: sqlx::PgPool) {
-    let env = create_env_with_external_urls(pool).await;
-
-    let (interface_id, _ip) =
-        preallocate_external_interface(&env, "AA:BB:CC:DD:EE:11", "10.99.0.61").await;
-
-    let by_uuid_only = get_pxe_instructions(
-        &env,
-        interface_id,
-        rpc::forge::MachineArchitecture::X86,
-        None,
-    )
-    .await;
-
-    let with_unknown_client_ip = env
-        .api
-        .get_pxe_instructions(tonic::Request::new(rpc::forge::PxeInstructionRequest {
-            arch: rpc::forge::MachineArchitecture::X86 as i32,
-            interface_id: Some(interface_id),
-            product: None,
-            // Deliberately-unknown IP. If the handler weren't preferring
-            // interface_id, this would NotFound. Instead, the client_ip
-            // is ignored and the script comes from the uuid lookup.
-            client_ip: Some("203.0.113.99".to_string()),
-        }))
-        .await
-        .expect("uuid wins; unknown client_ip should be ignored, not validated")
-        .into_inner();
-
-    assert_eq!(with_unknown_client_ip.pxe_script, by_uuid_only.pxe_script);
 }

--- a/crates/api/src/tests/machine_states.rs
+++ b/crates/api/src/tests/machine_states.rs
@@ -937,9 +937,9 @@ async fn test_failed_state_host_discovery_recovery(pool: sqlx::PgPool) {
         .api
         .get_pxe_instructions(tonic::Request::new(rpc::forge::PxeInstructionRequest {
             arch: rpc::forge::MachineArchitecture::X86 as i32,
-            interface_id: Some(host.interfaces[0].id),
             product: None,
-            client_ip: None,
+            client_ip: Some(host.interfaces[0].addresses[0].to_string()),
+            ..Default::default()
         }))
         .await
         .unwrap()

--- a/crates/api/src/tests/mod.rs
+++ b/crates/api/src/tests/mod.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+mod client_resolution;
 pub(crate) mod common;
 mod compute_allocation;
 mod connected_device;

--- a/crates/ipxe-renderer/templates.yaml
+++ b/crates/ipxe-renderer/templates.yaml
@@ -346,30 +346,15 @@ templates:
       
       :whoami
       ifconf -c dhcp
-      # When a DHCP server (carbide-dhcp or API-integrated DHCP server) populates
-      # option 43.70 with the machine_interface_id, use that as the identifier.
-      # Otherwise, just rely on the client IP -- carbide-pxe will resolve it via
-      # X-Forwarded-For (when proxied) or the TCP socket peer (when direct), then
-      # look up the interface by IP. iPXE itself doesn't need to put the IP in
-      # the URL since the network layer carries it.
-      isset ${43.70} && goto whoami_uuid || goto whoami_sourceip
-
-      :whoami_uuid
-      time chain --autofree http://${next-server}:8080/api/v0/pxe/whoami?uuid=${43.70}
-      goto carbide_menu
-
-      :whoami_sourceip
+      # carbide-pxe identifies the booting machine by its client IP (read from
+      # X-Forwarded-For when proxied, TCP socket peer otherwise) and resolves
+      # to a machine_interface_id via find_by_ip. iPXE doesn't need to encode
+      # anything identity-related in the URL -- the network layer carries it.
       time chain --autofree http://${next-server}:8080/api/v0/pxe/whoami
       goto carbide_menu
 
       :carbide
       ifconf -c dhcp
-      isset ${43.70} && goto carbide_uuid || goto carbide_sourceip
-
-      :carbide_uuid
-      time chain --autofree http://${next-server}:8080/api/v0/pxe/boot?uuid=${43.70}&buildarch=${buildarch}&platform=${platform}&manufacturer=${manufacturer}&product=${product}&serial=${serial} && exit 1 || goto error_handler
-
-      :carbide_sourceip
       time chain --autofree http://${next-server}:8080/api/v0/pxe/boot?buildarch=${buildarch}&platform=${platform}&manufacturer=${manufacturer}&product=${product}&serial=${serial} && exit 1 || goto error_handler
       
       :carbide_menu

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -475,15 +475,15 @@ impl ApiClient {
     pub async fn get_pxe_instructions(
         &self,
         arch: rpc::forge::MachineArchitecture,
-        interface_id: MachineInterfaceId,
+        client_ip: std::net::IpAddr,
         product: Option<String>,
     ) -> ClientApiResult<PxeInstructions> {
         self.0
             .get_pxe_instructions(rpc::forge::PxeInstructionRequest {
                 arch: arch.into(),
-                interface_id: Some(interface_id),
                 product,
-                client_ip: None,
+                client_ip: Some(client_ip.to_string()),
+                ..Default::default()
             })
             .await
             .map_err(ClientApiError::InvocationError)

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -573,11 +573,7 @@ impl MachineStateMachine {
     }
 
     async fn pxe_boot_request(&self) -> Result<OsImage, MachineStateError> {
-        let Some(machine_interface_id) = self
-            .machine_dhcp_info
-            .as_ref()
-            .and_then(|info| info.interface_id.as_ref())
-        else {
+        let Some(dhcp_info) = self.machine_dhcp_info.as_ref() else {
             return Err(MachineStateError::MissingInterfaceId);
         };
 
@@ -595,11 +591,8 @@ impl MachineStateMachine {
         let pxe_response = send_pxe_boot_request(
             &self.app_context,
             architecture,
-            *machine_interface_id,
+            dhcp_info.ip_address.into(),
             Some(product),
-            self.machine_dhcp_info
-                .as_ref()
-                .map(|info| info.ip_address.to_string()),
         )
         .await?;
 
@@ -752,11 +745,16 @@ impl MachineStateMachine {
         self.send_network_status_observation(machine_id.to_owned(), &network_config)
             .await?;
 
-        // Launch a DHCP server for the HostMachine to call, if it's not already running.
-        if let (Some(DpuDhcpRelay::DpuEnd(dhcp_relay)), true) = (
-            self.dpu_dhcp_relay.clone(),
-            self.dpu_dhcp_relay_handle.is_none(),
-        ) {
+        // Re-spawn the host-facing DHCP relay with the freshly-fetched
+        // network_config. We do this on every network observation (not
+        // just the first one) because the relay captures the config it
+        // was spawned with -- if we never re-spawn, the relay keeps
+        // returning stale tenant IPs after an instance is released and
+        // managed_host_network_config has switched back to admin-only.
+        // The caller assigns the returned handle into
+        // self.dpu_dhcp_relay_handle, which drops the prior handle and
+        // signals the old relay task to exit.
+        if let Some(DpuDhcpRelay::DpuEnd(dhcp_relay)) = self.dpu_dhcp_relay.clone() {
             Ok(Some(dhcp_relay.spawn(network_config.clone())))
         } else {
             Ok(None)

--- a/crates/machine-a-tron/src/machine_utils.rs
+++ b/crates/machine-a-tron/src/machine_utils.rs
@@ -17,7 +17,7 @@
 use std::collections::HashSet;
 use std::path::Path;
 
-use carbide_uuid::machine::{MachineId, MachineInterfaceId};
+use carbide_uuid::machine::MachineId;
 use carbide_uuid::machine_validation::MachineValidationId;
 use lazy_static::lazy_static;
 use rcgen::{CertifiedKey, generate_simple_self_signed};
@@ -89,39 +89,41 @@ pub fn get_validation_id(response: &ForgeAgentControlResponse) -> Option<Machine
 pub async fn send_pxe_boot_request(
     app_context: &MachineATronContext,
     arch: MachineArchitecture,
-    interface_id: MachineInterfaceId,
+    client_ip: std::net::IpAddr,
     product: Option<String>,
-    forward_ip: Option<String>,
 ) -> Result<PxeResponse, PxeError> {
     let pxe_script: String =
         if app_context.app_config.use_pxe_api {
             let response = app_context
                 .api_client()
-                .get_pxe_instructions(arch, interface_id, product)
+                .get_pxe_instructions(arch, client_ip, product)
                 .await?;
             tracing::info!("PXE Request successful");
             response.pxe_script
         } else {
             let url =
                 format!(
-                    "http://{}:{}/api/v0/pxe/boot?uuid={}&buildarch={}",
+                    "http://{}:{}/api/v0/pxe/boot?buildarch={}",
                     app_context.app_config.pxe_server_host.as_ref().expect(
                         "Config error: use_pxe_api is false but pxe_server_host is not set"
                     ),
                     app_context.app_config.pxe_server_port.as_ref().expect(
                         "Config error: use_pxe_api is false but pxe_server_port is not set"
                     ),
-                    interface_id,
                     match arch {
                         MachineArchitecture::X86 => "x86_64",
                         MachineArchitecture::Arm => "arm64",
                     }
                 );
 
-            let mut request = ClientBuilder::new().build().unwrap().get(&url);
-            if let Some(forward_ip) = forward_ip {
-                request = request.header("X-Forwarded-For", forward_ip);
-            }
+            // carbide-pxe identifies the machine by the request's client
+            // IP (via X-Forwarded-For when fronted by a proxy), so spoof
+            // it via XFF here.
+            let request = ClientBuilder::new()
+                .build()
+                .unwrap()
+                .get(&url)
+                .header("X-Forwarded-For", client_ip.to_string());
 
             let response = request.send().await?;
             if !response.status().is_success() {

--- a/crates/pxe/src/common.rs
+++ b/crates/pxe/src/common.rs
@@ -17,7 +17,6 @@
 use std::net::IpAddr;
 
 use axum_template::engine::Engine;
-use carbide_uuid::machine::MachineInterfaceId;
 use metrics_exporter_prometheus::PrometheusHandle;
 use rpc::forge::CloudInitInstructions;
 use serde::{Deserialize, Serialize};
@@ -32,23 +31,14 @@ pub(crate) struct Machine {
     pub instructions: CloudInitInstructions,
 }
 
-/// MachineLookup defines how the booting machine identified itself.
-/// The `uuid` query param (which comes from DHCP option 43.70, populated
-/// by carbide-dhcp or another API-integrated DHCP server) yields
-/// `InterfaceId`.
-/// When DHCP option 43.70 isn't set, carbide-pxe falls back to the
-/// observed source IP (`X-Forwarded-For` if proxied, TCP socket peer
-/// otherwise), populating `SourceIp`.
-#[derive(Debug, Serialize, Deserialize)]
-pub(crate) enum MachineLookup {
-    InterfaceId(MachineInterfaceId),
-    SourceIp(IpAddr),
-}
-
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct MachineInterface {
     pub architecture: Option<machine_architecture::MachineArchitecture>,
-    pub lookup: MachineLookup,
+    /// IP carbide-pxe observed for the booting machine: `X-Forwarded-For`
+    /// when fronted by a proxy that injects it, TCP socket peer otherwise.
+    /// Forwarded to carbide-api which resolves it via `find_by_ip` to
+    /// fetch the machine_interface_id.
+    pub client_ip: IpAddr,
     pub platform: Option<String>,
     pub manufacturer: Option<String>,
     pub product: Option<String>,

--- a/crates/pxe/src/extractors/machine_interface.rs
+++ b/crates/pxe/src/extractors/machine_interface.rs
@@ -14,15 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::collections::HashMap;
-
-use axum::extract::{FromRequestParts, Path, Query};
+use axum::extract::{FromRequestParts, Query};
 use axum::http::request::Parts;
 use axum_client_ip::ClientIp;
-use carbide_uuid::machine::MachineInterfaceId;
 use serde::{Deserialize, Serialize};
 
-use crate::common::{MachineInterface, MachineLookup};
+use crate::common::MachineInterface;
 use crate::extractors::machine_architecture::MachineArchitecture;
 use crate::rpc_error::PxeRequestError;
 
@@ -30,10 +27,6 @@ use crate::rpc_error::PxeRequestError;
 struct MaybeMachineInterface {
     #[serde(rename(deserialize = "buildarch"))]
     build_architecture: String,
-    #[serde(default)]
-    uuid: Option<MachineInterfaceId>,
-    #[serde(default)]
-    uuid_as_param: Option<String>,
     #[serde(default)]
     platform: Option<String>,
     #[serde(default)]
@@ -59,35 +52,20 @@ where
             // field; everything else is optional.
             return Err(PxeRequestError::InvalidBuildArch);
         };
-        let mut maybe = maybe.0;
-        maybe.uuid_as_param = Path::<HashMap<String, String>>::from_request_parts(parts, state)
-            .await
-            .ok()
-            .and_then(|params| params.0.get("uuid").cloned());
+        let maybe = maybe.0;
 
         let build_architecture = MachineArchitecture::try_from(maybe.build_architecture.as_str())?;
 
-        // Prefer interface_id (DHCP option 43.70 path) when present.
-        // Otherwise fall back to the source IP -- ClientIp uses
-        // X-Forwarded-For when a proxy injects it, and the TCP socket
-        // peer otherwise.
-        let lookup = match (maybe.uuid, maybe.uuid_as_param) {
-            (Some(uuid), _) => MachineLookup::InterfaceId(uuid),
-            (None, Some(uuid)) => MachineLookup::InterfaceId(uuid.parse().map_err(
-                |e: carbide_uuid::typed_uuids::UuidError| PxeRequestError::UuidConversion(e.into()),
-            )?),
-            (None, None) => {
-                let client_ip = ClientIp::from_request_parts(parts, state)
-                    .await
-                    .map_err(PxeRequestError::MissingIp)?
-                    .0;
-                MachineLookup::SourceIp(client_ip)
-            }
-        };
+        // ClientIp uses X-Forwarded-For when a proxy injects it, and falls
+        // back to the TCP socket peer otherwise.
+        let client_ip = ClientIp::from_request_parts(parts, state)
+            .await
+            .map_err(PxeRequestError::MissingIp)?
+            .0;
 
         Ok(MachineInterface {
             architecture: Some(build_architecture),
-            lookup,
+            client_ip,
             platform: maybe.platform,
             manufacturer: maybe.manufacturer,
             product: maybe.product,

--- a/crates/pxe/src/routes/ipxe.rs
+++ b/crates/pxe/src/routes/ipxe.rs
@@ -102,7 +102,7 @@ pub async fn boot(contents: MachineInterface, state: State<AppState>) -> impl In
 
             let pxe_response = RpcContext::get_pxe_instructions(
                 arch.into(),
-                &contents.lookup,
+                contents.client_ip,
                 contents.product,
                 &state.runtime_config.internal_api_url,
                 &ForgeClientConfig::new(

--- a/crates/pxe/src/routes/mod.rs
+++ b/crates/pxe/src/routes/mod.rs
@@ -14,10 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::net::IpAddr;
+
 use ::rpc::forge as rpc;
 use ::rpc::forge_tls_client::{self, ApiConfig, ForgeClientConfig};
-
-use crate::common::MachineLookup;
 
 pub(crate) mod cloud_init;
 pub(crate) mod ipxe;
@@ -29,7 +29,7 @@ pub struct RpcContext;
 impl RpcContext {
     async fn get_pxe_instructions(
         arch: rpc::MachineArchitecture,
-        lookup: &MachineLookup,
+        client_ip: IpAddr,
         product: Option<String>,
         url: &str,
         client_config: &ForgeClientConfig,
@@ -38,22 +38,22 @@ impl RpcContext {
         let mut client = forge_tls_client::ForgeTlsClient::retry_build(&api_config)
             .await
             .map_err(|err| err.to_string())?;
-        let (interface_id, client_ip) = match lookup {
-            MachineLookup::InterfaceId(id) => (Some(*id), None),
-            MachineLookup::SourceIp(ip) => (None, Some(ip.to_string())),
-        };
         let request = tonic::Request::new(rpc::PxeInstructionRequest {
             arch: arch as i32,
-            interface_id,
             product,
-            client_ip,
+            client_ip: Some(client_ip.to_string()),
+            // `interface_id` is deprecated; let Default fill it so we
+            // don't have to reference the deprecated field by name.
+            ..Default::default()
         });
         client
             .get_pxe_instructions(request)
             .await
             .map(|response| response.into_inner())
             .map_err(|error| {
-                format!("Error fetching PXE instructions for {lookup:?}; Error: {error}.")
+                format!(
+                    "Error fetching PXE instructions for client_ip {client_ip}; Error: {error}."
+                )
             })
     }
 }

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -4535,20 +4535,15 @@ message ForgeScoutErrorReportResult {
 
 message PxeInstructionRequest {
   MachineArchitecture arch = 1;
-  // interface_id is populated via DHCP option 43.70, either by
-  // carbide-dhcp or an operator DHCP server that integrates with
-  // carbide-api. If unset, we fall back to identifying the booting
-  // machine by its source IP (see client_ip below).
-  common.MachineInterfaceId interface_id = 2;
+  // DEPRECATED: interface_id is no longer read by carbide-api. The
+  // booting machine is now identified via client_ip (see below).
+  // We could potentially just drop this entirely and mark it as
+  // "reserved 2" in the future or similar.
+  common.MachineInterfaceId interface_id = 2 [deprecated = true];
   optional string product = 3;
   // client_ip is the IP carbide-pxe observed for the booting machine
   // -- read from X-Forwarded-For when carbide-pxe is fronted by a
   // proxy, or the TCP socket peer when reached directly.
-  // Used as the machine identifier when DHCP option 43.70 wasn't
-  // populated (and interface_id above isn't set). Resolved here via
-  // find_by_ip on machine_interface_addresses to fetch the matching
-  // interface_id. At least one of interface_id or client_ip must be
-  // set; interface_id wins if both are present.
   optional string client_ip = 4;
 }
 

--- a/pxe/ipxe/local/embed.ipxe
+++ b/pxe/ipxe/local/embed.ipxe
@@ -15,30 +15,15 @@ prompt --key p --timeout 4000 Hit the ${bold}p${boldoff} key to open carbide men
 
 :whoami
 ifconf -c dhcp
-# When a DHCP server (carbide-dhcp or API-integrated DHCP server) populates
-# option 43.70 with the machine_interface_id, use that as the identifier.
-# Otherwise, just rely on the client IP -- carbide-pxe will resolve it via
-# X-Forwarded-For (when proxied) or the TCP socket peer (when direct), then
-# look up the interface by IP. iPXE itself doesn't need to put the IP in
-# the URL since the network layer carries it.
-isset ${43.70} && goto whoami_uuid || goto whoami_sourceip
-
-:whoami_uuid
-time chain --autofree http://${next-server}:8080/api/v0/pxe/whoami?uuid=${43.70}
-goto carbide_menu
-
-:whoami_sourceip
+# carbide-pxe identifies the booting machine by its client IP (read from
+# X-Forwarded-For when proxied, TCP socket peer otherwise) and resolves
+# to a machine_interface_id via find_by_ip. iPXE doesn't need to encode
+# anything identity-related in the URL -- the network layer carries it.
 time chain --autofree http://${next-server}:8080/api/v0/pxe/whoami
 goto carbide_menu
 
 :carbide
 ifconf -c dhcp
-isset ${43.70} && goto carbide_uuid || goto carbide_sourceip
-
-:carbide_uuid
-time chain --autofree http://${next-server}:8080/api/v0/pxe/boot?uuid=${43.70}&buildarch=${buildarch}&platform=${platform}&manufacturer=${manufacturer}&product=${product}&serial=${serial} && exit 1 || goto error_handler
-
-:carbide_sourceip
 time chain --autofree http://${next-server}:8080/api/v0/pxe/boot?buildarch=${buildarch}&platform=${platform}&manufacturer=${manufacturer}&product=${product}&serial=${serial} && exit 1 || goto error_handler
 
 :carbide_menu


### PR DESCRIPTION
## Description

This closes https://github.com/NVIDIA/infra-controller-core/issues/1564.

Following up on #1464, this drops looking at DHCP option 43.70 entirely; `carbide-pxe` now just identifies the booting machine via the source IP it observed (either via `X-Forwarded-For` or its TCP socket peer), and `carbide-api` resolves to a `machine_interface_id` via `find_by_ip`.

Some key callouts are:
- Our `embed.ipxe` collapses to a single `:carbide` block -- no more `isset ${43.70}`.
- The `interface_id` proto field remains, but marked `[deprecated = true]`; `client_ip` is now the identifier.
- The `carbide-api` handler is now a single flow (with `PxeInstructionsReqquest` resolving into a `PxeInstructionsInput`).

Note: The `carbide-dhcp` side cleanup (to remove `set_vendor_options` / `machine_get_uuid`) will happen in a follow-up PR.

Tests updated!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

