### PR TITLE
fix(dhcp): zero-pad discovered mac addresses

### DIFF
--- a/crates/dhcp-server/src/util.rs
+++ b/crates/dhcp-server/src/util.rs
@@ -34,7 +34,7 @@ macro_rules! socket_opr {
 
 pub fn u8_to_mac(data: &[u8]) -> String {
     data.iter()
-        .map(|x| format!("{x:x}"))
+        .map(|x| format!("{x:02x}"))
         .collect::<Vec<String>>()
         .join(":")
 }
@@ -120,4 +120,17 @@ pub async fn get_socket(listen_address: core::net::SocketAddr, interface: String
         return UdpSocket::from_std(socket.into()).unwrap();
     }
     panic!("Could not create socket successfully.");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::u8_to_mac;
+
+    #[test]
+    fn u8_to_mac_zero_pads_octets() {
+        assert_eq!(
+            u8_to_mac(&[0x00, 0x00, 0x5e, 0x00, 0x53, 0x01]),
+            "00:00:5e:00:53:01"
+        );
+    }
 }


### PR DESCRIPTION
## Description
carbide-api expects full zero-padded octets, ie. 00:00:5e:00:53:01 not 0:0:5e:0:53:1 Align carbide-dhcp-server's util function with the zero padded format.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

