### PR TITLE
chore(model): RPC conversion code isolation (A-D)

### DIFF
--- a/crates/api-model/src/allocation_type.rs
+++ b/crates/api-model/src/allocation_type.rs
@@ -17,8 +17,6 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::address_selection_strategy::AddressSelectionStrategy;
-
 /// Distinguishes how an IP address was allocated to a machine interface,
 /// and are generally derived from the AddressSelectionStrategy used.
 ///
@@ -75,34 +73,12 @@ pub enum AssignStaticResult {
     ReplacedDhcp,
 }
 
-impl From<AssignStaticResult> for rpc::forge::AssignStaticAddressStatus {
-    fn from(result: AssignStaticResult) -> Self {
-        match result {
-            AssignStaticResult::Assigned => rpc::forge::AssignStaticAddressStatus::Assigned,
-            AssignStaticResult::ReplacedStatic => {
-                rpc::forge::AssignStaticAddressStatus::ReplacedStatic
-            }
-            AssignStaticResult::ReplacedDhcp => rpc::forge::AssignStaticAddressStatus::ReplacedDhcp,
-        }
-    }
-}
-
-impl From<AddressSelectionStrategy> for AllocationType {
-    fn from(strategy: AddressSelectionStrategy) -> Self {
-        match strategy {
-            AddressSelectionStrategy::NextAvailableIp => AllocationType::Dhcp,
-            AddressSelectionStrategy::Automatic => AllocationType::Dhcp,
-            AddressSelectionStrategy::NextAvailablePrefix(_) => AllocationType::Dhcp,
-            AddressSelectionStrategy::StaticAddress(_) => AllocationType::Static,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::net::Ipv4Addr;
 
     use super::*;
+    use crate::address_selection_strategy::AddressSelectionStrategy;
 
     #[test]
     fn next_available_ip_is_dhcp() {

--- a/crates/api-model/src/attestation.rs
+++ b/crates/api-model/src/attestation.rs
@@ -308,19 +308,6 @@ pub mod spdm {
         }
     }
 
-    impl From<SpdmDeviceAttestationDetails> for rpc::forge::SpdmAttestationDetails {
-        fn from(value: SpdmDeviceAttestationDetails) -> Self {
-            rpc::forge::SpdmAttestationDetails {
-                machine_id: Some(value.machine_id),
-                completed_at: value.completed_at.map(|x| x.into()),
-                started_at: Some(value.started_at.into()),
-                cancelled_at: value.cancelled_at.map(|x| x.into()),
-                state: format!("{:?}", value.state),
-                device_id: value.device_id,
-            }
-        }
-    }
-
     #[async_trait::async_trait]
     pub trait Verifier: std::fmt::Debug + Send + Sync + 'static {
         fn client(&self, nras_config: nras::Config) -> Box<dyn nras::VerifierClient>;

--- a/crates/api-model/src/bmc_info.rs
+++ b/crates/api-model/src/bmc_info.rs
@@ -18,8 +18,6 @@ use std::fmt::{Display, Formatter};
 use std::net::IpAddr;
 use std::str::FromStr;
 
-use ::rpc::errors::RpcDataConversionError;
-use ::rpc::forge as rpc;
 use eyre::{Report, eyre};
 use mac_address::MacAddress;
 use serde::{Deserialize, Serialize};
@@ -60,29 +58,6 @@ impl<'r> FromRow<'r, PgRow> for BmcInfo {
     }
 }
 
-impl TryFrom<rpc::BmcInfo> for BmcInfo {
-    type Error = RpcDataConversionError;
-    fn try_from(value: rpc::BmcInfo) -> Result<Self, RpcDataConversionError> {
-        let mac: Option<MacAddress> = if let Some(mac_address) = value.mac {
-            Some(
-                mac_address
-                    .parse()
-                    .map_err(|_| RpcDataConversionError::InvalidMacAddress(mac_address))?,
-            )
-        } else {
-            None
-        };
-
-        Ok(BmcInfo {
-            ip: value.ip,
-            port: value.port.map(|p| p as u16),
-            mac,
-            version: value.version,
-            firmware_version: value.firmware_version,
-        })
-    }
-}
-
 impl BmcInfo {
     pub fn ip_addr(&self) -> Result<IpAddr, Report> {
         self.ip
@@ -92,18 +67,6 @@ impl BmcInfo {
             .map_err(|e| {
                 eyre! {"Bad address {:?} {e}", self.ip }
             })
-    }
-}
-
-impl From<BmcInfo> for rpc::BmcInfo {
-    fn from(value: BmcInfo) -> Self {
-        rpc::BmcInfo {
-            ip: value.ip,
-            port: value.port.map(|p| p as u32),
-            mac: value.mac.map(|mac| mac.to_string()),
-            version: value.version,
-            firmware_version: value.firmware_version,
-        }
     }
 }
 
@@ -127,28 +90,6 @@ impl Display for UserRoles {
         };
 
         write!(f, "{string}")
-    }
-}
-
-impl From<rpc::UserRoles> for UserRoles {
-    fn from(action: rpc::UserRoles) -> Self {
-        match action {
-            rpc::UserRoles::User => UserRoles::User,
-            rpc::UserRoles::Administrator => UserRoles::Administrator,
-            rpc::UserRoles::Operator => UserRoles::Operator,
-            rpc::UserRoles::Noaccess => UserRoles::Noaccess,
-        }
-    }
-}
-
-impl From<UserRoles> for rpc::UserRoles {
-    fn from(action: UserRoles) -> Self {
-        match action {
-            UserRoles::User => rpc::UserRoles::User,
-            UserRoles::Administrator => rpc::UserRoles::Administrator,
-            UserRoles::Operator => rpc::UserRoles::Operator,
-            UserRoles::Noaccess => rpc::UserRoles::Noaccess,
-        }
     }
 }
 

--- a/crates/api-model/src/compute_allocation/mod.rs
+++ b/crates/api-model/src/compute_allocation/mod.rs
@@ -16,8 +16,6 @@
  */
 use std::collections::HashMap;
 
-use ::rpc::errors::RpcDataConversionError;
-use ::rpc::forge as rpc;
 use carbide_uuid::compute_allocation::ComputeAllocationId;
 use carbide_uuid::instance_type::InstanceTypeId;
 use chrono::prelude::*;
@@ -80,105 +78,5 @@ impl<'r> sqlx::FromRow<'r, PgRow> for ComputeAllocation {
                 .try_into()
                 .map_err(|e| sqlx::Error::Decode(Box::new(e)))?,
         })
-    }
-}
-
-impl TryFrom<ComputeAllocation> for rpc::ComputeAllocation {
-    type Error = RpcDataConversionError;
-
-    fn try_from(compute_alloc: ComputeAllocation) -> Result<Self, Self::Error> {
-        let attributes = rpc::ComputeAllocationAttributes {
-            instance_type_id: compute_alloc.instance_type_id.to_string(),
-            count: compute_alloc.count,
-        };
-
-        Ok(rpc::ComputeAllocation {
-            id: Some(compute_alloc.id),
-            tenant_organization_id: compute_alloc.tenant_organization_id.to_string(),
-            version: compute_alloc.version.to_string(),
-            attributes: Some(attributes),
-            created_at: Some(compute_alloc.created.to_string()),
-            created_by: compute_alloc.created_by,
-            updated_by: compute_alloc.updated_by,
-            metadata: Some(rpc::Metadata {
-                name: compute_alloc.metadata.name,
-                description: compute_alloc.metadata.description,
-                labels: compute_alloc
-                    .metadata
-                    .labels
-                    .iter()
-                    .map(|(key, value)| rpc::Label {
-                        key: key.to_owned(),
-                        value: if value.is_empty() {
-                            None
-                        } else {
-                            Some(value.to_owned())
-                        },
-                    })
-                    .collect(),
-            }),
-        })
-    }
-}
-
-/* ********************************** */
-/*              Tests                 */
-/* ********************************** */
-
-#[cfg(test)]
-mod tests {
-    use std::collections::HashMap;
-
-    use ::rpc::forge as rpc;
-    use config_version::ConfigVersion;
-
-    use super::*;
-
-    #[test]
-    fn test_model_compute_allocation_to_rpc_conversion() {
-        let version = ConfigVersion::initial();
-
-        let req_type = rpc::ComputeAllocation {
-            id: Some("dbe71f32-1bdc-11f1-8101-3b10d91c938c".parse().unwrap()),
-            version: version.to_string(),
-            metadata: Some(rpc::Metadata {
-                name: "fancy name".to_string(),
-                description: "".to_string(),
-                labels: vec![],
-            }),
-            tenant_organization_id: "theorg".to_string(),
-            attributes: Some(rpc::ComputeAllocationAttributes {
-                instance_type_id: "12345".to_string(),
-                count: 10,
-            }),
-            created_at: Some("2023-01-01 00:00:00 UTC".to_string()),
-            created_by: Some("user1".to_string()),
-            updated_by: Some("user2".to_string()),
-        };
-
-        let compute_alloc = ComputeAllocation {
-            id: "dbe71f32-1bdc-11f1-8101-3b10d91c938c".parse().unwrap(),
-            deleted: None,
-            created: "2023-01-01 00:00:00 UTC".parse().unwrap(),
-            version,
-            metadata: Metadata {
-                name: "fancy name".to_string(),
-                description: "".to_string(),
-                labels: HashMap::new(),
-            },
-            tenant_organization_id: "theorg".parse().unwrap(),
-
-            instance_type_id: "12345".parse().unwrap(),
-            count: 10,
-            created_by: Some("user1".to_string()),
-            updated_by: Some("user2".to_string()),
-        };
-
-        // Verify that we can go from an internal compute allocation to the
-        // protobuf ComputeAllocation message
-        assert_eq!(
-            req_type,
-            rpc::ComputeAllocation::try_from(compute_alloc).unwrap()
-        );
     }
 }

--- a/crates/api-model/src/controller_outcome.rs
+++ b/crates/api-model/src/controller_outcome.rs
@@ -76,41 +76,6 @@ impl From<&&'static Location<'static>> for PersistentSourceReference {
     }
 }
 
-impl From<PersistentSourceReference> for rpc::forge::ControllerStateSourceReference {
-    fn from(source_ref: PersistentSourceReference) -> Self {
-        rpc::forge::ControllerStateSourceReference {
-            file: source_ref.file,
-            line: source_ref.line.try_into().unwrap_or_default(),
-        }
-    }
-}
-
-impl From<PersistentStateHandlerOutcome> for rpc::forge::ControllerStateReason {
-    fn from(p: PersistentStateHandlerOutcome) -> rpc::forge::ControllerStateReason {
-        use rpc::forge::ControllerStateOutcome::*;
-        let (outcome, outcome_msg, source_ref) = match p {
-            PersistentStateHandlerOutcome::Wait { reason, source_ref } => {
-                (Wait, Some(reason), source_ref)
-            }
-            PersistentStateHandlerOutcome::Error { err, source_ref } => {
-                (Error, Some(err), source_ref)
-            }
-            PersistentStateHandlerOutcome::Transition { source_ref } => {
-                (Transition, None, source_ref)
-            }
-            PersistentStateHandlerOutcome::DoNothing { source_ref } => {
-                (DoNothing, None, source_ref)
-            }
-            PersistentStateHandlerOutcome::DoNothingWithDetails => (DoNothing, None, None),
-        };
-        rpc::forge::ControllerStateReason {
-            outcome: outcome.into(), // into converts it to i32
-            outcome_msg,
-            source_ref: source_ref.map(Into::into),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/api-model/src/dhcp_record.rs
+++ b/crates/api-model/src/dhcp_record.rs
@@ -47,22 +47,3 @@ pub struct DhcpRecord {
 
     pub last_invalidation_time: chrono::DateTime<chrono::Utc>,
 }
-
-impl From<DhcpRecord> for rpc::forge::DhcpRecord {
-    fn from(record: DhcpRecord) -> Self {
-        Self {
-            machine_id: record.machine_id,
-            machine_interface_id: Some(record.machine_interface_id),
-            segment_id: Some(record.segment_id),
-            subdomain_id: record.subdomain_id,
-            fqdn: record.fqdn,
-            mac_address: record.mac_address.to_string(),
-            address: record.address.to_string(),
-            mtu: record.mtu,
-            prefix: record.prefix.to_string(),
-            gateway: record.gateway.map(|gw| gw.to_string()),
-            booturl: None, // TODO(ajf): extend database, synthesize URL
-            last_invalidation_time: Some(record.last_invalidation_time.into()),
-        }
-    }
-}

--- a/crates/api-model/src/dns/domain_info.rs
+++ b/crates/api-model/src/dns/domain_info.rs
@@ -28,19 +28,6 @@ pub struct DomainInfo {
     pub masters: Vec<String>,
 }
 
-impl From<DomainInfo> for rpc::protos::dns::DomainInfo {
-    fn from(domain: DomainInfo) -> Self {
-        rpc::protos::dns::DomainInfo {
-            id: Some(domain.id),
-            zone: domain.zone,
-            kind: domain.kind,
-            serial: domain.serial as i32,
-            last_checked: domain.last_check.map(|v| v as i32),
-            notified_serial: domain.notified_serial.map(|v| v as i32),
-        }
-    }
-}
-
 impl From<super::Domain> for DomainInfo {
     fn from(domain: super::Domain) -> Self {
         let soa = domain

--- a/crates/api-model/src/dns/mod.rs
+++ b/crates/api-model/src/dns/mod.rs
@@ -15,9 +15,7 @@
  * limitations under the License.
  */
 
-use ::rpc::errors::RpcDataConversionError;
 use chrono::{DateTime, Utc};
-use dns_record::SoaRecord;
 use serde::{Deserialize, Serialize};
 
 pub mod domain_info;
@@ -74,98 +72,5 @@ impl NewDomain {
             soa: Some(SoaSnapshot::new(&name)),
             name,
         }
-    }
-}
-
-impl TryFrom<rpc::protos::dns::Domain> for NewDomain {
-    type Error = RpcDataConversionError;
-
-    fn try_from(proto: rpc::protos::dns::Domain) -> Result<Self, Self::Error> {
-        let soa = proto
-            .soa
-            .map(|soa| {
-                let record: SoaRecord = serde_json::from_str(&soa)
-                    .map_err(|e| RpcDataConversionError::InvalidSoaRecord(e.to_string()))?;
-                Ok::<SoaSnapshot, RpcDataConversionError>(SoaSnapshot(record))
-            })
-            .transpose()?;
-
-        Ok(NewDomain {
-            name: proto.name,
-            soa,
-        })
-    }
-}
-
-impl From<Domain> for rpc::protos::dns::Domain {
-    fn from(domain: Domain) -> Self {
-        rpc::protos::dns::Domain {
-            id: Some(domain.id),
-            name: domain.name,
-            created: Some(domain.created.into()),
-            updated: Some(domain.updated.into()),
-            deleted: domain.deleted.map(|d| d.into()),
-            metadata: domain.metadata.map(|m| m.into()),
-            soa: domain.soa.map(|s| s.0.to_string()),
-        }
-    }
-}
-
-impl TryFrom<rpc::protos::dns::Domain> for Domain {
-    type Error = RpcDataConversionError;
-
-    fn try_from(domain: rpc::protos::dns::Domain) -> Result<Self, Self::Error> {
-        let domain_id = match domain.id {
-            Some(id) => id,
-            None => uuid::Uuid::new_v4().into(),
-        };
-
-        let created = match domain.created {
-            Some(created) => {
-                let system_time = std::time::SystemTime::try_from(created)
-                    .map_err(|_| RpcDataConversionError::InvalidTimestamp(created.to_string()))?;
-                DateTime::<Utc>::from(system_time)
-            }
-            None => Utc::now(),
-        };
-
-        let updated = match domain.updated {
-            Some(updated) => {
-                let system_time = std::time::SystemTime::try_from(updated)
-                    .map_err(|_| RpcDataConversionError::InvalidTimestamp(updated.to_string()))?;
-                DateTime::<Utc>::from(system_time)
-            }
-            None => Utc::now(),
-        };
-
-        let deleted: Option<DateTime<Utc>> = match domain.deleted {
-            Some(deleted) => {
-                let system_time = std::time::SystemTime::try_from(deleted)
-                    .map_err(|_| RpcDataConversionError::InvalidTimestamp(deleted.to_string()))?;
-                Some(DateTime::<Utc>::from(system_time))
-            }
-            None => None,
-        };
-
-        let soa: Option<SoaSnapshot> = domain
-            .soa
-            .map(|soa| {
-                let record: SoaRecord = serde_json::from_str(&soa)
-                    .map_err(|e| RpcDataConversionError::InvalidSoaRecord(e.to_string()))?;
-                Ok::<SoaSnapshot, RpcDataConversionError>(SoaSnapshot(record))
-            })
-            .transpose()?;
-
-        let metadata = domain.metadata.map(DomainMetadata::from);
-
-        Ok(Domain {
-            id: domain_id,
-            name: domain.name,
-            created,
-            updated,
-            deleted,
-            soa,
-            metadata,
-        })
     }
 }

--- a/crates/api-model/src/dpa_interface/mod.rs
+++ b/crates/api-model/src/dpa_interface/mod.rs
@@ -18,7 +18,6 @@
 use std::convert::TryFrom;
 use std::fmt::Display;
 use std::net::IpAddr;
-use std::str::FromStr;
 
 use carbide_libmlx_model::device::info::MlxDeviceInfo;
 use carbide_libmlx_model::firmware::result::FirmwareFlashReport;
@@ -26,9 +25,7 @@ use carbide_uuid::dpa_interface::DpaInterfaceId;
 use carbide_uuid::machine::MachineId;
 use chrono::{DateTime, Utc};
 use config_version::{ConfigVersion, Versioned};
-use itertools::Itertools;
 use mac_address::MacAddress;
-use rpc::errors::RpcDataConversionError;
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgRow;
 use sqlx::{FromRow, Row};
@@ -195,8 +192,149 @@ pub fn state_sla(state: &DpaInterfaceControllerState, state_version: &ConfigVers
     }
 }
 
+#[derive(Clone, Debug)]
+pub struct DpaInterface {
+    pub id: DpaInterfaceId,
+    pub machine_id: MachineId,
+
+    pub mac_address: MacAddress,
+    pub pci_name: String,
+
+    pub underlay_ip: Option<IpAddr>,
+    pub overlay_ip: Option<IpAddr>,
+
+    pub created: DateTime<Utc>,
+    pub updated: DateTime<Utc>,
+    pub deleted: Option<DateTime<Utc>>,
+
+    pub controller_state: Versioned<DpaInterfaceControllerState>,
+
+    // Last time we issued a heartbeat command to the DPA
+    pub last_hb_time: DateTime<Utc>,
+
+    /// The result of the last attempt to change state
+    pub controller_state_outcome: Option<PersistentStateHandlerOutcome>,
+
+    pub network_config: Versioned<DpaInterfaceNetworkConfig>,
+    pub network_status_observation: Option<DpaInterfaceNetworkStatusObservation>,
+
+    pub card_state: Option<CardState>,
+
+    // device_info and its corresponding timestamp are used to
+    // keep track of the latest MlxDeviceInfo received by scout
+    // for the target Mellanox device. This contains information
+    // like the part number, PSID, firmware version(s), MAC address,
+    // etc. We store the received timestamp alongside it to detect
+    // if we're acting on potentially stale MlxDeviceInfo data.
+    pub device_info: Option<MlxDeviceInfo>,
+    pub device_info_ts: Option<DateTime<Utc>>,
+
+    // mlxconfig_profile is the name of an MlxConfigProfile from
+    // the mlx-config-profiles config map. When set, this profile
+    // will be applied to the device during the ApplyProfile state.
+    // When None, ApplyProfile will simply perform an mlxconfig
+    // reset and not apply any subsequent defaults, ensuring the
+    // card is back to stock before the next tenancy.
+    pub mlxconfig_profile: Option<String>,
+
+    pub history: Vec<StateHistoryRecord>,
+}
+
+#[derive(Clone, Debug)]
+pub struct NewDpaInterface {
+    pub machine_id: MachineId,
+    pub mac_address: MacAddress,
+    pub device_type: String,
+    pub pci_name: String,
+}
+
+impl NewDpaInterface {
+    /// from_device_info builds a NewDpaInterface instance for a given
+    /// MachineId from a given MlxDeviceInfo, since it contains everything
+    /// we use as input for an interface.
+    ///
+    /// Right now the only reason this would fail is if base_mac was unset,
+    /// at which point we'll just return None, meaning the caller knows that
+    /// the base_mac was unset. Since the mac_address is the latter half of
+    /// what is effectively a (machine_id, mac_address) compound primary key,
+    /// it's kind of important to have.
+    pub fn from_device_info(machine_id: MachineId, info: &MlxDeviceInfo) -> Option<Self> {
+        Some(Self {
+            machine_id,
+            mac_address: info.base_mac?,
+            device_type: info.device_type.clone(),
+            pci_name: info.pci_name.clone(),
+        })
+    }
+}
+
+impl DpaInterface {
+    pub fn get_machine_id(&self) -> MachineId {
+        self.machine_id
+    }
+
+    pub fn managed_host_network_config_version_synced(&self) -> bool {
+        let dpa_expected_version = self.network_config.version;
+        let dpa_observation = self.network_status_observation.as_ref();
+
+        let dpa_observed_version: ConfigVersion = match dpa_observation {
+            Some(network_status) => match network_status.network_config_version {
+                Some(version) => version,
+                None => return false,
+            },
+            None => return false,
+        };
+
+        dpa_expected_version == dpa_observed_version
+    }
+
+    pub fn is_ready(&self) -> bool {
+        self.controller_state.value == DpaInterfaceControllerState::Ready
+    }
+}
+
+impl<'r> FromRow<'r, PgRow> for DpaInterface {
+    fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
+        let json: serde_json::value::Value = row.try_get(0)?;
+        DpaInterfaceSnapshotPgJson::deserialize(json)
+            .map_err(|err| sqlx::Error::Decode(err.into()))?
+            .try_into()
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DpaInterfaceSnapshotPgJson {
+    pub id: DpaInterfaceId,
+    pub machine_id: MachineId,
+    pub mac_address: MacAddress,
+    pub created: DateTime<Utc>,
+    pub updated: DateTime<Utc>,
+    pub deleted: Option<DateTime<Utc>>,
+    pub last_hb_time: DateTime<Utc>,
+    pub controller_state: DpaInterfaceControllerState,
+    pub controller_state_version: String,
+    pub controller_state_outcome: Option<PersistentStateHandlerOutcome>,
+    pub network_config: DpaInterfaceNetworkConfig,
+    pub network_config_version: String,
+    pub network_status_observation: Option<DpaInterfaceNetworkStatusObservation>,
+    pub card_state: Option<CardState>,
+    pub pci_name: String,
+    pub underlay_ip: Option<IpAddr>,
+    pub overlay_ip: Option<IpAddr>,
+    #[serde(default, alias = "device_info_report")]
+    pub device_info: Option<MlxDeviceInfo>,
+    #[serde(default, alias = "device_info_report_ts")]
+    pub device_info_ts: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub mlxconfig_profile: Option<String>,
+    #[serde(default)]
+    pub history: Vec<StateHistoryRecord>,
+}
+
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use carbide_libmlx_model::device::info::MlxDeviceInfo;
 
     use super::*;
@@ -282,269 +420,5 @@ mod tests {
             serde_json::from_str::<DpaInterfaceControllerState>(&serialized).unwrap(),
             state
         );
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct DpaInterface {
-    pub id: DpaInterfaceId,
-    pub machine_id: MachineId,
-
-    pub mac_address: MacAddress,
-    pub pci_name: String,
-
-    pub underlay_ip: Option<IpAddr>,
-    pub overlay_ip: Option<IpAddr>,
-
-    pub created: DateTime<Utc>,
-    pub updated: DateTime<Utc>,
-    pub deleted: Option<DateTime<Utc>>,
-
-    pub controller_state: Versioned<DpaInterfaceControllerState>,
-
-    // Last time we issued a heartbeat command to the DPA
-    pub last_hb_time: DateTime<Utc>,
-
-    /// The result of the last attempt to change state
-    pub controller_state_outcome: Option<PersistentStateHandlerOutcome>,
-
-    pub network_config: Versioned<DpaInterfaceNetworkConfig>,
-    pub network_status_observation: Option<DpaInterfaceNetworkStatusObservation>,
-
-    pub card_state: Option<CardState>,
-
-    // device_info and its corresponding timestamp are used to
-    // keep track of the latest MlxDeviceInfo received by scout
-    // for the target Mellanox device. This contains information
-    // like the part number, PSID, firmware version(s), MAC address,
-    // etc. We store the received timestamp alongside it to detect
-    // if we're acting on potentially stale MlxDeviceInfo data.
-    pub device_info: Option<MlxDeviceInfo>,
-    pub device_info_ts: Option<DateTime<Utc>>,
-
-    // mlxconfig_profile is the name of an MlxConfigProfile from
-    // the mlx-config-profiles config map. When set, this profile
-    // will be applied to the device during the ApplyProfile state.
-    // When None, ApplyProfile will simply perform an mlxconfig
-    // reset and not apply any subsequent defaults, ensuring the
-    // card is back to stock before the next tenancy.
-    pub mlxconfig_profile: Option<String>,
-
-    pub history: Vec<StateHistoryRecord>,
-}
-
-#[derive(Clone, Debug)]
-pub struct NewDpaInterface {
-    pub machine_id: MachineId,
-    pub mac_address: MacAddress,
-    pub device_type: String,
-    pub pci_name: String,
-}
-
-impl NewDpaInterface {
-    /// from_device_info builds a NewDpaInterface instance for a given
-    /// MachineId from a given MlxDeviceInfo, since it contains everything
-    /// we use as input for an interface.
-    ///
-    /// Right now the only reason this would fail is if base_mac was unset,
-    /// at which point we'll just return None, meaning the caller knows that
-    /// the base_mac was unset. Since the mac_address is the latter half of
-    /// what is effectively a (machine_id, mac_address) compound primary key,
-    /// it's kind of important to have.
-    pub fn from_device_info(machine_id: MachineId, info: &MlxDeviceInfo) -> Option<Self> {
-        Some(Self {
-            machine_id,
-            mac_address: info.base_mac?,
-            device_type: info.device_type.clone(),
-            pci_name: info.pci_name.clone(),
-        })
-    }
-}
-
-impl TryFrom<rpc::forge::DpaInterfaceCreationRequest> for NewDpaInterface {
-    type Error = RpcDataConversionError;
-
-    fn try_from(value: rpc::forge::DpaInterfaceCreationRequest) -> Result<Self, Self::Error> {
-        let machine_id = value
-            .machine_id
-            .ok_or(RpcDataConversionError::MissingArgument("id"))?;
-        let mac_address = MacAddress::from_str(&value.mac_addr)
-            .map_err(|_| RpcDataConversionError::InvalidMacAddress(value.mac_addr.to_string()))?;
-        Ok(NewDpaInterface {
-            machine_id,
-            mac_address,
-            device_type: value.device_type,
-            pci_name: value.pci_name,
-        })
-    }
-}
-
-impl DpaInterface {
-    pub fn get_machine_id(&self) -> MachineId {
-        self.machine_id
-    }
-
-    pub fn managed_host_network_config_version_synced(&self) -> bool {
-        let dpa_expected_version = self.network_config.version;
-        let dpa_observation = self.network_status_observation.as_ref();
-
-        let dpa_observed_version: ConfigVersion = match dpa_observation {
-            Some(network_status) => match network_status.network_config_version {
-                Some(version) => version,
-                None => return false,
-            },
-            None => return false,
-        };
-
-        dpa_expected_version == dpa_observed_version
-    }
-
-    pub fn is_ready(&self) -> bool {
-        self.controller_state.value == DpaInterfaceControllerState::Ready
-    }
-}
-
-impl<'r> FromRow<'r, PgRow> for DpaInterface {
-    fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
-        let json: serde_json::value::Value = row.try_get(0)?;
-        DpaInterfaceSnapshotPgJson::deserialize(json)
-            .map_err(|err| sqlx::Error::Decode(err.into()))?
-            .try_into()
-    }
-}
-
-impl From<DpaInterface> for rpc::forge::DpaInterface {
-    fn from(src: DpaInterface) -> Self {
-        let (controller_state, controller_state_version) = src.controller_state.take();
-        let (network_config, network_config_version) = src.network_config.take();
-
-        let outcome = match src.controller_state_outcome {
-            Some(psho) => psho.to_string(),
-            None => "None".to_string(),
-        };
-
-        let network_status_observation = match src.network_status_observation {
-            Some(nso) => nso.to_string(),
-            None => "None".to_string(),
-        };
-
-        let cstate = match src.card_state {
-            Some(cs) => cs.to_string(),
-            None => "None".to_string(),
-        };
-
-        let underlay = match src.underlay_ip {
-            Some(ip) => ip.to_string(),
-            None => String::new(),
-        };
-
-        let overlay = match src.overlay_ip {
-            Some(ip) => ip.to_string(),
-            None => String::new(),
-        };
-
-        let history: Vec<rpc::forge::StateHistoryRecord> = src
-            .history
-            .into_iter()
-            .sorted_by(|s1: &StateHistoryRecord, s2: &StateHistoryRecord| {
-                Ord::cmp(&s1.state_version.timestamp(), &s2.state_version.timestamp())
-            })
-            .map(Into::into)
-            .collect();
-
-        rpc::forge::DpaInterface {
-            id: Some(src.id),
-            created: Some(src.created.into()),
-            updated: Some(src.updated.into()),
-            deleted: src.deleted.map(|t| t.into()),
-            last_hb_time: Some(src.last_hb_time.into()),
-            mac_addr: src.mac_address.to_string(),
-            machine_id: Some(src.machine_id),
-            controller_state: controller_state.to_string(),
-            controller_state_version: controller_state_version.to_string(),
-            network_config: network_config.to_string(),
-            network_config_version: network_config_version.to_string(),
-            controller_state_outcome: outcome,
-            network_status_observation,
-            history,
-            card_state: cstate,
-            pci_name: src.pci_name,
-            underlay_ip: underlay,
-            overlay_ip: overlay,
-            mlxconfig_profile: src.mlxconfig_profile,
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct DpaInterfaceSnapshotPgJson {
-    pub id: DpaInterfaceId,
-    pub machine_id: MachineId,
-    pub mac_address: MacAddress,
-    pub created: DateTime<Utc>,
-    pub updated: DateTime<Utc>,
-    pub deleted: Option<DateTime<Utc>>,
-    pub last_hb_time: DateTime<Utc>,
-    pub controller_state: DpaInterfaceControllerState,
-    pub controller_state_version: String,
-    pub controller_state_outcome: Option<PersistentStateHandlerOutcome>,
-    pub network_config: DpaInterfaceNetworkConfig,
-    pub network_config_version: String,
-    pub network_status_observation: Option<DpaInterfaceNetworkStatusObservation>,
-    pub card_state: Option<CardState>,
-    pub pci_name: String,
-    pub underlay_ip: Option<IpAddr>,
-    pub overlay_ip: Option<IpAddr>,
-    #[serde(default, alias = "device_info_report")]
-    pub device_info: Option<MlxDeviceInfo>,
-    #[serde(default, alias = "device_info_report_ts")]
-    pub device_info_ts: Option<DateTime<Utc>>,
-    #[serde(default)]
-    pub mlxconfig_profile: Option<String>,
-    #[serde(default)]
-    pub history: Vec<StateHistoryRecord>,
-}
-
-impl TryFrom<DpaInterfaceSnapshotPgJson> for DpaInterface {
-    type Error = sqlx::Error;
-
-    fn try_from(value: DpaInterfaceSnapshotPgJson) -> sqlx::Result<Self> {
-        Ok(Self {
-            id: value.id,
-            machine_id: value.machine_id,
-            mac_address: value.mac_address,
-            created: value.created,
-            updated: value.updated,
-            deleted: value.deleted,
-            last_hb_time: value.last_hb_time,
-            controller_state: Versioned {
-                value: value.controller_state,
-                version: value.controller_state_version.parse().map_err(|e| {
-                    sqlx::error::Error::ColumnDecode {
-                        index: "controller_state_version".to_string(),
-                        source: Box::new(e),
-                    }
-                })?,
-            },
-            controller_state_outcome: value.controller_state_outcome,
-            network_config: Versioned {
-                value: value.network_config,
-                version: value.network_config_version.parse().map_err(|e| {
-                    sqlx::error::Error::ColumnDecode {
-                        index: "network_config_version".to_string(),
-                        source: Box::new(e),
-                    }
-                })?,
-            },
-            network_status_observation: value.network_status_observation,
-            card_state: value.card_state,
-            device_info: value.device_info,
-            device_info_ts: value.device_info_ts,
-            mlxconfig_profile: value.mlxconfig_profile,
-            history: value.history,
-            pci_name: value.pci_name,
-            underlay_ip: value.underlay_ip,
-            overlay_ip: value.overlay_ip,
-        })
     }
 }

--- a/crates/api-model/src/dpu_remediation.rs
+++ b/crates/api-model/src/dpu_remediation.rs
@@ -20,11 +20,6 @@ use std::fmt::{Display, Formatter};
 use carbide_uuid::dpu_remediations::RemediationId;
 use carbide_uuid::machine::MachineId;
 use chrono::{DateTime, Utc};
-use rpc::errors::RpcDataConversionError;
-use rpc::forge::{
-    ApproveRemediationRequest, CreateRemediationRequest, DisableRemediationRequest,
-    EnableRemediationRequest, RevokeRemediationRequest,
-};
 use sqlx::postgres::PgRow;
 use sqlx::{FromRow, Row};
 
@@ -35,67 +30,11 @@ pub struct RemediationApplicationStatus {
     pub metadata: Option<Metadata>,
 }
 
-impl TryFrom<rpc::forge::RemediationApplicationStatus> for RemediationApplicationStatus {
-    type Error = RpcDataConversionError;
-
-    fn try_from(status: rpc::forge::RemediationApplicationStatus) -> Result<Self, Self::Error> {
-        let metadata = status.metadata.map(Metadata::try_from).transpose()?;
-        Ok(RemediationApplicationStatus {
-            succeeded: status.succeeded,
-            metadata,
-        })
-    }
-}
-
-// about 16KB file size, long enough for any reasonable script but small enough to make it
-// almost impossible to stuff a binary in the DB, which is the point of the limit.
-const MAXIMUM_SCRIPT_LENGTH: usize = 2 << 13;
-
 pub struct NewRemediation {
     pub script: String,
     pub metadata: Option<Metadata>,
     pub retries: i32,
     pub author: Author,
-}
-
-impl TryFrom<(CreateRemediationRequest, String)> for NewRemediation {
-    type Error = RpcDataConversionError;
-
-    fn try_from(value: (CreateRemediationRequest, String)) -> Result<Self, Self::Error> {
-        let rpc_request = value.0;
-        let author = value.1.into();
-
-        let metadata = if let Some(metadata) = rpc_request.metadata {
-            Some(Metadata::try_from(metadata)?)
-        } else {
-            None
-        };
-        let retries = if rpc_request.retries < 0 {
-            return Err(RpcDataConversionError::InvalidArgument(String::from(
-                "retries must be a positive integer or 0",
-            )));
-        } else {
-            rpc_request.retries
-        };
-
-        let script = rpc_request.script.to_string();
-        if script.len() > MAXIMUM_SCRIPT_LENGTH {
-            return Err(RpcDataConversionError::InvalidArgument(format!(
-                "script must not exceed length: {MAXIMUM_SCRIPT_LENGTH}"
-            )));
-        } else if script.is_empty() {
-            return Err(RpcDataConversionError::InvalidArgument(
-                "script cannot be empty".to_string(),
-            ));
-        }
-
-        Ok(Self {
-            script,
-            metadata,
-            retries,
-            author,
-        })
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -142,29 +81,6 @@ pub struct Remediation {
     pub retries: i32,
     pub enabled: bool,
     pub creation_time: DateTime<Utc>,
-}
-
-impl From<Remediation> for rpc::forge::Remediation {
-    fn from(value: Remediation) -> Self {
-        Self {
-            id: value.id.into(),
-            metadata: value.metadata.map(|m| m.into()),
-            creation_time: Some(value.creation_time.into()),
-            script_author: value.author.to_string(),
-            script_reviewed_by: value.reviewer.map(|r| r.to_string()),
-            script: value.script,
-            enabled: value.enabled,
-            retries: value.retries,
-        }
-    }
-}
-
-impl From<Remediation> for rpc::forge::CreateRemediationResponse {
-    fn from(value: Remediation) -> Self {
-        rpc::forge::CreateRemediationResponse {
-            remediation_id: value.id.into(),
-        }
-    }
 }
 
 impl<'r> FromRow<'r, PgRow> for Remediation {
@@ -246,44 +162,10 @@ impl<'r> FromRow<'r, PgRow> for AppliedRemediation {
     }
 }
 
-impl From<AppliedRemediation> for rpc::forge::AppliedRemediation {
-    fn from(value: AppliedRemediation) -> Self {
-        let metadata = Metadata {
-            labels: value.status,
-            description: String::new(),
-            name: String::new(),
-        };
-        Self {
-            dpu_machine_id: Some(value.dpu_machine_id),
-            remediation_id: Some(value.id),
-            attempt: value.attempt,
-            metadata: Some(metadata.into()),
-            succeeded: value.succeeded,
-            applied_time: Some(value.applied_time.into()),
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct ApproveRemediation {
     pub id: RemediationId,
     pub reviewer: Reviewer,
-}
-
-impl TryFrom<(ApproveRemediationRequest, String)> for ApproveRemediation {
-    type Error = RpcDataConversionError;
-
-    fn try_from(value: (ApproveRemediationRequest, String)) -> Result<Self, Self::Error> {
-        let id = value
-            .0
-            .remediation_id
-            .ok_or(RpcDataConversionError::MissingArgument(
-                "Request must contain a remediation id.",
-            ))?;
-        let reviewer = value.1.into();
-
-        Ok(Self { id, reviewer })
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -291,99 +173,12 @@ pub struct RevokeRemediation {
     pub id: RemediationId,
 }
 
-impl TryFrom<(RevokeRemediationRequest, String)> for RevokeRemediation {
-    type Error = RpcDataConversionError;
-
-    fn try_from(value: (RevokeRemediationRequest, String)) -> Result<Self, Self::Error> {
-        let id = value
-            .0
-            .remediation_id
-            .ok_or(RpcDataConversionError::MissingArgument(
-                "Request must contain a remediation id.",
-            ))?;
-        let revoked_by = value.1;
-        tracing::info!("Remediation: '{}' revoked by: '{}'", id, revoked_by);
-
-        Ok(Self { id })
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct EnableRemediation {
     pub id: RemediationId,
 }
 
-impl TryFrom<(EnableRemediationRequest, String)> for EnableRemediation {
-    type Error = RpcDataConversionError;
-
-    fn try_from(value: (EnableRemediationRequest, String)) -> Result<Self, Self::Error> {
-        let id = value
-            .0
-            .remediation_id
-            .ok_or(RpcDataConversionError::MissingArgument(
-                "Request must contain a remediation id.",
-            ))?;
-        let enabled_by = value.1;
-        tracing::info!("Remediation: '{}' enabled by: '{}'", id, enabled_by);
-
-        Ok(Self { id })
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct DisableRemediation {
     pub id: RemediationId,
-}
-
-impl TryFrom<(DisableRemediationRequest, String)> for DisableRemediation {
-    type Error = RpcDataConversionError;
-
-    fn try_from(value: (DisableRemediationRequest, String)) -> Result<Self, Self::Error> {
-        let id = value
-            .0
-            .remediation_id
-            .ok_or(RpcDataConversionError::MissingArgument(
-                "Request must contain a remediation id.",
-            ))?;
-        let disabled_by = value.1;
-        tracing::info!("Remediation: '{}' disabled by: '{}'", id, disabled_by);
-
-        Ok(Self { id })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn remediation_application_status_from_rpc_success_no_metadata() {
-        let rpc_status = rpc::forge::RemediationApplicationStatus {
-            succeeded: true,
-            metadata: None,
-        };
-        let status = RemediationApplicationStatus::try_from(rpc_status).unwrap();
-        assert!(status.succeeded);
-        assert!(status.metadata.is_none());
-    }
-
-    #[test]
-    fn remediation_application_status_from_rpc_with_metadata() {
-        let rpc_status = rpc::forge::RemediationApplicationStatus {
-            succeeded: false,
-            metadata: Some(rpc::Metadata {
-                name: "test".to_string(),
-                description: "desc".to_string(),
-                labels: vec![rpc::forge::Label {
-                    key: "status".to_string(),
-                    value: Some("failed".to_string()),
-                }],
-            }),
-        };
-        let status = RemediationApplicationStatus::try_from(rpc_status).unwrap();
-        assert!(!status.succeeded);
-        let metadata = status.metadata.unwrap();
-        assert_eq!(metadata.name, "test");
-        assert_eq!(metadata.labels.get("status"), Some(&"failed".to_string()));
-    }
 }

--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -85,6 +85,7 @@ pub mod rack_type;
 pub mod redfish;
 pub mod resource_pool;
 pub mod route_server;
+pub mod rpc_conv;
 pub mod site_explorer;
 pub mod sku;
 pub mod state_history;

--- a/crates/api-model/src/rpc_conv/allocation_type.rs
+++ b/crates/api-model/src/rpc_conv/allocation_type.rs
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::address_selection_strategy::AddressSelectionStrategy;
+use crate::allocation_type::{AllocationType, AssignStaticResult};
+
+impl From<AssignStaticResult> for rpc::forge::AssignStaticAddressStatus {
+    fn from(result: AssignStaticResult) -> Self {
+        match result {
+            AssignStaticResult::Assigned => rpc::forge::AssignStaticAddressStatus::Assigned,
+            AssignStaticResult::ReplacedStatic => {
+                rpc::forge::AssignStaticAddressStatus::ReplacedStatic
+            }
+            AssignStaticResult::ReplacedDhcp => rpc::forge::AssignStaticAddressStatus::ReplacedDhcp,
+        }
+    }
+}
+
+impl From<AddressSelectionStrategy> for AllocationType {
+    fn from(strategy: AddressSelectionStrategy) -> Self {
+        match strategy {
+            AddressSelectionStrategy::NextAvailableIp => AllocationType::Dhcp,
+            AddressSelectionStrategy::Automatic => AllocationType::Dhcp,
+            AddressSelectionStrategy::NextAvailablePrefix(_) => AllocationType::Dhcp,
+            AddressSelectionStrategy::StaticAddress(_) => AllocationType::Static,
+        }
+    }
+}

--- a/crates/api-model/src/rpc_conv/attestation.rs
+++ b/crates/api-model/src/rpc_conv/attestation.rs
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// Model for SPDM attestation via Redfish
+pub mod spdm {
+
+    use crate::attestation::spdm::SpdmDeviceAttestationDetails;
+
+    impl From<SpdmDeviceAttestationDetails> for rpc::forge::SpdmAttestationDetails {
+        fn from(value: SpdmDeviceAttestationDetails) -> Self {
+            rpc::forge::SpdmAttestationDetails {
+                machine_id: Some(value.machine_id),
+                completed_at: value.completed_at.map(|x| x.into()),
+                started_at: Some(value.started_at.into()),
+                cancelled_at: value.cancelled_at.map(|x| x.into()),
+                state: format!("{:?}", value.state),
+                device_id: value.device_id,
+            }
+        }
+    }
+}

--- a/crates/api-model/src/rpc_conv/bmc_info.rs
+++ b/crates/api-model/src/rpc_conv/bmc_info.rs
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::errors::RpcDataConversionError;
+use ::rpc::forge as rpc;
+use mac_address::MacAddress;
+
+use crate::bmc_info::{BmcInfo, UserRoles};
+
+impl TryFrom<rpc::BmcInfo> for BmcInfo {
+    type Error = RpcDataConversionError;
+    fn try_from(value: rpc::BmcInfo) -> Result<Self, RpcDataConversionError> {
+        let mac: Option<MacAddress> = if let Some(mac_address) = value.mac {
+            Some(
+                mac_address
+                    .parse()
+                    .map_err(|_| RpcDataConversionError::InvalidMacAddress(mac_address))?,
+            )
+        } else {
+            None
+        };
+
+        Ok(BmcInfo {
+            ip: value.ip,
+            port: value.port.map(|p| p as u16),
+            mac,
+            version: value.version,
+            firmware_version: value.firmware_version,
+        })
+    }
+}
+
+impl From<BmcInfo> for rpc::BmcInfo {
+    fn from(value: BmcInfo) -> Self {
+        rpc::BmcInfo {
+            ip: value.ip,
+            port: value.port.map(|p| p as u32),
+            mac: value.mac.map(|mac| mac.to_string()),
+            version: value.version,
+            firmware_version: value.firmware_version,
+        }
+    }
+}
+
+impl From<rpc::UserRoles> for UserRoles {
+    fn from(action: rpc::UserRoles) -> Self {
+        match action {
+            rpc::UserRoles::User => UserRoles::User,
+            rpc::UserRoles::Administrator => UserRoles::Administrator,
+            rpc::UserRoles::Operator => UserRoles::Operator,
+            rpc::UserRoles::Noaccess => UserRoles::Noaccess,
+        }
+    }
+}
+
+impl From<UserRoles> for rpc::UserRoles {
+    fn from(action: UserRoles) -> Self {
+        match action {
+            UserRoles::User => rpc::UserRoles::User,
+            UserRoles::Administrator => rpc::UserRoles::Administrator,
+            UserRoles::Operator => rpc::UserRoles::Operator,
+            UserRoles::Noaccess => rpc::UserRoles::Noaccess,
+        }
+    }
+}

--- a/crates/api-model/src/rpc_conv/compute_allocation.rs
+++ b/crates/api-model/src/rpc_conv/compute_allocation.rs
@@ -1,0 +1,122 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::errors::RpcDataConversionError;
+use ::rpc::forge as rpc;
+
+use crate::compute_allocation::ComputeAllocation;
+
+impl TryFrom<ComputeAllocation> for rpc::ComputeAllocation {
+    type Error = RpcDataConversionError;
+
+    fn try_from(compute_alloc: ComputeAllocation) -> Result<Self, Self::Error> {
+        let attributes = rpc::ComputeAllocationAttributes {
+            instance_type_id: compute_alloc.instance_type_id.to_string(),
+            count: compute_alloc.count,
+        };
+
+        Ok(rpc::ComputeAllocation {
+            id: Some(compute_alloc.id),
+            tenant_organization_id: compute_alloc.tenant_organization_id.to_string(),
+            version: compute_alloc.version.to_string(),
+            attributes: Some(attributes),
+            created_at: Some(compute_alloc.created.to_string()),
+            created_by: compute_alloc.created_by,
+            updated_by: compute_alloc.updated_by,
+            metadata: Some(rpc::Metadata {
+                name: compute_alloc.metadata.name,
+                description: compute_alloc.metadata.description,
+                labels: compute_alloc
+                    .metadata
+                    .labels
+                    .iter()
+                    .map(|(key, value)| rpc::Label {
+                        key: key.to_owned(),
+                        value: if value.is_empty() {
+                            None
+                        } else {
+                            Some(value.to_owned())
+                        },
+                    })
+                    .collect(),
+            }),
+        })
+    }
+}
+
+/* ********************************** */
+/*              Tests                 */
+/* ********************************** */
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use ::rpc::forge as rpc;
+    use config_version::ConfigVersion;
+
+    use super::*;
+    use crate::metadata::Metadata;
+
+    #[test]
+    fn test_model_compute_allocation_to_rpc_conversion() {
+        let version = ConfigVersion::initial();
+
+        let req_type = rpc::ComputeAllocation {
+            id: Some("dbe71f32-1bdc-11f1-8101-3b10d91c938c".parse().unwrap()),
+            version: version.to_string(),
+            metadata: Some(rpc::Metadata {
+                name: "fancy name".to_string(),
+                description: "".to_string(),
+                labels: vec![],
+            }),
+            tenant_organization_id: "theorg".to_string(),
+            attributes: Some(rpc::ComputeAllocationAttributes {
+                instance_type_id: "12345".to_string(),
+                count: 10,
+            }),
+            created_at: Some("2023-01-01 00:00:00 UTC".to_string()),
+            created_by: Some("user1".to_string()),
+            updated_by: Some("user2".to_string()),
+        };
+
+        let compute_alloc = ComputeAllocation {
+            id: "dbe71f32-1bdc-11f1-8101-3b10d91c938c".parse().unwrap(),
+            deleted: None,
+            created: "2023-01-01 00:00:00 UTC".parse().unwrap(),
+            version,
+            metadata: Metadata {
+                name: "fancy name".to_string(),
+                description: "".to_string(),
+                labels: HashMap::new(),
+            },
+            tenant_organization_id: "theorg".parse().unwrap(),
+
+            instance_type_id: "12345".parse().unwrap(),
+            count: 10,
+            created_by: Some("user1".to_string()),
+            updated_by: Some("user2".to_string()),
+        };
+
+        // Verify that we can go from an internal compute allocation to the
+        // protobuf ComputeAllocation message
+        assert_eq!(
+            req_type,
+            rpc::ComputeAllocation::try_from(compute_alloc).unwrap()
+        );
+    }
+}

--- a/crates/api-model/src/rpc_conv/controller_outcome.rs
+++ b/crates/api-model/src/rpc_conv/controller_outcome.rs
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::controller_outcome::{PersistentSourceReference, PersistentStateHandlerOutcome};
+
+impl From<PersistentSourceReference> for rpc::forge::ControllerStateSourceReference {
+    fn from(source_ref: PersistentSourceReference) -> Self {
+        rpc::forge::ControllerStateSourceReference {
+            file: source_ref.file,
+            line: source_ref.line.try_into().unwrap_or_default(),
+        }
+    }
+}
+
+impl From<PersistentStateHandlerOutcome> for rpc::forge::ControllerStateReason {
+    fn from(p: PersistentStateHandlerOutcome) -> rpc::forge::ControllerStateReason {
+        use rpc::forge::ControllerStateOutcome::*;
+        let (outcome, outcome_msg, source_ref) = match p {
+            PersistentStateHandlerOutcome::Wait { reason, source_ref } => {
+                (Wait, Some(reason), source_ref)
+            }
+            PersistentStateHandlerOutcome::Error { err, source_ref } => {
+                (Error, Some(err), source_ref)
+            }
+            PersistentStateHandlerOutcome::Transition { source_ref } => {
+                (Transition, None, source_ref)
+            }
+            PersistentStateHandlerOutcome::DoNothing { source_ref } => {
+                (DoNothing, None, source_ref)
+            }
+            PersistentStateHandlerOutcome::DoNothingWithDetails => (DoNothing, None, None),
+        };
+        rpc::forge::ControllerStateReason {
+            outcome: outcome.into(), // into converts it to i32
+            outcome_msg,
+            source_ref: source_ref.map(Into::into),
+        }
+    }
+}

--- a/crates/api-model/src/rpc_conv/dhcp_record.rs
+++ b/crates/api-model/src/rpc_conv/dhcp_record.rs
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::dhcp_record::DhcpRecord;
+
+impl From<DhcpRecord> for rpc::forge::DhcpRecord {
+    fn from(record: DhcpRecord) -> Self {
+        Self {
+            machine_id: record.machine_id,
+            machine_interface_id: Some(record.machine_interface_id),
+            segment_id: Some(record.segment_id),
+            subdomain_id: record.subdomain_id,
+            fqdn: record.fqdn,
+            mac_address: record.mac_address.to_string(),
+            address: record.address.to_string(),
+            mtu: record.mtu,
+            prefix: record.prefix.to_string(),
+            gateway: record.gateway.map(|gw| gw.to_string()),
+            booturl: None, // TODO(ajf): extend database, synthesize URL
+            last_invalidation_time: Some(record.last_invalidation_time.into()),
+        }
+    }
+}

--- a/crates/api-model/src/rpc_conv/dns.rs
+++ b/crates/api-model/src/rpc_conv/dns.rs
@@ -1,0 +1,129 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::errors::RpcDataConversionError;
+use chrono::{DateTime, Utc};
+use dns_record::SoaRecord;
+
+use crate::dns::domain_info::DomainInfo;
+use crate::dns::{Domain, DomainMetadata, NewDomain, SoaSnapshot};
+
+impl From<DomainInfo> for rpc::protos::dns::DomainInfo {
+    fn from(domain: DomainInfo) -> Self {
+        rpc::protos::dns::DomainInfo {
+            id: Some(domain.id),
+            zone: domain.zone,
+            kind: domain.kind,
+            serial: domain.serial as i32,
+            last_checked: domain.last_check.map(|v| v as i32),
+            notified_serial: domain.notified_serial.map(|v| v as i32),
+        }
+    }
+}
+
+impl TryFrom<rpc::protos::dns::Domain> for NewDomain {
+    type Error = RpcDataConversionError;
+
+    fn try_from(proto: rpc::protos::dns::Domain) -> Result<Self, Self::Error> {
+        let soa = proto
+            .soa
+            .map(|soa| {
+                let record: SoaRecord = serde_json::from_str(&soa)
+                    .map_err(|e| RpcDataConversionError::InvalidSoaRecord(e.to_string()))?;
+                Ok::<SoaSnapshot, RpcDataConversionError>(SoaSnapshot(record))
+            })
+            .transpose()?;
+
+        Ok(NewDomain {
+            name: proto.name,
+            soa,
+        })
+    }
+}
+
+impl From<Domain> for rpc::protos::dns::Domain {
+    fn from(domain: Domain) -> Self {
+        rpc::protos::dns::Domain {
+            id: Some(domain.id),
+            name: domain.name,
+            created: Some(domain.created.into()),
+            updated: Some(domain.updated.into()),
+            deleted: domain.deleted.map(|d| d.into()),
+            metadata: domain.metadata.map(|m| m.into()),
+            soa: domain.soa.map(|s| s.0.to_string()),
+        }
+    }
+}
+
+impl TryFrom<rpc::protos::dns::Domain> for Domain {
+    type Error = RpcDataConversionError;
+
+    fn try_from(domain: rpc::protos::dns::Domain) -> Result<Self, Self::Error> {
+        let domain_id = match domain.id {
+            Some(id) => id,
+            None => uuid::Uuid::new_v4().into(),
+        };
+
+        let created = match domain.created {
+            Some(created) => {
+                let system_time = std::time::SystemTime::try_from(created)
+                    .map_err(|_| RpcDataConversionError::InvalidTimestamp(created.to_string()))?;
+                DateTime::<Utc>::from(system_time)
+            }
+            None => Utc::now(),
+        };
+
+        let updated = match domain.updated {
+            Some(updated) => {
+                let system_time = std::time::SystemTime::try_from(updated)
+                    .map_err(|_| RpcDataConversionError::InvalidTimestamp(updated.to_string()))?;
+                DateTime::<Utc>::from(system_time)
+            }
+            None => Utc::now(),
+        };
+
+        let deleted: Option<DateTime<Utc>> = match domain.deleted {
+            Some(deleted) => {
+                let system_time = std::time::SystemTime::try_from(deleted)
+                    .map_err(|_| RpcDataConversionError::InvalidTimestamp(deleted.to_string()))?;
+                Some(DateTime::<Utc>::from(system_time))
+            }
+            None => None,
+        };
+
+        let soa: Option<SoaSnapshot> = domain
+            .soa
+            .map(|soa| {
+                let record: SoaRecord = serde_json::from_str(&soa)
+                    .map_err(|e| RpcDataConversionError::InvalidSoaRecord(e.to_string()))?;
+                Ok::<SoaSnapshot, RpcDataConversionError>(SoaSnapshot(record))
+            })
+            .transpose()?;
+
+        let metadata = domain.metadata.map(DomainMetadata::from);
+
+        Ok(Domain {
+            id: domain_id,
+            name: domain.name,
+            created,
+            updated,
+            deleted,
+            soa,
+            metadata,
+        })
+    }
+}

--- a/crates/api-model/src/rpc_conv/dpa_interface.rs
+++ b/crates/api-model/src/rpc_conv/dpa_interface.rs
@@ -1,0 +1,152 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::convert::TryFrom;
+use std::str::FromStr;
+
+use config_version::Versioned;
+use itertools::Itertools;
+use mac_address::MacAddress;
+use rpc::errors::RpcDataConversionError;
+
+use crate::dpa_interface::{DpaInterface, DpaInterfaceSnapshotPgJson, NewDpaInterface};
+use crate::state_history::StateHistoryRecord;
+
+impl TryFrom<rpc::forge::DpaInterfaceCreationRequest> for NewDpaInterface {
+    type Error = RpcDataConversionError;
+
+    fn try_from(value: rpc::forge::DpaInterfaceCreationRequest) -> Result<Self, Self::Error> {
+        let machine_id = value
+            .machine_id
+            .ok_or(RpcDataConversionError::MissingArgument("id"))?;
+        let mac_address = MacAddress::from_str(&value.mac_addr)
+            .map_err(|_| RpcDataConversionError::InvalidMacAddress(value.mac_addr.to_string()))?;
+        Ok(NewDpaInterface {
+            machine_id,
+            mac_address,
+            device_type: value.device_type,
+            pci_name: value.pci_name,
+        })
+    }
+}
+
+impl From<DpaInterface> for rpc::forge::DpaInterface {
+    fn from(src: DpaInterface) -> Self {
+        let (controller_state, controller_state_version) = src.controller_state.take();
+        let (network_config, network_config_version) = src.network_config.take();
+
+        let outcome = match src.controller_state_outcome {
+            Some(psho) => psho.to_string(),
+            None => "None".to_string(),
+        };
+
+        let network_status_observation = match src.network_status_observation {
+            Some(nso) => nso.to_string(),
+            None => "None".to_string(),
+        };
+
+        let cstate = match src.card_state {
+            Some(cs) => cs.to_string(),
+            None => "None".to_string(),
+        };
+
+        let underlay = match src.underlay_ip {
+            Some(ip) => ip.to_string(),
+            None => String::new(),
+        };
+
+        let overlay = match src.overlay_ip {
+            Some(ip) => ip.to_string(),
+            None => String::new(),
+        };
+
+        let history: Vec<rpc::forge::StateHistoryRecord> = src
+            .history
+            .into_iter()
+            .sorted_by(|s1: &StateHistoryRecord, s2: &StateHistoryRecord| {
+                Ord::cmp(&s1.state_version.timestamp(), &s2.state_version.timestamp())
+            })
+            .map(Into::into)
+            .collect();
+
+        rpc::forge::DpaInterface {
+            id: Some(src.id),
+            created: Some(src.created.into()),
+            updated: Some(src.updated.into()),
+            deleted: src.deleted.map(|t| t.into()),
+            last_hb_time: Some(src.last_hb_time.into()),
+            mac_addr: src.mac_address.to_string(),
+            machine_id: Some(src.machine_id),
+            controller_state: controller_state.to_string(),
+            controller_state_version: controller_state_version.to_string(),
+            network_config: network_config.to_string(),
+            network_config_version: network_config_version.to_string(),
+            controller_state_outcome: outcome,
+            network_status_observation,
+            history,
+            card_state: cstate,
+            pci_name: src.pci_name,
+            underlay_ip: underlay,
+            overlay_ip: overlay,
+            mlxconfig_profile: src.mlxconfig_profile,
+        }
+    }
+}
+
+impl TryFrom<DpaInterfaceSnapshotPgJson> for DpaInterface {
+    type Error = sqlx::Error;
+
+    fn try_from(value: DpaInterfaceSnapshotPgJson) -> sqlx::Result<Self> {
+        Ok(Self {
+            id: value.id,
+            machine_id: value.machine_id,
+            mac_address: value.mac_address,
+            created: value.created,
+            updated: value.updated,
+            deleted: value.deleted,
+            last_hb_time: value.last_hb_time,
+            controller_state: Versioned {
+                value: value.controller_state,
+                version: value.controller_state_version.parse().map_err(|e| {
+                    sqlx::error::Error::ColumnDecode {
+                        index: "controller_state_version".to_string(),
+                        source: Box::new(e),
+                    }
+                })?,
+            },
+            controller_state_outcome: value.controller_state_outcome,
+            network_config: Versioned {
+                value: value.network_config,
+                version: value.network_config_version.parse().map_err(|e| {
+                    sqlx::error::Error::ColumnDecode {
+                        index: "network_config_version".to_string(),
+                        source: Box::new(e),
+                    }
+                })?,
+            },
+            network_status_observation: value.network_status_observation,
+            card_state: value.card_state,
+            device_info: value.device_info,
+            device_info_ts: value.device_info_ts,
+            mlxconfig_profile: value.mlxconfig_profile,
+            history: value.history,
+            pci_name: value.pci_name,
+            underlay_ip: value.underlay_ip,
+            overlay_ip: value.overlay_ip,
+        })
+    }
+}

--- a/crates/api-model/src/rpc_conv/dpu_remediation.rs
+++ b/crates/api-model/src/rpc_conv/dpu_remediation.rs
@@ -1,0 +1,228 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use rpc::errors::RpcDataConversionError;
+use rpc::forge::{
+    ApproveRemediationRequest, CreateRemediationRequest, DisableRemediationRequest,
+    EnableRemediationRequest, RevokeRemediationRequest,
+};
+
+use crate::dpu_remediation::{
+    AppliedRemediation, ApproveRemediation, DisableRemediation, EnableRemediation, NewRemediation,
+    Remediation, RemediationApplicationStatus, RevokeRemediation,
+};
+use crate::metadata::Metadata;
+
+impl TryFrom<rpc::forge::RemediationApplicationStatus> for RemediationApplicationStatus {
+    type Error = RpcDataConversionError;
+
+    fn try_from(status: rpc::forge::RemediationApplicationStatus) -> Result<Self, Self::Error> {
+        let metadata = status.metadata.map(Metadata::try_from).transpose()?;
+        Ok(RemediationApplicationStatus {
+            succeeded: status.succeeded,
+            metadata,
+        })
+    }
+}
+
+// about 16KB file size, long enough for any reasonable script but small enough to make it
+// almost impossible to stuff a binary in the DB, which is the point of the limit.
+const MAXIMUM_SCRIPT_LENGTH: usize = 2 << 13;
+
+impl TryFrom<(CreateRemediationRequest, String)> for NewRemediation {
+    type Error = RpcDataConversionError;
+
+    fn try_from(value: (CreateRemediationRequest, String)) -> Result<Self, Self::Error> {
+        let rpc_request = value.0;
+        let author = value.1.into();
+
+        let metadata = if let Some(metadata) = rpc_request.metadata {
+            Some(Metadata::try_from(metadata)?)
+        } else {
+            None
+        };
+        let retries = if rpc_request.retries < 0 {
+            return Err(RpcDataConversionError::InvalidArgument(String::from(
+                "retries must be a positive integer or 0",
+            )));
+        } else {
+            rpc_request.retries
+        };
+
+        let script = rpc_request.script.to_string();
+        if script.len() > MAXIMUM_SCRIPT_LENGTH {
+            return Err(RpcDataConversionError::InvalidArgument(format!(
+                "script must not exceed length: {MAXIMUM_SCRIPT_LENGTH}"
+            )));
+        } else if script.is_empty() {
+            return Err(RpcDataConversionError::InvalidArgument(
+                "script cannot be empty".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            script,
+            metadata,
+            retries,
+            author,
+        })
+    }
+}
+
+impl From<Remediation> for rpc::forge::Remediation {
+    fn from(value: Remediation) -> Self {
+        Self {
+            id: value.id.into(),
+            metadata: value.metadata.map(|m| m.into()),
+            creation_time: Some(value.creation_time.into()),
+            script_author: value.author.to_string(),
+            script_reviewed_by: value.reviewer.map(|r| r.to_string()),
+            script: value.script,
+            enabled: value.enabled,
+            retries: value.retries,
+        }
+    }
+}
+
+impl From<Remediation> for rpc::forge::CreateRemediationResponse {
+    fn from(value: Remediation) -> Self {
+        rpc::forge::CreateRemediationResponse {
+            remediation_id: value.id.into(),
+        }
+    }
+}
+
+impl From<AppliedRemediation> for rpc::forge::AppliedRemediation {
+    fn from(value: AppliedRemediation) -> Self {
+        let metadata = Metadata {
+            labels: value.status,
+            description: String::new(),
+            name: String::new(),
+        };
+        Self {
+            dpu_machine_id: Some(value.dpu_machine_id),
+            remediation_id: Some(value.id),
+            attempt: value.attempt,
+            metadata: Some(metadata.into()),
+            succeeded: value.succeeded,
+            applied_time: Some(value.applied_time.into()),
+        }
+    }
+}
+
+impl TryFrom<(ApproveRemediationRequest, String)> for ApproveRemediation {
+    type Error = RpcDataConversionError;
+
+    fn try_from(value: (ApproveRemediationRequest, String)) -> Result<Self, Self::Error> {
+        let id = value
+            .0
+            .remediation_id
+            .ok_or(RpcDataConversionError::MissingArgument(
+                "Request must contain a remediation id.",
+            ))?;
+        let reviewer = value.1.into();
+
+        Ok(Self { id, reviewer })
+    }
+}
+
+impl TryFrom<(RevokeRemediationRequest, String)> for RevokeRemediation {
+    type Error = RpcDataConversionError;
+
+    fn try_from(value: (RevokeRemediationRequest, String)) -> Result<Self, Self::Error> {
+        let id = value
+            .0
+            .remediation_id
+            .ok_or(RpcDataConversionError::MissingArgument(
+                "Request must contain a remediation id.",
+            ))?;
+        let revoked_by = value.1;
+        tracing::info!("Remediation: '{}' revoked by: '{}'", id, revoked_by);
+
+        Ok(Self { id })
+    }
+}
+
+impl TryFrom<(EnableRemediationRequest, String)> for EnableRemediation {
+    type Error = RpcDataConversionError;
+
+    fn try_from(value: (EnableRemediationRequest, String)) -> Result<Self, Self::Error> {
+        let id = value
+            .0
+            .remediation_id
+            .ok_or(RpcDataConversionError::MissingArgument(
+                "Request must contain a remediation id.",
+            ))?;
+        let enabled_by = value.1;
+        tracing::info!("Remediation: '{}' enabled by: '{}'", id, enabled_by);
+
+        Ok(Self { id })
+    }
+}
+
+impl TryFrom<(DisableRemediationRequest, String)> for DisableRemediation {
+    type Error = RpcDataConversionError;
+
+    fn try_from(value: (DisableRemediationRequest, String)) -> Result<Self, Self::Error> {
+        let id = value
+            .0
+            .remediation_id
+            .ok_or(RpcDataConversionError::MissingArgument(
+                "Request must contain a remediation id.",
+            ))?;
+        let disabled_by = value.1;
+        tracing::info!("Remediation: '{}' disabled by: '{}'", id, disabled_by);
+
+        Ok(Self { id })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remediation_application_status_from_rpc_success_no_metadata() {
+        let rpc_status = rpc::forge::RemediationApplicationStatus {
+            succeeded: true,
+            metadata: None,
+        };
+        let status = RemediationApplicationStatus::try_from(rpc_status).unwrap();
+        assert!(status.succeeded);
+        assert!(status.metadata.is_none());
+    }
+
+    #[test]
+    fn remediation_application_status_from_rpc_with_metadata() {
+        let rpc_status = rpc::forge::RemediationApplicationStatus {
+            succeeded: false,
+            metadata: Some(rpc::Metadata {
+                name: "test".to_string(),
+                description: "desc".to_string(),
+                labels: vec![rpc::forge::Label {
+                    key: "status".to_string(),
+                    value: Some("failed".to_string()),
+                }],
+            }),
+        };
+        let status = RemediationApplicationStatus::try_from(rpc_status).unwrap();
+        assert!(!status.succeeded);
+        let metadata = status.metadata.unwrap();
+        assert_eq!(metadata.name, "test");
+        assert_eq!(metadata.labels.get("status"), Some(&"failed".to_string()));
+    }
+}

--- a/crates/api-model/src/rpc_conv/mod.rs
+++ b/crates/api-model/src/rpc_conv/mod.rs
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This is temporary module that will be moved to rpc crate once all
+// rpc-related code will be isolated here.
+
+pub mod allocation_type;
+pub mod attestation;
+pub mod bmc_info;
+pub mod compute_allocation;
+pub mod controller_outcome;
+pub mod dhcp_record;
+pub mod dns;
+pub mod dpa_interface;
+pub mod dpu_remediation;


### PR DESCRIPTION
## Description

This is part of longer effort to move all RPC-related code to rpc crate and inverse dependency from model -> rpc to rpc -> model.
 
Logic is that some crates don't use RPC but still needs model but code that related to RPC pretty-much
always needs model.

This PR is isolation of modules with names stared by a-d.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

