### PR TITLE
fix(api): Remove restrictions on multi-interface/multi-VPC

### DIFF
--- a/crates/api-db/Cargo.toml
+++ b/crates/api-db/Cargo.toml
@@ -91,7 +91,7 @@ carbide-secrets = { path = "../secrets" }
 lazy_static = { workspace = true }
 carbide-macros = { path = "../macros" }
 carbide-sqlx-testing = { path = "../sqlx-testing" }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { features = ["env-filter"], workspace = true }
 ctor = { workspace = true }
 
 [lints]

--- a/crates/api-db/src/instance_address.rs
+++ b/crates/api-db/src/instance_address.rs
@@ -18,7 +18,7 @@ use std::collections::HashSet;
 use std::net::IpAddr;
 use std::ops::DerefMut;
 
-use carbide_network::virtualization::get_host_ip;
+use carbide_network::virtualization::{VpcVirtualizationType, get_host_ip};
 use carbide_uuid::instance::InstanceId;
 use carbide_uuid::network::{NetworkPrefixId, NetworkSegmentId};
 use ipnetwork::IpNetwork;
@@ -36,7 +36,7 @@ use model::network_segment::{
 };
 use sqlx::{FromRow, PgConnection, PgTransaction, query_as};
 
-use super::{ObjectColumnFilter, network_segment};
+use super::{ObjectColumnFilter, network_segment, vpc};
 use crate::db_read::DbReader;
 use crate::ip_allocator::{IpAllocator, UsedIpResolver};
 use crate::{DatabaseError, DatabaseResult, Transaction};
@@ -135,6 +135,7 @@ fn validate(
     segments: &Vec<NetworkSegment>,
     instance_network: &InstanceNetworkConfig,
     segment_ids_using_vpc_prefix: &[NetworkSegmentId],
+    all_fnn: bool,
 ) -> DatabaseResult<()> {
     if segments.len() != instance_network.interfaces.len() {
         // Missing at least one segment in db.
@@ -173,7 +174,7 @@ fn validate(
         };
     }
 
-    if vpc_ids.len() != 1 {
+    if vpc_ids.len() != 1 && !all_fnn {
         return Err(ConfigValidationError::MultipleVpcFound.into());
     }
 
@@ -242,7 +243,34 @@ pub async fn allocate(
     )
     .await?;
 
-    validate(&segments, &updated_config, &segment_ids_using_vpc_prefix)?;
+    // Multi-VPC instance interfaces are supported only when every referenced VPC is FNN.
+    let vpc_ids = segments
+        .iter()
+        .filter_map(|segment| segment.vpc_id)
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect_vec();
+    let all_fnn = if vpc_ids.len() > 1 {
+        let vpcs = vpc::find_by(
+            &mut inner_txn,
+            ObjectColumnFilter::List(vpc::IdColumn, &vpc_ids),
+        )
+        .await?;
+
+        vpcs.len() == vpc_ids.len()
+            && vpcs
+                .iter()
+                .all(|vpc| vpc.network_virtualization_type == VpcVirtualizationType::Fnn)
+    } else {
+        false
+    };
+
+    validate(
+        &segments,
+        &updated_config,
+        &segment_ids_using_vpc_prefix,
+        all_fnn,
+    )?;
 
     let query = "LOCK TABLE instance_addresses IN ACCESS EXCLUSIVE MODE";
     sqlx::query(query)
@@ -692,7 +720,7 @@ mod tests {
     fn instance_address_segment_validation() {
         let data = create_valid_validation_data();
         let config = create_valid_network_config();
-        let x = super::validate(&data, &config, &[]);
+        let x = super::validate(&data, &config, &[], false);
         assert!(x.is_ok());
     }
 
@@ -701,7 +729,7 @@ mod tests {
         let mut data = create_valid_validation_data();
         let config = create_valid_network_config();
         data.swap_remove(10);
-        assert!(super::validate(&data, &config, &[]).is_err());
+        assert!(super::validate(&data, &config, &[], false).is_err());
     }
 
     #[test]
@@ -709,7 +737,19 @@ mod tests {
         let mut data = create_valid_validation_data();
         let config = create_valid_network_config();
         data[0].vpc_id = Some(uuid::Uuid::new_v4().into());
-        assert!(super::validate(&data, &config, &[]).is_err());
+
+        // Non-FNN and mixed VPCs still reject multi-VPC configs.
+        assert!(super::validate(&data, &config, &[], false).is_err());
+    }
+
+    #[test]
+    fn validate_multiple_fnn_vpc_must_pass() {
+        let mut data = create_valid_validation_data();
+        let config = create_valid_network_config();
+        data[0].vpc_id = Some(uuid::Uuid::new_v4().into());
+
+        // FNN VPCs allow interfaces to span multiple VPCs.
+        assert!(super::validate(&data, &config, &[], true).is_ok());
     }
 
     #[test]
@@ -717,7 +757,7 @@ mod tests {
         let mut data = create_valid_validation_data();
         let config = create_valid_network_config();
         data[2].vpc_id = None;
-        assert!(super::validate(&data, &config, &[]).is_err());
+        assert!(super::validate(&data, &config, &[], false).is_err());
     }
 
     #[test]
@@ -725,7 +765,7 @@ mod tests {
         let mut data = create_valid_validation_data();
         let config = create_valid_network_config();
         data[12].deleted = Some(Utc::now());
-        assert!(super::validate(&data, &config, &[]).is_err());
+        assert!(super::validate(&data, &config, &[], false).is_err());
     }
 
     #[test]
@@ -733,6 +773,6 @@ mod tests {
         let mut data = create_valid_validation_data();
         let config = create_valid_network_config();
         data[9].controller_state.value = NetworkSegmentControllerState::Provisioning;
-        assert!(super::validate(&data, &config, &[]).is_err());
+        assert!(super::validate(&data, &config, &[], false).is_err());
     }
 }

--- a/crates/api/src/handlers/dpu.rs
+++ b/crates/api/src/handlers/dpu.rs
@@ -359,40 +359,8 @@ pub(crate) async fn get_managed_host_network_config_inner(
 
             let segment_details = segment_details.iter().map(|x|(x.id, x)).collect::<HashMap<_,_>>();
 
-            let Some(segment) = segment_details.get(&network_segment_id) else {
-                return Err(CarbideError::Internal { message: format!(
-                    "Tenant segment id {network_segment_id} is not found in db."
-                ) }.into());
-            };
-
-            let domain = match segment.subdomain_id {
-                Some(domain_id) => {
-                    db::dns::domain::find_by_uuid(txn.as_pgconn(), domain_id)
-                        .await
-                        .map_err(CarbideError::from)?
-                        .ok_or_else(|| CarbideError::NotFoundError {
-                            kind: "domain",
-                            id: domain_id.to_string(),
-                        })?
-                        .name
-                }
-                None => "unknowndomain".to_string(),
-            };
-
-            //Set FQDN
-            let instance_hostname = &instance.config.tenant.hostname;
-            let fqdn: String;
-            if let Some(hostname) = instance_hostname.clone() {
-                fqdn = format!("{hostname}.{domain}");
-            } else {
-                let dashed_ip: String = physical_ip
-                    .to_string()
-                    .split('.')
-                    .collect::<Vec<&str>>()
-                    .join("-");
-                fqdn = format!("{dashed_ip}.{domain}");
-            }
-
+            // TODO: VPC loopbacks are currently blocked from being advertised out on the DPU.
+            // This must become per-interface/per-VPC before VPC loopbacks can be allowed out.
             let tenant_loopback_ip = if VpcVirtualizationType::Fnn == network_virtualization_type {
                 let tenant_loopback_ip = db::vpc_dpu_loopback::get_or_allocate_loopback_ip_for_vpc(
                     &api.common_pools,
@@ -425,12 +393,37 @@ pub(crate) async fn get_managed_host_network_config_inner(
                     ) }.into());
                 };
 
+                // Build the FQDN from this interface's segment domain.
+                let domain = match segment.subdomain_id {
+                    Some(domain_id) => {
+                        db::dns::domain::find_by_uuid(txn.as_pgconn(), domain_id)
+                            .await
+                            .map_err(CarbideError::from)?
+                            .ok_or_else(|| CarbideError::NotFoundError {
+                                kind: "domain",
+                                id: domain_id.to_string(),
+                            })?
+                            .name
+                    }
+                    None => "unknowndomain".to_string(),
+                };
+                let fqdn = if let Some(hostname) = &instance.config.tenant.hostname {
+                    format!("{hostname}.{domain}")
+                } else {
+                    let dashed_ip = physical_ip
+                        .to_string()
+                        .split('.')
+                        .collect::<Vec<_>>()
+                        .join("-");
+                    format!("{dashed_ip}.{domain}")
+                };
+
                 let tenant_interface =
                     ethernet_virtualization::tenant_network(
                         &mut txn,
                         instance.id,
                         iface,
-                        fqdn.clone(),
+                        fqdn,
                         // DPU agent reads loopback ip only from 0th interface.
                         // function build in nvue.rs
                         tenant_loopback_ip.clone(),

--- a/crates/api/src/instance/mod.rs
+++ b/crates/api/src/instance/mod.rs
@@ -19,6 +19,7 @@ use std::collections::{HashMap, HashSet};
 
 use ::rpc::errors::RpcDataConversionError;
 use ::rpc::forge as rpc;
+use carbide_network::virtualization::VpcVirtualizationType;
 use carbide_uuid::infiniband::IBPartitionId;
 use carbide_uuid::instance::InstanceId;
 use carbide_uuid::instance_type::InstanceTypeId;
@@ -187,7 +188,7 @@ pub async fn allocate_network(
     // This is needed so that last_used_prefix is not modified by multiple clients at same time.
     // Keep values in mut Hashmap and update last_used_prefix in the end of this function.
     // Also Validate:
-    // 1. All vpc_prefix_ids should point to same vpc.
+    // 1. vpc_prefix_ids can span VPCs only when every VPC is FNN.
     // 2. Pointed vpc'organization id must be same as instance's tenant_org.
     // 3. If no vpc_prefix_id is mentioned, return.
 
@@ -220,21 +221,37 @@ pub async fn allocate_network(
 
     // This can be empty also if vpc_prefix_id is not configured at carbide.
     // In this case error 'Unknown VPC prefix id' will be thrown.
-    if vpc_prefixes
+    let vpc_ids = vpc_prefixes
         .values()
         .map(|x| x.vpc_id)
-        .collect::<HashSet<_>>()
-        .len()
-        > 1
-    {
-        return Err(CarbideError::internal(format!(
-            "Interface config contains interfaces from multiple vpcs {:?}.",
-            vpc_prefixes
-                .values()
-                .map(|x| (x.id, x.vpc_id))
-                .collect_vec()
-        )));
-    };
+        .collect::<HashSet<_>>();
+    if vpc_ids.len() > 1 {
+        let vpc_ids = vpc_ids.into_iter().collect_vec();
+        let vpcs = db::vpc::find_by(
+            &mut *txn,
+            ObjectColumnFilter::List(db::vpc::IdColumn, &vpc_ids),
+        )
+        .await?;
+
+        if vpcs.len() != vpc_ids.len()
+            || vpcs
+                .iter()
+                .any(|x| x.network_virtualization_type != VpcVirtualizationType::Fnn)
+        {
+            return Err(CarbideError::InvalidConfiguration(
+                ConfigValidationError::InvalidValue(format!(
+                    "Interface config contains interfaces from multiple VPCs, which is only supported when all VPCs use FNN: prefixes={:?}, vpcs={:?}.",
+                    vpc_prefixes
+                        .values()
+                        .map(|x| (x.id, x.vpc_id))
+                        .collect_vec(),
+                    vpcs.iter()
+                        .map(|x| (x.id, x.network_virtualization_type))
+                        .collect_vec()
+                )),
+            ));
+        }
+    }
 
     // Allocate linknet prefixes for each interface's VPC prefix(es).
     for interface in &mut network_config.interfaces {
@@ -299,16 +316,25 @@ pub async fn allocate_network(
                 // Dual-stack: if IPv6 config is set, add a v6 linknet to the same segment.
                 if let Some(ref v6_config) = interface.ipv6_interface_config {
                     let v6_prefix_id = &v6_config.vpc_prefix_id;
-                    let (v6_vpc_prefix, v6_last_used) = {
+                    let (v6_vpc_id, v6_vpc_prefix, v6_last_used) = {
                         vpc_prefixes
                             .get(v6_prefix_id)
-                            .map(|vpc| (vpc.config.prefix, vpc.status.last_used_prefix))
+                            .map(|vpc| (vpc.vpc_id, vpc.config.prefix, vpc.status.last_used_prefix))
                             .ok_or_else(|| {
                                 CarbideError::internal(format!(
                                     "Unknown VPC prefix id: {v6_prefix_id}"
                                 ))
                             })?
                     };
+
+                    if v6_vpc_id != vpc_id {
+                        return Err(CarbideError::InvalidConfiguration(
+                            ConfigValidationError::InvalidValue(format!(
+                                "dual-stack VPC prefixes must belong to the same VPC: primary_vpc_prefix_id={vpc_prefix_id}, primary_vpc_id={vpc_id}, ipv6_vpc_prefix_id={v6_prefix_id}, ipv6_vpc_id={v6_vpc_id}",
+                            )),
+                        ));
+                    }
+
                     let v6_linknet_prefix = 127;
                     let v6_requested_prefix = v6_config
                         .requested_ip_addr

--- a/crates/api/src/tests/instance.rs
+++ b/crates/api/src/tests/instance.rs
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::collections::HashMap;
-use std::net::{IpAddr, Ipv4Addr};
+use std::collections::{HashMap, HashSet};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::ops::DerefMut;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -27,7 +27,7 @@ use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::machine_validation::MachineValidationId;
 use carbide_uuid::network::NetworkSegmentId;
-use carbide_uuid::vpc::VpcPrefixId;
+use carbide_uuid::vpc::{VpcId, VpcPrefixId};
 use chrono::Utc;
 use common::api_fixtures::instance::{
     advance_created_instance_into_ready_state, default_os_config, default_tenant_config,
@@ -47,7 +47,7 @@ use db::instance_address::UsedOverlayNetworkIpResolver;
 use db::ip_allocator::UsedIpResolver;
 use db::network_segment::IdColumn;
 use db::{self, ObjectColumnFilter};
-use ipnetwork::{IpNetwork, Ipv4Network};
+use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use itertools::Itertools;
 use mac_address::MacAddress;
 use model::dpu_machine_update::DpuMachineUpdate;
@@ -2870,11 +2870,26 @@ async fn test_vpc_prefix_handling(pool: PgPool) {
         .unwrap_err();
 }
 
-async fn create_tenant_overlay_prefix(
+async fn create_tenant_overlay_prefix(env: &TestEnv, vpc_id: VpcId) -> VpcPrefixId {
+    create_tenant_overlay_prefix_with_prefix(
+        env,
+        vpc_id,
+        "vpc prefix 1",
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(10, 217, 5, 224), 27).unwrap()),
+    )
+    .await
+}
+
+/// Creates a tenant overlay VPC prefix with an explicit CIDR for allocation tests.
+async fn create_tenant_overlay_prefix_with_prefix(
     env: &TestEnv,
-    vpc_id: carbide_uuid::vpc::VpcId,
+    vpc_id: VpcId,
+    name: &str,
+    prefix: IpNetwork,
 ) -> VpcPrefixId {
     let mut txn = env.db_txn().await;
+
+    // Look up the current VPC version so the prefix insert can increment it.
     let vpcs = db::vpc::find_by(
         txn.as_mut(),
         ObjectColumnFilter::One(db::vpc::IdColumn, &vpc_id),
@@ -2883,17 +2898,14 @@ async fn create_tenant_overlay_prefix(
     .unwrap();
     let expected_vpc_version = vpcs[0].version;
 
+    // Persist the prefix directly so tests can focus on allocation behavior.
     let vpc_prefix_id = db::vpc_prefix::persist(
         model::vpc_prefix::NewVpcPrefix {
             id: uuid::Uuid::new_v4().into(),
             vpc_id,
-            config: VpcPrefixConfig {
-                prefix: IpNetwork::V4(
-                    Ipv4Network::new(Ipv4Addr::new(10, 217, 5, 224), 27).unwrap(),
-                ),
-            },
+            config: VpcPrefixConfig { prefix },
             metadata: Metadata {
-                name: "vpc prefix 1".to_string(),
+                name: name.to_string(),
                 description: "desc".to_string(),
                 labels: HashMap::new(),
             },
@@ -2906,6 +2918,40 @@ async fn create_tenant_overlay_prefix(
     .id;
     txn.commit().await.unwrap();
     vpc_prefix_id
+}
+
+/// Builds a two-interface physical network config backed by VPC prefixes.
+fn dual_physical_network_config_with_vpc_prefixes(
+    first_prefix_id: VpcPrefixId,
+    second_prefix_id: VpcPrefixId,
+) -> rpc::InstanceNetworkConfig {
+    // Put each PF on a distinct BlueField device instance so validation treats
+    // them as separate physical interfaces.
+    let interfaces = [first_prefix_id, second_prefix_id]
+        .into_iter()
+        .enumerate()
+        .map(
+            |(device_instance, vpc_prefix_id)| rpc::InstanceInterfaceConfig {
+                function_type: rpc::InterfaceFunctionType::Physical as i32,
+                network_segment_id: None,
+                network_details: Some(
+                    rpc::forge::instance_interface_config::NetworkDetails::VpcPrefixId(
+                        vpc_prefix_id,
+                    ),
+                ),
+                device: Some("BlueField SoC".to_string()),
+                device_instance: device_instance as u32,
+                virtual_function_id: None,
+                ip_address: None,
+                ipv6_interface_config: None,
+            },
+        )
+        .collect();
+
+    rpc::InstanceNetworkConfig {
+        interfaces,
+        auto: false,
+    }
 }
 
 #[crate::sqlx_test]
@@ -4635,6 +4681,280 @@ async fn test_allocate_network_multi_dpu_vpc_prefix_id(
             IpNetwork::V6(_) => panic!("Can not be ipv6."),
         }
     }
+}
+
+#[crate::sqlx_test]
+async fn test_allocate_instance_with_multiple_fnn_vpc_prefixes(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host_multi_dpu(&env, 2).await;
+
+    // Create two FNN VPCs and prefixes to exercise cross-VPC allocation.
+    let first_vpc = env
+        .api
+        .create_vpc(
+            VpcCreationRequest::builder("2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                .metadata(Metadata {
+                    name: "fnn vpc 1".to_string(),
+                    ..Default::default()
+                })
+                .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
+                .tonic_request(),
+        )
+        .await
+        .unwrap()
+        .into_inner()
+        .id
+        .unwrap();
+    let second_vpc = env
+        .api
+        .create_vpc(
+            VpcCreationRequest::builder("2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                .metadata(Metadata {
+                    name: "fnn vpc 2".to_string(),
+                    ..Default::default()
+                })
+                .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
+                .tonic_request(),
+        )
+        .await
+        .unwrap()
+        .into_inner()
+        .id
+        .unwrap();
+    let first_prefix_id = create_tenant_overlay_prefix_with_prefix(
+        &env,
+        first_vpc,
+        "fnn vpc prefix 1",
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(10, 217, 5, 224), 27).unwrap()),
+    )
+    .await;
+    let second_prefix_id = create_tenant_overlay_prefix_with_prefix(
+        &env,
+        second_vpc,
+        "fnn vpc prefix 2",
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(10, 217, 6, 224), 27).unwrap()),
+    )
+    .await;
+
+    // Allocate an instance whose interfaces draw from both VPC prefixes.
+    let instance = env
+        .api
+        .allocate_instance(
+            InstanceAllocationRequest::builder(false)
+                .machine_id(mh.id)
+                .config(InstanceConfig::default_tenant_and_os().network(
+                    dual_physical_network_config_with_vpc_prefixes(
+                        first_prefix_id,
+                        second_prefix_id,
+                    ),
+                ))
+                .metadata(rpc::Metadata {
+                    name: "multi-fnn-vpc".to_string(),
+                    description: "tests/instance".to_string(),
+                    labels: Vec::new(),
+                })
+                .tonic_request(),
+        )
+        .await
+        .expect("FNN instance allocation across multiple VPCs should succeed")
+        .into_inner();
+
+    // Verify the response resolved both prefix-backed interfaces.
+    let interfaces = &instance
+        .config
+        .as_ref()
+        .unwrap()
+        .network
+        .as_ref()
+        .unwrap()
+        .interfaces;
+    assert_eq!(interfaces.len(), 2);
+    assert!(
+        interfaces
+            .iter()
+            .all(|iface| iface.network_segment_id.is_some())
+    );
+
+    // Fetch through the API to verify the persisted config, not just the create response.
+    let persisted = env.one_instance(instance.id.unwrap()).await;
+    let persisted_interfaces = &persisted.config().network().interfaces;
+    let segment_ids = persisted_interfaces
+        .iter()
+        .map(|iface| iface.network_segment_id.unwrap())
+        .collect_vec();
+    assert_eq!(segment_ids.iter().copied().collect::<HashSet<_>>().len(), 2);
+
+    // Verify the allocated segments are attached to both requested FNN VPCs.
+    let mut txn = env.db_txn().await;
+    let segments = db::network_segment::find_by(
+        txn.as_mut(),
+        ObjectColumnFilter::List(IdColumn, &segment_ids),
+        NetworkSegmentSearchConfig::default(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        segments
+            .iter()
+            .map(|segment| segment.vpc_id.unwrap())
+            .collect::<HashSet<_>>(),
+        HashSet::from([first_vpc, second_vpc])
+    );
+}
+
+/// Verifies that non-FNN interfaces cannot span direct segments from multiple VPCs.
+#[crate::sqlx_test]
+async fn test_allocate_instance_rejects_multiple_non_fnn_network_segments(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host_multi_dpu(&env, 2).await;
+
+    // Create two non-FNN tenant segments across two VPCs.
+    let (_, _, first_segment_id, _, _, second_segment_id) = env
+        .create_vpc_and_peer_vpc_with_tenant_segments(
+            rpc::forge::VpcVirtualizationType::EthernetVirtualizer,
+            rpc::forge::VpcVirtualizationType::EthernetVirtualizer,
+        )
+        .await;
+
+    // Non-FNN segments must still reject cross-VPC interface configs.
+    let err = env
+        .api
+        .allocate_instance(
+            InstanceAllocationRequest::builder(false)
+                .machine_id(mh.id)
+                .config(InstanceConfig::default_tenant_and_os().network(
+                    interface_network_config_with_devices(
+                        &[first_segment_id, second_segment_id],
+                        &[
+                            DeviceLocator {
+                                device: "BlueField SoC".to_string(),
+                                device_instance: 0,
+                            },
+                            DeviceLocator {
+                                device: "BlueField SoC".to_string(),
+                                device_instance: 1,
+                            },
+                        ],
+                    ),
+                ))
+                .tonic_request(),
+        )
+        .await
+        .expect_err("non-FNN cross-VPC segment allocation should fail");
+
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    assert!(
+        err.message()
+            .contains("Found segments attached to multiple VPCs")
+    );
+}
+
+/// Verifies that dual-stack prefixes on one interface cannot cross VPC boundaries.
+#[crate::sqlx_test]
+async fn test_allocate_instance_rejects_dual_stack_prefixes_from_different_vpcs(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+
+    // Create two FNN VPCs so the global multi-FNN check passes.
+    let first_vpc = env
+        .api
+        .create_vpc(
+            VpcCreationRequest::builder("2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                .metadata(Metadata {
+                    name: "dual-stack fnn vpc 1".to_string(),
+                    ..Default::default()
+                })
+                .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
+                .tonic_request(),
+        )
+        .await
+        .unwrap()
+        .into_inner()
+        .id
+        .unwrap();
+    let second_vpc = env
+        .api
+        .create_vpc(
+            VpcCreationRequest::builder("2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                .metadata(Metadata {
+                    name: "dual-stack fnn vpc 2".to_string(),
+                    ..Default::default()
+                })
+                .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
+                .tonic_request(),
+        )
+        .await
+        .unwrap()
+        .into_inner()
+        .id
+        .unwrap();
+
+    // Put the IPv4 and IPv6 prefixes in different VPCs on the same interface.
+    let primary_prefix_id = create_tenant_overlay_prefix_with_prefix(
+        &env,
+        first_vpc,
+        "dual-stack primary prefix",
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(10, 217, 9, 224), 27).unwrap()),
+    )
+    .await;
+    let ipv6_prefix_id = create_tenant_overlay_prefix_with_prefix(
+        &env,
+        second_vpc,
+        "dual-stack ipv6 prefix",
+        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::from_str("fd00:217:9::").unwrap(), 120).unwrap()),
+    )
+    .await;
+
+    // Reject creating a single dual-stack segment that crosses VPC boundaries.
+    let err = env
+        .api
+        .allocate_instance(
+            InstanceAllocationRequest::builder(false)
+                .machine_id(mh.id)
+                .config(InstanceConfig::default_tenant_and_os().network(
+                    rpc::InstanceNetworkConfig {
+                        interfaces: vec![rpc::InstanceInterfaceConfig {
+                            function_type: rpc::InterfaceFunctionType::Physical as i32,
+                            network_segment_id: None,
+                            network_details: Some(
+                                rpc::forge::instance_interface_config::NetworkDetails::VpcPrefixId(
+                                    primary_prefix_id,
+                                ),
+                            ),
+                            device: Some("BlueField SoC".to_string()),
+                            device_instance: 0,
+                            virtual_function_id: None,
+                            ip_address: None,
+                            ipv6_interface_config: Some(rpc::forge::InstanceInterfaceIpv6Config {
+                                vpc_prefix_id: Some(ipv6_prefix_id),
+                                ip_address: None,
+                            }),
+                        }],
+                        auto: false,
+                    },
+                ))
+                .tonic_request(),
+        )
+        .await
+        .expect_err("dual-stack prefixes from different VPCs should fail");
+
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    assert!(
+        err.message()
+            .contains("dual-stack VPC prefixes must belong to the same VPC")
+    );
 }
 
 // ================================================================================================


### PR DESCRIPTION
## Description

Previous understanding was that -core API already had support for instance spanning VPCs but it was missing from dpu-agent and -rest.   Previous PR completed the support in dpu-agent and -rest, but it looks like there are some spots with explicit blocks in -core api around multiple interfaces spanning multiple VPCs.

This PR fixes that.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

