### PR TITLE
feat(api): Move network definitions to initial_objects_file

### DIFF
--- a/crates/api-db/migrations/20260508100000_network_definition.sql
+++ b/crates/api-db/migrations/20260508100000_network_definition.sql
@@ -1,0 +1,7 @@
+-- Snapshot of the `NetworkDefinition` used to seed each network segment.
+-- Written once, when a network is first seeded.
+CREATE TABLE network_def (
+    name        TEXT PRIMARY KEY,
+    definition  JSONB NOT NULL,
+    seeded_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/crates/api-db/migrations/20260508100000_network_definition.sql
+++ b/crates/api-db/migrations/20260508100000_network_definition.sql
@@ -1,7 +1,10 @@
 -- Snapshot of the `NetworkDefinition` used to seed each network segment.
--- Written once, when a network is first seeded.
+-- Written once, when a network is first seeded. The segment_id link with
+-- ON DELETE CASCADE so the snapshot is dropped automatically when the segment
+-- is deleted.
 CREATE TABLE network_def (
     name        TEXT PRIMARY KEY,
+    segment_id  UUID NOT NULL UNIQUE REFERENCES network_segments(id) ON DELETE CASCADE,
     definition  JSONB NOT NULL,
     seeded_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/crates/api-db/src/network_segment.rs
+++ b/crates/api-db/src/network_segment.rs
@@ -28,8 +28,8 @@ use lazy_static::lazy_static;
 use model::address_selection_strategy::AddressSelectionStrategy;
 use model::controller_outcome::PersistentStateHandlerOutcome;
 use model::network_segment::{
-    NetworkSegment, NetworkSegmentControllerState, NetworkSegmentSearchConfig, NetworkSegmentType,
-    NewNetworkSegment,
+    NetworkDefinition, NetworkSegment, NetworkSegmentControllerState, NetworkSegmentSearchConfig,
+    NetworkSegmentType, NewNetworkSegment,
 };
 use sqlx::{PgConnection, PgTransaction};
 
@@ -264,7 +264,142 @@ pub async fn list_segment_ids(
 
     Ok(results)
 }
+/// Fetch the stored definition for a single network, or `None` if never seeded.
+pub async fn stored_def(
+    txn: impl DbReader<'_>,
+    name: &str,
+) -> Result<Option<NetworkDefinition>, DatabaseError> {
+    let query = "SELECT definition FROM network_def WHERE name = $1";
+    let row: Option<(sqlx::types::Json<NetworkDefinition>,)> = sqlx::query_as(query)
+        .bind(name)
+        .fetch_optional(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+    Ok(row.map(|(json,)| json.0))
+}
 
+/// Fetch every stored network definition as a `HashMap<name, def>`.
+pub async fn all_stored_defs(
+    txn: impl DbReader<'_>,
+) -> Result<HashMap<String, NetworkDefinition>, DatabaseError> {
+    let query = "SELECT name, definition FROM network_def";
+    let rows: Vec<(String, sqlx::types::Json<NetworkDefinition>)> = sqlx::query_as(query)
+        .fetch_all(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+    Ok(rows
+        .into_iter()
+        .map(|(name, json)| (name, json.0))
+        .collect())
+}
+
+/// Insert the `NetworkDefinition` snapshot for a network that has never been
+/// seeded. Callers must check with `stored_def` / `all_stored_defs` before
+/// calling this, and skip the insert when a snapshot is present.
+pub async fn insert_network_def(
+    txn: &mut PgConnection,
+    name: &str,
+    def: &NetworkDefinition,
+) -> Result<(), DatabaseError> {
+    let query = "INSERT INTO network_def (name, definition, seeded_at) VALUES ($1, $2, NOW())";
+    let definition = serde_json::to_value(def).map_err(|e| {
+        DatabaseError::InvalidArgument(format!(
+            "NetworkDefinition: {def:?} could not be serialized to JSON: {e}"
+        ))
+    })?;
+
+    sqlx::query(query)
+        .bind(name)
+        .bind(definition)
+        .execute(&mut *txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+    Ok(())
+}
+
+pub async fn segment_exists(txn: &mut PgConnection, name: &str) -> Result<bool, DatabaseError> {
+    let query = "SELECT EXISTS(SELECT 1 FROM network_segments WHERE name = $1)";
+    let (exists,): (bool,) = sqlx::query_as(query)
+        .bind(name)
+        .fetch_one(&mut *txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+    Ok(exists)
+}
+
+/// Reconcile declared network definitions against what was previously seeded.
+///
+///   1. **New** (no snapshot, no segment): no-op. The caller's
+///      segment-creation path is responsible for both creating the segment
+///      and writing the snapshot.
+///   2. **Backfill** (no snapshot, segment present): record the snapshot.
+///   3. **In sync** (snapshot matches declaration): no-op.
+///   4. **Drift** (snapshot differs from declaration, segment present):
+///      warn and leave both in place. Operator must reconcile by hand.
+///   5. **Anomaly** (snapshot present, segment absent): error-log and skip.
+///      Indicates a partial restore or manual deletion.
+///
+/// Networks that appear in the snapshot table but are no longer declared
+/// ("dropped" from `InitialObjectsConfig.networks`) are warned about, but
+/// not removed.
+pub async fn reconcile_network_defs(
+    txn: &mut PgConnection,
+    declared: &HashMap<String, NetworkDefinition>,
+) -> Result<(), DatabaseError> {
+    let stored = all_stored_defs(&mut *txn).await?;
+
+    for (name, def) in declared {
+        let exists = segment_exists(&mut *txn, name).await?;
+        match (stored.get(name), exists) {
+            // Snapshot exists but network segment is missing from network_segments.
+            // Anomaly: e.g. partial DB restore.  Don't auto-heal - operator must reconcile by hand
+            (Some(stored_def), false) => {
+                tracing::error!(
+                    network_name = name,
+                    stored = ?stored_def,
+                    "NetworkDefinition snapshot exists but network_segments has no rows for it; \
+                     manual recovery required"
+                );
+            }
+            // Already seeded with the current declaration
+            (Some(stored_def), true) if stored_def == def => {}
+            // Declaration has drifted since seed. Warn don't reapply
+            (Some(stored_def), true) => {
+                tracing::warn!(
+                    network_name = name,
+                    stored = ?stored_def,
+                    declared = ?def,
+                    "NetworkDefinition has changed since it was seeded; not re-applying"
+                );
+            }
+            // Network segment exists, but has no snapshot yet.
+            // Pre-migration deployment or a network was re-added after a snapshot was
+            // manually deleted.  Record the snapshot only
+            (None, true) => {
+                insert_network_def(txn, name, def).await?;
+                tracing::info!(
+                    network_name = name,
+                    "Backfilled NetworkDefinition snapshot for pre-existing network segment"
+                );
+            }
+            // New networks are seeded by the caller (`create_initial_networks`),
+            // which both expands the definition into a `NewNetworkSegment` and
+            // writes the snapshot in the same transaction.
+            (None, false) => {}
+        }
+    }
+
+    for name in stored.keys() {
+        if !declared.contains_key(name) {
+            tracing::warn!(
+                network_name = name,
+                "Network segment exists in database but is no longer declared in any config file"
+            );
+        }
+    }
+
+    Ok(())
+}
 pub async fn find_ids(
     txn: impl DbReader<'_>,
     filter: model::network_segment::NetworkSegmentSearchFilter,
@@ -699,4 +834,206 @@ pub async fn allocate_svi_ip(
         kind: "prefix",
         id: value.id.to_string(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use model::network_segment::NetworkDefinitionSegmentType;
+
+    use super::*;
+
+    // Insert just enough into `network_segments` to make
+    // `segment_exists(name)` all other columns have DEFAULTs;
+    // only `version` is VARCHAR(64) NOT NULL with no default, so we
+    // supply a placeholder.
+    async fn minimum_segment_data(pool: &sqlx::PgPool, name: &str) -> Result<(), sqlx::Error> {
+        sqlx::query("INSERT INTO network_segments (name, version) VALUES ($1, 'V1-T0')")
+            .bind(name)
+            .execute(pool)
+            .await?;
+        Ok(())
+    }
+    // A brand-new network is declared but no segment exists yet and no
+    // snapshot has been recorded.
+    // (`create_initial_networks`) is responsible for inserting both the
+    // segment and the snapshot in the same transaction.
+    #[crate::sqlx_test]
+    async fn test_reconcile_network_defs_brand_new_is_noop(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let def = NetworkDefinition {
+            segment_type: NetworkDefinitionSegmentType::Admin,
+            prefix: "192.168.1.0/24".to_string(),
+            gateway: "192.168.1.1".to_string(),
+            mtu: 1500,
+            reserve_first: 5,
+            allocation_strategy: Default::default(),
+        };
+
+        let mut txn = pool.begin().await?;
+        let declared: HashMap<String, NetworkDefinition> = [("brand-new".to_string(), def.clone())]
+            .into_iter()
+            .collect();
+
+        reconcile_network_defs(&mut txn, &declared).await?;
+
+        // Reconcile must not have written a snapshot for the brand-new entry.
+        let stored = stored_def(txn.as_mut(), "brand-new").await?;
+        assert!(
+            stored.is_none(),
+            "reconcile must leave brand-new networks alone; \
+             snapshot insertion is the caller's responsibility"
+        );
+
+        // And must not have created a network_segments row either.
+        assert!(
+            !segment_exists(&mut txn, "brand-new").await?,
+            "reconcile must not create a network_segments row for a brand-new network"
+        );
+
+        txn.rollback().await?;
+        Ok(())
+    }
+
+    // Test-only constructor for a `NetworkDefinition` with sensible defaults
+    fn def(prefix: &str, gateway: &str) -> NetworkDefinition {
+        NetworkDefinition {
+            segment_type: NetworkDefinitionSegmentType::Admin,
+            prefix: prefix.to_string(),
+            gateway: gateway.to_string(),
+            mtu: 1500,
+            reserve_first: 3,
+            allocation_strategy: Default::default(),
+        }
+    }
+
+    fn declared_one(name: &str, def: NetworkDefinition) -> HashMap<String, NetworkDefinition> {
+        [(name.to_string(), def)].into_iter().collect()
+    }
+
+    // A segment row exists in `network_segments` but has no `network_def`
+    // snapshot
+    // Reconcile must record the snapshot without re-creating the segment.
+    #[crate::sqlx_test]
+    async fn reconcile_network_defs_backfills_existing_segment(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        minimum_segment_data(&pool, "pre-existing").await?;
+
+        let mut txn = pool.begin().await?;
+        let def = def("192.168.1.0/24", "192.168.1.1");
+
+        reconcile_network_defs(&mut txn, &declared_one("pre-existing", def.clone())).await?;
+
+        let stored = stored_def(txn.as_mut(), "pre-existing").await?;
+        assert_eq!(stored.as_ref(), Some(&def), "snapshot must be backfilled");
+        txn.rollback().await?;
+        Ok(())
+    }
+
+    // Segment + snapshot both already exist and match the declaration
+    #[crate::sqlx_test]
+    async fn reconcile_network_defs_in_sync_is_noop(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        minimum_segment_data(&pool, "stable").await?;
+
+        let mut txn = pool.begin().await?;
+        let def = def("192.168.1.0/24", "192.168.1.1");
+        insert_network_def(&mut txn, "stable", &def).await?;
+
+        reconcile_network_defs(&mut txn, &declared_one("stable", def.clone())).await?;
+
+        let stored = stored_def(txn.as_mut(), "stable").await?;
+        assert_eq!(
+            stored.as_ref(),
+            Some(&def),
+            "in-sync snapshot must be left untouched",
+        );
+        txn.rollback().await?;
+        Ok(())
+    }
+
+    // Segment + snapshot exist, but the declared definition has drifted
+    // since seed. Reconcile must warn and leave the stored snapshot alone,
+    // not silently reapply the new declaration.
+    #[crate::sqlx_test]
+    async fn reconcile_network_defs_drift_does_not_apply(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        minimum_segment_data(&pool, "drifty").await?;
+
+        let mut txn = pool.begin().await?;
+        let original = def("192.168.1.0/24", "192.168.168.1");
+        let drifted = def("10.0.0.0/24", "10.0.0.1");
+        insert_network_def(&mut txn, "drifty", &original).await?;
+
+        reconcile_network_defs(&mut txn, &declared_one("drifty", drifted.clone())).await?;
+
+        let stored = stored_def(txn.as_mut(), "drifty").await?;
+        assert_eq!(
+            stored.as_ref(),
+            Some(&original),
+            "drift path must not overwrite the stored snapshot",
+        );
+        txn.rollback().await?;
+        Ok(())
+    }
+
+    // Snapshot exists, but no segment row — indicates a partial restore or
+    // manual deletion. Reconcile must error.
+    #[crate::sqlx_test]
+    async fn reconcile_network_defs_snapshot_without_segment_logs_error(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut txn = pool.begin().await?;
+        let def = def("192.168.1.0/24", "192.168.1.1");
+        insert_network_def(&mut txn, "orphan-snapshot", &def).await?;
+
+        reconcile_network_defs(&mut txn, &declared_one("orphan-snapshot", def.clone())).await?;
+
+        // Snapshot is preserved; no segment was created in recovery.
+        let stored = stored_def(txn.as_mut(), "orphan-snapshot").await?;
+        assert_eq!(
+            stored.as_ref(),
+            Some(&def),
+            "anomaly path must leave the snapshot alone",
+        );
+        assert!(
+            !segment_exists(&mut txn, "orphan-snapshot").await?,
+            "anomaly path must not auto-create a network_segments row",
+        );
+        txn.rollback().await?;
+        Ok(())
+    }
+
+    // A snapshot exists for a network that is no longer mentioned in any
+    // declared config — typical of an operator removing the definition.
+    // Reconcile must warn but not delete the snapshot
+    #[crate::sqlx_test]
+    async fn reconcile_network_defs_dropped_declaration_is_orphaned(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        minimum_segment_data(&pool, "abandoned").await?;
+
+        let mut txn = pool.begin().await?;
+        let def = def("192.168.1.0/24", "192.168.1.1");
+        insert_network_def(&mut txn, "abandoned", &def).await?;
+
+        let empty: HashMap<String, NetworkDefinition> = HashMap::new();
+        reconcile_network_defs(&mut txn, &empty).await?;
+
+        let stored = stored_def(txn.as_mut(), "abandoned").await?;
+        assert_eq!(
+            stored.as_ref(),
+            Some(&def),
+            "dropped declarations must not be deleted from network_def",
+        );
+        assert!(
+            segment_exists(&mut txn, "abandoned").await?,
+            "dropped declarations must not be deleted from network_segments",
+        );
+        txn.rollback().await?;
+        Ok(())
+    }
 }

--- a/crates/api-db/src/network_segment.rs
+++ b/crates/api-db/src/network_segment.rs
@@ -293,15 +293,19 @@ pub async fn all_stored_defs(
         .collect())
 }
 
-/// Insert the `NetworkDefinition` snapshot for a network that has never been
-/// seeded. Callers must check with `stored_def` / `all_stored_defs` before
-/// calling this, and skip the insert when a snapshot is present.
+/// Insert the `NetworkDefinition` snapshot for a network that has never
+/// been seeded. Callers must check with `stored_def` / `all_stored_defs`
+/// before calling this, and skip the insert when a snapshot is present.
+///
+/// `segment_id` must reference an existing row in `network_segments`.
 pub async fn insert_network_def(
     txn: &mut PgConnection,
     name: &str,
+    segment_id: NetworkSegmentId,
     def: &NetworkDefinition,
 ) -> Result<(), DatabaseError> {
-    let query = "INSERT INTO network_def (name, definition, seeded_at) VALUES ($1, $2, NOW())";
+    let query = "INSERT INTO network_def (name, segment_id, definition, seeded_at) \
+                 VALUES ($1, $2, $3, NOW())";
     let definition = serde_json::to_value(def).map_err(|e| {
         DatabaseError::InvalidArgument(format!(
             "NetworkDefinition: {def:?} could not be serialized to JSON: {e}"
@@ -310,6 +314,7 @@ pub async fn insert_network_def(
 
     sqlx::query(query)
         .bind(name)
+        .bind(segment_id)
         .bind(definition)
         .execute(&mut *txn)
         .await
@@ -319,12 +324,11 @@ pub async fn insert_network_def(
 
 pub async fn segment_exists(txn: &mut PgConnection, name: &str) -> Result<bool, DatabaseError> {
     let query = "SELECT EXISTS(SELECT 1 FROM network_segments WHERE name = $1)";
-    let (exists,): (bool,) = sqlx::query_as(query)
+    sqlx::query_scalar(query)
         .bind(name)
         .fetch_one(&mut *txn)
         .await
-        .map_err(|e| DatabaseError::query(query, e))?;
-    Ok(exists)
+        .map_err(|e| DatabaseError::query(query, e))
 }
 
 /// Reconcile declared network definitions against what was previously seeded.
@@ -332,12 +336,11 @@ pub async fn segment_exists(txn: &mut PgConnection, name: &str) -> Result<bool, 
 ///   1. **New** (no snapshot, no segment): no-op. The caller's
 ///      segment-creation path is responsible for both creating the segment
 ///      and writing the snapshot.
-///   2. **Backfill** (no snapshot, segment present): record the snapshot.
+///   2. **Backfill** (no snapshot, segment present): record the snapshot,
+///      linking it to the existing segment's id.
 ///   3. **In sync** (snapshot matches declaration): no-op.
 ///   4. **Drift** (snapshot differs from declaration, segment present):
 ///      warn and leave both in place. Operator must reconcile by hand.
-///   5. **Anomaly** (snapshot present, segment absent): error-log and skip.
-///      Indicates a partial restore or manual deletion.
 ///
 /// Networks that appear in the snapshot table but are no longer declared
 /// ("dropped" from `InitialObjectsConfig.networks`) are warned about, but
@@ -351,16 +354,6 @@ pub async fn reconcile_network_defs(
     for (name, def) in declared {
         let exists = segment_exists(&mut *txn, name).await?;
         match (stored.get(name), exists) {
-            // Snapshot exists but network segment is missing from network_segments.
-            // Anomaly: e.g. partial DB restore.  Don't auto-heal - operator must reconcile by hand
-            (Some(stored_def), false) => {
-                tracing::error!(
-                    network_name = name,
-                    stored = ?stored_def,
-                    "NetworkDefinition snapshot exists but network_segments has no rows for it; \
-                     manual recovery required"
-                );
-            }
             // Already seeded with the current declaration
             (Some(stored_def), true) if stored_def == def => {}
             // Declaration has drifted since seed. Warn don't reapply
@@ -373,19 +366,45 @@ pub async fn reconcile_network_defs(
                 );
             }
             // Network segment exists, but has no snapshot yet.
-            // Pre-migration deployment or a network was re-added after a snapshot was
-            // manually deleted.  Record the snapshot only
+            // Pre-migration deployment or a network was re-added after a
+            // snapshot was manually deleted.
+            //
+            // TOML-declared names are unique by nature, but
+            // `network_segments.name` has no UNIQUE constraint at the DB
+            // layer — multiple segments can share a name. If we
+            // see more than one match, we can't tell which one the
+            // operator originally seeded, so we skip the backfill and
+            // log; the operator can resolve by inserting `network_def`
+            // by hand.
             (None, true) => {
-                insert_network_def(txn, name, def).await?;
-                tracing::info!(
-                    network_name = name,
-                    "Backfilled NetworkDefinition snapshot for pre-existing network segment"
-                );
+                let query = "SELECT id FROM network_segments WHERE name = $1 LIMIT 2";
+                let candidates: Vec<NetworkSegmentId> = sqlx::query_scalar(query)
+                    .bind(name)
+                    .fetch_all(&mut *txn)
+                    .await
+                    .map_err(|e| DatabaseError::query(query, e))?;
+                if let [segment_id] = candidates.as_slice() {
+                    insert_network_def(txn, name, *segment_id, def).await?;
+                    tracing::info!(
+                        network_name = name,
+                        "Backfilled NetworkDefinition snapshot for pre-existing network segment"
+                    );
+                } else {
+                    tracing::warn!(
+                        network_name = name,
+                        count = candidates.len(),
+                        "Backfill skipped: multiple network_segments share this name; \
+                         operator must reconcile by hand",
+                    );
+                }
             }
             // New networks are seeded by the caller (`create_initial_networks`),
             // which both expands the definition into a `NewNetworkSegment` and
             // writes the snapshot in the same transaction.
             (None, false) => {}
+            (Some(_), false) => {
+                unreachable!("network_def.segment_id is FK; snapshot cannot outlive its segment")
+            }
         }
     }
 
@@ -843,15 +862,17 @@ mod tests {
     use super::*;
 
     // Insert just enough into `network_segments` to make
-    // `segment_exists(name)` all other columns have DEFAULTs;
-    // only `version` is VARCHAR(64) NOT NULL with no default, so we
-    // supply a placeholder.
-    async fn minimum_segment_data(pool: &sqlx::PgPool, name: &str) -> Result<(), sqlx::Error> {
-        sqlx::query("INSERT INTO network_segments (name, version) VALUES ($1, 'V1-T0')")
-            .bind(name)
-            .execute(pool)
-            .await?;
-        Ok(())
+    // `segment_exists(name)` return true;
+    async fn minimum_segment_data(
+        pool: &sqlx::PgPool,
+        name: &str,
+    ) -> Result<NetworkSegmentId, sqlx::Error> {
+        sqlx::query_scalar(
+            "INSERT INTO network_segments (name, version) VALUES ($1, 'V1-T0') RETURNING id",
+        )
+        .bind(name)
+        .fetch_one(pool)
+        .await
     }
     // A brand-new network is declared but no segment exists yet and no
     // snapshot has been recorded.
@@ -936,11 +957,11 @@ mod tests {
     async fn reconcile_network_defs_in_sync_is_noop(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        minimum_segment_data(&pool, "stable").await?;
+        let segment_id = minimum_segment_data(&pool, "stable").await?;
 
         let mut txn = pool.begin().await?;
         let def = def("192.168.1.0/24", "192.168.1.1");
-        insert_network_def(&mut txn, "stable", &def).await?;
+        insert_network_def(&mut txn, "stable", segment_id, &def).await?;
 
         reconcile_network_defs(&mut txn, &declared_one("stable", def.clone())).await?;
 
@@ -961,12 +982,12 @@ mod tests {
     async fn reconcile_network_defs_drift_does_not_apply(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        minimum_segment_data(&pool, "drifty").await?;
+        let segment_id = minimum_segment_data(&pool, "drifty").await?;
 
         let mut txn = pool.begin().await?;
         let original = def("192.168.1.0/24", "192.168.168.1");
         let drifted = def("10.0.0.0/24", "10.0.0.1");
-        insert_network_def(&mut txn, "drifty", &original).await?;
+        insert_network_def(&mut txn, "drifty", segment_id, &original).await?;
 
         reconcile_network_defs(&mut txn, &declared_one("drifty", drifted.clone())).await?;
 
@@ -980,33 +1001,6 @@ mod tests {
         Ok(())
     }
 
-    // Snapshot exists, but no segment row — indicates a partial restore or
-    // manual deletion. Reconcile must error.
-    #[crate::sqlx_test]
-    async fn reconcile_network_defs_snapshot_without_segment_logs_error(
-        pool: sqlx::PgPool,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let mut txn = pool.begin().await?;
-        let def = def("192.168.1.0/24", "192.168.1.1");
-        insert_network_def(&mut txn, "orphan-snapshot", &def).await?;
-
-        reconcile_network_defs(&mut txn, &declared_one("orphan-snapshot", def.clone())).await?;
-
-        // Snapshot is preserved; no segment was created in recovery.
-        let stored = stored_def(txn.as_mut(), "orphan-snapshot").await?;
-        assert_eq!(
-            stored.as_ref(),
-            Some(&def),
-            "anomaly path must leave the snapshot alone",
-        );
-        assert!(
-            !segment_exists(&mut txn, "orphan-snapshot").await?,
-            "anomaly path must not auto-create a network_segments row",
-        );
-        txn.rollback().await?;
-        Ok(())
-    }
-
     // A snapshot exists for a network that is no longer mentioned in any
     // declared config — typical of an operator removing the definition.
     // Reconcile must warn but not delete the snapshot
@@ -1014,11 +1008,11 @@ mod tests {
     async fn reconcile_network_defs_dropped_declaration_is_orphaned(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        minimum_segment_data(&pool, "abandoned").await?;
+        let segment_id = minimum_segment_data(&pool, "abandoned").await?;
 
         let mut txn = pool.begin().await?;
         let def = def("192.168.1.0/24", "192.168.1.1");
-        insert_network_def(&mut txn, "abandoned", &def).await?;
+        insert_network_def(&mut txn, "abandoned", segment_id, &def).await?;
 
         let empty: HashMap<String, NetworkDefinition> = HashMap::new();
         reconcile_network_defs(&mut txn, &empty).await?;
@@ -1032,6 +1026,62 @@ mod tests {
         assert!(
             segment_exists(&mut txn, "abandoned").await?,
             "dropped declarations must not be deleted from network_segments",
+        );
+        txn.rollback().await?;
+        Ok(())
+    }
+
+    // Deleting a segment via `final_delete` must cascade-delete its
+    // `network_def` snapshot.
+    #[crate::sqlx_test]
+    async fn final_delete_cascades_to_network_def(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let segment_id = minimum_segment_data(&pool, "doomed").await?;
+
+        // Seed the snapshot in its own committed transaction so it
+        // survives into the next one where we run `final_delete`.
+        let mut txn = pool.begin().await?;
+        let def = def("192.168.1.0/24", "192.168.1.1");
+        insert_network_def(&mut txn, "doomed", segment_id, &def).await?;
+        txn.commit().await?;
+
+        let mut txn = pool.begin().await?;
+        final_delete(segment_id, &mut txn).await?;
+        txn.commit().await?;
+
+        let mut txn = pool.begin().await?;
+        assert!(
+            stored_def(txn.as_mut(), "doomed").await?.is_none(),
+            "deleting a segment must cascade-delete its network_def snapshot",
+        );
+        assert!(
+            !segment_exists(&mut txn, "doomed").await?,
+            "segment row should be gone after final_delete",
+        );
+        Ok(())
+    }
+
+    // `network_segments.name` is not UNIQUE at the DB layer, so two rows
+    // can share a name Reconcile's backfill
+    // path can't tell which one to attach a snapshot to, so it must
+    // skip rather than guess.
+    #[crate::sqlx_test]
+    async fn reconcile_network_defs_skips_backfill_on_duplicate_names(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // Two segments, same name, neither has a snapshot.
+        minimum_segment_data(&pool, "ambiguous").await?;
+        minimum_segment_data(&pool, "ambiguous").await?;
+
+        let mut txn = pool.begin().await?;
+        let def = def("192.168.1.0/24", "192.168.1.1");
+
+        reconcile_network_defs(&mut txn, &declared_one("ambiguous", def.clone())).await?;
+
+        assert!(
+            stored_def(txn.as_mut(), "ambiguous").await?.is_none(),
+            "backfill must skip when multiple segments share the declared name",
         );
         txn.rollback().await?;
         Ok(())

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -1568,6 +1568,8 @@ pub struct InitialObjectsConfig {
     /// Required, but wrapped in `Option` so partial configs
     /// can be deserialized and merged.
     pub pools: Option<HashMap<String, ResourcePoolDef>>,
+    /// Network Segment definitions
+    pub networks: Option<HashMap<String, NetworkDefinition>>,
 }
 
 impl DpaConfig {
@@ -2729,6 +2731,7 @@ mod tests {
     use figment::providers::{Env, Format, Toml};
     use libmlx::variables::value::MlxValueType;
     use libredfish::model::service_root::RedfishVendor;
+    use model::network_segment::NetworkDefinitionSegmentType;
     use model::resource_pool;
 
     use super::*;
@@ -3967,6 +3970,32 @@ firmware_url = "https://firmware.example.com/fw-b.bin"
         let f = PathBuf::from(format!("{TEST_DATA_DIR}/initial_objects.toml"));
         let config: InitialObjectsConfig = Toml::from_path(f.as_path()).unwrap();
         let pools = config.pools.as_ref().unwrap();
+        let networks = config.networks.as_ref().unwrap();
+
+        assert_eq!(
+            networks.get("admin").unwrap(),
+            &NetworkDefinition {
+                segment_type: NetworkDefinitionSegmentType::Admin,
+                prefix: "172.20.0.0/24".to_string(),
+                gateway: "172.20.0.1".to_string(),
+                mtu: 9000,
+                reserve_first: 5,
+                allocation_strategy: Default::default(),
+            }
+        );
+
+        assert_eq!(
+            networks.get("DEV1-C09-IPMI-01").unwrap(),
+            &NetworkDefinition {
+                segment_type: NetworkDefinitionSegmentType::Underlay,
+                prefix: "172.99.0.0/26".to_string(),
+                gateway: "172.99.0.1".to_string(),
+                mtu: 1500,
+                reserve_first: 5,
+                allocation_strategy: Default::default(),
+            }
+        );
+
         assert_eq!(
             pools.get("lo-ip").unwrap(),
             &ResourcePoolDef {

--- a/crates/api/src/cfg/test_data/full_config_post_migration.toml
+++ b/crates/api/src/cfg/test_data/full_config_post_migration.toml
@@ -32,20 +32,6 @@ required_equals = { "IssuerO" = "NVIDIA Corporation", "IssuerCN" = "NVIDIA Forge
 group_from = "SubjectOU"
 username_from = "SubjectCN"
 
-[networks.admin]
-type = "admin"
-prefix = "172.20.0.0/24"
-gateway = "172.20.0.1"
-mtu = 9000
-reserve_first = 5
-
-[networks.DEV1-C09-IPMI-01]
-type = "underlay"
-prefix = "172.99.0.0/26"
-gateway = "172.99.0.1"
-mtu = 1500
-reserve_first = 5
-
 [ib_fabrics.default]
 endpoints = ["https://1.2.3.4"]
 pkeys = [{ start = "1", end = "10" }]

--- a/crates/api/src/cfg/test_data/initial_objects.toml
+++ b/crates/api/src/cfg/test_data/initial_objects.toml
@@ -17,3 +17,18 @@ ranges = [{ start = "1024500", end = "1024550" }]
 [pools.vpc-vni]
 type = "integer"
 ranges = [{ start = "2024500", end = "2024550" }]
+
+[networks.admin]
+type = "admin"
+prefix = "172.20.0.0/24"
+gateway = "172.20.0.1"
+mtu = 9000
+reserve_first = 5
+
+[networks.DEV1-C09-IPMI-01]
+type = "underlay"
+prefix = "172.99.0.0/26"
+gateway = "172.99.0.1"
+mtu = 1500
+reserve_first = 5
+

--- a/crates/api/src/db_init.rs
+++ b/crates/api/src/db_init.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 
 use carbide_network::virtualization::VpcVirtualizationType;
 use db::dns::domain;
+use db::network_segment::reconcile_network_defs;
 use db::vpc::{self};
 use db::{ObjectColumnFilter, Transaction, dpu_agent_upgrade_policy, network_segment};
 use itertools::Itertools;
@@ -82,12 +83,16 @@ pub async fn create_initial_networks(
         return Ok(());
     }
     let domain_id = all_domains[0].id;
+    reconcile_network_defs(&mut txn, networks).await?;
+
     for (name, def) in networks {
         if db::network_segment::find_by_name(&mut txn, name)
             .await
             .is_ok()
         {
-            // Network segments are only created the first time we start carbide-api
+            // Network segments are only created the first time we start carbide-api;
+            // `reconcile_network_defs` above has already recorded the snapshot if
+            // it was missing (the backfill path).
             tracing::debug!("Network segment {name} exists");
             continue;
         }
@@ -95,6 +100,9 @@ pub async fn create_initial_networks(
         ns.can_stretch = Some(true);
         // update_network_segments_svi_ip will take care of allocating svi ip.
         crate::handlers::network_segment::save(api, &mut txn, ns, true, false).await?;
+        // Snapshot the network definition in the same transaction as the network_segment row,
+        // so the two stay consistent across restarts.
+        db::network_segment::insert_network_def(&mut txn, name, def).await?;
         tracing::info!("Created network segment {name}");
     }
 

--- a/crates/api/src/db_init.rs
+++ b/crates/api/src/db_init.rs
@@ -98,11 +98,14 @@ pub async fn create_initial_networks(
         }
         let mut ns = NewNetworkSegment::build_from(name, domain_id, def)?;
         ns.can_stretch = Some(true);
+        // Capture before `save` moves `ns`. `insert_network_def` needs
+        // the id because `network_def.segment_id` is FK-bound to it.
+        let segment_id = ns.id;
         // update_network_segments_svi_ip will take care of allocating svi ip.
         crate::handlers::network_segment::save(api, &mut txn, ns, true, false).await?;
         // Snapshot the network definition in the same transaction as the network_segment row,
         // so the two stay consistent across restarts.
-        db::network_segment::insert_network_def(&mut txn, name, def).await?;
+        db::network_segment::insert_network_def(&mut txn, name, segment_id, def).await?;
         tracing::info!("Created network segment {name}");
     }
 

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -47,6 +47,7 @@ use model::attestation::spdm::VerifierImpl;
 use model::expected_machine::ExpectedMachine;
 use model::ib::DEFAULT_IB_FABRIC_NAME;
 use model::machine::HostHealthConfig;
+use model::network_segment::NetworkDefinition;
 use model::resource_pool::{self, ResourcePoolDef};
 use model::route_server::RouteServerSourceType;
 use opentelemetry::metrics::Meter;
@@ -131,6 +132,16 @@ fn pool_source(figment: Option<&Figment>, name: &str) -> String {
         .unwrap_or_else(|| "carbide-api config".to_string())
 }
 
+/// Given a figment and the name of a network definition, return the human-readable
+/// string describing where the network definition came from.
+fn network_source(figment: Option<&Figment>, name: &str) -> String {
+    figment
+        .and_then(|f| f.find_metadata(&format!("networks.{name}")))
+        .and_then(|m| m.source.as_ref())
+        .map(|source| source.to_string())
+        .unwrap_or_else(|| "carbide-api config".to_string())
+}
+
 /// Determines the authoritative set of resource pool definitions to reconcile
 /// against the database at startup, merging `InitialObjectsConfig.pools`
 /// with the legacy `CarbideConfig.pools` source.
@@ -209,6 +220,80 @@ fn resolve_initial_pools(
                     pool = %name,
                     source = %source,
                     "Resource pool `{name}` is still defined in both {source}. \
+                     Move it into initial_objects_file to silence this warning.",
+                );
+            }
+            Ok(merged)
+        }
+    }
+}
+
+/// Determines the authoritative set of network definitions to reconcile
+/// against the database at startup, merging `InitialObjectsConfig.networks`
+/// with the legacy `CarbideConfig.networks` source.
+fn resolve_initial_networks(
+    carbide_config: &CarbideConfig,
+    initial_objects: Option<&InitialObjectsConfig>,
+) -> eyre::Result<HashMap<String, NetworkDefinition>> {
+    let from_initial_objects = initial_objects.and_then(|io| io.networks.as_ref());
+    let from_carbide_config = carbide_config.networks.as_ref();
+
+    match (from_initial_objects, from_carbide_config) {
+        // No networks are defined anywhere — initial network creation is skipped.
+        (None, None) => Ok(HashMap::new()),
+        // Networks are defined in InitialObjectsConfig.networks
+        (Some(io), None) => Ok(io.clone()),
+        // Networks are defined only in the legacy CarbideConfig.networks
+        (None, Some(cc)) => {
+            for name in cc.keys() {
+                let source = network_source(carbide_config.config_ctx.as_ref(), name);
+                tracing::warn!(
+                    network = %name,
+                    source = %source,
+                    "Network `{name}` is defined in {source}. Defining networks in {source} \
+                     is deprecated; move the definitions into `initial_objects_file`.",
+                );
+            }
+            Ok(cc.clone())
+        }
+        // Networks are defined in both sources.
+        (Some(io), Some(cc)) => {
+            let mut merged = io.clone();
+            let mut conflicts: Vec<String> = vec![];
+            let mut legacy_names: Vec<String> = vec![];
+
+            for (name, legacy_def) in cc {
+                match merged.get(name) {
+                    Some(new_def) if new_def != legacy_def => conflicts.push(name.clone()),
+                    Some(_) => legacy_names.push(name.clone()),
+                    None => {
+                        legacy_names.push(name.clone());
+                        merged.insert(name.clone(), legacy_def.clone());
+                    }
+                }
+            }
+
+            if !conflicts.is_empty() {
+                let conflict_details: Vec<String> = conflicts
+                    .iter()
+                    .map(|name| {
+                        format!(
+                            "`{name}` (in {})",
+                            network_source(carbide_config.config_ctx.as_ref(), name)
+                        )
+                    })
+                    .collect();
+                return Err(eyre::eyre!(
+                    "networks have conflicting definitions {conflict_details:?}. \
+                     Reconcile each network by removing it from one source.",
+                ));
+            }
+            for name in &legacy_names {
+                let source = network_source(carbide_config.config_ctx.as_ref(), name);
+                tracing::warn!(
+                    network = %name,
+                    source = %source,
+                    "Network `{name}` is still defined in {source}. \
                      Move it into initial_objects_file to silence this warning.",
                 );
             }
@@ -418,6 +503,12 @@ pub async fn start_api(
     //
     // Pool reconciliation specifically must happen before `create_common_pools` runs below, because
     // that call queries `resource_pool` and bails if any mandatory pool is missing or empty.
+    //
+    // Resolve initial networks up-front so any configuration conflicts surface
+    // before we touch the database. The actual reconcile/creation runs inside
+    // `initialize_and_start_controllers`.
+    let resolved_networks = resolve_initial_networks(&carbide_config, initial_objects.as_ref())?;
+
     if carbide_config.listen_only {
         tracing::info!(
             "Not populating resource pools or route_servers in database, as listen_only=true"
@@ -634,6 +725,7 @@ pub async fn start_api(
             api_service.clone(),
             meter.clone(),
             ipmi_tool.clone(),
+            resolved_networks,
             cancel_token.clone(),
         )
         .await?;
@@ -673,6 +765,7 @@ pub async fn initialize_and_start_controllers(
     api_service: Arc<Api>,
     meter: Meter,
     ipmi_tool: Arc<dyn IPMITool>,
+    initial_networks: HashMap<String, NetworkDefinition>,
     cancel_token: CancellationToken,
 ) -> eyre::Result<()> {
     let Api {
@@ -775,8 +868,8 @@ pub async fn initialize_and_start_controllers(
         resource_pool_stats: common_pools.pool_stats.clone(),
     });
 
-    if let Some(networks) = carbide_config.networks.as_ref() {
-        db_init::create_initial_networks(&api_service, db_pool, networks).await?;
+    if !initial_networks.is_empty() {
+        db_init::create_initial_networks(&api_service, db_pool, &initial_networks).await?;
     }
 
     if let Some(fnn_config) = carbide_config.fnn.as_ref()
@@ -1185,12 +1278,29 @@ mod tests {
 
     use figment::Figment;
     use figment::providers::{Format, Toml};
+    use model::network_segment::{NetworkDefinition, NetworkDefinitionSegmentType};
     use model::resource_pool::ResourcePoolType;
     use model::resource_pool::define::ResourcePoolDef;
 
-    use super::resolve_initial_pools;
+    use super::{resolve_initial_networks, resolve_initial_pools};
     use crate::cfg::file::{CarbideConfig, InitialObjectsConfig};
 
+    fn carbide_with_networks(
+        networks: Option<HashMap<String, NetworkDefinition>>,
+    ) -> CarbideConfig {
+        let mut cfg: CarbideConfig = Figment::new()
+            .merge(Toml::string(
+                r#"
+               database_url = "postgres://test"
+               listen = "[::]:1081"
+               asn = 1
+            "#,
+            ))
+            .extract()
+            .expect("Unable to extract config");
+        cfg.networks = networks;
+        cfg
+    }
     // Builds a `CarbideConfig` from the smallest valid TOML and overrides
     // the `pools` field. `resolve_initial_pools` only reads `.pools`, so
     // the rest of the config can be defaulted.
@@ -1209,6 +1319,20 @@ mod tests {
         cfg
     }
 
+    fn network_definition(
+        prefix: &str,
+        segment_type: NetworkDefinitionSegmentType,
+    ) -> NetworkDefinition {
+        NetworkDefinition {
+            segment_type,
+            prefix: prefix.to_string(),
+            gateway: "".to_string(),
+            mtu: 0,
+            reserve_first: 0,
+            allocation_strategy: Default::default(),
+        }
+    }
+
     fn ipv4_pool(prefix: &str) -> ResourcePoolDef {
         ResourcePoolDef {
             ranges: Vec::new(),
@@ -1218,6 +1342,12 @@ mod tests {
         }
     }
 
+    fn network_map(entries: &[(&str, NetworkDefinition)]) -> HashMap<String, NetworkDefinition> {
+        entries
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
     fn pool_map(entries: &[(&str, ResourcePoolDef)]) -> HashMap<String, ResourcePoolDef> {
         entries
             .iter()
@@ -1225,15 +1355,23 @@ mod tests {
             .collect()
     }
 
-    fn initial_objects(entries: &[(&str, ResourcePoolDef)]) -> InitialObjectsConfig {
+    fn initial_objects_networks(entries: &[(&str, NetworkDefinition)]) -> InitialObjectsConfig {
+        InitialObjectsConfig {
+            pools: None,
+            networks: Some(network_map(entries)),
+        }
+    }
+
+    fn initial_objects_pools(entries: &[(&str, ResourcePoolDef)]) -> InitialObjectsConfig {
         InitialObjectsConfig {
             pools: Some(pool_map(entries)),
+            networks: None,
         }
     }
 
     // neither source declares pools — operator misconfiguration.
     #[test]
-    fn no_sources_errors() {
+    fn no_pool_sources_errors() {
         let cfg = carbide_with_pools(None);
         let err =
             resolve_initial_pools(&cfg, None).expect_err("missing pools must surface as an error");
@@ -1247,7 +1385,7 @@ mod tests {
     #[test]
     fn initial_objects_only_succeeds() {
         let cfg = carbide_with_pools(None);
-        let io = initial_objects(&[("lo-ip", ipv4_pool("10.0.0.0/24"))]);
+        let io = initial_objects_pools(&[("lo-ip", ipv4_pool("10.0.0.0/24"))]);
 
         let resolved =
             resolve_initial_pools(&cfg, Some(&io)).expect("InitialObjectsConfig-only must succeed");
@@ -1273,7 +1411,7 @@ mod tests {
     #[test]
     fn disjoint_union_returns_all_pools() {
         let cfg = carbide_with_pools(Some(pool_map(&[("legacy-only", ipv4_pool("10.0.1.0/24"))])));
-        let io = initial_objects(&[("new-only", ipv4_pool("10.0.2.0/24"))]);
+        let io = initial_objects_pools(&[("new-only", ipv4_pool("10.0.2.0/24"))]);
 
         let resolved = resolve_initial_pools(&cfg, Some(&io)).expect("disjoint union must succeed");
 
@@ -1288,7 +1426,7 @@ mod tests {
     fn overlap_identical_succeeds() {
         let pool = ipv4_pool("10.0.0.0/24");
         let cfg = carbide_with_pools(Some(pool_map(&[("lo-ip", pool.clone())])));
-        let io = initial_objects(&[("lo-ip", pool.clone())]);
+        let io = initial_objects_pools(&[("lo-ip", pool.clone())]);
 
         let resolved = resolve_initial_pools(&cfg, Some(&io)).expect("identical defs must succeed");
 
@@ -1301,7 +1439,7 @@ mod tests {
     #[test]
     fn overlap_conflict_errors() {
         let cfg = carbide_with_pools(Some(pool_map(&[("lo-ip", ipv4_pool("10.0.0.0/24"))])));
-        let io = initial_objects(&[("lo-ip", ipv4_pool("10.0.0.0/16"))]);
+        let io = initial_objects_pools(&[("lo-ip", ipv4_pool("10.0.0.0/16"))]);
 
         let err = resolve_initial_pools(&cfg, Some(&io)).expect_err("conflicting defs must error");
 
@@ -1319,12 +1457,156 @@ mod tests {
             ("alpha", ipv4_pool("10.0.0.0/24")),
             ("beta", ipv4_pool("10.0.1.0/24")),
         ])));
-        let io = initial_objects(&[
+        let io = initial_objects_pools(&[
             ("alpha", ipv4_pool("10.0.0.0/16")),
             ("beta", ipv4_pool("10.0.1.0/16")),
         ]);
 
         let err = resolve_initial_pools(&cfg, Some(&io)).expect_err("any conflict must error");
+        let msg = err.to_string();
+
+        assert!(msg.contains("alpha"), "expected `alpha` in {msg}");
+        assert!(msg.contains("beta"), "expected `beta` in {msg}");
+    }
+
+    // neither source declares networks — operator misconfiguration.
+    #[test]
+    fn no_network_sources_returns_empty() {
+        let cfg = carbide_with_networks(None);
+        let resolved =
+            resolve_initial_networks(&cfg, None).expect("missing networks must not be an error");
+        assert!(
+            resolved.is_empty(),
+            "no declared networks should produce an empty map"
+        );
+    }
+
+    // only `InitialObjectsConfig.pools` declares pools
+    #[test]
+    fn initial_objects_networks_only_succeeds() {
+        let cfg = carbide_with_networks(None);
+        let io = initial_objects_networks(&[(
+            "network1",
+            network_definition("10.0.0.0/24", NetworkDefinitionSegmentType::Admin),
+        )]);
+
+        let resolved = resolve_initial_networks(&cfg, Some(&io))
+            .expect("InitialObjectsConfig-only must succeed");
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(
+            resolved.get("network1"),
+            Some(&network_definition(
+                "10.0.0.0/24",
+                NetworkDefinitionSegmentType::Admin
+            ))
+        );
+    }
+
+    // only legacy `CarbideConfig.networks` declares networks
+    #[test]
+    fn legacy_only_returns_legacy_networks() {
+        let cfg = carbide_with_networks(Some(network_map(&[(
+            "network1",
+            network_definition("10.0.0.0/24", NetworkDefinitionSegmentType::Admin),
+        )])));
+
+        let resolved = resolve_initial_networks(&cfg, None).expect("legacy-only must succeed");
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(
+            resolved.get("network1"),
+            Some(&network_definition(
+                "10.0.0.0/24",
+                NetworkDefinitionSegmentType::Admin
+            ))
+        );
+    }
+
+    // both sources declare networks but with different names
+    // Resolver returns the union; emits a deprecation warning naming the still-legacy entries.
+    #[test]
+    fn disjoint_union_returns_all_networks() {
+        let cfg = carbide_with_networks(Some(network_map(&[(
+            "legacy-only",
+            network_definition("10.0.1.0/24", NetworkDefinitionSegmentType::Admin),
+        )])));
+        let io = initial_objects_networks(&[(
+            "new-only",
+            network_definition("10.0.2.0/24", NetworkDefinitionSegmentType::Admin),
+        )]);
+
+        let resolved =
+            resolve_initial_networks(&cfg, Some(&io)).expect("disjoint union must succeed");
+
+        assert_eq!(resolved.len(), 2);
+        assert!(resolved.contains_key("legacy-only"));
+        assert!(resolved.contains_key("new-only"));
+    }
+
+    // both sources declare the same network with identical definitions —
+    // Resolver dedupes silently; the still-legacy entry is included in the deprecation warning.
+    #[test]
+    fn overlap_networks_identical_succeeds() {
+        let pool = network_definition("10.0.0.0/24", NetworkDefinitionSegmentType::Admin);
+        let cfg = carbide_with_networks(Some(network_map(&[("network1", pool.clone())])));
+        let io = initial_objects_networks(&[("network1", pool.clone())]);
+
+        let resolved =
+            resolve_initial_networks(&cfg, Some(&io)).expect("identical defs must succeed");
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved.get("network1"), Some(&pool));
+    }
+
+    // both sources declare the same network name but with different definitions —
+    // Resolver must fail loudly so the bad state is fixed before reconcile runs.
+    #[test]
+    fn overlap_networks_conflict_errors() {
+        let cfg = carbide_with_networks(Some(network_map(&[(
+            "network1",
+            network_definition("10.0.0.0/24", NetworkDefinitionSegmentType::Admin),
+        )])));
+        let io = initial_objects_networks(&[(
+            "network1",
+            network_definition("10.0.0.0/16", NetworkDefinitionSegmentType::Admin),
+        )]);
+
+        let err =
+            resolve_initial_networks(&cfg, Some(&io)).expect_err("conflicting defs must error");
+
+        assert!(
+            err.to_string().contains("network1"),
+            "error message should name the conflicting network: {err}"
+        );
+    }
+
+    // every overlap is a conflict — the resolver collects all
+    // bad names so the operator can fixe them
+    #[test]
+    fn collects_all_conflict_network_names() {
+        let cfg = carbide_with_networks(Some(network_map(&[
+            (
+                "alpha",
+                network_definition("10.0.0.0/24", NetworkDefinitionSegmentType::Admin),
+            ),
+            (
+                "beta",
+                network_definition("10.0.1.0/24", NetworkDefinitionSegmentType::Admin),
+            ),
+        ])));
+        let io = initial_objects_networks(&[
+            (
+                "alpha",
+                network_definition("10.0.0.0/16", NetworkDefinitionSegmentType::Admin),
+            ),
+            (
+                "beta",
+                network_definition("10.0.1.0/16", NetworkDefinitionSegmentType::Admin),
+            ),
+        ]);
+
+        let err = resolve_initial_networks(&cfg, Some(&io)).expect_err("any conflict must error");
         let msg = err.to_string();
 
         assert!(msg.contains("alpha"), "expected `alpha` in {msg}");

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 use std::path::Path;
@@ -97,6 +97,10 @@ use crate::state_controller::state_change_emitter::StateChangeEmitterBuilder;
 use crate::state_controller::switch::handler::SwitchStateHandler;
 use crate::state_controller::switch::io::SwitchStateControllerIO;
 use crate::{attestation, db_init, ethernet_virtualization, listener};
+
+/// The resolved set of network declarations passed from `start_api` into
+/// `initialize_and_start_controllers`.
+pub(crate) type NetworkDefinitionSources<'a> = Cow<'a, HashMap<String, NetworkDefinition>>;
 
 /// Parse an `InitialObjectsConfig` file (the file pointed at by
 pub fn parse_initial_objects_config(path: &Path) -> eyre::Result<InitialObjectsConfig> {
@@ -231,18 +235,18 @@ fn resolve_initial_pools(
 /// Determines the authoritative set of network definitions to reconcile
 /// against the database at startup, merging `InitialObjectsConfig.networks`
 /// with the legacy `CarbideConfig.networks` source.
-fn resolve_initial_networks(
-    carbide_config: &CarbideConfig,
-    initial_objects: Option<&InitialObjectsConfig>,
-) -> eyre::Result<HashMap<String, NetworkDefinition>> {
+fn resolve_initial_networks<'a>(
+    carbide_config: &'a CarbideConfig,
+    initial_objects: Option<&'a InitialObjectsConfig>,
+) -> eyre::Result<NetworkDefinitionSources<'a>> {
     let from_initial_objects = initial_objects.and_then(|io| io.networks.as_ref());
     let from_carbide_config = carbide_config.networks.as_ref();
 
     match (from_initial_objects, from_carbide_config) {
         // No networks are defined anywhere — initial network creation is skipped.
-        (None, None) => Ok(HashMap::new()),
+        (None, None) => Ok(Cow::Owned(HashMap::new())),
         // Networks are defined in InitialObjectsConfig.networks
-        (Some(io), None) => Ok(io.clone()),
+        (Some(io), None) => Ok(Cow::Borrowed(io)),
         // Networks are defined only in the legacy CarbideConfig.networks
         (None, Some(cc)) => {
             for name in cc.keys() {
@@ -254,32 +258,30 @@ fn resolve_initial_networks(
                      is deprecated; move the definitions into `initial_objects_file`.",
                 );
             }
-            Ok(cc.clone())
+            Ok(Cow::Borrowed(cc))
         }
         // Networks are defined in both sources.
         (Some(io), Some(cc)) => {
-            let mut merged = io.clone();
-            let mut conflicts: Vec<String> = vec![];
-            let mut legacy_names: Vec<String> = vec![];
-
-            for (name, legacy_def) in cc {
-                match merged.get(name) {
-                    Some(new_def) if new_def != legacy_def => conflicts.push(name.clone()),
-                    Some(_) => legacy_names.push(name.clone()),
-                    None => {
-                        legacy_names.push(name.clone());
-                        merged.insert(name.clone(), legacy_def.clone());
-                    }
-                }
-            }
+            // detect conflicts.
+            let conflicts: Vec<&str> = cc
+                .iter()
+                .filter(|(name, legacy_def)| {
+                    io.get(name.as_str())
+                        .is_some_and(|new_def| new_def != *legacy_def)
+                })
+                .map(|(name, _)| name.as_str())
+                .collect();
 
             if !conflicts.is_empty() {
+                // Each conflicting name is declared in both sources.
+                // Name them both so the operator knows which two files
+                // to compare.
                 let conflict_details: Vec<String> = conflicts
                     .iter()
                     .map(|name| {
                         format!(
-                            "`{name}` (in {})",
-                            network_source(carbide_config.config_ctx.as_ref(), name)
+                            "`{name}` (in initial_objects_file vs {})",
+                            network_source(carbide_config.config_ctx.as_ref(), name),
                         )
                     })
                     .collect();
@@ -288,7 +290,19 @@ fn resolve_initial_networks(
                      Reconcile each network by removing it from one source.",
                 ));
             }
-            for name in &legacy_names {
+
+            // merge legacy-only entries into the result.
+            let mut merged = Cow::Borrowed(io);
+            for (name, legacy_def) in cc {
+                if !io.contains_key(name) {
+                    merged.to_mut().insert(name.clone(), legacy_def.clone());
+                }
+            }
+
+            // Every name in `cc` is still in the deprecated source —
+            // emit one warning per name regardless of whether it was a
+            // legacy-only entry or an identical overlap.
+            for name in cc.keys() {
                 let source = network_source(carbide_config.config_ctx.as_ref(), name);
                 tracing::warn!(
                     network = %name,
@@ -760,12 +774,12 @@ pub async fn start_api(
 ///
 /// All background tasks will be spawned into `join_set`, which can be awaited with
 /// [`JoinSet::join_all`] to wait for them to complete.
-pub async fn initialize_and_start_controllers(
+pub async fn initialize_and_start_controllers<'a>(
     join_set: &mut JoinSet<()>,
     api_service: Arc<Api>,
     meter: Meter,
     ipmi_tool: Arc<dyn IPMITool>,
-    initial_networks: HashMap<String, NetworkDefinition>,
+    initial_networks: NetworkDefinitionSources<'a>,
     cancel_token: CancellationToken,
 ) -> eyre::Result<()> {
     let Api {


### PR DESCRIPTION
At first seed, each network's `NetworkDefinition` is recorded in a new `network_def` table. On subsequent startups, a reconciler compares declared definitions against definitions stored in the table.

Network definitions can now be declared in `InitialObjectsConfig.networks` loaded from the optional `initial_objects_file`. Defining networks inside `carbide-api-site-config.toml` remains supported but is deprecated; a warning is emitted at startup as long as networks remain defined there. Conflicting definitions across the two sources cause `carbide-api` to error and fail to start, with the offending source file named via `Figment` metadata.

What the snapshot captures is the config-time `NetworkDefinition`, not the expanded `NetworkSegment` — segments carry derived state (`id`, `vlan_id`, `vni`, prefixes, ...) that is not included in the configuration file.  Storing only the `NetworkDefinition` keeps the snapshot serializable as JSONB and meaningful to compare against the next startup's declaration.

* Snapshots are stored as JSONB. Operators can run `SELECT name, definition FROM network_def` to inspect what was seeded.
* Snapshots are write-once. `insert_network_def` fails on duplicate name rather than updating; the snapshot records the definition that was originally applied to `network_segments`.
* This provides a solution to the network_segment portion of https://github.com/NVIDIA/infra-controller-core/issues/933





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network definitions can now be configured via initial configuration and persisted in the database, ensuring availability across restarts
  * Configuration validation detects and prevents mismatched network definitions

* **Chores**
  * Added backward compatibility support for legacy network configuration with deprecation warnings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/infra-controller-core/pull/1612)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->