### PR TITLE
chore(dhcp): discontinue population of option 43.70 (w/ machine_interface_id)

### DIFF
--- a/crates/dhcp/src/kea/callouts.cc
+++ b/crates/dhcp/src/kea/callouts.cc
@@ -320,7 +320,7 @@ void set_options(CalloutHandle &handle, Pkt4Ptr response4_ptr,
   machine_free_client_type(machine_client_type);
 }
 
-void set_vendor_options(Pkt4Ptr response4_ptr, Machine *machine) {
+void set_vendor_options(Pkt4Ptr response4_ptr) {
   OptionPtr option_vendor(
       new Option(Option::V4, DHO_VENDOR_ENCAPSULATED_OPTIONS));
   LOG_INFO(logger, isc::log::LOG_CARBIDE_GENERIC).arg(option_vendor->toText());
@@ -334,19 +334,7 @@ void set_vendor_options(Pkt4Ptr response4_ptr, Machine *machine) {
   vendor_option_6.reset(new OptionInt<uint32_t>(Option::V4, 6, 0x8));
   option_vendor->addOption(vendor_option_6);
 
-  // Option 70 we're using to set the UUID of the machine
-  OptionPtr vendor_option_70 = option_vendor->getOption(70);
-  if (vendor_option_70) {
-    option_vendor->delOption(70);
-  }
-  char *machine_uuid = machine_get_uuid(machine);
-  if (strlen(machine_uuid) > 0) {
-    vendor_option_70.reset(new OptionString(Option::V4, 70, machine_uuid));
-    option_vendor->addOption(vendor_option_70);
-  }
-
   response4_ptr->addOption(option_vendor);
-  machine_free_uuid(machine_uuid);
 }
 
 extern "C" {
@@ -531,7 +519,7 @@ int pkt4_send(CalloutHandle &handle) {
   /*
    * Encapsulate some PXE options in the vendor encapsulated
    */
-  set_vendor_options(response4_ptr, machine.get());
+  set_vendor_options(response4_ptr);
 
   LOG_INFO(logger, isc::log::LOG_CARBIDE_PKT4_SEND)
       .arg(response4_ptr->toText());

--- a/crates/dhcp/src/machine.rs
+++ b/crates/dhcp/src/machine.rs
@@ -290,24 +290,6 @@ pub extern "C" fn machine_get_client_type(ctx: *mut Machine) -> *mut libc::c_cha
     vendor_class.into_raw()
 }
 
-#[unsafe(no_mangle)]
-pub extern "C" fn machine_get_uuid(ctx: *mut Machine) -> *mut libc::c_char {
-    assert!(!ctx.is_null());
-    let machine = unsafe { &mut *ctx };
-
-    let uuid = if let Some(machine_interface_id) = &machine.inner.machine_interface_id {
-        CString::new(machine_interface_id.to_string()).unwrap()
-    } else {
-        log::debug!(
-            "Found a host missing UUID (Possibly a Instance), dumping everything we know about it: {:?}",
-            &machine
-        );
-        CString::new("").unwrap()
-    };
-
-    uuid.into_raw()
-}
-
 /// Get the broadcast address.
 ///
 /// This is, and will always be, specific to DHCPv4, as broadcast
@@ -353,17 +335,6 @@ pub extern "C" fn machine_free_client_type(client_type: *mut libc::c_char) {
         }
 
         drop(CString::from_raw(client_type))
-    };
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn machine_free_uuid(uuid: *mut libc::c_char) {
-    unsafe {
-        if uuid.is_null() {
-            return;
-        }
-
-        drop(CString::from_raw(uuid))
     };
 }
 


### PR DESCRIPTION
## Description

This closes https://github.com/NVIDIA/infra-controller-core/issues/1565.

PR #1464 introduced support for using client IP for PXE booting, and #1572 dropped `carbide-pxe` (and iPXE) branching for option 43.70 entirely, now purely looking at client IP. This drops it from the `carbide-dhcp` siide of things, cleaning up `set_vendor_options` (and `machine_get_uuid` and `machine_free_uuid`).

No tests touched -- there weren't any tests in here to change.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

