### PR TITLE
fix(api): generalize reserved DHCP allocations through the discover flow

### DIFF
--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -453,6 +453,67 @@ pub async fn validate_existing_mac_and_create(
     }
 }
 
+/// Ensure a a `machine_interface` exists for the `mac_address` with its reserved allocation,
+/// either falling into a Carbide-managed segment (when there is a match within a managed
+/// prefix), or into the `static_assignments` segment for IPs that are outside of managed
+/// networks.
+///
+/// Errors on conflicts that need operator attention, e.g.
+/// - The interface for this MAC exists but carries different addresses, or,
+/// - The IP is already allocated to a different MAC.
+///
+/// Called from the expected-machine handlers to do config time preallocation, and from
+/// the DHCP `discover()` path to re-allocate if needed (ensuring static DHCP reservations
+/// are maintained). Tbh it could probably just be in the DHCP `discover()` path only.
+pub async fn preallocate_machine_interface(
+    txn: &mut PgConnection,
+    mac_address: MacAddress,
+    static_ip: IpAddr,
+) -> DatabaseResult<()> {
+    let existing = find_by_mac_address(&mut *txn, mac_address).await?;
+    if let Some(iface) = existing.first() {
+        if iface.addresses.contains(&static_ip) {
+            return Ok(());
+        }
+        return Err(DatabaseError::InvalidArgument(format!(
+            "a machine interface already exists for MAC {mac_address} with addresses {:?}; use update to change the IP address",
+            iface.addresses,
+        )));
+    }
+
+    if let Some(existing_addr) =
+        crate::machine_interface_address::find_by_address(&mut *txn, static_ip).await?
+    {
+        return Err(DatabaseError::InvalidArgument(format!(
+            "IP address {static_ip} is already allocated to interface {} on segment {}; use 'machine-interfaces assign-address' to reassign it",
+            existing_addr.id, existing_addr.name,
+        )));
+    }
+
+    let segment = match db_network_segment::for_relay(&mut *txn, static_ip).await? {
+        Some(seg) => seg,
+        None => db_network_segment::static_assignments(&mut *txn).await?,
+    };
+
+    create(
+        txn,
+        std::slice::from_ref(&segment),
+        &mac_address,
+        true,
+        AddressSelectionStrategy::StaticAddress(static_ip),
+    )
+    .await?;
+
+    tracing::info!(
+        %mac_address,
+        %static_ip,
+        segment_id = %segment.id,
+        "Pre-allocated static machine interface"
+    );
+
+    Ok(())
+}
+
 pub async fn create(
     txn: &mut PgConnection,
     segments: &[NetworkSegment],

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -773,12 +773,7 @@ impl Forge for Api {
     ) -> Result<Response<rpc::DhcpRecord>, Status> {
         log_request_data(&request);
 
-        Ok(crate::dhcp::discover::discover_dhcp(
-            self,
-            request,
-            Some(self.runtime_config.rack_management_enabled),
-        )
-        .await?)
+        Ok(crate::dhcp::discover::discover_dhcp(self, request).await?)
     }
 
     async fn expire_dhcp_lease(

--- a/crates/api/src/dhcp/discover.rs
+++ b/crates/api/src/dhcp/discover.rs
@@ -164,7 +164,6 @@ async fn handle_dhcp_from_dpa(
 pub async fn discover_dhcp(
     api: &Api,
     request: Request<rpc::DhcpDiscovery>,
-    rack_level_service: Option<bool>,
 ) -> Result<Response<rpc::DhcpRecord>, CarbideError> {
     let mut txn = api.txn_begin().await?;
 
@@ -230,34 +229,71 @@ pub async fn discover_dhcp(
                         return Ok(resp);
                     }
 
-                    if let Some(x) = rack_level_service {
-                        // check expected machines. all mac addresses we should respond to should be
-                        // added in there for unknown machines that have not been discovered yet.
-                        // TODO: fix for dpu with VF nics, they will currently not get IPs
-                        if x {
-                            let expected_machine =
-                                expected_machine::find_by_host_mac_address(&mut txn, parsed_mac)
-                                    .await
-                                    .map_err(CarbideError::from)?;
-                            if let Some(m) = expected_machine {
-                                // select ip segment from Underlay for BMC, Admin for BF3/Onboard
-                                for nic in &m.data.host_nics {
-                                    if nic.mac_address == parsed_mac {
-                                        host_nic = Some(nic.clone());
-                                    }
-                                }
-                                // If any NIC on this host declares primary=true,
-                                // then this NIC is primary iff it's that one.
-                                // Handler-side validation keeps at most one
-                                // primary=true per ExpectedMachine.
-                                if let Some(declared_primary) =
-                                    m.data.host_nics.iter().find(|n| n.primary == Some(true))
-                                {
-                                    is_primary_nic =
-                                        Some(declared_primary.mac_address == parsed_mac);
-                                }
+                    // Now lets check expected machine data to see if there's any
+                    // useful configuration we need to address, such as primary NIC
+                    // assignment and/or static DHCP reservation allocations.
+                    //
+                    // For static DHCP reservations, we do this here for the simple
+                    // reason that it's a good place to put it. If an operator force
+                    // deletes a machine and its interfaces, how would we put them
+                    // back? The answer is the same way they would be put back in a
+                    // dynamic allocation -- during DHCPDISCOVER/DHCPREQUEST. We see
+                    // that a static DHCP reservation is configured per expected
+                    // machine data, so we make an idempotent call to ensure that
+                    // allocation exists, and if not, is created.
+                    if let Some(m) =
+                        expected_machine::find_by_host_mac_address(&mut txn, parsed_mac)
+                            .await
+                            .map_err(CarbideError::from)?
+                    {
+                        // If ExpectedHostNics are configured, see if any
+                        // of them are annotated as "primary", or if any of
+                        // them have a fixed_ip DHCP reservation.
+                        for nic in &m.data.host_nics {
+                            if nic.mac_address == parsed_mac {
+                                host_nic = Some(nic.clone());
                             }
                         }
+                        if let Some(declared_primary) =
+                            m.data.host_nics.iter().find(|n| n.primary == Some(true))
+                        {
+                            is_primary_nic = Some(declared_primary.mac_address == parsed_mac);
+                        }
+                        if let Some(nic) = m
+                            .data
+                            .host_nics
+                            .iter()
+                            .find(|n| n.mac_address == parsed_mac)
+                            && let Some(fixed_ip_str) = &nic.fixed_ip
+                        {
+                            let fixed_ip: IpAddr = fixed_ip_str.parse().map_err(|_| {
+                            CarbideError::InvalidArgument(format!(
+                                "invalid fixed_ip on ExpectedHostNic {parsed_mac}: {fixed_ip_str}"
+                            ))
+                        })?;
+                            // It looks like there's a DHCP reservation for this address,
+                            // so make an idempotent call to ensure we have a preallocated
+                            // machine interface (and machine interface address) for it,
+                            // creating one if needed.
+                            db::machine_interface::preallocate_machine_interface(
+                                &mut txn, parsed_mac, fixed_ip,
+                            )
+                            .await?;
+                        }
+                    } else if let Some(m) =
+                        expected_machine::find_by_bmc_mac_address(&mut txn, parsed_mac)
+                            .await
+                            .map_err(CarbideError::from)?
+                        && let Some(bmc_ip) = m.data.bmc_ip_address
+                    {
+                        // In this case it looks like our parsed MAC address is for the BMC
+                        // of an expected machine, and it has a static DHCP reservation per
+                        // its bmc_ip_address, so again, ensure the machine interface is
+                        // allocated before continuing.
+                        db::machine_interface::preallocate_machine_interface(
+                            &mut txn, parsed_mac, bmc_ip,
+                        )
+                        .await?;
                     }
                     None
                 }

--- a/crates/api/src/handlers/expected_machine.rs
+++ b/crates/api/src/handlers/expected_machine.rs
@@ -25,9 +25,7 @@ use uuid::Uuid;
 
 use crate::CarbideError;
 use crate::api::{Api, log_request_data};
-use crate::handlers::machine_interface_address::{
-    preallocate_machine_interface, update_preallocated_machine_interface,
-};
+use crate::handlers::machine_interface_address::update_preallocated_machine_interface;
 
 lazy_static! {
     // Verify what serial is alphanumeric string with, allows dashes '-' and underscores '_'
@@ -132,7 +130,8 @@ pub(crate) async fn preallocate_interfaces_for(
     validate_at_most_one_primary_host_nic(&machine.data.host_nics)?;
 
     if let Some(bmc_ip) = machine.data.bmc_ip_address {
-        preallocate_machine_interface(txn, machine.bmc_mac_address, bmc_ip).await?;
+        db::machine_interface::preallocate_machine_interface(txn, machine.bmc_mac_address, bmc_ip)
+            .await?;
     }
 
     for nic in &machine.data.host_nics {
@@ -140,7 +139,7 @@ pub(crate) async fn preallocate_interfaces_for(
             let ip: std::net::IpAddr = ip_str.parse().map_err(|_| {
                 CarbideError::InvalidArgument(format!("invalid fixed_ip: {ip_str}"))
             })?;
-            preallocate_machine_interface(txn, nic.mac_address, ip).await?;
+            db::machine_interface::preallocate_machine_interface(txn, nic.mac_address, ip).await?;
         }
     }
 
@@ -437,7 +436,12 @@ async fn create_expected_machine(
     };
 
     if let Some(bmc_ip) = expected_machine.data.bmc_ip_address {
-        preallocate_machine_interface(txn, expected_machine.bmc_mac_address, bmc_ip).await?;
+        db::machine_interface::preallocate_machine_interface(
+            txn,
+            expected_machine.bmc_mac_address,
+            bmc_ip,
+        )
+        .await?;
     }
 
     db::expected_machine::create(txn, expected_machine).await?;

--- a/crates/api/src/handlers/expected_power_shelf.rs
+++ b/crates/api/src/handlers/expected_power_shelf.rs
@@ -23,9 +23,7 @@ use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
 use crate::api::Api;
-use crate::handlers::machine_interface_address::{
-    preallocate_machine_interface, update_preallocated_machine_interface,
-};
+use crate::handlers::machine_interface_address::update_preallocated_machine_interface;
 
 pub async fn add_expected_power_shelf(
     api: &Api,
@@ -48,7 +46,12 @@ pub async fn add_expected_power_shelf(
         })?;
 
     if let Some(bmc_ip) = power_shelf.bmc_ip_address {
-        preallocate_machine_interface(&mut txn, power_shelf.bmc_mac_address, bmc_ip).await?;
+        db::machine_interface::preallocate_machine_interface(
+            &mut txn,
+            power_shelf.bmc_mac_address,
+            bmc_ip,
+        )
+        .await?;
     }
 
     db_expected_power_shelf::create(&mut txn, power_shelf)

--- a/crates/api/src/handlers/expected_switch.rs
+++ b/crates/api/src/handlers/expected_switch.rs
@@ -23,9 +23,7 @@ use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
 use crate::api::Api;
-use crate::handlers::machine_interface_address::{
-    preallocate_machine_interface, update_preallocated_machine_interface,
-};
+use crate::handlers::machine_interface_address::update_preallocated_machine_interface;
 
 pub async fn add_expected_switch(
     api: &Api,
@@ -48,7 +46,12 @@ pub async fn add_expected_switch(
         })?;
 
     if let Some(bmc_ip) = switch.bmc_ip_address {
-        preallocate_machine_interface(&mut txn, switch.bmc_mac_address, bmc_ip).await?;
+        db::machine_interface::preallocate_machine_interface(
+            &mut txn,
+            switch.bmc_mac_address,
+            bmc_ip,
+        )
+        .await?;
     }
 
     db_expected_switch::create(&mut txn, switch)

--- a/crates/api/src/handlers/machine_interface_address.rs
+++ b/crates/api/src/handlers/machine_interface_address.rs
@@ -37,61 +37,6 @@ async fn resolve_segment_for_static_ip(
     }
 }
 
-/// Pre-allocate a `machine_interface` with a static address so Site Explorer can discover the BMC
-/// at that IP. Expected machine / switch / power shelf handlers call this when the operator sets a
-/// configured BMC IP before DHCP has appeared.
-///
-/// If the IP is within a managed network prefix, the interface is created on that segment.
-/// Otherwise it uses the internal `static-assignments` anchor segment.
-///
-/// Fails if a `machine_interface` already exists for this MAC. Use
-/// [`update_preallocated_machine_interface`] to follow up on an existing interface.
-pub async fn preallocate_machine_interface(
-    txn: &mut sqlx::PgConnection,
-    bmc_mac_address: MacAddress,
-    bmc_ip: std::net::IpAddr,
-) -> Result<(), CarbideError> {
-    // Check if an interface already exists for this MAC.
-    let existing = db::machine_interface::find_by_mac_address(&mut *txn, bmc_mac_address).await?;
-    if !existing.is_empty() {
-        return Err(CarbideError::InvalidArgument(format!(
-            "a machine interface already exists for MAC {bmc_mac_address}; \
-             use update to change the IP address"
-        )));
-    }
-
-    // Check if the IP is already allocated to another interface.
-    if let Some(existing_addr) =
-        db::machine_interface_address::find_by_address(&mut *txn, bmc_ip).await?
-    {
-        return Err(CarbideError::InvalidArgument(format!(
-            "IP address {bmc_ip} is already allocated to interface {} \
-             on segment {}; use 'machine-interfaces assign-address' to reassign it",
-            existing_addr.id, existing_addr.name,
-        )));
-    }
-
-    let segment = resolve_segment_for_static_ip(txn, bmc_ip).await?;
-
-    db::machine_interface::create(
-        txn,
-        std::slice::from_ref(&segment),
-        &bmc_mac_address,
-        true,
-        AddressSelectionStrategy::StaticAddress(bmc_ip),
-    )
-    .await?;
-
-    tracing::info!(
-        %bmc_mac_address,
-        %bmc_ip,
-        segment_id = %segment.id,
-        "Pre-allocated static machine interface"
-    );
-
-    Ok(())
-}
-
 /// Update or create a machine_interface with a static address.
 ///
 /// If no interface exists for this MAC, creates a new one. If an

--- a/crates/api/src/tests/expected_machine.rs
+++ b/crates/api/src/tests/expected_machine.rs
@@ -2177,6 +2177,232 @@ async fn test_dhcp_discover_uses_fixed_ip_from_host_nics(
     Ok(())
 }
 
+/// Verify `db::machine_interface::preallocate_machine_interface` is idempotent.
+/// AddExpectedMachine, expected_machines.json, and the DHCP discover() flow can
+/// all fire against the same (ip, mac) pair, including after state has already
+/// converged, which is both on purpose and to help flexibly adjust where we
+/// find these calls fit best.
+///
+/// A repeat call must be Ok without changing rows.
+#[crate::sqlx_test]
+async fn test_preallocate_machine_interface_is_idempotent(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let mac: MacAddress = "7A:7B:7C:7D:7E:31".parse().unwrap();
+    let ip: std::net::IpAddr = "192.0.2.241".parse().unwrap();
+
+    let mut txn = env.db_txn().await;
+    db::machine_interface::preallocate_machine_interface(txn.as_mut(), mac, ip).await?;
+    txn.commit().await?;
+
+    let mut txn = env.db_txn().await;
+    db::machine_interface::preallocate_machine_interface(txn.as_mut(), mac, ip).await?;
+    let interfaces = db::machine_interface::find_by_mac_address(txn.as_mut(), mac).await?;
+    txn.commit().await?;
+
+    assert_eq!(
+        interfaces.len(),
+        1,
+        "second preallocate should be a no-op, not create a duplicate row"
+    );
+    assert!(
+        interfaces[0].addresses.contains(&ip),
+        "interface should still carry the static IP"
+    );
+
+    Ok(())
+}
+
+/// Pre-allocating a different IP for an existing MAC must error, rather than
+/// silently reassigning. If an `expected_machine.bmc_ip_address` (or a host_nic
+/// fixed_ip) drifts from its `machine_interface` row, operators should see the
+/// conflict instead of an automatic rewrite.
+#[crate::sqlx_test]
+async fn test_preallocate_machine_interface_rejects_conflicting_ip(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let mac: MacAddress = "7A:7B:7C:7D:7E:32".parse().unwrap();
+    let ip1: std::net::IpAddr = "192.0.2.242".parse().unwrap();
+    let ip2: std::net::IpAddr = "192.0.2.243".parse().unwrap();
+
+    let mut txn = env.db_txn().await;
+    db::machine_interface::preallocate_machine_interface(txn.as_mut(), mac, ip1).await?;
+    txn.commit().await?;
+
+    let mut txn = env.db_txn().await;
+    let result = db::machine_interface::preallocate_machine_interface(txn.as_mut(), mac, ip2).await;
+    assert!(
+        matches!(result, Err(DatabaseError::InvalidArgument(_))),
+        "preallocating a different IP for the same MAC should be rejected, got {result:?}"
+    );
+
+    Ok(())
+}
+
+/// After a `machine_interface` row gets deleted (e.g. force-delete
+/// --delete-interfaces), a subsequent `preallocate_machine_interface` call
+/// must successfully recreate it with the same static IP. This is the
+/// lazy-allocation flow that we rely on with DHCP discover(...).
+#[crate::sqlx_test]
+async fn test_preallocate_machine_interface_recreates_after_deletion(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let mac: MacAddress = "7A:7B:7C:7D:7E:33".parse().unwrap();
+    let ip: std::net::IpAddr = "192.0.2.244".parse().unwrap();
+
+    let mut txn = env.db_txn().await;
+    db::machine_interface::preallocate_machine_interface(txn.as_mut(), mac, ip).await?;
+    let interfaces_before = db::machine_interface::find_by_mac_address(txn.as_mut(), mac).await?;
+    let interface_id = interfaces_before[0].id;
+    db::machine_interface::delete(&interface_id, txn.as_mut()).await?;
+    txn.commit().await?;
+
+    let mut txn = env.db_txn().await;
+    db::machine_interface::preallocate_machine_interface(txn.as_mut(), mac, ip).await?;
+    let interfaces_after = db::machine_interface::find_by_mac_address(txn.as_mut(), mac).await?;
+    txn.commit().await?;
+
+    assert_eq!(
+        interfaces_after.len(),
+        1,
+        "interface should be re-created after deletion"
+    );
+    assert!(
+        interfaces_after[0].addresses.contains(&ip),
+        "re-created interface should carry the same static IP"
+    );
+
+    Ok(())
+}
+
+/// Recovery scenario for the BMC: operator force-deleted a managed machine
+/// and its interfaces, then the BMC re-DHCPs. With DHCP in the allocation
+/// path, discover(...) consults `find_by_bmc_mac_address`, re-preallocates,
+/// and the existing find_or_create path serves the static IP.
+#[crate::sqlx_test]
+async fn test_dhcp_discover_recovers_bmc_after_interface_deletion(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "7A:7B:7C:7D:7E:41".parse().unwrap();
+    let bmc_ip = "192.0.2.245";
+
+    env.api
+        .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+            id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: "EM-RECOVERY-001".into(),
+            bmc_ip_address: Some(bmc_ip.into()),
+            ..Default::default()
+        }))
+        .await?;
+
+    // Baseline -- pre-allocation happened during add.
+    let mut txn = env.db_txn().await;
+    let before = db::machine_interface::find_by_mac_address(txn.as_mut(), bmc_mac).await?;
+    assert_eq!(before.len(), 1, "expected_machine add should pre-allocate");
+    assert!(before[0].addresses.contains(&bmc_ip.parse().unwrap()));
+    let interface_id = before[0].id;
+
+    // Simulate `force-delete --delete-interfaces`: the machine_interface row
+    // goes away while the expected_machines entry stays.
+    db::machine_interface::delete(&interface_id, txn.as_mut()).await?;
+    txn.commit().await?;
+
+    let bmc_mac_str = bmc_mac.to_string();
+    let response = env
+        .api
+        .discover_dhcp(
+            common::rpc_builder::DhcpDiscovery::builder(
+                &bmc_mac_str,
+                common::api_fixtures::FIXTURE_DHCP_RELAY_ADDRESS,
+            )
+            .tonic_request(),
+        )
+        .await?
+        .into_inner();
+
+    assert_eq!(
+        response.address, bmc_ip,
+        "BMC re-DHCP should serve the configured bmc_ip_address, not a dynamic-pool allocation"
+    );
+
+    let mut txn = env.db_txn().await;
+    let after = db::machine_interface::find_by_mac_address(txn.as_mut(), bmc_mac).await?;
+    assert_eq!(after.len(), 1, "interface should be re-created");
+    assert!(
+        after[0].addresses.contains(&bmc_ip.parse().unwrap()),
+        "re-created interface should carry the configured static IP"
+    );
+
+    Ok(())
+}
+
+/// Same recovery scenario for a host NIC with `fixed_ip`. discover() passes
+/// the matched `ExpectedHostNic` through to `validate_existing_mac_and_create`,
+/// which honors `fixed_ip` via `AddressSelectionStrategy::StaticAddress`.
+/// This test pins that the DHCP discover allocation flow works.
+#[crate::sqlx_test]
+async fn test_dhcp_discover_recovers_host_nic_after_interface_deletion(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "7A:7B:7C:7D:7E:51".parse().unwrap();
+    let nic_mac: MacAddress = "7A:7B:7C:7D:7E:52".parse().unwrap();
+    let fixed_ip = "192.0.2.246";
+
+    env.api
+        .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+            id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: "EM-RECOVERY-002".into(),
+            host_nics: vec![rpc::forge::ExpectedHostNic {
+                mac_address: nic_mac.to_string(),
+                nic_type: Some("onboard".into()),
+                fixed_ip: Some(fixed_ip.into()),
+                fixed_mask: None,
+                fixed_gateway: None,
+                primary: None,
+            }],
+            ..Default::default()
+        }))
+        .await?;
+
+    let mut txn = env.db_txn().await;
+    let before = db::machine_interface::find_by_mac_address(txn.as_mut(), nic_mac).await?;
+    assert_eq!(before.len(), 1);
+    let interface_id = before[0].id;
+    db::machine_interface::delete(&interface_id, txn.as_mut()).await?;
+    txn.commit().await?;
+
+    let nic_mac_str = nic_mac.to_string();
+    let response = env
+        .api
+        .discover_dhcp(
+            common::rpc_builder::DhcpDiscovery::builder(
+                &nic_mac_str,
+                common::api_fixtures::FIXTURE_DHCP_RELAY_ADDRESS,
+            )
+            .tonic_request(),
+        )
+        .await?
+        .into_inner();
+
+    assert_eq!(
+        response.address, fixed_ip,
+        "host NIC re-DHCP should serve the configured fixed_ip"
+    );
+
+    Ok(())
+}
+
 /// When `bmc_retain_credentials` is set to true, the value should persist through
 /// add -> get round-trip via the RPC API.
 #[crate::sqlx_test()]

--- a/crates/api/src/tests/finder.rs
+++ b/crates/api/src/tests/finder.rs
@@ -395,15 +395,13 @@ async fn test_identify_serial(db_pool: sqlx::PgPool) -> Result<(), eyre::Report>
 async fn test_static_bmc_ip_finder(db_pool: sqlx::PgPool) -> Result<(), eyre::Report> {
     use std::net::IpAddr;
 
-    use crate::handlers::machine_interface_address::preallocate_machine_interface;
-
     let env = create_test_env(db_pool.clone()).await;
 
     let static_ip: IpAddr = "10.178.160.100".parse().unwrap();
     let bmc_mac = "AA:BB:CC:DD:EE:99".parse().unwrap();
 
     let mut txn = db_pool.begin().await.unwrap();
-    preallocate_machine_interface(txn.as_mut(), bmc_mac, static_ip)
+    db::machine_interface::preallocate_machine_interface(txn.as_mut(), bmc_mac, static_ip)
         .await
         .expect("preallocate static BMC interface");
     txn.commit().await.unwrap();

--- a/crates/api/src/tests/ipxe.rs
+++ b/crates/api/src/tests/ipxe.rs
@@ -28,7 +28,6 @@ use model::machine::{DpuInitState, HostReprovisionState, MachineState, ManagedHo
 use rpc::forge::CloudInitInstructionsRequest;
 use rpc::forge::forge_server::Forge;
 
-use crate::handlers::machine_interface_address::preallocate_machine_interface;
 use crate::tests::common;
 use crate::tests::common::api_fixtures::managed_host::ManagedHostConfig;
 use crate::tests::common::api_fixtures::site_explorer::MockExploredHost;
@@ -480,7 +479,7 @@ async fn preallocate_external_interface(
     let ip_addr: std::net::IpAddr = ip.parse().unwrap();
 
     let mut txn = env.pool.begin().await.unwrap();
-    preallocate_machine_interface(&mut txn, mac_address, ip_addr)
+    db::machine_interface::preallocate_machine_interface(&mut txn, mac_address, ip_addr)
         .await
         .unwrap();
     txn.commit().await.unwrap();


### PR DESCRIPTION
Pre-allocation of `machine_interfaces` for reserved `bmc_ip_address` and `ExpectedHostNic::fixed_ip` addresses would do initial setup during `AddExpectedMachine`, and then integrate with `discover_dhcp` for `ExpectedHostNic::fixed_ip` to check if a static reservation needed to be [re]allocated. **However, I missed the discover flow for static `bmc_ip_address`**, which was noticed in some environments currently using it. The side effect is someone needs to re-run `expected-machine add` to re-create the static BMC address reservations in cases where they were deleted.

`discover_dhcp` now consults `find_by_bmc_mac_address` when the BMC MAC lookup misses, and re-allocates from the configured `bmc_ip_address` before continuing through to `find_or_create_machine_interface`.

Moved the shared helper from `api` -> `api-db`.

Lots of tests added for this one to verify the flow(s) for BMCs and host NICs work as intended.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

