### PR TITLE
feat: Machine identity: Add jwt-svid signing key rotation

### DIFF
--- a/crates/api-db/Cargo.toml
+++ b/crates/api-db/Cargo.toml
@@ -91,7 +91,7 @@ carbide-secrets = { path = "../secrets" }
 lazy_static = { workspace = true }
 carbide-macros = { path = "../macros" }
 carbide-sqlx-testing = { path = "../sqlx-testing" }
-tracing-subscriber = { features = ["env-filter"], workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 ctor = { workspace = true }
 
 [lints]

--- a/crates/api-db/migrations/20260506120000_tenant_identity_signing_key_rotation.sql
+++ b/crates/api-db/migrations/20260506120000_tenant_identity_signing_key_rotation.sql
@@ -1,0 +1,34 @@
+-- JWT signing key rotation: two slots (encrypted + public JSON per slot), overlap / expiry GC.
+-- Replaces flat key_id, algorithm, signing_key_public (PEM), encrypted_signing_key with slotted columns.
+
+CREATE TYPE tenant_identity_current_signing_key_slot_t AS ENUM ('signing_key_1', 'signing_key_2');
+
+ALTER TABLE tenant_identity_config RENAME COLUMN encrypted_signing_key TO encrypted_signing_key_1;
+
+ALTER TABLE tenant_identity_config ADD COLUMN signing_key_public_1 JSONB;
+
+UPDATE tenant_identity_config
+SET signing_key_public_1 = jsonb_build_object(
+    'v', 1,
+    'kid', key_id,
+    'alg', algorithm,
+    'public_pem', signing_key_public::text
+)
+WHERE signing_key_public IS NOT NULL;
+
+ALTER TABLE tenant_identity_config DROP COLUMN signing_key_public;
+ALTER TABLE tenant_identity_config DROP COLUMN key_id;
+ALTER TABLE tenant_identity_config DROP COLUMN algorithm;
+
+-- Either slot may be empty; the active slot must be populated by the application when issuing tokens.
+ALTER TABLE tenant_identity_config ALTER COLUMN signing_key_public_1 DROP NOT NULL;
+ALTER TABLE tenant_identity_config ALTER COLUMN encrypted_signing_key_1 DROP NOT NULL;
+
+ALTER TABLE tenant_identity_config ADD COLUMN signing_key_public_2 JSONB;
+ALTER TABLE tenant_identity_config ADD COLUMN encrypted_signing_key_2 TEXT;
+
+ALTER TABLE tenant_identity_config
+    ADD COLUMN current_signing_key_slot tenant_identity_current_signing_key_slot_t NOT NULL DEFAULT 'signing_key_1';
+
+ALTER TABLE tenant_identity_config ADD COLUMN signing_key_overlap_sec INTEGER;
+ALTER TABLE tenant_identity_config ADD COLUMN non_active_slot_expires_at TIMESTAMPTZ;

--- a/crates/api-db/migrations/20260506120000_tenant_identity_signing_key_rotation.sql
+++ b/crates/api-db/migrations/20260506120000_tenant_identity_signing_key_rotation.sql
@@ -30,5 +30,4 @@ ALTER TABLE tenant_identity_config ADD COLUMN encrypted_signing_key_2 TEXT;
 ALTER TABLE tenant_identity_config
     ADD COLUMN current_signing_key_slot tenant_identity_current_signing_key_slot_t NOT NULL DEFAULT 'signing_key_1';
 
-ALTER TABLE tenant_identity_config ADD COLUMN signing_key_overlap_sec INTEGER;
 ALTER TABLE tenant_identity_config ADD COLUMN non_active_slot_expires_at TIMESTAMPTZ;

--- a/crates/api-db/src/tenant_identity_config.rs
+++ b/crates/api-db/src/tenant_identity_config.rs
@@ -19,24 +19,117 @@
 //! Stores per-org identity config and signing keys in `tenant_identity_config` table.
 
 use carbide_uuid::machine::MachineId;
+use chrono::{Duration as ChronoDuration, Utc};
+use model::tenant::identity_config::SigningKeyPublicV1;
 use model::tenant::{
     EncryptedTokenDelegationAuthConfig, IdentityConfig, SigningKeyMaterial, TenantIdentityConfig,
-    TenantOrganizationId, TokenDelegation, TokenDelegationAuthMethod,
+    TenantIdentityCurrentSigningKeySlot, TenantOrganizationId, TokenDelegation,
+    TokenDelegationAuthMethod,
 };
 use sqlx::PgConnection;
 use sqlx::types::Json;
 
 use crate::{DatabaseError, DatabaseResult};
 
+/// Column expressions for mapping a row into [`TenantIdentityConfig`], optionally qualified
+/// (e.g. `Some("tic")` → `tic.organization_id`, …) for `FROM tenant_identity_config tic` joins.
+fn tenant_identity_row_select_expr(table_alias: Option<&str>) -> String {
+    const COLS: &[&str] = &[
+        "organization_id",
+        "issuer::text AS issuer",
+        "default_audience::text AS default_audience",
+        "allowed_audiences",
+        "token_ttl_sec",
+        "subject_prefix::text AS subject_prefix",
+        "enabled",
+        "created_at",
+        "updated_at",
+        "encrypted_signing_key_1",
+        "encrypted_signing_key_2",
+        "signing_key_public_1",
+        "signing_key_public_2",
+        "current_signing_key_slot",
+        "signing_key_overlap_sec",
+        "non_active_slot_expires_at",
+        "encryption_key_id::text AS encryption_key_id",
+        "token_endpoint::text AS token_endpoint",
+        "auth_method",
+        "encrypted_auth_method_config",
+        "subject_token_audience::text AS subject_token_audience",
+        "token_delegation_created_at",
+    ];
+    let prefix = table_alias.map_or_else(String::new, |a| format!("{a}."));
+    COLS.iter()
+        .map(|c| format!("{prefix}{c}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// After `non_active_slot_expires_at`, clears the non-current slot (public + private ciphertext).
+pub async fn gc_expired_non_active_signing_key(
+    org_id: &TenantOrganizationId,
+    txn: &mut PgConnection,
+) -> DatabaseResult<()> {
+    let Some(row) = find(org_id, txn).await? else {
+        return Ok(());
+    };
+    let Some(expires) = row.non_active_slot_expires_at else {
+        return Ok(());
+    };
+    if expires > Utc::now() {
+        return Ok(());
+    }
+
+    let slot_to_clear = row.current_signing_key_slot.other();
+    let stmt = match slot_to_clear {
+        TenantIdentityCurrentSigningKeySlot::SigningKey1 => {
+            "UPDATE tenant_identity_config SET \
+                signing_key_public_1 = NULL, \
+                encrypted_signing_key_1 = NULL, \
+                non_active_slot_expires_at = NULL, \
+                updated_at = NOW() \
+                WHERE organization_id = $1"
+        }
+        TenantIdentityCurrentSigningKeySlot::SigningKey2 => {
+            "UPDATE tenant_identity_config SET \
+                signing_key_public_2 = NULL, \
+                encrypted_signing_key_2 = NULL, \
+                non_active_slot_expires_at = NULL, \
+                updated_at = NOW() \
+                WHERE organization_id = $1"
+        }
+    };
+    sqlx::query(stmt)
+        .bind(org_id.as_str())
+        .execute(txn)
+        .await
+        .map_err(|e| DatabaseError::query("gc_expired_non_active_signing_key", e))?;
+    Ok(())
+}
+
+fn signing_public_json_from_material(
+    km: &SigningKeyMaterial,
+) -> DatabaseResult<Json<SigningKeyPublicV1>> {
+    let doc = SigningKeyPublicV1::es256_from_public_pem(km.signing_key_public.as_str())
+        .map_err(DatabaseError::InvalidArgument)?;
+    doc.validate().map_err(DatabaseError::InvalidArgument)?;
+    Ok(Json(doc))
+}
+
 /// Set identity config for an org.
-/// When creating new or rotating key, caller must provide `key_material` (generated key pair, encrypted private key, key_id = sha256(public_key)).
+/// When creating new or rotating key, caller must provide `key_material` (generated key pair, encrypted private key).
 /// Caller must ensure tenant exists and global machine-identity is enabled.
+/// `site_signing_key_overlap_default_sec` is used when `config.signing_key_overlap_sec` is `None` to compute
+/// [`non_active_slot_expires_at`] on `rotate_key`.
 pub async fn set(
     org_id: &TenantOrganizationId,
     config: &IdentityConfig,
     key_material: Option<SigningKeyMaterial>,
+    site_signing_key_overlap_default_sec: u32,
     txn: &mut PgConnection,
 ) -> DatabaseResult<TenantIdentityConfig> {
+    gc_expired_non_active_signing_key(org_id, txn).await?;
+
     let allowed: Vec<String> = if config.allowed_audiences.is_empty() {
         vec![config.default_audience.clone()]
     } else {
@@ -48,29 +141,105 @@ pub async fn set(
         .try_into()
         .map_err(|_| DatabaseError::InvalidArgument("token_ttl out of range".into()))?;
 
-    // Bounds validation is done by the handler using site config (token_ttl_min_sec, token_ttl_max_sec).
-
     let existing = find(org_id, &mut *txn).await?;
-    let (key_id, encrypted_key, public_key) = match (&existing, config.rotate_key, key_material) {
+
+    let overlap_for_expiry = match config.signing_key_overlap_sec {
+        None => site_signing_key_overlap_default_sec,
+        Some(v) => u32::try_from(v).map_err(|_| {
+            DatabaseError::InvalidArgument(
+                "signing_key_overlap_sec must be non-negative and fit in u32".into(),
+            )
+        })?,
+    };
+
+    let overlap_i32 = config.signing_key_overlap_sec;
+
+    let (enc1, enc2, pub1, pub2, current_slot, non_active_expires): (
+        Option<_>,
+        Option<_>,
+        Option<_>,
+        Option<_>,
+        TenantIdentityCurrentSigningKeySlot,
+        Option<_>,
+    ) = match (&existing, config.rotate_key, key_material) {
         (None, _, None) | (_, true, None) => {
             return Err(DatabaseError::InvalidArgument(
                 "key_material is required when creating or rotating signing key".into(),
             ));
         }
-        (_, _, Some(km)) => (km.key_id, km.encrypted_signing_key, km.signing_key_public),
+        (Some(ex), true, Some(km)) => {
+            if ex.signing_key_public_1.is_some()
+                && ex.signing_key_public_2.is_some()
+                && ex
+                    .non_active_slot_expires_at
+                    .is_some_and(|t| t > Utc::now())
+            {
+                return Err(DatabaseError::InvalidArgument(
+                    "cannot rotate signing key while the previous key is still in the overlap period"
+                        .into(),
+                ));
+            }
+            let pub_doc = signing_public_json_from_material(&km)?;
+            let new_enc = km.encrypted_signing_key;
+            let other = ex.current_signing_key_slot.other();
+            let expires = Some(Utc::now() + ChronoDuration::seconds(i64::from(overlap_for_expiry)));
+            match other {
+                TenantIdentityCurrentSigningKeySlot::SigningKey1 => (
+                    Some(new_enc),
+                    ex.encrypted_signing_key_2.clone(),
+                    Some(pub_doc),
+                    ex.signing_key_public_2.clone(),
+                    TenantIdentityCurrentSigningKeySlot::SigningKey1,
+                    expires,
+                ),
+                TenantIdentityCurrentSigningKeySlot::SigningKey2 => (
+                    ex.encrypted_signing_key_1.clone(),
+                    Some(new_enc),
+                    ex.signing_key_public_1.clone(),
+                    Some(pub_doc),
+                    TenantIdentityCurrentSigningKeySlot::SigningKey2,
+                    expires,
+                ),
+            }
+        }
+        (None, _, Some(km)) => {
+            let pub_doc = signing_public_json_from_material(&km)?;
+            let new_enc = km.encrypted_signing_key;
+            (
+                Some(new_enc),
+                None,
+                Some(pub_doc),
+                None,
+                TenantIdentityCurrentSigningKeySlot::SigningKey1,
+                None,
+            )
+        }
         (Some(ex), false, None) => (
-            ex.key_id.clone(),
-            ex.encrypted_signing_key.clone(),
-            ex.signing_key_public.clone(),
+            ex.encrypted_signing_key_1.clone(),
+            ex.encrypted_signing_key_2.clone(),
+            ex.signing_key_public_1.clone(),
+            ex.signing_key_public_2.clone(),
+            ex.current_signing_key_slot,
+            ex.non_active_slot_expires_at,
         ),
+        (Some(_), false, Some(_)) => {
+            return Err(DatabaseError::InvalidArgument(
+                "key_material must not be set when rotate_key is false".into(),
+            ));
+        }
     };
 
-    let query = r#"
+    let returning = tenant_identity_row_select_expr(None);
+    let query = format!(
+        r#"
         INSERT INTO tenant_identity_config (
             organization_id, issuer, default_audience, allowed_audiences,
             token_ttl_sec, subject_prefix, enabled, created_at, updated_at,
-            encrypted_signing_key, signing_key_public, key_id, algorithm, encryption_key_id
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW(), $8, $9, $10, $11, $12)
+            encrypted_signing_key_1, encrypted_signing_key_2,
+            signing_key_public_1, signing_key_public_2,
+            current_signing_key_slot, signing_key_overlap_sec, non_active_slot_expires_at,
+            encryption_key_id
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW(), $8, $9, $10, $11, $12, $13, $14, $15)
         ON CONFLICT (organization_id) DO UPDATE SET
             issuer = EXCLUDED.issuer,
             default_audience = EXCLUDED.default_audience,
@@ -79,33 +248,19 @@ pub async fn set(
             subject_prefix = EXCLUDED.subject_prefix,
             enabled = EXCLUDED.enabled,
             updated_at = NOW(),
-            encrypted_signing_key = EXCLUDED.encrypted_signing_key,
-            signing_key_public = EXCLUDED.signing_key_public,
-            key_id = EXCLUDED.key_id,
-            algorithm = EXCLUDED.algorithm,
+            encrypted_signing_key_1 = EXCLUDED.encrypted_signing_key_1,
+            encrypted_signing_key_2 = EXCLUDED.encrypted_signing_key_2,
+            signing_key_public_1 = EXCLUDED.signing_key_public_1,
+            signing_key_public_2 = EXCLUDED.signing_key_public_2,
+            current_signing_key_slot = EXCLUDED.current_signing_key_slot,
+            signing_key_overlap_sec = EXCLUDED.signing_key_overlap_sec,
+            non_active_slot_expires_at = EXCLUDED.non_active_slot_expires_at,
             encryption_key_id = EXCLUDED.encryption_key_id
-        RETURNING organization_id,
-            issuer::text AS issuer,
-            default_audience::text AS default_audience,
-            allowed_audiences,
-            token_ttl_sec,
-            subject_prefix::text AS subject_prefix,
-            enabled,
-            created_at,
-            updated_at,
-            encrypted_signing_key,
-            signing_key_public::text AS signing_key_public,
-            key_id::text AS key_id,
-            algorithm,
-            encryption_key_id::text AS encryption_key_id,
-            token_endpoint::text AS token_endpoint,
-            auth_method,
-            encrypted_auth_method_config,
-            subject_token_audience::text AS subject_token_audience,
-            token_delegation_created_at
-    "#;
+        RETURNING {returning}
+    "#
+    );
 
-    sqlx::query_as(query)
+    sqlx::query_as(&query)
         .bind(org_id.as_str())
         .bind(&config.issuer)
         .bind(&config.default_audience)
@@ -113,67 +268,78 @@ pub async fn set(
         .bind(token_ttl_i32)
         .bind(&config.subject_prefix)
         .bind(config.enabled)
-        .bind(&encrypted_key)
-        .bind(&public_key)
-        .bind(&key_id)
-        .bind(config.algorithm)
+        .bind(enc1)
+        .bind(enc2)
+        .bind(pub1)
+        .bind(pub2)
+        .bind(current_slot)
+        .bind(overlap_i32)
+        .bind(non_active_expires)
         .bind(&config.encryption_key_id)
         .fetch_one(txn)
         .await
-        .map_err(|e| DatabaseError::query(query, e))
+        .map_err(|e| DatabaseError::query(&query, e))
 }
 
 pub async fn find(
     org_id: &TenantOrganizationId,
     txn: &mut PgConnection,
 ) -> DatabaseResult<Option<TenantIdentityConfig>> {
-    let query = "SELECT organization_id, \
-        issuer::text AS issuer, default_audience::text AS default_audience, allowed_audiences, token_ttl_sec, \
-        subject_prefix::text AS subject_prefix, enabled, created_at, updated_at, encrypted_signing_key, \
-        signing_key_public::text AS signing_key_public, key_id::text AS key_id, algorithm, \
-        encryption_key_id::text AS encryption_key_id, token_endpoint::text AS token_endpoint, auth_method, \
-        encrypted_auth_method_config, subject_token_audience::text AS subject_token_audience, \
-        token_delegation_created_at FROM tenant_identity_config WHERE organization_id = $1";
-    sqlx::query_as(query)
+    let select_list = tenant_identity_row_select_expr(None);
+    let query =
+        format!("SELECT {select_list} FROM tenant_identity_config WHERE organization_id = $1");
+    sqlx::query_as(&query)
         .bind(org_id.as_str())
         .fetch_optional(txn)
         .await
-        .map_err(|e| DatabaseError::query(query, e))
+        .map_err(|e| DatabaseError::query(&query, e))
 }
 
 pub async fn find_by_machine_id(
     txn: &mut PgConnection,
     machine_id: &MachineId,
 ) -> DatabaseResult<TenantIdentityConfig> {
-    const QUERY: &str = r#"
-SELECT tic.organization_id,
-    tic.issuer::text AS issuer,
-    tic.default_audience::text AS default_audience,
-    tic.allowed_audiences,
-    tic.token_ttl_sec,
-    tic.subject_prefix::text AS subject_prefix,
-    tic.enabled,
-    tic.created_at,
-    tic.updated_at,
-    tic.encrypted_signing_key,
-    tic.signing_key_public::text AS signing_key_public,
-    tic.key_id::text AS key_id,
-    tic.algorithm,
-    tic.encryption_key_id::text AS encryption_key_id,
-    tic.token_endpoint::text AS token_endpoint,
-    tic.auth_method,
-    tic.encrypted_auth_method_config,
-    tic.subject_token_audience::text AS subject_token_audience,
-    tic.token_delegation_created_at
+    const ORG_FOR_GC: &str = r#"
+SELECT tic.organization_id::text
 FROM tenant_identity_config tic
 INNER JOIN instances i ON tic.organization_id = i.tenant_org
 WHERE i.machine_id = $1 AND i.deleted IS NULL AND tic.enabled = true
 "#;
-    let row = sqlx::query_as::<_, TenantIdentityConfig>(QUERY)
+    if let Some(org_raw) = sqlx::query_scalar::<_, String>(ORG_FOR_GC)
         .bind(machine_id)
         .fetch_optional(&mut *txn)
         .await
-        .map_err(|e| DatabaseError::query(QUERY, e))?;
+        .map_err(|e| DatabaseError::query(ORG_FOR_GC, e))?
+    {
+        match org_raw.parse::<TenantOrganizationId>() {
+            Ok(oid) => {
+                gc_expired_non_active_signing_key(&oid, txn).await?;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    %machine_id,
+                    organization_id = %org_raw,
+                    error = %e,
+                    "tenant_identity_config.organization_id from join failed TenantOrganizationId parse; skipping non-active signing key GC"
+                );
+            }
+        }
+    }
+
+    let select_list = tenant_identity_row_select_expr(Some("tic"));
+    let query = format!(
+        r#"
+SELECT {select_list}
+FROM tenant_identity_config tic
+INNER JOIN instances i ON tic.organization_id = i.tenant_org
+WHERE i.machine_id = $1 AND i.deleted IS NULL AND tic.enabled = true
+"#
+    );
+    let row = sqlx::query_as::<_, TenantIdentityConfig>(&query)
+        .bind(machine_id)
+        .fetch_optional(&mut *txn)
+        .await
+        .map_err(|e| DatabaseError::query(&query, e))?;
     let Some(cfg) = row else {
         return Err(DatabaseError::NotFoundError {
             kind: "machine_identity",
@@ -193,33 +359,18 @@ pub async fn set_token_delegation(
     encrypted_auth_method_config: &EncryptedTokenDelegationAuthConfig,
     txn: &mut PgConnection,
 ) -> DatabaseResult<TenantIdentityConfig> {
-    let query = r#"
+    let returning = tenant_identity_row_select_expr(None);
+    let query = format!(
+        r#"
         UPDATE tenant_identity_config
         SET token_endpoint = $2, auth_method = $3, encrypted_auth_method_config = $4,
             subject_token_audience = $5, updated_at = NOW(),
             token_delegation_created_at = COALESCE(token_delegation_created_at, NOW())
         WHERE organization_id = $1
-        RETURNING organization_id,
-            issuer::text AS issuer,
-            default_audience::text AS default_audience,
-            allowed_audiences,
-            token_ttl_sec,
-            subject_prefix::text AS subject_prefix,
-            enabled,
-            created_at,
-            updated_at,
-            encrypted_signing_key,
-            signing_key_public::text AS signing_key_public,
-            key_id::text AS key_id,
-            algorithm,
-            encryption_key_id::text AS encryption_key_id,
-            token_endpoint::text AS token_endpoint,
-            auth_method,
-            encrypted_auth_method_config,
-            subject_token_audience::text AS subject_token_audience,
-            token_delegation_created_at
-    "#;
-    let row = sqlx::query_as::<_, TenantIdentityConfig>(query)
+        RETURNING {returning}
+    "#
+    );
+    let row = sqlx::query_as(&query)
         .bind(org_id.as_str())
         .bind(&config.token_endpoint)
         .bind(auth_method)
@@ -227,7 +378,7 @@ pub async fn set_token_delegation(
         .bind(Some(config.subject_token_audience.as_str()))
         .fetch_optional(txn)
         .await
-        .map_err(|e| DatabaseError::query(query, e))?;
+        .map_err(|e| DatabaseError::query(&query, e))?;
     row.ok_or_else(|| DatabaseError::NotFoundError {
         kind: "tenant_identity_config",
         id: org_id.as_str().to_string(),
@@ -249,36 +400,21 @@ pub async fn delete_token_delegation(
     org_id: &TenantOrganizationId,
     txn: &mut PgConnection,
 ) -> DatabaseResult<Option<TenantIdentityConfig>> {
-    let query = r#"
+    let returning = tenant_identity_row_select_expr(None);
+    let query = format!(
+        r#"
         UPDATE tenant_identity_config
         SET token_endpoint = NULL, auth_method = NULL, encrypted_auth_method_config = NULL,
             subject_token_audience = NULL, token_delegation_created_at = NULL, updated_at = NOW()
         WHERE organization_id = $1
-        RETURNING organization_id,
-            issuer::text AS issuer,
-            default_audience::text AS default_audience,
-            allowed_audiences,
-            token_ttl_sec,
-            subject_prefix::text AS subject_prefix,
-            enabled,
-            created_at,
-            updated_at,
-            encrypted_signing_key,
-            signing_key_public::text AS signing_key_public,
-            key_id::text AS key_id,
-            algorithm,
-            encryption_key_id::text AS encryption_key_id,
-            token_endpoint::text AS token_endpoint,
-            auth_method,
-            encrypted_auth_method_config,
-            subject_token_audience::text AS subject_token_audience,
-            token_delegation_created_at
-    "#;
-    sqlx::query_as(query)
+        RETURNING {returning}
+    "#
+    );
+    sqlx::query_as(&query)
         .bind(org_id.as_str())
         .fetch_optional(txn)
         .await
-        .map_err(|e| DatabaseError::query(query, e))
+        .map_err(|e| DatabaseError::query(&query, e))
 }
 
 #[cfg(test)]
@@ -289,7 +425,8 @@ mod tests {
     use model::metadata::Metadata;
     use model::tenant::identity_config::SigningAlgorithm;
     use model::tenant::{
-        IdentityConfig, TokenDelegation, TokenDelegationAuthMethod, TokenDelegationAuthMethodConfig,
+        IdentityConfig, KeyId, TokenDelegation, TokenDelegationAuthMethod,
+        TokenDelegationAuthMethodConfig,
     };
 
     use super::*;
@@ -320,6 +457,15 @@ mod tests {
         }
     }
 
+    fn placeholder_key_material() -> SigningKeyMaterial {
+        let pem = "PLACEHOLDER_PUBLIC_KEY";
+        SigningKeyMaterial {
+            key_id: KeyId::from_public_key_material(pem),
+            encrypted_signing_key: "PLACEHOLDER_ENCRYPTED_KEY".parse().unwrap(),
+            signing_key_public: pem.parse().unwrap(),
+        }
+    }
+
     #[crate::sqlx_test]
     async fn test_tenant_identity_config_set_find_delete(pool: sqlx::PgPool) {
         let mut txn = pool.begin().await.unwrap();
@@ -336,14 +482,11 @@ mod tests {
             rotate_key: false,
             algorithm: SigningAlgorithm::Es256,
             encryption_key_id: "test-master".parse().unwrap(),
+            signing_key_overlap_sec: None,
         };
 
-        let key_material = SigningKeyMaterial {
-            key_id: "test-key-id".parse().unwrap(),
-            encrypted_signing_key: "PLACEHOLDER_ENCRYPTED_KEY".parse().unwrap(),
-            signing_key_public: "PLACEHOLDER_PUBLIC_KEY".parse().unwrap(),
-        };
-        let cfg = set(&org_id, &config, Some(key_material), &mut txn)
+        let key_material = placeholder_key_material();
+        let cfg = set(&org_id, &config, Some(key_material), 3600, &mut txn)
             .await
             .unwrap();
         assert_eq!(cfg.issuer.as_str(), "https://issuer.example.com");
@@ -352,8 +495,12 @@ mod tests {
         assert_eq!(cfg.token_ttl_sec, 3600);
         assert_eq!(cfg.subject_prefix, "spiffe://issuer.example.com/org-x");
         assert!(cfg.enabled);
-        assert_eq!(cfg.algorithm, SigningAlgorithm::Es256);
         assert_eq!(cfg.encryption_key_id.as_str(), "test-master");
+        assert_eq!(
+            cfg.current_signing_key_slot,
+            TenantIdentityCurrentSigningKeySlot::SigningKey1
+        );
+        assert!(cfg.signing_key_public_1.is_some());
 
         let found = find(&org_id, &mut txn).await.unwrap().unwrap();
         assert_eq!(found.issuer, cfg.issuer);
@@ -362,9 +509,8 @@ mod tests {
         assert_eq!(found.token_ttl_sec, cfg.token_ttl_sec);
         assert_eq!(found.subject_prefix, cfg.subject_prefix);
         assert_eq!(found.enabled, cfg.enabled);
-        assert_eq!(found.algorithm, cfg.algorithm);
         assert_eq!(found.encryption_key_id, cfg.encryption_key_id);
-        assert_eq!(found.key_id, cfg.key_id);
+        assert_eq!(found.current_signing_key_slot, cfg.current_signing_key_slot);
 
         let deleted = delete(&org_id, &mut txn).await.unwrap();
         assert!(deleted);
@@ -389,13 +535,10 @@ mod tests {
             rotate_key: false,
             algorithm: SigningAlgorithm::Es256,
             encryption_key_id: "test-master".parse().unwrap(),
+            signing_key_overlap_sec: None,
         };
-        let key_material = SigningKeyMaterial {
-            key_id: "test-key-id".parse().unwrap(),
-            encrypted_signing_key: "PLACEHOLDER_ENCRYPTED_KEY".parse().unwrap(),
-            signing_key_public: "PLACEHOLDER_PUBLIC_KEY".parse().unwrap(),
-        };
-        set(&org_id, &config, Some(key_material), &mut txn)
+        let key_material = placeholder_key_material();
+        set(&org_id, &config, Some(key_material), 3600, &mut txn)
             .await
             .unwrap();
 

--- a/crates/api-db/src/tenant_identity_config.rs
+++ b/crates/api-db/src/tenant_identity_config.rs
@@ -19,7 +19,7 @@
 //! Stores per-org identity config and signing keys in `tenant_identity_config` table.
 
 use carbide_uuid::machine::MachineId;
-use chrono::{Duration as ChronoDuration, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use model::tenant::identity_config::SigningKeyPublicV1;
 use model::tenant::{
     EncryptedTokenDelegationAuthConfig, IdentityConfig, SigningKeyMaterial, TenantIdentityConfig,
@@ -64,10 +64,29 @@ fn tenant_identity_row_select_expr(table_alias: Option<&str>) -> String {
         .join(", ")
 }
 
+/// `FROM` / `JOIN` / `WHERE` for [`find_by_machine_id`]. Macro so the GC org scalar query and the
+/// main `SELECT` share one definition (`concat!` cannot reference `const` str slices).
+macro_rules! tenant_identity_find_by_machine_id_clause {
+    () => {
+        r"
+FROM tenant_identity_config tic
+INNER JOIN instances i ON tic.organization_id = i.tenant_org
+WHERE i.machine_id = $1 AND i.deleted IS NULL AND tic.enabled = true"
+    };
+}
+
 /// After `non_active_slot_expires_at`, clears the non-current slot (public + private ciphertext).
 pub async fn gc_expired_non_active_signing_key(
     org_id: &TenantOrganizationId,
     txn: &mut PgConnection,
+) -> DatabaseResult<()> {
+    gc_expired_non_active_signing_key_at(org_id, txn, Utc::now()).await
+}
+
+async fn gc_expired_non_active_signing_key_at(
+    org_id: &TenantOrganizationId,
+    txn: &mut PgConnection,
+    now: DateTime<Utc>,
 ) -> DatabaseResult<()> {
     let Some(row) = find(org_id, txn).await? else {
         return Ok(());
@@ -75,7 +94,7 @@ pub async fn gc_expired_non_active_signing_key(
     let Some(expires) = row.non_active_slot_expires_at else {
         return Ok(());
     };
-    if expires > Utc::now() {
+    if expires > now {
         return Ok(());
     }
 
@@ -115,6 +134,44 @@ fn signing_public_json_from_material(
     Ok(Json(doc))
 }
 
+/// Refuses rotation only when signing-slot metadata is inconsistent with
+/// [`gc_expired_non_active_signing_key_at`] invariants.
+fn ensure_rotation_allowed_for_existing(
+    ex: &TenantIdentityConfig,
+    now: DateTime<Utc>,
+) -> DatabaseResult<()> {
+    let both_public = ex.signing_key_public_1.is_some() && ex.signing_key_public_2.is_some();
+    if both_public {
+        let Some(expires_at) = ex.non_active_slot_expires_at else {
+            return Err(DatabaseError::InvalidArgument(
+                "cannot rotate signing key: both JWKS public key slots are populated but \
+                 non_active_slot_expires_at is NULL (inconsistent tenant_identity_config state)"
+                    .into(),
+            ));
+        };
+        if expires_at <= now {
+            return Err(DatabaseError::InvalidArgument(
+                "cannot rotate signing key: overlap period has ended but both JWKS public key slots are \
+                 still populated (inconsistent tenant_identity_config state after GC; retry the request \
+                 or repair the row)"
+                    .into(),
+            ));
+        }
+        return Ok(());
+    }
+    if ex
+        .non_active_slot_expires_at
+        .is_some_and(|expires_at| expires_at > now)
+    {
+        return Err(DatabaseError::InvalidArgument(
+            "cannot rotate signing key: non_active_slot_expires_at is in the future but only one \
+             JWKS public key slot is populated (inconsistent tenant_identity_config state)"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
 /// Set identity config for an org.
 /// When creating new or rotating key, caller must provide `key_material` (generated key pair, encrypted private key).
 /// Caller must ensure tenant exists and global machine-identity is enabled.
@@ -126,7 +183,8 @@ pub async fn set(
     key_material: Option<SigningKeyMaterial>,
     txn: &mut PgConnection,
 ) -> DatabaseResult<TenantIdentityConfig> {
-    gc_expired_non_active_signing_key(org_id, txn).await?;
+    let now = Utc::now();
+    gc_expired_non_active_signing_key_at(org_id, txn, now).await?;
 
     let allowed: Vec<String> = if config.allowed_audiences.is_empty() {
         vec![config.default_audience.clone()]
@@ -155,20 +213,7 @@ pub async fn set(
             ));
         }
         (Some(ex), true, Some(km)) => {
-            if ex.signing_key_public_1.is_some()
-                && ex.signing_key_public_2.is_some()
-                && let Some(expires_at) = ex.non_active_slot_expires_at
-                && expires_at > Utc::now()
-            {
-                let now = Utc::now();
-                let remain = (expires_at - now).num_seconds().max(0);
-                return Err(DatabaseError::InvalidArgument(format!(
-                    "cannot rotate signing key while the previous key is still in the overlap period \
-                     (overlap ends at {expires_at}; about {remain}s remaining). \
-                     Call SetTenantIdentityConfiguration again with rotate_key and an explicit \
-                     signing_key_overlap_sec after that time, or wait until the overlap window ends."
-                )));
-            }
+            ensure_rotation_allowed_for_existing(ex, now)?;
             let pub_doc = signing_public_json_from_material(&km)?;
             let new_enc = km.encrypted_signing_key;
             let other = ex.current_signing_key_slot.other();
@@ -297,12 +342,10 @@ pub async fn find_by_machine_id(
     txn: &mut PgConnection,
     machine_id: &MachineId,
 ) -> DatabaseResult<TenantIdentityConfig> {
-    const ORG_FOR_GC: &str = r#"
-SELECT tic.organization_id::text
-FROM tenant_identity_config tic
-INNER JOIN instances i ON tic.organization_id = i.tenant_org
-WHERE i.machine_id = $1 AND i.deleted IS NULL AND tic.enabled = true
-"#;
+    const ORG_FOR_GC: &str = concat!(
+        "SELECT tic.organization_id::text",
+        tenant_identity_find_by_machine_id_clause!()
+    );
     if let Some(org_raw) = sqlx::query_scalar::<_, String>(ORG_FOR_GC)
         .bind(machine_id)
         .fetch_optional(&mut *txn)
@@ -326,12 +369,8 @@ WHERE i.machine_id = $1 AND i.deleted IS NULL AND tic.enabled = true
 
     let select_list = tenant_identity_row_select_expr(Some("tic"));
     let query = format!(
-        r#"
-SELECT {select_list}
-FROM tenant_identity_config tic
-INNER JOIN instances i ON tic.organization_id = i.tenant_org
-WHERE i.machine_id = $1 AND i.deleted IS NULL AND tic.enabled = true
-"#
+        "SELECT {select_list}{}",
+        tenant_identity_find_by_machine_id_clause!()
     );
     let row = sqlx::query_as::<_, TenantIdentityConfig>(&query)
         .bind(machine_id)
@@ -419,6 +458,7 @@ pub async fn delete_token_delegation(
 mod tests {
     use std::collections::HashMap;
 
+    use chrono::Utc;
     use forge_secrets::key_encryption;
     use model::metadata::Metadata;
     use model::tenant::identity_config::SigningAlgorithm;
@@ -428,7 +468,42 @@ mod tests {
     };
 
     use super::*;
-    use crate::tenant;
+    use crate::{DatabaseError, tenant};
+
+    /// Synthetic P-256 SPKI public PEMs for tests (not secret). Prefer real PEM so validation stays
+    /// aligned with `SigningKeyPublicV1` / JWKS expectations.
+    const TEST_ES256_PUB_0: &str = r#"-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAElFrs3yp8XhslMB6ZG6BG3Hvas7kR
+tvTLdqh3uulBnXIXQBabKdLH8wuNfgO3xQrcRrm+Z0yucj/zCyGoJ8Iizw==
+-----END PUBLIC KEY-----"#;
+    const TEST_ES256_PUB_1: &str = r#"-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9tKNx7BW5TgNSJY31g4vT48RNl50
+qbRrVHjvFz02cAUcng9QGX/8L/DVb51jVFq/F1tOjXEyhDON7R9plMicHQ==
+-----END PUBLIC KEY-----"#;
+    const TEST_ES256_PUB_2: &str = r#"-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9/p2rFtxVIP09iS6CPHdcxRXBiqn
++tk2afmDFptBAWTP09T6M1MTiYWbdKzuOal+rEzv8y1VdqQDJ1egup0A2w==
+-----END PUBLIC KEY-----"#;
+    const TEST_ES256_PUB_3: &str = r#"-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMRBa5hEaWbdQn25IDNJLSfFXjXuT
+1UHxIJ/3NgMa/v7PLcgmfz2WW9wfTivfbhD5g2ndLCpQLXrgtirqbhvFWQ==
+-----END PUBLIC KEY-----"#;
+    const TEST_ES256_PUB_4: &str = r#"-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9BbItCsp6q5/UdMxyCUy2VkDT5Zk
+wLQJxr5OM1I00HA5WIuuYplqWIPWP5Lz3s6Qlh8Op4T51wMktUTYuO9lRA==
+-----END PUBLIC KEY-----"#;
+    const TEST_ES256_PUB_5: &str = r#"-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELpyN493ciT/h189YhNpnndwua7Qo
+CNBIXgZ2VUqZWsz+pNejmtX2i/sRs5mdGBmWxz5cEEXNQCAS9bSsVV9f3Q==
+-----END PUBLIC KEY-----"#;
+    const TEST_ES256_PUB_6: &str = r#"-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEVxhVG7gUkOkuGsTRlewt9srrggiK
+SPemXUDmBH8uKkQlKQwzJRPfzpKNi+pcEJRLQI5IWP+ktuWwc/ZZrkEXAQ==
+-----END PUBLIC KEY-----"#;
+    const TEST_ES256_PUB_7: &str = r#"-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKE0d2hbZdPmTpVKkmfMNi6ZmtnCa
+ecbC7Qcisdw2/9l8bk/zfF9gvu4kh3hXZzMWgk+vj1e8KSX+NYswYiacQA==
+-----END PUBLIC KEY-----"#;
 
     fn test_org_id() -> TenantOrganizationId {
         "IdentityConfigTestOrg".parse().unwrap()
@@ -456,11 +531,29 @@ mod tests {
     }
 
     fn placeholder_key_material() -> SigningKeyMaterial {
-        let pem = "PLACEHOLDER_PUBLIC_KEY";
+        test_signing_key_material_from_es256_public_pem(TEST_ES256_PUB_0)
+    }
+
+    fn test_signing_key_material_from_es256_public_pem(pem: &'static str) -> SigningKeyMaterial {
         SigningKeyMaterial {
             key_id: KeyId::from_public_key_material(pem),
             encrypted_signing_key: "PLACEHOLDER_ENCRYPTED_KEY".parse().unwrap(),
             signing_key_public: pem.parse().unwrap(),
+        }
+    }
+
+    fn base_identity_config(rotate_key: bool, overlap: Option<i32>) -> IdentityConfig {
+        IdentityConfig {
+            issuer: "https://issuer.example.com".parse().unwrap(),
+            default_audience: "api".to_string(),
+            allowed_audiences: vec!["api".to_string(), "other".to_string()],
+            token_ttl_sec: 3600,
+            subject_prefix: "spiffe://issuer.example.com/org-x".to_string(),
+            enabled: true,
+            rotate_key,
+            algorithm: SigningAlgorithm::Es256,
+            encryption_key_id: "test-master".parse().unwrap(),
+            signing_key_overlap_sec: overlap,
         }
     }
 
@@ -575,5 +668,162 @@ mod tests {
             .unwrap();
         assert!(cleared.token_endpoint.is_none());
         assert!(cleared.auth_method.is_none());
+    }
+
+    #[crate::sqlx_test]
+    async fn test_tenant_identity_second_rotation_ok_while_overlap_active(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+        let org_id = test_org_id();
+        ensure_tenant(&mut txn, &org_id).await;
+
+        let initial = base_identity_config(false, None);
+        set(
+            &org_id,
+            &initial,
+            Some(test_signing_key_material_from_es256_public_pem(
+                TEST_ES256_PUB_1,
+            )),
+            &mut txn,
+        )
+        .await
+        .unwrap();
+
+        let once = base_identity_config(true, Some(86_400));
+        set(
+            &org_id,
+            &once,
+            Some(test_signing_key_material_from_es256_public_pem(
+                TEST_ES256_PUB_2,
+            )),
+            &mut txn,
+        )
+        .await
+        .unwrap();
+
+        let twice = base_identity_config(true, Some(3600));
+        let cfg = set(
+            &org_id,
+            &twice,
+            Some(test_signing_key_material_from_es256_public_pem(
+                TEST_ES256_PUB_3,
+            )),
+            &mut txn,
+        )
+        .await
+        .unwrap();
+
+        assert!(cfg.signing_key_public_1.is_some());
+        assert!(cfg.signing_key_public_2.is_some());
+        assert!(
+            cfg.non_active_slot_expires_at
+                .is_some_and(|ex| ex > Utc::now()),
+            "new overlap deadline should be in the future"
+        );
+    }
+
+    #[crate::sqlx_test]
+    async fn test_tenant_identity_rotate_rejects_dual_public_without_overlap_deadline(
+        pool: sqlx::PgPool,
+    ) {
+        let mut txn = pool.begin().await.unwrap();
+        let org_id = test_org_id();
+        ensure_tenant(&mut txn, &org_id).await;
+
+        let initial = base_identity_config(false, None);
+        set(
+            &org_id,
+            &initial,
+            Some(test_signing_key_material_from_es256_public_pem(
+                TEST_ES256_PUB_4,
+            )),
+            &mut txn,
+        )
+        .await
+        .unwrap();
+
+        let rotated = base_identity_config(true, Some(3600));
+        set(
+            &org_id,
+            &rotated,
+            Some(test_signing_key_material_from_es256_public_pem(
+                TEST_ES256_PUB_5,
+            )),
+            &mut txn,
+        )
+        .await
+        .unwrap();
+
+        sqlx::query(
+            r#"UPDATE tenant_identity_config
+               SET non_active_slot_expires_at = NULL
+               WHERE organization_id = $1"#,
+        )
+        .bind(org_id.as_str())
+        .execute(&mut *txn)
+        .await
+        .unwrap();
+
+        let again = base_identity_config(true, Some(3600));
+        let err = set(
+            &org_id,
+            &again,
+            Some(test_signing_key_material_from_es256_public_pem(
+                TEST_ES256_PUB_6,
+            )),
+            &mut txn,
+        )
+        .await
+        .unwrap_err();
+        let DatabaseError::InvalidArgument(msg) = err else {
+            panic!("expected InvalidArgument, got {err:?}");
+        };
+        assert!(msg.contains("non_active_slot_expires_at is NULL"), "{msg}");
+    }
+
+    #[crate::sqlx_test]
+    async fn test_tenant_identity_rotate_rejects_future_overlap_with_single_public(
+        pool: sqlx::PgPool,
+    ) {
+        let mut txn = pool.begin().await.unwrap();
+        let org_id = test_org_id();
+        ensure_tenant(&mut txn, &org_id).await;
+
+        let initial = base_identity_config(false, None);
+        set(
+            &org_id,
+            &initial,
+            Some(test_signing_key_material_from_es256_public_pem(
+                TEST_ES256_PUB_7,
+            )),
+            &mut txn,
+        )
+        .await
+        .unwrap();
+
+        sqlx::query(
+            r#"UPDATE tenant_identity_config
+               SET non_active_slot_expires_at = NOW() + INTERVAL '3600 seconds'
+               WHERE organization_id = $1"#,
+        )
+        .bind(org_id.as_str())
+        .execute(&mut *txn)
+        .await
+        .unwrap();
+
+        let rotated = base_identity_config(true, Some(3600));
+        let err = set(
+            &org_id,
+            &rotated,
+            Some(test_signing_key_material_from_es256_public_pem(
+                TEST_ES256_PUB_0,
+            )),
+            &mut txn,
+        )
+        .await
+        .unwrap_err();
+        let DatabaseError::InvalidArgument(msg) = err else {
+            panic!("expected InvalidArgument, got {err:?}");
+        };
+        assert!(msg.contains("only one JWKS public key slot"), "{msg}");
     }
 }

--- a/crates/api-db/src/tenant_identity_config.rs
+++ b/crates/api-db/src/tenant_identity_config.rs
@@ -22,58 +22,69 @@ use carbide_uuid::machine::MachineId;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use model::tenant::identity_config::SigningKeyPublicV1;
 use model::tenant::{
-    EncryptedTokenDelegationAuthConfig, IdentityConfig, SigningKeyMaterial, TenantIdentityConfig,
-    TenantIdentityCurrentSigningKeySlot, TenantOrganizationId, TokenDelegation,
-    TokenDelegationAuthMethod,
+    EncryptedSigningPrivateKey, EncryptedTokenDelegationAuthConfig, IdentityConfig,
+    SigningKeyMaterial, TenantIdentityConfig, TenantIdentityCurrentSigningKeySlot,
+    TenantOrganizationId, TokenDelegation, TokenDelegationAuthMethod,
 };
 use sqlx::PgConnection;
 use sqlx::types::Json;
 
 use crate::{DatabaseError, DatabaseResult};
 
-/// Column expressions for mapping a row into [`TenantIdentityConfig`], optionally qualified
-/// (e.g. `Some("tic")` → `tic.organization_id`, …) for `FROM tenant_identity_config tic` joins.
-fn tenant_identity_row_select_expr(table_alias: Option<&str>) -> String {
-    const COLS: &[&str] = &[
-        "organization_id",
-        "issuer::text AS issuer",
-        "default_audience::text AS default_audience",
-        "allowed_audiences",
-        "token_ttl_sec",
-        "subject_prefix::text AS subject_prefix",
-        "enabled",
-        "created_at",
-        "updated_at",
-        "encrypted_signing_key_1",
-        "encrypted_signing_key_2",
-        "signing_key_public_1",
-        "signing_key_public_2",
-        "current_signing_key_slot",
-        "non_active_slot_expires_at",
-        "encryption_key_id::text AS encryption_key_id",
-        "token_endpoint::text AS token_endpoint",
-        "auth_method",
-        "encrypted_auth_method_config",
-        "subject_token_audience::text AS subject_token_audience",
-        "token_delegation_created_at",
-    ];
-    let prefix = table_alias.map_or_else(String::new, |a| format!("{a}."));
-    COLS.iter()
-        .map(|c| format!("{prefix}{c}"))
-        .collect::<Vec<_>>()
-        .join(", ")
-}
-
-/// `FROM` / `JOIN` / `WHERE` for [`find_by_machine_id`]. Macro so the GC org scalar query and the
-/// main `SELECT` share one definition (`concat!` cannot reference `const` str slices).
-macro_rules! tenant_identity_find_by_machine_id_clause {
-    () => {
-        r"
+/// Resolve tenant identity config for machine-identity RPCs: one join query, then overlap GC, then
+/// reload by org PK so the row matches the post-GC database state (GC may clear a JWKS slot).
+const TENANT_IDENTITY_FIND_BY_MACHINE_SQL: &str = r"
+SELECT tic.*
 FROM tenant_identity_config tic
 INNER JOIN instances i ON tic.organization_id = i.tenant_org
-WHERE i.machine_id = $1 AND i.deleted IS NULL AND tic.enabled = true"
-    };
-}
+WHERE i.machine_id = $1 AND i.deleted IS NULL AND tic.enabled = true";
+
+const TENANT_IDENTITY_FIND_BY_ORG_SQL: &str =
+    "SELECT * FROM tenant_identity_config WHERE organization_id = $1";
+
+const UPSERT_TENANT_IDENTITY_CONFIG_SQL: &str = r#"
+        INSERT INTO tenant_identity_config (
+            organization_id, issuer, default_audience, allowed_audiences,
+            token_ttl_sec, subject_prefix, enabled, created_at, updated_at,
+            encrypted_signing_key_1, encrypted_signing_key_2,
+            signing_key_public_1, signing_key_public_2,
+            current_signing_key_slot, non_active_slot_expires_at,
+            encryption_key_id
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW(), $8, $9, $10, $11, $12, $13, $14)
+        ON CONFLICT (organization_id) DO UPDATE SET
+            issuer = EXCLUDED.issuer,
+            default_audience = EXCLUDED.default_audience,
+            allowed_audiences = EXCLUDED.allowed_audiences,
+            token_ttl_sec = EXCLUDED.token_ttl_sec,
+            subject_prefix = EXCLUDED.subject_prefix,
+            enabled = EXCLUDED.enabled,
+            updated_at = NOW(),
+            encrypted_signing_key_1 = EXCLUDED.encrypted_signing_key_1,
+            encrypted_signing_key_2 = EXCLUDED.encrypted_signing_key_2,
+            signing_key_public_1 = EXCLUDED.signing_key_public_1,
+            signing_key_public_2 = EXCLUDED.signing_key_public_2,
+            current_signing_key_slot = EXCLUDED.current_signing_key_slot,
+            non_active_slot_expires_at = EXCLUDED.non_active_slot_expires_at,
+            encryption_key_id = EXCLUDED.encryption_key_id
+        RETURNING tenant_identity_config.*
+    "#;
+
+const UPDATE_TENANT_IDENTITY_TOKEN_DELEGATION_SQL: &str = r#"
+        UPDATE tenant_identity_config
+        SET token_endpoint = $2, auth_method = $3, encrypted_auth_method_config = $4,
+            subject_token_audience = $5, updated_at = NOW(),
+            token_delegation_created_at = COALESCE(token_delegation_created_at, NOW())
+        WHERE organization_id = $1
+        RETURNING tenant_identity_config.*
+    "#;
+
+const CLEAR_TENANT_IDENTITY_TOKEN_DELEGATION_SQL: &str = r#"
+        UPDATE tenant_identity_config
+        SET token_endpoint = NULL, auth_method = NULL, encrypted_auth_method_config = NULL,
+            subject_token_audience = NULL, token_delegation_created_at = NULL, updated_at = NOW()
+        WHERE organization_id = $1
+        RETURNING tenant_identity_config.*
+    "#;
 
 /// After `non_active_slot_expires_at`, clears the non-current slot (public + private ciphertext).
 pub async fn gc_expired_non_active_signing_key(
@@ -130,7 +141,6 @@ fn signing_public_json_from_material(
 ) -> DatabaseResult<Json<SigningKeyPublicV1>> {
     let doc = SigningKeyPublicV1::es256_from_public_pem(km.signing_key_public.as_str())
         .map_err(DatabaseError::InvalidArgument)?;
-    doc.validate().map_err(DatabaseError::InvalidArgument)?;
     Ok(Json(doc))
 }
 
@@ -172,6 +182,16 @@ fn ensure_rotation_allowed_for_existing(
     Ok(())
 }
 
+/// Signing-key slot ciphertext / JWKS JSON plus overlap deadline for [`set`]'s upsert row.
+struct KeyRows {
+    enc1: Option<EncryptedSigningPrivateKey>,
+    enc2: Option<EncryptedSigningPrivateKey>,
+    pub1: Option<Json<SigningKeyPublicV1>>,
+    pub2: Option<Json<SigningKeyPublicV1>>,
+    current_slot: TenantIdentityCurrentSigningKeySlot,
+    non_active_expires_at: Option<DateTime<Utc>>,
+}
+
 /// Set identity config for an org.
 /// When creating new or rotating key, caller must provide `key_material` (generated key pair, encrypted private key).
 /// Caller must ensure tenant exists and global machine-identity is enabled.
@@ -199,14 +219,7 @@ pub async fn set(
 
     let existing = find(org_id, &mut *txn).await?;
 
-    let (enc1, enc2, pub1, pub2, current_slot, non_active_expires): (
-        Option<_>,
-        Option<_>,
-        Option<_>,
-        Option<_>,
-        TenantIdentityCurrentSigningKeySlot,
-        Option<_>,
-    ) = match (&existing, config.rotate_key, key_material) {
+    let key_rows = match (&existing, config.rotate_key, key_material) {
         (None, _, None) | (_, true, None) => {
             return Err(DatabaseError::InvalidArgument(
                 "key_material is required when creating or rotating signing key".into(),
@@ -229,44 +242,44 @@ pub async fn set(
             })?;
             let expires = Some(Utc::now() + ChronoDuration::seconds(i64::from(overlap_for_expiry)));
             match other {
-                TenantIdentityCurrentSigningKeySlot::SigningKey1 => (
-                    Some(new_enc),
-                    ex.encrypted_signing_key_2.clone(),
-                    Some(pub_doc),
-                    ex.signing_key_public_2.clone(),
-                    TenantIdentityCurrentSigningKeySlot::SigningKey1,
-                    expires,
-                ),
-                TenantIdentityCurrentSigningKeySlot::SigningKey2 => (
-                    ex.encrypted_signing_key_1.clone(),
-                    Some(new_enc),
-                    ex.signing_key_public_1.clone(),
-                    Some(pub_doc),
-                    TenantIdentityCurrentSigningKeySlot::SigningKey2,
-                    expires,
-                ),
+                TenantIdentityCurrentSigningKeySlot::SigningKey1 => KeyRows {
+                    enc1: Some(new_enc),
+                    enc2: ex.encrypted_signing_key_2.clone(),
+                    pub1: Some(pub_doc),
+                    pub2: ex.signing_key_public_2.clone(),
+                    current_slot: TenantIdentityCurrentSigningKeySlot::SigningKey1,
+                    non_active_expires_at: expires,
+                },
+                TenantIdentityCurrentSigningKeySlot::SigningKey2 => KeyRows {
+                    enc1: ex.encrypted_signing_key_1.clone(),
+                    enc2: Some(new_enc),
+                    pub1: ex.signing_key_public_1.clone(),
+                    pub2: Some(pub_doc),
+                    current_slot: TenantIdentityCurrentSigningKeySlot::SigningKey2,
+                    non_active_expires_at: expires,
+                },
             }
         }
         (None, _, Some(km)) => {
             let pub_doc = signing_public_json_from_material(&km)?;
             let new_enc = km.encrypted_signing_key;
-            (
-                Some(new_enc),
-                None,
-                Some(pub_doc),
-                None,
-                TenantIdentityCurrentSigningKeySlot::SigningKey1,
-                None,
-            )
+            KeyRows {
+                enc1: Some(new_enc),
+                enc2: None,
+                pub1: Some(pub_doc),
+                pub2: None,
+                current_slot: TenantIdentityCurrentSigningKeySlot::SigningKey1,
+                non_active_expires_at: None,
+            }
         }
-        (Some(ex), false, None) => (
-            ex.encrypted_signing_key_1.clone(),
-            ex.encrypted_signing_key_2.clone(),
-            ex.signing_key_public_1.clone(),
-            ex.signing_key_public_2.clone(),
-            ex.current_signing_key_slot,
-            ex.non_active_slot_expires_at,
-        ),
+        (Some(ex), false, None) => KeyRows {
+            enc1: ex.encrypted_signing_key_1.clone(),
+            enc2: ex.encrypted_signing_key_2.clone(),
+            pub1: ex.signing_key_public_1.clone(),
+            pub2: ex.signing_key_public_2.clone(),
+            current_slot: ex.current_signing_key_slot,
+            non_active_expires_at: ex.non_active_slot_expires_at,
+        },
         (Some(_), false, Some(_)) => {
             return Err(DatabaseError::InvalidArgument(
                 "key_material must not be set when rotate_key is false".into(),
@@ -274,37 +287,7 @@ pub async fn set(
         }
     };
 
-    let returning = tenant_identity_row_select_expr(None);
-    let query = format!(
-        r#"
-        INSERT INTO tenant_identity_config (
-            organization_id, issuer, default_audience, allowed_audiences,
-            token_ttl_sec, subject_prefix, enabled, created_at, updated_at,
-            encrypted_signing_key_1, encrypted_signing_key_2,
-            signing_key_public_1, signing_key_public_2,
-            current_signing_key_slot, non_active_slot_expires_at,
-            encryption_key_id
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW(), $8, $9, $10, $11, $12, $13, $14)
-        ON CONFLICT (organization_id) DO UPDATE SET
-            issuer = EXCLUDED.issuer,
-            default_audience = EXCLUDED.default_audience,
-            allowed_audiences = EXCLUDED.allowed_audiences,
-            token_ttl_sec = EXCLUDED.token_ttl_sec,
-            subject_prefix = EXCLUDED.subject_prefix,
-            enabled = EXCLUDED.enabled,
-            updated_at = NOW(),
-            encrypted_signing_key_1 = EXCLUDED.encrypted_signing_key_1,
-            encrypted_signing_key_2 = EXCLUDED.encrypted_signing_key_2,
-            signing_key_public_1 = EXCLUDED.signing_key_public_1,
-            signing_key_public_2 = EXCLUDED.signing_key_public_2,
-            current_signing_key_slot = EXCLUDED.current_signing_key_slot,
-            non_active_slot_expires_at = EXCLUDED.non_active_slot_expires_at,
-            encryption_key_id = EXCLUDED.encryption_key_id
-        RETURNING {returning}
-    "#
-    );
-
-    sqlx::query_as(&query)
+    sqlx::query_as(UPSERT_TENANT_IDENTITY_CONFIG_SQL)
         .bind(org_id.as_str())
         .bind(&config.issuer)
         .bind(&config.default_audience)
@@ -312,78 +295,52 @@ pub async fn set(
         .bind(token_ttl_i32)
         .bind(&config.subject_prefix)
         .bind(config.enabled)
-        .bind(enc1)
-        .bind(enc2)
-        .bind(pub1)
-        .bind(pub2)
-        .bind(current_slot)
-        .bind(non_active_expires)
+        .bind(key_rows.enc1)
+        .bind(key_rows.enc2)
+        .bind(key_rows.pub1)
+        .bind(key_rows.pub2)
+        .bind(key_rows.current_slot)
+        .bind(key_rows.non_active_expires_at)
         .bind(&config.encryption_key_id)
         .fetch_one(txn)
         .await
-        .map_err(|e| DatabaseError::query(&query, e))
+        .map_err(|e| DatabaseError::query(UPSERT_TENANT_IDENTITY_CONFIG_SQL, e))
 }
 
 pub async fn find(
     org_id: &TenantOrganizationId,
     txn: &mut PgConnection,
 ) -> DatabaseResult<Option<TenantIdentityConfig>> {
-    let select_list = tenant_identity_row_select_expr(None);
-    let query =
-        format!("SELECT {select_list} FROM tenant_identity_config WHERE organization_id = $1");
-    sqlx::query_as(&query)
+    sqlx::query_as(TENANT_IDENTITY_FIND_BY_ORG_SQL)
         .bind(org_id.as_str())
         .fetch_optional(txn)
         .await
-        .map_err(|e| DatabaseError::query(&query, e))
+        .map_err(|e| DatabaseError::query(TENANT_IDENTITY_FIND_BY_ORG_SQL, e))
 }
 
 pub async fn find_by_machine_id(
     txn: &mut PgConnection,
     machine_id: &MachineId,
 ) -> DatabaseResult<TenantIdentityConfig> {
-    const ORG_FOR_GC: &str = concat!(
-        "SELECT tic.organization_id::text",
-        tenant_identity_find_by_machine_id_clause!()
-    );
-    if let Some(org_raw) = sqlx::query_scalar::<_, String>(ORG_FOR_GC)
+    let row = sqlx::query_as::<_, TenantIdentityConfig>(TENANT_IDENTITY_FIND_BY_MACHINE_SQL)
         .bind(machine_id)
         .fetch_optional(&mut *txn)
         .await
-        .map_err(|e| DatabaseError::query(ORG_FOR_GC, e))?
-    {
-        match org_raw.parse::<TenantOrganizationId>() {
-            Ok(oid) => {
-                gc_expired_non_active_signing_key(&oid, txn).await?;
-            }
-            Err(e) => {
-                tracing::warn!(
-                    %machine_id,
-                    organization_id = %org_raw,
-                    error = %e,
-                    "tenant_identity_config.organization_id from join failed TenantOrganizationId parse; skipping non-active signing key GC"
-                );
-            }
-        }
-    }
-
-    let select_list = tenant_identity_row_select_expr(Some("tic"));
-    let query = format!(
-        "SELECT {select_list}{}",
-        tenant_identity_find_by_machine_id_clause!()
-    );
-    let row = sqlx::query_as::<_, TenantIdentityConfig>(&query)
-        .bind(machine_id)
-        .fetch_optional(&mut *txn)
-        .await
-        .map_err(|e| DatabaseError::query(&query, e))?;
+        .map_err(|e| DatabaseError::query(TENANT_IDENTITY_FIND_BY_MACHINE_SQL, e))?;
     let Some(cfg) = row else {
         return Err(DatabaseError::NotFoundError {
             kind: "machine_identity",
             id: machine_id.to_string(),
         });
     };
-    Ok(cfg)
+    let org_id = cfg.organization_id.clone();
+    gc_expired_non_active_signing_key(&org_id, txn).await?;
+    find(&org_id, txn)
+        .await?
+        .ok_or_else(|| DatabaseError::NotFoundError {
+            kind: "machine_identity",
+            id: machine_id.to_string(),
+        })
 }
 
 /// Set token delegation for an org. Identity config must exist first.
@@ -396,18 +353,7 @@ pub async fn set_token_delegation(
     encrypted_auth_method_config: &EncryptedTokenDelegationAuthConfig,
     txn: &mut PgConnection,
 ) -> DatabaseResult<TenantIdentityConfig> {
-    let returning = tenant_identity_row_select_expr(None);
-    let query = format!(
-        r#"
-        UPDATE tenant_identity_config
-        SET token_endpoint = $2, auth_method = $3, encrypted_auth_method_config = $4,
-            subject_token_audience = $5, updated_at = NOW(),
-            token_delegation_created_at = COALESCE(token_delegation_created_at, NOW())
-        WHERE organization_id = $1
-        RETURNING {returning}
-    "#
-    );
-    let row = sqlx::query_as(&query)
+    let row = sqlx::query_as(UPDATE_TENANT_IDENTITY_TOKEN_DELEGATION_SQL)
         .bind(org_id.as_str())
         .bind(&config.token_endpoint)
         .bind(auth_method)
@@ -415,7 +361,7 @@ pub async fn set_token_delegation(
         .bind(Some(config.subject_token_audience.as_str()))
         .fetch_optional(txn)
         .await
-        .map_err(|e| DatabaseError::query(&query, e))?;
+        .map_err(|e| DatabaseError::query(UPDATE_TENANT_IDENTITY_TOKEN_DELEGATION_SQL, e))?;
     row.ok_or_else(|| DatabaseError::NotFoundError {
         kind: "tenant_identity_config",
         id: org_id.as_str().to_string(),
@@ -437,21 +383,11 @@ pub async fn delete_token_delegation(
     org_id: &TenantOrganizationId,
     txn: &mut PgConnection,
 ) -> DatabaseResult<Option<TenantIdentityConfig>> {
-    let returning = tenant_identity_row_select_expr(None);
-    let query = format!(
-        r#"
-        UPDATE tenant_identity_config
-        SET token_endpoint = NULL, auth_method = NULL, encrypted_auth_method_config = NULL,
-            subject_token_audience = NULL, token_delegation_created_at = NULL, updated_at = NOW()
-        WHERE organization_id = $1
-        RETURNING {returning}
-    "#
-    );
-    sqlx::query_as(&query)
+    sqlx::query_as(CLEAR_TENANT_IDENTITY_TOKEN_DELEGATION_SQL)
         .bind(org_id.as_str())
         .fetch_optional(txn)
         .await
-        .map_err(|e| DatabaseError::query(&query, e))
+        .map_err(|e| DatabaseError::query(CLEAR_TENANT_IDENTITY_TOKEN_DELEGATION_SQL, e))
 }
 
 #[cfg(test)]

--- a/crates/api-db/src/tenant_identity_config.rs
+++ b/crates/api-db/src/tenant_identity_config.rs
@@ -49,7 +49,6 @@ fn tenant_identity_row_select_expr(table_alias: Option<&str>) -> String {
         "signing_key_public_1",
         "signing_key_public_2",
         "current_signing_key_slot",
-        "signing_key_overlap_sec",
         "non_active_slot_expires_at",
         "encryption_key_id::text AS encryption_key_id",
         "token_endpoint::text AS token_endpoint",
@@ -119,13 +118,12 @@ fn signing_public_json_from_material(
 /// Set identity config for an org.
 /// When creating new or rotating key, caller must provide `key_material` (generated key pair, encrypted private key).
 /// Caller must ensure tenant exists and global machine-identity is enabled.
-/// `site_signing_key_overlap_default_sec` is used when `config.signing_key_overlap_sec` is `None` to compute
-/// [`non_active_slot_expires_at`] on `rotate_key`.
+/// On key rotation, `config.signing_key_overlap_sec` must be set (seconds until the previous JWKS key is dropped);
+/// see [`IdentityConfig::try_from_proto`].
 pub async fn set(
     org_id: &TenantOrganizationId,
     config: &IdentityConfig,
     key_material: Option<SigningKeyMaterial>,
-    site_signing_key_overlap_default_sec: u32,
     txn: &mut PgConnection,
 ) -> DatabaseResult<TenantIdentityConfig> {
     gc_expired_non_active_signing_key(org_id, txn).await?;
@@ -143,17 +141,6 @@ pub async fn set(
 
     let existing = find(org_id, &mut *txn).await?;
 
-    let overlap_for_expiry = match config.signing_key_overlap_sec {
-        None => site_signing_key_overlap_default_sec,
-        Some(v) => u32::try_from(v).map_err(|_| {
-            DatabaseError::InvalidArgument(
-                "signing_key_overlap_sec must be non-negative and fit in u32".into(),
-            )
-        })?,
-    };
-
-    let overlap_i32 = config.signing_key_overlap_sec;
-
     let (enc1, enc2, pub1, pub2, current_slot, non_active_expires): (
         Option<_>,
         Option<_>,
@@ -170,18 +157,31 @@ pub async fn set(
         (Some(ex), true, Some(km)) => {
             if ex.signing_key_public_1.is_some()
                 && ex.signing_key_public_2.is_some()
-                && ex
-                    .non_active_slot_expires_at
-                    .is_some_and(|t| t > Utc::now())
+                && let Some(expires_at) = ex.non_active_slot_expires_at
+                && expires_at > Utc::now()
             {
-                return Err(DatabaseError::InvalidArgument(
-                    "cannot rotate signing key while the previous key is still in the overlap period"
-                        .into(),
-                ));
+                let now = Utc::now();
+                let remain = (expires_at - now).num_seconds().max(0);
+                return Err(DatabaseError::InvalidArgument(format!(
+                    "cannot rotate signing key while the previous key is still in the overlap period \
+                     (overlap ends at {expires_at}; about {remain}s remaining). \
+                     Call SetTenantIdentityConfiguration again with rotate_key and an explicit \
+                     signing_key_overlap_sec after that time, or wait until the overlap window ends."
+                )));
             }
             let pub_doc = signing_public_json_from_material(&km)?;
             let new_enc = km.encrypted_signing_key;
             let other = ex.current_signing_key_slot.other();
+            let overlap_sec = config.signing_key_overlap_sec.ok_or_else(|| {
+                DatabaseError::InvalidArgument(
+                    "signing_key_overlap_sec is required when rotating the signing key".into(),
+                )
+            })?;
+            let overlap_for_expiry = u32::try_from(overlap_sec).map_err(|_| {
+                DatabaseError::InvalidArgument(
+                    "signing_key_overlap_sec must be non-negative and fit in u32".into(),
+                )
+            })?;
             let expires = Some(Utc::now() + ChronoDuration::seconds(i64::from(overlap_for_expiry)));
             match other {
                 TenantIdentityCurrentSigningKeySlot::SigningKey1 => (
@@ -237,9 +237,9 @@ pub async fn set(
             token_ttl_sec, subject_prefix, enabled, created_at, updated_at,
             encrypted_signing_key_1, encrypted_signing_key_2,
             signing_key_public_1, signing_key_public_2,
-            current_signing_key_slot, signing_key_overlap_sec, non_active_slot_expires_at,
+            current_signing_key_slot, non_active_slot_expires_at,
             encryption_key_id
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW(), $8, $9, $10, $11, $12, $13, $14, $15)
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW(), $8, $9, $10, $11, $12, $13, $14)
         ON CONFLICT (organization_id) DO UPDATE SET
             issuer = EXCLUDED.issuer,
             default_audience = EXCLUDED.default_audience,
@@ -253,7 +253,6 @@ pub async fn set(
             signing_key_public_1 = EXCLUDED.signing_key_public_1,
             signing_key_public_2 = EXCLUDED.signing_key_public_2,
             current_signing_key_slot = EXCLUDED.current_signing_key_slot,
-            signing_key_overlap_sec = EXCLUDED.signing_key_overlap_sec,
             non_active_slot_expires_at = EXCLUDED.non_active_slot_expires_at,
             encryption_key_id = EXCLUDED.encryption_key_id
         RETURNING {returning}
@@ -273,7 +272,6 @@ pub async fn set(
         .bind(pub1)
         .bind(pub2)
         .bind(current_slot)
-        .bind(overlap_i32)
         .bind(non_active_expires)
         .bind(&config.encryption_key_id)
         .fetch_one(txn)
@@ -486,7 +484,7 @@ mod tests {
         };
 
         let key_material = placeholder_key_material();
-        let cfg = set(&org_id, &config, Some(key_material), 3600, &mut txn)
+        let cfg = set(&org_id, &config, Some(key_material), &mut txn)
             .await
             .unwrap();
         assert_eq!(cfg.issuer.as_str(), "https://issuer.example.com");
@@ -538,7 +536,7 @@ mod tests {
             signing_key_overlap_sec: None,
         };
         let key_material = placeholder_key_material();
-        set(&org_id, &config, Some(key_material), 3600, &mut txn)
+        set(&org_id, &config, Some(key_material), &mut txn)
             .await
             .unwrap();
 

--- a/crates/api-model/src/rpc_conv/tenant.rs
+++ b/crates/api-model/src/rpc_conv/tenant.rs
@@ -495,8 +495,7 @@ pub fn identity_config_try_from_proto(
     })
 }
 
-/// After merging optional request overlap with any stored row (see `set_tenant_identity_configuration`),
-/// ensure rotation uses an overlap window at least as long as token TTL.
+/// Ensures rotation requests carry overlap at least [`IdentityConfig::token_ttl_sec`] (see docs).
 pub fn validate_identity_overlap_for_rotation(
     config: &IdentityConfig,
 ) -> Result<(), IdentityConfigValidationError> {

--- a/crates/api-model/src/rpc_conv/tenant.rs
+++ b/crates/api-model/src/rpc_conv/tenant.rs
@@ -468,6 +468,19 @@ pub fn identity_config_try_from_proto(
             bounds.signing_key_overlap_max_sec
         )));
     }
+    if !value.rotate_key && value.signing_key_overlap_sec.is_some() {
+        return Err(IdentityConfigValidationError(
+            "signing_key_overlap_sec may only be set when rotate_key is true".to_string(),
+        ));
+    }
+
+    let signing_key_overlap_sec = match value.signing_key_overlap_sec {
+        None => None,
+        Some(s) => Some(i32::try_from(s).map_err(|_| {
+            IdentityConfigValidationError("signing_key_overlap_sec out of range".to_string())
+        })?),
+    };
+
     Ok(IdentityConfig {
         issuer,
         default_audience: value.default_audience,
@@ -478,8 +491,34 @@ pub fn identity_config_try_from_proto(
         rotate_key: value.rotate_key,
         algorithm: bounds.algorithm,
         encryption_key_id: bounds.encryption_key_id.clone(),
-        signing_key_overlap_sec: None,
+        signing_key_overlap_sec,
     })
+}
+
+/// After merging optional request overlap with any stored row (see `set_tenant_identity_configuration`),
+/// ensure rotation uses an overlap window at least as long as token TTL.
+pub fn validate_identity_overlap_for_rotation(
+    config: &IdentityConfig,
+) -> Result<(), IdentityConfigValidationError> {
+    if !config.rotate_key {
+        return Ok(());
+    }
+    let Some(overlap) = config.signing_key_overlap_sec else {
+        return Err(IdentityConfigValidationError(
+            "signing_key_overlap_sec is required when rotate_key is true".to_string(),
+        ));
+    };
+    let overlap_u32 = u32::try_from(overlap).map_err(|_| {
+        IdentityConfigValidationError("signing_key_overlap_sec out of range".to_string())
+    })?;
+    if overlap_u32 < config.token_ttl_sec {
+        return Err(IdentityConfigValidationError(format!(
+            "signing_key_overlap_sec ({overlap_u32}) must be at least token_ttl_sec ({}) \
+             so JWTs signed with the previous key stay verifiable until they expire",
+            config.token_ttl_sec
+        )));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -582,7 +621,6 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test-master".parse().unwrap(),
             trust_domain_allowlist: vec![],
-            signing_key_overlap_default_sec: 86_400,
             signing_key_overlap_max_sec: 604_800,
         };
         let config = identity_config_try_from_proto(proto, &bounds).unwrap();
@@ -615,7 +653,6 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test-master".parse().unwrap(),
             trust_domain_allowlist: vec![],
-            signing_key_overlap_default_sec: 86400,
             signing_key_overlap_max_sec: 604800,
         };
         let config = identity_config_try_from_proto(proto, &bounds).unwrap();
@@ -641,7 +678,6 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec![],
-            signing_key_overlap_default_sec: 86400,
             signing_key_overlap_max_sec: 604800,
         };
         let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
@@ -666,7 +702,6 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec![],
-            signing_key_overlap_default_sec: 86400,
             signing_key_overlap_max_sec: 604800,
         };
         let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
@@ -691,7 +726,6 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec![],
-            signing_key_overlap_default_sec: 86400,
             signing_key_overlap_max_sec: 604800,
         };
         let config = identity_config_try_from_proto(proto, &bounds).unwrap();
@@ -719,7 +753,6 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec![],
-            signing_key_overlap_default_sec: 86400,
             signing_key_overlap_max_sec: 604800,
         };
         let config = identity_config_try_from_proto(proto, &bounds).unwrap();
@@ -744,7 +777,6 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec![],
-            signing_key_overlap_default_sec: 86400,
             signing_key_overlap_max_sec: 604800,
         };
         let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
@@ -769,7 +801,6 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec![],
-            signing_key_overlap_default_sec: 86400,
             signing_key_overlap_max_sec: 604800,
         };
         let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
@@ -794,7 +825,6 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec![],
-            signing_key_overlap_default_sec: 86400,
             signing_key_overlap_max_sec: 604800,
         };
         let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
@@ -819,7 +849,6 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec![],
-            signing_key_overlap_default_sec: 86400,
             signing_key_overlap_max_sec: 604800,
         };
         let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
@@ -844,7 +873,6 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec![],
-            signing_key_overlap_default_sec: 86400,
             signing_key_overlap_max_sec: 604800,
         };
         let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
@@ -869,7 +897,6 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec!["login.example.com".to_string()],
-            signing_key_overlap_default_sec: 86_400,
             signing_key_overlap_max_sec: 604_800,
         };
         let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
@@ -895,7 +922,6 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec!["**.login.example.com".to_string()],
-            signing_key_overlap_default_sec: 86_400,
             signing_key_overlap_max_sec: 604_800,
         };
         let config = identity_config_try_from_proto(proto, &bounds).unwrap();
@@ -929,7 +955,6 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: allowlist,
-            signing_key_overlap_default_sec: 86_400,
             signing_key_overlap_max_sec: 604_800,
         };
         let config = identity_config_try_from_proto(proto, &bounds).unwrap();
@@ -959,11 +984,91 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: allowlist,
-            signing_key_overlap_default_sec: 86_400,
             signing_key_overlap_max_sec: 604_800,
         };
         let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
         assert!(err.0.contains("allowlist"));
+    }
+
+    #[test]
+    fn identity_config_try_from_proto_rejects_overlap_when_not_rotating() {
+        let proto = rpc_forge::TenantIdentityConfig {
+            enabled: true,
+            issuer: "https://issuer.example.com".to_string(),
+            default_audience: "api".to_string(),
+            allowed_audiences: vec!["api".to_string()],
+            token_ttl_sec: 3600,
+            subject_prefix: None,
+            rotate_key: false,
+            signing_key_overlap_sec: Some(120),
+        };
+        let bounds = IdentityConfigValidationBounds {
+            token_ttl_min_sec: 60,
+            token_ttl_max_sec: 86400,
+            algorithm: identity_config::SigningAlgorithm::Es256,
+            encryption_key_id: "test-master".parse().unwrap(),
+            trust_domain_allowlist: vec![],
+            signing_key_overlap_max_sec: 604_800,
+        };
+        let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
+        assert!(err.0.contains("signing_key_overlap_sec may only be set"));
+    }
+
+    #[test]
+    fn validate_identity_overlap_requires_value_when_rotating() {
+        let config = IdentityConfig {
+            issuer: "https://issuer.example.com".parse().unwrap(),
+            default_audience: "api".to_string(),
+            allowed_audiences: vec![],
+            token_ttl_sec: 3600,
+            subject_prefix: "spiffe://issuer.example.com".to_string(),
+            enabled: true,
+            rotate_key: true,
+            algorithm: identity_config::SigningAlgorithm::Es256,
+            encryption_key_id: "test".parse().unwrap(),
+            signing_key_overlap_sec: None,
+        };
+        let err = validate_identity_overlap_for_rotation(&config).unwrap_err();
+        assert!(err.0.contains("signing_key_overlap_sec is required"));
+    }
+
+    #[test]
+    fn validate_identity_overlap_rejects_less_than_token_ttl() {
+        let config = IdentityConfig {
+            issuer: "https://issuer.example.com".parse().unwrap(),
+            default_audience: "api".to_string(),
+            allowed_audiences: vec![],
+            token_ttl_sec: 3600,
+            subject_prefix: "spiffe://issuer.example.com".to_string(),
+            enabled: true,
+            rotate_key: true,
+            algorithm: identity_config::SigningAlgorithm::Es256,
+            encryption_key_id: "test".parse().unwrap(),
+            signing_key_overlap_sec: Some(120),
+        };
+        let err = validate_identity_overlap_for_rotation(&config).unwrap_err();
+        assert!(
+            err.0.contains("must be at least token_ttl_sec"),
+            "unexpected: {}",
+            err.0
+        );
+    }
+
+    #[test]
+    fn validate_identity_overlap_ok_when_rotating() {
+        let config = IdentityConfig {
+            issuer: "https://issuer.example.com".parse().unwrap(),
+            default_audience: "api".to_string(),
+            allowed_audiences: vec![],
+            token_ttl_sec: 3600,
+            subject_prefix: "spiffe://issuer.example.com".to_string(),
+            enabled: true,
+            rotate_key: true,
+            algorithm: identity_config::SigningAlgorithm::Es256,
+            encryption_key_id: "test".parse().unwrap(),
+            signing_key_overlap_sec: Some(3600),
+        };
+        validate_identity_overlap_for_rotation(&config).unwrap();
     }
 
     #[test]

--- a/crates/api-model/src/rpc_conv/tenant.rs
+++ b/crates/api-model/src/rpc_conv/tenant.rs
@@ -18,6 +18,7 @@ use std::str::FromStr;
 
 use carbide_uuid::UuidConversionError;
 use carbide_uuid::instance::InstanceId;
+use config_version::ConfigVersion;
 use rpc::errors::RpcDataConversionError;
 use rpc::forge as rpc_forge;
 
@@ -86,6 +87,32 @@ impl TryFrom<Tenant> for rpc::forge::UpdateTenantResponse {
     fn try_from(value: Tenant) -> Result<Self, Self::Error> {
         Ok(rpc::forge::UpdateTenantResponse {
             tenant: Some(value.try_into()?),
+        })
+    }
+}
+
+impl TryFrom<rpc::forge::Tenant> for Tenant {
+    type Error = RpcDataConversionError;
+
+    fn try_from(src: rpc::forge::Tenant) -> Result<Self, Self::Error> {
+        let metadata = src
+            .metadata
+            .ok_or(RpcDataConversionError::MissingArgument("metadata"))?;
+        let version = src
+            .version
+            .parse::<ConfigVersion>()
+            .map_err(|_| RpcDataConversionError::InvalidConfigVersion(src.version))?;
+        let organization_id = src
+            .organization_id
+            .clone()
+            .try_into()
+            .map_err(|_| RpcDataConversionError::InvalidTenantOrg(src.organization_id))?;
+
+        Ok(Self {
+            organization_id,
+            metadata: metadata.try_into()?,
+            routing_profile_type: src.routing_profile_type,
+            version,
         })
     }
 }
@@ -433,6 +460,14 @@ pub fn identity_config_try_from_proto(
             "default_audience must be in allowed_audiences".to_string(),
         ));
     }
+    if let Some(s) = value.signing_key_overlap_sec
+        && s > bounds.signing_key_overlap_max_sec
+    {
+        return Err(IdentityConfigValidationError(format!(
+            "signing_key_overlap_sec must not exceed {} seconds",
+            bounds.signing_key_overlap_max_sec
+        )));
+    }
     Ok(IdentityConfig {
         issuer,
         default_audience: value.default_audience,
@@ -443,6 +478,7 @@ pub fn identity_config_try_from_proto(
         rotate_key: value.rotate_key,
         algorithm: bounds.algorithm,
         encryption_key_id: bounds.encryption_key_id.clone(),
+        signing_key_overlap_sec: None,
     })
 }
 
@@ -538,6 +574,7 @@ mod tests {
             token_ttl_sec: 3600,
             subject_prefix: None,
             rotate_key: false,
+            signing_key_overlap_sec: None,
         };
         let bounds = IdentityConfigValidationBounds {
             token_ttl_min_sec: 60,
@@ -545,6 +582,8 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test-master".parse().unwrap(),
             trust_domain_allowlist: vec![],
+            signing_key_overlap_default_sec: 86_400,
+            signing_key_overlap_max_sec: 604_800,
         };
         let config = identity_config_try_from_proto(proto, &bounds).unwrap();
         assert_eq!(config.issuer.as_str(), "https://issuer.example.com");
@@ -568,6 +607,7 @@ mod tests {
             token_ttl_sec: 3600,
             subject_prefix: None,
             rotate_key: false,
+            signing_key_overlap_sec: None,
         };
         let bounds = IdentityConfigValidationBounds {
             token_ttl_min_sec: 60,
@@ -575,6 +615,8 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test-master".parse().unwrap(),
             trust_domain_allowlist: vec![],
+            signing_key_overlap_default_sec: 86400,
+            signing_key_overlap_max_sec: 604800,
         };
         let config = identity_config_try_from_proto(proto, &bounds).unwrap();
         assert_eq!(config.issuer.as_str(), "https://issuer.example.com/wl");
@@ -591,6 +633,7 @@ mod tests {
             token_ttl_sec: 3600,
             subject_prefix: None,
             rotate_key: false,
+            signing_key_overlap_sec: None,
         };
         let bounds = IdentityConfigValidationBounds {
             token_ttl_min_sec: 60,
@@ -598,6 +641,8 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec![],
+            signing_key_overlap_default_sec: 86400,
+            signing_key_overlap_max_sec: 604800,
         };
         let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
         assert!(err.0.contains("issuer is required"));
@@ -613,6 +658,7 @@ mod tests {
             token_ttl_sec: 3600,
             subject_prefix: None,
             rotate_key: false,
+            signing_key_overlap_sec: None,
         };
         let bounds = IdentityConfigValidationBounds {
             token_ttl_min_sec: 60,
@@ -620,6 +666,8 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec![],
+            signing_key_overlap_default_sec: 86400,
+            signing_key_overlap_max_sec: 604800,
         };
         let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
         assert!(err.0.contains("default_audience is required"));
@@ -635,6 +683,7 @@ mod tests {
             token_ttl_sec: 3600,
             subject_prefix: Some("spiffe://issuer.example.com/workloads".to_string()),
             rotate_key: false,
+            signing_key_overlap_sec: None,
         };
         let bounds = IdentityConfigValidationBounds {
             token_ttl_min_sec: 60,
@@ -642,6 +691,8 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec![],
+            signing_key_overlap_default_sec: 86400,
+            signing_key_overlap_max_sec: 604800,
         };
         let config = identity_config_try_from_proto(proto, &bounds).unwrap();
         assert_eq!(
@@ -660,6 +711,7 @@ mod tests {
             token_ttl_sec: 3600,
             subject_prefix: Some(String::new()),
             rotate_key: false,
+            signing_key_overlap_sec: None,
         };
         let bounds = IdentityConfigValidationBounds {
             token_ttl_min_sec: 60,
@@ -667,6 +719,8 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec![],
+            signing_key_overlap_default_sec: 86400,
+            signing_key_overlap_max_sec: 604800,
         };
         let config = identity_config_try_from_proto(proto, &bounds).unwrap();
         assert_eq!(config.subject_prefix, "spiffe://issuer.example.com");
@@ -682,6 +736,7 @@ mod tests {
             token_ttl_sec: 3600,
             subject_prefix: Some("https://issuer.example.com/p".to_string()),
             rotate_key: false,
+            signing_key_overlap_sec: None,
         };
         let bounds = IdentityConfigValidationBounds {
             token_ttl_min_sec: 60,
@@ -689,6 +744,8 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec![],
+            signing_key_overlap_default_sec: 86400,
+            signing_key_overlap_max_sec: 604800,
         };
         let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
         assert!(err.0.contains("spiffe://"));
@@ -704,6 +761,7 @@ mod tests {
             token_ttl_sec: 3600,
             subject_prefix: Some("spiffe://other.example/wl".to_string()),
             rotate_key: false,
+            signing_key_overlap_sec: None,
         };
         let bounds = IdentityConfigValidationBounds {
             token_ttl_min_sec: 60,
@@ -711,6 +769,8 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec![],
+            signing_key_overlap_default_sec: 86400,
+            signing_key_overlap_max_sec: 604800,
         };
         let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
         assert!(err.0.contains("does not match"));
@@ -726,6 +786,7 @@ mod tests {
             token_ttl_sec: 0,
             subject_prefix: None,
             rotate_key: false,
+            signing_key_overlap_sec: None,
         };
         let bounds = IdentityConfigValidationBounds {
             token_ttl_min_sec: 60,
@@ -733,6 +794,8 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec![],
+            signing_key_overlap_default_sec: 86400,
+            signing_key_overlap_max_sec: 604800,
         };
         let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
         assert!(err.0.contains("token_ttl_sec"));
@@ -748,6 +811,7 @@ mod tests {
             token_ttl_sec: 30,
             subject_prefix: None,
             rotate_key: false,
+            signing_key_overlap_sec: None,
         };
         let bounds = IdentityConfigValidationBounds {
             token_ttl_min_sec: 60,
@@ -755,6 +819,8 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec![],
+            signing_key_overlap_default_sec: 86400,
+            signing_key_overlap_max_sec: 604800,
         };
         let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
         assert!(err.0.contains("token_ttl_sec must be between"));
@@ -770,6 +836,7 @@ mod tests {
             token_ttl_sec: 100000,
             subject_prefix: None,
             rotate_key: false,
+            signing_key_overlap_sec: None,
         };
         let bounds = IdentityConfigValidationBounds {
             token_ttl_min_sec: 60,
@@ -777,6 +844,8 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec![],
+            signing_key_overlap_default_sec: 86400,
+            signing_key_overlap_max_sec: 604800,
         };
         let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
         assert!(err.0.contains("token_ttl_sec must be between"));
@@ -792,6 +861,7 @@ mod tests {
             token_ttl_sec: 3600,
             subject_prefix: None,
             rotate_key: false,
+            signing_key_overlap_sec: None,
         };
         let bounds = IdentityConfigValidationBounds {
             token_ttl_min_sec: 60,
@@ -799,6 +869,8 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec!["login.example.com".to_string()],
+            signing_key_overlap_default_sec: 86_400,
+            signing_key_overlap_max_sec: 604_800,
         };
         let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
         assert!(err.0.contains("trust domain"));
@@ -815,6 +887,7 @@ mod tests {
             token_ttl_sec: 3600,
             subject_prefix: None,
             rotate_key: false,
+            signing_key_overlap_sec: None,
         };
         let bounds = IdentityConfigValidationBounds {
             token_ttl_min_sec: 60,
@@ -822,6 +895,8 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: vec!["**.login.example.com".to_string()],
+            signing_key_overlap_default_sec: 86_400,
+            signing_key_overlap_max_sec: 604_800,
         };
         let config = identity_config_try_from_proto(proto, &bounds).unwrap();
         assert_eq!(config.subject_prefix, "spiffe://auth.login.example.com");
@@ -846,6 +921,7 @@ mod tests {
             token_ttl_sec: 3600,
             subject_prefix: None,
             rotate_key: false,
+            signing_key_overlap_sec: None,
         };
         let bounds = IdentityConfigValidationBounds {
             token_ttl_min_sec: 60,
@@ -853,6 +929,8 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: allowlist,
+            signing_key_overlap_default_sec: 86_400,
+            signing_key_overlap_max_sec: 604_800,
         };
         let config = identity_config_try_from_proto(proto, &bounds).unwrap();
         assert_eq!(config.issuer.as_str(), "https://idp.other.example/oidc");
@@ -873,6 +951,7 @@ mod tests {
             token_ttl_sec: 3600,
             subject_prefix: None,
             rotate_key: false,
+            signing_key_overlap_sec: None,
         };
         let bounds = IdentityConfigValidationBounds {
             token_ttl_min_sec: 60,
@@ -880,6 +959,8 @@ mod tests {
             algorithm: identity_config::SigningAlgorithm::Es256,
             encryption_key_id: "test".parse().unwrap(),
             trust_domain_allowlist: allowlist,
+            signing_key_overlap_default_sec: 86_400,
+            signing_key_overlap_max_sec: 604_800,
         };
         let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
         assert!(err.0.contains("allowlist"));

--- a/crates/api-model/src/tenant/identity_config.rs
+++ b/crates/api-model/src/tenant/identity_config.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 /// JWT `alg` for per-tenant signing keys. Only ES256 (ECDSA P-256) is implemented end-to-end.
 pub const TENANT_IDENTITY_SIGNING_JWT_ALG: &str = "ES256";
 
-/// Per-tenant JWT signing algorithm persisted in `tenant_identity_config.algorithm` and site config.
+/// Per-tenant JWT signing algorithm persisted inside `signing_key_public_*` JSON (`alg`) and site config.
 /// Only [`SigningAlgorithm::Es256`] is implemented end-to-end today; the enum leaves room for more JOSE `alg` values later.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
@@ -293,11 +293,11 @@ pub struct EncryptionKeyIdTag;
 /// Selects the AES key under `machine_identity.encryption_keys` and labels encryption envelopes.
 pub type EncryptionKeyId = NonEmptyStr<EncryptionKeyIdTag>;
 
-/// Marker for JWT `kid` / `tenant_identity_config.key_id` (e.g. hex digest of public key material).
+/// Marker for JWT `kid` inside `signing_key_public_*` JSON (e.g. hex digest of public key material).
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct TenantIdentitySigningKeyIdTag;
 
-/// Per-tenant signing key identifier stored in `key_id` (JWT `kid`); must be non-empty.
+/// Per-tenant signing key identifier (JWT `kid`), stored in `signing_key_public_*` JSON; must be non-empty.
 pub type KeyId = NonEmptyStr<TenantIdentitySigningKeyIdTag>;
 
 impl KeyId {
@@ -313,22 +313,86 @@ impl KeyId {
     }
 }
 
-/// Marker for `tenant_identity_config.signing_key_public` (SPKI PEM text).
+/// Marker for `tenant_identity_config` PEM text embedded in signing public JSON (`public_pem`).
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct TenantSigningPublicKeyPemTag;
 
-/// ES256 public key in PEM form (`signing_key_public` column).
+/// ES256 public key in PEM form (stored in `signing_key_public_* .public_pem`).
 pub type SigningPublicKeyPem = NonEmptyStr<TenantSigningPublicKeyPemTag>;
+
+/// Versioned signing public metadata JSON (`tenant_identity_config.signing_key_public_1|2`).
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SigningKeyPublicV1 {
+    pub v: u32,
+    pub kid: String,
+    pub alg: String,
+    pub public_pem: String,
+}
+
+impl SigningKeyPublicV1 {
+    /// Builds version-1 JSON content for an ES256 SPKI PEM (canonical `kid` from [`KeyId::from_public_key_material`]).
+    pub fn es256_from_public_pem(public_pem: &str) -> Result<Self, String> {
+        let kid = KeyId::from_public_key_material(public_pem);
+        Ok(Self {
+            v: 1,
+            kid: kid.as_str().to_string(),
+            alg: TENANT_IDENTITY_SIGNING_JWT_ALG.to_string(),
+            public_pem: public_pem.trim().to_string(),
+        })
+    }
+
+    /// Ensures `kid` / `alg` match `public_pem` and only ES256 is allowed.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.v != 1 {
+            return Err(format!(
+                "unsupported tenant signing public document version {}",
+                self.v
+            ));
+        }
+        let expected_kid = KeyId::from_public_key_material(&self.public_pem);
+        if expected_kid.as_str() != self.kid {
+            return Err("signing public kid does not match public_pem".to_string());
+        }
+        let alg: SigningAlgorithm = self
+            .alg
+            .parse()
+            .map_err(|e: UnsupportedTenantSigningAlgorithm| e.to_string())?;
+        if alg != SigningAlgorithm::Es256 {
+            return Err("only ES256 tenant signing keys are supported".to_string());
+        }
+        Ok(())
+    }
+}
+
+/// Database enum `tenant_identity_current_signing_key_slot_t`: which slot signs new JWTs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, sqlx::Type)]
+#[sqlx(type_name = "tenant_identity_current_signing_key_slot_t")]
+pub enum TenantIdentityCurrentSigningKeySlot {
+    #[sqlx(rename = "signing_key_1")]
+    SigningKey1,
+    #[sqlx(rename = "signing_key_2")]
+    SigningKey2,
+}
+
+impl TenantIdentityCurrentSigningKeySlot {
+    #[must_use]
+    pub const fn other(self) -> Self {
+        match self {
+            Self::SigningKey1 => Self::SigningKey2,
+            Self::SigningKey2 => Self::SigningKey1,
+        }
+    }
+}
 
 /// Non-empty UTF-8 string holding a `key_encryption` JSON envelope (base64). `M` distinguishes
 /// what plaintext the ciphertext wraps so distinct columns are not interchangeable.
 pub type EnvelopeCiphertext<M> = NonEmptyStr<M>;
 
-/// Marker for `tenant_identity_config.encrypted_signing_key` (encrypted ES256 private PEM).
+/// Marker for `tenant_identity_config.encrypted_signing_key_*` (encrypted ES256 private PEM).
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct TenantSigningPrivateKeyCiphertextTag;
 
-/// Ciphertext for stored signing private key (`encrypted_signing_key`).
+/// Ciphertext for a stored signing private key slot (`encrypted_signing_key_1` / `_2`).
 pub type EncryptedSigningPrivateKey = EnvelopeCiphertext<TenantSigningPrivateKeyCiphertextTag>;
 
 /// Marker for token-delegation auth config ciphertext (`encrypted_auth_method_config`).

--- a/crates/api-model/src/tenant/identity_config.rs
+++ b/crates/api-model/src/tenant/identity_config.rs
@@ -91,7 +91,8 @@ impl<'r> sqlx::Decode<'r, sqlx::Postgres> for SigningAlgorithm {
 // --- JWT issuer (`iss`) ---
 
 /// Normalized JWT issuer URL or SPIFFE ID.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, sqlx::Type)]
+#[sqlx(transparent, type_name = "VARCHAR")]
 pub struct Issuer(String);
 
 impl Issuer {
@@ -175,28 +176,6 @@ impl FromStr for Issuer {
     }
 }
 
-impl sqlx::Type<sqlx::Postgres> for Issuer {
-    fn type_info() -> sqlx::postgres::PgTypeInfo {
-        <String as sqlx::Type<sqlx::Postgres>>::type_info()
-    }
-}
-
-impl sqlx::Encode<'_, sqlx::Postgres> for Issuer {
-    fn encode_by_ref(
-        &self,
-        buf: &mut <sqlx::Postgres as sqlx::Database>::ArgumentBuffer<'_>,
-    ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
-        <String as sqlx::Encode<'_, sqlx::Postgres>>::encode_by_ref(&self.0, buf)
-    }
-}
-
-impl<'r> sqlx::Decode<'r, sqlx::Postgres> for Issuer {
-    fn decode(value: sqlx::postgres::PgValueRef<'r>) -> Result<Self, sqlx::error::BoxDynError> {
-        let s = <String as sqlx::Decode<sqlx::Postgres>>::decode(value)?;
-        Self::try_from(s).map_err(|e: InvalidIssuer| sqlx::Error::Decode(Box::new(e)).into())
-    }
-}
-
 // --- Non-empty string newtype (shared) and machine-identity ciphertext types ---
 
 /// Owned UTF-8 string that is not empty and not only whitespace (`trim()` non-empty).
@@ -268,6 +247,10 @@ impl<S> sqlx::Type<sqlx::Postgres> for NonEmptyStr<S> {
     fn type_info() -> sqlx::postgres::PgTypeInfo {
         <String as sqlx::Type<sqlx::Postgres>>::type_info()
     }
+
+    fn compatible(ty: &sqlx::postgres::PgTypeInfo) -> bool {
+        <String as sqlx::Type<sqlx::Postgres>>::compatible(ty)
+    }
 }
 
 impl<S> sqlx::Encode<'_, sqlx::Postgres> for NonEmptyStr<S> {
@@ -320,54 +303,126 @@ pub struct TenantSigningPublicKeyPemTag;
 /// ES256 public key in PEM form (stored in `signing_key_public_* .public_pem`).
 pub type SigningPublicKeyPem = NonEmptyStr<TenantSigningPublicKeyPemTag>;
 
+fn serialize_signing_algorithm_as_jwt_alg_str<S>(
+    alg: &SigningAlgorithm,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(alg.as_jwt_alg_str())
+}
+
 /// Versioned signing public metadata JSON (`tenant_identity_config.signing_key_public_1|2`).
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+///
+/// Fields are private; use [`Self::v`], [`Self::kid`], [`Self::alg`], [`Self::public_pem`].
+/// `serde::Deserialize` trims `public_pem` before recomputing [`KeyId`], matching [`Self::es256_from_public_pem`].
+/// JSON `alg` remains a JWT string (e.g. `"ES256"`), not an enum object — see [`serialize_signing_algorithm_as_jwt_alg_str`].
+/// `kid` and `public_pem` are trimmed on build/deserialize so values match [`KeyId::from_public_key_material`].
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 pub struct SigningKeyPublicV1 {
-    pub v: u32,
-    pub kid: String,
-    pub alg: String,
-    pub public_pem: String,
+    v: u32,
+    kid: String,
+    #[serde(serialize_with = "serialize_signing_algorithm_as_jwt_alg_str")]
+    alg: SigningAlgorithm,
+    public_pem: String,
+}
+
+#[derive(Deserialize)]
+struct SigningKeyPublicV1Wire {
+    v: u32,
+    kid: String,
+    alg: String,
+    public_pem: String,
+}
+
+impl<'de> Deserialize<'de> for SigningKeyPublicV1 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let wire = SigningKeyPublicV1Wire::deserialize(deserializer)?;
+        let alg: SigningAlgorithm = wire.alg.parse().map_err(serde::de::Error::custom)?;
+        Self::try_from_parts(wire.v, wire.kid, alg, wire.public_pem)
+            .map_err(serde::de::Error::custom)
+    }
 }
 
 impl SigningKeyPublicV1 {
-    /// Builds version-1 JSON content for an ES256 SPKI PEM (canonical `kid` from [`KeyId::from_public_key_material`]).
-    ///
-    /// PEM is trimmed before hashing and storage so `kid` always matches [`Self::validate`] (which
-    /// recomputes the id from stored `public_pem`). Generated PEM often ends with a trailing newline.
-    pub fn es256_from_public_pem(public_pem: &str) -> Result<Self, String> {
+    /// Only [`SigningAlgorithm::Es256`] is accepted for v1 documents, even if more variants are
+    /// added to [`SigningAlgorithm`] later (e.g. for other config surfaces).
+    fn try_from_parts(
+        v: u32,
+        kid: String,
+        alg: SigningAlgorithm,
+        public_pem: String,
+    ) -> Result<Self, String> {
         let public_pem = public_pem.trim();
         if public_pem.is_empty() {
             return Err("signing public PEM is empty".to_string());
         }
-        let kid = KeyId::from_public_key_material(public_pem);
-        Ok(Self {
-            v: 1,
-            kid: kid.as_str().to_string(),
-            alg: TENANT_IDENTITY_SIGNING_JWT_ALG.to_string(),
-            public_pem: public_pem.to_string(),
-        })
-    }
-
-    /// Ensures `kid` / `alg` match `public_pem` and only ES256 is allowed.
-    pub fn validate(&self) -> Result<(), String> {
-        if self.v != 1 {
+        let public_pem = public_pem.to_string();
+        if v != 1 {
             return Err(format!(
-                "unsupported tenant signing public document version {}",
-                self.v
+                "unsupported tenant signing public document version {v}"
             ));
         }
-        let expected_kid = KeyId::from_public_key_material(&self.public_pem);
-        if expected_kid.as_str() != self.kid {
+        let kid = kid.trim();
+        if kid.is_empty() {
+            return Err("signing public kid is empty".to_string());
+        }
+        let expected_kid = KeyId::from_public_key_material(&public_pem);
+        if expected_kid.as_str() != kid {
             return Err("signing public kid does not match public_pem".to_string());
         }
-        let alg: SigningAlgorithm = self
-            .alg
-            .parse()
-            .map_err(|e: UnsupportedTenantSigningAlgorithm| e.to_string())?;
+        let kid = kid.to_string();
         if alg != SigningAlgorithm::Es256 {
             return Err("only ES256 tenant signing keys are supported".to_string());
         }
-        Ok(())
+        Ok(Self {
+            v,
+            kid,
+            alg,
+            public_pem,
+        })
+    }
+
+    #[must_use]
+    pub const fn v(&self) -> u32 {
+        self.v
+    }
+
+    #[must_use]
+    pub fn kid(&self) -> &str {
+        self.kid.as_str()
+    }
+
+    #[must_use]
+    pub const fn alg(&self) -> SigningAlgorithm {
+        self.alg
+    }
+
+    #[must_use]
+    pub fn public_pem(&self) -> &str {
+        self.public_pem.as_str()
+    }
+
+    /// Builds version-1 JSON content for an ES256 SPKI PEM (canonical `kid` from [`KeyId::from_public_key_material`]).
+    ///
+    /// PEM is trimmed before hashing and storage so `kid` always matches persisted `public_pem`.
+    /// Generated PEM often ends with a trailing newline.
+    pub fn es256_from_public_pem(public_pem: &str) -> Result<Self, String> {
+        let trimmed = public_pem.trim();
+        if trimmed.is_empty() {
+            return Err("signing public PEM is empty".to_string());
+        }
+        let kid = KeyId::from_public_key_material(trimmed);
+        Self::try_from_parts(
+            1,
+            kid.as_str().to_string(),
+            SigningAlgorithm::Es256,
+            trimmed.to_string(),
+        )
     }
 }
 
@@ -412,6 +467,8 @@ pub type EncryptedTokenDelegationAuthConfig =
 
 #[cfg(test)]
 mod key_id_tests {
+    use serde_json::json;
+
     use super::{KeyId, SigningKeyPublicV1};
 
     #[test]
@@ -425,11 +482,27 @@ mod key_id_tests {
     }
 
     #[test]
-    fn es256_public_doc_trailing_newline_passes_validate() {
+    fn es256_public_doc_trims_trailing_newline() {
         let base = "-----BEGIN PUBLIC KEY-----\nMFkw...\n-----END PUBLIC KEY-----";
         let pem = format!("{base}\n");
         let doc = SigningKeyPublicV1::es256_from_public_pem(&pem).expect("build doc");
-        assert_eq!(doc.public_pem, base);
-        doc.validate().expect("kid must match trimmed PEM");
+        assert_eq!(doc.public_pem(), base);
+        assert_eq!(doc.kid(), KeyId::from_public_key_material(base).as_str());
+    }
+
+    #[test]
+    fn signing_public_doc_trims_whitespace_around_kid() {
+        let base = "-----BEGIN PUBLIC KEY-----\nMFkw...\n-----END PUBLIC KEY-----";
+        let canonical = SigningKeyPublicV1::es256_from_public_pem(base).expect("build doc");
+        let loose_kid = format!(" \t{} \n", canonical.kid());
+        let v = json!({
+            "v": 1,
+            "kid": loose_kid,
+            "alg": "ES256",
+            "public_pem": canonical.public_pem(),
+        });
+        let doc: SigningKeyPublicV1 = serde_json::from_value(v).expect("deserialize");
+        assert_eq!(doc.kid(), canonical.kid());
+        assert_eq!(doc, canonical);
     }
 }

--- a/crates/api-model/src/tenant/identity_config.rs
+++ b/crates/api-model/src/tenant/identity_config.rs
@@ -331,13 +331,20 @@ pub struct SigningKeyPublicV1 {
 
 impl SigningKeyPublicV1 {
     /// Builds version-1 JSON content for an ES256 SPKI PEM (canonical `kid` from [`KeyId::from_public_key_material`]).
+    ///
+    /// PEM is trimmed before hashing and storage so `kid` always matches [`Self::validate`] (which
+    /// recomputes the id from stored `public_pem`). Generated PEM often ends with a trailing newline.
     pub fn es256_from_public_pem(public_pem: &str) -> Result<Self, String> {
+        let public_pem = public_pem.trim();
+        if public_pem.is_empty() {
+            return Err("signing public PEM is empty".to_string());
+        }
         let kid = KeyId::from_public_key_material(public_pem);
         Ok(Self {
             v: 1,
             kid: kid.as_str().to_string(),
             alg: TENANT_IDENTITY_SIGNING_JWT_ALG.to_string(),
-            public_pem: public_pem.trim().to_string(),
+            public_pem: public_pem.to_string(),
         })
     }
 
@@ -405,7 +412,7 @@ pub type EncryptedTokenDelegationAuthConfig =
 
 #[cfg(test)]
 mod key_id_tests {
-    use super::KeyId;
+    use super::{KeyId, SigningKeyPublicV1};
 
     #[test]
     fn key_id_from_public_key_material_is_deterministic_hex64() {
@@ -415,5 +422,14 @@ mod key_id_tests {
         assert_eq!(a, b);
         assert_eq!(a.as_str().len(), 64);
         assert!(a.as_str().chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn es256_public_doc_trailing_newline_passes_validate() {
+        let base = "-----BEGIN PUBLIC KEY-----\nMFkw...\n-----END PUBLIC KEY-----";
+        let pem = format!("{base}\n");
+        let doc = SigningKeyPublicV1::es256_from_public_pem(&pem).expect("build doc");
+        assert_eq!(doc.public_pem, base);
+        doc.validate().expect("kid must match trimmed PEM");
     }
 }

--- a/crates/api-model/src/tenant/mod.rs
+++ b/crates/api-model/src/tenant/mod.rs
@@ -296,6 +296,21 @@ impl TenantIdentityConfig {
                 .ok_or("missing encrypted_signing_key_2 for current_signing_key_slot"),
         }
     }
+
+    /// Value for `TenantIdentityConfig.rotate_key` on **Get/Set responses**: `true` while an
+    /// active JWKS overlap window is in progress (both published public slots are present and
+    /// `non_active_slot_expires_at` is still in the future). `false` otherwise, including
+    /// single-key configs and post-overlap rows (after GC clears the inactive slot).
+    #[must_use]
+    pub fn response_rotate_key(&self) -> bool {
+        let Some(expires) = self.non_active_slot_expires_at else {
+            return false;
+        };
+        if expires <= Utc::now() {
+            return false;
+        }
+        self.signing_key_public_1.is_some() && self.signing_key_public_2.is_some()
+    }
 }
 
 /// [`TenantIdentityConfig`] row plus decrypted token-delegation JSON for handlers / `TryInto` RPC.

--- a/crates/api-model/src/tenant/mod.rs
+++ b/crates/api-model/src/tenant/mod.rs
@@ -38,9 +38,9 @@ pub mod identity_config;
 pub use identity_config::{
     EncryptedSigningPrivateKey, EncryptedTokenDelegationAuthConfig, EncryptionKeyId,
     EncryptionKeyIdTag, EnvelopeCiphertext, InvalidIssuer, InvalidNonEmptyStr, Issuer, KeyId,
-    NonEmptyStr, SigningPublicKeyPem, TenantIdentitySigningKeyIdTag,
-    TenantSigningPrivateKeyCiphertextTag, TenantSigningPublicKeyPemTag,
-    TokenDelegationEncryptedAuthConfigTag,
+    NonEmptyStr, SigningKeyPublicV1, SigningPublicKeyPem, TenantIdentityCurrentSigningKeySlot,
+    TenantIdentitySigningKeyIdTag, TenantSigningPrivateKeyCiphertextTag,
+    TenantSigningPublicKeyPemTag, TokenDelegationEncryptedAuthConfigTag,
 };
 pub use identity_config_policy::{
     validate_token_endpoint_domain_allowlist_patterns, validate_trust_domain_allowlist_patterns,
@@ -243,10 +243,13 @@ pub struct TenantIdentityConfig {
     pub enabled: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
-    pub encrypted_signing_key: EncryptedSigningPrivateKey,
-    pub signing_key_public: SigningPublicKeyPem,
-    pub key_id: KeyId,
-    pub algorithm: identity_config::SigningAlgorithm,
+    pub encrypted_signing_key_1: Option<EncryptedSigningPrivateKey>,
+    pub encrypted_signing_key_2: Option<EncryptedSigningPrivateKey>,
+    pub signing_key_public_1: Option<Json<identity_config::SigningKeyPublicV1>>,
+    pub signing_key_public_2: Option<Json<identity_config::SigningKeyPublicV1>>,
+    pub current_signing_key_slot: identity_config::TenantIdentityCurrentSigningKeySlot,
+    pub signing_key_overlap_sec: Option<i32>,
+    pub non_active_slot_expires_at: Option<DateTime<Utc>>,
     pub encryption_key_id: EncryptionKeyId,
     // Token delegation (optional)
     pub token_endpoint: Option<String>,
@@ -259,6 +262,42 @@ pub struct TenantIdentityConfig {
     pub token_delegation_created_at: Option<DateTime<Utc>>,
 }
 
+impl TenantIdentityConfig {
+    /// Signing public JSON for [`Self::current_signing_key_slot`].
+    pub fn current_signing_public(
+        &self,
+    ) -> Result<&identity_config::SigningKeyPublicV1, &'static str> {
+        match self.current_signing_key_slot {
+            identity_config::TenantIdentityCurrentSigningKeySlot::SigningKey1 => self
+                .signing_key_public_1
+                .as_ref()
+                .map(|j| &j.0)
+                .ok_or("missing signing_key_public_1 for current_signing_key_slot"),
+            identity_config::TenantIdentityCurrentSigningKeySlot::SigningKey2 => self
+                .signing_key_public_2
+                .as_ref()
+                .map(|j| &j.0)
+                .ok_or("missing signing_key_public_2 for current_signing_key_slot"),
+        }
+    }
+
+    /// Encrypted private PEM for [`Self::current_signing_key_slot`].
+    pub fn current_encrypted_signing_key(
+        &self,
+    ) -> Result<&EncryptedSigningPrivateKey, &'static str> {
+        match self.current_signing_key_slot {
+            identity_config::TenantIdentityCurrentSigningKeySlot::SigningKey1 => self
+                .encrypted_signing_key_1
+                .as_ref()
+                .ok_or("missing encrypted_signing_key_1 for current_signing_key_slot"),
+            identity_config::TenantIdentityCurrentSigningKeySlot::SigningKey2 => self
+                .encrypted_signing_key_2
+                .as_ref()
+                .ok_or("missing encrypted_signing_key_2 for current_signing_key_slot"),
+        }
+    }
+}
+
 /// [`TenantIdentityConfig`] row plus decrypted token-delegation JSON for handlers / `TryInto` RPC.
 /// `row.encrypted_auth_method_config` stays ciphertext from the database; plaintext is only in
 /// `auth_method_config`. Do not log.
@@ -269,8 +308,11 @@ pub struct TenantIdentityConfigDecrypted {
     pub auth_method_config: Option<String>,
 }
 
-/// Key material for a new or rotated signing key.
-/// Caller generates the key pair, encrypts the private key, and computes key_id = hex(sha256(public_key)).
+/// Key material for a new or rotated signing key (caller-generated pair + encrypted private PEM).
+///
+/// [`Self::key_id`] is the same JWKS `kid` as in the persisted [`SigningKeyPublicV1`] built from
+/// [`Self::signing_key_public`]; it is not stored as a separate DB column. Kept for handler/logging
+/// and tests alongside the PEM-backed document.
 #[derive(Clone, Debug)]
 pub struct SigningKeyMaterial {
     pub key_id: KeyId,
@@ -291,6 +333,8 @@ pub struct IdentityConfig {
     pub rotate_key: bool,
     pub algorithm: identity_config::SigningAlgorithm,
     pub encryption_key_id: EncryptionKeyId,
+    /// Stored `signing_key_overlap_sec` override; `None` = SQL NULL (use site default when rotating).
+    pub signing_key_overlap_sec: Option<i32>,
 }
 
 /// Validation bounds for IdentityConfig. Passed from site config (machine_identity).
@@ -302,6 +346,10 @@ pub struct IdentityConfigValidationBounds {
     pub encryption_key_id: EncryptionKeyId,
     /// Site policy: JWT issuer trust domain must match at least one entry. Empty = no extra check.
     pub trust_domain_allowlist: Vec<String>,
+    /// Default overlap (seconds) when `signing_key_overlap_sec` is NULL at rotate time.
+    pub signing_key_overlap_default_sec: u32,
+    /// Max allowed overlap (seconds) for tenant override.
+    pub signing_key_overlap_max_sec: u32,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/api-model/src/tenant/mod.rs
+++ b/crates/api-model/src/tenant/mod.rs
@@ -248,7 +248,6 @@ pub struct TenantIdentityConfig {
     pub signing_key_public_1: Option<Json<identity_config::SigningKeyPublicV1>>,
     pub signing_key_public_2: Option<Json<identity_config::SigningKeyPublicV1>>,
     pub current_signing_key_slot: identity_config::TenantIdentityCurrentSigningKeySlot,
-    pub signing_key_overlap_sec: Option<i32>,
     pub non_active_slot_expires_at: Option<DateTime<Utc>>,
     pub encryption_key_id: EncryptionKeyId,
     // Token delegation (optional)

--- a/crates/api-model/src/tenant/mod.rs
+++ b/crates/api-model/src/tenant/mod.rs
@@ -333,7 +333,7 @@ pub struct IdentityConfig {
     pub rotate_key: bool,
     pub algorithm: identity_config::SigningAlgorithm,
     pub encryption_key_id: EncryptionKeyId,
-    /// Stored `signing_key_overlap_sec` override; `None` = SQL NULL (use site default when rotating).
+    /// Seconds to keep the previous verification key in JWKS after `rotate_key` (required when rotating).
     pub signing_key_overlap_sec: Option<i32>,
 }
 
@@ -346,9 +346,7 @@ pub struct IdentityConfigValidationBounds {
     pub encryption_key_id: EncryptionKeyId,
     /// Site policy: JWT issuer trust domain must match at least one entry. Empty = no extra check.
     pub trust_domain_allowlist: Vec<String>,
-    /// Default overlap (seconds) when `signing_key_overlap_sec` is NULL at rotate time.
-    pub signing_key_overlap_default_sec: u32,
-    /// Max allowed overlap (seconds) for tenant override.
+    /// Max allowed `signing_key_overlap_sec` (seconds) on rotate.
     pub signing_key_overlap_max_sec: u32,
 }
 

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -818,7 +818,7 @@ pub struct MachineIdentityConfig {
     /// Same pattern syntax as [`Self::trust_domain_allowlist`].
     #[serde(default)]
     pub token_endpoint_domain_allowlist: Vec<String>,
-    /// Upper bound for `TenantIdentityConfig.signing_key_overlap_sec` on rotate (seconds).
+    /// Upper bound for `signing_key_overlap_sec` on `SetTenantIdentityConfiguration` when `rotate_key` is true (seconds).
     #[serde(default = "machine_identity_default_signing_key_overlap_max_sec")]
     pub signing_key_overlap_max_sec: u32,
 }

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -818,10 +818,7 @@ pub struct MachineIdentityConfig {
     /// Same pattern syntax as [`Self::trust_domain_allowlist`].
     #[serde(default)]
     pub token_endpoint_domain_allowlist: Vec<String>,
-    /// When per-row `signing_key_overlap_sec` is NULL, new rotations use this default (seconds).
-    #[serde(default = "machine_identity_default_signing_key_overlap_default_sec")]
-    pub signing_key_overlap_default_sec: u32,
-    /// Upper bound for tenant `signing_key_overlap_sec` (seconds).
+    /// Upper bound for `TenantIdentityConfig.signing_key_overlap_sec` on rotate (seconds).
     #[serde(default = "machine_identity_default_signing_key_overlap_max_sec")]
     pub signing_key_overlap_max_sec: u32,
 }
@@ -836,9 +833,6 @@ fn machine_identity_default_token_ttl_min_sec() -> u32 {
     60
 }
 fn machine_identity_default_token_ttl_max_sec() -> u32 {
-    86400
-}
-fn machine_identity_default_signing_key_overlap_default_sec() -> u32 {
     86400
 }
 fn machine_identity_default_signing_key_overlap_max_sec() -> u32 {
@@ -856,8 +850,6 @@ impl Default for MachineIdentityConfig {
             current_encryption_key_id: None,
             trust_domain_allowlist: Vec::new(),
             token_endpoint_domain_allowlist: Vec::new(),
-            signing_key_overlap_default_sec:
-                machine_identity_default_signing_key_overlap_default_sec(),
             signing_key_overlap_max_sec: machine_identity_default_signing_key_overlap_max_sec(),
         }
     }
@@ -880,7 +872,6 @@ impl From<MachineIdentityConfig> for model::tenant::IdentityConfigValidationBoun
                     "current_encryption_key_id must be non-empty when machine identity is enabled",
                 ),
             trust_domain_allowlist: mi.trust_domain_allowlist,
-            signing_key_overlap_default_sec: mi.signing_key_overlap_default_sec,
             signing_key_overlap_max_sec: mi.signing_key_overlap_max_sec,
         }
     }

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -818,6 +818,12 @@ pub struct MachineIdentityConfig {
     /// Same pattern syntax as [`Self::trust_domain_allowlist`].
     #[serde(default)]
     pub token_endpoint_domain_allowlist: Vec<String>,
+    /// When per-row `signing_key_overlap_sec` is NULL, new rotations use this default (seconds).
+    #[serde(default = "machine_identity_default_signing_key_overlap_default_sec")]
+    pub signing_key_overlap_default_sec: u32,
+    /// Upper bound for tenant `signing_key_overlap_sec` (seconds).
+    #[serde(default = "machine_identity_default_signing_key_overlap_max_sec")]
+    pub signing_key_overlap_max_sec: u32,
 }
 
 fn machine_identity_default_enabled() -> bool {
@@ -832,6 +838,12 @@ fn machine_identity_default_token_ttl_min_sec() -> u32 {
 fn machine_identity_default_token_ttl_max_sec() -> u32 {
     86400
 }
+fn machine_identity_default_signing_key_overlap_default_sec() -> u32 {
+    86400
+}
+fn machine_identity_default_signing_key_overlap_max_sec() -> u32 {
+    604800
+}
 
 impl Default for MachineIdentityConfig {
     fn default() -> Self {
@@ -844,6 +856,9 @@ impl Default for MachineIdentityConfig {
             current_encryption_key_id: None,
             trust_domain_allowlist: Vec::new(),
             token_endpoint_domain_allowlist: Vec::new(),
+            signing_key_overlap_default_sec:
+                machine_identity_default_signing_key_overlap_default_sec(),
+            signing_key_overlap_max_sec: machine_identity_default_signing_key_overlap_max_sec(),
         }
     }
 }
@@ -865,6 +880,8 @@ impl From<MachineIdentityConfig> for model::tenant::IdentityConfigValidationBoun
                     "current_encryption_key_id must be non-empty when machine identity is enabled",
                 ),
             trust_domain_allowlist: mi.trust_domain_allowlist,
+            signing_key_overlap_default_sec: mi.signing_key_overlap_default_sec,
+            signing_key_overlap_max_sec: mi.signing_key_overlap_max_sec,
         }
     }
 }

--- a/crates/api/src/handlers/machine_identity.rs
+++ b/crates/api/src/handlers/machine_identity.rs
@@ -19,8 +19,6 @@
 //! PEM/JWK encoding helpers live in `crate::machine_identity`; persisted config in `tenant_identity_config`.
 //! Public signing metadata uses `signing_key_public_*` JSON (`kid`, `alg`, `public_pem`).
 
-use std::convert::TryFrom;
-
 use ::rpc::forge::{
     self as rpc, Jwks, JwksKind, JwksRequest, MachineIdentityResponse, OpenIdConfigRequest,
     OpenIdConfiguration,

--- a/crates/api/src/handlers/machine_identity.rs
+++ b/crates/api/src/handlers/machine_identity.rs
@@ -17,6 +17,7 @@
 
 //! gRPC handlers for machine identity: JWT-SVID signing, JWKS, and OpenID discovery.
 //! PEM/JWK encoding helpers live in `crate::machine_identity`; persisted config in `tenant_identity_config`.
+//! Public signing metadata uses `signing_key_public_*` JSON (`kid`, `alg`, `public_pem`).
 
 use std::convert::TryFrom;
 
@@ -71,7 +72,10 @@ async fn load_enabled_identity_for_well_known(
         .database_connection
         .with_txn(|txn| {
             let org_id = org_id.clone();
-            Box::pin(async move { tenant_identity_config::find(&org_id, txn).await })
+            Box::pin(async move {
+                tenant_identity_config::gc_expired_non_active_signing_key(&org_id, txn).await?;
+                tenant_identity_config::find(&org_id, txn).await
+            })
         })
         .await??;
     match cfg {
@@ -82,6 +86,24 @@ async fn load_enabled_identity_for_well_known(
         }
         .into()),
     }
+}
+
+fn push_jwk_from_signing_public_doc(
+    keys: &mut Vec<serde_json::Value>,
+    doc: &model::tenant::identity_config::SigningKeyPublicV1,
+    jwk_key_use: crate::machine_identity::JwkPublicKeyUse,
+) -> Result<(), CarbideError> {
+    doc.validate().map_err(CarbideError::InvalidArgument)?;
+    keys.push(
+        crate::machine_identity::public_pem_to_jwk_value(
+            &doc.public_pem,
+            doc.kid.as_str(),
+            doc.alg.as_str(),
+            jwk_key_use,
+        )
+        .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?,
+    );
+    Ok(())
 }
 
 /// SPIFFE `sub` claim: stored prefix plus `/<machine-id>` (single slash join).
@@ -172,17 +194,22 @@ pub(crate) async fn sign_machine_identity(
         &identity_row.encryption_key_id,
     )
     .await?;
-    let private_pem = key_encryption::decrypt(identity_row.encrypted_signing_key.as_str(), &aes)
-        .map_err(|e| {
-            tracing::error!(
-                error = %e,
-                org_id = %identity_row.organization_id.as_str(),
-                "tenant signing key decrypt failed"
-            );
-            CarbideError::internal("stored signing key could not be decrypted".to_string())
-        })?;
+    let enc_key = identity_row
+        .current_encrypted_signing_key()
+        .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?;
+    let private_pem = key_encryption::decrypt(enc_key.as_str(), &aes).map_err(|e| {
+        tracing::error!(
+            error = %e,
+            org_id = %identity_row.organization_id.as_str(),
+            "tenant signing key decrypt failed"
+        );
+        CarbideError::internal("stored signing key could not be decrypted".to_string())
+    })?;
 
-    let signer = Es256Signer::new(&private_pem, &identity_row.key_id)
+    let active_pub = identity_row
+        .current_signing_public()
+        .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?;
+    let signer = Es256Signer::new(&private_pem, active_pub.kid.as_str())
         .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?;
 
     let now = Utc::now().timestamp();
@@ -314,14 +341,26 @@ pub(crate) async fn get_jwks(
 
     let cfg = load_enabled_identity_for_well_known(api, &org_id).await?;
 
-    let jwk = crate::machine_identity::public_pem_to_jwk_value(
-        cfg.signing_key_public.as_ref(),
-        cfg.key_id.as_ref(),
-        cfg.algorithm.as_jwt_alg_str(),
-        jwk_key_use,
-    )
-    .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?;
-    let jwks = crate::machine_identity::jwks_document_string(&jwk)
+    let mut keys: Vec<serde_json::Value> = Vec::new();
+    if let Some(ref doc) = cfg.signing_key_public_1 {
+        push_jwk_from_signing_public_doc(&mut keys, &doc.0, jwk_key_use)?;
+    }
+    if let Some(ref doc) = cfg.signing_key_public_2 {
+        push_jwk_from_signing_public_doc(&mut keys, &doc.0, jwk_key_use)?;
+    }
+    keys.sort_by(|a, b| {
+        let ka = a.get("kid").and_then(|v| v.as_str()).unwrap_or("");
+        let kb = b.get("kid").and_then(|v| v.as_str()).unwrap_or("");
+        ka.cmp(kb)
+    });
+    if keys.is_empty() {
+        return Err(CarbideError::NotFoundError {
+            kind: "tenant_identity_config",
+            id: org_id.as_str().to_string(),
+        }
+        .into());
+    }
+    let jwks = crate::machine_identity::jwks_document_string(&keys)
         .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?;
 
     Ok(Response::new(Jwks { jwks }))
@@ -356,13 +395,20 @@ pub(crate) async fn get_open_id_configuration(
         .into());
     }
 
+    let active_pub = cfg
+        .current_signing_public()
+        .map_err(|_| CarbideError::NotFoundError {
+            kind: "tenant_identity_config",
+            id: org_id.as_str().to_string(),
+        })?;
+
     Ok(Response::new(OpenIdConfiguration {
         issuer: cfg.issuer.as_str().to_string(),
         jwks_uri: jwks_uri_for_issuer(cfg.issuer.as_ref()),
         spiffe_jwks_uri: spiffe_jwks_uri_for_issuer(cfg.issuer.as_ref()),
         response_types_supported: vec!["token".into()],
         subject_types_supported: vec!["public".into()],
-        id_token_signing_alg_values_supported: vec![cfg.algorithm.to_string()],
+        id_token_signing_alg_values_supported: vec![active_pub.alg.clone()],
     }))
 }
 

--- a/crates/api/src/handlers/machine_identity.rs
+++ b/crates/api/src/handlers/machine_identity.rs
@@ -91,12 +91,11 @@ fn push_jwk_from_signing_public_doc(
     doc: &model::tenant::identity_config::SigningKeyPublicV1,
     jwk_key_use: crate::machine_identity::JwkPublicKeyUse,
 ) -> Result<(), CarbideError> {
-    doc.validate().map_err(CarbideError::InvalidArgument)?;
     keys.push(
         crate::machine_identity::public_pem_to_jwk_value(
-            &doc.public_pem,
-            doc.kid.as_str(),
-            doc.alg.as_str(),
+            doc.public_pem(),
+            doc.kid(),
+            doc.alg().as_jwt_alg_str(),
             jwk_key_use,
         )
         .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?,
@@ -207,7 +206,7 @@ pub(crate) async fn sign_machine_identity(
     let active_pub = identity_row
         .current_signing_public()
         .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?;
-    let signer = Es256Signer::new(&private_pem, active_pub.kid.as_str())
+    let signer = Es256Signer::new(&private_pem, active_pub.kid())
         .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?;
 
     let now = Utc::now().timestamp();
@@ -406,7 +405,7 @@ pub(crate) async fn get_open_id_configuration(
         spiffe_jwks_uri: spiffe_jwks_uri_for_issuer(cfg.issuer.as_ref()),
         response_types_supported: vec!["token".into()],
         subject_types_supported: vec!["public".into()],
-        id_token_signing_alg_values_supported: vec![active_pub.alg.clone()],
+        id_token_signing_alg_values_supported: vec![active_pub.alg().to_string()],
     }))
 }
 

--- a/crates/api/src/handlers/tenant_identity_config.rs
+++ b/crates/api/src/handlers/tenant_identity_config.rs
@@ -31,16 +31,15 @@ use ::rpc::forge::{
 use db::{WithTransaction, tenant, tenant_identity_config};
 use forge_secrets::credentials::CredentialReader;
 use forge_secrets::key_encryption;
-use model::tenant::identity_config::TenantIdentityCurrentSigningKeySlot;
 use model::rpc_conv::tenant::{
     identity_config_try_from_proto, validate_identity_overlap_for_rotation,
 };
+use model::tenant::identity_config::TenantIdentityCurrentSigningKeySlot;
 use model::tenant::{
     EncryptedSigningPrivateKey, EncryptedTokenDelegationAuthConfig, IdentityConfigValidationBounds,
-    IdentityConfigValidationError, InvalidNonEmptyStr,
-    InvalidTenantOrg, KeyId, SigningKeyMaterial, SigningPublicKeyPem, TenantIdentityConfig,
-    TenantIdentityConfigDecrypted, TenantOrganizationId, TokenDelegation,
-    TokenDelegationValidationBounds, TokenDelegationValidationError,
+    IdentityConfigValidationError, InvalidNonEmptyStr, InvalidTenantOrg, KeyId, SigningKeyMaterial,
+    SigningPublicKeyPem, TenantIdentityConfig, TenantIdentityConfigDecrypted, TenantOrganizationId,
+    TokenDelegation, TokenDelegationValidationBounds, TokenDelegationValidationError,
 };
 use tonic::{Request, Response, Status};
 
@@ -206,8 +205,7 @@ pub(crate) async fn get_configuration(
             token_ttl_sec: cfg.token_ttl_sec as u32,
             subject_prefix: Some(cfg.subject_prefix.clone()),
             rotate_key: cfg.response_rotate_key(),
-            signing_key_overlap_sec: cfg.signing_key_overlap_sec.map(|v| v as u32),
-            ..Default::default()
+            signing_key_overlap_sec: None,
         }),
         created_at: Some(Timestamp::from(cfg.created_at)),
         updated_at: Some(Timestamp::from(cfg.updated_at)),
@@ -280,8 +278,7 @@ pub(crate) async fn set_configuration(
     let proto = req.config.ok_or_else(|| {
         CarbideError::InvalidArgument("TenantIdentityConfig is required".to_string())
     })?;
-    let overlap_from_request = proto.signing_key_overlap_sec;
-    let mut config = identity_config_try_from_proto(
+    let config = identity_config_try_from_proto(
         proto,
         &IdentityConfigValidationBounds::from(api.runtime_config.machine_identity.clone()),
     )
@@ -306,14 +303,6 @@ pub(crate) async fn set_configuration(
         })
         .await??;
 
-    let signing_key_overlap_sec = match overlap_from_request {
-        None => existing.as_ref().and_then(|e| e.signing_key_overlap_sec),
-        Some(0) => None,
-        Some(s) => Some(i32::try_from(s).map_err(|_| {
-            CarbideError::InvalidArgument("signing_key_overlap_sec out of range".to_string())
-        })?),
-    };
-    config.signing_key_overlap_sec = signing_key_overlap_sec;
     validate_identity_overlap_for_rotation(&config)
         .map_err(|e: IdentityConfigValidationError| CarbideError::InvalidArgument(e.0))?;
 
@@ -378,8 +367,7 @@ pub(crate) async fn set_configuration(
             token_ttl_sec: cfg.token_ttl_sec as u32,
             subject_prefix: Some(cfg.subject_prefix.clone()),
             rotate_key: cfg.response_rotate_key(),
-            signing_key_overlap_sec: cfg.signing_key_overlap_sec.map(|v| v as u32),
-            ..Default::default()
+            signing_key_overlap_sec: None,
         }),
         created_at: Some(Timestamp::from(cfg.created_at)),
         updated_at: Some(Timestamp::from(cfg.updated_at)),

--- a/crates/api/src/handlers/tenant_identity_config.rs
+++ b/crates/api/src/handlers/tenant_identity_config.rs
@@ -26,15 +26,18 @@ use ::rpc::Timestamp;
 use ::rpc::forge::{
     GetTenantIdentityConfigRequest, GetTokenDelegationRequest, SetTenantIdentityConfigRequest,
     TenantIdentityConfig as ProtoTenantIdentityConfig, TenantIdentityConfigResponse,
-    TokenDelegationRequest, TokenDelegationResponse, token_delegation,
+    TenantIdentitySigningKey, TokenDelegationRequest, TokenDelegationResponse, token_delegation,
 };
 use db::{WithTransaction, tenant, tenant_identity_config};
 use forge_secrets::credentials::CredentialReader;
 use forge_secrets::key_encryption;
+use model::tenant::identity_config::TenantIdentityCurrentSigningKeySlot;
+use model::rpc_conv::tenant::identity_config_try_from_proto;
 use model::tenant::{
-    EncryptedSigningPrivateKey, EncryptedTokenDelegationAuthConfig, IdentityConfigValidationError,
-    InvalidNonEmptyStr, InvalidTenantOrg, KeyId, SigningKeyMaterial, SigningPublicKeyPem,
-    TenantIdentityConfig, TenantIdentityConfigDecrypted, TenantOrganizationId, TokenDelegation,
+    EncryptedSigningPrivateKey, EncryptedTokenDelegationAuthConfig, IdentityConfigValidationBounds,
+    IdentityConfigValidationError, InvalidNonEmptyStr,
+    InvalidTenantOrg, KeyId, SigningKeyMaterial, SigningPublicKeyPem, TenantIdentityConfig,
+    TenantIdentityConfigDecrypted, TenantOrganizationId, TokenDelegation,
     TokenDelegationValidationBounds, TokenDelegationValidationError,
 };
 use tonic::{Request, Response, Status};
@@ -97,6 +100,54 @@ fn format_token_delegation_request_redacted(req: &TokenDelegationRequest) -> Str
 
 // --- Tenant identity configuration handlers ---
 
+/// Builds [`TenantIdentitySigningKey`] entries from slotted public JSON; exactly one has
+/// `current_signer == true`.
+fn tenant_identity_signing_keys_response(
+    cfg: &TenantIdentityConfig,
+) -> Result<Vec<TenantIdentitySigningKey>, Status> {
+    let mut keys = Vec::new();
+    if let Some(ref doc) = cfg.signing_key_public_1 {
+        doc.0.validate().map_err(|e| {
+            Status::from(CarbideError::InvalidArgument(format!(
+                "signing_key_public_1: {e}"
+            )))
+        })?;
+        keys.push(TenantIdentitySigningKey {
+            kid: doc.0.kid.clone(),
+            alg: doc.0.alg.clone(),
+            current_signer: cfg.current_signing_key_slot
+                == TenantIdentityCurrentSigningKeySlot::SigningKey1,
+        });
+    }
+    if let Some(ref doc) = cfg.signing_key_public_2 {
+        doc.0.validate().map_err(|e| {
+            Status::from(CarbideError::InvalidArgument(format!(
+                "signing_key_public_2: {e}"
+            )))
+        })?;
+        keys.push(TenantIdentitySigningKey {
+            kid: doc.0.kid.clone(),
+            alg: doc.0.alg.clone(),
+            current_signer: cfg.current_signing_key_slot
+                == TenantIdentityCurrentSigningKeySlot::SigningKey2,
+        });
+    }
+    let n_current = keys.iter().filter(|k| k.current_signer).count();
+    if keys.is_empty() {
+        return Err(CarbideError::InvalidArgument(
+            "tenant identity config has no published signing keys".to_string(),
+        )
+        .into());
+    }
+    if n_current != 1 {
+        return Err(CarbideError::InvalidArgument(format!(
+            "expected exactly one current signer in signing_keys; found {n_current}"
+        ))
+        .into());
+    }
+    Ok(keys)
+}
+
 /// `Forge::get_tenant_identity_configuration`: fetches per-org identity config.
 pub(crate) async fn get_configuration(
     api: &Api,
@@ -120,7 +171,12 @@ pub(crate) async fn get_configuration(
 
     let cfg = api
         .database_connection
-        .with_txn(|txn| Box::pin(async move { tenant_identity_config::find(&org_id, txn).await }))
+        .with_txn(|txn| {
+            Box::pin(async move {
+                tenant_identity_config::gc_expired_non_active_signing_key(&org_id, txn).await?;
+                tenant_identity_config::find(&org_id, txn).await
+            })
+        })
         .await??;
 
     let cfg = match cfg {
@@ -134,6 +190,8 @@ pub(crate) async fn get_configuration(
         }
     };
 
+    let signing_keys = tenant_identity_signing_keys_response(&cfg)?;
+
     Ok(Response::new(TenantIdentityConfigResponse {
         organization_id: org_id_str,
         config: Some(ProtoTenantIdentityConfig {
@@ -144,10 +202,11 @@ pub(crate) async fn get_configuration(
             token_ttl_sec: cfg.token_ttl_sec as u32,
             subject_prefix: Some(cfg.subject_prefix.clone()),
             rotate_key: false,
+            signing_key_overlap_sec: cfg.signing_key_overlap_sec.map(|v| v as u32),
         }),
         created_at: Some(Timestamp::from(cfg.created_at)),
         updated_at: Some(Timestamp::from(cfg.updated_at)),
-        key_id: cfg.key_id.as_str().to_string(),
+        signing_keys,
     }))
 }
 
@@ -216,13 +275,13 @@ pub(crate) async fn set_configuration(
     let proto = req.config.ok_or_else(|| {
         CarbideError::InvalidArgument("TenantIdentityConfig is required".to_string())
     })?;
-    let config = model::rpc_conv::tenant::identity_config_try_from_proto(
+    let overlap_from_request = proto.signing_key_overlap_sec;
+    let mut config = identity_config_try_from_proto(
         proto,
-        &model::tenant::IdentityConfigValidationBounds::from(
-            api.runtime_config.machine_identity.clone(),
-        ),
+        &IdentityConfigValidationBounds::from(api.runtime_config.machine_identity.clone()),
     )
     .map_err(|e: IdentityConfigValidationError| CarbideError::InvalidArgument(e.0))?;
+
     let org_id = req.organization_id.trim();
     if org_id.is_empty() {
         return Err(
@@ -241,6 +300,15 @@ pub(crate) async fn set_configuration(
             Box::pin(async move { tenant_identity_config::find(&org_id_for_find, txn).await })
         })
         .await??;
+
+    let signing_key_overlap_sec = match overlap_from_request {
+        None => existing.as_ref().and_then(|e| e.signing_key_overlap_sec),
+        Some(0) => None,
+        Some(s) => Some(i32::try_from(s).map_err(|_| {
+            CarbideError::InvalidArgument("signing_key_overlap_sec out of range".to_string())
+        })?),
+    };
+    config.signing_key_overlap_sec = signing_key_overlap_sec;
 
     let key_material = match (&existing, config.rotate_key) {
         (None, _) | (_, true) => {
@@ -271,6 +339,10 @@ pub(crate) async fn set_configuration(
         (Some(_), false) => None,
     };
 
+    let site_overlap_default = api
+        .runtime_config
+        .machine_identity
+        .signing_key_overlap_default_sec;
     let cfg = api
         .database_connection
         .with_txn(|txn| {
@@ -282,12 +354,21 @@ pub(crate) async fn set_configuration(
                         id: org_id.as_str().to_string(),
                     });
                 }
-                let cfg = tenant_identity_config::set(&org_id, &config, key_material, txn).await?;
+                let cfg = tenant_identity_config::set(
+                    &org_id,
+                    &config,
+                    key_material,
+                    site_overlap_default,
+                    txn,
+                )
+                .await?;
                 tenant::increment_version(org_id.as_str(), txn).await?;
                 Ok(cfg)
             })
         })
         .await??;
+
+    let signing_keys = tenant_identity_signing_keys_response(&cfg)?;
 
     Ok(Response::new(TenantIdentityConfigResponse {
         organization_id: org_id_str,
@@ -299,10 +380,11 @@ pub(crate) async fn set_configuration(
             token_ttl_sec: cfg.token_ttl_sec as u32,
             subject_prefix: Some(cfg.subject_prefix.clone()),
             rotate_key: false,
+            signing_key_overlap_sec: cfg.signing_key_overlap_sec.map(|v| v as u32),
         }),
         created_at: Some(Timestamp::from(cfg.created_at)),
         updated_at: Some(Timestamp::from(cfg.updated_at)),
-        key_id: cfg.key_id.as_str().to_string(),
+        signing_keys,
     }))
 }
 

--- a/crates/api/src/handlers/tenant_identity_config.rs
+++ b/crates/api/src/handlers/tenant_identity_config.rs
@@ -32,7 +32,9 @@ use db::{WithTransaction, tenant, tenant_identity_config};
 use forge_secrets::credentials::CredentialReader;
 use forge_secrets::key_encryption;
 use model::tenant::identity_config::TenantIdentityCurrentSigningKeySlot;
-use model::rpc_conv::tenant::identity_config_try_from_proto;
+use model::rpc_conv::tenant::{
+    identity_config_try_from_proto, validate_identity_overlap_for_rotation,
+};
 use model::tenant::{
     EncryptedSigningPrivateKey, EncryptedTokenDelegationAuthConfig, IdentityConfigValidationBounds,
     IdentityConfigValidationError, InvalidNonEmptyStr,
@@ -112,11 +114,17 @@ fn tenant_identity_signing_keys_response(
                 "signing_key_public_1: {e}"
             )))
         })?;
+        let current_signer =
+            cfg.current_signing_key_slot == TenantIdentityCurrentSigningKeySlot::SigningKey1;
         keys.push(TenantIdentitySigningKey {
             kid: doc.0.kid.clone(),
             alg: doc.0.alg.clone(),
-            current_signer: cfg.current_signing_key_slot
-                == TenantIdentityCurrentSigningKeySlot::SigningKey1,
+            current_signer,
+            expire_at: if current_signer {
+                None
+            } else {
+                cfg.non_active_slot_expires_at.map(Timestamp::from)
+            },
         });
     }
     if let Some(ref doc) = cfg.signing_key_public_2 {
@@ -125,11 +133,17 @@ fn tenant_identity_signing_keys_response(
                 "signing_key_public_2: {e}"
             )))
         })?;
+        let current_signer =
+            cfg.current_signing_key_slot == TenantIdentityCurrentSigningKeySlot::SigningKey2;
         keys.push(TenantIdentitySigningKey {
             kid: doc.0.kid.clone(),
             alg: doc.0.alg.clone(),
-            current_signer: cfg.current_signing_key_slot
-                == TenantIdentityCurrentSigningKeySlot::SigningKey2,
+            current_signer,
+            expire_at: if current_signer {
+                None
+            } else {
+                cfg.non_active_slot_expires_at.map(Timestamp::from)
+            },
         });
     }
     let n_current = keys.iter().filter(|k| k.current_signer).count();
@@ -309,6 +323,8 @@ pub(crate) async fn set_configuration(
         })?),
     };
     config.signing_key_overlap_sec = signing_key_overlap_sec;
+    validate_identity_overlap_for_rotation(&config)
+        .map_err(|e: IdentityConfigValidationError| CarbideError::InvalidArgument(e.0))?;
 
     let key_material = match (&existing, config.rotate_key) {
         (None, _) | (_, true) => {
@@ -319,7 +335,8 @@ pub(crate) async fn set_configuration(
             .await?;
             let (private_pem, public_pem) = key_encryption::generate_es256_key_pair()
                 .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?;
-            let key_id = KeyId::from_public_key_material(&public_pem);
+            let public_pem_trimmed = public_pem.trim();
+            let key_id = KeyId::from_public_key_material(public_pem_trimmed);
             let encrypted_signing_key: EncryptedSigningPrivateKey =
                 key_encryption::encrypt(&private_pem, &encryption_key, &config.encryption_key_id)
                     .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?
@@ -327,7 +344,8 @@ pub(crate) async fn set_configuration(
                     .map_err(|e: InvalidNonEmptyStr| {
                         CarbideError::InvalidArgument(e.to_string())
                     })?;
-            let signing_key_public: SigningPublicKeyPem = public_pem
+            let signing_key_public: SigningPublicKeyPem = public_pem_trimmed
+                .to_string()
                 .try_into()
                 .map_err(|e: InvalidNonEmptyStr| CarbideError::InvalidArgument(e.to_string()))?;
             Some(SigningKeyMaterial {
@@ -339,10 +357,6 @@ pub(crate) async fn set_configuration(
         (Some(_), false) => None,
     };
 
-    let site_overlap_default = api
-        .runtime_config
-        .machine_identity
-        .signing_key_overlap_default_sec;
     let cfg = api
         .database_connection
         .with_txn(|txn| {
@@ -354,14 +368,7 @@ pub(crate) async fn set_configuration(
                         id: org_id.as_str().to_string(),
                     });
                 }
-                let cfg = tenant_identity_config::set(
-                    &org_id,
-                    &config,
-                    key_material,
-                    site_overlap_default,
-                    txn,
-                )
-                .await?;
+                let cfg = tenant_identity_config::set(&org_id, &config, key_material, txn).await?;
                 tenant::increment_version(org_id.as_str(), txn).await?;
                 Ok(cfg)
             })

--- a/crates/api/src/handlers/tenant_identity_config.rs
+++ b/crates/api/src/handlers/tenant_identity_config.rs
@@ -215,8 +215,9 @@ pub(crate) async fn get_configuration(
             allowed_audiences: cfg.allowed_audiences.0.clone(),
             token_ttl_sec: cfg.token_ttl_sec as u32,
             subject_prefix: Some(cfg.subject_prefix.clone()),
-            rotate_key: false,
+            rotate_key: cfg.response_rotate_key(),
             signing_key_overlap_sec: cfg.signing_key_overlap_sec.map(|v| v as u32),
+            ..Default::default()
         }),
         created_at: Some(Timestamp::from(cfg.created_at)),
         updated_at: Some(Timestamp::from(cfg.updated_at)),
@@ -386,8 +387,9 @@ pub(crate) async fn set_configuration(
             allowed_audiences: cfg.allowed_audiences.0.clone(),
             token_ttl_sec: cfg.token_ttl_sec as u32,
             subject_prefix: Some(cfg.subject_prefix.clone()),
-            rotate_key: false,
+            rotate_key: cfg.response_rotate_key(),
             signing_key_overlap_sec: cfg.signing_key_overlap_sec.map(|v| v as u32),
+            ..Default::default()
         }),
         created_at: Some(Timestamp::from(cfg.created_at)),
         updated_at: Some(Timestamp::from(cfg.updated_at)),

--- a/crates/api/src/handlers/tenant_identity_config.rs
+++ b/crates/api/src/handlers/tenant_identity_config.rs
@@ -109,16 +109,11 @@ fn tenant_identity_signing_keys_response(
 ) -> Result<Vec<TenantIdentitySigningKey>, Status> {
     let mut keys = Vec::new();
     if let Some(ref doc) = cfg.signing_key_public_1 {
-        doc.0.validate().map_err(|e| {
-            Status::from(CarbideError::InvalidArgument(format!(
-                "signing_key_public_1: {e}"
-            )))
-        })?;
         let current_signer =
             cfg.current_signing_key_slot == TenantIdentityCurrentSigningKeySlot::SigningKey1;
         keys.push(TenantIdentitySigningKey {
-            kid: doc.0.kid.clone(),
-            alg: doc.0.alg.clone(),
+            kid: doc.0.kid().to_string(),
+            alg: doc.0.alg().to_string(),
             current_signer,
             expire_at: if current_signer {
                 None
@@ -128,16 +123,11 @@ fn tenant_identity_signing_keys_response(
         });
     }
     if let Some(ref doc) = cfg.signing_key_public_2 {
-        doc.0.validate().map_err(|e| {
-            Status::from(CarbideError::InvalidArgument(format!(
-                "signing_key_public_2: {e}"
-            )))
-        })?;
         let current_signer =
             cfg.current_signing_key_slot == TenantIdentityCurrentSigningKeySlot::SigningKey2;
         keys.push(TenantIdentitySigningKey {
-            kid: doc.0.kid.clone(),
-            alg: doc.0.alg.clone(),
+            kid: doc.0.kid().to_string(),
+            alg: doc.0.alg().to_string(),
             current_signer,
             expire_at: if current_signer {
                 None

--- a/crates/api/src/machine_identity/mod.rs
+++ b/crates/api/src/machine_identity/mod.rs
@@ -149,7 +149,7 @@ impl JwkPublicKeyUse {
     }
 }
 
-/// Maps `tenant_identity_config.signing_key_public` (SPKI PEM) into one RFC 7517 JWK JSON object.
+/// Maps `public_pem` (SPKI PEM) into one RFC 7517 JWK JSON object.
 pub fn public_pem_to_jwk_value(
     public_key_pem: &str,
     kid: &str,
@@ -185,9 +185,14 @@ pub fn public_pem_to_jwk_value(
     }))
 }
 
-/// Serializes `{"keys":[ key ]}` as compact UTF-8 JSON for gRPC [`rpc::forge::Jwks::jwks`].
-pub fn jwks_document_string(key: &Value) -> Result<String, JwkBuildError> {
-    let doc = serde_json::json!({ "keys": [key] });
+/// Serializes `{"keys":[ ... ]}` as compact UTF-8 JSON for gRPC [`rpc::forge::Jwks::jwks`].
+pub fn jwks_document_string(keys: &[Value]) -> Result<String, JwkBuildError> {
+    if keys.is_empty() {
+        return Err(JwkBuildError(
+            "JWKS document requires at least one verification key".into(),
+        ));
+    }
+    let doc = serde_json::json!({ "keys": keys });
     serde_json::to_string(&doc).map_err(|e| JwkBuildError(format!("serialize JWKS document: {e}")))
 }
 

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1002,11 +1002,13 @@ message GetTenantIdentityConfigRequest {
 }
 
 // Published signing key metadata (from `signing_key_public_*` JSON). Exactly one entry per
-// response should have `current_signer == true`.
+// response should have `current_signer == true`. The inactive (previous) key during rotation
+// includes `expire_at` when it is still published for verification (JWKS overlap end; JSON: expireAt).
 message TenantIdentitySigningKey {
   string kid = 1;
   string alg = 2;
   bool current_signer = 3;
+  optional google.protobuf.Timestamp expire_at = 4;
 }
 
 message TenantIdentityConfig {
@@ -1020,8 +1022,10 @@ message TenantIdentityConfig {
   // When unset or empty, defaults to spiffe://<trust-domain-from-issuer>
   optional string subject_prefix = 6;
   bool rotate_key = 7;
-  // Seconds to keep the previous verification key in JWKS after `rotate_key`. Unset on Set = preserve
-  // existing stored value; `0` = clear stored override (site default applies on the next rotation).
+  // Seconds to keep the previous verification key in JWKS after `rotate_key`. Required when
+  // `rotate_key` is true; must be omitted when `rotate_key` is false. Must be >= `token_ttl_sec`
+  // so JWTs signed with the previous key remain verifiable until they expire. Capped by site
+  // `machine_identity.signing_key_overlap_max_sec`.
   optional uint32 signing_key_overlap_sec = 8;
 }
 

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1001,6 +1001,14 @@ message GetTenantIdentityConfigRequest {
   string organization_id = 1;
 }
 
+// Published signing key metadata (from `signing_key_public_*` JSON). Exactly one entry per
+// response should have `current_signer == true`.
+message TenantIdentitySigningKey {
+  string kid = 1;
+  string alg = 2;
+  bool current_signer = 3;
+}
+
 message TenantIdentityConfig {
   bool enabled = 1;
   // JWT `iss` / OIDC issuer string: `https://` or `http://` URL (trust domain = host),
@@ -1012,6 +1020,9 @@ message TenantIdentityConfig {
   // When unset or empty, defaults to spiffe://<trust-domain-from-issuer>
   optional string subject_prefix = 6;
   bool rotate_key = 7;
+  // Seconds to keep the previous verification key in JWKS after `rotate_key`. Unset on Set = preserve
+  // existing stored value; `0` = clear stored override (site default applies on the next rotation).
+  optional uint32 signing_key_overlap_sec = 8;
 }
 
 message SetTenantIdentityConfigRequest {
@@ -1024,7 +1035,9 @@ message TenantIdentityConfigResponse {
   TenantIdentityConfig config = 2;
   google.protobuf.Timestamp created_at = 8;
   google.protobuf.Timestamp updated_at = 9;
-  string key_id = 10;
+  reserved 10;
+  reserved "key_id";
+  repeated TenantIdentitySigningKey signing_keys = 11;
 }
 
 // Token delegation config (per-org token exchange for machine identity).

--- a/docs/design/machine-identity/spiffe-svid-sdd.md
+++ b/docs/design/machine-identity/spiffe-svid-sdd.md
@@ -8,6 +8,8 @@
 | :---: | :---: | :---- | :---- |
 | 0.1 | 02/24/2026 | Binu Ramakrishnan | Initial version |
 | 0.2 | 03/11/2026 | Binu Ramakrishnan | gRPC/API updates and incorporated review feedback |
+| 0.3 | 05/11/2026 | Binu Ramakrishnan | DPU agent / FMDS optional HTTP sign proxy (`[machine-identity]` `sign-proxy-url`, `sign-proxy-tls-root-ca`); `FmdsMachineIdentityConfig` in FMDS config push |
+| 0.4 | 05/11/2026 | Binu Ramakrishnan | Signing key rotation (two slots), overlap policy on rotate only |
 |  |  |  |  |
 
 # **1\. Introduction**
@@ -66,9 +68,10 @@ From a high level, the goal for NICo is to issue a JWT-SVID identity to the requ
 
 *Figure-1 High-level architecture and flow diagram*
 
-1. The bare metal (BM) tenant process makes HTTP requests to the NICo meta-data service (IMDS) over a link-local address(169.254.169.254). IMDS is running inside the DPU as part of the NICo DPU agent.   
-2. IMDS in turn makes an mTLS authenticated request to the NICo site controller gRPC server to sign a SPIFFE compliant node identity token (JWT-SVID).  
-   a. Pull keys and machine and org metadata from the database, decrypt private key and sign JWT-SVID. The token is returned to Host’s tenant process (implicit, not shown in the diagram).
+1. The bare metal (BM) tenant process makes HTTP requests to the NICo meta-data service (IMDS) over a link-local address (169.254.169.254). IMDS is running inside the DPU as part of the NICo DPU agent (or standalone FMDS fed by the agent).   
+2. IMDS obtains a JWT-SVID for the workload in one of two ways (operator choice on the DPU agent):  
+   a. **Default:** mTLS-authenticated `SignMachineIdentity` gRPC to the NICo site controller. Pull keys and machine/org metadata from the database, decrypt the private key, sign the JWT-SVID, return it (implicit path to the host workload).  
+   b. **Optional HTTP sign proxy:** when `[machine-identity].sign-proxy-url` is set on the agent, IMDS forwards `GET …/latest/meta-data/identity` (same query string for `aud`, same `Metadata` and `Accept` headers) to `{sign-proxy-url}/latest/meta-data/identity`; the upstream HTTP status and body are returned to the workload. Use this when signing must pass through an in-path HTTP service (e.g. corporate PKI or API gateway) instead of direct agent→Forge gRPC.
 3. The tenant process subsequently makes a request to a service (say OpenBao/Vault) with the JWT-SVID token passed in the authentication header.  
    a. The server-x using the prefetched public keys from NICo will validate JWT-SVID
 
@@ -84,7 +87,7 @@ The system is composed of the following major components:
 
 | Component | Description |
 | :---- | :---- |
-| Meta-data service (IMDS) | A service part of the NICo DPU agent running inside DPU, listening on port 80 (def) |
+| Meta-data service (IMDS) | A service part of the NICo DPU agent running inside DPU, listening on port 80 (def). Serves `GET …/meta-data/identity`; may call Forge over gRPC or forward to an optional HTTP sign proxy configured under `[machine-identity]` |
 | NICo API (gRPC) server | Site controller NICo control plane API server  |
 | NICo REST | NICo REST API server, an aggregator service that controls multiple site controllers |
 | Database (Postgres) | Store NICo node-lifecycle and accounting data  |
@@ -122,12 +125,12 @@ SetTenantIdentityConfiguration (PUT identity/config)
               ▼
 ┌───────────────────────────────┐
 │ 3. If org has no key yet:     │
-│    Generate per-org keypair   │
-│    using global algorithm,    │
-│    encrypt with master key,   │
-│    store in tenant_identity_  │
-│    config                     │
-│ If rotate_key=true: same      │
+│    Generate per-org keypair,  │
+│    encrypt, store in slot 1.  │
+│    If rotate_key=true:        │
+│    require overlap sec ≥ TTL; │
+│    place new key in inactive  │
+│    slot;overlap timer for JWKS│
 └───────────────────────────────┘
               │
               ▼
@@ -135,7 +138,9 @@ SetTenantIdentityConfiguration (PUT identity/config)
 │ 4. Return IdentityConfigResp  │
 └───────────────────────────────┘
 ```
-*Figure-3 Per-tenant identity configuration and signing key provisioning flow* 
+*Figure-3 Per-tenant identity configuration and signing key provisioning flow*
+
+**Signing key rotation (two slots):** `tenant_identity_config` holds **two** optional encrypted private keys and matching public-key JSON documents (`signing_key_public_*`). Exactly one slot is **current** (`current_signing_key_slot`). On **first** provisioning, material is written to slot 1. On **rotate** (`rotate_key=true`), the new pair goes into the other slot, the current pointer moves, and **`non_active_slot_expires_at`** records when the previous key may be dropped from JWKS. Overlap duration is **not** stored as a column; each **SetTenantIdentityConfiguration** that rotates must supply **`signing_key_overlap_sec`**, which must be **≥ `token_ttl_sec`** (so tokens signed with the old key stay verifiable until `exp`) and **≤** site **`signing_key_overlap_max_sec`**. While two keys are published, **GetTenantIdentityConfiguration** returns **`signing_keys`**: one entry has **`current_signer`** true; the inactive entry may include **`expire_at`** (JSON **`expireAt`**) — the JWKS overlap end.
 
 ## **3.2 Per-tenant SPIFFE Key Bundle Discovery**
 
@@ -255,7 +260,40 @@ This is the core part of this SDD – issuing JWT-SVID based node identity token
       ▼
 JWT-SVID issued to workload/tenant
 ```
-*Figure-6 Node Identity request flow (direct, no callback)*
+*Figure-6 Node Identity request flow (direct, no callback). The hop from IMDS to NICo may be gRPC `SignMachineIdentity` (default) or an HTTP forward to `sign-proxy-url` when configured on the DPU agent.*
+
+### **3.3.1 DPU agent / FMDS: `[machine-identity]` and optional HTTP sign proxy**
+
+The embedded IMDS identity handler (`GET …/latest/meta-data/identity` and compatible API versions) shares **rate limits**, **wait**, and **sign** timeouts between both signing modes. These are set in the DPU agent TOML under **`[machine-identity]`** (kebab-case keys), validated at startup:
+
+| Key | Role |
+| :---- | :---- |
+| `requests-per-second` | Sustained rate limit for identity GETs (bounded range, default 3) |
+| `burst` | Burst allowance for the limiter |
+| `wait-timeout-secs` | Max wait for a rate-limit permit before failing |
+| `sign-timeout-secs` | Wall-clock timeout for the signing leg: both Forge gRPC (`SignMachineIdentity`) and the optional HTTP sign-proxy request |
+
+**Optional HTTP sign proxy**
+
+| Key | Role |
+| :---- | :---- |
+| `sign-proxy-url` | When set, the agent issues **`GET {url}/latest/meta-data/identity`** with the same query string as the workload request (e.g. repeated `aud=`). Scheme must be `http` or `https`. Trailing slashes on the base URL are normalized. |
+| `sign-proxy-tls-root-ca` | Optional path to a PEM file (one or more certs) added as trusted roots for **`https`** sign-proxy URLs (e.g. private CA). Ignored for `http:`. Requires `sign-proxy-url`. |
+
+When `sign-proxy-url` is **omitted**, the agent uses **Forge `SignMachineIdentity`** over mTLS as today. When it is **set**, the identity path uses **only** the HTTP forward for that request; the upstream response (status, `Content-Type`, body) is returned to the workload.
+
+**Standalone FMDS:** `carbide-dpu-agent` pushes `FmdsConfigUpdate.machine_identity` to the FMDS service as **`FmdsMachineIdentityConfig`** (`crates/rpc/proto/fmds.proto`), mirroring the same numeric fields and optional `sign_proxy_url` / `sign_proxy_tls_root_ca`. If a later `UpdateConfig` **omits** `machine_identity`, FMDS **retains** the previously applied settings.
+
+```toml
+# DPU agent / carbide-agent config excerpt (see crates/agent/example_agent_config.toml)
+[machine-identity]
+# requests-per-second = 3
+# burst = 8
+# wait-timeout-secs = 2
+# sign-timeout-secs = 5
+# sign-proxy-url = "https://sign-proxy.example.com/prefix"   # optional; if set, HTTP forward instead of Forge gRPC
+# sign-proxy-tls-root-ca = "/etc/forge/sign_proxy_root.pem" # optional; HTTPS private CA roots only
+```
 
 ```
 [ Tenant Workload ]
@@ -286,20 +324,29 @@ A new table will be created to store tenant signing key pairs and optional token
 
 | tenant\_identity\_config |  |  |
 | :---- | :---- | :---- |
-| `VARCHAR(255)` | `tenant_organization_id` | PK |
-| `TEXT` | `encrypted_signing_key` | Encrypted private key |
-| `VARCHAR(255)` | `signing_key_public` | Public key |
-| `VARCHAR(255)` | `key_id` | Key identifier (e.g. for JWKS kid) |
-| `VARCHAR(255)` | `algorithm` | Signing algorithm |
-| `VARCHAR(255)` | `encryption_key_id` | To identify encryption key used for encrypting signing key |
-| `BOOLEAN` | `enabled` | Key signing enabled by default. Set enable=false to disable |
-| `TIMESTAMPTZ` | `created_at` | When identity config was first created |
-| `TIMESTAMPTZ` | `updated_at` | When identity config or token delegation was last updated |
-| `VARCHAR(512)` | `token_endpoint` | Token exchange endpoint URL (optional; from PUT identity/token-delegation) |
-| `token_delegation_auth_method_t` (ENUM) | `auth_method` | none, client_secret_basic. (optional) |
-| `TEXT` | `encrypted_auth_method_config` | Encrypted blob of method-specific fields. For example: to store client_id and client_secret. (optional) |
-| `VARCHAR(255)` | `subject_token_audience` | Audience to include in NICo JWT-SVID sent to exchange. (optional) |
-| `TIMESTAMPTZ` | `token_delegation_created_at` | When token delegation was first configured. (optional) |
+| `VARCHAR(255)` | `organization_id` | PK |
+| `issuer` domain type | `issuer` | JWT `iss`; normalized URL / SPIFFE / host form |
+| `VARCHAR(…)` | `default_audience` | Default JWT audience |
+| `JSONB` | `allowed_audiences` | Allowed audience list |
+| `INTEGER` | `token_ttl_sec` | JWT lifetime (seconds) |
+| `VARCHAR(…)` | `subject_prefix` | SPIFFE prefix for `sub` |
+| `BOOLEAN` | `enabled` | Org-level enable |
+| `TEXT` | `encrypted_signing_key_1` | Encrypted private key slot 1 (nullable) |
+| `TEXT` | `encrypted_signing_key_2` | Encrypted private key slot 2 (nullable) |
+| `JSONB` | `signing_key_public_1` | Public metadata JSON (e.g. `kid`, `alg`, `public_pem`) slot 1 (nullable) |
+| `JSONB` | `signing_key_public_2` | Public metadata JSON slot 2 (nullable) |
+| `tenant_identity_current_signing_key_slot_t` (ENUM) | `current_signing_key_slot` | `signing_key_1` or `signing_key_2` — active signer |
+| `TIMESTAMPTZ` | `non_active_slot_expires_at` | When inactive-slot JWKS publication may end (nullable) |
+| `VARCHAR(255)` | `encryption_key_id` | Envelope encryption key id (Vault / secrets) |
+| `TIMESTAMPTZ` | `created_at` | Created |
+| `TIMESTAMPTZ` | `updated_at` | Updated |
+| `VARCHAR(512)` | `token_endpoint` | Token exchange URL (optional) |
+| `token_delegation_auth_method_t` (ENUM) | `auth_method` | none, client\_secret\_basic (optional) |
+| `TEXT` | `encrypted_auth_method_config` | Encrypted delegation credentials (optional) |
+| `VARCHAR(255)` | `subject_token_audience` | Subject JWT audience for exchange (optional) |
+| `TIMESTAMPTZ` | `token_delegation_created_at` | First delegation registration (optional) |
+
+_Previous single-column layout (`encrypted_signing_key`, `signing_key_public`, `key_id`, `algorithm`) is replaced by the slotted model above via migration._
 
 ### **3.4.2 Configuration**
 
@@ -315,6 +362,8 @@ algorithm = "ES256"
 current_encryption_key_id = "primary"
 token_ttl_min_sec = 60 # min ttl permitted in seconds
 token_ttl_max_sec = 86400 # max ttl permitted in seconds
+# Upper bound for per-request `signing_key_overlap_sec` on SetTenantIdentityConfiguration (rotate only).
+signing_key_overlap_max_sec = 604800
 token_endpoint_http_proxy = "https://carbide-ext.com" # optional, SSRF mitigation for token exchange
 # Optional operator allowlists (hostname / DNS patterns only; not full URLs). Empty = no extra restriction.
 # Patterns: exact hostname, *.suffix (one label under suffix), **.suffix (suffix or any subdomain).
@@ -322,12 +371,15 @@ trust_domain_allowlist = []           # JWT issuer trust domain (host from iss U
 token_endpoint_domain_allowlist = []    # token delegation token_endpoint URL host (http/https only)
 ```
 
+**DPU agent / IMDS (separate from site `[machine_identity]`):** Limits and optional HTTP sign-proxy for workload `GET …/meta-data/identity` are configured on the **DPU agent** (and mirrored to **standalone FMDS** via `FmdsConfigUpdate.machine_identity`). They do not live in the API server `site_config.toml`. See **§3.3.1**.
+
 **Global vs per-org:** 
 Global config provides:
   * the master switch (`enabled`)
   * site-wide signing algorithm (`algorithm`)
   * **`current_encryption_key_id`**: selects which master encryption key from site secrets is used for per-org signing-key material; required when `enabled` is `true`
   * optional token TTL bounds (`token_ttl_min_sec`, `token_ttl_max_sec`), and
+  * optional **`signing_key_overlap_max_sec`**: max allowed **`signing_key_overlap_sec`** on a **rotate** request (default in the tens of days range; tune per environment)
   * optional HTTP proxy for token endpoint calls (`token_endpoint_http_proxy`)
   * optional **`trust_domain_allowlist`**: when non-empty, each org’s configured JWT `issuer` must resolve to a trust domain (registered host) that matches at least one pattern; patterns are validated at startup
   * optional **`token_endpoint_domain_allowlist`**: when non-empty, the org’s token delegation `token_endpoint` must be `http://` or `https://` with a host that matches at least one pattern; patterns are validated at startup
@@ -457,7 +509,7 @@ These APIs manage per-org identity configuration that controls how NICo issues J
 
 **Carbide-rest config defaults:** Carbide-rest may still supply per-site defaults for `issuer`, `tokenTtlSec`, and related fields when a REST client omits them before calling the downstream gRPC `SetTenantIdentityConfiguration`. **`subjectPrefix` is optional in both REST and gRPC:** the NICo API (site controller) derives a default SPIFFE prefix when it is unset or empty — `spiffe://<trust-domain-from-issuer>` — where the trust domain is taken from `issuer` (HTTPS URL host, `spiffe://…` URI trust domain segment, or bare DNS hostname per implementation). When the client **does** send `subjectPrefix`, it must be a `spiffe://` URI whose trust domain matches the trust domain derived from `issuer`, with path segments and encoding rules enforced by the API (see validation below). If Carbide-rest cannot satisfy required fields (e.g. `issuer`) and the client omits them, PUT may return **400 Bad Request** so the caller can supply values explicitly.
 
-**Per-org key generation on PUT:** When PUT creates identity config for an org for the first time, NICo generates a new per-org signing key pair using the global `algorithm`, encrypts the private key with the Vault master key, and stores it in `tenant_identity_config` DB table. On subsequent PUTs (updates), the key is not regenerated unless `rotateKey` is `true`. On DELETE, the identity config and the org's signing key are removed.
+**Per-org key generation on PUT:** When PUT creates identity config for an org for the first time, NICo generates a new per-org signing key pair using the global `algorithm`, encrypts the private key with the site encryption key, and stores it in **slot 1** of `tenant_identity_config`. On subsequent PUTs, signing material is unchanged unless **`rotateKey`** is **`true`**. **Rotation** requires **`signingKeyOverlapSec`** (gRPC: `signing_key_overlap_sec`): seconds the **previous** key remains in JWKS. It must be **≥ `tokenTtlSec`**, **≤** global **`signing_key_overlap_max_sec`**, and must **not** be sent when **`rotateKey`** is false. Overlap is **not** persisted as its own column—the overlap window end is stored in **`non_active_slot_expires_at`** until GC. On DELETE, the identity config and keys are removed.
 
 **PUT when global is disabled:** If the global `enabled` setting in site config is `false`, PUT returns `503 Service Unavailable` with a message indicating that machine identity must be enabled at the site level first. This enforces the deployment order: global config must be enabled before per-org config can be created or updated.
 
@@ -484,6 +536,22 @@ PUT https://{carbide-rest}/v2/org/{org-id}/carbide/site/{site-id}/identity/confi
 }
 ```
 
+Example **rotation** request (overlap must be **≥ `tokenTtlSec`**):
+
+```json
+{
+  "orgId": "org-id",
+  "enabled": true,
+  "issuer": "https://carbide-rest.example.com/org/{org-id}/site/{site-id}",
+  "defaultAudience": "carbide-tenant-xxx",
+  "allowedAudiences": ["carbide-tenant-xxx"],
+  "tokenTtlSec": 300,
+  "subjectPrefix": "spiffe://trust-domain/workload-path",
+  "rotateKey": true,
+  "signingKeyOverlapSec": 3600
+}
+```
+
 | Field | Type | Required | Description |
 | :---- | :--- | :------- | :---------- |
 | `orgId` | string | Yes | Org identifier |
@@ -491,9 +559,10 @@ PUT https://{carbide-rest}/v2/org/{org-id}/carbide/site/{site-id}/identity/confi
 | `issuer` | string | No | Issuer URI that appears in NICo JWT-SVID. Optional in REST/JSON; required in gRPC `SetTenantIdentityConfiguration`. |
 | `defaultAudience` | string | Yes | Default audience. Must be in `allowedAudiences` when provided. |
 | `allowedAudiences` | string[] | No | Permitted audiences. Optional; when empty or omitted, all audiences are allowed (permissive mode). When non-empty, only audiences in the list are allowed. |
-| `tokenTtlSec` | number | No | Token TTL in seconds (300–86400). Optional in REST/JSON; required in gRPC `SetTenantIdentityConfiguration`. |
+| `tokenTtlSec` | number | No | Token TTL in seconds; must fall within global **`token_ttl_min_sec`–`token_ttl_max_sec`** (e.g. 60–86400 with defaults). Optional in REST/JSON; required in gRPC `SetTenantIdentityConfiguration`. |
 | `subjectPrefix` | string | No | SPIFFE URI prefix for JWT-SVID `sub` (must use `spiffe://`; trust domain must match trust domain derived from `issuer`). Optional in REST and in gRPC (`optional` proto3 field). When omitted or empty, the API stores the default `spiffe://<trust-domain-from-issuer>`. |
-| `rotateKey` | boolean | No | If `true`, regenerate the per-org signing key. Default `false`. |
+| `rotateKey` | boolean | No | If `true`, generate a new key pair and rotate to the other slot (see §3.1). Default `false`. |
+| `signingKeyOverlapSec` | number | Conditional | **Required** when **`rotateKey`** is **`true`**: seconds the previous verification key stays in JWKS. Must be **≥ `tokenTtlSec`**, **≤** site **`signing_key_overlap_max_sec`**. **Omit** when **`rotateKey`** is **`false`**. |
 
 **The trust domain in `issuer` is derived from the URL host for `https://` / `http://` issuers (port is not part of the trust domain), from the first segment after `spiffe://` for SPIFFE-form issuers, or from a bare hostname string. User-supplied prefixes must not use percent-encoding, query, or fragment; path segments must follow SPIFFE-safe character rules (see implementation). Mismatch between `subjectPrefix` trust domain and `issuer`-derived trust domain is rejected with `INVALID_ARGUMENT`.
 
@@ -510,14 +579,25 @@ Response:
   "allowedAudiences": ["carbide-tenant-xxx", "tenant-a", "tenant-b"],
   "tokenTtlSec": 300,
   "subjectPrefix": "spiffe://trust-domain/workload-path",
-  "keyId": "af6426a5-5f49-44b9-8721-b5294be20bb6",
+  "rotateKey": false,
+  "signingKeys": [
+    {
+      "kid": "99599fedb98a5f864e4da3042d9502ccaf11b65247f73bbb9bb06e3e46bca269",
+      "alg": "ES256",
+      "expireAt": "2026-05-11T22:32:44.110628Z"
+    },
+    {
+      "kid": "18269392acabfb89c52c5253a33c1a9e58da0f64035df9ed9c974bd49b9a2884",
+      "alg": "ES256",
+      "currentSigner": true
+    }
+  ],
+  "createdAt": "2026-02-24T12:00:00Z",
   "updatedAt": "2026-02-25T12:00:00Z"
 }
 ```
 
-| Response field | Description |
-| :------------- | :---------- |
-| `keyId` | Key identifier for the org's signing key; matches the JWKS `kid` used for JWT verification. |
+`signingKeys` lists **published** public keys (metadata only). Exactly one object has **`currentSigner`: true**. During rotation overlap, the **inactive** key may include **`expireAt`** (proto: `expire_at`) — end of the JWKS overlap window. With a single active key, only one object is returned and **`expireAt`** is omitted.
 
 #### **NICo Token Exchange Server Registration APIs**
 
@@ -820,34 +900,44 @@ message GetTenantIdentityConfigRequest {
   string organization_id = 1;
 }
 
-// Tenant identity config payload (reusable)
+// Published signing key metadata (Get/Put response). JSON: kid, alg, currentSigner, optional expireAt.
+message TenantIdentitySigningKey {
+  string kid = 1;
+  string alg = 2;
+  bool current_signer = 3;
+  optional google.protobuf.Timestamp expire_at = 4;
+}
+
+// Tenant identity config payload (Set input)
 message TenantIdentityConfig {
   bool enabled = 1;
   string issuer = 2;
   string default_audience = 3;
   repeated string allowed_audiences = 4;
   uint32 token_ttl_sec = 5;
-  // When unset or empty, API defaults to spiffe://<trust-domain-from-issuer>
   optional string subject_prefix = 6;
   bool rotate_key = 7;
+  // Required when rotate_key; must be omitted otherwise. >= token_ttl_sec; <= site signing_key_overlap_max_sec.
+  optional uint32 signing_key_overlap_sec = 8;
 }
 
-// Request to configure identity token settings (per org)
 message SetTenantIdentityConfigRequest {
   string organization_id = 1;
   TenantIdentityConfig config = 2;
 }
 
-// Response for Get/Put tenant identity configuration (persisted config per org)
+// Get/Put response: nested config + timestamps + all published keys (see TenantIdentitySigningKey).
 message TenantIdentityConfigResponse {
   string organization_id = 1;
-  TenantIdentityConfig config = 2;  // Nested message; subject_prefix is populated (optional field set) with effective stored value
+  TenantIdentityConfig config = 2;
   google.protobuf.Timestamp created_at = 8;
   google.protobuf.Timestamp updated_at = 9;
-  string key_id = 10;  // Matches JWKS kid for JWT verification
+  reserved 10;
+  reserved "key_id";
+  repeated TenantIdentitySigningKey signing_keys = 11;
 }
 
-// gRPC service
+// gRPC service (extract; see crates/rpc/proto/forge.proto for full Forge service)
 service Forge {
   rpc GetTenantIdentityConfiguration(GetTenantIdentityConfigRequest) returns (TenantIdentityConfigResponse);
   rpc SetTenantIdentityConfiguration(SetTenantIdentityConfigRequest) returns (TenantIdentityConfigResponse);
@@ -877,7 +967,7 @@ Use standard gRPC `Status` codes, aligned with REST:
 
 | REST | gRPC Status | Notes |
 | ----- | ----- | ----- |
-| 400 Bad Request | `INVALID_ARGUMENT` | Malformed request |
+| 400 Bad Request | `INVALID_ARGUMENT` | Malformed request; identity examples: overlap &lt; `token_ttl_sec`, `signing_key_overlap_sec` set without `rotate_key`, missing overlap on rotate |
 | 401 Unauthorized | `UNAUTHENTICATED` | Invalid credentials |
 | 403 Forbidden | `PERMISSION_DENIED` | Not allowed |
 | 404 Not Found | `NOT_FOUND` | Resource missing |
@@ -899,4 +989,5 @@ Use standard gRPC `Status` codes, aligned with REST:
 
 4. Requests to IMDS are limited to 3 requests per second. Requests exceeding this threshold will be rejected with 429 responses. This prevents DoS on DPU-agent and NICo API server due to frequent IMDS calls.  
 5. Input validation: The input such as machine id will be validated using the database before issuing the token.  
-6. HTTPS and optional HTTP proxy support for route token exchange call to limit SSRF attacks on internal systems. 
+6. HTTPS and optional HTTP proxy support for route token exchange call to limit SSRF attacks on internal systems.
+7. **IMDS HTTP sign proxy (DPU agent):** When `[machine-identity].sign-proxy-url` is set, the agent trusts that endpoint to return a valid identity response to the workload. The proxy must be operated and authenticated on the network path appropriate for your site; optional `sign-proxy-tls-root-ca` pins trust for private CAs only for that HTTP client. This path does not replace Forge mTLS for workloads that still use direct `SignMachineIdentity`—it is an **operator-chosen alternative transport** from IMDS to a signing-capable HTTP service. 


### PR DESCRIPTION
## Description
Add feature to support jwt-svid signing key rotation.
The existing API offers rolling of new key, but not key rotation. The new feature allow admins to rotate the keys reducing temporary signature validation failures.
 
#### Data model & migration

- New migration `20260506120000_tenant_identity_signing_key_rotation.sql`:
  - Replaces single `encrypted_signing_key` / `signing_key_public` / `key_id` / `algorithm` with **slotted** `encrypted_signing_key_1|2`, `signing_key_public_1|2`, `current_signing_key_slot`, `non_active_slot_expires_at`.
  - Migrates existing public material into **`signing_key_public_1`** as versioned JSON (`v`, `kid`, `alg`, `public_pem`).

#### API / proto (`forge.proto`)

- `TenantIdentityConfig`: `rotate_key`, optional `signing_key_overlap_sec` (rotate-only, bounded by site).
- `TenantIdentitySigningKey` + `TenantIdentityConfigResponse.signing_keys` for **multi-key metadata** (`current_signer`, optional `expire_at`).

#### Site config

- `[machine_identity]`: **`signing_key_overlap_max_sec`** (and wiring in `cfg/file.rs`) to cap per-request overlap on rotate.

#### Model (`api-model`)

- `SigningKeyPublicV1`, slot enum, overlap/TTL validation in `IdentityConfig::try_from_proto` (including **overlap ≥ token TTL**), tests for rotate / overlap / clippy cleanup.

#### DB (`api-db`)

- `tenant_identity_config` **set/find**, **GC** of expired non-active slot, **`find_by_machine_id`** reads **current** encrypted + public slot.

#### Handlers

- **`tenant_identity_config`**: build `signing_keys` response; set path handles rotation + overlap.
- **`machine_identity`**: sign with **current** slot; **JWKS** emits **both** published public docs when present; PEM / `kid` aligned with model.

#### Docs

- **`docs/design/machine-identity/spiffe-svid-sdd.md`**: two-slot rotation, overlap rules, `signingKeys` / `expireAt`, site limits (and related IMDS / sign-proxy notes if present on branch).

---

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
https://github.com/NVIDIA/infra-controller-core/issues/1504

## Breaking Changes
- [] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
https://github.com/NVIDIA/infra-controller-core/issues/1504
#261

