### PR TITLE
fix: if NSM is configured as the switch component manager, dispatch fw update requests directly to NSM

### DIFF
--- a/crates/api-model/src/component_manager.rs
+++ b/crates/api-model/src/component_manager.rs
@@ -49,6 +49,17 @@ pub enum NvSwitchComponent {
     Nvos,
 }
 
+impl std::fmt::Display for NvSwitchComponent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Bmc => f.write_str("BMC"),
+            Self::Cpld => f.write_str("CPLD"),
+            Self::Bios => f.write_str("BIOS"),
+            Self::Nvos => f.write_str("NVOS"),
+        }
+    }
+}
+
 /// Updatable components of a PowerShelf.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PowerShelfComponent {

--- a/crates/api/src/handlers/component_manager.rs
+++ b/crates/api/src/handlers/component_manager.rs
@@ -32,7 +32,7 @@ use forge_secrets::credentials::{
 };
 use futures_util::FutureExt;
 use mac_address::MacAddress;
-use model::component_manager::{PowerAction, PowerShelfComponent};
+use model::component_manager::{NvSwitchComponent, PowerAction, PowerShelfComponent};
 use model::firmware::FirmwareComponentType;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::rack::{FirmwareUpgradeJob, MaintenanceActivity};
@@ -403,13 +403,17 @@ fn get_compute_tray_firmware_version(
 }
 
 fn map_nv_switch_component_names(raw: &[i32]) -> Result<Vec<String>, Status> {
+    map_nv_switch_components(raw).map(|cs| cs.into_iter().map(|c| c.to_string()).collect())
+}
+
+fn map_nv_switch_components(raw: &[i32]) -> Result<Vec<NvSwitchComponent>, Status> {
     raw.iter()
         .filter(|&&v| v != rpc::NvSwitchComponent::Unknown as i32)
         .map(|&v| match rpc::NvSwitchComponent::try_from(v) {
-            Ok(rpc::NvSwitchComponent::Bmc) => Ok("BMC".to_string()),
-            Ok(rpc::NvSwitchComponent::Cpld) => Ok("CPLD".to_string()),
-            Ok(rpc::NvSwitchComponent::Bios) => Ok("BIOS".to_string()),
-            Ok(rpc::NvSwitchComponent::Nvos) => Ok("NVOS".to_string()),
+            Ok(rpc::NvSwitchComponent::Bmc) => Ok(NvSwitchComponent::Bmc),
+            Ok(rpc::NvSwitchComponent::Cpld) => Ok(NvSwitchComponent::Cpld),
+            Ok(rpc::NvSwitchComponent::Bios) => Ok(NvSwitchComponent::Bios),
+            Ok(rpc::NvSwitchComponent::Nvos) => Ok(NvSwitchComponent::Nvos),
             _ => Err(Status::invalid_argument(format!(
                 "unknown NV-Switch component: {v}"
             ))),
@@ -1161,6 +1165,41 @@ pub(crate) async fn update_component_firmware(
                 .ok_or_else(|| Status::invalid_argument("switch_ids is required"))?;
             if list.ids.is_empty() {
                 return Err(Status::invalid_argument("switch_ids must not be empty"));
+            }
+
+            if let Some(cm) = api.component_manager.as_ref().filter(|cm| {
+                cm.nv_switch.name() == component_manager::nsm::NsmSwitchBackend::BACKEND_NAME
+            }) {
+                let components = map_nv_switch_components(&t.components)?;
+                let endpoints = resolve_switch_endpoints(api, &list.ids).await?;
+
+                let mut results: Vec<_> = endpoints
+                    .unresolved
+                    .iter()
+                    .map(|u| error_result(&u.id.to_string(), u.reason.clone()))
+                    .collect();
+
+                let backend_results = cm
+                    .nv_switch
+                    .queue_firmware_updates(
+                        &endpoints.resolved.endpoints,
+                        &req.target_version,
+                        &components,
+                    )
+                    .await
+                    .map_err(component_manager_error_to_status)?;
+                results.extend(backend_results.into_iter().map(|r| {
+                    let id = switch_mac_to_id_str(&r.bmc_mac, &endpoints.resolved.mac_to_id);
+                    if r.success {
+                        success_result(&id)
+                    } else {
+                        error_result(&id, r.error.unwrap_or_default())
+                    }
+                }));
+
+                return Ok(Response::new(rpc::UpdateComponentFirmwareResponse {
+                    results,
+                }));
             }
 
             component_names = map_nv_switch_component_names(&t.components)?;

--- a/crates/component-manager/src/component_manager.rs
+++ b/crates/component-manager/src/component_manager.rs
@@ -42,7 +42,7 @@ pub async fn build_component_manager(
     db: Option<PgPool>,
 ) -> Result<ComponentManager, ComponentManagerError> {
     let nv_switch: Arc<dyn NvSwitchManager> = match config.nv_switch_backend.as_str() {
-        "nsm" => {
+        crate::nsm::NsmSwitchBackend::BACKEND_NAME => {
             let endpoint = config.nsm.as_ref().ok_or_else(|| {
                 ComponentManagerError::InvalidArgument(
                     "nv_switch_backend is 'nsm' but [component_manager.nsm] config is missing"

--- a/crates/component-manager/src/nsm.rs
+++ b/crates/component-manager/src/nsm.rs
@@ -22,6 +22,8 @@ pub struct NsmSwitchBackend {
 }
 
 impl NsmSwitchBackend {
+    pub const BACKEND_NAME: &str = "nsm";
+
     pub async fn connect(
         url: &str,
         tls: Option<&BackendTlsConfig>,
@@ -143,7 +145,7 @@ async fn register_and_map(
 #[async_trait::async_trait]
 impl NvSwitchManager for NsmSwitchBackend {
     fn name(&self) -> &str {
-        "nsm"
+        Self::BACKEND_NAME
     }
 
     #[instrument(skip(self), fields(backend = "nsm"))]


### PR DESCRIPTION
## Description
fix: if NSM is configured as the switch component manager, dispatch fw update requests directly to NSM

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

