### PR TITLE
fix(admin-cli): plumb through updating dpu_mode on expected machines

### DIFF
--- a/crates/admin-cli/src/expected_machines/patch/args.rs
+++ b/crates/admin-cli/src/expected_machines/patch/args.rs
@@ -20,6 +20,7 @@ use carbide_utils::has_duplicates;
 use carbide_uuid::rack::RackId;
 use clap::{ArgGroup, Parser};
 use mac_address::MacAddress;
+use rpc::forge::DpuMode;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -45,6 +46,7 @@ use uuid::Uuid;
 "fallback_dpu_serial_numbers",
 "sku_id",
 "bmc_ip_address",
+"dpu_mode",
 ])))]
 pub struct Args {
     #[clap(short = 'a', long, help = "BMC MAC Address of the expected machine")]
@@ -155,6 +157,15 @@ pub struct Args {
     pub bmc_retain_credentials: Option<bool>,
 
     #[clap(
+        long = "dpu-mode",
+        value_name = "DPU_MODE",
+        value_enum,
+        group = "group",
+        help = "Per-host DPU operating mode. `dpu-mode` (default): DPUs are managed by NICo; `nic-mode`: DPU hardware present but treated as a plain NIC; `no-dpu`: no DPU hardware at all. Unset preserves the existing per-host value."
+    )]
+    pub dpu_mode: Option<DpuMode>,
+
+    #[clap(
         long = "disable-lockdown",
         value_name = "DISABLE_LOCKDOWN",
         help = "If true, do not lock down the server as part of lifecycle management within the state machine. If unset or false, preserve the default behavior of locking down the server after configuring the BIOS."
@@ -184,8 +195,9 @@ impl Args {
             && self.sku_id.is_none()
             && self.rack_id.is_none()
             && self.bmc_ip_address.is_none()
+            && self.dpu_mode.is_none()
         {
-            return Err(CarbideCliError::GenericError("One of the following options must be specified: bmc-user-name and bmc-password or chassis-serial-number or fallback-dpu-serial-number or bmc-ip-address".to_string()));
+            return Err(CarbideCliError::GenericError("One of the following options must be specified: bmc-user-name and bmc-password or chassis-serial-number or fallback-dpu-serial-number or bmc-ip-address or dpu-mode".to_string()));
         }
         if self
             .fallback_dpu_serial_numbers

--- a/crates/admin-cli/src/expected_machines/patch/mod.rs
+++ b/crates/admin-cli/src/expected_machines/patch/mod.rs
@@ -50,6 +50,7 @@ impl Run for Args {
                 self.dpf_enabled,
                 self.bmc_ip_address,
                 self.bmc_retain_credentials,
+                self.dpu_mode,
                 self.disable_lockdown
                     .map(|dl| ::rpc::forge::HostLifecycleProfile {
                         disable_lockdown: Some(dl),

--- a/crates/admin-cli/src/expected_machines/show/cmd.rs
+++ b/crates/admin-cli/src/expected_machines/show/cmd.rs
@@ -17,6 +17,7 @@
 use std::collections::HashMap;
 
 use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use clap::ValueEnum;
 use mac_address::MacAddress;
 use prettytable::{Table, row};
 use rpc::forge::ExpectedMachineRequest;
@@ -133,6 +134,7 @@ async fn convert_and_print_into_nice_table(
         "Pause On Ingestion",
         "DPF Enabled",
         "Disable Lockdown",
+        "DPU Mode",
     ]);
 
     for expected_machine in &expected_machines.expected_machines {
@@ -153,6 +155,17 @@ async fn convert_and_print_into_nice_table(
             .map(String::as_str);
 
         let labels = crate::metadata::fmt_labels_as_kv_pairs(expected_machine.metadata.as_ref());
+
+        // None on the wire == the DB default (`DpuMode`); fall back to that
+        // rather than `Unspecified` so `to_possible_value()` produces the
+        // same kebab-case string the `--dpu-mode` CLI flag accepts.
+        let dpu_mode_display = expected_machine
+            .dpu_mode
+            .and_then(|i| ::rpc::forge::DpuMode::try_from(i).ok())
+            .unwrap_or(::rpc::forge::DpuMode::DpuMode)
+            .to_possible_value()
+            .map(|pv| pv.get_name().to_owned())
+            .unwrap_or_default();
 
         table.add_row(row![
             expected_machine.chassis_serial_number,
@@ -186,6 +199,7 @@ async fn convert_and_print_into_nice_table(
                 .and_then(|hlp| hlp.disable_lockdown)
                 .unwrap_or_default()
                 .to_string(),
+            dpu_mode_display,
         ]);
     }
 

--- a/crates/admin-cli/src/expected_machines/tests.rs
+++ b/crates/admin-cli/src/expected_machines/tests.rs
@@ -625,3 +625,98 @@ fn parse_add_rejects_invalid_dpu_mode() {
         "clap should reject --dpu-mode with an invalid value"
     );
 }
+
+// parse_patch_with_dpu_mode_nic ensures `patch ... --dpu-mode nic-mode`
+// parses to NicMode. Patch users flip dpu_mode on a single host without
+// rewriting the entire ExpectedMachine.
+#[test]
+fn parse_patch_with_dpu_mode_nic() {
+    let cmd = Cmd::try_parse_from([
+        "expected-machine",
+        "patch",
+        "--bmc-mac-address",
+        "1a:2b:3c:4d:5e:6f",
+        "--dpu-mode",
+        "nic-mode",
+    ])
+    .expect("should parse patch --dpu-mode nic-mode");
+
+    match cmd {
+        Cmd::Patch(args) => {
+            assert!(matches!(args.dpu_mode, Some(rpc::forge::DpuMode::NicMode)));
+        }
+        _ => panic!("expected Patch variant"),
+    }
+}
+
+// parse_patch_with_dpu_mode_no_dpu ensures `patch ... --dpu-mode no-dpu`
+// parses (host with no DPU hardware at all).
+#[test]
+fn parse_patch_with_dpu_mode_no_dpu() {
+    let cmd = Cmd::try_parse_from([
+        "expected-machine",
+        "patch",
+        "--bmc-mac-address",
+        "1a:2b:3c:4d:5e:6f",
+        "--dpu-mode",
+        "no-dpu",
+    ])
+    .expect("should parse patch --dpu-mode no-dpu");
+
+    match cmd {
+        Cmd::Patch(args) => {
+            assert!(matches!(args.dpu_mode, Some(rpc::forge::DpuMode::NoDpu)));
+        }
+        _ => panic!("expected Patch variant"),
+    }
+}
+
+// parse_patch_with_dpu_mode_dpu ensures `patch ... --dpu-mode dpu-mode`
+// parses; this is how operators revert a host back to the default after
+// previously setting NicMode/NoDpu.
+#[test]
+fn parse_patch_with_dpu_mode_dpu() {
+    let cmd = Cmd::try_parse_from([
+        "expected-machine",
+        "patch",
+        "--bmc-mac-address",
+        "1a:2b:3c:4d:5e:6f",
+        "--dpu-mode",
+        "dpu-mode",
+    ])
+    .expect("should parse patch --dpu-mode dpu-mode");
+
+    match cmd {
+        Cmd::Patch(args) => {
+            assert!(matches!(args.dpu_mode, Some(rpc::forge::DpuMode::DpuMode)));
+        }
+        _ => panic!("expected Patch variant"),
+    }
+}
+
+// validate_patch_with_dpu_mode_only ensures `patch --dpu-mode nic-mode`
+// alone (no other patchable fields) satisfies clap's ArgGroup and the
+// `Args::validate()` "at least one field" check. The whole point of this
+// patch is "flip dpu_mode", so it must work without dummy companion args.
+#[test]
+fn validate_patch_with_dpu_mode_only() {
+    let cmd = Cmd::try_parse_from([
+        "expected-machine",
+        "patch",
+        "--bmc-mac-address",
+        "00:00:00:00:00:00",
+        "--dpu-mode",
+        "nic-mode",
+    ])
+    .expect("patch --dpu-mode alone should parse (ArgGroup)");
+
+    match cmd {
+        Cmd::Patch(args) => {
+            assert!(
+                args.validate().is_ok(),
+                "patch --dpu-mode alone should validate"
+            );
+        }
+        _ => panic!("expected Patch variant"),
+    }
+}

--- a/crates/admin-cli/src/expected_machines/update/mod.rs
+++ b/crates/admin-cli/src/expected_machines/update/mod.rs
@@ -68,6 +68,7 @@ impl Run for Args {
                 expected_machine.dpf_enabled,
                 expected_machine.bmc_ip_address,
                 expected_machine.bmc_retain_credentials,
+                expected_machine.dpu_mode,
                 expected_machine.host_lifecycle_profile.map(|hlp| {
                     ::rpc::forge::HostLifecycleProfile {
                         disable_lockdown: hlp.disable_lockdown,

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -617,6 +617,7 @@ impl ApiClient {
         dpf_enabled: Option<bool>,
         bmc_ip_address: Option<String>,
         bmc_retain_credentials: Option<bool>,
+        dpu_mode: Option<::rpc::forge::DpuMode>,
         host_lifecycle_profile: Option<::rpc::forge::HostLifecycleProfile>,
     ) -> Result<(), CarbideCliError> {
         let get_req = match (bmc_mac_address, id) {
@@ -699,9 +700,7 @@ impl ApiClient {
             bmc_ip_address: bmc_ip_address.or(expected_machine.bmc_ip_address),
             bmc_retain_credentials: bmc_retain_credentials
                 .or(expected_machine.bmc_retain_credentials),
-            // Patch doesn't expose `--dpu-mode` yet; preserve the existing
-            // server-side value.
-            dpu_mode: expected_machine.dpu_mode,
+            dpu_mode: dpu_mode.map(|m| m as i32).or(expected_machine.dpu_mode),
             host_lifecycle_profile: host_lifecycle_profile
                 .or(expected_machine.host_lifecycle_profile),
         };

--- a/crates/api/src/tests/expected_machine.rs
+++ b/crates/api/src/tests/expected_machine.rs
@@ -2769,6 +2769,65 @@ async fn test_dpu_mode_default_value_omitted_on_wire(
     Ok(())
 }
 
+/// Verify the update RPC (for update/patch flows) actually flips
+/// `dpu_mode` as expected.
+#[crate::sqlx_test]
+async fn test_update_changes_dpu_mode(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    let mac = "5A:5B:5C:5D:5E:80";
+    let base = rpc::forge::ExpectedMachine {
+        bmc_mac_address: mac.into(),
+        bmc_username: "ADMIN".into(),
+        bmc_password: "PASS".into(),
+        chassis_serial_number: "EM-DPU-UPDATE".into(),
+        metadata: Some(rpc::forge::Metadata::default()),
+        ..Default::default()
+    };
+
+    env.api
+        .add_expected_machine(tonic::Request::new(base.clone()))
+        .await?;
+
+    for mode in [
+        rpc::forge::DpuMode::NicMode,
+        rpc::forge::DpuMode::NoDpu,
+        rpc::forge::DpuMode::DpuMode,
+    ] {
+        env.api
+            .update_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+                dpu_mode: Some(mode as i32),
+                ..base.clone()
+            }))
+            .await?;
+
+        let retrieved = env
+            .api
+            .get_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachineRequest {
+                bmc_mac_address: mac.into(),
+                id: None,
+            }))
+            .await?
+            .into_inner();
+
+        // DpuMode is the column default and the wire-default; the model
+        // collapses it to `None` on the way out (see `From<ExpectedMachine>
+        // for rpc::forge::ExpectedMachine`), so compare accordingly.
+        let expected_wire = match mode {
+            rpc::forge::DpuMode::DpuMode | rpc::forge::DpuMode::Unspecified => None,
+            other => Some(other as i32),
+        };
+        assert_eq!(
+            retrieved.dpu_mode, expected_wire,
+            "update to {mode:?} should persist and round-trip on the wire"
+        );
+    }
+
+    Ok(())
+}
+
 /// Make sure expected_machines.json, which uses create_missing_from,
 /// follows the shared codepath for handling interface allocation.
 #[crate::sqlx_test]


### PR DESCRIPTION
## Description

This closes https://github.com/NVIDIA/infra-controller-core/issues/1599.

Went to go do this to tweak a machine I wanted to re-ingest, and realized it wasn't plumbed down to the `admin-cli`.

Tests added on the `admin-cli` and `api` side to make sure this all does things as expected.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

