### PR TITLE
fix(dhcp): enhance lease expiration hook scope to an (ip, mac) pair

### DIFF
--- a/crates/api-db/src/machine_interface_address.rs
+++ b/crates/api-db/src/machine_interface_address.rs
@@ -206,6 +206,32 @@ pub async fn delete_by_address(
         .map_err(|e| DatabaseError::query(query, e))
 }
 
+/// Delete an address allocation for a given (ip, mac) pair, which
+/// of course only actually deletes when the pair matches.
+///
+/// Returns true if a matching allocation was found and deleted.
+pub async fn delete_by_address_and_mac(
+    txn: &mut PgConnection,
+    address: IpAddr,
+    mac_address: mac_address::MacAddress,
+    allocation_type: AllocationType,
+) -> Result<bool, DatabaseError> {
+    let query = "DELETE FROM machine_interface_addresses mia
+        USING machine_interfaces mi
+        WHERE mia.interface_id = mi.id
+          AND mia.address = $1::inet
+          AND mia.allocation_type = $2
+          AND mi.mac_address = $3::macaddr";
+    sqlx::query(query)
+        .bind(address)
+        .bind(allocation_type)
+        .bind(mac_address)
+        .execute(txn)
+        .await
+        .map(|r| r.rows_affected() > 0)
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
 /// Check whether an interface has any address assigned for the
 /// given address family.
 ///

--- a/crates/api/src/dhcp/expire.rs
+++ b/crates/api/src/dhcp/expire.rs
@@ -17,6 +17,7 @@
 
 use std::net::IpAddr;
 
+use mac_address::MacAddress;
 use rpc::forge as rpc;
 use tonic::{Request, Response};
 
@@ -27,22 +28,55 @@ pub async fn expire_dhcp_lease(
     api: &Api,
     request: Request<rpc::ExpireDhcpLeaseRequest>,
 ) -> Result<Response<rpc::ExpireDhcpLeaseResponse>, CarbideError> {
-    let ip_address: IpAddr = request.into_inner().ip_address.parse()?;
+    let rpc::ExpireDhcpLeaseRequest {
+        ip_address,
+        mac_address,
+    } = request.into_inner();
+    let ip_address: IpAddr = ip_address.parse()?;
+    let mac_address: Option<MacAddress> = mac_address
+        .as_deref()
+        .map(|m| m.parse::<MacAddress>().map_err(CarbideError::from))
+        .transpose()?;
 
     let mut txn = api.txn_begin().await?;
-    let deleted = db::machine_interface_address::delete_by_address(
-        &mut txn,
-        ip_address,
-        model::allocation_type::AllocationType::Dhcp,
-    )
-    .await?;
+    // When the caller provides the MAC, scope the delete to the (ip, mac)
+    // pair. Otherwise, just call the address-only variant, which would
+    // be something we would see from an admin-cli call used for deleting
+    // a specific IP allocation.
+    let deleted = match mac_address {
+        Some(mac) => {
+            db::machine_interface_address::delete_by_address_and_mac(
+                &mut txn,
+                ip_address,
+                mac,
+                model::allocation_type::AllocationType::Dhcp,
+            )
+            .await?
+        }
+        None => {
+            db::machine_interface_address::delete_by_address(
+                &mut txn,
+                ip_address,
+                model::allocation_type::AllocationType::Dhcp,
+            )
+            .await?
+        }
+    };
     txn.commit().await?;
 
     let status = if deleted {
-        tracing::info!(%ip_address, "Released expired DHCP lease allocation");
+        tracing::info!(
+            %ip_address,
+            ?mac_address,
+            "Released expired DHCP lease allocation"
+        );
         rpc::ExpireDhcpLeaseStatus::Released
     } else {
-        tracing::debug!(%ip_address, "No allocation found for expired DHCP lease");
+        tracing::debug!(
+            %ip_address,
+            ?mac_address,
+            "No allocation found for expired DHCP lease"
+        );
         rpc::ExpireDhcpLeaseStatus::NotFound
     };
 

--- a/crates/api/src/tests/dhcp_lease_expiration.rs
+++ b/crates/api/src/tests/dhcp_lease_expiration.rs
@@ -52,6 +52,7 @@ async fn test_expire_releases_allocation(
         .api
         .expire_dhcp_lease(Request::new(ExpireDhcpLeaseRequest {
             ip_address: ip.to_string(),
+            mac_address: None,
         }))
         .await?;
 
@@ -84,6 +85,7 @@ async fn test_expire_nonexistent_address_returns_not_found(
         .api
         .expire_dhcp_lease(Request::new(ExpireDhcpLeaseRequest {
             ip_address: "10.99.99.99".to_string(),
+            mac_address: None,
         }))
         .await?;
 
@@ -104,6 +106,7 @@ async fn test_expire_invalid_address_fails(
         .api
         .expire_dhcp_lease(Request::new(ExpireDhcpLeaseRequest {
             ip_address: "not-an-ip".to_string(),
+            mac_address: None,
         }))
         .await;
 
@@ -120,6 +123,7 @@ async fn test_expire_ipv6_address(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
         .api
         .expire_dhcp_lease(Request::new(ExpireDhcpLeaseRequest {
             ip_address: "fd00::42".to_string(),
+            mac_address: None,
         }))
         .await?;
 
@@ -159,6 +163,7 @@ async fn test_discover_reallocates_after_expiration(
         .api
         .expire_dhcp_lease(Request::new(ExpireDhcpLeaseRequest {
             ip_address: original_ip.clone(),
+            mac_address: None,
         }))
         .await?
         .into_inner();
@@ -219,6 +224,7 @@ async fn test_expire_does_not_delete_static_allocation(
         .api
         .expire_dhcp_lease(Request::new(ExpireDhcpLeaseRequest {
             ip_address: static_ip.to_string(),
+            mac_address: None,
         }))
         .await?
         .into_inner();
@@ -269,6 +275,7 @@ async fn test_static_address_survives_expiration_and_rediscover(
         .api
         .expire_dhcp_lease(Request::new(ExpireDhcpLeaseRequest {
             ip_address: static_ip.to_string(),
+            mac_address: None,
         }))
         .await?
         .into_inner();
@@ -297,6 +304,85 @@ async fn test_static_address_survives_expiration_and_rediscover(
         interface.id,
         "should reuse the same interface"
     );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_expire_with_matching_mac_releases(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let relay: std::net::IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
+    let mac = MacAddress::from_str("aa:bb:cc:dd:ee:0a").unwrap();
+
+    let mut txn = env.pool.begin().await?;
+    let interface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        mac,
+        std::slice::from_ref(&relay),
+        None,
+    )
+    .await?;
+    let ip = interface.addresses[0];
+    txn.commit().await?;
+
+    let response = env
+        .api
+        .expire_dhcp_lease(Request::new(ExpireDhcpLeaseRequest {
+            ip_address: ip.to_string(),
+            mac_address: Some(mac.to_string()),
+        }))
+        .await?
+        .into_inner();
+    assert_eq!(response.status(), ExpireDhcpLeaseStatus::Released);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_expire_with_mismatched_mac_is_no_op(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Simulates a race where MacAddressA expires after the IP was already
+    // re-allocated to MacAddressB. This late expiration hook should not
+    // delete MacAddressB's record/row.
+    let env = create_test_env(pool).await;
+    let relay: std::net::IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
+    let mac_b = MacAddress::from_str("aa:bb:cc:dd:ee:0b").unwrap();
+    let mac_a_stale = MacAddress::from_str("aa:bb:cc:dd:ee:0c").unwrap();
+
+    let mut txn = env.pool.begin().await?;
+    let interface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        mac_b,
+        std::slice::from_ref(&relay),
+        None,
+    )
+    .await?;
+    let ip = interface.addresses[0];
+    txn.commit().await?;
+
+    // Slow expire hook for the MacAddressA at this IP.
+    let response = env
+        .api
+        .expire_dhcp_lease(Request::new(ExpireDhcpLeaseRequest {
+            ip_address: ip.to_string(),
+            mac_address: Some(mac_a_stale.to_string()),
+        }))
+        .await?
+        .into_inner();
+    assert_eq!(
+        response.status(),
+        ExpireDhcpLeaseStatus::NotFound,
+        "late expire hook with previous MAC must not delete new record"
+    );
+
+    // Verify MacAddressB's record is still in tact.
+    let mut txn = env.pool.begin().await?;
+    let addr =
+        db::machine_interface_address::find_ipv4_for_interface(&mut txn, interface.id).await?;
+    assert_eq!(addr.address, ip, "MacAddressB address should still exist");
 
     Ok(())
 }

--- a/crates/dhcp/src/kea/callouts.cc
+++ b/crates/dhcp/src/kea/callouts.cc
@@ -550,9 +550,16 @@ int lease4_expire(CalloutHandle &handle) {
   }
 
   std::string ip_str = lease4->addr_.toText();
+  // Pass the MAC alongside the IP so NICo can scope the delete to
+  // exactly this (ip, mac) lease.
+  std::string mac_str;
+  if (lease4->hwaddr_ && !lease4->hwaddr_->hwaddr_.empty()) {
+    mac_str = lease4->hwaddr_->toText(false);
+  }
   LOG_INFO(logger, isc::log::LOG_CARBIDE_LEASE_EXPIRE).arg(ip_str);
 
-  auto result = carbide_expire_lease(ip_str.c_str());
+  auto result = carbide_expire_lease(
+      ip_str.c_str(), mac_str.empty() ? nullptr : mac_str.c_str());
   if (result != LeaseExpirationResult::Success) {
     LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE_EXPIRE_ERROR).arg(ip_str);
   }
@@ -571,9 +578,16 @@ int lease6_expire(CalloutHandle &handle) {
   }
 
   std::string ip_str = lease6->addr_.toText();
+  // DHCPv6 identifies clients by DUID, but Kea still records the
+  // client's hardware address on the lease when available.
+  std::string mac_str;
+  if (lease6->hwaddr_ && !lease6->hwaddr_->hwaddr_.empty()) {
+    mac_str = lease6->hwaddr_->toText(false);
+  }
   LOG_INFO(logger, isc::log::LOG_CARBIDE_LEASE_EXPIRE).arg(ip_str);
 
-  auto result = carbide_expire_lease(ip_str.c_str());
+  auto result = carbide_expire_lease(
+      ip_str.c_str(), mac_str.empty() ? nullptr : mac_str.c_str());
   if (result != LeaseExpirationResult::Success) {
     LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE_EXPIRE_ERROR).arg(ip_str);
   }

--- a/crates/dhcp/src/lease_expiration.rs
+++ b/crates/dhcp/src/lease_expiration.rs
@@ -38,8 +38,12 @@ pub enum LeaseExpirationResult {
 /// # Safety
 ///
 /// `ip_address` must be a valid, null-terminated C string.
+/// `mac_address`, if non-null, must be a valid, null-terminated C string.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn carbide_expire_lease(ip_address: *const c_char) -> LeaseExpirationResult {
+pub unsafe extern "C" fn carbide_expire_lease(
+    ip_address: *const c_char,
+    mac_address: *const c_char,
+) -> LeaseExpirationResult {
     let ip_str = unsafe {
         match CStr::from_ptr(ip_address).to_str() {
             Ok(s) => s,
@@ -47,13 +51,26 @@ pub unsafe extern "C" fn carbide_expire_lease(ip_address: *const c_char) -> Leas
         }
     };
 
+    let mac_str = if mac_address.is_null() {
+        None
+    } else {
+        unsafe {
+            match CStr::from_ptr(mac_address).to_str() {
+                Ok(s) if !s.is_empty() => Some(s),
+                Ok(_) => None,
+                Err(_) => return LeaseExpirationResult::InvalidAddress,
+            }
+        }
+    };
+
     let url = &CONFIG.read().unwrap().api_endpoint;
     let forge_client_config = tls::build_forge_client_config();
-    expire_lease_at(ip_str, url, &forge_client_config)
+    expire_lease_at(ip_str, mac_str, url, &forge_client_config)
 }
 
 fn expire_lease_at(
     ip_str: &str,
+    mac_str: Option<&str>,
     url: &str,
     client_config: &ForgeClientConfig,
 ) -> LeaseExpirationResult {
@@ -67,6 +84,7 @@ fn expire_lease_at(
         client
             .expire_dhcp_lease(tonic::Request::new(rpc::ExpireDhcpLeaseRequest {
                 ip_address: ip_str.to_string(),
+                mac_address: mac_str.map(|m| m.to_string()),
             }))
             .await
             .map_err(|e| format!("expire_dhcp_lease RPC failed: {e:?}"))
@@ -105,7 +123,12 @@ mod tests {
         let api_server = rt.block_on(mock_api_server::MockAPIServer::start());
         let client_config = tls::build_forge_client_config();
 
-        let result = expire_lease_at("10.0.0.1", api_server.local_http_addr(), &client_config);
+        let result = expire_lease_at(
+            "10.0.0.1",
+            None,
+            api_server.local_http_addr(),
+            &client_config,
+        );
 
         assert_eq!(result, LeaseExpirationResult::Success);
         assert_eq!(
@@ -120,8 +143,18 @@ mod tests {
         let api_server = rt.block_on(mock_api_server::MockAPIServer::start());
         let client_config = tls::build_forge_client_config();
 
-        let result1 = expire_lease_at("10.0.0.1", api_server.local_http_addr(), &client_config);
-        let result2 = expire_lease_at("10.0.0.1", api_server.local_http_addr(), &client_config);
+        let result1 = expire_lease_at(
+            "10.0.0.1",
+            None,
+            api_server.local_http_addr(),
+            &client_config,
+        );
+        let result2 = expire_lease_at(
+            "10.0.0.1",
+            None,
+            api_server.local_http_addr(),
+            &client_config,
+        );
 
         assert_eq!(result1, LeaseExpirationResult::Success);
         assert_eq!(result2, LeaseExpirationResult::Success);
@@ -137,7 +170,28 @@ mod tests {
         let api_server = rt.block_on(mock_api_server::MockAPIServer::start());
         let client_config = tls::build_forge_client_config();
 
-        let result = expire_lease_at("fd00::42", api_server.local_http_addr(), &client_config);
+        let result = expire_lease_at(
+            "fd00::42",
+            None,
+            api_server.local_http_addr(),
+            &client_config,
+        );
+
+        assert_eq!(result, LeaseExpirationResult::Success);
+    }
+
+    #[test]
+    fn test_expire_lease_with_mac() {
+        let rt = CarbideDhcpContext::get_tokio_runtime();
+        let api_server = rt.block_on(mock_api_server::MockAPIServer::start());
+        let client_config = tls::build_forge_client_config();
+
+        let result = expire_lease_at(
+            "10.0.0.1",
+            Some("aa:bb:cc:dd:ee:ff"),
+            api_server.local_http_addr(),
+            &client_config,
+        );
 
         assert_eq!(result, LeaseExpirationResult::Success);
     }

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -3552,6 +3552,11 @@ message DhcpDiscovery {
 
 message ExpireDhcpLeaseRequest {
   string ip_address = 1;
+  // Optional MAC of the expiring lease. When set, the handler only
+  // deletes the row whose (ip_address, mac) pair matches; Kea will
+  // set both. admin-cli calls may just set ip_address. We could
+  // probably just enforce that both must be set.
+  optional string mac_address = 2;
 }
 
 enum ExpireDhcpLeaseStatus {


### PR DESCRIPTION
## Description

The Kea `lease4_expire`/`lease6_expire` callouts only pass the IP to `carbide_expire_lease`, so the API handler deletes by IP alone, meaning we're open to a race between Kea's state of the world and our state of the world (e.g. `lease4_expire` firing after an allocation change, out of order calls, etc -- we'd just blindly blow away the recent row). In other words: we should be sending more information about the thing that expired beyond just the IP.

This adds `mac_address` to `ExpireDhcpLeaseRequest` and plumbs it through the Kea -> FFI -> API flow. When the MAC is present, the handler scopes the delete to the exact `(ip, mac)` pair via a new `delete_by_address_and_mac` helper, with the ability to "fall back" to our old address-only variant.

It's worth noting that:
- We need to do some work in here for IPv6 -- DHCPv6 would pass a DUID and not a MAC (although Kea does have a `hwaddr`).
- We'll probably switch to our pure-Rust `dhcp-server` for DHCPv6 anyway, so Kea-isms won't matter.

Tests added.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

