### PR TITLE
Upgrade to rust 1.95

### DIFF
--- a/crates/admin-cli/src/expected_machines/show/cmd.rs
+++ b/crates/admin-cli/src/expected_machines/show/cmd.rs
@@ -77,8 +77,8 @@ pub async fn show_expected_machines(
         }));
 
     let bmc_ips = expected_mi
-        .iter()
-        .filter_map(|(_mac, interface)| {
+        .values()
+        .filter_map(|interface| {
             let ip = interface.address.first()?;
             Some(ip.clone())
         })

--- a/crates/admin-cli/src/expected_power_shelf/show/cmd.rs
+++ b/crates/admin-cli/src/expected_power_shelf/show/cmd.rs
@@ -63,8 +63,8 @@ pub async fn show(
         }));
 
     let bmc_ips = expected_mi
-        .iter()
-        .filter_map(|(_, iface)| iface.address.first())
+        .values()
+        .filter_map(|iface| iface.address.first())
         .cloned()
         .collect::<Vec<_>>();
 

--- a/crates/admin-cli/src/expected_switch/show/cmd.rs
+++ b/crates/admin-cli/src/expected_switch/show/cmd.rs
@@ -61,8 +61,8 @@ pub async fn show(
         }));
 
     let bmc_ips = expected_mi
-        .iter()
-        .filter_map(|(_mac, interface)| {
+        .values()
+        .filter_map(|interface| {
             let ip = interface.address.first()?;
             Some(ip.clone())
         })

--- a/crates/admin-cli/src/instance/show/cmd.rs
+++ b/crates/admin-cli/src/instance/show/cmd.rs
@@ -504,7 +504,7 @@ pub async fn handle_show(
             .await?;
 
         match sort_by {
-            SortField::PrimaryId => all_instances.instances.sort_by(|i1, i2| i1.id.cmp(&i2.id)),
+            SortField::PrimaryId => all_instances.instances.sort_by_key(|instance| instance.id),
             SortField::State => all_instances.instances.sort_by(|i1, i2| {
                 let tenant_status1 = i1
                     .status

--- a/crates/admin-cli/src/machine/show/cmd.rs
+++ b/crates/admin-cli/src/machine/show/cmd.rs
@@ -334,7 +334,7 @@ async fn show_all_machines(
         .await?;
 
     match sort_by {
-        SortField::PrimaryId => machines.machines.sort_by(|m1, m2| m1.id.cmp(&m2.id)),
+        SortField::PrimaryId => machines.machines.sort_by_key(|machine| machine.id),
         SortField::State => machines.machines.sort_by(|m1, m2| m1.state.cmp(&m2.state)),
     };
 

--- a/crates/admin-cli/src/managed_host/show/cmd.rs
+++ b/crates/admin-cli/src/managed_host/show/cmd.rs
@@ -293,14 +293,9 @@ fn show_managed_host_details_view(m: carbide_rpc_utils::ManagedHostOutput) -> Ca
         writeln!(&mut lines, "    Reason        : {}", m.state_reason)?;
     }
 
-    if m.maintenance_reference.is_some() {
+    if let Some(maintenance_reference) = &m.maintenance_reference {
         writeln!(&mut lines, "Host is in maintenance mode")?;
-        writeln!(
-            &mut lines,
-            "  Reference  : {}",
-            m.maintenance_reference
-                .expect("Host in maintenance mode without reference - impossible")
-        )?;
+        writeln!(&mut lines, "  Reference  : {maintenance_reference}")?;
         writeln!(
             &mut lines,
             "  Started at : {}",

--- a/crates/admin-cli/src/mlx/connections/cmds.rs
+++ b/crates/admin-cli/src/mlx/connections/cmds.rs
@@ -46,7 +46,7 @@ async fn handle_show(
     let response = ctxt.grpc_conn.0.scout_stream_show_connections().await?;
 
     let mut connections = response.scout_stream_connections;
-    connections.sort_by(|a, b| a.machine_id.cmp(&b.machine_id));
+    connections.sort_by_key(|connection| connection.machine_id);
     match ctxt.format {
         OutputFormat::AsciiTable => {
             print_connections_table(&connections);

--- a/crates/admin-cli/src/scout_stream/mod.rs
+++ b/crates/admin-cli/src/scout_stream/mod.rs
@@ -83,7 +83,7 @@ async fn handle_show(
 ) -> CarbideCliResult<()> {
     let response = ctxt.grpc_conn.0.scout_stream_show_connections().await?;
     let mut connections = response.scout_stream_connections;
-    connections.sort_by(|a, b| a.machine_id.cmp(&b.machine_id));
+    connections.sort_by_key(|connection| connection.machine_id);
     match ctxt.format {
         OutputFormat::AsciiTable => {
             print_connections_table(&connections);

--- a/crates/agent/src/nvue.rs
+++ b/crates/agent/src/nvue.rs
@@ -449,7 +449,7 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
     };
 
     let mut vpcs = vpc_configs.into_values().collect::<Vec<TmplVpc>>();
-    vpcs.sort_by(|a, b| a.L3VNI.cmp(&b.L3VNI));
+    vpcs.sort_by_key(|a| a.L3VNI);
 
     let (traffic_intercept_ipv4, traffic_intercept_ipv6) =
         split_prefixes_by_family(&conf.traffic_intercept_public_prefixes, 1);

--- a/crates/api-db/src/ip_allocator.rs
+++ b/crates/api-db/src/ip_allocator.rs
@@ -295,9 +295,10 @@ pub async fn next_machine_interface_v4_ip(
     if prefix.prefix.is_ipv6() {
         return Ok(None);
     }
-    if prefix.gateway.is_none() {
-        let nr = prefix.num_reserved.max(2); // Reserve network and gateway addresses at least
-        let query = r#"
+    match prefix.gateway {
+        None => {
+            let nr = prefix.num_reserved.max(2); // Reserve network and gateway addresses at least
+            let query = r#"
 SELECT ($1::inet + ip_series.n)::inet AS ip
 FROM generate_series($3, (1 << (32 - $2)) - 2) AS ip_series(n)
 LEFT JOIN machine_interface_addresses AS mia
@@ -307,17 +308,17 @@ ORDER BY ip
 LIMIT 1;
     "#;
 
-        sqlx::query_scalar(query)
-            .bind(prefix.prefix.ip())
-            .bind(prefix.prefix.prefix() as i32)
-            .bind(nr)
-            .fetch_optional(txn)
-            .await
-            .map_err(|e| DatabaseError::query(query, e))
-    } else {
-        let nr = prefix.num_reserved.max(1); // Reserve network address at least
-        let gw = prefix.gateway.unwrap();
-        let query = r#"
+            sqlx::query_scalar(query)
+                .bind(prefix.prefix.ip())
+                .bind(prefix.prefix.prefix() as i32)
+                .bind(nr)
+                .fetch_optional(txn)
+                .await
+                .map_err(|e| DatabaseError::query(query, e))
+        }
+        Some(gw) => {
+            let nr = prefix.num_reserved.max(1); // Reserve network address at least
+            let query = r#"
 SELECT ($1::inet + ip_series.n)::inet AS ip
 FROM generate_series($3, (1 << (32 - $2)) - 2) AS ip_series(n)
 LEFT JOIN machine_interface_addresses AS mia
@@ -328,14 +329,15 @@ ORDER BY ip
 LIMIT 1;
     "#;
 
-        sqlx::query_scalar(query)
-            .bind(prefix.prefix.ip())
-            .bind(prefix.prefix.prefix() as i32)
-            .bind(nr)
-            .bind(gw)
-            .fetch_optional(txn)
-            .await
-            .map_err(|e| DatabaseError::query(query, e))
+            sqlx::query_scalar(query)
+                .bind(prefix.prefix.ip())
+                .bind(prefix.prefix.prefix() as i32)
+                .bind(nr)
+                .bind(gw)
+                .fetch_optional(txn)
+                .await
+                .map_err(|e| DatabaseError::query(query, e))
+        }
     }
 }
 

--- a/crates/api-db/src/measured_boot/bundle.rs
+++ b/crates/api-db/src/measured_boot/bundle.rs
@@ -453,7 +453,7 @@ async fn match_bundle(
     // in the bundle, and return the most specific bundle
     // match (as in, the most unique values, if there is
     // one). If there's a conflict, then return an error.
-    matching.sort_by(|a, b| b.values.len().cmp(&a.values.len()));
+    matching.sort_by_key(|b| std::cmp::Reverse(b.values.len()));
     if matching[0].values.len() == matching[1].values.len() {
         return Err(DatabaseError::internal(String::from(
             "cannot determine most specific bundle match",
@@ -713,7 +713,7 @@ fn remove_all_subsets(bundles: &mut Vec<MeasurementBundle>) {
     // 3. if the shorter bundle is the subset, then remove it from the vector
 
     // 1.
-    bundles.sort_by(|a, b| b.values.len().cmp(&a.values.len()));
+    bundles.sort_by_key(|b| std::cmp::Reverse(b.values.len()));
 
     // 2.
     let mut indices_to_be_removed = Vec::<usize>::new();
@@ -1019,7 +1019,7 @@ mod tests {
 
     #[test]
     fn test_match_closest_bundle_better_match() {
-        let measurement_bundles = vec![
+        let measurement_bundles = [
             create_bundle_no_matches(),
             create_bundle_one_matching(),
             create_bundle_two_matching(),

--- a/crates/api-db/src/measured_boot/profile.rs
+++ b/crates/api-db/src/measured_boot/profile.rs
@@ -242,7 +242,7 @@ where
     // in the bundle, and return the most specific bundle
     // match (as in, the most unique values, if there is
     // one). If there's a conflict, then return an error.
-    matching.sort_by(|a, b| b.attrs.len().cmp(&a.attrs.len()));
+    matching.sort_by_key(|b| std::cmp::Reverse(b.attrs.len()));
     if matching[0].attrs.len() == matching[1].attrs.len() {
         return Err(DatabaseError::internal(String::from(
             "cannot determine most specific profile match",

--- a/crates/api-db/src/power_shelf.rs
+++ b/crates/api-db/src/power_shelf.rs
@@ -172,9 +172,9 @@ pub async fn find_ids(
 
     qb.push(" WHERE TRUE");
 
-    if filter.rack_id.is_some() {
+    if let Some(rack_id) = filter.rack_id {
         qb.push(" AND ps.rack_id = ");
-        qb.push_bind(filter.rack_id.unwrap());
+        qb.push_bind(rack_id);
     }
     match filter.deleted {
         model::DeletedFilter::Exclude => qb.push(" AND ps.deleted IS NULL"),

--- a/crates/api-db/src/switch.rs
+++ b/crates/api-db/src/switch.rs
@@ -175,9 +175,9 @@ pub async fn find_ids(
 
     qb.push(" WHERE TRUE");
 
-    if filter.rack_id.is_some() {
+    if let Some(rack_id) = filter.rack_id {
         qb.push(" AND s.rack_id = ");
-        qb.push_bind(filter.rack_id.unwrap());
+        qb.push_bind(rack_id);
     }
 
     match filter.deleted {

--- a/crates/api-model/src/power_shelf/mod.rs
+++ b/crates/api-model/src/power_shelf/mod.rs
@@ -233,11 +233,7 @@ impl TryFrom<PowerShelf> for rpc::PowerShelf {
             voltage: src.config.voltage.map(|v| v as i32),
         };
 
-        let deleted = if src.deleted.is_some() {
-            Some(src.deleted.unwrap().into())
-        } else {
-            None
-        };
+        let deleted = src.deleted.map(Into::into);
         let state_version = src.controller_state.version.to_string();
         Ok(rpc::PowerShelf {
             id: Some(src.id),

--- a/crates/api-model/src/switch/mod.rs
+++ b/crates/api-model/src/switch/mod.rs
@@ -375,11 +375,7 @@ impl TryFrom<Switch> for rpc::Switch {
             enable_nmxc: src.config.enable_nmxc,
         };
 
-        let deleted = if src.deleted.is_some() {
-            Some(src.deleted.unwrap().into())
-        } else {
-            None
-        };
+        let deleted = src.deleted.map(Into::into);
         let state_version = src.controller_state.version.to_string();
         Ok(rpc::Switch {
             id: Some(src.id),

--- a/crates/api-model/src/tenant/identity_config.rs
+++ b/crates/api-model/src/tenant/identity_config.rs
@@ -25,16 +25,11 @@ pub const TENANT_IDENTITY_SIGNING_JWT_ALG: &str = "ES256";
 
 /// Per-tenant JWT signing algorithm persisted in `tenant_identity_config.algorithm` and site config.
 /// Only [`SigningAlgorithm::Es256`] is implemented end-to-end today; the enum leaves room for more JOSE `alg` values later.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum SigningAlgorithm {
+    #[default]
     Es256,
-}
-
-impl Default for SigningAlgorithm {
-    fn default() -> Self {
-        Self::Es256
-    }
 }
 
 impl SigningAlgorithm {

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -3658,6 +3658,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::result_large_err)] // complains about figma::Error which we don't control
     fn deserialize_env_patched_full_config() {
         figment::Jail::expect_with(|jail| {
             jail.set_env("CARBIDE_API_DATABASE_URL", "postgres://othersql");

--- a/crates/api/src/handlers/dns.rs
+++ b/crates/api/src/handlers/dns.rs
@@ -323,23 +323,17 @@ pub async fn lookup_record_legacy_compat(
     tracing::info!("Legacy RPC method lookup_record_legacy called");
 
     let question = request.into_inner();
-    let qname = question.q_name.map_or_else(
-        || {
-            tracing::warn!(
-                "Received legacy DNS request with missing q_name - defaulting to empty string"
-            );
-            "".to_string()
-        },
-        |name| name,
-    );
+    let qname = question.q_name.unwrap_or_else(|| {
+        tracing::warn!(
+            "Received legacy DNS request with missing q_name - defaulting to empty string"
+        );
+        "".to_string()
+    });
 
-    let q_type = question.q_type.map_or_else(
-        || {
-            tracing::warn!("Received legacy DNS request with missing q_type - defaulting to 'A'");
-            1
-        },
-        |qtype| qtype,
-    );
+    let q_type = question.q_type.unwrap_or_else(|| {
+        tracing::warn!("Received legacy DNS request with missing q_type - defaulting to 'A'");
+        1
+    });
 
     // Log the full incoming request for debugging
     tracing::info!(

--- a/crates/api/src/handlers/instance.rs
+++ b/crates/api/src/handlers/instance.rs
@@ -1526,7 +1526,7 @@ pub async fn force_delete_instance(
 
     let network_segments_set: std::collections::HashSet<::carbide_uuid::network::NetworkSegmentId> =
         network_segment_ids_with_vpc.drain(..).collect();
-    network_segment_ids_with_vpc.extend(network_segments_set.into_iter());
+    network_segment_ids_with_vpc.extend(network_segments_set);
 
     // Mark all network ready for delete which were created for vpc_prefixes.
     if !network_segment_ids_with_vpc.is_empty() {

--- a/crates/api/src/measured_boot/rpc/report.rs
+++ b/crates/api/src/measured_boot/rpc/report.rs
@@ -281,7 +281,7 @@ pub async fn handle_match_measurement_report(
             message: format!("failure during report matching: {e}"),
         })?;
 
-    reports.sort_by(|a, b| a.ts.cmp(&b.ts));
+    reports.sort_by_key(|a| a.ts);
 
     let report_pbs: Vec<MeasurementReportRecordPb> =
         reports.iter().map(|report| report.clone().into()).collect();

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -3134,8 +3134,7 @@ async fn check_fw_component_version(
                 fw_component
                     .known_firmware
                     .iter()
-                    .filter(|fw_entry| !fw_entry.preingestion_exclusive_config)
-                    .next_back()
+                    .rfind(|fw_entry| !fw_entry.preingestion_exclusive_config)
                     .cloned()
             })
             .map(|f| f.version)

--- a/crates/api/src/tests/common/network_segment.rs
+++ b/crates/api/src/tests/common/network_segment.rs
@@ -141,10 +141,9 @@ pub async fn text_history(txn: &mut PgConnection, segment_id: NetworkSegmentId) 
 
     // // Check that version numbers are always incrementing by 1
     if !entries.is_empty() {
-        let mut version = entries[0].state_version.version_nr();
-        for entry in &entries[1..] {
-            assert_eq!(entry.state_version.version_nr(), version + 1);
-            version += 1;
+        let first_version = entries[0].state_version.version_nr();
+        for (expected_version, entry) in ((first_version + 1)..).zip(&entries[1..]) {
+            assert_eq!(entry.state_version.version_nr(), expected_version);
         }
     }
 

--- a/crates/api/src/tests/machine_history.rs
+++ b/crates/api/src/tests/machine_history.rs
@@ -282,10 +282,9 @@ async fn test_old_machine_state_history(
 fn json_history(history: &[StateHistoryRecord]) -> serde_json::Result<Vec<serde_json::Value>> {
     // // Check that version numbers are always incrementing by 1
     if !history.is_empty() {
-        let mut version = history[0].state_version.version_nr();
-        for entry in &history[1..] {
-            assert_eq!(entry.state_version.version_nr(), version + 1);
-            version += 1;
+        let first_version = history[0].state_version.version_nr();
+        for (expected_version, entry) in ((first_version + 1)..).zip(&history[1..]) {
+            assert_eq!(entry.state_version.version_nr(), expected_version);
         }
     }
 

--- a/crates/api/src/web/dpa.rs
+++ b/crates/api/src/web/dpa.rs
@@ -85,11 +85,11 @@ async fn fetch_dpas(api: Arc<Api>) -> Result<Vec<forgerpc::DpaInterface>, tonic:
             .await
             .map(|response| response.into_inner())?;
 
-        dpas.extend(next_dpas.interfaces.into_iter());
+        dpas.extend(next_dpas.interfaces);
         offset += page_size;
     }
 
-    dpas.sort_unstable_by(|dpa1, dpa2| dpa1.id.cmp(&dpa2.id));
+    dpas.sort_unstable_by_key(|dpa1| dpa1.id);
 
     Ok(dpas)
 }

--- a/crates/api/src/web/ib_partition.rs
+++ b/crates/api/src/web/ib_partition.rs
@@ -130,7 +130,7 @@ async fn fetch_ib_partitions(api: Arc<Api>) -> Result<Vec<forgerpc::IbPartition>
             .await
             .map(|response| response.into_inner())?;
 
-        partitions.extend(next_partitions.ib_partitions.into_iter());
+        partitions.extend(next_partitions.ib_partitions);
         offset += page_size;
     }
 

--- a/crates/api/src/web/instance.rs
+++ b/crates/api/src/web/instance.rs
@@ -177,7 +177,7 @@ async fn fetch_instances(api: Arc<Api>) -> Result<forgerpc::InstanceList, tonic:
         });
         let next_instances = api.find_instances_by_ids(request).await?.into_inner();
 
-        instances.extend(next_instances.instances.into_iter());
+        instances.extend(next_instances.instances);
         offset += page_size;
     }
 

--- a/crates/api/src/web/machine.rs
+++ b/crates/api/src/web/machine.rs
@@ -420,7 +420,7 @@ pub async fn fetch_machines(
             .await?
             .into_inner();
 
-        machines.extend(next_machines.machines.into_iter());
+        machines.extend(next_machines.machines);
         offset += page_size;
     }
 

--- a/crates/api/src/web/managed_host.rs
+++ b/crates/api/src/web/managed_host.rs
@@ -673,7 +673,7 @@ async fn fetch_managed_hosts_with_metadata(
         });
         let next_machines = api.find_machines_by_ids(request).await?.into_inner();
 
-        all_machines.extend(next_machines.machines.into_iter());
+        all_machines.extend(next_machines.machines);
         offset += page_size;
     }
 

--- a/crates/api/src/web/network_segment.rs
+++ b/crates/api/src/web/network_segment.rs
@@ -168,7 +168,7 @@ async fn fetch_network_segments(
             .await?
             .into_inner();
 
-        segments.extend(next_vpcs.network_segments.into_iter());
+        segments.extend(next_vpcs.network_segments);
         offset += page_size;
     }
 

--- a/crates/api/src/web/nvlink.rs
+++ b/crates/api/src/web/nvlink.rs
@@ -244,7 +244,7 @@ async fn fetch_logical_partitions(
             .find_nv_link_logical_partitions_by_ids(request_partitions)
             .await
             .map(|response| response.into_inner())?;
-        partitions.extend(next_partitions.partitions.into_iter());
+        partitions.extend(next_partitions.partitions);
     } else {
         let mut offset = 0;
         while offset != partition_ids.len() {
@@ -261,7 +261,7 @@ async fn fetch_logical_partitions(
                 .await
                 .map(|response| response.into_inner())?;
 
-            partitions.extend(next_partitions.partitions.into_iter());
+            partitions.extend(next_partitions.partitions);
             offset += page_size;
         }
     }
@@ -319,7 +319,7 @@ async fn fetch_logical_partitions(
                     .await?
                     .into_inner();
 
-                machines.extend(next_vpcs.machines.into_iter());
+                machines.extend(next_vpcs.machines);
                 offset += page_size;
             }
 

--- a/crates/api/src/web/rack.rs
+++ b/crates/api/src/web/rack.rs
@@ -115,7 +115,7 @@ pub async fn fetch_racks(api: &Api) -> Result<rpc::forge::RackList, tonic::Statu
             .await?
             .into_inner();
 
-        racks.extend(next_racks.racks.into_iter());
+        racks.extend(next_racks.racks);
         offset += page_size;
     }
 

--- a/crates/api/src/web/sku.rs
+++ b/crates/api/src/web/sku.rs
@@ -130,7 +130,7 @@ async fn fetch_skus(api: Arc<Api>) -> Result<Vec<forgerpc::Sku>, tonic::Status> 
             .await
             .map(|response| response.into_inner())?;
 
-        skus.extend(next_skus.skus.into_iter());
+        skus.extend(next_skus.skus);
         offset += page_size;
     }
 

--- a/crates/api/src/web/tenant.rs
+++ b/crates/api/src/web/tenant.rs
@@ -105,7 +105,7 @@ async fn fetch_tenants(api: Arc<Api>) -> Result<forgerpc::TenantList, tonic::Sta
             .await?
             .into_inner();
 
-        tenants.extend(next_vpcs.tenants.into_iter());
+        tenants.extend(next_vpcs.tenants);
         offset += page_size;
     }
 

--- a/crates/api/src/web/tenant_keyset.rs
+++ b/crates/api/src/web/tenant_keyset.rs
@@ -119,7 +119,7 @@ async fn fetch_keysets(api: Arc<Api>) -> Result<forgerpc::TenantKeySetList, toni
             .await?
             .into_inner();
 
-        keyset.extend(next_keysets.keyset.into_iter());
+        keyset.extend(next_keysets.keyset);
         offset += page_size;
     }
 

--- a/crates/api/src/web/vpc.rs
+++ b/crates/api/src/web/vpc.rs
@@ -110,7 +110,7 @@ async fn fetch_vpcs(api: Arc<Api>) -> Result<Vec<forgerpc::Vpc>, tonic::Status> 
             .await?
             .into_inner();
 
-        vpcs.extend(next_vpcs.vpcs.into_iter());
+        vpcs.extend(next_vpcs.vpcs);
         offset += page_size;
     }
 

--- a/crates/dpf/dev/Dockerfile.carbide-dpf-api-harness-glibc2.34
+++ b/crates/dpf/dev/Dockerfile.carbide-dpf-api-harness-glibc2.34
@@ -30,7 +30,7 @@ RUN apt-get update && \
     libssl-dev \
     ca-certificates \
     git \
-    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.90.0 \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.95.0 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -551,17 +551,12 @@ impl Default for LeakDetectorCollectorConfig {
 
 /// SSE is the preferred mode for real-time log streaming.
 /// Periodic polling is retained as a fallback for BMCs that lack SSE support.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum LogCollectionMode {
+    #[default]
     Sse,
     Periodic,
-}
-
-impl Default for LogCollectionMode {
-    fn default() -> Self {
-        Self::Sse
-    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/crates/ib-fabric/src/config.rs
+++ b/crates/ib-fabric/src/config.rs
@@ -190,6 +190,7 @@ max_partition_per_tenant = 3
     }
 
     #[test]
+    #[allow(clippy::result_large_err)] // complains about figma::Error which we don't control
     fn deserialize_serialize_ib_config() {
         // An empty config matches the default object
         let deserialized_empty: IBFabricConfig = serde_json::from_str("{}").unwrap();

--- a/crates/libmlx/tests/variables/test_variable.rs
+++ b/crates/libmlx/tests/variables/test_variable.rs
@@ -280,7 +280,7 @@ fn test_mlx_config_variable_debug_formatting() {
 
 #[test]
 fn test_multiple_variables_with_different_specs() {
-    let variables = vec![
+    let variables = [
         MlxConfigVariable::builder()
             .name("boolean_var")
             .description("A boolean variable")

--- a/crates/network/src/virtualization.rs
+++ b/crates/network/src/virtualization.rs
@@ -37,8 +37,9 @@ pub const DEFAULT_NETWORK_VIRTUALIZATION_TYPE: VpcVirtualizationType =
 /// and plumb the value down to the DPU agent, which gets piped into
 /// the `update_nvue` function, which is then used to drive
 /// population of the appropriate template.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VpcVirtualizationType {
+    #[default]
     EthernetVirtualizer,
     EthernetVirtualizerWithNvue,
     Fnn,
@@ -122,12 +123,6 @@ mod sqlx_tests {
     #[test]
     fn encode_fnn_writes_fnn() {
         assert_eq!(encode_to_string(VpcVirtualizationType::Fnn), "fnn");
-    }
-}
-
-impl Default for VpcVirtualizationType {
-    fn default() -> Self {
-        Self::EthernetVirtualizer
     }
 }
 

--- a/crates/rpc-utils/src/dhcp.rs
+++ b/crates/rpc-utils/src/dhcp.rs
@@ -209,11 +209,13 @@ pub struct DhcpTimestamps {
     path: DhcpTimestampsFilePath,
 }
 
+#[derive(Default)]
 pub enum DhcpTimestampsFilePath {
     HbnTmp,
     Hbn,
     Dpu,
     Test,
+    #[default]
     NotSet,
 }
 
@@ -226,12 +228,6 @@ impl DhcpTimestampsFilePath {
             Self::Test => DHCP_TIMESTAMP_FILE_TEST,
             Self::NotSet => "Not set",
         }
-    }
-}
-
-impl Default for DhcpTimestampsFilePath {
-    fn default() -> Self {
-        Self::NotSet
     }
 }
 

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -1303,7 +1303,7 @@ fn warn_report_diff(report1: &EndpointExplorationReport, report2: &EndpointExplo
             let mut report2_idx = (0..s2.inventories.len()).collect::<Vec<_>>();
             report2_idx.sort_by_key(|i| &s2.inventories[*i].id);
 
-            for (i1, i2) in report1_idx.into_iter().zip(report2_idx.into_iter()) {
+            for (i1, i2) in report1_idx.into_iter().zip(report2_idx) {
                 let i1 = &s1.inventories[i1];
                 let i2 = &s2.inventories[i2];
                 if i1.id != i2.id
@@ -1353,7 +1353,7 @@ fn warn_report_diff(report1: &EndpointExplorationReport, report2: &EndpointExplo
                 r2.diffs
             );
         } else {
-            for (i1, i2) in sst1_idx.into_iter().zip(sst2_idx.into_iter()) {
+            for (i1, i2) in sst1_idx.into_iter().zip(sst2_idx) {
                 let d1 = &r1.diffs[i1];
                 let d2 = &r2.diffs[i2];
                 if d1 != d2 {

--- a/dev/docker/Dockerfile.build-artifacts-container-aarch64
+++ b/dev/docker/Dockerfile.build-artifacts-container-aarch64
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM arm64v8/rust:1.90.0-slim-bullseye
+FROM arm64v8/rust:1.95.0-slim-bullseye
 
 # Set in gitlab-templates/scripts/build-push-container-image.sh
 ARG CI_COMMIT_SHORT_SHA

--- a/dev/docker/Dockerfile.build-artifacts-container-cross-aarch64
+++ b/dev/docker/Dockerfile.build-artifacts-container-cross-aarch64
@@ -16,7 +16,7 @@
 # Note that the output container image needs to be able to produce artifacts
 # that are compatible with the DPU BFB, so for example the libc6 version can't
 # be greater than what we see in the BFB.
-FROM rust:1.90.0-bookworm
+FROM rust:1.95.0-bookworm
 
 RUN dpkg --add-architecture arm64 && \
     apt-get update && \

--- a/dev/docker/Dockerfile.build-artifacts-container-x86_64
+++ b/dev/docker/Dockerfile.build-artifacts-container-x86_64
@@ -26,7 +26,7 @@
 # - `docker push urm.nvidia.com/swngc-ngcc-docker-local/forge/carbide/x86-64/build-container:{OUTPUT_OF_GIT_DESCRIBE_HERE}`
 
 # This should match rust-toolchain.toml
-FROM rust:1.90.0-slim-bullseye
+FROM rust:1.95.0-slim-bullseye
 
 # Set in gitlab-templates/scripts/build-push-container-image.sh
 ARG CI_COMMIT_SHORT_SHA

--- a/dev/docker/Dockerfile.build-container-aarch64
+++ b/dev/docker/Dockerfile.build-container-aarch64
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM arm64v8/rust:1.90.0-slim-bookworm
+FROM arm64v8/rust:1.95.0-slim-bookworm
 
 # Set in gitlab-templates/scripts/build-push-container-image.sh
 ARG CI_COMMIT_SHORT_SHA

--- a/dev/docker/Dockerfile.build-container-x86_64
+++ b/dev/docker/Dockerfile.build-container-x86_64
@@ -16,7 +16,7 @@
 #
 
 # This should match rust-toolchain.toml
-FROM rust:1.90.0-slim-bookworm
+FROM rust:1.95.0-slim-bookworm
 
 # Set in gitlab-templates/scripts/build-push-container-image.sh
 ARG CI_COMMIT_SHORT_SHA

--- a/dev/docker/Dockerfile.cargo-docker-minimal
+++ b/dev/docker/Dockerfile.cargo-docker-minimal
@@ -9,7 +9,7 @@
 # On Apple Silicon (M1/M2/M3): do not set --platform=linux/amd64. Building on
 # arm64 produces a native image; use Colima with enough CPU/memory and virtiofs (see docs).
 #
-FROM rust:1.90.0-slim-bookworm
+FROM rust:1.95.0-slim-bookworm
 
 RUN apt-get update && \
 	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/dev/docker/Dockerfile.pxe-build-container
+++ b/dev/docker/Dockerfile.pxe-build-container
@@ -24,7 +24,7 @@
 #
 FROM ubuntu:24.04
 
-ARG RUST_VERSION=1.90.0
+ARG RUST_VERSION=1.95.0
 
 RUN apt-get update && \
 	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/dev/docker/sbom-tools/Dockerfile
+++ b/dev/docker/sbom-tools/Dockerfile
@@ -20,7 +20,7 @@ ARG IMG=nvcr.io/nvidia/distroless/cc
 ARG DEBUG_DISTROLESS=true
 ARG DISTROLESS_DEBUG_TAG=${DEBUG_DISTROLESS:+"dev"} # 'dev' provides a busybox shell
 
-FROM rust:1.90.0-slim-bookworm AS builder
+FROM rust:1.95.0-slim-bookworm AS builder
 
 WORKDIR /build
 

--- a/docs/manuals/cargo-via-docker-macos.md
+++ b/docs/manuals/cargo-via-docker-macos.md
@@ -8,13 +8,13 @@ This guide describes what is in place for running Cargo (build, test, check) via
 
 | Item | Location | Purpose |
 |------|----------|--------|
-| **Makefile task: `cargo-docker-minimal`** | `Makefile.toml` | Run Cargo in the minimal image (`carbide-build-minimal`: Rust 1.90 + protoc). **Recommended on Mac.** Requires `build-cargo-docker-image-minimal` once. |
+| **Makefile task: `cargo-docker-minimal`** | `Makefile.toml` | Run Cargo in the minimal image (`carbide-build-minimal`: Rust 1.95 + protoc). **Recommended on Mac.** Requires `build-cargo-docker-image-minimal` once. |
 | **Makefile task: `build-cargo-docker-image-minimal`** | `Makefile.toml` | Build the minimal image (Rust + protoc only). Quick (~2–5 min). Required once for workspace builds (e.g. `carbide-rpc` needs `protoc`). |
 | **Makefile task: `cargo-docker`** | `Makefile.toml` | Run Cargo inside the repo’s full build container (`carbide-build-x86_64`). Requires building that image first. |
 | **Makefile task: `build-cargo-docker-image`** | `Makefile.toml` | Build the full Linux build image from `dev/docker/Dockerfile.build-container-x86_64`. Slow on Apple Silicon (45+ min). |
 | **This guide** | `docs/development/cargo-via-docker-macos.md` | How to use the above and when to choose which option. |
-| **Minimal Dockerfile** | `dev/docker/Dockerfile.cargo-docker-minimal` | Rust 1.90 + `protobuf-compiler` + `libprotobuf-dev` (well-known types). Used for `carbide-build-minimal`. |
-| **Full build Dockerfile** | `dev/docker/Dockerfile.build-container-x86_64` | Defines the full build image (Rust 1.90, PostgreSQL, protobuf, TSS, etc.). |
+| **Minimal Dockerfile** | `dev/docker/Dockerfile.cargo-docker-minimal` | Rust 1.95 + `protobuf-compiler` + `libprotobuf-dev` (well-known types). Used for `carbide-build-minimal`. |
+| **Full build Dockerfile** | `dev/docker/Dockerfile.build-container-x86_64` | Defines the full build image (Rust 1.95, PostgreSQL, protobuf, TSS, etc.). |
 
 All commands below are run from the **repository root** unless noted.
 
@@ -173,7 +173,7 @@ If you get an error about the `loki` logging plugin, use: `docker-compose -f doc
 
 **2. Run IB partition tests:**
 
-**Locally (Rust 1.90 + `DATABASE_URL`):**
+**Locally (Rust 1.95 + `DATABASE_URL`):**
 
 ```bash
 export DATABASE_URL="postgres://carbide_development:notforprod@localhost:5432/carbide_development"
@@ -248,7 +248,7 @@ Output binaries appear under `target/` in your repo as usual.
 
 **When to use:** Day-to-day builds and checks on macOS when you don’t need the full API test stack (PostgreSQL, TSS, etc.).
 
-**What it uses:** The image `carbide-build-minimal` (Rust 1.90 + `protoc`). You must build it once with `build-cargo-docker-image-minimal` (~2–5 min). The `carbide-rpc` crate needs `protoc` and the Google well-known proto files (`libprotobuf-dev`), so the bare `rust:1.90.0-slim-bookworm` image is not enough for workspace builds.
+**What it uses:** The image `carbide-build-minimal` (Rust 1.95 + `protoc`). You must build it once with `build-cargo-docker-image-minimal` (~2–5 min). The `carbide-rpc` crate needs `protoc` and the Google well-known proto files (`libprotobuf-dev`), so the bare `rust:1.95.0-slim-bookworm` image is not enough for workspace builds.
 
 ### Usage
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -15,5 +15,5 @@
 # limitations under the License.
 #
 [toolchain]
-# If you change this grep for "FROM.*rust:1.90.0" and update those Dockerfiles
-channel = "1.90.0"
+# If you change this grep for "FROM.*rust:1.95.0" and update those Dockerfiles
+channel = "1.95.0"


### PR DESCRIPTION
## Description
After updating all cargo dependencies, this updates to latest stable rust, 1.95.0.

There are some new clippy lints, so this goes through and fixes them when we can.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes

