### PR TITLE
feat(dpf,admin-cli): admin-cli to display host snapshot in DPF/kube world and service versions.

### DIFF
--- a/crates/admin-cli/src/dpf/service_version/args.rs
+++ b/crates/admin-cli/src/dpf/service_version/args.rs
@@ -15,30 +15,7 @@
  * limitations under the License.
  */
 
-pub mod common;
-mod disable;
-mod enable;
-mod service_version;
-mod show;
-mod snapshot;
-
 use clap::Parser;
 
-use crate::cfg::dispatch::Dispatch;
-
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Enable DPF")]
-    Enable(enable::Args),
-    #[clap(about = "Disable DPF")]
-    Disable(disable::Args),
-    #[clap(about = "Check Status of DPF")]
-    Show(show::Args),
-    #[clap(about = "Snapshot DPF CRs (DPUNode, DPUDevices, DPUs) for a host")]
-    Snapshot(snapshot::Args),
-    #[clap(
-        alias = "sv",
-        about = "Compare configured vs deployed DPF service versions"
-    )]
-    ServiceVersion(service_version::Args),
-}
+#[derive(Parser, Debug)]
+pub struct Args {}

--- a/crates/admin-cli/src/dpf/service_version/cmd.rs
+++ b/crates/admin-cli/src/dpf/service_version/cmd.rs
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::CarbideCliResult;
+use prettytable::row;
+
+use crate::rpc::ApiClient;
+
+pub async fn service_version(api_client: &ApiClient) -> CarbideCliResult<()> {
+    let services = api_client.get_dpf_service_versions().await?;
+
+    if services.is_empty() {
+        println!("No DPF services configured");
+        return Ok(());
+    }
+
+    let mut table = prettytable::Table::new();
+    table.set_titles(row![
+        "Service",
+        "Config Helm Version",
+        "Live Helm Version",
+        "Config Docker Tag",
+        "Live Docker Tag",
+    ]);
+    for svc in services {
+        let live_helm = if svc.live_helm_version.is_empty() {
+            "n/a".to_string()
+        } else if svc.live_helm_version == svc.config_helm_version {
+            format!("{} (match)", svc.live_helm_version)
+        } else {
+            format!("{} (DIFFERS)", svc.live_helm_version)
+        };
+        let config_docker = if svc.config_docker_image_tag.is_empty() {
+            "-".to_string()
+        } else {
+            svc.config_docker_image_tag.clone()
+        };
+        let live_docker = if svc.live_docker_image_tag.is_empty() {
+            "n/a".to_string()
+        } else if svc.live_docker_image_tag == svc.config_docker_image_tag {
+            format!("{} (match)", svc.live_docker_image_tag)
+        } else {
+            format!("{} (DIFFERS)", svc.live_docker_image_tag)
+        };
+        table.add_row(row![
+            svc.service,
+            svc.config_helm_version,
+            live_helm,
+            config_docker,
+            live_docker,
+        ]);
+    }
+    table.printstd();
+    Ok(())
+}

--- a/crates/admin-cli/src/dpf/service_version/mod.rs
+++ b/crates/admin-cli/src/dpf/service_version/mod.rs
@@ -15,30 +15,17 @@
  * limitations under the License.
  */
 
-pub mod common;
-mod disable;
-mod enable;
-mod service_version;
-mod show;
-mod snapshot;
+pub mod args;
+pub mod cmd;
 
-use clap::Parser;
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
 
-use crate::cfg::dispatch::Dispatch;
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
 
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Enable DPF")]
-    Enable(enable::Args),
-    #[clap(about = "Disable DPF")]
-    Disable(disable::Args),
-    #[clap(about = "Check Status of DPF")]
-    Show(show::Args),
-    #[clap(about = "Snapshot DPF CRs (DPUNode, DPUDevices, DPUs) for a host")]
-    Snapshot(snapshot::Args),
-    #[clap(
-        alias = "sv",
-        about = "Compare configured vs deployed DPF service versions"
-    )]
-    ServiceVersion(service_version::Args),
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::service_version(&ctx.api_client).await
+    }
 }

--- a/crates/admin-cli/src/dpf/snapshot/args.rs
+++ b/crates/admin-cli/src/dpf/snapshot/args.rs
@@ -15,30 +15,17 @@
  * limitations under the License.
  */
 
-pub mod common;
-mod disable;
-mod enable;
-mod service_version;
-mod show;
-mod snapshot;
-
+use carbide_uuid::machine::MachineId;
 use clap::Parser;
 
-use crate::cfg::dispatch::Dispatch;
+#[derive(Parser, Debug)]
+pub struct Args {
+    #[clap(flatten)]
+    pub inner: SnapshotQuery,
+}
 
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Enable DPF")]
-    Enable(enable::Args),
-    #[clap(about = "Disable DPF")]
-    Disable(disable::Args),
-    #[clap(about = "Check Status of DPF")]
-    Show(show::Args),
-    #[clap(about = "Snapshot DPF CRs (DPUNode, DPUDevices, DPUs) for a host")]
-    Snapshot(snapshot::Args),
-    #[clap(
-        alias = "sv",
-        about = "Compare configured vs deployed DPF service versions"
-    )]
-    ServiceVersion(service_version::Args),
+#[derive(Parser, Debug)]
+pub struct SnapshotQuery {
+    /// Host machine id to snapshot. Must be a host (not a DPU) machine id.
+    pub host_machine_id: MachineId,
 }

--- a/crates/admin-cli/src/dpf/snapshot/cmd.rs
+++ b/crates/admin-cli/src/dpf/snapshot/cmd.rs
@@ -15,30 +15,22 @@
  * limitations under the License.
  */
 
-pub mod common;
-mod disable;
-mod enable;
-mod service_version;
-mod show;
-mod snapshot;
+use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+use carbide_uuid::machine::MachineType;
 
-use clap::Parser;
+use crate::dpf::snapshot::args::SnapshotQuery;
+use crate::rpc::ApiClient;
 
-use crate::cfg::dispatch::Dispatch;
+pub async fn snapshot(query: &SnapshotQuery, api_client: &ApiClient) -> CarbideCliResult<()> {
+    if query.host_machine_id.machine_type() == MachineType::Dpu {
+        return Err(CarbideCliError::GenericError(
+            "Only host machine id is expected".to_string(),
+        ));
+    }
 
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Enable DPF")]
-    Enable(enable::Args),
-    #[clap(about = "Disable DPF")]
-    Disable(disable::Args),
-    #[clap(about = "Check Status of DPF")]
-    Show(show::Args),
-    #[clap(about = "Snapshot DPF CRs (DPUNode, DPUDevices, DPUs) for a host")]
-    Snapshot(snapshot::Args),
-    #[clap(
-        alias = "sv",
-        about = "Compare configured vs deployed DPF service versions"
-    )]
-    ServiceVersion(service_version::Args),
+    let payload = api_client
+        .get_dpf_host_snapshot(query.host_machine_id)
+        .await?;
+    println!("{payload}");
+    Ok(())
 }

--- a/crates/admin-cli/src/dpf/snapshot/mod.rs
+++ b/crates/admin-cli/src/dpf/snapshot/mod.rs
@@ -15,30 +15,17 @@
  * limitations under the License.
  */
 
-pub mod common;
-mod disable;
-mod enable;
-mod service_version;
-mod show;
-mod snapshot;
+pub mod args;
+pub mod cmd;
 
-use clap::Parser;
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
 
-use crate::cfg::dispatch::Dispatch;
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
 
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Enable DPF")]
-    Enable(enable::Args),
-    #[clap(about = "Disable DPF")]
-    Disable(disable::Args),
-    #[clap(about = "Check Status of DPF")]
-    Show(show::Args),
-    #[clap(about = "Snapshot DPF CRs (DPUNode, DPUDevices, DPUs) for a host")]
-    Snapshot(snapshot::Args),
-    #[clap(
-        alias = "sv",
-        about = "Compare configured vs deployed DPF service versions"
-    )]
-    ServiceVersion(service_version::Args),
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::snapshot(&self.inner, &ctx.api_client).await
+    }
 }

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -21,7 +21,7 @@ use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge::instance_interface_config::NetworkDetails;
 use ::rpc::forge::{
     self as rpc, BmcEndpointRequest, FindInstanceTypesByIdsRequest,
-    FindNetworkSecurityGroupsByIdsRequest, GetDpfStateRequest,
+    FindNetworkSecurityGroupsByIdsRequest, GetDpfHostSnapshotRequest, GetDpfStateRequest,
     GetNetworkSecurityGroupAttachmentsRequest, GetNetworkSecurityGroupPropagationStatusRequest,
     IdentifySerialRequest, MachineHardwareInfo, MachineHardwareInfoUpdateType,
     ModifyDpfStateRequest, NetworkPrefix, NetworkSecurityGroupAttributes,
@@ -2202,5 +2202,21 @@ impl ApiClient {
         }
 
         Ok(all_dpf_states)
+    }
+
+    pub async fn get_dpf_host_snapshot(
+        &self,
+        host_machine_id: MachineId,
+    ) -> CarbideCliResult<String> {
+        let request = GetDpfHostSnapshotRequest {
+            host_machine_id: Some(host_machine_id),
+        };
+        let response = self.0.get_dpf_host_snapshot(request).await?;
+        Ok(response.json_payload)
+    }
+
+    pub async fn get_dpf_service_versions(&self) -> CarbideCliResult<Vec<rpc::DpfServiceVersion>> {
+        let response = self.0.get_dpf_service_versions().await?;
+        Ok(response.services)
     }
 }

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -3031,6 +3031,20 @@ impl Forge for Api {
         crate::handlers::dpf::get_dpf_state(self, request).await
     }
 
+    async fn get_dpf_host_snapshot(
+        &self,
+        request: Request<rpc::GetDpfHostSnapshotRequest>,
+    ) -> Result<Response<rpc::DpfHostSnapshotResponse>, Status> {
+        crate::handlers::dpf::get_dpf_host_snapshot(self, request).await
+    }
+
+    async fn get_dpf_service_versions(
+        &self,
+        request: Request<rpc::GetDpfServiceVersionsRequest>,
+    ) -> Result<Response<rpc::DpfServiceVersionsResponse>, Status> {
+        crate::handlers::dpf::get_dpf_service_versions(self, request).await
+    }
+
     // scout_stream handles the bidirectional streaming connection from scout agents.
     // scout agents call scout_stream and send an Init message, and then carbide-api
     // will send down "request" messages to connected agent(s) to either instruct them

--- a/crates/api/src/auth/internal_rbac_rules.rs
+++ b/crates/api/src/auth/internal_rbac_rules.rs
@@ -829,6 +829,8 @@ impl InternalRBACRules {
         x.perm("UpdateComponentFirmware", vec![ForgeAdminCLI, Flow]);
         x.perm("GetComponentFirmwareStatus", vec![ForgeAdminCLI, Flow]);
         x.perm("ListComponentFirmwareVersions", vec![ForgeAdminCLI, Flow]);
+        x.perm("GetDPFHostSnapshot", vec![ForgeAdminCLI]);
+        x.perm("GetDPFServiceVersions", vec![ForgeAdminCLI]);
         x
     }
     fn perm(&mut self, msg: &str, principals: Vec<RulePrincipal>) {

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -746,8 +746,6 @@ pub struct DpfMandatoryServicesConfig {
     pub fmds: DpfServiceConfig,
     #[serde(default = "crate::dpf_services::default_otelcol_service")]
     pub otel: DpfServiceConfig,
-    #[serde(default)]
-    pub otel_agent: DpfServiceConfig,
 }
 
 impl Default for DpfMandatoryServicesConfig {
@@ -759,7 +757,6 @@ impl Default for DpfMandatoryServicesConfig {
             dhcp_server: crate::dpf_services::default_dhcp_server_service(),
             fmds: crate::dpf_services::default_fmds_service(),
             otel: crate::dpf_services::default_otelcol_service(),
-            otel_agent: DpfServiceConfig::default(),
         }
     }
 }

--- a/crates/api/src/dpf.rs
+++ b/crates/api/src/dpf.rs
@@ -23,7 +23,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use carbide_dpf::{
     BmcPasswordProvider, DpfError, DpfSdk, DpuDeviceInfo, DpuNodeInfo, DpuPhase, DpuWatcher,
-    KubeRepository, ResourceLabeler, node_id_from_dpu_node_cr_name,
+    HostDpfSnapshot, KubeRepository, ResourceLabeler, ServiceTemplateVersion,
+    node_id_from_dpu_node_cr_name,
 };
 use sqlx::PgPool;
 use tokio::task::JoinSet;
@@ -76,6 +77,15 @@ pub trait DpfOperations: Send + Sync + std::fmt::Debug {
     /// Check that a DPUNode's labels match the current expected labels.
     /// Returns `false` when the node exists but has stale labels.
     async fn verify_node_labels(&self, node_name: &str) -> Result<bool, DpfError>;
+
+    /// Curated snapshot of all DPF CRs related to one host (DPUNode +
+    /// DPUDevices + DPUs). `node_name` is the full DPUNode CR name.
+    async fn snapshot_host(&self, node_name: &str) -> Result<HostDpfSnapshot, DpfError>;
+
+    /// List helm-chart versions declared on each live `DPUServiceTemplate`
+    /// CR — used for comparing config vs deployed state.
+    async fn list_service_template_versions(&self)
+    -> Result<Vec<ServiceTemplateVersion>, DpfError>;
 }
 
 /// Applies carbide-specific labels to DPF resources.
@@ -369,5 +379,15 @@ impl DpfOperations for DpfSdkOps {
 
     async fn verify_node_labels(&self, node_name: &str) -> Result<bool, DpfError> {
         self.sdk.verify_node_labels(node_name).await
+    }
+
+    async fn snapshot_host(&self, node_name: &str) -> Result<HostDpfSnapshot, DpfError> {
+        self.sdk.snapshot_host(node_name).await
+    }
+
+    async fn list_service_template_versions(
+        &self,
+    ) -> Result<Vec<ServiceTemplateVersion>, DpfError> {
+        self.sdk.list_service_template_versions().await
     }
 }

--- a/crates/api/src/handlers/dpf.rs
+++ b/crates/api/src/handlers/dpf.rs
@@ -16,7 +16,9 @@
  */
 
 use ::rpc::forge as rpc;
+use carbide_dpf::dpu_node_cr_name;
 use db::ObjectFilter;
+use db::machine::find_one;
 use db::managed_host::load_snapshot;
 use model::machine::LoadSnapshotOptions;
 use model::machine::machine_search_config::MachineSearchConfig;
@@ -90,4 +92,97 @@ pub(crate) async fn get_dpf_state(
             .map(|machine| machine.into())
             .collect(),
     }))
+}
+
+pub(crate) async fn get_dpf_host_snapshot(
+    api: &Api,
+    request: Request<rpc::GetDpfHostSnapshotRequest>,
+) -> Result<Response<rpc::DpfHostSnapshotResponse>, Status> {
+    log_request_data(&request);
+    let request = request.get_ref();
+    let machine_id = convert_and_log_machine_id(request.host_machine_id.as_ref())?;
+    log_machine_id(&machine_id);
+
+    if machine_id.machine_type().is_dpu() {
+        return Err(CarbideError::InvalidArgument("Only host id is expected".to_string()).into());
+    }
+
+    let Some(ops) = api.dpf_sdk.as_ref() else {
+        return Err(CarbideError::InvalidArgument(
+            "DPF is not enabled on this carbide instance".to_string(),
+        )
+        .into());
+    };
+
+    let mut txn = api.txn_begin().await?;
+    let machine = find_one(&mut txn, &machine_id, MachineSearchConfig::default())
+        .await?
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "machine",
+            id: machine_id.to_string(),
+        })?;
+    txn.commit().await?;
+
+    let host_dpf_id = machine.dpf_id().ok_or_else(|| {
+        CarbideError::InvalidArgument(format!(
+            "Host {machine_id} has no BMC MAC; cannot derive DPF node name"
+        ))
+    })?;
+    let node_name = dpu_node_cr_name(&host_dpf_id);
+
+    let snapshot = ops
+        .snapshot_host(&node_name)
+        .await
+        .map_err(CarbideError::DpfError)?;
+
+    let json_payload = serde_json::to_string_pretty(&snapshot).map_err(|e| {
+        CarbideError::internal(format!("Failed to serialize DPF host snapshot: {e}"))
+    })?;
+
+    Ok(Response::new(rpc::DpfHostSnapshotResponse { json_payload }))
+}
+
+pub(crate) async fn get_dpf_service_versions(
+    api: &Api,
+    request: Request<rpc::GetDpfServiceVersionsRequest>,
+) -> Result<Response<rpc::DpfServiceVersionsResponse>, Status> {
+    log_request_data(&request);
+
+    let cfg = &api.runtime_config.dpf.services;
+    let configured = [
+        &cfg.dts,
+        &cfg.doca_hbn,
+        &cfg.dpu_agent,
+        &cfg.dhcp_server,
+        &cfg.fmds,
+        &cfg.otel,
+    ];
+
+    let live = if let Some(ops) = api.dpf_sdk.as_ref() {
+        ops.list_service_template_versions()
+            .await
+            .map_err(CarbideError::DpfError)?
+    } else {
+        Vec::new()
+    };
+
+    let services = configured
+        .iter()
+        .map(|svc_cfg| {
+            let matched = live
+                .iter()
+                .find(|t| t.deployment_service_name == svc_cfg.name);
+            rpc::DpfServiceVersion {
+                service: svc_cfg.name.clone(),
+                config_helm_version: svc_cfg.helm_version.clone(),
+                config_docker_image_tag: svc_cfg.docker_image_tag.clone(),
+                live_helm_version: matched.map(|t| t.helm_version.clone()).unwrap_or_default(),
+                live_docker_image_tag: matched
+                    .map(|t| t.docker_image_tag.clone())
+                    .unwrap_or_default(),
+            }
+        })
+        .collect();
+
+    Ok(Response::new(rpc::DpfServiceVersionsResponse { services }))
 }

--- a/crates/dpf/src/lib.rs
+++ b/crates/dpf/src/lib.rs
@@ -79,10 +79,11 @@ pub use sdk::{
 };
 pub use services::{DEFAULT_DOCA_HELM_REGISTRY, ServiceRegistryConfig};
 pub use types::{
-    BmcPasswordProvider, ConfigPortsServiceType, DpuDeviceInfo, DpuErrorEvent, DpuEvent,
-    DpuNodeInfo, DpuPhase, DpuReadyEvent, InitDpfResourcesConfig, MaintenanceEvent,
-    RebootRequiredEvent, ServiceChainSwitch, ServiceConfigPort, ServiceConfigPortProtocol,
-    ServiceDefinition, ServiceInterface, ServiceNAD, ServiceNADResourceType,
+    BmcPasswordProvider, ConfigPortsServiceType, DpuDeviceInfo, DpuDeviceSummary, DpuErrorEvent,
+    DpuEvent, DpuNodeInfo, DpuNodeSummary, DpuPhase, DpuReadyEvent, DpuSummary, HostDpfSnapshot,
+    InitDpfResourcesConfig, MaintenanceEvent, RebootRequiredEvent, ServiceChainSwitch,
+    ServiceConfigPort, ServiceConfigPortProtocol, ServiceDefinition, ServiceInterface, ServiceNAD,
+    ServiceNADResourceType, ServiceTemplateVersion,
 };
 pub use watcher::{DpuWatcher, DpuWatcherBuilder};
 

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -76,10 +76,10 @@ use crate::repository::{
 };
 use crate::types::{
     BmcPasswordProvider, ConfigPortsServiceType, DHCP_SERVER_SERVICE_NAME, DOCA_HBN_SERVICE_NAME,
-    DPU_AGENT_SERVICE_NAME, DpuDeviceInfo, DpuNodeInfo, DpuPhase,
-    DpuServiceInterfaceTemplateDefinition, DpuServiceInterfaceTemplateType, FMDS_SERVICE_NAME,
-    InitDpfResourcesConfig, OTEL_COLLECTOR_SERVICE_NAME, ServiceConfigPortProtocol,
-    ServiceDefinition, ServiceNADResourceType,
+    DPU_AGENT_SERVICE_NAME, DpuDeviceInfo, DpuDeviceSummary, DpuNodeInfo, DpuNodeSummary, DpuPhase,
+    DpuServiceInterfaceTemplateDefinition, DpuServiceInterfaceTemplateType, DpuSummary,
+    FMDS_SERVICE_NAME, HostDpfSnapshot, InitDpfResourcesConfig, OTEL_COLLECTOR_SERVICE_NAME,
+    ServiceConfigPortProtocol, ServiceDefinition, ServiceNADResourceType, ServiceTemplateVersion,
 };
 use crate::watcher::DpuWatcherBuilder;
 
@@ -1534,6 +1534,111 @@ impl<R: DpuRepository + DpuNodeRepository + DpuDeviceRepository, L: ResourceLabe
             }
         }
         Ok(())
+    }
+}
+
+impl<R: DpuNodeRepository + DpuDeviceRepository + DpuRepository, L> DpfSdk<R, L> {
+    /// Read a curated snapshot of the DPUNode, DPUDevices, and DPUs for a
+    /// single host. `node_name` is the full `DPUNode` CR name (e.g.
+    /// `node-<bmc-mac>`).
+    ///
+    /// Returns `dpu_node = None` when the DPUNode CR does not exist.
+    /// Missing DPUDevice or DPU CRs (e.g. operator hasn't created the DPU
+    /// yet) are silently skipped — the resulting snapshot reflects what's
+    /// currently in K8s.
+    pub async fn snapshot_host(&self, node_name: &str) -> Result<HostDpfSnapshot, DpfError> {
+        let node = DpuNodeRepository::get(&*self.repo, node_name, &self.namespace).await?;
+
+        let device_refs: Vec<String> = node
+            .as_ref()
+            .and_then(|n| n.spec.dpus.as_ref())
+            .map(|dpus| dpus.iter().map(|d| d.name.clone()).collect())
+            .unwrap_or_default();
+
+        let dpu_node = node.as_ref().map(|n| DpuNodeSummary {
+            name: n.metadata.name.clone().unwrap_or_default(),
+            labels: n.metadata.labels.clone().unwrap_or_default(),
+            annotations: n.metadata.annotations.clone().unwrap_or_default(),
+            dpu_device_refs: device_refs.clone(),
+        });
+
+        let dpf_id = node_id_from_dpu_node_cr_name(node_name);
+
+        let mut dpu_devices = Vec::with_capacity(device_refs.len());
+        let mut dpus = Vec::with_capacity(device_refs.len());
+        for device_ref in &device_refs {
+            if let Some(dev) =
+                DpuDeviceRepository::get(&*self.repo, device_ref, &self.namespace).await?
+            {
+                dpu_devices.push(DpuDeviceSummary {
+                    name: dev.metadata.name.clone().unwrap_or_default(),
+                    labels: dev.metadata.labels.clone().unwrap_or_default(),
+                    bmc_ip: dev.spec.bmc_ip.clone(),
+                    bmc_port: dev.spec.bmc_port,
+                    serial_number: dev.spec.serial_number.clone(),
+                });
+            }
+
+            // device_ref on DPUNode.spec.dpus has the `device-` prefix the
+            // operator uses; strip it to recover the raw device_id needed by
+            // dpu_cr_name().
+            let raw_device_id = device_ref
+                .strip_prefix("device-")
+                .unwrap_or(device_ref.as_str());
+            let dpu_cr = dpu_cr_name(raw_device_id, dpf_id);
+            if let Some(d) = DpuRepository::get(&*self.repo, &dpu_cr, &self.namespace).await? {
+                dpus.push(DpuSummary {
+                    name: d.metadata.name.clone().unwrap_or_default(),
+                    labels: d.metadata.labels.clone().unwrap_or_default(),
+                    spec_bfb: d.spec.bfb.clone(),
+                    spec_dpu_flavor: d.spec.dpu_flavor.clone(),
+                    spec_dpu_device_name: d.spec.dpu_device_name.clone(),
+                    spec_dpu_node_name: d.spec.dpu_node_name.clone(),
+                    status_phase: d.status.as_ref().map(|s| format!("{:?}", s.phase)),
+                    status_bfb_file: d.status.as_ref().and_then(|s| s.bfb_file.clone()),
+                });
+            }
+        }
+
+        Ok(HostDpfSnapshot {
+            dpu_node,
+            dpu_devices,
+            dpus,
+        })
+    }
+}
+
+impl<R: DpuServiceTemplateRepository, L> DpfSdk<R, L> {
+    /// List the helm-chart versions currently declared on each live
+    /// `DPUServiceTemplate` CR. Useful for comparing what's deployed in
+    /// the cluster against the carbide-config service versions.
+    pub async fn list_service_template_versions(
+        &self,
+    ) -> Result<Vec<ServiceTemplateVersion>, DpfError> {
+        let templates = DpuServiceTemplateRepository::list(&*self.repo, &self.namespace).await?;
+        Ok(templates
+            .into_iter()
+            .map(|t| {
+                let docker_image_tag = t
+                    .spec
+                    .helm_chart
+                    .values
+                    .as_ref()
+                    .and_then(|v| v.get("image"))
+                    .and_then(|img| img.get("tag"))
+                    .and_then(|tag| tag.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                ServiceTemplateVersion {
+                    cr_name: t.metadata.name.unwrap_or_default(),
+                    deployment_service_name: t.spec.deployment_service_name,
+                    helm_repo_url: t.spec.helm_chart.source.repo_url,
+                    helm_chart: t.spec.helm_chart.source.chart,
+                    helm_version: t.spec.helm_chart.source.version,
+                    docker_image_tag,
+                }
+            })
+            .collect())
     }
 }
 

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -17,6 +17,8 @@
 
 //! SDK types for the DPF SDK.
 
+use std::collections::BTreeMap;
+
 use crate::crds::dpus_generated::DpuStatusPhase;
 
 /// Async provider for BMC passwords used to create and refresh the K8s BMC
@@ -364,6 +366,61 @@ pub struct DpuErrorEvent {
     pub device_name: String,
     /// Name of the DPUNode containing this DPU.
     pub node_name: String,
+}
+
+/// Curated snapshot of the DPF CRs related to a single host. Produced by
+/// [`crate::DpfSdk::snapshot_host`]. Designed for ad-hoc inspection (e.g.
+/// printing as JSON from an admin CLI), not as a stable wire format.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct HostDpfSnapshot {
+    pub dpu_node: Option<DpuNodeSummary>,
+    pub dpu_devices: Vec<DpuDeviceSummary>,
+    pub dpus: Vec<DpuSummary>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DpuNodeSummary {
+    pub name: String,
+    pub labels: BTreeMap<String, String>,
+    pub annotations: BTreeMap<String, String>,
+    pub dpu_device_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DpuDeviceSummary {
+    pub name: String,
+    pub labels: BTreeMap<String, String>,
+    pub bmc_ip: Option<String>,
+    pub bmc_port: Option<i32>,
+    pub serial_number: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DpuSummary {
+    pub name: String,
+    pub labels: BTreeMap<String, String>,
+    pub spec_bfb: String,
+    pub spec_dpu_flavor: Option<String>,
+    pub spec_dpu_device_name: String,
+    pub spec_dpu_node_name: String,
+    pub status_phase: Option<String>,
+    pub status_bfb_file: Option<String>,
+}
+
+/// Helm-chart version observed on a live `DPUServiceTemplate` CR. Used by
+/// [`crate::DpfSdk::list_service_template_versions`] so callers (e.g. the
+/// admin CLI) can compare configured vs deployed versions.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ServiceTemplateVersion {
+    pub cr_name: String,
+    pub deployment_service_name: String,
+    pub helm_repo_url: String,
+    pub helm_chart: Option<String>,
+    pub helm_version: String,
+    /// Docker image tag extracted from `helm_chart.values.image.tag`, if
+    /// present. Empty when the template doesn't pin an image (e.g. dts
+    /// relies on the chart default).
+    pub docker_image_tag: String,
 }
 
 #[cfg(test)]

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -900,6 +900,11 @@ service Forge {
 
   rpc ModifyDPFState(ModifyDPFStateRequest) returns (google.protobuf.Empty);
   rpc GetDPFState(GetDPFStateRequest) returns (DPFStateResponse);
+  // Curated snapshot of DPF CRs (DPUNode + DPUDevices + DPUs) for one host.
+  rpc GetDPFHostSnapshot(GetDPFHostSnapshotRequest) returns (DPFHostSnapshotResponse);
+  // Helm/docker versions for the carbide DPF mandatory services, from both
+  // the carbide config and the live DPUServiceTemplate CRs.
+  rpc GetDPFServiceVersions(GetDPFServiceVersionsRequest) returns (DPFServiceVersionsResponse);
 
   // --- Component management (unified switch + power shelf operations) ---
   rpc ComponentPowerControl(ComponentPowerControlRequest) returns (ComponentPowerControlResponse);
@@ -7782,6 +7787,44 @@ message DPFStateResponse {
 
 message GetDPFStateRequest {
   repeated common.MachineId machine_ids = 1;
+}
+
+// --- DPF host snapshot ---
+
+message GetDPFHostSnapshotRequest {
+  common.MachineId host_machine_id = 1;
+}
+
+// Returns the snapshot as a JSON string. The server-side curates the field
+// set; the CLI just pretty-prints. Keeps the wire format stable while letting
+// the SDK evolve its summary types.
+message DPFHostSnapshotResponse {
+  string json_payload = 1;
+}
+
+// --- DPF service versions ---
+
+message GetDPFServiceVersionsRequest {
+}
+
+message DPFServiceVersion {
+  // Service name (e.g. "dts", "doca-hbn", "carbide-dpu-agent").
+  string service = 1;
+  // Helm chart version from the carbide config.
+  string config_helm_version = 2;
+  // Docker image tag from the carbide config.
+  string config_docker_image_tag = 3;
+  // Helm chart version observed on a live DPUServiceTemplate CR, if a
+  // matching one exists. Empty if no template was found.
+  string live_helm_version = 4;
+  // Docker image tag observed on a live DPUServiceTemplate CR
+  // (helm_values.image.tag). Empty if no template was found or the
+  // template doesn't pin an image tag (e.g. dts uses the chart default).
+  string live_docker_image_tag = 5;
+}
+
+message DPFServiceVersionsResponse {
+  repeated DPFServiceVersion services = 1;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Description
admin-cli to display host snapshot in DPF/kube world and service versions.

```bash
❯ admin-cli dpf sv
+---------------------+------------------------+--------------------------------+-------------------------+---------------------------------+
| Service             | Config Helm Version    | Live Helm Version              | Config Docker Tag       | Live Docker Tag                 |
+=====================+========================+================================+=========================+=================================+
| dts                 | 1.22.1                 | 1.22.1 (match)                 | -                       | n/a                             |
+---------------------+------------------------+--------------------------------+-------------------------+---------------------------------+
| doca-hbn            | 1.0.5                  | 1.0.5 (match)                  | 3.2.1-doca3.2.1         | 3.2.1-doca3.2.1 (match)         |
+---------------------+------------------------+--------------------------------+-------------------------+---------------------------------+
| carbide-dpu-agent   | 0.9.0-pr-159.gc0c32bde | 0.9.0-pr-159.gc0c32bde (match) | v0.9.0-pr-159-gc0c32bde | v0.9.0-pr-159-gc0c32bde (match) |
+---------------------+------------------------+--------------------------------+-------------------------+---------------------------------+
| carbide-dhcp-server | 0.9.0-pr-159.gc0c32bde | 0.9.0-pr-159.gc0c32bde (match) | v0.9.0-pr-159-gc0c32bde | v0.9.0-pr-159-gc0c32bde (match) |
+---------------------+------------------------+--------------------------------+-------------------------+---------------------------------+
| carbide-fmds        | 0.9.0-pr-159.gc0c32bde | 0.9.0-pr-159.gc0c32bde (match) | v0.9.0-pr-159-gc0c32bde | v0.9.0-pr-159-gc0c32bde (match) |
+---------------------+------------------------+--------------------------------+-------------------------+---------------------------------+
| carbide-otelcol     | 0.9.0-pr-159.gc0c32bde | 0.9.0-pr-159.gc0c32bde (match) | v0.9.0-pr-159-gc0c32bde | v0.9.0-pr-159-gc0c32bde (match) |
+---------------------+------------------------+--------------------------------+-------------------------+---------------------------------+
```

```bash
❯ admin-cli dpf snapshot fm100htxxxxxxxxxxxxxxxxxxv80sbc0
{
  "dpu_node": {
    "name": "node-xx-xx-xx-xx-xx-xx",
    "labels": {
      "carbide.nvidia.com/controlled.node.v2": "true",
      "carbide.nvidia.com/host-bmc-ip": "10.217.168.190",
      "feature.node.kubernetes.io/dpu-enabled": "true"
    },
    "annotations": {},
    "dpu_device_refs": [
      "device-xx-xx-xx-6e-xx-xx",
      "device-xx-xx-xx-6e-xx-yy"
    ]
  },
  "dpu_devices": [
    {
      "name": "device-xx-xx-xx-6e-xx-xx",
      "labels": {
        "carbide.nvidia.com/controlled.device": "true",
        "carbide.nvidia.com/dpu-machine-id": "fm100dsh4ohq8fxxxxxxxxxx5aao1rkvrbkv3ufj3u90",
        "carbide.nvidia.com/host-bmc-ip": "10.217.168.190",
        "carbide.nvidia.com/is-primary-dpu": "true",
        "provisioning.dpu.nvidia.com/dpudevice-bmc-ip": "10.217.170.43",
        "provisioning.dpu.nvidia.com/dpudevice-opn": "900-9D3B6-xxxxxxxxxx",
        "provisioning.dpu.nvidia.com/dpudevice-psid": "MTxxxxxxxxTF",
        "provisioning.dpu.nvidia.com/dpunode-name": "node-xx-xx-xx-c8-xx-xx"
      },
      "bmc_ip": "10.217.170.43",
      "bmc_port": 443,
      "serial_number": "MTxxxxxxxxTF"
    },
    {
      "name": "device-xx-xx-xx-6e-xx-xx",
      "labels": {
        "carbide.nvidia.com/controlled.device": "true",
        "carbide.nvidia.com/dpu-machine-id": "fm100dsxxxxxxxxxxmj5kg2g20",
        "carbide.nvidia.com/host-bmc-ip": "10.217.168.190",
        "carbide.nvidia.com/is-primary-dpu": "false",
        "provisioning.dpu.nvidia.com/dpudevice-bmc-ip": "10.217.170.51",
        "provisioning.dpu.nvidia.com/dpudevice-opn": "900-9D3B6-xxxxxxx",
        "provisioning.dpu.nvidia.com/dpudevice-psid": "MTxxxxXKZ",
        "provisioning.dpu.nvidia.com/dpunode-name": "node-xx-xx-xx-c8-xx-xx"
      },
      "bmc_ip": "10.217.170.51",
      "bmc_port": 443,
      "serial_number": "MT2xxxxxxxxXKZ"
    }
  ],
  "dpus": [
    {
      "name": "node-xx-device-xx",
      "labels": {
        "carbide.nvidia.com/controlled.device": "true",
        "carbide.nvidia.com/dpu-machine-id": "fm100dsh4ohqxxxx1rkvrbkv3ufj3u90",
        "carbide.nvidia.com/host-bmc-ip": "10.217.168.190",
        "carbide.nvidia.com/is-primary-dpu": "true",
        "provisioning.dpu.nvidia.com/dpudevice-bmc-ip": "10.217.170.43",
        "provisioning.dpu.nvidia.com/dpudevice-name": "device-xx",
        "provisioning.dpu.nvidia.com/dpudevice-opn": "900-xx",
        "provisioning.dpu.nvidia.com/dpudevice-psid": "MTxxXTF",
        "provisioning.dpu.nvidia.com/dpunode-name": "node-xx",
        "provisioning.dpu.nvidia.com/dpuset-dpu-template-spec-hash": "e74b04da06",
        "provisioning.dpu.nvidia.com/dpuset-name": "nico-deployment-v2-default",
        "provisioning.dpu.nvidia.com/dpuset-namespace": "dpf-operator-system",
        "svc.dpu.nvidia.com/owned-by-dpudeployment": "dpf-operator-system_nico-deployment-v2"
      },
      "spec_bfb": "bf-bundle-65a08f5df0dec063071501cf750c6c0ebdac339d7277236e487fbf7754ec54a9",
      "spec_dpu_flavor": "carbide-dpu-flavor",
      "spec_dpu_device_name": "device-xx",
      "spec_dpu_node_name": "node-xx",
      "status_phase": "Ready",
      "status_bfb_file": "/bfb/dpf-operator-system-bf-bundle-65a08f5df0dec063071501cf750c6c0ebdac339d7277236e487fbf7754ec54a9.bfb"
    },
    {
      "name": "node-xx-device-xx",
      "labels": {
        "carbide.nvidia.com/controlled.device": "true",
        "carbide.nvidia.com/dpu-machine-id": "fm100dse6bexxxxadduu4i0mj5kg2g20",
        "carbide.nvidia.com/host-bmc-ip": "10.217.168.190",
        "carbide.nvidia.com/is-primary-dpu": "false",
        "provisioning.dpu.nvidia.com/dpudevice-bmc-ip": "10.217.170.51",
        "provisioning.dpu.nvidia.com/dpudevice-name": "device-xx",
        "provisioning.dpu.nvidia.com/dpudevice-opn": "900-9Dxx0",
        "provisioning.dpu.nvidia.com/dpudevice-psid": "MT2xxZ",
        "provisioning.dpu.nvidia.com/dpunode-name": "node-xxx",
        "provisioning.dpu.nvidia.com/dpuset-dpu-template-spec-hash": "e74b04da06",
        "provisioning.dpu.nvidia.com/dpuset-name": "nico-deployment-v2-default",
        "provisioning.dpu.nvidia.com/dpuset-namespace": "dpf-operator-system",
        "svc.dpu.nvidia.com/owned-by-dpudeployment": "dpf-operator-system_nico-deployment-v2"
      },
      "spec_bfb": "bf-bundle-65a08f5df0dec063071501cf750c6c0ebdac339d7277236e487fbf7754ec54a9",
      "spec_dpu_flavor": "carbide-dpu-flavor",
      "spec_dpu_device_name": "device-xx",
      "spec_dpu_node_name": "node-xxxx",
      "status_phase": "Ready",
      "status_bfb_file": "/bfb/dpf-operator-system-bf-bundle-65a08f5df0dec063071501cf750c6c0ebdac339d7277236e487fbf7754ec54a9.bfb"
    }
  ]
}

```

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

