### PR TITLE
Store Machine to BMC relationship in machine_interfaces

### DIFF
--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -38,7 +38,9 @@ use http_body_util::{BodyExt, Full};
 use hyper::body::Bytes;
 use hyper_util::rt::TokioExecutor;
 use ipnetwork::IpNetwork;
-use rpc::forge::{DpuInfo, FlatInterfaceNetworkSecurityGroupConfig, InterfaceAssociationType};
+use rpc::forge::{
+    DpuInfo, FlatInterfaceNetworkSecurityGroupConfig, InterfaceAssociationType, InterfaceType,
+};
 use rpc::{Timestamp, common as rpc_common};
 use tokio::sync::Mutex;
 
@@ -960,6 +962,7 @@ fn timestamp_from_secs_nanos(secs: i64, nanos: i32) -> Timestamp {
     Timestamp::from(system_time)
 }
 
+#[allow(deprecated)]
 async fn handle_find_interfaces() -> impl axum::response::IntoResponse {
     let interface = rpc::forge::MachineInterface {
         id: Some(
@@ -988,7 +991,8 @@ async fn handle_find_interfaces() -> impl axum::response::IntoResponse {
         vendor: None,
         created: Some(timestamp_from_secs_nanos(1773084037, 3824000)),
         last_dhcp: Some(timestamp_from_secs_nanos(1773097243, 70533000)),
-        is_bmc: None,
+        is_bmc: Some(false),
+        interface_type: Some(InterfaceType::Data.into()),
         power_shelf_id: None,
         switch_id: None,
         association_type: Some(InterfaceAssociationType::Machine.into()),

--- a/crates/api-db/migrations/20260512120000_link_bmc_machine_interfaces.sql
+++ b/crates/api-db/migrations/20260512120000_link_bmc_machine_interfaces.sql
@@ -1,0 +1,108 @@
+-- Persist the Machine <-> BMC interface link on machine_interfaces instead of
+-- deriving it from machine_topologies.topology->'bmc_info'.
+CREATE TYPE interface_type AS ENUM ('Data', 'Bmc');
+
+ALTER TABLE machine_interfaces
+ADD COLUMN interface_type interface_type NOT NULL DEFAULT 'Data';
+
+CREATE INDEX IF NOT EXISTS machine_interfaces_bmc_machine_id_idx
+ON machine_interfaces(machine_id)
+WHERE interface_type = 'Bmc';
+
+-- Backfill by BMC IP first. This is the most precise match when the BMC
+-- interface row has already been discovered or statically preallocated.
+UPDATE machine_interfaces mi
+SET
+    machine_id = mt.machine_id,
+    association_type = 'Machine',
+    primary_interface = FALSE,
+    interface_type = 'Bmc'
+FROM machine_interface_addresses mia,
+     machine_topologies mt
+WHERE mia.interface_id = mi.id
+  AND NULLIF(mt.topology->'bmc_info'->>'ip', '') IS NOT NULL
+  AND mia.address = (mt.topology->'bmc_info'->>'ip')::inet
+  AND mi.power_shelf_id IS NULL
+  AND mi.switch_id IS NULL
+  AND (mi.machine_id IS NULL OR mi.machine_id = mt.machine_id);
+
+-- Fall back to BMC MAC for rows that did not have a usable IP match.
+UPDATE machine_interfaces mi
+SET
+    machine_id = mt.machine_id,
+    association_type = 'Machine',
+    primary_interface = FALSE,
+    interface_type = 'Bmc'
+FROM machine_topologies mt
+WHERE mi.interface_type = 'Data'
+  AND NULLIF(mt.topology->'bmc_info'->>'mac', '') IS NOT NULL
+  AND mi.mac_address = (mt.topology->'bmc_info'->>'mac')::macaddr
+  AND mi.power_shelf_id IS NULL
+  AND mi.switch_id IS NULL
+  AND (mi.machine_id IS NULL OR mi.machine_id = mt.machine_id);
+
+-- BMC DNS records now use the linked BMC machine_interface address.
+DROP VIEW IF EXISTS dns_records;
+
+-- Shortname DNS records include primary data interfaces and BMC interfaces.
+-- BMC interfaces are intentionally not primary interfaces.
+CREATE OR REPLACE VIEW dns_records_shortname_combined AS
+SELECT
+    concat(mi.hostname, '.', d.name, '.') AS q_name,
+    mia.address AS resource_record,
+    COALESCE(rt.type_name, CASE WHEN family(mia.address) = 6 THEN 'AAAA' ELSE 'A' END)::varchar(10) AS q_type,
+    meta.ttl as ttl,
+    d.id as domain_id
+FROM
+    machine_interfaces mi
+    JOIN machine_interface_addresses mia ON mia.interface_id = mi.id
+    JOIN domains d ON d.id = mi.domain_id
+    LEFT JOIN dns_record_metadata meta ON meta.id = mi.id
+    LEFT JOIN dns_record_types rt ON meta.record_type_id = rt.id
+WHERE
+    mi.primary_interface = TRUE
+    OR mi.interface_type = 'Bmc';
+
+CREATE OR REPLACE VIEW dns_records_bmc_host_id AS
+SELECT
+    concat(mi.machine_id, '.bmc.', d.name, '.') AS q_name,
+    mia.address AS resource_record,
+    COALESCE(rt.type_name, CASE WHEN family(mia.address) = 6 THEN 'AAAA' ELSE 'A' END)::varchar(10) AS q_type,
+    meta.ttl as ttl,
+    d.id as domain_id
+FROM
+    machine_interfaces mi
+    JOIN machine_interface_addresses mia ON mia.interface_id = mi.id
+    JOIN domains d ON d.id = mi.domain_id
+    LEFT JOIN dns_record_metadata meta ON meta.id = mi.id
+    LEFT JOIN dns_record_types rt ON meta.record_type_id = rt.id
+WHERE
+    mi.machine_id IS NOT NULL
+    AND mi.interface_type = 'Bmc'
+    AND (starts_with(mi.machine_id, 'fm100h') OR starts_with(mi.machine_id, 'fm100p'));
+
+CREATE OR REPLACE VIEW dns_records_bmc_dpu_id AS
+SELECT
+    concat(mi.machine_id, '.bmc.', d.name, '.') AS q_name,
+    mia.address AS resource_record,
+    COALESCE(rt.type_name, CASE WHEN family(mia.address) = 6 THEN 'AAAA' ELSE 'A' END)::varchar(10) AS q_type,
+    meta.ttl as ttl,
+    d.id as domain_id
+FROM
+    machine_interfaces mi
+    JOIN machine_interface_addresses mia ON mia.interface_id = mi.id
+    JOIN domains d ON d.id = mi.domain_id
+    LEFT JOIN dns_record_metadata meta ON meta.id = mi.id
+    LEFT JOIN dns_record_types rt ON meta.record_type_id = rt.id
+WHERE
+    mi.machine_id IS NOT NULL
+    AND mi.interface_type = 'Bmc'
+    AND starts_with(mi.machine_id, 'fm100d');
+
+CREATE OR REPLACE VIEW dns_records AS
+SELECT *
+FROM
+  dns_records_shortname_combined
+  FULL JOIN dns_records_adm_combined USING (q_name, resource_record, q_type, ttl, domain_id)
+  FULL JOIN dns_records_bmc_host_id USING (q_name, resource_record, q_type, ttl, domain_id)
+  FULL JOIN dns_records_bmc_dpu_id USING (q_name, resource_record, q_type, ttl, domain_id);

--- a/crates/api-db/src/attestation/spdm.rs
+++ b/crates/api-db/src/attestation/spdm.rs
@@ -298,10 +298,27 @@ pub async fn load_snapshot_for_machine_and_device_id(
     let query = r#"
         SELECT
             mda.*,
-            to_jsonb(mt.topology->'bmc_info') AS bmc_info
+            jsonb_strip_nulls(
+                COALESCE(mt.topology->'bmc_info', '{}'::jsonb) ||
+                jsonb_build_object(
+                    'machine_interface_id', mi.id,
+                    'ip', host(mia.address),
+                    'mac', mi.mac_address::text
+                )
+            ) AS bmc_info
         FROM spdm_machine_devices_attestation AS mda
-        JOIN machine_topologies AS mt
+        LEFT JOIN machine_topologies AS mt
             ON mt.machine_id = mda.machine_id
+        JOIN machine_interfaces AS mi
+            ON mi.machine_id = mda.machine_id
+            AND mi.interface_type = 'Bmc'
+        LEFT JOIN LATERAL (
+            SELECT address
+            FROM machine_interface_addresses
+            WHERE interface_id = mi.id
+            ORDER BY family(address), address
+            LIMIT 1
+        ) AS mia ON true
         WHERE mda.machine_id = $1
             AND mda.device_id  = $2;
     "#;

--- a/crates/api-db/src/bmc_metadata.rs
+++ b/crates/api-db/src/bmc_metadata.rs
@@ -22,7 +22,7 @@ use sqlx::PgConnection;
 
 use crate::{DatabaseError, DatabaseResult};
 
-pub async fn update_bmc_network_into_topologies(
+async fn update_bmc_network_into_topologies(
     txn: &mut PgConnection,
     machine_id: &MachineId,
     bmc_info: &BmcInfo,
@@ -48,6 +48,52 @@ pub async fn update_bmc_network_into_topologies(
             id: machine_id.to_string(),
         })?;
     Ok(())
+}
+
+pub async fn update_bmc_network_into_machine_interfaces(
+    txn: &mut PgConnection,
+    machine_id: &MachineId,
+    bmc_info: &mut BmcInfo,
+) -> DatabaseResult<()> {
+    let Some(bmc_mac_address) = bmc_info.mac else {
+        return Err(DatabaseError::internal(format!(
+            "BMC Info does not have a MAC address for machine {machine_id}"
+        )));
+    };
+
+    let interface = if let Some(interface_id) = bmc_info.machine_interface_id {
+        crate::machine_interface::find_one(&mut *txn, interface_id).await?
+    } else if let Some(bmc_ip) = bmc_info.ip.as_ref() {
+        let bmc_ip_address = bmc_ip.parse()?;
+        crate::machine_interface::find_by_ip(&mut *txn, bmc_ip_address)
+            .await?
+            .ok_or_else(|| DatabaseError::NotFoundError {
+                kind: "machine_interfaces.address",
+                id: bmc_ip.to_string(),
+            })?
+    } else {
+        crate::machine_interface::find_by_mac_address(&mut *txn, bmc_mac_address)
+            .await?
+            .into_iter()
+            .next()
+            .ok_or_else(|| DatabaseError::NotFoundError {
+                kind: "machine_interfaces.mac_address",
+                id: bmc_mac_address.to_string(),
+            })?
+    };
+
+    if interface.mac_address != bmc_mac_address {
+        return Err(DatabaseError::internal(format!(
+            "BMC interface {} MAC {} does not match BMC Info MAC {} for machine {machine_id}",
+            interface.id, interface.mac_address, bmc_mac_address
+        )));
+    }
+
+    crate::machine_interface::associate_bmc_interface_with_machine(&interface.id, machine_id, txn)
+        .await?;
+    bmc_info.machine_interface_id = Some(interface.id);
+
+    update_bmc_network_into_topologies(txn, machine_id, bmc_info).await
 }
 
 // enrich_mac_address queries the MachineInterfaces table to populate the BMC mac address of the BmcMetaDataInfo structure in memory if it does not exist
@@ -80,6 +126,7 @@ pub async fn enrich_mac_address(
                 bmc_machine_interface.mac_address,
             );
             bmc_info.mac = Some(bmc_mac_address);
+            bmc_info.machine_interface_id = Some(bmc_machine_interface.id);
             if persist {
                 update_bmc_network_into_topologies(txn, machine_id, bmc_info).await?;
             }

--- a/crates/api-db/src/dpu_machine_update.rs
+++ b/crates/api-db/src/dpu_machine_update.rs
@@ -89,6 +89,7 @@ pub async fn get_reprovisioning_machines(
             FROM machines m
             INNER JOIN machine_interfaces mi ON m.id = mi.attached_dpu_machine_id
             WHERE m.reprovisioning_requested->>'initiator' like $1
+            AND mi.interface_type != 'Bmc'
             AND mi.attached_dpu_machine_id != mi.machine_id;"#;
 
     let result: Vec<DpuMachineUpdate> = sqlx::query_as(query)

--- a/crates/api-db/src/expected_machine.rs
+++ b/crates/api-db/src/expected_machine.rs
@@ -114,13 +114,12 @@ pub async fn find_one_linked(
  em.bmc_mac_address,
  mi.id AS interface_id,
  host(ee.address) AS address,
- mt.machine_id,
+ mi.machine_id,
  em.id AS expected_machine_id
 FROM expected_machines em
  LEFT JOIN machine_interfaces mi ON em.bmc_mac_address = mi.mac_address
  LEFT JOIN machine_interface_addresses mia ON mi.id = mia.interface_id
  LEFT JOIN explored_endpoints ee ON mia.address = ee.address
- LEFT JOIN machine_topologies mt ON host(ee.address) = mt.topology->'bmc_info'->>'ip'
  WHERE em.bmc_mac_address = $1
  ORDER BY em.bmc_mac_address
  "#;
@@ -159,13 +158,12 @@ pub async fn find_all_linked(txn: impl DbReader<'_>) -> DatabaseResult<Vec<Linke
  em.bmc_mac_address,
  mi.id AS interface_id,
  host(ee.address) AS address,
- mt.machine_id,
+ mi.machine_id,
  em.id AS expected_machine_id
 FROM expected_machines em
  LEFT JOIN machine_interfaces mi ON em.bmc_mac_address = mi.mac_address
  LEFT JOIN machine_interface_addresses mia ON mi.id = mia.interface_id
  LEFT JOIN explored_endpoints ee ON mia.address = ee.address
- LEFT JOIN machine_topologies mt ON host(ee.address) = mt.topology->'bmc_info'->>'ip'
  ORDER BY em.bmc_mac_address
  "#;
     sqlx::query_as(sql)
@@ -194,11 +192,10 @@ SELECT
     ee.address,
     mi.mac_address AS bmc_mac_address,
     ee.exploration_report,
-    mt.machine_id
+    mi.machine_id
 FROM explored_endpoints ee
     LEFT JOIN machine_interface_addresses mia ON ee.address = mia.address
     LEFT JOIN machine_interfaces mi ON mia.interface_id = mi.id
-    LEFT JOIN machine_topologies mt ON host(ee.address) = mt.topology->'bmc_info'->>'ip'
 WHERE mi.mac_address IS NOT NULL
   AND ee.exploration_report->>'EndpointType' = 'Bmc'
   AND mi.mac_address NOT IN (SELECT bmc_mac_address FROM expected_machines)

--- a/crates/api-db/src/host_machine_update.rs
+++ b/crates/api-db/src/host_machine_update.rs
@@ -47,10 +47,13 @@ pub async fn find_upgrade_needed(
     let query = format!(
         r#"select machines.id, explored_endpoints.exploration_report->>'Vendor', explored_endpoints.exploration_report->>'Model'
         FROM explored_endpoints
-        INNER JOIN machine_topologies
-            ON SPLIT_PART(explored_endpoints.address::text, '/', 1) = machine_topologies.topology->'bmc_info'->>'ip'
+        INNER JOIN machine_interface_addresses
+            ON explored_endpoints.address = machine_interface_addresses.address
+        INNER JOIN machine_interfaces
+            ON machine_interface_addresses.interface_id = machine_interfaces.id
+            AND machine_interfaces.interface_type = 'Bmc'
         INNER JOIN machines
-            ON machine_topologies.machine_id = machines.id
+            ON machine_interfaces.machine_id = machines.id
         INNER JOIN desired_firmware
             ON explored_endpoints.exploration_report->>'Vendor' = desired_firmware.vendor AND explored_endpoints.exploration_report->>'Model' = desired_firmware.model
         WHERE starts_with(machines.id, '{host_prefix}')

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -166,6 +166,8 @@ pub async fn find_existing_machine(
     WHERE
         mi.mac_address = $1::macaddr
         AND
+        mi.interface_type != 'Bmc'
+        AND
         $2::inet <<= np.prefix";
 
     let id: Option<MachineId> = sqlx::query_as(query)
@@ -308,7 +310,8 @@ pub async fn find_by_ip(
             r#"{}
                 INNER JOIN machine_interfaces mi ON mi.machine_id = m.id
                 INNER JOIN machine_interface_addresses mia on mia.interface_id=mi.id
-                WHERE mia.address = $1::inet"#,
+                WHERE mia.address = $1::inet
+                AND mi.interface_type != 'Bmc'"#,
             JSON_MACHINE_SNAPSHOT_QUERY.deref()
         );
     }
@@ -456,7 +459,7 @@ pub async fn find_by_hostname(
 ) -> Result<Option<Machine>, DatabaseError> {
     lazy_static! {
         static ref query: String = format!(
-            "{} JOIN machine_interfaces mi ON m.id = mi.machine_id WHERE mi.hostname = $1",
+            "{} JOIN machine_interfaces mi ON m.id = mi.machine_id WHERE mi.hostname = $1 AND mi.interface_type != 'Bmc'",
             JSON_MACHINE_SNAPSHOT_QUERY.deref()
         );
     }
@@ -476,7 +479,7 @@ pub async fn find_by_mac_address(
 ) -> Result<Option<Machine>, DatabaseError> {
     lazy_static! {
         static ref query: String = format!(
-            "{} JOIN machine_interfaces mi ON m.id = mi.machine_id WHERE mi.mac_address = $1::macaddr",
+            "{} JOIN machine_interfaces mi ON m.id = mi.machine_id WHERE mi.mac_address = $1::macaddr AND mi.interface_type != 'Bmc'",
             JSON_MACHINE_SNAPSHOT_QUERY.deref()
         );
     }
@@ -663,6 +666,7 @@ pub async fn find_host_by_dpu_machine_id(
         static ref query: String = format!(
             r#"{} INNER JOIN machine_interfaces mi ON m.id = mi.machine_id
                     WHERE mi.attached_dpu_machine_id=$1
+                    AND mi.interface_type != 'Bmc'
                     AND mi.attached_dpu_machine_id != mi.machine_id"#,
             JSON_MACHINE_SNAPSHOT_QUERY.deref()
         );
@@ -683,6 +687,7 @@ pub async fn lookup_host_machine_ids_by_dpu_ids(
     let query = r#"SELECT mi.machine_id
         FROM machine_interfaces mi
         WHERE mi.attached_dpu_machine_id != mi.machine_id
+        AND mi.interface_type != 'Bmc'
         AND mi.attached_dpu_machine_id = ANY($1)"#;
 
     sqlx::query_as(query)
@@ -726,7 +731,8 @@ pub async fn find_dpus_by_host_machine_id(
             r#"{}
                     INNER JOIN machine_interfaces mi
                       ON m.id = mi.attached_dpu_machine_id
-                    WHERE mi.machine_id=$1"#,
+                    WHERE mi.machine_id=$1
+                    AND mi.interface_type != 'Bmc'"#,
             JSON_MACHINE_SNAPSHOT_QUERY.deref()
         );
     }

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -34,6 +34,7 @@ use model::allocation_type::AllocationType;
 use model::expected_machine::ExpectedHostNic;
 use model::hardware_info::HardwareInfo;
 use model::machine::MachineInterfaceSnapshot;
+use model::machine_interface::InterfaceType;
 use model::machine_interface_address::MachineInterfaceAssociation;
 use model::network_prefix::NetworkPrefix;
 use model::network_segment::{AllocationStrategy, NetworkSegment, NetworkSegmentType};
@@ -166,6 +167,47 @@ pub async fn associate_interface_with_dpu_machine(
         .map_err(|e| DatabaseError::query(query, e))
 }
 
+pub async fn associate_bmc_interface_with_machine(
+    interface_id: &MachineInterfaceId,
+    machine_id: &MachineId,
+    txn: &mut PgConnection,
+) -> DatabaseResult<MachineInterfaceId> {
+    let query = "UPDATE machine_interfaces
+        SET machine_id=$1,
+            association_type='Machine'::association_type,
+            interface_type='Bmc'::interface_type,
+            primary_interface=false
+        WHERE id=$2::uuid
+        RETURNING id";
+    sqlx::query_as(query)
+        .bind(machine_id)
+        .bind(*interface_id)
+        .fetch_one(txn)
+        .await
+        .map_err(|err: sqlx::Error| match err {
+            sqlx::Error::Database(e)
+                if e.constraint() == Some(SQL_VIOLATION_MAX_ONE_ASSOCIATION) =>
+            {
+                DatabaseError::MaxOneInterfaceAssociation
+            }
+            _ => DatabaseError::query(query, err),
+        })
+}
+
+pub async fn set_interface_type(
+    interface_id: &MachineInterfaceId,
+    interface_type: InterfaceType,
+    txn: &mut PgConnection,
+) -> DatabaseResult<MachineInterfaceId> {
+    let query = "UPDATE machine_interfaces SET interface_type=$1 WHERE id=$2::uuid RETURNING id";
+    sqlx::query_as(query)
+        .bind(interface_type)
+        .bind(*interface_id)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
 pub async fn associate_interface_with_machine(
     interface_id: &MachineInterfaceId,
     association: MachineInterfaceAssociation,
@@ -244,6 +286,7 @@ pub async fn find_by_machine_ids(
         find_by(txn, ObjectColumnFilter::List(MachineIdColumn, machine_ids))
             .await?
             .into_iter()
+            .filter(|interface| interface.interface_type != InterfaceType::Bmc)
             .into_group_map_by(|interface| interface.machine_id.unwrap()),
     )
 }
@@ -470,9 +513,32 @@ pub async fn preallocate_machine_interface(
     mac_address: MacAddress,
     static_ip: IpAddr,
 ) -> DatabaseResult<()> {
+    preallocate_machine_interface_with_type(txn, mac_address, static_ip, InterfaceType::Data).await
+}
+
+pub async fn preallocate_bmc_machine_interface(
+    txn: &mut PgConnection,
+    mac_address: MacAddress,
+    static_ip: IpAddr,
+) -> DatabaseResult<()> {
+    preallocate_machine_interface_with_type(txn, mac_address, static_ip, InterfaceType::Bmc).await
+}
+
+async fn preallocate_machine_interface_with_type(
+    txn: &mut PgConnection,
+    mac_address: MacAddress,
+    static_ip: IpAddr,
+    interface_type: InterfaceType,
+) -> DatabaseResult<()> {
     let existing = find_by_mac_address(&mut *txn, mac_address).await?;
     if let Some(iface) = existing.first() {
         if iface.addresses.contains(&static_ip) {
+            if iface.interface_type != interface_type {
+                set_interface_type(&iface.id, interface_type, txn).await?;
+            }
+            if interface_type == InterfaceType::Bmc && iface.primary_interface {
+                set_primary_interface(&iface.id, false, txn).await?;
+            }
             return Ok(());
         }
         return Err(DatabaseError::InvalidArgument(format!(
@@ -495,12 +561,13 @@ pub async fn preallocate_machine_interface(
         None => db_network_segment::static_assignments(&mut *txn).await?,
     };
 
-    create(
+    create_with_type(
         txn,
         std::slice::from_ref(&segment),
         &mac_address,
-        true,
+        interface_type != InterfaceType::Bmc,
         AddressSelectionStrategy::StaticAddress(static_ip),
+        interface_type,
     )
     .await?;
 
@@ -521,12 +588,39 @@ pub async fn create(
     primary_interface: bool,
     address_strategy: AddressSelectionStrategy,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
+    create_with_type(
+        txn,
+        segments,
+        macaddr,
+        primary_interface,
+        address_strategy,
+        InterfaceType::Data,
+    )
+    .await
+}
+
+pub async fn create_with_type(
+    txn: &mut PgConnection,
+    segments: &[NetworkSegment],
+    macaddr: &MacAddress,
+    primary_interface: bool,
+    address_strategy: AddressSelectionStrategy,
+    interface_type: InterfaceType,
+) -> DatabaseResult<MachineInterfaceSnapshot> {
     match address_strategy {
         AddressSelectionStrategy::NextAvailableIp | AddressSelectionStrategy::Automatic => {
-            create_fast_path(txn, segments, macaddr, primary_interface).await
+            create_fast_path(txn, segments, macaddr, primary_interface, interface_type).await
         }
         AddressSelectionStrategy::StaticAddress(addr) => {
-            create_static_path(txn, segments, macaddr, primary_interface, addr).await
+            create_static_path(
+                txn,
+                segments,
+                macaddr,
+                primary_interface,
+                addr,
+                interface_type,
+            )
+            .await
         }
         //
         AddressSelectionStrategy::NextAvailablePrefix(_) => {
@@ -537,7 +631,15 @@ pub async fn create(
                 ));
             };
 
-            create_slow_path(txn, segment, macaddr, primary_interface, address_strategy).await
+            create_slow_path(
+                txn,
+                segment,
+                macaddr,
+                primary_interface,
+                address_strategy,
+                interface_type,
+            )
+            .await
         }
     }
 }
@@ -548,6 +650,7 @@ async fn create_fast_path(
     segments: &[NetworkSegment],
     macaddr: &MacAddress,
     primary_interface: bool,
+    interface_type: InterfaceType,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
     for segments_idx in 0..segments.len() {
         let segment = &segments[segments_idx];
@@ -564,6 +667,7 @@ async fn create_fast_path(
                 segment,
                 macaddr,
                 primary_interface,
+                interface_type,
             )
             .await
             {
@@ -619,6 +723,7 @@ async fn create_static_path(
     macaddr: &MacAddress,
     primary_interface: bool,
     address: IpAddr,
+    interface_type: InterfaceType,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
     // For the staic path, we need to be a little forgiving since
     // we expect to allow static assignment even if the requested
@@ -646,6 +751,7 @@ async fn create_static_path(
         primary_interface,
         &[address],
         AllocationType::Static,
+        interface_type,
     )
     .await?;
 
@@ -670,6 +776,7 @@ pub async fn create_slow_path(
     macaddr: &MacAddress,
     primary_interface: bool,
     address_strategy: AddressSelectionStrategy,
+    interface_type: InterfaceType,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
     // We're potentially about to insert a couple rows, so create a savepoint.
     let mut inner_txn = Transaction::begin_inner(txn).await?;
@@ -716,6 +823,7 @@ pub async fn create_slow_path(
         primary_interface,
         &allocated_addresses,
         AllocationType::Dhcp,
+        interface_type,
     )
     .await?;
     inner_txn.commit().await?;
@@ -737,6 +845,7 @@ async fn try_create_fast_path(
     segment: &NetworkSegment,
     macaddr: &MacAddress,
     primary_interface: bool,
+    interface_type: InterfaceType,
 ) -> DatabaseResult<MachineInterfaceId> {
     let allocated_addresses = allocate_addresses_from_segment(txn, segment).await?;
 
@@ -748,6 +857,7 @@ async fn try_create_fast_path(
         primary_interface,
         &allocated_addresses,
         AllocationType::Dhcp,
+        interface_type,
     )
     .await
 }
@@ -767,6 +877,7 @@ async fn allocate_addresses_from_segment(
 }
 
 /// Create the actual machine interface once we know what addresses we want.
+#[allow(clippy::too_many_arguments)]
 async fn create_inner(
     txn: &mut PgConnection,
     segment: &NetworkSegment,
@@ -775,6 +886,7 @@ async fn create_inner(
     primary_interface: bool,
     allocated_addresses: &[IpAddr],
     allocation_type: AllocationType,
+    interface_type: InterfaceType,
 ) -> DatabaseResult<MachineInterfaceId> {
     // Prefer IPv4 for hostname (more human-readable), fall back to
     // an IPv6-derived hostname otherwise.
@@ -802,6 +914,7 @@ async fn create_inner(
         hostname,
         domain_id,
         primary_interface,
+        interface_type,
     )
     .await?;
 
@@ -990,11 +1103,12 @@ async fn insert_machine_interface(
     hostname: String,
     domain_id: Option<DomainId>,
     is_primary_interface: bool,
+    interface_type: InterfaceType,
 ) -> DatabaseResult<MachineInterfaceId> {
     let query = "INSERT INTO machine_interfaces
-        (segment_id, mac_address, hostname, domain_id, primary_interface)
+        (segment_id, mac_address, hostname, domain_id, primary_interface, interface_type)
         VALUES
-        ($1::uuid, $2::macaddr, $3::varchar, $4::uuid, $5::bool) RETURNING id";
+        ($1::uuid, $2::macaddr, $3::varchar, $4::uuid, $5::bool, $6::interface_type) RETURNING id";
 
     let (interface_id,): (MachineInterfaceId,) = sqlx::query_as(query)
         .bind(segment_id)
@@ -1002,6 +1116,7 @@ async fn insert_machine_interface(
         .bind(hostname)
         .bind(domain_id)
         .bind(is_primary_interface)
+        .bind(interface_type)
         .fetch_one(txn)
         .await
         .map_err(|err: sqlx::Error| match err {

--- a/crates/api-db/src/machine_topology.rs
+++ b/crates/api-db/src/machine_topology.rs
@@ -16,7 +16,6 @@
  */
 
 use std::collections::HashMap;
-use std::net::IpAddr;
 
 use carbide_uuid::machine::MachineId;
 use chrono::{TimeDelta, Utc};
@@ -74,6 +73,7 @@ pub async fn create_or_update(
             info: hardware_info.clone(),
         },
         bmc_info: BmcInfo {
+            machine_interface_id: None,
             ip: None,
             port: None,
             mac: None,
@@ -138,26 +138,27 @@ pub async fn create_or_update_with_bom_validation(
     create_or_update(txn, machine_id, hardware_info).await
 }
 
-// update_firmware_version_by_bmc_address updates the stored firmware version info, using the BMC IP under the assumption that this came from site explorer reading from that address.
-pub async fn update_firmware_version_by_bmc_address(
+// update_firmware_version_by_machine_id updates the stored firmware version info for a machine.
+pub async fn update_firmware_version_by_machine_id(
     txn: &mut PgConnection,
-    bmc_address: &IpAddr,
+    machine_id: &MachineId,
     bmc_version: &str,
     bios_version: &str,
 ) -> DatabaseResult<()> {
-    // The IS NOT NULL checks that we're not partially creating stuff under an Option when adding a bios_version.  The firmware_version for the BMC gets implicitly checked when checking for the BMC IP.
-    let query = r#"UPDATE machine_topologies SET topology =
+    // The IS NOT NULL checks that we're not partially creating stuff under an Option when adding a bios_version.
+    let query = r#"UPDATE machine_topologies mt SET topology =
                         jsonb_set(jsonb_set(topology, '{bmc_info}',
                             jsonb_set(topology->'bmc_info', '{firmware_version}', $2)),
                             '{discovery_data}',
                                  jsonb_set(topology->'discovery_data', '{Info}',
                                             jsonb_set(topology->'discovery_data'->'Info', '{dmi_data}',
-                                                        jsonb_set(topology->'discovery_data'->'Info'->'dmi_data', '{bios_version}', $3))
-                        )) WHERE topology->'bmc_info'->>'ip' = $1
-                                            AND topology->'discovery_data'->'Info'->'dmi_data'->'bios_version' IS NOT NULL;"#;
+                                                         jsonb_set(topology->'discovery_data'->'Info'->'dmi_data', '{bios_version}', $3))
+                        ))
+                    WHERE mt.machine_id = $1
+                        AND topology->'discovery_data'->'Info'->'dmi_data'->'bios_version' IS NOT NULL;"#;
 
     sqlx::query(query)
-        .bind(bmc_address.to_string())
+        .bind(machine_id)
         .bind(sqlx::types::Json(bmc_version))
         .bind(sqlx::types::Json(bios_version))
         .execute(txn)
@@ -214,7 +215,14 @@ pub async fn find_machine_id_by_bmc_ip(
     txn: impl DbReader<'_>,
     address: &str,
 ) -> Result<Option<MachineId>, DatabaseError> {
-    let query = "SELECT machine_id FROM machine_topologies WHERE topology->'bmc_info'->>'ip' = $1";
+    let query = r#"
+        SELECT mi.machine_id
+        FROM machine_interfaces mi
+        JOIN machine_interface_addresses mia ON mia.interface_id = mi.id
+        WHERE mi.interface_type = 'Bmc'
+            AND mi.machine_id IS NOT NULL
+            AND mia.address = $1::inet
+    "#;
     sqlx::query_as(query)
         .bind(address)
         .fetch_optional(txn)
@@ -226,9 +234,15 @@ pub async fn find_machine_id_by_bmc_mac(
     txn: &mut PgConnection,
     mac_address: mac_address::MacAddress,
 ) -> Result<Option<MachineId>, DatabaseError> {
-    let query = "SELECT machine_id FROM machine_topologies WHERE topology->'bmc_info'->>'mac' = $1";
+    let query = r#"
+        SELECT machine_id
+        FROM machine_interfaces
+        WHERE interface_type = 'Bmc'
+            AND machine_id IS NOT NULL
+            AND mac_address = $1::macaddr
+    "#;
     sqlx::query_as(query)
-        .bind(mac_address.to_string())
+        .bind(mac_address)
         .fetch_optional(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))
@@ -238,9 +252,14 @@ pub async fn find_machine_bmc_pairs(
     txn: impl DbReader<'_>,
     bmc_ips: Vec<String>,
 ) -> Result<Vec<(MachineId, String)>, DatabaseError> {
-    let query = r#"SELECT machine_id, topology->'bmc_info'->>'ip'
-            FROM machine_topologies
-            WHERE topology->'bmc_info'->>'ip' = ANY($1)"#;
+    let query = r#"
+        SELECT mi.machine_id, host(mia.address)
+        FROM machine_interfaces mi
+        JOIN machine_interface_addresses mia ON mia.interface_id = mi.id
+        WHERE mi.interface_type = 'Bmc'
+            AND mi.machine_id IS NOT NULL
+            AND host(mia.address) = ANY($1)
+    "#;
     sqlx::query_as(query)
         .bind(bmc_ips)
         .fetch_all(txn)
@@ -250,27 +269,22 @@ pub async fn find_machine_bmc_pairs(
 
 /// Find the BMC IP address for each of the given machine IDs.
 ///
-/// Returns a list of (machine_id, bmc_ip) pairs. If a machine has multiple topology
-/// records, only the most recent one (by `created` timestamp) is returned.
+/// Returns a list of (machine_id, bmc_ip) pairs from BMC interface links.
 ///
 /// The BMC IP is returned as `Option<String>`:
 /// - `Some(ip)` if the topology has a valid BMC IP
-/// - `None` if the topology exists but has no BMC IP (caller can log/handle this case)
-///
-/// Note: Machines without topology records will be silently omitted from the result.
-///
-/// This query uses `DISTINCT ON` with `ORDER BY machine_id, created DESC` to efficiently
-/// select the latest topology per machine. This is optimized by the composite index
-/// `machine_topologies_machine_id_created_idx`.
+/// - `None` if the linked interface exists but has no BMC IP (caller can log/handle this case)
 pub async fn find_machine_bmc_pairs_by_machine_id(
     txn: &mut PgConnection,
     machine_ids: Vec<MachineId>,
 ) -> Result<Vec<(MachineId, Option<String>)>, DatabaseError> {
     let query = r#"
-        SELECT DISTINCT ON (machine_id) machine_id, topology->'bmc_info'->>'ip'
-        FROM machine_topologies
-        WHERE machine_id = ANY($1)
-        ORDER BY machine_id, created DESC
+        SELECT DISTINCT ON (mi.machine_id) mi.machine_id, host(mia.address)
+        FROM machine_interfaces mi
+        LEFT JOIN machine_interface_addresses mia ON mia.interface_id = mi.id
+        WHERE mi.interface_type = 'Bmc'
+            AND mi.machine_id = ANY($1)
+        ORDER BY mi.machine_id, family(mia.address), mia.address
     "#;
     sqlx::query_as(query)
         .bind(machine_ids)
@@ -448,6 +462,7 @@ pub mod test_helpers {
                 info: hardware_info.clone(),
             },
             bmc_info: BmcInfo {
+                machine_interface_id: None,
                 ip: None,
                 port: None,
                 mac: None,

--- a/crates/api-db/src/network_segment.rs
+++ b/crates/api-db/src/network_segment.rs
@@ -405,6 +405,7 @@ pub async fn batch_find_ids_by_machine_ids(
             .collect::<Vec<_>>(),
     );
     query.push(")");
+    query.push(" AND mi.interface_type != 'Bmc'");
 
     if let Some(network_segment_type) = network_segment_type {
         query

--- a/crates/api-db/src/sql/machine_snapshots.sql.template
+++ b/crates/api-db/src/sql/machine_snapshots.sql.template
@@ -8,12 +8,54 @@ SELECT
 m.*,
 sku.device_type as hw_sku_device_type,
 COALESCE(i.json, '[]') AS interfaces,
-COALESCE(t.json, '[]') AS topology
+COALESCE(t.json, '[]') AS topology,
+COALESCE(bmc.json, t.bmc_info, '{}'::jsonb) AS bmc_info
 __HISTORY_SELECT__
 FROM machines m
 LEFT JOIN machine_skus sku on  m.hw_sku = sku.id
 
--- (1) Read related interfaces as JSON
+-- (1) Read the latest topology as JSON
+LEFT JOIN LATERAL (
+    SELECT
+    json_build_array(json_build_object(
+        'machine_id', mt2.machine_id,
+        'topology', mt2.topology,
+        'created', mt2.created,
+        'updated', mt2.updated,
+        'topology_update_needed', mt2.topology_update_needed
+    )) AS json,
+    mt2.topology->'bmc_info' AS bmc_info
+    FROM machine_topologies mt2
+    WHERE mt2.machine_id = m.id
+    ORDER BY mt2.created DESC
+    LIMIT 1
+) AS t ON true
+
+-- (2) Read the linked BMC interface as JSON
+LEFT JOIN LATERAL (
+    SELECT jsonb_strip_nulls(
+        COALESCE(t.bmc_info, '{}'::jsonb) ||
+        jsonb_build_object(
+            'machine_interface_id', bmc_i.id,
+            'ip', COALESCE(host(bmc_addr.address), t.bmc_info->>'ip'),
+            'mac', COALESCE(bmc_i.mac_address::text, t.bmc_info->>'mac')
+        )
+    ) AS json
+    FROM machine_interfaces bmc_i
+    LEFT JOIN LATERAL (
+        SELECT a.address
+        FROM machine_interface_addresses a
+        WHERE a.interface_id = bmc_i.id
+        ORDER BY family(a.address), a.address
+        LIMIT 1
+    ) AS bmc_addr ON true
+    WHERE bmc_i.machine_id = m.id
+      AND bmc_i.interface_type = 'Bmc'
+    ORDER BY bmc_i.created ASC
+    LIMIT 1
+) AS bmc ON true
+
+-- (3) Read related non-BMC interfaces as JSON
 LEFT JOIN LATERAL (
     SELECT json_agg(x) AS json
     FROM (
@@ -39,27 +81,9 @@ LEFT JOIN LATERAL (
         ) AS v ON true
         INNER JOIN network_segments ns ON ns.id = i2.segment_id
         WHERE i2.machine_id = m.id
+          AND i2.interface_type != 'Bmc'
     ) x
 ) AS i ON true
 
--- (2) Read the latest topology as JSON
-LEFT JOIN LATERAL (
-    SELECT
-    json_agg(x.json) AS json
-    FROM (
-        SELECT
-        mt2.machine_id,
-        json_build_object('machine_id', mt2.machine_id, 'topology', mt2.topology, 'created', mt2.created, 'updated', mt2.updated, 'topology_update_needed', mt2.topology_update_needed) AS json,
-        row_number() OVER (
-            PARTITION BY mt2.machine_id
-            ORDER BY mt2.created DESC
-        ) AS rn
-        FROM machine_topologies mt2
-        WHERE mt2.machine_id = m.id
-    ) x
-    WHERE x.rn = 1
-) AS t ON true
-
--- (3) Read the history as JSON
+-- (4) Read the history as JSON
 __HISTORY_JOIN__
-

--- a/crates/api-db/src/sql/managed_hosts.sql.template
+++ b/crates/api-db/src/sql/managed_hosts.sql.template
@@ -26,6 +26,7 @@ SELECT m.* FROM (
         sku.device_type as hw_sku_device_type,
         COALESCE(i.json, '[]') AS interfaces,
         COALESCE(t.json, '[]') AS topology,
+        COALESCE(bmc.json, t.bmc_info, '{}'::jsonb) AS bmc_info,
         COALESCE(p.json, '[]') AS power_options
         __HISTORY_SELECT__
         FROM machines m2
@@ -57,31 +58,55 @@ SELECT m.* FROM (
                 ) AS v ON true
                 INNER JOIN network_segments ns ON ns.id = i2.segment_id
                 WHERE i2.machine_id = m2.id
+                  AND i2.interface_type != 'Bmc'
             ) x
         ) AS i ON true
 
         -- (1.2) Join in the latest topology (first row ordered by created date)
         LEFT JOIN LATERAL (
             SELECT
-            json_agg(x.json) AS json
-            FROM (
-                SELECT
-                mt2.machine_id,
-                json_build_object('machine_id', mt2.machine_id, 'topology', mt2.topology, 'created', mt2.created, 'updated', mt2.updated, 'topology_update_needed', mt2.topology_update_needed) AS json,
-                row_number() OVER (
-                    PARTITION BY mt2.machine_id
-                    ORDER BY mt2.created DESC
-                ) AS rn
-                FROM machine_topologies mt2
-                WHERE mt2.machine_id = m2.id
-            ) x
-            WHERE x.rn = 1
+            json_build_array(json_build_object(
+                'machine_id', mt2.machine_id,
+                'topology', mt2.topology,
+                'created', mt2.created,
+                'updated', mt2.updated,
+                'topology_update_needed', mt2.topology_update_needed
+            )) AS json,
+            mt2.topology->'bmc_info' AS bmc_info
+            FROM machine_topologies mt2
+            WHERE mt2.machine_id = m2.id
+            ORDER BY mt2.created DESC
+            LIMIT 1
         ) AS t ON true
 
-        -- (1.3) Join in the history
+        -- (1.3) Join in the linked BMC interface
+        LEFT JOIN LATERAL (
+            SELECT jsonb_strip_nulls(
+                COALESCE(t.bmc_info, '{}'::jsonb) ||
+                jsonb_build_object(
+                    'machine_interface_id', bmc_i.id,
+                    'ip', COALESCE(host(bmc_addr.address), t.bmc_info->>'ip'),
+                    'mac', COALESCE(bmc_i.mac_address::text, t.bmc_info->>'mac')
+                )
+            ) AS json
+            FROM machine_interfaces bmc_i
+            LEFT JOIN LATERAL (
+                SELECT a.address
+                FROM machine_interface_addresses a
+                WHERE a.interface_id = bmc_i.id
+                ORDER BY family(a.address), a.address
+                LIMIT 1
+            ) AS bmc_addr ON true
+            WHERE bmc_i.machine_id = m2.id
+              AND bmc_i.interface_type = 'Bmc'
+            ORDER BY bmc_i.created ASC
+            LIMIT 1
+        ) AS bmc ON true
+
+        -- (1.4) Join in the history
         __HISTORY_JOIN__
 
-        -- (1.4) Join power options
+        -- (1.5) Join power options
         LEFT JOIN LATERAL (
             SELECT
             row_to_json(x) AS json
@@ -99,7 +124,8 @@ SELECT m.* FROM (
         mi_parent.machine_id AS managed_host_id,
         m2.*,
         COALESCE(i.json, '[]') AS interfaces,
-        COALESCE(t.json, '[]') AS topology
+        COALESCE(t.json, '[]') AS topology,
+        COALESCE(bmc.json, t.bmc_info, '{}'::jsonb) AS bmc_info
         __HISTORY_SELECT__
         FROM machine_interfaces mi_parent
         INNER JOIN machines m2
@@ -131,31 +157,57 @@ SELECT m.* FROM (
                 ) AS v ON true
                 INNER JOIN network_segments ns ON ns.id = i2.segment_id
                 WHERE i2.machine_id = m2.id
+                  AND i2.interface_type != 'Bmc'
             ) x
         ) AS i ON true
 
         -- (2.2) Join in the latest topology (first row ordered by created date)
         LEFT JOIN LATERAL (
-            SELECT json_agg(x.json) AS json
-            FROM (
-                SELECT
-                mt2.machine_id,
-                json_build_object('machine_id', mt2.machine_id, 'topology', mt2.topology, 'created', mt2.created, 'updated', mt2.updated, 'topology_update_needed', mt2.topology_update_needed) AS json,
-                row_number() OVER (
-                    PARTITION BY mt2.machine_id
-                    ORDER BY mt2.created DESC
-                ) AS rn
-                FROM machine_topologies mt2
-                WHERE mt2.machine_id = m2.id
-            ) x
-            WHERE x.rn = 1
+            SELECT
+            json_build_array(json_build_object(
+                'machine_id', mt2.machine_id,
+                'topology', mt2.topology,
+                'created', mt2.created,
+                'updated', mt2.updated,
+                'topology_update_needed', mt2.topology_update_needed
+            )) AS json,
+            mt2.topology->'bmc_info' AS bmc_info
+            FROM machine_topologies mt2
+            WHERE mt2.machine_id = m2.id
+            ORDER BY mt2.created DESC
+            LIMIT 1
         ) AS t ON true
 
-        -- (2.3) Join in the history
+        -- (2.3) Join in the linked BMC interface
+        LEFT JOIN LATERAL (
+            SELECT jsonb_strip_nulls(
+                COALESCE(t.bmc_info, '{}'::jsonb) ||
+                jsonb_build_object(
+                    'machine_interface_id', bmc_i.id,
+                    'ip', COALESCE(host(bmc_addr.address), t.bmc_info->>'ip'),
+                    'mac', COALESCE(bmc_i.mac_address::text, t.bmc_info->>'mac')
+                )
+            ) AS json
+            FROM machine_interfaces bmc_i
+            LEFT JOIN LATERAL (
+                SELECT a.address
+                FROM machine_interface_addresses a
+                WHERE a.interface_id = bmc_i.id
+                ORDER BY family(a.address), a.address
+                LIMIT 1
+            ) AS bmc_addr ON true
+            WHERE bmc_i.machine_id = m2.id
+              AND bmc_i.interface_type = 'Bmc'
+            ORDER BY bmc_i.created ASC
+            LIMIT 1
+        ) AS bmc ON true
+
+        -- (2.4) Join in the history
         __HISTORY_JOIN__
 
         WHERE mi_parent.machine_id = m.id
         AND mi_parent.attached_dpu_machine_id != mi_parent.machine_id
+        AND mi_parent.interface_type != 'Bmc'
     ) AS dpu_snapshots ON true
 
     -- (3) Join rack-level health reports

--- a/crates/api-model/src/bmc_info.rs
+++ b/crates/api-model/src/bmc_info.rs
@@ -18,6 +18,7 @@ use std::fmt::{Display, Formatter};
 use std::net::IpAddr;
 use std::str::FromStr;
 
+use carbide_uuid::machine::MachineInterfaceId;
 use eyre::{Report, eyre};
 use mac_address::MacAddress;
 use serde::{Deserialize, Serialize};
@@ -32,6 +33,7 @@ use crate::errors::{ModelError, ModelResult};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BmcInfo {
+    pub machine_interface_id: Option<MachineInterfaceId>,
     pub ip: Option<String>,
     pub port: Option<u16>,
     pub mac: Option<MacAddress>,

--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -63,6 +63,7 @@ pub mod instance_address;
 pub mod instance_type;
 pub mod machine;
 pub mod machine_boot_override;
+pub mod machine_interface;
 pub mod machine_interface_address;
 pub mod machine_update_module;
 pub mod machine_validation;

--- a/crates/api-model/src/machine/capabilities.rs
+++ b/crates/api-model/src/machine/capabilities.rs
@@ -675,6 +675,7 @@ mod tests {
     use crate::ib::DEFAULT_IB_FABRIC_NAME;
     use crate::machine::MachineInterfaceId;
     use crate::machine::infiniband::MachineIbInterfaceStatusObservation;
+    use crate::machine_interface::InterfaceType;
     use crate::{MacAddress, NetworkSegmentId};
 
     const X86_INFO_JSON: &[u8] = include_bytes!(concat!(
@@ -1067,6 +1068,7 @@ mod tests {
                 MachineInterfaceSnapshot {
                     id: MachineInterfaceId::from(uuid::Uuid::nil()),
                     hostname: String::new(),
+                    interface_type: InterfaceType::Data,
                     primary_interface: true,
                     mac_address: MacAddress::from_str("08:c0:eb:cb:0e:96").unwrap(),
                     attached_dpu_machine_id: Some(
@@ -1090,6 +1092,7 @@ mod tests {
                 MachineInterfaceSnapshot {
                     id: MachineInterfaceId::from(uuid::Uuid::nil()),
                     hostname: String::new(),
+                    interface_type: InterfaceType::Data,
                     primary_interface: true,
                     mac_address: MacAddress::from_str("08:c0:eb:cb:0e:97").unwrap(),
                     attached_dpu_machine_id: Some(
@@ -1191,6 +1194,7 @@ mod tests {
             vec![MachineInterfaceSnapshot {
                 id: MachineInterfaceId::from(uuid::Uuid::nil()),
                 hostname: String::new(),
+                interface_type: InterfaceType::Data,
                 primary_interface: true,
                 mac_address: MacAddress::from_str("00:00:00:00:00:00").unwrap(),
                 attached_dpu_machine_id: None,

--- a/crates/api-model/src/machine/json.rs
+++ b/crates/api-model/src/machine/json.rs
@@ -87,6 +87,7 @@ pub struct MachineSnapshotPgJson {
     pub instance_type_id: Option<InstanceTypeId>,
     pub interfaces: Vec<MachineInterfaceSnapshot>,
     pub topology: Vec<MachineTopology>,
+    pub bmc_info: BmcInfo,
     pub labels: HashMap<String, String>,
     pub name: String,
     pub description: String,
@@ -115,18 +116,15 @@ impl TryFrom<MachineSnapshotPgJson> for Machine {
     type Error = sqlx::Error;
 
     fn try_from(value: MachineSnapshotPgJson) -> sqlx::Result<Self> {
-        let (hardware_info, bmc_info) = value
+        let hardware_info = value
             .topology
             .into_iter()
             .map(|t| {
                 let topology = t.into_topology();
-                (
-                    Some(topology.discovery_data.info.clone()),
-                    topology.bmc_info,
-                )
+                Some(topology.discovery_data.info)
             })
             .next()
-            .unwrap_or((None, BmcInfo::default()));
+            .unwrap_or(None);
 
         let metadata = Metadata {
             name: value.name,
@@ -178,7 +176,7 @@ impl TryFrom<MachineSnapshotPgJson> for Machine {
             history,
             interfaces: value.interfaces,
             hardware_info,
-            bmc_info,
+            bmc_info: value.bmc_info,
             last_reboot_time: value.last_reboot_time,
             last_cleanup_time: value.last_cleanup_time,
             last_discovery_time: value.last_discovery_time,

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -64,6 +64,7 @@ use crate::instance::config::network::DeviceLocator;
 use crate::instance::snapshot::InstanceSnapshotPgJson;
 use crate::machine::capabilities::MachineCapabilitiesSet;
 use crate::machine::health_override::HealthReportSources;
+use crate::machine_interface::InterfaceType;
 use crate::machine_interface_address::InterfaceAssociationType;
 use crate::network_segment::NetworkSegmentType;
 use crate::power_manager::PowerOptions;
@@ -2603,6 +2604,7 @@ impl ManagedHostState {
 pub struct MachineInterfaceSnapshot {
     pub id: MachineInterfaceId,
     pub hostname: String,
+    pub interface_type: InterfaceType,
     pub primary_interface: bool,
     pub mac_address: MacAddress,
     pub attached_dpu_machine_id: Option<MachineId>,
@@ -2630,6 +2632,7 @@ impl MachineInterfaceSnapshot {
             segment_id: uuid::Uuid::nil().into(),
             mac_address,
             hostname: String::new(),
+            interface_type: InterfaceType::Data,
             primary_interface: true,
             addresses: Vec::new(),
             vendors: Vec::new(),
@@ -2644,7 +2647,10 @@ impl MachineInterfaceSnapshot {
 }
 
 impl From<MachineInterfaceSnapshot> for rpc::MachineInterface {
+    #[allow(deprecated)]
     fn from(machine_interface: MachineInterfaceSnapshot) -> rpc::MachineInterface {
+        let is_bmc = machine_interface.interface_type == InterfaceType::Bmc;
+
         rpc::MachineInterface {
             id: Some(machine_interface.id),
             attached_dpu_machine_id: machine_interface.attached_dpu_machine_id,
@@ -2663,7 +2669,8 @@ impl From<MachineInterfaceSnapshot> for rpc::MachineInterface {
             created: Some(machine_interface.created.into()),
             last_dhcp: machine_interface.last_dhcp.map(|t| t.into()),
             power_shelf_id: machine_interface.power_shelf_id,
-            is_bmc: None,
+            is_bmc: Some(is_bmc),
+            interface_type: Some(machine_interface.interface_type as i32),
             switch_id: machine_interface.switch_id,
             association_type: machine_interface.association_type.map(|t| t as i32),
         }
@@ -3016,6 +3023,7 @@ impl<'r> FromRow<'r, PgRow> for MachineInterfaceSnapshot {
             segment_id: row.try_get("segment_id")?,
             domain_id: row.try_get("domain_id")?,
             hostname: row.try_get("hostname")?,
+            interface_type: row.try_get("interface_type")?,
             mac_address: row.try_get("mac_address")?,
             primary_interface: row.try_get("primary_interface")?,
             created: row.try_get("created")?,

--- a/crates/api-model/src/machine_interface.rs
+++ b/crates/api-model/src/machine_interface.rs
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, sqlx::Type, serde::Serialize, serde::Deserialize,
+)]
+#[sqlx(type_name = "interface_type")]
+pub enum InterfaceType {
+    #[default]
+    Data = 0,
+    Bmc = 1,
+}

--- a/crates/api-model/src/rpc_conv/bmc_info.rs
+++ b/crates/api-model/src/rpc_conv/bmc_info.rs
@@ -35,6 +35,7 @@ impl TryFrom<rpc::BmcInfo> for BmcInfo {
         };
 
         Ok(BmcInfo {
+            machine_interface_id: value.machine_interface_id,
             ip: value.ip,
             port: value.port.map(|p| p as u16),
             mac,
@@ -47,6 +48,7 @@ impl TryFrom<rpc::BmcInfo> for BmcInfo {
 impl From<BmcInfo> for rpc::BmcInfo {
     fn from(value: BmcInfo) -> Self {
         rpc::BmcInfo {
+            machine_interface_id: value.machine_interface_id,
             ip: value.ip,
             port: value.port.map(|p| p as u32),
             mac: value.mac.map(|mac| mac.to_string()),

--- a/crates/api/src/handlers/bmc_endpoint_explorer.rs
+++ b/crates/api/src/handlers/bmc_endpoint_explorer.rs
@@ -25,6 +25,7 @@ use libredfish::RoleId;
 use mac_address::MacAddress;
 use model::expected_entity::ExpectedEntity;
 use model::machine::machine_id::try_parse_machine_id;
+use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{LoadSnapshotOptions, MachineInterfaceSnapshot};
 use model::site_explorer::PreingestionState;
 use sqlx::PgConnection;
@@ -896,24 +897,20 @@ pub(crate) async fn validate_and_complete_bmc_endpoint_request(
         (_, Some(machine_id)) => {
             log_machine_id(&machine_id);
 
-            let mut topologies =
-                db::machine_topology::find_latest_by_machine_ids(txn, &[machine_id]).await?;
+            let machine = db::machine::find_one(txn, &machine_id, MachineSearchConfig::default())
+                .await?
+                .ok_or_else(|| CarbideError::NotFoundError {
+                    kind: "machine",
+                    id: machine_id.to_string(),
+                })?;
 
-            let topology =
-                topologies
-                    .remove(&machine_id)
-                    .ok_or_else(|| CarbideError::NotFoundError {
-                        kind: "machine",
-                        id: machine_id.to_string(),
-                    })?;
-
-            let bmc_ip = topology.topology().bmc_info.ip.as_ref().ok_or_else(|| {
+            let bmc_ip = machine.bmc_info.ip.as_ref().ok_or_else(|| {
                 CarbideError::internal(format!(
                     "Machine found for {machine_id} but BMC IP is missing"
                 ))
             })?;
 
-            let bmc_mac_address = topology.topology().bmc_info.mac.ok_or_else(|| {
+            let bmc_mac_address = machine.bmc_info.mac.ok_or_else(|| {
                 CarbideError::internal(format!("BMC endpoint for {bmc_ip} ({machine_id}) found but does not have associated MAC"))
             })?;
 

--- a/crates/api/src/handlers/expected_machine.rs
+++ b/crates/api/src/handlers/expected_machine.rs
@@ -130,8 +130,12 @@ pub(crate) async fn preallocate_interfaces_for(
     validate_at_most_one_primary_host_nic(&machine.data.host_nics)?;
 
     if let Some(bmc_ip) = machine.data.bmc_ip_address {
-        db::machine_interface::preallocate_machine_interface(txn, machine.bmc_mac_address, bmc_ip)
-            .await?;
+        db::machine_interface::preallocate_bmc_machine_interface(
+            txn,
+            machine.bmc_mac_address,
+            bmc_ip,
+        )
+        .await?;
     }
 
     for nic in &machine.data.host_nics {
@@ -436,7 +440,7 @@ async fn create_expected_machine(
     };
 
     if let Some(bmc_ip) = expected_machine.data.bmc_ip_address {
-        db::machine_interface::preallocate_machine_interface(
+        db::machine_interface::preallocate_bmc_machine_interface(
             txn,
             expected_machine.bmc_mac_address,
             bmc_ip,

--- a/crates/api/src/handlers/expected_power_shelf.rs
+++ b/crates/api/src/handlers/expected_power_shelf.rs
@@ -46,7 +46,7 @@ pub async fn add_expected_power_shelf(
         })?;
 
     if let Some(bmc_ip) = power_shelf.bmc_ip_address {
-        db::machine_interface::preallocate_machine_interface(
+        db::machine_interface::preallocate_bmc_machine_interface(
             &mut txn,
             power_shelf.bmc_mac_address,
             bmc_ip,

--- a/crates/api/src/handlers/expected_switch.rs
+++ b/crates/api/src/handlers/expected_switch.rs
@@ -46,7 +46,7 @@ pub async fn add_expected_switch(
         })?;
 
     if let Some(bmc_ip) = switch.bmc_ip_address {
-        db::machine_interface::preallocate_machine_interface(
+        db::machine_interface::preallocate_bmc_machine_interface(
             &mut txn,
             switch.bmc_mac_address,
             bmc_ip,

--- a/crates/api/src/handlers/machine.rs
+++ b/crates/api/src/handlers/machine.rs
@@ -771,7 +771,7 @@ pub async fn get_machine_position_info(
     let mut txn = api.txn_begin().await?;
 
     // Translate the machine IDs to BMC IPs.
-    // Note: Machines without topology records will be silently omitted from the result,
+    // Note: Machines without linked BMC interfaces will be silently omitted from the result,
     // consistent with how find_machines_by_ids handles missing machines.
     let pairs =
         db::machine_topology::find_machine_bmc_pairs_by_machine_id(&mut txn, request.machine_ids)

--- a/crates/api/src/handlers/machine_interface.rs
+++ b/crates/api/src/handlers/machine_interface.rs
@@ -19,8 +19,8 @@ use std::net::IpAddr;
 use std::str::FromStr;
 
 use ::rpc::forge as rpc;
-use carbide_uuid::machine::MachineType;
 use itertools::Itertools;
+use model::machine_interface::InterfaceType;
 use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
@@ -36,7 +36,7 @@ pub(crate) async fn find_interfaces(
 
     let rpc::InterfaceSearchQuery { id, ip } = request.into_inner();
 
-    let mut interfaces: Vec<rpc::MachineInterface> = match (id, ip) {
+    let interfaces: Vec<rpc::MachineInterface> = match (id, ip) {
         (Some(id), _) => vec![db::machine_interface::find_one(&mut txn, id).await?.into()],
         (None, Some(ip)) => match IpAddr::from_str(ip.as_ref()) {
             Ok(ip) => match db::machine_interface::find_by_ip(&mut txn, ip).await? {
@@ -64,38 +64,6 @@ pub(crate) async fn find_interfaces(
         },
     };
 
-    // Link BMC interface to its machine, for carbide-web and admin-cli.
-    // Don't link if the search returned multiple, in case perf is an issue.
-    if interfaces.len() == 1 {
-        let interface = interfaces.get_mut(0).unwrap();
-        let not_linked_yet = interface.machine_id.is_none();
-        let maybe_a_bmc_interface = interface.primary_interface && interface.address.len() == 1;
-        if not_linked_yet && maybe_a_bmc_interface {
-            let Some(ip) = interface.address.first() else {
-                return Err(CarbideError::Internal {
-                    message: "Impossible interface.address array length".into(),
-                }
-                .into());
-            };
-            match db::machine_topology::find_machine_id_by_bmc_ip(txn.as_pgconn(), ip).await {
-                Ok(Some(machine_id)) => {
-                    let rpc_machine_id = Some(machine_id);
-                    interface.is_bmc = Some(true);
-                    match machine_id.machine_type() {
-                        MachineType::Dpu => interface.attached_dpu_machine_id = rpc_machine_id,
-                        MachineType::Host | MachineType::PredictedHost => {
-                            interface.machine_id = rpc_machine_id
-                        }
-                    }
-                }
-                Ok(None) => {} // expected, not a BMC interface
-                Err(err) => {
-                    tracing::warn!(%err, %ip, "db::machine_topology::find_machine_id_by_bmc_ip error");
-                }
-            }
-        }
-    }
-
     txn.commit().await?;
 
     Ok(Response::new(rpc::InterfaceList { interfaces }))
@@ -118,6 +86,12 @@ pub(crate) async fn delete_interface(
 
     // There should not be any machine associated with this interface.
     if let Some(machine_id) = interface.machine_id {
+        if interface.interface_type == InterfaceType::Bmc {
+            return Err(CarbideError::InvalidArgument(format!(
+                "This looks like a BMC interface and attached with machine: {machine_id}. Delete that first."
+            ))
+            .into());
+        }
         return Err(CarbideError::InvalidArgument(format!(
             "Already a machine {machine_id} is attached to this interface. Delete that first."
         ))

--- a/crates/api/src/handlers/power_shelf.rs
+++ b/crates/api/src/handlers/power_shelf.rs
@@ -146,6 +146,7 @@ pub async fn find_by_ids(
                         version: None,
                         firmware_version: None,
                         port: None,
+                        machine_interface_id: None,
                     },
                 )
             })

--- a/crates/api/src/handlers/switch.rs
+++ b/crates/api/src/handlers/switch.rs
@@ -85,6 +85,7 @@ pub async fn find_switch(
                         version: None,
                         firmware_version: None,
                         port: None,
+                        machine_interface_id: None,
                     },
                 )
             })
@@ -174,6 +175,7 @@ pub async fn find_by_ids(
                         version: None,
                         firmware_version: None,
                         port: None,
+                        machine_interface_id: None,
                     },
                 )
             })

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -3187,7 +3187,6 @@ async fn check_fw_component_version(
                 .clone()
                 .firmware_version
                 .is_some_and(|v| v != cur_version)
-            && let Some(dpu_bmc_ip) = dpu_snapshot.bmc_addr().map(|a| a.ip())
         {
             let bios_version: String = redfish_client
                 .get_firmware("DPU_UEFI")
@@ -3208,10 +3207,10 @@ async fn check_fw_component_version(
                 });
 
             ctx.pending_db_writes.push(
-                // This is safe to defer to pending_db_writes because this is a no-op if for some
-                // reason dpu_bmc_ip is not found.
-                MachineWriteOp::UpdateFirmwareVersionByBmcAddress {
-                    bmc_address: dpu_bmc_ip,
+                // This is safe to defer to pending_db_writes because the DPU snapshot already has
+                // the machine ID needed for the topology update.
+                MachineWriteOp::UpdateFirmwareVersionByMachineId {
+                    machine_id: dpu_snapshot.id,
                     bmc_version: cur_version,
                     bios_version,
                 },

--- a/crates/api/src/state_controller/machine/write_ops.rs
+++ b/crates/api/src/state_controller/machine/write_ops.rs
@@ -82,8 +82,8 @@ pub enum MachineWriteOp {
         verified: Option<bool>,
         attempts: i32,
     },
-    UpdateFirmwareVersionByBmcAddress {
-        bmc_address: IpAddr,
+    UpdateFirmwareVersionByMachineId {
+        machine_id: MachineId,
         bmc_version: String,
         bios_version: String,
     },
@@ -175,14 +175,14 @@ impl WriteOp for MachineWriteOp {
                 )
                 .await?
             }
-            UpdateFirmwareVersionByBmcAddress {
-                bmc_address,
+            UpdateFirmwareVersionByMachineId {
+                machine_id,
                 bmc_version,
                 bios_version,
             } => {
-                db::machine_topology::update_firmware_version_by_bmc_address(
+                db::machine_topology::update_firmware_version_by_machine_id(
                     txn,
-                    &bmc_address,
+                    &machine_id,
                     &bmc_version,
                     &bios_version,
                 )

--- a/crates/api/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/site_explorer.rs
@@ -157,7 +157,7 @@ impl<'a> MockExploredHost<'a> {
                     self.managed_host.dpus[dpu_index as usize].bmc_mac_address,
                     FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY.ip(),
                 )
-                .vendor_string("SomeVendor")
+                .vendor_string("NVIDIA/BF/BMC")
                 .tonic_request(),
             )
             .await;

--- a/crates/api/src/tests/explored_endpoint_find.rs
+++ b/crates/api/src/tests/explored_endpoint_find.rs
@@ -207,7 +207,8 @@ async fn test_admin_bmc_reset(db_pool: sqlx::PgPool) -> Result<(), eyre::Report>
     let e = api_result.unwrap_err();
     assert!(e.code() == Code::NotFound);
 
-    // Check that we fail with an internal error if MAC is missing from BMC details.
+    // The topology copy may be missing the MAC, but machine_id lookup should
+    // still recover it from the linked BMC machine_interface.
     let mut txn = db_pool.begin().await?;
 
     let query = format!(
@@ -225,11 +226,11 @@ async fn test_admin_bmc_reset(db_pool: sqlx::PgPool) -> Result<(), eyre::Report>
         use_ipmitool: false,
     });
     let api_result = env.api.admin_bmc_reset(req).await;
-    let e = api_result.unwrap_err();
-    assert!(e.code() == Code::Internal);
-    assert!(e.message().contains("does not have associated MAC"));
+    assert!(api_result.is_ok());
 
-    // Check that we fail with an internal error if IP is missing from BMC details.
+    // The topology copy may be missing the IP or contain stale MAC data, but
+    // machine_id lookup should still recover the current endpoint data from
+    // the linked BMC machine_interface.
     let mut txn = db_pool.begin().await?;
 
     let query = "UPDATE machine_topologies SET topology = jsonb_set(topology, '{bmc_info}',  '{\"mac\": \"C8:4B:D6:7A:DB:66\", \"port\": null, \"version\": \"1\", \"firmware_version\": \"5.10\"}', false) WHERE machine_id = $1";
@@ -245,9 +246,7 @@ async fn test_admin_bmc_reset(db_pool: sqlx::PgPool) -> Result<(), eyre::Report>
         use_ipmitool: false,
     });
     let api_result = env.api.admin_bmc_reset(req).await;
-    let e = api_result.unwrap_err();
-    assert!(e.code() == Code::Internal);
-    assert!(e.message().contains("BMC IP is missing"));
+    assert!(api_result.is_ok());
 
     Ok(())
 }

--- a/crates/api/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api/src/tests/host_bmc_firmware_test.rs
@@ -661,9 +661,9 @@ async fn test_postingestion_bmc_upgrade(pool: sqlx::PgPool) -> CarbideResult<()>
         &mut txn,
     )
     .await?;
-    db::machine_topology::update_firmware_version_by_bmc_address(
+    db::machine_topology::update_firmware_version_by_machine_id(
         &mut txn,
-        &host.bmc_info.ip_addr().unwrap(),
+        &host.id,
         "6.00.30.00",
         "1.2.3",
     )
@@ -739,7 +739,7 @@ async fn test_postingestion_bmc_upgrade(pool: sqlx::PgPool) -> CarbideResult<()>
         "0"
     );
 
-    // Validate update_firmware_version_by_bmc_address behavior
+    // Validate update_firmware_version_by_machine_id behavior
     assert_eq!(
         host.bmc_info.firmware_version,
         Some("6.00.30.00".to_string())
@@ -1607,9 +1607,9 @@ async fn test_instance_upgrading_actual_part_2(
     )
     .await
     .unwrap();
-    db::machine_topology::update_firmware_version_by_bmc_address(
+    db::machine_topology::update_firmware_version_by_machine_id(
         &mut txn,
-        &host.bmc_info.ip_addr().unwrap(),
+        &host.id,
         "6.00.30.00",
         "1.2.3",
     )
@@ -1728,7 +1728,7 @@ async fn test_instance_upgrading_actual_part_2(
 
     txn.commit().await.unwrap();
 
-    // Validate update_firmware_version_by_bmc_address behavior
+    // Validate update_firmware_version_by_machine_id behavior
     assert_eq!(
         host.bmc_info.firmware_version,
         Some("6.00.30.00".to_string())

--- a/crates/api/src/tests/machine_creator.rs
+++ b/crates/api/src/tests/machine_creator.rs
@@ -46,6 +46,23 @@ use crate::tests::common::api_fixtures::dpu::DpuConfig;
 use crate::tests::common::api_fixtures::managed_host::ManagedHostConfig;
 use crate::tests::common::rpc_builder::DhcpDiscovery;
 
+async fn discover_dpu_bmc_ip(
+    env: &common::api_fixtures::TestEnv,
+    bmc_mac_address: MacAddress,
+) -> Result<IpAddr, Box<dyn std::error::Error>> {
+    let response = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder(bmc_mac_address, "192.0.1.1")
+                .vendor_string("NVIDIA/BF/BMC")
+                .tonic_request(),
+        )
+        .await?
+        .into_inner();
+
+    Ok(response.address.parse()?)
+}
+
 #[crate::sqlx_test]
 async fn test_site_explorer_reject_zero_dpu_hosts(
     pool: sqlx::PgPool,
@@ -228,10 +245,11 @@ async fn test_site_explorer_creates_managed_host(
     let host_bmc_ip = addresses.remove(0);
 
     let dpu_report = Arc::new(dpu_report);
+    let dpu_bmc_ip = discover_dpu_bmc_ip(&env, mock_dpu.bmc_mac_address).await?;
     let exploration_report = ExploredManagedHost {
         host_bmc_ip: IpAddr::from_str(&host_bmc_ip)?,
         dpus: vec![ExploredDpu {
-            bmc_ip: IpAddr::from_str(response.address.as_str())?,
+            bmc_ip: dpu_bmc_ip,
             host_pf_mac_address: Some(mock_dpu.host_mac_address),
             report: dpu_report.clone(),
         }],
@@ -280,7 +298,7 @@ async fn test_site_explorer_creates_managed_host(
     );
     assert_eq!(
         dpu_machine.bmc_info.ip.clone().unwrap(),
-        response.address.to_string()
+        dpu_bmc_ip.to_string()
     );
 
     assert_eq!(
@@ -516,7 +534,7 @@ async fn test_site_explorer_creates_managed_host(
         db::machine_topology::find_machine_bmc_pairs_by_machine_id(&mut txn, vec![dpu_machine.id])
             .await?;
     assert_eq!(pairs.len(), 1);
-    assert_eq!(pairs[0].1, Some("192.0.1.4".to_string()));
+    assert_eq!(pairs[0].1, Some(dpu_bmc_ip.to_string()));
 
     let topology = &topologies[&dpu_machine.id][0];
     assert!(topology.topology_update_needed());
@@ -643,7 +661,7 @@ async fn test_site_explorer_creates_multi_dpu_managed_host(
     let mock_host =
         ManagedHostConfig::with_dpus((0..NUM_DPUS).map(|_| DpuConfig::default()).collect());
 
-    for (i, mock_dpu) in mock_host.dpus.iter().enumerate() {
+    for mock_dpu in &mock_host.dpus {
         let oob_mac = mock_dpu.oob_mac_address;
         let response = env
             .api
@@ -665,8 +683,9 @@ async fn test_site_explorer_creates_multi_dpu_managed_host(
         let mut dpu_report: EndpointExplorationReport = mock_dpu.clone().into();
         dpu_report.generate_machine_id(false)?;
         let dpu_report = Arc::new(dpu_report);
+        let dpu_bmc_ip = discover_dpu_bmc_ip(&env, mock_dpu.bmc_mac_address).await?;
         explored_dpus.push(ExploredDpu {
-            bmc_ip: IpAddr::from_str(format!("192.168.1.{i}").as_str())?,
+            bmc_ip: dpu_bmc_ip,
             host_pf_mac_address: Some(mock_dpu.host_mac_address),
             report: dpu_report.clone(),
         })
@@ -929,7 +948,7 @@ async fn test_mi_attach_dpu_if_mi_exists_during_machine_creation(
     let dpu_report = Arc::new(dpu_report);
 
     let explored_dpus = vec![ExploredDpu {
-        bmc_ip: IpAddr::from_str("192.168.1.2")?,
+        bmc_ip: discover_dpu_bmc_ip(&env, mock_dpu.bmc_mac_address).await?,
         host_pf_mac_address: Some(mock_dpu.host_mac_address),
         report: dpu_report.clone(),
     }];
@@ -1039,7 +1058,7 @@ async fn test_mi_attach_dpu_if_mi_created_after_machine_creation(
     let dpu_machine_id = dpu_report.machine_id.unwrap();
 
     let explored_dpus = vec![ExploredDpu {
-        bmc_ip: IpAddr::from_str("192.168.1.2")?,
+        bmc_ip: discover_dpu_bmc_ip(&env, mock_dpu.bmc_mac_address).await?,
         host_pf_mac_address: Some(mock_dpu.host_mac_address),
         report: dpu_report.clone(),
     }];
@@ -1274,10 +1293,11 @@ async fn test_site_explorer_creates_managed_host_with_dpf_disable(
     let host_bmc_ip = addresses.remove(0);
 
     let dpu_report = Arc::new(dpu_report);
+    let dpu_bmc_ip = discover_dpu_bmc_ip(&env, mock_dpu.bmc_mac_address).await?;
     let exploration_report = ExploredManagedHost {
         host_bmc_ip: IpAddr::from_str(&host_bmc_ip)?,
         dpus: vec![ExploredDpu {
-            bmc_ip: IpAddr::from_str(response.address.as_str())?,
+            bmc_ip: dpu_bmc_ip,
             host_pf_mac_address: Some(mock_dpu.host_mac_address),
             report: dpu_report.clone(),
         }],
@@ -1422,10 +1442,11 @@ async fn test_site_explorer_creates_managed_host_with_dpf_enabled(
     let host_bmc_ip = addresses.remove(0);
 
     let dpu_report = Arc::new(dpu_report);
+    let dpu_bmc_ip = discover_dpu_bmc_ip(&env, mock_dpu.bmc_mac_address).await?;
     let exploration_report = ExploredManagedHost {
         host_bmc_ip: IpAddr::from_str(&host_bmc_ip)?,
         dpus: vec![ExploredDpu {
-            bmc_ip: IpAddr::from_str(response.address.as_str())?,
+            bmc_ip: dpu_bmc_ip,
             host_pf_mac_address: Some(mock_dpu.host_mac_address),
             report: dpu_report.clone(),
         }],

--- a/crates/api/src/tests/machine_interfaces.rs
+++ b/crates/api/src/tests/machine_interfaces.rs
@@ -19,7 +19,9 @@ use std::borrow::Borrow;
 use std::collections::HashSet;
 use std::str::FromStr;
 
-use common::api_fixtures::{FIXTURE_DHCP_RELAY_ADDRESS, create_test_env};
+use common::api_fixtures::{
+    FIXTURE_DHCP_RELAY_ADDRESS, create_managed_host_with_config, create_test_env,
+};
 use db::dhcp_entry::DhcpEntry;
 use db::{self};
 use itertools::Itertools;
@@ -27,6 +29,7 @@ use mac_address::MacAddress;
 use model::address_selection_strategy::AddressSelectionStrategy;
 use model::machine::MachineInterfaceSnapshot;
 use model::machine::machine_id::from_hardware_info;
+use model::machine_interface::InterfaceType;
 use model::machine_interface_address::MachineInterfaceAssociation;
 use rpc::forge::InterfaceSearchQuery;
 use rpc::forge::forge_server::Forge;
@@ -585,6 +588,146 @@ async fn test_delete_bmc_interface_with_machine(
             }
         }
     }
+}
+
+#[crate::sqlx_test]
+async fn machine_bmc_info_uses_bmc_interface_and_interfaces_exclude_it(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let host_config = env.managed_host_config();
+    let host_bmc_mac = host_config.bmc_mac_address;
+    let dpu_bmc_mac = host_config.get_and_assert_single_dpu().bmc_mac_address;
+    let managed_host = create_managed_host_with_config(&env, host_config).await;
+
+    let mut txn = pool.begin().await?;
+    let host_machine = managed_host.host().db_machine(&mut txn).await;
+    let dpu_machine = managed_host.dpu().db_machine(&mut txn).await;
+    let interfaces = db::machine_interface::find_all(&mut txn).await?;
+
+    let host_bmc_interface = interfaces
+        .iter()
+        .find(|interface| {
+            interface.machine_id == Some(host_machine.id)
+                && interface.interface_type == InterfaceType::Bmc
+        })
+        .expect("host BMC interface must exist");
+    let host_bmc_interface_id = host_bmc_interface.id;
+    let host_bmc_interface_mac = host_bmc_interface.mac_address;
+    let host_bmc_interface_ip = host_bmc_interface
+        .addresses
+        .first()
+        .expect("host BMC interface must have an address")
+        .to_string();
+    assert_eq!(host_bmc_interface_mac, host_bmc_mac);
+
+    let dpu_bmc_interface = interfaces
+        .iter()
+        .find(|interface| {
+            interface.machine_id == Some(dpu_machine.id)
+                && interface.interface_type == InterfaceType::Bmc
+        })
+        .expect("DPU BMC interface must exist");
+    let dpu_bmc_interface_id = dpu_bmc_interface.id;
+    let dpu_bmc_interface_mac = dpu_bmc_interface.mac_address;
+    let dpu_bmc_interface_ip = dpu_bmc_interface
+        .addresses
+        .first()
+        .expect("DPU BMC interface must have an address")
+        .to_string();
+    assert_eq!(dpu_bmc_interface_mac, dpu_bmc_mac);
+
+    assert_eq!(
+        host_machine.bmc_info.machine_interface_id,
+        Some(host_bmc_interface_id)
+    );
+    assert_eq!(host_machine.bmc_info.mac, Some(host_bmc_interface_mac));
+    assert_eq!(
+        host_machine.bmc_info.ip.as_deref(),
+        Some(host_bmc_interface_ip.as_str())
+    );
+    assert!(
+        host_machine
+            .interfaces
+            .iter()
+            .all(|interface| interface.interface_type != InterfaceType::Bmc
+                && interface.id != host_bmc_interface_id)
+    );
+
+    assert_eq!(
+        dpu_machine.bmc_info.machine_interface_id,
+        Some(dpu_bmc_interface_id)
+    );
+    assert_eq!(dpu_machine.bmc_info.mac, Some(dpu_bmc_interface_mac));
+    assert_eq!(
+        dpu_machine.bmc_info.ip.as_deref(),
+        Some(dpu_bmc_interface_ip.as_str())
+    );
+    assert!(
+        dpu_machine
+            .interfaces
+            .iter()
+            .all(|interface| interface.interface_type != InterfaceType::Bmc
+                && interface.id != dpu_bmc_interface_id)
+    );
+
+    txn.commit().await?;
+
+    let host_rpc_machine = managed_host.host().rpc_machine().await;
+    let dpu_rpc_machine = managed_host.dpu().rpc_machine().await;
+    let rpc_bmc_type = rpc::forge::InterfaceType::Bmc as i32;
+    let host_bmc_interface_mac = host_bmc_interface_mac.to_string();
+    let dpu_bmc_interface_mac = dpu_bmc_interface_mac.to_string();
+
+    let host_bmc_info = host_rpc_machine
+        .bmc_info
+        .as_ref()
+        .expect("host RPC BMC info must exist");
+    assert_eq!(
+        host_bmc_info.machine_interface_id,
+        Some(host_bmc_interface_id)
+    );
+    assert_eq!(
+        host_bmc_info.mac.as_deref(),
+        Some(host_bmc_interface_mac.as_str())
+    );
+    assert_eq!(
+        host_bmc_info.ip.as_deref(),
+        Some(host_bmc_interface_ip.as_str())
+    );
+    assert!(
+        host_rpc_machine
+            .interfaces
+            .iter()
+            .all(|interface| interface.interface_type != Some(rpc_bmc_type)
+                && interface.id != Some(host_bmc_interface_id))
+    );
+
+    let dpu_bmc_info = dpu_rpc_machine
+        .bmc_info
+        .as_ref()
+        .expect("DPU RPC BMC info must exist");
+    assert_eq!(
+        dpu_bmc_info.machine_interface_id,
+        Some(dpu_bmc_interface_id)
+    );
+    assert_eq!(
+        dpu_bmc_info.mac.as_deref(),
+        Some(dpu_bmc_interface_mac.as_str())
+    );
+    assert_eq!(
+        dpu_bmc_info.ip.as_deref(),
+        Some(dpu_bmc_interface_ip.as_str())
+    );
+    assert!(
+        dpu_rpc_machine
+            .interfaces
+            .iter()
+            .all(|interface| interface.interface_type != Some(rpc_bmc_type)
+                && interface.id != Some(dpu_bmc_interface_id))
+    );
+
+    Ok(())
 }
 
 #[crate::sqlx_test]

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -1481,30 +1481,40 @@ async fn test_disable_machine_creation_outside_site_explorer(
 async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
     let env = common::api_fixtures::create_test_env(pool.clone()).await;
 
-    const HOST1_DPU_MAC: &str = "B8:3F:D2:90:97:A6";
-    const HOST1_MAC: &str = "AA:AB:AC:AD:AA:02";
+    const HOST1_DPU_BMC_MAC: &str = "B8:3F:D2:90:97:A6";
+    const HOST1_BMC_MAC: &str = "AA:AB:AC:AD:AA:02";
     const HOST1_DPU_SERIAL_NUMBER: &str = "host1_dpu_serial_number";
 
-    let mut host1_dpu = FakeMachine::new(HOST1_DPU_MAC, "Vendor1", env.underlay_segment.unwrap());
+    let mut host1_dpu_bmc = FakeMachine::new(
+        HOST1_DPU_BMC_MAC,
+        "NVIDIA/BF/BMC",
+        env.underlay_segment.unwrap(),
+    );
 
-    let mut host1 = FakeMachine::new(HOST1_MAC, "Vendor2", env.underlay_segment.unwrap());
+    let mut host1_bmc = FakeMachine::new(HOST1_BMC_MAC, "Vendor2", env.underlay_segment.unwrap());
 
     // Create dhcp entries and machine_interface entries for the machines
-    for machine in [&mut host1_dpu, &mut host1] {
+    for machine in [&mut host1_dpu_bmc, &mut host1_bmc] {
         machine.discover_dhcp(&env).await?;
     }
     let endpoint_explorer = Arc::new(MockEndpointExplorer::default());
 
     // Create a host and dpu reports && host has no dpu_serial
+    let host1_dpu_report = DpuConfig {
+        serial: HOST1_DPU_SERIAL_NUMBER.to_string(),
+        bmc_mac_address: HOST1_DPU_BMC_MAC.parse()?,
+        ..Default::default()
+    };
+    let host1_report = ManagedHostConfig {
+        bmc_mac_address: HOST1_BMC_MAC.parse()?,
+        ..Default::default()
+    };
     endpoint_explorer.insert_endpoint_results(vec![
         (
-            host1_dpu.ip.parse().unwrap(),
-            Ok(DpuConfig::with_serial(HOST1_DPU_SERIAL_NUMBER.to_string()).into()),
+            host1_dpu_bmc.ip.parse().unwrap(),
+            Ok(host1_dpu_report.into()),
         ),
-        (
-            host1.ip.parse().unwrap(),
-            Ok(ManagedHostConfig::default().into()),
-        ),
+        (host1_bmc.ip.parse().unwrap(), Ok(host1_report.into())),
     ]);
 
     let explorer_config = SiteExplorerConfig {
@@ -1564,7 +1574,7 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
         &mut txn,
         ExpectedMachine {
             id: None,
-            bmc_mac_address: HOST1_MAC.to_string().parse().unwrap(),
+            bmc_mac_address: HOST1_BMC_MAC.to_string().parse().unwrap(),
             data: ExpectedMachineData {
                 bmc_username: "user1".to_string(),
                 bmc_password: "pw".to_string(),
@@ -1614,7 +1624,7 @@ async fn test_fallback_dpu_serial(pool: sqlx::PgPool) -> Result<(), Box<dyn std:
     // Now update expected_machine entry with fallback_dpu_serial
     let mut txn = env.pool.begin().await?;
     let mut host1_expected_machine =
-        db::expected_machine::find_by_bmc_mac_address(txn.as_mut(), HOST1_MAC.parse().unwrap())
+        db::expected_machine::find_by_bmc_mac_address(txn.as_mut(), HOST1_BMC_MAC.parse().unwrap())
             .await?
             .expect("Expected machine not found");
     host1_expected_machine.data = ExpectedMachineData {
@@ -1848,7 +1858,7 @@ async fn test_fetch_host_primary_interface_mac(
             .api
             .discover_dhcp(
                 DhcpDiscovery::builder(oob_mac, "192.0.1.1")
-                    .vendor_string("NVIDIA/OOB")
+                    .vendor_string("NVIDIA/BF/BMC")
                     .tonic_request(),
             )
             .await
@@ -2507,30 +2517,40 @@ async fn test_machine_creation_with_sku(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = common::api_fixtures::create_test_env(pool.clone()).await;
 
-    const HOST1_DPU_MAC: &str = "B8:3F:D2:90:97:A6";
-    const HOST1_MAC: &str = "AA:AB:AC:AD:AA:02";
+    const HOST1_DPU_BMC_MAC: &str = "B8:3F:D2:90:97:A6";
+    const HOST1_BMC_MAC: &str = "AA:AB:AC:AD:AA:02";
     const HOST1_DPU_SERIAL_NUMBER: &str = "host1_dpu_serial_number";
 
-    let mut host1_dpu = FakeMachine::new(HOST1_DPU_MAC, "Vendor1", env.underlay_segment.unwrap());
+    let mut host1_dpu_bmc = FakeMachine::new(
+        HOST1_DPU_BMC_MAC,
+        "NVIDIA/BF/BMC",
+        env.underlay_segment.unwrap(),
+    );
 
-    let mut host1 = FakeMachine::new(HOST1_MAC, "Vendor2", env.underlay_segment.unwrap());
+    let mut host1_bmc = FakeMachine::new(HOST1_BMC_MAC, "Vendor2", env.underlay_segment.unwrap());
 
     // Create dhcp entries and machine_interface entries for the machines
-    for machine in [&mut host1_dpu, &mut host1] {
+    for machine in [&mut host1_dpu_bmc, &mut host1_bmc] {
         machine.discover_dhcp(&env).await?;
     }
     let endpoint_explorer = Arc::new(MockEndpointExplorer::default());
 
     // Create a host and dpu reports && host has no dpu_serial
+    let host1_dpu_report = DpuConfig {
+        serial: HOST1_DPU_SERIAL_NUMBER.to_string(),
+        bmc_mac_address: HOST1_DPU_BMC_MAC.parse()?,
+        ..Default::default()
+    };
+    let host1_report = ManagedHostConfig {
+        bmc_mac_address: HOST1_BMC_MAC.parse()?,
+        ..Default::default()
+    };
     endpoint_explorer.insert_endpoint_results(vec![
         (
-            host1_dpu.ip.parse().unwrap(),
-            Ok(DpuConfig::with_serial(HOST1_DPU_SERIAL_NUMBER.to_string()).into()),
+            host1_dpu_bmc.ip.parse().unwrap(),
+            Ok(host1_dpu_report.into()),
         ),
-        (
-            host1.ip.parse().unwrap(),
-            Ok(ManagedHostConfig::default().into()),
-        ),
+        (host1_bmc.ip.parse().unwrap(), Ok(host1_report.into())),
     ]);
 
     let explorer_config = SiteExplorerConfig {
@@ -2590,7 +2610,7 @@ async fn test_machine_creation_with_sku(
         &mut txn,
         ExpectedMachine {
             id: None,
-            bmc_mac_address: HOST1_MAC.to_string().parse().unwrap(),
+            bmc_mac_address: HOST1_BMC_MAC.to_string().parse().unwrap(),
             data: ExpectedMachineData {
                 bmc_username: "user1".to_string(),
                 bmc_password: "pw".to_string(),

--- a/crates/api/src/web/interface.rs
+++ b/crates/api/src/web/interface.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use askama::Template;
@@ -38,6 +38,7 @@ struct InterfaceShow {
 
 struct InterfaceRowDisplay {
     id: String,
+    interface_type: String,
     mac_address: String,
     ip_address: String,
     machine_id: String,
@@ -50,6 +51,11 @@ impl From<forgerpc::MachineInterface> for InterfaceRowDisplay {
     fn from(mi: forgerpc::MachineInterface) -> Self {
         Self {
             id: mi.id.unwrap_or_default().to_string(),
+            interface_type: if mi.interface_type == Some(forgerpc::InterfaceType::Bmc as i32) {
+                "BMC".to_string()
+            } else {
+                "Data".to_string()
+            },
             mac_address: mi.mac_address,
             ip_address: mi.address.join(","),
             machine_id: mi
@@ -139,50 +145,7 @@ async fn fetch_machine_interfaces(
     out.interfaces
         .sort_unstable_by(|iface1, iface2| iface1.hostname.cmp(&iface2.hostname));
 
-    enrich_bmc_machine_ids(&api.database_connection, &mut out.interfaces).await;
-
     Ok(out.interfaces)
-}
-
-/// Resolve BMC IP → machine_id from `machine_topologies` and stamp it onto
-/// unlinked interfaces for display purposes only. No DB writes.
-async fn enrich_bmc_machine_ids(
-    pool: &sqlx::PgPool,
-    interfaces: &mut [forgerpc::MachineInterface],
-) {
-    let candidate_ips: Vec<String> = interfaces
-        .iter()
-        .filter(|i| i.machine_id.is_none() && i.attached_dpu_machine_id.is_none())
-        .flat_map(|i| i.address.iter().cloned())
-        .collect();
-
-    if candidate_ips.is_empty() {
-        return;
-    }
-
-    let pairs = match db::machine_topology::find_machine_bmc_pairs(pool, candidate_ips).await {
-        Ok(pairs) => pairs,
-        Err(err) => {
-            tracing::warn!(%err, "find_machine_bmc_pairs error during BMC interface enrichment");
-            return;
-        }
-    };
-
-    let bmc_ip_to_machine: HashMap<String, _> =
-        pairs.into_iter().map(|(mid, ip)| (ip, mid)).collect();
-
-    for interface in interfaces.iter_mut() {
-        if interface.machine_id.is_some() || interface.attached_dpu_machine_id.is_some() {
-            continue;
-        }
-        for ip in &interface.address {
-            if let Some(&machine_id) = bmc_ip_to_machine.get(ip) {
-                interface.is_bmc = Some(true);
-                interface.machine_id = Some(machine_id);
-                break;
-            }
-        }
-    }
 }
 
 #[derive(Template)]
@@ -241,7 +204,7 @@ impl From<forgerpc::MachineInterface> for InterfaceDetail {
             last_dhcp: last_dhcp
                 .map(|d| d.format("%F %T %Z").to_string())
                 .unwrap_or_default(),
-            is_bmc: mi.is_bmc.unwrap_or(false),
+            is_bmc: mi.interface_type == Some(forgerpc::InterfaceType::Bmc as i32),
         }
     }
 }

--- a/crates/api/templates/interface_show.html
+++ b/crates/api/templates/interface_show.html
@@ -9,6 +9,7 @@
 	<thead>
 	<tr>
 		<th>ID</th>
+		<th>Type</th>
 		<th>MAC Address</th>
 		<th>IP Address</th>
 		<th>Machine ID</th>
@@ -21,6 +22,7 @@
 	{% for iface in interfaces %}
 		<tr>
 			<td><a href="/admin/interface/{{ iface.id }}">{{ iface.id }}</a></td>
+			<td>{{ iface.interface_type }}</td>
 			<td>{{ iface.mac_address }}</td>
 			<td>{{ iface.ip_address }}</td>
 			<td>{{ iface.machine_id|machine_id_link|safe }}</td>

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -3197,6 +3197,7 @@ message BmcInfo {
   optional string version = 3;
   optional string firmware_version = 4;
   optional uint32 port = 5;
+  optional common.MachineInterfaceId machine_interface_id = 6;
 }
 
 message Machine {
@@ -3478,6 +3479,11 @@ enum InterfaceAssociationType {
   POWERSHELF = 3;
 }
 
+enum InterfaceType {
+  INTERFACE_TYPE_DATA = 0;
+  INTERFACE_TYPE_BMC = 1;
+}
+
 message MachineInterface {
   common.MachineInterfaceId id = 1;
   optional common.MachineId attached_dpu_machine_id = 2;
@@ -3497,11 +3503,12 @@ message MachineInterface {
   google.protobuf.Timestamp created = 11;
   optional google.protobuf.Timestamp last_dhcp = 12;
 
-  optional bool is_bmc = 13;
+  optional bool is_bmc = 13 [deprecated = true];
   optional common.PowerShelfId power_shelf_id = 14;
   optional common.SwitchId switch_id = 15;
 
   optional InterfaceAssociationType association_type = 16;
+  optional InterfaceType interface_type = 17;
 }
 
 // Infiniband interface status description

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -45,6 +45,7 @@ use model::expected_entity::ExpectedEntity;
 use model::expected_power_shelf::ExpectedPowerShelf;
 use model::machine::MachineInterfaceSnapshot;
 use model::machine::machine_search_config::MachineSearchConfig;
+use model::machine_interface::InterfaceType;
 use model::power_shelf::{NewPowerShelf, PowerShelfConfig};
 use model::resource_pool::common::CommonPools;
 use model::site_explorer::{
@@ -1441,7 +1442,8 @@ impl SiteExplorer {
         let underlay_interfaces: Vec<MachineInterfaceSnapshot> = interfaces
             .into_iter()
             .filter(|iface| {
-                underlay_segments.contains(&iface.segment_id) && iface.machine_id.is_none()
+                underlay_segments.contains(&iface.segment_id)
+                    && (iface.machine_id.is_none() || iface.interface_type == InterfaceType::Bmc)
             })
             .collect();
 
@@ -1684,13 +1686,20 @@ impl SiteExplorer {
                 && let Some(bmc_version) = report.versions.get(&FirmwareComponentType::Bmc)
                 && let Some(uefi_version) = report.versions.get(&FirmwareComponentType::Uefi)
             {
-                db::machine_topology::update_firmware_version_by_bmc_address(
-                    &mut txn,
-                    &address,
-                    bmc_version,
-                    uefi_version,
-                )
-                .await?;
+                let machine_id = match report.machine_id.as_ref().copied() {
+                    Some(machine_id) => Some(machine_id),
+                    None => db::machine::find_id_by_bmc_ip(&mut txn, &address).await?,
+                };
+
+                if let Some(machine_id) = machine_id {
+                    db::machine_topology::update_firmware_version_by_machine_id(
+                        &mut txn,
+                        &machine_id,
+                        bmc_version,
+                        uefi_version,
+                    )
+                    .await?;
+                }
             }
 
             match endpoint.last_explored {

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -625,7 +625,12 @@ impl MachineCreator {
         )
         .await?;
 
-        db::bmc_metadata::update_bmc_network_into_topologies(txn, machine_id, &bmc_info).await?;
+        db::bmc_metadata::update_bmc_network_into_machine_interfaces(
+            txn,
+            machine_id,
+            &mut bmc_info,
+        )
+        .await?;
 
         Ok(())
     }


### PR DESCRIPTION
## Description

So far we stored only the regular Machine to NIC relations in machine_interfaces. The BMC information was stored separately in relation machine_topologies.

This came with some downside: When an operator purely looked at a MachineInterface object, they had no knowledge on whether it was used by any BMC. The `machine_id` field was empty.

With this change, this changes:
- The `machine_interface` that is used as a machines BMC will have the `machine_id` stored.
- To distinguish BMCs from other network interfaces, the table has a new column `interface_type`. This is either set o `Network`  or `Bmc`.
- Migrations populate the link from existing machine_topologies data.
- For new Machines the assocation will be made during ingestion.
- On the `model::Machine` object as well as for RPC Machine objects, the 2 different types of interfaces are kept separate: `interfaces` represents non-bmc interfaces, while `bmc_info` references the bmc interface.

## Type of Change

- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

#925 

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

