### PR TITLE
fix(bmc-explorer): relax AMI lockdown validation for partial states

### DIFF
--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -339,10 +339,7 @@ fn lockdown_status<B: Bmc>(
             match (kcsacp, usb000, hi_enabled) {
                 (Some("Deny All"), Some("Disabled"), false) => Ok(InternalLockdownStatus::Enabled),
                 (Some("Allow All"), Some("Enabled"), true) => Ok(InternalLockdownStatus::Disabled),
-                (Some(_), Some(_), _) => Ok(InternalLockdownStatus::Partial),
-                _ => Err(Error::InvalidValue(format!(
-                    "AMI lockdown status: {message}"
-                ))),
+                _ => Ok(InternalLockdownStatus::Partial),
             }
             .map(|status| Some(LockdownStatus { status, message }))
         }

--- a/crates/bmc-explorer/tests/generic_ami.rs
+++ b/crates/bmc-explorer/tests/generic_ami.rs
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+mod common;
+
+use bmc_explorer::nv_generate_exploration_report;
+use bmc_mock::test_support;
+use model::site_explorer::{EndpointType, InternalLockdownStatus};
+use tokio::test;
+
+#[test]
+async fn explore_generic_ami() {
+    let h = test_support::generic_ami_bmc().await;
+    let report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
+        .await
+        .unwrap();
+
+    assert_eq!(report.endpoint_type, EndpointType::Bmc);
+    assert_eq!(report.vendor, None);
+    assert!(!report.systems.is_empty(), "systems must be present");
+    assert!(!report.chassis.is_empty(), "chassis must be present");
+
+    // Lockdown is always partial for generic AMI.
+    let lockdown = report
+        .lockdown_status
+        .as_ref()
+        .expect("lockdown status must be present for AMI");
+
+    assert_eq!(lockdown.status, InternalLockdownStatus::Partial);
+}

--- a/crates/bmc-mock/src/hw/generic_ami.rs
+++ b/crates/bmc-mock/src/hw/generic_ami.rs
@@ -1,0 +1,143 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use rpc::DiscoveryInfo;
+use serde_json::json;
+
+use crate::{BootOptionKind, Callbacks, hw, redfish};
+
+pub struct GenericAmi<'a> {
+    pub product_serial_number: Cow<'a, str>,
+    pub nics: Vec<(hw::nic::SlotNumber, hw::nic::Nic<'a>)>,
+}
+
+impl GenericAmi<'_> {
+    pub fn manager_config(&self) -> redfish::manager::Config {
+        let bmc_manager_id = "Self";
+        redfish::manager::Config {
+            managers: vec![redfish::manager::SingleConfig {
+                id: bmc_manager_id,
+                eth_interfaces: Some(vec![]),
+                host_interfaces: Some(vec![
+                    redfish::host_interface::builder(&redfish::host_interface::manager_resource(
+                        bmc_manager_id,
+                        "Self",
+                    ))
+                    .interface_enabled(true)
+                    .build(),
+                ]),
+                firmware_version: Some("47.20.02"),
+                oem: None,
+            }],
+        }
+    }
+
+    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
+        let system_id = "Self";
+
+        let boot_opt_builder = |id: &str, kind| {
+            redfish::boot_option::builder(&redfish::boot_option::resource(system_id, id), kind)
+                .boot_option_reference(id)
+        };
+        let boot_options = self
+            .nics
+            .iter()
+            .map(|(slot_number, nic)| {
+                (
+                    format!(
+                        "UEFI P{slot_number}: HTTP IPv4 Nvidia Network Adapter - {}",
+                        nic.mac_address
+                    ),
+                    BootOptionKind::Network,
+                )
+            })
+            .chain(std::iter::once((
+                "UEFI OS".to_string(),
+                BootOptionKind::Disk,
+            )))
+            .enumerate()
+            .map(|(index, (display_name, kind))| {
+                boot_opt_builder(&format!("Boot{index:04X}"), kind)
+                    .display_name(&display_name)
+                    .build()
+            })
+            .collect();
+        redfish::computer_system::Config {
+            systems: vec![redfish::computer_system::SingleSystemConfig {
+                id: Cow::Borrowed(system_id),
+                manufacturer: None,
+                model: None,
+                eth_interfaces: Some(vec![]),
+                serial_number: Some(self.product_serial_number.to_string().into()),
+                boot_order_mode: redfish::computer_system::BootOrderMode::Generic,
+                callbacks: Some(callbacks),
+                chassis: vec!["Self".into()],
+                boot_options: Some(boot_options),
+                bios_mode: redfish::computer_system::BiosMode::Generic,
+                oem: redfish::computer_system::Oem::Generic,
+                log_services: None,
+                storage: None,
+                base_bios: Some(
+                    redfish::bios::builder(&redfish::bios::resource(system_id))
+                        .attributes(json!({"EndlessBoot":""}))
+                        .build(),
+                ),
+                secure_boot_available: false,
+            }],
+        }
+    }
+
+    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+        let chassis_id = "Self";
+
+        let pcie_devices = self
+            .nics
+            .iter()
+            .map(|(slot, nic)| {
+                let pcie_device_id = format!("mat_{}", slot);
+                redfish::pcie_device::builder_from_nic(
+                    &redfish::pcie_device::chassis_resource(chassis_id, &pcie_device_id),
+                    nic,
+                )
+                .status(redfish::resource::Status::Ok)
+                .build()
+            })
+            .collect();
+
+        redfish::chassis::ChassisConfig {
+            chassis: vec![redfish::chassis::SingleChassisConfig {
+                id: chassis_id.into(),
+                chassis_type: "Component".into(),
+                pcie_devices: Some(pcie_devices),
+                ..redfish::chassis::SingleChassisConfig::defaults()
+            }],
+        }
+    }
+
+    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+        redfish::update_service::UpdateServiceConfig {
+            firmware_inventory: vec![],
+        }
+    }
+
+    pub fn discovery_info(&self) -> DiscoveryInfo {
+        DiscoveryInfo::default()
+    }
+}

--- a/crates/bmc-mock/src/hw/mod.rs
+++ b/crates/bmc-mock/src/hw/mod.rs
@@ -24,6 +24,9 @@ pub mod nic;
 /// Support of NVIDIA Bluefield3 DPU.
 pub mod bluefield3;
 
+/// Generic AMI server.
+pub mod generic_ami;
+
 /// Support of Dell PowerEdge R750 servers.
 pub mod dell_poweredge_r750;
 

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -65,6 +65,8 @@ pub enum HostHardwareType {
     NvidiaSwitchNd5200Ld,
     #[serde(rename = "nvidia_dgx_h100")]
     NvidiaDgxH100,
+    #[serde(rename = "generic_ami")]
+    GenericAmi,
 }
 
 impl fmt::Display for HostHardwareType {
@@ -76,6 +78,7 @@ impl fmt::Display for HostHardwareType {
             Self::LiteOnPowerShelf => "Lite-On Power Shelf".fmt(f),
             Self::NvidiaSwitchNd5200Ld => "NVIDIA Switch ND5200_LD".fmt(f),
             Self::NvidiaDgxH100 => "NVIDIA DGX H100".fmt(f),
+            Self::GenericAmi => "Generic AMI Server".fmt(f),
         }
     }
 }
@@ -92,6 +95,7 @@ impl HostHardwareType {
             Self::LiteOnPowerShelf => Some(0),
             Self::NvidiaSwitchNd5200Ld => Some(0),
             Self::NvidiaDgxH100 => Some(1),
+            Self::GenericAmi => None,
         }
     }
 }

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -110,11 +110,11 @@ impl DpuMachineInfo {
 
     fn bluefield3(&self) -> hw::bluefield3::Bluefield3<'_> {
         let mode = match self.hw_type {
-            HostHardwareType::DellPowerEdgeR750 | HostHardwareType::NvidiaDgxH100 => {
-                hw::bluefield3::Mode::SuperNIC {
-                    nic_mode: self.settings.nic_mode,
-                }
-            }
+            HostHardwareType::DellPowerEdgeR750
+            | HostHardwareType::NvidiaDgxH100
+            | HostHardwareType::GenericAmi => hw::bluefield3::Mode::SuperNIC {
+                nic_mode: self.settings.nic_mode,
+            },
             HostHardwareType::WiwynnGB200Nvl | HostHardwareType::LenovoGB300Nvl => {
                 hw::bluefield3::Mode::B3240ColdAisle
             }
@@ -174,7 +174,8 @@ impl HostMachineInfo {
             | HostHardwareType::LenovoGB300Nvl
             | HostHardwareType::LiteOnPowerShelf
             | HostHardwareType::NvidiaDgxH100
-            | HostHardwareType::NvidiaSwitchNd5200Ld => redfish::oem::State::Other,
+            | HostHardwareType::NvidiaSwitchNd5200Ld
+            | HostHardwareType::GenericAmi => redfish::oem::State::Other,
         }
     }
 
@@ -188,6 +189,7 @@ impl HostMachineInfo {
                 redfish::oem::BmcVendor::Nvidia(redfish::oem::NvidiaNamestyle::Uppercase)
             }
             HostHardwareType::NvidiaDgxH100 => redfish::oem::BmcVendor::Ami,
+            HostHardwareType::GenericAmi => redfish::oem::BmcVendor::Ami,
         }
     }
 
@@ -199,6 +201,7 @@ impl HostMachineInfo {
             HostHardwareType::LiteOnPowerShelf => None,
             HostHardwareType::NvidiaSwitchNd5200Ld => Some("P3809"),
             HostHardwareType::NvidiaDgxH100 => Some("AMI Redfish Server"),
+            HostHardwareType::GenericAmi => Some("AMI Redfish Server"),
         }
     }
 
@@ -210,6 +213,7 @@ impl HostMachineInfo {
             HostHardwareType::LiteOnPowerShelf => "1.9.0",
             HostHardwareType::NvidiaSwitchNd5200Ld => "1.17.0",
             HostHardwareType::NvidiaDgxH100 => "1.11.0",
+            HostHardwareType::GenericAmi => "1.17.0",
         }
     }
 
@@ -223,6 +227,7 @@ impl HostMachineInfo {
                 self.nvidia_switch_nd5200_ld().manager_config()
             }
             HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().manager_config(),
+            HostHardwareType::GenericAmi => self.generic_ami().manager_config(),
         }
     }
 
@@ -241,6 +246,7 @@ impl HostMachineInfo {
                 self.nvidia_switch_nd5200_ld().system_config()
             }
             HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().system_config(callbacks),
+            HostHardwareType::GenericAmi => self.generic_ami().system_config(callbacks),
         }
     }
 
@@ -254,6 +260,7 @@ impl HostMachineInfo {
                 self.nvidia_switch_nd5200_ld().chassis_config()
             }
             HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().chassis_config(),
+            HostHardwareType::GenericAmi => self.generic_ami().chassis_config(),
         }
     }
 
@@ -269,6 +276,7 @@ impl HostMachineInfo {
                 self.nvidia_switch_nd5200_ld().update_service_config()
             }
             HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().update_service_config(),
+            HostHardwareType::GenericAmi => self.generic_ami().update_service_config(),
         }
     }
 
@@ -278,6 +286,7 @@ impl HostMachineInfo {
             HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().discovery_info(),
             HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().discovery_info(),
             HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().discovery_info(),
+            HostHardwareType::GenericAmi => self.generic_ami().discovery_info(),
             HostHardwareType::LiteOnPowerShelf | HostHardwareType::NvidiaSwitchNd5200Ld => {
                 panic!("discovery_info requested for {}", self.hw_type)
             }
@@ -287,7 +296,7 @@ impl HostMachineInfo {
     pub fn factory_default_account(&self) -> redfish::account_service::Account {
         // TODO: need to be updated for each individual system.
         let id = match self.hw_type {
-            HostHardwareType::NvidiaDgxH100 => "2",
+            HostHardwareType::NvidiaDgxH100 | HostHardwareType::GenericAmi => "2",
             _ => DUMMY_FACTORY_USERNAME,
         };
         redfish::account_service::Account::administrator(
@@ -489,6 +498,20 @@ impl HostMachineInfo {
             bmc_mac_address_eth0: next_mac(),
             bmc_mac_address_usb0: next_mac(),
             hgx_bmc_mac_address_usb0: next_mac(),
+        }
+    }
+
+    fn generic_ami(&self) -> hw::generic_ami::GenericAmi<'_> {
+        let nics = self
+            .dpus
+            .iter()
+            .enumerate()
+            .map(|(index, dpu)| (index + 1, dpu.bluefield3().host_nic()))
+            .collect();
+
+        hw::generic_ami::GenericAmi {
+            product_serial_number: Cow::Borrowed(&self.serial),
+            nics,
         }
     }
 }

--- a/crates/bmc-mock/src/redfish/manager.rs
+++ b/crates/bmc-mock/src/redfish/manager.rs
@@ -176,7 +176,7 @@ pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
         )
         .route(
             &redfish::host_interface::manager_resource(MGR_ID, HOST_IF_ID).odata_id,
-            get(get_host_interface),
+            get(get_host_interface).patch(patch_host_interface),
         )
         .route(&reset_target(MGR_ID), post(post_reset_manager))
         .route(
@@ -376,6 +376,23 @@ async fn get_host_interface(
                 .iter()
                 .find(|iface| iface.id == iface_id)
                 .map(|iface| iface.to_json().into_ok_response())
+        })
+        .unwrap_or_else(http::not_found)
+}
+
+async fn patch_host_interface(
+    State(state): State<BmcState>,
+    Path((manager_id, iface_id)): Path<(String, String)>,
+) -> Response {
+    state
+        .manager
+        .find(&manager_id)
+        .and_then(|manager| manager.config.host_interfaces.as_ref())
+        .and_then(|host_interfaces| {
+            host_interfaces
+                .iter()
+                .find(|iface| iface.id == iface_id)
+                .map(|_| http::ok_no_content())
         })
         .unwrap_or_else(http::not_found)
 }

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -139,6 +139,16 @@ pub async fn dell_poweredge_r750_bluefield3_bmc(settings: DpuSettings) -> TestBm
     .await
 }
 
+pub async fn generic_ami_bmc() -> TestBmcHandle {
+    test_bmc(machine_router(
+        MachineInfo::Host(HostMachineInfo::new(HostHardwareType::GenericAmi, vec![])),
+        Arc::new(NoopCallbacks),
+        "test-host-id".to_string(),
+        false,
+    ))
+    .await
+}
+
 #[cfg(test)]
 mod test {
 


### PR DESCRIPTION
## Description
Treat unexpected AMI lockdown field combinations as Partial instead of failing exploration with InvalidValue. This fixes an over-strict lockdown check for AMI-based BMCs.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

#1506 

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

